### PR TITLE
py: Put all global state together in state structures.

### DIFF
--- a/py/builtin.h
+++ b/py/builtin.h
@@ -90,7 +90,6 @@ extern const mp_obj_module_t mp_module_sys;
 extern const mp_obj_module_t mp_module_gc;
 
 extern const mp_obj_dict_t mp_module_builtins_globals;
-extern mp_obj_dict_t *mp_module_builtins_override_dict;
 
 struct _dummy_t;
 extern struct _dummy_t mp_sys_stdin_obj;

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "py/mpstate.h"
 #include "py/emit.h"
 #include "py/bc0.h"
 
@@ -383,7 +384,7 @@ STATIC void emit_bc_adjust_stack_size(emit_t *emit, mp_int_t delta) {
 STATIC void emit_bc_set_source_line(emit_t *emit, mp_uint_t source_line) {
     //printf("source: line %d -> %d  offset %d -> %d\n", emit->last_source_line, source_line, emit->last_source_line_offset, emit->bytecode_offset);
 #if MICROPY_ENABLE_SOURCE_LINE
-    if (mp_optimise_value >= 3) {
+    if (MP_STATE_VM(mp_optimise_value) >= 3) {
         // If we compile with -O3, don't store line numbers.
         return;
     }

--- a/py/gc.c
+++ b/py/gc.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "py/mpstate.h"
 #include "py/gc.h"
 #include "py/obj.h"
 #include "py/runtime.h"
@@ -47,25 +48,6 @@
 
 #define WORDS_PER_BLOCK (4)
 #define BYTES_PER_BLOCK (WORDS_PER_BLOCK * BYTES_PER_WORD)
-
-STATIC byte *gc_alloc_table_start;
-STATIC mp_uint_t gc_alloc_table_byte_len;
-#if MICROPY_ENABLE_FINALISER
-STATIC byte *gc_finaliser_table_start;
-#endif
-// We initialise gc_pool_start to a dummy value so it stays out of the bss
-// section.  This makes sure we don't trace this pointer in a collect cycle.
-// If we did trace it, it would make the first block of the heap always
-// reachable, and hence we can never free that block.
-STATIC mp_uint_t *gc_pool_start = (void*)4;
-STATIC mp_uint_t *gc_pool_end;
-
-STATIC int gc_stack_overflow;
-STATIC mp_uint_t gc_stack[MICROPY_ALLOC_GC_STACK_SIZE];
-STATIC mp_uint_t *gc_sp;
-STATIC uint16_t gc_lock_depth;
-uint16_t gc_auto_collect_enabled;
-STATIC mp_uint_t gc_last_free_atb_index;
 
 // ATB = allocation table byte
 // 0b00 = FREE -- free block
@@ -90,15 +72,15 @@ STATIC mp_uint_t gc_last_free_atb_index;
 #define ATB_3_IS_FREE(a) (((a) & ATB_MASK_3) == 0)
 
 #define BLOCK_SHIFT(block) (2 * ((block) & (BLOCKS_PER_ATB - 1)))
-#define ATB_GET_KIND(block) ((gc_alloc_table_start[(block) / BLOCKS_PER_ATB] >> BLOCK_SHIFT(block)) & 3)
-#define ATB_ANY_TO_FREE(block) do { gc_alloc_table_start[(block) / BLOCKS_PER_ATB] &= (~(AT_MARK << BLOCK_SHIFT(block))); } while (0)
-#define ATB_FREE_TO_HEAD(block) do { gc_alloc_table_start[(block) / BLOCKS_PER_ATB] |= (AT_HEAD << BLOCK_SHIFT(block)); } while (0)
-#define ATB_FREE_TO_TAIL(block) do { gc_alloc_table_start[(block) / BLOCKS_PER_ATB] |= (AT_TAIL << BLOCK_SHIFT(block)); } while (0)
-#define ATB_HEAD_TO_MARK(block) do { gc_alloc_table_start[(block) / BLOCKS_PER_ATB] |= (AT_MARK << BLOCK_SHIFT(block)); } while (0)
-#define ATB_MARK_TO_HEAD(block) do { gc_alloc_table_start[(block) / BLOCKS_PER_ATB] &= (~(AT_TAIL << BLOCK_SHIFT(block))); } while (0)
+#define ATB_GET_KIND(block) ((MP_STATE_MEM(gc_alloc_table_start)[(block) / BLOCKS_PER_ATB] >> BLOCK_SHIFT(block)) & 3)
+#define ATB_ANY_TO_FREE(block) do { MP_STATE_MEM(gc_alloc_table_start)[(block) / BLOCKS_PER_ATB] &= (~(AT_MARK << BLOCK_SHIFT(block))); } while (0)
+#define ATB_FREE_TO_HEAD(block) do { MP_STATE_MEM(gc_alloc_table_start)[(block) / BLOCKS_PER_ATB] |= (AT_HEAD << BLOCK_SHIFT(block)); } while (0)
+#define ATB_FREE_TO_TAIL(block) do { MP_STATE_MEM(gc_alloc_table_start)[(block) / BLOCKS_PER_ATB] |= (AT_TAIL << BLOCK_SHIFT(block)); } while (0)
+#define ATB_HEAD_TO_MARK(block) do { MP_STATE_MEM(gc_alloc_table_start)[(block) / BLOCKS_PER_ATB] |= (AT_MARK << BLOCK_SHIFT(block)); } while (0)
+#define ATB_MARK_TO_HEAD(block) do { MP_STATE_MEM(gc_alloc_table_start)[(block) / BLOCKS_PER_ATB] &= (~(AT_TAIL << BLOCK_SHIFT(block))); } while (0)
 
-#define BLOCK_FROM_PTR(ptr) (((ptr) - (mp_uint_t)gc_pool_start) / BYTES_PER_BLOCK)
-#define PTR_FROM_BLOCK(block) (((block) * BYTES_PER_BLOCK + (mp_uint_t)gc_pool_start))
+#define BLOCK_FROM_PTR(ptr) (((ptr) - (mp_uint_t)MP_STATE_MEM(gc_pool_start)) / BYTES_PER_BLOCK)
+#define PTR_FROM_BLOCK(block) (((block) * BYTES_PER_BLOCK + (mp_uint_t)MP_STATE_MEM(gc_pool_start)))
 #define ATB_FROM_BLOCK(bl) ((bl) / BLOCKS_PER_ATB)
 
 #if MICROPY_ENABLE_FINALISER
@@ -107,9 +89,9 @@ STATIC mp_uint_t gc_last_free_atb_index;
 
 #define BLOCKS_PER_FTB (8)
 
-#define FTB_GET(block) ((gc_finaliser_table_start[(block) / BLOCKS_PER_FTB] >> ((block) & 7)) & 1)
-#define FTB_SET(block) do { gc_finaliser_table_start[(block) / BLOCKS_PER_FTB] |= (1 << ((block) & 7)); } while (0)
-#define FTB_CLEAR(block) do { gc_finaliser_table_start[(block) / BLOCKS_PER_FTB] &= (~(1 << ((block) & 7))); } while (0)
+#define FTB_GET(block) ((MP_STATE_MEM(gc_finaliser_table_start)[(block) / BLOCKS_PER_FTB] >> ((block) & 7)) & 1)
+#define FTB_SET(block) do { MP_STATE_MEM(gc_finaliser_table_start)[(block) / BLOCKS_PER_FTB] |= (1 << ((block) & 7)); } while (0)
+#define FTB_CLEAR(block) do { MP_STATE_MEM(gc_finaliser_table_start)[(block) / BLOCKS_PER_FTB] &= (~(1 << ((block) & 7))); } while (0)
 #endif
 
 // TODO waste less memory; currently requires that all entries in alloc_table have a corresponding block in pool
@@ -125,67 +107,67 @@ void gc_init(void *start, void *end) {
     // => T = A * (1 + BLOCKS_PER_ATB / BLOCKS_PER_FTB + BLOCKS_PER_ATB * BYTES_PER_BLOCK)
     mp_uint_t total_byte_len = (byte*)end - (byte*)start;
 #if MICROPY_ENABLE_FINALISER
-    gc_alloc_table_byte_len = total_byte_len * BITS_PER_BYTE / (BITS_PER_BYTE + BITS_PER_BYTE * BLOCKS_PER_ATB / BLOCKS_PER_FTB + BITS_PER_BYTE * BLOCKS_PER_ATB * BYTES_PER_BLOCK);
+    MP_STATE_MEM(gc_alloc_table_byte_len) = total_byte_len * BITS_PER_BYTE / (BITS_PER_BYTE + BITS_PER_BYTE * BLOCKS_PER_ATB / BLOCKS_PER_FTB + BITS_PER_BYTE * BLOCKS_PER_ATB * BYTES_PER_BLOCK);
 #else
-    gc_alloc_table_byte_len = total_byte_len / (1 + BITS_PER_BYTE / 2 * BYTES_PER_BLOCK);
+    MP_STATE_MEM(gc_alloc_table_byte_len) = total_byte_len / (1 + BITS_PER_BYTE / 2 * BYTES_PER_BLOCK);
 #endif
 
-    gc_alloc_table_start = (byte*)start;
+    MP_STATE_MEM(gc_alloc_table_start) = (byte*)start;
 
 #if MICROPY_ENABLE_FINALISER
-    mp_uint_t gc_finaliser_table_byte_len = (gc_alloc_table_byte_len * BLOCKS_PER_ATB + BLOCKS_PER_FTB - 1) / BLOCKS_PER_FTB;
-    gc_finaliser_table_start = gc_alloc_table_start + gc_alloc_table_byte_len;
+    mp_uint_t gc_finaliser_table_byte_len = (MP_STATE_MEM(gc_alloc_table_byte_len) * BLOCKS_PER_ATB + BLOCKS_PER_FTB - 1) / BLOCKS_PER_FTB;
+    MP_STATE_MEM(gc_finaliser_table_start) = MP_STATE_MEM(gc_alloc_table_start) + MP_STATE_MEM(gc_alloc_table_byte_len);
 #endif
 
-    mp_uint_t gc_pool_block_len = gc_alloc_table_byte_len * BLOCKS_PER_ATB;
-    gc_pool_start = (mp_uint_t*)((byte*)end - gc_pool_block_len * BYTES_PER_BLOCK);
-    gc_pool_end = (mp_uint_t*)end;
+    mp_uint_t gc_pool_block_len = MP_STATE_MEM(gc_alloc_table_byte_len) * BLOCKS_PER_ATB;
+    MP_STATE_MEM(gc_pool_start) = (mp_uint_t*)((byte*)end - gc_pool_block_len * BYTES_PER_BLOCK);
+    MP_STATE_MEM(gc_pool_end) = (mp_uint_t*)end;
 
 #if MICROPY_ENABLE_FINALISER
-    assert((byte*)gc_pool_start >= gc_finaliser_table_start + gc_finaliser_table_byte_len);
+    assert((byte*)MP_STATE_MEM(gc_pool_start) >= MP_STATE_MEM(gc_finaliser_table_start) + gc_finaliser_table_byte_len);
 #endif
 
     // clear ATBs
-    memset(gc_alloc_table_start, 0, gc_alloc_table_byte_len);
+    memset(MP_STATE_MEM(gc_alloc_table_start), 0, MP_STATE_MEM(gc_alloc_table_byte_len));
 
 #if MICROPY_ENABLE_FINALISER
     // clear FTBs
-    memset(gc_finaliser_table_start, 0, gc_finaliser_table_byte_len);
+    memset(MP_STATE_MEM(gc_finaliser_table_start), 0, gc_finaliser_table_byte_len);
 #endif
 
     // set last free ATB index to start of heap
-    gc_last_free_atb_index = 0;
+    MP_STATE_MEM(gc_last_free_atb_index) = 0;
 
     // unlock the GC
-    gc_lock_depth = 0;
+    MP_STATE_MEM(gc_lock_depth) = 0;
 
     // allow auto collection
-    gc_auto_collect_enabled = 1;
+    MP_STATE_MEM(gc_auto_collect_enabled) = 1;
 
     DEBUG_printf("GC layout:\n");
-    DEBUG_printf("  alloc table at %p, length " UINT_FMT " bytes, " UINT_FMT " blocks\n", gc_alloc_table_start, gc_alloc_table_byte_len, gc_alloc_table_byte_len * BLOCKS_PER_ATB);
+    DEBUG_printf("  alloc table at %p, length " UINT_FMT " bytes, " UINT_FMT " blocks\n", MP_STATE_MEM(gc_alloc_table_start), MP_STATE_MEM(gc_alloc_table_byte_len), MP_STATE_MEM(gc_alloc_table_byte_len) * BLOCKS_PER_ATB);
 #if MICROPY_ENABLE_FINALISER
-    DEBUG_printf("  finaliser table at %p, length " UINT_FMT " bytes, " UINT_FMT " blocks\n", gc_finaliser_table_start, gc_finaliser_table_byte_len, gc_finaliser_table_byte_len * BLOCKS_PER_FTB);
+    DEBUG_printf("  finaliser table at %p, length " UINT_FMT " bytes, " UINT_FMT " blocks\n", MP_STATE_MEM(gc_finaliser_table_start), gc_finaliser_table_byte_len, gc_finaliser_table_byte_len * BLOCKS_PER_FTB);
 #endif
-    DEBUG_printf("  pool at %p, length " UINT_FMT " bytes, " UINT_FMT " blocks\n", gc_pool_start, gc_pool_block_len * BYTES_PER_BLOCK, gc_pool_block_len);
+    DEBUG_printf("  pool at %p, length " UINT_FMT " bytes, " UINT_FMT " blocks\n", MP_STATE_MEM(gc_pool_start), gc_pool_block_len * BYTES_PER_BLOCK, gc_pool_block_len);
 }
 
 void gc_lock(void) {
-    gc_lock_depth++;
+    MP_STATE_MEM(gc_lock_depth)++;
 }
 
 void gc_unlock(void) {
-    gc_lock_depth--;
+    MP_STATE_MEM(gc_lock_depth)--;
 }
 
 bool gc_is_locked(void) {
-    return gc_lock_depth != 0;
+    return MP_STATE_MEM(gc_lock_depth) != 0;
 }
 
 #define VERIFY_PTR(ptr) ( \
         (ptr & (BYTES_PER_BLOCK - 1)) == 0          /* must be aligned on a block */ \
-        && ptr >= (mp_uint_t)gc_pool_start     /* must be above start of pool */ \
-        && ptr < (mp_uint_t)gc_pool_end        /* must be below end of pool */ \
+        && ptr >= (mp_uint_t)MP_STATE_MEM(gc_pool_start)     /* must be above start of pool */ \
+        && ptr < (mp_uint_t)MP_STATE_MEM(gc_pool_end)        /* must be below end of pool */ \
     )
 
 #define VERIFY_MARK_AND_PUSH(ptr) \
@@ -195,19 +177,19 @@ bool gc_is_locked(void) {
             if (ATB_GET_KIND(_block) == AT_HEAD) { \
                 /* an unmarked head, mark it, and push it on gc stack */ \
                 ATB_HEAD_TO_MARK(_block); \
-                if (gc_sp < &gc_stack[MICROPY_ALLOC_GC_STACK_SIZE]) { \
-                    *gc_sp++ = _block; \
+                if (MP_STATE_MEM(gc_sp) < &MP_STATE_MEM(gc_stack)[MICROPY_ALLOC_GC_STACK_SIZE]) { \
+                    *MP_STATE_MEM(gc_sp)++ = _block; \
                 } else { \
-                    gc_stack_overflow = 1; \
+                    MP_STATE_MEM(gc_stack_overflow) = 1; \
                 } \
             } \
         } \
     } while (0)
 
 STATIC void gc_drain_stack(void) {
-    while (gc_sp > gc_stack) {
+    while (MP_STATE_MEM(gc_sp) > MP_STATE_MEM(gc_stack)) {
         // pop the next block off the stack
-        mp_uint_t block = *--gc_sp;
+        mp_uint_t block = *--MP_STATE_MEM(gc_sp);
 
         // work out number of consecutive blocks in the chain starting with this one
         mp_uint_t n_blocks = 0;
@@ -225,15 +207,15 @@ STATIC void gc_drain_stack(void) {
 }
 
 STATIC void gc_deal_with_stack_overflow(void) {
-    while (gc_stack_overflow) {
-        gc_stack_overflow = 0;
-        gc_sp = gc_stack;
+    while (MP_STATE_MEM(gc_stack_overflow)) {
+        MP_STATE_MEM(gc_stack_overflow) = 0;
+        MP_STATE_MEM(gc_sp) = MP_STATE_MEM(gc_stack);
 
         // scan entire memory looking for blocks which have been marked but not their children
-        for (mp_uint_t block = 0; block < gc_alloc_table_byte_len * BLOCKS_PER_ATB; block++) {
+        for (mp_uint_t block = 0; block < MP_STATE_MEM(gc_alloc_table_byte_len) * BLOCKS_PER_ATB; block++) {
             // trace (again) if mark bit set
             if (ATB_GET_KIND(block) == AT_MARK) {
-                *gc_sp++ = block;
+                *MP_STATE_MEM(gc_sp)++ = block;
                 gc_drain_stack();
             }
         }
@@ -250,7 +232,7 @@ STATIC void gc_sweep(void) {
     #endif
     // free unmarked heads and their tails
     int free_tail = 0;
-    for (mp_uint_t block = 0; block < gc_alloc_table_byte_len * BLOCKS_PER_ATB; block++) {
+    for (mp_uint_t block = 0; block < MP_STATE_MEM(gc_alloc_table_byte_len) * BLOCKS_PER_ATB; block++) {
         switch (ATB_GET_KIND(block)) {
             case AT_HEAD:
 #if MICROPY_ENABLE_FINALISER
@@ -292,8 +274,12 @@ STATIC void gc_sweep(void) {
 
 void gc_collect_start(void) {
     gc_lock();
-    gc_stack_overflow = 0;
-    gc_sp = gc_stack;
+    MP_STATE_MEM(gc_stack_overflow) = 0;
+    MP_STATE_MEM(gc_sp) = MP_STATE_MEM(gc_stack);
+    // trace dict_locals and dict_globals
+    gc_collect_root((void**)&MP_STATE_CTX(dict_locals), 2);
+    // trace other root pointers from state
+    gc_collect_root((void**)&MP_STATE_VM(last_pool), offsetof(mp_state_vm_t, stack_top) / sizeof(mp_uint_t));
 }
 
 void gc_collect_root(void **ptrs, mp_uint_t len) {
@@ -307,18 +293,18 @@ void gc_collect_root(void **ptrs, mp_uint_t len) {
 void gc_collect_end(void) {
     gc_deal_with_stack_overflow();
     gc_sweep();
-    gc_last_free_atb_index = 0;
+    MP_STATE_MEM(gc_last_free_atb_index) = 0;
     gc_unlock();
 }
 
 void gc_info(gc_info_t *info) {
-    info->total = (gc_pool_end - gc_pool_start) * sizeof(mp_uint_t);
+    info->total = (MP_STATE_MEM(gc_pool_end) - MP_STATE_MEM(gc_pool_start)) * sizeof(mp_uint_t);
     info->used = 0;
     info->free = 0;
     info->num_1block = 0;
     info->num_2block = 0;
     info->max_block = 0;
-    for (mp_uint_t block = 0, len = 0; block < gc_alloc_table_byte_len * BLOCKS_PER_ATB; block++) {
+    for (mp_uint_t block = 0, len = 0; block < MP_STATE_MEM(gc_alloc_table_byte_len) * BLOCKS_PER_ATB; block++) {
         mp_uint_t kind = ATB_GET_KIND(block);
         if (kind == AT_FREE || kind == AT_HEAD) {
             if (len == 1) {
@@ -361,7 +347,7 @@ void *gc_alloc(mp_uint_t n_bytes, bool has_finaliser) {
     DEBUG_printf("gc_alloc(" UINT_FMT " bytes -> " UINT_FMT " blocks)\n", n_bytes, n_blocks);
 
     // check if GC is locked
-    if (gc_lock_depth > 0) {
+    if (MP_STATE_MEM(gc_lock_depth) > 0) {
         return NULL;
     }
 
@@ -374,12 +360,12 @@ void *gc_alloc(mp_uint_t n_bytes, bool has_finaliser) {
     mp_uint_t end_block;
     mp_uint_t start_block;
     mp_uint_t n_free = 0;
-    int collected = !gc_auto_collect_enabled;
+    int collected = !MP_STATE_MEM(gc_auto_collect_enabled);
     for (;;) {
 
         // look for a run of n_blocks available blocks
-        for (i = gc_last_free_atb_index; i < gc_alloc_table_byte_len; i++) {
-            byte a = gc_alloc_table_start[i];
+        for (i = MP_STATE_MEM(gc_last_free_atb_index); i < MP_STATE_MEM(gc_alloc_table_byte_len); i++) {
+            byte a = MP_STATE_MEM(gc_alloc_table_start)[i];
             if (ATB_0_IS_FREE(a)) { if (++n_free >= n_blocks) { i = i * BLOCKS_PER_ATB + 0; goto found; } } else { n_free = 0; }
             if (ATB_1_IS_FREE(a)) { if (++n_free >= n_blocks) { i = i * BLOCKS_PER_ATB + 1; goto found; } } else { n_free = 0; }
             if (ATB_2_IS_FREE(a)) { if (++n_free >= n_blocks) { i = i * BLOCKS_PER_ATB + 2; goto found; } } else { n_free = 0; }
@@ -407,7 +393,7 @@ found:
     // before this one.  Also, whenever we free or shink a block we must check
     // if this index needs adjusting (see gc_realloc and gc_free).
     if (n_free == 1) {
-        gc_last_free_atb_index = (i + 1) / BLOCKS_PER_ATB;
+        MP_STATE_MEM(gc_last_free_atb_index) = (i + 1) / BLOCKS_PER_ATB;
     }
 
     // mark first block as used head
@@ -420,7 +406,7 @@ found:
     }
 
     // get pointer to first block
-    void *ret_ptr = (void*)(gc_pool_start + start_block * WORDS_PER_BLOCK);
+    void *ret_ptr = (void*)(MP_STATE_MEM(gc_pool_start) + start_block * WORDS_PER_BLOCK);
     DEBUG_printf("gc_alloc(%p)\n", ret_ptr);
 
     // zero out the additional bytes of the newly allocated blocks
@@ -458,7 +444,7 @@ void *gc_alloc_with_finaliser(mp_uint_t n_bytes) {
 
 // force the freeing of a piece of memory
 void gc_free(void *ptr_in) {
-    if (gc_lock_depth > 0) {
+    if (MP_STATE_MEM(gc_lock_depth) > 0) {
         // TODO how to deal with this error?
         return;
     }
@@ -470,8 +456,8 @@ void gc_free(void *ptr_in) {
         mp_uint_t block = BLOCK_FROM_PTR(ptr);
         if (ATB_GET_KIND(block) == AT_HEAD) {
             // set the last_free pointer to this block if it's earlier in the heap
-            if (block / BLOCKS_PER_ATB < gc_last_free_atb_index) {
-                gc_last_free_atb_index = block / BLOCKS_PER_ATB;
+            if (block / BLOCKS_PER_ATB < MP_STATE_MEM(gc_last_free_atb_index)) {
+                MP_STATE_MEM(gc_last_free_atb_index) = block / BLOCKS_PER_ATB;
             }
 
             // free head and all of its tail blocks
@@ -540,7 +526,7 @@ void *gc_realloc(void *ptr, mp_uint_t n_bytes) {
 #else // Alternative gc_realloc impl
 
 void *gc_realloc(void *ptr_in, mp_uint_t n_bytes) {
-    if (gc_lock_depth > 0) {
+    if (MP_STATE_MEM(gc_lock_depth) > 0) {
         return NULL;
     }
 
@@ -581,7 +567,7 @@ void *gc_realloc(void *ptr_in, mp_uint_t n_bytes) {
     // efficiently shrink it (see below for shrinking code).
     mp_uint_t n_free   = 0;
     mp_uint_t n_blocks = 1; // counting HEAD block
-    mp_uint_t max_block = gc_alloc_table_byte_len * BLOCKS_PER_ATB;
+    mp_uint_t max_block = MP_STATE_MEM(gc_alloc_table_byte_len) * BLOCKS_PER_ATB;
     for (mp_uint_t bl = block + n_blocks; bl < max_block; bl++) {
         byte block_type = ATB_GET_KIND(bl);
         if (block_type == AT_TAIL) {
@@ -612,8 +598,8 @@ void *gc_realloc(void *ptr_in, mp_uint_t n_bytes) {
         }
 
         // set the last_free pointer to end of this block if it's earlier in the heap
-        if ((block + new_blocks) / BLOCKS_PER_ATB < gc_last_free_atb_index) {
-            gc_last_free_atb_index = (block + new_blocks) / BLOCKS_PER_ATB;
+        if ((block + new_blocks) / BLOCKS_PER_ATB < MP_STATE_MEM(gc_last_free_atb_index)) {
+            MP_STATE_MEM(gc_last_free_atb_index) = (block + new_blocks) / BLOCKS_PER_ATB;
         }
 
         #if EXTENSIVE_HEAP_PROFILING
@@ -675,22 +661,22 @@ void gc_dump_alloc_table(void) {
     #if !EXTENSIVE_HEAP_PROFILING
     // When comparing heap output we don't want to print the starting
     // pointer of the heap because it changes from run to run.
-    printf("GC memory layout; from %p:", gc_pool_start);
+    printf("GC memory layout; from %p:", MP_STATE_MEM(gc_pool_start));
     #endif
-    for (mp_uint_t bl = 0; bl < gc_alloc_table_byte_len * BLOCKS_PER_ATB; bl++) {
+    for (mp_uint_t bl = 0; bl < MP_STATE_MEM(gc_alloc_table_byte_len) * BLOCKS_PER_ATB; bl++) {
         if (bl % DUMP_BYTES_PER_LINE == 0) {
             // a new line of blocks
             {
                 // check if this line contains only free blocks
                 mp_uint_t bl2 = bl;
-                while (bl2 < gc_alloc_table_byte_len * BLOCKS_PER_ATB && ATB_GET_KIND(bl2) == AT_FREE) {
+                while (bl2 < MP_STATE_MEM(gc_alloc_table_byte_len) * BLOCKS_PER_ATB && ATB_GET_KIND(bl2) == AT_FREE) {
                     bl2++;
                 }
                 if (bl2 - bl >= 2 * DUMP_BYTES_PER_LINE) {
                     // there are at least 2 lines containing only free blocks, so abbreviate their printing
                     printf("\n       (" UINT_FMT " lines all free)", (bl2 - bl) / DUMP_BYTES_PER_LINE);
                     bl = bl2 & (~(DUMP_BYTES_PER_LINE - 1));
-                    if (bl >= gc_alloc_table_byte_len * BLOCKS_PER_ATB) {
+                    if (bl >= MP_STATE_MEM(gc_alloc_table_byte_len) * BLOCKS_PER_ATB) {
                         // got to end of heap
                         break;
                     }
@@ -736,7 +722,7 @@ void gc_dump_alloc_table(void) {
             */
             /* this prints the uPy object type of the head block */
             case AT_HEAD: {
-                mp_uint_t *ptr = gc_pool_start + bl * WORDS_PER_BLOCK;
+                mp_uint_t *ptr = MP_STATE_MEM(gc_pool_start) + bl * WORDS_PER_BLOCK;
                 if (*ptr == (mp_uint_t)&mp_type_tuple) { c = 'T'; }
                 else if (*ptr == (mp_uint_t)&mp_type_list) { c = 'L'; }
                 else if (*ptr == (mp_uint_t)&mp_type_dict) { c = 'D'; }

--- a/py/gc.c
+++ b/py/gc.c
@@ -277,9 +277,11 @@ void gc_collect_start(void) {
     MP_STATE_MEM(gc_stack_overflow) = 0;
     MP_STATE_MEM(gc_sp) = MP_STATE_MEM(gc_stack);
     // trace dict_locals and dict_globals
-    gc_collect_root((void**)&MP_STATE_CTX(dict_locals), 2);
+    void **ptrs = (void**)(void*)&MP_STATE_CTX(dict_locals);
+    gc_collect_root(ptrs, 2);
     // trace other root pointers from state
-    gc_collect_root((void**)&MP_STATE_VM(last_pool), offsetof(mp_state_vm_t, stack_top) / sizeof(mp_uint_t));
+    ptrs = (void**)(void*)&MP_STATE_VM(last_pool);
+    gc_collect_root(ptrs, offsetof(mp_state_vm_t, stack_top) / sizeof(mp_uint_t));
 }
 
 void gc_collect_root(void **ptrs, mp_uint_t len) {

--- a/py/gc.c
+++ b/py/gc.c
@@ -276,12 +276,11 @@ void gc_collect_start(void) {
     gc_lock();
     MP_STATE_MEM(gc_stack_overflow) = 0;
     MP_STATE_MEM(gc_sp) = MP_STATE_MEM(gc_stack);
-    // trace dict_locals and dict_globals
-    void **ptrs = (void**)(void*)&MP_STATE_CTX(dict_locals);
-    gc_collect_root(ptrs, 2);
-    // trace other root pointers from state
-    ptrs = (void**)(void*)&MP_STATE_VM(last_pool);
-    gc_collect_root(ptrs, offsetof(mp_state_vm_t, stack_top) / sizeof(mp_uint_t));
+    // Trace root pointers.  This relies on the root pointers being organised
+    // correctly in the mp_state_ctx structure.  We scan nlr_top, dict_locals,
+    // dict_globals, then the root pointer section of mp_state_vm.
+    void **ptrs = (void**)(void*)&mp_state_ctx;
+    gc_collect_root(ptrs, offsetof(mp_state_ctx_t, vm.stack_top) / sizeof(mp_uint_t));
 }
 
 void gc_collect_root(void **ptrs, mp_uint_t len) {

--- a/py/gc.h
+++ b/py/gc.h
@@ -39,11 +39,6 @@ void gc_lock(void);
 void gc_unlock(void);
 bool gc_is_locked(void);
 
-// This variable controls auto garbage collection.  If set to 0 then the
-// GC won't automatically run when gc_alloc can't find enough blocks.  But
-// you can still allocate/free memory and also explicitly call gc_collect.
-extern uint16_t gc_auto_collect_enabled;
-
 // A given port must implement gc_collect by using the other collect functions.
 void gc_collect(void);
 void gc_collect_start(void);

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -27,14 +27,13 @@
 #include <stdio.h>
 #include <assert.h>
 
+#include "py/mpstate.h"
 #include "py/lexer.h"
 
 #define TAB_SIZE (8)
 
 // TODO seems that CPython allows NULL byte in the input stream
 // don't know if that's intentional or not, but we don't allow it
-
-mp_uint_t mp_optimise_value;
 
 // TODO replace with a call to a standard function
 STATIC bool str_strn_equal(const char *str, const char *strn, mp_uint_t len) {
@@ -662,7 +661,7 @@ STATIC void mp_lexer_next_token_into(mp_lexer_t *lex, bool first_token) {
             if (str_strn_equal(tok_kw[i], lex->vstr.buf, lex->vstr.len)) {
                 if (i == MP_ARRAY_SIZE(tok_kw) - 1) {
                     // tok_kw[MP_ARRAY_SIZE(tok_kw) - 1] == "__debug__"
-                    lex->tok_kind = (mp_optimise_value == 0 ? MP_TOKEN_KW_TRUE : MP_TOKEN_KW_FALSE);
+                    lex->tok_kind = (MP_STATE_VM(mp_optimise_value) == 0 ? MP_TOKEN_KW_TRUE : MP_TOKEN_KW_FALSE);
                 } else {
                     lex->tok_kind = MP_TOKEN_KW_FALSE + i;
                 }

--- a/py/lexer.h
+++ b/py/lexer.h
@@ -192,6 +192,4 @@ typedef enum {
 mp_import_stat_t mp_import_stat(const char *path);
 mp_lexer_t *mp_lexer_new_from_file(const char *filename);
 
-extern mp_uint_t mp_optimise_value;
-
 #endif // __MICROPY_INCLUDED_PY_LEXER_H__

--- a/py/malloc.c
+++ b/py/malloc.c
@@ -30,6 +30,7 @@
 
 #include "py/mpconfig.h"
 #include "py/misc.h"
+#include "py/mpstate.h"
 
 #if 0 // print debugging info
 #define DEBUG_printf DEBUG_printf
@@ -38,11 +39,7 @@
 #endif
 
 #if MICROPY_MEM_STATS
-STATIC size_t total_bytes_allocated = 0;
-STATIC size_t current_bytes_allocated = 0;
-STATIC size_t peak_bytes_allocated = 0;
-
-#define UPDATE_PEAK() { if (current_bytes_allocated > peak_bytes_allocated) peak_bytes_allocated = current_bytes_allocated; }
+#define UPDATE_PEAK() { if (MP_STATE_MEM(current_bytes_allocated) > MP_STATE_MEM(peak_bytes_allocated)) MP_STATE_MEM(peak_bytes_allocated) = MP_STATE_MEM(current_bytes_allocated); }
 #endif
 
 #if MICROPY_ENABLE_GC
@@ -68,8 +65,8 @@ void *m_malloc(size_t num_bytes) {
         return m_malloc_fail(num_bytes);
     }
 #if MICROPY_MEM_STATS
-    total_bytes_allocated += num_bytes;
-    current_bytes_allocated += num_bytes;
+    MP_STATE_MEM(total_bytes_allocated) += num_bytes;
+    MP_STATE_MEM(current_bytes_allocated) += num_bytes;
     UPDATE_PEAK();
 #endif
     DEBUG_printf("malloc %d : %p\n", num_bytes, ptr);
@@ -79,8 +76,8 @@ void *m_malloc(size_t num_bytes) {
 void *m_malloc_maybe(size_t num_bytes) {
     void *ptr = malloc(num_bytes);
 #if MICROPY_MEM_STATS
-    total_bytes_allocated += num_bytes;
-    current_bytes_allocated += num_bytes;
+    MP_STATE_MEM(total_bytes_allocated) += num_bytes;
+    MP_STATE_MEM(current_bytes_allocated) += num_bytes;
     UPDATE_PEAK();
 #endif
     DEBUG_printf("malloc %d : %p\n", num_bytes, ptr);
@@ -94,8 +91,8 @@ void *m_malloc_with_finaliser(size_t num_bytes) {
         return m_malloc_fail(num_bytes);
     }
 #if MICROPY_MEM_STATS
-    total_bytes_allocated += num_bytes;
-    current_bytes_allocated += num_bytes;
+    MP_STATE_MEM(total_bytes_allocated) += num_bytes;
+    MP_STATE_MEM(current_bytes_allocated) += num_bytes;
     UPDATE_PEAK();
 #endif
     DEBUG_printf("malloc %d : %p\n", num_bytes, ptr);
@@ -124,8 +121,8 @@ void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes) {
     // allocated total. If we process only positive increments,
     // we'll count 3K.
     size_t diff = new_num_bytes - old_num_bytes;
-    total_bytes_allocated += diff;
-    current_bytes_allocated += diff;
+    MP_STATE_MEM(total_bytes_allocated) += diff;
+    MP_STATE_MEM(current_bytes_allocated) += diff;
     UPDATE_PEAK();
 #endif
     DEBUG_printf("realloc %p, %d, %d : %p\n", ptr, old_num_bytes, new_num_bytes, new_ptr);
@@ -143,8 +140,8 @@ void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes) {
     // Also, don't count failed reallocs.
     if (!(new_ptr == NULL && new_num_bytes != 0)) {
         size_t diff = new_num_bytes - old_num_bytes;
-        total_bytes_allocated += diff;
-        current_bytes_allocated += diff;
+        MP_STATE_MEM(total_bytes_allocated) += diff;
+        MP_STATE_MEM(current_bytes_allocated) += diff;
         UPDATE_PEAK();
     }
 #endif
@@ -155,21 +152,21 @@ void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes) {
 void m_free(void *ptr, size_t num_bytes) {
     free(ptr);
 #if MICROPY_MEM_STATS
-    current_bytes_allocated -= num_bytes;
+    MP_STATE_MEM(current_bytes_allocated) -= num_bytes;
 #endif
     DEBUG_printf("free %p, %d\n", ptr, num_bytes);
 }
 
 #if MICROPY_MEM_STATS
 size_t m_get_total_bytes_allocated(void) {
-    return total_bytes_allocated;
+    return MP_STATE_MEM(total_bytes_allocated);
 }
 
 size_t m_get_current_bytes_allocated(void) {
-    return current_bytes_allocated;
+    return MP_STATE_MEM(current_bytes_allocated);
 }
 
 size_t m_get_peak_bytes_allocated(void) {
-    return peak_bytes_allocated;
+    return MP_STATE_MEM(peak_bytes_allocated);
 }
 #endif

--- a/py/modgc.c
+++ b/py/modgc.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "py/mpstate.h"
 #include "py/obj.h"
 #include "py/gc.h"
 
@@ -48,7 +49,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(gc_collect_obj, py_gc_collect);
 /// \function disable()
 /// Disable the garbage collector.
 STATIC mp_obj_t gc_disable(void) {
-    gc_auto_collect_enabled = 0;
+    MP_STATE_MEM(gc_auto_collect_enabled) = 0;
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(gc_disable_obj, gc_disable);
@@ -56,13 +57,13 @@ MP_DEFINE_CONST_FUN_OBJ_0(gc_disable_obj, gc_disable);
 /// \function enable()
 /// Enable the garbage collector.
 STATIC mp_obj_t gc_enable(void) {
-    gc_auto_collect_enabled = 1;
+    MP_STATE_MEM(gc_auto_collect_enabled) = 1;
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(gc_enable_obj, gc_enable);
 
 STATIC mp_obj_t gc_isenabled(void) {
-    return MP_BOOL(gc_auto_collect_enabled);
+    return MP_BOOL(MP_STATE_MEM(gc_auto_collect_enabled));
 }
 MP_DEFINE_CONST_FUN_OBJ_0(gc_isenabled_obj, gc_isenabled);
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -488,6 +488,11 @@ typedef double mp_float_t;
 #define MICROPY_PORT_CONSTANTS
 #endif
 
+// Any root pointers for GC scanning - see mpstate.c
+#ifndef MICROPY_PORT_ROOT_POINTERS
+#define MICROPY_PORT_ROOT_POINTERS
+#endif
+
 /*****************************************************************************/
 /* Miscellaneous settings                                                    */
 

--- a/py/mpstate.c
+++ b/py/mpstate.c
@@ -26,7 +26,4 @@
 
 #include "py/mpstate.h"
 
-nlr_buf_t *nlr_top;
-mp_state_mem_t mp_state_mem;
-mp_state_vm_t mp_state_vm;
 mp_state_ctx_t mp_state_ctx;

--- a/py/mpstate.c
+++ b/py/mpstate.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013, 2014 Damien P. George
+ * Copyright (c) 2014 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,15 +24,9 @@
  * THE SOFTWARE.
  */
 
-#include "py/nlr.h"
+#include "py/mpstate.h"
 
-#if MICROPY_NLR_SETJMP
-
-void nlr_setjmp_jump(void *val) {
-    nlr_buf_t *buf = nlr_top;
-    nlr_top = buf->prev;
-    buf->ret_val = val;
-    longjmp(buf->jmpbuf, 1);
-}
-
-#endif
+nlr_buf_t *nlr_top;
+mp_state_mem_t mp_state_mem;
+mp_state_vm_t mp_state_vm;
+mp_state_ctx_t mp_state_ctx;

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -1,0 +1,136 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef __MICROPY_INCLUDED_PY_MPSTATE_H__
+#define __MICROPY_INCLUDED_PY_MPSTATE_H__
+
+#include <stdint.h>
+
+#include "py/mpconfig.h"
+#include "py/misc.h"
+#include "py/nlr.h"
+#include "py/obj.h"
+#include "py/objexcept.h"
+
+extern nlr_buf_t *nlr_top;
+
+// should be zerod on init
+typedef struct _mp_state_mem_t {
+    #if MICROPY_MEM_STATS
+    size_t total_bytes_allocated;
+    size_t current_bytes_allocated;
+    size_t peak_bytes_allocated;
+    #endif
+
+    byte *gc_alloc_table_start;
+    mp_uint_t gc_alloc_table_byte_len;
+    #if MICROPY_ENABLE_FINALISER
+    byte *gc_finaliser_table_start;
+    #endif
+    // We initialise gc_pool_start to a dummy value so it stays out of the bss
+    // section.  This makes sure we don't trace this pointer in a collect cycle.
+    // If we did trace it, it would make the first block of the heap always
+    // reachable, and hence we can never free that block.
+    mp_uint_t *gc_pool_start;
+    mp_uint_t *gc_pool_end;
+
+    int gc_stack_overflow;
+    mp_uint_t gc_stack[MICROPY_ALLOC_GC_STACK_SIZE];
+    mp_uint_t *gc_sp;
+    uint16_t gc_lock_depth;
+
+    // This variable controls auto garbage collection.  If set to 0 then the
+    // GC won't automatically run when gc_alloc can't find enough blocks.  But
+    // you can still allocate/free memory and also explicitly call gc_collect.
+    uint16_t gc_auto_collect_enabled;
+
+    mp_uint_t gc_last_free_atb_index;
+} mp_state_mem_t;
+
+// zero
+typedef struct _mp_state_vm_t {
+    // root pointer section (need last_pool at start, stack_top after end)
+
+    qstr_pool_t *last_pool;
+
+    #if MICROPY_CAN_OVERRIDE_BUILTINS
+    mp_obj_dict_t *mp_module_builtins_override_dict;
+    #endif
+
+    // Local non-heap memory for allocating an exception when we run out of RAM
+    mp_obj_exception_t mp_emergency_exception_obj;
+
+    #if MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF
+    #if MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE > 0
+    byte mp_emergency_exception_buf[MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE];
+    #else
+    byte *mp_emergency_exception_buf;
+    #endif
+    #endif
+
+    mp_map_t mp_loaded_modules_map; // TODO: expose as sys.modules
+
+    // pending exception object (MP_OBJ_NULL if not pending)
+    mp_obj_t mp_pending_exception;
+
+    // dictionary for the __main__ module
+    mp_obj_dict_t dict_main;
+
+    // include any root pointers defined by a port
+    MICROPY_PORT_ROOT_POINTERS
+
+    // Stack top at the start of program
+    char *stack_top;
+
+    #if MICROPY_STACK_CHECK
+    mp_uint_t stack_limit;
+    #endif
+
+    mp_uint_t mp_optimise_value;
+
+    #if MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF && MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE == 0
+    mp_int_t mp_emergency_exception_buf_size;
+    #endif
+
+} mp_state_vm_t;
+
+typedef struct _mp_state_ctx_t {
+    // locals and globals need to be pointers because they can be the same in outer module scope
+    mp_obj_dict_t *dict_locals;
+    mp_obj_dict_t *dict_globals;
+    // mp_state_mem_t *mem;
+    // mp_state_vm_t *vm;
+} mp_state_ctx_t;
+
+extern mp_state_mem_t mp_state_mem;
+#define MP_STATE_MEM(x) (mp_state_mem.x)
+
+extern mp_state_vm_t mp_state_vm;
+#define MP_STATE_VM(x) (mp_state_vm.x)
+
+extern mp_state_ctx_t mp_state_ctx;
+#define MP_STATE_CTX(x) (mp_state_ctx.x)
+
+#endif // __MICROPY_INCLUDED_PY_MPSTATE_H__

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -64,8 +64,6 @@ struct _nlr_buf_t {
 #endif
 };
 
-extern nlr_buf_t *nlr_top;
-
 #if MICROPY_NLR_SETJMP
 NORETURN void nlr_setjmp_jump(void *val);
 // nlr_push() must be defined as a macro, because "The stack context will be

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -33,8 +33,6 @@
 #include <setjmp.h>
 #include <assert.h>
 
-#include "py/mpconfig.h"
-
 typedef struct _nlr_buf_t nlr_buf_t;
 struct _nlr_buf_t {
     // the entries here must all be machine word size
@@ -63,6 +61,8 @@ struct _nlr_buf_t {
     jmp_buf jmpbuf;
 #endif
 };
+
+#include "py/mpstate.h"
 
 #if MICROPY_NLR_SETJMP
 NORETURN void nlr_setjmp_jump(void *val);

--- a/py/nlrthumb.S
+++ b/py/nlrthumb.S
@@ -68,7 +68,7 @@ nlr_push:
     bx      lr                      @ return
     .align  2
 nlr_top_addr:
-    .word   nlr_top
+    .word   mp_state_ctx
     .size   nlr_push, .-nlr_push
 
 /**************************************/

--- a/py/nlrx64.S
+++ b/py/nlrx64.S
@@ -35,6 +35,8 @@
     .file   "nlr.s"
     .text
 
+#define NLR_TOP mp_state_ctx
+
 #if !defined(__CYGWIN__)
 
 /******************************************************************************/
@@ -64,9 +66,9 @@ _nlr_push:
     movq    %r13, 56(%rdi)          # store %r13 into nlr_buf
     movq    %r14, 64(%rdi)          # store %r14 into nlr_buf
     movq    %r15, 72(%rdi)          # store %r15 into nlr_buf
-    movq    nlr_top(%rip), %rax     # get last nlr_buf
+    movq    NLR_TOP(%rip), %rax     # get last nlr_buf
     movq    %rax, (%rdi)            # store it
-    movq    %rdi, nlr_top(%rip)     # stor new nlr_buf (to make linked list)
+    movq    %rdi, NLR_TOP(%rip)     # stor new nlr_buf (to make linked list)
     xorq    %rax, %rax              # return 0, normal return
     ret                             # return
 #if !(defined(__APPLE__) && defined(__MACH__))
@@ -84,9 +86,9 @@ nlr_pop:
     .globl  _nlr_pop
 _nlr_pop:
 #endif
-    movq    nlr_top(%rip), %rax     # get nlr_top into %rax
+    movq    NLR_TOP(%rip), %rax     # get nlr_top into %rax
     movq    (%rax), %rax            # load prev nlr_buf
-    movq    %rax, nlr_top(%rip)     # store prev nlr_buf (to unlink list)
+    movq    %rax, NLR_TOP(%rip)     # store prev nlr_buf (to unlink list)
     ret                             # return
 #if !(defined(__APPLE__) && defined(__MACH__))
     .size   nlr_pop, .-nlr_pop
@@ -104,12 +106,12 @@ nlr_jump:
     _nlr_jump:
 #endif
     movq    %rdi, %rax              # put return value in %rax
-    movq    nlr_top(%rip), %rdi     # get nlr_top into %rdi
+    movq    NLR_TOP(%rip), %rdi     # get nlr_top into %rdi
     test    %rdi, %rdi              # check for nlr_top being NULL
     je      .fail                   # fail if nlr_top is NULL
     movq    %rax, 8(%rdi)           # store return value
     movq    (%rdi), %rax            # load prev nlr_buf
-    movq    %rax, nlr_top(%rip)     # store prev nlr_buf (to unlink list)
+    movq    %rax, NLR_TOP(%rip)     # store prev nlr_buf (to unlink list)
     movq    72(%rdi), %r15          # load saved %r15
     movq    64(%rdi), %r14          # load saved %r14
     movq    56(%rdi), %r13          # load saved %r13
@@ -155,9 +157,9 @@ nlr_push:
     movq    %r15, 72(%rcx)          # store %r15 into
     movq    %rdi, 80(%rcx)          # store %rdr into
     movq    %rsi, 88(%rcx)          # store %rsi into
-    movq    nlr_top(%rip), %rax     # get last nlr_buf
+    movq    NLR_TOP(%rip), %rax     # get last nlr_buf
     movq    %rax, (%rcx)            # store it
-    movq    %rcx, nlr_top(%rip)     # stor new nlr_buf (to make linked list)
+    movq    %rcx, NLR_TOP(%rip)     # stor new nlr_buf (to make linked list)
     xorq    %rax, %rax              # return 0, normal return
     ret                             # return
 
@@ -166,9 +168,9 @@ nlr_push:
 
     .globl  nlr_pop
 nlr_pop:
-    movq    nlr_top(%rip), %rax     # get nlr_top into %rax
+    movq    NLR_TOP(%rip), %rax     # get nlr_top into %rax
     movq    (%rax), %rax            # load prev nlr_buf
-    movq    %rax, nlr_top(%rip)     # store prev nlr_buf (to unlink list)
+    movq    %rax, NLR_TOP(%rip)     # store prev nlr_buf (to unlink list)
     ret                             # return
 
 /**************************************/
@@ -177,12 +179,12 @@ nlr_pop:
     .globl  nlr_jump
 nlr_jump:
     movq    %rcx, %rax              # put return value in %rax
-    movq    nlr_top(%rip), %rcx     # get nlr_top into %rcx
+    movq    NLR_TOP(%rip), %rcx     # get nlr_top into %rcx
     test    %rcx, %rcx              # check for nlr_top being NULL
     je      .fail                   # fail if nlr_top is NULL
     movq    %rax, 8(%rcx)           # store return value
     movq    (%rcx), %rax            # load prev nlr_buf
-    movq    %rax, nlr_top(%rip)     # store prev nlr_buf (to unlink list)
+    movq    %rax, NLR_TOP(%rip)     # store prev nlr_buf (to unlink list)
     movq    72(%rcx), %r15          # load saved %r15
     movq    64(%rcx), %r14          # load saved %r14
     movq    56(%rcx), %r13          # load saved %r13

--- a/py/nlrx86.S
+++ b/py/nlrx86.S
@@ -33,9 +33,9 @@
 //      ebx, esi, edi, ebp, esp, eip
 
 #ifdef _WIN32
-#define NLR_TOP _nlr_top
+#define NLR_TOP _mp_state_ctx
 #else
-#define NLR_TOP nlr_top
+#define NLR_TOP mp_state_ctx
 #endif
 
     .file   "nlr.s"

--- a/py/nlrxtensa.S
+++ b/py/nlrxtensa.S
@@ -38,7 +38,7 @@
     .text
 
     .literal_position
-    .literal .LC0, nlr_top
+    .literal .LC0, mp_state_ctx
     .align  4
     .global nlr_push
     .type   nlr_push, @function
@@ -64,7 +64,7 @@ nlr_push:
     .size   nlr_push, .-nlr_push
 
     .literal_position
-    .literal .LC1, nlr_top
+    .literal .LC1, mp_state_ctx
     .align  4
     .global nlr_pop
     .type   nlr_pop, @function
@@ -77,7 +77,7 @@ nlr_pop:
     .size   nlr_pop, .-nlr_pop
 
     .literal_position
-    .literal .LC2, nlr_top
+    .literal .LC2, mp_state_ctx
     .align    4
     .global    nlr_jump
     .type    nlr_jump, @function

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 #include <stdio.h>
 
+#include "py/mpstate.h"
 #include "py/nlr.h"
 #include "py/objlist.h"
 #include "py/objstr.h"
@@ -36,23 +37,13 @@
 #include "py/objtype.h"
 #include "py/gc.h"
 
-typedef struct _mp_obj_exception_t {
-    mp_obj_base_t base;
-    mp_obj_t traceback; // a list object, holding (file,line,block) as numbers (not Python objects); a hack for now
-    mp_obj_tuple_t *args;
-} mp_obj_exception_t;
-
 // Instance of MemoryError exception - needed by mp_malloc_fail
 const mp_obj_exception_t mp_const_MemoryError_obj = {{&mp_type_MemoryError}, MP_OBJ_NULL, mp_const_empty_tuple};
-
-// Local non-heap memory for allocating an exception when we run out of RAM
-STATIC mp_obj_exception_t mp_emergency_exception_obj;
 
 // Optionally allocated buffer for storing the first argument of an exception
 // allocated when the heap is locked.
 #if MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF
 #   if MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE > 0
-STATIC byte  mp_emergency_exception_buf[MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE];
 #define mp_emergency_exception_buf_size MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE
 
 void mp_init_emergency_exception_buf(void) {
@@ -62,12 +53,11 @@ void mp_init_emergency_exception_buf(void) {
 }
 
 #else
-STATIC mp_int_t mp_emergency_exception_buf_size = 0;
-STATIC byte *mp_emergency_exception_buf = NULL;
+#define mp_emergency_exception_buf_size MP_STATE_VM(mp_emergency_exception_buf_size)
 
 void mp_init_emergency_exception_buf(void) {
     mp_emergency_exception_buf_size = 0;
-    mp_emergency_exception_buf = NULL;
+    MP_STATE_VM(mp_emergency_exception_buf) = NULL;
 }
 
 mp_obj_t mp_alloc_emergency_exception_buf(mp_obj_t size_in) {
@@ -78,13 +68,13 @@ mp_obj_t mp_alloc_emergency_exception_buf(mp_obj_t size_in) {
     }
 
     int old_size = mp_emergency_exception_buf_size;
-    void *old_buf = mp_emergency_exception_buf;
+    void *old_buf = MP_STATE_VM(mp_emergency_exception_buf);
 
     // Update the 2 variables atomically so that an interrupt can't occur
     // between the assignments.
     mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     mp_emergency_exception_buf_size = size;
-    mp_emergency_exception_buf = buf;
+    MP_STATE_VM(mp_emergency_exception_buf) = buf;
     MICROPY_END_ATOMIC_SECTION(atomic_state);
 
     if (old_buf != NULL) {
@@ -134,7 +124,7 @@ mp_obj_t mp_obj_exception_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t
     mp_obj_exception_t *o = m_new_obj_var_maybe(mp_obj_exception_t, mp_obj_t, 0);
     if (o == NULL) {
         // Couldn't allocate heap memory; use local data instead.
-        o = &mp_emergency_exception_obj;
+        o = &MP_STATE_VM(mp_emergency_exception_obj);
         // We can't store any args.
         n_args = 0;
         o->args = mp_const_empty_tuple;
@@ -308,7 +298,7 @@ mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const char
     if (o == NULL) {
         // Couldn't allocate heap memory; use local data instead.
         // Unfortunately, we won't be able to format the string...
-        o = &mp_emergency_exception_obj;
+        o = &MP_STATE_VM(mp_emergency_exception_obj);
         o->base.type = exc_type;
         o->traceback = MP_OBJ_NULL;
         o->args = mp_const_empty_tuple;
@@ -318,7 +308,7 @@ mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const char
         // of length 1, which has a string object and the string data.
 
         if (mp_emergency_exception_buf_size > (sizeof(mp_obj_tuple_t) + sizeof(mp_obj_str_t) + sizeof(mp_obj_t))) {
-            mp_obj_tuple_t *tuple = (mp_obj_tuple_t *)mp_emergency_exception_buf;
+            mp_obj_tuple_t *tuple = (mp_obj_tuple_t *)MP_STATE_VM(mp_emergency_exception_buf);
             mp_obj_str_t *str = (mp_obj_str_t *)&tuple->items[1];
 
             tuple->base.type = &mp_type_tuple;
@@ -326,7 +316,7 @@ mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const char
             tuple->items[0] = str;
 
             byte *str_data = (byte *)&str[1];
-            uint max_len = mp_emergency_exception_buf + mp_emergency_exception_buf_size
+            uint max_len = MP_STATE_VM(mp_emergency_exception_buf) + mp_emergency_exception_buf_size
                          - str_data;
 
             va_list ap;
@@ -340,16 +330,16 @@ mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const char
 
             o->args = tuple;
 
-            uint offset = &str_data[str->len] - mp_emergency_exception_buf;
+            uint offset = &str_data[str->len] - MP_STATE_VM(mp_emergency_exception_buf);
             offset += sizeof(void *) - 1;
             offset &= ~(sizeof(void *) - 1);
 
             if ((mp_emergency_exception_buf_size - offset) > (sizeof(mp_obj_list_t) + sizeof(mp_obj_t) * 3)) {
                 // We have room to store some traceback.
-                mp_obj_list_t *list = (mp_obj_list_t *)((byte *)mp_emergency_exception_buf + offset);
+                mp_obj_list_t *list = (mp_obj_list_t *)((byte *)MP_STATE_VM(mp_emergency_exception_buf) + offset);
                 list->base.type = &mp_type_list;
                 list->items = (mp_obj_t)&list[1];
-                list->alloc = (mp_emergency_exception_buf + mp_emergency_exception_buf_size - (byte *)list->items) / sizeof(list->items[0]);
+                list->alloc = (MP_STATE_VM(mp_emergency_exception_buf) + mp_emergency_exception_buf_size - (byte *)list->items) / sizeof(list->items[0]);
                 list->len = 0;
 
                 o->traceback = list;

--- a/py/objexcept.h
+++ b/py/objexcept.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef __MICROPY_INCLUDED_PY_OBJEXCEPT_H__
+#define __MICROPY_INCLUDED_PY_OBJEXCEPT_H__
+
+#include "py/obj.h"
+#include "py/objtuple.h"
+
+typedef struct _mp_obj_exception_t {
+    mp_obj_base_t base;
+    mp_obj_t traceback; // a list object, holding (file,line,block) as numbers (not Python objects); a hack for now
+    mp_obj_tuple_t *args;
+} mp_obj_exception_t;
+
+#endif // __MICROPY_INCLUDED_PY_OBJEXCEPT_H__

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -27,12 +27,11 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#include "py/mpstate.h"
 #include "py/nlr.h"
 #include "py/objmodule.h"
 #include "py/runtime.h"
 #include "py/builtin.h"
-
-STATIC mp_map_t mp_loaded_modules_map; // TODO: expose as sys.modules
 
 STATIC void module_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
     mp_obj_module_t *self = self_in;
@@ -65,10 +64,10 @@ STATIC bool module_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t value) {
     if (dict->map.table_is_fixed_array) {
         #if MICROPY_CAN_OVERRIDE_BUILTINS
         if (dict == &mp_module_builtins_globals) {
-            if (mp_module_builtins_override_dict == NULL) {
-                mp_module_builtins_override_dict = mp_obj_new_dict(1);
+            if (MP_STATE_VM(mp_module_builtins_override_dict) == NULL) {
+                MP_STATE_VM(mp_module_builtins_override_dict) = mp_obj_new_dict(1);
             }
-            dict = mp_module_builtins_override_dict;
+            dict = MP_STATE_VM(mp_module_builtins_override_dict);
         } else
         #endif
         {
@@ -96,7 +95,7 @@ const mp_obj_type_t mp_type_module = {
 };
 
 mp_obj_t mp_obj_new_module(qstr module_name) {
-    mp_map_elem_t *el = mp_map_lookup(&mp_loaded_modules_map, MP_OBJ_NEW_QSTR(module_name), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
+    mp_map_elem_t *el = mp_map_lookup(&MP_STATE_VM(mp_loaded_modules_map), MP_OBJ_NEW_QSTR(module_name), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
     // We could error out if module already exists, but let C extensions
     // add new members to existing modules.
     if (el->value != MP_OBJ_NULL) {
@@ -192,17 +191,17 @@ STATIC const mp_map_elem_t mp_builtin_module_table[] = {
 STATIC MP_DEFINE_CONST_MAP(mp_builtin_module_map, mp_builtin_module_table);
 
 void mp_module_init(void) {
-    mp_map_init(&mp_loaded_modules_map, 3);
+    mp_map_init(&MP_STATE_VM(mp_loaded_modules_map), 3);
 }
 
 void mp_module_deinit(void) {
-    mp_map_deinit(&mp_loaded_modules_map);
+    mp_map_deinit(&MP_STATE_VM(mp_loaded_modules_map));
 }
 
 // returns MP_OBJ_NULL if not found
 mp_obj_t mp_module_get(qstr module_name) {
     // lookup module
-    mp_map_elem_t *el = mp_map_lookup(&mp_loaded_modules_map, MP_OBJ_NEW_QSTR(module_name), MP_MAP_LOOKUP);
+    mp_map_elem_t *el = mp_map_lookup(&MP_STATE_VM(mp_loaded_modules_map), MP_OBJ_NEW_QSTR(module_name), MP_MAP_LOOKUP);
 
     if (el == NULL) {
         // module not found, look for builtin module names
@@ -217,5 +216,5 @@ mp_obj_t mp_module_get(qstr module_name) {
 }
 
 void mp_module_register(qstr qstr, mp_obj_t module) {
-    mp_map_lookup(&mp_loaded_modules_map, MP_OBJ_NEW_QSTR(qstr), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = module;
+    mp_map_lookup(&MP_STATE_VM(mp_loaded_modules_map), MP_OBJ_NEW_QSTR(qstr), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = module;
 }

--- a/py/py.mk
+++ b/py/py.mk
@@ -12,6 +12,7 @@ CSUPEROPT = -O3
 
 # py object files
 PY_O_BASENAME = \
+	mpstate.o \
 	nlrx86.o \
 	nlrx64.o \
 	nlrthumb.o \

--- a/py/qstr.h
+++ b/py/qstr.h
@@ -46,6 +46,14 @@ enum {
 
 typedef mp_uint_t qstr;
 
+typedef struct _qstr_pool_t {
+    struct _qstr_pool_t *prev;
+    mp_uint_t total_prev_len;
+    mp_uint_t alloc;
+    mp_uint_t len;
+    const byte *qstrs[];
+} qstr_pool_t;
+
 #define QSTR_FROM_STR_STATIC(s) (qstr_from_strn((s), strlen(s)))
 
 void qstr_init(void);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -56,7 +56,7 @@
 const mp_obj_module_t mp_module___main__ = {
     .base = { &mp_type_module },
     .name = MP_QSTR___main__,
-    .globals = (mp_obj_dict_t*)&mp_state_vm.dict_main,
+    .globals = (mp_obj_dict_t*)&MP_STATE_VM(dict_main),
 };
 
 void mp_init(void) {
@@ -1227,26 +1227,6 @@ void mp_import_all(mp_obj_t module) {
         }
     }
 }
-
-/*
-mp_obj_dict_t *mp_locals_get(void) {
-    return MP_STATE_CTX(dict_locals);
-}
-
-void mp_locals_set(mp_obj_dict_t *d) {
-    DEBUG_OP_printf("mp_locals_set(%p)\n", d);
-    MP_STATE_CTX(dict_locals) = d;
-}
-
-mp_obj_dict_t *mp_globals_get(void) {
-    return MP_STATE_CTX(dict_globals);
-}
-
-void mp_globals_set(mp_obj_dict_t *d) {
-    DEBUG_OP_printf("mp_globals_set(%p)\n", d);
-    MP_STATE_CTX(dict_globals) = d;
-}
-*/
 
 // this is implemented in this file so it can optimise access to locals/globals
 mp_obj_t mp_parse_compile_execute(mp_lexer_t *lex, mp_parse_input_kind_t parse_input_kind, mp_obj_dict_t *globals, mp_obj_dict_t *locals) {

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1228,6 +1228,7 @@ void mp_import_all(mp_obj_t module) {
     }
 }
 
+/*
 mp_obj_dict_t *mp_locals_get(void) {
     return MP_STATE_CTX(dict_locals);
 }
@@ -1245,6 +1246,7 @@ void mp_globals_set(mp_obj_dict_t *d) {
     DEBUG_OP_printf("mp_globals_set(%p)\n", d);
     MP_STATE_CTX(dict_globals) = d;
 }
+*/
 
 // this is implemented in this file so it can optimise access to locals/globals
 mp_obj_t mp_parse_compile_execute(mp_lexer_t *lex, mp_parse_input_kind_t parse_input_kind, mp_obj_dict_t *globals, mp_obj_dict_t *locals) {

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -26,6 +26,7 @@
 #ifndef __MICROPY_INCLUDED_PY_RUNTIME_H__
 #define __MICROPY_INCLUDED_PY_RUNTIME_H__
 
+#include "py/mpstate.h"
 #include "py/obj.h"
 
 typedef enum {
@@ -64,10 +65,10 @@ void mp_arg_parse_all_kw_array(mp_uint_t n_pos, mp_uint_t n_kw, const mp_obj_t *
 NORETURN void mp_arg_error_terse_mismatch(void);
 NORETURN void mp_arg_error_unimpl_kw(void);
 
-mp_obj_dict_t *mp_locals_get(void);
-void mp_locals_set(mp_obj_dict_t *d);
-mp_obj_dict_t *mp_globals_get(void);
-void mp_globals_set(mp_obj_dict_t *d);
+static inline mp_obj_dict_t *mp_locals_get(void) { return MP_STATE_CTX(dict_locals); }
+static inline void mp_locals_set(mp_obj_dict_t *d) { MP_STATE_CTX(dict_locals) = d; }
+static inline mp_obj_dict_t *mp_globals_get(void) { return MP_STATE_CTX(dict_globals); }
+static inline void mp_globals_set(mp_obj_dict_t *d) { MP_STATE_CTX(dict_globals) = d; }
 
 mp_obj_t mp_load_name(qstr qstr);
 mp_obj_t mp_load_global(qstr qstr);

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -120,7 +120,6 @@ mp_obj_t mp_convert_native_to_obj(mp_uint_t val, mp_uint_t type);
 mp_obj_t mp_native_call_function_n_kw(mp_obj_t fun_in, mp_uint_t n_args_kw, const mp_obj_t *args);
 NORETURN void mp_native_raise(mp_obj_t o);
 
-extern mp_obj_t mp_pending_exception;
 extern struct _mp_obj_list_t mp_sys_path_obj;
 extern struct _mp_obj_list_t mp_sys_argv_obj;
 #define mp_sys_path ((mp_obj_t)&mp_sys_path_obj)

--- a/py/stackctrl.c
+++ b/py/stackctrl.c
@@ -24,34 +24,30 @@
  * THE SOFTWARE.
  */
 
+#include "py/mpstate.h"
 #include "py/nlr.h"
 #include "py/obj.h"
 #include "py/stackctrl.h"
 
-// Stack top at the start of program
-char *stack_top;
-
 void mp_stack_ctrl_init(void) {
     volatile int stack_dummy;
-    stack_top = (char*)&stack_dummy;
+    MP_STATE_VM(stack_top) = (char*)&stack_dummy;
 }
 
 mp_uint_t mp_stack_usage(void) {
     // Assumes descending stack
     volatile int stack_dummy;
-    return stack_top - (char*)&stack_dummy;
+    return MP_STATE_VM(stack_top) - (char*)&stack_dummy;
 }
 
 #if MICROPY_STACK_CHECK
 
-static mp_uint_t stack_limit = 10240;
-
 void mp_stack_set_limit(mp_uint_t limit) {
-    stack_limit = limit;
+    MP_STATE_VM(stack_limit) = limit;
 }
 
 void mp_stack_check(void) {
-    if (mp_stack_usage() >= stack_limit) {
+    if (mp_stack_usage() >= MP_STATE_VM(stack_limit)) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_RuntimeError, "maximum recursion depth exceeded"));
     }
 }

--- a/py/vm.c
+++ b/py/vm.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "py/mpstate.h"
 #include "py/nlr.h"
 #include "py/emitglue.h"
 #include "py/runtime.h"
@@ -991,10 +992,10 @@ yield:
 #endif
 
 pending_exception_check:
-                if (mp_pending_exception != MP_OBJ_NULL) {
+                if (MP_STATE_VM(mp_pending_exception) != MP_OBJ_NULL) {
                     MARK_EXC_IP_SELECTIVE();
-                    mp_obj_t obj = mp_pending_exception;
-                    mp_pending_exception = MP_OBJ_NULL;
+                    mp_obj_t obj = MP_STATE_VM(mp_pending_exception);
+                    MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
                     RAISE(obj);
                 }
 

--- a/stmhal/pendsv.c
+++ b/stmhal/pendsv.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <stm32f4xx_hal.h>
 
+#include "py/mpstate.h"
 #include "py/runtime.h"
 #include "pendsv.h"
 
@@ -46,10 +47,10 @@ void pendsv_init(void) {
 // the given exception object using nlr_jump in the context of the top-level
 // thread.
 void pendsv_nlr_jump(void *o) {
-    if (mp_pending_exception == MP_OBJ_NULL) {
-        mp_pending_exception = o;
+    if (MP_STATE_VM(mp_pending_exception) == MP_OBJ_NULL) {
+        MP_STATE_VM(mp_pending_exception) = o;
     } else {
-        mp_pending_exception = MP_OBJ_NULL;
+        MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
         pendsv_object = o;
         SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
     }

--- a/unix/gccollect.c
+++ b/unix/gccollect.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 
+#include "py/mpstate.h"
 #include "py/gc.h"
 
 #if MICROPY_ENABLE_GC
@@ -127,6 +128,7 @@ void gc_collect(void) {
     //gc_dump_info();
 
     gc_collect_start();
+    #if 0
     // this traces the .bss section
 #if defined( __CYGWIN__ )
 #define BSS_START __bss_start__
@@ -139,11 +141,12 @@ void gc_collect(void) {
     extern char BSS_START, _end;
     //printf(".bss: %p-%p\n", &BSS_START, &_end);
     gc_collect_root((void**)&BSS_START, ((mp_uint_t)&_end - (mp_uint_t)&BSS_START) / sizeof(mp_uint_t));
+    #endif
     regs_t regs;
     gc_helper_get_regs(regs);
     // GC stack (and regs because we captured them)
     void **regs_ptr = (void**)(void*)&regs;
-    gc_collect_root(regs_ptr, ((mp_uint_t)stack_top - (mp_uint_t)&regs) / sizeof(mp_uint_t));
+    gc_collect_root(regs_ptr, ((mp_uint_t)MP_STATE_VM(stack_top) - (mp_uint_t)&regs) / sizeof(mp_uint_t));
     gc_collect_end();
 
     //printf("-----\n");

--- a/unix/gccollect.c
+++ b/unix/gccollect.c
@@ -128,20 +128,6 @@ void gc_collect(void) {
     //gc_dump_info();
 
     gc_collect_start();
-    #if 0
-    // this traces the .bss section
-#if defined( __CYGWIN__ )
-#define BSS_START __bss_start__
-#elif defined( _MSC_VER ) || defined( __MINGW32__ )
-#define BSS_START *bss_start
-#define _end *bss_end
-#else
-#define BSS_START __bss_start
-#endif
-    extern char BSS_START, _end;
-    //printf(".bss: %p-%p\n", &BSS_START, &_end);
-    gc_collect_root((void**)&BSS_START, ((mp_uint_t)&_end - (mp_uint_t)&BSS_START) / sizeof(mp_uint_t));
-    #endif
     regs_t regs;
     gc_helper_get_regs(regs);
     // GC stack (and regs because we captured them)

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -153,6 +153,9 @@ extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
     { MP_OBJ_NEW_QSTR(MP_QSTR_input), (mp_obj_t)&mp_builtin_input_obj }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_open), (mp_obj_t)&mp_builtin_open_obj },
 
+#define MICROPY_PORT_ROOT_POINTERS \
+    mp_obj_t keyboard_interrupt_obj;
+
 // We need to provide a declaration/definition of alloca()
 #ifdef __FreeBSD__
 #include <stdlib.h>


### PR DESCRIPTION
This is a second attempt at consolidating global state into one place.  It supersedes #1017.

Improvements upon previous attempt:
- guarded includes now fully implemented by previous patches
- most nlr changes pushed in separate patch already to master (they were nice clean changes)
- state separated into 3 structure: mem (for common memory stuff, like GC), vm (VM specific), ctx (context specific, globals and locals dict)
- state accessed by macros so that it can easily be changed from a global structure to one passed by argument
- bss no longer needed for GC! root pointers are now known because they live in a specific part of the vm state (only implemented properly for unix, stmhal requires some work to separate root pointers from other bss data)
