### PR TITLE
Implement default function arguments (for Python functions).

### DIFF
--- a/py/bc0.h
+++ b/py/bc0.h
@@ -94,7 +94,9 @@
 #define MP_BC_CALL_METHOD_VAR    (0x97) // uint
 #define MP_BC_CALL_METHOD_KW     (0x98) // uint
 #define MP_BC_CALL_METHOD_VAR_KW (0x99) // uint
+#define MP_BC_MAKE_FUNCTION_DEFARGS  (0x9a) // uint
 
 #define MP_BC_IMPORT_NAME        (0xe0) // qstr
 #define MP_BC_IMPORT_FROM        (0xe1) // qstr
 #define MP_BC_IMPORT_STAR        (0xe2)
+

--- a/py/compile.c
+++ b/py/compile.c
@@ -3212,7 +3212,7 @@ mp_obj_t mp_compile(mp_parse_node_t pn, qstr source_file, bool is_repl) {
         return mp_const_true;
 #else
         // return function that executes the outer module
-        return rt_make_function_from_id(unique_code_id);
+        return rt_make_function_from_id(unique_code_id, MP_OBJ_NULL);
 #endif
     }
 }

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -664,9 +664,15 @@ static void emit_bc_unpack_ex(emit_t *emit, int n_left, int n_right) {
 }
 
 static void emit_bc_make_function(emit_t *emit, scope_t *scope, int n_dict_params, int n_default_params) {
-    assert(n_default_params == 0 && n_dict_params == 0);
-    emit_pre(emit, 1);
-    emit_write_byte_code_byte_uint(emit, MP_BC_MAKE_FUNCTION, scope->unique_code_id);
+    assert(n_dict_params == 0);
+    if (n_default_params != 0) {
+        emit_bc_build_tuple(emit, n_default_params);
+        emit_pre(emit, 0);
+        emit_write_byte_code_byte_uint(emit, MP_BC_MAKE_FUNCTION_DEFARGS, scope->unique_code_id);
+    } else {
+        emit_pre(emit, 1);
+        emit_write_byte_code_byte_uint(emit, MP_BC_MAKE_FUNCTION, scope->unique_code_id);
+    }
 }
 
 static void emit_bc_make_closure(emit_t *emit, scope_t *scope, int n_dict_params, int n_default_params) {

--- a/py/obj.h
+++ b/py/obj.h
@@ -221,7 +221,7 @@ mp_obj_t mp_obj_new_exception_msg_2_args(qstr id, const char *fmt, const char *a
 mp_obj_t mp_obj_new_exception_msg_varg(qstr id, const char *fmt, ...); // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
 mp_obj_t mp_obj_new_range(int start, int stop, int step);
 mp_obj_t mp_obj_new_range_iterator(int cur, int stop, int step);
-mp_obj_t mp_obj_new_fun_bc(int n_args, uint n_state, const byte *code);
+mp_obj_t mp_obj_new_fun_bc(int n_args, mp_obj_t def_args, uint n_state, const byte *code);
 mp_obj_t mp_obj_new_fun_asm(uint n_args, void *fun);
 mp_obj_t mp_obj_new_gen_wrap(mp_obj_t fun);
 mp_obj_t mp_obj_new_gen_instance(const byte *bytecode, uint n_state, int n_args, const mp_obj_t *args);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -674,7 +674,7 @@ mp_obj_t rt_binary_op(int op, mp_obj_t lhs, mp_obj_t rhs) {
     return mp_const_none;
 }
 
-mp_obj_t rt_make_function_from_id(int unique_code_id) {
+mp_obj_t rt_make_function_from_id(int unique_code_id, mp_obj_t def_args) {
     DEBUG_OP_printf("make_function_from_id %d\n", unique_code_id);
     if (unique_code_id < 1 || unique_code_id >= next_unique_code_id) {
         // illegal code id
@@ -686,7 +686,7 @@ mp_obj_t rt_make_function_from_id(int unique_code_id) {
     mp_obj_t fun;
     switch (c->kind) {
         case MP_CODE_BYTE:
-            fun = mp_obj_new_fun_bc(c->n_args, c->n_state, c->u_byte.code);
+            fun = mp_obj_new_fun_bc(c->n_args, def_args, c->n_state, c->u_byte.code);
             break;
         case MP_CODE_NATIVE:
             fun = rt_make_function_n(c->n_args, c->u_native.fun);
@@ -710,7 +710,7 @@ mp_obj_t rt_make_function_from_id(int unique_code_id) {
 mp_obj_t rt_make_closure_from_id(int unique_code_id, mp_obj_t closure_tuple) {
     DEBUG_OP_printf("make_closure_from_id %d\n", unique_code_id);
     // make function object
-    mp_obj_t ffun = rt_make_function_from_id(unique_code_id);
+    mp_obj_t ffun = rt_make_function_from_id(unique_code_id, MP_OBJ_NULL);
     // wrap function in closure object
     return mp_obj_new_closure(ffun, closure_tuple);
 }

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -12,7 +12,7 @@ void rt_store_name(qstr qstr, mp_obj_t obj);
 void rt_store_global(qstr qstr, mp_obj_t obj);
 mp_obj_t rt_unary_op(int op, mp_obj_t arg);
 mp_obj_t rt_binary_op(int op, mp_obj_t lhs, mp_obj_t rhs);
-mp_obj_t rt_make_function_from_id(int unique_code_id);
+mp_obj_t rt_make_function_from_id(int unique_code_id, mp_obj_t def_args);
 mp_obj_t rt_make_function_n(int n_args, void *fun); // fun must have the correct signature for n_args fixed arguments
 mp_obj_t rt_make_function_var(int n_args_min, mp_fun_var_t fun);
 mp_obj_t rt_make_function_var_between(int n_args_min, int n_args_max, mp_fun_var_t fun); // min and max are inclusive

--- a/py/showbc.c
+++ b/py/showbc.c
@@ -339,6 +339,11 @@ void mp_byte_code_print(const byte *ip, int len) {
                 printf("MAKE_FUNCTION " UINT_FMT, unum);
                 break;
 
+            case MP_BC_MAKE_FUNCTION_DEFARGS:
+                DECODE_UINT;
+                printf("MAKE_FUNCTION_DEFARGS " UINT_FMT, unum);
+                break;
+
             case MP_BC_MAKE_CLOSURE:
                 DECODE_UINT;
                 printf("MAKE_CLOSURE " UINT_FMT, unum);

--- a/py/vm.c
+++ b/py/vm.c
@@ -476,7 +476,12 @@ bool mp_execute_byte_code_2(const byte *code_info, const byte **ip_in_out, mp_ob
 
                     case MP_BC_MAKE_FUNCTION:
                         DECODE_UINT;
-                        PUSH(rt_make_function_from_id(unum));
+                        PUSH(rt_make_function_from_id(unum, MP_OBJ_NULL));
+                        break;
+
+                    case MP_BC_MAKE_FUNCTION_DEFARGS:
+                        DECODE_UINT;
+                        SET_TOP(rt_make_function_from_id(unum, TOP()));
                         break;
 
                     case MP_BC_MAKE_CLOSURE:

--- a/tests/basics/fun-defargs.py
+++ b/tests/basics/fun-defargs.py
@@ -1,0 +1,20 @@
+def fun1(val=5):
+    print(5)
+
+fun1()
+fun1(10)
+
+def fun2(p1, p2=100, p3="foo"):
+    print(p1, p2, p3)
+
+fun2(1)
+fun2(1, None)
+fun2(0, "bar", 200)
+try:
+    fun2()
+except TypeError:
+    print("TypeError")
+try:
+    fun2(1, 2, 3, 4)
+except TypeError:
+    print("TypeError")


### PR DESCRIPTION
TODO: Decide if we really need separate bytecode for creating functions
with default arguments - we would need same for closures, then there're
keywords arguments too. Having all combinations is a small exponential
explosion, likely we need just 2 cases - simplest (no defaults, no kw),
and full - defaults & kw.
