### PR TITLE
added install/uninstall

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -97,3 +97,15 @@ include ../py/mkrules.mk
 test: $(PROG) ../tests/run-tests
 	$(eval DIRNAME=$(notdir $(CURDIR)))
 	cd ../tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) ./run-tests
+
+# install micropython in /usr/local/bin
+TARGET = micropython
+PREFIX = $(DESTDIR)/usr/local
+BINDIR = $(PREFIX)/bin
+
+install: micropython
+	install -D $(TARGET) $(BINDIR)/$(TARGET)
+
+# uninstall micropython
+uninstall:
+	-rm $(BINDIR)/$(TARGET)


### PR DESCRIPTION
This adds install and uninstall to the Makefile of the Unix port.
micropython is installed to /usr/local/bin
uninstalling removes the executable  from there

Note that this is the first time ever I made changes to a Makefile. It tested on Ubuntu and it seems to work fine.

```
plam@newlinx:~/Documents/micropython/unix$ make
mkdir -p build/genhdr
CPP ../py/qstrdefs.h
makeqstrdata ../py/qstrdefs.h qstrdefsport.h
Generating build/genhdr/py-version.h
mkdir -p build/py
mkdir -p build/py/../extmod
CC ../py/nlrx86.S
.
.
.
CC modffi.c
LINK micropython
   text    data     bss     dec     hex filename
 290151    1384    1400  292935   47847 micropython
plam@newlinx:~/Documents/micropython/unix$ sudo make install
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
install -D micropython /usr/local/bin/micropython
plam@newlinx:~/Documents/micropython/unix$ micropython
Micro Python v1.2-99-g2eeeafc on 2014-08-11; linux version
>>> 
plam@newlinx:~/Documents/micropython/unix$ cd ..
plam@newlinx:~/Documents/micropython$ micropython
Micro Python v1.2-99-g2eeeafc on 2014-08-11; linux version
>>> plam@newlinx:~/Documents/micropython$ 
```
