### PR TITLE
Tab completion

### DIFF
--- a/lib/mp-readline/readline.c
+++ b/lib/mp-readline/readline.c
@@ -85,6 +85,7 @@ typedef struct _readline_t {
     int hist_cur;
     int cursor_pos;
     char escape_seq_buf[1];
+    const char *prompt;
 } readline_t;
 
 STATIC readline_t rl;
@@ -260,23 +261,26 @@ end_key:
     return -1;
 }
 
-void readline_note_newline(void) {
+void readline_note_newline(const char *prompt) {
     rl.orig_line_len = rl.line->len;
     rl.cursor_pos = rl.orig_line_len;
+    rl.prompt = prompt;
+    mp_hal_stdout_tx_str(prompt);
 }
 
-void readline_init(vstr_t *line) {
+void readline_init(vstr_t *line, const char *prompt) {
     rl.line = line;
     rl.orig_line_len = line->len;
     rl.escape_seq = ESEQ_NONE;
     rl.escape_seq_buf[0] = 0;
     rl.hist_cur = -1;
     rl.cursor_pos = rl.orig_line_len;
+    rl.prompt = prompt;
+    mp_hal_stdout_tx_str(prompt);
 }
 
 int readline(vstr_t *line, const char *prompt) {
-    mp_hal_stdout_tx_str(prompt);
-    readline_init(line);
+    readline_init(line, prompt);
     for (;;) {
         int c = mp_hal_stdin_rx_chr();
         int r = readline_process_char(c);

--- a/lib/mp-readline/readline.h
+++ b/lib/mp-readline/readline.h
@@ -33,6 +33,6 @@
 void readline_init0(void);
 int readline(vstr_t *line, const char *prompt);
 
-void readline_init(vstr_t *line);
-void readline_note_newline(void);
+void readline_init(vstr_t *line, const char *prompt);
+void readline_note_newline(const char *prompt);
 int readline_process_char(int c);

--- a/py/repl.h
+++ b/py/repl.h
@@ -28,9 +28,11 @@
 
 #include "py/mpconfig.h"
 #include "py/misc.h"
+#include "py/mpprint.h"
 
 #if MICROPY_HELPER_REPL
 bool mp_repl_continue_with_input(const char *input);
+const char *mp_repl_autocomplete(const char *str, mp_uint_t len, const mp_print_t *print, mp_uint_t *compl_len);
 #endif
 
 #endif // __MICROPY_INCLUDED_PY_REPL_H__

--- a/stmhal/pyexec.c
+++ b/stmhal/pyexec.c
@@ -181,14 +181,13 @@ friendly_repl_t repl;
 void pyexec_friendly_repl_init(void) {
     vstr_init(&repl.line, 32);
     repl.cont_line = false;
-    readline_init(&repl.line);
-    mp_hal_stdout_tx_str(">>> ");
+    readline_init(&repl.line, ">>> ");
 }
 
-void pyexec_friendly_repl_reset() {
-    repl.cont_line = false;
+void pyexec_friendly_repl_reset(void) {
     vstr_reset(&repl.line);
-    readline_init(&repl.line);
+    repl.cont_line = false;
+    readline_init(&repl.line, ">>> ");
 }
 
 int pyexec_friendly_repl_process_char(int c) {
@@ -229,8 +228,7 @@ int pyexec_friendly_repl_process_char(int c) {
 
         vstr_add_byte(&repl.line, '\n');
         repl.cont_line = true;
-        mp_hal_stdout_tx_str("... ");
-        readline_note_newline();
+        readline_note_newline("... ");
         return 0;
 
     } else {
@@ -251,8 +249,7 @@ int pyexec_friendly_repl_process_char(int c) {
 
         if (mp_repl_continue_with_input(vstr_null_terminated_str(&repl.line))) {
             vstr_add_byte(&repl.line, '\n');
-            mp_hal_stdout_tx_str("... ");
-            readline_note_newline();
+            readline_note_newline("... ");
             return 0;
         }
 
@@ -270,7 +267,6 @@ exec: ;
 friendly_repl_reset: // TODO
 input_restart:
         pyexec_friendly_repl_reset();
-        mp_hal_stdout_tx_str(">>> ");
         return 0;
     }
 }


### PR DESCRIPTION
This PR adds tab completion to mp-readline (so works only on bare-metal at the moment).  The basic implementation (to find out the list of possible completions) is quite simple and concise.  But a bit of extra code is needed to print a nice table of names for more than one match.  This extra stuff could be omitted via a #define for ports that don't have the space but still want some completion functionality.  Also, this entire thing can be #define'd out (I just didn't add that feature yet).

It works almost as CPython 3.x.  Tab can complete the last word in a chain of dotted words:
1. <tab> will print a list of global names (eg pyb, micropython).
2. mic<tab> will complete to "micropython".
3. pyb.<tab> will print a list of names in pyb module.
4. pyb.Pin.board.<tab> will print a list of all board pins.
5. pyb.ela<tab> will complete to "pyb.elapsed_mi"; <tab> a second time will list the 2 options (elapsed_micros, elapsed_millis).
6. etc.

It can be enabled in the unix port 1 of 2 ways:
1. Make unix use mp-readline instead of system readline (my preference, eliminates dependencies).
2. Use readline's rl_completion hook (requires some glue code to interface with new mp_repl_autocomplete function).

What do people think?  Already after playing with this feature on pyboard for 1 minute I find it extremely useful :)
