### PR TITLE
Implement modules as singletons Python semantics.

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -28,8 +28,13 @@ mp_obj_t mp_builtin___import__(int n_args, mp_obj_t *args) {
     }
     */
 
-    // find the file to import
     qstr mod_name = mp_obj_get_qstr(args[0]);
+    mp_obj_t loaded = mp_obj_module_get(mod_name);
+    if (loaded != MP_OBJ_NULL) {
+        return loaded;
+    }
+
+    // find the file to import
     mp_lexer_t *lex = mp_import_open_file(mod_name);
     if (lex == NULL) {
         // TODO handle lexer error correctly

--- a/py/obj.h
+++ b/py/obj.h
@@ -356,6 +356,7 @@ extern const mp_obj_type_t gen_instance_type;
 // module
 extern const mp_obj_type_t module_type;
 mp_obj_t mp_obj_new_module(qstr module_name);
+mp_obj_t mp_obj_module_get(qstr module_name);
 struct _mp_map_t *mp_obj_module_get_globals(mp_obj_t self_in);
 
 // staticmethod and classmethod types; defined here so we can make const versions


### PR DESCRIPTION
In Python, importing module several times returns same underlying module
object. This also fixes import statement handling for builtin modules.

There're still issues:
1. CPython exposes set of loaded modules as sys.modules, we may want to
do that either.
2. Builtin modules are implicitly imported, which is not really correct.
We should separate registering a (builtin) module and importing a module.
CPython keeps builtin module names in sys.builtin_module_names .
