### PR TITLE
mpz: Fix 64bit msvc build

### DIFF
--- a/py/mpz.c
+++ b/py/mpz.c
@@ -37,9 +37,9 @@
 #if MICROPY_LONGINT_IMPL == MICROPY_LONGINT_IMPL_MPZ
 
 #define DIG_SIZE (MPZ_DIG_SIZE)
-#define DIG_MASK ((1L << DIG_SIZE) - 1)
-#define DIG_MSB  (1L << (DIG_SIZE - 1))
-#define DIG_BASE (1L << DIG_SIZE)
+#define DIG_MASK ((MPZ_LONG_1 << DIG_SIZE) - 1)
+#define DIG_MSB  (MPZ_LONG_1 << (DIG_SIZE - 1))
+#define DIG_BASE (MPZ_LONG_1 << DIG_SIZE)
 
 /*
  mpz is an arbitrary precision integer type with a public API.

--- a/py/mpz.h
+++ b/py/mpz.h
@@ -36,7 +36,7 @@
 // depending on the machine, but it (and MPZ_DIG_SIZE) can be freely changed so
 // long as the constraints mentioned above are met.
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(_WIN64)
 // 64-bit machine, using 32-bit storage for digits
 typedef uint32_t mpz_dig_t;
 typedef uint64_t mpz_dbl_dig_t;
@@ -48,6 +48,12 @@ typedef uint16_t mpz_dig_t;
 typedef uint32_t mpz_dbl_dig_t;
 typedef int32_t mpz_dbl_dig_signed_t;
 #define MPZ_DIG_SIZE (16)
+#endif
+
+#ifdef _WIN64
+  #define MPZ_LONG_1 1i64
+#else
+  #define MPZ_LONG_1 1L
 #endif
 
 #define MPZ_NUM_DIG_FOR_INT (sizeof(mp_int_t) * 8 / MPZ_DIG_SIZE + 1)

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -45,7 +45,7 @@
 
 #if MICROPY_PY_SYS_MAXSIZE
 // Export value for sys.maxsize
-#define DIG_MASK ((1L << MPZ_DIG_SIZE) - 1)
+#define DIG_MASK ((MPZ_LONG_1 << MPZ_DIG_SIZE) - 1)
 STATIC const mpz_dig_t maxsize_dig[MPZ_NUM_DIG_FOR_INT] = {
     (MP_SSIZE_MAX >> MPZ_DIG_SIZE * 0) & DIG_MASK,
     #if (MP_SSIZE_MAX >> MPZ_DIG_SIZE * 0) > DIG_MASK


### PR DESCRIPTION
msvc does not treat 1L a 64bit integer hence all occurences of shifting it left or right
result in undefined behaviour since the maximum allowed shift count for 32bit ints is 31.
Forcing the correct type explicitely, stored in MPZ_LONG_1, solves this.
