### PR TITLE
stmhal: Add qstr definition for ifconfig when building for WizNet

### DIFF
--- a/stmhal/qstrdefsport.h
+++ b/stmhal/qstrdefsport.h
@@ -446,6 +446,7 @@ Q(route)
 #if MICROPY_PY_WIZNET5K
 Q(WIZNET5K)
 Q(regs)
+Q(ifconfig)
 Q(ipaddr)
 #endif
 


### PR DESCRIPTION
Fix for the issue raised on the forum:
http://forum.micropython.org/posting.php?mode=reply&f=3&t=801#pr4606
