### PR TITLE
Add RT_BINARY_OP_SUBSCR_STORE and implement rt_store_subscr() in its terms

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -94,7 +94,7 @@ typedef mp_obj_t (*mp_make_new_fun_t)(mp_obj_t type_in, int n_args, const mp_obj
 typedef mp_obj_t (*mp_call_n_fun_t)(mp_obj_t fun, int n_args, const mp_obj_t *args); // args are in reverse order in the array
 typedef mp_obj_t (*mp_call_n_kw_fun_t)(mp_obj_t fun, int n_args, int n_kw, const mp_obj_t *args); // args are in reverse order in the array
 typedef mp_obj_t (*mp_unary_op_fun_t)(int op, mp_obj_t);
-typedef mp_obj_t (*mp_binary_op_fun_t)(int op, mp_obj_t, mp_obj_t);
+typedef mp_obj_t (*mp_binary_op_fun_t)(int op, mp_obj_t, mp_obj_t, ...);
 typedef void (*mp_load_attr_fun_t)(mp_obj_t self_in, qstr attr, mp_obj_t *dest); // for fail, do nothing; for attr, dest[1] = value; for method, dest[0] = self, dest[1] = method
 typedef bool (*mp_store_attr_fun_t)(mp_obj_t self_in, qstr attr, mp_obj_t value); // return true if store succeeded
 

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -79,7 +79,7 @@ static mp_obj_t complex_unary_op(int op, mp_obj_t o_in) {
     }
 }
 
-static mp_obj_t complex_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
+static mp_obj_t complex_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in, ...) {
     mp_obj_complex_t *lhs = lhs_in;
     return mp_obj_complex_binary_op(op, lhs->real, lhs->imag, rhs_in);
 }

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -53,7 +53,7 @@ static mp_obj_t float_unary_op(int op, mp_obj_t o_in) {
     }
 }
 
-static mp_obj_t float_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
+static mp_obj_t float_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in, ...) {
     mp_obj_float_t *lhs = lhs_in;
     if (MP_OBJ_IS_TYPE(rhs_in, &complex_type)) {
         return mp_obj_complex_binary_op(op, lhs->value, 0, rhs_in);

--- a/py/objint.c
+++ b/py/objint.c
@@ -49,7 +49,7 @@ void int_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj
 }
 
 // This is called only for non-SMALL_INT
-mp_obj_t int_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
+mp_obj_t int_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in, ...) {
     assert(0);
     return mp_const_none;
 }

--- a/py/objint.h
+++ b/py/objint.h
@@ -6,4 +6,4 @@ typedef struct _mp_obj_int_t {
 } mp_obj_int_t;
 
 void int_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind);
-mp_obj_t int_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in);
+mp_obj_t int_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in, ...);

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -28,7 +28,7 @@ void int_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj
     print(env, "%lld" SUFFIX, self->val);
 }
 
-mp_obj_t int_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
+mp_obj_t int_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in, ...) {
     mp_obj_int_t *lhs = lhs_in;
     mp_obj_int_t *rhs = rhs_in;
     long long rhs_val;

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdarg.h>
 #include <assert.h>
 
 #include "nlr.h"
@@ -117,7 +118,7 @@ static bool list_cmp_helper(int op, mp_obj_t self_in, mp_obj_t another_in) {
     return true;
 }
 
-static mp_obj_t list_binary_op(int op, mp_obj_t lhs, mp_obj_t rhs) {
+static mp_obj_t list_binary_op(int op, mp_obj_t lhs, mp_obj_t rhs, ...) {
     mp_obj_list_t *o = lhs;
     switch (op) {
         case RT_BINARY_OP_SUBSCR:
@@ -125,6 +126,16 @@ static mp_obj_t list_binary_op(int op, mp_obj_t lhs, mp_obj_t rhs) {
             // list load
             uint index = mp_get_index(o->base.type, o->len, rhs);
             return o->items[index];
+        }
+        case RT_BINARY_OP_SUBSCR_STORE:
+        {
+            va_list args;
+            va_start(args, rhs);
+            mp_obj_t val = va_arg(args, mp_obj_t);
+            va_end(args);
+            uint index = mp_get_index(o->base.type, o->len, rhs);
+            o->items[index] = val;
+            return val;
         }
         case RT_BINARY_OP_ADD:
         {

--- a/py/objset.c
+++ b/py/objset.c
@@ -375,7 +375,7 @@ static mp_obj_t set_union(mp_obj_t self_in, mp_obj_t other_in) {
 static MP_DEFINE_CONST_FUN_OBJ_2(set_union_obj, set_union);
 
 
-static mp_obj_t set_binary_op(int op, mp_obj_t lhs, mp_obj_t rhs) {
+static mp_obj_t set_binary_op(int op, mp_obj_t lhs, mp_obj_t rhs, ...) {
     mp_obj_t args[] = {lhs, rhs};
     switch (op) {
     case RT_BINARY_OP_OR:

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -32,7 +32,7 @@ void str_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj
     }
 }
 
-mp_obj_t str_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
+mp_obj_t str_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in, ...) {
     mp_obj_str_t *lhs = lhs_in;
     const char *lhs_str = qstr_str(lhs->qstr);
     switch (op) {

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -72,7 +72,7 @@ static mp_obj_t tuple_make_new(mp_obj_t type_in, int n_args, const mp_obj_t *arg
     }
 }
 
-static mp_obj_t tuple_binary_op(int op, mp_obj_t lhs, mp_obj_t rhs) {
+static mp_obj_t tuple_binary_op(int op, mp_obj_t lhs, mp_obj_t rhs, ...) {
     mp_obj_tuple_t *o = lhs;
     switch (op) {
         case RT_BINARY_OP_SUBSCR:

--- a/py/runtime0.h
+++ b/py/runtime0.h
@@ -7,6 +7,7 @@ typedef enum {
 
 typedef enum {
     RT_BINARY_OP_SUBSCR,
+    RT_BINARY_OP_SUBSCR_STORE,
     RT_BINARY_OP_OR,
     RT_BINARY_OP_XOR,
     RT_BINARY_OP_AND,


### PR DESCRIPTION
This allows types to implement **setitem**() and thus properly support
Python sequence/dictionary protocols.

Addresses #186.
