### PR TITLE
unix: Enable extra compiler warnings.

### DIFF
--- a/extmod/crypto-algorithms/sha256.c
+++ b/extmod/crypto-algorithms/sha256.c
@@ -41,7 +41,7 @@ static const WORD k[64] = {
 };
 
 /*********************** FUNCTION DEFINITIONS ***********************/
-void sha256_transform(SHA256_CTX *ctx, const BYTE data[])
+static void sha256_transform(SHA256_CTX *ctx, const BYTE data[])
 {
 	WORD a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
 

--- a/extmod/re1.5/compilecode.c
+++ b/extmod/re1.5/compilecode.c
@@ -66,7 +66,7 @@ int re1_5_sizecode(const char *re)
 
 #define EMIT(at, byte) code[at] = byte
 
-const char *_compilecode(const char *re, ByteProg *prog)
+static const char *_compilecode(const char *re, ByteProg *prog)
 {
     char *code = prog->insts;
     int pc = prog->bytelen;

--- a/extmod/uzlib/tinf.h
+++ b/extmod/uzlib/tinf.h
@@ -76,7 +76,7 @@ int TINFCC tinf_zlib_uncompress_dyn(TINF_DATA *d, unsigned int sourceLen);
 
 /* high-level API */
 
-void TINFCC tinf_init();
+void TINFCC tinf_init(void);
 
 int TINFCC tinf_uncompress(void *dest, unsigned int *destLen,
                            const void *source, unsigned int sourceLen);

--- a/extmod/uzlib/tinflate.c
+++ b/extmod/uzlib/tinflate.c
@@ -340,8 +340,8 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
 
       } else {
 
-         int length, dist, offs;
-         int i;
+         unsigned int length, offs, i;
+         int dist;
 
          sym -= 257;
 
@@ -429,7 +429,7 @@ static int tinf_inflate_dynamic_block(TINF_DATA *d)
  * ---------------------- */
 
 /* initialize global (static) data */
-void tinf_init()
+void tinf_init(void)
 {
 #ifdef RUNTIME_BITS_TABLES
    /* build extra bits and base tables */
@@ -446,6 +446,7 @@ void tinf_init()
 int tinf_uncompress(void *dest, unsigned int *destLen,
                     const void *source, unsigned int sourceLen)
 {
+   (void)sourceLen;
    TINF_DATA d;
    int res;
 

--- a/extmod/uzlib/tinflate.c
+++ b/extmod/uzlib/tinflate.c
@@ -362,7 +362,7 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
          /* copy match */
          for (i = 0; i < length; ++i)
          {
-            d->dest[i] = d->dest[i - offs];
+            d->dest[i] = d->dest[(int)(i - offs)];
          }
 
          d->dest += length;

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -19,6 +19,7 @@ INC += -I$(BUILD)
 
 # compiler settings
 CWARN = -Wall -Wpointer-arith -Werror
+CWARN += -Wdouble-promotion -Wformat -Wmissing-declarations -Wmissing-prototypes -Wold-style-definition -Wpointer-arith -Wredundant-decls -Wshadow -Wsign-compare -Wstrict-prototypes -Wuninitialized -Wunused-parameter
 CFLAGS = $(INC) $(CWARN) -ansi -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
 
 # Debugging/Optimization


### PR DESCRIPTION
Although we are not enabling all warnings, this will be enough to close issue #699.

The reason it's a PR is that it requires changes to 3rd-party code in extmod.  @pfalcon can we make the changes upstream?
