### PR TITLE
Added python script to map AF to a pin name

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -238,6 +238,7 @@ GEN_PINS_SRC = $(BUILD)/pins_$(BOARD).c
 GEN_PINS_HDR = $(HEADER_BUILD)/pins.h
 GEN_PINS_QSTR = $(BUILD)/pins_qstr.h
 GEN_PINS_AF_CONST = $(HEADER_BUILD)/pins_af_const.h
+GEN_PINS_AF_PY = $(BUILD)/pins_af.py
 
 INSERT_USB_IDS = ../tools/insert-usb-ids.py
 FILE2H = ../tools/file2h.py
@@ -260,7 +261,7 @@ $(BUILD)/main.o: $(GEN_CDCINF_HEADER)
 # both pins_$(BOARD).c and pins.h
 $(BUILD)/%_$(BOARD).c $(HEADER_BUILD)/%.h $(HEADER_BUILD)/%_af_const.h $(BUILD)/%_qstr.h: boards/$(BOARD)/%.csv $(MAKE_PINS) $(AF_FILE) $(PREFIX_FILE) | $(HEADER_BUILD)
 	$(ECHO) "Create $@"
-	$(Q)$(PYTHON) $(MAKE_PINS) --board $(BOARD_PINS) --af $(AF_FILE) --prefix $(PREFIX_FILE) --hdr $(GEN_PINS_HDR) --qstr $(GEN_PINS_QSTR) --af-const $(GEN_PINS_AF_CONST) > $(GEN_PINS_SRC)
+	$(Q)$(PYTHON) $(MAKE_PINS) --board $(BOARD_PINS) --af $(AF_FILE) --prefix $(PREFIX_FILE) --hdr $(GEN_PINS_HDR) --qstr $(GEN_PINS_QSTR) --af-const $(GEN_PINS_AF_CONST) --af-py $(GEN_PINS_AF_PY) > $(GEN_PINS_SRC)
 
 $(BUILD)/pins_$(BOARD).o: $(BUILD)/pins_$(BOARD).c
 	$(call compile_c)

--- a/stmhal/boards/make-pins.py
+++ b/stmhal/boards/make-pins.py
@@ -315,6 +315,17 @@ class Pins(object):
                 print('    { %-*s %s },' % (mux_name_width + 26, key, val),
                       file=af_const_file)
 
+    def print_af_py(self, af_py_filename):
+        with open(af_py_filename,  'wt') as af_py_file:
+            print('PINS_AF = (', file=af_py_file);
+            for named_pin in self.board_pins:
+                print("  ('%s', " % named_pin.name(), end='', file=af_py_file)
+                for af in named_pin.pin().alt_fn:
+                    if af.is_supported():
+                        print("(%d, '%s'), " % (af.idx, af.af_str), end='', file=af_py_file)
+                print('),', file=af_py_file)
+            print(')',  file=af_py_file)
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -333,6 +344,12 @@ def main():
         dest="af_const_filename",
         help="Specifies header file for alternate function constants.",
         default="build/pins_af_const.h"
