### PR TITLE
Fix small compilation issues

### DIFF
--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -25,6 +25,7 @@
  */
 
 #include <stdint.h>
+#include <assert.h>
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/py/misc.h
+++ b/py/misc.h
@@ -82,7 +82,9 @@ int m_get_peak_bytes_allocated(void);
 /** array helpers ***********************************************/
 
 // get the number of elements in a fixed-size array
+#ifndef ARRAY_SIZE
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+#endif
 
 /** unichar / UTF-8 *********************************************/
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -28,7 +28,7 @@
 // You can override any of these options using mpconfigport.h file located
 // in a directory of your port.
 
-#include <mpconfigport.h>
+#include "mpconfigport.h"
 
 // Any options not explicitly set in mpconfigport.h will get default
 // values below.

--- a/py/objgetitemiter.c
+++ b/py/objgetitemiter.c
@@ -25,6 +25,7 @@
  */
 
 #include <stdlib.h>
+#include <assert.h>
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -26,6 +26,7 @@
  */
 
 #include <string.h>
+#include <assert.h>
 
 #include "mpconfig.h"
 #include "misc.h"

--- a/py/objobject.c
+++ b/py/objobject.c
@@ -25,6 +25,7 @@
  */
 
 #include <stdlib.h>
+#include <assert.h>
 
 #include "mpconfig.h"
 #include "nlr.h"

--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -26,6 +26,7 @@
 
 #include <stdbool.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #include "misc.h"
 #include "mpconfig.h"

--- a/py/stream.c
+++ b/py/stream.c
@@ -26,6 +26,7 @@
  */
 
 #include <string.h>
+#include <assert.h>
 
 #include "mpconfig.h"
 #include "nlr.h"


### PR DESCRIPTION
- Add missing “assert.h” file header inclusion
- Do not define ARRAY_SIZE if it is already defined
- “mpconfigport.h” is a library header, not a system header
