### PR TITLE
stmhal: Actually disable unhandled timer interrupts.

### DIFF
--- a/stmhal/timer.c
+++ b/stmhal/timer.c
@@ -1382,6 +1382,7 @@ void timer_irq_handler(uint tim_id) {
         // just get called continuously.
         uint32_t unhandled = tim->tim.Instance->DIER & 0xff & ~handled;
         if (unhandled != 0) {
+            __HAL_TIM_DISABLE_IT(&tim->tim, unhandled);
             __HAL_TIM_CLEAR_IT(&tim->tim, unhandled);
             printf("Unhandled interrupt SR=0x%02lx (now disabled)\n", unhandled);
         }


### PR DESCRIPTION
Previously it wasn't disabling the unhandled interrupt, so it may continue to fire.
