### PR TITLE
Remove unnecessary bounds check from mp_seq_get_fast_slice_indexes.

### DIFF
--- a/py/sequence.c
+++ b/py/sequence.c
@@ -80,10 +80,6 @@ bool mp_seq_get_fast_slice_indexes(machine_uint_t len, mp_obj_t slice, mp_bound_
     }
     if (stop < 0) {
         stop = len + stop;
-        // CPython returns empty sequence in such case
-        if (stop < 0) {
-            stop = start;
-        }
     } else if (stop > len) {
         stop = len;
     }


### PR DESCRIPTION
At this point, start will be >= 0, so checking if stop < 0 is redundant with
checking if start > stop a few lines later.
