### PR TITLE
esp8266: Changed esp_scan to keep the current WiFi operating mode but throw an exception if WiFi is in AP only mode

### DIFF
--- a/esp8266/modesp.c
+++ b/esp8266/modesp.c
@@ -528,7 +528,10 @@ STATIC void esp_scan_cb(scaninfo *si, STATUS status) {
 
 STATIC mp_obj_t esp_scan(mp_obj_t cb_in) {
     MP_STATE_PORT(scan_cb_obj) = cb_in;
-    wifi_set_opmode(STATION_MODE);
+    if (wifi_get_opmode() == SOFTAP_MODE) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, 
+            "Scan not supported in AP mode"));
+    }
     wifi_station_scan(NULL, (scan_done_cb_t)esp_scan_cb);
     return mp_const_none;
 }


### PR DESCRIPTION
While reading modesp.c I discovered that esp.scan() calls wifi_set_opmode to change the operating mode of the radio to 'station mode', disabling the Soft AP function. That appears to be taken from an example in the ESP SDK docs. However, this has two side effects; it changes the operational mode and makes 'station mode' the new bootup default. I changed the function to have it get the current mode (with wifi_get_opmode), then change just the current setting (wifi_set_opmode_current), and change it back afterwards. I also switched from STATION_MODE to the hex literal because I couldn't figure out where STATION_MODE is defined; it seems to be in the SDK somewhere rather than in the MicroPython code, so I wasn't sure whether it was robust against changes to the SDK.

I put this into Issue #1313 and said that I didn't feel comfortable submitting a pull request, but after reading the developer workflow and some docs on rebase, I decided to give it a try ;) Please correct anything I've done wrong, either code or process missteps...
