### PR TITLE
Clean up differences between print() and repr_print()

### DIFF
--- a/py/builtin.c
+++ b/py/builtin.c
@@ -89,15 +89,6 @@ STATIC mp_obj_t mp_builtin___build_class__(mp_uint_t n_args, const mp_obj_t *arg
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR(mp_builtin___build_class___obj, 2, mp_builtin___build_class__);
 
-STATIC mp_obj_t mp_builtin___repl_print__(mp_obj_t o) {
-    if (o != mp_const_none) {
-        mp_obj_print(o, PRINT_REPR);
-        printf("\n");
-    }
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin___repl_print___obj, mp_builtin___repl_print__);
-
 STATIC mp_obj_t mp_builtin_abs(mp_obj_t o_in) {
     if (MP_OBJ_IS_SMALL_INT(o_in)) {
         mp_int_t val = MP_OBJ_SMALL_INT_VALUE(o_in);
@@ -451,6 +442,14 @@ STATIC mp_obj_t mp_builtin_print(mp_uint_t n_args, const mp_obj_t *args, mp_map_
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_print_obj, 0, mp_builtin_print);
+
+STATIC mp_obj_t mp_builtin___repl_print__(mp_obj_t o) {
+    if (o != mp_const_none) {
+        mp_builtin_print(1, &o, &mp_const_empty_map);
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin___repl_print___obj, mp_builtin___repl_print__);
 
 STATIC mp_obj_t mp_builtin_repr(mp_obj_t o_in) {
     vstr_t *vstr = vstr_new();

--- a/py/map.c
+++ b/py/map.c
@@ -34,6 +34,16 @@
 #include "obj.h"
 #include "runtime0.h"
 
+// Fixed empty map. Useful when need to call kw-receiving functions
+// without any keywords from C, etc.
+mp_map_t mp_const_empty_map = {
+    .all_keys_are_qstrs = 0,
+    .table_is_fixed_array = 1,
+    .used = 0,
+    .alloc = 0,
+    .table = NULL,
+};
+
 // approximatelly doubling primes; made with Mathematica command: Table[Prime[Floor[(1.7)^n]], {n, 3, 24}]
 // prefixed with zero for the empty case.
 STATIC uint32_t doubling_primes[] = {0, 7, 19, 43, 89, 179, 347, 647, 1229, 2297, 4243, 7829, 14347, 26017, 47149, 84947, 152443, 273253, 488399, 869927, 1547173, 2745121, 4861607};

--- a/py/obj.h
+++ b/py/obj.h
@@ -159,6 +159,8 @@ mp_map_elem_t* mp_map_lookup(mp_map_t *map, mp_obj_t index, mp_map_lookup_kind_t
 void mp_map_clear(mp_map_t *map);
 void mp_map_dump(mp_map_t *map);
 
+extern mp_map_t mp_const_empty_map;
+
 // Underlying set implementation (not set object)
 
 typedef struct _mp_set_t {

--- a/py/pfenv_printf.c
+++ b/py/pfenv_printf.c
@@ -146,12 +146,14 @@ int pfenv_vprintf(const pfenv_t *pfenv, const char *fmt, va_list args) {
                 chrs += pfenv_print_int(pfenv, va_arg(args, int), 1, 10, 'a', flags, fill, width);
                 break;
             case 'x':
-            case 'p': // ?
                 chrs += pfenv_print_int(pfenv, va_arg(args, int), 0, 16, 'a', flags, fill, width);
                 break;
             case 'X':
-            case 'P': // ?
                 chrs += pfenv_print_int(pfenv, va_arg(args, int), 0, 16, 'A', flags, fill, width);
+                break;
+            case 'p':
+            case 'P': // don't bother to handle upcase for 'P'
+                chrs += pfenv_print_int(pfenv, va_arg(args, mp_uint_t), 0, 16, 'a', flags, fill, width);
                 break;
 #if MICROPY_PY_BUILTINS_FLOAT
             case 'e':


### PR DESCRIPTION
To see the problem, try following commands in interactive prompt on x64:

```
>>> class A: pass
... 
>>> A()
<A object at 0x7fc3b7925f00>
>>> print(A())
<A object at ffffffffb7926000>
```

As can be seen, 1) using print() truncates %p format spec value to 32 bit. Fixing that, there's still discrepancy in that `__repr_print__` prints value with "0x" prefix, while print() - without. That's because former uses libc implementation of printf(), while the latter - our own. I was reluctant changing that, but figuring out that in CPython, overriding sys.stdout makes implicit interactive prints go to it, it's clear that `__repr_print__` should behave like `print`.

That's still only partially resolve issue still, as:

```
print(str(A()))
```

still uses system routines (and has "0x" prefix), so more refactoring is needed to achieve consistency.
