### PR TITLE
py: Use a wrapper to explicitly check self argument of builtin methods.

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -887,6 +887,47 @@ mp_obj_t mp_load_attr(mp_obj_t base, qstr attr) {
     }
 }
 
+// The following "checked fun" type is local to the mp_convert_member_lookup
+// function, and serves to check that the first argument to a builtin function
+// has the correct type.
+
+typedef struct _mp_obj_checked_fun_t {
+    mp_obj_base_t base;
+    const mp_obj_type_t *type;
+    mp_obj_t fun;
+} mp_obj_checked_fun_t;
+
+STATIC mp_obj_t checked_fun_call(mp_obj_t self_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+    mp_obj_checked_fun_t *self = self_in;
+    if (n_args > 0) {
+        const mp_obj_type_t *arg0_type = mp_obj_get_type(args[0]);
+        if (arg0_type != self->type) {
+            if (MICROPY_ERROR_REPORTING != MICROPY_ERROR_REPORTING_DETAILED) {
+                nlr_raise(mp_obj_new_exception_msg(&mp_type_TypeError,
+                    "argument has wrong type"));
+            } else {
+                nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+                    "argument should be a '%q' not a '%q'", self->type->name, arg0_type->name));
+            }
+        }
+    }
+    return mp_call_function_n_kw(self->fun, n_args, n_kw, args);
+}
+
+STATIC const mp_obj_type_t mp_type_checked_fun = {
+    { &mp_type_type },
+    .name = MP_QSTR_function,
+    .call = checked_fun_call,
+};
+
+STATIC mp_obj_t mp_obj_new_checked_fun(const mp_obj_type_t *type, mp_obj_t fun) {
+    mp_obj_checked_fun_t *o = m_new_obj(mp_obj_checked_fun_t);
+    o->base.type = &mp_type_checked_fun;
+    o->type = type;
+    o->fun = fun;
+    return o;
+}
+
 // Given a member that was extracted from an instance, convert it correctly
 // and put the result in the dest[] array for a possible method call.
 // Conversion means dealing with static/class methods, callables, and values.
@@ -903,9 +944,15 @@ void mp_convert_member_lookup(mp_obj_t self, const mp_obj_type_t *type, mp_obj_t
         // Don't try to bind types (even though they're callable)
         dest[0] = member;
     } else if (mp_obj_is_callable(member)) {
-        // return a bound method, with self being this object
-        dest[0] = member;
-        dest[1] = self;
+        if (self == MP_OBJ_NULL && mp_obj_get_type(member) == &mp_type_fun_builtin) {
+            // we extracted a builtin method without a first argument, so we must
+            // wrap this function in a type checker
+            dest[0] = mp_obj_new_checked_fun(type, member);
+        } else {
+            // return a bound method, with self being this object
+            dest[0] = member;
+            dest[1] = self;
+        }
     } else {
         // class member is a value, so just return that value
         dest[0] = member;

--- a/tests/basics/class_use_other.py
+++ b/tests/basics/class_use_other.py
@@ -1,0 +1,12 @@
+# check that we can use an instance of B in a method of A
+
+class A:
+    def store(a, b):
+        a.value = b
+
+class B:
+    pass
+
+b = B()
+A.store(b, 1)
+print(b.value)

--- a/tests/basics/self_type_check.py
+++ b/tests/basics/self_type_check.py
@@ -1,0 +1,31 @@
+# make sure type of first arg (self) to a builtin method is checked
+
+list.append
+
+try:
+    list.append()
+except TypeError as e:
+    print("TypeError")
+
+try:
+    list.append(1)
+except TypeError as e:
+    print("TypeError")
+
+try:
+    list.append(1, 2)
+except TypeError as e:
+    print("TypeError")
+
+l = []
+list.append(l, 2)
+print(l)
+
+try:
+    getattr(list, "append")(1, 2)
+except TypeError as e:
+    print("TypeError")
+
+l = []
+getattr(list, "append")(l, 2)
+print(l)


### PR DESCRIPTION
Previous to this patch a call such as list.append(1, 2) would lead to a
seg fault.  This is because list.append is a builtin method and the first
argument to such methods is always assumed to have the correct type.

Now, when a builtin method is extracted like this it is wrapped in a
checker object which checks the the type of the first argument before
calling the builtin function.

See issue #1216.
