### PR TITLE
unix, py: Clean up includes.

### DIFF
--- a/py/asmthumb.c
+++ b/py/asmthumb.c
@@ -1,6 +1,4 @@
-#include <stdint.h>
 #include <stdio.h>
-#include <assert.h>
 #include <string.h>
 
 #include "misc.h"

--- a/py/asmx64.c
+++ b/py/asmx64.c
@@ -1,4 +1,3 @@
-#include <stdint.h>
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>

--- a/py/binary.c
+++ b/py/binary.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include <stdint.h>
 #include <assert.h>
 

--- a/py/builtin.c
+++ b/py/builtin.c
@@ -1,8 +1,4 @@
-#include <stdint.h>
-#include <stdlib.h>
 #include <stdio.h>
-#include <stdarg.h>
-#include <string.h>
 #include <assert.h>
 
 #include "nlr.h"

--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -1,9 +1,4 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdarg.h>
-#include <string.h>
-#include <assert.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -1,7 +1,5 @@
-#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <stdarg.h>
 #include <string.h>
 #include <assert.h>
 

--- a/py/builtinmath.c
+++ b/py/builtinmath.c
@@ -1,4 +1,3 @@
-#include <stdint.h>
 #include <math.h>
 
 #include "misc.h"

--- a/py/builtinmp.c
+++ b/py/builtinmp.c
@@ -1,4 +1,3 @@
-#include <stdint.h>
 
 #include "misc.h"
 #include "mpconfig.h"

--- a/py/compile.c
+++ b/py/compile.c
@@ -1,5 +1,4 @@
-#include <unistd.h>
-#include <stdlib.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -1,5 +1,4 @@
-#include <unistd.h>
-#include <stdlib.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/py/emitcommon.c
+++ b/py/emitcommon.c
@@ -1,7 +1,5 @@
 #include <unistd.h>
-#include <stdio.h>
 #include <stdint.h>
-#include <string.h>
 #include <assert.h>
 
 #include "misc.h"

--- a/py/emitcpy.c
+++ b/py/emitcpy.c
@@ -1,9 +1,7 @@
-#include <unistd.h>
-#include <stdlib.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 #include "misc.h"
 #include "mpconfig.h"

--- a/py/emitinlinethumb.c
+++ b/py/emitinlinethumb.c
@@ -1,9 +1,6 @@
-#include <unistd.h>
-#include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 #include "misc.h"
 #include "mpconfig.h"

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -16,8 +16,7 @@
 
 // for x in l[0:8]: can be compiled into a native loop if l has pointer type
 
-#include <unistd.h>
-#include <stdlib.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/py/emitpass1.c
+++ b/py/emitpass1.c
@@ -1,8 +1,4 @@
-#include <unistd.h>
 #include <stdlib.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
 #include <assert.h>
 
 #include "misc.h"

--- a/py/formatfloat.c
+++ b/py/formatfloat.c
@@ -13,8 +13,6 @@
 
 ***********************************************************************/
 
-#include <stdint.h>
-#include <stdlib.h>
 
 #include "mpconfig.h"
 

