### PR TITLE
objlist: Make .extend accept arbitrary iterable.

### DIFF
--- a/tests/basics/list1.py
+++ b/tests/basics/list1.py
@@ -13,6 +13,8 @@ print(x)
 
 x.extend([100, 200])
 print(x)
+x.extend(range(3))
+print(x)
 
 x += [2, 1]
 print(x)


### PR DESCRIPTION
Pretty simple, why review? Because this again starts mumbo-jumbo with rge-sm.py, this time with "gcc version 4.8.1 (Ubuntu 4.8.1-2ubuntu1~12.04)".

When run with run-test, I get following with 95% probability:

```
raceback (most recent call last):
  File "misc/rge-sm.py", line 114, in <module>
  File "misc/rge-sm.py", line 103, in singleTraj
  File "misc/rge-sm.py", line 38, in solve
  File "misc/rge-sm.py", line 24, in iterate
  File "misc/rge-sm.py", line 22, in iterate
TypeError: tuple takes at most 1 argument, 6 given
```

When run directly from tests/misc/ dir, I get other weird errors in 10% of cases. Downgrading to gcc 4.7 fixes this. So, please test with your gcc, I don't want to land code which hits bugs which may affect production builds ;-).
