### PR TITLE
Various build fixes to enable a certain level of cross-platform support

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -29,7 +29,11 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#ifndef __FreeBSD__
 #include <alloca.h>
+#else
+#include <stdlib.h>
+#endif
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -42,14 +42,14 @@ ECHO = @echo
 CP = cp
 MKDIR = mkdir
 SED = sed
-PYTHON = python
+PYTHON ?= python
 
-AS = $(CROSS_COMPILE)as
-CC = $(CROSS_COMPILE)gcc
-LD = $(CROSS_COMPILE)ld
-OBJCOPY = $(CROSS_COMPILE)objcopy
-SIZE = $(CROSS_COMPILE)size
-STRIP = $(CROSS_COMPILE)strip
+AS ?= $(CROSS_COMPILE)as
+CC ?= $(CROSS_COMPILE)gcc
+LD ?= $(CROSS_COMPILE)ld
+OBJCOPY ?= $(CROSS_COMPILE)objcopy
+SIZE ?= $(CROSS_COMPILE)size
+STRIP ?= $(CROSS_COMPILE)strip
 
 all:
 .PHONY: all

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -28,7 +28,11 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
+#ifndef __FreeBSD__
 #include <alloca.h>
+#else
+#include <stdlib.h>
+#endif
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/py/objint.c
+++ b/py/objint.c
@@ -154,7 +154,7 @@ char *mp_obj_int_formatted(char **buf, int *buf_size, int *fmt_size, mp_const_ob
 #endif
     } else {
         // Not an int.
-        buf[0] = '\0';
+        buf[0] = "\0";
         *fmt_size = 0;
         return *buf;
     }

--- a/py/py-version.sh
+++ b/py/py-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Note: git describe doesn't work if no tag is available
 git_tag="$(git describe --dirty --always)"

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -27,7 +27,11 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#ifndef __FreeBSD__
 #include <alloca.h>
+#else
+#include <stdlib.h> /* alloca() */
+#endif
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/py/vm.c
+++ b/py/vm.c
@@ -28,7 +28,11 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#ifndef __FreeBSD__
 #include <alloca.h>
+#else
+#include <stdlib.h>
+#endif
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -48,7 +48,10 @@ ifeq ($(MICROPY_PY_FFI),1)
 LIBFFI_LDFLAGS_MOD := $(shell pkg-config --libs libffi)
 LIBFFI_CFLAGS_MOD := $(shell pkg-config --cflags libffi)
 CFLAGS_MOD += $(LIBFFI_CFLAGS_MOD) -DMICROPY_PY_FFI=1
-LDFLAGS_MOD += -ldl $(LIBFFI_LDFLAGS_MOD)
+ifeq ($(UNAME_S),Linux)
+LDFLAGS_MOD += -ldl
+endif
+LDFLAGS_MOD += $(LIBFFI_LDFLAGS_MOD)
 SRC_MOD += modffi.c
 endif
 

--- a/unix/modsocket.c
+++ b/unix/modsocket.c
@@ -37,7 +37,11 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <errno.h>
+#ifndef __FreeBSD__
 #include <alloca.h>
+#else
+#include <stdlib.h>
+#endif
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/unix/modtime.c
+++ b/unix/modtime.c
@@ -57,6 +57,8 @@ void msec_sleep_tv(struct timeval *tv) {
 
 #if defined(MP_CLOCKS_PER_SEC) && (MP_CLOCKS_PER_SEC == 1000000) // POSIX
 #define CLOCK_DIV 1000.0
+#elif defined(__FreeBSD__) && (MP_CLOCKS_PER_SEC == 128)
+#define CLOCK_DIV 0.128
 #elif defined(MP_CLOCKS_PER_SEC) && (MP_CLOCKS_PER_SEC == 1000) // WIN32
 #define CLOCK_DIV 1.0
 #else


### PR DESCRIPTION
Various build fixes to enable a certain level of cross-platform support, including
- respect build environment settings
- remove superfluous dependency on bash for py-version.sh
- enable alloca() support on FreeBSD
