### PR TITLE
Add Initial Support for STM32F4DISCOVERY Board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Compiled Sources
+###################
+*.o
+*.a
+*.elf
+*.bin
+*.map
+*.hex
+*.dis
+
+# Packages 
+############
+
+# Logs and Databases
+######################
+*.log
+
+# VIM Swap Files
+######################
+*.swp
+

--- a/stm/Makefile
+++ b/stm/Makefile
@@ -5,12 +5,13 @@ CC3KSRC=cc3k
 PYSRC=../py
 BUILD=build
 DFU=../tools/dfu.py
+TARGET=PYBOARD
 
 AS = arm-none-eabi-as
 CC = arm-none-eabi-gcc
 LD = arm-none-eabi-ld
 CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mabi=aapcs-linux -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -fsingle-precision-constant -Wdouble-promotion -DSTM32F40XX -DHSE_VALUE=8000000
-CFLAGS = -I. -I$(PYSRC) -I$(FATFSSRC) -I$(STMSRC) -Wall -ansi -std=gnu99 -Os -DNDEBUG $(CFLAGS_CORTEX_M4)
+CFLAGS = -I. -I$(PYSRC) -I$(FATFSSRC) -I$(STMSRC) -Wall -ansi -std=gnu99 -Os -DNDEBUG $(CFLAGS_CORTEX_M4) -D$(TARGET)
 #CFLAGS += -I$(STMOTGSRC) -DUSE_HOST_MODE -DUSE_OTG_MODE
 LDFLAGS = --nostdlib -T stm32f405.ld
 

--- a/stm/led.c
+++ b/stm/led.c
@@ -7,66 +7,144 @@
 #include "obj.h"
 #include "led.h"
 
