### PR TITLE
stmhal - Add usart support

### DIFF
--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -8,7 +8,6 @@
 #include "misc.h"
 #include "systick.h"
 #include "pendsv.h"
-#include "usart.h"
 #include "mpconfig.h"
 #include "qstr.h"
 #include "nlr.h"
@@ -24,6 +23,7 @@
 #include "gccollect.h"
 #include "pyexec.h"
 #include "pybmodule.h"
+#include "usart.h"
 #include "led.h"
 #include "exti.h"
 #include "usrsw.h"
@@ -253,37 +253,21 @@ int main(void) {
     storage_init();
 #endif
 
-    // uncomment these 2 lines if you want REPL on USART_6 (or another usart) as well as on USB VCP
-    pyb_usart_global_debug = PYB_USART_YA;
-    usart_init(pyb_usart_global_debug, 115200);
-
-#if 0
-    pyb_led_t led = 1;
-    for (int i = 0; i < 24; i++) {
-    //while (1) {
-        led_state(led, 1);
-        usart_tx_strn_cooked(pyb_usart_global_debug, "on\n", 3);
-        HAL_Delay(100);
-        led_state(led, 0);
-        usart_tx_strn_cooked(pyb_usart_global_debug, "off\n", 4);
-        HAL_Delay(100);
-        led_state(led, 1);
-        usart_tx_strn_cooked(pyb_usart_global_debug, "on\n", 3);
-        HAL_Delay(100);
-        led_state(led, 0);
-        usart_tx_strn_cooked(pyb_usart_global_debug, "off\n", 4);
-        HAL_Delay(700);
-
-        led = (led % 4) + 1;
-    }
-#endif
-
     int first_soft_reset = true;
 
 soft_reset:
 
     // GC init
     gc_init(&_heap_start, &_heap_end);
+
+    // Change #if 0 to #if 1 if you want REPL on USART_6 (or another usart)
+    // as well as on USB VCP
+#if 0
+    pyb_usart_global_debug = pyb_Usart(MP_OBJ_NEW_SMALL_INT(PYB_USART_YA),
+                                       MP_OBJ_NEW_SMALL_INT(115200));
+#else
+    pyb_usart_global_debug = NULL;
+#endif
 
     // Micro Python init
     qstr_init();

--- a/stmhal/printf.c
+++ b/stmhal/printf.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdarg.h>
+#include <stm32f4xx_hal.h>
 
 #include "std.h"
 #include "misc.h"

--- a/stmhal/pybmodule.c
+++ b/stmhal/pybmodule.c
@@ -21,6 +21,7 @@
 #include "exti.h"
 #include "usrsw.h"
 #include "rtc.h"
+#include "usart.h"
 #if 0
 #include "servo.h"
 #include "storage.h"
@@ -28,7 +29,6 @@
 #include "sdcard.h"
 #include "accel.h"
 #include "i2c.h"
-#include "usart.h"
 #include "adc.h"
 #include "audio.h"
 #endif
@@ -274,7 +274,9 @@ STATIC const mp_map_elem_t pyb_module_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_Led), (mp_obj_t)&pyb_Led_obj },
 #if 0
     { MP_OBJ_NEW_QSTR(MP_QSTR_I2C), (mp_obj_t)&pyb_I2C_obj },
+#endif
     { MP_OBJ_NEW_QSTR(MP_QSTR_Usart), (mp_obj_t)&pyb_Usart_obj },
+#if 0
     { MP_OBJ_NEW_QSTR(MP_QSTR_ADC_all), (mp_obj_t)&pyb_ADC_all_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ADC), (mp_obj_t)&pyb_ADC_obj },
 

--- a/stmhal/usart.h
+++ b/stmhal/usart.h
@@ -12,15 +12,17 @@ typedef enum {
     PYB_USART_YB = 3, // USART3 on Y9, Y10 = PB10, PB11
 } pyb_usart_t;
 
-extern pyb_usart_t pyb_usart_global_debug;
+typedef struct _pyb_usart_obj_t pyb_usart_obj_t;
 
-void usart_init(pyb_usart_t usart_id, uint32_t baudrate);
-bool usart_rx_any(pyb_usart_t usart_id);
-int usart_rx_char(pyb_usart_t usart_id);
-void usart_tx_str(pyb_usart_t usart_id, const char *str);
-void usart_tx_strn(pyb_usart_t usart_id, const char *str, uint len);
-void usart_tx_strn_cooked(pyb_usart_t usart_id, const char *str, uint len);
+extern pyb_usart_obj_t *pyb_usart_global_debug;
 
-#if 0
+void usart_init(pyb_usart_obj_t *usart_obj, uint32_t baudrate);
+bool usart_rx_any(pyb_usart_obj_t *usart_obj);
+int usart_rx_char(pyb_usart_obj_t *usart_obj);
+void usart_tx_str(pyb_usart_obj_t *usart_obj, const char *str);
+void usart_tx_strn(pyb_usart_obj_t *usart_obj, const char *str, uint len);
+void usart_tx_strn_cooked(pyb_usart_obj_t *usart_obj, const char *str, uint len);
+
+mp_obj_t pyb_Usart(mp_obj_t usart_id, mp_obj_t baudrate);
+
 MP_DECLARE_CONST_FUN_OBJ(pyb_Usart_obj);
-#endif


### PR DESCRIPTION
stmhal - Add usart support
- moved struct definition into .c file (left typedef in header since all of the API's were modified to take a pyb_usart_obj_t rather then a pyb_usart_id_t to accomodate the use of the new HAL).
