### PR TITLE
py: Implement very simple frozen modules support.

### DIFF
--- a/minimal/mpconfigport.h
+++ b/minimal/mpconfigport.h
@@ -32,6 +32,7 @@
 #define MICROPY_PY_IO               (0)
 #define MICROPY_PY_STRUCT           (0)
 #define MICROPY_PY_SYS              (0)
+#define MICROPY_MODULE_FROZEN       (0)
 #define MICROPY_CPYTHON_COMPAT      (0)
 #define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_NONE)
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_NONE)

--- a/py/frozenmod.c
+++ b/py/frozenmod.c
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Paul Sokolovsky
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <string.h>
+#include <stdint.h>
+
+#include "py/lexer.h"
+
+#if MICROPY_MODULE_FROZEN
+
+extern const uint16_t mp_frozen_sizes[];
+extern const char mp_frozen_content[];
+
+mp_lexer_t *mp_find_frozen_module(const char *str, int len) {
+    const uint16_t *sz_ptr = mp_frozen_sizes;
+    const char *s = mp_frozen_content;
+
+    while (*sz_ptr) {
+        int l = strlen(s);
+        if (l == len && !memcmp(str, s, l)) {
+            s += l + 1;
+            mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR_, s, *sz_ptr, 0);
+            return lex;
+        }
+        s += l + 1 + *sz_ptr++;
+    }
+    return NULL;
+}
+
+#endif // MICROPY_MODULE_FROZEN

--- a/py/frozenmod.h
+++ b/py/frozenmod.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+mp_lexer_t *mp_find_frozen_module(const char *str, int len);

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -328,6 +328,11 @@ typedef double mp_float_t;
 #define MICROPY_MODULE_WEAK_LINKS (0)
 #endif
 
+// Whether frozen modules are supported
+#ifndef MICROPY_MODULE_FROZEN
+#define MICROPY_MODULE_FROZEN (0)
+#endif
+
 // Whether you can override builtins in the builtins module
 #ifndef MICROPY_CAN_OVERRIDE_BUILTINS
 #define MICROPY_CAN_OVERRIDE_BUILTINS (0)

--- a/py/py.mk
+++ b/py/py.mk
@@ -112,6 +112,7 @@ PY_O_BASENAME = \
 	smallint.o \
 	pfenv.o \
 	pfenv_printf.o \
+	frozenmod.o \
 	../extmod/moductypes.o \
 	../extmod/modujson.o \
 	../extmod/modure.o \

--- a/tools/make-frozen.py
+++ b/tools/make-frozen.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+#
+# Create frozen modules structure for MicroPython.
+#
+# Usage:
+#
+# Have a directory with modules to be frozen (only modules, not packages
+# supported so far):
+#
+# frozen/foo.py
+# frozen/bar.py
+#
+# Run script, passing path to the directory above:
+#
+# ./make-frozen.py frozen > frozen.c
+#
+# Include frozen.c in your build, having defined MICROPY_MODULE_FROZEN in
+# config.
+#
+import sys
+import os
+
+
+def module_name(f):
+    return f[:-len(".py")]
+
+modules = []
+
+for dirpath, dirnames, filenames in os.walk(sys.argv[1]):
+    for f in filenames:
+        st = os.stat(dirpath + "/" + f)
+        modules.append((f, st))
+
+print("#include <stdint.h>")
+print("const uint16_t mp_frozen_sizes[] = {")
+
+for f, st in modules:
+    print("%d," % st.st_size)
+
+print("0};")
+
+print("const char mp_frozen_content[] = {")
+for f, st in modules:
+    m = module_name(f)
+    print('"%s\\0"' % m)
+    data = open(sys.argv[1] + "/" + f).read()
+    data = repr(data)[1:-1]
+    data = data.replace('"', '\\"')
+    print('"%s"' % data)
+print("};")


### PR DESCRIPTION
Only modules (not packages) supported now. Source modules can be converted
to frozen module structures using tools/make-frozen.py script.
