### PR TITLE
esp8266: Fix lost chars problem when block-xfering data (e.g., when pasting).

### DIFF
--- a/esp8266/esp_mphal.h
+++ b/esp8266/esp_mphal.h
@@ -27,6 +27,9 @@
 #ifndef _INCLUDED_MPHAL_H_
 #define _INCLUDED_MPHAL_H_
 
+// SDK functions not declared in SDK itself
+void ets_isr_mask(unsigned);
+
 void mp_hal_init(void);
 void mp_hal_feed_watchdog(void);
 void mp_hal_udelay(uint32_t);


### PR DESCRIPTION
Pasting more or less sizable text into ESP8266 REPL leads to random chars
missing in the received input. Apparent cause is that using RTOS messages
to pass individual chars one by one is to slow and leads to UART FIFO
overflow. So, instead of passing chars one by one, use RTOS msg to signal
that input data is available in FIFO, and then let task handler to read
data directly from FIFO.

With this change, lost chars problem is gone, but the pasted text is
truncated after some position. At least 500 chars can be pasted reliably
(at 115200 baud), but 1K never pastes completely.
