### PR TITLE
get and set read protection level

### DIFF
--- a/stmhal/qstrdefsport.h
+++ b/stmhal/qstrdefsport.h
@@ -264,6 +264,8 @@ Q(mem)
 Q(mem8)
 Q(mem16)
 Q(mem32)
+Q(get_RDP)
+Q(set_RDP)
 
 // for stm constants
 Q(ADC)


### PR DESCRIPTION
Implemented STM32 read protection (#612)

Careful when you unset RDP with `stm.set_RDP(0)`, the board maybe unflashable and you must erase the RDP option with JTAG or ST-LINK tools if your power down the board too fast. And `stm.set_RDP(2)` is dangerous too.
