### PR TITLE
Make modubinascii functions public

### DIFF
--- a/extmod/modubinascii.c
+++ b/extmod/modubinascii.c
@@ -31,10 +31,10 @@
 #include "py/nlr.h"
 #include "py/runtime.h"
 #include "py/binary.h"
+#include "modubinascii.h"
 
-#if MICROPY_PY_UBINASCII
 
-STATIC mp_obj_t mod_binascii_hexlify(mp_uint_t n_args, const mp_obj_t *args) {
+mp_obj_t mod_binascii_hexlify(mp_uint_t n_args, const mp_obj_t *args) {
     // Second argument is for an extension to allow a separator to be used
     // between values.
     (void)n_args;
@@ -60,7 +60,7 @@ STATIC mp_obj_t mod_binascii_hexlify(mp_uint_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_binascii_hexlify_obj, 1, 2, mod_binascii_hexlify);
 
-STATIC mp_obj_t mod_binascii_unhexlify(mp_obj_t data) {
+mp_obj_t mod_binascii_unhexlify(mp_obj_t data) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(data, &bufinfo, MP_BUFFER_READ);
 
@@ -88,6 +88,8 @@ STATIC mp_obj_t mod_binascii_unhexlify(mp_obj_t data) {
     return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(mod_binascii_unhexlify_obj, mod_binascii_unhexlify);
+
+#if MICROPY_PY_UBINASCII
 
 STATIC const mp_map_elem_t mp_module_binascii_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_ubinascii) },

--- a/extmod/modubinascii.h
+++ b/extmod/modubinascii.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Paul Sokolovsky
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_EXTMOD_MODUBINASCII
+#define MICROPY_EXTMOD_MODUBINASCII
+
+extern mp_obj_t mod_binascii_hexlify(mp_uint_t n_args, const mp_obj_t *args);
+extern mp_obj_t mod_binascii_unhexlify(mp_obj_t data);
+
+#endif /* MICROPY_EXTMOD_MODUBINASCII */


### PR DESCRIPTION
I made both functions from modubinascii public so that they can be reused by other modules. I want the CC3200 to have its own modubinascii module reusing the code that is already in the extmod dir. The reason to do so is because the CC3200 has a hardware CRC32 engine that I am going to use to implement `binascii.crc32()`.
