### PR TITLE
SDHC support

### DIFF
--- a/lib/libm/crt.S
+++ b/lib/libm/crt.S
@@ -1,0 +1,44 @@
+/* Runtime ABI for the ARM Cortex-M0  
+ * crt.S: C runtime environment
+ *
+ * Copyright (c) 2012 Jörg Mische <bobbl@gmx.de>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+ * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+
+
+	.syntax unified
+	.text
+	.thumb
+	.cpu cortex-m0
+
+
+@ int __aeabi_idiv0(int r)
+@
+@ Handler for 32 bit division by zero
+@
+	.thumb_func
+        .global __aeabi_idiv0
+__aeabi_idiv0:
+
+
+
+@ long long __aeabi_ldiv0(long long r)
+@
+@ Handler for 64 bit division by zero
+@
+	.thumb_func
+        .global __aeabi_ldiv0
+__aeabi_ldiv0:
+	bx	lr

--- a/lib/libm/uidivmod.S
+++ b/lib/libm/uidivmod.S
@@ -1,0 +1,92 @@
+/* Runtime ABI for the ARM Cortex-M0  
+ * uidivmod.S: unsigned 32 bit division
+ *
+ * Copyright (c) 2012 Jörg Mische <bobbl@gmx.de>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+ * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+
+
+	.syntax unified
+	.text
+	.thumb
+	.cpu cortex-m0
+
+
+
+@ unsigned __udivsi3(unsigned num, unsigned denom)
+@
+@ libgcc wrapper: just an alias for __aeabi_uidivmod(), the remainder is ignored
+@
+	.thumb_func
+        .global __udivsi3
+__udivsi3:
+
+
+
+@ unsigned __aeabi_uidiv(unsigned num, unsigned denom)
+@
+@ Just an alias for __aeabi_uidivmod(), the remainder is ignored
+@
+	.thumb_func
+        .global __aeabi_uidiv
+__aeabi_uidiv:
+
+
+
+@ {unsigned quotient:r0, unsigned remainder:r1}
+@  __aeabi_uidivmod(unsigned numerator:r0, unsigned denominator:r1)
+@
+@ Divide r0 by r1 and return the quotient in r0 and the remainder in r1
+@
+	.thumb_func
+        .global __aeabi_uidivmod
+__aeabi_uidivmod:
+
+
+	cmp	r1, #0
+	bne	L_no_div0
+	b	__aeabi_idiv0
+L_no_div0:
+
+	@ Shift left the denominator until it is greater than the numerator
+	movs	r2, #1		@ counter
+	movs	r3, #0		@ result
+	cmp	r0, r1
+	bls	L_sub_loop0
+	adds	r1, #0		@ dont shift if denominator would overflow
+	bmi	L_sub_loop0
+	
+L_denom_shift_loop:
+	lsls	r2, #1
+	lsls	r1, #1
+	bmi	L_sub_loop0
+	cmp	r0, r1
+	bhi	L_denom_shift_loop	
+	
+L_sub_loop0:	
+	cmp	r0, r1
+	bcc	L_dont_sub0	@ if (num>denom)
+
+	subs	r0, r1		@ numerator -= denom
+	orrs	r3, r2		@ result(r3) |= bitmask(r2)
+L_dont_sub0:
+
+	lsrs	r1, #1		@ denom(r1) >>= 1
+	lsrs	r2, #1		@ bitmask(r2) >>= 1
+	bne	L_sub_loop0
+
+	mov	r1, r0		@ remainder(r1) = numerator(r0)
+	mov	r0, r3		@ quotient(r0) = result(r3)
+	bx	lr

--- a/lib/libm/uldivmod.S
+++ b/lib/libm/uldivmod.S
@@ -1,0 +1,181 @@
+/* Runtime ABI for the ARM Cortex-M0  
+ * uldivmod.S: unsigned 64 bit division
+ *
+ * Copyright (c) 2012 Jörg Mische <bobbl@gmx.de>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+ * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+
+
+	.syntax unified
+	.text
+	.thumb
+	.cpu cortex-m0
+
+
+
+@ unsigned long long __udivdi3(unsigned long long num, unsigned long long denom)
+@
+@ libgcc wrapper: just an alias for __aeabi_uldivmod(), the remainder is ignored
+@
+	.thumb_func
+        .global __udivdi3
+__udivdi3:
+
+
+
+@ {unsigned long long quotient, unsigned long long remainder}
+@ __aeabi_uldivmod(unsigned long long numerator, unsigned long long denominator)
+@
+@ Divide r1:r0 by r3:r2 and return the quotient in r1:r0 and the remainder
+@ in r3:r2 (all unsigned)
+@
+	.thumb_func
+        .global __aeabi_uldivmod
+__aeabi_uldivmod:
+	
+	cmp	r3, #0
+	bne	L_large_denom
+	cmp	r2, #0
+	beq	L_divison_by_0
+	cmp	r1, #0
+	beq	L_fallback_32bits
+
+
+
+	@ case 1: num >= 2^32 and denom < 2^32
+	@ Result might be > 2^32, therefore we first calculate the upper 32
+	@ bits of the result. It is done similar to the calculation of the
+	@ lower 32 bits, but with a denominator that is shifted by 32.
+	@ Hence the lower 32 bits of the denominator are always 0 and the
+	@ costly 64 bit shift and sub operations can be replaced by cheap 32
+	@ bit operations.
+
+	push	{r4, r5, r6, r7, lr}
+
+	@ shift left the denominator until it is greater than the numerator
+	@ denom(r7:r6) = r3:r2 << 32
+
+	movs	r5, #1		@ bitmask
+	adds	r7, r2, #0	@ dont shift if denominator would overflow
+	bmi	L_upper_result
+	cmp	r1, r7
+	blo	L_upper_result
+	
+L_denom_shift_loop1:
+	lsls	r5, #1
+	lsls	r7, #1
+	bmi	L_upper_result	@ dont shift if overflow
+	cmp	r1, r7
+	bhs	L_denom_shift_loop1
+	
+L_upper_result:
+	mov	r3, r1
+	mov	r2, r0
+	movs	r1, #0		@ upper result = 0
+
+L_sub_loop1:	
+	cmp	r3, r7
+	bcc	L_dont_sub1	@ if (num>denom)
+
+	subs	r3, r7		@ num -= denom
+	orrs	r1, r5		@ result(r7:r6) |= bitmask(r5)
+L_dont_sub1:
+
+	lsrs	r7, #1		@ denom(r7:r6) >>= 1
+	lsrs	r5, #1		@ bitmask(r5) >>= 1
+	bne	L_sub_loop1
+	
+	movs	r5, #1
+	lsls	r5, #31
+	movs	r6, #0
+	b	L_lower_result
+
+
+
+	@ case 2: division by 0
+	@ call __aeabi_ldiv0
+	
+L_divison_by_0:
+	b	__aeabi_ldiv0
+
+
+
+	@ case 3: num < 2^32 and denom < 2^32
+	@ fallback to 32 bit division
+
+L_fallback_32bits:
+	mov	r1, r2
+	push	{lr}
+	bl	__aeabi_uidivmod
+	mov	r2, r1
+	movs	r1, #0
+	movs	r3, #0
+	pop	{pc}
+
+
+
+	@ case 4: denom >= 2^32
+	@ result is smaller than 2^32
+	
+L_large_denom:
+	push	{r4, r5, r6, r7, lr}
+
+	mov	r7, r3
+	mov	r6, r2
+	mov	r3, r1
+	mov	r2, r0
+
+	@ Shift left the denominator until it is greater than the numerator
+
+	movs	r1, #0		@ high word of result is 0
+	movs	r5, #1		@ bitmask
+	adds	r7, #0		@ dont shift if denominator would overflow
+	bmi	L_lower_result
+	cmp	r3, r7
+	blo	L_lower_result
+	
+L_denom_shift_loop4:
+	lsls	r5, #1
+	lsls	r7, #1
+	lsls	r6, #1
+	adcs	r7, r1		@ r1=0
+	bmi	L_lower_result	@ dont shift if overflow
+	cmp	r3, r7
+	bhs	L_denom_shift_loop4
+
+
+
+L_lower_result:
+	movs	r0, #0
+	
+L_sub_loop4:
+	mov	r4, r3
+	cmp	r2, r6
+	sbcs	r4, r7
+	bcc	L_dont_sub4	@ if (num>denom)
+
+	subs	r2, r6		@ numerator -= denom
+	sbcs	r3, r7
+	orrs	r0, r5		@ result(r1:r0) |= bitmask(r5)
+L_dont_sub4:
+
+	lsls	r4, r7, #31	@ denom(r7:r6) >>= 1
+	lsrs	r6, #1
+	lsrs	r7, #1
+	orrs	r6, r4
+	lsrs	r5, #1		@ bitmask(r5) >>= 1
+	bne	L_sub_loop4
+
+	pop	{r4, r5, r6, r7, pc}

--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -68,6 +68,12 @@ SRC_LIB = $(addprefix lib/,\
 	libm/atan2f.c \
 	)
 
+SRC_LIB_S = $(addprefix lib/,\
+	libm/uldivmod.S\
+	libm/uidivmod.S\
+	libm/crt.S\
+	)
+
 SRC_C = \
 	main.c \
 	string0.c \
@@ -214,6 +220,7 @@ endif
 OBJ =
 OBJ += $(PY_O)
 OBJ += $(addprefix $(BUILD)/, $(SRC_LIB:.c=.o))
+OBJ += $(addprefix $(BUILD)/, $(SRC_LIB_S:.S=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_S:.s=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_HAL:.c=.o))

--- a/stmhal/hal/src/stm32f4xx_hal_sd.c
+++ b/stmhal/hal/src/stm32f4xx_hal_sd.c
@@ -1578,7 +1578,7 @@ HAL_SD_ErrorTypedef HAL_SD_Get_CardInfo(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTy
     /* Byte 10 */
     tmp = (uint8_t)((hsd->CSD[2] & 0x0000FF00) >> 8);
     
