### PR TITLE
Validate qemu-arm console output as part of test

### DIFF
--- a/qemu-arm/Makefile
+++ b/qemu-arm/Makefile
@@ -58,7 +58,10 @@ endif
 all: run
 
 run: $(BUILD)/flash.elf
-	qemu-system-arm -cpu cortex-m3 -nographic -monitor null -serial null -semihosting -kernel $(BUILD)/flash.elf
+	qemu-system-arm -cpu cortex-m3 -nographic -monitor null -serial null -semihosting -kernel \
+		$(BUILD)/flash.elf > $(BUILD)/console.out
+	cat $(BUILD)/console.out
+	grep -q "hello world\!" $(BUILD)/console.out
 
 .PHONY: $(BUILD)/genhdr/tests.h
 


### PR DESCRIPTION
Right now qemu-arm build will not return non-zero if the incorrect console output is generated.  This redirects the output to a file and checks file contents.
