### PR TITLE
Make pyboard.enter_raw_repl more robust

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -50,6 +50,7 @@ class Pyboard:
         return data
 
     def enter_raw_repl(self):
+        self.serial.write(b'\r\x03') # ctrl-C: interrupt any running program
         self.serial.write(b'\r\x01') # ctrl-A: enter raw REPL
         self.serial.write(b'\x04') # ctrl-D: soft reset
         data = self.read_until(1, b'to exit\r\n>')


### PR DESCRIPTION
In case there's a program in the microcontroller's main.py running in an infinite loop
