### PR TITLE
vm: Try to abstract dealing with tagged pointers in VM using macros.

### DIFF
--- a/py/bc.h
+++ b/py/bc.h
@@ -8,7 +8,7 @@ typedef enum {
 typedef struct _mp_exc_stack {
     const byte *handler;
     // bit 0 is saved currently_in_except_block value
-    machine_uint_t val_sp;
+    mp_obj_t *val_sp;
     // We might only have 2 interesting cases here: SETUP_EXCEPT & SETUP_FINALLY,
     // consider storing it in bit 1 of val_sp. TODO: SETUP_WITH?
     byte opcode;
@@ -17,3 +17,8 @@ typedef struct _mp_exc_stack {
 mp_vm_return_kind_t mp_execute_byte_code(const byte *code, const mp_obj_t *args, uint n_args, const mp_obj_t *args2, uint n_args2, uint n_state, mp_obj_t *ret);
 mp_vm_return_kind_t mp_execute_byte_code_2(const byte *code_info, const byte **ip_in_out, mp_obj_t *fastn, mp_obj_t **sp_in_out, mp_exc_stack *exc_stack, mp_exc_stack **exc_sp_in_out, volatile mp_obj_t inject_exc);
 void mp_byte_code_print(const byte *code, int len);
+
+// Helper macros to access pointer with least significant bit holding a flag
+#define MP_TAGPTR_PTR(x) ((void*)((machine_uint_t)(x) & ~((machine_uint_t)1)))
+#define MP_TAGPTR_TAG(x) ((machine_uint_t)(x) & 1)
+#define MP_TAGPTR_MAKE(ptr, tag) ((void*)((machine_uint_t)(ptr) | tag))


### PR DESCRIPTION
Based on issues raised during recent review and inconsistency of different implementations.
