### PR TITLE
Issue/1044

### DIFF
--- a/py/mpz.c
+++ b/py/mpz.c
@@ -1351,14 +1351,17 @@ mpz_t *mpz_mod(const mpz_t *lhs, const mpz_t *rhs) {
 // must return actual int value if it fits in mp_int_t
 mp_int_t mpz_hash(const mpz_t *z) {
     mp_int_t val = 0;
-    mpz_dig_t *d = z->dig + z->len;
 
-    while (--d >= z->dig) {
-        val = (val << DIG_SIZE) | *d;
-    }
+	if (z->dig != NULL) {
+        mpz_dig_t *d = z->dig + z->len;
 
-    if (z->neg != 0) {
-        val = -val;
+        while (--d >= z->dig) {
+            val = (val << DIG_SIZE) | *d;
+        }
+
+        if (z->neg != 0) {
+            val = -val;
+        }
     }
 
     return val;

--- a/py/mpz.c
+++ b/py/mpz.c
@@ -1352,7 +1352,7 @@ mpz_t *mpz_mod(const mpz_t *lhs, const mpz_t *rhs) {
 mp_int_t mpz_hash(const mpz_t *z) {
     mp_int_t val = 0;
 
-	if (z->dig != NULL) {
+    if (z->dig != NULL) {
         mpz_dig_t *d = z->dig + z->len;
 
         while (--d >= z->dig) {


### PR DESCRIPTION
To protect against segfault found in #1044, even though this particular case is now avoided by ad2307c9.
Although small ints should be used where possible, it might always be possible to create a zero mpz, therefore zeros must be handled correctly.
