### PR TITLE
Add pulse_width_percent to teensy.

### DIFF
--- a/stmhal/qstrdefsport.h
+++ b/stmhal/qstrdefsport.h
@@ -175,7 +175,7 @@ Q(BOTH)
 // for TimerChannel class
 Q(TimerChannel)
 Q(pulse_width)
-Q(pulse_width_ratio)
+Q(pulse_width_percent)
 Q(compare)
 Q(capture)
 Q(polarity)

--- a/teensy/Makefile
+++ b/teensy/Makefile
@@ -6,10 +6,28 @@ QSTR_DEFS = qstrdefsport.h $(BUILD)/pins_qstr.h
 # include py core make definitions
 include ../py/py.mk
 
+# If you set USE_ARDUINO_TOOLCHAIN=1 then this makefile will attempt to use
+# the toolchain that comes with Teensyduino
+ifeq ($(USE_ARDUINO_TOOLCHAIN),)
+USE_ARDUINO_TOOLCHAIN = 0
+endif
+
+ifeq ($(USE_ARDUINO_TOOLCHAIN),1)
+ifeq ($(ARDUINO),)
+$(error USE_ARDUINO_TOOLCHAIN requires that ARDUINO be set)
+endif
+endif
+
+ifeq ($(USE_ARDUINO_TOOLCHAIN),1)
+$(info Using ARDUINO toolchain)
+CROSS_COMPILE = $(ARDUINO)/hardware/tools/arm-none-eabi/bin/arm-none-eabi-
+else
+$(info Using toolchain from PATH)
 CROSS_COMPILE = arm-none-eabi-
+endif
 
 CFLAGS_TEENSY = -DF_CPU=96000000 -DUSB_SERIAL -D__MK20DX256__
-CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mcpu=cortex-m4 -fsingle-precision-constant -Wdouble-promotion $(CFLAGS_TEENSY)
+CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mcpu=cortex-m4 -msoft-float -mfloat-abi=soft -fsingle-precision-constant -Wdouble-promotion $(CFLAGS_TEENSY)
 
 INC =  -I.
 INC += -I$(PY_SRC)
@@ -18,11 +36,21 @@ INC += -I$(BUILD)
 INC += -Icore
 
 CFLAGS = $(INC) -Wall -ansi -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4)
-LDFLAGS = -nostdlib -T mk20dx256.ld
+LDFLAGS = -nostdlib -T mk20dx256.ld -msoft-float -mfloat-abi=soft
 
-LIBGCC_FILE_NAME = $(shell $(CC) -print-libgcc-file-name)
-LIBM_FILE_NAME   = $(shell $(CC) -print-file-name=libm.a)
-LIBC_FILE_NAME   = $(shell $(CC) -print-file-name=libc.a)
+ifeq ($(USE_ARDUINO_TOOLCHAIN),1)
+
+LIBGCC_FILE_NAME = $(ARDUINO)/hardware/tools/arm-none-eabi/lib/gcc/arm-none-eabi/4.7.2/thumb2/libgcc.a
+LIBM_FILE_NAME   = $(ARDUINO)/hardware/tools/arm-none-eabi/arm-none-eabi/lib/thumb2/libm.a
+LIBC_FILE_NAME   = $(ARDUINO)/hardware/tools/arm-none-eabi/arm-none-eabi/lib/thumb2/libc.a
+
+else
+
+LIBGCC_FILE_NAME = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
+LIBM_FILE_NAME   = $(shell $(CC) $(CFLAGS) -print-file-name=libm.a)
+LIBC_FILE_NAME   = $(shell $(CC) $(CFLAGS) -print-file-name=libc.a)
+
+endif
 
 #$(info %%%%% LIBGCC_FILE_NAME = $(LIBGCC_FILE_NAME))
 #$(info %%%%% LIBM_FILE_NAME = $(LIBM_FILE_NAME))

--- a/teensy/qstrdefsport.h
+++ b/teensy/qstrdefsport.h
@@ -119,6 +119,7 @@ Q(BOTH)
 // for TimerChannel class
 Q(TimerChannel)
 Q(pulse_width)
+Q(pulse_width_percent)
 Q(compare)
 Q(capture)
 Q(polarity)

--- a/teensy/timer.h
+++ b/teensy/timer.h
@@ -25,7 +25,6 @@
  */
 
 extern const mp_obj_type_t pyb_timer_type;
-extern const mp_obj_type_t pyb_timer_channel_type;
 
 void timer_init0(void);
 void timer_deinit(void);


### PR DESCRIPTION
While testing pulse_width_ratio, I discovered that trying to do any floating point opertions on the teensy would cause a hang. This is because the teensy CPU has no HW floating point support.

Fix stmhal and teensy print routines to report actual prescaler and period.
Fix teensy build to use soft-float
Add USE_ARDUINO_TOOLCHAIN option to teensy build
