### PR TITLE
[pre-review] bare-arm: Make runnable port.

### DIFF
--- a/bare-arm/Makefile
+++ b/bare-arm/Makefile
@@ -1,19 +1,28 @@
 include ../py/mkenv.mk
 
+CROSS = 0
+
 # qstr definitions (must come before including py.mk)
 QSTR_DEFS = qstrdefsport.h
 
 # include py core make definitions
 include ../py/py.mk
 
+ifeq ($(CROSS), 1)
 CROSS_COMPILE = arm-none-eabi-
+endif
 
 INC =  -I.
 INC += -I..
+INC += -I$(PY_SRC) -I../stmhal
 INC += -I$(BUILD)
 
+ifeq ($(CROSS), 1)
 CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mabi=aapcs-linux -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -fsingle-precision-constant -Wdouble-promotion
 CFLAGS = $(INC) -Wall -Werror -ansi -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
+else
+CFLAGS = -m32 $(INC) -Wall -Werror -ansi -std=gnu99 $(COPT)
+endif
 
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)
@@ -22,15 +31,23 @@ else
 CFLAGS += -Os -DNDEBUG
 endif
 
+ifeq ($(CROSS), 1)
 LDFLAGS = -nostdlib -T stm32f405.ld -Map=$@.map --cref
+else
+LD = gcc
+LDFLAGS = -m32 -Wl,-Map=$@.map,--cref
+endif
 LIBS =
 
 SRC_C = \
 	main.c \
-#	printf.c \
-	string0.c \
-	malloc0.c \
-	gccollect.c \
+	../stmhal/printf.c \
+	../stmhal/string0.c \
+\
+	../stmhal/pyexec.c \
+	../stmhal/readline.c \
+#	../stmhal/malloc0.c \
+#	../stmhal/gccollect.c \
 
 SRC_S = \
 #	startup_stm32f40xx.s \

--- a/bare-arm/mpconfigport.h
+++ b/bare-arm/mpconfigport.h
@@ -2,7 +2,7 @@
 
 // options to control how Micro Python is built
 
-#define MICROPY_ALLOC_PATH_MAX      (512)
+#define MICROPY_ALLOC_PATH_MAX      (256)
 #define MICROPY_EMIT_X64            (0)
 #define MICROPY_EMIT_THUMB          (0)
 #define MICROPY_EMIT_INLINE_THUMB   (0)
@@ -10,8 +10,8 @@
 #define MICROPY_COMP_CONST          (0)
 #define MICROPY_MEM_STATS           (0)
 #define MICROPY_DEBUG_PRINTERS      (0)
-#define MICROPY_ENABLE_GC           (0)
-#define MICROPY_HELPER_REPL         (0)
+#define MICROPY_ENABLE_GC           (1)
+#define MICROPY_HELPER_REPL         (1)
 #define MICROPY_HELPER_LEXER_UNIX   (0)
 #define MICROPY_ENABLE_SOURCE_LINE  (0)
 #define MICROPY_ENABLE_DOC_STRING   (0)
@@ -35,17 +35,23 @@
 #define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_NONE)
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_NONE)
 
+#define MICROPY_ALLOC_PARSE_RULE_INIT (48)
+#define MICROPY_ALLOC_PARSE_RULE_INC (8)
+#define MICROPY_ALLOC_PARSE_RESULT_INC (8)
+
 // type definitions for the specific machine
 
 #define BYTES_PER_WORD (4)
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void*)((mp_uint_t)(p) | 1))
 
-#define UINT_FMT "%lu"
-#define INT_FMT "%ld"
+//#define UINT_FMT "%lu"
+//#define INT_FMT "%ld"
+#define UINT_FMT "%u"
+#define INT_FMT "%d"
 
-typedef int32_t mp_int_t; // must be pointer size
-typedef uint32_t mp_uint_t; // must be pointer size
+typedef int mp_int_t; // must be pointer size
+typedef unsigned mp_uint_t; // must be pointer size
 typedef void *machine_ptr_t; // must be of pointer size
 typedef const void *machine_const_ptr_t; // must be of pointer size
 typedef long mp_off_t;
@@ -57,3 +63,19 @@ extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
 
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
+
+#define HAL_GetTick() 0
+
+static inline void mp_hal_set_interrupt_char(char c) {}
+
+#define MICROPY_HW_BOARD_NAME "minimal"
+#define MICROPY_HW_MCU_NAME "unknown"
+
+#ifdef __linux__
+#define MICROPY_MIN_USE_STDOUT (1)
+#endif
+
+#define MP_STATE_PORT MP_STATE_VM
+
+#define MICROPY_PORT_ROOT_POINTERS \
+    const char *readline_hist[8];


### PR DESCRIPTION
Patch which addresses #1053. It's made against bare-arm to show what kind of changes were required. I'd like to confirm list of steps to make this mergeable:
1. As discussed in #1053, we want to leave bare-arm as is. Then, this should be a new port dir, initially based off bare-arm still. Suggestion for name are welcome just "bare"? Or "minimal"?
2. I don't want to base, or relate this port to "unix" port in any way. This is intended to show a bare embedded port, with additional feature of being able to be compiled in "emulation" mode on POSIX system (where UART will be emulated by tty, configured suitably).
3. As a workaround to various small&dirty issues, this port is intended to be limited to 32-bit.

So, let me know if this sounds ok to create a "production" branch.
