### PR TITLE
Add quick impl for MP_BC_LOAD_CONST_BYTES which just creates qstr so far...

### DIFF
--- a/py/vm.c
+++ b/py/vm.c
@@ -115,6 +115,11 @@ bool mp_execute_byte_code_2(const byte **ip_in_out, mp_obj_t *fastn, mp_obj_t **
                         PUSH(rt_load_const_str(qstr)); // TODO
                         break;
 
+                    case MP_BC_LOAD_CONST_BYTES:
+                        DECODE_QSTR;
+                        PUSH(rt_load_const_str(qstr)); // TODO
+                        break;
+
                     case MP_BC_LOAD_CONST_STRING:
                         DECODE_QSTR;
                         PUSH(rt_load_const_str(qstr));


### PR DESCRIPTION
....

This is based on the fact that qstr so far behaves more like byte string
than like Unicode string (for example, "012"[0] returns 48 (int)).

Per thoughts expressed in #22.
