### PR TITLE
Add O_WRONLY | O_CREAT to open call when opening file for append ("a")

### DIFF
--- a/unix/file.c
+++ b/unix/file.c
@@ -161,7 +161,7 @@ STATIC mp_obj_t fdfile_open(mp_obj_t type_in, mp_arg_val_t *args) {
                 mode |= O_WRONLY | O_CREAT | O_TRUNC;
                 break;
             case 'a':
-                mode |= O_APPEND;
+                mode |= O_WRONLY | O_CREAT | O_APPEND;
                 break;
             case '+':
                 mode |= O_RDWR;


### PR DESCRIPTION
mode. Otherwise write fails with EBADF (at least on FreeBSD). This is also now newlib stdio layer
handles "a" flag.
