### PR TITLE
Add %q support.

### DIFF
--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -74,7 +74,7 @@ void mp_arg_parse_all(uint n_pos, const mp_obj_t *pos, mp_map_t *kws, uint n_all
             mp_map_elem_t *kw = mp_map_lookup(kws, MP_OBJ_NEW_QSTR(allowed[i].qstr), MP_MAP_LOOKUP);
             if (kw == NULL) {
                 if (allowed[i].flags & MP_ARG_REQUIRED) {
-                    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "'%s' argument required", qstr_str(allowed[i].qstr)));
+                    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "'%q' argument required", allowed[i].qstr));
                 }
                 out_vals[i] = allowed[i].defval;
                 continue;

--- a/py/builtin.c
+++ b/py/builtin.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <assert.h>
 

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -297,7 +297,7 @@ mp_obj_t mp_builtin___import__(uint n_args, mp_obj_t *args) {
 
             // fail if we couldn't find the file
             if (stat == MP_IMPORT_STAT_NO_EXIST) {
-                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ImportError, "No module named '%s'", qstr_str(mod_name)));
+                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ImportError, "No module named '%q'", mod_name));
             }
 
             module_obj = mp_module_get(mod_name);

--- a/py/mpsnprintf.c
+++ b/py/mpsnprintf.c
@@ -1,0 +1,42 @@
+#include <string.h>
+#include <stdarg.h>
+
+#include "mpconfig.h"
+#include "misc.h"
+#include "qstr.h"
+#include "obj.h"
+#include "pfenv.h"
+
+typedef struct _strn_pfenv_t {
+    char *cur;
+    size_t remain;
+} strn_pfenv_t;
+
+STATIC void strn_print_strn(void *data, const char *str, unsigned int len) {
+    strn_pfenv_t *strn_pfenv = data;
+    if (len > strn_pfenv->remain) {
+        len = strn_pfenv->remain;
+    }
+    memcpy(strn_pfenv->cur, str, len);
+    strn_pfenv->cur += len;
+    strn_pfenv->remain -= len;
+}
+
+int mp_vsnprintf(char *str, size_t size, const char *fmt, va_list ap) {
+    strn_pfenv_t strn_pfenv;
+    strn_pfenv.cur = str;
+    strn_pfenv.remain = size;
+    pfenv_t pfenv;
+    pfenv.data = &strn_pfenv;
+    pfenv.print_strn = strn_print_strn;
+    int len = pfenv_vprintf(&pfenv, fmt, ap);
+    // add terminating null byte
+    if (size > 0) {
+        if (strn_pfenv.remain == 0) {
+            strn_pfenv.cur[-1] = 0;
+        } else {
+            strn_pfenv.cur[0] = 0;
+        }
+    }
+    return len;
+}

--- a/py/mpsnprintf.h
+++ b/py/mpsnprintf.h
@@ -1,0 +1,2 @@
+int mp_vsnprintf(char *str, size_t size, const char *fmt, va_list ap);
+

--- a/py/obj.c
+++ b/py/obj.c
@@ -75,7 +75,7 @@ void mp_obj_print_helper(void (*print)(void *env, const char *fmt, ...), void *e
     if (type->print != NULL) {
         type->print(print, env, o_in, kind);
     } else {
-        print(env, "<%s>", qstr_str(type->name));
+        print(env, "<%q>", type->name);
     }
 }
 
@@ -340,7 +340,7 @@ uint mp_get_index(const mp_obj_type_t *type, mp_uint_t len, mp_obj_t index, bool
     if (MP_OBJ_IS_SMALL_INT(index)) {
         i = MP_OBJ_SMALL_INT_VALUE(index);
     } else if (!mp_obj_get_int_maybe(index, &i)) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "%s indices must be integers, not %s", qstr_str(type->name), mp_obj_get_type_str(index)));
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "%q indices must be integers, not %s", type->name, mp_obj_get_type_str(index)));
     }
 
     if (i < 0) {
@@ -354,7 +354,7 @@ uint mp_get_index(const mp_obj_type_t *type, mp_uint_t len, mp_obj_t index, bool
         }
     } else {
         if (i < 0 || i >= len) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_IndexError, "%s index out of range", qstr_str(type->name)));
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_IndexError, "%q index out of range", type->name));
         }
     }
     return i;

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -41,6 +41,7 @@
 #include "runtime.h"
 #include "runtime0.h"
 #include "gc.h"
