### PR TITLE
Enhance str.format support

### DIFF
--- a/py/formatfloat.c
+++ b/py/formatfloat.c
@@ -14,6 +14,7 @@
 ***********************************************************************/
 
 #include <stdlib.h>
+#include <stdint.h>
 
 #include "mpconfig.h"
 

--- a/py/obj.c
+++ b/py/obj.c
@@ -198,6 +198,10 @@ machine_int_t mp_obj_get_int(mp_obj_t arg) {
         return MP_OBJ_SMALL_INT_VALUE(arg);
     } else if (MP_OBJ_IS_TYPE(arg, &mp_type_int)) {
         return mp_obj_int_get_checked(arg);
+#if MICROPY_ENABLE_FLOAT
+    } else if (MP_OBJ_IS_TYPE(arg, &mp_type_float)) {
+        return mp_obj_float_get(arg);
+#endif
     } else {
         nlr_jump(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "can't convert %s to int", mp_obj_get_type_str(arg)));
     }

--- a/py/pfenv.c
+++ b/py/pfenv.c
@@ -1,0 +1,208 @@
+#include <stdint.h>
+#include <string.h>
+
+///#include "std.h"
+#include "misc.h"
+#include "mpconfig.h"
+#include "qstr.h"
+#include "obj.h"
+#include "pfenv.h"
+
+#if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
+#include <stdio.h>
+#endif
+
+#if MICROPY_ENABLE_FLOAT
+#include "formatfloat.h"
+#endif
+
+#define PF_PAD_SIZE 16
+static const char *pad_spaces = "                ";
+static const char *pad_zeroes = "0000000000000000";
+
+void pfenv_vstr_add_strn(void *data, const char *str, unsigned int len){
+    vstr_add_strn(data, str, len);
+}
+
+int pfenv_print_strn(const pfenv_t *pfenv, const char *str, unsigned int len, int flags, char fill, int width) {
+    int left_pad = 0;
+    int right_pad = 0;
+    int pad = width - len;
+    char pad_fill[PF_PAD_SIZE];
+    const char *pad_chars;
+
+    if (!fill || fill == ' ' ) {
+        pad_chars = pad_spaces;
+    } else if (fill == '0') {
+        pad_chars = pad_zeroes;
+    } else {
+        memset(pad_fill, fill, PF_PAD_SIZE);
+        pad_chars = pad_fill;
+    }
+
+    if (flags & PF_FLAG_CENTER_ADJUST) {
+        left_pad = pad / 2;
+        right_pad = pad - left_pad;
+    } else if (flags & PF_FLAG_LEFT_ADJUST) {
+        right_pad = pad;
+    } else {
+        left_pad = pad;
+    }
+
+    if (left_pad) {
+        while (left_pad > 0) {
+            int p = left_pad;
+            if (p > PF_PAD_SIZE)
+                p = PF_PAD_SIZE;
+            pfenv->print_strn(pfenv->data, pad_chars, p);
+            left_pad -= p;
+        }
+    }
+    pfenv->print_strn(pfenv->data, str, len);
+    if (right_pad) {
+        while (right_pad > 0) {
+            int p = right_pad;
+            if (p > PF_PAD_SIZE)
+                p = PF_PAD_SIZE;
+            pfenv->print_strn(pfenv->data, pad_chars, p);
+            right_pad -= p;
+        }
+    }
+    return len;
+}
+
+// enough room for 32 signed number
+#define INT_BUF_SIZE (16)
+
+int pfenv_print_int(const pfenv_t *pfenv, unsigned int x, int sgn, int base, int base_char, int flags, char fill, int width) {
+    char sign = 0;
+    if (sgn) {
+        if ((int)x < 0) {
+            sign = '-';
+            x = -x;
+        } else if (flags & PF_FLAG_SHOW_SIGN) {
+            sign = '+';
+        } else if (flags & PF_FLAG_SPACE_SIGN) {
+            sign = ' ';
+        }
+    }
+
+    char buf[INT_BUF_SIZE];
+    char *b = buf + INT_BUF_SIZE;
+
+    if (x == 0) {
+        *(--b) = '0';
+    } else {
+        do {
+            int c = x % base;
+            x /= base;
+            if (c >= 10) {
+                c += base_char - 10;
+            } else {
+                c += '0';
+            }
+            *(--b) = c;
+        } while (b > buf && x != 0);
+    }
+
+    char prefix_char = '\0';
+
+    if (flags & PF_FLAG_SHOW_PREFIX) {
+        if (base == 2) {
+            prefix_char = base_char + 'b' - 'a';
+        } else if (base == 8) {
+            prefix_char = base_char + 'o' - 'a';
+        } else if (base == 16) {
+            prefix_char = base_char + 'x' - 'a';
+        }
+    }
+
+    int len = 0;
+    if (flags & PF_FLAG_PAD_AFTER_SIGN) {
+        if (sign) {
+            len += pfenv_print_strn(pfenv, &sign, 1, flags, fill, 1);
+            width--;
+        }
+        if (prefix_char) {
+            len += pfenv_print_strn(pfenv, "0", 1, flags, fill, 1);
+            len += pfenv_print_strn(pfenv, &prefix_char, 1, flags, fill, 1);
+            width -= 2;
+        }
+    } else {
+        if (prefix_char && b > &buf[1]) {
+            *(--b) = prefix_char;
+            *(--b) = '0';
+        }
+        if (sign && b > buf) {
+            *(--b) = sign;
+        }
+    }
+
+    len += pfenv_print_strn(pfenv, b, buf + INT_BUF_SIZE - b, flags, fill, width);
+    return len;
+}
+
+#if MICROPY_ENABLE_FLOAT
+int pfenv_print_float(const pfenv_t *pfenv, mp_float_t f, char fmt, int flags, char fill, int width, int prec) {
+    char buf[32];
+    char sign = '\0';
+    int chrs = 0;
+
+    if (flags & PF_FLAG_SHOW_SIGN) {
+        sign = '+';
+    }
+    else
+    if (flags & PF_FLAG_SPACE_SIGN) {
+        sign = ' ';
+    }
+    int len;
+#if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
+    len = format_float(f, buf, sizeof(buf), fmt, prec, sign);
+#elif MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
+    char fmt_buf[6];
+    char *fmt_s = fmt_buf;
+
+    *fmt_s++ = '%';
+    if (sign) {
+        *fmt_s++ = sign;
+    }
+    *fmt_s++ = '.';
+    *fmt_s++ = '*';
+    *fmt_s++ = fmt;
+    *fmt_s = '\0';
+
+    len = snprintf(buf, sizeof(buf), fmt_buf, prec, f);
+#else
+#error Unknown MICROPY FLOAT IMPL
+#endif
+    char *s = buf;
+
+    if ((flags & PF_FLAG_ADD_PERCENT) && (len + 1) < sizeof(buf)) {
+        buf[len++] = '%';
+        buf[len] = '\0';
+    }
+
+    // buf[0] < '0' returns true if the first character is space, + or -
+    if ((flags & PF_FLAG_PAD_AFTER_SIGN) && buf[0] < '0') {
+        // We have a sign character
+        s++;
+        if (*s <= '9' || (flags & PF_FLAG_PAD_NAN_INF)) {
+            // We have a number, or we have a inf/nan and PAD_NAN_INF is set
+            // With '{:06e}'.format(float('-inf')) you get '-00inf'
+            chrs += pfenv_print_strn(pfenv, &buf[0], 1, 0, 0, 1);
+            width--;
+            len--;
+        }
+    }
+
+    if (*s > 'A' && (flags & PF_FLAG_PAD_NAN_INF) == 0) {
+        // We have one of the inf or nan variants, suppress zero fill.
+        // With printf, if you use: printf("%06e", -inf) then you get "  -inf"
+        // so suppress the zero fill.
+        fill = ' ';
+    }
+    chrs += pfenv_print_strn(pfenv, s, len, flags, fill, width); 
+
+    return chrs;
+}
+#endif

