### PR TITLE
[review] unix: Add target to build "minimal" uPy interpreter.

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -69,6 +69,10 @@ ifeq ($(MICROPY_PY_TERMIOS),1)
 CFLAGS_MOD += -DMICROPY_PY_TERMIOS=1
 SRC_MOD += modtermios.c
 endif
+ifeq ($(MICROPY_PY_SOCKET),1)
+CFLAGS_MOD += -DMICROPY_PY_SOCKET=1
+SRC_MOD += modsocket.c
+endif
 ifeq ($(MICROPY_PY_FFI),1)
 LIBFFI_LDFLAGS_MOD := $(shell pkg-config --libs libffi)
 LIBFFI_CFLAGS_MOD := $(shell pkg-config --cflags libffi)
@@ -87,7 +91,6 @@ SRC_C = \
 	gccollect.c \
 	input.c \
 	file.c \
-	modsocket.c \
 	modos.c \
 	alloc.c \
 	$(SRC_MOD)
@@ -122,4 +125,9 @@ uninstall:
 # build synthetically fast interpreter for benchmarking
 fast:
 	@echo Make sure to run make -B
-	$(MAKE) COPT="-O2 -DNDEBUG -fno-crossjumping" CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_fast.h>"' BUILD=build-fast
+	$(MAKE) COPT="-O2 -DNDEBUG -fno-crossjumping" CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_fast.h>"' BUILD=build-fast PROG=micropython_fast
+
+# build a minimal interpreter
+minimal:
+	@echo Make sure to run make -B
+	$(MAKE) COPT="-Os -DNDEBUG" CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_minimal.h>"' BUILD=build-minimal PROG=micropython_minimal MICROPY_PY_TIME=0 MICROPY_PY_TERMIOS=0 MICROPY_PY_SOCKET=0 MICROPY_PY_FFI=0

--- a/unix/file.c
+++ b/unix/file.c
@@ -35,6 +35,8 @@
 #include "py/runtime.h"
 #include "py/stream.h"
 
+#if MICROPY_PY_IO
+
 #ifdef _WIN32
 #define fsync _commit
 #endif
@@ -263,3 +265,5 @@ MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
 const mp_obj_fdfile_t mp_sys_stdin_obj  = { .base = {&mp_type_textio}, .fd = STDIN_FILENO };
 const mp_obj_fdfile_t mp_sys_stdout_obj = { .base = {&mp_type_textio}, .fd = STDOUT_FILENO };
 const mp_obj_fdfile_t mp_sys_stderr_obj = { .base = {&mp_type_textio}, .fd = STDERR_FILENO };
+
+#endif // MICROPY_PY_IO

--- a/unix/main.c
+++ b/unix/main.c
@@ -481,10 +481,12 @@ int main(int argc, char **argv) {
         ret = do_repl();
     }
 
+    #if MICROPY_PY_MICROPYTHON_MEM_INFO
     if (mp_verbose_flag) {
         extern mp_obj_t mp_micropython_mem_info(mp_uint_t n_args, const mp_obj_t *args);
         mp_micropython_mem_info(0, NULL);
     }
+    #endif
 
     mp_deinit();
 

--- a/unix/mpconfigport.mk
+++ b/unix/mpconfigport.mk
@@ -12,5 +12,8 @@ MICROPY_PY_TIME = 1
 # Subset of CPython termios module
 MICROPY_PY_TERMIOS = 1
 
+# Subset of CPython socket module
+MICROPY_PY_SOCKET = 1
+
 # ffi module requires libffi (libffi-dev Debian package)
 MICROPY_PY_FFI = 1

--- a/unix/mpconfigport_minimal.h
+++ b/unix/mpconfigport_minimal.h
@@ -27,58 +27,58 @@
 // options to control how Micro Python is built
 
 #define MICROPY_ALLOC_PATH_MAX      (PATH_MAX)
-#if !defined(MICROPY_EMIT_X64) && defined(__x86_64__)
-    #define MICROPY_EMIT_X64        (1)
-#endif
-#if !defined(MICROPY_EMIT_X86) && defined(__i386__)
-    #define MICROPY_EMIT_X86        (1)
-#endif
-#if !defined(MICROPY_EMIT_THUMB) && defined(__thumb2__)
-    #define MICROPY_EMIT_THUMB      (1)
-#endif
-#if !defined(MICROPY_EMIT_ARM) && defined(__arm__)
-    #define MICROPY_EMIT_ARM        (1)
-#endif
-#define MICROPY_COMP_MODULE_CONST   (1)
 #define MICROPY_ENABLE_GC           (1)
