### PR TITLE
windows: Fix compilation with mingw-w64 so it uses correct printf implem...

### DIFF
--- a/windows/Makefile
+++ b/windows/Makefile
@@ -17,6 +17,9 @@ INC += -I$(BUILD)
 # compiler settings
 CFLAGS = $(INC) -Wall -Werror -ansi -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT)
 LDFLAGS = $(LDFLAGS_MOD) -lm
+ifeq ($(CROSS_COMPILE),i686-w64-mingw32-)
+CFLAGS += -D__USE_MINGW_ANSI_STDIO=1
+endif
 
 # Debugging/Optimization
 ifdef DEBUG


### PR DESCRIPTION
...entations

Without this flag, mingw-w64 uses the msvcimplementations of snpintf and the likes.
This is not really a problem since they work with the the fixes provided for msvc,
but due to the way mingw-w64's stdio.h is structured we cannot get it to use the fixes.
