### PR TITLE
make it possible to configure the USART pins completely via mpconfigboard.h

### DIFF
--- a/stmhal/boards/PYBV10/mpconfigboard.h
+++ b/stmhal/boards/PYBV10/mpconfigboard.h
@@ -60,3 +60,20 @@
 // USB config
 #define MICROPY_HW_USB_VBUS_DETECT_PIN (pin_A9)
 #define MICROPY_HW_USB_OTG_ID_PIN      (pin_A10)
+
+// UARTs config
+#define PYB_USART_1_PORT    GPIOB
+#define PYB_USART_1_PINS    (GPIO_PIN_6 | GPIO_PIN_7)
+#define PYB_USART_2_PORT    GPIOA
+#define PYB_USART_2_PINS    (GPIO_PIN_2 | GPIO_PIN_3)
+#define PYB_USART_2_RTS     GPIO_PIN_1
+#define PYB_USART_2_CTS     GPIO_PIN_0
+#define PYB_USART_3_PORT    GPIOB
+#define PYB_USART_3_PINS    (GPIO_PIN_10 | GPIO_PIN_11)
+#define PYB_USART_3_RTS     GPIO_PIN_14
+#define PYB_USART_3_CTS     GPIO_PIN_13
+#define PYB_USART_4_PORT    GPIOA
+#define PYB_USART_4_PINS    (GPIO_PIN_0 | GPIO_PIN_1)
+// There is no 5
+#define PYB_USART_6_PORT    GPIOC
+#define PYB_USART_6_PINS    (GPIO_PIN_6 | GPIO_PIN_7)

--- a/stmhal/boards/PYBV3/mpconfigboard.h
+++ b/stmhal/boards/PYBV3/mpconfigboard.h
@@ -57,3 +57,20 @@
 
 // USB VBUS detect pin
 #define MICROPY_HW_USB_VBUS_DETECT_PIN (pin_A9)
+
+// UARTs config
+#define PYB_USART_1_PORT    GPIOA
+#define PYB_USART_1_PINS    (GPIO_PIN_9 | GPIO_PIN_10)
+#define PYB_USART_2_PORT    GPIOA
+#define PYB_USART_2_PINS    (GPIO_PIN_2 | GPIO_PIN_3)
+#define PYB_USART_2_RTS     GPIO_PIN_1
+#define PYB_USART_2_CTS     GPIO_PIN_0
+#define PYB_USART_3_PORT    GPIOB
+#define PYB_USART_3_PINS    (GPIO_PIN_10 | GPIO_PIN_11)
+#define PYB_USART_3_RTS     GPIO_PIN_14
+#define PYB_USART_3_CTS     GPIO_PIN_13
+#define PYB_USART_4_PORT    GPIOA
+#define PYB_USART_4_PINS    (GPIO_PIN_0 | GPIO_PIN_1)
+// There is no 5
+#define PYB_USART_6_PORT    GPIOC
+#define PYB_USART_6_PINS    (GPIO_PIN_6 | GPIO_PIN_7)

--- a/stmhal/boards/PYBV4/mpconfigboard.h
+++ b/stmhal/boards/PYBV4/mpconfigboard.h
@@ -59,3 +59,20 @@
 // USB config
 #define MICROPY_HW_USB_VBUS_DETECT_PIN (pin_A9)
 #define MICROPY_HW_USB_OTG_ID_PIN      (pin_A10)
+
+// UARTs config
+#define PYB_USART_1_PORT    GPIOB
+#define PYB_USART_1_PINS    (GPIO_PIN_6 | GPIO_PIN_7)
+#define PYB_USART_2_PORT    GPIOA
+#define PYB_USART_2_PINS    (GPIO_PIN_2 | GPIO_PIN_3)
+#define PYB_USART_2_RTS     GPIO_PIN_1
+#define PYB_USART_2_CTS     GPIO_PIN_0
+#define PYB_USART_3_PORT    GPIOB
+#define PYB_USART_3_PINS    (GPIO_PIN_10 | GPIO_PIN_11)
+#define PYB_USART_3_RTS     GPIO_PIN_14
+#define PYB_USART_3_CTS     GPIO_PIN_13
+#define PYB_USART_4_PORT    GPIOA
+#define PYB_USART_4_PINS    (GPIO_PIN_0 | GPIO_PIN_1)
+// There is no 5
+#define PYB_USART_6_PORT    GPIOC
+#define PYB_USART_6_PINS    (GPIO_PIN_6 | GPIO_PIN_7)

