### PR TITLE
A couple of small fixes to run-tests

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -33,6 +33,9 @@ def run_tests(pyb, tests):
     skip_travis_tests = set(['basics/memoryerror.py'])
 
     for test_file in tests:
+        test_basename = os.path.basename(test_file)
+        test_name = os.path.splitext(test_basename)[0]
+
         if running_under_travis and test_file in skip_travis_tests:
             print("skip ", test_file)
             skipped_tests.append(test_name)
@@ -67,9 +70,6 @@ def run_tests(pyb, tests):
                 output_mupy = pyb.execfile(test_file).replace(b'\r\n', b'\n')
             except pyboard.PyboardError:
                 output_mupy = b'CRASH'
-
-        test_basename = os.path.basename(test_file)
-        test_name = os.path.splitext(test_basename)[0]
 
         if output_mupy == b'SKIP\n':
             print("skip ", test_file)

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -27,16 +27,17 @@ def run_tests(pyb, tests):
     failed_tests = []
     skipped_tests = []
 
-    running_under_travis = os.getenv('TRAVIS') == 'true'
+    skip_tests = set()
 
-    # Set of tests that we shouldn't run under Travis CI
-    skip_travis_tests = set(['basics/memoryerror.py'])
+    # Some tests shouldn't be run under Travis CI
+    if os.getenv('TRAVIS') == 'true':
+        skip_tests.add('basics/memoryerror.py')
 
     for test_file in tests:
         test_basename = os.path.basename(test_file)
         test_name = os.path.splitext(test_basename)[0]
 
-        if running_under_travis and test_file in skip_travis_tests:
+        if test_file in skip_tests:
             print("skip ", test_file)
             skipped_tests.append(test_name)
             continue


### PR DESCRIPTION
In theory, expanding the scope of test skipping should make it possible to make rules like "if we're running tests against CPython 3.3, skip these tests". Currently I don't have any that specifically need that, as the string-format-modulo tests have been commented out; but it could be done.
