### PR TITLE
parse: Implement hacky way to handle full range of small ints.

### DIFF
--- a/tests/basics/int-small.py
+++ b/tests/basics/int-small.py
@@ -1,5 +1,30 @@
 # This tests small int range for 32-bit machine
 
+# Small ints are variable-length encoded in MicroPython, so first
+# test that encoding works as expected.
+
+print(0)
+print(1)
+print(-1)
+# Value is split in 7-bit "subwords", and taking into account that all
+# ints in Python are signed, there're 6 bits of magnitude. So, around 2^6
+# there's "turning point"
+print(63)
+print(64)
+print(65)
+print(-63)
+print(-64)
+print(-65)
+# Maximum values of small ints on 32-bit platform
+print(1073741823)
+# Per python semantics, lexical integer is without a sign (i.e. positive)
+# and '-' is unary minus operation applied to it. That's why -1073741824
+# (min two-complement's negative value) is not allowed. To fix this,
+# see compile.c:fold_constants()
+print(-1073741823)
+
+# Operations tests
+
 a = 0x3fffff
 print(a)
 a *= 0x10


### PR DESCRIPTION
So, I proceeded to write testcases for varlen encoded small ints, and that's why I paid attention that parser has its own "small ints" which don't match normal "small ints". So, while my aim was to let people write a billion as a number in uPy, that still can't be done. OMG, let's work around it then, but see TODO below.

Parser has its own "small small ints", which unfortunately means that full
range of small ints are not available in lexical form. This issue is usually
masked by presence of long int, but without them, it's not possible to write
biggish numbers in a Python program.

To work that around, CONST_INT node is overloaded with special encoding for
full-range small ints, which eventually propagated to bytecode properly, as
LOAD_CONST_SMALL_INT.

TODO: Ideally, parser should not have its own "small int" type, and instead
all parts of interpreter should use single consistent type (even if that on
parser side requires more fat representation) - dealing with types fragmented
without real need is a chore.
