### PR TITLE
Pass function flags from parser scope to code objects.

### DIFF
--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -242,7 +242,7 @@ STATIC void emit_bc_end_pass(emit_t *emit) {
         emit->code_base = m_new(byte, emit->code_info_size + emit->byte_code_size);
 
     } else if (emit->pass == PASS_3) {
-        rt_assign_byte_code(emit->scope->unique_code_id, emit->code_base, emit->code_info_size + emit->byte_code_size, emit->scope->num_params, emit->scope->num_locals, emit->scope->stack_size, (emit->scope->flags & SCOPE_FLAG_GENERATOR) != 0);
+        rt_assign_byte_code(emit->scope->unique_code_id, emit->code_base, emit->code_info_size + emit->byte_code_size, emit->scope->num_params, emit->scope->num_locals, emit->scope->stack_size, emit->scope->flags);
     }
 }
 

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -45,8 +45,8 @@ typedef enum {
 
 typedef struct _mp_code_t {
     struct {
-        mp_code_kind_t kind : 8;
-        bool is_generator : 1;
+        mp_code_kind_t kind : 2;
+        int flags : 14;
     };
     struct {
         uint n_args : 16;
@@ -242,12 +242,12 @@ STATIC void alloc_unique_codes(void) {
     }
 }
 
-void rt_assign_byte_code(uint unique_code_id, byte *code, uint len, int n_args, int n_locals, int n_stack, bool is_generator) {
+void rt_assign_byte_code(uint unique_code_id, byte *code, uint len, int n_args, int n_locals, int n_stack, int flags) {
     alloc_unique_codes();
 
     assert(1 <= unique_code_id && unique_code_id < next_unique_code_id && unique_codes[unique_code_id].kind == MP_CODE_NONE);
     unique_codes[unique_code_id].kind = MP_CODE_BYTE;
-    unique_codes[unique_code_id].is_generator = is_generator;
+    unique_codes[unique_code_id].flags = flags;
     unique_codes[unique_code_id].n_args = n_args;
     unique_codes[unique_code_id].n_state = n_locals + n_stack;
     unique_codes[unique_code_id].u_byte.code = code;
@@ -275,7 +275,7 @@ void rt_assign_native_code(uint unique_code_id, void *fun, uint len, int n_args)
 
     assert(1 <= unique_code_id && unique_code_id < next_unique_code_id && unique_codes[unique_code_id].kind == MP_CODE_NONE);
     unique_codes[unique_code_id].kind = MP_CODE_NATIVE;
-    unique_codes[unique_code_id].is_generator = false;
+    unique_codes[unique_code_id].flags = 0;
     unique_codes[unique_code_id].n_args = n_args;
     unique_codes[unique_code_id].n_state = 0;
     unique_codes[unique_code_id].u_native.fun = fun;
@@ -307,7 +307,7 @@ void rt_assign_inline_asm_code(uint unique_code_id, void *fun, uint len, int n_a
 
     assert(1 <= unique_code_id && unique_code_id < next_unique_code_id && unique_codes[unique_code_id].kind == MP_CODE_NONE);
     unique_codes[unique_code_id].kind = MP_CODE_INLINE_ASM;
-    unique_codes[unique_code_id].is_generator = false;
+    unique_codes[unique_code_id].flags = 0;
     unique_codes[unique_code_id].n_args = n_args;
     unique_codes[unique_code_id].n_state = 0;
     unique_codes[unique_code_id].u_inline_asm.fun = fun;
@@ -728,7 +728,7 @@ mp_obj_t rt_make_function_from_id(int unique_code_id, mp_obj_t def_args) {
     }
 
     // check for generator functions and if so wrap in generator object
-    if (c->is_generator) {
+    if (c->flags & SCOPE_FLAG_GENERATOR) {
         fun = mp_obj_new_gen_wrap(fun);
     }
 

--- a/py/runtime0.h
+++ b/py/runtime0.h
@@ -78,11 +78,25 @@ typedef enum {
     RT_F_NUMBER_OF,
 } rt_fun_kind_t;
 
+// taken from python source, Include/code.h
+#define SCOPE_FLAG_OPTIMISED    0x0001
+#define SCOPE_FLAG_NEWLOCALS    0x0002
+#define SCOPE_FLAG_VARARGS      0x0004
+#define SCOPE_FLAG_VARKEYWORDS  0x0008
+#define SCOPE_FLAG_NESTED       0x0010
+#define SCOPE_FLAG_GENERATOR    0x0020
+/* The SCOPE_FLAG_NOFREE flag is set if there are no free or cell variables.
+   This information is redundant, but it allows a single flag test
+   to determine whether there is any extra work to be done when the
+   call frame is setup.
+*/
+#define SCOPE_FLAG_NOFREE       0x0040
+
 extern void *const rt_fun_table[RT_F_NUMBER_OF];
 
 void rt_init(void);
 void rt_deinit(void);
 uint rt_get_unique_code_id(void);
-void rt_assign_byte_code(uint unique_code_id, byte *code, uint len, int n_args, int n_locals, int n_stack, bool is_generator);
+void rt_assign_byte_code(uint unique_code_id, byte *code, uint len, int n_args, int n_locals, int n_stack, int flags);
 void rt_assign_native_code(uint unique_code_id, void *f, uint len, int n_args);
 void rt_assign_inline_asm_code(uint unique_code_id, void *f, uint len, int n_args);

--- a/py/scope.h
+++ b/py/scope.h
@@ -17,20 +17,6 @@ typedef struct _id_info_t {
     int local_num;
 } id_info_t;
 
-// taken from python source, Include/code.h
-#define SCOPE_FLAG_OPTIMISED    0x0001
-#define SCOPE_FLAG_NEWLOCALS    0x0002
-#define SCOPE_FLAG_VARARGS      0x0004
-#define SCOPE_FLAG_VARKEYWORDS  0x0008
-#define SCOPE_FLAG_NESTED       0x0010
-#define SCOPE_FLAG_GENERATOR    0x0020
-/* The SCOPE_FLAG_NOFREE flag is set if there are no free or cell variables.
-   This information is redundant, but it allows a single flag test
-   to determine whether there is any extra work to be done when the
-   call frame is setup.
-*/
-#define SCOPE_FLAG_NOFREE       0x0040
-
 // scope is a "block" in Python parlance
 typedef enum { SCOPE_MODULE, SCOPE_FUNCTION, SCOPE_LAMBDA, SCOPE_LIST_COMP, SCOPE_DICT_COMP, SCOPE_SET_COMP, SCOPE_GEN_EXPR, SCOPE_CLASS } scope_kind_t;
 typedef struct _scope_t {


### PR DESCRIPTION
This will allow to access flags like VARARGS, VARKEYWORDS which are needed
to peroperly handle arg passing in calls.

First step towards resolving #295.