-#define PYB_LED_R_PORT (GPIOA)
-#define PYB_LED_R1_PIN (GPIO_Pin_8)
-#define PYB_LED_R2_PIN (GPIO_Pin_10)
-#define PYB_LED_G_PORT   (GPIOC)
-#define PYB_LED_G1_PIN (GPIO_Pin_4)
-#define PYB_LED_G2_PIN (GPIO_Pin_5)
+/* LED numbers, used internally */
+#define PYB_LED_1   (1)
+#define PYB_LED_2   (2)
+#define PYB_LED_3   (3)
+#define PYB_LED_4   (4)
+
+#if defined(PYBOARD)
+    #define PYB_LED1_PORT   (GPIOA)
+    #define PYB_LED1_PIN    (GPIO_Pin_8)
+
+    #define PYB_LED2_PORT   (GPIOA)
+    #define PYB_LED2_PIN    (GPIO_Pin_10)
+
+    #define PYB_LED3_PORT   (GPIOC)
+    #define PYB_LED3_PIN    (GPIO_Pin_4)
+
+    #define PYB_LED4_PORT   (GPIOC)
+    #define PYB_LED4_PIN    (GPIO_Pin_5)
+
+    #define PYB_OTYPE       (GPIO_OType_OD)
+
+    #define PYB_LED_ON(port, pin)  (port->BSRRH = pin)
+    #define PYB_LED_OFF(port, pin) (port->BSRRL = pin)
+
+#elif defined(STM32F4DISC)
+    #define PYB_LED1_PORT   (GPIOD)
+    #define PYB_LED1_PIN    (GPIO_Pin_14)
+
+    #define PYB_LED2_PORT   (GPIOD)
+    #define PYB_LED2_PIN    (GPIO_Pin_12)
+
+    #define PYB_LED3_PORT   (GPIOD)
+    #define PYB_LED3_PIN    (GPIO_Pin_15)
+
+    #define PYB_LED4_PORT   (GPIOD)
+    #define PYB_LED4_PIN    (GPIO_Pin_13)
+
+    #define PYB_OTYPE       (GPIO_OType_PP)
+
+    #define PYB_LED_ON(port, pin)  (port->BSRRL = pin)
+    #define PYB_LED_OFF(port, pin) (port->BSRRH = pin)
+#endif
 
 void led_init(void) {
-    // set the output high (so LED is off)
-    PYB_LED_R_PORT->BSRRL = PYB_LED_R1_PIN;
-    PYB_LED_R_PORT->BSRRL = PYB_LED_R2_PIN;
-    PYB_LED_G_PORT->BSRRL = PYB_LED_G1_PIN;
-    PYB_LED_G_PORT->BSRRL = PYB_LED_G2_PIN;
-    // make them open drain outputs
+    /* GPIO structure */
     GPIO_InitTypeDef GPIO_InitStructure;
-    GPIO_InitStructure.GPIO_Pin = PYB_LED_R1_PIN | PYB_LED_R2_PIN;
+
+    /* Configure I/O speed, mode, output type and pull */
     GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
     GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
-    GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
     GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
-    GPIO_Init(PYB_LED_R_PORT, &GPIO_InitStructure);
-    GPIO_InitStructure.GPIO_Pin = PYB_LED_G1_PIN | PYB_LED_G2_PIN;
-    GPIO_Init(PYB_LED_G_PORT, &GPIO_InitStructure);
+    GPIO_InitStructure.GPIO_OType = PYB_OTYPE;
+
+    /* Turn off LEDs */
+    PYB_LED_OFF(PYB_LED1_PORT, PYB_LED1_PIN);
+    PYB_LED_OFF(PYB_LED2_PORT, PYB_LED2_PIN);
+    PYB_LED_OFF(PYB_LED3_PORT, PYB_LED1_PIN);
+    PYB_LED_OFF(PYB_LED4_PORT, PYB_LED2_PIN);
+
+    /* Initialize LEDs */
+    GPIO_InitStructure.GPIO_Pin = PYB_LED1_PIN;
+    GPIO_Init(PYB_LED1_PORT, &GPIO_InitStructure);
+
+    GPIO_InitStructure.GPIO_Pin = PYB_LED2_PIN;
+    GPIO_Init(PYB_LED2_PORT, &GPIO_InitStructure);
+
+    GPIO_InitStructure.GPIO_Pin = PYB_LED3_PIN;
+    GPIO_Init(PYB_LED3_PORT, &GPIO_InitStructure);
+
+    GPIO_InitStructure.GPIO_Pin = PYB_LED4_PIN;
+    GPIO_Init(PYB_LED4_PORT, &GPIO_InitStructure);
 }
 
 void led_state(pyb_led_t led, int state) {
     GPIO_TypeDef *port;
     uint32_t pin;
+
     switch (led) {
-        case PYB_LED_R1: port = PYB_LED_R_PORT; pin = PYB_LED_R1_PIN; break;
-        case PYB_LED_R2: port = PYB_LED_R_PORT; pin = PYB_LED_R2_PIN; break;
-        case PYB_LED_G1: port = PYB_LED_G_PORT; pin = PYB_LED_G1_PIN; break;
-        case PYB_LED_G2: port = PYB_LED_G_PORT; pin = PYB_LED_G2_PIN; break;
-        default: return;
+        case PYB_LED_1:
+            pin  = PYB_LED1_PIN; 
+            port = PYB_LED1_PORT; 
+            break;
+        case PYB_LED_2:
+            pin  = PYB_LED2_PIN; 
+            port = PYB_LED2_PORT; 
+            break;
+        case PYB_LED_3:
+            pin  = PYB_LED3_PIN; 
+            port = PYB_LED3_PORT; 
+            break;
+        case PYB_LED_4:
+            pin  = PYB_LED4_PIN; 
+            port = PYB_LED4_PORT; 
+            break;
+        default: 
+            return;
     }
+
     if (state == 0) {
-        // turn LED off (output is high)
-        port->BSRRL = pin;
+        // turn LED off
+        PYB_LED_OFF(port, pin);
     } else {
-        // turn LED on (output is low)
-        port->BSRRH = pin;
+        // turn LED on
+        PYB_LED_ON(port, pin);
     }
 }
 
 void led_toggle(pyb_led_t led) {
     GPIO_TypeDef *port;
     uint32_t pin;
+
     switch (led) {
-        case PYB_LED_R1: port = PYB_LED_R_PORT; pin = PYB_LED_R1_PIN; break;
-        case PYB_LED_R2: port = PYB_LED_R_PORT; pin = PYB_LED_R2_PIN; break;
-        case PYB_LED_G1: port = PYB_LED_G_PORT; pin = PYB_LED_G1_PIN; break;
-        case PYB_LED_G2: port = PYB_LED_G_PORT; pin = PYB_LED_G2_PIN; break;
-        default: return;
+        case PYB_LED_1:
+            pin  = PYB_LED1_PIN; 
+            port = PYB_LED1_PORT; 
+            break;
+        case PYB_LED_2:
+            pin  = PYB_LED2_PIN; 
+            port = PYB_LED2_PORT; 
+            break;
+        case PYB_LED_3:
+            pin  = PYB_LED3_PIN; 
+            port = PYB_LED3_PORT; 
+            break;
+        case PYB_LED_4:
+            pin  = PYB_LED4_PIN; 
+            port = PYB_LED4_PORT; 
+            break;
+        default: 
+            return;
     }
+
     if (!(port->ODR & pin)) {
-        // turn LED off (output high)
-        port->BSRRL = pin;
+        // turn LED off 
+        PYB_LED_OFF(port, pin);
     } else {
         // turn LED on (output low)
-        port->BSRRH = pin;
+        PYB_LED_ON(port, pin);
     }
 }
 
