### PR TITLE
unix: Enable GC.

### DIFF
--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -3,6 +3,7 @@
 #define MICROPY_EMIT_X64            (1)
 #define MICROPY_EMIT_THUMB          (0)
 #define MICROPY_EMIT_INLINE_THUMB   (0)
+#define MICROPY_ENABLE_GC           (1)
 #define MICROPY_MEM_STATS           (1)
 #define MICROPY_DEBUG_PRINTERS      (1)
 #define MICROPY_ENABLE_REPL_HELPERS (1)


### PR DESCRIPTION
GC support for "unix" port was implemented some time ago, but still not
enabled.
