### PR TITLE
Declare do_str() function before the implementation

### DIFF
--- a/qemu-arm/test_main.c
+++ b/qemu-arm/test_main.c
@@ -18,6 +18,7 @@
 #include "tinytest.h"
 #include "tinytest_macros.h"
 
+void do_str(const char *src);
 inline void do_str(const char *src) {
     mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
     if (lex == NULL) {


### PR DESCRIPTION
This ensures that GCC does not discard the do_str implementation in
some cases eg when compiling tests with debug enabled:
  make RUN_TESTS=1 DEBUG=1
