### PR TITLE
toolchain fixes to enable cross compatibility

### DIFF
--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -42,14 +42,14 @@ ECHO = @echo
 CP = cp
 MKDIR = mkdir
 SED = sed
-PYTHON = python
+PYTHON ?= python
 
-AS = $(CROSS_COMPILE)as
-CC = $(CROSS_COMPILE)gcc
-LD = $(CROSS_COMPILE)ld
-OBJCOPY = $(CROSS_COMPILE)objcopy
-SIZE = $(CROSS_COMPILE)size
-STRIP = $(CROSS_COMPILE)strip
+AS ?= $(CROSS_COMPILE)as
+CC ?= $(CROSS_COMPILE)gcc
+LD ?= $(CROSS_COMPILE)ld
+OBJCOPY ?= $(CROSS_COMPILE)objcopy
+SIZE ?= $(CROSS_COMPILE)size
+STRIP ?= $(CROSS_COMPILE)strip
 
 all:
 .PHONY: all

--- a/py/py-version.sh
+++ b/py/py-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Note: git describe doesn't work if no tag is available
 git_tag="$(git describe --dirty --always)"

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -48,7 +48,10 @@ ifeq ($(MICROPY_PY_FFI),1)
 LIBFFI_LDFLAGS_MOD := $(shell pkg-config --libs libffi)
 LIBFFI_CFLAGS_MOD := $(shell pkg-config --cflags libffi)
 CFLAGS_MOD += $(LIBFFI_CFLAGS_MOD) -DMICROPY_PY_FFI=1
-LDFLAGS_MOD += -ldl $(LIBFFI_LDFLAGS_MOD)
+ifeq ($(UNAME_S),Linux)
+LDFLAGS_MOD += -ldl
+endif
+LDFLAGS_MOD += $(LIBFFI_LDFLAGS_MOD)
 SRC_MOD += modffi.c
 endif
 


### PR DESCRIPTION
- Let the build environment decide about the toolchain to be used, in casethere are special tweaks and paths to be considered. Just provide some defaults, in case the values are undefined.
- py-version.sh does not need any bash specific features.
- Use libdl only on Linux for now. FreeBSD provides dl*() calls from libc.

This supersedes the mess from pull request #666
