### PR TITLE
stmhal: changed USB HID interval to 1ms (i.e. 1kHz frequency)

### DIFF
--- a/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
+++ b/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
@@ -297,7 +297,7 @@ static const uint8_t cdc_hid_template_config_desc[CDC_HID_TEMPLATE_CONFIG_DESC_S
     0x03,                           // bmAttributes: Interrupt endpoint type
     LOBYTE(USBD_HID_MOUSE_MAX_PACKET), // wMaxPacketSize
     HIBYTE(USBD_HID_MOUSE_MAX_PACKET),
-    0x08,                           // bInterval: Polling interval
+    0x01,                           // bInterval: Polling interval
 
     //==========================================================================
     // Interface Association for CDC VCP


### PR DESCRIPTION
It would be nice to have 1kHz update frequency in USB HID. 
This is the maximum allowed by the USB norm. 

I don't see any drawbacks on changing the frequency, legacy code should work the same. 
