### PR TITLE
py: Fix float to int conversion for large exponents.

### DIFF
--- a/py/mpz.h
+++ b/py/mpz.h
@@ -85,6 +85,9 @@ void mpz_deinit(mpz_t *z);
 mpz_t *mpz_zero(void);
 mpz_t *mpz_from_int(mp_int_t i);
 mpz_t *mpz_from_ll(long long i, bool is_signed);
+#if MICROPY_PY_BUILTINS_FLOAT
+mpz_t *mpz_from_float(mp_float_t i);
+#endif
 mpz_t *mpz_from_str(const char *str, mp_uint_t len, bool neg, mp_uint_t base);
 void mpz_free(mpz_t *z);
 
@@ -93,6 +96,9 @@ mpz_t *mpz_clone(const mpz_t *src);
 void mpz_set(mpz_t *dest, const mpz_t *src);
 void mpz_set_from_int(mpz_t *z, mp_int_t src);
 void mpz_set_from_ll(mpz_t *z, long long i, bool is_signed);
+#if MICROPY_PY_BUILTINS_FLOAT
+void mpz_set_from_float(mpz_t *z, mp_float_t src);
+#endif
 mp_uint_t mpz_set_from_str(mpz_t *z, const char *str, mp_uint_t len, bool neg, mp_uint_t base);
 
 bool mpz_is_zero(const mpz_t *z);

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -298,9 +298,9 @@ mp_obj_t mp_obj_new_int_from_uint(mp_uint_t value) {
 
 #if MICROPY_PY_BUILTINS_FLOAT
 mp_obj_t mp_obj_new_int_from_float(mp_float_t val) {
-    // TODO: This doesn't handle numbers with large exponent
-    long long i = MICROPY_FLOAT_C_FUN(trunc)(val);
-    return mp_obj_new_int_from_ll(i);
+    mp_obj_int_t *o = mp_obj_int_new_mpz();
+    mpz_set_from_float(&o->mpz, val);
+    return o;
 }
 #endif
 

--- a/tests/float/float2int.py
+++ b/tests/float/float2int.py
@@ -1,10 +1,24 @@
 # This case occurs with time.time() values
 print(int(1418774543.))
 
-# TODO: General case with large exponent
-#print(int(2.**100))
+print(int(2.**100))
 
 print("%d" % 1418774543.)
 
-# TODO: General case with large exponent
-#print("%d" % 2.**100)
+print("%d" % 2.**100)
+
+testpass = True
+for i in range(0,1024):
+    bitcnt = len(bin(int(2.**i))) - 3;
+    if i != bitcnt:
+        print('fail: 2**%u was %u bits long' % (i, bitcnt));
+        testpass = False
+print("power of  2 test: %s" % (testpass and 'passed' or 'failed'))
+
+testpass = True
+for i in range(0,23):
+    digcnt = len(str(int(10.**i))) - 1;
+    if i != digcnt:
+        print('fail: 10**%u was %u digits long' % (i, digcnt));
+        testpass = False
+print("power of 10 test: %s" % (testpass and 'passed' or 'failed'))


### PR DESCRIPTION
To address issue #1009, I've implemented a mpz_set_from_float() that works for any size exponent, to add to the work done in 12033df511a5a5f0237a764379aacfbceb6c45dd.
I've tested it under x86 Linux with all 4 combinations of single/double precision floats, and 16-bit/32-bit mpz digits.
Inf/NaN handling might not be as desired.
