### PR TITLE
Make unix port use mp-readline library

### DIFF
--- a/lib/mp-readline/readline.h
+++ b/lib/mp-readline/readline.h
@@ -32,6 +32,7 @@
 
 void readline_init0(void);
 int readline(vstr_t *line, const char *prompt);
+void readline_push_history(const char *line);
 
 void readline_init(vstr_t *line, const char *prompt);
 void readline_note_newline(const char *prompt);

--- a/tests/cmdline/repl_basic.py
+++ b/tests/cmdline/repl_basic.py
@@ -1,3 +1,3 @@
 # basic REPL tests
 print(1)
-OA
+[A

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -15,6 +15,7 @@ include ../py/py.mk
 
 INC =  -I.
 INC +=  -I..
+INC +=  -I../lib/mp-readline
 INC += -I$(BUILD)
 
 # compiler settings
@@ -56,12 +57,6 @@ endif
 endif
 endif
 
-ifeq ($(MICROPY_USE_READLINE),1)
-CFLAGS_MOD += -DMICROPY_USE_READLINE=1
-LDFLAGS_MOD += -lreadline
-# the following is needed for BSD
-#LDFLAGS_MOD += -ltermcap
-endif
 ifeq ($(MICROPY_PY_TIME),1)
 CFLAGS_MOD += -DMICROPY_PY_TIME=1
 SRC_MOD += modtime.c
@@ -95,10 +90,17 @@ SRC_C = \
 	modos.c \
 	alloc.c \
 	coverage.c \
+	unix_mphal.c \
 	$(SRC_MOD)
 
+LIB_SRC_C = $(addprefix lib/,\
+	mp-readline/readline.c \
+	)
 
-OBJ = $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+
+OBJ = $(PY_O)
+OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+OBJ += $(addprefix $(BUILD)/, $(LIB_SRC_C:.c=.o))
 
 include ../py/mkrules.mk
 

--- a/unix/input.c
+++ b/unix/input.c
@@ -28,53 +28,78 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "py/nlr.h"
-#include "py/obj.h"
+#include "py/mpstate.h"
+#include "lib/mp-readline/readline.h"
 #include "input.h"
 
-#if MICROPY_USE_READLINE
-#include <readline/readline.h>
-#include <readline/history.h>
-#include <readline/tilde.h>
-#else
-#undef MICROPY_USE_READLINE_HISTORY
-#define MICROPY_USE_READLINE_HISTORY (0)
-#endif
-
 char *prompt(char *p) {
-#if MICROPY_USE_READLINE
-    char *line = readline(p);
-    if (line) {
-        add_history(line);
+    vstr_t vstr;
+    vstr_init(&vstr, 16);
+    int ret = readline(&vstr, p);
+    if (ret != 0) {
+        vstr_clear(&vstr);
+        if (ret == CHAR_CTRL_D) {
+            // EOF
+            return NULL;
+        } else {
+            printf("\n");
+            char *line = malloc(1);
+            line[0] = '\0';
+            return line;
+        }
     }
-#else
-    static char buf[256];
-    fputs(p, stdout);
-    char *s = fgets(buf, sizeof(buf), stdin);
-    if (!s) {
-        return NULL;
-    }
-    int l = strlen(buf);
-    if (buf[l - 1] == '\n') {
-        buf[l - 1] = 0;
-    } else {
-        l++;
-    }
-    char *line = malloc(l);
-    memcpy(line, buf, l);
-#endif
+    vstr_null_terminated_str(&vstr);
+    char *line = malloc(vstr.len + 1);
+    memcpy(line, vstr.buf, vstr.len + 1);
+    vstr_clear(&vstr);
     return line;
 }
 
 void prompt_read_history(void) {
 #if MICROPY_USE_READLINE_HISTORY
-    read_history(tilde_expand("~/.micropython.history"));
+    readline_init0(); // will clear history pointers
+    char *home = getenv("HOME");
+    if (home != NULL) {
+        vstr_t vstr;
+        vstr_init(&vstr, 50);
+        vstr_printf(&vstr, "%s/.micropython.history", home);
+        FILE *fp = fopen(vstr_null_terminated_str(&vstr), "r");
+        vstr_reset(&vstr);
+        for (;;) {
+            int c = fgetc(fp);
+            if (c == EOF || c == '\n') {
+                readline_push_history(vstr_null_terminated_str(&vstr));
+                if (c == EOF) {
+                    break;
+                }
+                vstr_reset(&vstr);
+            } else {
+                vstr_add_byte(&vstr, c);
+            }
+        }
+        vstr_clear(&vstr);
+        fclose(fp);
+    }
 #endif
 }
 
 void prompt_write_history(void) {
 #if MICROPY_USE_READLINE_HISTORY
-    write_history(tilde_expand("~/.micropython.history"));
+    char *home = getenv("HOME");
+    if (home != NULL) {
+        vstr_t vstr;
+        vstr_init(&vstr, 50);
+        vstr_printf(&vstr, "%s/.micropython.history", home);
+        FILE *fp = fopen(vstr_null_terminated_str(&vstr), "w");
+        for (int i = MP_ARRAY_SIZE(MP_STATE_PORT(readline_hist)) - 1; i >= 0; i--) {
+            const char *line = MP_STATE_PORT(readline_hist)[i];
+            if (line != NULL) {
+                fwrite(line, 1, strlen(line), fp);
+                fputc('\n', fp);
+            }
+        }
+        fclose(fp);
+    }
 #endif
 }
 

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -187,9 +187,14 @@ extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
     { MP_OBJ_NEW_QSTR(MP_QSTR_input), (mp_obj_t)&mp_builtin_input_obj }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_open), (mp_obj_t)&mp_builtin_open_obj },
 
