### PR TITLE
modtermios: Add "termios" unix module, subset of CPython's.

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -51,6 +51,10 @@ ifeq ($(MICROPY_PY_TIME),1)
 CFLAGS_MOD += -DMICROPY_PY_TIME=1
 SRC_MOD += modtime.c
 endif
+ifeq ($(MICROPY_PY_TERMIOS),1)
+CFLAGS_MOD += -DMICROPY_PY_TERMIOS=1
+SRC_MOD += modtermios.c
+endif
 ifeq ($(MICROPY_PY_FFI),1)
 LIBFFI_LDFLAGS_MOD := $(shell pkg-config --libs libffi)
 LIBFFI_CFLAGS_MOD := $(shell pkg-config --cflags libffi)

--- a/unix/modtermios.c
+++ b/unix/modtermios.c
@@ -1,0 +1,155 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Paul Sokolovsky
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <termios.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "mpconfig.h"
+#include "misc.h"
+#include "nlr.h"
+#include "qstr.h"
+#include "obj.h"
+#include "runtime.h"
+#include "objlist.h"
+
+#define RAISE_ERRNO(err_flag, error_val) \
+    { if (err_flag == -1) \
+        { nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(error_val))); } }
+
+STATIC mp_obj_t mod_termios_tcgetattr(mp_obj_t fd_in) {
+    struct termios term;
+    int fd = mp_obj_get_int(fd_in);
+
+    int res = tcgetattr(fd, &term);
+    RAISE_ERRNO(res, errno);
+
+    mp_obj_list_t *r = mp_obj_new_list(7, NULL);
+    r->items[0] = MP_OBJ_NEW_SMALL_INT(term.c_iflag);
+    r->items[1] = MP_OBJ_NEW_SMALL_INT(term.c_oflag);
+    r->items[2] = MP_OBJ_NEW_SMALL_INT(term.c_cflag);
+    r->items[3] = MP_OBJ_NEW_SMALL_INT(term.c_lflag);
+    r->items[4] = MP_OBJ_NEW_SMALL_INT(cfgetispeed(&term));
+    r->items[5] = MP_OBJ_NEW_SMALL_INT(cfgetospeed(&term));
+
+    mp_obj_list_t *cc = mp_obj_new_list(NCCS, NULL);
+    r->items[6] = cc;
+    for (int i = 0; i < NCCS; i++) {
+        if (i == VMIN || i == VTIME) {
+            cc->items[i] = MP_OBJ_NEW_SMALL_INT(term.c_cc[i]);
+        } else {
+            // https://docs.python.org/3/library/termios.html says value is *string*,
+            // but now way unicode chars could be there.
+            cc->items[i] = mp_obj_new_bytes(&term.c_cc[i], 1);
+        }
+    }
+    return r;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_termios_tcgetattr_obj, mod_termios_tcgetattr);
+
+STATIC mp_obj_t mod_termios_tcsetattr(mp_obj_t fd_in, mp_obj_t when_in, mp_obj_t attrs_in) {
+    struct termios term;
+    int fd = mp_obj_get_int(fd_in);
+    int when = mp_obj_get_int(when_in);
+    assert(MP_OBJ_IS_TYPE(attrs_in, &mp_type_list));
+    mp_obj_list_t *attrs = attrs_in;
+
+    term.c_iflag = mp_obj_get_int(attrs->items[0]);
+    term.c_oflag = mp_obj_get_int(attrs->items[1]);
+    term.c_cflag = mp_obj_get_int(attrs->items[2]);
+    term.c_lflag = mp_obj_get_int(attrs->items[3]);
+
+    mp_obj_list_t *cc = attrs->items[6];
+    for (int i = 0; i < NCCS; i++) {
+        if (i == VMIN || i == VTIME) {
+            term.c_cc[i] = mp_obj_get_int(cc->items[i]);
+        } else {
+            uint len;
+            term.c_cc[i] = *mp_obj_str_get_data(cc->items[i], &len);
+        }
+    }
+
+    int res = cfsetispeed(&term, mp_obj_get_int(attrs->items[4]));
+    RAISE_ERRNO(res, errno);
+    res = cfsetispeed(&term, mp_obj_get_int(attrs->items[5]));
+    RAISE_ERRNO(res, errno);
+
+    res = tcsetattr(fd, when, &term);
+    RAISE_ERRNO(res, errno);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(mod_termios_tcsetattr_obj, mod_termios_tcsetattr);
+
+STATIC mp_obj_t mod_termios_setraw(mp_obj_t fd_in) {
+    struct termios term;
+    int fd = mp_obj_get_int(fd_in);
+    int res = tcgetattr(fd, &term);
+    RAISE_ERRNO(res, errno);
+
+    term.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+    term.c_oflag = 0;
+    term.c_cflag = (term.c_cflag & ~(CSIZE | PARENB)) | CS8;
+    term.c_lflag = 0;
+    term.c_cc[VMIN] = 1;
+    term.c_cc[VTIME] = 0;
+    res = tcsetattr(fd, TCSAFLUSH, &term);
+    RAISE_ERRNO(res, errno);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_termios_setraw_obj, mod_termios_setraw);
+
+STATIC const mp_map_elem_t mp_module_termios_globals_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_termios) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_tcgetattr), (mp_obj_t)&mod_termios_tcgetattr_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_tcsetattr), (mp_obj_t)&mod_termios_tcsetattr_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_setraw), (mp_obj_t)&mod_termios_setraw_obj },
+
+#define C(name) { MP_OBJ_NEW_QSTR(MP_QSTR_ ## name), MP_OBJ_NEW_SMALL_INT(name) }
+    C(TCSANOW),
+
+    C(B9600),
+    C(B57600),
+    C(B115200),
+#undef C
+};
+
+STATIC const mp_obj_dict_t mp_module_termios_globals = {
+    .base = {&mp_type_dict},
+    .map = {
+        .all_keys_are_qstrs = 1,
+        .table_is_fixed_array = 1,
+        .used = MP_ARRAY_SIZE(mp_module_termios_globals_table),
+        .alloc = MP_ARRAY_SIZE(mp_module_termios_globals_table),
+        .table = (mp_map_elem_t*)mp_module_termios_globals_table,
+    },
+};
+
+const mp_obj_module_t mp_module_termios = {
+    .base = { &mp_type_module },
+    .name = MP_QSTR_termios,
+    .globals = (mp_obj_dict_t*)&mp_module_termios_globals,
+};

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -70,6 +70,7 @@
 
 extern const struct _mp_obj_module_t mp_module_os;
 extern const struct _mp_obj_module_t mp_module_time;
