### PR TITLE
Save/restore function's globals in exception-safe manner.

### DIFF
--- a/py/bc.h
+++ b/py/bc.h
@@ -1,3 +1,3 @@
-mp_obj_t mp_execute_byte_code(const byte *code, const mp_obj_t *args, uint n_args, const mp_obj_t *args2, uint n_args2, uint n_state);
-bool mp_execute_byte_code_2(const byte *code_info, const byte **ip_in_out, mp_obj_t *fastn, mp_obj_t **sp_in_out);
+mp_obj_t mp_execute_byte_code(mp_map_t *globals, const byte *code, const mp_obj_t *args, uint n_args, const mp_obj_t *args2, uint n_args2, uint n_state);
+bool mp_execute_byte_code_2(mp_map_t *globals, const byte *code_info, const byte **ip_in_out, mp_obj_t *fastn, mp_obj_t **sp_in_out);
 void mp_byte_code_print(const byte *code, int len);

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -150,10 +150,7 @@ STATIC mp_obj_t fun_bc_call(mp_obj_t self_in, uint n_args, uint n_kw, const mp_o
     }
 
     uint use_def_args = self->n_args - n_args;
-    mp_map_t *old_globals = rt_globals_get();
-    rt_globals_set(self->globals);
-    mp_obj_t result = mp_execute_byte_code(self->bytecode, args, n_args, self->def_args + self->n_def_args - use_def_args, use_def_args, self->n_state);
-    rt_globals_set(old_globals);
+    mp_obj_t result = mp_execute_byte_code(self->globals, self->bytecode, args, n_args, self->def_args + self->n_def_args - use_def_args, use_def_args, self->n_state);
 
     return result;
 }

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -9,6 +9,7 @@
 #include "qstr.h"
 #include "obj.h"
 #include "runtime.h"
+#include "map.h"
 #include "bc.h"
 
 /******************************************************************************/
@@ -82,7 +83,8 @@ STATIC mp_obj_t gen_next_send(mp_obj_t self_in, mp_obj_t send_value) {
     } else {
         *self->sp = send_value;
     }
-    bool yield = mp_execute_byte_code_2(self->code_info, &self->ip, &self->state[self->n_state - 1], &self->sp);
+    // TODO: globals == NULL is not correct, generator should capture defining namespace just like a func!
+    bool yield = mp_execute_byte_code_2(NULL, self->code_info, &self->ip, &self->state[self->n_state - 1], &self->sp);
     if (yield) {
         return *self->sp;
     } else {


### PR DESCRIPTION
This is proposed fix for #290.

Comments:

As usual, if there're concerns what's passed in regs on ARM, globals arg can be added last instead of first to bytecode exec functions.

Otherwise, it looks kinda like breaking layer separation, for example vm suddenly knows about maps. But code execution always happens within context of some environment, and managing environments apparently a task for VM (especially if we model target exception with exceptions on meta level). But rt_globals_get/set() are there exactly to abstract it away, so they can be made accept void*,and then we don't have env implementation details leak into VM.
