### PR TITLE
Build patches for FreeBSD (as discussed in the former pull request #666)

### DIFF
--- a/unix/modos.c
+++ b/unix/modos.c
@@ -52,7 +52,7 @@ STATIC mp_obj_t mod_os_stat(mp_obj_t path_in) {
 
     mp_obj_tuple_t *t = mp_obj_new_tuple(10, NULL);
     t->items[0] = MP_OBJ_NEW_SMALL_INT((machine_int_t)sb.st_mode);
-    t->items[1] = MP_OBJ_NEW_SMALL_INT(sb.st_ino);
+    t->items[1] = MP_OBJ_NEW_SMALL_INT((machine_int_t)sb.st_ino);
     t->items[2] = MP_OBJ_NEW_SMALL_INT((machine_int_t)sb.st_dev);
     t->items[3] = MP_OBJ_NEW_SMALL_INT((machine_int_t)sb.st_nlink);
     t->items[4] = MP_OBJ_NEW_SMALL_INT((machine_int_t)sb.st_uid);

--- a/unix/modtime.c
+++ b/unix/modtime.c
@@ -55,10 +55,8 @@ void msec_sleep_tv(struct timeval *tv) {
 #define MP_CLOCKS_PER_SEC CLOCKS_PER_SEC
 #endif
 
-#if defined(MP_CLOCKS_PER_SEC) && (MP_CLOCKS_PER_SEC == 1000000) // POSIX
-#define CLOCK_DIV 1000.0
-#elif defined(MP_CLOCKS_PER_SEC) && (MP_CLOCKS_PER_SEC == 1000) // WIN32
-#define CLOCK_DIV 1.0
+#if defined(MP_CLOCKS_PER_SEC)
+#define CLOCK_DIV (MP_CLOCKS_PER_SEC / 1000.0)
 #else
 #error Unsupported clock() implementation
 #endif


### PR DESCRIPTION
- Cast the struct stat sb.st_ino field to machine_int_t explicitly to avoid a cast error in MP_OBJ_NEW_SMALL_INT(). This is necessary for FreeBSD, where st_ino is of different size
- If MP_CLOCKS_PER_SEC is defined on the target host, simply define CLOCK_DIV
  as a fraction, regardless of the value of MP_CLOCKS_PER_SEC.
  FreeBSD uses a non-POSIX compliant value of 128 for CLOCKS_PER_SEC
