### PR TITLE
Combine load_attr and store_attr type methods

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -482,13 +482,17 @@ STATIC mp_obj_t uctypes_struct_attr_op(mp_obj_t self_in, qstr attr, mp_obj_t set
     return MP_OBJ_NULL;
 }
 
-STATIC void uctypes_struct_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
-    mp_obj_t val = uctypes_struct_attr_op(self_in, attr, MP_OBJ_NULL);
-    *dest = val;
-}
-
-STATIC bool uctypes_struct_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t val) {
-    return uctypes_struct_attr_op(self_in, attr, val) != MP_OBJ_NULL;
+STATIC void uctypes_struct_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] == MP_OBJ_NULL) {
+        // load attribute
+        mp_obj_t val = uctypes_struct_attr_op(self_in, attr, MP_OBJ_NULL);
+        dest[0] = val;
+    } else {
+        // delete/store attribute
+        if (uctypes_struct_attr_op(self_in, attr, dest[1]) != MP_OBJ_NULL) {
+            dest[0] = MP_OBJ_NULL; // indicate success
+        }
+    }
 }
 
 STATIC mp_obj_t uctypes_struct_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value) {
@@ -589,8 +593,7 @@ STATIC const mp_obj_type_t uctypes_struct_type = {
     .name = MP_QSTR_struct,
     .print = uctypes_struct_print,
     .make_new = uctypes_struct_make_new,
-    .load_attr = uctypes_struct_load_attr,
-    .store_attr = uctypes_struct_store_attr,
+    .attr = uctypes_struct_attr,
     .subscr = uctypes_struct_subscr,
 };
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -232,8 +232,7 @@ typedef mp_obj_t (*mp_make_new_fun_t)(mp_obj_t type_in, mp_uint_t n_args, mp_uin
 typedef mp_obj_t (*mp_call_fun_t)(mp_obj_t fun, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args);
 typedef mp_obj_t (*mp_unary_op_fun_t)(mp_uint_t op, mp_obj_t);
 typedef mp_obj_t (*mp_binary_op_fun_t)(mp_uint_t op, mp_obj_t, mp_obj_t);
-typedef void (*mp_load_attr_fun_t)(mp_obj_t self_in, qstr attr, mp_obj_t *dest); // for fail, do nothing; for attr, dest[0] = value; for method, dest[0] = method, dest[1] = self
-typedef bool (*mp_store_attr_fun_t)(mp_obj_t self_in, qstr attr, mp_obj_t value); // return true if store succeeded; if value==MP_OBJ_NULL then delete
+typedef void (*mp_attr_fun_t)(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
 typedef mp_obj_t (*mp_subscr_fun_t)(mp_obj_t self_in, mp_obj_t index, mp_obj_t value);
 
 typedef struct _mp_method_t {
@@ -297,8 +296,18 @@ struct _mp_obj_type_t {
     mp_unary_op_fun_t unary_op;     // can return MP_OBJ_NULL if op not supported
     mp_binary_op_fun_t binary_op;   // can return MP_OBJ_NULL if op not supported
 
-    mp_load_attr_fun_t load_attr;
-    mp_store_attr_fun_t store_attr; // if value is MP_OBJ_NULL, then delete that attribute
+    // implements load, store and delete attribute
+    //
+    // dest[0] = MP_OBJ_NULL means load
+    //  return: for fail, do nothing
+    //          for attr, dest[0] = value
+    //          for method, dest[0] = method, dest[1] = self
+    //
+    // dest[0,1] = {MP_OBJ_SENTINEL, MP_OBJ_NULL} means delete
+    // dest[0,1] = {MP_OBJ_SENTINEL, object} means store
+    //  return: for fail, do nothing
+    //          for success set dest[0] = MP_OBJ_NULL
+    mp_attr_fun_t attr;
 
     mp_subscr_fun_t subscr;         // implements load, store, delete subscripting
                                     // value=MP_OBJ_NULL means delete, value=MP_OBJ_SENTINEL means load, else store

--- a/py/objboundmeth.c
+++ b/py/objboundmeth.c
@@ -71,8 +71,12 @@ STATIC mp_obj_t bound_meth_call(mp_obj_t self_in, mp_uint_t n_args, mp_uint_t n_
 }
 
 #if MICROPY_PY_FUNCTION_ATTRS
-STATIC void bound_meth_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
-    if(attr == MP_QSTR___name__) {
+STATIC void bound_meth_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] != MP_OBJ_NULL) {
+        // not load attribute
+        return;
+    }
+    if (attr == MP_QSTR___name__) {
         mp_obj_bound_meth_t *o = self_in;
         dest[0] = MP_OBJ_NEW_QSTR(mp_obj_fun_get_name(o->meth));
     }
@@ -87,7 +91,7 @@ const mp_obj_type_t bound_meth_type = {
 #endif
     .call = bound_meth_call,
 #if MICROPY_PY_FUNCTION_ATTRS
-    .load_attr = bound_meth_load_attr,
+    .attr = bound_meth_attr,
 #endif
 };
 

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -141,7 +141,11 @@ STATIC mp_obj_t complex_binary_op(mp_uint_t op, mp_obj_t lhs_in, mp_obj_t rhs_in
     return mp_obj_complex_binary_op(op, lhs->real, lhs->imag, rhs_in);
 }
 
-STATIC void complex_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+STATIC void complex_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] != MP_OBJ_NULL) {
+        // not load attribute
+        return;
+    }
     mp_obj_complex_t *self = self_in;
     if (attr == MP_QSTR_real) {
         dest[0] = mp_obj_new_float(self->real);
@@ -157,7 +161,7 @@ const mp_obj_type_t mp_type_complex = {
     .make_new = complex_make_new,
     .unary_op = complex_unary_op,
     .binary_op = complex_binary_op,
-    .load_attr = complex_load_attr,
+    .attr = complex_attr,
 };
 
 mp_obj_t mp_obj_new_complex(mp_float_t real, mp_float_t imag) {

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -140,7 +140,11 @@ mp_obj_t mp_obj_exception_get_value(mp_obj_t self_in) {
     }
 }
 
-STATIC void exception_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+STATIC void exception_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] != MP_OBJ_NULL) {
+        // not load attribute
+        return;
+    }
     mp_obj_exception_t *self = self_in;
     if (attr == MP_QSTR_args) {
         dest[0] = self->args;
@@ -168,7 +172,7 @@ const mp_obj_type_t mp_type_BaseException = {
     .name = MP_QSTR_BaseException,
     .print = mp_obj_exception_print,
     .make_new = mp_obj_exception_make_new,
-    .load_attr = exception_load_attr,
+    .attr = exception_attr,
     .locals_dict = (mp_obj_t)&exc_locals_dict,
 };
 
@@ -181,7 +185,7 @@ const mp_obj_type_t mp_type_ ## exc_name = { \
     .name = MP_QSTR_ ## exc_name, \
     .print = mp_obj_exception_print, \
     .make_new = mp_obj_exception_make_new, \
-    .load_attr = exception_load_attr, \
+    .attr = exception_attr, \
     .bases_tuple = (mp_obj_t)&mp_type_ ## base_name ## _base_tuple, \
 };
 

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -247,8 +247,12 @@ STATIC mp_obj_t fun_bc_call(mp_obj_t self_in, mp_uint_t n_args, mp_uint_t n_kw, 
 }
 
 #if MICROPY_PY_FUNCTION_ATTRS
-STATIC void fun_bc_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
-    if(attr == MP_QSTR___name__) {
+STATIC void fun_bc_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] != MP_OBJ_NULL) {
+        // not load attribute
+        return;
+    }
+    if (attr == MP_QSTR___name__) {
         dest[0] = MP_OBJ_NEW_QSTR(mp_obj_fun_get_name(self_in));
     }
 }
