### PR TITLE
msvc: Use built-in alignof

### DIFF
--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -119,6 +119,7 @@ void msec_sleep(double msec);
 
 #define restrict
 #define inline                      __inline
+#define alignof(t)                  __alignof(t)
 #define STDIN_FILENO                0
 #define STDOUT_FILENO               1
 #define STDERR_FILENO               2


### PR DESCRIPTION
This also fixes a 'unnamed type definition in parentheses' warning on the
alignof implementation defined in binary.c