@@ -85,19 +163,13 @@ void led_obj_print(void (*print)(void *env, const char *fmt, ...), void *env, mp
 
 mp_obj_t led_obj_on(mp_obj_t self_in) {
     pyb_led_obj_t *self = self_in;
-    switch (self->led_id) {
-        case 1: led_state(PYB_LED_G1, 1); break;
-        case 2: led_state(PYB_LED_G2, 1); break;
-    }
+    led_state(self->led_id, 1);
     return mp_const_none;
 }
 
 mp_obj_t led_obj_off(mp_obj_t self_in) {
     pyb_led_obj_t *self = self_in;
-    switch (self->led_id) {
-        case 1: led_state(PYB_LED_G1, 0); break;
-        case 2: led_state(PYB_LED_G2, 0); break;
-    }
+    led_state(self->led_id, 0);
     return mp_const_none;
 }
 

--- a/stm/led.h
+++ b/stm/led.h
@@ -3,6 +3,11 @@ typedef enum {
     PYB_LED_R2 = 1,
     PYB_LED_G1 = 2,
     PYB_LED_G2 = 3,
+    //STM32F4DISC
+    PYB_LED_R = 0,
+    PYB_LED_G = 1,
+    PYB_LED_B = 2,
+    PYB_LED_O = 3,
 } pyb_led_t;
 
 void led_init(void);

--- a/stm/stm32fxxx_it.c
+++ b/stm/stm32fxxx_it.c
@@ -298,4 +298,10 @@ void EXTI15_10_IRQHandler(void) {
     }
 }
 
+#if defined(STM32F4DISC)
+void EXTI0_IRQHandler(void) {
+    // clear pending interrupt bit
+    EXTI_ClearITPendingBit(EXTI_Line0);
+}
+#endif
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm/usrsw.c
+++ b/stm/usrsw.c
@@ -9,36 +9,50 @@
 #include "obj.h"
 #include "usrsw.h"
 
