### PR TITLE
Fix the documentation for esp.connect() and esp.disconnect()

### DIFF
--- a/docs/library/esp.rst
+++ b/docs/library/esp.rst
@@ -10,14 +10,6 @@ The ``esp`` module contains specific functions related to the ESP8266 module.
 Functions
 ---------
 
-.. function:: connect(ssid, password)
-
-    Connect to the specified wireless network, using the specified password.
-
-.. function:: disconnect()
-
-    Disconnect from the currently connected wireless network.
-
 .. function:: scan(cb)
 
     Initiate scanning for the available wireless networks.

--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -121,3 +121,4 @@ it will fallback to loading the built-in ``ujson`` module.
 
       pyb.rst
       esp.rst
+      network.rst

--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -178,6 +178,39 @@ For example::
     
        Dump the WIZnet5x00 registers.  Useful for debugging.
 
+.. only:: port_esp8266
+
+    class WLAN
+    ==========
+
+    .. _network.WLAN:
+
+    This class provides a driver for WiFi network processor in the ESP8266.  Example usage::
+
+        import network
+        # setup as a station
+        nic = network.WLAN()
+        nic.connect('your-ssid', 'your-password')
+        # now use socket as usual
+
+    Constructors
+    ------------
+    .. class:: WLAN()
+
+    Create a WLAN driver object.
+
+    Methods
+    -------
+
+    .. method:: wlan.connect(ssid, password)
+
+        Connect to the specified wireless network, using the specified password.
+
+    .. method:: wlan.disconnect()
+
+        Disconnect from the currently connected wireless network.
+
+
 .. only:: port_wipy
 
     class WLAN


### PR DESCRIPTION
Since the commit that moved those two functions failed to update
the documentation, this is a fix for that.
