### PR TITLE
Expose memory stats functions via "micropython" module.

### DIFF
--- a/py/builtin.h
+++ b/py/builtin.h
@@ -26,3 +26,7 @@ MP_DECLARE_CONST_FUN_OBJ(mp_builtin_repr_obj);
 MP_DECLARE_CONST_FUN_OBJ(mp_builtin_sorted_obj);
 MP_DECLARE_CONST_FUN_OBJ(mp_builtin_sum_obj);
 MP_DECLARE_CONST_FUN_OBJ(mp_builtin_str_obj);
+
+MP_DECLARE_CONST_FUN_OBJ(mp_builtin_mem_total_obj);
+MP_DECLARE_CONST_FUN_OBJ(mp_builtin_mem_current_obj);
+MP_DECLARE_CONST_FUN_OBJ(mp_builtin_mem_peak_obj);

--- a/py/builtinmp.c
+++ b/py/builtinmp.c
@@ -1,0 +1,32 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <assert.h>
+
+#include "misc.h"
+#include "mpconfig.h"
+#include "obj.h"
+#include "builtin.h"
+
+// Various builtins specific to MicroPython runtime,
+// living in micropython module
+
+#if MICROPY_MEM_STATS
+static mp_obj_t mem_total() {
+    return MP_OBJ_NEW_SMALL_INT(m_get_total_bytes_allocated());
+}
+
+static mp_obj_t mem_current() {
+    return MP_OBJ_NEW_SMALL_INT(m_get_current_bytes_allocated());
+}
+
+static mp_obj_t mem_peak() {
+    return MP_OBJ_NEW_SMALL_INT(m_get_peak_bytes_allocated());
+}
+
+MP_DEFINE_CONST_FUN_OBJ_0(mp_builtin_mem_total_obj, mem_total);
+MP_DEFINE_CONST_FUN_OBJ_0(mp_builtin_mem_current_obj, mem_current);
+MP_DEFINE_CONST_FUN_OBJ_0(mp_builtin_mem_peak_obj, mem_peak);
+#endif

--- a/py/py.mk
+++ b/py/py.mk
@@ -101,6 +101,7 @@ PY_O_BASENAME = \
 	builtin.o \
 	builtinimport.o \
 	builtineval.o \
+	builtinmp.o \
 	vm.o \
 	showbc.o \
 	repl.o \

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -153,13 +153,16 @@ void rt_init(void) {
     mp_map_add_qstr(&map_builtins, MP_QSTR_bytearray, (mp_obj_t)&mp_builtin_bytearray_obj);
 
 #if MICROPY_CPYTHON_COMPAT
-    // Add (empty) micropython module, so it was possible to "import micropython",
-    // which can be a placeholder module on CPython.
-    mp_obj_t m_mp = mp_obj_new_module(qstr_from_str_static("micropython"));
-    rt_store_name(qstr_from_str_static("micropython"), m_mp);
-
     // Precreate sys module, so "import sys" didn't throw exceptions.
     mp_obj_new_module(qstr_from_str_static("sys"));
+#endif
+
+    mp_obj_t m_mp = mp_obj_new_module(qstr_from_str_static("micropython"));
+    rt_store_name(qstr_from_str_static("micropython"), m_mp);
+#if MICROPY_MEM_STATS
+    rt_store_attr(m_mp, qstr_from_str_static("mem_total"), (mp_obj_t)&mp_builtin_mem_total_obj);
+    rt_store_attr(m_mp, qstr_from_str_static("mem_current"), (mp_obj_t)&mp_builtin_mem_current_obj);
+    rt_store_attr(m_mp, qstr_from_str_static("mem_peak"), (mp_obj_t)&mp_builtin_mem_peak_obj);
 #endif
 
     next_unique_code_id = 1; // 0 indicates "no code"


### PR DESCRIPTION
These are micropython.mem_total(), .mem_current(), .mem_peak(). These are 3
individual functions with simple scalar return value to make sure that
calls to these functions themselves have minimal (hopefully zero) impact on
memory allocation.
