### PR TITLE
py: Strip extra new line after comments in headers

### DIFF
--- a/bare-arm/mpconfigport.h
+++ b/bare-arm/mpconfigport.h
@@ -1,7 +1,6 @@
 #include <stdint.h>
 
 // options to control how Micro Python is built
-
 #define MICROPY_ALLOC_PATH_MAX      (512)
 #define MICROPY_EMIT_X64            (0)
 #define MICROPY_EMIT_THUMB          (0)
@@ -27,7 +26,6 @@
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_NONE)
 
 // type definitions for the specific machine
-
 #define BYTES_PER_WORD (4)
 
 #define UINT_FMT "%lu"

--- a/py/asmthumb.h
+++ b/py/asmthumb.h
@@ -85,7 +85,6 @@ void asm_thumb_data(asm_thumb_t* as, uint bytesize, uint val);
 
 // argument order follows ARM, in general dest is first
 // note there is a difference between movw and mov.w, and many others!
-
 #define ASM_THUMB_OP_NOP        (0xbf00)
 #define ASM_THUMB_OP_WFI        (0xbf30)
 #define ASM_THUMB_OP_CPSID_I    (0xb672) // cpsid i, disable irq
@@ -95,7 +94,6 @@ void asm_thumb_op16(asm_thumb_t *as, uint op);
 void asm_thumb_op32(asm_thumb_t *as, uint op1, uint op2);
 
 // FORMAT 2: add/subtract
-
 #define ASM_THUMB_FORMAT_2_ADD (0x1800)
 #define ASM_THUMB_FORMAT_2_SUB (0x1a00)
 #define ASM_THUMB_FORMAT_2_REG_OPERAND (0x0000)