+    )
+    parser.add_argument(
+        "--af-py",
+        dest="af_py_filename",
+        help="Specifies the filename for the python alternate function mappings.",
+        default="build/pins_af.py"
     )
     parser.add_argument(
         "-b", "--board",
@@ -383,6 +400,7 @@ def main():
     pins.print_header(args.hdr_filename)
     pins.print_qstr(args.qstr_filename)
     pins.print_af_hdr(args.af_const_filename)
+    pins.print_af_py(args.af_py_filename)
 
 
 if __name__ == "__main__":

--- a/stmhal/pin.c
+++ b/stmhal/pin.c
@@ -508,6 +508,33 @@ STATIC mp_obj_t pin_gpio(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(pin_gpio_obj, pin_gpio);
 
+/// \method mode()
+/// Returns the currently configured mode of the pin. The integer returned
+/// will match one of the allowed constants for the mode argument to the init
+/// function.
+STATIC mp_obj_t pin_mode(mp_obj_t self_in) {
+    return MP_OBJ_NEW_SMALL_INT(pin_get_mode(self_in));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pin_mode_obj, pin_mode);
+
+/// \method pull()
+/// Returns the currently configured pull of the pin. The integer returned
+/// will match one of the allowed constants for the pull argument to the init
+/// function.
+STATIC mp_obj_t pin_pull(mp_obj_t self_in) {
+    return MP_OBJ_NEW_SMALL_INT(pin_get_pull(self_in));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pin_pull_obj, pin_pull);
+
+/// \method af()
+/// Returns the currently configured af of the pin. The integer returned
+/// will match one of the allowed constants for the af argument to the init
+/// function.
+STATIC mp_obj_t pin_af(mp_obj_t self_in) {
+    return MP_OBJ_NEW_SMALL_INT(pin_get_af(self_in));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pin_af_obj, pin_af);
+
 STATIC const mp_map_elem_t pin_locals_dict_table[] = {
     // instance methods
     { MP_OBJ_NEW_QSTR(MP_QSTR_init),    (mp_obj_t)&pin_init_obj },
@@ -520,6 +547,9 @@ STATIC const mp_map_elem_t pin_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_port),    (mp_obj_t)&pin_port_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_pin),     (mp_obj_t)&pin_pin_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_gpio),    (mp_obj_t)&pin_gpio_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_mode),    (mp_obj_t)&pin_mode_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_pull),    (mp_obj_t)&pin_pull_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_af),      (mp_obj_t)&pin_af_obj },
 
     // class methods
     { MP_OBJ_NEW_QSTR(MP_QSTR_mapper),  (mp_obj_t)&pin_mapper_obj },


### PR DESCRIPTION
Added some functions to Pin class to query mode, pull, and af.

Now I can run this script:

``` python
import pyb
import pins_af

def af():
    max_name_width = 0
    max_af_width = 0
    for pin_entry in pins_af.PINS_AF:
        max_name_width = max(max_name_width, len(pin_entry[0]))
        for af_entry in pin_entry[1:]:
            max_af_width = max(max_af_width, len(af_entry[1]))
    for pin_entry in pins_af.PINS_AF:
        pin_name = pin_entry[0]
        print('%-*s ' % (max_name_width, pin_name),  end='')
        for af_entry in pin_entry[1:]:
            print('%2d: %-*s ' % (af_entry[0], max_af_width, af_entry[1]), end='')
        print('')

def pins():
    mode_str = { pyb.Pin.IN     : 'IN',
                 pyb.Pin.OUT_PP : 'OUT_PP',
                 pyb.Pin.OUT_OD : 'OUT_OD',
                 pyb.Pin.AF_PP  : 'AF_PP',
                 pyb.Pin.AF_OD  : 'AF_OD',
                 pyb.Pin.ANALOG : 'ANALOG' }
    pull_str = { pyb.Pin.PULL_NONE : '',
                 pyb.Pin.PULL_UP   : 'PULL_UP',
                 pyb.Pin.PULL_DOWN : 'PULL_DOWN' }
    width = [0, 0, 0, 0]
    rows = []
    for pin_entry in pins_af.PINS_AF:
        row = []
        pin_name = pin_entry[0]
        pin = pyb.Pin(pin_name)
        pin_mode = pin.mode()
        row.append(pin_name)
        row.append(mode_str[pin_mode])
        row.append(pull_str[pin.pull()])
        if pin_mode == pyb.Pin.AF_PP or pin_mode == pyb.Pin.AF_OD:
            pin_af = pin.af()
            for af_entry in pin_entry[1:]:
                if pin_af == af_entry[0]:
                    af_str = '%d: %s' % (pin_af, af_entry[1])
                    break
            else:
                af_str = '%d' % pin_af
        else:
            af_str = ''
        row.append(af_str)
        for col in range(len(width)):
            width[col] = max(width[col], len(row[col]))
        rows.append(row)
    for row in rows:
        for col in range(len(width)):
            print('%-*s ' % (width[col], row[col]), end='')
        print('')

```

and get this output:

