### PR TITLE
Draft: try to free parse tree after compilation

### DIFF
--- a/py/parse.c
+++ b/py/parse.c
@@ -135,6 +135,20 @@ mp_parse_node_struct_t *parse_node_new_struct(int src_line, int rule_id, int num
     return pn;
 }
 
+int parse_node_free_struct(mp_parse_node_t pn_in) {
+    int cnt = 0;
+    if (MP_PARSE_NODE_IS_STRUCT(pn_in)) {
+        mp_parse_node_struct_t *pn = (mp_parse_node_struct_t *)pn_in;
+        int n = pn->kind_num_nodes >> 8;
+        for (int i = 0; i < n; i++) {
+            cnt += parse_node_free_struct(pn->nodes[i]);
+        }
+        m_del_var(mp_parse_node_struct_t, mp_parse_node_t, n, pn);
+        cnt++;
+    }
+    return cnt;
+}
+
 #if MICROPY_DEBUG_PRINTERS
 void mp_parse_node_print(mp_parse_node_t pn, int indent) {
     if (MP_PARSE_NODE_IS_STRUCT(pn)) {

--- a/py/parse.h
+++ b/py/parse.h
@@ -53,6 +53,7 @@ typedef struct _mp_parse_node_struct_t {
 #define MP_PARSE_NODE_STRUCT_NUM_NODES(pns) ((pns)->kind_num_nodes >> 8)
 
 mp_parse_node_t mp_parse_node_new_leaf(machine_int_t kind, machine_int_t arg);
+int parse_node_free_struct(mp_parse_node_t pn_in);
 
 void mp_parse_node_print(mp_parse_node_t pn, int indent);
 

--- a/unix/main.c
+++ b/unix/main.c
@@ -62,6 +62,7 @@ static void execute_from_lexer(mp_lexer_t *lex, mp_parse_input_kind_t input_kind
     */
 
     mp_obj_t module_fun = mp_compile(pn, source_name, is_repl);
+    parse_node_free_struct(pn);
 
     if (module_fun == mp_const_none) {
         // compile error


### PR DESCRIPTION
So, this would conclude series of "use explicit memory management during compilation phase" - with it, I get strictly bytecode buffer, code object and function object un-freed after compile - with simple expression at interactive prompt.

But it fails miserably on testsuite with double-free and plain segfaults. Double-free's hint that it's not a tree, but acyclic graph. But looking at some segfault, I saw:

```
#2540 0x0804b5cf in parse_node_free_struct (pn_in=134747584) at ../py/parse.c:144
#2541 0x0804b5cf in parse_node_free_struct (pn_in=134746360) at ../py/parse.c:144
#2542 0x0804b5cf in parse_node_free_struct (pn_in=134747584) at ../py/parse.c:144
#2543 0x0804b5cf in parse_node_free_struct (pn_in=134746360) at ../py/parse.c:144
#2544 0x0804b5cf in parse_node_free_struct (pn_in=134747584) at ../py/parse.c:144
#2545 0x0804b5cf in parse_node_free_struct (pn_in=134746360) at ../py/parse.c:144
#2546 0x0804b5cf in parse_node_free_struct (pn_in=134747584) at ../py/parse.c:144
```

So, it's not even acyclic sometimes, and loops until stack overflow. Damien, would you have ideas how to do that right quickly? (My idea is that some node kinds should be filtered regarding arg recursion, but digging for specifics is ... well, digging too deep ;-) ). Also, do you have an idea if that would clean up properly in case of various errors during lexing/parsing/compiling (like, is there a chance that some node may not link subtrees and they will be left separate, not reachable from result_stack[0]?)
