### PR TITLE
Switch esp8266 port to event-driven REPL

### DIFF
--- a/esp8266/qstrdefsport.h
+++ b/esp8266/qstrdefsport.h
@@ -39,3 +39,5 @@ Q(elapsed_micros)
 Q(delay)
 Q(udelay)
 Q(sync)
+
+Q(scan)

--- a/esp8266/uart.c
+++ b/esp8266/uart.c
@@ -9,6 +9,7 @@
  * Modification history:
  *     2014/3/12, v1.0 create this file.
 *******************************************************************************/
+#include <stdbool.h>
 #include "ets_sys.h"
 #include "osapi.h"
 #include "uart.h"


### PR DESCRIPTION
I'd like to keep normal REPL #ifdef'ed until event-driven will have all needed features. 2nd commit is just if anyone will want to test that these efforts achieved intended results, it's not intended for merge.
