### PR TITLE
Add pic16bit port

### DIFF
--- a/pic16bit/Makefile
+++ b/pic16bit/Makefile
@@ -1,0 +1,66 @@
+include ../py/mkenv.mk
+
+# qstr definitions (must come before including py.mk)
+QSTR_DEFS = qstrdefsport.h
+
+# include py core make definitions
+include ../py/py.mk
+
+XC16 = /opt/microchip/xc16/v1.24
+CROSS_COMPILE = $(XC16)/bin/xc16-
+
+PARTFAMILY = dsPIC33F
+PART = 33FJ256GP506
+
+INC =  -I.
+INC += -I..
+INC += -I../lib/mp-readline
+INC += -I../stmhal
+INC += -I$(BUILD)
+INC += -I$(XC16)/include
+INC += -I$(XC16)/support/$(PARTFAMILY)/h
+
+CFLAGS_PIC16BIT = -mcpu=$(PART) -mlarge-code
+CFLAGS = $(INC) -Wall -Werror -ansi -std=gnu99 -nostdlib $(CFLAGS_PIC16BIT) $(COPT)
+
+#Debugging/Optimization
+ifeq ($(DEBUG), 1)
+CFLAGS += -O0 -ggdb
+else
+CFLAGS += -O1 -DNDEBUG
+endif
+
+LDFLAGS = --heap=0 -nostdlib -T $(XC16)/support/$(PARTFAMILY)/gld/p$(PART).gld -Map=$@.map --cref -p$(PART)
+LIBS = -L$(XC16)/lib -L$(XC16)/lib/$(PARTFAMILY) -lc -lm -lpic30 -lp$(PART)
+
+SRC_C = \
+	main.c \
+	board.c \
+	pic16bit_mphal.c \
+	modpyb.c \
+	modpybled.c \
+	modpybswitch.c \
+	stmhal/pybstdio.c \
+	stmhal/pyexec.c \
+	lib/mp-readline/readline.c \
+
+SRC_S = \
+#	gchelper.s \
+
+OBJ = $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o) $(SRC_S:.s=.o))
+
+all: $(BUILD)/firmware.hex
+
+$(BUILD)/firmware.hex: $(BUILD)/firmware.elf
+	$(ECHO) "Create $@"
+	$(Q)$(CROSS_COMPILE)bin2hex $<
+
+$(BUILD)/firmware.elf: $(OBJ)
+	$(ECHO) "LINK $@"
+	$(Q)$(LD) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)
+	$(Q)size $@
+
+$(PY_BUILD)/gc.o: CFLAGS += -O1
+$(PY_BUILD)/vm.o: CFLAGS += -O1
+
+include ../py/mkrules.mk

