### PR TITLE
Added LIS302DL ID check

### DIFF
--- a/stmhal/boards/STM32F4DISC/staccel.py
+++ b/stmhal/boards/STM32F4DISC/staccel.py
@@ -21,6 +21,7 @@ from pyb import SPI
 READWRITE_CMD = const(0x80) 
 MULTIPLEBYTE_CMD = const(0x40)
 LIS302DL_WHO_AM_I_ADDR = const(0x0f)
+LIS302DL_WHO_AM_I_VAL = const(0x3b)
 LIS302DL_CTRL_REG1_ADDR = const(0x20)
 LIS302DL_OUT_X = const(0x29)
 # Configuration for 100Hz sampling rate, +-2g range
@@ -38,6 +39,8 @@ class STAccel:
         self.cs_pin.high()
         self.spi = SPI(1, SPI.MASTER, baudrate=328125, polarity=0, phase=1, bits=8)
         self.wr(LIS302DL_CTRL_REG1_ADDR, bytearray([LIS302DL_CONF]))
+        if(self.read_id()[0] != LIS302DL_WHO_AM_I_VAL):
+            raise Exception('LIS302DL accelerometer not present')
 
     def rd(self, addr, nbytes):
         if nbytes > 1:


### PR DESCRIPTION
As suggested, I added check for LIS302DL ID in STAccel **init** function. If it fails, raises an exception.
