### PR TITLE
py: Add py-version.h order-only dependency to all objects

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -59,7 +59,7 @@ $(BUILD)/%.pp: %.c
 # object directories (but only for existence), and the object directories
 # will be created if they don't exist.
 OBJ_DIRS = $(sort $(dir $(OBJ)))
-$(OBJ): $(HEADER_BUILD)/qstrdefs.generated.h | $(OBJ_DIRS)
+$(OBJ): $(HEADER_BUILD)/qstrdefs.generated.h | $(OBJ_DIRS) $(HEADER_BUILD)/py-version.h
 $(OBJ_DIRS):
 	$(MKDIR) -p $@
 

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -53,13 +53,20 @@ $(BUILD)/%.pp: %.c
 # prerequisites only get built if they don't exist. They don't cause timestamp
 # checking to be performed.
 #
+# We don't know which source files actually need the generated.h (since
+# it is #included from str.h). The compiler generated dependencies will cause
+# the right .o's to get recompiled if the generated.h file changes. Adding
+# an order-only dependendency to all of the .o's will cause the generated .h
+# to get built before we try to compile any of them.
+$(OBJ): | $(HEADER_BUILD)/qstrdefs.generated.h $(HEADER_BUILD)/py-version.h
+
 # $(sort $(var)) removes duplicates
 #
 # The net effect of this, is it causes the objects to depend on the
 # object directories (but only for existence), and the object directories
 # will be created if they don't exist.
 OBJ_DIRS = $(sort $(dir $(OBJ)))
-$(OBJ): $(HEADER_BUILD)/qstrdefs.generated.h | $(OBJ_DIRS) $(HEADER_BUILD)/py-version.h
+$(OBJ): | $(OBJ_DIRS)
 $(OBJ_DIRS):
 	$(MKDIR) -p $@
 

--- a/py/py.mk
+++ b/py/py.mk
@@ -137,13 +137,6 @@ $(HEADER_BUILD)/qstrdefs.generated.h: $(PY_QSTR_DEFS) $(QSTR_DEFS) $(PY_SRC)/mak
 	$(ECHO) "makeqstrdata $(PY_QSTR_DEFS) $(QSTR_DEFS)"
 	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdata.py $(HEADER_BUILD)/qstrdefs.preprocessed.h $(QSTR_DEFS) > $@
 
-# We don't know which source files actually need the generated.h (since
-# it is #included from str.h). The compiler generated dependencies will cause
-# the right .o's to get recompiled if the generated.h file changes. Adding
-# an order-only dependendency to all of the .o's will cause the generated .h
-# to get built before we try to compile any of them.
-$(PY_O): | $(HEADER_BUILD)/qstrdefs.generated.h $(HEADER_BUILD)/py-version.h
-
 # emitters
 
 $(PY_BUILD)/emitnx64.o: CFLAGS += -DN_X64


### PR DESCRIPTION
One more small build fix:

Currently compilation sporadically fails, because the automatic
dependency gets created _during_ the compilation of objects.
