### PR TITLE
Disable IRQs around sdcard reads.

### DIFF
--- a/stmhal/sdcard.c
+++ b/stmhal/sdcard.c
@@ -144,7 +144,13 @@ bool sdcard_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t num_blocks) 
         return false;
     }
 
-    if (HAL_SD_ReadBlocks(&sd_handle, (uint32_t*)dest, block_num * SDCARD_BLOCK_SIZE, SDCARD_BLOCK_SIZE, num_blocks) != SD_OK) {
+    HAL_SD_ErrorTypedef err;
+
+    __disable_irq();
+    err = HAL_SD_ReadBlocks(&sd_handle, (uint32_t*)dest, block_num * SDCARD_BLOCK_SIZE, SDCARD_BLOCK_SIZE, num_blocks);
+    __enable_irq();
+
+    if (err != SD_OK) {
         return false;
     }
 


### PR DESCRIPTION
Once the code switches to using DMA, this can be removed.

This should fix #743

I tracked the problem down to an SDIO_FLAG_RXOVERR error. Since the FIFO is only 32 bit x 32 entries (or 128 bytes), I guessed that the timer tick interrupt was probably happening during a read and causing the FIFO to overflow.

Once the code is switched to using DMA, then the disable/enable IRQ can be removed.
