### PR TITLE
unix: Fix mpconfig.h not being included before misc.h

### DIFF
--- a/unix/gccollect.c
+++ b/unix/gccollect.c
@@ -26,8 +26,8 @@
 
 #include <stdio.h>
 
-#include "misc.h"
 #include "mpconfig.h"
+#include "misc.h"
 #include "gc.h"
 
 #if MICROPY_ENABLE_GC

--- a/unix/modos.c
+++ b/unix/modos.c
@@ -30,8 +30,8 @@
 #include <unistd.h>
 #include <errno.h>
 
-#include "misc.h"
 #include "mpconfig.h"
+#include "misc.h"
 #include "nlr.h"
 #include "qstr.h"
 #include "obj.h"

--- a/unix/modtime.c
+++ b/unix/modtime.c
@@ -30,8 +30,8 @@
 #include <sys/time.h>
 #include <math.h>
 
-#include "misc.h"
 #include "mpconfig.h"
+#include "misc.h"
 #include "qstr.h"
 #include "obj.h"
 #include "runtime.h"


### PR DESCRIPTION
This fixes count_lead_ones in misc.h not compiling due to unknown types