--- a/pic16bit/board.c
+++ b/pic16bit/board.c
@@ -1,0 +1,153 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <p33Fxxxx.h>
+#include "board.h"
+
+/********************************************************************/
+// CPU
+
+void cpu_init(void) {
+    // set oscillator to operate at 40MHz
+    // Fosc = Fin*M/(N1*N2), Fcy = Fosc/2
+    // Fosc = 7.37M*40/(2*2) = 80Mhz for 7.37M input clock
+    PLLFBD = 41;            // M=39
+    CLKDIVbits.PLLPOST = 0; // N1=2
+    CLKDIVbits.PLLPRE = 0;  // N2=2
+    OSCTUN = 0;
+
+    // initiate clock wwitch to FRC with PLL
+    __builtin_write_OSCCONH(0x01);
+    __builtin_write_OSCCONL(0x01);
+
+    // wait for clock switch to occur
+    while (OSCCONbits.COSC != 0x01) {
+    }
+    while (!OSCCONbits.LOCK) {
+    }
+}
+
+/********************************************************************/
+// LEDs
+
+#define RED_LED_TRIS _TRISC15
+#define YELLOW_LED_TRIS _TRISC13
+#define GREEN_LED_TRIS _TRISC14
+
+#define RED_LED _LATC15
+#define YELLOW_LED _LATC13
+#define GREEN_LED _LATC14
+
+#define LED_ON (0)
+#define LED_OFF (1)
+
+void led_init(void) {
+    // set led GPIO as outputs
+    RED_LED_TRIS = 0;
+    YELLOW_LED_TRIS = 0;
+    GREEN_LED_TRIS = 0;
+
+    // turn off the LEDs
+    RED_LED = LED_OFF;
+    YELLOW_LED = LED_OFF;
+    GREEN_LED = LED_OFF;
+}
+
+void led_state(int led, int state) {
+    int val = state ? LED_ON : LED_OFF;
+    switch (led) {
+        case 1: RED_LED = val; break;
+        case 2: YELLOW_LED = val; break;
+        case 3: GREEN_LED = val; break;
+    }
+}
+
+void led_toggle(int led) {
+    switch (led) {
+        case 1: RED_LED ^= 1; break;
+        case 2: YELLOW_LED ^= 1; break;
+        case 3: GREEN_LED ^= 1; break;
+    }
+}
+
+/********************************************************************/
+// switches
+
+#define SWITCH_S1_TRIS _TRISD8
+#define SWITCH_S2_TRIS _TRISD9
+
+#define SWITCH_S1 _RD8
+#define SWITCH_S2 _RD9
+
+void switch_init(void) {
+    // set switch GPIO as inputs
+    SWITCH_S1_TRIS = 1;
+    SWITCH_S2_TRIS = 1;
+}
+
+int switch_get(int sw) {
+    int val = 1;
+    switch (sw) {
+        case 1: val = SWITCH_S1; break;
+        case 2: val = SWITCH_S2; break;
+    }
+    return val == 0;
+}
+
+/********************************************************************/
+// UART
+
+/*
+// TODO need an irq
+void uart_rx_irq(void) {
+    if (c == interrupt_char) {
+        MP_STATE_VM(mp_pending_exception) = MP_STATE_PORT(keyboard_interrupt_obj);
+    }
+}
+*/
+
+void uart_init(void) {
+    // baudrate = F_CY / 16 (uxbrg + 1)
+    // F_CY = 40MHz for us
+    UART1.uxbrg = 64; // 38400 baud
+    UART1.uxmode = 1 << 15; // UARTEN
+    UART1.uxsta = 1 << 10;  // UTXEN
+}
+
+int uart_rx_any(void) {
+    return UART1.uxsta & 1; // URXDA
+}
+
+int uart_rx_char(void) {
+    return UART1.uxrxreg;
+}
+
+void uart_tx_char(int chr) {
+    while (UART1.uxsta & (1 << 9)) {
+        // tx fifo is full
+    }
+    UART1.uxtxreg = chr;
+}

--- a/pic16bit/board.h
+++ b/pic16bit/board.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef __MICROPY_INCLUDED_PIC16BIT_BOARD_H__
+#define __MICROPY_INCLUDED_PIC16BIT_BOARD_H__
+
+void cpu_init(void);
+
+void led_init(void);
+void led_state(int led, int state);
+void led_toggle(int led);
+
+void switch_init(void);
+int switch_get(int sw);
+
+void uart_init(void);
+int uart_rx_any(void);
+int uart_rx_char(void);
+void uart_tx_char(int chr);
+
+#endif // __MICROPY_INCLUDED_PIC16BIT_BOARD_H__

