### PR TITLE
Makefile target to flash STM32F4DISCOVERY with st-flash, when dfu-util fails to work

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -28,6 +28,7 @@ DFU=../tools/dfu.py
 USE_PYDFU ?= 0
 PYDFU = ../tools/pydfu.py
 DFU_UTIL ?= dfu-util
+ST_FLASH ?= st-flash
 DEVICE=0483:df11
 
 CROSS_COMPILE = arm-none-eabi-
@@ -254,7 +255,7 @@ $(BUILD)/$(HAL_DIR)/src/stm32f4xx_hal_sd.o: COPT += -Os
 
 all: $(BUILD)/firmware.dfu $(BUILD)/firmware.hex
 
-.PHONY: deploy
+.PHONY: deploy deploy-st-flash
 
 deploy: $(BUILD)/firmware.dfu
 	$(ECHO) "Writing $< to the board"
@@ -263,6 +264,11 @@ ifeq ($(USE_PYDFU),1)
 else
 	$(Q)$(DFU_UTIL) -a 0 -d $(DEVICE) -D $<
 endif
+
+deploy-st-flash: $(BUILD)/firmware.dfu
+	$(ECHO) "Writing $< to the board"
+	$(Q)$(ST_FLASH) write $(BUILD)/firmware0.bin 0x8000000
+	$(Q)$(ST_FLASH) write $(BUILD)/firmware1.bin 0x8020000
 
 $(BUILD)/firmware.dfu: $(BUILD)/firmware.elf
 	$(ECHO) "Create $@"


### PR DESCRIPTION
I guess I have a comparatively old revision of the ST dev board, and dfu-util (at least version 0.5) fails for me. Add deploy-st-flash target to properly flash board with st-flash (https://github.com/texane/stlink).

This way, flashing works flawlessly on my board with most current micropython git HEAD that this PR is based on.
