### PR TITLE
Allow DFU_UTIL to be overridden from the environment.

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -24,7 +24,7 @@ FATFS_DIR=fatfs
 CC3K_DIR=cc3k
 DFU=../tools/dfu.py
 # may need to prefix dfu-util with sudo
-DFU_UTIL=dfu-util
+DFU_UTIL ?= dfu-util
 DEVICE=0483:df11
 
 CROSS_COMPILE = arm-none-eabi-


### PR DESCRIPTION
By using ?= instead of = we can override for a couple of scenarios:

1 - Users that haven't setup their udev rules properly can add

``` bash
export DFU_UTIL='sudo dfu-util'
```

2 - If you build dfu-util from the latest source, then you can use the -s :leave option:

``` bash
export DFU_UTIL='dfu-util -s :leave'
```

and this will cause micropython to run automatically as soon its finished programming.
