### PR TITLE
Make qstr_init reinitialize last_pool.

### DIFF
--- a/py/qstr.c
+++ b/py/qstr.c
@@ -36,10 +36,10 @@ const static qstr_pool_t const_pool = {
     },
 };
 
-static qstr_pool_t *last_pool = (qstr_pool_t*)&const_pool; // we won't modify the const_pool since it has no allocated room left
+static qstr_pool_t *last_pool;
 
 void qstr_init(void) {
-    // nothing to do!
+    last_pool = (qstr_pool_t*)&const_pool; // we won't modify the const_pool since it has no allocated room left
 }
 
 static qstr qstr_add(const char *str) {


### PR DESCRIPTION
This causes the pool to get reinitialized properly on a soft-reset.

This should fix issue #87
