### PR TITLE
Put some code into the first 16K of flash

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -200,6 +200,13 @@ OBJ += $(addprefix $(BUILD)/, $(SRC_FATFS:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_CC3K:.c=.o))
 OBJ += $(BUILD)/pins_$(BOARD).o
 
+# We put ff.o and stm32f4xx_hal_sd.o into the first 16K section with the ISRs.
+# If we compile these using -O0 then it won't fit. So if you really want these
+# to be compiled with -O0, then edit stm32f405.ld (in the .isr_vector section)
+# and comment out the following 2 lines.
+$(BUILD)/$(FATFS_DIR)/src/ff.o: COPT += -Os
+$(BUILD)/$(HAL_DIR)/src/stm32f4xx_hal_sd.o: COPT += -Os
+
 all: $(BUILD)/firmware.dfu $(BUILD)/firmware.hex
 
 .PHONY: deploy

--- a/stmhal/stm32f405.ld
+++ b/stmhal/stm32f405.ld
@@ -34,6 +34,14 @@ SECTIONS
         . = ALIGN(4);
         KEEP(*(.isr_vector)) /* Startup code */
 
+        /* This first flash block is 16K annd the isr vectors only take up
+           about 400 bytes. So we pull in a couple of object files to pad it
+           out. */
+
+        . = ALIGN(4);
+        */ff.o(.text*)
+        */stm32f4xx_hal_sd.o(.text*)
+
         . = ALIGN(4);
     } >FLASH_ISR
    
@@ -41,9 +49,7 @@ SECTIONS
     .text :
     {
         . = ALIGN(4);
-        *(.text)           /* .text sections (code) */
         *(.text*)          /* .text* sections (code) */
-        *(.rodata)         /* .rodata sections (constants, strings, etc.) */
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
     /*  *(.glue_7)   */    /* glue arm to thumb code */
     /*  *(.glue_7t)  */    /* glue thumb to arm code */
@@ -78,7 +84,6 @@ SECTIONS
         . = ALIGN(4);
         _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
         _ram_start = .;    /* create a global symbol at ram start for garbage collector */
-        *(.data)           /* .data sections */
         *(.data*)          /* .data* sections */
 
         . = ALIGN(4);
@@ -90,7 +95,6 @@ SECTIONS
     {
         . = ALIGN(4);
         _sbss = .;         /* define a global symbol at bss start; used by startup code */
-        *(.bss)
         *(.bss*)
         *(COMMON)
 


### PR DESCRIPTION
This basically shrinks the remaining size of flash in the portion
that goes after the internal flash drive.

Comparison of the overall flash usage:

BEFORE:

```
LINK build-PYBV10/firmware.elf
   text    data     bss     dec     hex filename
 228412     392   28104  256908   3eb8c build-PYBV10/firmware.elf
```

AFTER:

```
LINK build-PYBV10/firmware.elf
   text    data     bss     dec     hex filename
 228416     392   28104  256912   3eb90 build-PYBV10/firmware.elf
```

and the section sizes BEFORE:

```
2885 >objdump -h build-PYBV10/firmware.elf 

build-PYBV10/firmware.elf:     file format elf32-little

Sections:
Idx Name          Size      VMA       LMA       File off  Algn
  0 .isr_vector   00000188  08000000  08000000  00008000  2**0
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  1 .text         00037ab4  08020000  08020000  00010000  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  2 .data         00000188  20000000  08057ab4  00048000  2**2
                  CONTENTS, ALLOC, LOAD, DATA
  3 .bss          000025c8  20000188  08057c3c  00048188  2**2
                  ALLOC
  4 .heap         00004000  20002750  08057c3c  0004a750  2**0
                  ALLOC
  5 .stack        00000800  20006750  08057c3c  0004e750  2**0
                  ALLOC
  6 .ARM.attributes 00000035  00000000  00000000  00048188  2**0
                  CONTENTS, READONLY
  7 .comment      00000070  00000000  00000000  000481bd  2**0
                  CONTENTS, READONLY
```

and AFTER:

```
2889 >objdump -h build-PYBV10/firmware.elf 

build-PYBV10/firmware.elf:     file format elf32-little

Sections:
Idx Name          Size      VMA       LMA       File off  Algn
  0 .isr_vector   000033e4  08000000  08000000  00008000  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  1 .text         0003485c  08020000  08020000  00010000  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  2 .data         00000188  20000000  0805485c  00048000  2**2
                  CONTENTS, ALLOC, LOAD, DATA
  3 .bss          000025c8  20000188  080549e4  00048188  2**2
                  ALLOC
  4 .heap         00004000  20002750  080549e4  0004a750  2**0
                  ALLOC
  5 .stack        00000800  20006750  080549e4  0004e750  2**0
                  ALLOC
  6 .ARM.attributes 00000035  00000000  00000000  00048188  2**0
                  CONTENTS, READONLY
  7 .comment      00000070  00000000  00000000  000481bd  2**0
                  CONTENTS, READONLY
```
