### PR TITLE
Working on timer-pwm

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -73,6 +73,7 @@ SRC_C = \
 	pendsv.c \
 	systick.c  \
 	timer.c \
+	timer_pwm.c \
 	led.c \
 	pin.c \
 	pin_defs_stmhal.c \

--- a/stmhal/modpyb.c
+++ b/stmhal/modpyb.c
@@ -34,6 +34,7 @@
 #include "nlr.h"
 #include "qstr.h"
 #include "obj.h"
+#include "runtime.h"
 #include "gc.h"
 #include "gccollect.h"
 #include "systick.h"
@@ -41,6 +42,7 @@
 #include "led.h"
 #include "pin.h"
 #include "timer.h"
+#include "timer_pwm.h"
 #include "extint.h"
 #include "usrsw.h"
 #include "rng.h"
@@ -373,6 +375,7 @@ STATIC const mp_map_elem_t pyb_module_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_sync), (mp_obj_t)&pyb_sync_obj },
 
     { MP_OBJ_NEW_QSTR(MP_QSTR_Timer), (mp_obj_t)&pyb_timer_type },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_PWM), (mp_obj_t)&pyb_pwm_type },
 
 #if MICROPY_HW_ENABLE_RNG
     { MP_OBJ_NEW_QSTR(MP_QSTR_rng), (mp_obj_t)&pyb_rng_get_obj },

--- a/stmhal/qstrdefsport.h
+++ b/stmhal/qstrdefsport.h
@@ -151,6 +151,17 @@ Q(freq)
 Q(mode)
 Q(div)
 
+// For PWM
+Q(PWM)
+Q(channel)
+Q(oc_mode)
+Q(pulse)  
+Q(oc_polarity) 
+Q(ocn_polarity) 
+Q(oc_fast_mode)
+Q(oc_idle_state)
+Q(ocn_idle_state)
+
 // for ExtInt class
 Q(ExtInt)
 Q(pin)

--- a/stmhal/stm32f4xx_it.c
+++ b/stmhal/stm32f4xx_it.c
@@ -74,6 +74,7 @@
 #include "misc.h"
 #include "qstr.h"
 #include "obj.h"
+#include "runtime.h"
 #include "extint.h"
 #include "timer.h"
 #include "storage.h"

--- a/stmhal/timer-modes.c
+++ b/stmhal/timer-modes.c
@@ -1,0 +1,77 @@
+// mode = IC        HAL_TIM_IC_ConfigChannel - triggers irq
+// 
+// channel          1..4
+// ic_polarity      rising, falling, both
+// ic_selection     direct, indirect, trc
+// ic_prescaler     div 1, 2, 4, 8
+// ic_filter        0..15
+//
+// mode = OC        HAL_TIM_OC_ConfigChannel
+// 
+// channel          1..4
+// oc_mode          Timing, Active, Inactive, Toggle, ForcedActie, ForcedInactive
+// pulse            0x0000 .. 0xffff
+// oc_polarity      high, low
+// oc_npolarity     high, low
+// oc_fastmode      disable, enable
+// oc_idlestate     set, reset
+// oc_nidlestate    set, reset
+// 
+// mode = PWM       HAL_TIM_PWM_ConfigChannel
+// 
+// channel          1..4
+// pwm_mode         PWM1, PWM2
+// pulse            0x0000 .. 0xffff
+// oc_polarity      high, low
+// oc_npolarity     high, low
+// oc_fastmode      disable, enable
+// oc_idlestate     set, reset
+// oc_nidlestate    set, reset
+// 
+// mode = OP        HAL_TIM_OnePulse_ConfigChannel
+// 
+// input channel    1..4
+// ouput channel    1..4
+// opm_mode         single, repetitive
+// pulse            0x0000 .. 0xfffff
+// oc_polarity      high, low
+// oc_npolarity     high, low
+// oc_idlestate     set, reset
+// oc_nidlestate    set, reset
+// ic_polarity      rising, falling, both
+// ic_selection     div 1, 2, 4, 8
+// ic_filter        0..15
+//
+// mode = ENC
+// 
+// enc_mode         TI1, TI2, TI12
+// ic1_polarity     rising, falling, both 
+// ic1_selection    direct, indirect, trc 
+// ic1_prescaler    div 1, 2, 4, 8        
+// ic1_filter       0..15                 
+// ic2_polarity     rising, falling, both 
+// ic2_selection    direct, indirect, trc 
+// ic2_prescaler    div 1, 2, 4, 8        
+// ic2_filter       0..15                 
+
+HAL_TIM_Base_Init
+HAL_TIM_Base_Start
+
+HAL_TIM_PWM_Init
+HAL_TIM_PWM_ConfigChannel
+HAL_TIM_PWM_Start
+
+HAL_TIM_OC_Init
+HAL_TIM_OC_ConfigChannel
+HAL_TIM_OC_Start
+
+HAL_TIM_IC_Init
+HAL_TIM_IC_ConfigChannel
+HAL_TIM_IC_Start
+
+HAL_TIM_OnePulse_Init
+HAL_TIM_OnePulse_ConfigChannel
+HAL_TIM_OnePulse_Start
+
+HAL_TIM_Encoder_Init
+HAL_TIM_Encoder_Start

