### PR TITLE
LDFLAGS changes to enable build on OSX

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -12,7 +12,14 @@ include ../py/py.mk
 
 # compiler settings
 CFLAGS = -I. -I$(PY_SRC) -Wall -Werror -ansi -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT)
-LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-Map=$@.map,--cref
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+    LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-Map=$@.map,--cref
+endif
+ifeq ($(UNAME_S),Darwin)
+    LDFLAGS = $(LDFLAGS_MOD) -lm -Wl
+endif
 
 ifeq ($(MICROPY_MOD_TIME),1)
 CFLAGS_MOD += -DMICROPY_MOD_TIME=1

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -14,11 +14,10 @@ include ../py/py.mk
 CFLAGS = -I. -I$(PY_SRC) -Wall -Werror -ansi -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT)
 
 UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Linux)
-    LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-Map=$@.map,--cref
-endif
 ifeq ($(UNAME_S),Darwin)
-    LDFLAGS = $(LDFLAGS_MOD) -lm -Wl
+    LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-map,$@.map
+else
+    LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-Map=$@.map,--cref
 endif
 
 ifeq ($(MICROPY_MOD_TIME),1)
@@ -27,7 +26,7 @@ SRC_MOD += time.c
 endif
 ifeq ($(MICROPY_MOD_FFI),1)
 CFLAGS_MOD += `pkg-config --cflags libffi` -DMICROPY_MOD_FFI=1
-LDFLAGS_MOD += -ldl -lffi
+LDFLAGS_MOD += -ldl -lffi 
 SRC_MOD += ffi.c
 endif
 


### PR DESCRIPTION
Small change to the unix Makefile to change the -Map syntax to be OS X/clang compatible. 

All tests (other than basics/int-long.py) pass

basics/int-long.py fails with

Assertion failed: (0 <= num && num <= 0xffffff), function emit_write_byte_code_byte_int, file ../py/emitbc.c, line 129.
