### PR TITLE
Add MICROPY_HW_MICRO_NAME to boards config

### DIFF
--- a/stmhal/boards/HYDRABUS/mpconfigboard.h
+++ b/stmhal/boards/HYDRABUS/mpconfigboard.h
@@ -1,6 +1,7 @@
 #define HYDRABUSV10
 
 #define MICROPY_HW_BOARD_NAME       "HydraBus1.0"
+#define MICROPY_HW_MICRO_NAME       "STM32F4"
 
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_SDCARD       (1)

--- a/stmhal/boards/NETDUINO_PLUS_2/mpconfigboard.h
+++ b/stmhal/boards/NETDUINO_PLUS_2/mpconfigboard.h
@@ -1,6 +1,7 @@
 #define NETDUINO_PLUS_2
 
 #define MICROPY_HW_BOARD_NAME       "NetduinoPlus2"
+#define MICROPY_HW_MICRO_NAME       "STM32F405RG"
 
 #define MICROPY_HW_HAS_SWITCH       (1)
 

--- a/stmhal/boards/PYBV10/mpconfigboard.h
+++ b/stmhal/boards/PYBV10/mpconfigboard.h
@@ -1,6 +1,7 @@
 #define PYBV10
 
 #define MICROPY_HW_BOARD_NAME       "PYBv1.0"
+#define MICROPY_HW_MICRO_NAME       "STM32F405RG"
 
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_SDCARD       (1)

--- a/stmhal/boards/PYBV3/mpconfigboard.h
+++ b/stmhal/boards/PYBV3/mpconfigboard.h
@@ -1,6 +1,7 @@
 #define PYBV3
 
 #define MICROPY_HW_BOARD_NAME       "PYBv3"
+#define MICROPY_HW_MICRO_NAME       "STM32F405RG"
 
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_SDCARD       (1)

--- a/stmhal/boards/PYBV4/mpconfigboard.h
+++ b/stmhal/boards/PYBV4/mpconfigboard.h
@@ -1,6 +1,7 @@
 #define PYBV4
 
 #define MICROPY_HW_BOARD_NAME       "PYBv4"
+#define MICROPY_HW_MICRO_NAME       "STM32F405RG"
 
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_SDCARD       (1)

--- a/stmhal/boards/STM32F4DISC/mpconfigboard.h
+++ b/stmhal/boards/STM32F4DISC/mpconfigboard.h
@@ -1,6 +1,7 @@
 #define STM32F4DISC
 
 #define MICROPY_HW_BOARD_NAME       "F4DISC"
+#define MICROPY_HW_MICRO_NAME       "STM32F407"
 
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_SDCARD       (0)

--- a/stmhal/pyexec.c
+++ b/stmhal/pyexec.c
@@ -185,7 +185,7 @@ int pyexec_friendly_repl(void) {
 #endif
 
 friendly_repl_reset:
-    stdout_tx_str("Micro Python " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_HW_BOARD_NAME " with STM32F405RG\r\n");
+    stdout_tx_str("Micro Python " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MICRO_NAME "\r\n");
     stdout_tx_str("Type \"help()\" for more information.\r\n");
 
     // to test ctrl-C


### PR DESCRIPTION
Add config option to set MCU name, instead of hard-coded "STM32F405RG"
