### PR TITLE
stm: Initialize sys.path with ["0:/", "0:/src", "0:/lib"].

### DIFF
--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -10,6 +10,8 @@ elif platform.python_version_tuple()[0] == '3':
 
 # add some custom names to map characters that aren't in HTML
 codepoint2name[ord('.')] = 'dot'
+codepoint2name[ord(':')] = 'colon'
+codepoint2name[ord('/')] = 'slash'
 
 # this must match the equivalent function in qstr.c
 def compute_hash(qstr):

--- a/stm/main.c
+++ b/stm/main.c
@@ -411,6 +411,11 @@ soft_reset:
     // Micro Python init
     qstr_init();
     rt_init();
+    mp_obj_t def_path[3];
+    def_path[0] = MP_OBJ_NEW_QSTR(MP_QSTR_0_colon__slash_);
+    def_path[1] = MP_OBJ_NEW_QSTR(MP_QSTR_0_colon__slash_src);
+    def_path[2] = MP_OBJ_NEW_QSTR(MP_QSTR_0_colon__slash_lib);
+    sys_path = mp_obj_new_list(3, def_path);
 
 #if MICROPY_HW_HAS_LCD
     // LCD init (just creates class, init hardware by calling LCD())

--- a/stm/qstrdefsport.h
+++ b/stm/qstrdefsport.h
@@ -30,3 +30,7 @@ Q(Usart)
 Q(ADC)
 Q(open)
 Q(File)
+// Entries for sys.path
+Q(0:/)
+Q(0:/src)
+Q(0:/lib)


### PR DESCRIPTION
This is compatible with what search path was before sys.path refactor,
with addition of module library path ("0:/lib").
