### PR TITLE
py: Prevent many extra vstr allocations

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1920,7 +1920,11 @@ mp_obj_t mp_obj_new_str_from_vstr(const mp_obj_type_t *type, vstr_t *vstr) {
     o->base.type = type;
     o->len = vstr->len;
     o->hash = qstr_compute_hash((byte*)vstr->buf, vstr->len);
-    o->data = (byte*)m_renew(char, vstr->buf, vstr->alloc, vstr->len + 1);
+    if (vstr->len + 1 == vstr->alloc) {
+        o->data = (byte*)vstr->buf;
+    } else {
+        o->data = (byte*)m_renew(char, vstr->buf, vstr->alloc, vstr->len + 1);
+    }
     ((byte*)o->data)[o->len] = '\0'; // add null byte
     vstr->buf = NULL;
     vstr->alloc = 0;

--- a/py/vstr.c
+++ b/py/vstr.c
@@ -53,8 +53,10 @@ void vstr_init(vstr_t *vstr, size_t alloc) {
 }
 
 // Init the vstr so it allocs exactly enough ram to hold given length, and set the length.
+// As an optimization we over-allocate by 1 byte, which in many situations
+// will prevent an extra allocation later on when this is converted to a string.
 void vstr_init_len(vstr_t *vstr, size_t len) {
-    vstr_init(vstr, len);
+    vstr_init(vstr, len + 1);
     vstr->len = len;
 }
 


### PR DESCRIPTION
I checked the entire codebase, and every place that vstr_init_len
was called, there was a call to mp_obj_new_str_from_vstr after it.

mp_obj_new_str_from_vstr always tries to reallocate a new buffer
1 byte larger than the original to store the terminating null
character.

In many cases, if we allocated the initial buffer to be 1 byte
longer, we can prevent this extra allocation, and just reuse
the originally allocated buffer.

Asking to read 256 bytes and only getting 100 will still cause
the extra allocation, but if you ask to read 256 and get 256
then the extra allocation will be optimized away.

Yes - the reallocation is optimized in the heap to try and reuse
the buffer if it can, but it takes quite a few cycles to figure
this out.
