### PR TITLE
stmhal/boards/stm32fxx_prefix.c: Fix alt function number calculation

### DIFF
--- a/stmhal/boards/stm32f4xx_prefix.c
+++ b/stmhal/boards/stm32f4xx_prefix.c
@@ -23,7 +23,7 @@
     .name = MP_QSTR_ ## p_port ## p_pin, \
     .port = PORT_ ## p_port, \
     .pin = (p_pin), \
-    .num_af = (sizeof(p_af) / sizeof(pin_obj_t)), \
+    .num_af = (sizeof(p_af) / sizeof(pin_af_obj_t)), \
     .pin_mask = (1 << ((p_pin) & 0x0f)), \
     .gpio = GPIO ## p_port, \
     .af = p_af, \


### PR DESCRIPTION
This prevented the `pin_find_af*` functions in `pin_named_pins.c` from being able to find some
of the higher-numbered alternate functions in the pin struct.
Hadn't been an issue until now because these functions had limited use; I will be using them in I2S and will add another function (pin_find_af_type) as well.
