### PR TITLE
Enable unix build for current versions of clang (OSX)

### DIFF
--- a/py/nlrx64.S
+++ b/py/nlrx64.S
@@ -113,10 +113,7 @@ nlr_jump:
     je      nlr_jump_fail           # transfer control to nlr_jump_fail
 #if !(defined(__APPLE__) && defined(__MACH__))
     .size   nlr_jump, .-nlr_jump
-#endif
-
     .bss
-#if !(defined(__APPLE__) && defined(__MACH__))
     .local  nlr_top
 #endif
     .comm   nlr_top,8,8


### PR DESCRIPTION
When the unix port is compiled for OSX, the build scripts employ several tricks to make sure that the __bss_start and _end symbols needed by gc are in the right place; the reason is that clang for OSX does not support certain directives which make this more straightforward on gcc.
These tricks seem to work; micropython can be built for OSX with certain older versions of clang.
However, line 118 in py/nlrx64.S contains the `.bss` directive that triggers a warning in clang version 3.1 (my version) and throws an error in version 4.2 (reported on issue #865)
The warning states 'ignoring directive for now', but apparently it is ignored forever; micropython can be built with this directive enabled or commented out, either way produces identical executables and map files, and the executable passes all tests.
The strange part is that the lines immediately before and after the offending directive are explicitly skipped for OSX, but this line seems to have been intentionally left in.
My question- is this just an oversight? Or is this .bss directive still supposed to do something important that is not getting exercised in the test suite? Also, why does line 118 trigger an error but not line 182? Does that one just get skipped due to logic which I haven't grasped yet? Should that directive also be skipped when building for OSX, just for consistency?

Error on clang version 4.2:

```
CC ../py/nlrx64.S
clang -I. -I../py -Ibuild -Wall -Werror -ansi -std=gnu99 -DUNIX -DMICROPY_USE_READLINE=1 -DMICROPY_PY_TIME=1 -DMICROPY_PY_TERMIOS=1
-I/opt/local/lib/libffi-3.1/include  -DMICROPY_PY_FFI=1 -Os   -c -o
build/py/nlrx64.o ../py/nlrx64.S
../py/nlrx64.S:118:5: error: unknown directive
    .bss
    ^
make: *** [build/py/nlrx64.o] Error 1
```

Warning on clang version 3.1:

```
CC ../py/nlrx64.S
clang -I. -I../py -Ibuild -Wall -Werror -ansi -std=gnu99 -DUNIX -DMICROPY_USE_READLINE=1 -DMICROPY_PY_TIME=1 -DMICROPY_PY_TERMIOS=1 
-I/opt/local/lib/libffi-3.1/include  -DMICROPY_PY_FFI=1 -Os   -c -o 
build/py/nlrx64.o ../py/nlrx64.S
../py/nlrx64.S:118:5: warning: ignoring directive for now
    .bss
(...build process continues after warning...)
```
