### PR TITLE
Adjust dependency file sed regex so that it is windows-compatible.

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -36,7 +36,7 @@ $(Q)$(CC) $(CFLAGS) -c -MD -o $@ $<
 @# The following fixes the dependency file.
 @# See http://make.paulandlesley.org/autodep.html for details.
 @$(CP) $(@:.o=.d) $(@:.o=.P); \
-  $(SED) -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+  $(SED) -e 's/#.*//' -e 's/^.*:  *//' -e 's/ *\\$$//' \
       -e '/^$$/ d' -e 's/$$/ :/' < $(@:.o=.d) >> $(@:.o=.P); \
   $(RM) -f $(@:.o=.d)
 endef


### PR DESCRIPTION
When cross-compiling on windows (for Arm or pic32 for example), dependency file generated by compiler (.d) contains file names that include drive letter. When Makefile tries to do some processing with sed for it's contents (in mkrules.mk) result is incorrect because regex in sed matches drive letter part (ie. C:) instead of beginning of the line until ":".

After this small change, resulting .P files are correct also on windows. Change does not affect results in unix.
