### PR TITLE
stmhal: Implement sys.std{in,out,err}.buffer, for raw byte mode.

### DIFF
--- a/stmhal/pybstdio.c
+++ b/stmhal/pybstdio.c
@@ -48,6 +48,8 @@ typedef struct _pyb_stdio_obj_t {
     int fd;
 } pyb_stdio_obj_t;
 
+STATIC const pyb_stdio_obj_t stdio_buffer_obj;
+
 void stdio_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_stdio_obj_t *self = self_in;
     mp_printf(print, "<io.FileIO %d>", self->fd);
@@ -89,6 +91,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(stdio_obj___exit___obj, 4, 4, stdio_o
 // TODO gc hook to close the file if not already closed
 
 STATIC const mp_map_elem_t stdio_locals_dict_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR_buffer), (mp_obj_t)&stdio_buffer_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_read), (mp_obj_t)&mp_stream_read_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_readall), (mp_obj_t)&mp_stream_readall_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_readinto), (mp_obj_t)&mp_stream_readinto_obj },
@@ -123,3 +126,33 @@ STATIC const mp_obj_type_t stdio_obj_type = {
 const pyb_stdio_obj_t mp_sys_stdin_obj = {{&stdio_obj_type}, .fd = STDIO_FD_IN};
 const pyb_stdio_obj_t mp_sys_stdout_obj = {{&stdio_obj_type}, .fd = STDIO_FD_OUT};
 const pyb_stdio_obj_t mp_sys_stderr_obj = {{&stdio_obj_type}, .fd = STDIO_FD_ERR};
+
+STATIC mp_uint_t stdio_buffer_read(mp_obj_t self_in, void *buf, mp_uint_t size, int *errcode) {
+    for (uint i = 0; i < size; i++) {
+        ((byte*)buf)[i] = mp_hal_stdin_rx_chr();
+    }
+    return size;
+}
+
+STATIC mp_uint_t stdio_buffer_write(mp_obj_t self_in, const void *buf, mp_uint_t size, int *errcode) {
+    mp_hal_stdout_tx_strn(buf, size);
+    return size;
+}
+
+STATIC const mp_stream_p_t stdio_buffer_obj_stream_p = {
+    .read = stdio_buffer_read,
+    .write = stdio_buffer_write,
+    .is_text = false,
+};
+
+STATIC const mp_obj_type_t stdio_buffer_obj_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_FileIO,
+    .print = stdio_obj_print,
+    .getiter = mp_identity,
+    .iternext = mp_stream_unbuffered_iter,
+    .stream_p = &stdio_buffer_obj_stream_p,
+    .locals_dict = (mp_obj_t)&stdio_locals_dict,
+};
+
+STATIC const pyb_stdio_obj_t stdio_buffer_obj = {{&stdio_buffer_obj_type}, .fd = 0}; // fd unused

--- a/stmhal/qstrdefsport.h
+++ b/stmhal/qstrdefsport.h
@@ -70,6 +70,7 @@ Q(millis)
 Q(micros)
 Q(elapsed_millis)
 Q(elapsed_micros)
+Q(buffer)
 
 // for user-mountable block devices
 Q(mount)


### PR DESCRIPTION
This is proof of concept (and not necessarily going to be merged) for adding sys.stdin.buffer, sys.stdout.buffer and sys.stderr.buffer objects.  These are raw, uncooked, bytes versions of sys.std{in,out,err}.

It costs 170 bytes ROM.  See issue #1260 for background.

For comparison with cooked version:

```
>>> sys.stdout.write('aaa\na')
aaa
a5
>>> sys.stdout.buffer.write('aaa\na')
aaa
   a5
>>> sys.stdin.read(1) # then hit enter as the character to read
'\n'
>>> sys.stdin.buffer.read(1) # then hit enter as the character to read
b'\r'
```
