### PR TITLE
tools: Add telnet support to pyboard.py

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -266,17 +266,19 @@ def run_tests(pyb, tests, args):
 def main():
     cmd_parser = argparse.ArgumentParser(description='Run tests for Micro Python.')
     cmd_parser.add_argument('--target', default='unix', help='the target platform')
-    cmd_parser.add_argument('--device', default='/dev/ttyACM0', help='the serial device of the target board')
+    cmd_parser.add_argument('--device', default='/dev/ttyACM0', help='the serial device or the IP address of the pyboard')
+    cmd_parser.add_argument('-b', '--baudrate', default=115200, help='the baud rate of the serial device')
+    cmd_parser.add_argument('-u', '--user', default='micro', help='the telnet login username')
+    cmd_parser.add_argument('-p', '--password', default='python', help='the telnet login password')
     cmd_parser.add_argument('-d', '--test-dirs', nargs='*', help='input test directories (if no files given)')
     cmd_parser.add_argument('--write-exp', action='store_true', help='save .exp files to run tests w/o CPython')
     cmd_parser.add_argument('--emit', default='bytecode', help='Micro Python emitter to use (bytecode or native)')
-    cmd_parser.add_argument('-b', '--baudrate', default=115200, help='the baud rate of the serial device')
     cmd_parser.add_argument('files', nargs='*', help='input test files')
     args = cmd_parser.parse_args()
 
     if args.target == 'pyboard' or args.target == 'wipy':
         import pyboard
-        pyb = pyboard.Pyboard(args.device, args.baudrate)
+        pyb = pyboard.Pyboard(args.device, args.baudrate, args.user, args.password)
         pyb.enter_raw_repl()
     elif args.target == 'unix':
         pyb = None

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -226,7 +226,7 @@ def run_tests(pyb, tests, args):
             # (using Wine).
             output_mupy = output_mupy.replace(b'\r\n', b'\n')
 
-        if output_mupy == b'SKIP\n' or output_mupy == b'SKIP\r\n':
+        if b'SKIP' in output_mupy[-6:]:
             print("skip ", test_file)
             skipped_tests.append(test_name)
             continue


### PR DESCRIPTION
The file wipy.py contains two classes "WiPy" which inherits from
"Pyboard" reusing all it's functionality and adding  the option to
connect to the WiPy via Telnet. The second one is the adapter class
"TelnetToSerial" which is used to access the Telnet connection using
the same API as with the serial connection.
