### PR TITLE
Inline assembler: getlbl pseudo-instruction initial implementation

### DIFF
--- a/py/asmthumb.c
+++ b/py/asmthumb.c
@@ -248,6 +248,13 @@ STATIC mp_uint_t get_label_dest(asm_thumb_t *as, uint label) {
     return as->label_offsets[label];
 }
 
+mp_int_t get_label_abs_addr(asm_thumb_t *as, uint label) {
+    mp_uint_t dest = get_label_dest(as, label);
+    mp_int_t rel = dest - as->code_offset;
+    rel -= 4; // account for instruction prefetch, PC is 4 bytes ahead of this instruction
+    return rel;
+}
+
 void asm_thumb_op16(asm_thumb_t *as, uint op) {
     byte *c = asm_thumb_get_cur_to_write_bytes(as, 2);
     // little endian

--- a/py/asmthumb.h
+++ b/py/asmthumb.h
@@ -214,6 +214,7 @@ static inline void asm_thumb_ldrh_rlo_rlo_i5(asm_thumb_t *as, uint rlo_dest, uin
 
 void asm_thumb_mov_reg_reg(asm_thumb_t *as, uint reg_dest, uint reg_src);
 void asm_thumb_mov_reg_i16(asm_thumb_t *as, uint mov_op, uint reg_dest, int i16_src);
+mp_int_t get_label_abs_addr(asm_thumb_t *as, uint label); // For getlbl
 
 // these return true if the destination is in range, false otherwise
 bool asm_thumb_b_n_label(asm_thumb_t *as, uint label);

--- a/py/emitinlinethumb.c
+++ b/py/emitinlinethumb.c
@@ -748,6 +748,16 @@ STATIC void emit_inline_thumb_op(emit_inline_asm_t *emit, qstr op, mp_uint_t n_a
                 mp_uint_t i8 = get_arg_i(emit, op_str, pn_offset, 0xff) >> 2;
                 asm_thumb_op32(emit->as, 0xe840 | r_base, (r_src << 12) | (r_dest << 8) | i8);
             }
+        } else if (strcmp(op_str, "getlbl") == 0) {
+            // pseudo-instruction enables using labels to access data
+            // getlbl(reg1, reg2, label) reg1 = pc reg2 = label offset
+            mp_uint_t reg_dest = get_arg_reg(emit, op_str, pn_args[0], 15);
+            mp_uint_t reg_offs = get_arg_reg(emit, op_str, pn_args[1], 15);
+            int label_num = get_arg_label(emit, op_str, pn_args[2]);
+            mp_int_t rel = get_label_abs_addr(emit->as, label_num);
+            asm_thumb_mov_reg_reg(emit->as, reg_dest, 15); // pc
+            asm_thumb_mov_reg_i16(emit->as, ASM_THUMB_OP_MOVW, reg_offs, rel & 0xffff);
+            asm_thumb_mov_reg_i16(emit->as, ASM_THUMB_OP_MOVT, reg_offs, (rel >> 16)); // can be -ve
         } else {
             goto unknown_op;
         }


### PR DESCRIPTION
This allows data created with the data() statement to be accessed using labels. Given a label it returns the pc/offset pair which can be added to address the data (see tests/asmdatalabels.py).