-#define MICROPY_ENABLE_FINALISER    (1)
-#define MICROPY_STACK_CHECK         (1)
-#define MICROPY_MEM_STATS           (1)
-#define MICROPY_DEBUG_PRINTERS      (1)
+#define MICROPY_ENABLE_FINALISER    (0)
+#define MICROPY_STACK_CHECK         (0)
+#define MICROPY_MEM_STATS           (0)
+#define MICROPY_DEBUG_PRINTERS      (0)
 #define MICROPY_HELPER_REPL         (1)
 #define MICROPY_HELPER_LEXER_UNIX   (1)
-#define MICROPY_ENABLE_SOURCE_LINE  (1)
-#define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_DOUBLE)
-#define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_MPZ)
-#define MICROPY_STREAMS_NON_BLOCK   (1)
-#define MICROPY_OPT_COMPUTED_GOTO   (1)
-#define MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE (1)
-#define MICROPY_CAN_OVERRIDE_BUILTINS (1)
-#define MICROPY_PY_BUILTINS_STR_UNICODE (1)
-#define MICROPY_PY_BUILTINS_MEMORYVIEW (1)
-#define MICROPY_PY_BUILTINS_FROZENSET (1)
-#define MICROPY_PY_BUILTINS_COMPILE (1)
-#define MICROPY_PY_MICROPYTHON_MEM_INFO (1)
-#define MICROPY_PY_SYS_EXIT         (1)
+#define MICROPY_ENABLE_SOURCE_LINE  (0)
+#define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_NONE)
+#define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_NONE)
+#define MICROPY_STREAMS_NON_BLOCK   (0)
+#define MICROPY_OPT_COMPUTED_GOTO   (0)
+#define MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE (0)
+#define MICROPY_CAN_OVERRIDE_BUILTINS (0)
+#define MICROPY_CPYTHON_COMPAT      (0)
+#define MICROPY_PY_BUILTINS_MEMORYVIEW (0)
+#define MICROPY_PY_BUILTINS_COMPILE (0)
+#define MICROPY_PY_BUILTINS_FROZENSET (0)
+#define MICROPY_PY_BUILTINS_SET     (0)
+#define MICROPY_PY_BUILTINS_SLICE   (0)
+#define MICROPY_PY_BUILTINS_STR_UNICODE (0)
+#define MICROPY_PY_BUILTINS_PROPERTY (0)
+#define MICROPY_PY___FILE__         (0)
+#define MICROPY_PY_MICROPYTHON_MEM_INFO (0)
+#define MICROPY_PY_GC               (0)
+#define MICROPY_PY_ARRAY            (0)
+#define MICROPY_PY_COLLECTIONS      (0)
+#define MICROPY_PY_MATH             (0)
+#define MICROPY_PY_CMATH            (0)
+#define MICROPY_PY_IO               (0)
+#define MICROPY_PY_STRUCT           (0)
+#define MICROPY_PY_SYS              (1)
+#define MICROPY_PY_SYS_EXIT         (0)
 #define MICROPY_PY_SYS_PLATFORM     "linux"
-#define MICROPY_PY_SYS_MAXSIZE      (1)
-#define MICROPY_PY_SYS_STDFILES     (1)
-#define MICROPY_PY_CMATH            (1)
-#define MICROPY_PY_IO_FILEIO        (1)
-#define MICROPY_PY_GC_COLLECT_RETVAL (1)
+#define MICROPY_PY_SYS_MAXSIZE      (0)
+#define MICROPY_PY_SYS_STDFILES     (0)
+#define MICROPY_PY_CMATH            (0)
+#define MICROPY_PY_IO_FILEIO        (0)
+#define MICROPY_PY_GC_COLLECT_RETVAL (0)
 
