### PR TITLE
py: Add option to cache LOAD_NAME/LOAD_GLOBAL result in bytecode.

### DIFF
--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -509,11 +509,17 @@ STATIC void emit_bc_load_deref(emit_t *emit, qstr qst, mp_uint_t local_num) {
 STATIC void emit_bc_load_name(emit_t *emit, qstr qst) {
     emit_bc_pre(emit, 1);
     emit_write_bytecode_byte_qstr(emit, MP_BC_LOAD_NAME, qst);
+    if (MICROPY_BYTECODE_CACHE_LOAD_NAME_LOAD_GLOBAL) {
+        emit_write_bytecode_byte(emit, 0);
+    }
 }
 
 STATIC void emit_bc_load_global(emit_t *emit, qstr qst) {
     emit_bc_pre(emit, 1);
     emit_write_bytecode_byte_qstr(emit, MP_BC_LOAD_GLOBAL, qst);
+    if (MICROPY_BYTECODE_CACHE_LOAD_NAME_LOAD_GLOBAL) {
+        emit_write_bytecode_byte(emit, 0);
+    }
 }
 
 STATIC void emit_bc_load_attr(emit_t *emit, qstr qst) {

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -525,6 +525,9 @@ STATIC void emit_bc_load_global(emit_t *emit, qstr qst) {
 STATIC void emit_bc_load_attr(emit_t *emit, qstr qst) {
     emit_bc_pre(emit, 0);
     emit_write_bytecode_byte_qstr(emit, MP_BC_LOAD_ATTR, qst);
+    if (MICROPY_BYTECODE_CACHE_LOAD_ATTR) {
+        emit_write_bytecode_byte(emit, 0);
+    }
 }
 
 STATIC void emit_bc_load_method(emit_t *emit, qstr qst) {

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -573,6 +573,9 @@ STATIC void emit_bc_store_global(emit_t *emit, qstr qst) {
 STATIC void emit_bc_store_attr(emit_t *emit, qstr qst) {
     emit_bc_pre(emit, -2);
     emit_write_bytecode_byte_qstr(emit, MP_BC_STORE_ATTR, qst);
+    if (MICROPY_BYTECODE_CACHE_STORE_ATTR) {
+        emit_write_bytecode_byte(emit, 0);
+    }
 }
 
 STATIC void emit_bc_store_subscr(emit_t *emit) {

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -182,6 +182,13 @@
 #define MICROPY_OPT_COMPUTED_GOTO (0)
 #endif
 
+// Whether to cache lookups of LOAD_NAME/LOAD_GLOBAL in bytecode
+// Uses 1 byte extra RAM for each of these opcodes and uses a bit of extra code
+// ROM, but greatly improves lookup speed
+#ifndef MICROPY_BYTECODE_CACHE_LOAD_NAME_LOAD_GLOBAL
+#define MICROPY_BYTECODE_CACHE_LOAD_NAME_LOAD_GLOBAL (1)
+#endif
+
 /*****************************************************************************/
 /* Python internal features                                                  */
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -193,7 +193,14 @@
 // Uses 1 byte extra RAM for each of these opcodes and uses a bit of extra code
 // ROM, but improves lookup speed
 #ifndef MICROPY_BYTECODE_CACHE_LOAD_ATTR
-#define MICROPY_BYTECODE_CACHE_LOAD_ATTR (0)
+#define MICROPY_BYTECODE_CACHE_LOAD_ATTR (1)
+#endif
+
+// Whether to cache lookups of STORE_ATTR in bytecode
+// Uses 1 byte extra RAM for each of these opcodes and uses a bit of extra code
+// ROM, but improves store speed
+#ifndef MICROPY_BYTECODE_CACHE_STORE_ATTR
+#define MICROPY_BYTECODE_CACHE_STORE_ATTR (1)
 #endif
 
 /*****************************************************************************/

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -189,6 +189,13 @@
 #define MICROPY_BYTECODE_CACHE_LOAD_NAME_LOAD_GLOBAL (1)
 #endif
 
+// Whether to cache lookups of LOAD_ATTR in bytecode
+// Uses 1 byte extra RAM for each of these opcodes and uses a bit of extra code
+// ROM, but improves lookup speed
+#ifndef MICROPY_BYTECODE_CACHE_LOAD_ATTR
+#define MICROPY_BYTECODE_CACHE_LOAD_ATTR (0)
+#endif
+
 /*****************************************************************************/
 /* Python internal features                                                  */
 

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -456,7 +456,7 @@ STATIC mp_obj_t instance_binary_op(mp_uint_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
     }
 }
 
-STATIC void instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     // logic: look in obj members then class locals (TODO check this against CPython)
     assert(is_instance_type(mp_obj_get_type(self_in)));
     mp_obj_instance_t *self = self_in;
@@ -817,7 +817,7 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     o->make_new = instance_make_new;
     o->unary_op = instance_unary_op;
     o->binary_op = instance_binary_op;
-    o->load_attr = instance_load_attr;
+    o->load_attr = mp_obj_instance_load_attr;
     o->store_attr = instance_store_attr;
     o->subscr = instance_subscr;
     o->call = mp_obj_instance_call;

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -510,7 +510,7 @@ void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     }
 }
 
-STATIC bool instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t value) {
+bool mp_obj_instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t value) {
     mp_obj_instance_t *self = self_in;
 
 #if MICROPY_PY_BUILTINS_PROPERTY
@@ -818,7 +818,7 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     o->unary_op = instance_unary_op;
     o->binary_op = instance_binary_op;
     o->load_attr = mp_obj_instance_load_attr;
-    o->store_attr = instance_store_attr;
+    o->store_attr = mp_obj_instance_store_attr;
     o->subscr = instance_subscr;
     o->call = mp_obj_instance_call;
     o->getiter = instance_getiter;

--- a/py/objtype.h
+++ b/py/objtype.h
@@ -40,6 +40,9 @@ typedef struct _mp_obj_instance_t {
 // this needs to be exposed for MICROPY_BYTECODE_CACHE_LOAD_ATTR to work
 void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
 
+// this needs to be exposed for MICROPY_BYTECODE_CACHE_STORE_ATTR to work
+bool mp_obj_instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t value);
+
 // these need to be exposed so mp_obj_is_callable can work correctly
 bool mp_obj_instance_is_callable(mp_obj_t self_in);
 mp_obj_t mp_obj_instance_call(mp_obj_t self_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args);

--- a/py/objtype.h
+++ b/py/objtype.h
@@ -37,6 +37,9 @@ typedef struct _mp_obj_instance_t {
     // TODO maybe cache __getattr__ and __setattr__ for efficient lookup of them
 } mp_obj_instance_t;
 
+// this needs to be exposed for MICROPY_BYTECODE_CACHE_LOAD_ATTR to work
+void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
+
 // these need to be exposed so mp_obj_is_callable can work correctly
 bool mp_obj_instance_is_callable(mp_obj_t self_in);
 mp_obj_t mp_obj_instance_call(mp_obj_t self_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -56,11 +56,13 @@
 mp_obj_t mp_pending_exception;
 
 // locals and globals need to be pointers because they can be the same in outer module scope
-STATIC mp_obj_dict_t *dict_locals;
-STATIC mp_obj_dict_t *dict_globals;
+mp_obj_dict_t *dict_locals;
+mp_obj_dict_t *dict_globals;
 
 // dictionary for the __main__ module
 STATIC mp_obj_dict_t dict_main;
+
+mp_uint_t dict_cache_hit, dict_cache_miss;
 
 const mp_obj_module_t mp_module___main__ = {
     .base = { &mp_type_module },
@@ -105,9 +107,13 @@ void mp_init(void) {
     // start with no extensions to builtins
     mp_module_builtins_override_dict = NULL;
     #endif
+
+    dict_cache_hit = dict_cache_miss = 0;
 }
 
 void mp_deinit(void) {
+    //printf("dict cache: hit=" UINT_FMT "; miss=" UINT_FMT "; percent_hit=%llu\n", dict_cache_hit, dict_cache_miss, (unsigned long long)100 * (unsigned long long)dict_cache_hit / (dict_cache_hit + dict_cache_miss));
+
     //mp_obj_dict_free(&dict_main);
     mp_module_deinit();
 


### PR DESCRIPTION
This is a simple optimisation inspired by JITing technology: we cache in the bytecode (using 1 byte) the offset of the last successful lookup in dict_locals or dict_globals.  This allows us to next time round check in that location in the hash table (mp_map_t) for the desired entry, and if it's there, use that entry straight away.  Otherwise fallback to a normal map lookup.

On a few tests it gives >90% cache hit and greatly improves speed of code relying on globals.

Pystone test results run 6 times with this new optimisation:

```
Pystone(1.1) time for 200000 passes = 2.559 This machine benchmarks at 78155.5 pystones/second
Pystone(1.1) time for 200000 passes = 2.711 This machine benchmarks at 73773.5 pystones/second
Pystone(1.1) time for 200000 passes = 2.644 This machine benchmarks at 75643 pystones/second
Pystone(1.1) time for 200000 passes = 2.596 This machine benchmarks at 77041.6 pystones/second
Pystone(1.1) time for 200000 passes = 2.497 This machine benchmarks at 80096.1 pystones/second
Pystone(1.1) time for 200000 passes = 2.558 This machine benchmarks at 78186.1 pystones/second
```

Results without optimisation:

```
Pystone(1.1) time for 200000 passes = 3.061 This machine benchmarks at 65338.1 pystones/second
Pystone(1.1) time for 200000 passes = 3.117 This machine benchmarks at 64164.3 pystones/second
Pystone(1.1) time for 200000 passes = 3.034 This machine benchmarks at 65919.6 pystones/second
Pystone(1.1) time for 200000 passes = 3.026 This machine benchmarks at 66093.9 pystones/second
Pystone(1.1) time for 200000 passes = 3.428 This machine benchmarks at 58343.1 pystones/second
Pystone(1.1) time for 200000 passes = 3.237 This machine benchmarks at 61785.6 pystones/second
```

Pystone varies a lot, but we see here about 0.5s reduction in running time (3.1 down to 2.6s) which is a 16% reduction in running time, and about 16% increase in pystones.
