### PR TITLE
tests/run-tests: set PYTHONIOENCODING='utf-8' 

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -17,6 +17,9 @@ else:
     CPYTHON3 = os.getenv('MICROPY_CPYTHON3', 'python3')
     MICROPYTHON = os.getenv('MICROPY_MICROPYTHON', '../unix/micropython')
 
+# Set PYTHONIOENCODING so that CPython will use utf-8 on systems which set another encoding in the locale
+os.environ['PYTHONIOENCODING']='utf-8'
+
 def rm_f(fname):
     if os.path.exists(fname):
         os.remove(fname)


### PR DESCRIPTION
This change allows certain unicode tests to pass on CPython on systems where another encoding is set in the locale

Should resolve #874 