--- a/pic16bit/main.c
+++ b/pic16bit/main.c
@@ -1,0 +1,125 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <p33Fxxxx.h>
+
+#include "py/compile.h"
+#include "py/runtime.h"
+#include "py/gc.h"
+#include "pyexec.h"
+#include "readline.h"
+#include MICROPY_HAL_H
+#include "board.h"
+#include "modpyb.h"
+
+_FGS(GWRP_OFF & GCP_OFF);
+_FOSCSEL(FNOSC_FRC);
+_FOSC(FCKSM_CSECMD & OSCIOFNC_ON & POSCMD_NONE);
+_FWDT(FWDTEN_OFF);
+
+// maximum heap for device with 8k RAM
+static char heap[4600];
+
+int main(int argc, char **argv) {
+    // init the CPU and the peripherals
+    cpu_init();
+    led_init();
+    switch_init();
+    uart_init();
+
+soft_reset:
+
+    // flash green led for 150ms to indicate boot
+    led_state(1, 0);
+    led_state(2, 0);
+    led_state(3, 1);
+    mp_hal_milli_delay(150);
+    led_state(3, 0);
+
+    // init MicroPython runtime
+    int stack_dummy;
+    MP_STATE_VM(stack_top) = (char*)&stack_dummy;
+    gc_init(heap, heap + sizeof(heap));
+    mp_init();
+    mp_hal_init();
+    readline_init0();
+
+    // REPL loop
+    for (;;) {
+        if (pyexec_mode_kind == PYEXEC_MODE_RAW_REPL) {
+            if (pyexec_raw_repl() != 0) {
+                break;
+            }
+        } else {
+            if (pyexec_friendly_repl() != 0) {
+                break;
+            }
+        }
+    }
+
+    printf("PYB: soft reboot\n");
+    mp_deinit();
+    goto soft_reset;
+}
+
+void gc_collect(void) {
+    // TODO possibly need to trace registers
+    void *dummy;
+    gc_collect_start();
+    // Node: stack is ascending
+    gc_collect_root(&dummy, ((mp_uint_t)&dummy - (mp_uint_t)MP_STATE_VM(stack_top)) / sizeof(mp_uint_t));
+    gc_collect_end();
+}
+
+mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
+    return NULL;
+}
+
+mp_import_stat_t mp_import_stat(const char *path) {
+    return MP_IMPORT_STAT_NO_EXIST;
+}
+
+mp_obj_t mp_builtin_open(uint n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
+
+void nlr_jump_fail(void *val) {
+}
+
+void NORETURN __fatal_error(const char *msg) {
+    while (1);
+}
+
+#ifndef NDEBUG
+void MP_WEAK __assert_func(const char *file, int line, const char *func, const char *expr) {
+    printf("Assertion '%s' failed, at file %s:%d\n", expr, file, line);
+    __fatal_error("Assertion failed");
+}
+#endif

--- a/pic16bit/modpyb.c
+++ b/pic16bit/modpyb.c
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+
+#include "py/obj.h"
+#include MICROPY_HAL_H
+#include "modpyb.h"
+
+STATIC mp_obj_t pyb_millis(void) {
+    return MP_OBJ_NEW_SMALL_INT(mp_hal_get_milliseconds());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(pyb_millis_obj, pyb_millis);
+
+STATIC mp_obj_t pyb_elapsed_millis(mp_obj_t start) {
+    uint32_t startMillis = mp_obj_get_int(start);
+    uint32_t currMillis = mp_hal_get_milliseconds();
+    return MP_OBJ_NEW_SMALL_INT((currMillis - startMillis) & 0x1fff);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_elapsed_millis_obj, pyb_elapsed_millis);
+
+STATIC mp_obj_t pyb_delay(mp_obj_t ms_in) {
+    mp_int_t ms = mp_obj_get_int(ms_in);
+    if (ms >= 0) {
+        mp_hal_milli_delay(ms);
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_delay_obj, pyb_delay);
+
+STATIC const mp_map_elem_t pyb_module_globals_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_pyb) },
+
+    { MP_OBJ_NEW_QSTR(MP_QSTR_millis), (mp_obj_t)&pyb_millis_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_elapsed_millis), (mp_obj_t)&pyb_elapsed_millis_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_delay), (mp_obj_t)&pyb_delay_obj },
+
+    { MP_OBJ_NEW_QSTR(MP_QSTR_LED), (mp_obj_t)&pyb_led_type },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_Switch), (mp_obj_t)&pyb_switch_type },
+};
+
+STATIC MP_DEFINE_CONST_DICT(pyb_module_globals, pyb_module_globals_table);
+
+const mp_obj_module_t pyb_module = {
+    .base = { &mp_type_module },
+    .name = MP_QSTR_pyb,
+    .globals = (mp_obj_dict_t*)&pyb_module_globals,
+};