``` python
>>> import pins
>>> pins.af()
X1          1: TIM2_CH1_ETR  2: TIM5_CH1      3: TIM8_ETR      7: USART2_CTS    8: UART4_TX     
X2          1: TIM2_CH2      2: TIM5_CH2      7: USART2_RTS    8: UART4_RX     
X3          1: TIM2_CH3      2: TIM5_CH3      3: TIM9_CH1      7: USART2_TX    
X4          1: TIM2_CH4      2: TIM5_CH4      3: TIM9_CH2      7: USART2_RX    
X5          5: SPI1_NSS      6: SPI3_NSS      7: USART2_CK    
X6          1: TIM2_CH1_ETR  3: TIM8_CH1N     5: SPI1_SCK     
X7          1: TIM1_BKIN     2: TIM3_CH1      3: TIM8_BKIN     5: SPI1_MISO     9: TIM13_CH1    
X8          1: TIM1_CH1N     2: TIM3_CH2      3: TIM8_CH1N     5: SPI1_MOSI     9: TIM14_CH1    
X9          2: TIM4_CH1      4: I2C1_SCL      7: USART1_TX    
X10         2: TIM4_CH2      4: I2C1_SDA      7: USART1_RX    
X11        
X12        
X17         1: TIM2_CH2      5: SPI1_SCK      6: SPI3_SCK     
X18        
X19        
X20        
X21         5: SPI2_MISO    
X22         5: SPI2_MOSI    
Y1          2: TIM3_CH1      3: TIM8_CH1      8: USART6_TX    
Y2          2: TIM3_CH2      3: TIM8_CH2      8: USART6_RX    
Y3          2: TIM4_CH3      3: TIM10_CH1     4: I2C1_SCL     
Y4          2: TIM4_CH4      3: TIM11_CH1     4: I2C1_SDA      5: SPI2_NSS     
Y5          1: TIM1_BKIN     5: SPI2_NSS      7: USART3_CK    
Y6          1: TIM1_CH1N     5: SPI2_SCK      7: USART3_CTS   
Y7          1: TIM1_CH2N     3: TIM8_CH2N     5: SPI2_MISO     7: USART3_RTS    9: TIM12_CH1    
Y8          1: TIM1_CH3N     3: TIM8_CH3N     5: SPI2_MOSI     9: TIM12_CH2    
Y9          1: TIM2_CH3      4: I2C2_SCL      5: SPI2_SCK      7: USART3_TX    
Y10         1: TIM2_CH4      4: I2C2_SDA      7: USART3_RX    
Y11         1: TIM1_CH2N     2: TIM3_CH3      3: TIM8_CH2N    
Y12         1: TIM1_CH3N     2: TIM3_CH4      3: TIM8_CH3N    
LED_BLUE    2: TIM3_CH1      5: SPI1_MISO     6: SPI3_MISO    
LED_RED    
LED_GREEN  
LED_YELLOW  1: TIM2_CH1      1: TIM2_ETR      5: SPI1_NSS      6: SPI3_NSS     
SW          1: TIM2_CH2      5: SPI1_SCK      6: SPI3_SCK     
SD          1: TIM1_CH1      4: I2C3_SCL      7: USART1_CK    
>>> pins.pins()
X1         AF_PP            2: TIM5_CH1  
X2         IN                            
X3         ANALOG                        
X4         AF_PP            3: TIM9_CH2  
X5         ANALOG                        
X6         IN                            
X7         IN                            
X8         IN                            
X9         AF_OD            4: I2C1_SCL  
X10        AF_OD            4: I2C1_SDA  
X11        IN                            
X12        IN                            
X17        IN     PULL_UP                
X18        IN                            
X19        IN     PULL_UP                
X20        IN     PULL_DOWN              
X21        IN                            
X22        IN                            
Y1         AF_OD            3: TIM8_CH1  
Y2         OUT_PP                        
Y3         OUT_OD PULL_UP                
Y4         OUT_OD PULL_DOWN              
Y5         AF_PP  PULL_UP   5: SPI2_NSS  
Y6         AF_PP  PULL_UP   5: SPI2_SCK  
Y7         AF_PP  PULL_UP   5: SPI2_MISO 
Y8         AF_PP  PULL_UP   5: SPI2_MOSI 
Y9         AF_PP  PULL_UP   7: USART3_TX 
Y10        AF_PP  PULL_UP   7: USART3_RX 
Y11        IN                            
Y12        IN                            
LED_BLUE   AF_PP            2: TIM3_CH1  
LED_RED    OUT_PP                        
LED_GREEN  OUT_PP                        
LED_YELLOW OUT_PP                        
SW         IN     PULL_UP                
SD         IN     PULL_UP                
```
