### PR TITLE
Make unix port use mp-readline library, take 2

### DIFF
--- a/lib/mp-readline/readline.c
+++ b/lib/mp-readline/readline.c
@@ -81,10 +81,10 @@ STATIC void erase_line_from_cursor(void) {
 
 typedef struct _readline_t {
     vstr_t *line;
-    int orig_line_len;
+    size_t orig_line_len;
     int escape_seq;
     int hist_cur;
-    int cursor_pos;
+    size_t cursor_pos;
     char escape_seq_buf[1];
     const char *prompt;
 } readline_t;
@@ -92,7 +92,7 @@ typedef struct _readline_t {
 STATIC readline_t rl;
 
 int readline_process_char(int c) {
-    int last_line_len = rl.line->len;
+    size_t last_line_len = rl.line->len;
     int redraw_step_back = 0;
     bool redraw_from_cursor = false;
     int redraw_step_forward = 0;
@@ -112,17 +112,7 @@ int readline_process_char(int c) {
         } else if (c == '\r') {
             // newline
             mp_hal_stdout_tx_str("\r\n");
-            if (rl.line->len > rl.orig_line_len && (MP_STATE_PORT(readline_hist)[0] == NULL || strcmp(MP_STATE_PORT(readline_hist)[0], rl.line->buf + rl.orig_line_len) != 0)) {
-                // a line which is not empty and different from the last one
-                // so update the history
-                char *most_recent_hist = str_dup_maybe(vstr_null_terminated_str(rl.line) + rl.orig_line_len);
-                if (most_recent_hist != NULL) {
-                    for (int i = READLINE_HIST_SIZE - 1; i > 0; i--) {
-                        MP_STATE_PORT(readline_hist)[i] = MP_STATE_PORT(readline_hist)[i - 1];
-                    }
-                    MP_STATE_PORT(readline_hist)[0] = most_recent_hist;
-                }
-            }
+            readline_push_history(vstr_null_terminated_str(rl.line) + rl.orig_line_len);
             return 0;
         } else if (c == 27) {
             // escape sequence
@@ -149,7 +139,7 @@ int readline_process_char(int c) {
                 redraw_from_cursor = true;
             } else {
                 // one match
-                for (int i = 0; i < compl_len; ++i) {
+                for (mp_uint_t i = 0; i < compl_len; ++i) {
                     vstr_ins_byte(rl.line, rl.cursor_pos + i, *compl_str++);
                 }
                 // set redraw parameters
@@ -184,7 +174,7 @@ int readline_process_char(int c) {
             rl.escape_seq = ESEQ_NONE;
             if (c == 'A') {
                 // up arrow
-                if (rl.hist_cur + 1 < READLINE_HIST_SIZE && MP_STATE_PORT(readline_hist)[rl.hist_cur + 1] != NULL) {
+                if (rl.hist_cur + 1 < (int)READLINE_HIST_SIZE && MP_STATE_PORT(readline_hist)[rl.hist_cur + 1] != NULL) {
                     // increase hist num
                     rl.hist_cur += 1;
                     // set line to history
@@ -309,6 +299,22 @@ int readline(vstr_t *line, const char *prompt) {
         int r = readline_process_char(c);
         if (r >= 0) {
             return r;
+        }
+    }
+}
+
+void readline_push_history(const char *line) {
+    if (line[0] != '\0'
+        && (MP_STATE_PORT(readline_hist)[0] == NULL
+            || strcmp(MP_STATE_PORT(readline_hist)[0], line) != 0)) {
+        // a line which is not empty and different from the last one
+        // so update the history
+        char *most_recent_hist = str_dup_maybe(line);
+        if (most_recent_hist != NULL) {
+            for (int i = READLINE_HIST_SIZE - 1; i > 0; i--) {
+                MP_STATE_PORT(readline_hist)[i] = MP_STATE_PORT(readline_hist)[i - 1];
+            }
+            MP_STATE_PORT(readline_hist)[0] = most_recent_hist;
         }
     }
 }

--- a/lib/mp-readline/readline.h
+++ b/lib/mp-readline/readline.h
@@ -32,6 +32,7 @@
 
 void readline_init0(void);
 int readline(vstr_t *line, const char *prompt);
+void readline_push_history(const char *line);
 
 void readline_init(vstr_t *line, const char *prompt);
 void readline_note_newline(const char *prompt);

--- a/tests/cmdline/repl_basic.py
+++ b/tests/cmdline/repl_basic.py
@@ -1,3 +1,3 @@
 # basic REPL tests
 print(1)
-OA
+[A

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -90,6 +90,7 @@ endif
 SRC_C = \
 	main.c \
 	gccollect.c \
+	unix_mphal.c \
 	input.c \
 	file.c \
 	modos.c \

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -57,7 +57,12 @@ endif
 endif
 
 ifeq ($(MICROPY_USE_READLINE),1)
+INC +=  -I../lib/mp-readline
 CFLAGS_MOD += -DMICROPY_USE_READLINE=1
+LIB_SRC_C_EXTRA += mp-readline/readline.c
+endif
+ifeq ($(MICROPY_USE_READLINE),2)
+CFLAGS_MOD += -DMICROPY_USE_READLINE=2
 LDFLAGS_MOD += -lreadline
 # the following is needed for BSD
 #LDFLAGS_MOD += -ltermcap
@@ -98,8 +103,13 @@ SRC_C = \
 	coverage.c \
 	$(SRC_MOD)
 
+LIB_SRC_C = $(addprefix lib/,\
+	$(LIB_SRC_C_EXTRA) \
+	)
 
-OBJ = $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+OBJ = $(PY_O)
+OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+OBJ += $(addprefix $(BUILD)/, $(LIB_SRC_C:.c=.o))
 
 include ../py/mkrules.mk
 

--- a/unix/input.c
+++ b/unix/input.c
@@ -28,21 +28,39 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "py/nlr.h"
-#include "py/obj.h"
+#include "py/mpstate.h"
 #include "input.h"
 
-#if MICROPY_USE_READLINE
+#if MICROPY_USE_READLINE == 1
+#include "lib/mp-readline/readline.h"
+#elif MICROPY_USE_READLINE == 2
 #include <readline/readline.h>
 #include <readline/history.h>
 #include <readline/tilde.h>
-#else
-#undef MICROPY_USE_READLINE_HISTORY
-#define MICROPY_USE_READLINE_HISTORY (0)
 #endif
 
 char *prompt(char *p) {
-#if MICROPY_USE_READLINE
+#if MICROPY_USE_READLINE == 1
+    vstr_t vstr;
+    vstr_init(&vstr, 16);
+    int ret = readline(&vstr, p);
+    if (ret != 0) {
+        vstr_clear(&vstr);
+        if (ret == CHAR_CTRL_D) {
+            // EOF
+            return NULL;
+        } else {
+            printf("\n");
+            char *line = malloc(1);
+            line[0] = '\0';
+            return line;
+        }
+    }
+    vstr_null_terminated_str(&vstr);
+    char *line = malloc(vstr.len + 1);
+    memcpy(line, vstr.buf, vstr.len + 1);
+    vstr_clear(&vstr);
+#elif MICROPY_USE_READLINE == 2
     char *line = readline(p);
     if (line) {
         add_history(line);
@@ -68,13 +86,57 @@ char *prompt(char *p) {
 
 void prompt_read_history(void) {
 #if MICROPY_USE_READLINE_HISTORY
+    #if MICROPY_USE_READLINE == 1
+    readline_init0(); // will clear history pointers
+    char *home = getenv("HOME");
+    if (home != NULL) {
+        vstr_t vstr;
+        vstr_init(&vstr, 50);
+        vstr_printf(&vstr, "%s/.micropython.history", home);
+        FILE *fp = fopen(vstr_null_terminated_str(&vstr), "r");
+        vstr_reset(&vstr);
+        for (;;) {
+            int c = fgetc(fp);
+            if (c == EOF || c == '\n') {
+                readline_push_history(vstr_null_terminated_str(&vstr));
+                if (c == EOF) {
+                    break;
+                }
+                vstr_reset(&vstr);
+            } else {
+                vstr_add_byte(&vstr, c);
+            }
+        }
+        vstr_clear(&vstr);
+        fclose(fp);
+    }
+    #elif MICROPY_USE_READLINE == 2
     read_history(tilde_expand("~/.micropython.history"));
+    #endif
 #endif
 }
 
 void prompt_write_history(void) {
 #if MICROPY_USE_READLINE_HISTORY
+    #if MICROPY_USE_READLINE == 1
+    char *home = getenv("HOME");
+    if (home != NULL) {
+        vstr_t vstr;
+        vstr_init(&vstr, 50);
+        vstr_printf(&vstr, "%s/.micropython.history", home);
+        FILE *fp = fopen(vstr_null_terminated_str(&vstr), "w");
+        for (int i = MP_ARRAY_SIZE(MP_STATE_PORT(readline_hist)) - 1; i >= 0; i--) {
+            const char *line = MP_STATE_PORT(readline_hist)[i];
+            if (line != NULL) {
+                fwrite(line, 1, strlen(line), fp);
+                fputc('\n', fp);
+            }
+        }
+        fclose(fp);
+    }
+    #elif MICROPY_USE_READLINE == 2
     write_history(tilde_expand("~/.micropython.history"));
+    #endif
 #endif
 }
 

--- a/unix/main.c
+++ b/unix/main.c
@@ -290,8 +290,6 @@ int main(int argc, char **argv) {
     mp_hal_init();
     mp_init();
 
-    prompt_read_history();
-
     #ifndef _WIN32
     // create keyboard interrupt object
     MP_STATE_VM(keyboard_interrupt_obj) = mp_obj_new_exception(&mp_type_KeyboardInterrupt);
@@ -446,7 +444,9 @@ int main(int argc, char **argv) {
     }
 
     if (ret == NOTHING_EXECUTED) {
+        prompt_read_history();
         ret = do_repl();
+        prompt_write_history();
     }
 
     #if MICROPY_PY_MICROPYTHON_MEM_INFO
@@ -454,8 +454,6 @@ int main(int argc, char **argv) {
         mp_micropython_mem_info(0, NULL);
     }
     #endif
-
-    prompt_write_history();
 
     mp_deinit();
     mp_hal_deinit();

--- a/unix/main.c
+++ b/unix/main.c
@@ -44,6 +44,7 @@
 #include "py/gc.h"
 #include "py/stackctrl.h"
 #include "genhdr/mpversion.h"
+#include "unix_mphal.h"
 #include "input.h"
 
 // Command line options, with their defaults
@@ -55,22 +56,6 @@ mp_uint_t mp_verbose_flag = 0;
 // Heap size of GC heap (if enabled)
 // Make it larger on a 64 bit machine, because pointers are larger.
 long heap_size = 128*1024 * (sizeof(mp_uint_t) / 4);
-#endif
-
-#ifndef _WIN32
-#include <signal.h>
-
-STATIC void sighandler(int signum) {
-    if (signum == SIGINT) {
-        mp_obj_exception_clear_traceback(MP_STATE_VM(keyboard_interrupt_obj));
-        MP_STATE_VM(mp_pending_exception) = MP_STATE_VM(keyboard_interrupt_obj);
-        // disable our handler so next we really die
-        struct sigaction sa;
-        sa.sa_handler = SIG_DFL;
-        sigemptyset(&sa.sa_mask);
-        sigaction(SIGINT, &sa, NULL);
-    }
-}
 #endif
 
 STATIC void stderr_print_strn(void *env, const char *str, mp_uint_t len) {
@@ -110,14 +95,7 @@ STATIC int execute_from_lexer(mp_lexer_t *lex, mp_parse_input_kind_t input_kind,
         return 1;
     }
 
-    #ifndef _WIN32
-    // enable signal handler
-    struct sigaction sa;
-    sa.sa_handler = sighandler;
-    sigemptyset(&sa.sa_mask);
-    sigaction(SIGINT, &sa, NULL);
-    sa.sa_handler = SIG_DFL;
-    #endif
+    mp_hal_set_interrupt_char(CHAR_CTRL_C);
 
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
@@ -144,20 +122,13 @@ STATIC int execute_from_lexer(mp_lexer_t *lex, mp_parse_input_kind_t input_kind,
             mp_call_function_0(module_fun);
         }
 
-        #ifndef _WIN32
-        // disable signal handler
-        sigaction(SIGINT, &sa, NULL);
-        #endif
-
+        mp_hal_set_interrupt_char(-1);
         nlr_pop();
         return 0;
 
     } else {
         // uncaught exception
-        #ifndef _WIN32
-        // disable signal handler
-        sigaction(SIGINT, &sa, NULL);
-        #endif
+        mp_hal_set_interrupt_char(-1);
         return handle_uncaught_exception((mp_obj_t)nlr.ret_val);
     }
 }
@@ -177,7 +148,7 @@ STATIC char *strjoin(const char *s1, int sep_char, const char *s2) {
 }
 
 STATIC int do_repl(void) {
-    printf("Micro Python " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_PY_SYS_PLATFORM " version\n");
+    mp_hal_stdout_tx_str("Micro Python " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_PY_SYS_PLATFORM " version\n");
 
     for (;;) {
         char *line = prompt(">>> ");
@@ -307,8 +278,6 @@ STATIC void set_sys_argv(char *argv[], int argc, int start_arg) {
 #endif
 
 int main(int argc, char **argv) {
-    prompt_read_history();
-
     mp_stack_set_limit(40000 * (BYTES_PER_WORD / 4));
 
     pre_process_options(argc, argv);
@@ -318,7 +287,10 @@ int main(int argc, char **argv) {
     gc_init(heap, heap + heap_size);
 #endif
 
+    mp_hal_init();
     mp_init();
+
+    prompt_read_history();
 
     #ifndef _WIN32
     // create keyboard interrupt object
@@ -483,7 +455,10 @@ int main(int argc, char **argv) {
     }
     #endif
 
+    prompt_write_history();
+
     mp_deinit();
+    mp_hal_deinit();
 
 #if MICROPY_ENABLE_GC && !defined(NDEBUG)
     // We don't really need to free memory since we are about to exit the
@@ -492,7 +467,6 @@ int main(int argc, char **argv) {
 #endif
 
     //printf("total bytes = %d\n", m_get_total_bytes_allocated());
-    prompt_write_history();
     return ret & 0xff;
 }
 

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -184,9 +184,14 @@ extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
     { MP_OBJ_NEW_QSTR(MP_QSTR_input), (mp_obj_t)&mp_builtin_input_obj }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_open), (mp_obj_t)&mp_builtin_open_obj },
 
+#define MP_STATE_PORT MP_STATE_VM
+
 #define MICROPY_PORT_ROOT_POINTERS \
+    const char *readline_hist[50]; \
     mp_obj_t keyboard_interrupt_obj; \
     void *mmap_region_head; \
+
+#define MICROPY_HAL_H "unix_mphal.h"
 
 // We need to provide a declaration/definition of alloca()
 #ifdef __FreeBSD__

--- a/unix/mpconfigport.mk
+++ b/unix/mpconfigport.mk
@@ -3,7 +3,10 @@
 # Build 32-bit binaries on a 64-bit host
 MICROPY_FORCE_32BIT = 0
 
-# Linking with GNU readline causes binary to be licensed under GPL
+# This variable can take the following values:
+#  0 - no readline, just simple input
+#  1 - use MicroPython version of readline
+#  2 - use GNU readline (causes binary to be licensed under GPL)
 MICROPY_USE_READLINE = 1
 
 # Subset of CPython time module

--- a/unix/unix_mphal.c
+++ b/unix/unix_mphal.c
@@ -1,0 +1,98 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <string.h>
+
+#include "py/mpstate.h"
+#include "unix_mphal.h"
+
+#ifndef _WIN32
+#include <signal.h>
+
+STATIC void sighandler(int signum) {
+    if (signum == SIGINT) {
+        mp_obj_exception_clear_traceback(MP_STATE_VM(keyboard_interrupt_obj));
+        MP_STATE_VM(mp_pending_exception) = MP_STATE_VM(keyboard_interrupt_obj);
+        // disable our handler so next we really die
+        struct sigaction sa;
+        sa.sa_handler = SIG_DFL;
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGINT, &sa, NULL);
+    }
+}
+#endif
+
+void mp_hal_init(void) {
+}
+
+void mp_hal_deinit(void) {
+}
+
+void mp_hal_set_interrupt_char(char c) {
+    // configure terminal settings to (not) let ctrl-C through
+    if (c == CHAR_CTRL_C) {
+        #ifndef _WIN32
+        // enable signal handler
+        struct sigaction sa;
+        sa.sa_handler = sighandler;
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGINT, &sa, NULL);
+        #endif
+    } else {
+        #ifndef _WIN32
+        // disable signal handler
+        struct sigaction sa;
+        sa.sa_handler = SIG_DFL;
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGINT, &sa, NULL);
+        #endif
+    }
+}
+
+int mp_hal_stdin_rx_chr(void) {
+    unsigned char c;
+    int ret = read(0, &c, 1);
+    if (ret == 0) {
+        c = 4; // EOF, ctrl-D
+    } else if (c == '\n') {
+        c = '\r';
+    }
+    return c;
+}
+
+void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+    write(1, str, len);
+}
+
+// cooked is same as uncooked because they terminal does some postprocessing
+void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len) {
+    mp_hal_stdout_tx_strn(str, len);
+}
+
+void mp_hal_stdout_tx_str(const char *str) {
+    mp_hal_stdout_tx_strn(str, strlen(str));
+}

--- a/unix/unix_mphal.c
+++ b/unix/unix_mphal.c
@@ -128,7 +128,8 @@ int mp_hal_stdin_rx_chr(void) {
 }
 
 void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
-    write(1, str, len);
+    int ret = write(1, str, len);
+    (void)ret; // to suppress compiler warning
 }
 
 // cooked is same as uncooked because they terminal does some postprocessing

--- a/unix/unix_mphal.h
+++ b/unix/unix_mphal.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef CHAR_CTRL_C
+#define CHAR_CTRL_C (3)
+#endif
+
+void mp_hal_init(void);
+void mp_hal_deinit(void);
+
+void mp_hal_set_interrupt_char(char c);
+
+int mp_hal_stdin_rx_chr(void);
+void mp_hal_stdout_tx_str(const char *str);
+void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len);
+void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -31,6 +31,7 @@ SRC_C = \
 	unix/main.c \
 	unix/file.c \
 	unix/input.c \
+	unix/unix_mphal.c \
 	unix/modos.c \
 	unix/modtime.c \
 	unix/gccollect.c \


### PR DESCRIPTION
An improved version of #1263, which adds mp-readline to unix port, but also keeps option to use GNU readline.  Default is mp-readline.

@blmorris could you please check this on OSX?

@stinos could you please check this on Windows?
