### PR TITLE
msvc: Allow overriding of build options with custom file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,7 @@ tests/*.out
 ######################
 __pycache__/
 
-# Customized Makefile overrides
+# Customized Makefile/project overrides
+######################
 GNUmakefile
+user.props

--- a/windows/micropython.vcxproj
+++ b/windows/micropython.vcxproj
@@ -72,7 +72,9 @@
     <Import Project="msvc/common.props" />
     <Import Project="msvc/release.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Label="UserMacros">
+    <CustomPropsFile Condition="'$(CustomPropsFile)'==''">msvc/user.props</CustomPropsFile>
+  </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile />
@@ -94,6 +96,7 @@
   </ItemGroup>
   <Import Project="msvc/sources.props" />
   <Import Project="msvc/genhdr.targets" />
+  <Import Project="$(CustomPropsFile)" Condition="exists('$(CustomPropsFile)')" />
   <Target Name="GenHeaders" BeforeTargets="BuildGenerateSources" DependsOnTargets="GenerateHeaders">
   </Target>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
- by default look for a user.props in the msvc directory, which is more convenient
  than the built-in way of looking for such file in the user's home directory
- make git ignore the file

Setting custom build options is required to build against most external libraries, for instance readline, and cannot be done simply by adding arguments to command line build.
