### PR TITLE
USB CDC ACM: populate bFunction{Class,SubClass,Protocol} in the interface association descriptor

### DIFF
--- a/stmhal/usbdev/class/cdc_msc_hid/src/usbd_cdc_msc_hid.c
+++ b/stmhal/usbdev/class/cdc_msc_hid/src/usbd_cdc_msc_hid.c
@@ -92,9 +92,9 @@ __ALIGN_BEGIN static uint8_t USBD_CDC_MSC_CfgDesc[USB_CDC_MSC_CONFIG_DESC_SIZ] _
     USB_DESC_TYPE_ASSOCIATION, // bDescriptorType: IAD
     CDC_IFACE_NUM, // bFirstInterface: first interface for this association
     0x02,   // bInterfaceCount: nummber of interfaces for this association
-    0x00,   // bFunctionClass: ?
-    0x00,   // bFunctionSubClass: ?
-    0x00,   // bFunctionProtocol: ?
+    0x02,   // bFunctionClass: Communication Interface Class
+    0x02,   // bFunctionSubClass: Abstract Control Model
+    0x01,   // bFunctionProtocol: Common AT commands
     0x00,   // iFunction: index of string for this function
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
I hope I get this correct.

Windows currently doesn't automatically load the CDC-ACM driver (and hence requires an .inf file, or manually installing the driver via "chose driver") because it does not see the compatibility of the CDC aspect of the default CDC+MSD configuration.

usbser.inf (that ships with windows) binds to UsbSerial_Install, USB\Class_02&SubClass_02, but by default the pyboard is detected as USB\Class_00&SubClass_00 in the "compatible IDs".

This is because an interface association descriptor is present that - and now my understanding of the USB specs get a bit fuzzy - overrides the class codes of the underlying interface descriptor.

The interface descriptor correctly specifies bInterfaceClass=2, bInterfaceSubClass=2, bInterfaceProtocol=1, but the IAD does not (bFunctionClass=0, bFunctionSubClass=0, bFunctionProtocol=0, which is illegal according to http://www.usb.org/developers/docs/InterfaceAssociationDescriptor_ecn.pdf: Table 9-Z, bFunctionClass, "A value of zero is not allowed in this descriptor. ")

I believe we need to fill in the CDC-ACM class code (bFunctionClass=2, bFunctionSubClass=2, bFunctionProtocol=1); and indeed, in makes Windows see the device as "Compatible Ids: USB\Class_02&SubClass_02&Prot_01", and it loads the usbser driver by default.

This patch changes the IAD bFunction{Class,SubClass,Protocol} codes to 2/2/1 respectively.

TESTED: Windows 10 (Technical Preview), build 9841

OLD BEHAVIOR: Did not find driver, displayed "Pyboard Virtual Comm Port in FS Mode" with exclamation mark
NEW BEHAVIOR: automatically loads drivers and assigns COM port ("USB Serial Device").
