### PR TITLE
DMA support for SDcard

### DIFF
--- a/stmhal/boards/PYBV3/mpconfigboard.h
+++ b/stmhal/boards/PYBV3/mpconfigboard.h
@@ -3,6 +3,9 @@
 
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_SDCARD       (1)
+#if MICROPY_HW_HAS_SDCARD
+#define MICROPY_HW_HAS_SDCARD_DMA   (1)
+#endif
 #define MICROPY_HW_HAS_MMA7660      (1)
 #define MICROPY_HW_HAS_LIS3DSH      (0)
 #define MICROPY_HW_HAS_LCD          (0)

--- a/stmhal/diskio.c
+++ b/stmhal/diskio.c
@@ -144,7 +144,11 @@ DRESULT disk_read (
 
 #if MICROPY_HW_HAS_SDCARD
         case PD_SDCARD:
+#if MICROPY_HW_HAS_SDCARD_DMA
+            if (sdcard_read_blocks_dma(buff, sector, count) != 0) {
+#else
             if (sdcard_read_blocks(buff, sector, count) != 0) {
+#endif
                 return RES_ERROR;
             }
             return RES_OK;
@@ -183,7 +187,11 @@ DRESULT disk_write (
 
 #if MICROPY_HW_HAS_SDCARD
         case PD_SDCARD:
+#if MICROPY_HW_HAS_SDCARD_DMA
+            if (sdcard_write_blocks_dma(buff, sector, count) != 0) {
+#else
             if (sdcard_write_blocks(buff, sector, count) != 0) {
+#endif
                 return RES_ERROR;
             }
             return RES_OK;

--- a/stmhal/dma.c
+++ b/stmhal/dma.c
@@ -101,9 +101,6 @@ void dma_init(DMA_HandleTypeDef *dma, DMA_Stream_TypeDef *dma_stream, const DMA_
     int dma_id = get_dma_id(dma_stream);
     //printf("dma_init(%p, %p(%d), 0x%x, 0x%x, %p)\n", dma, dma_stream, dma_id, (uint)dma_channel, (uint)direction, data);
 
-    // TODO possibly don't need to clear the entire structure
-    memset(dma, 0, sizeof(*dma));
-
     // set global pointer for IRQ handler
     dma_handle[dma_id] = dma;
 

--- a/stmhal/sdcard.h
+++ b/stmhal/sdcard.h
@@ -37,4 +37,10 @@ uint64_t sdcard_get_capacity_in_bytes(void);
 mp_uint_t sdcard_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t num_blocks);
 mp_uint_t sdcard_write_blocks(const uint8_t *src, uint32_t block_num, uint32_t num_blocks);
 
+#if MICROPY_HW_HAS_SDCARD_DMA
+void sdcard_irq_handler(void);
+bool sdcard_read_blocks_dma(uint8_t *dest, uint32_t block_num, uint32_t num_blocks);
+bool sdcard_write_blocks_dma(const uint8_t *src, uint32_t block_num, uint32_t num_blocks);
+#endif
+
 extern const struct _mp_obj_base_t pyb_sdcard_obj;

--- a/stmhal/stm32f4xx_it.c
+++ b/stmhal/stm32f4xx_it.c
@@ -77,6 +77,7 @@
 #include "uart.h"
 #include "storage.h"
 #include "can.h"
+#include "sdcard.h"
 
 extern void __fatal_error(const char*);
 extern PCD_HandleTypeDef pcd_handle;
@@ -438,3 +439,9 @@ void CAN2_RX1_IRQHandler(void) {
     can_rx_irq_handler(PYB_CAN_2, CAN_FIFO1);
 }
 #endif // MICROPY_HW_ENABLE_CAN
+
+#if MICROPY_HW_HAS_SDCARD_DMA
+void SDIO_IRQHandler(void) {
+    sdcard_irq_handler();
+}
+#endif // MICROPY_HW_HAS_SDCARD_DMA

--- a/stmhal/usbd_msc_storage.c
+++ b/stmhal/usbd_msc_storage.c
@@ -301,7 +301,11 @@ int8_t SDCARD_STORAGE_PreventAllowMediumRemoval(uint8_t lun, uint8_t param) {
   * @retval Status
   */
 int8_t SDCARD_STORAGE_Read(uint8_t lun, uint8_t *buf, uint32_t blk_addr, uint16_t blk_len) {
+#if MICROPY_HW_HAS_SDCARD_DMA
+    if (sdcard_read_blocks_dma(buf, blk_addr, blk_len) != 0) {
+#else
     if (sdcard_read_blocks(buf, blk_addr, blk_len) != 0) {
+#endif
         return -1;
     }
     return 0;
@@ -316,7 +320,11 @@ int8_t SDCARD_STORAGE_Read(uint8_t lun, uint8_t *buf, uint32_t blk_addr, uint16_
   * @retval Status
   */
 int8_t SDCARD_STORAGE_Write(uint8_t lun, uint8_t *buf, uint32_t blk_addr, uint16_t blk_len) {
+#if MICROPY_HW_HAS_SDCARD_DMA
+    if (sdcard_write_blocks_dma(buf, blk_addr, blk_len) != 0) {
+#else
     if (sdcard_write_blocks(buf, blk_addr, blk_len) != 0) {
+#endif
         return -1;
     }
     return 0;


### PR DESCRIPTION
It fixes possible troubles when irq disabled during SDcard writing. Tested with PYBV3. Need testing with other boards. Additional MICROPY_HW_HAS_SDCARD_DMA was included to "boards/PYBV3/mpconfigboard.h" for DMA/nonDMA swithing. Can be removed in future.
