### PR TITLE
modsys: Land gc() function here. Unfinished.

### DIFF
--- a/py/builtin.h
+++ b/py/builtin.h
@@ -68,6 +68,8 @@ MP_DECLARE_CONST_FUN_OBJ(mp_op_getitem_obj);
 MP_DECLARE_CONST_FUN_OBJ(mp_op_setitem_obj);
 MP_DECLARE_CONST_FUN_OBJ(mp_op_delitem_obj);
 
+MP_DECLARE_CONST_FUN_OBJ(mp_sys_gc_obj);
+
 extern const mp_obj_module_t mp_module___main__;
 extern const mp_obj_module_t mp_module_array;
 extern const mp_obj_module_t mp_module_collections;

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -53,6 +53,9 @@ STATIC const MP_DEFINE_STR_OBJ(version_obj, "3.4.0");
 
 STATIC const mp_map_elem_t mp_module_sys_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_sys) },
+#if MICROPY_ENABLE_GC
+    { MP_OBJ_NEW_QSTR(MP_QSTR_gc), (mp_obj_t)&mp_sys_gc_obj },
+#endif
     { MP_OBJ_NEW_QSTR(MP_QSTR_path), (mp_obj_t)&mp_sys_path_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_argv), (mp_obj_t)&mp_sys_argv_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_version), (mp_obj_t)&version_obj },

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -346,6 +346,10 @@ Q(BytesIO)
 Q(getvalue)
 #endif
 
+#if MICROPY_ENABLE_GC
+Q(gc)
+#endif
+
 #if MICROPY_ENABLE_PROPERTY
 Q(property)
 Q(getter)

--- a/unix/main.c
+++ b/unix/main.c
@@ -291,11 +291,11 @@ mp_obj_t qstr_info(void) {
 
 #if MICROPY_ENABLE_GC
 // TODO: this doesn't belong here
-STATIC mp_obj_t pyb_gc(void) {
+STATIC mp_obj_t sys_gc(void) {
     gc_collect();
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_0(pyb_gc_obj, pyb_gc);
+MP_DEFINE_CONST_FUN_OBJ_0(mp_sys_gc_obj, sys_gc);
 #endif
 
 // Process options which set interpreter init options
@@ -381,9 +381,6 @@ int main(int argc, char **argv) {
     mp_store_name(qstr_from_str("test"), test_obj_new(42));
     mp_store_name(qstr_from_str("mem_info"), mp_make_function_n(0, mem_info));
     mp_store_name(qstr_from_str("qstr_info"), mp_make_function_n(0, qstr_info));
-#if MICROPY_ENABLE_GC
-    mp_store_name(qstr_from_str("gc"), (mp_obj_t)&pyb_gc_obj);
-#endif
 
     // Here is some example code to create a class and instance of that class.
     // First is the Python, then the C code.


### PR DESCRIPTION
This is RFC for providing port-independent location for gc() call. CPython has a special module "gc" to deal with gc, but apparently, it's overkill to introduce that for ~1 function (such module can be made on Python level). Sys seams like a natural choice, even if such name there is not compliant with CPython. "micropython" module would seem other choice, but that IMHO is hints its implementation-specific, while generally concept of GC is not.

This is just initial RFC, which, if approved, should be refactored further. A next question then will be - should "gc" be removed from "pyb" module with this change.
