### PR TITLE
stmhal: Detect disk full condition

### DIFF
--- a/stmhal/file.c
+++ b/stmhal/file.c
@@ -88,6 +88,11 @@ STATIC mp_uint_t file_obj_write(mp_obj_t self_in, const void *buf, mp_uint_t siz
         *errcode = fresult_to_errno_table[res];
         return MP_STREAM_ERROR;
     }
+    if (sz_out != size) {
+        // The FatFS documentation says that this means disk full.
+        *errcode = ENOSPC;
+        return MP_STREAM_ERROR;
+    }
     return sz_out;
 }
 


### PR DESCRIPTION
If I call file.write(buf) I confirmed that it returns 0 when disk full is detected, but it felt to me like disk full should generate an exception.

With this patch, executing this code:

``` python
buf = bytearray(1024)
for i in range(len(buf)):
    buf[i] = ord('A') + (i % 32)
with open('/flash/data', 'wb') as file:
    for i in range(150):
        print(i, file.write(buf))
```

generates this output:

```
>>> import fill_flash
0 1024
1 1024
2 1024
3 1024
4 1024
5 1024
6 1024
7 1024
8 1024
9 1024
10 1024
11 1024
12 1024
13 1024
14 1024
15 1024
16 1024
17 1024
18 1024
19 1024
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "fill_flash.py", line 6, in <module>
  File "fill_flash.py", line 6, in <module>
OSError: 28
```

Without the patch, file.write returns 0 starting at 20K mark and onwards.
