### PR TITLE
run-tests can now skip certain tests when run under Travis CI

### DIFF
--- a/tests/basics/memoryerror.py
+++ b/tests/basics/memoryerror.py
@@ -1,11 +1,6 @@
-# this test for MemoryError can be difficult to reproduce
-# on different machine configurations (notably Travis CI)
-# so we disable it
-# TODO is there a way of testing that we are on Travis CI?
-if False:
-    l = list(range(10000))
-    try:
-        100000000 * l
-    except MemoryError:
-        print('MemoryError')
-    print(len(l), l[0], l[-1])
+l = list(range(10000))
+try:
+    100000000 * l
+except MemoryError:
+    print('MemoryError')
+print(len(l), l[0], l[-1])

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -15,6 +15,9 @@ else:
     CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3')
     MP_PY = '../unix/micropython'
 
+# Set of tests that we shouldn't run under Travis CI
+skip_travis_tests = set(['basics/memoryerror.py'])
+
 def rm_f(fname):
     if os.path.exists(fname):
         os.remove(fname)
@@ -36,8 +39,12 @@ if test_on_pyboard:
     pyb = pyboard.Pyboard('/dev/ttyACM0')
     pyb.enter_raw_repl()
 
+running_under_travis = os.environ.get('TRAVIS', 'false') == 'true'
+
 for test_file in tests:
-    test_name = os.path.splitext(os.path.basename(test_file))[0]
+    if running_under_travis and test_file in skip_travis_tests:
+        print("skip ", test_file)
+        continue
 
     # run CPython
     try:
@@ -64,15 +71,20 @@ for test_file in tests:
 
     testcase_count += len(output_expected.splitlines())
 
+    test_basename = os.path.basename(test_file)
+    test_name = os.path.splitext(test_basename)[0]
+    filename_expected = test_basename + ".exp"
+    filename_mupy = test_basename + ".out"
+
     if output_expected == output_mupy:
         print("pass ", test_file)
         passed_count += 1
-        rm_f(os.path.basename(test_file + ".exp"))
-        rm_f(os.path.basename(test_file + ".out"))
+        rm_f(filename_expected)
+        rm_f(filename_mupy)
     else:
-        with open(os.path.basename(test_file + ".exp"), "w") as f:
+        with open(filename_expected, "w") as f:
             f.write(str(output_expected, "ascii"))
-        with open(os.path.basename(test_file + ".out"), "w") as f:
+        with open(filename_mupy, "w") as f:
             f.write(str(output_mupy, "ascii"))
         print("FAIL ", test_file)
         failed_tests.append(test_name)


### PR DESCRIPTION
See the `skip_travis_tests` variable. Fixes #495
(also tidied up usage of os.path.basename() function)
