### PR TITLE
Fix UART BRR when OVERSAMPLING_8

### DIFF
--- a/stmhal/hal/inc/stm32f4xx_hal_uart.h
+++ b/stmhal/hal/inc/stm32f4xx_hal_uart.h
@@ -548,8 +548,8 @@ typedef struct
 
 #define __DIV_SAMPLING8(_PCLK_, _BAUD_)             (((_PCLK_)*25)/(2*(_BAUD_)))
 #define __DIVMANT_SAMPLING8(_PCLK_, _BAUD_)         (__DIV_SAMPLING8((_PCLK_), (_BAUD_))/100)
-#define __DIVFRAQ_SAMPLING8(_PCLK_, _BAUD_)         (((__DIV_SAMPLING8((_PCLK_), (_BAUD_)) - (__DIVMANT_SAMPLING8((_PCLK_), (_BAUD_)) * 100)) * 16 + 50) / 100)
-#define __UART_BRR_SAMPLING8(_PCLK_, _BAUD_)        ((__DIVMANT_SAMPLING8((_PCLK_), (_BAUD_)) << 4)|(__DIVFRAQ_SAMPLING8((_PCLK_), (_BAUD_)) & 0x0F))
+#define __DIVFRAQ_SAMPLING8(_PCLK_, _BAUD_)         (((__DIV_SAMPLING8((_PCLK_), (_BAUD_)) - (__DIVMANT_SAMPLING8((_PCLK_), (_BAUD_)) * 100)) * 8 + 50) / 100)
+#define __UART_BRR_SAMPLING8(_PCLK_, _BAUD_)        ((__DIVMANT_SAMPLING8((_PCLK_), (_BAUD_)) << 4)|(__DIVFRAQ_SAMPLING8((_PCLK_), (_BAUD_)) & 0x07))
 
 #define IS_UART_BAUDRATE(BAUDRATE) ((BAUDRATE) < 10500001)
 #define IS_UART_ADDRESS(ADDRESS) ((ADDRESS) <= 0xF)                             


### PR DESCRIPTION
There was a bug in ST UART driver when OVERSAMPLING_8.
At the moment micropython is only using OVERSAMPLING_16 so this bug is not affecting current micropython fw.
But if one day one wants to enable higher baudrates (~5.5M to 10.5M) and use OVERSAMPLING_8 the bug is triggered (and e.g. setting 7M would give an actual 10.5M baudrate).
This bug was revealed when playing around with the native firmware of hydrabus, see https://github.com/bvernoux/hydrafw/pull/14

Source:
STM32F405 reference manual, 30.3.4 page 965:

 USARTDIV is an unsigned fixed point number that is coded on the USART_BRR register.
 Note:
 • When OVER8=0, the fractional part is coded on 4 bits and programmed by the DIV_fraction[3:0] bits in the USART_BRR register
 • When OVER8=1, the fractional part is coded on 3 bits and programmed by the DIV_fraction[2:0] bits in the USART_BRR register, and bit DIV_fraction[3] must be kept cleared.