-    pCardInfo->CardCapacity  = ((pCardInfo->SD_csd.DeviceSize + 1)) * 512 * 1024;
+    pCardInfo->CardCapacity  = ((pCardInfo->SD_csd.DeviceSize + 1ULL)) * 512 * 1024;
     pCardInfo->CardBlockSize = 512;    
   }
   else

--- a/stmhal/sdcard.c
+++ b/stmhal/sdcard.c
@@ -29,6 +29,7 @@
 #include <stm32f4xx_hal.h>
 
 #include "mpconfig.h"
+#include "nlr.h"
 #include "misc.h"
 #include "qstr.h"
 #include "obj.h"
@@ -36,6 +37,7 @@
 #include "sdcard.h"
 #include "pin.h"
 #include "genhdr/pins.h"
+#include "bufhelper.h"
 
 #if MICROPY_HW_HAS_SDCARD
 
@@ -154,7 +156,7 @@ bool sdcard_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t num_blocks) 
     // buffer and we can't let it fill up in the middle of a read.
     // This will not be needed when SD uses DMA for transfer.
     __disable_irq();
-    HAL_SD_ErrorTypedef err = HAL_SD_ReadBlocks(&sd_handle, (uint32_t*)dest, block_num * SDCARD_BLOCK_SIZE, SDCARD_BLOCK_SIZE, num_blocks);
+    HAL_SD_ErrorTypedef err = HAL_SD_ReadBlocks(&sd_handle, (uint32_t*)dest, (uint64_t)block_num * SDCARD_BLOCK_SIZE, SDCARD_BLOCK_SIZE, num_blocks);
     __enable_irq();
 
     if (err != SD_OK) {
@@ -179,7 +181,7 @@ bool sdcard_write_blocks(const uint8_t *src, uint32_t block_num, uint32_t num_bl
     // buffer and we can't let it drain to empty in the middle of a write.
     // This will not be needed when SD uses DMA for transfer.
     __disable_irq();
-    HAL_SD_ErrorTypedef err = HAL_SD_WriteBlocks(&sd_handle, (uint32_t*)src, block_num * SDCARD_BLOCK_SIZE, SDCARD_BLOCK_SIZE, num_blocks);
+    HAL_SD_ErrorTypedef err = HAL_SD_WriteBlocks(&sd_handle, (uint32_t*)src, (uint64_t)block_num * SDCARD_BLOCK_SIZE, SDCARD_BLOCK_SIZE, num_blocks);
     __enable_irq();
 
     if (err != SD_OK) {
@@ -203,7 +205,7 @@ bool sdcard_read_blocks_dma(uint8_t *dest, uint32_t block_num, uint32_t num_bloc
     }
 
     // do the read
-    if (HAL_SD_ReadBlocks_DMA(&sd_handle, (uint32_t*)dest, block_num * SDCARD_BLOCK_SIZE, SDCARD_BLOCK_SIZE) != SD_OK) {
+    if (HAL_SD_ReadBlocks_DMA(&sd_handle, (uint32_t*)dest, (uint64_t)block_num * SDCARD_BLOCK_SIZE, SDCARD_BLOCK_SIZE) != SD_OK) {
         return false;
     }
 
@@ -228,7 +230,7 @@ bool sdcard_write_blocks_dma(const uint8_t *src, uint32_t block_num, uint32_t nu
 
     SD_Error status;
 
-    status = HAL_SD_WriteBlock_DMA(&sd_handle, (uint32_t*)src, block_num * SDCARD_BLOCK_SIZE, SDCARD_BLOCK_SIZE, num_blocks);
+    status = HAL_SD_WriteBlock_DMA(&sd_handle, (uint32_t*)src, (uint64_t)block_num * SDCARD_BLOCK_SIZE, SDCARD_BLOCK_SIZE, num_blocks);
     if (status != SD_OK) {
         return false;
     }
@@ -276,10 +278,28 @@ static mp_obj_t sd_read(mp_obj_t self, mp_obj_t block_num) {
 
 static MP_DEFINE_CONST_FUN_OBJ_2(sd_read_obj, sd_read);
 
+static mp_obj_t sd_write(mp_obj_t self, mp_obj_t block_num, mp_obj_t source) {
+    mp_buffer_info_t bufinfo;
+    uint8_t tmp[1];
+
+    pyb_buf_get_for_send(source, &bufinfo, tmp);
+    if (bufinfo.len % SDCARD_BLOCK_SIZE != 0) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "writes must be aligned to SDCARD_BLOCK_SIZE (%d) bytes", SDCARD_BLOCK_SIZE));
+    }
+
+    if (!sdcard_write_blocks(bufinfo.buf, mp_obj_get_int(block_num), bufinfo.len / SDCARD_BLOCK_SIZE)) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_Exception, "sdcard_write_blocks failed"));
+    }
+    return mp_const_none;
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_3(sd_write_obj, sd_write);
+
 STATIC const mp_map_elem_t sdcard_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_present), (mp_obj_t)&sd_present_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_power), (mp_obj_t)&sd_power_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_read), (mp_obj_t)&sd_read_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_write), (mp_obj_t)&sd_write_obj },
 };
 
 STATIC MP_DEFINE_CONST_DICT(sdcard_locals_dict, sdcard_locals_dict_table);

