### PR TITLE
tools: Add script to install "upip" package manager.

### DIFF
--- a/tools/bootstrap_upip.sh
+++ b/tools/bootstrap_upip.sh
@@ -1,0 +1,19 @@
+# This script performs bootstrap installation of upip package manager from PyPI
+# All the other packages can be installed using it.
+
+if [ -z "$TMPDIR" ]; then
+    cd /tmp
+else
+    cd $TMPDIR
+fi
+
+# Remove any stale old version
+rm -rf micropython-upip-*
+wget -nd -r -l1 https://pypi.python.org/pypi/micropython-upip/ --accept-regex ".*pypi.python.org/packages/source/.*.gz" --reject=html
+
+tar xfz micropython-upip-*.tar.gz
+mkdir -p ~/.micropython/lib/
+cp micropython-upip-*/upip*.py ~/.micropython/lib/
+
+echo "upip is installed. To use:"
+echo "micropython -m upip --help"


### PR DESCRIPTION
upip is a simple and light-weight package manager for MicroPython modules,
offering subset of pip functionality. upip is part of micropython-lib
project: https://github.com/micropython/micropython-lib/tree/master/upip
This script bootstraps upip by downloading and unpacking it directly from
PyPI repository, with all other packages to be installed with upip itself.
