### PR TITLE
objgenerator: Handle default args to generator functions.

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -331,7 +331,6 @@ mp_obj_t mp_obj_new_range_iterator(int cur, int stop, int step);
 mp_obj_t mp_obj_new_fun_bc(uint scope_flags, qstr *args, uint n_args, mp_obj_t def_args, const byte *code);
 mp_obj_t mp_obj_new_fun_asm(uint n_args, void *fun);
 mp_obj_t mp_obj_new_gen_wrap(mp_obj_t fun);
-mp_obj_t mp_obj_new_gen_instance(const byte *bytecode, int n_args, const mp_obj_t *args);
 mp_obj_t mp_obj_new_closure(mp_obj_t fun, mp_obj_t closure_tuple);
 mp_obj_t mp_obj_new_tuple(uint n, const mp_obj_t *items);
 mp_obj_t mp_obj_new_list(uint n, mp_obj_t *items);
@@ -462,6 +461,8 @@ typedef struct _mp_obj_fun_native_t { // need this so we can define const object
 } mp_obj_fun_native_t;
 
 void mp_obj_fun_bc_get(mp_obj_t self_in, int *n_args, const byte **code);
+bool mp_obj_fun_prepare_simple_args(mp_obj_t self_in, uint n_args, uint n_kw, const mp_obj_t *args,
+                            uint *out_args1_len, const mp_obj_t **out_args1, uint *out_args2_len, const mp_obj_t **out_args2);
 
 mp_obj_t mp_identity(mp_obj_t self);
 MP_DECLARE_CONST_FUN_OBJ(mp_identity_obj);

--- a/tests/basics/generator-args.py
+++ b/tests/basics/generator-args.py
@@ -1,0 +1,9 @@
+# Handling of "complicated" arg forms to generators
+# https://github.com/micropython/micropython/issues/397
+def gen(v=5):
+    for i in range(v):
+        yield i
+
+print(list(gen()))
+# Still not supported, ditto for *args and **kwargs
+#print(list(gen(v=10)))


### PR DESCRIPTION
This addresses initial report in #397.

Despite what's written in comments to new function, I now think that the forward is to make even mp_execute_byte_code() accept pointer to state array. We allocate that unconditionally, so should use it right away for argument munging, instead of allocating temporary buffers. for them to be eventually copied into state.

(But please merge this nonetheless, otherwise it's "lost in refactoring" - besides, I'm trying to make test_pep380.py run as far as possible).