-#define MICROPY_PY_UCTYPES          (1)
-#define MICROPY_PY_UZLIB            (1)
-#define MICROPY_PY_UJSON            (1)
-#define MICROPY_PY_URE              (1)
-#define MICROPY_PY_UHEAPQ           (1)
-#define MICROPY_PY_UHASHLIB         (1)
-#define MICROPY_PY_UBINASCII        (1)
+#define MICROPY_PY_UCTYPES          (0)
+#define MICROPY_PY_UZLIB            (0)
+#define MICROPY_PY_UJSON            (0)
+#define MICROPY_PY_URE              (0)
+#define MICROPY_PY_UHEAPQ           (0)
+#define MICROPY_PY_UHASHLIB         (0)
+#define MICROPY_PY_UBINASCII        (0)
 
 // Define to MICROPY_ERROR_REPORTING_DETAILED to get function, etc.
 // names in exception messages (may require more RAM).
-#define MICROPY_ERROR_REPORTING     (MICROPY_ERROR_REPORTING_DETAILED)
-#define MICROPY_WARNINGS            (1)
+#define MICROPY_ERROR_REPORTING     (MICROPY_ERROR_REPORTING_TERSE)
+#define MICROPY_WARNINGS            (0)
 
 // Define to 1 to use undertested inefficient GC helper implementation
 // (if more efficient arch-specific one is not available).
@@ -90,42 +90,12 @@
     #endif
 #endif
 
-#define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF   (1)
-#define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE  (256)
+#define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF   (0)
 
 extern const struct _mp_obj_module_t mp_module_os;
-extern const struct _mp_obj_module_t mp_module_time;
-extern const struct _mp_obj_module_t mp_module_termios;
-extern const struct _mp_obj_module_t mp_module_socket;
-extern const struct _mp_obj_module_t mp_module_ffi;
-
-#if MICROPY_PY_FFI
-#define MICROPY_PY_FFI_DEF { MP_OBJ_NEW_QSTR(MP_QSTR_ffi), (mp_obj_t)&mp_module_ffi },
-#else
-#define MICROPY_PY_FFI_DEF
-#endif
-#if MICROPY_PY_TIME
-#define MICROPY_PY_TIME_DEF { MP_OBJ_NEW_QSTR(MP_QSTR_utime), (mp_obj_t)&mp_module_time },
-#else
-#define MICROPY_PY_TIME_DEF
-#endif
-#if MICROPY_PY_TERMIOS
-#define MICROPY_PY_TERMIOS_DEF { MP_OBJ_NEW_QSTR(MP_QSTR_termios), (mp_obj_t)&mp_module_termios },
-#else
-#define MICROPY_PY_TERMIOS_DEF
-#endif
-#if MICROPY_PY_SOCKET
-#define MICROPY_PY_SOCKET_DEF { MP_OBJ_NEW_QSTR(MP_QSTR_usocket), (mp_obj_t)&mp_module_socket },
-#else
-#define MICROPY_PY_SOCKET_DEF
-#endif
 
 #define MICROPY_PORT_BUILTIN_MODULES \
-    MICROPY_PY_FFI_DEF \
-    MICROPY_PY_TIME_DEF \
-    MICROPY_PY_SOCKET_DEF \
     { MP_OBJ_NEW_QSTR(MP_QSTR__os), (mp_obj_t)&mp_module_os }, \
-    MICROPY_PY_TERMIOS_DEF \
 
 // type definitions for the specific machine
 
@@ -155,12 +125,6 @@ void mp_unix_alloc_exec(mp_uint_t min_size, void** ptr, mp_uint_t *size);
 void mp_unix_free_exec(void *ptr, mp_uint_t size);
 #define MP_PLAT_ALLOC_EXEC(min_size, ptr, size) mp_unix_alloc_exec(min_size, ptr, size)
 #define MP_PLAT_FREE_EXEC(ptr, size) mp_unix_free_exec(ptr, size)
-
-extern const struct _mp_obj_fun_builtin_t mp_builtin_input_obj;
-extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
-#define MICROPY_PORT_BUILTINS \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_input), (mp_obj_t)&mp_builtin_input_obj }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_open), (mp_obj_t)&mp_builtin_open_obj },
 
 #define MICROPY_PORT_ROOT_POINTERS \
     mp_obj_t keyboard_interrupt_obj;


### PR DESCRIPTION
Perhaps complimentary to #1055, this adds a "minimal" target to unix Makefile.  It builds a minimal interpreter with most options disabled.  Binary is about half the size of full binary.

Do we want something like this?  Would be nice to test minimal feature set.
