### PR TITLE
objint_mpz: Quick&dirty implementation of bitwise operations.

### DIFF
--- a/py/mpz.h
+++ b/py/mpz.h
@@ -59,6 +59,9 @@ void mpz_add_inpl(mpz_t *dest, const mpz_t *lhs, const mpz_t *rhs);
 void mpz_sub_inpl(mpz_t *dest, const mpz_t *lhs, const mpz_t *rhs);
 void mpz_mul_inpl(mpz_t *dest, const mpz_t *lhs, const mpz_t *rhs);
 void mpz_pow_inpl(mpz_t *dest, const mpz_t *lhs, const mpz_t *rhs);
+void mpz_and_inpl(mpz_t *dest, const mpz_t *lhs, const mpz_t *rhs);
+void mpz_or_inpl(mpz_t *dest, const mpz_t *lhs, const mpz_t *rhs);
+void mpz_xor_inpl(mpz_t *dest, const mpz_t *lhs, const mpz_t *rhs);
 
 mpz_t *mpz_gcd(const mpz_t *z1, const mpz_t *z2);
 mpz_t *mpz_lcm(const mpz_t *z1, const mpz_t *z2);

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -78,7 +78,7 @@ mp_obj_t int_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
         return mp_obj_new_float(flhs / frhs);
 #endif
 
-    } else if (op <= RT_BINARY_OP_POWER) {
+    } else if (op <= RT_BINARY_OP_INPLACE_POWER) {
         mp_obj_int_t *res = mp_obj_int_new_mpz();
 
         switch (op) {
@@ -119,12 +119,18 @@ mp_obj_t int_binary_op(int op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
                 break;
             }
 
-            //case RT_BINARY_OP_AND:
-            //case RT_BINARY_OP_INPLACE_AND:
-            //case RT_BINARY_OP_OR:
-            //case RT_BINARY_OP_INPLACE_OR:
-            //case RT_BINARY_OP_XOR:
-            //case RT_BINARY_OP_INPLACE_XOR:
+            case RT_BINARY_OP_AND:
+            case RT_BINARY_OP_INPLACE_AND:
+                mpz_and_inpl(&res->mpz, zlhs, zrhs);
+                break;
+            case RT_BINARY_OP_OR:
+            case RT_BINARY_OP_INPLACE_OR:
+                mpz_or_inpl(&res->mpz, zlhs, zrhs);
+                break;
+            case RT_BINARY_OP_XOR:
+            case RT_BINARY_OP_INPLACE_XOR:
+                mpz_xor_inpl(&res->mpz, zlhs, zrhs);
+                break;
 
             case RT_BINARY_OP_LSHIFT:
             case RT_BINARY_OP_INPLACE_LSHIFT:


### PR DESCRIPTION
Made solely to unbreak int-long.py test which in turn uncovered thinko
with implementation of inplace ops. On mpz level, bitwise ops implemented
only for same-sign numbers, and are not efficient (unconditional calling of
mpn_cmp() is apparently superfluous).
