### PR TITLE
py: Fix segfault for operations on closed StringIO

### DIFF
--- a/tests/io/stringio1.py
+++ b/tests/io/stringio1.py
@@ -28,3 +28,14 @@ print(a.getvalue())
 a = io.StringIO()
 a.write("foo")
 print(a.read())
+
+a = io.StringIO()
+a.close()
+for f in [a.read, a.getvalue, lambda:a.write("")]:
+    # CPython throws for operations on closed I/O, micropython makes
+    # the underlying string empty unless MICROPY_CPYTHON_COMPAT defined
+    try:
+        f()
+        print("ValueError")
+    except ValueError:
+        print("ValueError")


### PR DESCRIPTION
This is a simple fix for #1067.

Originally I wanted to put the `nlr_raise(...."I/O operation on closed file"));` in a function and reuse it in unix/file.c since it uses the exact same error message, but I couldn't figure out the most suitable header/source files for such function.. Suggestions?
