### PR TITLE
Fix unix/Makefile to build on OSX

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -30,6 +30,13 @@ COPT = -Os #-DNDEBUG
 endif
 
 LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-Map=$@.map,--cref $(LDFLAGS_EXTRA)
+ifeq ($(UNAME_S),Darwin)
+# Force OSX to use clang even if gcc is present, value set in mkenv.mk
+# must be ovewritten here to avoid breaking stmhal build on OSX
+CC = clang
+# Use clang syntax for LDFLAGS
+LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-map,$@.map $(LDFLAGS_EXTRA)
+endif
 
 ifeq ($(MICROPY_FORCE_32BIT),1)
 CFLAGS += -m32
@@ -80,7 +87,7 @@ SRC_C = \
 
 ifeq ($(UNAME_S),Darwin)
 
-LDFLAGS+ = -Wl,-order_file,$(BUILD)/order.def
+LDFLAGS += -Wl,-order_file,$(BUILD)/order.def
 
 # Must be the last file in list of sources
 SRC_C += seg_helpers.c
@@ -92,7 +99,7 @@ seg_helpers.c: $(BUILD)/order.def
 $(BUILD)/order.def:
 	$(Q)echo "seg_helpers.o: ___bss_start" > $@
 endif
-	
+
 OBJ = $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
 include ../py/mkrules.mk

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -29,13 +29,16 @@ else
 COPT = -Os #-DNDEBUG
 endif
 
-LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-Map=$@.map,--cref $(LDFLAGS_EXTRA)
+LDFLAGS = $(LDFLAGS_MOD) -lm -Wl$(LDFLAGS_MAP_EXTRA) $(LDFLAGS_EXTRA)
 ifeq ($(UNAME_S),Darwin)
 # Force OSX to use clang even if gcc is present, value set in mkenv.mk
 # must be ovewritten here to avoid breaking stmhal build on OSX
 CC = clang
 # Use clang syntax for LDFLAGS
-LDFLAGS = $(LDFLAGS_MOD) -lm -Wl,-map,$@.map $(LDFLAGS_EXTRA)
+LDFLAGS_MAP_EXTRA = ,-map,$@.map
+else
+# Use gcc syntax
+LDFLAGS_MAP_EXTRA = ,-Map=$@.map,--cref
 endif
 
 ifeq ($(MICROPY_FORCE_32BIT),1)

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -29,17 +29,19 @@ else
 COPT = -Os #-DNDEBUG
 endif
 
-LDFLAGS = $(LDFLAGS_MOD) -lm -Wl$(LDFLAGS_MAP_EXTRA) $(LDFLAGS_EXTRA)
+# On OSX, 'gcc' is a symlink to clang unless a real gcc is installed.
+# The unix port of micropython on OSX must be compiled with clang,
+# while cross-compile ports require gcc, so we test here for OSX and 
+# if necessary override the value of 'CC' set in py/mkenv.mk
 ifeq ($(UNAME_S),Darwin)
-# Force OSX to use clang even if gcc is present, value set in mkenv.mk
-# must be ovewritten here to avoid breaking stmhal build on OSX
 CC = clang
-# Use clang syntax for LDFLAGS
-LDFLAGS_MAP_EXTRA = ,-map,$@.map
+# Use clang syntax for map file and set osx specific flags
+LDFLAGS_ARCH = -Wl,-order_file,$(BUILD)/order.def -Wl,-map,$@.map
 else
-# Use gcc syntax
-LDFLAGS_MAP_EXTRA = ,-Map=$@.map,--cref
+# Use gcc syntax for map file
+LDFLAGS_ARCH = -Wl,-Map=$@.map,--cref
 endif
+LDFLAGS = $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
 
 ifeq ($(MICROPY_FORCE_32BIT),1)
 CFLAGS += -m32
@@ -89,9 +91,6 @@ SRC_C = \
 	$(SRC_MOD)
 
 ifeq ($(UNAME_S),Darwin)
-
-LDFLAGS += -Wl,-order_file,$(BUILD)/order.def
-
 # Must be the last file in list of sources
 SRC_C += seg_helpers.c
 


### PR DESCRIPTION
Please comment and review - I am not an expert in the subtleties of Makefiles!

This unix/Makefile change should allow the unix port to build on OSX without breaking stmhal build on OSX or affecting other platforms. Tested build for unix and stmhal on OSX 10.7.5 (Lion):

Force OSX to compile with clang even if gcc is available
Change LDFLAGS syntax to be compatible with clang
Fix questionable syntax on line 90
Remove extraneous tab character on line 102
