### PR TITLE
obj: Handle user instance hash based on Python adhoc rules.

### DIFF
--- a/tests/basics/builtin_hash.py
+++ b/tests/basics/builtin_hash.py
@@ -19,3 +19,16 @@ class A:
 
 print(hash(A()))
 print({A():1})
+
+class B:
+    pass
+hash(B())
+
+
+class C:
+    def __eq__(self, another):
+        return True
+try:
+    hash(C())
+except TypeError:
+    print("TypeError")


### PR DESCRIPTION
User instances are hashable by default (using **hash** inherited from
"object"). But if **eq** is defined and **hash** not defined in particular
class, instance is not hashable.
