### PR TITLE
Remove generated .h file if the generation process fails.

### DIFF
--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -54,4 +54,6 @@ STRIP = $(CROSS_COMPILE)strip
 all:
 .PHONY: all
 
+.DELETE_ON_ERROR:
+
 MKENV_INCLUDED = 1


### PR DESCRIPTION
If the script fails for any reason, or python isn't installed, we don't want to leave an incomplete qstrdefs.generated.h lying around.
