### PR TITLE
Fix issue #62: Cache loses data

### DIFF
--- a/stm/storage.c
+++ b/stm/storage.c
@@ -49,6 +49,16 @@ static uint8_t *cache_get_addr_for_write(uint32_t flash_addr) {
     return (uint8_t*)CACHE_MEM_START_ADDR + flash_addr - flash_sector_start;
 }
 
+static uint8_t *cache_get_addr_for_read(uint32_t flash_addr) {
+    uint32_t flash_sector_start;
+    uint32_t flash_sector_size;
+    uint32_t flash_sector_id = flash_get_sector_info(flash_addr, &flash_sector_start, &flash_sector_size);
+    if (cache_flash_sector_id == flash_sector_id)
+        return (uint8_t*)CACHE_MEM_START_ADDR + flash_addr - flash_sector_start;
+    // not in cache, copy straight from flash
+    return (uint8_t*)flash_addr;
+}
+
 void storage_init(void) {
     if (!is_initialised) {
         cache_flash_sector_id = 0;
@@ -131,8 +141,8 @@ bool storage_read_block(uint8_t *dest, uint32_t block) {
         return true;
 
     } else if (FLASH_PART1_START_BLOCK <= block && block < FLASH_PART1_START_BLOCK + FLASH_PART1_NUM_BLOCKS) {
-        // non-MBR block, just copy straight from flash
-        uint8_t *src = (uint8_t*)FLASH_MEM_START_ADDR + (block - FLASH_PART1_START_BLOCK) * BLOCK_SIZE;
+        uint32_t flash_addr = FLASH_MEM_START_ADDR + (block - FLASH_PART1_START_BLOCK) * BLOCK_SIZE;
+        uint8_t *src = cache_get_addr_for_read(flash_addr);
         memcpy(dest, src, BLOCK_SIZE);
         return true;
 


### PR DESCRIPTION
Use the storage cache not only for writing but also for reading. This
avoids reading stale data and thus data loss.
