### PR TITLE
py/builtinmath.c: use tgamma() instead of gamma().

### DIFF
--- a/py/builtinmath.c
+++ b/py/builtinmath.c
@@ -57,7 +57,7 @@ MATH_FUN_1(trunc, trunc)
 MATH_FUN_2(ldexp, ldexp)
 MATH_FUN_1(erf, erf)
 MATH_FUN_1(erfc, erfc)
-MATH_FUN_1(gamma, gamma)
+MATH_FUN_1(gamma, tgamma)
 MATH_FUN_1(lgamma, lgamma)
 //TODO: factorial, fsum
 


### PR DESCRIPTION
[gamma() is now deprecated](http://man7.org/linux/man-pages/man3/gamma.3.html).

GCC 4.9.0 with  "-Werror=deprecated-declarations" generates a warning because of gamma().
