### PR TITLE
Fix assert_func warning/error

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -381,3 +381,8 @@ typedef double mp_float_t;
 #ifndef NORETURN
 #define NORETURN __attribute__((noreturn))
 #endif
+
+// Modifier for weak functions
+#ifndef MP_WEAK
+#define MP_WEAK __attribute__((weak))
+#endif

--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -85,7 +85,7 @@ void flash_error(int n) {
     led_state(PYB_LED_R2, 0);
 }
 
-void __fatal_error(const char *msg) {
+void NORETURN __fatal_error(const char *msg) {
     for (volatile uint delay = 0; delay < 10000000; delay++) {
     }
     led_state(1, 1);
@@ -115,7 +115,6 @@ void MP_WEAK __assert_func(const char *file, int line, const char *func, const c
     (void)func;
     printf("Assertion '%s' failed, at file %s:%d\n", expr, file, line);
     __fatal_error("");
-    while (1);
 }
 #endif
 

--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -111,11 +111,11 @@ void nlr_jump_fail(void *val) {
 }
 
 #ifndef NDEBUG
-void __attribute__((weak))
-    __assert_func(const char *file, int line, const char *func, const char *expr) {
+void MP_WEAK __assert_func(const char *file, int line, const char *func, const char *expr) {
     (void)func;
     printf("Assertion '%s' failed, at file %s:%d\n", expr, file, line);
     __fatal_error("");
+    while (1);
 }
 #endif
 


### PR DESCRIPTION
- Add while(1) to assert_func to avoid "function returns" warning
- Define a weak attr in mpconfig.h
