### PR TITLE
mingw: Fix number of exponent digits in floating point formatting

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -42,6 +42,11 @@ const mp_obj_module_t mp_module___main__ = {
 };
 
 void mp_init(void) {
+    // call port specific initialization if any 
+#ifdef MICROPY_PORT_INIT_FUNC
+    MICROPY_PORT_INIT_FUNC;
+#endif
+
     mp_emit_glue_init();
 
     // init global module stuff

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -31,6 +31,7 @@ SRC_C = \
 	unix/main.c \
 	unix/file.c \
 	realpath.c \
+	init.c \
 
 OBJ = $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 

--- a/windows/init.c
+++ b/windows/init.c
@@ -1,0 +1,5 @@
+#include <stdlib.h>
+
+void init() {
+    putenv("PRINTF_EXPONENT_DIGITS=2");
+}

--- a/windows/init.h
+++ b/windows/init.h
@@ -1,0 +1,1 @@
+void init();

--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -15,6 +15,7 @@
 #define MICROPY_MOD_SYS_STDFILES    (1)
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_DOUBLE)
 #define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_MPZ)
+#define MICROPY_PORT_INIT_FUNC      init()
 
 // type definitions for the specific machine
 
@@ -38,3 +39,4 @@ extern const struct _mp_obj_fun_native_t mp_builtin_open_obj;
     { MP_OBJ_NEW_QSTR(MP_QSTR_open), (mp_obj_t)&mp_builtin_open_obj },
 
 #include "realpath.h"
+#include "init.h"


### PR DESCRIPTION
By default mingw outputs 3 digits instead of the standard 2 so all float
tests using printf fail. Using setenv at the start of the program fixes this.
To accomodate calling platform specific initialization a
MICROPY_MAIN_INIT_FUNC macro is used which is called in mp_init()