--- a/pic16bit/modpyb.h
+++ b/pic16bit/modpyb.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef __MICROPY_INCLUDED_PIC16BIT_MODPYB_H__
+#define __MICROPY_INCLUDED_PIC16BIT_MODPYB_H__
+
+extern const mp_obj_type_t pyb_led_type;
+extern const mp_obj_type_t pyb_switch_type;
+extern const mp_obj_module_t pyb_module;
+
+#endif // __MICROPY_INCLUDED_PIC16BIT_MODPYB_H__

--- a/pic16bit/modpybled.c
+++ b/pic16bit/modpybled.c
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "board.h"
+#include "modpyb.h"
+
+typedef struct _pyb_led_obj_t {
+    mp_obj_base_t base;
+} pyb_led_obj_t;
+
+STATIC const pyb_led_obj_t pyb_led_obj[] = {
+    {{&pyb_led_type}},
+    {{&pyb_led_type}},
+    {{&pyb_led_type}},
+};
+
+#define NUM_LED MP_ARRAY_SIZE(pyb_led_obj)
+#define LED_ID(obj) ((obj) - &pyb_led_obj[0] + 1)
+
+void pyb_led_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
+    pyb_led_obj_t *self = self_in;
+    print(env, "LED(%u)", LED_ID(self));
+}
+
+STATIC mp_obj_t pyb_led_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+    mp_int_t led_id = mp_obj_get_int(args[0]);
+    if (!(1 <= led_id && led_id <= NUM_LED)) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "LED %d does not exist", led_id));
+    }
+    return (mp_obj_t)&pyb_led_obj[led_id - 1];
+}
+
+mp_obj_t pyb_led_on(mp_obj_t self_in) {
+    pyb_led_obj_t *self = self_in;
+    led_state(LED_ID(self), 1);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_led_on_obj, pyb_led_on);
+
+mp_obj_t pyb_led_off(mp_obj_t self_in) {
+    pyb_led_obj_t *self = self_in;
+    led_state(LED_ID(self), 0);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_led_off_obj, pyb_led_off);
+
+mp_obj_t pyb_led_toggle(mp_obj_t self_in) {
+    pyb_led_obj_t *self = self_in;
+    led_toggle(LED_ID(self));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_led_toggle_obj, pyb_led_toggle);
+
+STATIC const mp_map_elem_t pyb_led_locals_dict_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR_on), (mp_obj_t)&pyb_led_on_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_off), (mp_obj_t)&pyb_led_off_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_toggle), (mp_obj_t)&pyb_led_toggle_obj },
+};
+
+STATIC MP_DEFINE_CONST_DICT(pyb_led_locals_dict, pyb_led_locals_dict_table);
+
+const mp_obj_type_t pyb_led_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_LED,
+    .print = pyb_led_print,
+    .make_new = pyb_led_make_new,
+    .locals_dict = (mp_obj_t)&pyb_led_locals_dict,
+};

