### PR TITLE
py: the entire `<unistd.h>` shouldn't be needed

### DIFF
--- a/py/emitcommon.c
+++ b/py/emitcommon.c
@@ -1,4 +1,4 @@
-#include <unistd.h>
+#include <string.h>
 #include <stdint.h>
 #include <assert.h>
 

--- a/py/stream.c
+++ b/py/stream.c
@@ -1,4 +1,4 @@
-#include <unistd.h>
+#include <string.h>
 
 #include "nlr.h"
 #include "misc.h"


### PR DESCRIPTION
Chaning this worked for me with AMRCC and their libc, but I'm not too sure whether `<string.h>` is the lowest common denominator.
Potentially we could put a check around what compiler we are using, but looks like there is nothing specific in `<unistd.h>` that these files currently require.