--- a/py/pfenv.h
+++ b/py/pfenv.h
@@ -1,0 +1,23 @@
+#define PF_FLAG_LEFT_ADJUST     (0x001)
+#define PF_FLAG_SHOW_SIGN       (0x002)
+#define PF_FLAG_SPACE_SIGN      (0x004)
+#define PF_FLAG_NO_TRAILZ       (0x008)
+#define PF_FLAG_SHOW_PREFIX     (0x010)
+#define PF_FLAG_SHOW_COMMA      (0x020)
+#define PF_FLAG_PAD_AFTER_SIGN  (0x040)
+#define PF_FLAG_CENTER_ADJUST   (0x080)
+#define PF_FLAG_ADD_PERCENT     (0x100)
+#define PF_FLAG_PAD_NAN_INF     (0x200)
+
+typedef struct _pfenv_t {
+    void *data;
+    void (*print_strn)(void *, const char *str, unsigned int len);
+} pfenv_t;
+
+void pfenv_vstr_add_strn(void *data, const char *str, unsigned int len);
+
+int pfenv_print_strn(const pfenv_t *pfenv, const char *str, unsigned int len, int flags, char fill, int width);
+int pfenv_print_int(const pfenv_t *pfenv, unsigned int x, int sgn, int base, int base_char, int flags, char fill, int width);
+#if MICROPY_ENABLE_FLOAT
+int pfenv_print_float(const pfenv_t *pfenv, mp_float_t f, char fmt, int flags, char fill, int width, int prec);
+#endif

