### PR TITLE
Fix modos.c to compile for the STM32F4Discovery board

### DIFF
--- a/stmhal/modos.c
+++ b/stmhal/modos.c
@@ -92,9 +92,11 @@ STATIC mp_obj_t os_listdir(uint n_args, const mp_obj_t *args) {
     if (path[0] == '/' && path[1] == '\0') {
         mp_obj_t dir_list = mp_obj_new_list(0, NULL);
         mp_obj_list_append(dir_list, MP_OBJ_NEW_QSTR(MP_QSTR_flash));
+#if MICROPY_HW_HAS_SDCARD
         if (sdcard_is_present()) { // TODO this is not the correct logic to check for /sd
             mp_obj_list_append(dir_list, MP_OBJ_NEW_QSTR(MP_QSTR_sd));
         }
+#endif
         return dir_list;
     }
 


### PR DESCRIPTION
The discovery board doesn't have MICROPY_HW_SDCARD conffigured, so the sdcard_is_present test doesn't exist.
