### PR TITLE
Add support for complimentary channel output and deadtime.

### DIFF
--- a/stmhal/qstrdefsport.h
+++ b/stmhal/qstrdefsport.h
@@ -198,6 +198,7 @@ Q(pulse_width_percent)
 Q(compare)
 Q(capture)
 Q(polarity)
+Q(deadtime)
 
 // for ExtInt class
 Q(ExtInt)


### PR DESCRIPTION
This patch enables output on the complimentary channels (TIMx_CHyN).
Timers 1 and 8 have complimentary channels available (on the pyboard, for timer 1, only complimentary channels are available).

When available (Timers 1 and 8, Channels 1-3) deadtime can also be inserted when the channels
transition. For the pyboard, TIM8_CH1/CH1N and TIM8_CH2/CH2N can
take advantage of this.

Using deadtime is extremely useful when you're using the complimentary channnels to directly drive the top and bottom halves of an H-Bridge. The deadtime allows both the top and bottom to be inactive when transittioning. Otherwise you wind up with short periods of time when Vcc is shorted to ground (while the MOFETs are switching).
