### PR TITLE
Make micropython build on OpenBSD.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Additional components:
 The Unix version
 ----------------
 
-The "unix" part requires a standard Unix environment with gcc.  It works
-only for 64-bit machines due to a small piece of x86-64 assembler for
-the exception handling.
+The "unix" part requires a standard Unix environment with gcc and GNU make.
+It works only for 64-bit machines due to a small piece of x86-64 assembler
+for the exception handling.
 
 To build:
 

--- a/py/asmx64.c
+++ b/py/asmx64.c
@@ -7,6 +7,10 @@
 #include "misc.h"
 #include "asmx64.h"
 
+#if defined(__OpenBSD__)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
 /* all offsets are measured in multiples of 8 bytes */
 #define WORD_SIZE                (8)
 

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -3,7 +3,7 @@ BUILD=build
 
 CC = gcc
 CFLAGS = -I. -I$(PYSRC) -Wall -Werror -ansi -std=gnu99 -Os -DUSE_READLINE #-DNDEBUG
-LDFLAGS = -lm
+LDFLAGS = -lm -ltermcap
 
 SRC_C = \
 	main.c \

--- a/unix/main.c
+++ b/unix/main.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #include "nlr.h"
 #include "misc.h"


### PR DESCRIPTION
The following commits allow micropython to build on OpenBSD.

Among other things, fixes #27.
