### PR TITLE
Add GNUmakefile to the .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ tests/*.out
 # Python cache files
 ######################
 __pycache__/
+
+# Customized Makefile overrides
+GNUmakefile


### PR DESCRIPTION
Using GNUmakefile allows for custom overrides without having to specify them everytime you run make.

See #768 for an example.
