### PR TITLE
Detect ffi

### DIFF
--- a/unix/mpconfigport.mk
+++ b/unix/mpconfigport.mk
@@ -10,4 +10,4 @@ MICROPY_USE_READLINE = 1
 MICROPY_MOD_TIME = 1
 
 # ffi module requires libffi (libffi-dev Debian package)
-MICROPY_MOD_FFI = 1
+MICROPY_MOD_FFI = $(shell if pkg-config --exists libffi; then echo 1; else echo 0; fi)


### PR DESCRIPTION
Since the makefile relies on pkg-config, we might as well use it to query if libffi is installed or not.
