### PR TITLE
objgenerator: close(): Throw instance of GeneratorExit (not type).

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -231,6 +231,7 @@ extern const mp_obj_t mp_const_false;
 extern const mp_obj_t mp_const_true;
 extern const mp_obj_t mp_const_empty_tuple;
 extern const mp_obj_t mp_const_ellipsis;
+extern const mp_obj_t mp_const_GeneratorExit;
 
 // General API for objects
 

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -21,6 +21,12 @@ typedef struct mp_obj_exception_t {
     mp_obj_tuple_t args;
 } mp_obj_exception_t;
 
+// Instance of GeneratorExit exception - needed by generator.close()
+// This would belong to objgenerator.c, but to keep mp_obj_exception_t
+// definition module-private so far, have it here.
+STATIC mp_obj_exception_t GeneratorExit_obj = {{&mp_type_GeneratorExit}, MP_OBJ_NULL, NULL, {{&tuple_type}, 0}};
+const mp_obj_t mp_const_GeneratorExit = (mp_obj_t)&GeneratorExit_obj;
+
 STATIC void mp_obj_exception_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t o_in, mp_print_kind_t kind) {
     mp_obj_exception_t *o = o_in;
     if (o->msg != NULL) {

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -171,7 +171,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(gen_instance_throw_obj, 2, 4, gen_ins
 
 STATIC mp_obj_t gen_instance_close(mp_obj_t self_in) {
     mp_obj_t ret;
-    switch (mp_obj_gen_resume(self_in, mp_const_none, (mp_obj_t)&mp_type_GeneratorExit, &ret)) {
+    switch (mp_obj_gen_resume(self_in, mp_const_none, mp_const_GeneratorExit, &ret)) {
         case MP_VM_RETURN_YIELD:
             nlr_jump(mp_obj_new_exception_msg(&mp_type_RuntimeError, "generator ignored GeneratorExit"));
 


### PR DESCRIPTION
To comply with Python semantics and allow use of mp_obj_is_subclass_fast()
for exception matching.
