### PR TITLE
Changes to nrf24l01 driver: nonblocking send option etc.

### DIFF
--- a/drivers/nrf24l01/nrf24l01.py
+++ b/drivers/nrf24l01/nrf24l01.py
@@ -1,10 +1,4 @@
 """NRF24L01 driver for Micro Python
-
-Support for nonblocking send added. Minor fixes:
-Timeout now uses pyb.elapsed_millis().
-Channel numbers constrained to 125 as per datasheet.
-Status register read with reg_read() - reg_read_ret_status() removed.
-Default speed 250K for improved range/error rate.
 """
 
 import pyb
@@ -145,7 +139,7 @@ class NRF24L01:
         self.reg_write(CONFIG, config)
 
     def set_channel(self, channel):
-        self.reg_write(RF_CH, min(channel, 125)) # Changed from 127
+        self.reg_write(RF_CH, min(channel, 125))
 
     # address should be a bytes object 5 bytes long
     def open_tx_pipe(self, address):
@@ -207,44 +201,39 @@ class NRF24L01:
         start = pyb.millis()
         result = None
         while result is None and (pyb.elapsed_millis(start) < timeout):
-            result = send_nonblock() # 1 == success 2 == fail
+            result = next(send_nonblock) # 1 == success 2 == fail
         if result == 2:
             raise OSError("send failed")
 
     def send_nonblocking(self, buf):
         '''
-        Support for nonblocking transmission. Returns a function instance.
-        The first call to a function instance sends the data and returns None.
-        Subsequent calls test TX status returning not ready None, ready 1, error 2.
+        Support for nonblocking transmission. Returns a generator instance.
+        First use sends the data and returns None. Subsequently tests TX status
+        returning not ready None, ready 1, error 2.
         '''
-        init = True
-        def make_snb():
-            nonlocal init
-            if init:
-                # power up
-                self.reg_write(CONFIG, (self.reg_read(CONFIG) | PWR_UP) & ~PRIM_RX)
-                pyb.udelay(150)
+        # power up
+        self.reg_write(CONFIG, (self.reg_read(CONFIG) | PWR_UP) & ~PRIM_RX)
+        pyb.udelay(150)
 
-                # send the data
-                self.cs.low()
-                self.spi.send(W_TX_PAYLOAD)
-                self.spi.send(buf)
-                if len(buf) < self.payload_size:
-                    self.spi.send(b'\x00' * (self.payload_size - len(buf))) # pad out data
-                self.cs.high()
+        # send the data
+        self.cs.low()
+        self.spi.send(W_TX_PAYLOAD)
+        self.spi.send(buf)
+        if len(buf) < self.payload_size:
+            self.spi.send(b'\x00' * (self.payload_size - len(buf))) # pad out data
+        self.cs.high()
 
-                # enable the chip so it can send the data
-                self.ce.high()
-                pyb.udelay(15) # needs to be >10us
-                self.ce.low()
-                init = False
-                return None # Not ready
+        # enable the chip so it can send the data
+        self.ce.high()
+        pyb.udelay(15) # needs to be >10us
+        self.ce.low()
+        init = False
+        yield None # Not ready
 
-            if not (self.reg_read(STATUS) & (TX_DS | MAX_RT)):
-                return None # Not ready
-            # Either ready or failed: get and clear status flags, power down
-            status = self.reg_write(STATUS, RX_DR | TX_DS | MAX_RT)
-            self.reg_write(CONFIG, self.reg_read(CONFIG) & ~PWR_UP)
-            return 1 if status & TX_DS else 2
-        return make_snb
+        while not (self.reg_read(STATUS) & (TX_DS | MAX_RT)):
+            yield None # Not ready
+        # Either ready or failed: get and clear status flags, power down
+        status = self.reg_write(STATUS, RX_DR | TX_DS | MAX_RT)
+        self.reg_write(CONFIG, self.reg_read(CONFIG) & ~PWR_UP)
+        yield 1 if status & TX_DS else 2
 

--- a/drivers/nrf24l01/nrf24l01.py
+++ b/drivers/nrf24l01/nrf24l01.py
@@ -227,7 +227,6 @@ class NRF24L01:
         self.ce.high()
         pyb.udelay(15) # needs to be >10us
         self.ce.low()
-        init = False
         yield None # Not ready
 
         while not (self.reg_read(STATUS) & (TX_DS | MAX_RT)):


### PR DESCRIPTION
Principal changes:
1. Constructor throws exception on hardware failure.
2. A new method for nonblocking send, blocking send() method amended to use it.
3. Change default speed to 256K: this improves range/error rate.
4. Channel numbers constrained to 125 rather than 127. (As per datasheet.)
5. reg_read_ret_status() method removed. Replaced by a reg_read(STATUS) (simplification of code).
