### PR TITLE
unix: Make -v dump memory info at exit.

### DIFF
--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -67,7 +67,7 @@ void mp_emit_glue_assign_bytecode(mp_raw_code_t *rc, byte *code, mp_uint_t len, 
     DEBUG_printf("assign byte code: code=%p len=" UINT_FMT " n_pos_args=" UINT_FMT " n_kwonly_args=" UINT_FMT " flags=%x\n", code, len, n_pos_args, n_kwonly_args, (uint)scope_flags);
 #endif
 #if MICROPY_DEBUG_PRINTERS
-    if (mp_verbose_flag > 0) {
+    if (mp_verbose_flag >= 2) {
         mp_bytecode_print(rc, n_pos_args + n_kwonly_args, code, len);
     }
 #endif

--- a/unix/main.c
+++ b/unix/main.c
@@ -506,6 +506,10 @@ int main(int argc, char **argv) {
         ret = do_repl();
     }
 
+    if (mp_verbose_flag) {
+        mem_info(0, NULL);
+    }
+
     mp_deinit();
 
 #if MICROPY_ENABLE_GC && !defined(NDEBUG)


### PR DESCRIPTION
Also, move bytecode dumps to -v -v, because they're too verbose for just -v.
