### PR TITLE
Add missing ADC driver

### DIFF
--- a/stm/Makefile
+++ b/stm/Makefile
@@ -57,6 +57,7 @@ SRC_C = \
 	pybwlan.c \
 	i2c.c \
 	usrsw.c \
+	adc.c \
 
 SRC_S = \
 	startup_stm32f40xx.s \
@@ -100,6 +101,7 @@ SRC_STM = \
 	usbd_storage_msd.c \
 	stm324x7i_eval.c \
 	stm324x7i_eval_sdio_sd.c \
+	stm32f4xx_adc.c \
 
 #SRC_STM_OTG = \
 #	usb_hcd.c \

--- a/stm/adc.c
+++ b/stm/adc.c
@@ -1,0 +1,163 @@
+#include <stdio.h>
+#include <stm32f4xx_rcc.h>
+#include <stm32f4xx_gpio.h>
+#include <stm32f4xx_adc.h>
+
+#include "misc.h"
+#include "mpconfig.h"
+#include "obj.h"
+#include "adc.h"
+
+/* ADC defintions */
+#define ADCx                (ADC1)
+#define ADCx_CLK            (RCC_APB2Periph_ADC1)
+#define ADC_NUM_CHANNELS    (16)
+
+/* GPIO struct */
+typedef struct {
+    GPIO_TypeDef* port;
+    uint32_t pin;
+} gpio_t;
+
+/* ADC GPIOs */
+static gpio_t adc_gpio[] = {
+    {GPIOA, GPIO_Pin_0},    /* ADC123_IN0 */
+    {GPIOA, GPIO_Pin_1},    /* ADC123_IN1 */
+    {GPIOA, GPIO_Pin_2},    /* ADC123_IN2 */
+    {GPIOA, GPIO_Pin_3},    /* ADC123_IN3 */
+    {GPIOA, GPIO_Pin_4},    /* ADC12_IN4 */
+    {GPIOA, GPIO_Pin_5},    /* ADC12_IN5 */
+    {GPIOA, GPIO_Pin_6},    /* ADC12_IN6 */
+    {GPIOA, GPIO_Pin_7},    /* ADC12_IN7 */
+    {GPIOB, GPIO_Pin_0},    /* ADC12_IN8 */
+    {GPIOB, GPIO_Pin_1},    /* ADC12_IN9 */
+    {GPIOC, GPIO_Pin_0},    /* ADC123_IN10 */
+    {GPIOC, GPIO_Pin_1},    /* ADC123_IN11 */
+    {GPIOC, GPIO_Pin_2},    /* ADC123_IN12 */
+    {GPIOC, GPIO_Pin_3},    /* ADC123_IN13 */
+    {GPIOC, GPIO_Pin_4},    /* ADC12_IN14 */
+    {GPIOC, GPIO_Pin_5},    /* ADC12_IN15 */
+
+};
+
+void adc_init(uint32_t resolution) {
+  ADC_InitTypeDef       ADC_InitStructure;
+  GPIO_InitTypeDef      GPIO_InitStructure;
+  ADC_CommonInitTypeDef ADC_CommonInitStructure;
+
+  /* Enable ADCx, DMA and GPIO clocks */ 
+#if 0
+  /* GPIO clocks enabled in main */
+  RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOA |
+                         RCC_AHB1Periph_GPIOB |
+                         RCC_AHB1Periph_GPIOC, ENABLE);
+#endif
+  RCC_APB2PeriphClockCmd(ADCx_CLK, ENABLE);
+
+  /* ADC Common Init */
+  ADC_CommonInitStructure.ADC_Mode = ADC_Mode_Independent;
+  ADC_CommonInitStructure.ADC_Prescaler = ADC_Prescaler_Div2;
+  ADC_CommonInitStructure.ADC_DMAAccessMode = ADC_DMAAccessMode_Disabled;
+  ADC_CommonInitStructure.ADC_TwoSamplingDelay = ADC_TwoSamplingDelay_5Cycles;
+  ADC_CommonInit(&ADC_CommonInitStructure);
+
+  /* Configure ADC GPIOs */
+  for (int i=0; i<ADC_NUM_CHANNELS; i++) {
+      GPIO_InitStructure.GPIO_Pin = adc_gpio[i].pin;
+      GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AN;
+      GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
+      GPIO_Init(adc_gpio[i].port, &GPIO_InitStructure);
+  }
+
+  /* ADCx Init */
+//  ADC_DeInit();
+  ADC_InitStructure.ADC_Resolution = ADC_Resolution_12b;
+  ADC_InitStructure.ADC_ScanConvMode = DISABLE;
+  ADC_InitStructure.ADC_ContinuousConvMode = DISABLE;
+  ADC_InitStructure.ADC_ExternalTrigConvEdge = ADC_ExternalTrigConvEdge_None;
+  ADC_InitStructure.ADC_ExternalTrigConv = ADC_ExternalTrigConv_T1_CC1;
+  ADC_InitStructure.ADC_DataAlign = ADC_DataAlign_Right;
+  ADC_InitStructure.ADC_NbrOfConversion = 1;
+  ADC_Init(ADCx, &ADC_InitStructure);
+
+  /* Enable ADCx */
+  ADC_Cmd(ADCx, ENABLE);
+}
+
+uint32_t adc_read_channel(int channel)
+{
+    int timeout = 10000;
+
+    if (channel > (ADC_NUM_CHANNELS-1)) {
+        return 0;
+    }
+
+    /* ADC regular channel config ADC/Channel/SEQ Rank/Sample time */
+    ADC_RegularChannelConfig(ADCx, channel, 1, ADC_SampleTime_3Cycles);
+
+    /* Start ADC single conversion */
+    ADC_SoftwareStartConv(ADCx);
+
+    /* Wait for conversion to be complete*/
+    while(!ADC_GetFlagStatus(ADCx, ADC_FLAG_EOC) && --timeout >0) {
+    }
+
+    /* ADC conversion timed out */ 
+    if (timeout == 0) {
+        return 0;
+    }
+
+    /* Return converted data */
+    return ADC_GetConversionValue(ADCx); 
+}
+
+/******************************************************************************/
+/* Micro Python bindings                                                      */
+
+typedef struct _pyb_adc_obj_t {
+    mp_obj_base_t base;
+    int adc_id;
+    bool is_enabled;
+} pyb_adc_obj_t;
+
+static mp_obj_t adc_obj_read_channel(mp_obj_t self_in, mp_obj_t channel) {
+    mp_obj_t ret = mp_const_none;
+    pyb_adc_obj_t *self = self_in;
+
+    if (self->is_enabled) {
+        uint32_t chan = mp_obj_get_int(channel);
+        uint32_t data = adc_read_channel(chan);
+        ret = mp_obj_new_int(data);
+    }
+    return ret;
+}
+
+static void adc_obj_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in) {
+    pyb_adc_obj_t *self = self_in;
+    print(env, "<ADC %lu>", self->adc_id);
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_2(adc_obj_read_channel_obj, adc_obj_read_channel);
+
+static const mp_method_t adc_methods[] = {
+    { "read_channel",   &adc_obj_read_channel_obj},
+    { NULL, NULL },
+};
+
+static const mp_obj_type_t adc_obj_type = {
+    { &mp_const_type },
+    "ADC",
+    .print = adc_obj_print,
+    .methods = adc_methods,
+};
+
+mp_obj_t pyb_ADC(mp_obj_t resolution) {
+    /* init ADC */
+    adc_init(mp_obj_get_int(resolution));
+
+    pyb_adc_obj_t *o = m_new_obj(pyb_adc_obj_t);
+    o->base.type = &adc_obj_type;
+    o->adc_id = 1;
+    o->is_enabled = true;
+    return o;
+}

--- a/stm/adc.h
+++ b/stm/adc.h
@@ -1,0 +1,1 @@
+mp_obj_t pyb_ADC(mp_obj_t resolution);

--- a/stm/lib/stm32f4xx_adc.c
+++ b/stm/lib/stm32f4xx_adc.c
@@ -1,0 +1,1746 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_adc.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    08-November-2013
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the Analog to Digital Convertor (ADC) peripheral:
+  *           + Initialization and Configuration (in addition to ADC multi mode 
+  *             selection)
+  *           + Analog Watchdog configuration
+  *           + Temperature Sensor & Vrefint (Voltage Reference internal) & VBAT
+  *             management 
+  *           + Regular Channels Configuration
+  *           + Regular Channels DMA Configuration
+  *           + Injected channels Configuration
+  *           + Interrupts and flags management
+  *         
+  @verbatim
+ ===============================================================================
+                     ##### How to use this driver #####
+ ===============================================================================
+    [..]
+    (#) Enable the ADC interface clock using 
+        RCC_APB2PeriphClockCmd(RCC_APB2Periph_ADCx, ENABLE); 
+       
+    (#) ADC pins configuration
+         (++) Enable the clock for the ADC GPIOs using the following function:
+             RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOx, ENABLE);   
+         (++) Configure these ADC pins in analog mode using GPIO_Init();  
+  
+     (#) Configure the ADC Prescaler, conversion resolution and data 
+         alignment using the ADC_Init() function.
+     (#) Activate the ADC peripheral using ADC_Cmd() function.
+  
+     *** Regular channels group configuration ***
+     ============================================
+     [..]    
+       (+) To configure the ADC regular channels group features, use 
+           ADC_Init() and ADC_RegularChannelConfig() functions.
+       (+) To activate the continuous mode, use the ADC_continuousModeCmd()
+           function.
+       (+) To configurate and activate the Discontinuous mode, use the 
+           ADC_DiscModeChannelCountConfig() and ADC_DiscModeCmd() functions.
+       (+) To read the ADC converted values, use the ADC_GetConversionValue()
+           function.
+  
+     *** Multi mode ADCs Regular channels configuration ***
+     ======================================================
+     [..]
+       (+) Refer to "Regular channels group configuration" description to
+           configure the ADC1, ADC2 and ADC3 regular channels.        
+       (+) Select the Multi mode ADC regular channels features (dual or 
+           triple mode) using ADC_CommonInit() function and configure 
+           the DMA mode using ADC_MultiModeDMARequestAfterLastTransferCmd() 
+           functions.        
+       (+) Read the ADCs converted values using the 
+           ADC_GetMultiModeConversionValue() function.
+  
+     *** DMA for Regular channels group features configuration ***
+     ============================================================= 
+     [..]
+       (+) To enable the DMA mode for regular channels group, use the 
+           ADC_DMACmd() function.
+       (+) To enable the generation of DMA requests continuously at the end
+           of the last DMA transfer, use the ADC_DMARequestAfterLastTransferCmd() 
+           function.
+  
+     *** Injected channels group configuration ***
+     =============================================    
+     [..]
+       (+) To configure the ADC Injected channels group features, use 
+           ADC_InjectedChannelConfig() and  ADC_InjectedSequencerLengthConfig()
+           functions.
+       (+) To activate the continuous mode, use the ADC_continuousModeCmd()
+           function.
+       (+) To activate the Injected Discontinuous mode, use the 
+           ADC_InjectedDiscModeCmd() function.  
+       (+) To activate the AutoInjected mode, use the ADC_AutoInjectedConvCmd() 
+           function.        
+       (+) To read the ADC converted values, use the ADC_GetInjectedConversionValue() 
+           function.
+  
+    @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2013 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx_adc.h"
+#include "stm32f4xx_rcc.h"
+#include "stm32f4xx_conf.h"
+
+/** @addtogroup STM32F4xx_StdPeriph_Driver
+  * @{
+  */
+
+/** @defgroup ADC 
+  * @brief ADC driver modules
+  * @{
+  */ 
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/ 
+
+/* ADC DISCNUM mask */
+#define CR1_DISCNUM_RESET         ((uint32_t)0xFFFF1FFF)
+
+/* ADC AWDCH mask */
+#define CR1_AWDCH_RESET           ((uint32_t)0xFFFFFFE0)   
+
+/* ADC Analog watchdog enable mode mask */
+#define CR1_AWDMode_RESET         ((uint32_t)0xFF3FFDFF)   
+
+/* CR1 register Mask */
+#define CR1_CLEAR_MASK            ((uint32_t)0xFCFFFEFF)
+
+/* ADC EXTEN mask */
+#define CR2_EXTEN_RESET           ((uint32_t)0xCFFFFFFF)  
+
+/* ADC JEXTEN mask */
+#define CR2_JEXTEN_RESET          ((uint32_t)0xFFCFFFFF)  
+
+/* ADC JEXTSEL mask */
+#define CR2_JEXTSEL_RESET         ((uint32_t)0xFFF0FFFF)  
+
+/* CR2 register Mask */
+#define CR2_CLEAR_MASK            ((uint32_t)0xC0FFF7FD)
+
+/* ADC SQx mask */
+#define SQR3_SQ_SET               ((uint32_t)0x0000001F)  
+#define SQR2_SQ_SET               ((uint32_t)0x0000001F)  
+#define SQR1_SQ_SET               ((uint32_t)0x0000001F)  
+
+/* ADC L Mask */
+#define SQR1_L_RESET              ((uint32_t)0xFF0FFFFF) 
+
+/* ADC JSQx mask */
+#define JSQR_JSQ_SET              ((uint32_t)0x0000001F) 
+
+/* ADC JL mask */
+#define JSQR_JL_SET               ((uint32_t)0x00300000) 
+#define JSQR_JL_RESET             ((uint32_t)0xFFCFFFFF) 
+
+/* ADC SMPx mask */
+#define SMPR1_SMP_SET             ((uint32_t)0x00000007)  
+#define SMPR2_SMP_SET             ((uint32_t)0x00000007) 
+
+/* ADC JDRx registers offset */
+#define JDR_OFFSET                ((uint8_t)0x28) 
+
+/* ADC CDR register base address */
+#define CDR_ADDRESS               ((uint32_t)0x40012308)   
+
+/* ADC CCR register Mask */
+#define CR_CLEAR_MASK             ((uint32_t)0xFFFC30E0)  
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup ADC_Private_Functions
+  * @{
+  */ 
+
+/** @defgroup ADC_Group1 Initialization and Configuration functions
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+ ===============================================================================
+              ##### Initialization and Configuration functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the ADC Prescaler
+      (+) ADC Conversion Resolution (12bit..6bit)
+      (+) Scan Conversion Mode (multichannel or one channel) for regular group
+      (+) ADC Continuous Conversion Mode (Continuous or Single conversion) for 
+          regular group
+      (+) External trigger Edge and source of regular group, 
+      (+) Converted data alignment (left or right)
+      (+) The number of ADC conversions that will be done using the sequencer for 
+          regular channel group
+      (+) Multi ADC mode selection
+      (+) Direct memory access mode selection for multi ADC mode  
+      (+) Delay between 2 sampling phases (used in dual or triple interleaved modes)
+      (+) Enable or disable the ADC peripheral   
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Deinitializes all ADCs peripherals registers to their default reset 
+  *         values.
+  * @param  None
+  * @retval None
+  */
+void ADC_DeInit(void)
+{
+  /* Enable all ADCs reset state */
+  RCC_APB2PeriphResetCmd(RCC_APB2Periph_ADC, ENABLE);
+  
+  /* Release all ADCs from reset state */
+  RCC_APB2PeriphResetCmd(RCC_APB2Periph_ADC, DISABLE);
+}
+
+/**
+  * @brief  Initializes the ADCx peripheral according to the specified parameters 
+  *         in the ADC_InitStruct.
+  * @note   This function is used to configure the global features of the ADC ( 
+  *         Resolution and Data Alignment), however, the rest of the configuration
+  *         parameters are specific to the regular channels group (scan mode 
+  *         activation, continuous mode activation, External trigger source and 
+  *         edge, number of conversion in the regular channels group sequencer).  
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_InitStruct: pointer to an ADC_InitTypeDef structure that contains
+  *         the configuration information for the specified ADC peripheral.
+  * @retval None
+  */
+void ADC_Init(ADC_TypeDef* ADCx, ADC_InitTypeDef* ADC_InitStruct)
+{
+  uint32_t tmpreg1 = 0;
+  uint8_t tmpreg2 = 0;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_RESOLUTION(ADC_InitStruct->ADC_Resolution)); 
+  assert_param(IS_FUNCTIONAL_STATE(ADC_InitStruct->ADC_ScanConvMode));
+  assert_param(IS_FUNCTIONAL_STATE(ADC_InitStruct->ADC_ContinuousConvMode)); 
+  assert_param(IS_ADC_EXT_TRIG_EDGE(ADC_InitStruct->ADC_ExternalTrigConvEdge)); 
+  assert_param(IS_ADC_EXT_TRIG(ADC_InitStruct->ADC_ExternalTrigConv));    
+  assert_param(IS_ADC_DATA_ALIGN(ADC_InitStruct->ADC_DataAlign)); 
+  assert_param(IS_ADC_REGULAR_LENGTH(ADC_InitStruct->ADC_NbrOfConversion));
+  
+  /*---------------------------- ADCx CR1 Configuration -----------------*/
+  /* Get the ADCx CR1 value */
+  tmpreg1 = ADCx->CR1;
+  
+  /* Clear RES and SCAN bits */
+  tmpreg1 &= CR1_CLEAR_MASK;
+  
+  /* Configure ADCx: scan conversion mode and resolution */
+  /* Set SCAN bit according to ADC_ScanConvMode value */
+  /* Set RES bit according to ADC_Resolution value */ 
+  tmpreg1 |= (uint32_t)(((uint32_t)ADC_InitStruct->ADC_ScanConvMode << 8) | \
+                                   ADC_InitStruct->ADC_Resolution);
+  /* Write to ADCx CR1 */
+  ADCx->CR1 = tmpreg1;
+  /*---------------------------- ADCx CR2 Configuration -----------------*/
+  /* Get the ADCx CR2 value */
+  tmpreg1 = ADCx->CR2;
+  
+  /* Clear CONT, ALIGN, EXTEN and EXTSEL bits */
+  tmpreg1 &= CR2_CLEAR_MASK;
+  
+  /* Configure ADCx: external trigger event and edge, data alignment and 
+     continuous conversion mode */
+  /* Set ALIGN bit according to ADC_DataAlign value */
+  /* Set EXTEN bits according to ADC_ExternalTrigConvEdge value */ 
+  /* Set EXTSEL bits according to ADC_ExternalTrigConv value */
+  /* Set CONT bit according to ADC_ContinuousConvMode value */
+  tmpreg1 |= (uint32_t)(ADC_InitStruct->ADC_DataAlign | \
+                        ADC_InitStruct->ADC_ExternalTrigConv | 
+                        ADC_InitStruct->ADC_ExternalTrigConvEdge | \
+                        ((uint32_t)ADC_InitStruct->ADC_ContinuousConvMode << 1));
+                        
+  /* Write to ADCx CR2 */
+  ADCx->CR2 = tmpreg1;
+  /*---------------------------- ADCx SQR1 Configuration -----------------*/
+  /* Get the ADCx SQR1 value */
+  tmpreg1 = ADCx->SQR1;
+  
+  /* Clear L bits */
+  tmpreg1 &= SQR1_L_RESET;
+  
+  /* Configure ADCx: regular channel sequence length */
+  /* Set L bits according to ADC_NbrOfConversion value */
+  tmpreg2 |= (uint8_t)(ADC_InitStruct->ADC_NbrOfConversion - (uint8_t)1);
+  tmpreg1 |= ((uint32_t)tmpreg2 << 20);
+  
+  /* Write to ADCx SQR1 */
+  ADCx->SQR1 = tmpreg1;
+}
+
+/**
+  * @brief  Fills each ADC_InitStruct member with its default value.
+  * @note   This function is used to initialize the global features of the ADC ( 
+  *         Resolution and Data Alignment), however, the rest of the configuration
+  *         parameters are specific to the regular channels group (scan mode 
+  *         activation, continuous mode activation, External trigger source and 
+  *         edge, number of conversion in the regular channels group sequencer).  
+  * @param  ADC_InitStruct: pointer to an ADC_InitTypeDef structure which will 
+  *         be initialized.
+  * @retval None
+  */
+void ADC_StructInit(ADC_InitTypeDef* ADC_InitStruct)
+{
+  /* Initialize the ADC_Mode member */
+  ADC_InitStruct->ADC_Resolution = ADC_Resolution_12b;
+
+  /* initialize the ADC_ScanConvMode member */
+  ADC_InitStruct->ADC_ScanConvMode = DISABLE;
+
+  /* Initialize the ADC_ContinuousConvMode member */
+  ADC_InitStruct->ADC_ContinuousConvMode = DISABLE;
+
+  /* Initialize the ADC_ExternalTrigConvEdge member */
+  ADC_InitStruct->ADC_ExternalTrigConvEdge = ADC_ExternalTrigConvEdge_None;
+
+  /* Initialize the ADC_ExternalTrigConv member */
+  ADC_InitStruct->ADC_ExternalTrigConv = ADC_ExternalTrigConv_T1_CC1;
+
+  /* Initialize the ADC_DataAlign member */
+  ADC_InitStruct->ADC_DataAlign = ADC_DataAlign_Right;
+
+  /* Initialize the ADC_NbrOfConversion member */
+  ADC_InitStruct->ADC_NbrOfConversion = 1;
+}
+
+/**
+  * @brief  Initializes the ADCs peripherals according to the specified parameters 
+  *         in the ADC_CommonInitStruct.
+  * @param  ADC_CommonInitStruct: pointer to an ADC_CommonInitTypeDef structure 
+  *         that contains the configuration information for  All ADCs peripherals.
+  * @retval None
+  */
+void ADC_CommonInit(ADC_CommonInitTypeDef* ADC_CommonInitStruct)
+{
+  uint32_t tmpreg1 = 0;
+  /* Check the parameters */
+  assert_param(IS_ADC_MODE(ADC_CommonInitStruct->ADC_Mode));
+  assert_param(IS_ADC_PRESCALER(ADC_CommonInitStruct->ADC_Prescaler));
+  assert_param(IS_ADC_DMA_ACCESS_MODE(ADC_CommonInitStruct->ADC_DMAAccessMode));
+  assert_param(IS_ADC_SAMPLING_DELAY(ADC_CommonInitStruct->ADC_TwoSamplingDelay));
+  /*---------------------------- ADC CCR Configuration -----------------*/
+  /* Get the ADC CCR value */
+  tmpreg1 = ADC->CCR;
+  
+  /* Clear MULTI, DELAY, DMA and ADCPRE bits */
+  tmpreg1 &= CR_CLEAR_MASK;
+  
+  /* Configure ADCx: Multi mode, Delay between two sampling time, ADC prescaler,
+     and DMA access mode for multimode */
+  /* Set MULTI bits according to ADC_Mode value */
+  /* Set ADCPRE bits according to ADC_Prescaler value */
+  /* Set DMA bits according to ADC_DMAAccessMode value */
+  /* Set DELAY bits according to ADC_TwoSamplingDelay value */    
+  tmpreg1 |= (uint32_t)(ADC_CommonInitStruct->ADC_Mode | 
+                        ADC_CommonInitStruct->ADC_Prescaler | 
+                        ADC_CommonInitStruct->ADC_DMAAccessMode | 
+                        ADC_CommonInitStruct->ADC_TwoSamplingDelay);
+                        
+  /* Write to ADC CCR */
+  ADC->CCR = tmpreg1;
+}
+
+/**
+  * @brief  Fills each ADC_CommonInitStruct member with its default value.
+  * @param  ADC_CommonInitStruct: pointer to an ADC_CommonInitTypeDef structure
+  *         which will be initialized.
+  * @retval None
+  */
+void ADC_CommonStructInit(ADC_CommonInitTypeDef* ADC_CommonInitStruct)
+{
+  /* Initialize the ADC_Mode member */
+  ADC_CommonInitStruct->ADC_Mode = ADC_Mode_Independent;
+
+  /* initialize the ADC_Prescaler member */
+  ADC_CommonInitStruct->ADC_Prescaler = ADC_Prescaler_Div2;
+
+  /* Initialize the ADC_DMAAccessMode member */
+  ADC_CommonInitStruct->ADC_DMAAccessMode = ADC_DMAAccessMode_Disabled;
+
+  /* Initialize the ADC_TwoSamplingDelay member */
+  ADC_CommonInitStruct->ADC_TwoSamplingDelay = ADC_TwoSamplingDelay_5Cycles;
+}
+
+/**
+  * @brief  Enables or disables the specified ADC peripheral.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  NewState: new state of the ADCx peripheral. 
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void ADC_Cmd(ADC_TypeDef* ADCx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    /* Set the ADON bit to wake up the ADC from power down mode */
+    ADCx->CR2 |= (uint32_t)ADC_CR2_ADON;
+  }
+  else
+  {
+    /* Disable the selected ADC peripheral */
+    ADCx->CR2 &= (uint32_t)(~ADC_CR2_ADON);
+  }
+}
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Group2 Analog Watchdog configuration functions
+ *  @brief    Analog Watchdog configuration functions 
+ *
+@verbatim   
+ ===============================================================================
+             ##### Analog Watchdog configuration functions #####
+ ===============================================================================  
+    [..] This section provides functions allowing to configure the Analog Watchdog
+         (AWD) feature in the ADC.
+  
+    [..] A typical configuration Analog Watchdog is done following these steps :
+      (#) the ADC guarded channel(s) is (are) selected using the 
+          ADC_AnalogWatchdogSingleChannelConfig() function.
+      (#) The Analog watchdog lower and higher threshold are configured using the  
+          ADC_AnalogWatchdogThresholdsConfig() function.
+      (#) The Analog watchdog is enabled and configured to enable the check, on one
+          or more channels, using the  ADC_AnalogWatchdogCmd() function.
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Enables or disables the analog watchdog on single/all regular or 
+  *         injected channels
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_AnalogWatchdog: the ADC analog watchdog configuration.
+  *         This parameter can be one of the following values:
+  *            @arg ADC_AnalogWatchdog_SingleRegEnable: Analog watchdog on a single regular channel
+  *            @arg ADC_AnalogWatchdog_SingleInjecEnable: Analog watchdog on a single injected channel
+  *            @arg ADC_AnalogWatchdog_SingleRegOrInjecEnable: Analog watchdog on a single regular or injected channel
+  *            @arg ADC_AnalogWatchdog_AllRegEnable: Analog watchdog on all regular channel
+  *            @arg ADC_AnalogWatchdog_AllInjecEnable: Analog watchdog on all injected channel
+  *            @arg ADC_AnalogWatchdog_AllRegAllInjecEnable: Analog watchdog on all regular and injected channels
+  *            @arg ADC_AnalogWatchdog_None: No channel guarded by the analog watchdog
+  * @retval None	  
+  */
+void ADC_AnalogWatchdogCmd(ADC_TypeDef* ADCx, uint32_t ADC_AnalogWatchdog)
+{
+  uint32_t tmpreg = 0;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_ANALOG_WATCHDOG(ADC_AnalogWatchdog));
+  
+  /* Get the old register value */
+  tmpreg = ADCx->CR1;
+  
+  /* Clear AWDEN, JAWDEN and AWDSGL bits */
+  tmpreg &= CR1_AWDMode_RESET;
+  
+  /* Set the analog watchdog enable mode */
+  tmpreg |= ADC_AnalogWatchdog;
+  
+  /* Store the new register value */
+  ADCx->CR1 = tmpreg;
+}
+
+/**
+  * @brief  Configures the high and low thresholds of the analog watchdog.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  HighThreshold: the ADC analog watchdog High threshold value.
+  *          This parameter must be a 12-bit value.
+  * @param  LowThreshold:  the ADC analog watchdog Low threshold value.
+  *          This parameter must be a 12-bit value.
+  * @retval None
+  */
+void ADC_AnalogWatchdogThresholdsConfig(ADC_TypeDef* ADCx, uint16_t HighThreshold,
+                                        uint16_t LowThreshold)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_THRESHOLD(HighThreshold));
+  assert_param(IS_ADC_THRESHOLD(LowThreshold));
+  
+  /* Set the ADCx high threshold */
+  ADCx->HTR = HighThreshold;
+  
+  /* Set the ADCx low threshold */
+  ADCx->LTR = LowThreshold;
+}
+
+/**
+  * @brief  Configures the analog watchdog guarded single channel
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_Channel: the ADC channel to configure for the analog watchdog. 
+  *          This parameter can be one of the following values:
+  *            @arg ADC_Channel_0: ADC Channel0 selected
+  *            @arg ADC_Channel_1: ADC Channel1 selected
+  *            @arg ADC_Channel_2: ADC Channel2 selected
+  *            @arg ADC_Channel_3: ADC Channel3 selected
+  *            @arg ADC_Channel_4: ADC Channel4 selected
+  *            @arg ADC_Channel_5: ADC Channel5 selected
+  *            @arg ADC_Channel_6: ADC Channel6 selected
+  *            @arg ADC_Channel_7: ADC Channel7 selected
+  *            @arg ADC_Channel_8: ADC Channel8 selected
+  *            @arg ADC_Channel_9: ADC Channel9 selected
+  *            @arg ADC_Channel_10: ADC Channel10 selected
+  *            @arg ADC_Channel_11: ADC Channel11 selected
+  *            @arg ADC_Channel_12: ADC Channel12 selected
+  *            @arg ADC_Channel_13: ADC Channel13 selected
+  *            @arg ADC_Channel_14: ADC Channel14 selected
+  *            @arg ADC_Channel_15: ADC Channel15 selected
+  *            @arg ADC_Channel_16: ADC Channel16 selected
+  *            @arg ADC_Channel_17: ADC Channel17 selected
+  *            @arg ADC_Channel_18: ADC Channel18 selected
+  * @retval None
+  */
+void ADC_AnalogWatchdogSingleChannelConfig(ADC_TypeDef* ADCx, uint8_t ADC_Channel)
+{
+  uint32_t tmpreg = 0;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_CHANNEL(ADC_Channel));
+  
+  /* Get the old register value */
+  tmpreg = ADCx->CR1;
+  
+  /* Clear the Analog watchdog channel select bits */
+  tmpreg &= CR1_AWDCH_RESET;
+  
+  /* Set the Analog watchdog channel */
+  tmpreg |= ADC_Channel;
+  
+  /* Store the new register value */
+  ADCx->CR1 = tmpreg;
+}
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Group3 Temperature Sensor, Vrefint (Voltage Reference internal) 
+ *            and VBAT (Voltage BATtery) management functions
+ *  @brief   Temperature Sensor, Vrefint and VBAT management functions 
+ *
+@verbatim   
+ ===============================================================================
+      ##### Temperature Sensor, Vrefint and VBAT management functions #####
+ ===============================================================================  
+    [..] This section provides functions allowing to enable/ disable the internal 
+         connections between the ADC and the Temperature Sensor, the Vrefint and 
+         the Vbat sources.
+     
+    [..] A typical configuration to get the Temperature sensor and Vrefint channels 
+         voltages is done following these steps :
+      (#) Enable the internal connection of Temperature sensor and Vrefint sources 
+          with the ADC channels using ADC_TempSensorVrefintCmd() function. 
+      (#) Select the ADC_Channel_TempSensor and/or ADC_Channel_Vrefint using 
+          ADC_RegularChannelConfig() or  ADC_InjectedChannelConfig() functions 
+      (#) Get the voltage values, using ADC_GetConversionValue() or  
+          ADC_GetInjectedConversionValue().
+
+    [..] A typical configuration to get the VBAT channel voltage is done following 
+         these steps :
+      (#) Enable the internal connection of VBAT source with the ADC channel using 
+          ADC_VBATCmd() function. 
+      (#) Select the ADC_Channel_Vbat using ADC_RegularChannelConfig() or  
+          ADC_InjectedChannelConfig() functions 
+      (#) Get the voltage value, using ADC_GetConversionValue() or  
+          ADC_GetInjectedConversionValue().
+ 
+@endverbatim
+  * @{
+  */
+  
+  
+/**
+  * @brief  Enables or disables the temperature sensor and Vrefint channels.
+  * @param  NewState: new state of the temperature sensor and Vrefint channels.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void ADC_TempSensorVrefintCmd(FunctionalState NewState)                
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    /* Enable the temperature sensor and Vrefint channel*/
+    ADC->CCR |= (uint32_t)ADC_CCR_TSVREFE;
+  }
+  else
+  {
+    /* Disable the temperature sensor and Vrefint channel*/
+    ADC->CCR &= (uint32_t)(~ADC_CCR_TSVREFE);
+  }
+}
+
+/**
+  * @brief  Enables or disables the VBAT (Voltage Battery) channel.
+  * 
+  * @note   the Battery voltage measured is equal to VBAT/2 on STM32F40xx and 
+  *         STM32F41xx devices and equal to VBAT/4 on STM32F42xx and STM32F43xx devices 
+  *              
+  * @param  NewState: new state of the VBAT channel.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void ADC_VBATCmd(FunctionalState NewState)                             
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    /* Enable the VBAT channel*/
+    ADC->CCR |= (uint32_t)ADC_CCR_VBATE;
+  }
+  else
+  {
+    /* Disable the VBAT channel*/
+    ADC->CCR &= (uint32_t)(~ADC_CCR_VBATE);
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Group4 Regular Channels Configuration functions
+ *  @brief   Regular Channels Configuration functions 
+ *
+@verbatim   
+ ===============================================================================
+             ##### Regular Channels Configuration functions #####
+ ===============================================================================  
+
+    [..] This section provides functions allowing to manage the ADC's regular channels,
+         it is composed of 2 sub sections : 
+  
+      (#) Configuration and management functions for regular channels: This subsection 
+          provides functions allowing to configure the ADC regular channels :    
+         (++) Configure the rank in the regular group sequencer for each channel
+         (++) Configure the sampling time for each channel
+         (++) select the conversion Trigger for regular channels
+         (++) select the desired EOC event behavior configuration
+         (++) Activate the continuous Mode  (*)
+         (++) Activate the Discontinuous Mode 
+         -@@- Please Note that the following features for regular channels 
+             are configurated using the ADC_Init() function : 
+           (+@@) scan mode activation 
+           (+@@) continuous mode activation (**) 
+           (+@@) External trigger source  
+           (+@@) External trigger edge 
+           (+@@) number of conversion in the regular channels group sequencer.
+     
+         -@@- (*) and (**) are performing the same configuration
+     
+      (#) Get the conversion data: This subsection provides an important function in 
+          the ADC peripheral since it returns the converted data of the current 
+          regular channel. When the Conversion value is read, the EOC Flag is 
+          automatically cleared.
+     
+          -@- For multi ADC mode, the last ADC1, ADC2 and ADC3 regular conversions 
+              results data (in the selected multi mode) can be returned in the same 
+              time using ADC_GetMultiModeConversionValue() function. 
+         
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Configures for the selected ADC regular channel its corresponding
+  *         rank in the sequencer and its sample time.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_Channel: the ADC channel to configure. 
+  *          This parameter can be one of the following values:
+  *            @arg ADC_Channel_0: ADC Channel0 selected
+  *            @arg ADC_Channel_1: ADC Channel1 selected
+  *            @arg ADC_Channel_2: ADC Channel2 selected
+  *            @arg ADC_Channel_3: ADC Channel3 selected
+  *            @arg ADC_Channel_4: ADC Channel4 selected
+  *            @arg ADC_Channel_5: ADC Channel5 selected
+  *            @arg ADC_Channel_6: ADC Channel6 selected
+  *            @arg ADC_Channel_7: ADC Channel7 selected
+  *            @arg ADC_Channel_8: ADC Channel8 selected
+  *            @arg ADC_Channel_9: ADC Channel9 selected
+  *            @arg ADC_Channel_10: ADC Channel10 selected
+  *            @arg ADC_Channel_11: ADC Channel11 selected
+  *            @arg ADC_Channel_12: ADC Channel12 selected
+  *            @arg ADC_Channel_13: ADC Channel13 selected
+  *            @arg ADC_Channel_14: ADC Channel14 selected
+  *            @arg ADC_Channel_15: ADC Channel15 selected
+  *            @arg ADC_Channel_16: ADC Channel16 selected
+  *            @arg ADC_Channel_17: ADC Channel17 selected
+  *            @arg ADC_Channel_18: ADC Channel18 selected                       
+  * @param  Rank: The rank in the regular group sequencer.
+  *          This parameter must be between 1 to 16.
+  * @param  ADC_SampleTime: The sample time value to be set for the selected channel. 
+  *          This parameter can be one of the following values:
+  *            @arg ADC_SampleTime_3Cycles: Sample time equal to 3 cycles
+  *            @arg ADC_SampleTime_15Cycles: Sample time equal to 15 cycles
+  *            @arg ADC_SampleTime_28Cycles: Sample time equal to 28 cycles
+  *            @arg ADC_SampleTime_56Cycles: Sample time equal to 56 cycles	
+  *            @arg ADC_SampleTime_84Cycles: Sample time equal to 84 cycles	
+  *            @arg ADC_SampleTime_112Cycles: Sample time equal to 112 cycles	
+  *            @arg ADC_SampleTime_144Cycles: Sample time equal to 144 cycles	
+  *            @arg ADC_SampleTime_480Cycles: Sample time equal to 480 cycles	
+  * @retval None
+  */
+void ADC_RegularChannelConfig(ADC_TypeDef* ADCx, uint8_t ADC_Channel, uint8_t Rank, uint8_t ADC_SampleTime)
+{
+  uint32_t tmpreg1 = 0, tmpreg2 = 0;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_CHANNEL(ADC_Channel));
+  assert_param(IS_ADC_REGULAR_RANK(Rank));
+  assert_param(IS_ADC_SAMPLE_TIME(ADC_SampleTime));
+  
+  /* if ADC_Channel_10 ... ADC_Channel_18 is selected */
+  if (ADC_Channel > ADC_Channel_9)
+  {
+    /* Get the old register value */
+    tmpreg1 = ADCx->SMPR1;
+    
+    /* Calculate the mask to clear */
+    tmpreg2 = SMPR1_SMP_SET << (3 * (ADC_Channel - 10));
+    
+    /* Clear the old sample time */
+    tmpreg1 &= ~tmpreg2;
+    
+    /* Calculate the mask to set */
+    tmpreg2 = (uint32_t)ADC_SampleTime << (3 * (ADC_Channel - 10));
+    
+    /* Set the new sample time */
+    tmpreg1 |= tmpreg2;
+    
+    /* Store the new register value */
+    ADCx->SMPR1 = tmpreg1;
+  }
+  else /* ADC_Channel include in ADC_Channel_[0..9] */
+  {
+    /* Get the old register value */
+    tmpreg1 = ADCx->SMPR2;
+    
+    /* Calculate the mask to clear */
+    tmpreg2 = SMPR2_SMP_SET << (3 * ADC_Channel);
+    
+    /* Clear the old sample time */
+    tmpreg1 &= ~tmpreg2;
+    
+    /* Calculate the mask to set */
+    tmpreg2 = (uint32_t)ADC_SampleTime << (3 * ADC_Channel);
+    
+    /* Set the new sample time */
+    tmpreg1 |= tmpreg2;
+    
+    /* Store the new register value */
+    ADCx->SMPR2 = tmpreg1;
+  }
+  /* For Rank 1 to 6 */
+  if (Rank < 7)
+  {
+    /* Get the old register value */
+    tmpreg1 = ADCx->SQR3;
+    
+    /* Calculate the mask to clear */
+    tmpreg2 = SQR3_SQ_SET << (5 * (Rank - 1));
+    
+    /* Clear the old SQx bits for the selected rank */
+    tmpreg1 &= ~tmpreg2;
+    
+    /* Calculate the mask to set */
+    tmpreg2 = (uint32_t)ADC_Channel << (5 * (Rank - 1));
+    
+    /* Set the SQx bits for the selected rank */
+    tmpreg1 |= tmpreg2;
+    
+    /* Store the new register value */
+    ADCx->SQR3 = tmpreg1;
+  }
+  /* For Rank 7 to 12 */
+  else if (Rank < 13)
+  {
+    /* Get the old register value */
+    tmpreg1 = ADCx->SQR2;
+    
+    /* Calculate the mask to clear */
+    tmpreg2 = SQR2_SQ_SET << (5 * (Rank - 7));
+    
+    /* Clear the old SQx bits for the selected rank */
+    tmpreg1 &= ~tmpreg2;
+    
+    /* Calculate the mask to set */
+    tmpreg2 = (uint32_t)ADC_Channel << (5 * (Rank - 7));
+    
+    /* Set the SQx bits for the selected rank */
+    tmpreg1 |= tmpreg2;
+    
+    /* Store the new register value */
+    ADCx->SQR2 = tmpreg1;
+  }
+  /* For Rank 13 to 16 */
+  else
+  {
+    /* Get the old register value */
+    tmpreg1 = ADCx->SQR1;
+    
+    /* Calculate the mask to clear */
+    tmpreg2 = SQR1_SQ_SET << (5 * (Rank - 13));
+    
+    /* Clear the old SQx bits for the selected rank */
+    tmpreg1 &= ~tmpreg2;
+    
+    /* Calculate the mask to set */
+    tmpreg2 = (uint32_t)ADC_Channel << (5 * (Rank - 13));
+    
+    /* Set the SQx bits for the selected rank */
+    tmpreg1 |= tmpreg2;
+    
+    /* Store the new register value */
+    ADCx->SQR1 = tmpreg1;
+  }
+}
+
+/**
+  * @brief  Enables the selected ADC software start conversion of the regular channels.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @retval None
+  */
+void ADC_SoftwareStartConv(ADC_TypeDef* ADCx)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  
+  /* Enable the selected ADC conversion for regular group */
+  ADCx->CR2 |= (uint32_t)ADC_CR2_SWSTART;
+}
+
+/**
+  * @brief  Gets the selected ADC Software start regular conversion Status.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @retval The new state of ADC software start conversion (SET or RESET).
+  */
+FlagStatus ADC_GetSoftwareStartConvStatus(ADC_TypeDef* ADCx)
+{
+  FlagStatus bitstatus = RESET;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  
+  /* Check the status of SWSTART bit */
+  if ((ADCx->CR2 & ADC_CR2_SWSTART) != (uint32_t)RESET)
+  {
+    /* SWSTART bit is set */
+    bitstatus = SET;
+  }
+  else
+  {
+    /* SWSTART bit is reset */
+    bitstatus = RESET;
+  }
+  
+  /* Return the SWSTART bit status */
+  return  bitstatus;
+}
+
+
+/**
+  * @brief  Enables or disables the EOC on each regular channel conversion
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  NewState: new state of the selected ADC EOC flag rising
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void ADC_EOCOnEachRegularChannelCmd(ADC_TypeDef* ADCx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  
+  if (NewState != DISABLE)
+  {
+    /* Enable the selected ADC EOC rising on each regular channel conversion */
+    ADCx->CR2 |= (uint32_t)ADC_CR2_EOCS;
+  }
+  else
+  {
+    /* Disable the selected ADC EOC rising on each regular channel conversion */
+    ADCx->CR2 &= (uint32_t)(~ADC_CR2_EOCS);
+  }
+}
+
+/**
+  * @brief  Enables or disables the ADC continuous conversion mode 
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  NewState: new state of the selected ADC continuous conversion mode
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void ADC_ContinuousModeCmd(ADC_TypeDef* ADCx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  
+  if (NewState != DISABLE)
+  {
+    /* Enable the selected ADC continuous conversion mode */
+    ADCx->CR2 |= (uint32_t)ADC_CR2_CONT;
+  }
+  else
+  {
+    /* Disable the selected ADC continuous conversion mode */
+    ADCx->CR2 &= (uint32_t)(~ADC_CR2_CONT);
+  }
+}
+
+/**
+  * @brief  Configures the discontinuous mode for the selected ADC regular group 
+  *         channel.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  Number: specifies the discontinuous mode regular channel count value.
+  *          This number must be between 1 and 8.
+  * @retval None
+  */
+void ADC_DiscModeChannelCountConfig(ADC_TypeDef* ADCx, uint8_t Number)
+{
+  uint32_t tmpreg1 = 0;
+  uint32_t tmpreg2 = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_REGULAR_DISC_NUMBER(Number));
+  
+  /* Get the old register value */
+  tmpreg1 = ADCx->CR1;
+  
+  /* Clear the old discontinuous mode channel count */
+  tmpreg1 &= CR1_DISCNUM_RESET;
+  
+  /* Set the discontinuous mode channel count */
+  tmpreg2 = Number - 1;
+  tmpreg1 |= tmpreg2 << 13;
+  
+  /* Store the new register value */
+  ADCx->CR1 = tmpreg1;
+}
+
+/**
+  * @brief  Enables or disables the discontinuous mode on regular group channel 
+  *         for the specified ADC
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  NewState: new state of the selected ADC discontinuous mode on 
+  *         regular group channel.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void ADC_DiscModeCmd(ADC_TypeDef* ADCx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  
+  if (NewState != DISABLE)
+  {
+    /* Enable the selected ADC regular discontinuous mode */
+    ADCx->CR1 |= (uint32_t)ADC_CR1_DISCEN;
+  }
+  else
+  {
+    /* Disable the selected ADC regular discontinuous mode */
+    ADCx->CR1 &= (uint32_t)(~ADC_CR1_DISCEN);
+  }
+}
+
+/**
+  * @brief  Returns the last ADCx conversion result data for regular channel.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @retval The Data conversion value.
+  */
+uint16_t ADC_GetConversionValue(ADC_TypeDef* ADCx)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  
+  /* Return the selected ADC conversion value */
+  return (uint16_t) ADCx->DR;
+}
+
+/**
+  * @brief  Returns the last ADC1, ADC2 and ADC3 regular conversions results 
+  *         data in the selected multi mode.
+  * @param  None  
+  * @retval The Data conversion value.
+  * @note   In dual mode, the value returned by this function is as following
+  *           Data[15:0] : these bits contain the regular data of ADC1.
+  *           Data[31:16]: these bits contain the regular data of ADC2.
+  * @note   In triple mode, the value returned by this function is as following
+  *           Data[15:0] : these bits contain alternatively the regular data of ADC1, ADC3 and ADC2.
+  *           Data[31:16]: these bits contain alternatively the regular data of ADC2, ADC1 and ADC3.           
+  */
+uint32_t ADC_GetMultiModeConversionValue(void)
+{
+  /* Return the multi mode conversion value */
+  return (*(__IO uint32_t *) CDR_ADDRESS);
+}
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Group5 Regular Channels DMA Configuration functions
+ *  @brief   Regular Channels DMA Configuration functions 
+ *
+@verbatim   
+ ===============================================================================
+            ##### Regular Channels DMA Configuration functions #####
+ ===============================================================================  
+    [..] This section provides functions allowing to configure the DMA for ADC 
+         regular channels.
+         Since converted regular channel values are stored into a unique data 
+         register, it is useful to use DMA for conversion of more than one regular 
+         channel. This avoids the loss of the data already stored in the ADC 
+         Data register.   
+         When the DMA mode is enabled (using the ADC_DMACmd() function), after each
+         conversion of a regular channel, a DMA request is generated.
+    [..] Depending on the "DMA disable selection for Independent ADC mode" 
+         configuration (using the ADC_DMARequestAfterLastTransferCmd() function), 
+         at the end of the last DMA transfer, two possibilities are allowed:
+      (+) No new DMA request is issued to the DMA controller (feature DISABLED) 
+      (+) Requests can continue to be generated (feature ENABLED).  
+    [..] Depending on the "DMA disable selection for multi ADC mode" configuration 
+         (using the void ADC_MultiModeDMARequestAfterLastTransferCmd() function), 
+         at the end of the last DMA transfer, two possibilities are allowed:
+        (+) No new DMA request is issued to the DMA controller (feature DISABLED) 
+        (+) Requests can continue to be generated (feature ENABLED).
+
+@endverbatim
+  * @{
+  */
+  
+ /**
+  * @brief  Enables or disables the specified ADC DMA request.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  NewState: new state of the selected ADC DMA transfer.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void ADC_DMACmd(ADC_TypeDef* ADCx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    /* Enable the selected ADC DMA request */
+    ADCx->CR2 |= (uint32_t)ADC_CR2_DMA;
+  }
+  else
+  {
+    /* Disable the selected ADC DMA request */
+    ADCx->CR2 &= (uint32_t)(~ADC_CR2_DMA);
+  }
+}
+
+/**
+  * @brief  Enables or disables the ADC DMA request after last transfer (Single-ADC mode)  
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  NewState: new state of the selected ADC DMA request after last transfer.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void ADC_DMARequestAfterLastTransferCmd(ADC_TypeDef* ADCx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    /* Enable the selected ADC DMA request after last transfer */
+    ADCx->CR2 |= (uint32_t)ADC_CR2_DDS;
+  }
+  else
+  {
+    /* Disable the selected ADC DMA request after last transfer */
+    ADCx->CR2 &= (uint32_t)(~ADC_CR2_DDS);
+  }
+}
+
+/**
+  * @brief  Enables or disables the ADC DMA request after last transfer in multi ADC mode       
+  * @param  NewState: new state of the selected ADC DMA request after last transfer.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @note   if Enabled, DMA requests are issued as long as data are converted and 
+  *         DMA mode for multi ADC mode (selected using ADC_CommonInit() function 
+  *         by ADC_CommonInitStruct.ADC_DMAAccessMode structure member) is 
+  *          ADC_DMAAccessMode_1, ADC_DMAAccessMode_2 or ADC_DMAAccessMode_3.     
+  * @retval None
+  */
+void ADC_MultiModeDMARequestAfterLastTransferCmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    /* Enable the selected ADC DMA request after last transfer */
+    ADC->CCR |= (uint32_t)ADC_CCR_DDS;
+  }
+  else
+  {
+    /* Disable the selected ADC DMA request after last transfer */
+    ADC->CCR &= (uint32_t)(~ADC_CCR_DDS);
+  }
+}
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Group6 Injected channels Configuration functions
+ *  @brief   Injected channels Configuration functions 
+ *
+@verbatim   
+ ===============================================================================
+              ##### Injected channels Configuration functions #####
+ ===============================================================================  
+
+    [..] This section provide functions allowing to configure the ADC Injected channels,
+         it is composed of 2 sub sections : 
+    
+      (#) Configuration functions for Injected channels: This subsection provides 
+          functions allowing to configure the ADC injected channels :    
+        (++) Configure the rank in the injected group sequencer for each channel
+        (++) Configure the sampling time for each channel    
+        (++) Activate the Auto injected Mode  
+        (++) Activate the Discontinuous Mode 
+        (++) scan mode activation  
+        (++) External/software trigger source   
+        (++) External trigger edge 
+        (++) injected channels sequencer.
+    
+      (#) Get the Specified Injected channel conversion data: This subsection 
+          provides an important function in the ADC peripheral since it returns the 
+          converted data of the specific injected channel.
+
+@endverbatim
+  * @{
+  */ 
+/**
+  * @brief  Configures for the selected ADC injected channel its corresponding
+  *         rank in the sequencer and its sample time.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_Channel: the ADC channel to configure. 
+  *          This parameter can be one of the following values:
+  *            @arg ADC_Channel_0: ADC Channel0 selected
+  *            @arg ADC_Channel_1: ADC Channel1 selected
+  *            @arg ADC_Channel_2: ADC Channel2 selected
+  *            @arg ADC_Channel_3: ADC Channel3 selected
+  *            @arg ADC_Channel_4: ADC Channel4 selected
+  *            @arg ADC_Channel_5: ADC Channel5 selected
+  *            @arg ADC_Channel_6: ADC Channel6 selected
+  *            @arg ADC_Channel_7: ADC Channel7 selected
+  *            @arg ADC_Channel_8: ADC Channel8 selected
+  *            @arg ADC_Channel_9: ADC Channel9 selected
+  *            @arg ADC_Channel_10: ADC Channel10 selected
+  *            @arg ADC_Channel_11: ADC Channel11 selected
+  *            @arg ADC_Channel_12: ADC Channel12 selected
+  *            @arg ADC_Channel_13: ADC Channel13 selected
+  *            @arg ADC_Channel_14: ADC Channel14 selected
+  *            @arg ADC_Channel_15: ADC Channel15 selected
+  *            @arg ADC_Channel_16: ADC Channel16 selected
+  *            @arg ADC_Channel_17: ADC Channel17 selected
+  *            @arg ADC_Channel_18: ADC Channel18 selected                       
+  * @param  Rank: The rank in the injected group sequencer. 
+  *          This parameter must be between 1 to 4.
+  * @param  ADC_SampleTime: The sample time value to be set for the selected channel. 
+  *          This parameter can be one of the following values:
+  *            @arg ADC_SampleTime_3Cycles: Sample time equal to 3 cycles
+  *            @arg ADC_SampleTime_15Cycles: Sample time equal to 15 cycles
+  *            @arg ADC_SampleTime_28Cycles: Sample time equal to 28 cycles
+  *            @arg ADC_SampleTime_56Cycles: Sample time equal to 56 cycles	
+  *            @arg ADC_SampleTime_84Cycles: Sample time equal to 84 cycles	
+  *            @arg ADC_SampleTime_112Cycles: Sample time equal to 112 cycles	
+  *            @arg ADC_SampleTime_144Cycles: Sample time equal to 144 cycles	
+  *            @arg ADC_SampleTime_480Cycles: Sample time equal to 480 cycles	
+  * @retval None
+  */
+void ADC_InjectedChannelConfig(ADC_TypeDef* ADCx, uint8_t ADC_Channel, uint8_t Rank, uint8_t ADC_SampleTime)
+{
+  uint32_t tmpreg1 = 0, tmpreg2 = 0, tmpreg3 = 0;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_CHANNEL(ADC_Channel));
+  assert_param(IS_ADC_INJECTED_RANK(Rank));
+  assert_param(IS_ADC_SAMPLE_TIME(ADC_SampleTime));
+  /* if ADC_Channel_10 ... ADC_Channel_18 is selected */
+  if (ADC_Channel > ADC_Channel_9)
+  {
+    /* Get the old register value */
+    tmpreg1 = ADCx->SMPR1;
+    /* Calculate the mask to clear */
+    tmpreg2 = SMPR1_SMP_SET << (3*(ADC_Channel - 10));
+    /* Clear the old sample time */
+    tmpreg1 &= ~tmpreg2;
+    /* Calculate the mask to set */
+    tmpreg2 = (uint32_t)ADC_SampleTime << (3*(ADC_Channel - 10));
+    /* Set the new sample time */
+    tmpreg1 |= tmpreg2;
+    /* Store the new register value */
+    ADCx->SMPR1 = tmpreg1;
+  }
+  else /* ADC_Channel include in ADC_Channel_[0..9] */
+  {
+    /* Get the old register value */
+    tmpreg1 = ADCx->SMPR2;
+    /* Calculate the mask to clear */
+    tmpreg2 = SMPR2_SMP_SET << (3 * ADC_Channel);
+    /* Clear the old sample time */
+    tmpreg1 &= ~tmpreg2;
+    /* Calculate the mask to set */
+    tmpreg2 = (uint32_t)ADC_SampleTime << (3 * ADC_Channel);
+    /* Set the new sample time */
+    tmpreg1 |= tmpreg2;
+    /* Store the new register value */
+    ADCx->SMPR2 = tmpreg1;
+  }
+  /* Rank configuration */
+  /* Get the old register value */
+  tmpreg1 = ADCx->JSQR;
+  /* Get JL value: Number = JL+1 */
+  tmpreg3 =  (tmpreg1 & JSQR_JL_SET)>> 20;
+  /* Calculate the mask to clear: ((Rank-1)+(4-JL-1)) */
+  tmpreg2 = JSQR_JSQ_SET << (5 * (uint8_t)((Rank + 3) - (tmpreg3 + 1)));
+  /* Clear the old JSQx bits for the selected rank */
+  tmpreg1 &= ~tmpreg2;
+  /* Calculate the mask to set: ((Rank-1)+(4-JL-1)) */
+  tmpreg2 = (uint32_t)ADC_Channel << (5 * (uint8_t)((Rank + 3) - (tmpreg3 + 1)));
+  /* Set the JSQx bits for the selected rank */
+  tmpreg1 |= tmpreg2;
+  /* Store the new register value */
+  ADCx->JSQR = tmpreg1;
+}
+
+/**
+  * @brief  Configures the sequencer length for injected channels
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  Length: The sequencer length. 
+  *          This parameter must be a number between 1 to 4.
+  * @retval None
+  */
+void ADC_InjectedSequencerLengthConfig(ADC_TypeDef* ADCx, uint8_t Length)
+{
+  uint32_t tmpreg1 = 0;
+  uint32_t tmpreg2 = 0;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_INJECTED_LENGTH(Length));
+  
+  /* Get the old register value */
+  tmpreg1 = ADCx->JSQR;
+  
+  /* Clear the old injected sequence length JL bits */
+  tmpreg1 &= JSQR_JL_RESET;
+  
+  /* Set the injected sequence length JL bits */
+  tmpreg2 = Length - 1; 
+  tmpreg1 |= tmpreg2 << 20;
+  
+  /* Store the new register value */
+  ADCx->JSQR = tmpreg1;
+}
+
+/**
+  * @brief  Set the injected channels conversion value offset
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_InjectedChannel: the ADC injected channel to set its offset. 
+  *          This parameter can be one of the following values:
+  *            @arg ADC_InjectedChannel_1: Injected Channel1 selected
+  *            @arg ADC_InjectedChannel_2: Injected Channel2 selected
+  *            @arg ADC_InjectedChannel_3: Injected Channel3 selected
+  *            @arg ADC_InjectedChannel_4: Injected Channel4 selected
+  * @param  Offset: the offset value for the selected ADC injected channel
+  *          This parameter must be a 12bit value.
+  * @retval None
+  */
+void ADC_SetInjectedOffset(ADC_TypeDef* ADCx, uint8_t ADC_InjectedChannel, uint16_t Offset)
+{
+    __IO uint32_t tmp = 0;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_INJECTED_CHANNEL(ADC_InjectedChannel));
+  assert_param(IS_ADC_OFFSET(Offset));
+  
+  tmp = (uint32_t)ADCx;
+  tmp += ADC_InjectedChannel;
+  
+  /* Set the selected injected channel data offset */
+ *(__IO uint32_t *) tmp = (uint32_t)Offset;
+}
+
+ /**
+  * @brief  Configures the ADCx external trigger for injected channels conversion.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_ExternalTrigInjecConv: specifies the ADC trigger to start injected conversion.
+  *          This parameter can be one of the following values:                    
+  *            @arg ADC_ExternalTrigInjecConv_T1_CC4: Timer1 capture compare4 selected 
+  *            @arg ADC_ExternalTrigInjecConv_T1_TRGO: Timer1 TRGO event selected 
+  *            @arg ADC_ExternalTrigInjecConv_T2_CC1: Timer2 capture compare1 selected 
+  *            @arg ADC_ExternalTrigInjecConv_T2_TRGO: Timer2 TRGO event selected 
+  *            @arg ADC_ExternalTrigInjecConv_T3_CC2: Timer3 capture compare2 selected 
+  *            @arg ADC_ExternalTrigInjecConv_T3_CC4: Timer3 capture compare4 selected 
+  *            @arg ADC_ExternalTrigInjecConv_T4_CC1: Timer4 capture compare1 selected                       
+  *            @arg ADC_ExternalTrigInjecConv_T4_CC2: Timer4 capture compare2 selected 
+  *            @arg ADC_ExternalTrigInjecConv_T4_CC3: Timer4 capture compare3 selected                        
+  *            @arg ADC_ExternalTrigInjecConv_T4_TRGO: Timer4 TRGO event selected 
+  *            @arg ADC_ExternalTrigInjecConv_T5_CC4: Timer5 capture compare4 selected                        
+  *            @arg ADC_ExternalTrigInjecConv_T5_TRGO: Timer5 TRGO event selected                        
+  *            @arg ADC_ExternalTrigInjecConv_T8_CC2: Timer8 capture compare2 selected
+  *            @arg ADC_ExternalTrigInjecConv_T8_CC3: Timer8 capture compare3 selected                        
+  *            @arg ADC_ExternalTrigInjecConv_T8_CC4: Timer8 capture compare4 selected 
+  *            @arg ADC_ExternalTrigInjecConv_Ext_IT15: External interrupt line 15 event selected                          
+  * @retval None
+  */
+void ADC_ExternalTrigInjectedConvConfig(ADC_TypeDef* ADCx, uint32_t ADC_ExternalTrigInjecConv)
+{
+  uint32_t tmpreg = 0;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_EXT_INJEC_TRIG(ADC_ExternalTrigInjecConv));
+  
+  /* Get the old register value */
+  tmpreg = ADCx->CR2;
+  
+  /* Clear the old external event selection for injected group */
+  tmpreg &= CR2_JEXTSEL_RESET;
+  
+  /* Set the external event selection for injected group */
+  tmpreg |= ADC_ExternalTrigInjecConv;
+  
+  /* Store the new register value */
+  ADCx->CR2 = tmpreg;
+}
+
+/**
+  * @brief  Configures the ADCx external trigger edge for injected channels conversion.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_ExternalTrigInjecConvEdge: specifies the ADC external trigger edge
+  *         to start injected conversion. 
+  *          This parameter can be one of the following values:
+  *            @arg ADC_ExternalTrigInjecConvEdge_None: external trigger disabled for 
+  *                                                     injected conversion
+  *            @arg ADC_ExternalTrigInjecConvEdge_Rising: detection on rising edge
+  *            @arg ADC_ExternalTrigInjecConvEdge_Falling: detection on falling edge
+  *            @arg ADC_ExternalTrigInjecConvEdge_RisingFalling: detection on both rising 
+  *                                                               and falling edge
+  * @retval None
+  */
+void ADC_ExternalTrigInjectedConvEdgeConfig(ADC_TypeDef* ADCx, uint32_t ADC_ExternalTrigInjecConvEdge)
+{
+  uint32_t tmpreg = 0;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_EXT_INJEC_TRIG_EDGE(ADC_ExternalTrigInjecConvEdge));
+  /* Get the old register value */
+  tmpreg = ADCx->CR2;
+  /* Clear the old external trigger edge for injected group */
+  tmpreg &= CR2_JEXTEN_RESET;
+  /* Set the new external trigger edge for injected group */
+  tmpreg |= ADC_ExternalTrigInjecConvEdge;
+  /* Store the new register value */
+  ADCx->CR2 = tmpreg;
+}
+
+/**
+  * @brief  Enables the selected ADC software start conversion of the injected channels.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @retval None
+  */
+void ADC_SoftwareStartInjectedConv(ADC_TypeDef* ADCx)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  /* Enable the selected ADC conversion for injected group */
+  ADCx->CR2 |= (uint32_t)ADC_CR2_JSWSTART;
+}
+
+/**
+  * @brief  Gets the selected ADC Software start injected conversion Status.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @retval The new state of ADC software start injected conversion (SET or RESET).
+  */
+FlagStatus ADC_GetSoftwareStartInjectedConvCmdStatus(ADC_TypeDef* ADCx)
+{
+  FlagStatus bitstatus = RESET;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  
+  /* Check the status of JSWSTART bit */
+  if ((ADCx->CR2 & ADC_CR2_JSWSTART) != (uint32_t)RESET)
+  {
+    /* JSWSTART bit is set */
+    bitstatus = SET;
+  }
+  else
+  {
+    /* JSWSTART bit is reset */
+    bitstatus = RESET;
+  }
+  /* Return the JSWSTART bit status */
+  return  bitstatus;
+}
+
+/**
+  * @brief  Enables or disables the selected ADC automatic injected group 
+  *         conversion after regular one.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  NewState: new state of the selected ADC auto injected conversion
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void ADC_AutoInjectedConvCmd(ADC_TypeDef* ADCx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    /* Enable the selected ADC automatic injected group conversion */
+    ADCx->CR1 |= (uint32_t)ADC_CR1_JAUTO;
+  }
+  else
+  {
+    /* Disable the selected ADC automatic injected group conversion */
+    ADCx->CR1 &= (uint32_t)(~ADC_CR1_JAUTO);
+  }
+}
+
+/**
+  * @brief  Enables or disables the discontinuous mode for injected group 
+  *         channel for the specified ADC
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  NewState: new state of the selected ADC discontinuous mode on injected
+  *         group channel.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void ADC_InjectedDiscModeCmd(ADC_TypeDef* ADCx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    /* Enable the selected ADC injected discontinuous mode */
+    ADCx->CR1 |= (uint32_t)ADC_CR1_JDISCEN;
+  }
+  else
+  {
+    /* Disable the selected ADC injected discontinuous mode */
+    ADCx->CR1 &= (uint32_t)(~ADC_CR1_JDISCEN);
+  }
+}
+
+/**
+  * @brief  Returns the ADC injected channel conversion result
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_InjectedChannel: the converted ADC injected channel.
+  *          This parameter can be one of the following values:
+  *            @arg ADC_InjectedChannel_1: Injected Channel1 selected
+  *            @arg ADC_InjectedChannel_2: Injected Channel2 selected
+  *            @arg ADC_InjectedChannel_3: Injected Channel3 selected
+  *            @arg ADC_InjectedChannel_4: Injected Channel4 selected
+  * @retval The Data conversion value.
+  */
+uint16_t ADC_GetInjectedConversionValue(ADC_TypeDef* ADCx, uint8_t ADC_InjectedChannel)
+{
+  __IO uint32_t tmp = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_INJECTED_CHANNEL(ADC_InjectedChannel));
+
+  tmp = (uint32_t)ADCx;
+  tmp += ADC_InjectedChannel + JDR_OFFSET;
+  
+  /* Returns the selected injected channel conversion data value */
+  return (uint16_t) (*(__IO uint32_t*)  tmp); 
+}
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Group7 Interrupts and flags management functions
+ *  @brief   Interrupts and flags management functions
+ *
+@verbatim   
+ ===============================================================================
+            ##### Interrupts and flags management functions #####
+ ===============================================================================  
+
+    [..] This section provides functions allowing to configure the ADC Interrupts 
+         and to get the status and clear flags and Interrupts pending bits.
+  
+    [..] Each ADC provides 4 Interrupts sources and 6 Flags which can be divided
+        into 3 groups:
+  
+  *** Flags and Interrupts for ADC regular channels ***
+  =====================================================
+    [..]
+      (+) Flags :
+        (##) ADC_FLAG_OVR : Overrun detection when regular converted data are lost
+
+        (##) ADC_FLAG_EOC : Regular channel end of conversion ==> to indicate 
+             (depending on EOCS bit, managed by ADC_EOCOnEachRegularChannelCmd() )
+             the end of:
+             (+++) a regular CHANNEL conversion 
+             (+++) sequence of regular GROUP conversions .
+
+        (##) ADC_FLAG_STRT: Regular channel start ==> to indicate when regular 
+             CHANNEL conversion starts.
+    [..]
+      (+) Interrupts :
+        (##) ADC_IT_OVR : specifies the interrupt source for Overrun detection 
+             event.  
+        (##) ADC_IT_EOC : specifies the interrupt source for Regular channel end
+             of conversion event.
+  
+  
+  *** Flags and Interrupts for ADC Injected channels ***
+  ======================================================
+    [..]
+      (+) Flags :
+        (##) ADC_FLAG_JEOC : Injected channel end of conversion ==> to indicate 
+             at the end of injected GROUP conversion  
+              
+        (##) ADC_FLAG_JSTRT: Injected channel start ==> to indicate hardware when 
+             injected GROUP conversion starts.
+    [..]
+      (+) Interrupts :
+        (##) ADC_IT_JEOC : specifies the interrupt source for Injected channel 
+             end of conversion event.     
+
+  *** General Flags and Interrupts for the ADC ***
+  ================================================ 
+    [..]
+      (+)Flags :
+        (##) ADC_FLAG_AWD: Analog watchdog ==> to indicate if the converted voltage 
+             crosses the programmed thresholds values.
+    [..]          
+      (+) Interrupts :
+        (##) ADC_IT_AWD : specifies the interrupt source for Analog watchdog event. 
+
+  
+    [..] The user should identify which mode will be used in his application to 
+         manage the ADC controller events: Polling mode or Interrupt mode.
+  
+    [..] In the Polling Mode it is advised to use the following functions:
+      (+) ADC_GetFlagStatus() : to check if flags events occur. 
+      (+) ADC_ClearFlag()     : to clear the flags events.
+      
+    [..] In the Interrupt Mode it is advised to use the following functions:
+      (+) ADC_ITConfig()          : to enable or disable the interrupt source.
+      (+) ADC_GetITStatus()       : to check if Interrupt occurs.
+      (+) ADC_ClearITPendingBit() : to clear the Interrupt pending Bit 
+                                   (corresponding Flag). 
+@endverbatim
+  * @{
+  */ 
+/**
+  * @brief  Enables or disables the specified ADC interrupts.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_IT: specifies the ADC interrupt sources to be enabled or disabled. 
+  *          This parameter can be one of the following values:
+  *            @arg ADC_IT_EOC: End of conversion interrupt mask
+  *            @arg ADC_IT_AWD: Analog watchdog interrupt mask
+  *            @arg ADC_IT_JEOC: End of injected conversion interrupt mask
+  *            @arg ADC_IT_OVR: Overrun interrupt enable                       
+  * @param  NewState: new state of the specified ADC interrupts.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void ADC_ITConfig(ADC_TypeDef* ADCx, uint16_t ADC_IT, FunctionalState NewState)  
+{
+  uint32_t itmask = 0;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  assert_param(IS_ADC_IT(ADC_IT)); 
+
+  /* Get the ADC IT index */
+  itmask = (uint8_t)ADC_IT;
+  itmask = (uint32_t)0x01 << itmask;    
+
+  if (NewState != DISABLE)
+  {
+    /* Enable the selected ADC interrupts */
+    ADCx->CR1 |= itmask;
+  }
+  else
+  {
+    /* Disable the selected ADC interrupts */
+    ADCx->CR1 &= (~(uint32_t)itmask);
+  }
+}
+
+/**
+  * @brief  Checks whether the specified ADC flag is set or not.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_FLAG: specifies the flag to check. 
+  *          This parameter can be one of the following values:
+  *            @arg ADC_FLAG_AWD: Analog watchdog flag
+  *            @arg ADC_FLAG_EOC: End of conversion flag
+  *            @arg ADC_FLAG_JEOC: End of injected group conversion flag
+  *            @arg ADC_FLAG_JSTRT: Start of injected group conversion flag
+  *            @arg ADC_FLAG_STRT: Start of regular group conversion flag
+  *            @arg ADC_FLAG_OVR: Overrun flag                                                 
+  * @retval The new state of ADC_FLAG (SET or RESET).
+  */
+FlagStatus ADC_GetFlagStatus(ADC_TypeDef* ADCx, uint8_t ADC_FLAG)
+{
+  FlagStatus bitstatus = RESET;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_GET_FLAG(ADC_FLAG));
+
+  /* Check the status of the specified ADC flag */
+  if ((ADCx->SR & ADC_FLAG) != (uint8_t)RESET)
+  {
+    /* ADC_FLAG is set */
+    bitstatus = SET;
+  }
+  else
+  {
+    /* ADC_FLAG is reset */
+    bitstatus = RESET;
+  }
+  /* Return the ADC_FLAG status */
+  return  bitstatus;
+}
+
+/**
+  * @brief  Clears the ADCx's pending flags.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_FLAG: specifies the flag to clear. 
+  *          This parameter can be any combination of the following values:
+  *            @arg ADC_FLAG_AWD: Analog watchdog flag
+  *            @arg ADC_FLAG_EOC: End of conversion flag
+  *            @arg ADC_FLAG_JEOC: End of injected group conversion flag
+  *            @arg ADC_FLAG_JSTRT: Start of injected group conversion flag
+  *            @arg ADC_FLAG_STRT: Start of regular group conversion flag
+  *            @arg ADC_FLAG_OVR: Overrun flag                          
+  * @retval None
+  */
+void ADC_ClearFlag(ADC_TypeDef* ADCx, uint8_t ADC_FLAG)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_CLEAR_FLAG(ADC_FLAG));
+
+  /* Clear the selected ADC flags */
+  ADCx->SR = ~(uint32_t)ADC_FLAG;
+}
+
+/**
+  * @brief  Checks whether the specified ADC interrupt has occurred or not.
+  * @param  ADCx:   where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_IT: specifies the ADC interrupt source to check. 
+  *          This parameter can be one of the following values:
+  *            @arg ADC_IT_EOC: End of conversion interrupt mask
+  *            @arg ADC_IT_AWD: Analog watchdog interrupt mask
+  *            @arg ADC_IT_JEOC: End of injected conversion interrupt mask
+  *            @arg ADC_IT_OVR: Overrun interrupt mask                        
+  * @retval The new state of ADC_IT (SET or RESET).
+  */
+ITStatus ADC_GetITStatus(ADC_TypeDef* ADCx, uint16_t ADC_IT)
+{
+  ITStatus bitstatus = RESET;
+  uint32_t itmask = 0, enablestatus = 0;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_IT(ADC_IT));
+
+  /* Get the ADC IT index */
+  itmask = ADC_IT >> 8;
+
+  /* Get the ADC_IT enable bit status */
+  enablestatus = (ADCx->CR1 & ((uint32_t)0x01 << (uint8_t)ADC_IT)) ;
+
+  /* Check the status of the specified ADC interrupt */
+  if (((ADCx->SR & itmask) != (uint32_t)RESET) && enablestatus)
+  {
+    /* ADC_IT is set */
+    bitstatus = SET;
+  }
+  else
+  {
+    /* ADC_IT is reset */
+    bitstatus = RESET;
+  }
+  /* Return the ADC_IT status */
+  return  bitstatus;
+}
+
+/**
+  * @brief  Clears the ADCx's interrupt pending bits.
+  * @param  ADCx: where x can be 1, 2 or 3 to select the ADC peripheral.
+  * @param  ADC_IT: specifies the ADC interrupt pending bit to clear.
+  *          This parameter can be one of the following values:
+  *            @arg ADC_IT_EOC: End of conversion interrupt mask
+  *            @arg ADC_IT_AWD: Analog watchdog interrupt mask
+  *            @arg ADC_IT_JEOC: End of injected conversion interrupt mask
+  *            @arg ADC_IT_OVR: Overrun interrupt mask                         
+  * @retval None
+  */
+void ADC_ClearITPendingBit(ADC_TypeDef* ADCx, uint16_t ADC_IT)
+{
+  uint8_t itmask = 0;
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_PERIPH(ADCx));
+  assert_param(IS_ADC_IT(ADC_IT)); 
+  /* Get the ADC IT index */
+  itmask = (uint8_t)(ADC_IT >> 8);
+  /* Clear the selected ADC interrupt pending bits */
+  ADCx->SR = ~(uint32_t)itmask;
+}                    
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm/lib/stm32f4xx_adc.h
+++ b/stm/lib/stm32f4xx_adc.h
@@ -1,0 +1,656 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_adc.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    08-November-2013
+  * @brief   This file contains all the functions prototypes for the ADC firmware 
+  *          library.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2013 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F4xx_ADC_H
+#define __STM32F4xx_ADC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx.h"
+
+/** @addtogroup STM32F4xx_StdPeriph_Driver
+  * @{
+  */
+
+/** @addtogroup ADC
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+
+/** 
+  * @brief   ADC Init structure definition  
+  */ 
+typedef struct
+{
+  uint32_t ADC_Resolution;                /*!< Configures the ADC resolution dual mode. 
+                                               This parameter can be a value of @ref ADC_resolution */                                   
+  FunctionalState ADC_ScanConvMode;       /*!< Specifies whether the conversion 
+                                               is performed in Scan (multichannels) 
+                                               or Single (one channel) mode.
+                                               This parameter can be set to ENABLE or DISABLE */ 
+  FunctionalState ADC_ContinuousConvMode; /*!< Specifies whether the conversion 
+                                               is performed in Continuous or Single mode.
+                                               This parameter can be set to ENABLE or DISABLE. */
+  uint32_t ADC_ExternalTrigConvEdge;      /*!< Select the external trigger edge and
+                                               enable the trigger of a regular group. 
+                                               This parameter can be a value of 
+                                               @ref ADC_external_trigger_edge_for_regular_channels_conversion */
+  uint32_t ADC_ExternalTrigConv;          /*!< Select the external event used to trigger 
+                                               the start of conversion of a regular group.
+                                               This parameter can be a value of 
+                                               @ref ADC_extrenal_trigger_sources_for_regular_channels_conversion */
+  uint32_t ADC_DataAlign;                 /*!< Specifies whether the ADC data  alignment
+                                               is left or right. This parameter can be 
+                                               a value of @ref ADC_data_align */
+  uint8_t  ADC_NbrOfConversion;           /*!< Specifies the number of ADC conversions
+                                               that will be done using the sequencer for
+                                               regular channel group.
+                                               This parameter must range from 1 to 16. */
+}ADC_InitTypeDef;
+  
+/** 
+  * @brief   ADC Common Init structure definition  
+  */ 
+typedef struct 
+{
+  uint32_t ADC_Mode;                      /*!< Configures the ADC to operate in 
+                                               independent or multi mode. 
+                                               This parameter can be a value of @ref ADC_Common_mode */                                              
+  uint32_t ADC_Prescaler;                 /*!< Select the frequency of the clock 
+                                               to the ADC. The clock is common for all the ADCs.
+                                               This parameter can be a value of @ref ADC_Prescaler */
+  uint32_t ADC_DMAAccessMode;             /*!< Configures the Direct memory access 
+                                              mode for multi ADC mode.
+                                               This parameter can be a value of 
+                                               @ref ADC_Direct_memory_access_mode_for_multi_mode */
+  uint32_t ADC_TwoSamplingDelay;          /*!< Configures the Delay between 2 sampling phases.
+                                               This parameter can be a value of 
+                                               @ref ADC_delay_between_2_sampling_phases */
+  
+}ADC_CommonInitTypeDef;
+
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup ADC_Exported_Constants
+  * @{
+  */ 
+#define IS_ADC_ALL_PERIPH(PERIPH) (((PERIPH) == ADC1) || \
+                                   ((PERIPH) == ADC2) || \
+                                   ((PERIPH) == ADC3))  
+
+/** @defgroup ADC_Common_mode 
+  * @{
+  */ 
+#define ADC_Mode_Independent                       ((uint32_t)0x00000000)       
+#define ADC_DualMode_RegSimult_InjecSimult         ((uint32_t)0x00000001)
+#define ADC_DualMode_RegSimult_AlterTrig           ((uint32_t)0x00000002)
+#define ADC_DualMode_InjecSimult                   ((uint32_t)0x00000005)
+#define ADC_DualMode_RegSimult                     ((uint32_t)0x00000006)
+#define ADC_DualMode_Interl                        ((uint32_t)0x00000007)
+#define ADC_DualMode_AlterTrig                     ((uint32_t)0x00000009)
+#define ADC_TripleMode_RegSimult_InjecSimult       ((uint32_t)0x00000011)
+#define ADC_TripleMode_RegSimult_AlterTrig         ((uint32_t)0x00000012)
+#define ADC_TripleMode_InjecSimult                 ((uint32_t)0x00000015)
+#define ADC_TripleMode_RegSimult                   ((uint32_t)0x00000016)
+#define ADC_TripleMode_Interl                      ((uint32_t)0x00000017)
+#define ADC_TripleMode_AlterTrig                   ((uint32_t)0x00000019)
+#define IS_ADC_MODE(MODE) (((MODE) == ADC_Mode_Independent) || \
+                           ((MODE) == ADC_DualMode_RegSimult_InjecSimult) || \
+                           ((MODE) == ADC_DualMode_RegSimult_AlterTrig) || \
+                           ((MODE) == ADC_DualMode_InjecSimult) || \
+                           ((MODE) == ADC_DualMode_RegSimult) || \
+                           ((MODE) == ADC_DualMode_Interl) || \
+                           ((MODE) == ADC_DualMode_AlterTrig) || \
+                           ((MODE) == ADC_TripleMode_RegSimult_InjecSimult) || \
+                           ((MODE) == ADC_TripleMode_RegSimult_AlterTrig) || \
+                           ((MODE) == ADC_TripleMode_InjecSimult) || \
+                           ((MODE) == ADC_TripleMode_RegSimult) || \
+                           ((MODE) == ADC_TripleMode_Interl) || \
+                           ((MODE) == ADC_TripleMode_AlterTrig))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_Prescaler 
+  * @{
+  */ 
+#define ADC_Prescaler_Div2                         ((uint32_t)0x00000000)
+#define ADC_Prescaler_Div4                         ((uint32_t)0x00010000)
+#define ADC_Prescaler_Div6                         ((uint32_t)0x00020000)
+#define ADC_Prescaler_Div8                         ((uint32_t)0x00030000)
+#define IS_ADC_PRESCALER(PRESCALER) (((PRESCALER) == ADC_Prescaler_Div2) || \
+                                     ((PRESCALER) == ADC_Prescaler_Div4) || \
+                                     ((PRESCALER) == ADC_Prescaler_Div6) || \
+                                     ((PRESCALER) == ADC_Prescaler_Div8))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_Direct_memory_access_mode_for_multi_mode 
+  * @{
+  */ 
+#define ADC_DMAAccessMode_Disabled      ((uint32_t)0x00000000)     /* DMA mode disabled */
+#define ADC_DMAAccessMode_1             ((uint32_t)0x00004000)     /* DMA mode 1 enabled (2 / 3 half-words one by one - 1 then 2 then 3)*/
+#define ADC_DMAAccessMode_2             ((uint32_t)0x00008000)     /* DMA mode 2 enabled (2 / 3 half-words by pairs - 2&1 then 1&3 then 3&2)*/
+#define ADC_DMAAccessMode_3             ((uint32_t)0x0000C000)     /* DMA mode 3 enabled (2 / 3 bytes by pairs - 2&1 then 1&3 then 3&2) */
+#define IS_ADC_DMA_ACCESS_MODE(MODE) (((MODE) == ADC_DMAAccessMode_Disabled) || \
+                                      ((MODE) == ADC_DMAAccessMode_1) || \
+                                      ((MODE) == ADC_DMAAccessMode_2) || \
+                                      ((MODE) == ADC_DMAAccessMode_3))
+                                     
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_delay_between_2_sampling_phases 
+  * @{
+  */ 
+#define ADC_TwoSamplingDelay_5Cycles               ((uint32_t)0x00000000)
+#define ADC_TwoSamplingDelay_6Cycles               ((uint32_t)0x00000100)
+#define ADC_TwoSamplingDelay_7Cycles               ((uint32_t)0x00000200)
+#define ADC_TwoSamplingDelay_8Cycles               ((uint32_t)0x00000300)
+#define ADC_TwoSamplingDelay_9Cycles               ((uint32_t)0x00000400)
+#define ADC_TwoSamplingDelay_10Cycles              ((uint32_t)0x00000500)
+#define ADC_TwoSamplingDelay_11Cycles              ((uint32_t)0x00000600)
+#define ADC_TwoSamplingDelay_12Cycles              ((uint32_t)0x00000700)
+#define ADC_TwoSamplingDelay_13Cycles              ((uint32_t)0x00000800)
+#define ADC_TwoSamplingDelay_14Cycles              ((uint32_t)0x00000900)
+#define ADC_TwoSamplingDelay_15Cycles              ((uint32_t)0x00000A00)
+#define ADC_TwoSamplingDelay_16Cycles              ((uint32_t)0x00000B00)
+#define ADC_TwoSamplingDelay_17Cycles              ((uint32_t)0x00000C00)
+#define ADC_TwoSamplingDelay_18Cycles              ((uint32_t)0x00000D00)
+#define ADC_TwoSamplingDelay_19Cycles              ((uint32_t)0x00000E00)
+#define ADC_TwoSamplingDelay_20Cycles              ((uint32_t)0x00000F00)
+#define IS_ADC_SAMPLING_DELAY(DELAY) (((DELAY) == ADC_TwoSamplingDelay_5Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_6Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_7Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_8Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_9Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_10Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_11Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_12Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_13Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_14Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_15Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_16Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_17Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_18Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_19Cycles) || \
+                                      ((DELAY) == ADC_TwoSamplingDelay_20Cycles))
+                                     
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_resolution 
+  * @{
+  */ 
+#define ADC_Resolution_12b                         ((uint32_t)0x00000000)
+#define ADC_Resolution_10b                         ((uint32_t)0x01000000)
+#define ADC_Resolution_8b                          ((uint32_t)0x02000000)
+#define ADC_Resolution_6b                          ((uint32_t)0x03000000)
+#define IS_ADC_RESOLUTION(RESOLUTION) (((RESOLUTION) == ADC_Resolution_12b) || \
+                                       ((RESOLUTION) == ADC_Resolution_10b) || \
+                                       ((RESOLUTION) == ADC_Resolution_8b) || \
+                                       ((RESOLUTION) == ADC_Resolution_6b))
+                                      
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_external_trigger_edge_for_regular_channels_conversion 
+  * @{
+  */ 
+#define ADC_ExternalTrigConvEdge_None          ((uint32_t)0x00000000)
+#define ADC_ExternalTrigConvEdge_Rising        ((uint32_t)0x10000000)
+#define ADC_ExternalTrigConvEdge_Falling       ((uint32_t)0x20000000)
+#define ADC_ExternalTrigConvEdge_RisingFalling ((uint32_t)0x30000000)
+#define IS_ADC_EXT_TRIG_EDGE(EDGE) (((EDGE) == ADC_ExternalTrigConvEdge_None) || \
+                             ((EDGE) == ADC_ExternalTrigConvEdge_Rising) || \
+                             ((EDGE) == ADC_ExternalTrigConvEdge_Falling) || \
+                             ((EDGE) == ADC_ExternalTrigConvEdge_RisingFalling))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_extrenal_trigger_sources_for_regular_channels_conversion 
+  * @{
+  */ 
+#define ADC_ExternalTrigConv_T1_CC1                ((uint32_t)0x00000000)
+#define ADC_ExternalTrigConv_T1_CC2                ((uint32_t)0x01000000)
+#define ADC_ExternalTrigConv_T1_CC3                ((uint32_t)0x02000000)
+#define ADC_ExternalTrigConv_T2_CC2                ((uint32_t)0x03000000)
+#define ADC_ExternalTrigConv_T2_CC3                ((uint32_t)0x04000000)
+#define ADC_ExternalTrigConv_T2_CC4                ((uint32_t)0x05000000)
+#define ADC_ExternalTrigConv_T2_TRGO               ((uint32_t)0x06000000)
+#define ADC_ExternalTrigConv_T3_CC1                ((uint32_t)0x07000000)
+#define ADC_ExternalTrigConv_T3_TRGO               ((uint32_t)0x08000000)
+#define ADC_ExternalTrigConv_T4_CC4                ((uint32_t)0x09000000)
+#define ADC_ExternalTrigConv_T5_CC1                ((uint32_t)0x0A000000)
+#define ADC_ExternalTrigConv_T5_CC2                ((uint32_t)0x0B000000)
+#define ADC_ExternalTrigConv_T5_CC3                ((uint32_t)0x0C000000)
+#define ADC_ExternalTrigConv_T8_CC1                ((uint32_t)0x0D000000)
+#define ADC_ExternalTrigConv_T8_TRGO               ((uint32_t)0x0E000000)
+#define ADC_ExternalTrigConv_Ext_IT11              ((uint32_t)0x0F000000)
+#define IS_ADC_EXT_TRIG(REGTRIG) (((REGTRIG) == ADC_ExternalTrigConv_T1_CC1) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T1_CC2) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T1_CC3) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T2_CC2) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T2_CC3) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T2_CC4) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T2_TRGO) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T3_CC1) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T3_TRGO) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T4_CC4) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T5_CC1) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T5_CC2) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T5_CC3) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T8_CC1) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_T8_TRGO) || \
+                                  ((REGTRIG) == ADC_ExternalTrigConv_Ext_IT11))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_data_align 
+  * @{
+  */ 
+#define ADC_DataAlign_Right                        ((uint32_t)0x00000000)
+#define ADC_DataAlign_Left                         ((uint32_t)0x00000800)
+#define IS_ADC_DATA_ALIGN(ALIGN) (((ALIGN) == ADC_DataAlign_Right) || \
+                                  ((ALIGN) == ADC_DataAlign_Left))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_channels 
+  * @{
+  */ 
+#define ADC_Channel_0                               ((uint8_t)0x00)
+#define ADC_Channel_1                               ((uint8_t)0x01)
+#define ADC_Channel_2                               ((uint8_t)0x02)
+#define ADC_Channel_3                               ((uint8_t)0x03)
+#define ADC_Channel_4                               ((uint8_t)0x04)
+#define ADC_Channel_5                               ((uint8_t)0x05)
+#define ADC_Channel_6                               ((uint8_t)0x06)
+#define ADC_Channel_7                               ((uint8_t)0x07)
+#define ADC_Channel_8                               ((uint8_t)0x08)
+#define ADC_Channel_9                               ((uint8_t)0x09)
+#define ADC_Channel_10                              ((uint8_t)0x0A)
+#define ADC_Channel_11                              ((uint8_t)0x0B)
+#define ADC_Channel_12                              ((uint8_t)0x0C)
+#define ADC_Channel_13                              ((uint8_t)0x0D)
+#define ADC_Channel_14                              ((uint8_t)0x0E)
+#define ADC_Channel_15                              ((uint8_t)0x0F)
+#define ADC_Channel_16                              ((uint8_t)0x10)
+#define ADC_Channel_17                              ((uint8_t)0x11)
+#define ADC_Channel_18                              ((uint8_t)0x12)
+
+#if defined (STM32F40_41xxx)
+#define ADC_Channel_TempSensor                      ((uint8_t)ADC_Channel_16)
+#endif /* STM32F40_41xxx */
+
+#if defined (STM32F427_437xx) || defined (STM32F429_439xx) || defined (STM32F401xx)
+#define ADC_Channel_TempSensor                      ((uint8_t)ADC_Channel_18)
+#endif /* STM32F427_437xx || STM32F429_439xx || STM32F401xx */
+
+#define ADC_Channel_Vrefint                         ((uint8_t)ADC_Channel_17)
+#define ADC_Channel_Vbat                            ((uint8_t)ADC_Channel_18)
+
+#define IS_ADC_CHANNEL(CHANNEL) (((CHANNEL) == ADC_Channel_0) || \
+                                 ((CHANNEL) == ADC_Channel_1) || \
+                                 ((CHANNEL) == ADC_Channel_2) || \
+                                 ((CHANNEL) == ADC_Channel_3) || \
+                                 ((CHANNEL) == ADC_Channel_4) || \
+                                 ((CHANNEL) == ADC_Channel_5) || \
+                                 ((CHANNEL) == ADC_Channel_6) || \
+                                 ((CHANNEL) == ADC_Channel_7) || \
+                                 ((CHANNEL) == ADC_Channel_8) || \
+                                 ((CHANNEL) == ADC_Channel_9) || \
+                                 ((CHANNEL) == ADC_Channel_10) || \
+                                 ((CHANNEL) == ADC_Channel_11) || \
+                                 ((CHANNEL) == ADC_Channel_12) || \
+                                 ((CHANNEL) == ADC_Channel_13) || \
+                                 ((CHANNEL) == ADC_Channel_14) || \
+                                 ((CHANNEL) == ADC_Channel_15) || \
+                                 ((CHANNEL) == ADC_Channel_16) || \
+                                 ((CHANNEL) == ADC_Channel_17) || \
+                                 ((CHANNEL) == ADC_Channel_18))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_sampling_times 
+  * @{
+  */ 
+#define ADC_SampleTime_3Cycles                    ((uint8_t)0x00)
+#define ADC_SampleTime_15Cycles                   ((uint8_t)0x01)
+#define ADC_SampleTime_28Cycles                   ((uint8_t)0x02)
+#define ADC_SampleTime_56Cycles                   ((uint8_t)0x03)
+#define ADC_SampleTime_84Cycles                   ((uint8_t)0x04)
+#define ADC_SampleTime_112Cycles                  ((uint8_t)0x05)
+#define ADC_SampleTime_144Cycles                  ((uint8_t)0x06)
+#define ADC_SampleTime_480Cycles                  ((uint8_t)0x07)
+#define IS_ADC_SAMPLE_TIME(TIME) (((TIME) == ADC_SampleTime_3Cycles) || \
+                                  ((TIME) == ADC_SampleTime_15Cycles) || \
+                                  ((TIME) == ADC_SampleTime_28Cycles) || \
+                                  ((TIME) == ADC_SampleTime_56Cycles) || \
+                                  ((TIME) == ADC_SampleTime_84Cycles) || \
+                                  ((TIME) == ADC_SampleTime_112Cycles) || \
+                                  ((TIME) == ADC_SampleTime_144Cycles) || \
+                                  ((TIME) == ADC_SampleTime_480Cycles))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_external_trigger_edge_for_injected_channels_conversion 
+  * @{
+  */ 
+#define ADC_ExternalTrigInjecConvEdge_None          ((uint32_t)0x00000000)
+#define ADC_ExternalTrigInjecConvEdge_Rising        ((uint32_t)0x00100000)
+#define ADC_ExternalTrigInjecConvEdge_Falling       ((uint32_t)0x00200000)
+#define ADC_ExternalTrigInjecConvEdge_RisingFalling ((uint32_t)0x00300000)
+#define IS_ADC_EXT_INJEC_TRIG_EDGE(EDGE) (((EDGE) == ADC_ExternalTrigInjecConvEdge_None) || \
+                                          ((EDGE) == ADC_ExternalTrigInjecConvEdge_Rising) || \
+                                          ((EDGE) == ADC_ExternalTrigInjecConvEdge_Falling) || \
+                                          ((EDGE) == ADC_ExternalTrigInjecConvEdge_RisingFalling))
+                                            
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_extrenal_trigger_sources_for_injected_channels_conversion 
+  * @{
+  */ 
+#define ADC_ExternalTrigInjecConv_T1_CC4            ((uint32_t)0x00000000)
+#define ADC_ExternalTrigInjecConv_T1_TRGO           ((uint32_t)0x00010000)
+#define ADC_ExternalTrigInjecConv_T2_CC1            ((uint32_t)0x00020000)
+#define ADC_ExternalTrigInjecConv_T2_TRGO           ((uint32_t)0x00030000)
+#define ADC_ExternalTrigInjecConv_T3_CC2            ((uint32_t)0x00040000)
+#define ADC_ExternalTrigInjecConv_T3_CC4            ((uint32_t)0x00050000)
+#define ADC_ExternalTrigInjecConv_T4_CC1            ((uint32_t)0x00060000)
+#define ADC_ExternalTrigInjecConv_T4_CC2            ((uint32_t)0x00070000)
+#define ADC_ExternalTrigInjecConv_T4_CC3            ((uint32_t)0x00080000)
+#define ADC_ExternalTrigInjecConv_T4_TRGO           ((uint32_t)0x00090000)
+#define ADC_ExternalTrigInjecConv_T5_CC4            ((uint32_t)0x000A0000)
+#define ADC_ExternalTrigInjecConv_T5_TRGO           ((uint32_t)0x000B0000)
+#define ADC_ExternalTrigInjecConv_T8_CC2            ((uint32_t)0x000C0000)
+#define ADC_ExternalTrigInjecConv_T8_CC3            ((uint32_t)0x000D0000)
+#define ADC_ExternalTrigInjecConv_T8_CC4            ((uint32_t)0x000E0000)
+#define ADC_ExternalTrigInjecConv_Ext_IT15          ((uint32_t)0x000F0000)
+#define IS_ADC_EXT_INJEC_TRIG(INJTRIG) (((INJTRIG) == ADC_ExternalTrigInjecConv_T1_CC4) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T1_TRGO) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T2_CC1) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T2_TRGO) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T3_CC2) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T3_CC4) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T4_CC1) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T4_CC2) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T4_CC3) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T4_TRGO) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T5_CC4) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T5_TRGO) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T8_CC2) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T8_CC3) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_T8_CC4) || \
+                                        ((INJTRIG) == ADC_ExternalTrigInjecConv_Ext_IT15))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_injected_channel_selection 
+  * @{
+  */ 
+#define ADC_InjectedChannel_1                       ((uint8_t)0x14)
+#define ADC_InjectedChannel_2                       ((uint8_t)0x18)
+#define ADC_InjectedChannel_3                       ((uint8_t)0x1C)
+#define ADC_InjectedChannel_4                       ((uint8_t)0x20)
+#define IS_ADC_INJECTED_CHANNEL(CHANNEL) (((CHANNEL) == ADC_InjectedChannel_1) || \
+                                          ((CHANNEL) == ADC_InjectedChannel_2) || \
+                                          ((CHANNEL) == ADC_InjectedChannel_3) || \
+                                          ((CHANNEL) == ADC_InjectedChannel_4))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_analog_watchdog_selection 
+  * @{
+  */ 
+#define ADC_AnalogWatchdog_SingleRegEnable         ((uint32_t)0x00800200)
+#define ADC_AnalogWatchdog_SingleInjecEnable       ((uint32_t)0x00400200)
+#define ADC_AnalogWatchdog_SingleRegOrInjecEnable  ((uint32_t)0x00C00200)
+#define ADC_AnalogWatchdog_AllRegEnable            ((uint32_t)0x00800000)
+#define ADC_AnalogWatchdog_AllInjecEnable          ((uint32_t)0x00400000)
+#define ADC_AnalogWatchdog_AllRegAllInjecEnable    ((uint32_t)0x00C00000)
+#define ADC_AnalogWatchdog_None                    ((uint32_t)0x00000000)
+#define IS_ADC_ANALOG_WATCHDOG(WATCHDOG) (((WATCHDOG) == ADC_AnalogWatchdog_SingleRegEnable) || \
+                                          ((WATCHDOG) == ADC_AnalogWatchdog_SingleInjecEnable) || \
+                                          ((WATCHDOG) == ADC_AnalogWatchdog_SingleRegOrInjecEnable) || \
+                                          ((WATCHDOG) == ADC_AnalogWatchdog_AllRegEnable) || \
+                                          ((WATCHDOG) == ADC_AnalogWatchdog_AllInjecEnable) || \
+                                          ((WATCHDOG) == ADC_AnalogWatchdog_AllRegAllInjecEnable) || \
+                                          ((WATCHDOG) == ADC_AnalogWatchdog_None))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_interrupts_definition 
+  * @{
+  */ 
+#define ADC_IT_EOC                                 ((uint16_t)0x0205)  
+#define ADC_IT_AWD                                 ((uint16_t)0x0106)  
+#define ADC_IT_JEOC                                ((uint16_t)0x0407)  
+#define ADC_IT_OVR                                 ((uint16_t)0x201A)  
+#define IS_ADC_IT(IT) (((IT) == ADC_IT_EOC) || ((IT) == ADC_IT_AWD) || \
+                       ((IT) == ADC_IT_JEOC)|| ((IT) == ADC_IT_OVR)) 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_flags_definition 
+  * @{
+  */ 
+#define ADC_FLAG_AWD                               ((uint8_t)0x01)
+#define ADC_FLAG_EOC                               ((uint8_t)0x02)
+#define ADC_FLAG_JEOC                              ((uint8_t)0x04)
+#define ADC_FLAG_JSTRT                             ((uint8_t)0x08)
+#define ADC_FLAG_STRT                              ((uint8_t)0x10)
+#define ADC_FLAG_OVR                               ((uint8_t)0x20)   
+  
+#define IS_ADC_CLEAR_FLAG(FLAG) ((((FLAG) & (uint8_t)0xC0) == 0x00) && ((FLAG) != 0x00))   
+#define IS_ADC_GET_FLAG(FLAG) (((FLAG) == ADC_FLAG_AWD) || \
+                               ((FLAG) == ADC_FLAG_EOC) || \
+                               ((FLAG) == ADC_FLAG_JEOC) || \
+                               ((FLAG)== ADC_FLAG_JSTRT) || \
+                               ((FLAG) == ADC_FLAG_STRT) || \
+                               ((FLAG)== ADC_FLAG_OVR))     
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_thresholds 
+  * @{
+  */ 
+#define IS_ADC_THRESHOLD(THRESHOLD) ((THRESHOLD) <= 0xFFF)
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_injected_offset 
+  * @{
+  */ 
+#define IS_ADC_OFFSET(OFFSET) ((OFFSET) <= 0xFFF)
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_injected_length 
+  * @{
+  */ 
+#define IS_ADC_INJECTED_LENGTH(LENGTH) (((LENGTH) >= 0x1) && ((LENGTH) <= 0x4))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_injected_rank 
+  * @{
+  */ 
+#define IS_ADC_INJECTED_RANK(RANK) (((RANK) >= 0x1) && ((RANK) <= 0x4))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_regular_length 
+  * @{
+  */ 
+#define IS_ADC_REGULAR_LENGTH(LENGTH) (((LENGTH) >= 0x1) && ((LENGTH) <= 0x10))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_regular_rank 
+  * @{
+  */ 
+#define IS_ADC_REGULAR_RANK(RANK) (((RANK) >= 0x1) && ((RANK) <= 0x10))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup ADC_regular_discontinuous_mode_number 
+  * @{
+  */ 
+#define IS_ADC_REGULAR_DISC_NUMBER(NUMBER) (((NUMBER) >= 0x1) && ((NUMBER) <= 0x8))
+/**
+  * @}
+  */ 
+
+
+/**
+  * @}
+  */ 
+
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/  
+
+/*  Function used to set the ADC configuration to the default reset state *****/  
+void ADC_DeInit(void);
+
+/* Initialization and Configuration functions *********************************/
+void ADC_Init(ADC_TypeDef* ADCx, ADC_InitTypeDef* ADC_InitStruct);
+void ADC_StructInit(ADC_InitTypeDef* ADC_InitStruct);
+void ADC_CommonInit(ADC_CommonInitTypeDef* ADC_CommonInitStruct);
+void ADC_CommonStructInit(ADC_CommonInitTypeDef* ADC_CommonInitStruct);
+void ADC_Cmd(ADC_TypeDef* ADCx, FunctionalState NewState);
+
+/* Analog Watchdog configuration functions ************************************/
+void ADC_AnalogWatchdogCmd(ADC_TypeDef* ADCx, uint32_t ADC_AnalogWatchdog);
+void ADC_AnalogWatchdogThresholdsConfig(ADC_TypeDef* ADCx, uint16_t HighThreshold,uint16_t LowThreshold);
+void ADC_AnalogWatchdogSingleChannelConfig(ADC_TypeDef* ADCx, uint8_t ADC_Channel);
+
+/* Temperature Sensor, Vrefint and VBAT management functions ******************/
+void ADC_TempSensorVrefintCmd(FunctionalState NewState);
+void ADC_VBATCmd(FunctionalState NewState);
+
+/* Regular Channels Configuration functions ***********************************/
+void ADC_RegularChannelConfig(ADC_TypeDef* ADCx, uint8_t ADC_Channel, uint8_t Rank, uint8_t ADC_SampleTime);
+void ADC_SoftwareStartConv(ADC_TypeDef* ADCx);
+FlagStatus ADC_GetSoftwareStartConvStatus(ADC_TypeDef* ADCx);
+void ADC_EOCOnEachRegularChannelCmd(ADC_TypeDef* ADCx, FunctionalState NewState);
+void ADC_ContinuousModeCmd(ADC_TypeDef* ADCx, FunctionalState NewState);
+void ADC_DiscModeChannelCountConfig(ADC_TypeDef* ADCx, uint8_t Number);
+void ADC_DiscModeCmd(ADC_TypeDef* ADCx, FunctionalState NewState);
+uint16_t ADC_GetConversionValue(ADC_TypeDef* ADCx);
+uint32_t ADC_GetMultiModeConversionValue(void);
+
+/* Regular Channels DMA Configuration functions *******************************/
+void ADC_DMACmd(ADC_TypeDef* ADCx, FunctionalState NewState);
+void ADC_DMARequestAfterLastTransferCmd(ADC_TypeDef* ADCx, FunctionalState NewState);
+void ADC_MultiModeDMARequestAfterLastTransferCmd(FunctionalState NewState);
+
+/* Injected channels Configuration functions **********************************/
+void ADC_InjectedChannelConfig(ADC_TypeDef* ADCx, uint8_t ADC_Channel, uint8_t Rank, uint8_t ADC_SampleTime);
+void ADC_InjectedSequencerLengthConfig(ADC_TypeDef* ADCx, uint8_t Length);
+void ADC_SetInjectedOffset(ADC_TypeDef* ADCx, uint8_t ADC_InjectedChannel, uint16_t Offset);
+void ADC_ExternalTrigInjectedConvConfig(ADC_TypeDef* ADCx, uint32_t ADC_ExternalTrigInjecConv);
+void ADC_ExternalTrigInjectedConvEdgeConfig(ADC_TypeDef* ADCx, uint32_t ADC_ExternalTrigInjecConvEdge);
+void ADC_SoftwareStartInjectedConv(ADC_TypeDef* ADCx);
+FlagStatus ADC_GetSoftwareStartInjectedConvCmdStatus(ADC_TypeDef* ADCx);
+void ADC_AutoInjectedConvCmd(ADC_TypeDef* ADCx, FunctionalState NewState);
+void ADC_InjectedDiscModeCmd(ADC_TypeDef* ADCx, FunctionalState NewState);
+uint16_t ADC_GetInjectedConversionValue(ADC_TypeDef* ADCx, uint8_t ADC_InjectedChannel);
+
+/* Interrupts and flags management functions **********************************/
+void ADC_ITConfig(ADC_TypeDef* ADCx, uint16_t ADC_IT, FunctionalState NewState);
+FlagStatus ADC_GetFlagStatus(ADC_TypeDef* ADCx, uint8_t ADC_FLAG);
+void ADC_ClearFlag(ADC_TypeDef* ADCx, uint8_t ADC_FLAG);
+ITStatus ADC_GetITStatus(ADC_TypeDef* ADCx, uint16_t ADC_IT);
+void ADC_ClearITPendingBit(ADC_TypeDef* ADCx, uint16_t ADC_IT);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32F4xx_ADC_H */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm/main.c
+++ b/stm/main.c
@@ -40,6 +40,7 @@
 #include "pybwlan.h"
 #include "i2c.h"
 #include "usrsw.h"
+#include "adc.h"
 
 int errno;
 
@@ -839,6 +840,7 @@ soft_reset:
         rt_store_attr(m, qstr_from_str_static("I2C"), rt_make_function_n(2, pyb_I2C));
         rt_store_attr(m, qstr_from_str_static("gpio"), (mp_obj_t)&pyb_gpio_obj);
         rt_store_attr(m, qstr_from_str_static("Usart"), rt_make_function_n(2, pyb_Usart));
+        rt_store_attr(m, qstr_from_str_static("ADC"), rt_make_function_n(1, pyb_ADC));
         rt_store_name(qstr_from_str_static("pyb"), m);
 
         rt_store_name(qstr_from_str_static("open"), rt_make_function_n(2, pyb_io_open));


### PR DESCRIPTION
- Add missing ADC driver from STM32F4xx_StdPeriph_Lib_V1.3.0