@@ -262,7 +266,7 @@ const mp_obj_type_t mp_type_fun_bc = {
 #endif
     .call = fun_bc_call,
 #if MICROPY_PY_FUNCTION_ATTRS
-    .load_attr = fun_bc_load_attr,
+    .attr = fun_bc_attr,
 #endif
 };
 

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -68,20 +68,20 @@ STATIC void namedtuple_print(void (*print)(void *env, const char *fmt, ...), voi
     print(env, ")");
 }
 
-STATIC void namedtuple_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
-    mp_obj_namedtuple_t *self = self_in;
-    int id = namedtuple_find_field((mp_obj_namedtuple_type_t*)self->tuple.base.type, attr);
-    if (id == -1) {
-        return;
+STATIC void namedtuple_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] == MP_OBJ_NULL) {
+        // load attribute
+        mp_obj_namedtuple_t *self = self_in;
+        int id = namedtuple_find_field((mp_obj_namedtuple_type_t*)self->tuple.base.type, attr);
+        if (id == -1) {
+            return;
+        }
+        dest[0] = self->tuple.items[id];
+    } else {
+        // delete/store attribute
+        // provide more detailed error message
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_AttributeError, "can't set attribute"));
     }
-    dest[0] = self->tuple.items[id];
-}
-
-STATIC bool namedtuple_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t value) {
-    (void)self_in;
-    (void)attr;
-    (void)value;
-    nlr_raise(mp_obj_new_exception_msg(&mp_type_AttributeError, "can't set attribute"));
 }
 
 STATIC mp_obj_t namedtuple_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
