### PR TITLE
py: Remove exc_state member fom mp_obj_gen_instance_t as it is never ref...

### DIFF
--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -90,7 +90,7 @@ typedef struct _mp_obj_gen_instance_t {
     // Variable-length
     mp_obj_t state[0];
     // Variable-length, never accessed by name, only as (void*)(state + n_state)
-    mp_exc_stack_t exc_state[0];
+    //mp_exc_stack_t exc_state[0];
 } mp_obj_gen_instance_t;
 
 void gen_instance_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {


### PR DESCRIPTION
...erenced

See disussion on #568 as well.
