### PR TITLE
Compatibility and Debug fixes

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -164,12 +164,13 @@ static inline mp_uint_t uctypes_struct_scalar_size(int val_type) {
 STATIC mp_uint_t uctypes_struct_size(mp_obj_t desc_in, mp_uint_t *max_field_size) {
     mp_obj_dict_t *d = desc_in;
     mp_uint_t total_size = 0;
+    mp_uint_t i;
 
     if (!MP_OBJ_IS_TYPE(desc_in, &mp_type_dict)) {
         syntax_error();
     }
 
-    for (mp_uint_t i = 0; i < d->map.alloc; i++) {
+    for (i = 0; i < d->map.alloc; i++) {
         if (MP_MAP_SLOT_IS_FILLED(&d->map, i)) {
             mp_obj_t v = d->map.table[i].value;
             if (MP_OBJ_IS_SMALL_INT(v)) {

--- a/extmod/modujson.c
+++ b/extmod/modujson.c
@@ -127,7 +127,8 @@ STATIC mp_obj_t mod_ujson_loads(mp_obj_t obj) {
                             case 'u': {
                                 if (s + 4 >= top) { goto fail; }
                                 mp_uint_t num = 0;
-                                for (int i = 0; i < 4; i++) {
+                                int i;
+                                for (i = 0; i < 4; i++) {
                                     c = (*++s | 0x20) - '0';
                                     if (c > 9) {
                                         c -= ('a' - ('9' + 1));

--- a/extmod/modzlibd.c
+++ b/extmod/modzlibd.c
@@ -41,7 +41,7 @@
 
 #include "miniz/tinfl.c"
 
-#if 0 // print debugging info
+#if DEBUG_PRINT
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0

--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -62,7 +62,8 @@ void mp_arg_check_num(mp_uint_t n_args, mp_uint_t n_kw, mp_uint_t n_args_min, mp
 
 void mp_arg_parse_all(mp_uint_t n_pos, const mp_obj_t *pos, mp_map_t *kws, mp_uint_t n_allowed, const mp_arg_t *allowed, mp_arg_val_t *out_vals) {
     mp_uint_t pos_found = 0, kws_found = 0;
-    for (mp_uint_t i = 0; i < n_allowed; i++) {
+    mp_uint_t i;
+    for (i = 0; i < n_allowed; i++) {
         mp_obj_t given_arg;
         if (i < n_pos) {
             if (allowed[i].flags & MP_ARG_KW_ONLY) {

--- a/py/asmarm.h
+++ b/py/asmarm.h
@@ -25,6 +25,11 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <stdbool.h>
+#include "misc.h"
+
 #define ASM_ARM_PASS_COMPUTE (1)
 #define ASM_ARM_PASS_EMIT    (2)
 

--- a/py/asmthumb.h
+++ b/py/asmthumb.h
@@ -24,6 +24,11 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <stdbool.h>
+#include "misc.h"
+
 #define ASM_THUMB_PASS_COMPUTE (1)
 #define ASM_THUMB_PASS_EMIT    (2)
 

--- a/py/asmx64.h
+++ b/py/asmx64.h
@@ -36,6 +36,11 @@
 // NOTE: this is a change from the old convention used in this file and
 // some functions still use the old (reverse) convention.
 
+#pragma once
+
+#include <stdbool.h>
+#include "misc.h"
+
 #define ASM_X64_PASS_COMPUTE (1)
 #define ASM_X64_PASS_EMIT    (2)
 

--- a/py/asmx86.h
+++ b/py/asmx86.h
@@ -37,6 +37,11 @@
 // NOTE: this is a change from the old convention used in this file and
 // some functions still use the old (reverse) convention.
 
+#pragma once
+
+#include <stdbool.h>
+#include "misc.h"
+
 #define ASM_X86_PASS_COMPUTE (1)
 #define ASM_X86_PASS_EMIT    (2)
 

--- a/py/bc.c
+++ b/py/bc.c
@@ -41,8 +41,7 @@
 #include "bc.h"
 #include "stackctrl.h"
 
-#if 0 // print debugging info
-#define DEBUG_PRINT (1)
+#if DEBUG_PRINT
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0
 #endif

--- a/py/bc.h
+++ b/py/bc.h
@@ -24,6 +24,13 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <mpconfigport.h>
+#include "misc.h"
+#include "obj.h"
+#include "runtime.h"
+
 // Exception stack entry
 typedef struct _mp_exc_stack {
     const byte *handler;

--- a/py/binary.c
+++ b/py/binary.c
@@ -142,6 +142,7 @@ mp_obj_t mp_binary_get_val_array(char typecode, void *p, int index) {
 // and fit it into a long long.
 long long mp_binary_get_int(mp_uint_t size, bool is_signed, bool big_endian, byte *p) {
     int delta;
+    uint i;
     if (!big_endian) {
         delta = -1;
         p += size - 1;
@@ -153,7 +154,7 @@ long long mp_binary_get_int(mp_uint_t size, bool is_signed, bool big_endian, byt
     if (is_signed && *p & 0x80) {
         val = -1;
     }
-    for (uint i = 0; i < size; i++) {
+    for (i = 0; i < size; i++) {
         val <<= 8;
         val |= *p;
         p += delta;
@@ -203,6 +204,7 @@ mp_obj_t mp_binary_get_val(char struct_type, char val_type, byte **ptr) {
 
 void mp_binary_set_int(mp_uint_t val_sz, bool big_endian, byte *p, byte *val_ptr) {
     int in_delta, out_delta;
+    uint i;
     if (big_endian) {
         in_delta = -1;
         out_delta = 1;
@@ -211,7 +213,7 @@ void mp_binary_set_int(mp_uint_t val_sz, bool big_endian, byte *p, byte *val_ptr
         in_delta = out_delta = 1;
     }
 
-    for (uint i = val_sz; i > 0; i--) {
+    for (i = val_sz; i > 0; i--) {
         *p = *val_ptr;
         p += out_delta;
         val_ptr += in_delta;
@@ -245,6 +247,7 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte **
             break;
         default:
             val = mp_obj_get_int(val_in);
+            break;
     }
 
     mp_binary_set_int(MIN(size, sizeof(val)), struct_type == '>', p, in);
@@ -262,6 +265,7 @@ void mp_binary_set_val_array(char typecode, void *p, int index, mp_obj_t val_in)
 #endif
         default:
             mp_binary_set_val_array_from_int(typecode, p, index, mp_obj_get_int(val_in));
+            break;
     }
 }
 

--- a/py/binary.h
+++ b/py/binary.h
@@ -24,6 +24,13 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <stdbool.h>
+#include <mpconfigport.h>
+#include "misc.h"
+#include "obj.h"
+
 // Use special typecode to differentiate repr() of bytearray vs array.array('B')
 // (underlyingly they're same).
 #define BYTEARRAY_TYPECODE 0

--- a/py/builtin.c
+++ b/py/builtin.c
@@ -230,7 +230,8 @@ STATIC mp_obj_t mp_builtin_dir(mp_uint_t n_args, const mp_obj_t *args) {
 
     mp_obj_t dir = mp_obj_new_list(0, NULL);
     if (dict != NULL) {
-        for (mp_uint_t i = 0; i < dict->map.alloc; i++) {
+        mp_uint_t i;
+        for (i = 0; i < dict->map.alloc; i++) {
             if (MP_MAP_SLOT_IS_FILLED(&dict->map, i)) {
                 mp_obj_list_append(dir, dict->map.table[i].key);
             }
@@ -316,7 +317,8 @@ STATIC mp_obj_t mp_builtin_min_max(mp_uint_t n_args, const mp_obj_t *args, mp_ma
         // given many args
         mp_obj_t best_key = MP_OBJ_NULL;
         mp_obj_t best_obj = MP_OBJ_NULL;
-        for (mp_uint_t i = 0; i < n_args; i++) {
+        mp_uint_t i;
+        for (i = 0; i < n_args; i++) {
             mp_obj_t key = key_fn == MP_OBJ_NULL ? args[i] : mp_call_function_1(key_fn, args[i]);
             if (best_obj == MP_OBJ_NULL || (mp_binary_op(op, key, best_key) == mp_const_true)) {
                 best_key = key;
@@ -360,7 +362,8 @@ STATIC mp_obj_t mp_builtin_ord(mp_obj_t o_in) {
     if (charlen == 1) {
         if (MP_OBJ_IS_STR(o_in) && UTF8_IS_NONASCII(*str)) {
             mp_int_t ord = *str++ & 0x7F;
-            for (mp_int_t mask = 0x40; ord & mask; mask >>= 1) {
+            mp_int_t mask;
+            for (mask = 0x40; ord & mask; mask >>= 1) {
                 ord &= ~mask;
             }
             while (UTF8_IS_CONT(*str)) {
@@ -400,6 +403,7 @@ STATIC mp_obj_t mp_builtin_print(mp_uint_t n_args, const mp_obj_t *args, mp_map_
     mp_uint_t sep_len = 1;
     const char *end_data = "\n";
     mp_uint_t end_len = 1;
+    int i;
     if (sep_elem != NULL && sep_elem->value != mp_const_none) {
         sep_data = mp_obj_str_get_data(sep_elem->value, &sep_len);
     }
@@ -417,7 +421,7 @@ STATIC mp_obj_t mp_builtin_print(mp_uint_t n_args, const mp_obj_t *args, mp_map_
     pfenv.data = stream_obj;
     pfenv.print_strn = (void (*)(void *, const char *, unsigned int))mp_stream_write;
     #endif
-    for (int i = 0; i < n_args; i++) {
+    for (i = 0; i < n_args; i++) {
         if (i > 0) {
             #if MICROPY_PY_IO
             mp_stream_write(stream_obj, sep_data, sep_len);

--- a/py/builtin.h
+++ b/py/builtin.h
@@ -24,6 +24,11 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <mpconfigport.h>
+#include "obj.h"
+
 mp_obj_t mp_builtin___import__(mp_uint_t n_args, mp_obj_t *args);
 mp_obj_t mp_builtin_open(mp_uint_t n_args, const mp_obj_t *args);
 

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -71,7 +71,7 @@ STATIC mp_import_stat_t stat_dir_or_file(vstr_t *path) {
 STATIC mp_import_stat_t find_file(const char *file_str, uint file_len, vstr_t *dest) {
     // extract the list of paths
     mp_uint_t path_num = 0;
-    mp_obj_t *path_items;
+    mp_obj_t *path_items = NULL;
 #if MICROPY_PY_SYS
     mp_obj_list_get(mp_sys_path, &path_num, &path_items);
 #endif
@@ -81,8 +81,9 @@ STATIC mp_import_stat_t find_file(const char *file_str, uint file_len, vstr_t *d
         vstr_add_strn(dest, file_str, file_len);
         return stat_dir_or_file(dest);
     } else {
+        int i;
         // go through each path looking for a directory or file
-        for (int i = 0; i < path_num; i++) {
+        for (i = 0; i < path_num; i++) {
             vstr_reset(dest);
             mp_uint_t p_len;
             const char *p = mp_obj_str_get_data(path_items[i], &p_len);
@@ -166,10 +167,11 @@ STATIC void do_load(mp_obj_t module_obj, vstr_t *file) {
 
 mp_obj_t mp_builtin___import__(mp_uint_t n_args, mp_obj_t *args) {
 #if DEBUG_PRINT
+    int j;
     DEBUG_printf("__import__:\n");
-    for (int i = 0; i < n_args; i++) {
+    for (j = 0; j < n_args; j++) {
         DEBUG_printf("  ");
-        mp_obj_print(args[i], PRINT_REPR);
+        mp_obj_print(args[j], PRINT_REPR);
         DEBUG_printf("\n");
     }
 #endif

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -45,8 +45,7 @@
 #include "runtime.h"
 #include "builtin.h"
 
-#if 0 // print debugging info
-#define DEBUG_PRINT (1)
+#if DEBUG_PRINT
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0

--- a/py/builtintables.h
+++ b/py/builtintables.h
@@ -24,5 +24,9 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include "obj.h"
+
 extern const mp_obj_dict_t mp_builtin_object_dict_obj;
 extern const mp_obj_dict_t mp_builtin_module_dict_obj;

--- a/py/compile.h
+++ b/py/compile.h
@@ -24,6 +24,13 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <stdbool.h>
+#include "obj.h"
+#include "parse.h"
+#include "misc.h"
+
 // These must fit in 8 bits; see scope.h
 enum {
     MP_EMIT_OPT_NONE,

--- a/py/emit.h
+++ b/py/emit.h
@@ -34,6 +34,15 @@
  * stack size to compile the entry to the function, and this affects code size.
  */
 
+#pragma once
+
+#include <stdbool.h>
+#include <mpconfigport.h>
+#include "qstr.h"
+#include "scope.h"
+#include "lexer.h"
+#include "runtime0.h"
+
 typedef enum {
     MP_PASS_SCOPE = 1,      // work out id's and their kind, and number of labels
     MP_PASS_STACK_SIZE = 2, // work out maximum stack size

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -309,7 +309,8 @@ STATIC void emit_bc_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scope) {
 
     // bytecode prelude: initialise closed over variables
     int num_cell = 0;
-    for (int i = 0; i < scope->id_info_len; i++) {
+    int i;
+    for (i = 0; i < scope->id_info_len; i++) {
         id_info_t *id = &scope->id_info[i];
         if (id->kind == ID_INFO_KIND_CELL) {
             num_cell += 1;
@@ -317,7 +318,7 @@ STATIC void emit_bc_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scope) {
     }
     assert(num_cell <= 255);
     emit_write_bytecode_byte(emit, num_cell); // write number of locals that are cells
-    for (int i = 0; i < scope->id_info_len; i++) {
+    for (i = 0; i < scope->id_info_len; i++) {
         id_info_t *id = &scope->id_info[i];
         if (id->kind == ID_INFO_KIND_CELL) {
             emit_write_bytecode_byte(emit, id->local_num); // write the local which should be converted to a cell
@@ -359,7 +360,8 @@ STATIC void emit_bc_end_pass(emit_t *emit) {
 
     } else if (emit->pass == MP_PASS_EMIT) {
         qstr *arg_names = m_new(qstr, emit->scope->num_pos_args + emit->scope->num_kwonly_args);
-        for (int i = 0; i < emit->scope->num_pos_args + emit->scope->num_kwonly_args; i++) {
+        int i;
+        for (i = 0; i < emit->scope->num_pos_args + emit->scope->num_kwonly_args; i++) {
             arg_names[i] = emit->scope->id_info[i].qst;
         }
         mp_emit_glue_assign_bytecode(emit->scope->raw_code, emit->code_base,

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -39,9 +39,8 @@
 #include "emitglue.h"
 #include "bc.h"
 
-#if 0 // print debugging info
-#define DEBUG_PRINT (1)
-#define WRITE_CODE (1)
+#if DEBUG_PRINT
+//#define WRITE_CODE (1)
 #define DEBUG_printf DEBUG_printf
 #define DEBUG_OP_printf(...) DEBUG_printf(__VA_ARGS__)
 #else // don't print debugging info

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -67,14 +67,16 @@ void mp_emit_glue_assign_bytecode(mp_raw_code_t *rc, byte *code, mp_uint_t len, 
 #ifdef DEBUG_PRINT
     DEBUG_printf("assign byte code: code=%p len=" UINT_FMT " n_pos_args=" UINT_FMT " n_kwonly_args=" UINT_FMT " flags=%x\n", code, len, n_pos_args, n_kwonly_args, (uint)scope_flags);
     DEBUG_printf("  arg names:");
-    for (int i = 0; i < n_pos_args + n_kwonly_args; i++) {
-        DEBUG_printf(" %s", qstr_str(arg_names[i]));
+    int j;
+    for (j = 0; j < n_pos_args + n_kwonly_args; j++) {
+        DEBUG_printf(" %s", qstr_str(arg_names[j]));
     }
     DEBUG_printf("\n");
 #endif
 #if MICROPY_DEBUG_PRINTERS
     if (mp_verbose_flag > 0) {
-        for (mp_uint_t i = 0; i < len; i++) {
+        mp_uint_t i;
+        for (i = 0; i < len; i++) {
             if (i > 0 && i % 16 == 0) {
                 printf("\n");
             }

--- a/py/emitglue.h
+++ b/py/emitglue.h
@@ -26,6 +26,13 @@
 
 // These variables and functions glue the code emitters to the runtime.
 
+#pragma once
+
+#include <mpconfigport.h>
+#include "misc.h"
+#include "qstr.h"
+#include "obj.h"
+
 typedef enum {
     MP_CODE_UNUSED,
     MP_CODE_RESERVED,

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -61,8 +61,7 @@
 #include "emit.h"
 #include "runtime.h"
 
-#if 0 // print debugging info
-#define DEBUG_PRINT (1)
+#if DEBUG_PRINT
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0

--- a/py/formatfloat.h
+++ b/py/formatfloat.h
@@ -24,4 +24,8 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <stddef.h>
+
 int format_float(float f, char *buf, size_t bufSize, char fmt, int prec, char sign);

--- a/py/gc.c
+++ b/py/gc.c
@@ -40,8 +40,7 @@
 
 #if MICROPY_ENABLE_GC
 
-#if 0 // print debugging info
-#define DEBUG_PRINT (1)
+#if DEBUG_PRINT
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0

--- a/py/gc.h
+++ b/py/gc.h
@@ -24,6 +24,11 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <stdbool.h>
+#include <mpconfigport.h>
+
 void gc_init(void *start, void *end);
 
 // These lock/unlock functions can be nested.

--- a/py/grammar.h
+++ b/py/grammar.h
@@ -24,6 +24,9 @@
  * THE SOFTWARE.
  */
 
+/* SPECIAL HEADER - Gets included inside table code */
+/* DO NOT USE INCLUDES */
+
 // rules for writing rules:
 // - zero_or_more is implemented using opt_rule around a one_or_more rule
 // - don't put opt_rule in arguments of or rule; instead, wrap the call to this or rule in opt_rule

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -81,7 +81,7 @@ bool str_strn_equal(const char *str, const char *strn, mp_uint_t len) {
 
 #ifdef MICROPY_DEBUG_PRINTERS
 void mp_token_show(const mp_token_t *tok) {
-    printf("(" UINT_FMT ":" UINT_FMT ") kind:%u str:%p len:" UINT_FMT, tok->src_line, tok->src_column, tok->kind, tok->str, tok->len);
+    printf("(" UINT_FMT ":" UINT_FMT ") kind:%u str:%p len:" UINT_FMT, (unsigned int)(tok->src_line), (unsigned int)(tok->src_column), (unsigned int)(tok->kind), tok->str, (unsigned int)(tok->len));
     if (tok->str != NULL && tok->len > 0) {
         const byte *i = (const byte *)tok->str;
         const byte *j = (const byte *)i + tok->len;
@@ -511,6 +511,7 @@ STATIC void mp_lexer_next_token_into(mp_lexer_t *lex, mp_token_t *tok, bool firs
                                     break;
                                 }
                                 // Otherwise fall through.
+                                //no break - disable eclipse static analysis warning
                             case 'x':
                             {
                                 mp_uint_t num = 0;
@@ -716,7 +717,8 @@ STATIC void mp_lexer_next_token_into(mp_lexer_t *lex, mp_token_t *tok, bool firs
         // need to check for this special token in many places in the compiler.
         // TODO improve speed of these string comparisons
         //for (mp_int_t i = 0; tok_kw[i] != NULL; i++) {
-        for (mp_int_t i = 0; i < MP_ARRAY_SIZE(tok_kw); i++) {
+        mp_int_t i;
+        for (i = 0; i < MP_ARRAY_SIZE(tok_kw); i++) {
             if (str_strn_equal(tok_kw[i], tok->str, tok->len)) {
                 if (i == MP_ARRAY_SIZE(tok_kw) - 1) {
                     // tok_kw[MP_ARRAY_SIZE(tok_kw) - 1] == "__debug__"

--- a/py/lexer.h
+++ b/py/lexer.h
@@ -30,6 +30,12 @@
  * Tokens are the same - UTF-8 with (byte) length.
  */
 
+#pragma once
+
+#include <stdbool.h>
+#include <mpconfigport.h>
+#include "qstr.h"
+
 typedef enum _mp_token_kind_t {
     MP_TOKEN_END,                   // 0
 

--- a/py/lexerunix.h
+++ b/py/lexerunix.h
@@ -24,6 +24,10 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include "lexer.h"
+
 mp_lexer_t *mp_lexer_new_from_file(const char *filename);
 
 void mp_import_set_directory(const char *dir);

--- a/py/malloc.c
+++ b/py/malloc.c
@@ -31,7 +31,7 @@
 #include "mpconfig.h"
 #include "misc.h"
 
-#if 0 // print debugging info
+#if DEBUG_PRINT
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0

--- a/py/malloc.c
+++ b/py/malloc.c
@@ -94,6 +94,10 @@ void *m_malloc_maybe(size_t num_bytes) {
 }
 
 #if MICROPY_ENABLE_FINALISER
+#if !MICROPY_ENABLE_GC
+#error FINALISER requires GC
+#endif
+
 void *m_malloc_with_finaliser(size_t num_bytes) {
     if (num_bytes == 0) {
         return NULL;

--- a/py/map.c
+++ b/py/map.c
@@ -25,6 +25,7 @@
  */
 
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
 
@@ -39,7 +40,8 @@
 STATIC uint32_t doubling_primes[] = {0, 7, 19, 43, 89, 179, 347, 647, 1229, 2297, 4243, 7829, 14347, 26017, 47149, 84947, 152443, 273253, 488399, 869927, 1547173, 2745121, 4861607};
 
 STATIC mp_uint_t get_doubling_prime_greater_or_equal_to(mp_uint_t x) {
-    for (int i = 0; i < MP_ARRAY_SIZE(doubling_primes); i++) {
+    int i;
+    for (i = 0; i < MP_ARRAY_SIZE(doubling_primes); i++) {
         if (doubling_primes[i] >= x) {
             return doubling_primes[i];
         }
@@ -104,13 +106,14 @@ void mp_map_clear(mp_map_t *map) {
 }
 
 STATIC void mp_map_rehash(mp_map_t *map) {
+    mp_uint_t i;
     mp_uint_t old_alloc = map->alloc;
     mp_map_elem_t *old_table = map->table;
     map->alloc = get_doubling_prime_greater_or_equal_to(map->alloc + 1);
     map->used = 0;
     map->all_keys_are_qstrs = 1;
     map->table = m_new0(mp_map_elem_t, map->alloc);
-    for (mp_uint_t i = 0; i < old_alloc; i++) {
+    for (i = 0; i < old_alloc; i++) {
         if (old_table[i].key != MP_OBJ_NULL && old_table[i].key != MP_OBJ_SENTINEL) {
             mp_map_lookup(map, old_table[i].key, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = old_table[i].value;
         }
@@ -147,10 +150,11 @@ mp_map_elem_t* mp_map_lookup(mp_map_t *map, mp_obj_t index, mp_map_lookup_kind_t
 
     // if the map is a fixed array then we must do a brute force linear search
     if (map->table_is_fixed_array) {
+        mp_map_elem_t *elem, *top;
         if (lookup_kind != MP_MAP_LOOKUP) {
             return NULL;
         }
-        for (mp_map_elem_t *elem = &map->table[0], *top = &map->table[map->used]; elem < top; elem++) {
+        for (elem = &map->table[0], top = &map->table[map->used]; elem < top; elem++) {
             if (elem->key == index || (!compare_only_ptrs && mp_obj_equal(elem->key, index))) {
                 return elem;
             }
@@ -250,12 +254,13 @@ void mp_set_init(mp_set_t *set, mp_uint_t n) {
 }
 
 STATIC void mp_set_rehash(mp_set_t *set) {
+    mp_uint_t i;
     mp_uint_t old_alloc = set->alloc;
     mp_obj_t *old_table = set->table;
     set->alloc = get_doubling_prime_greater_or_equal_to(set->alloc + 1);
     set->used = 0;
     set->table = m_new0(mp_obj_t, set->alloc);
-    for (mp_uint_t i = 0; i < old_alloc; i++) {
+    for (i = 0; i < old_alloc; i++) {
         if (old_table[i] != MP_OBJ_NULL && old_table[i] != MP_OBJ_SENTINEL) {
             mp_set_lookup(set, old_table[i], MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
         }
@@ -334,7 +339,8 @@ mp_obj_t mp_set_lookup(mp_set_t *set, mp_obj_t index, mp_map_lookup_kind_t looku
 }
 
 mp_obj_t mp_set_remove_first(mp_set_t *set) {
-    for (mp_uint_t pos = 0; pos < set->alloc; pos++) {
+    mp_uint_t pos;
+    for (pos = 0; pos < set->alloc; pos++) {
         if (MP_SET_SLOT_IS_FILLED(set, pos)) {
             mp_obj_t elem = set->table[pos];
             // delete element
@@ -360,7 +366,8 @@ void mp_set_clear(mp_set_t *set) {
 
 #if DEBUG_PRINT
 void mp_map_dump(mp_map_t *map) {
-    for (mp_uint_t i = 0; i < map->alloc; i++) {
+    mp_uint_t i;
+    for (i = 0; i < map->alloc; i++) {
         if (map->table[i].key != NULL) {
             mp_obj_print(map->table[i].key, PRINT_REPR);
         } else {

--- a/py/misc.h
+++ b/py/misc.h
@@ -33,6 +33,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <mpconfigport.h>
 
 typedef unsigned char byte;
 typedef unsigned int uint;
@@ -177,7 +178,8 @@ extern mp_uint_t mp_verbose_flag;
 #ifndef count_lead_ones
 static inline mp_uint_t count_lead_ones(byte val) {
     mp_uint_t c = 0;
-    for (byte mask = 0x80; val & mask; mask >>= 1) {
+    byte mask;
+    for (mask = 0x80; val & mask; mask >>= 1) {
         c++;
     }
     return c;

--- a/py/modstruct.c
+++ b/py/modstruct.c
@@ -129,6 +129,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(struct_calcsize_obj, struct_calcsize);
 
 STATIC mp_obj_t struct_unpack(mp_obj_t fmt_in, mp_obj_t data_in) {
     // TODO: "The buffer must contain exactly the amount of data required by the format (len(bytes) must equal calcsize(fmt))."
+    uint i;
     const char *fmt = mp_obj_str_get_str(fmt_in);
     char fmt_type = get_fmt_type(&fmt);
     uint size = calcsize_items(fmt);
@@ -137,7 +138,7 @@ STATIC mp_obj_t struct_unpack(mp_obj_t fmt_in, mp_obj_t data_in) {
     mp_get_buffer_raise(data_in, &bufinfo, MP_BUFFER_READ);
     byte *p = bufinfo.buf;
 
-    for (uint i = 0; i < size; i++) {
+    for (i = 0; i < size; i++) {
         mp_uint_t sz = 1;
         if (unichar_isdigit(*fmt)) {
             sz = get_fmt_num(&fmt);
@@ -166,10 +167,11 @@ STATIC mp_obj_t struct_pack(uint n_args, mp_obj_t *args) {
     char fmt_type = get_fmt_type(&fmt);
     int size = MP_OBJ_SMALL_INT_VALUE(struct_calcsize(args[0]));
     byte *p;
+    uint i;
     mp_obj_t res = mp_obj_str_builder_start(&mp_type_bytes, size, &p);
     memset(p, 0, size);
 
-    for (uint i = 1; i < n_args; i++) {
+    for (i = 1; i < n_args; i++) {
         mp_uint_t sz = 1;
         if (unichar_isdigit(*fmt)) {
             sz = get_fmt_num(&fmt);

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -28,6 +28,8 @@
 // You can override any of these options using mpconfigport.h file located
 // in a directory of your port.
 
+#pragma once
+
 #include <mpconfigport.h>
 
 // Any options not explicitly set in mpconfigport.h will get default

--- a/py/mpz.h
+++ b/py/mpz.h
@@ -36,6 +36,12 @@
 // depending on the machine, but it (and MPZ_DIG_SIZE) can be freely changed so
 // long as the constraints mentioned above are met.
 
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <mpconfigport.h>
+
 #if defined(__x86_64__)
 // 64-bit machine, using 32-bit storage for digits
 typedef uint32_t mpz_dig_t;

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -39,7 +39,7 @@
 
 #if MICROPY_EMIT_NATIVE
 
-#if 0 // print debugging info
+#if DEBUG_PRINT
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -27,9 +27,13 @@
 // non-local return
 // exception handling, basically a stack of setjmp/longjmp buffers
 
+
+#pragma once
+
 #include <limits.h>
 #include <setjmp.h>
 #include <assert.h>
+#include "mpconfig.h"
 
 typedef struct _nlr_buf_t nlr_buf_t;
 struct _nlr_buf_t {

--- a/py/obj.c
+++ b/py/obj.c
@@ -89,9 +89,10 @@ void mp_obj_print_exception(mp_obj_t exc) {
         mp_uint_t n, *values;
         mp_obj_exception_get_traceback(exc, &n, &values);
         if (n > 0) {
+            int i;
             assert(n % 3 == 0);
             printf("Traceback (most recent call last):\n");
-            for (int i = n - 3; i >= 0; i -= 3) {
+            for (i = n - 3; i >= 0; i -= 3) {
 #if MICROPY_ENABLE_SOURCE_LINE
                 printf("  File \"%s\", line %d", qstr_str(values[i]), (int)values[i + 1]);
 #else

--- a/py/obj.h
+++ b/py/obj.h
@@ -32,6 +32,12 @@
 // All Micro Python objects are at least this type
 // It must be of pointer size
 
+#pragma once
+
+#include <stdbool.h>
+#include <mpconfigport.h>
+#include "qstr.h"
+
 typedef machine_ptr_t mp_obj_t;
 typedef machine_const_ptr_t mp_const_obj_t;
 

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -65,8 +65,9 @@ STATIC void array_print(void (*print)(void *env, const char *fmt, ...), void *en
     } else {
         print(env, "array('%c'", o->typecode);
         if (o->len > 0) {
+            int i;
             print(env, ", [");
-            for (int i = 0; i < o->len; i++) {
+            for (i = 0; i < o->len; i++) {
                 if (i > 0) {
                     print(env, ", ");
                 }

--- a/py/objarray.h
+++ b/py/objarray.h
@@ -24,4 +24,10 @@
  * THE SOFTWARE.
  */
 
+
+#pragma once
+
+#include <mpconfigport.h>
+#include "obj.h"
+
 mp_obj_t mp_obj_new_bytearray(mp_uint_t n, void *items);

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -46,8 +46,8 @@ STATIC mp_obj_t dict_update(mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw
 STATIC mp_map_elem_t *dict_iter_next(mp_obj_dict_t *dict, mp_uint_t *cur) {
     mp_uint_t max = dict->map.alloc;
     mp_map_t *map = &dict->map;
-
-    for (mp_uint_t i = *cur; i < max; i++) {
+    mp_uint_t i;
+    for (i = *cur; i < max; i++) {
         if (MP_MAP_SLOT_IS_FILLED(map, i)) {
             *cur = i + 1;
             return &(map->table[i]);
@@ -334,6 +334,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(dict_popitem_obj, dict_popitem);
 STATIC mp_obj_t dict_update(mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
     assert(MP_OBJ_IS_TYPE(args[0], &mp_type_dict));
     mp_obj_dict_t *self = args[0];
+    mp_uint_t i;
 
     mp_arg_check_num(n_args, kwargs->used, 1, 2, true);
 
@@ -372,7 +373,7 @@ STATIC mp_obj_t dict_update(mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw
     }
 
     // update the dict with any keyword args
-    for (mp_uint_t i = 0; i < kwargs->alloc; i++) {
+    for (i = 0; i < kwargs->alloc; i++) {
         if (MP_MAP_SLOT_IS_FILLED(kwargs, i)) {
             mp_map_lookup(&self->map, kwargs->table[i].key, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = kwargs->table[i].value;
         }

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -162,8 +162,9 @@ STATIC void fun_bc_print(void (*print)(void *env, const char *fmt, ...), void *e
 
 #if DEBUG_PRINT
 STATIC void dump_args(const mp_obj_t *a, int sz) {
+    int i;
     DEBUG_printf("%p: ", a);
-    for (int i = 0; i < sz; i++) {
+    for (i = 0; i < sz; i++) {
         DEBUG_printf("%p ", a[i]);
     }
     DEBUG_printf("\n");

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -41,8 +41,8 @@
 #include "bc.h"
 #include "stackctrl.h"
 
-#if 0 // print debugging info
-#define DEBUG_PRINT (1)
+#if DEBUG_PRINT
+#define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0
 #endif

--- a/py/objfun.h
+++ b/py/objfun.h
@@ -24,6 +24,13 @@
  * THE SOFTWARE.
  */
 
+
+#pragma once
+
+#include <mpconfigport.h>
+#include "obj.h"
+#include "misc.h"
+
 typedef struct _mp_obj_fun_bc_t {
     mp_obj_base_t base;
     mp_obj_dict_t *globals;         // the context within which this function was defined

--- a/py/objgenerator.h
+++ b/py/objgenerator.h
@@ -24,4 +24,9 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include "obj.h"
+#include "runtime.h"
+
 mp_vm_return_kind_t mp_obj_gen_resume(mp_obj_t self_in, mp_obj_t send_val, mp_obj_t throw_val, mp_obj_t *ret_val);

--- a/py/objint.c
+++ b/py/objint.c
@@ -316,7 +316,8 @@ STATIC mp_obj_t int_from_bytes(mp_uint_t n_args, const mp_obj_t *args) {
 
     // convert the bytes to an integer
     mp_uint_t value = 0;
-    for (const byte* buf = (const byte*)bufinfo.buf + bufinfo.len - 1; buf >= (byte*)bufinfo.buf; buf--) {
+    const byte* buf;
+    for (buf = (const byte*)bufinfo.buf + bufinfo.len - 1; buf >= (byte*)bufinfo.buf; buf--) {
         value = (value << 8) | *buf;
     }
 

--- a/py/objint.h
+++ b/py/objint.h
@@ -24,6 +24,13 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <stdbool.h>
+#include <mpconfigport.h>
+#include "mpconfig.h"
+#include "obj.h"
+
 typedef struct _mp_obj_int_t {
     mp_obj_base_t base;
 #if MICROPY_LONGINT_IMPL == MICROPY_LONGINT_IMPL_LONGLONG

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -49,11 +49,12 @@ STATIC mp_obj_t list_pop(mp_uint_t n_args, const mp_obj_t *args);
 
 STATIC void list_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t o_in, mp_print_kind_t kind) {
     mp_obj_list_t *o = o_in;
+    mp_uint_t i;
     if (!(MICROPY_PY_UJSON && kind == PRINT_JSON)) {
         kind = PRINT_REPR;
     }
     print(env, "[");
-    for (mp_uint_t i = 0; i < o->len; i++) {
+    for (i = 0; i < o->len; i++) {
         if (i > 0) {
             print(env, ", ");
         }
@@ -362,6 +363,7 @@ STATIC mp_obj_t list_insert(mp_obj_t self_in, mp_obj_t idx, mp_obj_t obj) {
     mp_obj_list_t *self = self_in;
     // insert has its own strange index logic
     mp_int_t index = MP_OBJ_SMALL_INT_VALUE(idx);
+    mp_int_t i;
     if (index < 0) {
          index += self->len;
     }
@@ -374,7 +376,7 @@ STATIC mp_obj_t list_insert(mp_obj_t self_in, mp_obj_t idx, mp_obj_t obj) {
 
     mp_obj_list_append(self_in, mp_const_none);
 
-    for (mp_int_t i = self->len-1; i > index; i--) {
+    for (i = self->len-1; i > index; i--) {
          self->items[i] = self->items[i-1];
     }
     self->items[index] = obj;
@@ -396,7 +398,8 @@ STATIC mp_obj_t list_reverse(mp_obj_t self_in) {
     mp_obj_list_t *self = self_in;
 
     mp_int_t len = self->len;
-    for (mp_int_t i = 0; i < len/2; i++) {
+    mp_int_t i;
+    for (i = 0; i < len/2; i++) {
          mp_obj_t *a = self->items[i];
          self->items[i] = self->items[len-i-1];
          self->items[len-i-1] = a;
@@ -462,7 +465,8 @@ STATIC mp_obj_list_t *list_new(mp_uint_t n) {
 mp_obj_t mp_obj_new_list(mp_uint_t n, mp_obj_t *items) {
     mp_obj_list_t *o = list_new(n);
     if (items != NULL) {
-        for (mp_uint_t i = 0; i < n; i++) {
+        mp_uint_t i;
+        for (i = 0; i < n; i++) {
             o->items[i] = items[i];
         }
     }

--- a/py/objlist.h
+++ b/py/objlist.h
@@ -24,6 +24,11 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <mpconfigport.h>
+#include "obj.h"
+
 typedef struct _mp_obj_list_t {
     mp_obj_base_t base;
     mp_uint_t alloc;

--- a/py/objmap.c
+++ b/py/objmap.c
@@ -42,6 +42,7 @@ typedef struct _mp_obj_map_t {
 } mp_obj_map_t;
 
 STATIC mp_obj_t map_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+    mp_uint_t i;
     if (n_args < 2 || n_kw != 0) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_TypeError, "map must have at least 2 arguments and no keyword arguments"));
     }
@@ -50,18 +51,19 @@ STATIC mp_obj_t map_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_kw,
     o->base.type = &mp_type_map;
     o->n_iters = n_args - 1;
     o->fun = args[0];
-    for (mp_uint_t i = 0; i < n_args - 1; i++) {
+    for (i = 0; i < n_args - 1; i++) {
         o->iters[i] = mp_getiter(args[i + 1]);
     }
     return o;
 }
 
 STATIC mp_obj_t map_iternext(mp_obj_t self_in) {
+    mp_uint_t i;
     assert(MP_OBJ_IS_TYPE(self_in, &mp_type_map));
     mp_obj_map_t *self = self_in;
     mp_obj_t *nextses = m_new(mp_obj_t, self->n_iters);
 
-    for (mp_uint_t i = 0; i < self->n_iters; i++) {
+    for (i = 0; i < self->n_iters; i++) {
         mp_obj_t next = mp_iternext(self->iters[i]);
         if (next == MP_OBJ_STOP_ITERATION) {
             m_del(mp_obj_t, nextses, self->n_iters);

--- a/py/objmodule.h
+++ b/py/objmodule.h
@@ -24,6 +24,11 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include "obj.h"
+#include "qstr.h"
+
 void mp_module_init(void);
 void mp_module_deinit(void);
 mp_obj_t mp_module_get(qstr module_name);

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -98,10 +98,11 @@ STATIC int namedtuple_find_field(const char *name, const char *namedef) {
 
 STATIC void namedtuple_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t o_in, mp_print_kind_t kind) {
     mp_obj_namedtuple_t *o = o_in;
+    int i;
     print(env, "%s(", qstr_str(o->tuple.base.type->name));
     const char *fields = ((mp_obj_namedtuple_type_t*)o->tuple.base.type)->fields;
 
-    for (int i = 0; i < o->tuple.len; i++) {
+    for (i = 0; i < o->tuple.len; i++) {
         if (i > 0) {
                 print(env, ", ");
         }

--- a/py/objset.c
+++ b/py/objset.c
@@ -85,6 +85,7 @@ STATIC void check_set(mp_obj_t o) {
 
 STATIC void set_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
     mp_obj_set_t *self = self_in;
+    mp_uint_t i;
     #if MICROPY_PY_BUILTINS_FROZENSET
     bool is_frozen = MP_OBJ_IS_TYPE(self_in, &mp_type_frozenset);
     #endif
@@ -104,7 +105,7 @@ STATIC void set_print(void (*print)(void *env, const char *fmt, ...), void *env,
     }
     #endif
     print(env, "{");
-    for (mp_uint_t i = 0; i < self->set.alloc; i++) {
+    for (i = 0; i < self->set.alloc; i++) {
         if (MP_SET_SLOT_IS_FILLED(&self->set, i)) {
             if (!first) {
                 print(env, ", ");
@@ -158,12 +159,13 @@ const mp_obj_type_t mp_type_set_it = {
 };
 
 STATIC mp_obj_t set_it_iternext(mp_obj_t self_in) {
+    mp_uint_t i;
     assert(MP_OBJ_IS_TYPE(self_in, &mp_type_set_it));
     mp_obj_set_it_t *self = self_in;
     mp_uint_t max = self->set->set.alloc;
     mp_set_t *set = &self->set->set;
 
-    for (mp_uint_t i = self->cur; i < max; i++) {
+    for (i = self->cur; i < max; i++) {
         if (MP_SET_SLOT_IS_FILLED(set, i)) {
             self->cur = i + 1;
             return set->table[i];
@@ -235,6 +237,7 @@ STATIC mp_obj_t set_discard(mp_obj_t self_in, mp_obj_t item) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(set_discard_obj, set_discard);
 
 STATIC mp_obj_t set_diff_int(mp_uint_t n_args, const mp_obj_t *args, bool update) {
+    mp_uint_t i;
     assert(n_args > 0);
 
     mp_obj_set_t *self;
@@ -247,7 +250,7 @@ STATIC mp_obj_t set_diff_int(mp_uint_t n_args, const mp_obj_t *args, bool update
     }
 
 
-    for (mp_uint_t i = 1; i < n_args; i++) {
+    for (i = 1; i < n_args; i++) {
         mp_obj_t other = args[i];
         if (self == other) {
             set_clear(self);
@@ -454,9 +457,10 @@ STATIC void set_update_int(mp_obj_set_t *self, mp_obj_t other_in) {
 }
 
 STATIC mp_obj_t set_update(mp_uint_t n_args, const mp_obj_t *args) {
+    mp_uint_t i;
     assert(n_args > 0);
 
-    for (mp_uint_t i = 1; i < n_args; i++) {
+    for (i = 1; i < n_args; i++) {
         set_update_int(args[0], args[i]);
     }
 
@@ -572,10 +576,11 @@ const mp_obj_type_t mp_type_frozenset = {
 #endif
 
 mp_obj_t mp_obj_new_set(mp_uint_t n_args, mp_obj_t *items) {
+    mp_uint_t i;
     mp_obj_set_t *o = m_new_obj(mp_obj_set_t);
     o->base.type = &mp_type_set;
     mp_set_init(&o->set, n_args);
-    for (mp_uint_t i = 0; i < n_args; i++) {
+    for (i = 0; i < n_args; i++) {
         mp_set_lookup(&o->set, items[i], MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
     }
     return o;

--- a/py/objstr.h
+++ b/py/objstr.h
@@ -24,6 +24,12 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <mpconfigport.h>
+#include "obj.h"
+#include "qstr.h"
+
 typedef struct _mp_obj_str_t {
     mp_obj_base_t base;
     mp_uint_t hash;

--- a/py/objstrunicode.c
+++ b/py/objstrunicode.c
@@ -48,10 +48,11 @@ STATIC mp_obj_t mp_obj_new_str_iterator(mp_obj_t str);
 /* str                                                                        */
 
 STATIC void uni_print_quoted(void (*print)(void *env, const char *fmt, ...), void *env, const byte *str_data, uint str_len) {
+    const byte *s, *top;
     // this escapes characters, but it will be very slow to print (calling print many times)
     bool has_single_quote = false;
     bool has_double_quote = false;
-    for (const byte *s = str_data, *top = str_data + str_len; !has_double_quote && s < top; s++) {
+    for (s = str_data, top = str_data + str_len; !has_double_quote && s < top; s++) {
         if (*s == '\'') {
             has_single_quote = true;
         } else if (*s == '"') {
@@ -63,7 +64,8 @@ STATIC void uni_print_quoted(void (*print)(void *env, const char *fmt, ...), voi
         quote_char = '"';
     }
     print(env, "%c", quote_char);
-    const byte *s = str_data, *top = str_data + str_len;
+    s = str_data;
+    top = str_data + str_len;
     while (s < top) {
         unichar ch;
         ch = utf8_get_char(s);
@@ -268,8 +270,9 @@ STATIC mp_obj_t str_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
         const byte *s = str_index_to_ptr(type, self_data, self_len, index, false);
         int len = 1;
         if (UTF8_IS_NONASCII(*s)) {
+            char mask;
             // Count the number of 1 bits (after the first)
-            for (char mask = 0x40; *s & mask; mask >>= 1) {
+            for (mask = 0x40; *s & mask; mask >>= 1) {
                 ++len;
             }
         }

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -42,6 +42,7 @@ STATIC mp_obj_t mp_obj_new_tuple_iterator(mp_obj_tuple_t *tuple, mp_uint_t cur);
 /* tuple                                                                      */
 
 void mp_obj_tuple_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t o_in, mp_print_kind_t kind) {
+    mp_uint_t i;
     mp_obj_tuple_t *o = o_in;
     if (MICROPY_PY_UJSON && kind == PRINT_JSON) {
         print(env, "[");
@@ -49,7 +50,7 @@ void mp_obj_tuple_print(void (*print)(void *env, const char *fmt, ...), void *en
         print(env, "(");
         kind = PRINT_REPR;
     }
-    for (mp_uint_t i = 0; i < o->len; i++) {
+    for (i = 0; i < o->len; i++) {
         if (i > 0) {
             print(env, ", ");
         }
@@ -240,7 +241,8 @@ mp_obj_t mp_obj_new_tuple(mp_uint_t n, const mp_obj_t *items) {
     o->base.type = &mp_type_tuple;
     o->len = n;
     if (items) {
-        for (mp_uint_t i = 0; i < n; i++) {
+        mp_uint_t i;
+        for (i = 0; i < n; i++) {
             o->items[i] = items[i];
         }
     }
@@ -265,7 +267,8 @@ mp_int_t mp_obj_tuple_hash(mp_obj_t self_in) {
     mp_obj_tuple_t *self = self_in;
     // start hash with pointer to empty tuple, to make it fairly unique
     mp_int_t hash = (mp_int_t)mp_const_empty_tuple;
-    for (mp_uint_t i = 0; i < self->len; i++) {
+    mp_uint_t i;
+    for (i = 0; i < self->len; i++) {
         hash += mp_obj_hash(self->items[i]);
     }
     return hash;

--- a/py/objtuple.h
+++ b/py/objtuple.h
@@ -24,6 +24,11 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <mpconfigport.h>
+#include "obj.h"
+
 typedef struct _mp_obj_tuple_t {
     mp_obj_base_t base;
     mp_uint_t len;

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -39,8 +39,7 @@
 #include "runtime.h"
 #include "objtype.h"
 
-#if 0 // print debugging info
-#define DEBUG_PRINT (1)
+#if DEBUG_PRINT
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -70,7 +70,8 @@ STATIC int instance_count_native_bases(const mp_obj_type_t *type, const mp_obj_t
     mp_obj_tuple_get(type->bases_tuple, &len, &items);
 
     int count = 0;
-    for (uint i = 0; i < len; i++) {
+    uint i;
+    for (i = 0; i < len; i++) {
         assert(MP_OBJ_IS_TYPE(items[i], &mp_type_type));
         const mp_obj_type_t *bt = (const mp_obj_type_t *)items[i];
         if (bt == &mp_type_object) {
@@ -172,7 +173,8 @@ STATIC void mp_obj_class_lookup(struct class_lookup_data  *lookup, const mp_obj_
         if (len == 0) {
             return;
         }
-        for (uint i = 0; i < len - 1; i++) {
+        uint i;
+        for (i = 0; i < len - 1; i++) {
             assert(MP_OBJ_IS_TYPE(items[i], &mp_type_type));
             mp_obj_type_t *bt = (mp_obj_type_t*)items[i];
             if (bt == &mp_type_object) {
@@ -658,6 +660,7 @@ STATIC mp_obj_t type_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_kw
 
         default:
             nlr_raise(mp_obj_new_exception_msg(&mp_type_TypeError, "type takes 1 or 3 arguments"));
+            break;
     }
 }
 
@@ -757,8 +760,9 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     // Basic validation of base classes
     mp_uint_t len;
     mp_obj_t *items;
+    uint i;
     mp_obj_tuple_get(bases_tuple, &len, &items);
-    for (uint i = 0; i < len; i++) {
+    for (i = 0; i < len; i++) {
         assert(MP_OBJ_IS_TYPE(items[i], &mp_type_type));
         mp_obj_type_t *t = items[i];
         // TODO: Verify with CPy, tested on function type
@@ -844,6 +848,7 @@ STATIC void super_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 
     mp_uint_t len;
     mp_obj_t *items;
+    uint i;
     mp_obj_tuple_get(type->bases_tuple, &len, &items);
     struct class_lookup_data lookup = {
         .obj = self->obj,
@@ -851,7 +856,7 @@ STATIC void super_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
         .meth_offset = 0,
         .dest = dest,
     };
-    for (uint i = 0; i < len; i++) {
+    for (i = 0; i < len; i++) {
         assert(MP_OBJ_IS_TYPE(items[i], &mp_type_type));
         mp_obj_class_lookup(&lookup, (mp_obj_type_t*)items[i]);
         if (dest[0] != MP_OBJ_NULL) {
@@ -903,13 +908,14 @@ bool mp_obj_is_subclass_fast(mp_const_obj_t object, mp_const_obj_t classinfo) {
         // get the base objects (they should be type objects)
         mp_uint_t len;
         mp_obj_t *items;
+        uint i;
         mp_obj_tuple_get(self->bases_tuple, &len, &items);
         if (len == 0) {
             return false;
         }
 
         // iterate through the base objects
-        for (uint i = 0; i < len - 1; i++) {
+        for (i = 0; i < len - 1; i++) {
             if (mp_obj_is_subclass_fast(items[i], classinfo)) {
                 return true;
             }
@@ -923,6 +929,7 @@ bool mp_obj_is_subclass_fast(mp_const_obj_t object, mp_const_obj_t classinfo) {
 STATIC mp_obj_t mp_obj_is_subclass(mp_obj_t object, mp_obj_t classinfo) {
     mp_uint_t len;
     mp_obj_t *items;
+    uint i;
     if (MP_OBJ_IS_TYPE(classinfo, &mp_type_type)) {
         len = 1;
         items = &classinfo;
@@ -932,7 +939,7 @@ STATIC mp_obj_t mp_obj_is_subclass(mp_obj_t object, mp_obj_t classinfo) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_TypeError, "issubclass() arg 2 must be a class or a tuple of classes"));
     }
 
-    for (uint i = 0; i < len; i++) {
+    for (i = 0; i < len; i++) {
         // We explicitly check for 'object' here since no-one explicitly derives from it
         if (items[i] == &mp_type_object || mp_obj_is_subclass_fast(object, items[i])) {
             return mp_const_true;

--- a/py/objtype.h
+++ b/py/objtype.h
@@ -24,6 +24,10 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include "obj.h"
+
 // instance object
 // creating an instance of a class makes one of these objects
 typedef struct _mp_obj_instance_t {

--- a/py/objzip.c
+++ b/py/objzip.c
@@ -41,18 +41,20 @@ typedef struct _mp_obj_zip_t {
 } mp_obj_zip_t;
 
 STATIC mp_obj_t zip_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+    mp_uint_t i;
     mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, false);
 
     mp_obj_zip_t *o = m_new_obj_var(mp_obj_zip_t, mp_obj_t, n_args);
     o->base.type = &mp_type_zip;
     o->n_iters = n_args;
-    for (mp_uint_t i = 0; i < n_args; i++) {
+    for (i = 0; i < n_args; i++) {
         o->iters[i] = mp_getiter(args[i]);
     }
     return o;
 }
 
 STATIC mp_obj_t zip_iternext(mp_obj_t self_in) {
+    mp_uint_t i;
     assert(MP_OBJ_IS_TYPE(self_in, &mp_type_zip));
     mp_obj_zip_t *self = self_in;
     if (self->n_iters == 0) {
@@ -60,7 +62,7 @@ STATIC mp_obj_t zip_iternext(mp_obj_t self_in) {
     }
     mp_obj_tuple_t *tuple = mp_obj_new_tuple(self->n_iters, NULL);
 
-    for (mp_uint_t i = 0; i < self->n_iters; i++) {
+    for (i = 0; i < self->n_iters; i++) {
         mp_obj_t next = mp_iternext(self->iters[i]);
         if (next == MP_OBJ_STOP_ITERATION) {
             mp_obj_tuple_del(tuple);

--- a/py/parse.h
+++ b/py/parse.h
@@ -24,6 +24,11 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <stdint.h>
+#include <mpconfigport.h>
+
 struct _mp_lexer_t;
 
 // a mp_parse_node_t is:

--- a/py/parsehelper.c
+++ b/py/parsehelper.c
@@ -43,7 +43,7 @@
 #define STR_INVALID_SYNTAX "invalid syntax"
 
 void mp_parse_show_exception(mp_lexer_t *lex, mp_parse_error_kind_t parse_error_kind) {
-    printf("  File \"%s\", line " UINT_FMT ", column " UINT_FMT "\n", qstr_str(mp_lexer_source_name(lex)), mp_lexer_cur(lex)->src_line, mp_lexer_cur(lex)->src_column);
+    printf("  File \"%s\", line " UINT_FMT ", column " UINT_FMT "\n", qstr_str(mp_lexer_source_name(lex)), (unsigned int)mp_lexer_cur(lex)->src_line, (unsigned int)mp_lexer_cur(lex)->src_column);
     switch (parse_error_kind) {
         case MP_PARSE_ERROR_MEMORY:
             printf("MemoryError: %s\n", STR_MEMORY);

--- a/py/parsehelper.h
+++ b/py/parsehelper.h
@@ -24,5 +24,11 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include "lexer.h"
+#include "parse.h"
+#include "obj.h"
+
 void mp_parse_show_exception(mp_lexer_t *lex, mp_parse_error_kind_t parse_error_kind);
 mp_obj_t mp_parse_make_exception(mp_lexer_t *lex, mp_parse_error_kind_t parse_error_kind);

--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -41,9 +41,9 @@
 #include <math.h>
 #endif
 
-mp_obj_t mp_parse_num_integer(const char *restrict str_, mp_uint_t len, mp_uint_t base) {
-    const byte *restrict str = (const byte *)str_;
-    const byte *restrict top = str + len;
+mp_obj_t mp_parse_num_integer(const char *__restrict str_, mp_uint_t len, mp_uint_t base) {
+    const byte *__restrict str = (const byte *)str_;
+    const byte *__restrict top = str + len;
     bool neg = false;
     mp_obj_t ret_val;
 
@@ -71,7 +71,7 @@ mp_obj_t mp_parse_num_integer(const char *restrict str_, mp_uint_t len, mp_uint_
 
     // string should be an integer number
     mp_int_t int_val = 0;
-    const byte *restrict str_val_start = str;
+    const byte *__restrict str_val_start = str;
     for (; str < top; str++) {
         // get next digit as a value
         mp_uint_t dig = *str;

--- a/py/parsenum.h
+++ b/py/parsenum.h
@@ -24,5 +24,10 @@
  * THE SOFTWARE.
  */
 
-mp_obj_t mp_parse_num_integer(const char *restrict str, mp_uint_t len, mp_uint_t base);
+#pragma once
+
+#include "obj.h"
+#include <mpconfigport.h>
+
+mp_obj_t mp_parse_num_integer(const char *__restrict str, mp_uint_t len, mp_uint_t base);
 mp_obj_t mp_parse_num_decimal(const char *str, mp_uint_t len, bool allow_imag, bool force_complex);

--- a/py/parsenumbase.h
+++ b/py/parsenumbase.h
@@ -24,4 +24,8 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <mpconfigport.h>
+
 mp_uint_t mp_parse_num_base(const char *str, mp_uint_t len, mp_uint_t *base);

--- a/py/pfenv.h
+++ b/py/pfenv.h
@@ -24,6 +24,12 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <mpconfigport.h>
+#include "mpconfig.h"
+#include "obj.h"
+
 #define PF_FLAG_LEFT_ADJUST       (0x001)
 #define PF_FLAG_SHOW_SIGN         (0x002)
 #define PF_FLAG_SPACE_SIGN        (0x004)

--- a/py/qstr.c
+++ b/py/qstr.c
@@ -35,7 +35,7 @@
 // ultimately we will replace this with a static hash table of some kind
 // also probably need to include the length in the string data, to allow null bytes in the string
 
-#if 0 // print debugging info
+#if DEBUG_PRINT
 #define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0

--- a/py/qstr.h
+++ b/py/qstr.h
@@ -30,6 +30,10 @@
 // Note: it would be possible to define MP_QSTR_xxx as qstr_from_str_static("xxx")
 // for qstrs that are referenced this way, but you don't want to have them in ROM.
 
+#pragma once
+
+#include "misc.h"
+
 enum {
     MP_QSTR_NULL = 0, // indicates invalid/no qstr
     MP_QSTR_ = 1, // the empty qstr

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -24,6 +24,8 @@
  * THE SOFTWARE.
  */
 
+/* SPECIAL HEADER - Used to generate qstrdefs.generated.h */
+
 #include "mpconfig.h"
 // All the qstr definitions in this file are available as constants.
 // That is, they are in ROM and you can reference them simply as MP_QSTR_xxxx.

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -48,8 +48,8 @@
 #include "lexer.h"
 #include "stackctrl.h"
 
-#if 0 // print debugging info
-#define DEBUG_PRINT (1)
+
+#if DEBUG_PRINT
 #define DEBUG_printf DEBUG_printf
 #define DEBUG_OP_printf(...) DEBUG_printf(__VA_ARGS__)
 #else // don't print debugging info

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -270,7 +270,8 @@ mp_obj_t mp_binary_op(mp_uint_t op, mp_obj_t lhs, mp_obj_t rhs) {
             }
         } else if (MP_OBJ_IS_TYPE(rhs, &mp_type_tuple)) {
             mp_obj_tuple_t *tuple = rhs;
-            for (mp_uint_t i = 0; i < tuple->len; i++) {
+            mp_uint_t i;
+            for (i = 0; i < tuple->len; i++) {
                 rhs = tuple->items[i];
                 if (!mp_obj_is_exception_type(rhs)) {
                     goto unsupported_op;
@@ -659,8 +660,9 @@ mp_obj_t mp_call_method_n_kw_var(bool have_self, mp_uint_t n_args_n_kw, const mp
     } else if (MP_OBJ_IS_TYPE(kw_dict, &mp_type_dict)) {
         // dictionary
         mp_map_t *map = mp_obj_dict_get_map(kw_dict);
+        uint i;
         assert(args2_len + 2 * map->used <= args2_alloc); // should have enough, since kw_dict_len is in this case hinted correctly above
-        for (uint i = 0; i < map->alloc; i++) {
+        for (i = 0; i < map->alloc; i++) {
             if (map->table[i].key != MP_OBJ_NULL) {
                 args2[args2_len++] = map->table[i].key;
                 args2[args2_len++] = map->table[i].value;
@@ -700,6 +702,7 @@ void mp_unpack_sequence(mp_obj_t seq_in, mp_uint_t num, mp_obj_t *items) {
     mp_uint_t seq_len;
     if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple) || MP_OBJ_IS_TYPE(seq_in, &mp_type_list)) {
         mp_obj_t *seq_items;
+        mp_uint_t i;
         if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple)) {
             mp_obj_tuple_get(seq_in, &seq_len, &seq_items);
         } else {
@@ -710,7 +713,7 @@ void mp_unpack_sequence(mp_obj_t seq_in, mp_uint_t num, mp_obj_t *items) {
         } else if (seq_len > num) {
             goto too_long;
         }
-        for (mp_uint_t i = 0; i < num; i++) {
+        for (i = 0; i < num; i++) {
             items[i] = seq_items[num - 1 - i];
         }
     } else {
@@ -741,6 +744,7 @@ void mp_unpack_ex(mp_obj_t seq_in, mp_uint_t num_in, mp_obj_t *items) {
     mp_uint_t num_right = (num_in >> 8) & 0xff;
     DEBUG_OP_printf("unpack ex " UINT_FMT " " UINT_FMT "\n", num_left, num_right);
     mp_uint_t seq_len;
+    mp_uint_t i;
     if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple) || MP_OBJ_IS_TYPE(seq_in, &mp_type_list)) {
         mp_obj_t *seq_items;
         if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple)) {
@@ -756,11 +760,11 @@ void mp_unpack_ex(mp_obj_t seq_in, mp_uint_t num_in, mp_obj_t *items) {
         if (seq_len < num_left + num_right) {
             goto too_short;
         }
-        for (mp_uint_t i = 0; i < num_right; i++) {
+        for (i = 0; i < num_right; i++) {
             items[i] = seq_items[seq_len - 1 - i];
         }
         items[num_right] = mp_obj_new_list(seq_len - num_left - num_right, seq_items + num_left);
-        for (mp_uint_t i = 0; i < num_left; i++) {
+        for (i = 0; i < num_left; i++) {
             items[num_right + 1 + i] = seq_items[num_left - 1 - i];
         }
     } else {
@@ -785,7 +789,7 @@ void mp_unpack_ex(mp_obj_t seq_in, mp_uint_t num_in, mp_obj_t *items) {
             goto too_short;
         }
         items[num_right] = rest;
-        for (mp_uint_t i = 0; i < num_right; i++) {
+        for (i = 0; i < num_right; i++) {
             items[num_right - 1 - i] = rest->items[rest->len - num_right + i];
         }
         mp_obj_list_set_len(rest, rest->len - num_right);
@@ -1125,7 +1129,8 @@ void mp_import_all(mp_obj_t module) {
 
     // TODO: Support __all__
     mp_map_t *map = mp_obj_dict_get_map(mp_obj_module_get_globals(module));
-    for (uint i = 0; i < map->alloc; i++) {
+    uint i;
+    for (i = 0; i < map->alloc; i++) {
         if (MP_MAP_SLOT_IS_FILLED(map, i)) {
             qstr name = MP_OBJ_QSTR_VALUE(map->table[i].key);
             if (*qstr_str(name) != '_') {

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -24,6 +24,13 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include "mpconfig.h"
+#include <mpconfigport.h>
+#include "obj.h"
+#include "qstr.h"
+
 typedef enum {
     MP_VM_RETURN_NORMAL,
     MP_VM_RETURN_YIELD,

--- a/py/runtime0.h
+++ b/py/runtime0.h
@@ -24,6 +24,8 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
 // taken from python source, Include/code.h
 // These must fit in 8 bits; see scope.h
 #define MP_SCOPE_FLAG_OPTIMISED    0x01

--- a/py/scope.c
+++ b/py/scope.c
@@ -109,7 +109,8 @@ id_info_t *scope_find_or_add_id(scope_t *scope, qstr qst, bool *added) {
 }
 
 id_info_t *scope_find(scope_t *scope, qstr qst) {
-    for (mp_uint_t i = 0; i < scope->id_info_len; i++) {
+    mp_uint_t i;
+    for (i = 0; i < scope->id_info_len; i++) {
         if (scope->id_info[i].qst == qst) {
             return &scope->id_info[i];
         }
@@ -125,10 +126,11 @@ id_info_t *scope_find_global(scope_t *scope, qstr qst) {
 }
 
 id_info_t *scope_find_local_in_parent(scope_t *scope, qstr qst) {
+    scope_t *s;
     if (scope->parent == NULL) {
         return NULL;
     }
-    for (scope_t *s = scope->parent; s->parent != NULL; s = s->parent) {
+    for (s = scope->parent; s->parent != NULL; s = s->parent) {
         id_info_t *id = scope_find(s, qst);
         if (id != NULL) {
             return id;
@@ -138,8 +140,9 @@ id_info_t *scope_find_local_in_parent(scope_t *scope, qstr qst) {
 }
 
 void scope_close_over_in_parents(scope_t *scope, qstr qst) {
+    scope_t *s;
     assert(scope->parent != NULL); // we should have at least 1 parent
-    for (scope_t *s = scope->parent; s->parent != NULL; s = s->parent) {
+    for (s = scope->parent; s->parent != NULL; s = s->parent) {
         bool added;
         id_info_t *id = scope_find_or_add_id(s, qst, &added);
         if (added) {

--- a/py/scope.h
+++ b/py/scope.h
@@ -24,6 +24,15 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <mpconfigport.h>
+#include "qstr.h"
+#include "parse.h"
+#include "emitglue.h"
+
 enum {
     ID_INFO_KIND_GLOBAL_IMPLICIT,
     ID_INFO_KIND_GLOBAL_EXPLICIT,

--- a/py/sequence.c
+++ b/py/sequence.c
@@ -44,7 +44,8 @@
 // Implements backend of sequence * integer operation. Assumes elements are
 // memory-adjacent in sequence.
 void mp_seq_multiply(const void *items, mp_uint_t item_sz, mp_uint_t len, mp_uint_t times, void *dest) {
-    for (int i = 0; i < times; i++) {
+    int i;
+    for (i = 0; i < times; i++) {
         uint copy_sz = item_sz * len;
         memcpy(dest, items, copy_sz);
         dest = (char*)dest + copy_sz;
@@ -186,7 +187,8 @@ bool mp_seq_cmp_objs(mp_uint_t op, const mp_obj_t *items1, mp_uint_t len1, const
     }
 
     int len = len1 < len2 ? len1 : len2;
-    for (int i = 0; i < len; i++) {
+    int i;
+    for (i = 0; i < len; i++) {
         // If current elements equal, can't decide anything - go on
         if (mp_obj_equal(items1[i], items2[i])) {
             continue;
@@ -223,6 +225,7 @@ mp_obj_t mp_seq_index_obj(const mp_obj_t *items, mp_uint_t len, mp_uint_t n_args
     mp_obj_t *value = args[1];
     uint start = 0;
     uint stop = len;
+    mp_uint_t i;
 
     if (n_args >= 3) {
         start = mp_get_index(type, len, args[2], true);
@@ -231,7 +234,7 @@ mp_obj_t mp_seq_index_obj(const mp_obj_t *items, mp_uint_t len, mp_uint_t n_args
         }
     }
 
-    for (mp_uint_t i = start; i < stop; i++) {
+    for (i = start; i < stop; i++) {
         if (mp_obj_equal(items[i], value)) {
             // Common sense says this cannot overflow small int
             return MP_OBJ_NEW_SMALL_INT(i);
@@ -243,7 +246,8 @@ mp_obj_t mp_seq_index_obj(const mp_obj_t *items, mp_uint_t len, mp_uint_t n_args
 
 mp_obj_t mp_seq_count_obj(const mp_obj_t *items, mp_uint_t len, mp_obj_t value) {
     mp_uint_t count = 0;
-    for (uint i = 0; i < len; i++) {
+    uint i;
+    for (i = 0; i < len; i++) {
          if (mp_obj_equal(items[i], value)) {
               count++;
          }

--- a/py/showbc.c
+++ b/py/showbc.c
@@ -94,10 +94,11 @@ void mp_bytecode_print(const void *descr, const byte *ip, int len) {
 
     // print out line number info
     {
+        const byte* ci;
         mp_int_t bc = (code_info + code_info_size) - ip;
         mp_uint_t source_line = 1;
-        printf("  bc=" INT_FMT " line=" UINT_FMT "\n", bc, source_line);
-        for (const byte* ci = code_info + 12; *ci;) {
+        printf("  bc=" INT_FMT " line=" UINT_FMT "\n", (int)bc, (unsigned int)source_line);
+        for (ci = code_info + 12; *ci;) {
             if ((ci[0] & 0x80) == 0) {
                 // 0b0LLBBBBB encoding
                 bc += ci[0] & 0x1f;
@@ -109,7 +110,7 @@ void mp_bytecode_print(const void *descr, const byte *ip, int len) {
                 source_line += ((ci[0] << 4) & 0x700) | ci[1];
                 ci += 2;
             }
-            printf("  bc=" INT_FMT " line=" UINT_FMT "\n", bc, source_line);
+            printf("  bc=" INT_FMT " line=" UINT_FMT "\n", (int)bc, (unsigned int)source_line);
         }
     }
     mp_bytecode_print2(ip, len - 0);
@@ -148,7 +149,7 @@ void mp_bytecode_print2(const byte *ip, int len) {
                 do {
                     num = (num << 7) | (*ip & 0x7f);
                 } while ((*ip++ & 0x80) != 0);
-                printf("LOAD_CONST_SMALL_INT " INT_FMT, num);
+                printf("LOAD_CONST_SMALL_INT " INT_FMT, (int)num);
                 break;
             }
 
@@ -190,12 +191,12 @@ void mp_bytecode_print2(const byte *ip, int len) {
 
             case MP_BC_LOAD_FAST_N:
                 DECODE_UINT;
-                printf("LOAD_FAST_N " UINT_FMT, unum);
+                printf("LOAD_FAST_N " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_LOAD_DEREF:
                 DECODE_UINT;
-                printf("LOAD_DEREF " UINT_FMT, unum);
+                printf("LOAD_DEREF " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_LOAD_NAME:
@@ -240,12 +241,12 @@ void mp_bytecode_print2(const byte *ip, int len) {
 
             case MP_BC_STORE_FAST_N:
                 DECODE_UINT;
-                printf("STORE_FAST_N " UINT_FMT, unum);
+                printf("STORE_FAST_N " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_STORE_DEREF:
                 DECODE_UINT;
-                printf("STORE_DEREF " UINT_FMT, unum);
+                printf("STORE_DEREF " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_STORE_NAME:
@@ -269,12 +270,12 @@ void mp_bytecode_print2(const byte *ip, int len) {
 
             case MP_BC_DELETE_FAST:
                 DECODE_UINT;
-                printf("DELETE_FAST " UINT_FMT, unum);
+                printf("DELETE_FAST " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_DELETE_DEREF:
                 DECODE_UINT;
-                printf("DELETE_DEREF " UINT_FMT, unum);
+                printf("DELETE_DEREF " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_DELETE_NAME:
@@ -304,32 +305,32 @@ void mp_bytecode_print2(const byte *ip, int len) {
 
             case MP_BC_JUMP:
                 DECODE_SLABEL;
-                printf("JUMP " UINT_FMT, ip + unum - ip_start);
+                printf("JUMP " UINT_FMT, (unsigned int)(ip + unum - ip_start));
                 break;
 
             case MP_BC_POP_JUMP_IF_TRUE:
                 DECODE_SLABEL;
-                printf("POP_JUMP_IF_TRUE " UINT_FMT, ip + unum - ip_start);
+                printf("POP_JUMP_IF_TRUE " UINT_FMT, (unsigned int)(ip + unum - ip_start));
                 break;
 
             case MP_BC_POP_JUMP_IF_FALSE:
                 DECODE_SLABEL;
-                printf("POP_JUMP_IF_FALSE " UINT_FMT, ip + unum - ip_start);
+                printf("POP_JUMP_IF_FALSE " UINT_FMT, (unsigned int)(ip + unum - ip_start));
                 break;
 
             case MP_BC_JUMP_IF_TRUE_OR_POP:
                 DECODE_SLABEL;
-                printf("JUMP_IF_TRUE_OR_POP " UINT_FMT, ip + unum - ip_start);
+                printf("JUMP_IF_TRUE_OR_POP " UINT_FMT, (unsigned int)(ip + unum - ip_start));
                 break;
 
             case MP_BC_JUMP_IF_FALSE_OR_POP:
                 DECODE_SLABEL;
-                printf("JUMP_IF_FALSE_OR_POP " UINT_FMT, ip + unum - ip_start);
+                printf("JUMP_IF_FALSE_OR_POP " UINT_FMT, (unsigned int)(ip + unum - ip_start));
                 break;
 
             case MP_BC_SETUP_WITH:
                 DECODE_ULABEL; // loop-like labels are always forward
-                printf("SETUP_WITH " UINT_FMT, ip + unum - ip_start);
+                printf("SETUP_WITH " UINT_FMT, (unsigned int)(ip + unum - ip_start));
                 break;
 
             case MP_BC_WITH_CLEANUP:
@@ -338,18 +339,18 @@ void mp_bytecode_print2(const byte *ip, int len) {
 
             case MP_BC_UNWIND_JUMP:
                 DECODE_SLABEL;
-                printf("UNWIND_JUMP " UINT_FMT " %d", ip + unum - ip_start, *ip);
+                printf("UNWIND_JUMP " UINT_FMT " %d", (unsigned int)(ip + unum - ip_start), *ip);
                 ip += 1;
                 break;
 
             case MP_BC_SETUP_EXCEPT:
                 DECODE_ULABEL; // except labels are always forward
-                printf("SETUP_EXCEPT " UINT_FMT, ip + unum - ip_start);
+                printf("SETUP_EXCEPT " UINT_FMT, (unsigned int)(ip + unum - ip_start));
                 break;
 
             case MP_BC_SETUP_FINALLY:
                 DECODE_ULABEL; // except labels are always forward
-                printf("SETUP_FINALLY " UINT_FMT, ip + unum - ip_start);
+                printf("SETUP_FINALLY " UINT_FMT, (unsigned int)(ip + unum - ip_start));
                 break;
 
             case MP_BC_END_FINALLY:
@@ -366,7 +367,7 @@ void mp_bytecode_print2(const byte *ip, int len) {
 
             case MP_BC_FOR_ITER:
                 DECODE_ULABEL; // the jump offset if iteration finishes; for labels are always forward
-                printf("FOR_ITER " UINT_FMT, ip + unum - ip_start);
+                printf("FOR_ITER " UINT_FMT, (unsigned int)(ip + unum - ip_start));
                 break;
 
             case MP_BC_POP_BLOCK:
@@ -385,32 +386,32 @@ void mp_bytecode_print2(const byte *ip, int len) {
 
             case MP_BC_UNARY_OP:
                 unum = *ip++;
-                printf("UNARY_OP " UINT_FMT, unum);
+                printf("UNARY_OP " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_BINARY_OP:
                 unum = *ip++;
-                printf("BINARY_OP " UINT_FMT, unum);
+                printf("BINARY_OP " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_BUILD_TUPLE:
                 DECODE_UINT;
-                printf("BUILD_TUPLE " UINT_FMT, unum);
+                printf("BUILD_TUPLE " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_BUILD_LIST:
                 DECODE_UINT;
-                printf("BUILD_LIST " UINT_FMT, unum);
+                printf("BUILD_LIST " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_LIST_APPEND:
                 DECODE_UINT;
-                printf("LIST_APPEND " UINT_FMT, unum);
+                printf("LIST_APPEND " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_BUILD_MAP:
                 DECODE_UINT;
-                printf("BUILD_MAP " UINT_FMT, unum);
+                printf("BUILD_MAP " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_STORE_MAP:
@@ -419,29 +420,29 @@ void mp_bytecode_print2(const byte *ip, int len) {
 
             case MP_BC_MAP_ADD:
                 DECODE_UINT;
-                printf("MAP_ADD " UINT_FMT, unum);
+                printf("MAP_ADD " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_BUILD_SET:
                 DECODE_UINT;
-                printf("BUILD_SET " UINT_FMT, unum);
+                printf("BUILD_SET " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_SET_ADD:
                 DECODE_UINT;
-                printf("SET_ADD " UINT_FMT, unum);
+                printf("SET_ADD " UINT_FMT, (unsigned int)unum);
                 break;
 
 #if MICROPY_PY_BUILTINS_SLICE
             case MP_BC_BUILD_SLICE:
                 DECODE_UINT;
-                printf("BUILD_SLICE " UINT_FMT, unum);
+                printf("BUILD_SLICE " UINT_FMT, (unsigned int)unum);
                 break;
 #endif
 
             case MP_BC_UNPACK_SEQUENCE:
                 DECODE_UINT;
-                printf("UNPACK_SEQUENCE " UINT_FMT, unum);
+                printf("UNPACK_SEQUENCE " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_MAKE_FUNCTION:
@@ -457,35 +458,35 @@ void mp_bytecode_print2(const byte *ip, int len) {
             case MP_BC_MAKE_CLOSURE: {
                 DECODE_PTR;
                 mp_uint_t n_closed_over = *ip++;
-                printf("MAKE_CLOSURE %p " UINT_FMT, (void*)unum, n_closed_over);
+                printf("MAKE_CLOSURE %p " UINT_FMT, (void*)unum, (unsigned int)n_closed_over);
                 break;
             }
 
             case MP_BC_MAKE_CLOSURE_DEFARGS: {
                 DECODE_PTR;
                 mp_uint_t n_closed_over = *ip++;
-                printf("MAKE_CLOSURE_DEFARGS %p " UINT_FMT, (void*)unum, n_closed_over);
+                printf("MAKE_CLOSURE_DEFARGS %p " UINT_FMT, (void*)unum, (unsigned int)n_closed_over);
                 break;
             }
 
             case MP_BC_CALL_FUNCTION:
                 DECODE_UINT;
-                printf("CALL_FUNCTION n=" UINT_FMT " nkw=" UINT_FMT, unum & 0xff, (unum >> 8) & 0xff);
+                printf("CALL_FUNCTION n=" UINT_FMT " nkw=" UINT_FMT, (unsigned int)(unum & 0xff), (unsigned int)((unum >> 8) & 0xff));
                 break;
 
             case MP_BC_CALL_FUNCTION_VAR_KW:
                 DECODE_UINT;
-                printf("CALL_FUNCTION_VAR_KW n=" UINT_FMT " nkw=" UINT_FMT, unum & 0xff, (unum >> 8) & 0xff);
+                printf("CALL_FUNCTION_VAR_KW n=" UINT_FMT " nkw=" UINT_FMT, (unsigned int)(unum & 0xff), (unsigned int)((unum >> 8) & 0xff));
                 break;
 
             case MP_BC_CALL_METHOD:
                 DECODE_UINT;
-                printf("CALL_METHOD n=" UINT_FMT " nkw=" UINT_FMT, unum & 0xff, (unum >> 8) & 0xff);
+                printf("CALL_METHOD n=" UINT_FMT " nkw=" UINT_FMT, (unsigned int)(unum & 0xff), (unsigned int)((unum >> 8) & 0xff));
                 break;
 
             case MP_BC_CALL_METHOD_VAR_KW:
                 DECODE_UINT;
-                printf("CALL_METHOD_VAR_KW n=" UINT_FMT " nkw=" UINT_FMT, unum & 0xff, (unum >> 8) & 0xff);
+                printf("CALL_METHOD_VAR_KW n=" UINT_FMT " nkw=" UINT_FMT, (unsigned int)(unum & 0xff), (unsigned int)((unum >> 8) & 0xff));
                 break;
 
             case MP_BC_RETURN_VALUE:
@@ -494,7 +495,7 @@ void mp_bytecode_print2(const byte *ip, int len) {
 
             case MP_BC_RAISE_VARARGS:
                 unum = *ip++;
-                printf("RAISE_VARARGS " UINT_FMT, unum);
+                printf("RAISE_VARARGS " UINT_FMT, (unsigned int)unum);
                 break;
 
             case MP_BC_YIELD_VALUE:

--- a/py/smallint.h
+++ b/py/smallint.h
@@ -24,6 +24,11 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <stdbool.h>
+#include <mpconfigport.h>
+
 // Functions for small integer arithmetic
 
 // In SMALL_INT, next-to-highest bits is used as sign, so both must match for value in range

--- a/py/stackctrl.h
+++ b/py/stackctrl.h
@@ -24,6 +24,10 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <mpconfigport.h>
+
 void mp_stack_ctrl_init();
 mp_uint_t mp_stack_usage();
 

--- a/py/stream.c
+++ b/py/stream.c
@@ -91,6 +91,7 @@ STATIC mp_obj_t stream_read(uint n_args, const mp_obj_t *args) {
         mp_uint_t more_bytes = sz;
         mp_uint_t last_buf_offset = 0;
         while (more_bytes > 0) {
+            mp_uint_t off;
             char *p = vstr_add_len(&vstr, more_bytes);
             if (p == NULL) {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_MemoryError, "out of memory"));
@@ -123,7 +124,7 @@ STATIC mp_obj_t stream_read(uint n_args, const mp_obj_t *args) {
             }
 
             // count chars from bytes just read
-            for (mp_uint_t off = last_buf_offset;;) {
+            for (off = last_buf_offset;;) {
                 byte b = vstr.buf[off];
                 int n;
                 if (!UTF8_IS_NONASCII(b)) {

--- a/py/stream.h
+++ b/py/stream.h
@@ -24,6 +24,11 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
+#include <mpconfigport.h>
+#include "obj.h"
+
 MP_DECLARE_CONST_FUN_OBJ(mp_stream_read_obj);
 MP_DECLARE_CONST_FUN_OBJ(mp_stream_readall_obj);
 MP_DECLARE_CONST_FUN_OBJ(mp_stream_unbuffered_readline_obj);

--- a/py/unicode.c
+++ b/py/unicode.c
@@ -69,9 +69,10 @@ STATIC const uint8_t attr[] = {
 unichar utf8_get_char(const byte *s) {
 #if MICROPY_PY_BUILTINS_STR_UNICODE
     unichar ord = *s++;
+    unichar mask;
     if (!UTF8_IS_NONASCII(ord)) return ord;
     ord &= 0x7F;
-    for (unichar mask = 0x40; ord & mask; mask >>= 1) {
+    for (mask = 0x40; ord & mask; mask >>= 1) {
         ord &= ~mask;
     }
     while (UTF8_IS_CONT(*s)) {
@@ -112,7 +113,8 @@ mp_uint_t unichar_charlen(const char *str, mp_uint_t len)
 {
 #if MICROPY_PY_BUILTINS_STR_UNICODE
     mp_uint_t charlen = 0;
-    for (const char *top = str + len; str < top; ++str) {
+    const char *top;
+    for (top = str + len; str < top; ++str) {
         if (!UTF8_IS_CONT(*str)) {
             ++charlen;
         }

--- a/py/unicode.h
+++ b/py/unicode.h
@@ -1,1 +1,32 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <mpconfigport.h>
+#include "misc.h"
+
 mp_uint_t utf8_ptr_to_index(const byte *s, const byte *ptr);

--- a/py/vm.c
+++ b/py/vm.c
@@ -793,9 +793,10 @@ unwind_return:
                     mp_obj_t obj;
                     assert(unum <= 1);
                     if (unum == 0) {
+                        mp_exc_stack_t *e;
                         // search for the inner-most previous exception, to reraise it
                         obj = MP_OBJ_NULL;
-                        for (mp_exc_stack_t *e = exc_sp; e >= exc_stack; e--) {
+                        for (e = exc_sp; e >= exc_stack; e--) {
                             if (e->prev_exc != MP_OBJ_NULL) {
                                 obj = e->prev_exc;
                                 break;

--- a/py/vmentrytable.h
+++ b/py/vmentrytable.h
@@ -24,6 +24,9 @@
  * THE SOFTWARE.
  */
 
+/* SPECIAL HEADER - Gets included inside table code */
+/* DO NOT USE INCLUDES */
+
 #if __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winitializer-overrides"

--- a/stmhal/readline.c
+++ b/stmhal/readline.c
@@ -39,9 +39,8 @@
 #include "uart.h"
 #include "pybstdio.h"
 
-#if 0 // print debugging info
-#define DEBUG_PRINT (1)
-#define DEBUG_printf printf
+#if DEBUG_PRINT
+#define DEBUG_printf DEBUG_printf
 #else // don't print debugging info
 #define DEBUG_printf(...) (void)0
 #endif


### PR DESCRIPTION
Hi,

I have made a number of changes to the code to give wider compatibility and usability. These include:
- Moving loop variable declarations out of "for loop" statements - gives errors with some compiler settings
- Consolidated debug printing so it can all be switched mpconfigport.h
- Ensure headers are only parsed once (I used "pragma once" but this could be done with ifdef instead)
- Make headers able to stand alone - i.e. each header has includes for all types it uses, so the header can be used by an external program as a single include.
- Add breaks at end of switch statements ( or add comments that tell eclipse static analyzer that it is an intentional fall-through. (Some were after asserts, and assert action depends on the platform and build)
- Cast printf arguments to match types - (some gcc options seem to give warnings even if "%d" uses a type that is typedef'd to int. (This might be better done with macros defined in mpconfigport.h)

Regards,

Evan
