### PR TITLE
Document parameter "data" of i2c.mem_read() more clear

### DIFF
--- a/docs/library/pyb.I2C.rst
+++ b/docs/library/pyb.I2C.rst
@@ -91,7 +91,7 @@ Methods
 
    Read from the memory of an I2C device:
    
-     - ``data`` can be an integer or a buffer to read into
+     - ``data`` can be an integer (number of bytes to read) or a buffer to read into
      - ``addr`` is the I2C device address
      - ``memaddr`` is the memory location within the I2C device
      - ``timeout`` is the timeout in milliseconds to wait for the read


### PR DESCRIPTION
Hi,

i would like to add a little clarification to the parameter "data" of i2c.mem_read(): I misunderstood 

```
    ``data`` can be an integer or a buffer to read into
```

as "i can give a integer variable to read a integer into" .  This pull-request adds the following clarification:

```
     ``data`` can be an integer (number of bytes to read) or a buffer to read into
```

Thanks for your great work!

Best wishes,
Matthias
