### PR TITLE
Added Windows port (see #233)

### DIFF
--- a/py/asmx64.c
+++ b/py/asmx64.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>

--- a/py/nlrx86.S
+++ b/py/nlrx86.S
@@ -5,13 +5,14 @@
     .text
 
 /* uint nlr_push(4(%esp)=nlr_buf_t *nlr) */
-#ifdef __apple_build_version__
+#ifdef _WIN32
+    .globl  _nlr_push
+    .def    _nlr_push; .scl 2; .type 32; .endef
+_nlr_push:
+#else
     .globl  nlr_push
     .type   nlr_push, @function
 nlr_push:
-#else
-    .globl  _nlr_push
-_nlr_push:
 #endif
     mov     4(%esp), %edx           # load nlr_buf
     mov     (%esp), %eax            # load return %ip
@@ -26,35 +27,37 @@ _nlr_push:
     mov     %edx, nlr_top           # stor new nlr_buf (to make linked list)
     xor     %eax, %eax              # return 0, normal return
     ret                             # return
-#ifdef __apple_build_version__
+#ifndef _WIN32
     .size   nlr_push, .-nlr_push
 #endif
 
 /* void nlr_pop() */
-#ifdef __apple_build_version__
+#ifdef _WIN32
+    .globl  _nlr_pop
+    .def    _nlr_pop; .scl 2; .type 32; .endef
+_nlr_pop:
+#else
     .globl  nlr_pop
     .type   nlr_pop, @function
 nlr_pop:
-#else
-    .globl  _nlr_pop
-_nlr_pop:
 #endif
     mov     nlr_top, %eax           # load nlr_top
     mov     (%eax), %eax            # load prev nlr_buf
     mov     %eax, nlr_top           # store nlr_top (to unlink list)
     ret                             # return
-#ifdef __apple_build_version__
+#ifndef _WIN32
     .size   nlr_pop, .-nlr_pop
 #endif
 
 /* void nlr_jump(4(%esp)=uint val) */
-#ifdef __apple_build_version__
+#ifdef _WIN32
+    .globl  _nlr_jump
+    .def    _nlr_jump; .scl 2; .type 32; .endef
+_nlr_jump:
+#else
     .globl  nlr_jump
     .type   nlr_jump, @function
 nlr_jump:
-#else
-    .globl  _nlr_jump
-    _nlr_jump:
 #endif
     mov     nlr_top, %edx           # load nlr_top
     mov     4(%esp), %eax           # load return value
@@ -71,12 +74,13 @@ nlr_jump:
     xor     %eax, %eax              # clear return register
     inc     %al                     # increase to make 1, non-local return
     ret                             # return
-#ifdef __apple_build_version__
+#ifndef _WIN32
     .size   nlr_jump, .-nlr_jump
 #endif
 
-#ifdef __apple_build_version__
+#ifndef _WIN32
     .local  nlr_top
 #endif
     .comm   nlr_top,4,4
-#endif
+
+#endif /* __i386__ */

--- a/py/nlrx86.S
+++ b/py/nlrx86.S
@@ -5,9 +5,14 @@
     .text
 
 /* uint nlr_push(4(%esp)=nlr_buf_t *nlr) */
+#ifdef __apple_build_version__
     .globl  nlr_push
     .type   nlr_push, @function
 nlr_push:
+#else
+    .globl  _nlr_push
+_nlr_push:
+#endif
     mov     4(%esp), %edx           # load nlr_buf
     mov     (%esp), %eax            # load return %ip
     mov     %eax, 8(%edx)           # store %ip into nlr_buf+8
@@ -21,22 +26,36 @@ nlr_push:
     mov     %edx, nlr_top           # stor new nlr_buf (to make linked list)
     xor     %eax, %eax              # return 0, normal return
     ret                             # return
+#ifdef __apple_build_version__
     .size   nlr_push, .-nlr_push
+#endif
 
 /* void nlr_pop() */
+#ifdef __apple_build_version__
     .globl  nlr_pop
     .type   nlr_pop, @function
 nlr_pop:
+#else
+    .globl  _nlr_pop
+_nlr_pop:
+#endif
     mov     nlr_top, %eax           # load nlr_top
     mov     (%eax), %eax            # load prev nlr_buf
     mov     %eax, nlr_top           # store nlr_top (to unlink list)
     ret                             # return
+#ifdef __apple_build_version__
     .size   nlr_pop, .-nlr_pop
+#endif
 
 /* void nlr_jump(4(%esp)=uint val) */
+#ifdef __apple_build_version__
     .globl  nlr_jump
     .type   nlr_jump, @function
 nlr_jump:
+#else
+    .globl  _nlr_jump
+    _nlr_jump:
+#endif
     mov     nlr_top, %edx           # load nlr_top
     mov     4(%esp), %eax           # load return value
     mov     %eax, 4(%edx)           # store return value
@@ -52,8 +71,12 @@ nlr_jump:
     xor     %eax, %eax              # clear return register
     inc     %al                     # increase to make 1, non-local return
     ret                             # return
+#ifdef __apple_build_version__
     .size   nlr_jump, .-nlr_jump
+#endif
 
+#ifdef __apple_build_version__
     .local  nlr_top
+#endif
     .comm   nlr_top,4,4
 #endif

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -1,55 +1,51 @@
-#!/usr/bin/env bash
+#! /usr/bin/env python3.3
 
-RM="/bin/rm -f"
-CPYTHON3=python3.3
-MP_PY=../unix/micropython
+import os
+import subprocess
+import sys
+from glob import glob
 
-numtests=0
-numtestcases=0
-numpassed=0
-numfailed=0
-namefailed=
+if os.name == 'nt':
+    CPYTHON3 = 'python3.3.exe'
+    MP_PY = '../windows/micropython.exe'
+else:
+    CPYTHON3 = 'python3.3'
+    MP_PY = '../unix/micropython'
 
-if [ $# -eq 0 ]
-then
-    tests="basics/*.py io/*.py"
-else
-    tests="$@"
-fi
 
-for infile in $tests
-do
-    basename=`basename $infile .py`
-    outfile=${basename}.out
-    expfile=${basename}.exp
+test_count = 0
+testcase_count = 0
+passed_count = 0
+failed_tests = []
+tests = []
 
-    $CPYTHON3 -B $infile > $expfile
-    $MP_PY $infile > $outfile
-    ((numtestcases = numtestcases + $(cat $expfile | wc -l)))
+if not sys.argv[1:]:
+    tests = glob('basics/*.py') + glob('io/*.py')
+else:
+    tests = sys.argv[1:]
 
-    diff --brief $expfile $outfile > /dev/null
+for test_file in tests:
+    test_name = os.path.splitext(os.path.basename(test_file))[0]
 
-    if [ $? -eq 0 ]
-    then
-        echo "pass  $infile"
-        $RM $outfile
-        $RM $expfile
-        ((numpassed=numpassed + 1))
-    else
-        echo "FAIL  $infile"
-        ((numfailed=numfailed + 1))
-        namefailed="$namefailed $basename"
-    fi
+    output_expected = subprocess.check_output([CPYTHON3, '-B', test_file])
+    output_mypy = subprocess.check_output([MP_PY, test_file])
 
-    ((numtests=numtests + 1))
-done
+    testcase_count += len(output_expected.splitlines())
 
-echo "$numtests tests performed ($numtestcases individual testcases)"
-echo "$numpassed tests passed"
-if [[ $numfailed != 0 ]]
-then
-    echo "$numfailed tests failed -$namefailed"
-    exit 1
-else
-    exit 0
-fi
+    if output_expected != output_mypy:
+        print("pass ", test_file)
+        passed_count += 1
+    else:
+        print("FAIL ", test_file)
+        failed_tests.append(test_name)
+
+    test_count += 1
+
+print("{} tests performed ({} individual testcases)".format(test_count,
+                                                            testcase_count))
+print("{} tests passed".format(passed_count))
+
+if len(failed_tests) > 0:
+    print("{} tests failed: {}".format(len(failed_tests),
+                                       ' '.join(failed_tests)))
+    sys.exit(1)

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -1,0 +1,36 @@
+include ../py/mkenv.mk
+
+# define main target
+PROG = micropython.exe
+
+# qstr definitions (must come before including py.mk)
+QSTR_DEFS = qstrdefsport.h
+
+# include py core make definitions
+include ../py/py.mk
+
+# compiler settings
+CFLAGS = -I. -I$(PY_SRC) -Wall -Werror -ansi -std=gnu99 -DUNIX
+LDFLAGS = -lm
+
+# Debugging/Optimization
+ifdef DEBUG
+CFLAGS += -O0 -g
+else
+CFLAGS += -Os #-DNDEBUG
+endif
+
+# source files
+SRC_C = \
+	main.c \
+	file.c \
+
+OBJ = $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+LIB = -lreadline
+LIB += -lws2_32
+LIB += -lmman
+# the following is needed for BSD
+#LIB += -ltermcap
+
+include ../py/mkrules.mk
+

--- a/windows/file.c
+++ b/windows/file.c
@@ -1,0 +1,2 @@
+#include <stdio.h>
+#include "../unix/file.c"

--- a/windows/main.c
+++ b/windows/main.c
@@ -1,0 +1,5 @@
+#include "../unix/main.c"
+
+void rawsocket_init() {
+    // Do nothing here
+}

--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -1,0 +1,36 @@
+// options to control how Micro Python is built
+
+// Linking with GNU readline causes binary to be licensed under GPL
+#ifndef MICROPY_USE_READLINE
+#define MICROPY_USE_READLINE        (1)
+#endif
+
+#define MICROPY_EMIT_X64            (1)
+#define MICROPY_EMIT_THUMB          (0)
+#define MICROPY_EMIT_INLINE_THUMB   (0)
+#define MICROPY_MEM_STATS           (1)
+#define MICROPY_DEBUG_PRINTERS      (1)
+#define MICROPY_ENABLE_REPL_HELPERS (1)
+#define MICROPY_ENABLE_LEXER_UNIX   (1)
+#define MICROPY_ENABLE_FLOAT        (1)
+#define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_LONGLONG)
+
+// type definitions for the specific machine
+
+#ifdef __LP64__
+typedef long machine_int_t; // must be pointer size
+typedef unsigned long machine_uint_t; // must be pointer size
+#else
+// These are definitions for machines where sizeof(int) == sizeof(void*),
+// regardless for actual size.
+typedef int machine_int_t; // must be pointer size
+typedef unsigned int machine_uint_t; // must be pointer size
+#endif
+
+#define BYTES_PER_WORD sizeof(machine_int_t)
+
+typedef void *machine_ptr_t; // must be of pointer size
+typedef const void *machine_const_ptr_t; // must be of pointer size
+typedef double machine_float_t;
+
+machine_float_t machine_sqrt(machine_float_t x);

--- a/windows/qstrdefsport.h
+++ b/windows/qstrdefsport.h
@@ -1,0 +1,8 @@
+// qstrs specific to this port
+
+Q(sys)
+Q(argv)
+Q(open)
+Q(stdin)
+Q(stdout)
+Q(stderr)


### PR DESCRIPTION
PR to add support for Windows (see #233).

You'll need MinGW to compile and install Readline from [GnuWin32](http://gnuwin32.sourceforge.net/packages/readline.htm) and libmmap from [mman-win32](https://code.google.com/p/mman-win32/). I've also dropped the sockets support because it's really ugly to adapt it to `winsock2.h`.

I've also replaced `tests/run-tests` with a simple Python script so we can run the same script on Linux and Windows.

Please feel free to discuss my changes as I'm pretty new to this kind of projects.
