### PR TITLE
unix: Fix GC not tracing .data

### DIFF
--- a/unix/gccollect.c
+++ b/unix/gccollect.c
@@ -77,7 +77,7 @@ void gc_collect(void) {
     //gc_dump_info();
 
     gc_collect_start();
-    // this traces .data and .bss sections
+    // this traces the .bss section
 #ifdef __CYGWIN__
 #define BSS_START __bss_start__
 #else


### PR DESCRIPTION
In unix/gccollect.c the gc_collect() function's first call to gc_collect_root() aims to trace .data and .bss. However it starts at "__bss_start", so to my understanding it doesn't trace .data. If we instead start the trace at "__data_start" then it will start at .data, go all the way through .bss, and end at _end as it did before.