+#include "mpsnprintf.h"
 
 typedef struct _mp_obj_exception_t {
     mp_obj_base_t base;
@@ -111,7 +112,7 @@ STATIC void mp_obj_exception_print(void (*print)(void *env, const char *fmt, ...
     mp_print_kind_t k = kind & ~PRINT_EXC_SUBCLASS;
     bool is_subclass = kind & PRINT_EXC_SUBCLASS;
     if (!is_subclass && (k == PRINT_REPR || k == PRINT_EXC)) {
-        print(env, "%s", qstr_str(o->base.type->name));
+        print(env, "%q", o->base.type->name);
     }
 
     if (k == PRINT_EXC) {
@@ -337,7 +338,7 @@ mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const char
 
             va_list ap;
             va_start(ap, fmt);
-            str->len = vsnprintf((char *)str_data, max_len, fmt, ap);
+            str->len = mp_vsnprintf((char *)str_data, max_len, fmt, ap);
             va_end(ap);
 
             str->base.type = &mp_type_str;

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -57,7 +57,7 @@ STATIC void float_print(void (*print)(void *env, const char *fmt, ...), void *en
     }
 #else
     char buf[32];
-    sprintf(buf, "%.17g", (double) o->value);
+    snprintf(buf, sizeof(buf), "%.17g", (double) o->value);
     print(env, buf);
     if (strchr(buf, '.') == NULL) {
         // Python floats always have decimal point

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -275,7 +275,7 @@ void mp_setup_code_state(mp_code_state *code_state, mp_obj_t self_in, uint n_arg
                 if (arg_name == self->args[j]) {
                     if (code_state->state[n_state - 1 - j] != MP_OBJ_NULL) {
                         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                            "function got multiple values for argument '%s'", qstr_str(arg_name)));
+                            "function got multiple values for argument '%q'", arg_name));
                     }
                     code_state->state[n_state - 1 - j] = kwargs[2 * i + 1];
                     goto continue2;
@@ -324,7 +324,7 @@ continue2:;
                     code_state->state[n_state - 1 - self->n_pos_args - i] = elem->value;
                 } else {
                     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-                        "function missing required keyword argument '%s'", qstr_str(self->args[self->n_pos_args + i])));
+                        "function missing required keyword argument '%q'", self->args[self->n_pos_args + i]));
                 }
             }
         }

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -40,7 +40,7 @@ STATIC mp_map_t mp_loaded_modules_map; // TODO: expose as sys.modules
 
 STATIC void module_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
     mp_obj_module_t *self = self_in;
