### PR TITLE
Framework for exception messages "levels" + func.__str__ with name

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -94,6 +94,17 @@ typedef long long mp_longint_impl_t;
 #define MICROPY_ENABLE_DOC_STRING (0)
 #endif
 
+// Exception messages are short static strings (TODO)
+#define MICROPY_ERROR_REPORTING_TERSE    (1)
+// Exception messages provide basic error details
+#define MICROPY_ERROR_REPORTING_NORMAL   (2)
+// Exception messages provide full info, e.g. object names
+#define MICROPY_ERROR_REPORTING_DETAILED (3)
+
+#ifndef MICROPY_ERROR_REPORTING
+#define MICROPY_ERROR_REPORTING (MICROPY_ERROR_REPORTING_NORMAL)
+#endif
+
 // Float and complex implementation
 #define MICROPY_FLOAT_IMPL_NONE (0)
 #define MICROPY_FLOAT_IMPL_FLOAT (1)

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -126,6 +126,19 @@ mp_obj_t mp_make_function_var_between(int n_args_min, int n_args_max, mp_fun_var
 /******************************************************************************/
 /* byte code functions                                                        */
 
+const char *mp_obj_fun_get_name(mp_obj_fun_bc_t *o) {
+    const byte *code_info = o->bytecode;
+    qstr block_name = code_info[8] | (code_info[9] << 8) | (code_info[10] << 16) | (code_info[11] << 24);
+    return qstr_str(block_name);
+}
+
+#if MICROPY_CPYTHON_COMPAT
+STATIC void fun_bc_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t o_in, mp_print_kind_t kind) {
+    mp_obj_fun_bc_t *o = o_in;
+    print(env, "<function %s at 0x%x>", mp_obj_fun_get_name(o), o);
+}
+#endif
+
 #if DEBUG_PRINT
 STATIC void dump_args(const mp_obj_t *a, int sz) {
     DEBUG_printf("%p: ", a);
@@ -335,6 +348,9 @@ continue2:;
 const mp_obj_type_t mp_type_fun_bc = {
     { &mp_type_type },
     .name = MP_QSTR_function,
+#if MICROPY_CPYTHON_COMPAT
+    .print = fun_bc_print,
+#endif
     .call = fun_bc_call,
     .binary_op = fun_binary_op,
 };

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -152,8 +152,18 @@ STATIC void dump_args(const mp_obj_t *a, int sz) {
 #endif
 
 STATIC NORETURN void fun_pos_args_mismatch(mp_obj_fun_bc_t *f, uint expected, uint given) {
+#if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
+    // Generic message, to be reused for other argument issues
+    nlr_raise(mp_obj_new_exception_msg(&mp_type_TypeError,
+        "argument num/types mismatch"));
+#elif MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_NORMAL
     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
         "function takes %d positional arguments but %d were given", expected, given));
+#elif MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_DETAILED
+    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+        "%s() takes %d positional arguments but %d were given",
+        mp_obj_fun_get_name(f), expected, given));
+#endif
 }
 
 // If it's possible to call a function without allocating new argument array,

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -16,6 +16,9 @@
 #define MICROPY_USE_COMPUTED_GOTO   (1)
 #define MICROPY_MOD_SYS_STDFILES    (1)
 #define MICROPY_ENABLE_MOD_CMATH    (1)
+// Define to MICROPY_ERROR_REPORTING_DETAILED to get function, etc.
+// names in exception messages (may require more RAM).
+#define MICROPY_ERROR_REPORTING     (MICROPY_ERROR_REPORTING_DETAILED)
 
 extern const struct _mp_obj_module_t mp_module_time;
 extern const struct _mp_obj_module_t mp_module_socket;


### PR DESCRIPTION
And now, something completely different. That's why I started to refactor func error functions, as a usecase. Hopefully this patch gives good framework to actually do consistent exception messages refactor.
