### PR TITLE
OS X compatible -map syntax for LDFLAGS

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -12,7 +12,13 @@ include ../py/py.mk
 
 # compiler settings
 CFLAGS = -I. -I$(PY_SRC) -Wall -Werror -ansi -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT)
-LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-Map=$@.map,--cref
+
+UNAME_S := $(shell uname -s)
+ ifeq ($(UNAME_S),Darwin)
+    LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-map,$@.map
+else
+    LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-Map=$@.map,--cref
+ endif
 
 ifeq ($(MICROPY_MOD_TIME),1)
 CFLAGS_MOD += -DMICROPY_MOD_TIME=1


### PR DESCRIPTION
OS X only LDFLAGS changes for different linker syntax for map file generation