@@ -154,8 +154,7 @@ STATIC mp_obj_t mp_obj_new_namedtuple_type(qstr name, mp_uint_t n_fields, mp_obj
     o->base.make_new = namedtuple_make_new;
     o->base.unary_op = mp_obj_tuple_unary_op;
     o->base.binary_op = mp_obj_tuple_binary_op;
-    o->base.load_attr = namedtuple_load_attr;
-    o->base.store_attr = namedtuple_store_attr;
+    o->base.attr = namedtuple_attr;
     o->base.subscr = mp_obj_tuple_subscr;
     o->base.getiter = mp_obj_tuple_getiter;
     o->base.bases_tuple = (mp_obj_t)&namedtuple_base_tuple;

--- a/py/objrange.c
+++ b/py/objrange.c
@@ -168,7 +168,11 @@ STATIC mp_obj_t range_getiter(mp_obj_t o_in) {
 
 
 #if MICROPY_PY_BUILTINS_RANGE_ATTRS
-STATIC void range_load_attr(mp_obj_t o_in, qstr attr, mp_obj_t *dest) {
+STATIC void range_attr(mp_obj_t o_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] != MP_OBJ_NULL) {
+        // not load attribute
+        return;
+    }
     mp_obj_range_t *o = o_in;
     if (attr == MP_QSTR_start) {
         dest[0] = mp_obj_new_int(o->start);
@@ -189,6 +193,6 @@ const mp_obj_type_t mp_type_range = {
     .subscr = range_subscr,
     .getiter = range_getiter,
 #if MICROPY_PY_BUILTINS_RANGE_ATTRS
-    .load_attr = range_load_attr,
+    .attr = range_attr,
 #endif
 };

--- a/py/objtype.h
+++ b/py/objtype.h
@@ -37,9 +37,8 @@ typedef struct _mp_obj_instance_t {
     // TODO maybe cache __getattr__ and __setattr__ for efficient lookup of them
 } mp_obj_instance_t;
 
-// these need to be exposed for MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE to work
-void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
-bool mp_obj_instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t value);
+// this needs to be exposed for MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE to work
+void mp_obj_instance_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
 
 // these need to be exposed so mp_obj_is_callable can work correctly
 bool mp_obj_instance_is_callable(mp_obj_t self_in);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -902,9 +902,9 @@ void mp_load_method_maybe(mp_obj_t obj, qstr attr, mp_obj_t *dest) {
         dest[0] = (mp_obj_t)&mp_builtin_next_obj;
         dest[1] = obj;
 
-    } else if (type->load_attr != NULL) {
+    } else if (type->attr != NULL) {
         // this type can do its own load, so call it
-        type->load_attr(obj, attr, dest);
+        type->attr(obj, attr, dest);
 
     } else if (type->locals_dict != NULL) {
         // generic method lookup
@@ -946,8 +946,11 @@ void mp_load_method(mp_obj_t base, qstr attr, mp_obj_t *dest) {
 void mp_store_attr(mp_obj_t base, qstr attr, mp_obj_t value) {
     DEBUG_OP_printf("store attr %p.%s <- %p\n", base, qstr_str(attr), value);
     mp_obj_type_t *type = mp_obj_get_type(base);
-    if (type->store_attr != NULL) {
-        if (type->store_attr(base, attr, value)) {
+    if (type->attr != NULL) {
+        mp_obj_t dest[2] = {MP_OBJ_SENTINEL, value};
+        type->attr(base, attr, dest);
+        if (dest[0] == MP_OBJ_NULL) {
+            // success
             return;
         }
     }

--- a/py/vm.c
+++ b/py/vm.c
@@ -312,7 +312,7 @@ dispatch_loop:
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_QSTR;
                     mp_obj_t top = TOP();
-                    if (mp_obj_get_type(top)->load_attr == mp_obj_instance_load_attr) {
+                    if (mp_obj_get_type(top)->attr == mp_obj_instance_attr) {
                         mp_obj_instance_t *self = top;
                         mp_uint_t x = *ip;
                         mp_obj_t key = MP_OBJ_NEW_QSTR(qst);
@@ -402,7 +402,7 @@ dispatch_loop:
                     MARK_EXC_IP_SELECTIVE();
                     DECODE_QSTR;
                     mp_obj_t top = TOP();
-                    if (mp_obj_get_type(top)->store_attr == mp_obj_instance_store_attr && sp[-1] != MP_OBJ_NULL) {
+                    if (mp_obj_get_type(top)->attr == mp_obj_instance_attr && sp[-1] != MP_OBJ_NULL) {
                         mp_obj_instance_t *self = top;
                         mp_uint_t x = *ip;
                         mp_obj_t key = MP_OBJ_NEW_QSTR(qst);


### PR DESCRIPTION
This simplifies the API for objects and reduces code size by combining the .load_attr and .store_attr methods in mp_obj_type_t.

Code size decreases:
- 2816 on unix x86
- 1588 on minimal
- 252 on bare-arm
- 444 on stmhal
- 384 on cc3200
- 400 on teensy

In also saves RAM: each user-defined class is 1 word smaller.  Furthermore, any further additions of new static objects will be 1 word smaller than previously.

But it does also hamper performance, although only very slightly.  I measured about 1% decrease in pystone score on x86 (down from around 84k to around 83k).

My feeling is that this is a good patch to merge because it reduces code size by a non-trivial amount, and reduces RAM usage, making micropython more micro.  If people want performance there's CPython and PyPy for that (and Pyston and Cython etc).  If a port has bytes to spend on optimisations, then likely there are better things to spend those bytes on than separating load/store.  Note that subscr load/store is already combined.
