### PR TITLE
Implement __bool__ and __len__ via unary_op virtual method for all types.

### DIFF
--- a/py/obj.c
+++ b/py/obj.c
@@ -251,9 +251,15 @@ mp_obj_t mp_obj_len_maybe(mp_obj_t o_in) {
         len = seq_len;
     } else if (MP_OBJ_IS_TYPE(o_in, &dict_type)) {
         len = mp_obj_dict_len(o_in);
-    } else if (MP_OBJ_IS_TYPE(o_in, &array_type)) {
-        len = mp_obj_array_len(o_in);
     } else {
+        mp_obj_type_t *type = mp_obj_get_type(o_in);
+        if (type->unary_op != NULL) {
+            mp_obj_t result = type->unary_op(RT_UNARY_OP_LEN, o_in);
+            if (result != MP_OBJ_NULL) {
+                return result;
+            }
+        }
+
         return MP_OBJ_NULL;
     }
     return MP_OBJ_NEW_SMALL_INT(len);

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -189,6 +189,15 @@ static mp_obj_t mp_builtin_bytearray(mp_obj_t arg) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin_bytearray_obj, mp_builtin_bytearray);
 
+static mp_obj_t array_unary_op(int op, mp_obj_t o_in) {
+    mp_obj_array_t *o = o_in;
+    switch (op) {
+        case RT_UNARY_OP_BOOL: return MP_BOOL(o->len != 0);
+        case RT_UNARY_OP_LEN: return MP_OBJ_NEW_SMALL_INT(o->len);
+        default: return MP_OBJ_NULL; // op not supported
+    }
+}
+
 static mp_obj_t array_binary_op(int op, mp_obj_t lhs, mp_obj_t rhs) {
     mp_obj_array_t *o = lhs;
     switch (op) {
@@ -245,6 +254,7 @@ const mp_obj_type_t array_type = {
     .print = array_print,
     .make_new = array_make_new,
     .getiter = array_iterator_new,
+    .unary_op = array_unary_op,
     .binary_op = array_binary_op,
     .store_item = array_store_item,
     .methods = array_type_methods,

--- a/py/objbool.c
+++ b/py/objbool.c
@@ -36,7 +36,7 @@ static mp_obj_t bool_make_new(mp_obj_t type_in, uint n_args, uint n_kw, const mp
 static mp_obj_t bool_unary_op(int op, mp_obj_t o_in) {
     machine_int_t value = ((mp_obj_bool_t*)o_in)->value;
     switch (op) {
-        case RT_UNARY_OP_NOT: if (value) { return mp_const_false; } else { return mp_const_true; }
+        case RT_UNARY_OP_BOOL: return o_in;
         case RT_UNARY_OP_POSITIVE: return MP_OBJ_NEW_SMALL_INT(value);
         case RT_UNARY_OP_NEGATIVE: return MP_OBJ_NEW_SMALL_INT(-value);
         case RT_UNARY_OP_INVERT:

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -73,7 +73,7 @@ static mp_obj_t complex_make_new(mp_obj_t type_in, uint n_args, uint n_kw, const
 static mp_obj_t complex_unary_op(int op, mp_obj_t o_in) {
     mp_obj_complex_t *o = o_in;
     switch (op) {
-        case RT_UNARY_OP_NOT: if (o->real != 0 || o->imag != 0) { return mp_const_true;} else { return mp_const_false; }
+        case RT_UNARY_OP_BOOL: return MP_BOOL(o->real != 0 || o->imag != 0);
         case RT_UNARY_OP_POSITIVE: return o_in;
         case RT_UNARY_OP_NEGATIVE: return mp_obj_new_complex(-o->real, -o->imag);
         default: return MP_OBJ_NULL; // op not supported

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -46,7 +46,8 @@ static mp_obj_t dict_make_new(mp_obj_t type_in, uint n_args, uint n_kw, const mp
 static mp_obj_t dict_unary_op(int op, mp_obj_t self_in) {
     mp_obj_dict_t *self = self_in;
     switch (op) {
-        case RT_UNARY_OP_NOT: if (self->map.used == 0) { return mp_const_true; } else { return mp_const_false; }
+        case RT_UNARY_OP_BOOL: return MP_BOOL(self->map.used != 0);
+        case RT_UNARY_OP_LEN: return MP_OBJ_NEW_SMALL_INT(self->map.used);
         default: return MP_OBJ_NULL; // op not supported for None
     }
 }

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -47,7 +47,7 @@ static mp_obj_t float_make_new(mp_obj_t type_in, uint n_args, uint n_kw, const m
 static mp_obj_t float_unary_op(int op, mp_obj_t o_in) {
     mp_obj_float_t *o = o_in;
     switch (op) {
-        case RT_UNARY_OP_NOT: if (o->value != 0) { return mp_const_true;} else { return mp_const_false; }
+        case RT_UNARY_OP_BOOL: return MP_BOOL(o->value != 0);
         case RT_UNARY_OP_POSITIVE: return o_in;
         case RT_UNARY_OP_NEGATIVE: return mp_obj_new_float(-o->value);
         default: return NULL; // op not supported

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -35,7 +35,7 @@ void int_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj
 mp_obj_t int_unary_op(int op, mp_obj_t o_in) {
     mp_obj_int_t *o = o_in;
     switch (op) {
-        case RT_UNARY_OP_NOT: return MP_BOOL(o->val != 0); // TODO: implements RT_UNARY_OP_BOOL
+        case RT_UNARY_OP_BOOL: return MP_BOOL(o->val != 0);
         case RT_UNARY_OP_POSITIVE: return o_in;
         case RT_UNARY_OP_NEGATIVE: return mp_obj_new_int_from_ll(-o->val);
         case RT_UNARY_OP_INVERT: return mp_obj_new_int_from_ll(~o->val);

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -125,7 +125,8 @@ static bool list_cmp_helper(int op, mp_obj_t self_in, mp_obj_t another_in) {
 static mp_obj_t list_unary_op(int op, mp_obj_t self_in) {
     mp_obj_list_t *self = self_in;
     switch (op) {
-        case RT_UNARY_OP_NOT: if (self->len == 0) { return mp_const_true; } else { return mp_const_false; }
+        case RT_UNARY_OP_BOOL: return MP_BOOL(self->len != 0);
+        case RT_UNARY_OP_LEN: return MP_OBJ_NEW_SMALL_INT(self->len);
         default: return MP_OBJ_NULL; // op not supported for None
     }
 }

--- a/py/objnone.c
+++ b/py/objnone.c
@@ -18,7 +18,7 @@ static void none_print(void (*print)(void *env, const char *fmt, ...), void *env
 
 static mp_obj_t none_unary_op(int op, mp_obj_t o_in) {
     switch (op) {
-        case RT_UNARY_OP_NOT: return mp_const_true;
+        case RT_UNARY_OP_BOOL: return mp_const_false;
         default: return MP_OBJ_NULL; // op not supported for None
     }
 }

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -76,7 +76,8 @@ static mp_obj_t tuple_make_new(mp_obj_t type_in, uint n_args, uint n_kw, const m
 static mp_obj_t tuple_unary_op(int op, mp_obj_t self_in) {
     mp_obj_tuple_t *self = self_in;
     switch (op) {
-        case RT_UNARY_OP_NOT: if (self->len == 0) { return mp_const_true; } else { return mp_const_false; }
+        case RT_UNARY_OP_BOOL: return MP_BOOL(self->len != 0);
+        case RT_UNARY_OP_LEN: return MP_OBJ_NEW_SMALL_INT(self->len);
         default: return MP_OBJ_NULL; // op not supported for None
     }
 }

--- a/py/runtime0.h
+++ b/py/runtime0.h
@@ -1,8 +1,11 @@
 typedef enum {
-    RT_UNARY_OP_NOT, // TODO remove this op since it's no longer needed
+    RT_UNARY_OP_BOOL, // __bool__
+    RT_UNARY_OP_LEN, // __len__
     RT_UNARY_OP_POSITIVE,
     RT_UNARY_OP_NEGATIVE,
     RT_UNARY_OP_INVERT,
+    // Used only for CPython-compatible codegeneration
+    RT_UNARY_OP_NOT,
 } rt_unary_op_t;
 
 typedef enum {

--- a/tests/basics/true-value.py
+++ b/tests/basics/true-value.py
@@ -3,8 +3,17 @@
 if not False:
     print("False")
 
+if not None:
+    print("None")
+
 if not 0:
     print("0")
+
+if not 0.0:
+    print("float 0")
+
+if not 0+0j:
+    print("complex 0")
 
 if not "":
     print("Empty string")


### PR DESCRIPTION
Per #229

**bool**() and **len**() are just the same as **neg**() or **invert**(),
and require efficient dispatching implementation (not requiring search/lookup).
type->unary_op() is just the right choice for this short of adding
standalone virtual method(s) to already big mp_obj_type_t structure.
