### PR TITLE
Towards support full range of small ints in bytecode

### DIFF
--- a/py/vm.c
+++ b/py/vm.c
@@ -38,10 +38,31 @@ typedef enum {
     UNWIND_JUMP,
 } mp_unwind_reason_t;
 
-#define DECODE_UINT do { unum = *ip++; if (unum > 127) { unum = ((unum & 0x3f) << 8) | (*ip++); } } while (0)
+#if 0
+uint decode_uint() {
+    uint val = 0;
+    do {
+        val = (val << 7) + (*ip & 0x7f);
+    } while ((*ip++ & 0x80) != 0);
+}
+#endif
+
+//#define DECODE_UINT do { unum = *ip++; if (unum > 127) { unum = ((unum & 0x3f) << 8) | (*ip++); } } while (0)
+#define DECODE_UINT { \
+    unum = 0; \
+    do { \
+        unum = (unum << 7) + (*ip & 0x7f); \
+    } while ((*ip++ & 0x80) != 0); \
+}
 #define DECODE_ULABEL do { unum = (ip[0] | (ip[1] << 8)); ip += 2; } while (0)
 #define DECODE_SLABEL do { unum = (ip[0] | (ip[1] << 8)) - 0x8000; ip += 2; } while (0)
-#define DECODE_QSTR do { qst = *ip++; if (qst > 127) { qst = ((qst & 0x3f) << 8) | (*ip++); } } while (0)
+//#define DECODE_QSTR do { qst = *ip++; if (qst > 127) { qst = ((qst & 0x3f) << 8) | (*ip++); } } while (0)
+#define DECODE_QSTR { \
+    qst = 0; \
+    do { \
+        qst = (qst << 7) + (*ip & 0x7f); \
+    } while ((*ip++ & 0x80) != 0); \
+}
 #define PUSH(val) *++sp = (val)
 #define POP() (*sp--)
 #define TOP() (*sp)


### PR DESCRIPTION
So, one issue we have is:

```
>>> 10000000
micropython: ../py/emitbc.c:146: emit_write_byte_code_byte_int: Assertion `0 <= num && num <= 0xffffff' failed.
Aborted
```

Encoding of int's apparently should be consistent with encoding of uint's. Then this patch tries to support encoding arbitrary uint's (and regardless of its bitsize). Let me know if you like and I clean it up (tests pass with it).

Then beyond uint's, varlen encoding for ints has its peculiarities. Note that I don't think that static biasing like you emit_write_byte_code_byte_int() with num += 0x800000 helps here. It turns "short" 0 in a big long value for example (I guess that's why you didn't make it varlen encoded, just static 3-byte). Obvious way to overcome that is to use "sign + magnitude" encoding (like floats), but that requires extra magic to handle MIN_INT, so I'd hope that some smart sign management allow to store two's complement still...
