### PR TITLE
tools: Add pip-micropython to install packages in MicroPython-friendly way

### DIFF
--- a/tools/pip-micropython
+++ b/tools/pip-micropython
@@ -1,0 +1,61 @@
+#!/bin/sh
+#
+# This tool can be used to install a new package into MicroPython
+# library location (for unix port, default behavior), or produce
+# complete library snapshot to be deployed on a device for baremetal
+# ports (if PIP_MICROPY_DEST environment var is set).
+#
+
+if [ -n "$PIP_MICROPY_DEST" ]; then
+    dest="$PIP_MICROPY_DEST"
+    echo "Destination snapshot directory: $dest"
+elif [ -n "$MICROPYPATH" ]; then
+    libdest=$(echo "$MICROPYPATH" | awk -F: ' {print $1}')
+    echo "Destination library directory: $libdest"
+else
+    echo "Warning: MICROPYPATH is not set, assuming default value"
+    libdest=~/.micropython/lib
+    echo "Destination library directory: $libdest"
+fi
+
+# Due to bugs in pip, installation should happen with active virtualenv
+# The issue (at least with pip 1.0 which is still what's shipped with many
+# distros) is that even if --ignore-installed is used, package is not
+# installed if it's already installed for main python distribution.
+if [ ! -d /tmp/pip-micropy-venv ]; then
+    virtualenv --no-site-packages /tmp/pip-micropy-venv
+fi
+. /tmp/pip-micropy-venv/bin/activate
+
+# We need to specify --record to override this switch as passed by pip
+# pip will try to parse this file (at the location in specifies), and try to
+# access files as specified in it. But paths there will be relative to --root
+# we pass, so it won't find files and crash. However, if it won't find the
+# file, it will just issue a warning and continue.
+if [ -n "$dest" ]; then
+pip install "$@" \
+    --install-option="--install-base=." \
+    --install-option="--install-purelib=lib" \
+    --install-option="--install-platlib=lib" \
+    --install-option="--install-scripts=." \
+    --install-option="--install-headers=headers" \
+    --install-option="--install-data=lib" \
+    --install-option="--record=/tmp/setuptools-record.txt" \
+    --install-option="--no-compile" \
+    --install-option="--root=$dest"
+else
+# Here we assume that base dir is lib dir, and install scripts a level
+# higher. For default value of ~/micropython/lib/ , this should give
+# reasonable behavior, though better would make it overridable (or
+# go bold and use ~/bin ?)
+pip install "$@" \
+    --install-option="--install-base=." \
+    --install-option="--install-purelib=." \
+    --install-option="--install-platlib=." \
+    --install-option="--install-scripts=.." \
+    --install-option="--install-headers=../headers" \
+    --install-option="--install-data=." \
+    --install-option="--record=/tmp/setuptools-record.txt" \
+    --install-option="--no-compile" \
+    --install-option="--root=$libdest"
+fi


### PR DESCRIPTION
This closes cycle for being able to use PyPI for uPy modules. Caveat: the script uses various workarounds to make pip and setuptools work in the needed way, so needed to test on various system configurations. To try:

```
./pip-micropython micropython-unittest
...
./micropython
>>> import unittest
```
