### PR TITLE
Apple clang fixes

### DIFF
--- a/py/nlrx64.S
+++ b/py/nlrx64.S
@@ -27,7 +27,9 @@ _nlr_push:
     movq    %rdi, nlr_top(%rip)     # stor new nlr_buf (to make linked list)
     xorq    %rax, %rax              # return 0, normal return
     ret                             # return
-//    .size   nlr_push, .-nlr_push
+#ifndef __llvm__
+    .size   nlr_push, .-nlr_push
+#endif
 
 /* void nlr_pop() */
 #ifndef __llvm__
@@ -42,7 +44,9 @@ _nlr_pop:
     movq    (%rax), %rax            # load prev nlr_buf
     movq    %rax, nlr_top(%rip)     # store prev nlr_buf (to unlink list)
     ret                             # return
-//    .size   nlr_pop, .-nlr_pop
+#ifndef __llvm__
+    .size   nlr_pop, .-nlr_pop
+#endif
 
 /* void nlr_jump(rdi=uint val) */
 #ifndef __llvm__

--- a/py/nlrx64.S
+++ b/py/nlrx64.S
@@ -5,7 +5,7 @@
     .text
 
 /* uint nlr_push(rdi=nlr_buf_t *nlr) */
-#ifndef __llvm__
+#ifndef __apple_build_version__
     .globl  nlr_push
     .type   nlr_push, @function
 nlr_push:
@@ -27,12 +27,12 @@ _nlr_push:
     movq    %rdi, nlr_top(%rip)     # stor new nlr_buf (to make linked list)
     xorq    %rax, %rax              # return 0, normal return
     ret                             # return
-#ifndef __llvm__
+#ifndef __apple_build_version__
     .size   nlr_push, .-nlr_push
 #endif
 
 /* void nlr_pop() */
-#ifndef __llvm__
+#ifndef __apple_build_version__
     .globl  nlr_pop
     .type   nlr_pop, @function
 nlr_pop:
@@ -44,12 +44,12 @@ _nlr_pop:
     movq    (%rax), %rax            # load prev nlr_buf
     movq    %rax, nlr_top(%rip)     # store prev nlr_buf (to unlink list)
     ret                             # return
-#ifndef __llvm__
+#ifndef __apple_build_version__
     .size   nlr_pop, .-nlr_pop
 #endif
 
 /* void nlr_jump(rdi=uint val) */
-#ifndef __llvm__
+#ifndef __apple_build_version__
     .globl  nlr_jump
     .type   nlr_jump, @function
 nlr_jump:
@@ -74,11 +74,11 @@ nlr_jump:
     xorq    %rax, %rax              # clear return register
     inc     %al                     # increase to make 1, non-local return
     ret                             # return
-#ifndef __llvm__
+#ifndef __apple_build_version__
     .size   nlr_jump, .-nlr_jump
 #endif
 
-#ifndef __llvm__
+#ifndef __apple_build_version__
     .local  nlr_top
 #endif
     .comm   nlr_top,8,8

--- a/py/nlrx64.S
+++ b/py/nlrx64.S
@@ -5,9 +5,14 @@
     .text
 
 /* uint nlr_push(rdi=nlr_buf_t *nlr) */
+#ifndef __llvm__
     .globl  nlr_push
     .type   nlr_push, @function
 nlr_push:
+#else
+    .globl  _nlr_push
+_nlr_push:
+#endif
     movq    (%rsp), %rax            # load return %rip
     movq    %rax, 16(%rdi)          # store %rip into nlr_buf
     movq    %rbp, 24(%rdi)          # store %rbp into nlr_buf
@@ -22,22 +27,32 @@ nlr_push:
     movq    %rdi, nlr_top(%rip)     # stor new nlr_buf (to make linked list)
     xorq    %rax, %rax              # return 0, normal return
     ret                             # return
-    .size   nlr_push, .-nlr_push
+//    .size   nlr_push, .-nlr_push
 
 /* void nlr_pop() */
+#ifndef __llvm__
     .globl  nlr_pop
     .type   nlr_pop, @function
 nlr_pop:
+#else
+    .globl  _nlr_pop
+_nlr_pop:
+#endif
     movq    nlr_top(%rip), %rax     # get nlr_top into %rax
     movq    (%rax), %rax            # load prev nlr_buf
     movq    %rax, nlr_top(%rip)     # store prev nlr_buf (to unlink list)
     ret                             # return
-    .size   nlr_pop, .-nlr_pop
+//    .size   nlr_pop, .-nlr_pop
 
 /* void nlr_jump(rdi=uint val) */
+#ifndef __llvm__
     .globl  nlr_jump
     .type   nlr_jump, @function
 nlr_jump:
+#else
+    .globl  _nlr_jump
+    _nlr_jump:
+#endif
     movq    %rdi, %rax              # put return value in %rax
     movq    nlr_top(%rip), %rdi     # get nlr_top into %rdi
     movq    %rax, 8(%rdi)           # store return value
@@ -55,8 +70,12 @@ nlr_jump:
     xorq    %rax, %rax              # clear return register
     inc     %al                     # increase to make 1, non-local return
     ret                             # return
+#ifndef __llvm__
     .size   nlr_jump, .-nlr_jump
+#endif
 
+#ifndef __llvm__
     .local  nlr_top
+#endif
     .comm   nlr_top,8,8
 #endif


### PR DESCRIPTION
With these assembly tweaks "unix" builds with Apple's gcc-alike-clang.

Makes the function headers a bit uglier, but IMHO it's not too bad.

Using an Apple-specific define; could use **llvm** instead if needed for other clang variants.
