### PR TITLE
docs: Add additional example/note for Timer's callback usage

### DIFF
--- a/docs/library/pyb.Timer.rst
+++ b/docs/library/pyb.Timer.rst
@@ -18,6 +18,13 @@ Example usage to toggle an LED at a fixed frequency::
     tim.init(freq=2)                # trigger at 2Hz
     tim.callback(lambda t:pyb.LED(1).toggle())
 
+Example using named function for the callback::
+
+    def tick(timer):                # we will receive the timer object when being called
+        print(timer.counter())      # show current timer's counter value
+    tim = pyb.Timer(4, freq = 1)    # create a timer object using timer 4 - trigger at 1Hz
+    tim.callback(tick)              # set the callback to our tick function
+
 Further examples::
 
     tim = pyb.Timer(4, freq=100)    # freq in Hz
@@ -31,6 +38,10 @@ Further examples::
 *Note:* Timer 3 is reserved for internal use.  Timer 5 controls
 the servo driver, and Timer 6 is used for timed ADC/DAC reading/writing.
 It is recommended to use the other timers in your programs.
+
+*Note:* Since even the exception handler can't allocate memory during interrupts,
+in order to get good traceback inside the interrupt timers use:
+``import micropython; micropython.alloc_emergency_exception_buf(100)``
 
 
 Constructors


### PR DESCRIPTION
Add example: using named function for the Timer's callback.
Add note: improving traceback inside interrupt timers.
