### PR TITLE
msvc: Fix default MICROPYPATH

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -775,4 +775,9 @@ typedef double mp_float_t;
 #define MP_UNLIKELY(x) __builtin_expect((x), 0)
 #endif
 
+// Environment variable to fetch for user's home directory
+#ifndef MP_ENVVAR_HOME
+#define MP_ENVVAR_HOME "HOME"
+#endif
+
 #endif // __MICROPY_INCLUDED_PY_MPCONFIG_H__

--- a/unix/main.c
+++ b/unix/main.c
@@ -325,10 +325,14 @@ int main(int argc, char **argv) {
     MP_STATE_VM(keyboard_interrupt_obj) = mp_obj_new_exception(&mp_type_KeyboardInterrupt);
     #endif
 
-    char *home = getenv("HOME");
+    char *home = getenv(MP_ENVVAR_HOME);
     char *path = getenv("MICROPYPATH");
     if (path == NULL) {
+#ifndef _MSC_VER
         path = "~/.micropython/lib:/usr/lib/micropython";
+#else
+        path = "~/.micropython/lib";
+#endif
     }
     mp_uint_t path_num = 1; // [0] is for current dir (or base dir of the script)
     for (char *p = path; p != NULL; p = strchr(p, PATHLIST_SEP_CHAR)) {

--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -169,7 +169,7 @@ void msec_sleep(double msec);
 #else
 #define MP_SSIZE_MAX                _I32_MAX
 #endif
-
+#define MP_ENVVAR_HOME              "USERPROFILE"
 
 // CL specific definitions
 


### PR DESCRIPTION
Default windows installations do not use HOME but USERPROFILE as the environment
variable for the user's home directory. Also there is no notion of a common
directory like /usr/lib so exclude it from the default path.
