### PR TITLE
tests: Add support for the WiPy in run-tests script.

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -147,6 +147,17 @@ def run_tests(pyb, tests, args):
         skip_tests.add('float/float2int_doubleprec.py') # requires double precision floating point to work
         skip_tests.add('micropython/meminfo.py') # output is very different to PC output
 
+        if args.target == 'wipy':
+            skip_tests.add('misc/print_exception.py')       # requires error reporting full
+            skip_tests.add('misc/recursion.py')             # requires stack checking enabled
+            skip_tests.add('misc/recursive_data.py')        # requires stack checking enabled
+            skip_tests.add('misc/recursive_iternext.py')    # requires stack checking enabled
+            skip_tests.add('misc/rge_sm.py')                # requires floating point
+            skip_tests.update({'extmod/uctypes_%s.py' % t for t in 'bytearray le native_le ptr_le ptr_native_le sizeof sizeof_native'.split()}) # requires uctypes
+            skip_tests.add('extmod/zlibd_decompress.py')    # requires zlib
+            skip_tests.add('extmod/ujson_dumps.py')         # requires floating point
+            skip_tests.add('extmod/ujson_loads.py')         # requires floating point
+
     # Some tests are known to fail on 64-bit machines
     if pyb is None and platform.architecture()[0] == '64bit':
         pass
@@ -254,29 +265,35 @@ def run_tests(pyb, tests, args):
 
 def main():
     cmd_parser = argparse.ArgumentParser(description='Run tests for Micro Python.')
-    cmd_parser.add_argument('--pyboard', action='store_true', help='run the tests on the pyboard')
-    cmd_parser.add_argument('--device', default='/dev/ttyACM0', help='the serial device of the pyboard')
+    cmd_parser.add_argument('--target', default='unix', help='the target platform')
+    cmd_parser.add_argument('--device', default='/dev/ttyACM0', help='the serial device of the target board')
     cmd_parser.add_argument('-d', '--test-dirs', nargs='*', help='input test directories (if no files given)')
     cmd_parser.add_argument('--write-exp', action='store_true', help='save .exp files to run tests w/o CPython')
     cmd_parser.add_argument('--emit', default='bytecode', help='Micro Python emitter to use (bytecode or native)')
+    cmd_parser.add_argument('-b', '--baudrate', default=115200, help='the baud rate of the serial device')
     cmd_parser.add_argument('files', nargs='*', help='input test files')
     args = cmd_parser.parse_args()
 
-    if args.pyboard:
+    if args.target == 'pyboard' or args.target == 'wipy':
         import pyboard
-        pyb = pyboard.Pyboard(args.device)
+        pyb = pyboard.Pyboard(args.device, args.baudrate)
         pyb.enter_raw_repl()
-    else:
+    elif args.target == 'unix':
         pyb = None
+    else:
+        raise ValueError('target must be either unix, pyboard or wipy')
 
     if len(args.files) == 0:
         if args.test_dirs is None:
-            if pyb is None:
-                # run PC tests
-                test_dirs = ('basics', 'micropython', 'float', 'import', 'io', 'misc', 'unicode', 'extmod', 'unix', 'cmdline')
-            else:
+            if args.target == 'pyboard':
                 # run pyboard tests
                 test_dirs = ('basics', 'micropython', 'float', 'misc', 'extmod', 'pyb', 'pybnative', 'inlineasm')
+            elif args.target == 'wipy':
+                # run WiPy tests
+                test_dirs = ('basics', 'micropython', 'misc', 'extmod')
+            else:
+                # run PC tests
+                test_dirs = ('basics', 'micropython', 'float', 'import', 'io', 'misc', 'unicode', 'extmod', 'unix', 'cmdline')
         else:
             # run tests from these directories
             test_dirs = args.test_dirs


### PR DESCRIPTION
The --pyboard param has been replaced by --port which defaults to
'unix'. Possible values at this moment are 'unix', 'pyboard' and
'wipy'. Now is also possible to select the baud rate of the serial
device when calling the script.

For some reason some tests like `int_big_div.py` fail because pyserial looses data received from the WiPy. Running the test manually via Putty gives correct results, also via Telnet, so I discard any issue with the WiPy itself, therefore, the problem seems to be caused by the driver, pyserial or by pyboard.py. Anyhow, reducing the baudrate to 57600 makes it go away, and IMHO this is OK for now.
