### PR TITLE
esp8266: Fix broken garbage collector

### DIFF
--- a/esp8266/gccollect.c
+++ b/esp8266/gccollect.c
@@ -29,16 +29,11 @@
 #include "py/gc.h"
 #include "gccollect.h"
 
-STATIC uint32_t stack_end;
+// As we do not have control over the application entry point, there is no way
+// to figure out the real stack base on runtime, so it needs to be hardcoded
+#define STACK_END   0x40000000
 
 mp_uint_t gc_helper_get_regs_and_sp(mp_uint_t *regs);
-
-void gc_collect_init(void) {
-    mp_uint_t regs[8];
-    mp_uint_t sp = gc_helper_get_regs_and_sp(regs);
-    stack_end = sp;
-    //printf("stack=%p ram_end=%p %d\n", stack_end, &_ram_end);
-}
 
 void gc_collect(void) {
     // start the GC
@@ -53,7 +48,7 @@ void gc_collect(void) {
     mp_uint_t sp = gc_helper_get_regs_and_sp(regs);
 
     // trace the stack, including the registers (since they live on the stack in this function)
-    gc_collect_root((void**)sp, (stack_end - sp) / sizeof(uint32_t));
+    gc_collect_root((void**)sp, (STACK_END - sp) / sizeof(uint32_t));
 
     // end the GC
     gc_collect_end();

--- a/esp8266/gccollect.h
+++ b/esp8266/gccollect.h
@@ -37,5 +37,4 @@ extern uint32_t _bss_end;
 extern uint32_t _heap_start;
 extern uint32_t _heap_end;
 
-void gc_collect_init(void);
 void gc_collect(void);

--- a/esp8266/main.c
+++ b/esp8266/main.c
@@ -43,7 +43,6 @@ STATIC void mp_reset(void) {
     mp_stack_set_limit(10240);
     mp_hal_init();
     gc_init(heap, heap + sizeof(heap));
-    gc_collect_init();
     mp_init();
     mp_obj_list_init(mp_sys_path, 0);
     mp_obj_list_init(mp_sys_argv, 0);


### PR DESCRIPTION
As user_init() is not a true main functions, the stack pointer captured within
is not pointing at the base of the stack. This caused gc_collect being called
with sp being higher than stack_end, causing integer overflow and crashing as
gc tried to scan almost the entire address space.