+extern const struct _mp_obj_module_t mp_module_termios;
 extern const struct _mp_obj_module_t mp_module_socket;
 extern const struct _mp_obj_module_t mp_module_ffi;
 
@@ -89,6 +90,7 @@ extern const struct _mp_obj_module_t mp_module_ffi;
     MICROPY_PY_TIME_DEF \
     { MP_OBJ_NEW_QSTR(MP_QSTR_microsocket), (mp_obj_t)&mp_module_socket }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR__os), (mp_obj_t)&mp_module_os }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_termios), (mp_obj_t)&mp_module_termios }, \
 
 // type definitions for the specific machine
 

--- a/unix/mpconfigport.mk
+++ b/unix/mpconfigport.mk
@@ -9,5 +9,8 @@ MICROPY_USE_READLINE = 1
 # Subset of CPython time module
 MICROPY_PY_TIME = 1
 
+# Subset of CPython termios module
+MICROPY_PY_TERMIOS = 1
+
 # ffi module requires libffi (libffi-dev Debian package)
 MICROPY_PY_FFI = 1

--- a/unix/qstrdefsport.h
+++ b/unix/qstrdefsport.h
@@ -83,3 +83,14 @@ Q(SO_ERROR)
 Q(SO_KEEPALIVE)
 Q(SO_LINGER)
 Q(SO_REUSEADDR)
+
+#if MICROPY_PY_TERMIOS
+Q(termios)
+Q(tcgetattr)
+Q(tcsetattr)
+Q(setraw)
+Q(TCSANOW)
+Q(B9600)
+Q(B57600)
+Q(B115200)
+#endif


### PR DESCRIPTION
Also provides setraw() function from "tty" module (which in CPython is
implemented in Python). The idea here is that 95% of "termios" module usage
is to set raw mode to allow access to normal serial devices. Then, instead
of exporting gazillion termios symbols, it's better to implement it in C,
and export minimal number of symbols (mostly baud rates and drain values).