@@ -114,7 +112,6 @@ static inline void asm_thumb_sub_rlo_rlo_i3(asm_thumb_t *as, uint rlo_dest, uint
 
 // FORMAT 3: move/compare/add/subtract immediate
 // These instructions all do zero extension of the i8 value
-
 #define ASM_THUMB_FORMAT_3_MOV (0x2000)
 #define ASM_THUMB_FORMAT_3_CMP (0x2800)
 #define ASM_THUMB_FORMAT_3_ADD (0x3000)
@@ -128,7 +125,6 @@ static inline void asm_thumb_add_rlo_i8(asm_thumb_t *as, uint rlo, int i8) { asm
 static inline void asm_thumb_sub_rlo_i8(asm_thumb_t *as, uint rlo, int i8) { asm_thumb_format_3(as, ASM_THUMB_FORMAT_3_SUB, rlo, i8); }
 
 // FORMAT 4: ALU operations
-
 #define ASM_THUMB_FORMAT_4_AND (0x4000)
 #define ASM_THUMB_FORMAT_4_EOR (0x4040)
 #define ASM_THUMB_FORMAT_4_LSL (0x4080)
@@ -152,16 +148,14 @@ static inline void asm_thumb_cmp_rlo_rlo(asm_thumb_t *as, uint rlo_dest, uint rl
 
 // FORMAT 9: load/store with immediate offset
 // For word transfers the offset must be aligned, and >>2
-
-// FORMAT 10: load/store halfword
-// The offset must be aligned, and >>1
-// The load is zero extended into the register
-
 #define ASM_THUMB_FORMAT_9_STR (0x6000)
 #define ASM_THUMB_FORMAT_9_LDR (0x6800)
 #define ASM_THUMB_FORMAT_9_WORD_TRANSFER (0x0000)
 #define ASM_THUMB_FORMAT_9_BYTE_TRANSFER (0x1000)
 
+// FORMAT 10: load/store halfword
+// The offset must be aligned, and >>1
+// The load is zero extended into the register
 #define ASM_THUMB_FORMAT_10_STRH (0x8000)
 #define ASM_THUMB_FORMAT_10_LDRH (0x8800)
 

--- a/py/bc0.h
+++ b/py/bc0.h
@@ -26,7 +26,6 @@
 
 // Micro Python byte-codes.
 // The comment at the end of the line (if it exists) tells the arguments to the byte-code.
-
 #define MP_BC_LOAD_CONST_FALSE   (0x10)
 #define MP_BC_LOAD_CONST_NONE    (0x11)
 #define MP_BC_LOAD_CONST_TRUE    (0x12)

--- a/py/emitglue.h
+++ b/py/emitglue.h
@@ -25,7 +25,6 @@
  */
 
 // These variables and functions glue the code emitters to the runtime.
-
 typedef enum {
     MP_CODE_UNUSED,
     MP_CODE_RESERVED,

--- a/py/grammar.h
+++ b/py/grammar.h
@@ -36,7 +36,6 @@
 // single_input: NEWLINE | simple_stmt | compound_stmt
 // file_input: (NEWLINE | stmt)* ENDMARKER
 // eval_input: testlist NEWLINE* ENDMARKER
-
 DEF_RULE(single_input, nc, or(3), tok(NEWLINE), rule(simple_stmt), rule(compound_stmt))
 DEF_RULE(file_input, nc, and(1), opt_rule(file_input_2))
 DEF_RULE(file_input_2, c(generic_all_nodes), one_or_more, rule(file_input_3))
@@ -53,7 +52,6 @@ DEF_RULE(eval_input_2, nc, and(1), tok(NEWLINE))
 // tfpdef: NAME [':' test]
 // varargslist: vfpdef ['=' test] (',' vfpdef ['=' test])* [',' ['*' [vfpdef] (',' vfpdef ['=' test])* [',' '**' vfpdef] | '**' vfpdef]] |  '*' [vfpdef] (',' vfpdef ['=' test])* [',' '**' vfpdef] | '**' vfpdef
 // vfpdef: NAME
-
 DEF_RULE(decorator, nc, and(4), tok(DEL_AT), rule(dotted_name), opt_rule(trailer_paren), tok(NEWLINE))
 //DEF_RULE(decorator_2, nc, and(3), tok(DEL_PAREN_OPEN), opt_rule(arglist), tok(DEL_PAREN_CLOSE))
 DEF_RULE(decorators, nc, one_or_more, rule(decorator))
@@ -80,11 +78,9 @@ DEF_RULE(varargslist_equal, nc, and(2), tok(DEL_EQUAL), rule(test))
 DEF_RULE(vfpdef, nc, and(1), tok(NAME))
 
 // stmt: if_stmt | while_stmt | for_stmt | try_stmt | with_stmt | funcdef | classdef | decorated | simple_stmt
-
 DEF_RULE(stmt, nc, or(9), rule(if_stmt), rule(while_stmt), rule(for_stmt), rule(try_stmt), rule(with_stmt), rule(funcdef), rule(classdef), rule(decorated), rule(simple_stmt))
 
 // simple_stmt: small_stmt (';' small_stmt)* [';'] NEWLINE
-
 DEF_RULE(simple_stmt, nc, and(2), rule(simple_stmt_2), tok(NEWLINE))
 DEF_RULE(simple_stmt_2, c(generic_all_nodes), list_with_end, rule(small_stmt), tok(DEL_SEMICOLON))
 
@@ -93,7 +89,6 @@ DEF_RULE(simple_stmt_2, c(generic_all_nodes), list_with_end, rule(small_stmt), t
 // testlist_star_expr: (test|star_expr) (',' (test|star_expr))* [',']
 // augassign: '+=' | '-=' | '*=' | '/=' | '%=' | '&=' | '|=' | '^=' | '<<=' | '>>=' | '**=' | '//='
 // # For normal assignments, additional restrictions enforced by the interpreter
-
 DEF_RULE(small_stmt, nc, or(8), rule(del_stmt), rule(pass_stmt), rule(flow_stmt), rule(import_stmt), rule(global_stmt), rule(nonlocal_stmt), rule(assert_stmt), rule(expr_stmt))
 DEF_RULE(expr_stmt, c(expr_stmt), and(2), rule(testlist_star_expr), opt_rule(expr_stmt_2))
 DEF_RULE(expr_stmt_2, nc, or(2), rule(expr_stmt_augassign), rule(expr_stmt_assign_list))
@@ -113,7 +108,6 @@ DEF_RULE(augassign, nc, or(12), tok(DEL_PLUS_EQUAL), tok(DEL_MINUS_EQUAL), tok(D
 // return_stmt: 'return' [testlist]
 // yield_stmt: yield_expr
 // raise_stmt: 'raise' [test ['from' test]]
-
 DEF_RULE(del_stmt, c(del_stmt), and(2), tok(KW_DEL), rule(exprlist))
 DEF_RULE(pass_stmt, c(generic_all_nodes), and(1), tok(KW_PASS))
 DEF_RULE(flow_stmt, nc, or(5), rule(break_stmt), rule(continue_stmt), rule(return_stmt), rule(raise_stmt), rule(yield_stmt))
@@ -136,7 +130,6 @@ DEF_RULE(raise_stmt_from, nc, and(2), tok(KW_FROM), rule(test))
 // global_stmt: 'global' NAME (',' NAME)*
 // nonlocal_stmt: 'nonlocal' NAME (',' NAME)*
 // assert_stmt: 'assert' test [',' test]
-
 DEF_RULE(import_stmt, nc, or(2), rule(import_name), rule(import_from))
 DEF_RULE(import_name, c(import_name), and(2), tok(KW_IMPORT), rule(dotted_as_names))
 DEF_RULE(import_from, c(import_from), and(4), tok(KW_FROM), rule(import_from_2), tok(KW_IMPORT), rule(import_from_3))
@@ -168,7 +161,6 @@ DEF_RULE(assert_stmt_extra, nc, and(2), tok(DEL_COMMA), rule(test))
 // with_stmt: 'with' with_item (',' with_item)* ':' suite
 // with_item: test ['as' expr]
 // suite: simple_stmt | NEWLINE INDENT stmt+ DEDENT
-
 DEF_RULE(compound_stmt, nc, or(8), rule(if_stmt), rule(while_stmt), rule(for_stmt), rule(try_stmt), rule(with_stmt), rule(funcdef), rule(classdef), rule(decorated))
 DEF_RULE(if_stmt, c(if_stmt), and(6), tok(KW_IF), rule(test), tok(DEL_COLON), rule(suite), opt_rule(if_stmt_elif_list), opt_rule(else_stmt))
 DEF_RULE(if_stmt_elif_list, nc, one_or_more, rule(if_stmt_elif))
@@ -195,7 +187,6 @@ DEF_RULE(suite_block_stmts, c(generic_all_nodes), one_or_more, rule(stmt))
 // test_nocond: or_test | lambdef_nocond
 // lambdef: 'lambda' [varargslist] ':' test
 // lambdef_nocond: 'lambda' [varargslist] ':' test_nocond
-
 DEF_RULE(test, nc, or(2), rule(lambdef), rule(test_if_expr))
 DEF_RULE(test_if_expr, c(test_if_expr), and(2), rule(or_test), opt_rule(test_if_else))
 DEF_RULE(test_if_else, nc, and(4), tok(KW_IF), rule(or_test), tok(KW_ELSE), rule(test))
@@ -217,7 +208,6 @@ DEF_RULE(lambdef_nocond, c(lambdef), and(4), tok(KW_LAMBDA), opt_rule(varargslis
 // term: factor (('*'|'/'|'%'|'//') factor)*
 // factor: ('+'|'-'|'~') factor | power
 // power: atom trailer* ['**' factor]
-
 DEF_RULE(or_test, c(or_test), list, rule(and_test), tok(KW_OR))
 DEF_RULE(and_test, c(and_test), list, rule(not_test), tok(KW_AND))
 DEF_RULE(not_test, nc, or(2), rule(not_test_2), rule(comparison))
@@ -247,7 +237,6 @@ DEF_RULE(power_dbl_star, c(power_dbl_star), and(2), tok(OP_DBL_STAR), rule(facto
 // atom: '(' [yield_expr|testlist_comp] ')' | '[' [testlist_comp] ']' | '{' [dictorsetmaker] '}' | NAME | NUMBER | STRING+ | '...' | 'None' | 'True' | 'False'
 // testlist_comp: (test|star_expr) ( comp_for | (',' (test|star_expr))* [','] )
 // trailer: '(' [arglist] ')' | '[' subscriptlist ']' | '.' NAME
-
 DEF_RULE(atom, nc, or(10), tok(NAME), tok(NUMBER), rule(atom_string), tok(ELLIPSIS), tok(KW_NONE), tok(KW_TRUE), tok(KW_FALSE), rule(atom_paren), rule(atom_bracket), rule(atom_brace))
 DEF_RULE(atom_string, c(atom_string), one_or_more, rule(string_or_bytes))
 DEF_RULE(string_or_bytes, nc, or(2), tok(STRING), tok(BYTES))
@@ -268,7 +257,6 @@ DEF_RULE(trailer_period, c(trailer_period), and(2), tok(DEL_PERIOD), tok(NAME))
 // subscriptlist: subscript (',' subscript)* [',']
 // subscript: test | [test] ':' [test] [sliceop]
 // sliceop: ':' [test]
-
 DEF_RULE(subscriptlist, c(generic_tuple), list_with_end, rule(subscript), tok(DEL_COMMA))
 DEF_RULE(subscript, nc, or(2), rule(subscript_3), rule(subscript_2))
 DEF_RULE(subscript_2, c(subscript_2), and(2), rule(test), opt_rule(subscript_3))
@@ -281,7 +269,6 @@ DEF_RULE(sliceop, nc, and(2), tok(DEL_COLON), opt_rule(test))
 // exprlist: (expr|star_expr) (',' (expr|star_expr))* [',']
 // testlist: test (',' test)* [',']
 // dictorsetmaker: (test ':' test (comp_for | (',' test ':' test)* [','])) | (test (comp_for | (',' test)* [',']))
-
 DEF_RULE(exprlist, nc, list_with_end, rule(exprlist_2), tok(DEL_COMMA))
 DEF_RULE(exprlist_2, nc, or(2), rule(star_expr), rule(expr))
 DEF_RULE(testlist, c(generic_tuple), list_with_end, rule(test), tok(DEL_COMMA))
@@ -294,12 +281,10 @@ DEF_RULE(dictorsetmaker_list, nc, and(2), tok(DEL_COMMA), opt_rule(dictorsetmake
 DEF_RULE(dictorsetmaker_list2, nc, list_with_end, rule(dictorsetmaker_item), tok(DEL_COMMA))
 
 // classdef: 'class' NAME ['(' [arglist] ')'] ':' suite
-
 DEF_RULE(classdef, c(classdef), and(5), tok(KW_CLASS), tok(NAME), opt_rule(classdef_2), tok(DEL_COLON), rule(suite))
 DEF_RULE(classdef_2, nc, and(3), tok(DEL_PAREN_OPEN), opt_rule(arglist), tok(DEL_PAREN_CLOSE))
 
 // arglist: (argument ',')* (argument [','] | '*' test (',' argument)* [',' '**' test] | '**' test)
-
 // TODO arglist lets through more than is allowed, compiler needs to do further verification
 DEF_RULE(arglist, nc, list_with_end, rule(arglist_2), tok(DEL_COMMA))
 DEF_RULE(arglist_2, nc, or(3), rule(arglist_star), rule(arglist_dbl_star), rule(argument))
@@ -312,7 +297,6 @@ DEF_RULE(arglist_dbl_star, nc, and(2), tok(OP_DBL_STAR), rule(test))
 // comp_iter: comp_for | comp_if
 // comp_for: 'for' exprlist 'in' or_test [comp_iter]
 // comp_if: 'if' test_nocond [comp_iter]
-
 DEF_RULE(argument, nc, and(2), rule(test), opt_rule(argument_2))
 DEF_RULE(argument_2, nc, or(2), rule(comp_for), rule(argument_3))
 DEF_RULE(argument_3, nc, and(2), tok(DEL_EQUAL), rule(test))
@@ -322,10 +306,8 @@ DEF_RULE(comp_if, nc, and(3), tok(KW_IF), rule(test_nocond), opt_rule(comp_iter)
 
 // # not used in grammar, but may appear in "node" passed from Parser to Compiler
 // encoding_decl: NAME
-
 // yield_expr: 'yield' [yield_arg]
 // yield_arg: 'from' test | testlist
-
 DEF_RULE(yield_expr, c(yield_expr), and(2), tok(KW_YIELD), opt_rule(yield_arg))
 DEF_RULE(yield_arg, nc, or(2), rule(yield_arg_from), rule(testlist))
 DEF_RULE(yield_arg_from, nc, and(2), tok(KW_FROM), rule(test))

--- a/py/misc.h
+++ b/py/misc.h
@@ -25,7 +25,6 @@
  */
 
 // a mini library of useful types and functions
-
 #ifndef _INCLUDED_MINILIB_H
 #define _INCLUDED_MINILIB_H
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -31,18 +31,15 @@
 
 // All Micro Python objects are at least this type
 // It must be of pointer size
-
 typedef machine_ptr_t mp_obj_t;
 typedef machine_const_ptr_t mp_const_obj_t;
 
 // Integers that fit in a pointer have this type
 // (do we need to expose this in the public API?)
-
 typedef machine_int_t mp_small_int_t;
 
 // Anything that wants to be a Micro Python object must have
 // mp_obj_base_t as its first member (except small ints and qstrs)
-
 struct _mp_obj_type_t;
 struct _mp_obj_base_t {
     const struct _mp_obj_type_t *type;
@@ -59,7 +56,6 @@ typedef struct _mp_obj_base_t mp_obj_base_t;
 //
 // For debugging purposes they are all different.  For non-debug mode, we alias
 // as many as we can to MP_OBJ_NULL because it's cheaper to load/compare 0.
-
 #if NDEBUG
 #define MP_OBJ_NULL             ((mp_obj_t)0)
 #define MP_OBJ_STOP_ITERATION   ((mp_obj_t)0)
@@ -71,7 +67,6 @@ typedef struct _mp_obj_base_t mp_obj_base_t;
 #endif
 
 // These macros check for small int, qstr or object, and access small int and qstr values
-
 // these macros have now become inline functions; see below
 //#define MP_OBJ_IS_SMALL_INT(o) ((((mp_small_int_t)(o)) & 1) != 0)
 //#define MP_OBJ_IS_QSTR(o) ((((mp_small_int_t)(o)) & 3) == 2)
@@ -88,7 +83,6 @@ typedef struct _mp_obj_base_t mp_obj_base_t;
 
 // These macros are used to declare and define constant function objects
 // You can put "static" in front of the definitions to make them local
-
 #define MP_DECLARE_CONST_FUN_OBJ(obj_name) extern const mp_obj_fun_native_t obj_name
 
 #define MP_DEFINE_CONST_FUN_OBJ_VOID_PTR(obj_name, is_kw, n_args_min, n_args_max, fun_name) const mp_obj_fun_native_t obj_name = {{&mp_type_fun_native}, is_kw, n_args_min, n_args_max, (void *)fun_name}
@@ -102,7 +96,6 @@ typedef struct _mp_obj_base_t mp_obj_base_t;
 
 // This macro is used to define constant dict objects
 // You can put "static" in front of the definition to make it local
-
 #define MP_DEFINE_CONST_DICT(dict_name, table_name) \
     const mp_obj_dict_t dict_name = { \
         .base = {&mp_type_dict}, \
@@ -117,7 +110,6 @@ typedef struct _mp_obj_base_t mp_obj_base_t;
 
 // These macros are used to declare and define constant staticmethond and classmethod objects
 // You can put "static" in front of the definitions to make them local
-
 #define MP_DECLARE_CONST_STATICMETHOD_OBJ(obj_name) extern const mp_obj_static_class_method_t obj_name
 #define MP_DECLARE_CONST_CLASSMETHOD_OBJ(obj_name) extern const mp_obj_static_class_method_t obj_name
 
@@ -125,7 +117,6 @@ typedef struct _mp_obj_base_t mp_obj_base_t;
 #define MP_DEFINE_CONST_CLASSMETHOD_OBJ(obj_name, fun_name) const mp_obj_static_class_method_t obj_name = {{&mp_type_classmethod}, fun_name}
 
 // Underlying map/hash table implementation (not dict object or map function)
-
 typedef struct _mp_map_elem_t {
     mp_obj_t key;
     mp_obj_t value;
@@ -163,7 +154,6 @@ void mp_map_clear(mp_map_t *map);
 void mp_map_dump(mp_map_t *map);
 
 // Underlying set implementation (not set object)
-
 typedef struct _mp_set_t {
     machine_uint_t alloc;
     machine_uint_t used;
@@ -178,7 +168,6 @@ mp_obj_t mp_set_remove_first(mp_set_t *set);
 void mp_set_clear(mp_set_t *set);
 
 // Type definitions for methods
-
 typedef mp_obj_t (*mp_fun_0_t)(void);
 typedef mp_obj_t (*mp_fun_1_t)(mp_obj_t);
 typedef mp_obj_t (*mp_fun_2_t)(mp_obj_t, mp_obj_t);
@@ -360,7 +349,6 @@ extern const struct _mp_obj_exception_t mp_const_MemoryError_obj;
 extern const struct _mp_obj_exception_t mp_const_GeneratorExit_obj;
 
 // General API for objects
-
 mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict);
 mp_obj_t mp_obj_new_none(void);
 mp_obj_t mp_obj_new_bool(bool value);

--- a/py/parse.h
+++ b/py/parse.h
@@ -56,7 +56,6 @@ typedef struct _mp_parse_node_struct_t {
 
 // macros for mp_parse_node_t usage
 // some of these evaluate their argument more than once
-
 #define MP_PARSE_NODE_IS_NULL(pn) ((pn) == MP_PARSE_NODE_NULL)
 #define MP_PARSE_NODE_IS_LEAF(pn) ((pn) & 3)
 #define MP_PARSE_NODE_IS_STRUCT(pn) ((pn) != MP_PARSE_NODE_NULL && ((pn) & 3) == 0)

--- a/qemu-arm/mpconfigport.h
+++ b/qemu-arm/mpconfigport.h
@@ -1,7 +1,6 @@
 #include <stdint.h>
 
 // options to control how Micro Python is built
-
 #define MICROPY_ALLOC_PATH_MAX      (512)
 #define MICROPY_EMIT_X64            (0)
 #define MICROPY_EMIT_THUMB          (0)
@@ -17,7 +16,6 @@
 #define MICROPY_PY_IO               (0)
 
 // type definitions for the specific machine
-
 #define BYTES_PER_WORD (4)
 
 #define UINT_FMT "%lu"

--- a/teensy/mpconfigport.h
+++ b/teensy/mpconfigport.h
@@ -1,7 +1,6 @@
 #include <stdint.h>
 
 // options to control how Micro Python is built
-
 #define MICROPY_EMIT_THUMB          (1)
 #define MICROPY_EMIT_INLINE_THUMB   (1)
 #define MICROPY_ENABLE_GC           (1)
@@ -9,7 +8,6 @@
 #define MICROPY_PY_BUILTINS_FLOAT   (1)
 
 // type definitions for the specific machine
-
 #define BYTES_PER_WORD (4)
 
 typedef int32_t machine_int_t; // must be pointer size

--- a/unix-cpy/mpconfigport.h
+++ b/unix-cpy/mpconfigport.h
@@ -25,14 +25,12 @@
  */
 
 // options to control how Micro Python is built
-
 #define MICROPY_EMIT_CPYTHON        (1)
 #define MICROPY_HELPER_LEXER_UNIX   (1)
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_DOUBLE)
 #define MICROPY_PY_IO               (0)
 
 // type definitions for the specific machine
-
 #ifdef __LP64__
 typedef long machine_int_t; // must be pointer size
 typedef unsigned long machine_uint_t; // must be pointer size

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -25,7 +25,6 @@
  */
 
 // options to control how Micro Python is built
-
 #define MICROPY_ALLOC_PATH_MAX      (PATH_MAX)
 #define MICROPY_EMIT_X64            (1)
 #define MICROPY_EMIT_THUMB          (0)
@@ -80,7 +79,6 @@ extern const struct _mp_obj_module_t mp_module_ffi;
     { MP_OBJ_NEW_QSTR(MP_QSTR__os), (mp_obj_t)&mp_module_os }, \
 
 // type definitions for the specific machine
-
 #ifdef __LP64__
 typedef long machine_int_t; // must be pointer size
 typedef unsigned long machine_uint_t; // must be pointer size

--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -25,9 +25,8 @@
  */
 
 // options to control how Micro Python is built
-
-// Linking with GNU readline causes binary to be licensed under GPL
 #ifndef MICROPY_USE_READLINE
+// Linking with GNU readline causes binary to be licensed under GPL
 #define MICROPY_USE_READLINE        (0)
 #endif
 
@@ -55,7 +54,6 @@
 #define MICROPY_PORT_DEINIT_FUNC    deinit()
 
 // type definitions for the specific machine
-
 #if defined( __MINGW32__ ) && defined( __LP64__ )
 typedef long machine_int_t; // must be pointer size
 typedef unsigned long machine_uint_t; // must be pointer size
@@ -95,20 +93,15 @@ void msec_sleep(double msec);
 #ifdef _MSC_VER
 
 // Sanity check
-
 #if ( _MSC_VER < 1800 )
     #error Can only build with Visual Studio 2013 toolset
 #endif
 
-
 // CL specific overrides from mpconfig
-
 #define NORETURN                   __declspec(noreturn)
 #define MICROPY_PORT_CONSTANTS     { "dummy", 0 } //can't have zero-sized array
 
-
 // CL specific definitions
-
 #define restrict
 #define inline                      __inline
 #define STDIN_FILENO                0
@@ -118,7 +111,6 @@ void msec_sleep(double msec);
 #define S_ISREG(m)                  (((m) & S_IFMT) == S_IFREG)
 #define S_ISDIR(m)                  (((m) & S_IFMT) == S_IFDIR)
 
-
 // Put static/global variables in sections with a known name we can lookup for the GC
 // For this to work this header must be included by all sources, which is the case normally
 #define MICROPY_PORT_DATASECTION "upydata"
@@ -126,14 +118,11 @@ void msec_sleep(double msec);
 #pragma data_seg(MICROPY_PORT_DATASECTION)
 #pragma bss_seg(MICROPY_PORT_BSSSECTION)
 
-
 // System headers (needed e.g. for nlr.h)
-
 #include <stddef.h> //for NULL
 #include <assert.h> //for assert
 
 // Functions implemented in platform code
-
 int snprintf(char *dest, size_t count, const char *format, ...);
 #endif
 


### PR DESCRIPTION
The majority of // comments for functions/definitions/... have no
new newline after them, but some do so unify this accorss headers.

This changes no actual code whatsoever, but more than once I found myself wondering what style to use especially in headers (like the mpconfigports) where both are mixed. This should clear most of the confusion..
