### PR TITLE
Add exception stack unwind support for RETURN_VALUE.

### DIFF
--- a/tests/basics/try-finally-return.py
+++ b/tests/basics/try-finally-return.py
@@ -1,0 +1,7 @@
+def func1():
+    try:
+        return "it worked"
+    finally:
+        print("finally 1")
+
+print(func1())


### PR DESCRIPTION
This properly implements return from try/finally block(s).

TODO: Consider if we need to do any value stack unwinding for RETURN_VALUE
case. Intuitively, this is "success" return, so value stack should be in
good shape, and unwinding shouldn't be required.
