### PR TITLE
Add module weak-ref support.

### DIFF
--- a/py/builtintables.c
+++ b/py/builtintables.c
@@ -227,3 +227,20 @@ const mp_obj_dict_t mp_builtin_module_dict_obj = {
         .table = (mp_map_elem_t*)mp_builtin_module_table,
     },
 };
+
+#if MICROPY_MODULE_WEAK_REF
+STATIC const mp_map_elem_t mp_builtin_module_weak_ref_table[] = {
+    MICROPY_PORT_BUILTIN_MODULE_WEAK_REFS
+};
+
+const mp_obj_dict_t mp_builtin_module_weak_ref_dict_obj = {
+    .base = {&mp_type_dict},
+    .map = {
+        .all_keys_are_qstrs = 1,
+        .table_is_fixed_array = 1,
+        .used = MP_ARRAY_SIZE(mp_builtin_module_weak_ref_table),
+        .alloc = MP_ARRAY_SIZE(mp_builtin_module_weak_ref_table),
+        .table = (mp_map_elem_t*)mp_builtin_module_weak_ref_table,
+    },
+};
+#endif

--- a/py/builtintables.h
+++ b/py/builtintables.h
@@ -26,3 +26,7 @@
 
 extern const mp_obj_dict_t mp_builtin_object_dict_obj;
 extern const mp_obj_dict_t mp_builtin_module_dict_obj;
+
+#if MICROPY_MODULE_WEAK_REF
+extern const mp_obj_dict_t mp_builtin_module_weak_ref_dict_obj;
+#endif

--- a/stmhal/mpconfigport.h
+++ b/stmhal/mpconfigport.h
@@ -48,6 +48,7 @@
 */
 #define MICROPY_ENABLE_LFN          (1)
 #define MICROPY_LFN_CODE_PAGE       (437) /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */
+#define MICROPY_MODULE_WEAK_REF     (1)
 #define MICROPY_PY_BUILTINS_STR_UNICODE (1)
 #define MICROPY_PY_BUILTINS_FROZENSET (1)
 #define MICROPY_PY_SYS_EXIT         (1)
@@ -88,8 +89,10 @@ extern const struct _mp_obj_module_t mp_module_network;
     { MP_OBJ_NEW_QSTR(MP_QSTR_time), (mp_obj_t)&time_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_select), (mp_obj_t)&mp_module_select }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_usocket), (mp_obj_t)&mp_module_usocket }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_socket), (mp_obj_t)&mp_module_usocket }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_network), (mp_obj_t)&mp_module_network }, \
+
+#define MICROPY_PORT_BUILTIN_MODULE_WEAK_REFS \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_socket), (mp_obj_t)&mp_module_usocket }, \
 
 // extra constants
 #define MICROPY_PORT_CONSTANTS \


### PR DESCRIPTION
With this patch a port can enable module weak-ref support and provide a
dict of qstr->module mapping.  This mapping is looked up only if an
import fails to find the requested module in the filesystem.

This allows to have the builtin module named, eg, usocket, and provide
a weak-ref of "socket" to the same module, but this weak-ref can be
overridden if a file by the name "socket.py" is found in the import
path.