+#define MP_STATE_PORT MP_STATE_VM
+
 #define MICROPY_PORT_ROOT_POINTERS \
+    const char *readline_hist[50]; \
     mp_obj_t keyboard_interrupt_obj; \
     void *mmap_region_head; \
+
+#define MICROPY_HAL_H "unix_mphal.h"
 
 // We need to provide a declaration/definition of alloca()
 #ifdef __FreeBSD__

--- a/unix/mpconfigport.mk
+++ b/unix/mpconfigport.mk
@@ -3,9 +3,6 @@
 # Build 32-bit binaries on a 64-bit host
 MICROPY_FORCE_32BIT = 0
 
-# Linking with GNU readline causes binary to be licensed under GPL
-MICROPY_USE_READLINE = 1
-
 # Subset of CPython time module
 MICROPY_PY_TIME = 1
 

--- a/unix/unix_mphal.c
+++ b/unix/unix_mphal.c
@@ -1,0 +1,127 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <termios.h>
+
+#include "py/mpstate.h"
+#include "lib/mp-readline/readline.h"
+#include "unix_mphal.h"
+
+static struct termios orig_termios;
+static struct termios cur_termios;
+static char interrupt_char;
+
+#ifndef _WIN32
+#include <signal.h>
+
+static struct sigaction sa;
+
+STATIC void sighandler(int signum) {
+    if (signum == SIGINT && interrupt_char == CHAR_CTRL_C) {
+        if (MP_STATE_VM(mp_pending_exception) == MP_STATE_VM(keyboard_interrupt_obj)) {
+            mp_hal_deinit();
+            exit(1);
+        }
+        mp_obj_exception_clear_traceback(MP_STATE_VM(keyboard_interrupt_obj));
+        MP_STATE_VM(mp_pending_exception) = MP_STATE_VM(keyboard_interrupt_obj);
+        // disable our handler so next we really die
+
+        /*
+        struct sigaction sa;
+        sa.sa_handler = SIG_DFL;
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGINT, &sa, NULL);
+        */
+    }
+}
+#endif
+
+void mp_hal_init(void) {
+    tcgetattr(0, &orig_termios);
+    cur_termios = orig_termios;
+    cur_termios.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+    cur_termios.c_cflag = (cur_termios.c_cflag & ~(CSIZE | PARENB)) | CS8;
+    cur_termios.c_lflag = 0;
+    cur_termios.c_cc[VMIN] = 1;
+    cur_termios.c_cc[VTIME] = 0;
+    tcsetattr(0, TCSAFLUSH, &cur_termios);
+
+    interrupt_char = -1;
+
+    #ifndef _WIN32
+    // enable signal handler
+    sa.sa_handler = sighandler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGINT, &sa, NULL);
+    sa.sa_handler = SIG_DFL;
+    #endif
+}
+
+void mp_hal_deinit(void) {
+    #ifndef _WIN32
+    // disable signal handler
+    sigaction(SIGINT, &sa, NULL);
+    #endif
+    tcsetattr(0, TCSAFLUSH, &orig_termios);
+}
+
+void mp_hal_set_interrupt_char(char c) {
+    interrupt_char = c;
+    if (c == -1) {
+        cur_termios.c_lflag = 0;
+        tcsetattr(0, TCSAFLUSH, &cur_termios);
+    } else {
+        cur_termios.c_lflag = ISIG;
+        tcsetattr(0, TCSAFLUSH, &cur_termios);
+    }
+}
+
+int mp_hal_stdin_rx_chr(void) {
+    unsigned char c;
+    int ret = read(0, &c, 1);
+    if (ret == 0) {
+        c = 4; // EOF, ctrl-D
+    } else if (c == '\n') {
+        c = '\r';
+    }
+    return c;
+}
+
+void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+    write(1, str, len);
+}
+
+// cooked is same as uncooked because they terminal does some postprocessing
+void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len) {
+    mp_hal_stdout_tx_strn(str, len);
+}
+
+void mp_hal_stdout_tx_str(const char *str) {
+    mp_hal_stdout_tx_strn(str, strlen(str));
+}

--- a/unix/unix_mphal.h
+++ b/unix/unix_mphal.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+void mp_hal_init(void);
+void mp_hal_deinit(void);
+
+void mp_hal_set_interrupt_char(char c);
+
+int mp_hal_stdin_rx_chr(void);
+void mp_hal_stdout_tx_str(const char *str);
+void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len);
+void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);


### PR DESCRIPTION
With this patch unix uses our own mp-readline library.  So now it has tab completion, yay!  Also has history read/write capabilities.

Hopefully addresses issue #1253.
