### PR TITLE
py: Move all global state (variables) to a common place.

### DIFF
--- a/py/builtin.h
+++ b/py/builtin.h
@@ -86,7 +86,6 @@ extern const mp_obj_module_t mp_module_sys;
 extern const mp_obj_module_t mp_module_gc;
 
 extern const mp_obj_dict_t mp_module_builtins_globals;
-extern mp_obj_dict_t *mp_module_builtins_override_dict;
 
 struct _dummy_t;
 extern struct _dummy_t mp_sys_stdin_obj;

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -392,7 +392,7 @@ STATIC void emit_bc_adjust_stack_size(emit_t *emit, mp_int_t delta) {
 STATIC void emit_bc_set_source_line(emit_t *emit, mp_uint_t source_line) {
     //printf("source: line %d -> %d  offset %d -> %d\n", emit->last_source_line, source_line, emit->last_source_line_offset, emit->bytecode_offset);
 #if MICROPY_ENABLE_SOURCE_LINE
-    if (mp_optimise_value >= 3) {
+    if (mp_state.mp_optimise_value >= 3) {
         // If we compile with -O3, don't store line numbers.
         return;
     }

--- a/py/gc.c
+++ b/py/gc.c
@@ -53,26 +53,6 @@
 
 #define WORDS_PER_BLOCK (4)
 #define BYTES_PER_BLOCK (WORDS_PER_BLOCK * BYTES_PER_WORD)
-#define STACK_SIZE (64) // tunable; minimum is 1
-
-STATIC byte *gc_alloc_table_start;
-STATIC mp_uint_t gc_alloc_table_byte_len;
-#if MICROPY_ENABLE_FINALISER
-STATIC byte *gc_finaliser_table_start;
-#endif
-// We initialise gc_pool_start to a dummy value so it stays out of the bss
-// section.  This makes sure we don't trace this pointer in a collect cycle.
-// If we did trace it, it would make the first block of the heap always
-// reachable, and hence we can never free that block.
-STATIC mp_uint_t *gc_pool_start = (void*)4;
-STATIC mp_uint_t *gc_pool_end;
-
-STATIC int gc_stack_overflow;
-STATIC mp_uint_t gc_stack[STACK_SIZE];
-STATIC mp_uint_t *gc_sp;
-STATIC uint16_t gc_lock_depth;
-uint16_t gc_auto_collect_enabled;
-STATIC mp_uint_t gc_last_free_atb_index;
 
 // ATB = allocation table byte
 // 0b00 = FREE -- free block
@@ -97,12 +77,12 @@ STATIC mp_uint_t gc_last_free_atb_index;
 #define ATB_3_IS_FREE(a) (((a) & ATB_MASK_3) == 0)
 
 #define BLOCK_SHIFT(block) (2 * ((block) & (BLOCKS_PER_ATB - 1)))
-#define ATB_GET_KIND(block) ((gc_alloc_table_start[(block) / BLOCKS_PER_ATB] >> BLOCK_SHIFT(block)) & 3)
-#define ATB_ANY_TO_FREE(block) do { gc_alloc_table_start[(block) / BLOCKS_PER_ATB] &= (~(AT_MARK << BLOCK_SHIFT(block))); } while (0)
-#define ATB_FREE_TO_HEAD(block) do { gc_alloc_table_start[(block) / BLOCKS_PER_ATB] |= (AT_HEAD << BLOCK_SHIFT(block)); } while (0)
-#define ATB_FREE_TO_TAIL(block) do { gc_alloc_table_start[(block) / BLOCKS_PER_ATB] |= (AT_TAIL << BLOCK_SHIFT(block)); } while (0)
-#define ATB_HEAD_TO_MARK(block) do { gc_alloc_table_start[(block) / BLOCKS_PER_ATB] |= (AT_MARK << BLOCK_SHIFT(block)); } while (0)
-#define ATB_MARK_TO_HEAD(block) do { gc_alloc_table_start[(block) / BLOCKS_PER_ATB] &= (~(AT_TAIL << BLOCK_SHIFT(block))); } while (0)
+#define ATB_GET_KIND(block) ((mp_state.gc_alloc_table_start[(block) / BLOCKS_PER_ATB] >> BLOCK_SHIFT(block)) & 3)
+#define ATB_ANY_TO_FREE(block) do { mp_state.gc_alloc_table_start[(block) / BLOCKS_PER_ATB] &= (~(AT_MARK << BLOCK_SHIFT(block))); } while (0)
+#define ATB_FREE_TO_HEAD(block) do { mp_state.gc_alloc_table_start[(block) / BLOCKS_PER_ATB] |= (AT_HEAD << BLOCK_SHIFT(block)); } while (0)
+#define ATB_FREE_TO_TAIL(block) do { mp_state.gc_alloc_table_start[(block) / BLOCKS_PER_ATB] |= (AT_TAIL << BLOCK_SHIFT(block)); } while (0)
+#define ATB_HEAD_TO_MARK(block) do { mp_state.gc_alloc_table_start[(block) / BLOCKS_PER_ATB] |= (AT_MARK << BLOCK_SHIFT(block)); } while (0)
+#define ATB_MARK_TO_HEAD(block) do { mp_state.gc_alloc_table_start[(block) / BLOCKS_PER_ATB] &= (~(AT_TAIL << BLOCK_SHIFT(block))); } while (0)
 
 #define BLOCK_FROM_PTR(ptr) (((ptr) - (mp_uint_t)gc_pool_start) / BYTES_PER_BLOCK)
 #define PTR_FROM_BLOCK(block) (((block) * BYTES_PER_BLOCK + (mp_uint_t)gc_pool_start))
@@ -114,9 +94,9 @@ STATIC mp_uint_t gc_last_free_atb_index;
 
 #define BLOCKS_PER_FTB (8)
 
-#define FTB_GET(block) ((gc_finaliser_table_start[(block) / BLOCKS_PER_FTB] >> ((block) & 7)) & 1)
-#define FTB_SET(block) do { gc_finaliser_table_start[(block) / BLOCKS_PER_FTB] |= (1 << ((block) & 7)); } while (0)
-#define FTB_CLEAR(block) do { gc_finaliser_table_start[(block) / BLOCKS_PER_FTB] &= (~(1 << ((block) & 7))); } while (0)
+#define FTB_GET(block) ((mp_state.gc_finaliser_table_start[(block) / BLOCKS_PER_FTB] >> ((block) & 7)) & 1)
+#define FTB_SET(block) do { mp_state.gc_finaliser_table_start[(block) / BLOCKS_PER_FTB] |= (1 << ((block) & 7)); } while (0)
+#define FTB_CLEAR(block) do { mp_state.gc_finaliser_table_start[(block) / BLOCKS_PER_FTB] &= (~(1 << ((block) & 7))); } while (0)
 #endif
 
 // TODO waste less memory; currently requires that all entries in alloc_table have a corresponding block in pool
@@ -132,45 +112,45 @@ void gc_init(void *start, void *end) {
     // => T = A * (1 + BLOCKS_PER_ATB / BLOCKS_PER_FTB + BLOCKS_PER_ATB * BYTES_PER_BLOCK)
     mp_uint_t total_byte_len = (byte*)end - (byte*)start;
 #if MICROPY_ENABLE_FINALISER
-    gc_alloc_table_byte_len = total_byte_len * BITS_PER_BYTE / (BITS_PER_BYTE + BITS_PER_BYTE * BLOCKS_PER_ATB / BLOCKS_PER_FTB + BITS_PER_BYTE * BLOCKS_PER_ATB * BYTES_PER_BLOCK);
+    mp_state.gc_alloc_table_byte_len = total_byte_len * BITS_PER_BYTE / (BITS_PER_BYTE + BITS_PER_BYTE * BLOCKS_PER_ATB / BLOCKS_PER_FTB + BITS_PER_BYTE * BLOCKS_PER_ATB * BYTES_PER_BLOCK);
 #else
-    gc_alloc_table_byte_len = total_byte_len / (1 + BITS_PER_BYTE / 2 * BYTES_PER_BLOCK);
+    mp_state.gc_alloc_table_byte_len = total_byte_len / (1 + BITS_PER_BYTE / 2 * BYTES_PER_BLOCK);
 #endif
 
-    gc_alloc_table_start = (byte*)start;
+    mp_state.gc_alloc_table_start = (byte*)start;
 
 #if MICROPY_ENABLE_FINALISER
-    mp_uint_t gc_finaliser_table_byte_len = (gc_alloc_table_byte_len * BLOCKS_PER_ATB + BLOCKS_PER_FTB - 1) / BLOCKS_PER_FTB;
-    gc_finaliser_table_start = gc_alloc_table_start + gc_alloc_table_byte_len;
+    mp_uint_t gc_finaliser_table_byte_len = (mp_state.gc_alloc_table_byte_len * BLOCKS_PER_ATB + BLOCKS_PER_FTB - 1) / BLOCKS_PER_FTB;
+    mp_state.gc_finaliser_table_start = mp_state.gc_alloc_table_start + mp_state.gc_alloc_table_byte_len;
 #endif
 
-    mp_uint_t gc_pool_block_len = gc_alloc_table_byte_len * BLOCKS_PER_ATB;
+    mp_uint_t gc_pool_block_len = mp_state.gc_alloc_table_byte_len * BLOCKS_PER_ATB;
     gc_pool_start = (mp_uint_t*)((byte*)end - gc_pool_block_len * BYTES_PER_BLOCK);
-    gc_pool_end = (mp_uint_t*)end;
+    mp_state.gc_pool_end = (mp_uint_t*)end;
 
 #if MICROPY_ENABLE_FINALISER
-    assert((byte*)gc_pool_start >= gc_finaliser_table_start + gc_finaliser_table_byte_len);
+    assert((byte*)gc_pool_start >= mp_state.gc_finaliser_table_start + gc_finaliser_table_byte_len);
 #endif
 
     // clear ATBs
-    memset(gc_alloc_table_start, 0, gc_alloc_table_byte_len);
+    memset(mp_state.gc_alloc_table_start, 0, mp_state.gc_alloc_table_byte_len);
 
 #if MICROPY_ENABLE_FINALISER
     // clear FTBs
-    memset(gc_finaliser_table_start, 0, gc_finaliser_table_byte_len);
+    memset(mp_state.gc_finaliser_table_start, 0, gc_finaliser_table_byte_len);
 #endif
 
     // set last free ATB index to start of heap
-    gc_last_free_atb_index = 0;
+    mp_state.gc_last_free_atb_index = 0;
 
     // unlock the GC
-    gc_lock_depth = 0;
+    mp_state.gc_lock_depth = 0;
 
     // allow auto collection
-    gc_auto_collect_enabled = 1;
+    mp_state.gc_auto_collect_enabled = 1;
 
     DEBUG_printf("GC layout:\n");
-    DEBUG_printf("  alloc table at %p, length " UINT_FMT " bytes, " UINT_FMT " blocks\n", gc_alloc_table_start, gc_alloc_table_byte_len, gc_alloc_table_byte_len * BLOCKS_PER_ATB);
+    DEBUG_printf("  alloc table at %p, length " UINT_FMT " bytes, " UINT_FMT " blocks\n", mp_state.gc_alloc_table_start, mp_state.gc_alloc_table_byte_len, mp_state.gc_alloc_table_byte_len * BLOCKS_PER_ATB);
 #if MICROPY_ENABLE_FINALISER
     DEBUG_printf("  finaliser table at %p, length " UINT_FMT " bytes, " UINT_FMT " blocks\n", gc_finaliser_table_start, gc_finaliser_table_byte_len, gc_finaliser_table_byte_len * BLOCKS_PER_FTB);
 #endif
@@ -178,21 +158,21 @@ void gc_init(void *start, void *end) {
 }
 
 void gc_lock(void) {
-    gc_lock_depth++;
+    mp_state.gc_lock_depth++;
 }
 
 void gc_unlock(void) {
-    gc_lock_depth--;
+    mp_state.gc_lock_depth--;
 }
 
 bool gc_is_locked(void) {
-    return gc_lock_depth != 0;
+    return mp_state.gc_lock_depth != 0;
 }
 
 #define VERIFY_PTR(ptr) ( \
         (ptr & (BYTES_PER_BLOCK - 1)) == 0          /* must be aligned on a block */ \
         && ptr >= (mp_uint_t)gc_pool_start     /* must be above start of pool */ \
-        && ptr < (mp_uint_t)gc_pool_end        /* must be below end of pool */ \
+        && ptr < (mp_uint_t)mp_state.gc_pool_end        /* must be below end of pool */ \
     )
 
 #define VERIFY_MARK_AND_PUSH(ptr) \
@@ -202,19 +182,19 @@ bool gc_is_locked(void) {
             if (ATB_GET_KIND(_block) == AT_HEAD) { \
                 /* an unmarked head, mark it, and push it on gc stack */ \
                 ATB_HEAD_TO_MARK(_block); \
-                if (gc_sp < &gc_stack[STACK_SIZE]) { \
-                    *gc_sp++ = _block; \
+                if (mp_state.gc_sp < &mp_state.gc_stack[MICROPY_GC_STACK_SIZE]) { \
+                    *mp_state.gc_sp++ = _block; \
                 } else { \
-                    gc_stack_overflow = 1; \
+                    mp_state.gc_stack_overflow = 1; \
                 } \
             } \
         } \
     } while (0)
 
 STATIC void gc_drain_stack(void) {
-    while (gc_sp > gc_stack) {
+    while (mp_state.gc_sp > mp_state.gc_stack) {
         // pop the next block off the stack
-        mp_uint_t block = *--gc_sp;
+        mp_uint_t block = *--mp_state.gc_sp;
 
         // work out number of consecutive blocks in the chain starting with this one
         mp_uint_t n_blocks = 0;
@@ -232,15 +212,15 @@ STATIC void gc_drain_stack(void) {
 }
 
 STATIC void gc_deal_with_stack_overflow(void) {
-    while (gc_stack_overflow) {
-        gc_stack_overflow = 0;
-        gc_sp = gc_stack;
+    while (mp_state.gc_stack_overflow) {
+        mp_state.gc_stack_overflow = 0;
+        mp_state.gc_sp = mp_state.gc_stack;
 
         // scan entire memory looking for blocks which have been marked but not their children
-        for (mp_uint_t block = 0; block < gc_alloc_table_byte_len * BLOCKS_PER_ATB; block++) {
+        for (mp_uint_t block = 0; block < mp_state.gc_alloc_table_byte_len * BLOCKS_PER_ATB; block++) {
             // trace (again) if mark bit set
             if (ATB_GET_KIND(block) == AT_MARK) {
-                *gc_sp++ = block;
+                *mp_state.gc_sp++ = block;
                 gc_drain_stack();
             }
         }
@@ -257,7 +237,7 @@ STATIC void gc_sweep(void) {
     #endif
     // free unmarked heads and their tails
     int free_tail = 0;
-    for (mp_uint_t block = 0; block < gc_alloc_table_byte_len * BLOCKS_PER_ATB; block++) {
+    for (mp_uint_t block = 0; block < mp_state.gc_alloc_table_byte_len * BLOCKS_PER_ATB; block++) {
         switch (ATB_GET_KIND(block)) {
             case AT_HEAD:
 #if MICROPY_ENABLE_FINALISER
@@ -299,8 +279,8 @@ STATIC void gc_sweep(void) {
 
 void gc_collect_start(void) {
     gc_lock();
-    gc_stack_overflow = 0;
-    gc_sp = gc_stack;
+    mp_state.gc_stack_overflow = 0;
+    mp_state.gc_sp = mp_state.gc_stack;
 }
 
 void gc_collect_root(void **ptrs, mp_uint_t len) {
@@ -314,18 +294,18 @@ void gc_collect_root(void **ptrs, mp_uint_t len) {
 void gc_collect_end(void) {
     gc_deal_with_stack_overflow();
     gc_sweep();
-    gc_last_free_atb_index = 0;
+    mp_state.gc_last_free_atb_index = 0;
     gc_unlock();
 }
 
 void gc_info(gc_info_t *info) {
-    info->total = (gc_pool_end - gc_pool_start) * sizeof(mp_uint_t);
+    info->total = (mp_state.gc_pool_end - gc_pool_start) * sizeof(mp_uint_t);
     info->used = 0;
     info->free = 0;
     info->num_1block = 0;
     info->num_2block = 0;
     info->max_block = 0;
-    for (mp_uint_t block = 0, len = 0; block < gc_alloc_table_byte_len * BLOCKS_PER_ATB; block++) {
+    for (mp_uint_t block = 0, len = 0; block < mp_state.gc_alloc_table_byte_len * BLOCKS_PER_ATB; block++) {
         mp_uint_t kind = ATB_GET_KIND(block);
         if (kind == AT_FREE || kind == AT_HEAD) {
             if (len == 1) {
@@ -368,7 +348,7 @@ void *gc_alloc(mp_uint_t n_bytes, bool has_finaliser) {
     DEBUG_printf("gc_alloc(" UINT_FMT " bytes -> " UINT_FMT " blocks)\n", n_bytes, n_blocks);
 
     // check if GC is locked
-    if (gc_lock_depth > 0) {
+    if (mp_state.gc_lock_depth > 0) {
         return NULL;
     }
 
@@ -381,12 +361,12 @@ void *gc_alloc(mp_uint_t n_bytes, bool has_finaliser) {
     mp_uint_t end_block;
     mp_uint_t start_block;
     mp_uint_t n_free = 0;
-    int collected = !gc_auto_collect_enabled;
+    int collected = !mp_state.gc_auto_collect_enabled;
     for (;;) {
 
         // look for a run of n_blocks available blocks
-        for (i = gc_last_free_atb_index; i < gc_alloc_table_byte_len; i++) {
-            byte a = gc_alloc_table_start[i];
+        for (i = mp_state.gc_last_free_atb_index; i < mp_state.gc_alloc_table_byte_len; i++) {
+            byte a = mp_state.gc_alloc_table_start[i];
             if (ATB_0_IS_FREE(a)) { if (++n_free >= n_blocks) { i = i * BLOCKS_PER_ATB + 0; goto found; } } else { n_free = 0; }
             if (ATB_1_IS_FREE(a)) { if (++n_free >= n_blocks) { i = i * BLOCKS_PER_ATB + 1; goto found; } } else { n_free = 0; }
             if (ATB_2_IS_FREE(a)) { if (++n_free >= n_blocks) { i = i * BLOCKS_PER_ATB + 2; goto found; } } else { n_free = 0; }
@@ -414,7 +394,7 @@ found:
     // before this one.  Also, whenever we free or shink a block we must check
     // if this index needs adjusting (see gc_realloc and gc_free).
     if (n_free == 1) {
-        gc_last_free_atb_index = (i + 1) / BLOCKS_PER_ATB;
+        mp_state.gc_last_free_atb_index = (i + 1) / BLOCKS_PER_ATB;
     }
 
     // mark first block as used head
@@ -465,7 +445,7 @@ void *gc_alloc_with_finaliser(mp_uint_t n_bytes) {
 
 // force the freeing of a piece of memory
 void gc_free(void *ptr_in) {
-    if (gc_lock_depth > 0) {
+    if (mp_state.gc_lock_depth > 0) {
         // TODO how to deal with this error?
         return;
     }
@@ -477,8 +457,8 @@ void gc_free(void *ptr_in) {
         mp_uint_t block = BLOCK_FROM_PTR(ptr);
         if (ATB_GET_KIND(block) == AT_HEAD) {
             // set the last_free pointer to this block if it's earlier in the heap
-            if (block / BLOCKS_PER_ATB < gc_last_free_atb_index) {
-                gc_last_free_atb_index = block / BLOCKS_PER_ATB;
+            if (block / BLOCKS_PER_ATB < mp_state.gc_last_free_atb_index) {
+                mp_state.gc_last_free_atb_index = block / BLOCKS_PER_ATB;
             }
 
             // free head and all of its tail blocks
@@ -547,7 +527,7 @@ void *gc_realloc(void *ptr, mp_uint_t n_bytes) {
 #else // Alternative gc_realloc impl
 
 void *gc_realloc(void *ptr_in, mp_uint_t n_bytes) {
-    if (gc_lock_depth > 0) {
+    if (mp_state.gc_lock_depth > 0) {
         return NULL;
     }
 
@@ -588,7 +568,7 @@ void *gc_realloc(void *ptr_in, mp_uint_t n_bytes) {
     // efficiently shrink it (see below for shrinking code).
     mp_uint_t n_free   = 0;
     mp_uint_t n_blocks = 1; // counting HEAD block
-    mp_uint_t max_block = gc_alloc_table_byte_len * BLOCKS_PER_ATB;
+    mp_uint_t max_block = mp_state.gc_alloc_table_byte_len * BLOCKS_PER_ATB;
     for (mp_uint_t bl = block + n_blocks; bl < max_block; bl++) {
         byte block_type = ATB_GET_KIND(bl);
         if (block_type == AT_TAIL) {
@@ -619,8 +599,8 @@ void *gc_realloc(void *ptr_in, mp_uint_t n_bytes) {
         }
 
         // set the last_free pointer to end of this block if it's earlier in the heap
-        if ((block + new_blocks) / BLOCKS_PER_ATB < gc_last_free_atb_index) {
-            gc_last_free_atb_index = (block + new_blocks) / BLOCKS_PER_ATB;
+        if ((block + new_blocks) / BLOCKS_PER_ATB < mp_state.gc_last_free_atb_index) {
+            mp_state.gc_last_free_atb_index = (block + new_blocks) / BLOCKS_PER_ATB;
         }
 
         #if EXTENSIVE_HEAP_PROFILING
@@ -684,20 +664,20 @@ void gc_dump_alloc_table(void) {
     // pointer of the heap because it changes from run to run.
     printf("GC memory layout; from %p:", gc_pool_start);
     #endif
-    for (mp_uint_t bl = 0; bl < gc_alloc_table_byte_len * BLOCKS_PER_ATB; bl++) {
+    for (mp_uint_t bl = 0; bl < mp_state.gc_alloc_table_byte_len * BLOCKS_PER_ATB; bl++) {
         if (bl % DUMP_BYTES_PER_LINE == 0) {
             // a new line of blocks
             {
                 // check if this line contains only free blocks
                 mp_uint_t bl2 = bl;
-                while (bl2 < gc_alloc_table_byte_len * BLOCKS_PER_ATB && ATB_GET_KIND(bl2) == AT_FREE) {
+                while (bl2 < mp_state.gc_alloc_table_byte_len * BLOCKS_PER_ATB && ATB_GET_KIND(bl2) == AT_FREE) {
                     bl2++;
                 }
                 if (bl2 - bl >= 2 * DUMP_BYTES_PER_LINE) {
                     // there are at least 2 lines containing only free blocks, so abbreviate their printing
                     printf("\n       (" UINT_FMT " lines all free)", (bl2 - bl) / DUMP_BYTES_PER_LINE);
                     bl = bl2 & (~(DUMP_BYTES_PER_LINE - 1));
-                    if (bl >= gc_alloc_table_byte_len * BLOCKS_PER_ATB) {
+                    if (bl >= mp_state.gc_alloc_table_byte_len * BLOCKS_PER_ATB) {
                         // got to end of heap
                         break;
                     }

--- a/py/gc.h
+++ b/py/gc.h
@@ -35,7 +35,7 @@ bool gc_is_locked(void);
 // This variable controls auto garbage collection.  If set to 0 then the
 // GC won't automatically run when gc_alloc can't find enough blocks.  But
 // you can still allocate/free memory and also explicitly call gc_collect.
-extern uint16_t gc_auto_collect_enabled;
+//extern uint16_t gc_auto_collect_enabled;
 
 // A given port must implement gc_collect by using the other collect functions.
 void gc_collect(void);

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -42,8 +42,6 @@
 // TODO seems that CPython allows NULL byte in the input stream
 // don't know if that's intentional or not, but we don't allow it
 
-mp_uint_t mp_optimise_value;
-
 // TODO replace with a call to a standard function
 STATIC bool str_strn_equal(const char *str, const char *strn, mp_uint_t len) {
     mp_uint_t i = 0;
@@ -670,7 +668,7 @@ STATIC void mp_lexer_next_token_into(mp_lexer_t *lex, bool first_token) {
             if (str_strn_equal(tok_kw[i], lex->vstr.buf, lex->vstr.len)) {
                 if (i == MP_ARRAY_SIZE(tok_kw) - 1) {
                     // tok_kw[MP_ARRAY_SIZE(tok_kw) - 1] == "__debug__"
-                    lex->tok_kind = (mp_optimise_value == 0 ? MP_TOKEN_KW_TRUE : MP_TOKEN_KW_FALSE);
+                    lex->tok_kind = (mp_state.mp_optimise_value == 0 ? MP_TOKEN_KW_TRUE : MP_TOKEN_KW_FALSE);
                 } else {
                     lex->tok_kind = MP_TOKEN_KW_FALSE + i;
                 }

--- a/py/lexer.h
+++ b/py/lexer.h
@@ -184,5 +184,3 @@ typedef enum {
 
 mp_import_stat_t mp_import_stat(const char *path);
 mp_lexer_t *mp_lexer_new_from_file(const char *filename);
-
-extern mp_uint_t mp_optimise_value;

--- a/py/malloc.c
+++ b/py/malloc.c
@@ -39,11 +39,7 @@
 #endif
 
 #if MICROPY_MEM_STATS
-STATIC size_t total_bytes_allocated = 0;
-STATIC size_t current_bytes_allocated = 0;
-STATIC size_t peak_bytes_allocated = 0;
-
-#define UPDATE_PEAK() { if (current_bytes_allocated > peak_bytes_allocated) peak_bytes_allocated = current_bytes_allocated; }
+#define UPDATE_PEAK() { if (mp_state.current_bytes_allocated > mp_state.peak_bytes_allocated) mp_state.peak_bytes_allocated = mp_state.current_bytes_allocated; }
 #endif
 
 #if MICROPY_ENABLE_GC
@@ -69,8 +65,8 @@ void *m_malloc(size_t num_bytes) {
         return m_malloc_fail(num_bytes);
     }
 #if MICROPY_MEM_STATS
-    total_bytes_allocated += num_bytes;
-    current_bytes_allocated += num_bytes;
+    mp_state.total_bytes_allocated += num_bytes;
+    mp_state.current_bytes_allocated += num_bytes;
     UPDATE_PEAK();
 #endif
     DEBUG_printf("malloc %d : %p\n", num_bytes, ptr);
@@ -80,8 +76,8 @@ void *m_malloc(size_t num_bytes) {
 void *m_malloc_maybe(size_t num_bytes) {
     void *ptr = malloc(num_bytes);
 #if MICROPY_MEM_STATS
-    total_bytes_allocated += num_bytes;
-    current_bytes_allocated += num_bytes;
+    mp_state.total_bytes_allocated += num_bytes;
+    mp_state.current_bytes_allocated += num_bytes;
     UPDATE_PEAK();
 #endif
     DEBUG_printf("malloc %d : %p\n", num_bytes, ptr);
@@ -95,8 +91,8 @@ void *m_malloc_with_finaliser(size_t num_bytes) {
         return m_malloc_fail(num_bytes);
     }
 #if MICROPY_MEM_STATS
-    total_bytes_allocated += num_bytes;
-    current_bytes_allocated += num_bytes;
+    mp_state.total_bytes_allocated += num_bytes;
+    mp_state.current_bytes_allocated += num_bytes;
     UPDATE_PEAK();
 #endif
     DEBUG_printf("malloc %d : %p\n", num_bytes, ptr);
@@ -125,8 +121,8 @@ void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes) {
     // allocated total. If we process only positive increments,
     // we'll count 3K.
     size_t diff = new_num_bytes - old_num_bytes;
-    total_bytes_allocated += diff;
-    current_bytes_allocated += diff;
+    mp_state.total_bytes_allocated += diff;
+    mp_state.current_bytes_allocated += diff;
     UPDATE_PEAK();
 #endif
     DEBUG_printf("realloc %p, %d, %d : %p\n", ptr, old_num_bytes, new_num_bytes, new_ptr);
@@ -144,8 +140,8 @@ void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes) {
     // Also, don't count failed reallocs.
     if (!(new_ptr == NULL && new_num_bytes != 0)) {
         size_t diff = new_num_bytes - old_num_bytes;
-        total_bytes_allocated += diff;
-        current_bytes_allocated += diff;
+        mp_state.total_bytes_allocated += diff;
+        mp_state.current_bytes_allocated += diff;
         UPDATE_PEAK();
     }
 #endif
@@ -156,21 +152,21 @@ void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes) {
 void m_free(void *ptr, size_t num_bytes) {
     free(ptr);
 #if MICROPY_MEM_STATS
-    current_bytes_allocated -= num_bytes;
+    mp_state.current_bytes_allocated -= num_bytes;
 #endif
     DEBUG_printf("free %p, %d\n", ptr, num_bytes);
 }
 
 #if MICROPY_MEM_STATS
 size_t m_get_total_bytes_allocated(void) {
-    return total_bytes_allocated;
+    return mp_state.total_bytes_allocated;
 }
 
 size_t m_get_current_bytes_allocated(void) {
-    return current_bytes_allocated;
+    return mp_state.current_bytes_allocated;
 }
 
 size_t m_get_peak_bytes_allocated(void) {
-    return peak_bytes_allocated;
+    return mp_state.peak_bytes_allocated;
 }
 #endif

--- a/py/misc.h
+++ b/py/misc.h
@@ -185,4 +185,6 @@ static inline mp_uint_t count_lead_ones(byte val) {
 }
 #endif
 
+#include "mpstate.h"
+
 #endif // _INCLUDED_MINILIB_H

--- a/py/modgc.c
+++ b/py/modgc.c
@@ -54,7 +54,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(gc_collect_obj, py_gc_collect);
 /// \function disable()
 /// Disable the garbage collector.
 STATIC mp_obj_t gc_disable(void) {
-    gc_auto_collect_enabled = 0;
+    mp_state.gc_auto_collect_enabled = 0;
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(gc_disable_obj, gc_disable);
@@ -62,13 +62,13 @@ MP_DEFINE_CONST_FUN_OBJ_0(gc_disable_obj, gc_disable);
 /// \function enable()
 /// Enable the garbage collector.
 STATIC mp_obj_t gc_enable(void) {
-    gc_auto_collect_enabled = 1;
+    mp_state.gc_auto_collect_enabled = 1;
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(gc_enable_obj, gc_enable);
 
 STATIC mp_obj_t gc_isenabled(void) {
-    return MP_BOOL(gc_auto_collect_enabled);
+    return MP_BOOL(mp_state.gc_auto_collect_enabled);
 }
 MP_DEFINE_CONST_FUN_OBJ_0(gc_isenabled_obj, gc_isenabled);
 

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -1,0 +1,134 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef __MICROPY_INCLUDED_MPSTATE_H__
+#define __MICROPY_INCLUDED_MPSTATE_H__
+
+#include <stdint.h>
+
+#include "qstr.h"
+#include "nlr.h"
+#include "obj.h"
+#include "objtuple.h"
+
+#define MICROPY_GC_STACK_SIZE (64) // tunable; minimum is 1
+
+typedef struct _mp_obj_exception_t {
+    mp_obj_base_t base;
+    mp_obj_t traceback; // a list object, holding (file,line,block) as numbers (not Python objects); a hack for now
+    mp_obj_tuple_t *args;
+} mp_obj_exception_t;
+
+typedef struct _mp_state_t {
+    //////// qstr.c ////////
+
+    qstr_pool_t *last_pool;
+
+    //////// stackctrl.c ////////
+
+    // Stack top at the start of program
+    char *stack_top;
+
+    //////// lexer.c ////////
+
+    mp_uint_t mp_optimise_value;
+
+    //////// runtime.c ////////
+
+    // pending exception object (MP_OBJ_NULL if not pending)
+    mp_obj_t mp_pending_exception;
+
+    // locals and globals need to be pointers because they can be the same in outer module scope
+    mp_obj_dict_t *dict_locals;
+    mp_obj_dict_t *dict_globals;
+
+    // dictionary for the __main__ module
+    mp_obj_dict_t dict_main;
+
+    #if MICROPY_CAN_OVERRIDE_BUILTINS
+    mp_obj_dict_t *mp_module_builtins_override_dict;
+    #endif
+
+    //////// gc.c ////////
+
+    #if MICROPY_ENABLE_GC
+    byte *gc_alloc_table_start;
+    mp_uint_t gc_alloc_table_byte_len;
+    #if MICROPY_ENABLE_FINALISER
+    byte *gc_finaliser_table_start;
+    #endif
+    mp_uint_t *gc_pool_end;
+
+    int gc_stack_overflow;
+    mp_uint_t gc_stack[MICROPY_GC_STACK_SIZE];
+    mp_uint_t *gc_sp;
+    uint16_t gc_lock_depth;
+    uint16_t gc_auto_collect_enabled;
+    mp_uint_t gc_last_free_atb_index;
+    #endif
+
+    //////// malloc.c ////////
+
+    #if MICROPY_MEM_STATS
+    size_t total_bytes_allocated;
+    size_t current_bytes_allocated;
+    size_t peak_bytes_allocated;
+    #endif
+
+    //////// objmodule.c ////////
+
+    mp_map_t mp_loaded_modules_map; // TODO: expose as sys.modules
+
+    //////// objexcept.c ////////
+
+    // Local non-heap memory for allocating an exception when we run out of RAM
+    mp_obj_exception_t mp_emergency_exception_obj;
+
+    // Optionally allocated buffer for storing the first argument of an exception
+    // allocated when the heap is locked.
+    #if MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF
+    #if MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE > 0
+    byte mp_emergency_exception_buf[MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE];
+    #else
+    mp_int_t mp_emergency_exception_buf_size;
+    byte *mp_emergency_exception_buf;
+    #endif
+    #endif
+
+} mp_state_t;
+
+#if MICROPY_STACK_CHECK
+extern mp_uint_t stack_limit;
+#endif
+
+#if MICROPY_ENABLE_GC
+extern mp_uint_t *gc_pool_start;
+#endif
+
+extern nlr_buf_t *nlr_top;
+extern mp_state_t mp_state;
+
+#endif // __MICROPY_INCLUDED_MPSTATE_H__

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -24,6 +24,9 @@
  * THE SOFTWARE.
  */
 
+#ifndef __MICROPY_INLCUDED_NLR_H__
+#define __MICROPY_INLCUDED_NLR_H__
+
 // non-local return
 // exception handling, basically a stack of setjmp/longjmp buffers
 
@@ -61,12 +64,11 @@ struct _nlr_buf_t {
 };
 
 #if MICROPY_NLR_SETJMP
-extern nlr_buf_t *nlr_setjmp_top;
 NORETURN void nlr_setjmp_jump(void *val);
 // nlr_push() must be defined as a macro, because "The stack context will be
 // invalidated if the function which called setjmp() returns."
-#define nlr_push(buf) ((buf)->prev = nlr_setjmp_top, nlr_setjmp_top = (buf), setjmp((buf)->jmpbuf))
-#define nlr_pop() { nlr_setjmp_top = nlr_setjmp_top->prev; }
+#define nlr_push(buf) ((buf)->prev = nlr_top, nlr_top = (buf), setjmp((buf)->jmpbuf))
+#define nlr_pop() { nlr_top = nlr_top->prev; }
 #define nlr_jump(val) nlr_setjmp_jump(val)
 #else
 unsigned int nlr_push(nlr_buf_t *);
@@ -91,3 +93,5 @@ void nlr_jump_fail(void *val);
         nlr_jump(_val); \
     } while (0)
 #endif
+
+#endif // __MICROPY_INLCUDED_NLR_H__

--- a/py/nlrsetjmp.c
+++ b/py/nlrsetjmp.c
@@ -31,11 +31,9 @@
 
 #if MICROPY_NLR_SETJMP
 
-nlr_buf_t *nlr_setjmp_top;
-
 void nlr_setjmp_jump(void *val) {
-    nlr_buf_t *buf = nlr_setjmp_top;
-    nlr_setjmp_top = buf->prev;
+    nlr_buf_t *buf = mp_state.nlr_top;
+    mp_state.nlr_top = buf->prev;
     buf->ret_val = val;
     longjmp(buf->jmpbuf, 1);
 }

--- a/py/nlrthumb.S
+++ b/py/nlrthumb.S
@@ -59,7 +59,7 @@ nlr_push:
     str     r11, [r0, #40]          @ store r11 into nlr_buf
     str     r13, [r0, #44]          @ store r13=sp into nlr_buf
 
-    ldr     r3, .L2                 @ load addr of nlr_top
+    ldr     r3, nlr_top_addr        @ load addr of nlr_top
     ldr     r2, [r3]                @ load nlr_top
     str     r2, [r0]                @ store nlr_top into nlr_buf
     str     r0, [r3]                @ store nlr_buf into nlr_top (to link list)
@@ -67,8 +67,8 @@ nlr_push:
     movs    r0, #0                  @ return 0, normal return
     bx      lr                      @ return
     .align  2
-.L2:
-    .word   .LANCHOR0
+nlr_top_addr:
+    .word   nlr_top
     .size   nlr_push, .-nlr_push
 
 /**************************************/
@@ -81,14 +81,11 @@ nlr_push:
 #endif
     .type   nlr_pop, %function
 nlr_pop:
-    ldr     r3, .L5                 @ load addr of nlr_top
+    ldr     r3, nlr_top_addr        @ load addr of nlr_top
     ldr     r2, [r3]                @ load nlr_top
     ldr     r2, [r2]                @ load prev nlr_buf
     str     r2, [r3]                @ store prev nlr_buf to nlr_top (to unlink list)
     bx      lr                      @ return
-    .align    2
-.L5:
-    .word    .LANCHOR0
     .size   nlr_pop, .-nlr_pop
 
 /**************************************/
@@ -101,7 +98,7 @@ nlr_pop:
 #endif
     .type   nlr_jump, %function
 nlr_jump:
-    ldr     r3, .L2                 @ load addr of nlr_top
+    ldr     r3, nlr_top_addr        @ load addr of nlr_top
     ldr     r2, [r3]                @ load nlr_top
     cmp     r2, #0                  @ test if nlr_top is NULL
     beq     nlr_jump_fail           @ if nlr_top is NULL, transfer control to nlr_jump_fail
@@ -122,20 +119,6 @@ nlr_jump:
 
     movs    r0, #1                  @ return 1, non-local return
     bx      lr                      @ return
-    .align    2
-.L6:
-    .word    .LANCHOR0
     .size   nlr_jump, .-nlr_jump
-
-/**************************************/
-// local variable nlr_top
-
-    .bss
-    .align  2
-    .set    .LANCHOR0,. + 0
-    .type   nlr_top, %object
-    .size   nlr_top, 4
-nlr_top:
-    .space  4
 
 #endif // (!defined(MICROPY_NLR_SETJMP) || !MICROPY_NLR_SETJMP) && (defined(__thumb2__) || defined(__thumb__) || defined(__arm__))

--- a/py/nlrx64.S
+++ b/py/nlrx64.S
@@ -131,15 +131,6 @@ nlr_jump:
     je      _nlr_jump_fail          # transfer control to nlr_jump_fail
 #endif
 
-/**************************************/
-// local variable nlr_top
-
-#if !(defined(__APPLE__) && defined(__MACH__))
-    .bss
-    .local  nlr_top
-#endif
-    .comm   nlr_top,8,8
-
 #else // !defined(__CYGWIN__)
 
 /******************************************************************************/
@@ -209,12 +200,6 @@ nlr_jump:
 .fail:
     movq    %rax, %rcx              # put argument back in first-arg register
     je      nlr_jump_fail           # transfer control to nlr_jump_fail
-
-/**************************************/
-// local variable nlr_top
-
-    .bss
-    .comm   nlr_top,8,8
 
 #endif // !defined(__CYGWIN__)
 

--- a/py/nlrx86.S
+++ b/py/nlrx86.S
@@ -121,13 +121,4 @@ nlr_jump:
     .size   nlr_jump, .-nlr_jump
 #endif
 
-/**************************************/
-// local variable nlr_top
-
-    .bss
-#ifndef _WIN32
-    .local  nlr_top
-#endif
-    .comm   nlr_top,4,4
-
 #endif // defined(__i386__) && !MICROPY_NLR_SETJMP

--- a/py/obj.h
+++ b/py/obj.h
@@ -24,6 +24,9 @@
  * THE SOFTWARE.
  */
 
+#ifndef __MICROPY_INLCUDED_OBJ_H__
+#define __MICROPY_INLCUDED_OBJ_H__
+
 // A Micro Python object is a machine word having the following form:
 //  - xxxx...xxx1 : a small int, bits 1 and above are the value
 //  - xxxx...xx10 : a qstr, bits 2 and above are the value
@@ -620,3 +623,5 @@ mp_obj_t mp_seq_extract_slice(mp_uint_t len, const mp_obj_t *seq, mp_bound_slice
     /*printf("memmove(%p, %p, %d)\n", dest + beg + len_adj, dest + beg, (dest_len - beg) * sizeof(item_t));*/ \
     memmove(dest + beg + len_adj, dest + beg, (dest_len - beg) * sizeof(item_t)); \
     memcpy(dest + beg, slice, slice_len * sizeof(item_t));
+
+#endif // __MICROPY_INLCUDED_OBJ_H__

--- a/py/objtuple.h
+++ b/py/objtuple.h
@@ -24,6 +24,9 @@
  * THE SOFTWARE.
  */
 
+#ifndef __MICROPY_INLCUDED_OBJTUPLE_H__
+#define __MICROPY_INLCUDED_OBJTUPLE_H__
+
 typedef struct _mp_obj_tuple_t {
     mp_obj_base_t base;
     mp_uint_t len;
@@ -35,3 +38,5 @@ mp_obj_t mp_obj_tuple_unary_op(mp_uint_t op, mp_obj_t self_in);
 mp_obj_t mp_obj_tuple_binary_op(mp_uint_t op, mp_obj_t lhs, mp_obj_t rhs);
 mp_obj_t mp_obj_tuple_subscr(mp_obj_t base, mp_obj_t index, mp_obj_t value);
 mp_obj_t mp_obj_tuple_getiter(mp_obj_t o_in);
+
+#endif // __MICROPY_INLCUDED_OBJTUPLE_H__

--- a/py/qstr.c
+++ b/py/qstr.c
@@ -71,14 +71,6 @@ mp_uint_t qstr_compute_hash(const byte *data, mp_uint_t len) {
     return hash;
 }
 
-typedef struct _qstr_pool_t {
-    struct _qstr_pool_t *prev;
-    mp_uint_t total_prev_len;
-    mp_uint_t alloc;
-    mp_uint_t len;
-    const byte *qstrs[];
-} qstr_pool_t;
-
 STATIC const qstr_pool_t const_pool = {
     NULL,               // no previous pool
     0,                  // no previous pool
@@ -93,15 +85,13 @@ STATIC const qstr_pool_t const_pool = {
     },
 };
 
-STATIC qstr_pool_t *last_pool;
-
 void qstr_init(void) {
-    last_pool = (qstr_pool_t*)&const_pool; // we won't modify the const_pool since it has no allocated room left
+    mp_state.last_pool = (qstr_pool_t*)&const_pool; // we won't modify the const_pool since it has no allocated room left
 }
 
 STATIC const byte *find_qstr(qstr q) {
     // search pool for this qstr
-    for (qstr_pool_t *pool = last_pool; pool != NULL; pool = pool->prev) {
+    for (qstr_pool_t *pool = mp_state.last_pool; pool != NULL; pool = pool->prev) {
         if (q >= pool->total_prev_len) {
             return pool->qstrs[q - pool->total_prev_len];
         }
@@ -115,21 +105,21 @@ STATIC qstr qstr_add(const byte *q_ptr) {
     DEBUG_printf("QSTR: add hash=%d len=%d data=%.*s\n", Q_GET_HASH(q_ptr), Q_GET_LENGTH(q_ptr), Q_GET_LENGTH(q_ptr), Q_GET_DATA(q_ptr));
 
     // make sure we have room in the pool for a new qstr
-    if (last_pool->len >= last_pool->alloc) {
-        qstr_pool_t *pool = m_new_obj_var(qstr_pool_t, const char*, last_pool->alloc * 2);
-        pool->prev = last_pool;
-        pool->total_prev_len = last_pool->total_prev_len + last_pool->len;
-        pool->alloc = last_pool->alloc * 2;
+    if (mp_state.last_pool->len >= mp_state.last_pool->alloc) {
+        qstr_pool_t *pool = m_new_obj_var(qstr_pool_t, const char*, mp_state.last_pool->alloc * 2);
+        pool->prev = mp_state.last_pool;
+        pool->total_prev_len = mp_state.last_pool->total_prev_len + mp_state.last_pool->len;
+        pool->alloc = mp_state.last_pool->alloc * 2;
         pool->len = 0;
-        last_pool = pool;
-        DEBUG_printf("QSTR: allocate new pool of size %d\n", last_pool->alloc);
+        mp_state.last_pool = pool;
+        DEBUG_printf("QSTR: allocate new pool of size %d\n", mp_state.last_pool->alloc);
     }
 
     // add the new qstr
-    last_pool->qstrs[last_pool->len++] = q_ptr;
+    mp_state.last_pool->qstrs[mp_state.last_pool->len++] = q_ptr;
 
     // return id for the newly-added qstr
-    return last_pool->total_prev_len + last_pool->len - 1;
+    return mp_state.last_pool->total_prev_len + mp_state.last_pool->len - 1;
 }
 
 qstr qstr_find_strn(const char *str, mp_uint_t str_len) {
@@ -137,7 +127,7 @@ qstr qstr_find_strn(const char *str, mp_uint_t str_len) {
     mp_uint_t str_hash = qstr_compute_hash((const byte*)str, str_len);
 
     // search pools for the data
-    for (qstr_pool_t *pool = last_pool; pool != NULL; pool = pool->prev) {
+    for (qstr_pool_t *pool = mp_state.last_pool; pool != NULL; pool = pool->prev) {
         for (const byte **q = pool->qstrs, **q_top = pool->qstrs + pool->len; q < q_top; q++) {
             if (Q_GET_HASH(*q) == str_hash && Q_GET_LENGTH(*q) == str_len && memcmp(Q_GET_DATA(*q), str, str_len) == 0) {
                 return pool->total_prev_len + (q - pool->qstrs);
@@ -218,7 +208,7 @@ void qstr_pool_info(mp_uint_t *n_pool, mp_uint_t *n_qstr, mp_uint_t *n_str_data_
     *n_qstr = 0;
     *n_str_data_bytes = 0;
     *n_total_bytes = 0;
-    for (qstr_pool_t *pool = last_pool; pool != NULL && pool != &const_pool; pool = pool->prev) {
+    for (qstr_pool_t *pool = mp_state.last_pool; pool != NULL && pool != &const_pool; pool = pool->prev) {
         *n_pool += 1;
         *n_qstr += pool->len;
         for (const byte **q = pool->qstrs, **q_top = pool->qstrs + pool->len; q < q_top; q++) {

--- a/py/qstr.h
+++ b/py/qstr.h
@@ -24,6 +24,9 @@
  * THE SOFTWARE.
  */
 
+#ifndef __MICROPY_INLCUDED_QSTR_H__
+#define __MICROPY_INLCUDED_QSTR_H__
+
 // See qstrdefs.h for a list of qstr's that are available as constants.
 // Reference them as MP_QSTR_xxxx.
 //
@@ -40,6 +43,14 @@ enum {
 };
 
 typedef mp_uint_t qstr;
+
+typedef struct _qstr_pool_t {
+    struct _qstr_pool_t *prev;
+    mp_uint_t total_prev_len;
+    mp_uint_t alloc;
+    mp_uint_t len;
+    const byte *qstrs[];
+} qstr_pool_t;
 
 #define QSTR_FROM_STR_STATIC(s) (qstr_from_strn((s), strlen(s)))
 
@@ -60,3 +71,5 @@ mp_uint_t qstr_len(qstr q);
 const byte* qstr_data(qstr q, mp_uint_t *len);
 
 void qstr_pool_info(mp_uint_t *n_pool, mp_uint_t *n_qstr, mp_uint_t *n_str_data_bytes, mp_uint_t *n_total_bytes);
+
+#endif // __MICROPY_INLCUDED_QSTR_H__

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -115,7 +115,6 @@ mp_obj_t mp_convert_native_to_obj(mp_uint_t val, mp_uint_t type);
 mp_obj_t mp_native_call_function_n_kw(mp_obj_t fun_in, mp_uint_t n_args_kw, const mp_obj_t *args);
 NORETURN void mp_native_raise(mp_obj_t o);
 
-extern mp_obj_t mp_pending_exception;
 extern struct _mp_obj_list_t mp_sys_path_obj;
 extern struct _mp_obj_list_t mp_sys_argv_obj;
 #define mp_sys_path ((mp_obj_t)&mp_sys_path_obj)

--- a/py/stackctrl.c
+++ b/py/stackctrl.c
@@ -32,23 +32,18 @@
 #include "runtime.h"
 #include "stackctrl.h"
 
-// Stack top at the start of program
-char *stack_top;
-
 void mp_stack_ctrl_init(void) {
     volatile int stack_dummy;
-    stack_top = (char*)&stack_dummy;
+    mp_state.stack_top = (char*)&stack_dummy;
 }
 
 mp_uint_t mp_stack_usage(void) {
     // Assumes descending stack
     volatile int stack_dummy;
-    return stack_top - (char*)&stack_dummy;
+    return mp_state.stack_top - (char*)&stack_dummy;
 }
 
 #if MICROPY_STACK_CHECK
-
-static mp_uint_t stack_limit = 10240;
 
 void mp_stack_set_limit(mp_uint_t limit) {
     stack_limit = limit;

--- a/py/vm.c
+++ b/py/vm.c
@@ -939,9 +939,9 @@ yield:
 #endif
 
 pending_exception_check:
-                if (mp_pending_exception != MP_OBJ_NULL) {
-                    mp_obj_t obj = mp_pending_exception;
-                    mp_pending_exception = MP_OBJ_NULL;
+                if (mp_state.mp_pending_exception != MP_OBJ_NULL) {
+                    mp_obj_t obj = mp_state.mp_pending_exception;
+                    mp_state.mp_pending_exception = MP_OBJ_NULL;
                     RAISE(obj);
                 }
 

--- a/stmhal/pendsv.c
+++ b/stmhal/pendsv.c
@@ -50,10 +50,10 @@ void pendsv_init(void) {
 // the given exception object using nlr_jump in the context of the top-level
 // thread.
 void pendsv_nlr_jump(void *o) {
-    if (mp_pending_exception == MP_OBJ_NULL) {
-        mp_pending_exception = o;
+    if (mp_state.mp_pending_exception == MP_OBJ_NULL) {
+        mp_state.mp_pending_exception = o;
     } else {
-        mp_pending_exception = MP_OBJ_NULL;
+        mp_state.mp_pending_exception = MP_OBJ_NULL;
         pendsv_object = o;
         SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
     }

--- a/unix/gccollect.c
+++ b/unix/gccollect.c
@@ -33,8 +33,6 @@
 
 #if MICROPY_ENABLE_GC
 
-extern char *stack_top;
-
 #if MICROPY_GCREGS_SETJMP
 #include <setjmp.h>
 
@@ -146,7 +144,7 @@ void gc_collect(void) {
     gc_helper_get_regs(regs);
     // GC stack (and regs because we captured them)
     void **regs_ptr = (void**)(void*)&regs;
-    gc_collect_root(regs_ptr, ((mp_uint_t)stack_top - (mp_uint_t)&regs) / sizeof(mp_uint_t));
+    gc_collect_root(regs_ptr, ((mp_uint_t)mp_state.stack_top - (mp_uint_t)&regs) / sizeof(mp_uint_t));
     gc_collect_end();
 
     //printf("-----\n");

--- a/unix/main.c
+++ b/unix/main.c
@@ -74,7 +74,7 @@ STATIC mp_obj_t keyboard_interrupt_obj;
 STATIC void sighandler(int signum) {
     if (signum == SIGINT) {
         mp_obj_exception_clear_traceback(keyboard_interrupt_obj);
-        mp_pending_exception = keyboard_interrupt_obj;
+        mp_state.mp_pending_exception = keyboard_interrupt_obj;
         // disable our handler so next we really die
         struct sigaction sa;
         sa.sa_handler = SIG_DFL;
@@ -456,10 +456,10 @@ int main(int argc, char **argv) {
                 mp_verbose_flag++;
             } else if (strncmp(argv[a], "-O", 2) == 0) {
                 if (isdigit(argv[a][2])) {
-                    mp_optimise_value = argv[a][2] & 0xf;
+                    mp_state.mp_optimise_value = argv[a][2] & 0xf;
                 } else {
-                    mp_optimise_value = 0;
-                    for (char *p = argv[a] + 1; *p && *p == 'O'; p++, mp_optimise_value++);
+                    mp_state.mp_optimise_value = 0;
+                    for (char *p = argv[a] + 1; *p && *p == 'O'; p++, mp_state.mp_optimise_value++);
                 }
             } else {
                 return usage(argv);


### PR DESCRIPTION
This is allows to keep track of where all the global variables are, and will help if we ever want to have a global state object to pass to each function.  Although code size was not a reason for doing this, the change actually gives some savings of code size: about 60 bytes on x64, and 200 bytes (!) on stmhal.

This is for review only, and is still a bit messy.  It also includes a partial move away from Plan 9 style header includes.

Comments welcome!
