### PR TITLE
Support passing positional args as keywords to bytecode functions.

### DIFF
--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -242,7 +242,14 @@ STATIC void emit_bc_end_pass(emit_t *emit) {
         emit->code_base = m_new(byte, emit->code_info_size + emit->byte_code_size);
 
     } else if (emit->pass == PASS_3) {
-        rt_assign_byte_code(emit->scope->unique_code_id, emit->code_base, emit->code_info_size + emit->byte_code_size, emit->scope->num_params, emit->scope->num_locals, emit->scope->stack_size, emit->scope->scope_flags);
+        qstr *arg_names = m_new(qstr, emit->scope->num_params);
+        for (int i = 0; i < emit->scope->num_params; i++) {
+            arg_names[i] = emit->scope->id_info[i].qstr;
+        }
+        rt_assign_byte_code(emit->scope->unique_code_id, emit->code_base,
+            emit->code_info_size + emit->byte_code_size,
+            emit->scope->num_params, emit->scope->num_locals, emit->scope->stack_size,
+            emit->scope->scope_flags, arg_names);
     }
 }
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -236,7 +236,7 @@ mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const char *msg
 mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const char *fmt, ...); // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
 mp_obj_t mp_obj_new_range(int start, int stop, int step);
 mp_obj_t mp_obj_new_range_iterator(int cur, int stop, int step);
-mp_obj_t mp_obj_new_fun_bc(uint scope_flags, uint n_args, mp_obj_t def_args, uint n_state, const byte *code);
+mp_obj_t mp_obj_new_fun_bc(uint scope_flags, qstr *args, uint n_args, mp_obj_t def_args, uint n_state, const byte *code);
 mp_obj_t mp_obj_new_fun_asm(uint n_args, void *fun);
 mp_obj_t mp_obj_new_gen_wrap(mp_obj_t fun);
 mp_obj_t mp_obj_new_gen_instance(const byte *bytecode, uint n_state, int n_args, const mp_obj_t *args);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -64,6 +64,7 @@ typedef struct _mp_code_t {
             void *fun;
         } u_inline_asm;
     };
+    qstr *arg_names;
 } mp_code_t;
 
 STATIC uint next_unique_code_id;
@@ -242,7 +243,7 @@ STATIC void alloc_unique_codes(void) {
     }
 }
 
-void rt_assign_byte_code(uint unique_code_id, byte *code, uint len, int n_args, int n_locals, int n_stack, uint scope_flags) {
+void rt_assign_byte_code(uint unique_code_id, byte *code, uint len, int n_args, int n_locals, int n_stack, uint scope_flags, qstr *arg_names) {
     alloc_unique_codes();
 
     assert(1 <= unique_code_id && unique_code_id < next_unique_code_id && unique_codes[unique_code_id].kind == MP_CODE_NONE);
@@ -252,6 +253,7 @@ void rt_assign_byte_code(uint unique_code_id, byte *code, uint len, int n_args, 
     unique_codes[unique_code_id].n_state = n_locals + n_stack;
     unique_codes[unique_code_id].u_byte.code = code;
     unique_codes[unique_code_id].u_byte.len = len;
+    unique_codes[unique_code_id].arg_names = arg_names;
 
     //printf("byte code: %d bytes\n", len);
 
@@ -714,7 +716,7 @@ mp_obj_t rt_make_function_from_id(int unique_code_id, mp_obj_t def_args) {
     mp_obj_t fun;
     switch (c->kind) {
         case MP_CODE_BYTE:
-            fun = mp_obj_new_fun_bc(c->scope_flags, c->n_args, def_args, c->n_state, c->u_byte.code);
+            fun = mp_obj_new_fun_bc(c->scope_flags, c->arg_names, c->n_args, def_args, c->n_state, c->u_byte.code);
             break;
         case MP_CODE_NATIVE:
             fun = rt_make_function_n(c->n_args, c->u_native.fun);

--- a/py/runtime0.h
+++ b/py/runtime0.h
@@ -97,6 +97,6 @@ extern void *const rt_fun_table[RT_F_NUMBER_OF];
 void rt_init(void);
 void rt_deinit(void);
 uint rt_get_unique_code_id(void);
-void rt_assign_byte_code(uint unique_code_id, byte *code, uint len, int n_args, int n_locals, int n_stack, uint scope_flags);
+void rt_assign_byte_code(uint unique_code_id, byte *code, uint len, int n_args, int n_locals, int n_stack, uint scope_flags, qstr *arg_names);
 void rt_assign_native_code(uint unique_code_id, void *f, uint len, int n_args);
 void rt_assign_inline_asm_code(uint unique_code_id, void *f, uint len, int n_args);

--- a/tests/basics/fun-kwargs.py
+++ b/tests/basics/fun-kwargs.py
@@ -1,0 +1,35 @@
+def f1(a):
+    print(a)
+
+f1(123)
+f1(a=123)
+try:
+    f1(b=123)
+except TypeError:
+    print("TypeError")
+
+def f2(a, b):
+    print(a, b)
+
+f2(1, 2)
+f2(a=3, b=4)
+f2(b=5, a=6)
+f2(7, b=8)
+try:
+    f2(9, a=10)
+except TypeError:
+    print("TypeError")
+
+def f3(a, b, *args):
+    print(a, b, args)
+
+
+f3(1, b=3)
+try:
+    f3(1, a=3)
+except TypeError:
+    print("TypeError")
+try:
+    f3(1, 2, 3, 4, a=5)
+except TypeError:
+    print("TypeError")


### PR DESCRIPTION
For this, record argument names along with each bytecode function. The code
still includes extensive debug logging support so far. I recommend playing with this well, trying to come up with crazy way to pass args and use debug logging just in case.
