### PR TITLE
objstr: Be 8-bit clean even for repr().

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -469,7 +469,7 @@ qstr mp_obj_str_get_qstr(mp_obj_t self_in); // use this if you will anyway conve
 const char *mp_obj_str_get_str(mp_obj_t self_in); // use this only if you need the string to be null terminated
 const char *mp_obj_str_get_data(mp_obj_t self_in, uint *len);
 mp_obj_t mp_obj_str_intern(mp_obj_t str);
-void mp_str_print_quoted(void (*print)(void *env, const char *fmt, ...), void *env, const byte *str_data, uint str_len);
+void mp_str_print_quoted(void (*print)(void *env, const char *fmt, ...), void *env, const byte *str_data, uint str_len, bool is_bytes);
 
 #if MICROPY_PY_BUILTINS_FLOAT
 // float

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -58,7 +58,7 @@ STATIC void array_print(void (*print)(void *env, const char *fmt, ...), void *en
     mp_obj_array_t *o = o_in;
     if (o->typecode == BYTEARRAY_TYPECODE) {
         print(env, "bytearray(b", o->typecode);
-        mp_str_print_quoted(print, env, o->items, o->len);
+        mp_str_print_quoted(print, env, o->items, o->len, true);
     } else {
         print(env, "array('%c'", o->typecode);
         if (o->len > 0) {

--- a/tests/basics/string-repr.py
+++ b/tests/basics/string-repr.py
@@ -1,3 +1,4 @@
 # anything above 0xa0 is printed as Unicode by CPython
-for c in range(0xa1):
+# the abobe is CPython implementation detail, stick to ASCII
+for c in range(0x80):
     print("0x%02x: %s" % (c, repr(chr(c))))


### PR DESCRIPTION
This will allow roughly the same behavior as Python3 for non-ASCII strings,
for example, print("<phrase in non-Latin script>".split()) will print list
of words, not weird hex dump (like Python2 behaves). (Of course, that it
will print list of words, if there're "words" in that phrase at all, separated
by ASCII-compatible whitespace; that surely won't apply to every human
language in existence).
