### PR TITLE
Fix support for STM32F4DISCOVERY

### DIFF
--- a/stm/lib/stm324x7i_eval.h
+++ b/stm/lib/stm324x7i_eval.h
@@ -49,6 +49,11 @@
 #define SD_DETECT_PIN                    GPIO_Pin_8                  /* PA..8 */
 #define SD_DETECT_GPIO_PORT              GPIOA                       /* GPIOA */
 #define SD_DETECT_GPIO_CLK               RCC_AHB1Periph_GPIOA
+#elif defined(STM32F4DISC)
+// PB15 on the DM-STSTF4BB Base Board
+#define SD_DETECT_PIN                    GPIO_Pin_15                 /* PB.15 */
+#define SD_DETECT_GPIO_PORT              GPIOB                       /* GPIOB */
+#define SD_DETECT_GPIO_CLK               RCC_AHB1Periph_GPIOB
 #endif
 
 #define SDIO_FIFO_ADDRESS                ((uint32_t)0x40012C80)

--- a/stm/main.c
+++ b/stm/main.c
@@ -763,7 +763,11 @@ int main(void) {
     NVIC_PriorityGroupConfig(NVIC_PriorityGroup_4);
 
     // enable the CCM RAM and the GPIO's
-    RCC->AHB1ENR |= RCC_AHB1ENR_CCMDATARAMEN | RCC_AHB1ENR_GPIOAEN | RCC_AHB1ENR_GPIOBEN | RCC_AHB1ENR_GPIOCEN;
+    RCC->AHB1ENR |= RCC_AHB1ENR_CCMDATARAMEN | RCC_AHB1ENR_GPIOAEN | RCC_AHB1ENR_GPIOBEN | RCC_AHB1ENR_GPIOCEN
+#if defined(STM32F4DISC)
+        | RCC_AHB1ENR_GPIODEN
+#endif
+        ;
 
     // configure SDIO pins to be high to start with (apparently makes it more robust)
     {
@@ -843,9 +847,11 @@ soft_reset:
         rt_store_attr(m, MP_QSTR_switch, (mp_obj_t)&pyb_switch_obj);
         rt_store_attr(m, MP_QSTR_servo, rt_make_function_n(2, pyb_servo_set));
         rt_store_attr(m, MP_QSTR_pwm, rt_make_function_n(2, pyb_pwm_set));
+#if BOARD_HAS_MMA7660
         rt_store_attr(m, MP_QSTR_accel, (mp_obj_t)&pyb_mma_read_obj);
         rt_store_attr(m, MP_QSTR_mma_read, (mp_obj_t)&pyb_mma_read_all_obj);
         rt_store_attr(m, MP_QSTR_mma_mode, (mp_obj_t)&pyb_mma_write_mode_obj);
+#endif
         rt_store_attr(m, MP_QSTR_hid, rt_make_function_n(1, pyb_hid_send_report));
         rt_store_attr(m, MP_QSTR_time, rt_make_function_n(0, pyb_rtc_read));
         rt_store_attr(m, MP_QSTR_rand, rt_make_function_n(0, pyb_rng_get));
@@ -962,8 +968,10 @@ soft_reset:
 
     // MMA
     if (first_soft_reset) {
+#if BOARD_HAS_MMA7660
         // init and reset address to zero
         mma_init();
+#endif
     }
 
     // turn boot-up LED off
@@ -1135,6 +1143,7 @@ soft_reset:
         }
     }
 
+#if BOARD_HAS_MMA7660
     // HID example
     if (0) {
         uint8_t data[4];
@@ -1163,6 +1172,7 @@ soft_reset:
             sys_tick_delay_ms(15);
         }
     }
+#endif
 
     // wifi
     //pyb_wlan_init();

--- a/stm/mpconfigport.h
+++ b/stm/mpconfigport.h
@@ -27,6 +27,14 @@ machine_float_t machine_sqrt(machine_float_t x);
 #define PYBOARD4
 //#define STM32F4DISC
 
+#if defined(PYBOARD) || defined(PYBOARD4)
+#define BOARD_HAS_MMA7660   (1)
+#define BOARD_HAS_LIS3DSH   (0)
+#else
+#define BOARD_HAS_MMA7660   (0)
+#define BOARD_HAS_LIS3DSH   (1)
+#endif
+
 #define STM32F40_41xxx
 #define USE_STDPERIPH_DRIVER
 #define HSE_VALUE (8000000)


### PR DESCRIPTION
Enable GPIO Port D for the Discovery (since the 4 LEDs are on PortD)
Disable MMA7660 support for Discovery
Added PB15 SD Card detect (the DM-STF4BB Base Board has an SDCard slot on it, and the card detect is connected to PB15)
