### PR TITLE
Prevent email harvesting from acknowledgements file

### DIFF
--- a/ACKNOWLEDGEMENTS
+++ b/ACKNOWLEDGEMENTS
@@ -127,9 +127,9 @@ today.  The names appear in order of pledging.
   236 Siggy , Belgium
   238 Mauro De Giorgi
   239 Belug http://belug.ca/
-  241 Arik Baratz <micropython@arik.baratz.org>
+  241 Arik Baratz - @arikb
   242 Zvika Palkovich
-  243 Yves Dorfsman - yves@zioup.com
+  243 Yves Dorfsman - yves at zioup dot com
   244 Asad Ansari, Canada
   245 Brandon Bennett
   246 Christoph Bluoss
@@ -140,8 +140,8 @@ today.  The names appear in order of pledging.
   256 NoisyGecko
   258 Lothilius
   262 Jay Deiman
-  263 flo@twigs.de
-  265 _Mark_ eichin@thok.org
+  263 flo at twigs dot de
+  265 _Mark_ eichin at thok dot org
   267 Adrian Astley
   268 aknerats[::-1]
   271 @robberwick
@@ -150,7 +150,7 @@ today.  The names appear in order of pledging.
   275 Paul Paradigm, Australia
   276 lyuden
   277 www.SamuelJohn.de
-  279 John Pinner, funthyme@gmail.com
+  279 John Pinner, funthyme at gmail dot com
   280 Michael and Vicky Twomey-Lee
   281 Kenneth Ljungqvist
   292 Karin Beitins, Australia
@@ -182,7 +182,7 @@ today.  The names appear in order of pledging.
   343 Brush Technology (NZ)
   346 Jason Fehr
   347 Olivier Vigneresse
-  348 Nano Gennari, me@nngn.net, Brasilia, Brazil
+  348 Nano Gennari, me at nngn dot net, Brasilia, Brazil
   352 Petr Viktorin (http://encukou.cz)
   355 Karijn Wessing (IN2TECH)
   356 Arsham Hatambeiki
@@ -229,7 +229,7 @@ today.  The names appear in order of pledging.
   438 Ben Hockley
   439 Geoffrey Webb
   441 Vladimir Mikulik
-  442 7 Elements & Troy Benjegerdes <hozer@hozed.org>
+  442 7 Elements & Troy Benjegerdes - hozer at hozed dot org
   443 Pashakun
   444 Craig Barnes, UK
   445 Andres Ayala
@@ -277,7 +277,7 @@ today.  The names appear in order of pledging.
   538 Tontonisback Belgium
   539 Greg Benson, Professor, University of San Francisco
   542 Thomas Sarlandie aka @sarfata
-  545 JanTheMan (kickstarter@embedded-systems.craftx.biz)
+  545 JanTheMan kickstarter at embedded-systems dot craftx dot biz
   546 Chuhan Frank Qin
   549 Peb R Aryan, Indonesia
   553 Johan Deimert, http://www.ldchome.org
@@ -385,7 +385,7 @@ today.  The names appear in order of pledging.
   792 Sylvain Maziere
   794 Milen
   795 Robert Mai, Germany, hsapps.com
-  797 Angelo Compagnucci <angelo.compagnucci@gmail.com>
+  797 Angelo Compagnucci angelo.compagnucci at gmail dot com
   801 Long Live Micro Python, airtripper.com
   804 António M P Mendes
   805 Marc Z.
@@ -459,7 +459,7 @@ today.  The names appear in order of pledging.
   974 Evseev Alexey
   976 Arnaud
   978 Jannis Rosenbaum
-  980 paul@fontenworks.com
+  980 paul at fontenworks dot com
   981 John Griessen ecosensory.com USA
   982 Tobias Ammann
   983 Simon V.
@@ -474,7 +474,7 @@ today.  The names appear in order of pledging.
  1001 Joe Baker
  1002 Jon Hylands, Canada (blog.huv.com)
  1004 Mike Asker (aka mpymike)
- 1007 Charles V Bock - Charles@CharlesBock.com
+ 1007 Charles V Bock - Charles at CharlesBock dot com
  1010 Remember June 4th, 1989
  1012 Stuart Marsden
  1014 Arthur P, USA
@@ -694,7 +694,7 @@ today.  The names appear in order of pledging.
  1509 Team
  1513 A. Lamborn KD0ZFY
  1514 olifink
- 1520 mike@sustainable-opportunities.com
+ 1520 mike at sustainable-opportunities dot com
  1521 luis almeida, Teresina - Brazil
  1523 Muhammad Jamaludin
  1524 Sdlion


### PR DESCRIPTION
The ACKNOWLEDGMENTS file, well intended as it is, contains some email addresses (including mine!). Being the non-spam-lover that I am, I rather my email address would not appear in a world-readable file on the internet to be harvested by spammers.

This pull request converts all email addresses to a non-harvestable format using a very simple "@" --> " at ", "." --> " dot " algorithm.
