### PR TITLE
Fix i2c and spi to compile for Netduino Plus 2

### DIFF
--- a/stmhal/boards/NETDUINO_PLUS_2/mpconfigboard.h
+++ b/stmhal/boards/NETDUINO_PLUS_2/mpconfigboard.h
@@ -17,6 +17,8 @@
 #define MICROPY_HW_ENABLE_TIMER     (1)
 #define MICROPY_HW_ENABLE_SERVO     (1)
 #define MICROPY_HW_ENABLE_DAC       (0)
+#define MICROPU_HW_ENABLE_I2C1      (0)
+#define MICROPU_HW_ENABLE_SPI1      (0)
 
 // USRSW is pulled low. Pressing the button makes the input go high.
 #define MICROPY_HW_USRSW_PIN        (pin_B11)


### PR DESCRIPTION
I added MICROPY_HW_ENABLE_I2C1 and MICROPY_HW_ENABLE_SPI1

I kept the unaccessible instances around so that the same python id refers to the same SPI/I2C bus.
