### PR TITLE
py: Make stream readall return when bytes_read < bytes_requested.

### DIFF
--- a/py/stream.c
+++ b/py/stream.c
@@ -270,13 +270,9 @@ STATIC mp_obj_t stream_readall(mp_obj_t self_in) {
             }
             nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(error)));
         }
-        if (out_sz == 0) {
-            break;
-        }
         total_size += out_sz;
         if (out_sz < current_read) {
-            current_read -= out_sz;
-            p += out_sz;
+            break;
         } else {
             p = vstr_extend(&vstr, DEFAULT_BUFFER_SIZE);
             current_read = DEFAULT_BUFFER_SIZE;


### PR DESCRIPTION
Before this patch a readall would only return because of a stream
error or when getting 0 bytes from the stream object. This works
well with files but not with blocking sockets.
Suppose you have 50 bytes received on a socket and you call readall,
the first time it tries to read 256 bytes (default read size), but it
only gets 50, so it tries to read again asking for 206 bytes, but since
there's no more data available, the operation blocks indefinitely,
hopefully until the socket is closed by the other end.
