### PR TITLE
Add 'test' target to unix/Makefile

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -67,3 +67,8 @@ OBJ = $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
 include ../py/mkrules.mk
 
+.PHONY: test
+
+test: $(PROG) ../tests/run-tests
+	$(eval DIRNAME=$(notdir $(CURDIR)))
+	cd ../tests && MICROPY_MP_PY=../$(DIRNAME)/$(PROG) ./run-tests

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -71,4 +71,4 @@ include ../py/mkrules.mk
 
 test: $(PROG) ../tests/run-tests
 	$(eval DIRNAME=$(notdir $(CURDIR)))
-	cd ../tests && MICROPY_MP_PY=../$(DIRNAME)/$(PROG) ./run-tests
+	cd ../tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) ./run-tests


### PR DESCRIPTION
In conjunction with #504 this allows you to do things like:

``` shell
make -C unix clean && make -C unix test CC=gcc-4.7 PROG=micropython-gcc4.7
```

all from the top-level micropython directory :-)

Something similar could probably be done for windows/Makefile too, but I don't have a cygwin setup to test with.
