### PR TITLE
bare-arm, stmhal: Disable stack protector

### DIFF
--- a/bare-arm/Makefile
+++ b/bare-arm/Makefile
@@ -22,7 +22,7 @@ else
 CFLAGS += -Os -DNDEBUG
 endif
 
-LDFLAGS = --nostdlib -T stm32f405.ld
+LDFLAGS = -nostdlib -T stm32f405.ld
 LIBS =
 
 SRC_C = \

--- a/bare-arm/Makefile
+++ b/bare-arm/Makefile
@@ -13,7 +13,7 @@ INC += -I$(PY_SRC)
 INC += -I$(BUILD)
 
 CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mabi=aapcs-linux -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -fsingle-precision-constant -Wdouble-promotion
-CFLAGS = $(INC) -Wall -Werror -ansi -std=gnu99 $(CFLAGS_CORTEX_M4) $(COPT)
+CFLAGS = $(INC) -Wall -Werror -ansi -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
 
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)

--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -53,7 +53,7 @@ else
 COPT += -Os -DNDEBUG
 endif
 
-LDFLAGS = --nostdlib -T stm32f405.ld -Map=$(@:.elf=.map) --cref
+LDFLAGS = -nostdlib -T stm32f405.ld -Map=$(@:.elf=.map) --cref
 LIBS =
 
 # uncomment this if you want libgcc

--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -41,7 +41,7 @@ INC += -I$(FATFS_DIR)/src
 INC += -I$(CC3K_DIR)
 
 CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mabi=aapcs-linux -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -fsingle-precision-constant -Wdouble-promotion
-CFLAGS = $(INC) -Wall -Werror -ansi -std=gnu99 $(CFLAGS_CORTEX_M4) $(COPT)
+CFLAGS = $(INC) -Wall -Werror -ansi -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
 
 CFLAGS += -Iboards/$(BOARD)
 

--- a/teensy/Makefile
+++ b/teensy/Makefile
@@ -23,7 +23,7 @@ INC += -I$(PY_SRC)
 INC += -I$(BUILD)
 INC += -I$(CORE_PATH)
 
-CFLAGS = $(INC) -Wall -ansi -std=gnu99 $(CFLAGS_CORTEX_M4)
+CFLAGS = $(INC) -Wall -ansi -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4)
 LDFLAGS = -nostdlib -T mk20dx256.ld
 LIBS = -L $(COMPILER_PATH)/../lib/gcc/arm-none-eabi/4.7.2/thumb2 -lgcc
 


### PR DESCRIPTION
As we are building with --nostdlib the stack protector will fail
linking, because the failure handlers are in gcc's internal libs.

Signed-off-by: Sven Wegener sven.wegener@stealer.net
