### PR TITLE
unix Makefile: -Og doesn't work (at least) with gcc 4.6 below.

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -15,7 +15,7 @@ LDFLAGS = -lm
 
 #Debugging/Optimization
 ifdef DEBUG
-CFLAGS += -Og -ggdb
+CFLAGS += -O0 -g
 else
 CFLAGS += -Os #-DNDEBUG
 endif


### PR DESCRIPTION
I'm using standard gcc 4.6 from Ubuntu 12.04LTS, and that doesn't understand -Og. And there's no reason not to support even older versions.

Also, not sure why there's -ggdb, look again like some workaround for particular environment (embedded? non-native open-source POSIX?), but that hardly should be forced on generic POSIX port. So, -g should be enough to select native debug format for a particular toolchain
