### PR TITLE
stmhal/adc.c: Fix calculation of read_core_vref()

### DIFF
--- a/stmhal/adc.c
+++ b/stmhal/adc.c
@@ -363,7 +363,7 @@ float adc_read_core_vref(ADC_HandleTypeDef *adcHandle) {
     //       be 12-bits.
     raw_value <<= (12 - adc_get_resolution(adcHandle));
 
-    return raw_value * VBAT_DIV / 4096.0f * 3.3f;
+    return raw_value / 4096.0f * 3.3f;
 }
 #endif
 


### PR DESCRIPTION
There was a stray factor of 2 (VBAT_DIV) that looks like it was copied incorrectly from the read_core_vbat() function.
The factor exists in read_core_vbat() because VBAT is measured through a 2:1 voltage divider.
read_core_vref() now returns values around 1.21V (assuming that external reference voltage is 3.3V) which is in line with the datasheet.
See comment at http://forum.micropython.org/viewtopic.php?f=6&t=533&p=2991#p2991
