### PR TITLE
py: Add MICROPY_MALLOC_USES_ALLOCATED_SIZE to allow simpler malloc API.

### DIFF
--- a/py/malloc.c
+++ b/py/malloc.c
@@ -109,7 +109,11 @@ void *m_malloc0(size_t num_bytes) {
     return ptr;
 }
 
+#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
 void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes) {
+#else
+void *m_realloc(void *ptr, size_t new_num_bytes) {
+#endif
     void *new_ptr = realloc(ptr, new_num_bytes);
     if (new_ptr == NULL && new_num_bytes != 0) {
         return m_malloc_fail(new_num_bytes);
@@ -129,7 +133,11 @@ void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes) {
     return new_ptr;
 }
 
+#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
 void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes) {
+#else
+void *m_realloc_maybe(void *ptr, size_t new_num_bytes) {
+#endif
     void *new_ptr = realloc(ptr, new_num_bytes);
 #if MICROPY_MEM_STATS
     // At first thought, "Total bytes allocated" should only grow,
@@ -149,7 +157,11 @@ void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes) {
     return new_ptr;
 }
 
+#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
 void m_free(void *ptr, size_t num_bytes) {
+#else
+void m_free(void *ptr) {
+#endif
     free(ptr);
 #if MICROPY_MEM_STATS
     MP_STATE_MEM(current_bytes_allocated) -= num_bytes;

--- a/py/misc.h
+++ b/py/misc.h
@@ -61,19 +61,32 @@ typedef unsigned int uint;
 #else
 #define m_new_obj_with_finaliser(type) m_new_obj(type)
 #endif
+#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
 #define m_renew(type, ptr, old_num, new_num) ((type*)(m_realloc((ptr), sizeof(type) * (old_num), sizeof(type) * (new_num))))
 #define m_renew_maybe(type, ptr, old_num, new_num) ((type*)(m_realloc_maybe((ptr), sizeof(type) * (old_num), sizeof(type) * (new_num))))
 #define m_del(type, ptr, num) m_free(ptr, sizeof(type) * (num))
-#define m_del_obj(type, ptr) (m_del(type, ptr, 1))
 #define m_del_var(obj_type, var_type, var_num, ptr) (m_free(ptr, sizeof(obj_type) + sizeof(var_type) * (var_num)))
+#else
+#define m_renew(type, ptr, old_num, new_num) ((type*)(m_realloc((ptr), sizeof(type) * (new_num))))
+#define m_renew_maybe(type, ptr, old_num, new_num) ((type*)(m_realloc_maybe((ptr), sizeof(type) * (new_num))))
+#define m_del(type, ptr, num) ((void)(num), m_free(ptr))
+#define m_del_var(obj_type, var_type, var_num, ptr) ((void)(var_num), m_free(ptr))
+#endif
+#define m_del_obj(type, ptr) (m_del(type, ptr, 1))
 
 void *m_malloc(size_t num_bytes);
 void *m_malloc_maybe(size_t num_bytes);
 void *m_malloc_with_finaliser(size_t num_bytes);
 void *m_malloc0(size_t num_bytes);
+#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
 void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes);
 void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes);
 void m_free(void *ptr, size_t num_bytes);
+#else
+void *m_realloc(void *ptr, size_t new_num_bytes);
+void *m_realloc_maybe(void *ptr, size_t new_num_bytes);
+void m_free(void *ptr);
+#endif
 void *m_malloc_fail(size_t num_bytes);
 
 #if MICROPY_MEM_STATS

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -112,6 +112,12 @@
 #define MICROPY_MODULE_DICT_SIZE (1)
 #endif
 
+// Whether realloc/free should be passed allocated memory region size
+// You must enable this if MICROPY_MEM_STATS is enabled
+#ifndef MICROPY_MALLOC_USES_ALLOCATED_SIZE
+#define MICROPY_MALLOC_USES_ALLOCATED_SIZE (0)
+#endif
+
 // Number of bytes used to store qstr length
 // Dictates hard limit on maximum Python identifier length, but 1 byte
 // (limit of 255 bytes in an identifier) should be enough for everyone

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -43,6 +43,7 @@
 #define MICROPY_ENABLE_GC           (1)
 #define MICROPY_ENABLE_FINALISER    (1)
 #define MICROPY_STACK_CHECK         (1)
+#define MICROPY_MALLOC_USES_ALLOCATED_SIZE (1)
 #define MICROPY_MEM_STATS           (1)
 #define MICROPY_DEBUG_PRINTERS      (1)
 #define MICROPY_HELPER_REPL         (1)


### PR DESCRIPTION
In the current GC implementation, the previously allocated size from malloc is never used, so we can optionally disable it in the calls, saving code size.

@danicampora this saves cc3200 160 bytes.
