### PR TITLE
Draft approach towards resolving docstring early interning issue

### DIFF
--- a/py/parse.h
+++ b/py/parse.h
@@ -80,6 +80,7 @@ typedef struct _mp_parse_node_struct_t {
 #define MP_PARSE_NODE_LEAF_SMALL_INT(pn) (((machine_int_t)(pn)) >> 1)
 #define MP_PARSE_NODE_STRUCT_KIND(pns) ((pns)->kind_num_nodes & 0xff)
 #define MP_PARSE_NODE_STRUCT_NUM_NODES(pns) ((pns)->kind_num_nodes >> 8)
+#define MP_PARSE_NODE_IS_STRING(pn) (MP_PARSE_NODE_STRUCT_KIND((mp_parse_node_struct_t*)pn) == RULE_string)
 
 mp_parse_node_t mp_parse_node_new_leaf(machine_int_t kind, machine_int_t arg);
 uint mp_parse_node_free(mp_parse_node_t pn);


### PR DESCRIPTION
Per discussion https://github.com/micropython/micropython/issues/560#issuecomment-42213955

@dpgeorge, so I take a look into parser myself, and the only easy enough idea I had is to abuse mp_parse_node_struct_t node type to capture non-interned string in an adhoc way. Then your "#if 0 && !MICROPY_ENABLE_DOC_STRING" works (augmented). Do you like such approach? I'd argue it's correct - that's what needed to support constant folding for strings for example. On the other hand, it's not exactly memory friendly (but that issue is rooted in how re represent interned vs non-interned strings, as we know). And apparently, reusing mp_parse_node_struct_t is the most direct way either, the alternative would be to "subclass" it, just to produce more C code for the same effect.

So, if by any chance you think it makes sense, would you take it from here? - as I don't know what would be the best place to intern a string after it passed docstring check (and maybe it would be good to do some constant folding too after all?). No hurry with this, of course, just would be interesting to know if you find this acceptable.
