### PR TITLE
emitnative: Make ARM codegen compile after full-arg support refactors.

### DIFF
--- a/py/asmarm.c
+++ b/py/asmarm.c
@@ -111,6 +111,10 @@ STATIC byte *asm_arm_get_cur_to_write_bytes(asm_arm_t *as, int num_bytes_to_writ
     }
 }
 
+uint asm_arm_get_code_pos(asm_arm_t *as) {
+    return as->code_offset;
+}
+
 uint asm_arm_get_code_size(asm_arm_t *as) {
     return as->code_size;
 }
@@ -245,6 +249,14 @@ void asm_arm_exit(asm_arm_t *as) {
     emit_al(as, asm_arm_op_pop(as->push_reglist | (1 << ASM_ARM_REG_PC)));
 }
 
+void asm_arm_push(asm_arm_t *as, uint reglist) {
+    emit_al(as, asm_arm_op_push(reglist));
+}
+
+void asm_arm_pop(asm_arm_t *as, uint reglist) {
+    emit_al(as, asm_arm_op_pop(reglist));
+}
+
 void asm_arm_label_assign(asm_arm_t *as, uint label) {
     assert(label < as->max_num_labels);
     if (as->pass < ASM_ARM_PASS_EMIT) {
@@ -358,9 +370,9 @@ void asm_arm_asr_reg_reg(asm_arm_t *as, uint rd, uint rs) {
     emit_al(as, 0x1a00050 | (rd << 12) | (rs << 8) | rd);
 }
 
-void asm_arm_ldr_reg_reg(asm_arm_t *as, uint rd, uint rn) {
-    // ldr rd, [rn]
-    emit_al(as, 0x5900000 | (rn << 16) | (rd << 12));
+void asm_arm_ldr_reg_reg(asm_arm_t *as, uint rd, uint rn, uint off) {
+    // ldr rd, [rn, #off]
+    emit_al(as, 0x5900000 | (rn << 16) | (rd << 12) | off);
 }
 
 void asm_arm_ldrh_reg_reg(asm_arm_t *as, uint rd, uint rn) {
@@ -373,9 +385,9 @@ void asm_arm_ldrb_reg_reg(asm_arm_t *as, uint rd, uint rn) {
     emit_al(as, 0x5d00000 | (rn << 16) | (rd << 12));
 }
 
-void asm_arm_str_reg_reg(asm_arm_t *as, uint rd, uint rm) {
-    // str rd, [rm]
-    emit_al(as, 0x5800000 | (rm << 16) | (rd << 12));
+void asm_arm_str_reg_reg(asm_arm_t *as, uint rd, uint rm, uint off) {
+    // str rd, [rm, #off]
+    emit_al(as, 0x5800000 | (rm << 16) | (rd << 12) | off);
 }
 
 void asm_arm_strh_reg_reg(asm_arm_t *as, uint rd, uint rm) {

--- a/py/asmarm.h
+++ b/py/asmarm.h
@@ -74,6 +74,7 @@ asm_arm_t *asm_arm_new(uint max_num_labels);
 void asm_arm_free(asm_arm_t *as, bool free_code);
 void asm_arm_start_pass(asm_arm_t *as, uint pass);
 void asm_arm_end_pass(asm_arm_t *as);
+uint asm_arm_get_code_pos(asm_arm_t *as);
 uint asm_arm_get_code_size(asm_arm_t *as);
 void *asm_arm_get_code(asm_arm_t *as);
 
@@ -108,16 +109,20 @@ void asm_arm_lsl_reg_reg(asm_arm_t *as, uint rd, uint rs);
 void asm_arm_asr_reg_reg(asm_arm_t *as, uint rd, uint rs);
 
 // memory
-void asm_arm_ldr_reg_reg(asm_arm_t *as, uint rd, uint rn);
+void asm_arm_ldr_reg_reg(asm_arm_t *as, uint rd, uint rn, uint off);
 void asm_arm_ldrh_reg_reg(asm_arm_t *as, uint rd, uint rn);
 void asm_arm_ldrb_reg_reg(asm_arm_t *as, uint rd, uint rn);
-void asm_arm_str_reg_reg(asm_arm_t *as, uint rd, uint rm);
+void asm_arm_str_reg_reg(asm_arm_t *as, uint rd, uint rm, uint off);
 void asm_arm_strh_reg_reg(asm_arm_t *as, uint rd, uint rm);
 void asm_arm_strb_reg_reg(asm_arm_t *as, uint rd, uint rm);
 // store to array
 void asm_arm_str_reg_reg_reg(asm_arm_t *as, uint rd, uint rm, uint rn);
 void asm_arm_strh_reg_reg_reg(asm_arm_t *as, uint rd, uint rm, uint rn);
 void asm_arm_strb_reg_reg_reg(asm_arm_t *as, uint rd, uint rm, uint rn);
+
+// stack
+void asm_arm_push(asm_arm_t *as, uint reglist);
+void asm_arm_pop(asm_arm_t *as, uint reglist);
 
 // control flow
 void asm_arm_bcc_label(asm_arm_t *as, int cond, uint label);

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -35,8 +35,11 @@
 #endif
 #if !defined(MICROPY_EMIT_THUMB) && defined(__thumb2__)
     #define MICROPY_EMIT_THUMB      (1)
+    #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void*)((mp_uint_t)(p) | 1))
 #endif
-#if !defined(MICROPY_EMIT_ARM) && defined(__arm__)
+// Some compilers define __thumb2__ and __arm__ at the same time, let
+// autodetected thumb2 emitter have priority.
+#if !defined(MICROPY_EMIT_ARM) && defined(__arm__) && !defined(__thumb2__)
     #define MICROPY_EMIT_ARM        (1)
 #endif
 #define MICROPY_COMP_MODULE_CONST   (1)


### PR DESCRIPTION
The code was apparently broken after 9988618e0e0f5c319e31b135d993e22efb593093
"py: Implement full func arg passing for native emitter.". However,
while these changes make it compile, it still crashes at runtime and need
more work.
