### PR TITLE
More relaxed parsing of preprocessed qstr header

### DIFF
--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -29,43 +29,15 @@ def compute_hash(qstr):
         hash = (hash * 33) ^ ord(char)
     return hash & 0xffff
 
-# given a list of (name,regex) pairs, find the first one that matches the given line
-def re_match_first(regexs, line):
-    for name, regex in regexs:
-        match = re.match(regex, line)
-        if match:
-            return name, match
-    return None, None
-
-# regexs to recognise lines that the CPP emits
-# use a list so that matching order is honoured
-cpp_regexs = [
-    ('qstr', r'Q\((.+)\)$'),
-    ('cdecl', r'(typedef|extern) [A-Za-z0-9_* ]+;$')
-]
-
 def do_work(infiles):
     # read the qstrs in from the input files
     qstrs = {}
     for infile in infiles:
         with open(infile, 'rt') as f:
-            line_number = 0
             for line in f:
-                line_number += 1
-                line = line.strip()
-
-                # ignore blank lines, comments and preprocessor directives
-                if len(line) == 0 or line.startswith('//') or line.startswith('#'):
-                    continue
-
-                # work out what kind of line it is
-                match_kind, match = re_match_first(cpp_regexs, line)
-                if match_kind is None:
-                    # unknown line format
-                    print('({}:{}) bad qstr format, got {}'.format(infile, line_number, line), file=sys.stderr)
-                    return False
-                elif match_kind != 'qstr':
-                    # not a line with a qstr
+                # is this a QSTR line?
+                match = re.match(r'^Q\((.+)\)$', line.strip())
+                if not match:
                     continue
 
                 # get the qstr value


### PR DESCRIPTION
The original parsing would error out on any C declarations that are not typedefs
or extern variables. This limits what can go in mpconfig.h and mpconfigport.h,
as they are included in qstr.h. For instance even a function declaration would be
rejected and including system headers is a complete no-go.
That seems too limiting for a global config header, so makeqstrdata now
ignores everything that does not match a qstr definition.
The regex is set to match _Q(.+)_ and just that on a line which I think should be strict enough.
