### PR TITLE
Set Class,Subclass,Protocol in USB Device Descriptor

### DIFF
--- a/stmhal/usbd_desc_cdc_msc.c
+++ b/stmhal/usbd_desc_cdc_msc.c
@@ -54,9 +54,9 @@ __ALIGN_BEGIN static uint8_t hUSBDDeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
     USB_DESC_TYPE_DEVICE,       // bDescriptorType
     0x00,                       // bcdUSB
     0x02,
-    0x00,                       // bDeviceClass
-    0x00,                       // bDeviceSubClass
-    0x00,                       // bDeviceProtocol
+    0xEF,                       // bDeviceClass: Miscellaneous Device Class
+    0x02,                       // bDeviceSubClass: Common Class
+    0x01,                       // bDeviceProtocol: Interface Association Descriptor
     USB_MAX_EP0_SIZE,           // bMaxPacketSize
     LOBYTE(USBD_VID),           // idVendor
     HIBYTE(USBD_VID),           // idVendor


### PR DESCRIPTION
Composite Devices with IADs should use those values, see [USB Interface Association Descriptor](http://msdn.microsoft.com/en-us/library/windows/hardware/ff540054%28v=vs.85%29.aspx):

> The USB-IF core team has devised a special class and protocol code set that notifies the operating system that one or more IADs are present in device firmware. A device's device descriptor must have the values that appear in the following table or else the operating system will not detect the device's IADs or group the device's interfaces properly.   

And   

> These code values also alert versions of Windows that do not support IADs to install a special-purpose bus driver that correctly enumerates the device. Without these codes in the device descriptor, the system might fail to enumerate the device, or the device might not work properly
