### PR TITLE
windows: Complete rename of MICROPY_PATH_MAX to MICROPY_ALLOC_PATH_MAX (...

### DIFF
--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -105,7 +105,7 @@ void msec_sleep(double msec);
 #define STDIN_FILENO                0
 #define STDOUT_FILENO               1
 #define STDERR_FILENO               2
-#define PATH_MAX                    MICROPY_PATH_MAX
+#define PATH_MAX                    MICROPY_ALLOC_PATH_MAX
 #define S_ISREG(m)                  (((m) & S_IFMT) == S_IFREG)
 #define S_ISDIR(m)                  (((m) & S_IFMT) == S_IFDIR)
 


### PR DESCRIPTION
...58ebde4)
