### PR TITLE
Make int(b'123') work properly.

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -74,6 +74,7 @@ typedef struct _mp_obj_base_t mp_obj_base_t;
 #define MP_OBJ_IS_TYPE(o, t) (MP_OBJ_IS_OBJ(o) && (((mp_obj_base_t*)(o))->type == (t))) // this does not work for checking int, str or fun; use below macros for that
 #define MP_OBJ_IS_INT(o) (MP_OBJ_IS_SMALL_INT(o) || MP_OBJ_IS_TYPE(o, &mp_type_int))
 #define MP_OBJ_IS_STR(o) (MP_OBJ_IS_QSTR(o) || MP_OBJ_IS_TYPE(o, &mp_type_str))
+#define MP_OBJ_IS_STR_OR_BYTES(o) (MP_OBJ_IS_STR(o) || MP_OBJ_IS_TYPE(o, &mp_type_bytes))
 #define MP_OBJ_IS_FUN(o) (MP_OBJ_IS_OBJ(o) && (((mp_obj_base_t*)(o))->type->binary_op == mp_obj_fun_binary_op))
 
 #define MP_OBJ_SMALL_INT_VALUE(o) (((mp_int_t)(o)) >> 1)

--- a/py/objint.c
+++ b/py/objint.c
@@ -57,7 +57,7 @@ STATIC mp_obj_t mp_obj_int_make_new(mp_obj_t type_in, uint n_args, uint n_kw, co
             if (MP_OBJ_IS_INT(args[0])) {
                 // already an int (small or long), just return it
                 return args[0];
-            } else if (MP_OBJ_IS_STR(args[0])) {
+            } else if (MP_OBJ_IS_STR_OR_BYTES(args[0])) {
                 // a string, parse it
                 uint l;
                 const char *s = mp_obj_str_get_data(args[0], &l);

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -49,10 +49,6 @@ STATIC mp_obj_t mp_obj_new_bytes_iterator(mp_obj_t str);
 STATIC NORETURN void bad_implicit_conversion(mp_obj_t self_in);
 STATIC NORETURN void arg_type_mixup();
 
-STATIC bool is_str_or_bytes(mp_obj_t o) {
-    return MP_OBJ_IS_STR(o) || MP_OBJ_IS_TYPE(o, &mp_type_bytes);
-}
-
 /******************************************************************************/
 /* str                                                                        */
 
@@ -388,7 +384,7 @@ STATIC mp_obj_t bytes_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
 }
 
 STATIC mp_obj_t str_join(mp_obj_t self_in, mp_obj_t arg) {
-    assert(is_str_or_bytes(self_in));
+    assert(MP_OBJ_IS_STR_OR_BYTES(self_in));
     const mp_obj_type_t *self_type = mp_obj_get_type(self_in);
 
     // get separation string
@@ -660,7 +656,7 @@ enum { LSTRIP, RSTRIP, STRIP };
 
 STATIC mp_obj_t str_uni_strip(int type, uint n_args, const mp_obj_t *args) {
     assert(1 <= n_args && n_args <= 2);
-    assert(is_str_or_bytes(args[0]));
+    assert(MP_OBJ_IS_STR_OR_BYTES(args[0]));
     const mp_obj_type_t *self_type = mp_obj_get_type(args[0]);
 
     const byte *chars_to_del;
@@ -1477,7 +1473,7 @@ STATIC mp_obj_t str_count(uint n_args, const mp_obj_t *args) {
 }
 
 STATIC mp_obj_t str_partitioner(mp_obj_t self_in, mp_obj_t arg, mp_int_t direction) {
-    if (!is_str_or_bytes(self_in)) {
+    if (!MP_OBJ_IS_STR_OR_BYTES(self_in)) {
         assert(0);
     }
     mp_obj_type_t *self_type = mp_obj_get_type(self_in);
@@ -1877,7 +1873,7 @@ const char *mp_obj_str_get_str(mp_obj_t self_in) {
 }
 
 const char *mp_obj_str_get_data(mp_obj_t self_in, uint *len) {
-    if (is_str_or_bytes(self_in)) {
+    if (MP_OBJ_IS_STR_OR_BYTES(self_in)) {
         GET_STR_DATA_LEN(self_in, s, l);
         *len = l;
         return (const char*)s;

--- a/tests/basics/int1.py
+++ b/tests/basics/int1.py
@@ -47,6 +47,7 @@ print(int('0100', 2))
 print(int(' \t 0o12', 8))
 print(int('0o12  \t  ', 8))
 print(int(b"12", 10))
+print(int(b"12"))
 
 
 def test(value, base):


### PR DESCRIPTION
int(b'123', 10) was working properly, but int(b'123) was failing.

I wasn't sure exactly how/if you'd want to fix objstr.c (it has a static is_str_or_bytes function).