-#define PYB_USRSW_PORT (GPIOA)
-#define PYB_USRSW_PIN (GPIO_Pin_13)
-
+#if defined (PYBOARD)
+    #define USRSW_PORT          (GPIOA)
+    #define USRSW_PIN           (GPIO_Pin_13)
+    #define USRSW_EXTI_PIN      (EXTI_PinSource13)
+    #define USRSW_EXTI_PORT     (EXTI_PortSourceGPIOA)
+    #define USRSW_EXTI_LINE     (EXTI_Line13)
+    #define USRSW_EXTI_IRQN     (EXTI15_10_IRQn)
+    #define USRSW_EXTI_EDGE     (EXTI_Trigger_Rising)
+#elif defined (STM32F4DISC)
+    #define USRSW_PORT          (GPIOA)
+    #define USRSW_PIN           (GPIO_Pin_0)
+    #define USRSW_EXTI_PIN      (EXTI_PinSource0)
+    #define USRSW_EXTI_PORT     (EXTI_PortSourceGPIOA)
+    #define USRSW_EXTI_LINE     (EXTI_Line0)
+    #define USRSW_EXTI_IRQN     (EXTI0_IRQn)
+    #define USRSW_EXTI_EDGE     (EXTI_Trigger_Falling)
+#endif 
 void switch_init(void) {
     // make it an input with pull-up
     GPIO_InitTypeDef GPIO_InitStructure;
-    GPIO_InitStructure.GPIO_Pin = PYB_USRSW_PIN;
+    GPIO_InitStructure.GPIO_Pin  = USRSW_PIN;
     GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN;
-    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
-    GPIO_Init(PYB_USRSW_PORT, &GPIO_InitStructure);
+    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL; /* allow external pull up/down */
+    GPIO_Init(USRSW_PORT, &GPIO_InitStructure);
 
     // the rest does the EXTI interrupt
 
     /* Enable SYSCFG clock */
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
 
-    /* Connect EXTI Line13 to PA13 pin */
-    SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOA, EXTI_PinSource13);
+    /* Connect EXTI Line to GPIO pin */
+    SYSCFG_EXTILineConfig(USRSW_EXTI_PORT, USRSW_EXTI_PIN);
 
-    /* Configure EXTI Line13, rising edge */
+    /* Configure EXTI Line */
     EXTI_InitTypeDef EXTI_InitStructure;
-    EXTI_InitStructure.EXTI_Line = EXTI_Line13;
+    EXTI_InitStructure.EXTI_Line = USRSW_EXTI_LINE;
     EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt;
-    EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
+    EXTI_InitStructure.EXTI_Trigger = USRSW_EXTI_EDGE;
     EXTI_InitStructure.EXTI_LineCmd = ENABLE;
     EXTI_Init(&EXTI_InitStructure);
 
     /* Enable and set EXTI15_10 Interrupt to the lowest priority */
     NVIC_InitTypeDef NVIC_InitStructure;
-    NVIC_InitStructure.NVIC_IRQChannel = EXTI15_10_IRQn;
+    NVIC_InitStructure.NVIC_IRQChannel = USRSW_EXTI_IRQN;
     NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0x0F;
     NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0x0F;
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
@@ -46,13 +60,24 @@ void switch_init(void) {
 }
 
 int switch_get(void) {
-    if (PYB_USRSW_PORT->IDR & PYB_USRSW_PIN) {
+#if defined (PYBOARD)
+    if (USRSW_PORT->IDR & USRSW_PIN) {
         // pulled high, so switch is not pressed
         return 0;
     } else {
         // pulled low, so switch is pressed
         return 1;
     }
+#elif defined (STM32F4DISC)
+    /* switch pulled down */
+    if (USRSW_PORT->IDR & USRSW_PIN) {
+        // pulled high, so switch is pressed
+        return 1;
+    } else {
+        // pulled low, so switch is not pressed
+        return 0;
+    }
+#endif
 }
 
 /******************************************************************************/


### PR DESCRIPTION
- Add a TARGET definition to Makefile (default PYBOARD).
- Add support for discovery LEDs in led module.
- Add support for discovery user switch in usersw
- Add EXTI interrupt handler for discovery user switch on (PA0).
- Parameterize led and usrsw modules pins and port.
- Issue #83