--- a/pic16bit/modpybswitch.c
+++ b/pic16bit/modpybswitch.c
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "board.h"
+#include "modpyb.h"
+
+typedef struct _pyb_switch_obj_t {
+    mp_obj_base_t base;
+} pyb_switch_obj_t;
+
+STATIC const pyb_switch_obj_t pyb_switch_obj[] = {
+    {{&pyb_switch_type}},
+    {{&pyb_switch_type}},
+};
+
+#define NUM_SWITCH MP_ARRAY_SIZE(pyb_switch_obj)
+#define SWITCH_ID(obj) ((obj) - &pyb_switch_obj[0] + 1)
+
+void pyb_switch_print(void (*print)(void *env, const char *fmt, ...), void *env, mp_obj_t self_in, mp_print_kind_t kind) {
+    pyb_switch_obj_t *self = self_in;
+    print(env, "Switch(%u)", SWITCH_ID(self));
+}
+
+STATIC mp_obj_t pyb_switch_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+    mp_int_t sw_id = mp_obj_get_int(args[0]);
+    if (!(1 <= sw_id && sw_id <= NUM_SWITCH)) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Switch %d does not exist", sw_id));
+    }
+    return (mp_obj_t)&pyb_switch_obj[sw_id - 1];
+}
+
+mp_obj_t pyb_switch_value(mp_obj_t self_in) {
+    pyb_switch_obj_t *self = self_in;
+    return switch_get(SWITCH_ID(self)) ? mp_const_true : mp_const_false;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_switch_value_obj, pyb_switch_value);
+
+mp_obj_t pyb_switch_call(mp_obj_t self_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+    return pyb_switch_value(self_in);
+}
+
+STATIC const mp_map_elem_t pyb_switch_locals_dict_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR_value), (mp_obj_t)&pyb_switch_value_obj },
+};
+
+STATIC MP_DEFINE_CONST_DICT(pyb_switch_locals_dict, pyb_switch_locals_dict_table);
+
+const mp_obj_type_t pyb_switch_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_Switch,
+    .print = pyb_switch_print,
+    .make_new = pyb_switch_make_new,
+    .call = pyb_switch_call,
+    .locals_dict = (mp_obj_t)&pyb_switch_locals_dict,
+};