--- a/stmhal/timer.h
+++ b/stmhal/timer.h
@@ -29,11 +29,37 @@
 // The value is in ms. The max is 65 and the min is 1.
 #define USBD_CDC_POLLING_INTERVAL (10)
 
+typedef struct _pyb_timer_obj_t {
+    mp_obj_base_t base;
+    mp_uint_t tim_id;
+    mp_obj_t callback;
+    TIM_HandleTypeDef tim;
+    IRQn_Type irqn;
+} pyb_timer_obj_t;
+
+void pyb_timer_init_new(pyb_timer_obj_t *tim, mp_uint_t tim_id);
+
 extern TIM_HandleTypeDef TIM3_Handle;
 extern TIM_HandleTypeDef TIM5_Handle;
 extern TIM_HandleTypeDef TIM6_Handle;
 
 extern const mp_obj_type_t pyb_timer_type;
+
+#define TIMER_BASE_ARGS \
+    { MP_QSTR_freq,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} }, \
+    { MP_QSTR_prescaler, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} }, \
+    { MP_QSTR_period,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0xffffffff} }, \
+    { MP_QSTR_mode,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = TIM_COUNTERMODE_UP} }, \
+    { MP_QSTR_div,       MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = TIM_CLOCKDIVISION_DIV1} },
+
+MP_DECLARE_CONST_FUN_OBJ(pyb_timer_counter_obj);
+MP_DECLARE_CONST_FUN_OBJ(pyb_timer_prescaler_obj);
+MP_DECLARE_CONST_FUN_OBJ(pyb_timer_period_obj);
+MP_DECLARE_CONST_FUN_OBJ(pyb_timer_callback_obj);
+
+mp_obj_t pyb_timer_callback(mp_obj_t self_in, mp_obj_t callback);
+
+void pyb_timer_base_init_helper(pyb_timer_obj_t *self, mp_arg_val_t *vals);
 
 void timer_init0(void);
 void timer_tim3_init(void);

