### PR TITLE
stmhal: Set entry point for ELF binary debugging

### DIFF
--- a/stmhal/stm32f405.ld
+++ b/stmhal/stm32f405.ld
@@ -11,7 +11,9 @@ MEMORY
     CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 0x010000 /* 64 KiB */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x020000 /* 128 KiB */
 }
- 
+
+ENTRY(Reset_Handler)
+
 /* produce a link error if there is not this amount of RAM for these sections */
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;


### PR DESCRIPTION
When loading the ELF binary to the board with a debugger, the debugger
needs to know at which point to start executing the code. Currently the
entry point defaults to the start of the .text section.

Signed-off-by: Sven Wegener sven.wegener@stealer.net