--- a/pic16bit/mpconfigport.h
+++ b/pic16bit/mpconfigport.h
@@ -1,0 +1,114 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+
+// options to control how Micro Python is built
+#define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_B)
+#define MICROPY_ALLOC_PATH_MAX      (64)
+#define MICROPY_EMIT_X64            (0)
+#define MICROPY_EMIT_THUMB          (0)
+#define MICROPY_EMIT_INLINE_THUMB   (0)
+#define MICROPY_COMP_MODULE_CONST   (0)
+#define MICROPY_COMP_CONST          (0)
+#define MICROPY_MEM_STATS           (0)
+#define MICROPY_DEBUG_PRINTERS      (0)
+#define MICROPY_ENABLE_GC           (1)
+#define MICROPY_REPL_EVENT_DRIVEN   (0)
+#define MICROPY_HELPER_REPL         (1)
+#define MICROPY_HELPER_LEXER_UNIX   (0)
+#define MICROPY_ENABLE_SOURCE_LINE  (0)
+#define MICROPY_ENABLE_DOC_STRING   (0)
+#define MICROPY_ERROR_REPORTING     (MICROPY_ERROR_REPORTING_TERSE)
+#define MICROPY_PY_BUILTINS_BYTEARRAY (0)
+#define MICROPY_PY_BUILTINS_MEMORYVIEW (0)
+#define MICROPY_PY_BUILTINS_FROZENSET (0)
+#define MICROPY_PY_BUILTINS_SET     (0)
+#define MICROPY_PY_BUILTINS_SLICE   (0)
+#define MICROPY_PY_BUILTINS_PROPERTY (0)
+#define MICROPY_PY_MICROPYTHON_MEM_INFO (1)
+#define MICROPY_PY___FILE__         (0)
+#define MICROPY_PY_GC               (1)
+#define MICROPY_PY_ARRAY            (0)
+#define MICROPY_PY_COLLECTIONS      (0)
+#define MICROPY_PY_MATH             (0)
+#define MICROPY_PY_CMATH            (0)
+#define MICROPY_PY_IO               (0)
+#define MICROPY_PY_STRUCT           (0)
+#define MICROPY_PY_SYS              (0)
+#define MICROPY_MODULE_FROZEN       (0)
+#define MICROPY_CPYTHON_COMPAT      (0)
+#define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_MPZ)
+#define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_NONE)
+
+// type definitions for the specific machine
+
+#define MP_ENDIANNESS_LITTLE        (1)
+#define BYTES_PER_WORD              (2)
+#define MPZ_DIG_SIZE                (8)
+
+// The xc16 compiler doesn't seem to respect alignment (!!) so we
+// need to use instead an object representation that allows for
+// 2-byte aligned pointers (see config setting above).
+//#define MICROPY_OBJ_BASE_ALIGNMENT  __attribute__((aligned(4)))
+
+#define MICROPY_MAKE_POINTER_CALLABLE(p) ((void*)((mp_uint_t)(p)))
+
+// This port is intended to be 32-bit, but unfortunately, int32_t for
+// different targets may be defined in different ways - either as int
+// or as long. This requires different printf formatting specifiers
+// to print such value. So, we avoid int32_t and use int directly.
+#define UINT_FMT "%u"
+#define INT_FMT "%d"
+typedef int mp_int_t; // must be pointer size
+typedef unsigned int mp_uint_t; // must be pointer size
+
+typedef void *machine_ptr_t; // must be of pointer size
+typedef const void *machine_const_ptr_t; // must be of pointer size
+typedef int mp_off_t;
+
+// extra builtin names to add to the global namespace
+extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
+#define MICROPY_PORT_BUILTINS \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_open), (mp_obj_t)&mp_builtin_open_obj },
+
+// extra builtin modules to add to the list of known ones
+extern const struct _mp_obj_module_t pyb_module;
+#define MICROPY_PORT_BUILTIN_MODULES \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_pyb), (mp_obj_t)&pyb_module }, \
+
+// We need to provide a declaration/definition of alloca()
+#define alloca(x) (void*)m_new(byte, (x))
+
+#define MP_STATE_PORT MP_STATE_VM
+
+#define MICROPY_PORT_ROOT_POINTERS \
+    char *readline_hist[8]; \
+    mp_obj_t keyboard_interrupt_obj; \
+
+#define MICROPY_HAL_H "pic16bit_mphal.h"
+#define MICROPY_HW_BOARD_NAME "dsPICSK"
+#define MICROPY_HW_MCU_NAME "dsPIC33"

--- a/pic16bit/pic16bit_mphal.c
+++ b/pic16bit/pic16bit_mphal.c
@@ -1,0 +1,79 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <string.h>
+#include "pic16bit_mphal.h"
+#include "board.h"
+
+static int interrupt_char;
+
+void mp_hal_init(void) {
+    MP_STATE_PORT(keyboard_interrupt_obj) = mp_obj_new_exception(&mp_type_KeyboardInterrupt);
+}
+
+mp_uint_t mp_hal_get_milliseconds(void) {
+    // TODO
+    return 0;
+}
+
+void mp_hal_milli_delay(mp_uint_t ms) {
+    // tuned for fixed CPU frequency
+    for (int i = ms; i > 0; i--) {
+        for (volatile int j = 0; j < 5000; j++) {
+        }
+    }
+}
+
+void mp_hal_set_interrupt_char(int c) {
+    interrupt_char = c;
+}
+
+int mp_hal_stdin_rx_chr(void) {
+    for (;;) {
+        if (uart_rx_any()) {
+            return uart_rx_char();
+        }
+    }
+}
+
+void mp_hal_stdout_tx_str(const char *str) {
+    mp_hal_stdout_tx_strn(str, strlen(str));
+}
+
+void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+    for (; len > 0; --len) {
+        uart_tx_char(*str++);
+    }
+}
+
+void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len) {
+    for (; len > 0; --len) {
+        if (*str == '\n') {
+            uart_tx_char('\r');
+        }
+        uart_tx_char(*str++);
+    }
+}

