### PR TITLE
run-tests: Allow to run testuite against Windows build on Linux (using Wine)

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -121,6 +121,10 @@ def run_tests(pyb, tests, args):
 
         # run Micro Python
         output_mupy = run_micropython(pyb, args, test_file)
+        if os.name != 'nt':
+            # It may be the case that we run Windows build under Linux
+            # (using Wine).
+            output_mupy = output_mupy.replace(b'\r\n', b'\n')
 
         if output_mupy == b'SKIP\n':
             print("skip ", test_file)


### PR DESCRIPTION
Just adjust line-endings of micropython.exe output, the rest should be
handled by Wine (automagically on properly configured distro).

To run:

MICROPY_MICROPYTHON=../windows/micropython.exe ./run-tests
