### PR TITLE
esp8266: Updated documentation for scan() and moved to network

### DIFF
--- a/docs/library/esp.rst
+++ b/docs/library/esp.rst
@@ -10,14 +10,6 @@ The ``esp`` module contains specific functions related to the ESP8266 module.
 Functions
 ---------
 
-.. function:: scan(cb)
-
-    Initiate scanning for the available wireless networks.
-
-    Once the scanning is complete, the provided callback function ``cb`` will
-    be called once for each network found, and passed a tuple with information
-    about that network.
-
 .. function:: status()
 
     Return the current status of the wireless connection.

--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -210,6 +210,31 @@ For example::
 
         Disconnect from the currently connected wireless network.
 
+    .. method:: wlan.scan(cb)
+
+        Initiate scanning for the available wireless networks.
+
+        Scanning is only possible if the radio is in station or station+AP mode; if
+        called while in AP only mode, an OSError exception will be raised.
+
+        Once the scanning is complete, the provided callback function ``cb`` will
+        be called once for each network found, and passed a tuple with information
+        about that network:
+
+            (ssid, bssid, channel, RSSI, authmode, hidden)
+
+        There are five values for authmode:
+
+            * 0 -- open
+            * 1 -- WEP
+            * 2 -- WPA-PSK
+            * 3 -- WPA2-PSK
+            * 4 -- WPA/WPA2-PSK
+
+        and two for hidden:
+
+            * 0 -- visible
+            * 1 -- hidden
 
 .. only:: port_wipy
 


### PR DESCRIPTION
This PR replaces #1325 and provides documentation updates for #1315 (updated the scan function) and #1332 (moved it from esp to network). 