--- a/py/gc.c
+++ b/py/gc.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 
 #include "mpconfig.h"

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -1,9 +1,9 @@
 /* lexer.c -- simple tokeniser for Python implementation
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <string.h>
 #include <assert.h>
 
 #include "misc.h"

--- a/py/lexerstr.c
+++ b/py/lexerstr.c
@@ -1,5 +1,3 @@
-#include <stdint.h>
-#include <stdio.h>
 
 #include "misc.h"
 #include "mpconfig.h"

--- a/py/lexerunix.c
+++ b/py/lexerunix.c
@@ -1,4 +1,3 @@
-#include <stdint.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -10,6 +9,9 @@
 #include "lexerunix.h"
 
 #if MICROPY_ENABLE_LEXER_UNIX
+
+#include <sys/stat.h>
+#include <sys/types.h>
 
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
     int fd = open(filename, O_RDONLY);

--- a/py/malloc.c
+++ b/py/malloc.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/py/map.c
+++ b/py/map.c
@@ -1,6 +1,4 @@
-#include <stdint.h>
 #include <stdlib.h>
-#include <assert.h>
 
 #include "misc.h"
 #include "mpconfig.h"

--- a/py/mpz.c
+++ b/py/mpz.c
@@ -1,4 +1,3 @@
-#include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/py/obj.c
+++ b/py/obj.c
@@ -1,8 +1,5 @@
-#include <stdint.h>
-#include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
-#include <string.h>
 #include <assert.h>
 
 #include "nlr.h"

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -1,7 +1,4 @@
-#include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
-#include <stdarg.h>
 #include <assert.h>
 
 #include "nlr.h"

--- a/py/objbool.c
+++ b/py/objbool.c
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-#include <stdint.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/objboundmeth.c
+++ b/py/objboundmeth.c
@@ -1,7 +1,4 @@
-#include <stdlib.h>
-#include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/objcell.c
+++ b/py/objcell.c
@@ -1,6 +1,3 @@
-#include <stdlib.h>
-#include <stdint.h>
-#include <assert.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/objclosure.c
+++ b/py/objclosure.c
@@ -1,7 +1,4 @@
-#include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
-#include <assert.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -1,6 +1,4 @@
 #include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
 #include <assert.h>
 
 #include "nlr.h"

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -1,5 +1,4 @@
-#include <stdlib.h>
-#include <stdint.h>
+#include <stdbool.h>
 #include <string.h>
 #include <assert.h>
 

--- a/py/objenumerate.c
+++ b/py/objenumerate.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include <assert.h>
 
 #include "misc.h"

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 #include <stdarg.h>
 #include <assert.h>

--- a/py/objfilter.c
+++ b/py/objfilter.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include <assert.h>
 
 #include "nlr.h"

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -1,6 +1,4 @@
 #include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
 #include <assert.h>
 
 #include "nlr.h"

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -1,5 +1,5 @@
+#include <stdbool.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 #include <assert.h>
 

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -1,6 +1,4 @@
 #include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
 #include <assert.h>
 
 #include "nlr.h"

--- a/py/objgetitemiter.c
+++ b/py/objgetitemiter.c
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-#include <stdint.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/objint.c
+++ b/py/objint.c
@@ -1,7 +1,4 @@
-#include <stdlib.h>
 #include <stdint.h>
-#include <string.h>
-#include <assert.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -1,7 +1,4 @@
-#include <stdlib.h>
 #include <stdint.h>
-#include <string.h>
-#include <assert.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -1,7 +1,5 @@
-#include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <assert.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 #include <assert.h>
 

--- a/py/objmap.c
+++ b/py/objmap.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include <assert.h>
 
 #include "nlr.h"

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -1,6 +1,4 @@
 #include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
 #include <assert.h>
 
 #include "nlr.h"

--- a/py/objnone.c
+++ b/py/objnone.c
@@ -1,5 +1,4 @@
 #include <stdlib.h>
-#include <stdint.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/objrange.c
+++ b/py/objrange.c
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-#include <stdint.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/objset.c
+++ b/py/objset.c
@@ -1,5 +1,4 @@
-#include <stdlib.h>
-#include <stdint.h>
+#include <stdbool.h>
 #include <string.h>
 #include <assert.h>
 

--- a/py/objslice.c
+++ b/py/objslice.c
@@ -1,6 +1,4 @@
 #include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
 #include <assert.h>
 
 #include "nlr.h"

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1,6 +1,4 @@
-#include <stdlib.h>
-#include <stdint.h>
-#include <stdarg.h>
+#include <stdbool.h>
 #include <string.h>
 #include <assert.h>
 

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -1,6 +1,4 @@
 #include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
 #include <assert.h>
 
 #include "nlr.h"

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 #include <assert.h>
 

--- a/py/parse.c
+++ b/py/parse.c
@@ -1,9 +1,6 @@
-#include <unistd.h>
-#include <stdlib.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <ctype.h>
-#include <string.h>
 #include <assert.h>
 
 #include "misc.h"

--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include "misc.h"

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -2,8 +2,6 @@
 // mp_xxx functions are safer and can be called by anyone
 // note that rt_assign_xxx are called only from emit*, and maybe we can rename them to reflect this
 
-#include <stdint.h>
-#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>

--- a/py/scope.c
+++ b/py/scope.c
@@ -1,6 +1,6 @@
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <string.h>
 #include <assert.h>
 
 #include "misc.h"

--- a/py/sequence.c
+++ b/py/sequence.c
@@ -1,7 +1,5 @@
-#include <stdlib.h>
-#include <stdint.h>
+#include <stdbool.h>
 #include <string.h>
-#include <assert.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/showbc.c
+++ b/py/showbc.c
@@ -1,7 +1,4 @@
-#include <stdint.h>
-#include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
 #include <assert.h>
 
 #include "misc.h"

--- a/py/stream.c
+++ b/py/stream.c
@@ -1,4 +1,4 @@
-#include <string.h>
+#include <unistd.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/py/vm.c
+++ b/py/vm.c
@@ -1,7 +1,4 @@
-#include <stdint.h>
-#include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
 #include <assert.h>
 
 #include "nlr.h"

--- a/py/vstr.c
+++ b/py/vstr.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>

--- a/unix/file.c
+++ b/unix/file.c
@@ -1,7 +1,8 @@
-#include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #include "nlr.h"
 #include "misc.h"

--- a/unix/gccollect.c
+++ b/unix/gccollect.c
@@ -1,4 +1,3 @@
-#include <stdint.h>
 #include <stdio.h>
 
 #include "misc.h"

--- a/unix/main.c
+++ b/unix/main.c
@@ -1,8 +1,10 @@
-#include <stdint.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #include "nlr.h"
 #include "misc.h"
@@ -390,8 +392,6 @@ int main(int argc, char **argv) {
     //printf("total bytes = %d\n", m_get_total_bytes_allocated());
     return 0;
 }
-
-#include <sys/stat.h>
 
 uint mp_import_stat(const char *path) {
     struct stat st;

--- a/unix/socket.c
+++ b/unix/socket.c
@@ -2,7 +2,10 @@
 #include <assert.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <errno.h>

--- a/unix/time.c
+++ b/unix/time.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include <string.h>
 #include <time.h>
 #include <sys/time.h>


### PR DESCRIPTION
Removed many unnecessary system header includes and added a few to improve portability.

I used [esr](http://www.catb.org/esr/)'s [deheader](http://www.catb.org/esr/deheader/).
