### PR TITLE
stmhal: Move stack, data and bss in CCM

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -46,7 +46,14 @@ CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mabi=aapcs-linux -mcpu=cortex-m4 -m
 CFLAGS = $(INC) -Wall -Wpointer-arith -Werror -ansi -std=gnu99 -nostdlib $(CFLAGS_MOD) $(CFLAGS_CORTEX_M4) $(COPT)
 CFLAGS += -Iboards/$(BOARD)
 
-LDFLAGS = -nostdlib -T stm32f405.ld -Map=$(@:.elf=.map) --cref
+# USE CCM ?
+ifeq ($(MICROPY_USE_CCM), 1)
+LINK_SCRIPT = stm32f405-ccm.ld
+else
+LINK_SCRIPT = stm32f405.ld
+endif
+
+LDFLAGS = -nostdlib -T $(LINK_SCRIPT) -Map=$(@:.elf=.map) --cref
 LIBS =
 
 # Debugging/Optimization

--- a/stmhal/gccollect.c
+++ b/stmhal/gccollect.c
@@ -48,7 +48,7 @@ void gc_collect(void) {
     mp_uint_t sp = gc_helper_get_regs_and_sp(regs);
 
     // trace the stack, including the registers (since they live on the stack in this function)
-    gc_collect_root((void**)sp, ((uint32_t)&_ram_end - sp) / sizeof(uint32_t));
+    gc_collect_root((void**)sp, ((uint32_t)&_estack - sp) / sizeof(uint32_t));
 
     // end the GC
     gc_collect_end();

--- a/stmhal/gccollect.h
+++ b/stmhal/gccollect.h
@@ -36,6 +36,7 @@ extern uint32_t _ebss;
 extern uint32_t _heap_start;
 extern uint32_t _heap_end;
 extern uint32_t _estack;
+extern uint32_t _stack_limit;
 extern uint32_t _ram_end;
 
 void gc_collect(void);

--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -255,7 +255,7 @@ int main(void) {
 
     // Stack limit should be less than real stack size, so we have a chance
     // to recover from limit hit.  (Limit is measured in bytes.)
-    mp_stack_set_limit((char*)&_ram_end - (char*)&_heap_end - 1024);
+    mp_stack_set_limit((char*)&_estack - (char*)&_stack_limit - 1024);
 
     /* STM32F4xx HAL library initialization:
          - Configure the Flash prefetch, instruction and Data caches
@@ -273,9 +273,6 @@ int main(void) {
     __GPIOB_CLK_ENABLE();
     __GPIOC_CLK_ENABLE();
     __GPIOD_CLK_ENABLE();
-
-    // enable the CCM RAM
-    __CCMDATARAMEN_CLK_ENABLE();
 
 #if 0
 #if defined(NETDUINO_PLUS_2)

--- a/stmhal/mpconfigport.mk
+++ b/stmhal/mpconfigport.mk
@@ -5,3 +5,6 @@ MICROPY_PY_WIZNET5K ?= 0
 
 # cc3k module for wifi support
 MICROPY_PY_CC3K ?= 0
+
+#
+MICROPY_USE_CCM ?= 1

--- a/stmhal/startup_stm32f40xx.s
+++ b/stmhal/startup_stm32f40xx.s
@@ -76,7 +76,14 @@ defined in linker script */
     .section  .text.Reset_Handler
   .weak  Reset_Handler
   .type  Reset_Handler, %function
-Reset_Handler:  
+Reset_Handler: 
+
+  /* enable the CCM RAM : RCC->AHB1ENR |= (RCC_AHB1ENR_CCMDATARAMEN) */
+  ldr   r1, = #0x40023800     /* RCC */
+  ldr   r0, [r1, #0x30]       /* AHB1ENR */
+  orr.w r0, r0, #0x00100000   /* RCC_AHB1ENR_CCMDATARAMEN */
+  str   r0, [r1, #0x30]
+
   ldr   sp, =_estack     /* set stack pointer */
 
 /* Copy the data segment initializers from flash to SRAM */  
@@ -141,7 +148,7 @@ Infinite_Loop:
     
     
 g_pfnVectors:
-  .word  _estack
+  .word  _ram_end
   .word  Reset_Handler
   .word  NMI_Handler
   .word  HardFault_Handler

--- a/stmhal/stm32f405-ccm.ld
+++ b/stmhal/stm32f405-ccm.ld
@@ -8,7 +8,7 @@ MEMORY
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 0x100000 /* entire flash, 1 MiB */
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 0x004000 /* sector 0, 16 KiB */
     FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 0x080000 /* sectors 5,6,7,8, 4*128KiB = 512 KiB (could increase it more) */
-    CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 0x010000 /* 64 KiB */
+    CCMRAM (rw)     : ORIGIN = 0x10000000, LENGTH = 0x010000 /* 64 KiB */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x020000 /* 128 KiB */
 }
 
@@ -19,14 +19,13 @@ _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
  
 /* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
+   above last byte of CCMRAM.  Note that EABI requires the stack to be 8-byte
    aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(CCMRAM) + LENGTH(CCMRAM);
 
 /* RAM extents for the garbage collector */
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x2001c000; /* tunable */
-_stack_limit = _heap_end;
+_heap_end = _ram_end; /* whole ram is available as heap */
 
 /* define output sections */
 SECTIONS
@@ -91,7 +90,7 @@ SECTIONS
 
         . = ALIGN(4);
         _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM AT> FLASH_TEXT
+    } >CCMRAM AT> FLASH_TEXT
             
     /* Uninitialized data section */
     .bss :
@@ -103,25 +102,25 @@ SECTIONS
 
         . = ALIGN(4);
         _ebss = .;         /* define a global symbol at bss end; used by startup code and GC */
-    } >RAM
-
-    /* this is to define the start of the heap, and make sure we have a minimum size */
-    .heap :
-    {
-        . = ALIGN(4);
-	PROVIDE ( end = . );
-	PROVIDE ( _end = . );
-        _heap_start = .;    /* define a global symbol at heap start */
-        . = . + _minimum_heap_size;
-    } >RAM
+    } >CCMRAM
 
     /* this just checks there is enough RAM for the stack */
     .stack :
     {
         . = ALIGN(4);
+        _stack_limit = .;
         . = . + _minimum_stack_size;
         . = ALIGN(4);
+    } >CCMRAM
+
+    /* this is to define the start of the heap, and make sure we have a minimum size */
+    .heap :
+    {
+        . = ALIGN(4);
+        _heap_start = .;    /* define a global symbol at heap start */
+        . = . + _minimum_heap_size;
     } >RAM
+
 
     /* Remove information from the standard libraries */
     /*


### PR DESCRIPTION
Enabled / disabled by MICROPY_USE_CCM in stmhal/mpconfigport.mk.

This allows to use the entire sram as heap, by moving the stack and C data and bss in CCM (Core Coupled Memory).

Warning : statically allocated memory (data and bss) can't be used for DMA anymore, as CCM is not reachable thru the bus matrix.
