### PR TITLE
unix: Provide "fast" target to build interpreter for benchmarking.

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -129,3 +129,8 @@ install: micropython
 uninstall:
 	-rm $(BINDIR)/$(TARGET)
 	-rm $(BINDIR)/$(PIPTARGET)
+
+# build synthetically fast interpreter for benchmarking
+fast:
+	@echo Make sure to run make -B
+	$(MAKE) COPT="-O2 -DNDEBUG" CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_fast.h>"' BUILD=build-fast

--- a/unix/mpconfigport_fast.h
+++ b/unix/mpconfigport_fast.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// This config file is intended to configure artificially fast uPy build for
+// synthetic benchmarking, at the expense of features supported and memory
+// usage. This config is not intended to be used in production.
+
+#include <mpconfigport.h>
+#define MICROPY_PY___FILE__ (0)


### PR DESCRIPTION
This build is not intended for real use, but rather for benchmarking,
and may have random features enabled/disabled to get high scores
in synthetic benchmarks. The intent is to show/prove that MicroPython
codebase can compete with CPython, when configured appropriately. But
the main MicroPython aim still remains to optimize for memory usage
(which inevitibly leads to performance degradation in some areas on
some workloads).
