### PR TITLE
Simple json printing using existing print framework.

### DIFF
--- a/extmod/mod_json.c
+++ b/extmod/mod_json.c
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+#include "mpconfig.h"
+#include "misc.h"
+#include "qstr.h"
+#include "obj.h"
+#include "runtime.h"
+
+#if MICROPY_PY__JSON
+
+STATIC mp_obj_t mod__json_dumps(mp_obj_t obj) {
+    vstr_t vstr;
+    vstr_init(&vstr, 8);
+    mp_obj_print_helper((void (*)(void *env, const char *fmt, ...))vstr_printf, &vstr, obj, PRINT_JSON);
+    mp_obj_t ret = mp_obj_new_str(vstr.buf, vstr.len, false);
+    vstr_clear(&vstr);
+    return ret;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod__json_dumps_obj, mod__json_dumps);
+
+STATIC const mp_map_elem_t mp_module__json_globals_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR__json) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_dumps), (mp_obj_t)&mod__json_dumps_obj },
+};
+
+STATIC const mp_obj_dict_t mp_module__json_globals = {
+    .base = {&mp_type_dict},
+    .map = {
+        .all_keys_are_qstrs = 1,
+        .table_is_fixed_array = 1,
+        .used = MP_ARRAY_SIZE(mp_module__json_globals_table),
+        .alloc = MP_ARRAY_SIZE(mp_module__json_globals_table),
+        .table = (mp_map_elem_t*)mp_module__json_globals_table,
+    },
+};
+
+const mp_obj_module_t mp_module__json = {
+    .base = { &mp_type_module },
+    .name = MP_QSTR__json,
+    .globals = (mp_obj_dict_t*)&mp_module__json_globals,
+};
+
+#endif //MICROPY_PY__JSON

--- a/py/builtin.h
+++ b/py/builtin.h
@@ -89,3 +89,4 @@ extern struct _dummy_t mp_sys_stderr_obj;
 // extmod modules
 extern const mp_obj_module_t mp_module_uctypes;
 extern const mp_obj_module_t mp_module_zlibd;
+extern const mp_obj_module_t mp_module__json;

--- a/py/builtintables.c
+++ b/py/builtintables.c
@@ -200,6 +200,9 @@ STATIC const mp_map_elem_t mp_builtin_module_table[] = {
 #if MICROPY_PY_ZLIBD
     { MP_OBJ_NEW_QSTR(MP_QSTR_zlibd), (mp_obj_t)&mp_module_zlibd },
 #endif
+#if MICROPY_PY__JSON
+    { MP_OBJ_NEW_QSTR(MP_QSTR__json), (mp_obj_t)&mp_module__json },
+#endif
 
     // extra builtin modules as defined by a port
     MICROPY_PORT_BUILTIN_MODULES

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -390,6 +390,10 @@ typedef double mp_float_t;
 #define MICROPY_PY_ZLIBD (0)
 #endif
 
+#ifndef MICROPY_PY__JSON
+#define MICROPY_PY__JSON (0)
+#endif
+
 /*****************************************************************************/
 /* Hooks for a port to add builtins                                          */
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -187,7 +187,8 @@ typedef enum {
     PRINT_STR = 0,
     PRINT_REPR = 1,
     PRINT_EXC = 2, // Special format for printing exception in unhandled exception message
-    PRINT_EXC_SUBCLASS = 4, // Internal flag for printing exception subclasses
+    PRINT_JSON = 3,
+    PRINT_EXC_SUBCLASS = 0x80, // Internal flag for printing exception subclasses
 } mp_print_kind_t;
 
 typedef void (*mp_print_fun_t)(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t o, mp_print_kind_t kind);

--- a/py/objbool.c
+++ b/py/objbool.c
@@ -41,10 +41,18 @@ typedef struct _mp_obj_bool_t {
 
 STATIC void bool_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
     mp_obj_bool_t *self = self_in;
-    if (self->value) {
-        print(env, "True");
+    if (MICROPY_PY__JSON && kind == PRINT_JSON) {
+        if (self->value) {
+            print(env, "true");
+        } else {
+            print(env, "false");
+        }
     } else {
-        print(env, "False");
+        if (self->value) {
+            print(env, "True");
+        } else {
+            print(env, "False");
+        }
     }
 }
 

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -44,6 +44,9 @@ STATIC mp_obj_t dict_update(mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw
 
 STATIC void dict_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
     mp_obj_dict_t *self = self_in;
+    if (!(MICROPY_PY__JSON && kind == PRINT_JSON)) {
+        kind = PRINT_REPR;
+    }
     bool first = true;
     print(env, "{");
     mp_obj_t *dict_iter = mp_obj_new_dict_iterator(self, 0);
@@ -53,9 +56,9 @@ STATIC void dict_print(void (*print)(void *env, const char *fmt, ...), void *env
             print(env, ", ");
         }
         first = false;
-        mp_obj_print_helper(print, env, next->key, PRINT_REPR);
+        mp_obj_print_helper(print, env, next->key, kind);
         print(env, ": ");
-        mp_obj_print_helper(print, env, next->value, PRINT_REPR);
+        mp_obj_print_helper(print, env, next->value, kind);
     }
     print(env, "}");
 }

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -49,12 +49,15 @@ STATIC mp_obj_t list_pop(mp_uint_t n_args, const mp_obj_t *args);
 
 STATIC void list_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t o_in, mp_print_kind_t kind) {
     mp_obj_list_t *o = o_in;
+    if (!(MICROPY_PY__JSON && kind == PRINT_JSON)) {
+        kind = PRINT_REPR;
+    }
     print(env, "[");
     for (mp_uint_t i = 0; i < o->len; i++) {
         if (i > 0) {
             print(env, ", ");
         }
-        mp_obj_print_helper(print, env, o->items[i], PRINT_REPR);
+        mp_obj_print_helper(print, env, o->items[i], kind);
     }
     print(env, "]");
 }

