### PR TITLE
py: Fix mp_obj_t -> mp_const_obj_t for mp_obj_int_get_checked()

### DIFF
--- a/py/objint.c
+++ b/py/objint.c
@@ -258,7 +258,7 @@ machine_int_t mp_obj_int_get(mp_obj_t self_in) {
     return MP_OBJ_SMALL_INT_VALUE(self_in);
 }
 
-machine_int_t mp_obj_int_get_checked(mp_obj_t self_in) {
+machine_int_t mp_obj_int_get_checked(mp_const_obj_t self_in) {
     return MP_OBJ_SMALL_INT_VALUE(self_in);
 }
 


### PR DESCRIPTION
@pfalcon: this fixes the following build error introduced in commit ab7bf28489fde83c73da2a3a20b9eadb08e8cc81

../py/objint.c:261:15: error: conflicting types for ‘mp_obj_int_get_checked’
In file included from ../py/objint.c:36:0:
../py/obj.h:455:15: note: previous declaration of ‘mp_obj_int_get_checked’ was here
