### PR TITLE
stmhal: Use new %q format to print qstr's in a few more places

### DIFF
--- a/stmhal/adc.c
+++ b/stmhal/adc.c
@@ -163,7 +163,7 @@ STATIC mp_obj_t adc_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_kw,
         const pin_obj_t *pin = pin_find(pin_obj);
         if ((pin->adc_num & PIN_ADC1) == 0) {
             // No ADC1 function on that pin
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "pin %s does not have ADC capabilities", qstr_str(pin->name)));
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "pin %q does not have ADC capabilities", pin->name));
         }
         channel = pin->adc_channel;
     }

--- a/stmhal/can.c
+++ b/stmhal/can.c
@@ -186,13 +186,13 @@ STATIC void pyb_can_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
             case CAN_MODE_SILENT: mode = MP_QSTR_SILENT; break;
             case CAN_MODE_SILENT_LOOPBACK: default: mode = MP_QSTR_SILENT_LOOPBACK; break;
         }
-        mp_printf(print, "%s, extframe=", qstr_str(mode));
+        mp_printf(print, "%q, extframe=", mode);
         if (self->extframe) {
             mode = MP_QSTR_True;
         } else {
             mode = MP_QSTR_False;
         }
-        mp_printf(print, "%s)", qstr_str(mode));
+        mp_printf(print, "%q)", mode);
     }
 }
 

--- a/stmhal/dac.c
+++ b/stmhal/dac.c
@@ -124,7 +124,7 @@ STATIC mp_obj_t pyb_dac_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n
         } else if (pin == &pin_A5) {
             dac_id = 2;
         } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "pin %s does not have DAC capabilities", qstr_str(pin->name)));
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "pin %q does not have DAC capabilities", pin->name));
         }
     }
 

--- a/stmhal/pin.c
+++ b/stmhal/pin.c
@@ -184,7 +184,7 @@ STATIC void pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
     pin_obj_t *self = self_in;
 
     // pin name
-    mp_printf(print, "Pin(Pin.cpu.%s, mode=Pin.", qstr_str(self->name));
+    mp_printf(print, "Pin(Pin.cpu.%q, mode=Pin.", self->name);
 
     uint32_t mode = pin_get_mode(self);
 
@@ -221,7 +221,7 @@ STATIC void pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
             pull_qst = MP_QSTR_PULL_DOWN;
         }
         if (pull_qst != MP_QSTR_NULL) {
-            mp_printf(print, ", pull=Pin.%s", qstr_str(pull_qst));
+            mp_printf(print, ", pull=Pin.%q", pull_qst);
         }
 
         // AF mode
@@ -231,7 +231,7 @@ STATIC void pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
             if (af_obj == NULL) {
                 mp_printf(print, ", af=%d)", af_idx);
             } else {
-                mp_printf(print, ", af=Pin.%s)", qstr_str(af_obj->name));
+                mp_printf(print, ", af=Pin.%q)", af_obj->name);
             }
         } else {
             mp_print_str(print, ")");
@@ -618,7 +618,7 @@ const mp_obj_type_t pin_type = {
 /// Return a string describing the alternate function.
 STATIC void pin_af_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pin_af_obj_t *self = self_in;
-    mp_printf(print, "Pin.%s", qstr_str(self->name));
+    mp_printf(print, "Pin.%q", self->name);
 }
 
 /// \method index()

--- a/stmhal/pin_named_pins.c
+++ b/stmhal/pin_named_pins.c
@@ -33,7 +33,7 @@
 
 STATIC void pin_named_pins_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pin_named_pins_obj_t *self = self_in;
-    mp_printf(print, "<Pin.%s>", qstr_str(self->name));
+    mp_printf(print, "<Pin.%q>", self->name);
 }
 
 const mp_obj_type_t pin_cpu_pins_obj_type = {

--- a/stmhal/timer.c
+++ b/stmhal/timer.c
@@ -846,7 +846,7 @@ STATIC mp_obj_t pyb_timer_channel(mp_uint_t n_args, const mp_obj_t *pos_args, mp
         const pin_obj_t *pin = pin_obj;
         const pin_af_obj_t *af = pin_find_af(pin, AF_FN_TIM, self->tim_id);
         if (af == NULL) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "pin %s doesn't have an af for TIM%d", qstr_str(pin->name), self->tim_id));
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "pin %q doesn't have an af for TIM%d", pin->name, self->tim_id));
         }
         // pin.init(mode=AF_PP, af=idx)
         const mp_obj_t args2[6] = {


### PR DESCRIPTION
Saves 68 bytes on stmhal
