### PR TITLE
lib/timeutils: Fix problem with dates prior to Mar 1, 2000

### DIFF
--- a/lib/timeutils/timeutils.c
+++ b/lib/timeutils/timeutils.c
@@ -73,6 +73,10 @@ void timeutils_seconds_since_2000_to_struct_time(mp_uint_t t, timeutils_struct_t
 
     mp_int_t days = seconds / 86400;
     seconds %= 86400;
+    if (seconds < 0) {
+        seconds += 86400;
+        days -= 1;
+    }
     tm->tm_hour = seconds / 3600;
     tm->tm_min = seconds / 60 % 60;
     tm->tm_sec = seconds % 60;

--- a/tests/pyb/modtime.py
+++ b/tests/pyb/modtime.py
@@ -35,4 +35,25 @@ def test():
                 yday += 1
                 wday = (wday + 1) % 7
 
+def spot_test(seconds, expected_time):
+    actual_time = time.localtime(seconds)
+    for i in range(len(actual_time)):
+        if actual_time[i] != expected_time[i]:
+            print("time.localtime(", seconds, ") returned", actual_time, "expecting", expected_time)
+            return
+    print("time.localtime(", seconds, ") returned", actual_time, "(pass)")
+
+
 test()
+spot_test(          0,  (2000,  1,  1,  0,  0,  0, 5,   1))
+spot_test(          1,  (2000,  1,  1,  0,  0,  1, 5,   1))
+spot_test(         59,  (2000,  1,  1,  0,  0, 59, 5,   1))
+spot_test(         60,  (2000,  1,  1,  0,  1,  0, 5,   1))
+spot_test(       3599,  (2000,  1,  1,  0, 59, 59, 5,   1))
+spot_test(       3600,  (2000,  1,  1,  1,  0,  0, 5,   1))
+spot_test(         -1,  (1999, 12, 31, 23, 59, 59, 4, 365))
+spot_test(  447549467,  (2014,  3,  7, 23, 17, 47, 4,  66))
+spot_test( -940984933,  (1970,  3,  7, 23, 17, 47, 5,  66))
+spot_test(-1072915199,  (1966,  1,  1,  0,  0,  1, 5,   1))
+spot_test(-1072915200,  (1966,  1,  1,  0,  0,  0, 5,   1))
+spot_test(-1072915201,  (1965, 12, 31, 23, 59, 59, 4, 365))

--- a/tests/pyb/modtime.py.exp
+++ b/tests/pyb/modtime.py.exp
@@ -32,3 +32,15 @@ Testing 2030
 Testing 2031
 Testing 2032
 Testing 2033
+time.localtime( 0 ) returned (2000, 1, 1, 0, 0, 0, 5, 1) (pass)
+time.localtime( 1 ) returned (2000, 1, 1, 0, 0, 1, 5, 1) (pass)
+time.localtime( 59 ) returned (2000, 1, 1, 0, 0, 59, 5, 1) (pass)
+time.localtime( 60 ) returned (2000, 1, 1, 0, 1, 0, 5, 1) (pass)
+time.localtime( 3599 ) returned (2000, 1, 1, 0, 59, 59, 5, 1) (pass)
+time.localtime( 3600 ) returned (2000, 1, 1, 1, 0, 0, 5, 1) (pass)
+time.localtime( -1 ) returned (1999, 12, 31, 23, 59, 59, 4, 365) (pass)
+time.localtime( 447549467 ) returned (2014, 3, 7, 23, 17, 47, 4, 66) (pass)
+time.localtime( -940984933 ) returned (1970, 3, 7, 23, 17, 47, 5, 66) (pass)
+time.localtime( -1072915199 ) returned (1966, 1, 1, 0, 0, 1, 5, 1) (pass)
+time.localtime( -1072915200 ) returned (1966, 1, 1, 0, 0, 0, 5, 1) (pass)
+time.localtime( -1072915201 ) returned (1965, 12, 31, 23, 59, 59, 4, 365) (pass)


### PR DESCRIPTION
The easiest way to see this is to do:

``` python
>>> import time
>>> time.localtime(0)
(2000, 1, 1, 0, 0, 0, 5, 1)
>>> time.localtime(1)
(2000, 1, 2, 233, 197, 197, 6, 2)
```

With this patch, we instead get:

``` python
>>> import time
>>> time.localtime(1)
(2000, 1, 1, 0, 0, 1, 5, 1)
```

Doh - In C % is NOT a modulo operator, it's a remainder operator.
