### PR TITLE
Support building "unix" port for ARM

### DIFF
--- a/py/nlr.h
+++ b/py/nlr.h
@@ -3,23 +3,19 @@
 
 #include <limits.h>
 
-//#ifndef __WORDSIZE
-//#error __WORDSIZE needs to be defined
-//#endif
-
 typedef struct _nlr_buf_t nlr_buf_t;
 struct _nlr_buf_t {
     // the entries here must all be machine word size
     nlr_buf_t *prev;
     void *ret_val;
-#if __WORDSIZE == 32
+#if defined(__i386__)
     void *regs[6];
-#elif __WORDSIZE == 64
+#elif defined(__x86_64__)
     void *regs[8];
-#else
-    // hack for thumb
+#elif defined(__thumb2__)
     void *regs[10];
-//#error Unsupported __WORDSIZE
+#else
+#error Unknown arch in nlr.h
 #endif
 };
 

--- a/py/nlrthumb.S
+++ b/py/nlrthumb.S
@@ -2,7 +2,7 @@
 /* thumb callee save: bx, bp, sp, r12, r14, r14, r15 */
 
     .syntax unified
-    .cpu cortex-m4
+    /*.cpu cortex-m4*/
     .thumb
     .text
     .align  2


### PR DESCRIPTION
This allows to build "unix" version for ARM hosts. Specifically tested on Ubuntu 12.04 armhf running in chroot on Samsung ARM Chromebook (Cortex-A15).

Having specific .cpu directive produces errors regarding A/M variants mismatch. There's nothing magic in nlrthumb.S, so it should not be required. But as I don't have cortex-m crosscompiler here, I just commented it out so far - please try STM port before merging.
