### PR TITLE
Allow the uPy used by run-tests to be overridden

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -10,10 +10,10 @@ from glob import glob
 # to the correct executable.
 if os.name == 'nt':
     CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3.exe')
-    MP_PY = os.getenv('MICROPY_MP_PY', '../windows/micropython.exe')
+    MICROPYTHON = os.getenv('MICROPY_MICROPYTHON', '../windows/micropython.exe')
 else:
     CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3')
-    MP_PY = os.getenv('MICROPY_MP_PY', '../unix/micropython')
+    MICROPYTHON = os.getenv('MICROPY_MICROPYTHON', '../unix/micropython')
 
 # Set of tests that we shouldn't run under Travis CI
 skip_travis_tests = set(['basics/memoryerror.py'])
@@ -65,7 +65,7 @@ for test_file in tests:
             output_mupy = b'CRASH\n' + output_mupy
     else:
         try:
-            output_mupy = subprocess.check_output([MP_PY, '-X', 'emit=bytecode', test_file])
+            output_mupy = subprocess.check_output([MICROPYTHON, '-X', 'emit=bytecode', test_file])
         except subprocess.CalledProcessError:
             output_mupy = b'CRASH'
 

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -13,7 +13,7 @@ if os.name == 'nt':
     MP_PY = os.getenv('MICROPY_MP_PY', '../windows/micropython.exe')
 else:
     CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3')
-    MP_PY = ('MICROPY_MP_PY', '../unix/micropython')
+    MP_PY = os.getenv('MICROPY_MP_PY', '../unix/micropython')
 
 # Set of tests that we shouldn't run under Travis CI
 skip_travis_tests = set(['basics/memoryerror.py'])

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -10,10 +10,10 @@ from glob import glob
 # to the correct executable.
 if os.name == 'nt':
     CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3.exe')
-    MP_PY = '../windows/micropython.exe'
+    MP_PY = os.getenv('MICROPY_MP_PY', '../windows/micropython.exe')
 else:
     CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3')
-    MP_PY = '../unix/micropython'
+    MP_PY = ('MICROPY_MP_PY', '../unix/micropython')
 
 # Set of tests that we shouldn't run under Travis CI
 skip_travis_tests = set(['basics/memoryerror.py'])
@@ -39,7 +39,7 @@ if test_on_pyboard:
     pyb = pyboard.Pyboard('/dev/ttyACM0')
     pyb.enter_raw_repl()
 
-running_under_travis = os.environ.get('TRAVIS', 'false') == 'true'
+running_under_travis = os.getenv('TRAVIS') == 'true'
 
 for test_file in tests:
     if running_under_travis and test_file in skip_travis_tests:


### PR DESCRIPTION
with MICROPY_MICROPYTHON envvar, in an analogous way to MICROPY_CPYTHON3 envvar.

(the reason for this will be made clearer by a later PR)