--- a/py/objnone.c
+++ b/py/objnone.c
@@ -38,7 +38,11 @@ typedef struct _mp_obj_none_t {
 } mp_obj_none_t;
 
 STATIC void none_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
-    print(env, "None");
+    if (MICROPY_PY__JSON && kind == PRINT_JSON) {
+        print(env, "null");
+    } else {
+        print(env, "None");
+    }
 }
 
 STATIC mp_obj_t none_unary_op(mp_uint_t op, mp_obj_t o_in) {

--- a/py/objstrunicode.c
+++ b/py/objstrunicode.c
@@ -91,8 +91,44 @@ STATIC void uni_print_quoted(void (*print)(void *env, const char *fmt, ...), voi
     print(env, "%c", quote_char);
 }
 
+#if MICROPY_PY__JSON
+STATIC void uni_print_json(void (*print)(void *env, const char *fmt, ...), void *env, const byte *str_data, uint str_len) {
+    print(env, "\"");
+    const byte *s = str_data, *top = str_data + str_len;
+    while (s < top) {
+        unichar ch;
+        ch = utf8_get_char(s);
+        s = utf8_next_char(s);
+        if (ch == '"' || ch == '\\' || ch == '/') {
+            print(env, "\\%c", ch);
+        } else if (32 <= ch && ch <= 126) {
+            print(env, "%c", ch);
+        } else if (*s == '\b') {
+            print(env, "\\b");
+        } else if (*s == '\f') {
+            print(env, "\\f");
+        } else if (*s == '\n') {
+            print(env, "\\n");
+        } else if (*s == '\r') {
+            print(env, "\\r");
+        } else if (*s == '\t') {
+            print(env, "\\t");
+        } else {
+            print(env, "\\u%04x", ch);
+        }
+    }
+    print(env, "\"");
+}
+#endif
+
 STATIC void uni_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
     GET_STR_DATA_LEN(self_in, str_data, str_len);
+    #if MICROPY_PY__JSON
+    if (kind == PRINT_JSON) {
+        uni_print_json(print, env, str_data, str_len);
+        return;
+    }
+    #endif
     if (kind == PRINT_STR) {
         print(env, "%.*s", str_len, str_data);
     } else {

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -43,17 +43,26 @@ STATIC mp_obj_t mp_obj_new_tuple_iterator(mp_obj_tuple_t *tuple, mp_uint_t cur);
 
 void mp_obj_tuple_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t o_in, mp_print_kind_t kind) {
     mp_obj_tuple_t *o = o_in;
-    print(env, "(");
+    if (MICROPY_PY__JSON && kind == PRINT_JSON) {
+        print(env, "[");
+    } else {
+        print(env, "(");
+        kind = PRINT_REPR;
+    }
     for (mp_uint_t i = 0; i < o->len; i++) {
         if (i > 0) {
             print(env, ", ");
         }
-        mp_obj_print_helper(print, env, o->items[i], PRINT_REPR);
+        mp_obj_print_helper(print, env, o->items[i], kind);
     }
-    if (o->len == 1) {
-        print(env, ",");
+    if (MICROPY_PY__JSON && kind == PRINT_JSON) {
+        print(env, "]");
+    } else {
+        if (o->len == 1) {
+            print(env, ",");
+        }
+        print(env, ")");
     }
-    print(env, ")");
 }
 
 STATIC mp_obj_t mp_obj_tuple_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {

--- a/py/py.mk
+++ b/py/py.mk
@@ -112,6 +112,7 @@ PY_O_BASENAME = \
 	pfenv_printf.o \
 	../extmod/moductypes.o \
 	../extmod/modzlibd.o \
+	../extmod/mod_json.o \
 
 # prepend the build destination prefix to the py object files
 PY_O = $(addprefix $(PY_BUILD)/, $(PY_O_BASENAME))

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -463,3 +463,8 @@ Q(deleter)
 Q(zlibd)
 Q(decompress)
 #endif
+
+#if MICROPY_PY__JSON
+Q(_json)
+Q(dumps)
+#endif

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -58,6 +58,7 @@
 
 #define MICROPY_PY_UCTYPES          (1)
 #define MICROPY_PY_ZLIBD            (1)
+#define MICROPY_PY__JSON            (1)
 
 // Define to MICROPY_ERROR_REPORTING_DETAILED to get function, etc.
 // names in exception messages (may require more RAM).


### PR DESCRIPTION
I thought I would have a quick go at implementing a json.dumps printer using the existing print framework.  See discussion in issue #804 for background.

It should print any valid json-able object correctly.  It doesn't handle non-json-able objects correctly, eg numbers as dictionary keys.

I've called the module `_json` so that its only function (dumps) can be used by the proper `json` module to implement a full module.  We can add loads to `_json` in the future.
