### PR TITLE
REVIEW ONLY! py: Very first step towards handling intra-module constants.

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -3491,10 +3491,10 @@ mp_obj_t mp_compile(mp_parse_node_t pn, qstr source_file, uint emit_opt, bool is
     comp->is_repl = is_repl;
 
     // optimise constants
-    mp_map_t consts;
-    mp_map_init(&consts, 0);
-    pn = fold_constants(comp, pn, &consts);
-    mp_map_deinit(&consts);
+    mp_obj_dict_t *module_globals = mp_globals_get();
+    mp_obj_dict_t *const_dict = mp_obj_new_dict(0);
+    mp_obj_dict_store(module_globals, MP_OBJ_NEW_QSTR(MP_QSTR___const__), const_dict);
+    pn = fold_constants(comp, pn, &const_dict->map);
 
     // set the outer scope
     scope_t *module_scope = scope_new_and_link(comp, SCOPE_MODULE, pn, emit_opt);

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -42,6 +42,7 @@ Q(__name__)
 Q(__next__)
 Q(__qualname__)
 Q(__path__)
+Q(__const__)
 Q(__repl_print__)
 
 Q(__bool__)


### PR DESCRIPTION
Store module's constant values in **const** dict. They could be looked up
from there to implement intra-module constant resolution. Except, that's
not going to work that easy. The reason is that constants within current
module are resolved at parse time, while module importing triggered at runtime.
That means that a "main" module won't really be able to use constant from
imported modules, because these modules are not really imported until that
module is parsed, compiled, and then executed.

It's unclear how to resolve that. Or rather, it's clear how to - parser could,
after detecting a (first question - only toplevel?) import, it recursively
parses, compiles, and runs that module before coming back to current module.
It's unclear if it makes sense to do this - for MicroPython. Because this
will lead to drastically higher memory requirements for parsing (up to OOM
completely), may have troubles with import/execution order, etc. Well, it might
be "optimized" by having a "constant-only" parsing stage, whcih first collects
just constants from modules, and then runs another pass over all files for
normal processing. Again, it's unclear if it's worth to have this complexity
in MicroPython core.
