### PR TITLE
Skip special math fun tests when math module exists but MICROPY_PY_MATH_...

### DIFF
--- a/tests/float/math_fun_special.py
+++ b/tests/float/math_fun_special.py
@@ -2,7 +2,8 @@
 
 try:
     from math import *
-except ImportError:
+    erf
+except (ImportError, NameError):
     print("SKIP")
     import sys
     sys.exit()


### PR DESCRIPTION
...SPECIAL_FUNCTIONS is not defined