--- a/stmhal/usbdev/class/cdc_msc_hid/inc/usbd_cdc_msc_hid.h
+++ b/stmhal/usbdev/class/cdc_msc_hid/inc/usbd_cdc_msc_hid.h
@@ -83,7 +83,7 @@ typedef struct {
   uint16_t                 scsi_blk_size;
   uint32_t                 scsi_blk_nbr;
   
-  uint32_t                 scsi_blk_addr;
+  uint64_t                 scsi_blk_addr;
   uint32_t                 scsi_blk_len;
 } USBD_MSC_BOT_HandleTypeDef;
 

--- a/stmhal/usbdev/class/msc/inc/usbd_msc.h
+++ b/stmhal/usbdev/class/msc/inc/usbd_msc.h
@@ -96,7 +96,7 @@ typedef struct
   uint16_t                 scsi_blk_size;
   uint32_t                 scsi_blk_nbr;
   
-  uint32_t                 scsi_blk_addr;
+  uint64_t                 scsi_blk_addr;
   uint32_t                 scsi_blk_len;
 }
 USBD_MSC_BOT_HandleTypeDef; 


### PR DESCRIPTION
SDHC support is lacking in 3 different areas:

1.) the capacity reported by HAL_SD_Get_CardInfo is truncated to 32-bit
2.) sdcard_read_blocks/sdcard_write_blocks is truncating the byte address to 32-bit
3.) the msc usb class is truncating the read pointer to 32-bit

Unfortunately this naive fix requires 64-bit udivmod support, which I grabbed from libaeabi-cortexm0, which is thankfully published under a compatible license. I also added pyb.SD.write for completeness. (Not sure if absence was intentional)

A better fix may be replacing some of the multiplications within the MSC USB class with shifts, but I wanted to keep this patch as simple as possible.

Test: 
1. Custom test to write a bunch of sectors with pseudo-random data over full capacity using pyb.SD.write, and then reading them back via pyb.SD.read, make sure that writes don't alias (when address is truncated); this is to test hal_sd etc.
2. Same test from PC via mass storage. 
3. Same test (only read) from PC via commercial microSD reader.

Limitations:
1. Number of blocks may still be limited to 32-bit in a number of places; this creates a 2TB limit. Not an issue for SDHC.
2. Performance isn't optimal because of 64-bit multiplications; should not matter since limiting factor is very likely USB FS speed.
