### PR TITLE
Alignment violation fix in emitbc

### DIFF
--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -50,7 +50,6 @@
 struct _emit_t {
     pass_kind_t pass : 8;
     uint last_emit_was_return_value : 8;
-    byte dummy_data[DUMMY_DATA_SIZE];
 
     int stack_size;
 
@@ -67,6 +66,8 @@ struct _emit_t {
     uint bytecode_offset;
     uint bytecode_size;
     byte *code_base; // stores both byte code and code info
+    // Accessed as uint, so must be aligned as such
+    byte dummy_data[DUMMY_DATA_SIZE];
 };
 
 STATIC void emit_bc_rot_two(emit_t *emit);
@@ -207,6 +208,8 @@ STATIC void emit_write_bytecode_byte_ptr(emit_t* emit, byte b, void *ptr) {
     emit_write_bytecode_byte(emit, b);
     emit_align_bytecode_to_machine_word(emit);
     mp_uint_t *c = (mp_uint_t*)emit_get_cur_to_write_bytecode(emit, sizeof(mp_uint_t));
+    // Verify thar c is already uint-aligned
+    assert(c == MP_ALIGN(c, sizeof(mp_uint_t)));
     *c = (mp_uint_t)ptr;
 }
 

--- a/py/misc.h
+++ b/py/misc.h
@@ -84,6 +84,9 @@ int m_get_peak_bytes_allocated(void);
 // get the number of elements in a fixed-size array
 #define MP_ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
+// align ptr to the nearest multiple of "alignment"
+#define MP_ALIGN(ptr, alignment) (void*)(((mp_uint_t)(ptr) + ((alignment) - 1)) & ~((alignment) - 1))
+
 /** unichar / UTF-8 *********************************************/
 
 typedef int unichar; // TODO


### PR DESCRIPTION
I caught this when running on armv5. There specifically alignment violation didn't cause any segfault, just using non-aligned word pointer masks 2 lowest bits. In this case, uint assignment to dummy_data actually overwrote ->pass. It was a bit of chore to debug ;-). And I wonder, if we have more such cases...
