### PR TITLE
Add allocation macros (per platform) and ARM cache flush

### DIFF
--- a/py/asmthumb.c
+++ b/py/asmthumb.c
@@ -67,7 +67,7 @@ asm_thumb_t *asm_thumb_new(uint max_num_labels) {
 
 void asm_thumb_free(asm_thumb_t *as, bool free_code) {
     if (free_code) {
-        m_del(byte, as->code_base, as->code_size);
+        MP_PLAT_FREE_EXEC(as->code_base, as->code_size);
     }
     /*
     if (as->label != NULL) {
@@ -94,9 +94,10 @@ void asm_thumb_start_pass(asm_thumb_t *as, uint pass) {
 
 void asm_thumb_end_pass(asm_thumb_t *as) {
     if (as->pass == ASM_THUMB_PASS_COMPUTE) {
-        // calculate size of code in bytes
-        as->code_size = as->code_offset;
-        as->code_base = m_new(byte, as->code_size);
+        MP_PLAT_ALLOC_EXEC(as->code_offset, (void**) &as->code_base, &as->code_size);
+        if(as->code_base == NULL) {
+            assert(0);
+        }
         //printf("code_size: %u\n", as->code_size);
     }
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -440,6 +440,14 @@ typedef double mp_float_t;
 #define MICROPY_MAKE_POINTER_CALLABLE(p) (p)
 #endif
 
+#ifndef MP_PLAT_ALLOC_EXEC
+#define MP_PLAT_ALLOC_EXEC(min_size, ptr, size) do { *ptr = m_new(byte, min_size); *size = min_size; } while(0)
+#endif
+
+#ifndef MP_PLAT_FREE_EXEC
+#define MP_PLAT_FREE_EXEC(ptr, size) m_del(byte, ptr, size)
+#endif
+
 // printf format spec to use for mp_int_t and friends
 #ifndef INT_FMT
 #ifdef __LP64__

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -75,6 +75,7 @@ SRC_C = \
 	file.c \
 	modsocket.c \
 	modos.c \
+        alloc.c \
 	$(SRC_MOD)
 
 ifeq ($(UNAME_S),Darwin)

--- a/unix/alloc.c
+++ b/unix/alloc.c
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Fabian Vogt
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+
+#include "mpconfigport.h"
+
+void mp_unix_alloc_exec(mp_uint_t min_size, void** ptr, mp_uint_t *size)
+{
+    // size needs to be a multiple of the page size
+    *size = (min_size + 0xfff) & (~0xfff);
+    *ptr = mmap(NULL, *size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (*ptr == MAP_FAILED) {
+        *ptr = NULL;
+    }
+}
+
+void mp_unix_free_exec(void *ptr, mp_uint_t size)
+{
+    munmap(ptr, size);
+}

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -114,6 +114,11 @@ typedef unsigned int mp_uint_t; // must be pointer size
 typedef void *machine_ptr_t; // must be of pointer size
 typedef const void *machine_const_ptr_t; // must be of pointer size
 
+void mp_unix_alloc_exec(mp_uint_t min_size, void** ptr, mp_uint_t *size);
+void mp_unix_free_exec(void *ptr, mp_uint_t size);
+#define MP_PLAT_ALLOC_EXEC(min_size, ptr, size) mp_unix_alloc_exec(min_size, ptr, size)
+#define MP_PLAT_FREE_EXEC(ptr, size) mp_unix_free_exec(ptr, size)
+
 extern const struct _mp_obj_fun_builtin_t mp_builtin_input_obj;
 extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
 #define MICROPY_PORT_BUILTINS \


### PR DESCRIPTION
If MP_PLAT_ALLOC_EXEC isn't defined, it will fall back to m_new and m_del.
All tests for unix x64 pass.

Fixes issue #840