--- a/py/py.mk
+++ b/py/py.mk
@@ -84,6 +84,7 @@ PY_O_BASENAME = \
 	showbc.o \
 	repl.o \
 	intdivmod.o \
+	pfenv.o \
 
 # prepend the build destination prefix to the py object files
 PY_O = $(addprefix $(PY_BUILD)/, $(PY_O_BASENAME))

--- a/tests/basics/string-format.py
+++ b/tests/basics/string-format.py
@@ -1,8 +1,138 @@
-print("{}-{}".format(1, [4, 5]))
-print("{0}-{1}".format(1, [4, 5]))
-print("{:x}".format(1))
-print("{!r}".format(2))
-# TODO
-#print("{1}-{0}".format(1, [4, 5]))
-#print("{:x}".format(0x10))
-#print("{!r}".format("foo"))
+def test(fmt, *args):
+    print('{:8s}'.format(fmt) + '>' +  fmt.format(*args) + '<')
+
+test("{}-{}", 1, [4, 5])
+test("{0}-{1}", 1, [4, 5])
+test("{1}-{0}", 1, [4, 5])
+test("{:x}", 1)
+test("{!r}", 2)
+test("{1}-{0}", 1, [4, 5])
+test("{:x}", 0x10)
+test("{!r}", "foo")
+test("{!s}", "foo")
+
+def test_fmt(conv, fill, alignment, sign, prefix, width, precision, type, arg):
+    fmt = '{'
+    if conv:
+        fmt += '!'
+        fmt += conv
+    fmt += ':'
+    if alignment:
+        fmt += fill
+        fmt += alignment
+    fmt += sign
+    fmt += prefix
+    fmt += width
+    if precision:
+        fmt += '.'
+        fmt += precision
+    fmt += type
+    fmt += '}'
+    test(fmt,  arg)
+    if fill == '0' and alignment == '=':
+        fmt = '{:'
+        fmt += sign
+        fmt += prefix
+        fmt += width
+        if precision:
+            fmt += '.'
+            fmt += precision
+        fmt += type
+        fmt += '}'
+        test(fmt, arg)
+
+int_nums = (-1234, -123, -12, -1, 0, 1, 12, 123, 1234, True, False)
+int_nums2 = (-12, -1, 0, 1, 12, True, False)
+
+if True:
+    for type in ('', 'b', 'd', 'o', 'x', 'X'):
+        for width in ('', '1', '3', '5', '7'):
+            for alignment in ('', '<', '>', '=', '^'):
+                for fill in ('', ' ', '0', '@'):
+                    for sign in ('', '+', '-', ' '):
+                        for prefix in ('', '#'):
+                            for num in int_nums:
+                                test_fmt('', fill, alignment, sign, prefix, width, '', type, num)
+
+if True:
+    for width in ('', '1', '2'):
+        for alignment in ('', '<', '>', '^'):
+            for fill in ('', ' ', '0', '@'):
+                test_fmt('', fill, alignment, '', '', width, '', 'c', 48)
+
+if True:
+    for conv in ('', 'r', 's'):
+        for width in ('', '1', '4', '10'):
+            for alignment in ('', '<', '>', '^'):
+                for fill in ('', ' ', '0', '@'):
+                    for str in ('', 'a', 'bcd', 'This is a test with a longer string'):
+                        test_fmt(conv, fill, alignment, '', '', width, '', 's', str)
+
+eg_nums = (0.0, -0.0, 0.1, 1.234, 12.3459, 1.23456789, 123456789.0, -0.0,
+    -0.1, -1.234, -12.3459, 1e4, 1e-4, 1e5, 1e-5, 1e6, 1e-6, 1e10,
+    1e37, -1e37, 1e-37, -1e-37,
+    1.23456e8, 1.23456e7, 1.23456e6, 1.23456e5, 1.23456e4, 1.23456e3, 1.23456e2, 1.23456e1, 1.23456e0,
+    1.23456e-1, 1.23456e-2, 1.23456e-3, 1.23456e-4, 1.23456e-5, 1.23456e-6, 1.23456e-7, 1.23456e-8,
+    -1.23456e8, -1.23456e7, -1.23456e6, -1.23456e5, -1.23456e4, -1.23456e3, -1.23456e2, -1.23456e1, -1.23456e0,
+    -1.23456e-1, -1.23456e-2, -1.23456e-3, -1.23456e-4, -1.23456e-5, -1.23456e-6, -1.23456e-7, -1.23456e-8)
+
+if True:
+    for type in ('e', 'E', 'g', 'G', 'n'):
+        for width in ('', '4', '6', '8', '10'):
+            for alignment in ('', '<', '>', '=', '^'):
+                for fill in ('', '@', '0', ' '):
+                    for sign in ('', '+', '-', ' '):
+                        for prec in ('', '1', '3', '6'):
+                            for num in eg_nums:
+                                test_fmt('', fill, alignment, sign, '', width, prec, type, num)
+
+# Note: We use 1.23459 rather than 1.2345 because '{:3f}'.format(1.2345)
+#       rounds differently than print("%.3f", 1.2345);
+
+f_nums = (0.0, -0.0, 0.0001, 0.001, 0.01, 0.1, 1.0, 10.0,
+     0.0012,  0.0123,  0.1234,  1.23459,  12.3456,
+    -0.0001, -0.001,  -0.01,   -0.1,      -1.0, -10.0,
+    -0.0012, -0.0123, -0.1234, -1.23459, -12.3456)
+
+if True:
+    for type in ('f', 'F'):
+        for width in ('', '4', '6', '8', '10'):
+            for alignment in ('', '<', '>', '=', '^'):
+                for fill in ('', ' ', '0', '@'):
+                    for sign in ('', '+', '-', ' '):
+                        # An empty precision defaults to 6, but when uPy is
+                        # configured to use a float, we can only use a
+                        # precision of 6 with numbers less than 10 and still
+                        # get results that compare to CPython (which uses
+                        # long doubles).
+                        for prec in ('1', '2', '3'):
+                            for num in f_nums:
+                                test_fmt('', fill, alignment, sign, '', width, prec, type, num)
+                        for num in int_nums2:
+                            test_fmt('', fill, alignment, sign, '', width, '', type, num)
+
+pct_nums1 = (0.1, 0.58, 0.99, -0.1, -0.58, -0.99)
+pct_nums2 = (True, False, 1, 0, -1)
+
+if True:
+    type = '%'
+    for width in ('', '4', '6', '8', '10'):
+        for alignment in ('', '<', '>', '=', '^'):
+            for fill in ('', ' ', '0', '@'):
+                for sign in ('', '+', '-', ' '):
+                    # An empty precision defaults to 6, but when uPy is
+                    # configured to use a float, we can only use a
+                    # precision of 6 with numbers less than 10 and still
+                    # get results that compare to CPython (which uses
+                    # long doubles).
+                    for prec in ('1', '2', '3'):
+                        for num in pct_nums1:
+                            test_fmt('', fill, alignment, sign, '', width, prec, type, num)
+                    for num in pct_nums2:
+                        test_fmt('', fill, alignment, sign, '', width, '', type, num)
+
+# We don't currently test a type of '' with floats (see the detailed comment
+# in  objstr.c)
+
+# TODO Add tests for erroneous format strings.
+


### PR DESCRIPTION
This adds support for almost everything (the comma isn't currently
supported).

The "unspecified" type with floats also doesn't behave exactly like
python.

Tested under unix with float and double
Spot tested on stmhal
