### PR TITLE
Allow real memory errors (from locked gc) to be reported with traceback.

### DIFF
--- a/stmhal/printf.c
+++ b/stmhal/printf.c
@@ -67,8 +67,9 @@ int vprintf(const char *fmt, va_list ap) {
 }
 
 #if MICROPY_DEBUG_PRINTERS
+mp_uint_t mp_verbose_flag = 1;
+
 int DEBUG_printf(const char *fmt, ...) {
-    (void)stream;
     va_list ap;
     va_start(ap, fmt);
     int ret = pfenv_vprintf(&pfenv_stdout, fmt, ap);

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -72,7 +72,7 @@
 #endif
 
 #define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF   (1)
-#define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE  (128)
+#define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE  (256)
 
 extern const struct _mp_obj_module_t mp_module_os;
 extern const struct _mp_obj_module_t mp_module_time;


### PR DESCRIPTION
This is related to: http://forum.micropython.org/viewtopic.php?f=3&t=328

I was able to reproduce the problem in the unix microptyhon with the following code:

``` python
import gc

class Foo(object):
    def __init__(self):
        pass

    def bar(self):
        pass

x = Foo()

def Func():
    print("Func called")
    x.bar
    print("After x")

gc.disable()
Func()
gc.enable()
```

If I run under unix micropython then I get the following reported:

```
>>> import x
Func called
MemoryError:
```

with no traceback information.

I've tracked down the memory allocation failure to this line:
https://github.com/micropython/micropython/blob/master/py/runtime.c#L813

It should fail here since we're trying to do a memory allocation while the heap is locked. But the issue is, why is there no traceback?

The issue is that the code for using the special exception buffer exists in the mp_obj_new_exception_msg_varg function, and m_malloc_fail calls:

``` C
nlr_raise((mp_obj_t)&mp_const_MemoryError_obj);
```

If I change m_malloc_fail to use:

``` C
    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_MemoryError,
                                            "memory allocation failed, allocating " UINT_FMT " bytes", num_bytes));
```

instead, and increase the size of the exception buffer to 256 bytes, then I now get this failure:

```
Func called
Traceback (most recent call last):
  File "x.py", line 18, in <module>
  File "x.py", line 14, in Func
MemoryError: memory allocation failed, allocating 24 bytes
```

With this patch, the original pyboard code:

``` python
import pyb
import micropython
micropython.alloc_emergency_exception_buf(200)

sw = pyb.Switch()

def BTN_callback():
    pyb.LED(1).toggle

sw.callback(BTN_callback)
```

Now produces this error:

```
>>> import switch
>>> Uncaught exception in ExtInt interrupt handler line 3
Traceback (most recent call last):
  File "switch.py", line 8, in BTN_callback
MemoryError: memory allocation failed, allocating 12 bytes
```
