### PR TITLE
esp8266: Add "esp" module with esp8266-specific "cooperative" networking...

### DIFF
--- a/esp8266/Makefile
+++ b/esp8266/Makefile
@@ -48,6 +48,7 @@ SRC_C = \
 	pybstdio.c \
 	uart.c \
 	modpyb.c \
+	modesp.c \
 
 STM_SRC_C = $(addprefix stmhal/,\
 	printf.c \

--- a/esp8266/modesp.c
+++ b/esp8266/modesp.c
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Paul Sokolovsky
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "py/nlr.h"
+#include "py/obj.h"
+#include "py/gc.h"
+#include "py/runtime.h"
+#include MICROPY_HAL_H
+#include "queue.h"
+#include "user_interface.h"
+
+STATIC mp_obj_t scan_cb_obj;
+
+STATIC void esp_scan_cb(scaninfo *si, STATUS status) {
+    //printf("in pyb_scan_cb: %d, si=%p, si->pbss=%p\n", status, si, si->pbss);
+    struct bss_info *bs;
+    if (si->pbss) {
+        STAILQ_FOREACH(bs, si->pbss, next) {
+            mp_obj_tuple_t *t = mp_obj_new_tuple(6, NULL);
+            t->items[0] = mp_obj_new_bytes(bs->ssid, strlen((char*)bs->ssid));
+            t->items[1] = mp_obj_new_bytes(bs->bssid, sizeof(bs->bssid));
+            t->items[2] = MP_OBJ_NEW_SMALL_INT(bs->channel);
+            t->items[3] = MP_OBJ_NEW_SMALL_INT(bs->rssi);
+            t->items[4] = MP_OBJ_NEW_SMALL_INT(bs->authmode);
+            t->items[5] = MP_OBJ_NEW_SMALL_INT(bs->is_hidden);
+            mp_call_function_1(scan_cb_obj, t);
+        }
+    }
+}
+
+STATIC mp_obj_t esp_scan(mp_obj_t cb_in) {
+    scan_cb_obj = cb_in;
+    wifi_set_opmode(STATION_MODE);
+    wifi_station_scan(NULL, (scan_done_cb_t)esp_scan_cb);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_scan_obj, esp_scan);
+
+STATIC const mp_map_elem_t esp_module_globals_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_esp) },
+
+    { MP_OBJ_NEW_QSTR(MP_QSTR_scan), (mp_obj_t)&esp_scan_obj },
+};
+
+STATIC MP_DEFINE_CONST_DICT(esp_module_globals, esp_module_globals_table);
+
+const mp_obj_module_t esp_module = {
+    .base = { &mp_type_module },
+    .name = MP_QSTR_esp,
+    .globals = (mp_obj_dict_t*)&esp_module_globals,
+};

--- a/esp8266/mpconfigport.h
+++ b/esp8266/mpconfigport.h
@@ -59,9 +59,11 @@ extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
 
 // extra built in modules to add to the list of known ones
 extern const struct _mp_obj_module_t pyb_module;
+extern const struct _mp_obj_module_t esp_module;
 
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_OBJ_NEW_QSTR(MP_QSTR_pyb), (mp_obj_t)&pyb_module }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_esp), (mp_obj_t)&esp_module }, \
 
 #define MP_STATE_PORT MP_STATE_VM
 

--- a/esp8266/qstrdefsport.h
+++ b/esp8266/qstrdefsport.h
@@ -40,3 +40,6 @@ Q(delay)
 Q(udelay)
 Q(sync)
 Q(hard_reset)
+
+Q(esp)
+Q(scan)


### PR DESCRIPTION
....

So far implements .scan(lambda x: print(x)) function to scan for WiFi access
points.
