### PR TITLE
Correct file reference (there's no qstrraw.h)

### DIFF
--- a/py/qstr.h
+++ b/py/qstr.h
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-// See qstrraw.h for a list of qstr's that are available as constants.
+// See qstrdefs.h for a list of qstr's that are available as constants.
 // Reference them as MP_QSTR_xxxx.
 //
 // Note: it would be possible to define MP_QSTR_xxx as qstr_from_str_static("xxx")


### PR DESCRIPTION
Poking around and came across something that I think is a simple naming error
