### PR TITLE
Get rid of calloc().

### DIFF
--- a/py/malloc.c
+++ b/py/malloc.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "misc.h"
 #include "mpconfig.h"
@@ -37,20 +38,10 @@ void *m_malloc(int num_bytes) {
 }
 
 void *m_malloc0(int num_bytes) {
-    if (num_bytes == 0) {
-        return NULL;
+    void *ptr = m_malloc(num_bytes);
+    if (ptr != NULL) {
+        memset(ptr, 0, num_bytes);
     }
-    void *ptr = calloc(1, num_bytes);
-    if (ptr == NULL) {
-        printf("could not allocate memory, allocating %d bytes\n", num_bytes);
-        return NULL;
-    }
-#if MICROPY_MEM_STATS
-    total_bytes_allocated += num_bytes;
-    current_bytes_allocated += num_bytes;
-    UPDATE_PEAK();
-#endif
-    DEBUG_printf("malloc0 %d : %p\n", num_bytes, ptr);
     return ptr;
 }
 

--- a/stm/malloc0.c
+++ b/stm/malloc0.c
@@ -29,14 +29,6 @@ void *realloc(void *ptr, size_t n) {
 
 #endif
 
-void *calloc(size_t sz, size_t n) {
-    char *ptr = malloc(sz * n);
-    for (int i = 0; i < sz * n; i++) {
-        ptr[i] = 0;
-    }
-    return ptr;
-}
-
 void *malloc(size_t n) {
     return gc_alloc(n);
 }

--- a/stm/std.h
+++ b/stm/std.h
@@ -4,7 +4,6 @@ void __assert_func(void);
 
 void *malloc(size_t n);
 void free(void *ptr);
-void *calloc(size_t sz, size_t n);
 void *realloc(void *ptr, size_t n);
 
 void *memcpy(void *dest, const void *src, size_t n);

--- a/teensy/std.h
+++ b/teensy/std.h
@@ -4,7 +4,6 @@ void __assert_func(void);
 
 void *malloc(size_t n);
 void free(void *ptr);
-void *calloc(size_t sz, size_t n);
 void *realloc(void *ptr, size_t n);
 
 void *memcpy(void *dest, const void *src, size_t n);


### PR DESCRIPTION
If there's malloc and memset, then there's no need for calloc, especially if
we need to implement it ourselves.
