### PR TITLE
Add support for freeing code emitter objects at the end of compilation.

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -3155,6 +3155,9 @@ mp_obj_t mp_compile(mp_parse_node_t pn, qstr source_file, bool is_repl) {
     }
 
     bool had_error = comp->had_error;
+    if (comp->emit_method_table->free != NULL) {
+        comp->emit_method_table->free(comp->emit);
+    }
     m_del_obj(compiler_t, comp);
     uint unique_code_id = module_scope->unique_code_id;
     for (scope_t *s = module_scope; s;) {

--- a/py/emit.h
+++ b/py/emit.h
@@ -17,6 +17,8 @@ typedef enum {
 typedef struct _emit_t emit_t;
 
 typedef struct _emit_method_table_t {
+    void (*free)(emit_t *emit);
+
     void (*set_native_types)(emit_t *emit, bool do_native_types);
     void (*start_pass)(emit_t *emit, pass_kind_t pass, scope_t *scope);
     void (*end_pass)(emit_t *emit);

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -43,6 +43,11 @@ emit_t *emit_bc_new(uint max_num_labels) {
     return emit;
 }
 
+static void emit_bc_free(emit_t *emit) {
+    m_del(uint, emit->label_offsets, emit->max_num_labels);
+    m_del_obj(emit_t, emit);
+}
+
 // all functions must go through this one to emit code info
 static byte* emit_get_cur_to_write_code_info(emit_t* emit, int num_bytes_to_write) {
     //printf("emit %d\n", num_bytes_to_write);
@@ -751,6 +756,8 @@ static void emit_bc_yield_from(emit_t *emit) {
 }
 
 const emit_method_table_t emit_bc_method_table = {
+    emit_bc_free,
+
     emit_bc_set_native_types,
     emit_bc_start_pass,
     emit_bc_end_pass,

--- a/py/emitcpy.c
+++ b/py/emitcpy.c
@@ -796,6 +796,8 @@ static void emit_cpy_yield_from(emit_t *emit) {
 }
 
 const emit_method_table_t emit_cpython_method_table = {
+    NULL,
+
     emit_cpy_set_native_types,
     emit_cpy_start_pass,
     emit_cpy_end_pass,

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -146,6 +146,15 @@ emit_t *EXPORT_FUN(new)(uint max_num_labels) {
     return emit;
 }
 
+static void emit_native_free(emit_t *emit) {
+#if N_X64
+    asm_x64_free(emit->as, false);
+#elif N_THUMB
+    asm_thumb_free(emit->as, false);
+#endif
+    m_del_obj(emit_t, emit);
+}
+
 static void emit_native_set_viper_types(emit_t *emit, bool do_viper_types) {
     emit->do_viper_types = do_viper_types;
 }
@@ -1226,6 +1235,8 @@ static void emit_native_yield_from(emit_t *emit) {
 }
 
 const emit_method_table_t EXPORT_FUN(method_table) = {
+    emit_native_free,
+
     emit_native_set_viper_types,
     emit_native_start_pass,
     emit_native_end_pass,

--- a/py/emitpass1.c
+++ b/py/emitpass1.c
@@ -97,6 +97,8 @@ static void emit_pass1_delete_id(emit_t *emit, qstr qstr) {
 }
 
 const emit_method_table_t emit_pass1_method_table = {
+    emit_pass1_free,
+
     (void*)emit_pass1_dummy,
     emit_pass1_start_pass,
     emit_pass1_end_pass,


### PR DESCRIPTION
Per https://github.com/micropython/micropython/pull/214#issuecomment-33176425 .
