### PR TITLE
vm: Introduce structure for exception stack entry, record entry type.

### DIFF
--- a/py/vm.c
+++ b/py/vm.c
@@ -13,6 +13,13 @@
 #include "bc0.h"
 #include "bc.h"
 
+// Value stack grows up (this makes it incompatible with native C stack, but
+// makes sure that arguments to functions are in natural order arg1..argN
+// (Python semantics mandates left-to-right evaluation order, including for
+// function arguments). Stack pointer is pre-incremented and points at the
+// top element.
+// Exception stack also grows up, top element is also pointed at.
+
 // Exception stack entry
 typedef struct _mp_exc_stack {
     const byte *handler;
@@ -22,9 +29,6 @@ typedef struct _mp_exc_stack {
     // consider storing it in bit 1 of val_sp. TODO: SETUP_WITH?
     byte opcode;
 } mp_exc_stack;
-
-// (value) stack grows down (to be compatible with native code when passing pointers to the stack), top element is pointed to
-// exception stack grows up, top element is pointed to
 
 #define DECODE_UINT do { unum = *ip++; if (unum > 127) { unum = ((unum & 0x3f) << 8) | (*ip++); } } while (0)
 #define DECODE_ULABEL do { unum = (ip[0] | (ip[1] << 8)); ip += 2; } while (0)

--- a/tests/basics/try-finally1.py
+++ b/tests/basics/try-finally1.py
@@ -1,0 +1,71 @@
+print("noexc-finally")
+try:
+    print("try")
+finally:
+    print("finally")
+
+print("noexc-finally-finally")
+try:
+    print("try1")
+    try:
+        print("try2")
+    finally:
+        print("finally2")
+finally:
+    print("finally1")
+print()
+
+print("noexc-finally-func-finally")
+def func2():
+    try:
+        print("try2")
+    finally:
+        print("finally2")
+
+try:
+    print("try1")
+    func2()
+finally:
+    print("finally1")
+print()
+
+
+print("exc-finally-except")
+try:
+    print("try1")
+    try:
+        print("try2")
+        foo()
+    except:
+        print("except2")
+finally:
+    print("finally1")
+print()
+
+print("exc-finally-except-filter")
+try:
+    print("try1")
+    try:
+        print("try2")
+        foo()
+    except NameError:
+        print("except2")
+finally:
+    print("finally1")
+print()
+
+
+print("exc-except-finally-finally")
+try:  # top-level catch-all except to not fail script
+    try:
+        print("try1")
+        try:
+            print("try2")
+            foo()
+        finally:
+            print("finally2")
+    finally:
+        print("finally1")
+except:
+    print("catch-all except")
+print()


### PR DESCRIPTION
Trying to scratch "finally" implementation, I'd like to clean up exception stack implementation. We also need to record type of exception entry, because "except" ones are easy to unwind by just popping, but "finally" needs handler execution.