-    print(env, "<module '%s' from '-unknown-file-'>", qstr_str(self->name));
+    print(env, "<module '%q' from '-unknown-file-'>", self->name);
 }
 
 STATIC void module_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -98,7 +98,7 @@ STATIC int namedtuple_find_field(const char *name, const char *namedef) {
 
 STATIC void namedtuple_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t o_in, mp_print_kind_t kind) {
     mp_obj_namedtuple_t *o = o_in;
-    print(env, "%s(", qstr_str(o->tuple.base.type->name));
+    print(env, "%q(", o->tuple.base.type->name);
     const char *fields = ((mp_obj_namedtuple_type_t*)o->tuple.base.type)->fields;
 
     for (int i = 0; i < o->tuple.len; i++) {

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -25,6 +25,7 @@
  * THE SOFTWARE.
  */
 
+#include <stdarg.h>
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
@@ -1055,7 +1056,7 @@ mp_obj_t mp_obj_str_format(uint n_args, const mp_obj_t *args) {
                 // A proper solution would involve adding a special flag
                 // or something to format_float, and create a format_double
                 // to deal with doubles. In order to fix this when using
-                // sprintf, we'd need to use the e format and tweak the
+                // snprintf, we'd need to use the e format and tweak the
                 // returned result to strip trailing zeros like the g format
                 // does.
                 //

--- a/py/objstrunicode.c
+++ b/py/objstrunicode.c
@@ -25,6 +25,7 @@
  * THE SOFTWARE.
  */
 
+#include <stdarg.h>
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -217,7 +217,7 @@ STATIC void instance_print(void (*print)(void *env, const char *fmt, ...), void 
         // Handle Exception subclasses specially
         if (mp_obj_is_native_exception_instance(self->subobj[0])) {
             if (kind != PRINT_STR) {
-                print(env, "%s", qstr_str(self->base.type->name));
+                print(env, "%q", self->base.type->name);
             }
             mp_obj_print_helper(print, env, self->subobj[0], kind | PRINT_EXC_SUBCLASS);
         } else {
@@ -639,7 +639,7 @@ STATIC mp_obj_t instance_getiter(mp_obj_t self_in) {
 
 STATIC void type_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
     mp_obj_type_t *self = self_in;
-    print(env, "<class '%s'>", qstr_str(self->name));
+    print(env, "<class '%q'>", self->name);
 }
 
 STATIC mp_obj_t type_make_new(mp_obj_t type_in, uint n_args, uint n_kw, const mp_obj_t *args) {
@@ -666,7 +666,7 @@ STATIC mp_obj_t type_call(mp_obj_t self_in, uint n_args, uint n_kw, const mp_obj
     mp_obj_type_t *self = self_in;
 
     if (self->make_new == NULL) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "cannot create '%s' instances", qstr_str(self->name)));
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "cannot create '%q' instances", self->name));
     }
 
     // make new instance
@@ -762,7 +762,7 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
         mp_obj_type_t *t = items[i];
         // TODO: Verify with CPy, tested on function type
         if (t->make_new == NULL) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "type '%s' is not an acceptable base type", qstr_str(t->name)));
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError, "type '%q' is not an acceptable base type", t->name));
         }
     }
 

--- a/py/pfenv.c
+++ b/py/pfenv.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include <stdarg.h>
 #include <stdint.h>
 #include <string.h>
 

--- a/py/pfenv.h
+++ b/py/pfenv.h
@@ -50,5 +50,5 @@ int pfenv_print_mp_int(const pfenv_t *pfenv, mp_obj_t x, int sgn, int base, int 
 int pfenv_print_float(const pfenv_t *pfenv, mp_float_t f, char fmt, int flags, char fill, int width, int prec);
 #endif
 
-//int pfenv_vprintf(const pfenv_t *pfenv, const char *fmt, va_list args);
+int pfenv_vprintf(const pfenv_t *pfenv, const char *fmt, va_list args);
 int pfenv_printf(const pfenv_t *pfenv, const char *fmt, ...);

--- a/py/pfenv_printf.c
+++ b/py/pfenv_printf.c
@@ -126,6 +126,15 @@ int pfenv_vprintf(const pfenv_t *pfenv, const char *fmt, va_list args) {
                 chrs += pfenv_print_strn(pfenv, &str, 1, flags, fill, width);
                 break;
             }
+            case 'q':
+            {
+                qstr q = va_arg(args, qstr);
+                if (prec < 0) {
+                    prec = qstr_len(q);
+                }
+                chrs += pfenv_print_strn(pfenv, qstr_str(q), prec, flags, fill, width);
+                break;
+            }
             case 's':
             {
                 const char *str = va_arg(args, const char*);

--- a/py/py.mk
+++ b/py/py.mk
@@ -103,6 +103,7 @@ PY_O_BASENAME = \
 	smallint.o \
 	pfenv.o \
 	pfenv_printf.o \
+	mpsnprintf.o \
 	../extmod/moductypes.o
 
 # prepend the build destination prefix to the py object files

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -153,7 +153,7 @@ mp_obj_t mp_load_global(qstr qstr) {
         // TODO lookup in dynamic table of builtins first
         elem = mp_map_lookup((mp_map_t*)&mp_builtin_object_dict_obj.map, MP_OBJ_NEW_QSTR(qstr), MP_MAP_LOOKUP);
         if (elem == NULL) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_NameError, "name '%s' is not defined", qstr_str(qstr)));
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_NameError, "name '%q' is not defined", qstr));
         }
     }
     return elem->value;
