### PR TITLE
unix: When specifying a file as argument pass absolute file path to lexe...

### DIFF
--- a/unix/main.c
+++ b/unix/main.c
@@ -378,8 +378,8 @@ int main(int argc, char **argv) {
             }
         } else {
             char *pathbuf = malloc(PATH_MAX);
-            char *basedir = realpath(argv[a], pathbuf);
-            if (basedir == NULL) {
+            char *filepath = realpath(argv[a], pathbuf);
+            if (filepath == NULL) {
                 fprintf(stderr, "%s: can't open file '%s': [Errno %d] ", argv[0], argv[a], errno);
                 perror("");
                 // CPython exits with 2 in such case
@@ -388,14 +388,14 @@ int main(int argc, char **argv) {
             }
 
             // Set base dir of the script as first entry in sys.path
-            char *p = strrchr(basedir, '/');
-            path_items[0] = MP_OBJ_NEW_QSTR(qstr_from_strn(basedir, p - basedir));
-            free(pathbuf);
+            char *basedir = strrchr(filepath, '/');
+            path_items[0] = MP_OBJ_NEW_QSTR(qstr_from_strn(filepath, basedir - filepath));
 
             for (int i = a; i < argc; i++) {
                 mp_obj_list_append(mp_sys_argv, MP_OBJ_NEW_QSTR(qstr_from_str(argv[i])));
             }
-            ret = do_file(argv[a]);
+            ret = do_file(filepath);
+            free(pathbuf);
             break;
         }
     }


### PR DESCRIPTION
...r

This fixes an inconvenient inconsistency when passing a relative path as argument:
the argument was passed to the lexer as-is resulting in `__file__` being equal to
the original path passed in.
All other occurrences of `__file__` (when using import) however use the fully
resolved absolute path.

So when you have two files

```
# foo.py
import bar
print( __file__ )

# bar.py
print( __file__ )
```

and run e.g. `micropython ../foo.py` you now get this output

```
/path/to/bar.py
/path/to/foo.py
```

instead of

```
/path/to/bar.py
../foo.py
```

Also renamed basedir to filepath since that reflects what it is, and renamed p to basedir in turn.
