### PR TITLE
Fixed dependency problem for qstrdefs.generated.h

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -65,7 +65,7 @@ ifneq ($(PROG),)
 all: $(PROG)
 
 $(PROG): $(OBJ)
-	$(ECHO) "LINK $<"
+	$(ECHO) "LINK $@"
 	$(Q)$(CC) -o $@ $(OBJ) $(LIB) $(LDFLAGS)
 ifndef DEBUG
 	$(Q)strip $(PROG)

--- a/py/py.mk
+++ b/py/py.mk
@@ -78,7 +78,7 @@ PY_O = $(addprefix $(PY_BUILD)/, $(PY_O_BASENAME))
 
 # Adding an order only dependency on $(PY_BUILD) causes $(PY_BUILD) to get
 # created before we run the script to generate the .h
-$(PY_BUILD)/qstrdefs.generated.h: | $(PY_BUILD)
+$(PY_BUILD)/qstrdefs.generated.h: | $(PY_BUILD)/
 $(PY_BUILD)/qstrdefs.generated.h: $(PY_QSTR_DEFS) $(QSTR_DEFS) $(PY_SRC)/makeqstrdata.py
 	$(ECHO) "makeqstrdata $(PY_QSTR_DEFS) $(QSTR_DEFS)"
 	$(Q)python $(PY_SRC)/makeqstrdata.py $(PY_QSTR_DEFS) $(QSTR_DEFS) > $@


### PR DESCRIPTION
The problem manifests itself in make 4.0

I also fixed the LINK message when linking the final executable for unix and unix-cpy.
