### PR TITLE
py: Put default namespace into module __main__.

### DIFF
--- a/py/builtin.h
+++ b/py/builtin.h
@@ -33,6 +33,7 @@ MP_DECLARE_CONST_FUN_OBJ(mp_builtin_sum_obj);
 
 MP_DECLARE_CONST_FUN_OBJ(mp_namedtuple_obj);
 
+extern const mp_obj_module_t mp_module___main__;
 extern const mp_obj_module_t mp_module_array;
 extern const mp_obj_module_t mp_module_collections;
 extern const mp_obj_module_t mp_module_io;

--- a/py/builtintables.c
+++ b/py/builtintables.c
@@ -118,6 +118,7 @@ STATIC const mp_builtin_elem_t builtin_object_table[] = {
 };
 
 STATIC const mp_builtin_elem_t builtin_module_table[] = {
+    { MP_QSTR___main__, (mp_obj_t)&mp_module___main__ },
     { MP_QSTR_micropython, (mp_obj_t)&mp_module_micropython },
 
     { MP_QSTR_array, (mp_obj_t)&mp_module_array },


### PR DESCRIPTION
That's how CPython has it, in particular, "import **main**" should work.
