### PR TITLE
cc3200: Create separate release/debug build directories

### DIFF
--- a/cc3200/Makefile
+++ b/cc3200/Makefile
@@ -5,15 +5,15 @@ ifeq ($(wildcard boards/$(BOARD)/.),)
 $(error Invalid BOARD specified)
 endif
 
+BTYPE ?= release
+
 # If the build directory is not given, make it reflect the board name.
-BUILD ?= build/$(BOARD)
+BUILD ?= build/$(BOARD)/$(BTYPE)
 
 include ../py/mkenv.mk
 -include ../../localconfig.mk
 
 CROSS_COMPILE ?= arm-none-eabi-
-
-BTYPE ?= release
 
 CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -march=armv7e-m -mabi=aapcs -mcpu=cortex-m4 -msoft-float -mfloat-abi=soft -fsingle-precision-constant -Wdouble-promotion
 CFLAGS = -Wall -Wpointer-arith -Werror -ansi -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4)

--- a/cc3200/application.mk
+++ b/cc3200/application.mk
@@ -216,7 +216,7 @@ $(BUILD)/application.bin: $(BUILD)/application.axf
 
 $(BUILD)/MCUIMG.BIN: $(BUILD)/application.bin
 	$(ECHO) "Create $@"
-	$(Q)$(SHELL) $(APP_SIGN) $(BOARD)
+	$(Q)$(SHELL) $(APP_SIGN) $(BOARD) $(BTYPE)
 
 MAKE_PINS = boards/make-pins.py
 BOARD_PINS = boards/$(BOARD)/pins.csv

--- a/cc3200/appsign.sh
+++ b/cc3200/appsign.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
+if [ "$#" -ne 2 ]; then
+    echo "Usage: appsign.sh *board type* *build type*"
+    exit 1
+fi
+
+BOARD=$1
+BTYPE=$2
+
 # Build location
-# First parameter passed is the board type
-BUILD=build/$1
+# Based on build type and board type
+BUILD=build/${BOARD}/${BTYPE}
 
 # Generate the MD5 hash
 echo -n `md5sum --binary $BUILD/application.bin | awk '{ print $1 }'` > __md5hash.bin

--- a/cc3200/bootmgr/bootgen.sh
+++ b/cc3200/bootmgr/bootgen.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 
+if [ "$#" -ne 2 ]; then
+    echo "Usage: bootgen.sh *board type* *build type*"
+    exit 1
+fi
+
+BOARD=$1
+BTYPE=$2
+
 # Re-locator Path
 RELOCATOR=bootmgr/relocator
 
 # Boot Manager Path
 # First parameter passed is the board type
-BOOTMGR=bootmgr/build/$1
+BOOTMGR=bootmgr/build/${BOARD}/${BTYPE}
 
 # Check for re-locator binary
 if [ ! -f $RELOCATOR/relocator.bin ]; then

--- a/cc3200/bootmgr/bootloader.mk
+++ b/cc3200/bootmgr/bootloader.mk
@@ -1,4 +1,4 @@
-BUILD = bootmgr/build/$(BOARD)
+BUILD = bootmgr/build/$(BOARD)/$(BTYPE)
 
 BOOT_INC  = -Ibootmgr
 BOOT_INC += -Ibootmgr/sl
@@ -122,7 +122,7 @@ $(BUILD)/bootmgr.bin: $(BUILD)/bootmgr.axf
 
 $(BUILD)/bootloader.bin: $(BUILD)/bootmgr.bin
 	$(ECHO) "Create $@"
-	$(Q)$(SHELL) $(BOOT_GEN) $(BOARD)
+	$(Q)$(SHELL) $(BOOT_GEN) $(BOARD) $(BTYPE)
 
 # Create an empty "qstrdefs.generated.h" needed by py/mkrules.mk
 $(HEADER_BUILD)/qstrdefs.generated.h: | $(HEADER_BUILD)


### PR DESCRIPTION
Create a separate build directory for release and debug. Changed usage of appsign and bootgen (extra build type argument).
