### PR TITLE
Make lexer fail gracefully when memory can't be allocated.

### DIFF
--- a/py/lexerstr.c
+++ b/py/lexerstr.c
@@ -52,7 +52,10 @@ STATIC void str_buf_free(mp_lexer_str_buf_t *sb) {
 }
 
 mp_lexer_t *mp_lexer_new_from_str_len(qstr src_name, const char *str, mp_uint_t len, mp_uint_t free_len) {
-    mp_lexer_str_buf_t *sb = m_new_obj(mp_lexer_str_buf_t);
+    mp_lexer_str_buf_t *sb = m_new_maybe(mp_lexer_str_buf_t, 1);
+    if (sb == NULL) {
+        return NULL;
+    }
     sb->free_len = free_len;
     sb->src_beg = str;
     sb->src_cur = str;


### PR DESCRIPTION
This should address the issue raised in #895 

With this patch, you now get:

``` python
>>> import gc
>>> gc.disable()
>>> gc.enable()
MemoryError
```

rather than a fatal error.

We're still hooped, in that no further code can be executed, but you can still hit Control-D and get a soft-reset.