--- a/stmhal/timer_pwm.c
+++ b/stmhal/timer_pwm.c
@@ -1,0 +1,205 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <stm32f4xx_hal.h>
+
+#include "mpconfig.h"
+#include "nlr.h"
+#include "misc.h"
+#include "qstr.h"
+#include "gc.h"
+#include "obj.h"
+#include "objtuple.h"
+#include "runtime.h"
+#include "timer.h"
+#include "timer_pwm.h"
+
+// mode = PWM       HAL_TIM_PWM_ConfigChannel
+// 
+// channel          1..4
+// pwm_mode         PWM1, PWM2
+// pulse            0x0000 .. 0xffff
+// oc_polarity      high, low
+// oc_npolarity     high, low
+// oc_fastmode      disable, enable
+// oc_idlestate     set, reset
+// oc_nidlestate    set, reset
+
+STATIC void pyb_pwm_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
+    pyb_timer_obj_t *self = self_in;
+
+    if (self->tim.State == HAL_TIM_STATE_RESET) {
+        print(env, "PWM(%u)", self->tim_id);
+    } else {
+        print(env, "PWM(%u, prescaler=%u, period=%u, mode=%u, div=%u)",
+            self->tim_id,
+            self->tim.Init.Prescaler,
+            self->tim.Init.Period,
+            self->tim.Init.CounterMode,
+            self->tim.Init.ClockDivision
+        );
+    }
+}
+
+STATIC const mp_arg_t pyb_pwm_init_args[] = {
+    TIMER_BASE_ARGS
+    { MP_QSTR_channel,          MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+    { MP_QSTR_oc_mode,          MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = TIM_OCMODE_PWM1} },
+    { MP_QSTR_pulse,            MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+    { MP_QSTR_oc_polarity,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = TIM_OCPOLARITY_HIGH} },
+    { MP_QSTR_ocn_polarity,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = TIM_OCNPOLARITY_HIGH} },
+    { MP_QSTR_oc_fast_mode,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = TIM_OCFAST_DISABLE} },
+    { MP_QSTR_oc_idle_state,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = TIM_OCIDLESTATE_RESET} },
+    { MP_QSTR_ocn_idle_state,   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = TIM_OCNIDLESTATE_RESET} },
+};
+#define PYB_PWM_INIT_NUM_ARGS MP_ARRAY_SIZE(pyb_pwm_init_args)
+
+STATIC void pyb_pwm_init_helper(pyb_pwm_obj_t *self, uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    // parse args
+    mp_arg_val_t vals[PYB_PWM_INIT_NUM_ARGS];
+    mp_arg_parse_all(n_args, args, kw_args, PYB_PWM_INIT_NUM_ARGS, pyb_pwm_init_args, vals);
+
+    pyb_timer_base_init_helper(&self->timer, vals);
+
+    self->channel = vals[5].u_int;
+    
+    self->pwm_config.OCMode = vals[6].u_int; 
+    if (!IS_TIM_PWM_MODE(self->pwm_config.OCMode)) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid pwm_mode: %d", self->pwm_config.OCMode));
+    }
+
+    self->pwm_config.Pulse = vals[7].u_int;
+    self->pwm_config.OCPolarity = vals[8].u_int;
+    if (!IS_TIM_OC_POLARITY(self->pwm_config.OCPolarity)) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid oc_polarity: %d", self->pwm_config.OCPolarity));
+    }
+
+    self->pwm_config.OCNPolarity = vals[9].u_int;
+    if (!IS_TIM_OCN_POLARITY(self->pwm_config.OCNPolarity)) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid ocn_polarity: %d", self->pwm_config.OCNPolarity));
+    }
+
+    self->pwm_config.OCFastMode = vals[10].u_int;
+    if (!IS_TIM_FAST_STATE(self->pwm_config.OCFastMode)) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid oc_fast_mode: %d", self->pwm_config.OCMode));
+    }
+    self->pwm_config.OCIdleState = vals[11].u_int;
+    if (!IS_TIM_OCIDLE_STATE(self->pwm_config.OCIdleState)) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid oc_idle_state: %d", self->pwm_config.OCIdleState));
+    }
+
+    self->pwm_config.OCNIdleState = vals[12].u_int;
+    if (!IS_TIM_OCNIDLE_STATE(self->pwm_config.OCNIdleState)) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid ocn_idle_state: %d", self->pwm_config.OCNIdleState));
+    }
+
+    HAL_TIM_PWM_Init(&self->timer.tim);
+    HAL_TIM_PWM_ConfigChannel(&self->timer.tim, &self->pwm_config, self->channel);
+    HAL_TIM_PWM_Start(&self->timer.tim, self->channel);
+}
+
+STATIC mp_obj_t pyb_pwm_make_new(mp_obj_t type_in, uint n_args, uint n_kw, const mp_obj_t *args) {
+    printf("pyb_pwm_make_new called\n");
+    // check arguments
+    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+
+    // create new Timer object
+    pyb_pwm_obj_t *pwm = m_new_obj(pyb_pwm_obj_t);
+    pwm->timer.base.type = &pyb_pwm_type;
+
+    pyb_timer_init_new(&pwm->timer, mp_obj_get_int(args[0]));
+
+    if (n_args > 1 || n_kw > 0) {
+        // start the peripheral
+        mp_map_t kw_args;
+        mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+        pyb_pwm_init_helper(pwm, n_args - 1, args + 1, &kw_args);
+    }
+
+    return (mp_obj_t)pwm;
+}
+
+STATIC mp_obj_t pyb_pwm_init(uint n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    printf("pyb_pwm_init called\n");
+    pyb_pwm_init_helper(args[0], n_args - 1, args + 1, kw_args);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pyb_pwm_init_obj, 1, pyb_pwm_init);
+
+STATIC mp_obj_t pyb_pwm_deinit(mp_obj_t self_in) {
+    printf("pyb_pwm_deinit called\n");
+    pyb_pwm_obj_t *self = self_in;
+
+    // Disable the interrupt
+    pyb_timer_callback(self_in, mp_const_none);
+
+    HAL_TIM_PWM_DeInit(&self->timer.tim);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pyb_pwm_deinit_obj, 1, pyb_pwm_deinit);
+
+STATIC mp_obj_t pyb_pwm_pulse(uint n_args, const mp_obj_t *args) {
+    printf("pyb_pwm_pulse called\n");
+    pyb_pwm_obj_t *self = args[0];
+    if (n_args == 1) {
+        // get
+        return mp_obj_new_int(__HAL_TIM_GetCompare(&self->timer.tim, self->channel));
+    }
+    // set
+    __HAL_TIM_SetCompare(&self->timer.tim, self->channel, mp_obj_get_int(args[1]));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_pwm_pulse_obj, 1, 2, pyb_pwm_pulse);
+
+
+STATIC const mp_obj_tuple_t pyb_pwm_base_tuple = {
+  {&mp_type_tuple}, 2, {(mp_obj_t)&pyb_timer_type, (mp_obj_t)&mp_type_type} 
+};
+
+STATIC const mp_map_elem_t pyb_pwm_locals_dict_table[] = {
+  { MP_OBJ_NEW_QSTR(MP_QSTR_init), (mp_obj_t)&pyb_pwm_init_obj },
+  { MP_OBJ_NEW_QSTR(MP_QSTR_pulse), (mp_obj_t)&pyb_pwm_pulse_obj },
+  { MP_OBJ_NEW_QSTR(MP_QSTR_deinit), (mp_obj_t)&pyb_pwm_deinit_obj },
+
+  { MP_OBJ_NEW_QSTR(MP_QSTR_counter), (mp_obj_t)&pyb_timer_counter_obj },
+  { MP_OBJ_NEW_QSTR(MP_QSTR_prescaler), (mp_obj_t)&pyb_timer_prescaler_obj },
+  { MP_OBJ_NEW_QSTR(MP_QSTR_period), (mp_obj_t)&pyb_timer_period_obj },
+  { MP_OBJ_NEW_QSTR(MP_QSTR_callback), (mp_obj_t)&pyb_timer_callback_obj },
+};
+STATIC MP_DEFINE_CONST_DICT(pyb_pwm_locals_dict, pyb_pwm_locals_dict_table);
+
+const mp_obj_type_t pyb_pwm_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_PWM,
+    .print = pyb_pwm_print,
+    .make_new = pyb_pwm_make_new,
+    .bases_tuple = (mp_obj_t)&pyb_pwm_base_tuple,
+    .locals_dict = (mp_obj_t)&pyb_pwm_locals_dict,
+};

--- a/stmhal/timer_pwm.h
+++ b/stmhal/timer_pwm.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+typedef struct {
+  pyb_timer_obj_t timer;
+  mp_int_t channel;
+  TIM_OC_InitTypeDef pwm_config;
+} pyb_pwm_obj_t;
+
+extern const mp_obj_type_t pyb_pwm_type;
+


### PR DESCRIPTION
This is what I was working on (just for comparison).

Upon looking at this a bit more, I think that I would move most of the Timer class into a base class, and have TImer, PWM, etc derive from the base class.

This would put common functionality, like management of the callback into the base class, and the calls to HAL_TIM_Base_Init, HAL_TIM_PWM_Init, etc in the derived class.

If I was doing this purely in python, I'd create the following classes:

```
TimerBase -+- Timer
           +- TimerIC
           +- TimerEncoder
           +- TimerOCBase -+- TimerOC
                           +- TimerPWM
                           +- TimerOnePulse
```
