### PR TITLE
Don't allow both ENDIANNESSes to be set

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -187,6 +187,10 @@ typedef double mp_float_t;
 // Just because most archs are such?
 #define MP_ENDIANNESS_LITTLE (1)
 #endif
+// Ensure we don't accidentally set both endiannesses
+#if MP_ENDIANNESS_BIG
+#define MP_ENDIANNESS_LITTLE (0)
+#endif
 
 // printf format spec to use for machine_int_t and friends
 #ifndef INT_FMT


### PR DESCRIPTION
See discussion on https://github.com/micropython/micropython/commit/2da81fa80c4cd965f05ad237d81d9764322fde20

Explicitly set `MP_ENDIANNESS_LITTLE` because that's the #define that is used in code elsewhere.
