### PR TITLE
move alloca() includes to a central location for better compatibility

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -29,7 +29,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-#include <alloca.h>
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -28,7 +28,6 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <alloca.h>
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -27,7 +27,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-#include <alloca.h>
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/py/vm.c
+++ b/py/vm.c
@@ -28,7 +28,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-#include <alloca.h>
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/unix/modsocket.c
+++ b/unix/modsocket.c
@@ -37,7 +37,6 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <errno.h>
-#include <alloca.h>
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -98,3 +98,11 @@ extern const struct _mp_obj_fun_native_t mp_builtin_open_obj;
 #define MICROPY_PORT_BUILTINS \
     { MP_OBJ_NEW_QSTR(MP_QSTR_input), (mp_obj_t)&mp_builtin_input_obj }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_open), (mp_obj_t)&mp_builtin_open_obj },
+
+
+/* We need the correct header for alloca() */
+#ifdef __FreeBSD__
+#include <stdlib.h>
+#else
+#include <alloca.h>
+#endif

--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -114,7 +114,7 @@ void msec_sleep(double msec);
 
 #include <stddef.h> //for NULL
 #include <assert.h> //for assert
-
+#include <alloca.h> //for alloca()
 
 // Functions implemented in platform code
 


### PR DESCRIPTION
- FreeBSD provides alloca() via stdlib.h, in contrast to Linux and Windows
- Move the includes for alloca() intp mpconfigport.h
