### PR TITLE
Fix tests/unix/ffi_float.py to pass on OSX

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -17,11 +17,6 @@ else:
     CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3')
     MICROPYTHON = os.getenv('MICROPY_MICROPYTHON', '../unix/micropython')
 
-# Unicode tests fail to run on CPython unless locale variable LC_CTYPE specifies UTF-8 encoding
-# Set encoding tag to 'UTF-8' while keeping language/territory tag the same
-[language, encoding] = os.environ['LC_CTYPE'].split('.')
-os.environ['LC_CTYPE'] = '.'.join([language,'UTF-8'])
-
 def rm_f(fname):
     if os.path.exists(fname):
         os.remove(fname)

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -17,6 +17,11 @@ else:
     CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3')
     MICROPYTHON = os.getenv('MICROPY_MICROPYTHON', '../unix/micropython')
 
+# Unicode tests fail to run on CPython unless locale variable LC_CTYPE specifies UTF-8 encoding
+# Set encoding tag to 'UTF-8' while keeping language/territory tag the same
+[language, encoding] = os.environ['LC_CTYPE'].split('.')
+os.environ['LC_CTYPE'] = '.'.join([language,'UTF-8'])
+
 def rm_f(fname):
     if os.path.exists(fname):
         os.remove(fname)

--- a/tests/unix/ffi_float.py
+++ b/tests/unix/ffi_float.py
@@ -12,7 +12,7 @@ def ffi_open(names):
             err = e
     raise err
 
-libc = ffi_open(('libc.so', 'libc.so.0', 'libc.so.6'))
+libc = ffi_open(('libc.so', 'libc.so.0', 'libc.so.6', 'libc.dylib'))
 
 strtof = libc.func("f", "strtof", "sp")
 print('%.6f' % strtof('1.23', None))

--- a/tests/unix/ffi_float.py
+++ b/tests/unix/ffi_float.py
@@ -12,7 +12,7 @@ def ffi_open(names):
             err = e
     raise err
 
-libc = ffi_open(('libc.so', 'libc.so.0', 'libc.so.6', 'libc.dylib'))
+libc = ffi_open(('libc.so', 'libc.so.0', 'libc.so.6'))
 
 strtof = libc.func("f", "strtof", "sp")
 print('%.6f' % strtof('1.23', None))


### PR DESCRIPTION
OSX uses dynamic libraries, so this test needed an entry for `libc.dylib` to work.

Side note - I needed to update my locale settings to use `en-US.UTF-8` instead of `en-US.us-ascii` in order to make the unicode tests pass for CPython.
Now all 293 tests run by `tests/run-tests` pass on OSX