--- a/stmhal/uart.c
+++ b/stmhal/uart.c
@@ -126,13 +126,8 @@ STATIC bool uart_init2(pyb_uart_obj_t *uart_obj) {
             GPIO_Port = PYB_USART_1_PORT;
             GPIO_Pin = PYB_USART_1_PINS;
 #else
-#if defined (PYBV4) || defined(PYBV10)
-            GPIO_Port = GPIOB;
-            GPIO_Pin = GPIO_PIN_6 | GPIO_PIN_7;
-#else
             GPIO_Port = GPIOA;
             GPIO_Pin = GPIO_PIN_9 | GPIO_PIN_10;
-#endif
 #endif
 
             __USART1_CLK_ENABLE();
@@ -191,20 +186,8 @@ STATIC bool uart_init2(pyb_uart_obj_t *uart_obj) {
             }
 #endif
 #else
-#if defined(PYBV3) || defined(PYBV4) | defined(PYBV10)
-            GPIO_Port = GPIOB;
-            GPIO_Pin = GPIO_PIN_10 | GPIO_PIN_11;
-
-            if (uart_obj->uart.Init.HwFlowCtl & UART_HWCONTROL_RTS) {
-                GPIO_Pin |= GPIO_PIN_14;
-            }
-            if (uart_obj->uart.Init.HwFlowCtl & UART_HWCONTROL_CTS) {
-                GPIO_Pin |= GPIO_PIN_13;
-            }
-#else
             GPIO_Port = GPIOD;
             GPIO_Pin = GPIO_PIN_8 | GPIO_PIN_9;
-#endif
 #endif
             __USART3_CLK_ENABLE();
             break;

--- a/stmhal/uart.c
+++ b/stmhal/uart.c
@@ -122,13 +122,17 @@ STATIC bool uart_init2(pyb_uart_obj_t *uart_obj) {
             UARTx = USART1;
             irqn = USART1_IRQn;
             GPIO_AF_UARTx = GPIO_AF7_USART1;
-
+#if defined(PYB_USART_1_PORT) && defined(PYB_USART_1_PINS)
+            GPIO_Port = PYB_USART_1_PORT;
+            GPIO_Pin = PYB_USART_1_PINS;
+#else
 #if defined (PYBV4) || defined(PYBV10)
             GPIO_Port = GPIOB;
             GPIO_Pin = GPIO_PIN_6 | GPIO_PIN_7;
 #else
             GPIO_Port = GPIOA;
             GPIO_Pin = GPIO_PIN_9 | GPIO_PIN_10;
+#endif
 #endif
 
             __USART1_CLK_ENABLE();
@@ -140,6 +144,16 @@ STATIC bool uart_init2(pyb_uart_obj_t *uart_obj) {
             irqn = USART2_IRQn;
             GPIO_AF_UARTx = GPIO_AF7_USART2;
 
+#if defined(PYB_USART_2_PORT) && defined(PYB_USART_2_PINS) && defined(PYB_USART_2_RTS) && defined(PYB_USART_2_CTS)
+            GPIO_Port = PYB_USART_2_PORT;
+            GPIO_Pin = PYB_USART_2_PINS;
+            if (uart_obj->uart.Init.HwFlowCtl & UART_HWCONTROL_RTS) {
+                GPIO_Pin |= PYB_USART_2_RTS;
+            }
+            if (uart_obj->uart.Init.HwFlowCtl & UART_HWCONTROL_CTS) {
+                GPIO_Pin |= PYB_USART_2_CTS;
+            }
+#else
             GPIO_Port = GPIOA;
             GPIO_Pin = GPIO_PIN_2 | GPIO_PIN_3;
 
@@ -149,7 +163,7 @@ STATIC bool uart_init2(pyb_uart_obj_t *uart_obj) {
             if (uart_obj->uart.Init.HwFlowCtl & UART_HWCONTROL_CTS) {
                 GPIO_Pin |= GPIO_PIN_0;
             }
-
+#endif
             __USART2_CLK_ENABLE();
             break;
 
@@ -159,7 +173,16 @@ STATIC bool uart_init2(pyb_uart_obj_t *uart_obj) {
             UARTx = USART3;
             irqn = USART3_IRQn;
             GPIO_AF_UARTx = GPIO_AF7_USART3;
-
+#if defined(PYB_USART_3_PORT) && defined(PYB_USART_3_PINS) && defined(PYB_USART_3_RTS) && defined(PYB_USART_3_CTS)
+            GPIO_Port = PYB_USART_3_PORT;
+            GPIO_Pin = PYB_USART_3_PINS;
+            if (uart_obj->uart.Init.HwFlowCtl & UART_HWCONTROL_RTS) {
+                GPIO_Pin |= PYB_USART_3_RTS;
+            }
+            if (uart_obj->uart.Init.HwFlowCtl & UART_HWCONTROL_CTS) {
+                GPIO_Pin |= PYB_USART_3_CTS;
+            }
+#else
 #if defined(PYBV3) || defined(PYBV4) | defined(PYBV10)
             GPIO_Port = GPIOB;
             GPIO_Pin = GPIO_PIN_10 | GPIO_PIN_11;
@@ -174,6 +197,7 @@ STATIC bool uart_init2(pyb_uart_obj_t *uart_obj) {
             GPIO_Port = GPIOD;
             GPIO_Pin = GPIO_PIN_8 | GPIO_PIN_9;
 #endif
+#endif
             __USART3_CLK_ENABLE();
             break;
         #endif
@@ -185,8 +209,13 @@ STATIC bool uart_init2(pyb_uart_obj_t *uart_obj) {
             irqn = UART4_IRQn;
             GPIO_AF_UARTx = GPIO_AF8_UART4;
 
+#if defined(PYB_USART_4_PORT) && defined(PYB_USART_4_PINS)
+            GPIO_Port = PYB_USART_4_PORT;
+            GPIO_Pin = PYB_USART_4_PINS;
+#else
             GPIO_Port = GPIOA;
             GPIO_Pin = GPIO_PIN_0 | GPIO_PIN_1;
+#endif
 
             __UART4_CLK_ENABLE();
             break;
@@ -198,8 +227,13 @@ STATIC bool uart_init2(pyb_uart_obj_t *uart_obj) {
             irqn = USART6_IRQn;
             GPIO_AF_UARTx = GPIO_AF8_USART6;
 
+#if defined(PYB_USART_6_PORT) && defined(PYB_USART_6_PINS)
+            GPIO_Port = PYB_USART_6_PORT;
+            GPIO_Pin = PYB_USART_6_PINS;
+#else
             GPIO_Port = GPIOC;
             GPIO_Pin = GPIO_PIN_6 | GPIO_PIN_7;
+#endif
 
             __USART6_CLK_ENABLE();
             break;

--- a/stmhal/uart.c
+++ b/stmhal/uart.c
@@ -144,15 +144,19 @@ STATIC bool uart_init2(pyb_uart_obj_t *uart_obj) {
             irqn = USART2_IRQn;
             GPIO_AF_UARTx = GPIO_AF7_USART2;
 
-#if defined(PYB_USART_2_PORT) && defined(PYB_USART_2_PINS) && defined(PYB_USART_2_RTS) && defined(PYB_USART_2_CTS)
+#if defined(PYB_USART_2_PORT) && defined(PYB_USART_2_PINS)
             GPIO_Port = PYB_USART_2_PORT;
             GPIO_Pin = PYB_USART_2_PINS;
+#if defined(PYB_USART_2_RTS)
             if (uart_obj->uart.Init.HwFlowCtl & UART_HWCONTROL_RTS) {
                 GPIO_Pin |= PYB_USART_2_RTS;
             }
+#endif
+#if  defined(PYB_USART_2_CTS)
             if (uart_obj->uart.Init.HwFlowCtl & UART_HWCONTROL_CTS) {
                 GPIO_Pin |= PYB_USART_2_CTS;
             }
+#endif
 #else
             GPIO_Port = GPIOA;
             GPIO_Pin = GPIO_PIN_2 | GPIO_PIN_3;
@@ -173,15 +177,19 @@ STATIC bool uart_init2(pyb_uart_obj_t *uart_obj) {
             UARTx = USART3;
             irqn = USART3_IRQn;
             GPIO_AF_UARTx = GPIO_AF7_USART3;
-#if defined(PYB_USART_3_PORT) && defined(PYB_USART_3_PINS) && defined(PYB_USART_3_RTS) && defined(PYB_USART_3_CTS)
+#if defined(PYB_USART_3_PORT) && defined(PYB_USART_3_PINS)
             GPIO_Port = PYB_USART_3_PORT;
             GPIO_Pin = PYB_USART_3_PINS;
+#if defined(PYB_USART_3_RTS)
             if (uart_obj->uart.Init.HwFlowCtl & UART_HWCONTROL_RTS) {
                 GPIO_Pin |= PYB_USART_3_RTS;
             }
+#endif
+#if defined(PYB_USART_3_CTS)
             if (uart_obj->uart.Init.HwFlowCtl & UART_HWCONTROL_CTS) {
                 GPIO_Pin |= PYB_USART_3_CTS;
             }
+#endif
 #else
 #if defined(PYBV3) || defined(PYBV4) | defined(PYBV10)
             GPIO_Port = GPIOB;


### PR DESCRIPTION
Instead of adding yet another `if defined(BOARDNAME)` define the port and pins.

[Example configuration](https://github.com/rambo/ruuvitracker_fw/blob/MicroPython_rambo/stmhal/boards/RUUVITRACKER_C3/mpconfigboard.h#L67) (tested to work).
