### PR TITLE
py: Add guards against using nlr_push() macro where function is required...

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1226,8 +1226,11 @@ void *const mp_fun_table[MP_F_NUMBER_OF] = {
     mp_call_method_n_kw,
     mp_getiter,
     mp_iternext,
+// If nlr_push is a proper function, not a macro
+#ifndef nlr_push
     nlr_push,
     nlr_pop,
+#endif
     mp_native_raise,
     mp_import_name,
     mp_import_from,

--- a/py/runtime0.h
+++ b/py/runtime0.h
@@ -134,8 +134,11 @@ typedef enum {
     MP_F_CALL_METHOD_N_KW,
     MP_F_GETITER,
     MP_F_ITERNEXT,
+// If nlr_push is a proper function, not a macro
+#ifndef nlr_push
     MP_F_NLR_PUSH,
     MP_F_NLR_POP,
+#endif
     MP_F_NATIVE_RAISE,
     MP_F_IMPORT_NAME,
     MP_F_IMPORT_FROM,


### PR DESCRIPTION
It's probably unfortunate that array required only for native codegen
sits in runtime.c.
