### PR TITLE
New config option MICROPY_FORCE_32BIT (defaulted to 0)

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -20,6 +20,16 @@ else
     LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-Map=$@.map,--cref
  endif
 
+ifeq ($(MICROPY_FORCE_32BIT),1)
+CFLAGS += -m32
+LDFLAGS += -m32
+ifeq ($(MICROPY_MOD_FFI),1)
+ifeq ($(UNAME_S),Linux)
+CFLAGS_MOD += -I/usr/include/i686-linux-gnu
+endif
+endif
+endif
+
 ifeq ($(MICROPY_USE_READLINE),1)
 CFLAGS_MOD += -DMICROPY_USE_READLINE=1
 LDFLAGS_MOD += -lreadline

--- a/unix/mpconfigport.mk
+++ b/unix/mpconfigport.mk
@@ -1,5 +1,8 @@
 # Enable/disable modules and 3rd-party libs to be included in interpreter
 
+# Build 32-bit binaries on a 64-bit host
+MICROPY_FORCE_32BIT = 0
+
 # Linking with GNU readline causes binary to be licensed under GPL
 MICROPY_USE_READLINE = 1
 


### PR DESCRIPTION
Makes it easier for 64-bit unix hosts to build 32-bit unix
binaries (for testing)