--- a/pic16bit/pic16bit_mphal.h
+++ b/pic16bit/pic16bit_mphal.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef __MICROPY_INCLUDED_PIC16BIT_PIC16BIT_MPHAL_H__
+#define __MICROPY_INCLUDED_PIC16BIT_PIC16BIT_MPHAL_H__
+
+#define HAL_GetTick mp_hal_get_milliseconds
+
+#include "py/mpstate.h"
+
+void mp_hal_init(void);
+
+mp_uint_t mp_hal_get_milliseconds(void);
+void mp_hal_milli_delay(mp_uint_t ms);
+
+void mp_hal_set_interrupt_char(int c);
+int mp_hal_stdin_rx_chr(void);
+void mp_hal_stdout_tx_str(const char *str);
+void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len);
+void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
+
+#endif // __MICROPY_INCLUDED_PIC16BIT_PIC16BIT_MPHAL_H__

--- a/pic16bit/qstrdefsport.h
+++ b/pic16bit/qstrdefsport.h
@@ -1,0 +1,15 @@
+// qstrs specific to this port
+
+Q(pyb)
+Q(millis)
+Q(elapsed_millis)
+Q(delay)
+Q(LED)
+Q(on)
+Q(off)
+Q(toggle)
+Q(Switch)
+Q(value)
+Q(readall)
+Q(readline)
+Q(FileIO)

--- a/py/gc.c
+++ b/py/gc.c
@@ -680,10 +680,11 @@ void gc_dump_alloc_table(void) {
                 }
             }
             // print header for new line of blocks
+            // (the cast to uint32_t is for 16-bit ports)
             #if EXTENSIVE_HEAP_PROFILING
-            printf("\n%05x: ", (uint)(bl * BYTES_PER_BLOCK) & 0xfffff);
+            printf("\n%05x: ", (uint)((bl * BYTES_PER_BLOCK) & (uint32_t)0xfffff));
             #else
-            printf("\n%05x: ", (uint)PTR_FROM_BLOCK(bl) & 0xfffff);
+            printf("\n%05x: ", (uint)(PTR_FROM_BLOCK(bl) & (uint32_t)0xfffff));
             #endif
         }
         int c = ' ';

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -49,6 +49,25 @@
 // values below.
 
 /*****************************************************************************/
+/* Object representation                                                     */
+
+// A Micro Python object is a machine word having the following form:
+//  - xxxx...xxx1 : a small int, bits 1 and above are the value
+//  - xxxx...xx10 : a qstr, bits 2 and above are the value
+//  - xxxx...xx00 : a pointer to an mp_obj_base_t (unless a fake object)
+#define MICROPY_OBJ_REPR_A (0)
+
+// A Micro Python object is a machine word having the following form:
+//  - xxxx...xx01 : a small int, bits 2 and above are the value
+//  - xxxx...xx11 : a qstr, bits 2 and above are the value
+//  - xxxx...xxx0 : a pointer to an mp_obj_base_t (unless a fake object)
+#define MICROPY_OBJ_REPR_B (1)
+
+#ifndef MICROPY_OBJ_REPR
+#define MICROPY_OBJ_REPR (MICROPY_OBJ_REPR_A)
+#endif
+
+/*****************************************************************************/
 /* Memory allocation policy                                                  */
 
 // Number of words allocated (in BSS) to the GC stack (minimum is 1)

--- a/py/mpz.h
+++ b/py/mpz.h
@@ -39,22 +39,37 @@
 // unsigned versions.
 //
 // MPZ_DIG_SIZE can be between 4 and 8*sizeof(mpz_dig_t), but it makes most
-// sense to have it as large as possible.  Below, the type is auto-detected
-// depending on the machine, but it (and MPZ_DIG_SIZE) can be freely changed so
-// long as the constraints mentioned above are met.
+// sense to have it as large as possible.  If MPZ_DIG_SIZE is not already
+// defined then it is auto-detected below, depending on the machine.  The types
+// are then set based on the value of MPZ_DIG_SIZE (although they can be freely
+// changed so long as the constraints mentioned above are met).
 
