### PR TITLE
Change comments (mainly URLs) to no longer specifically say Python 3.3

### DIFF
--- a/py/builtin.c
+++ b/py/builtin.c
@@ -466,7 +466,7 @@ STATIC mp_obj_t mp_builtin_hasattr(mp_obj_t object_in, mp_obj_t attr_in) {
     assert(MP_OBJ_IS_QSTR(attr_in));
 
     mp_obj_t dest[2];
-    // TODO: https://docs.python.org/3.3/library/functions.html?highlight=hasattr#hasattr
+    // TODO: https://docs.python.org/3/library/functions.html?highlight=hasattr#hasattr
     // explicitly says "This is implemented by calling getattr(object, name) and seeing
     // whether it raises an AttributeError or not.", so we should explicitly wrap this
     // in nlr_push and handle exception.

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -306,7 +306,7 @@ mp_obj_t mp_builtin___import__(uint n_args, mp_obj_t *args) {
 
                 if (stat == MP_IMPORT_STAT_DIR) {
                     DEBUG_printf("%s is dir\n", vstr_str(&path));
-                    // https://docs.python.org/3.3/reference/import.html
+                    // https://docs.python.org/3/reference/import.html
                     // "Specifically, any module that contains a __path__ attribute is considered a package."
                     mp_store_attr(module_obj, MP_QSTR___path__, mp_obj_new_str(vstr_str(&path), vstr_len(&path), false));
                     vstr_add_char(&path, PATH_SEP_CHAR);

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -157,7 +157,7 @@ const mp_obj_type_t mp_type_ ## exc_name = { \
 };
 
 // List of all exceptions, arranged as in the table at:
-// http://docs.python.org/3.3/library/exceptions.html
+// http://docs.python.org/3/library/exceptions.html
 MP_DEFINE_EXCEPTION_BASE(BaseException)
 MP_DEFINE_EXCEPTION(SystemExit, BaseException)
 //MP_DEFINE_EXCEPTION(KeyboardInterrupt, BaseException)

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -352,7 +352,7 @@ STATIC const qstr binary_op_method_name[] = {
 // Given a member that was extracted from an instance, convert it correctly
 // and put the result in the dest[] array for a possible method call.
 // Conversion means dealing with static/class methods, callables, and values.
-// see http://docs.python.org/3.3/howto/descriptor.html
+// see http://docs.python.org/3/howto/descriptor.html
 STATIC void instance_convert_return_attr(mp_obj_t self, const mp_obj_type_t *type, mp_obj_t member, mp_obj_t *dest) {
     assert(dest[1] == NULL);
     if (MP_OBJ_IS_TYPE(member, &mp_type_staticmethod)) {

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -837,7 +837,7 @@ void mp_load_method_maybe(mp_obj_t base, qstr attr, mp_obj_t *dest) {
         mp_map_elem_t *elem = mp_map_lookup(locals_map, MP_OBJ_NEW_QSTR(attr), MP_MAP_LOOKUP);
         if (elem != NULL) {
             // check if the methods are functions, static or class methods
-            // see http://docs.python.org/3.3/howto/descriptor.html
+            // see http://docs.python.org/3/howto/descriptor.html
             if (MP_OBJ_IS_TYPE(elem->value, &mp_type_staticmethod)) {
                 // return just the function
                 dest[0] = ((mp_obj_static_class_method_t*)elem->value)->fun;

--- a/tests/basics/string-repr.py
+++ b/tests/basics/string-repr.py
@@ -1,3 +1,3 @@
-# anything above 0xa0 is printed as Unicode by CPython3.3
+# anything above 0xa0 is printed as Unicode by CPython
 for c in range(0xa1):
     print("0x%02x: %s" % (c, repr(chr(c))))


### PR DESCRIPTION
Non-functional changes only. Most of these are URLs that point to docs.python.org/3.3/ and are now going to just /3/ which means "whatever's latest stable on the 3.x branch". There are some remaining references to CPython 3.3 or Python 3.3, eg "inspired by urlparse", and the test suite stipulates a minimum of 3.3; these I haven't changed, for obvious reasons.
