### PR TITLE
unix: Enable modffi by default.

### DIFF
--- a/unix/mpconfigport.mk
+++ b/unix/mpconfigport.mk
@@ -7,4 +7,4 @@ MICROPY_USE_READLINE = 1
 MICROPY_MOD_TIME = 1
 
 # ffi module requires libffi (libffi-dev Debian package)
-MICROPY_MOD_FFI = 0
+MICROPY_MOD_FFI = 1


### PR DESCRIPTION
ffi is needed to use micropython-lib, so let's have it enabled by default,
then folks who have troubles with libffi can disable it, instead of everyone
doing manual actions again and again.