@@ -879,9 +879,9 @@ void mp_load_method(mp_obj_t base, qstr attr, mp_obj_t *dest) {
         // following CPython, we give a more detailed error message for type objects
         if (MP_OBJ_IS_TYPE(base, &mp_type_type)) {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_AttributeError,
-                "type object '%s' has no attribute '%s'", qstr_str(((mp_obj_type_t*)base)->name), qstr_str(attr)));
+                "type object '%q' has no attribute '%q'", ((mp_obj_type_t*)base)->name, attr));
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_AttributeError, "'%s' object has no attribute '%s'", mp_obj_get_type_str(base), qstr_str(attr)));
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_AttributeError, "'%s' object has no attribute '%q'", mp_obj_get_type_str(base), attr));
         }
     }
 }
@@ -894,7 +894,7 @@ void mp_store_attr(mp_obj_t base, qstr attr, mp_obj_t value) {
             return;
         }
     }
-    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_AttributeError, "'%s' object has no attribute '%s'", mp_obj_get_type_str(base), qstr_str(attr)));
+    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_AttributeError, "'%s' object has no attribute '%q'", mp_obj_get_type_str(base), attr));
 }
 
 mp_obj_t mp_getiter(mp_obj_t o_in) {
@@ -1086,7 +1086,7 @@ mp_obj_t mp_import_from(mp_obj_t module, qstr name) {
     if (dest[1] != MP_OBJ_NULL) {
         // Hopefully we can't import bound method from an object
 import_error:
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ImportError, "cannot import name %s", qstr_str(name)));
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ImportError, "cannot import name %q", name));
     }
 
     if (dest[0] != MP_OBJ_NULL) {

--- a/py/vstr.c
+++ b/py/vstr.c
@@ -31,6 +31,7 @@
 #include <assert.h>
 #include "mpconfig.h"
 #include "misc.h"
+#include "mpsnprintf.h"
 
 // returned value is always at least 1 greater than argument
 #define ROUND_ALLOC(a) (((a) & ((~0) - 7)) + 8)
@@ -360,11 +361,11 @@ void vstr_vprintf(vstr_t *vstr, const char *fmt, va_list ap) {
 
     while (1) {
         // try to print in the allocated space
-        // need to make a copy of the va_list because we may call vsnprintf multiple times
+        // need to make a copy of the va_list because we may call mp_vsnprintf multiple times
         int size = vstr->alloc - vstr->len;
         va_list ap2;
         va_copy(ap2, ap);
-        int n = vsnprintf(vstr->buf + vstr->len, size, fmt, ap2);
+        int n = mp_vsnprintf(vstr->buf + vstr->len, size, fmt, ap2);
         va_end(ap2);
 
         // if that worked, return

--- a/stmhal/pin.c
+++ b/stmhal/pin.c
@@ -190,7 +190,7 @@ STATIC void pin_print(void (*print)(void *env, const char *fmt, ...), void *env,
     pin_obj_t *self = self_in;
 
     // pin name
-    print(env, "Pin(Pin.cpu.%s, mode=Pin.", qstr_str(self->name));
+    print(env, "Pin(Pin.cpu.%q, mode=Pin.", self->name);
 
     uint32_t mode = pin_get_mode(self);
 
@@ -216,7 +216,7 @@ STATIC void pin_print(void (*print)(void *env, const char *fmt, ...), void *env,
                 mode_qst = MP_QSTR_AF_OD;
             }
         }
-        print(env, qstr_str(mode_qst)); // safe because mode_qst has no formating chars
+        print(env, "%q", mode_qst);
 
         // pull mode
         qstr pull_qst = MP_QSTR_NULL;
@@ -227,7 +227,7 @@ STATIC void pin_print(void (*print)(void *env, const char *fmt, ...), void *env,
             pull_qst = MP_QSTR_PULL_DOWN;
         }
         if (pull_qst != MP_QSTR_NULL) {
-            print(env, ", pull=Pin.%s", qstr_str(pull_qst));
+            print(env, ", pull=Pin.%q", pull_qst);
         }
 
         // AF mode
@@ -237,7 +237,7 @@ STATIC void pin_print(void (*print)(void *env, const char *fmt, ...), void *env,
             if (af_obj == NULL) {
                 print(env, ", af=%d)", af_idx);
             } else {
-                print(env, ", af=Pin.%s)", qstr_str(af_obj->name));
+                print(env, ", af=Pin.%q)", af_obj->name);
             }
         } else {
             print(env, ")");
@@ -591,7 +591,7 @@ const mp_obj_type_t pin_type = {
 /// Return a string describing the alternate function.
 STATIC void pin_af_obj_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
     pin_af_obj_t *self = self_in;
-    print(env, "Pin.%s", qstr_str(self->name));
+    print(env, "Pin.%q", self->name);
 }
 
 /// \method index()

--- a/stmhal/pin_named_pins.c
+++ b/stmhal/pin_named_pins.c
@@ -38,7 +38,7 @@
 
 STATIC void pin_named_pins_obj_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
     pin_named_pins_obj_t *self = self_in;
-    print(env, "<Pin.%s>", qstr_str(self->name));
+    print(env, "<Pin.%q>", self->name);
 }
 
 const mp_obj_type_t pin_cpu_pins_obj_type = {

--- a/stmhal/printf.c
+++ b/stmhal/printf.c
@@ -35,6 +35,7 @@
 #include "qstr.h"
 #include "obj.h"
 #include "pfenv.h"
+#include "mpsnprintf.h"
 #if 0
 #include "lcd.h"
 #endif
@@ -92,44 +93,10 @@ int puts(const char *s) {
     return 1;
 }
 
-typedef struct _strn_pfenv_t {
-    char *cur;
-    size_t remain;
-} strn_pfenv_t;
-
-void strn_print_strn(void *data, const char *str, unsigned int len) {
-    strn_pfenv_t *strn_pfenv = data;
-    if (len > strn_pfenv->remain) {
-        len = strn_pfenv->remain;
-    }
-    memcpy(strn_pfenv->cur, str, len);
-    strn_pfenv->cur += len;
-    strn_pfenv->remain -= len;
-}
-
-int vsnprintf(char *str, size_t size, const char *fmt, va_list ap) {
-    strn_pfenv_t strn_pfenv;
-    strn_pfenv.cur = str;
-    strn_pfenv.remain = size;
-    pfenv_t pfenv;
-    pfenv.data = &strn_pfenv;
-    pfenv.print_strn = strn_print_strn;
-    int len = pfenv_vprintf(&pfenv, fmt, ap);
-    // add terminating null byte
-    if (size > 0) {
-        if (strn_pfenv.remain == 0) {
-            strn_pfenv.cur[-1] = 0;
-        } else {
-            strn_pfenv.cur[0] = 0;
-        }
-    }
-    return len;
-}
-
 int snprintf(char *str, size_t size, const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
-    int ret = vsnprintf(str, size, fmt, ap);
+    int ret = mp_vsnprintf(str, size, fmt, ap);
     va_end(ap);
     return ret;
 }

--- a/unix/modsocket.c
+++ b/unix/modsocket.c
@@ -365,7 +365,7 @@ STATIC mp_obj_t mod_socket_getaddrinfo(uint n_args, const mp_obj_t *args) {
     if (MP_OBJ_IS_SMALL_INT(args[1])) {
         int port = (short)MP_OBJ_SMALL_INT_VALUE(args[1]);
         char buf[6];
-        sprintf(buf, "%d", port);
+        snprintf(buf, sizeof(buf), "%d", port);
         serv = buf;
         hints.ai_flags = AI_NUMERICSERV;
 #ifdef __UCLIBC_MAJOR__


### PR DESCRIPTION
This allows us to use print("%q", some_qstr) instead
of print("%s", qstr_str(some_qstr))

This has a net savings of 68 bytes on the stmhal port.