-#if defined(__x86_64__) || defined(_WIN64)
-// 64-bit machine, using 32-bit storage for digits
+#ifndef MPZ_DIG_SIZE
+  #if defined(__x86_64__) || defined(_WIN64)
+    // 64-bit machine, using 32-bit storage for digits
+    #define MPZ_DIG_SIZE (32)
+  #else
+    // default: 32-bit machine, using 16-bit storage for digits
+    #define MPZ_DIG_SIZE (16)
+  #endif
+#endif
+
+#if MPZ_DIG_SIZE > 16
 typedef uint32_t mpz_dig_t;
 typedef uint64_t mpz_dbl_dig_t;
 typedef int64_t mpz_dbl_dig_signed_t;
-#define MPZ_DIG_SIZE (32)
-#else
-// 32-bit machine, using 16-bit storage for digits
+#elif MPZ_DIG_SIZE > 8
 typedef uint16_t mpz_dig_t;
 typedef uint32_t mpz_dbl_dig_t;
 typedef int32_t mpz_dbl_dig_signed_t;
-#define MPZ_DIG_SIZE (16)
+#elif MPZ_DIG_SIZE > 4
+typedef uint8_t mpz_dig_t;
+typedef uint16_t mpz_dbl_dig_t;
+typedef int16_t mpz_dbl_dig_signed_t;
+#else
+typedef uint8_t mpz_dig_t;
+typedef uint8_t mpz_dbl_dig_t;
+typedef int8_t mpz_dbl_dig_signed_t;
 #endif
 
 #ifdef _WIN64

--- a/py/smallint.h
+++ b/py/smallint.h
@@ -32,9 +32,19 @@
 // Functions for small integer arithmetic
 
 // In SMALL_INT, next-to-highest bits is used as sign, so both must match for value in range
+#if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A
+
 #define MP_SMALL_INT_MIN ((mp_int_t)(((mp_int_t)WORD_MSBIT_HIGH) >> 1))
-#define MP_SMALL_INT_MAX ((mp_int_t)(~(MP_SMALL_INT_MIN)))
 #define MP_SMALL_INT_FITS(n) ((((n) ^ ((n) << 1)) & WORD_MSBIT_HIGH) == 0)
+
+#elif MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_B
+
+#define MP_SMALL_INT_MIN ((mp_int_t)(((mp_int_t)WORD_MSBIT_HIGH) >> 2))
+#define MP_SMALL_INT_FITS(n) ((((n) & MP_SMALL_INT_MIN) == 0) || (((n) & MP_SMALL_INT_MIN) == MP_SMALL_INT_MIN))
+
+#endif
+
+#define MP_SMALL_INT_MAX ((mp_int_t)(~(MP_SMALL_INT_MIN)))
 
 bool mp_small_int_mul_overflow(mp_int_t x, mp_int_t y);
 mp_int_t mp_small_int_modulo(mp_int_t dividend, mp_int_t divisor);


### PR DESCRIPTION
This is a port to a dsPIC33, which is a 16-bit PIC microcontroller by Microchip.  It was one of the port pledges sponsored on Kickstarter.  It demonstrates that uPy can run on 16-bit systems without much change to the code base.

One main issue with PIC development is the compiler.  I'm using xc16 which has a Linux version and is freely downloadable from Microchip (there is even an Archlinux package, although I couldn't get that working...).  But you're limited to at-most -O1 compiler optimisations so the resulting binary is around 185k.  Still, it fits and runs in 8k RAM.

Also, this compiler seems to have a bug (feature?) in that it doesn't correctly align things in memory (a long story and many hourse debugging behind this, in summary it does try to align things as requested but randomly adds 2 bytes offset here and there), so the uPy object representation needed to be adjusted.  See details in obj.h.
