### PR TITLE
stmhal: Add hal and cmsis files from STM32Cube_FW_F7_V1.1.0

### DIFF
--- a/stmhal/cmsis/devinc/stm32f745xx.h
+++ b/stmhal/cmsis/devinc/stm32f745xx.h
@@ -1,0 +1,9233 @@
+/**
+  ******************************************************************************
+  * @file    stm32f745xx.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   CMSIS STM32F745xx Device Peripheral Access Layer Header File.
+  *
+  *          This file contains:
+  *           - Data structures and the address mapping for all peripherals
+  *           - Peripheral's registers declarations and bits definition
+  *           - Macros to access peripheral’s registers hardware
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS_Device
+  * @{
+  */
+
+/** @addtogroup stm32f745xx
+  * @{
+  */
+
+#ifndef __STM32F745xx_H
+#define __STM32F745xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Configuration_section_for_CMSIS
+  * @{
+  */
+
+/**
+ * @brief STM32F7xx Interrupt Number Definition, according to the selected device
+ *        in @ref Library_configuration_section
+ */
+typedef enum IRQn
+{
+/******  Cortex-M7 Processor Exceptions Numbers ****************************************************************/
+  NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                          */
+  MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M7 Memory Management Interrupt                           */
+  BusFault_IRQn               = -11,    /*!< 5 Cortex-M7 Bus Fault Interrupt                                   */
+  UsageFault_IRQn             = -10,    /*!< 6 Cortex-M7 Usage Fault Interrupt                                 */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M7 SV Call Interrupt                                    */
+  DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M7 Debug Monitor Interrupt                              */
+  PendSV_IRQn                 = -2,     /*!< 14 Cortex-M7 Pend SV Interrupt                                    */
+  SysTick_IRQn                = -1,     /*!< 15 Cortex-M7 System Tick Interrupt                                */
+/******  STM32 specific Interrupt Numbers **********************************************************************/
+  WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
+  PVD_IRQn                    = 1,      /*!< PVD through EXTI Line detection Interrupt                         */
+  TAMP_STAMP_IRQn             = 2,      /*!< Tamper and TimeStamp interrupts through the EXTI line             */
+  RTC_WKUP_IRQn               = 3,      /*!< RTC Wakeup interrupt through the EXTI line                        */
+  FLASH_IRQn                  = 4,      /*!< FLASH global Interrupt                                            */
+  RCC_IRQn                    = 5,      /*!< RCC global Interrupt                                              */
+  EXTI0_IRQn                  = 6,      /*!< EXTI Line0 Interrupt                                              */
+  EXTI1_IRQn                  = 7,      /*!< EXTI Line1 Interrupt                                              */
+  EXTI2_IRQn                  = 8,      /*!< EXTI Line2 Interrupt                                              */
+  EXTI3_IRQn                  = 9,      /*!< EXTI Line3 Interrupt                                              */
+  EXTI4_IRQn                  = 10,     /*!< EXTI Line4 Interrupt                                              */
+  DMA1_Stream0_IRQn           = 11,     /*!< DMA1 Stream 0 global Interrupt                                    */
+  DMA1_Stream1_IRQn           = 12,     /*!< DMA1 Stream 1 global Interrupt                                    */
+  DMA1_Stream2_IRQn           = 13,     /*!< DMA1 Stream 2 global Interrupt                                    */
+  DMA1_Stream3_IRQn           = 14,     /*!< DMA1 Stream 3 global Interrupt                                    */
+  DMA1_Stream4_IRQn           = 15,     /*!< DMA1 Stream 4 global Interrupt                                    */
+  DMA1_Stream5_IRQn           = 16,     /*!< DMA1 Stream 5 global Interrupt                                    */
+  DMA1_Stream6_IRQn           = 17,     /*!< DMA1 Stream 6 global Interrupt                                    */
+  ADC_IRQn                    = 18,     /*!< ADC1, ADC2 and ADC3 global Interrupts                             */
+  CAN1_TX_IRQn                = 19,     /*!< CAN1 TX Interrupt                                                 */
+  CAN1_RX0_IRQn               = 20,     /*!< CAN1 RX0 Interrupt                                                */
+  CAN1_RX1_IRQn               = 21,     /*!< CAN1 RX1 Interrupt                                                */
+  CAN1_SCE_IRQn               = 22,     /*!< CAN1 SCE Interrupt                                                */
+  EXTI9_5_IRQn                = 23,     /*!< External Line[9:5] Interrupts                                     */
+  TIM1_BRK_TIM9_IRQn          = 24,     /*!< TIM1 Break interrupt and TIM9 global interrupt                    */
+  TIM1_UP_TIM10_IRQn          = 25,     /*!< TIM1 Update Interrupt and TIM10 global interrupt                  */
+  TIM1_TRG_COM_TIM11_IRQn     = 26,     /*!< TIM1 Trigger and Commutation Interrupt and TIM11 global interrupt */
+  TIM1_CC_IRQn                = 27,     /*!< TIM1 Capture Compare Interrupt                                    */
+  TIM2_IRQn                   = 28,     /*!< TIM2 global Interrupt                                             */
+  TIM3_IRQn                   = 29,     /*!< TIM3 global Interrupt                                             */
+  TIM4_IRQn                   = 30,     /*!< TIM4 global Interrupt                                             */
+  I2C1_EV_IRQn                = 31,     /*!< I2C1 Event Interrupt                                              */
+  I2C1_ER_IRQn                = 32,     /*!< I2C1 Error Interrupt                                              */
+  I2C2_EV_IRQn                = 33,     /*!< I2C2 Event Interrupt                                              */
+  I2C2_ER_IRQn                = 34,     /*!< I2C2 Error Interrupt                                              */
+  SPI1_IRQn                   = 35,     /*!< SPI1 global Interrupt                                             */
+  SPI2_IRQn                   = 36,     /*!< SPI2 global Interrupt                                             */
+  USART1_IRQn                 = 37,     /*!< USART1 global Interrupt                                           */
+  USART2_IRQn                 = 38,     /*!< USART2 global Interrupt                                           */
+  USART3_IRQn                 = 39,     /*!< USART3 global Interrupt                                           */
+  EXTI15_10_IRQn              = 40,     /*!< External Line[15:10] Interrupts                                   */
+  RTC_Alarm_IRQn              = 41,     /*!< RTC Alarm (A and B) through EXTI Line Interrupt                   */
+  OTG_FS_WKUP_IRQn            = 42,     /*!< USB OTG FS Wakeup through EXTI line interrupt                     */
+  TIM8_BRK_TIM12_IRQn         = 43,     /*!< TIM8 Break Interrupt and TIM12 global interrupt                   */
+  TIM8_UP_TIM13_IRQn          = 44,     /*!< TIM8 Update Interrupt and TIM13 global interrupt                  */
+  TIM8_TRG_COM_TIM14_IRQn     = 45,     /*!< TIM8 Trigger and Commutation Interrupt and TIM14 global interrupt */
+  TIM8_CC_IRQn                = 46,     /*!< TIM8 Capture Compare Interrupt                                    */
+  DMA1_Stream7_IRQn           = 47,     /*!< DMA1 Stream7 Interrupt                                            */
+  FMC_IRQn                    = 48,     /*!< FMC global Interrupt                                              */
+  SDMMC1_IRQn                 = 49,     /*!< SDMMC1 global Interrupt                                             */
+  TIM5_IRQn                   = 50,     /*!< TIM5 global Interrupt                                             */
+  SPI3_IRQn                   = 51,     /*!< SPI3 global Interrupt                                             */
+  UART4_IRQn                  = 52,     /*!< UART4 global Interrupt                                            */
+  UART5_IRQn                  = 53,     /*!< UART5 global Interrupt                                            */
+  TIM6_DAC_IRQn               = 54,     /*!< TIM6 global and DAC1&2 underrun error  interrupts                 */
+  TIM7_IRQn                   = 55,     /*!< TIM7 global interrupt                                             */
+  DMA2_Stream0_IRQn           = 56,     /*!< DMA2 Stream 0 global Interrupt                                    */
+  DMA2_Stream1_IRQn           = 57,     /*!< DMA2 Stream 1 global Interrupt                                    */
+  DMA2_Stream2_IRQn           = 58,     /*!< DMA2 Stream 2 global Interrupt                                    */
+  DMA2_Stream3_IRQn           = 59,     /*!< DMA2 Stream 3 global Interrupt                                    */
+  DMA2_Stream4_IRQn           = 60,     /*!< DMA2 Stream 4 global Interrupt                                    */
+  ETH_IRQn                    = 61,     /*!< Ethernet global Interrupt                                         */
+  ETH_WKUP_IRQn               = 62,     /*!< Ethernet Wakeup through EXTI line Interrupt                       */
+  CAN2_TX_IRQn                = 63,     /*!< CAN2 TX Interrupt                                                 */
+  CAN2_RX0_IRQn               = 64,     /*!< CAN2 RX0 Interrupt                                                */
+  CAN2_RX1_IRQn               = 65,     /*!< CAN2 RX1 Interrupt                                                */
+  CAN2_SCE_IRQn               = 66,     /*!< CAN2 SCE Interrupt                                                */
+  OTG_FS_IRQn                 = 67,     /*!< USB OTG FS global Interrupt                                       */
+  DMA2_Stream5_IRQn           = 68,     /*!< DMA2 Stream 5 global interrupt                                    */
+  DMA2_Stream6_IRQn           = 69,     /*!< DMA2 Stream 6 global interrupt                                    */
+  DMA2_Stream7_IRQn           = 70,     /*!< DMA2 Stream 7 global interrupt                                    */
+  USART6_IRQn                 = 71,     /*!< USART6 global interrupt                                           */
+  I2C3_EV_IRQn                = 72,     /*!< I2C3 event interrupt                                              */
+  I2C3_ER_IRQn                = 73,     /*!< I2C3 error interrupt                                              */
+  OTG_HS_EP1_OUT_IRQn         = 74,     /*!< USB OTG HS End Point 1 Out global interrupt                       */
+  OTG_HS_EP1_IN_IRQn          = 75,     /*!< USB OTG HS End Point 1 In global interrupt                        */
+  OTG_HS_WKUP_IRQn            = 76,     /*!< USB OTG HS Wakeup through EXTI interrupt                          */
+  OTG_HS_IRQn                 = 77,     /*!< USB OTG HS global interrupt                                       */
+  DCMI_IRQn                   = 78,     /*!< DCMI global interrupt                                             */
+  RNG_IRQn                    = 80,     /*!< RNG global interrupt                                              */
+  FPU_IRQn                    = 81,     /*!< FPU global interrupt                                              */
+  UART7_IRQn                  = 82,     /*!< UART7 global interrupt                                            */
+  UART8_IRQn                  = 83,     /*!< UART8 global interrupt                                            */
+  SPI4_IRQn                   = 84,     /*!< SPI4 global Interrupt                                             */
+  SPI5_IRQn                   = 85,     /*!< SPI5 global Interrupt                                             */
+  SPI6_IRQn                   = 86,     /*!< SPI6 global Interrupt                                             */
+  SAI1_IRQn                   = 87,     /*!< SAI1 global Interrupt                                             */
+  DMA2D_IRQn                  = 90,     /*!< DMA2D global Interrupt                                            */
+  SAI2_IRQn                   = 91,     /*!< SAI2 global Interrupt                                             */
+  QUADSPI_IRQn                = 92,     /*!< Quad SPI global interrupt                                         */
+  LPTIM1_IRQn                 = 93,     /*!< LP TIM1 interrupt                                                 */
+  CEC_IRQn                    = 94,     /*!< HDMI-CEC global Interrupt                                         */
+  I2C4_EV_IRQn                = 95,     /*!< I2C4 Event Interrupt                                              */
+  I2C4_ER_IRQn                = 96,     /*!< I2C4 Error Interrupt                                              */
+  SPDIF_RX_IRQn               = 97      /*!< SPDIF-RX global Interrupt                                         */
+} IRQn_Type;
+
+/**
+  * @}
+  */
+
+/**
+ * @brief Configuration of the Cortex-M7 Processor and Core Peripherals
+ */
+#define __CM7_REV                 0x0000   /*!< Cortex-M7 revision r0p1                       */
+#define __MPU_PRESENT             1       /*!< CM7 provides an MPU                           */
+#define __NVIC_PRIO_BITS          4       /*!< CM7 uses 4 Bits for the Priority Levels       */
+#define __Vendor_SysTickConfig    0       /*!< Set to 1 if different SysTick Config is used  */
+#define __FPU_PRESENT             1       /*!< FPU present                                   */
+#define __ICACHE_PRESENT          1       /*!< CM7 instruction cache present                 */
+#define __DCACHE_PRESENT          1       /*!< CM7 data cache present                        */
+#include "core_cm7.h"                 /*!< Cortex-M7 processor and core peripherals      */
+
+
+#include "system_stm32f7xx.h"
+#include <stdint.h>
+
+/** @addtogroup Peripheral_registers_structures
+  * @{
+  */
+
+/**
+  * @brief Analog to Digital Converter
+  */
+
+typedef struct
+{
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+} ADC_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
+                             AND triple modes,                            Address offset: ADC1 base address + 0x308 */
+} ADC_Common_TypeDef;
+
+
+/**
+  * @brief Controller Area Network TxMailBox
+  */
+
+typedef struct
+{
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
+} CAN_TxMailBox_TypeDef;
+
+/**
+  * @brief Controller Area Network FIFOMailBox
+  */
+
+typedef struct
+{
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+} CAN_FIFOMailBox_TypeDef;
+
+/**
+  * @brief Controller Area Network FilterRegister
+  */
+
+typedef struct
+{
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
+} CAN_FilterRegister_TypeDef;
+
+/**
+  * @brief Controller Area Network
+  */
+
+typedef struct
+{
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
+  CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
+  CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
+  uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */
+  CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
+} CAN_TypeDef;
+
+/**
+  * @brief HDMI-CEC
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;           /*!< CEC control register,                                       Address offset:0x00 */
+  __IO uint32_t CFGR;         /*!< CEC configuration register,                                 Address offset:0x04 */
+  __IO uint32_t TXDR;         /*!< CEC Tx data register ,                                      Address offset:0x08 */
+  __IO uint32_t RXDR;         /*!< CEC Rx Data Register,                                       Address offset:0x0C */
+  __IO uint32_t ISR;          /*!< CEC Interrupt and Status Register,                          Address offset:0x10 */
+  __IO uint32_t IER;          /*!< CEC interrupt enable register,                              Address offset:0x14 */
+}CEC_TypeDef;
+
+
+/**
+  * @brief CRC calculation unit
+  */
+
+typedef struct
+{
+  __IO uint32_t  DR;          /*!< CRC Data register,                           Address offset: 0x00 */
+  __IO uint8_t  IDR;          /*!< CRC Independent data register,               Address offset: 0x04 */
+  uint8_t       RESERVED0;    /*!< Reserved, 0x05                                                    */
+  uint16_t      RESERVED1;    /*!< Reserved, 0x06                                                    */
+  __IO uint32_t  CR;          /*!< CRC Control register,                        Address offset: 0x08 */
+  uint32_t       RESERVED2;   /*!< Reserved,                                                    0x0C */
+  __IO uint32_t  INIT;        /*!< Initial CRC value register,                  Address offset: 0x10 */
+  __IO uint32_t  POL;         /*!< CRC polynomial register,                     Address offset: 0x14 */
+} CRC_TypeDef;
+
+/**
+  * @brief Digital to Analog Converter
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+} DAC_TypeDef;
+
+/**
+  * @brief Debug MCU
+  */
+
+typedef struct
+{
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+}DBGMCU_TypeDef;
+
+/**
+  * @brief DCMI
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
+  __IO uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
+  __IO uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
+  __IO uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
+  __IO uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
+  __IO uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
+  __IO uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
+  __IO uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
+  __IO uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
+  __IO uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
+  __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
+} DCMI_TypeDef;
+
+/**
+  * @brief DMA Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+} DMA_Stream_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+} DMA_TypeDef;
+
+
+/**
+  * @brief DMA2D Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
+  __IO uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
+  __IO uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
+  __IO uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
+  __IO uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
+  __IO uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
+  __IO uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
+  __IO uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
+  __IO uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
+  __IO uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
+  __IO uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
+  __IO uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
+  __IO uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
+  __IO uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
+  __IO uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
+  __IO uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
+  __IO uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
+  __IO uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
+  __IO uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
+  __IO uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
+  uint32_t      RESERVED[236]; /*!< Reserved, 0x50-0x3FF */
+  __IO uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
+  __IO uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
+} DMA2D_TypeDef;
+
+
+/**
+  * @brief Ethernet MAC
+  */
+
+typedef struct
+{
+  __IO uint32_t MACCR;
+  __IO uint32_t MACFFR;
+  __IO uint32_t MACHTHR;
+  __IO uint32_t MACHTLR;
+  __IO uint32_t MACMIIAR;
+  __IO uint32_t MACMIIDR;
+  __IO uint32_t MACFCR;
+  __IO uint32_t MACVLANTR;             /*    8 */
+  uint32_t      RESERVED0[2];
+  __IO uint32_t MACRWUFFR;             /*   11 */
+  __IO uint32_t MACPMTCSR;
+  uint32_t      RESERVED1[2];
+  __IO uint32_t MACSR;                 /*   15 */
+  __IO uint32_t MACIMR;
+  __IO uint32_t MACA0HR;
+  __IO uint32_t MACA0LR;
+  __IO uint32_t MACA1HR;
+  __IO uint32_t MACA1LR;
+  __IO uint32_t MACA2HR;
+  __IO uint32_t MACA2LR;
+  __IO uint32_t MACA3HR;
+  __IO uint32_t MACA3LR;               /*   24 */
+  uint32_t      RESERVED2[40];
+  __IO uint32_t MMCCR;                 /*   65 */
+  __IO uint32_t MMCRIR;
+  __IO uint32_t MMCTIR;
+  __IO uint32_t MMCRIMR;
+  __IO uint32_t MMCTIMR;               /*   69 */
+  uint32_t      RESERVED3[14];
+  __IO uint32_t MMCTGFSCCR;            /*   84 */
+  __IO uint32_t MMCTGFMSCCR;
+  uint32_t      RESERVED4[5];
+  __IO uint32_t MMCTGFCR;
+  uint32_t      RESERVED5[10];
+  __IO uint32_t MMCRFCECR;
+  __IO uint32_t MMCRFAECR;
+  uint32_t      RESERVED6[10];
+  __IO uint32_t MMCRGUFCR;
+  uint32_t      RESERVED7[334];
+  __IO uint32_t PTPTSCR;
+  __IO uint32_t PTPSSIR;
+  __IO uint32_t PTPTSHR;
+  __IO uint32_t PTPTSLR;
+  __IO uint32_t PTPTSHUR;
+  __IO uint32_t PTPTSLUR;
+  __IO uint32_t PTPTSAR;
+  __IO uint32_t PTPTTHR;
+  __IO uint32_t PTPTTLR;
+  __IO uint32_t RESERVED8;
+  __IO uint32_t PTPTSSR;
+  uint32_t      RESERVED9[565];
+  __IO uint32_t DMABMR;
+  __IO uint32_t DMATPDR;
+  __IO uint32_t DMARPDR;
+  __IO uint32_t DMARDLAR;
+  __IO uint32_t DMATDLAR;
+  __IO uint32_t DMASR;
+  __IO uint32_t DMAOMR;
+  __IO uint32_t DMAIER;
+  __IO uint32_t DMAMFBOCR;
+  __IO uint32_t DMARSWTR;
+  uint32_t      RESERVED10[8];
+  __IO uint32_t DMACHTDR;
+  __IO uint32_t DMACHRDR;
+  __IO uint32_t DMACHTBAR;
+  __IO uint32_t DMACHRBAR;
+} ETH_TypeDef;
+
+/**
+  * @brief External Interrupt/Event Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+} EXTI_TypeDef;
+
+/**
+  * @brief FLASH Registers
+  */
+
+typedef struct
+{
+  __IO uint32_t ACR;      /*!< FLASH access control register,     Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,                Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,         Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,             Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,            Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,    Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1 ,  Address offset: 0x18 */
+} FLASH_TypeDef;
+
+
+
+/**
+  * @brief Flexible Memory Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
+} FMC_Bank1_TypeDef;
+
+/**
+  * @brief Flexible Memory Controller Bank1E
+  */
+
+typedef struct
+{
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+} FMC_Bank1E_TypeDef;
+
+/**
+  * @brief Flexible Memory Controller Bank3
+  */
+
+typedef struct
+{
+  __IO uint32_t PCR;        /*!< NAND Flash control register,                       Address offset: 0x80 */
+  __IO uint32_t SR;         /*!< NAND Flash FIFO status and interrupt register,     Address offset: 0x84 */
+  __IO uint32_t PMEM;       /*!< NAND Flash Common memory space timing register,    Address offset: 0x88 */
+  __IO uint32_t PATT;       /*!< NAND Flash Attribute memory space timing register, Address offset: 0x8C */
+  uint32_t      RESERVED0;  /*!< Reserved, 0x90                                                          */
+  __IO uint32_t ECCR;       /*!< NAND Flash ECC result registers,                   Address offset: 0x94 */
+} FMC_Bank3_TypeDef;
+
+/**
+  * @brief Flexible Memory Controller Bank5_6
+  */
+
+typedef struct
+{
+  __IO uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
+  __IO uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
+  __IO uint32_t SDCMR;       /*!< SDRAM Command Mode register,    Address offset: 0x150  */
+  __IO uint32_t SDRTR;       /*!< SDRAM Refresh Timer register,   Address offset: 0x154  */
+  __IO uint32_t SDSR;        /*!< SDRAM Status register,          Address offset: 0x158  */
+} FMC_Bank5_6_TypeDef;
+
+
+/**
+  * @brief General Purpose I/O
+  */
+
+typedef struct
+{
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+} GPIO_TypeDef;
+
+/**
+  * @brief System configuration controller
+  */
+
+typedef struct
+{
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+} SYSCFG_TypeDef;
+
+/**
+  * @brief Inter-integrated Circuit Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< I2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;      /*!< I2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;     /*!< I2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;     /*!< I2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;  /*!< I2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR; /*!< I2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;      /*!< I2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;      /*!< I2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;     /*!< I2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;     /*!< I2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;     /*!< I2C Transmit data register,        Address offset: 0x28 */
+} I2C_TypeDef;
+
+/**
+  * @brief Independent WATCHDOG
+  */
+
+typedef struct
+{
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t WINR; /*!< IWDG Window register,    Address offset: 0x10 */
+} IWDG_TypeDef;
+
+
+/**
+  * @brief Power Control
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;   /*!< PWR power control register 1,        Address offset: 0x00 */
+  __IO uint32_t CSR1;  /*!< PWR power control/status register 2, Address offset: 0x04 */
+  __IO uint32_t CR2;   /*!< PWR power control register 2,        Address offset: 0x08 */
+  __IO uint32_t CSR2;  /*!< PWR power control/status register 2, Address offset: 0x0C */
+} PWR_TypeDef;
+
+
+/**
+  * @brief Reset and Clock Control
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
+  __IO uint32_t DCKCFGR1;      /*!< RCC Dedicated Clocks configuration register1,                 Address offset: 0x8C */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x90 */
+
+} RCC_TypeDef;
+
+/**
+  * @brief Real-Time Clock
+  */
+
+typedef struct
+{
+  __IO uint32_t TR;         /*!< RTC time register,                                         Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< RTC date register,                                         Address offset: 0x04 */
+  __IO uint32_t CR;         /*!< RTC control register,                                      Address offset: 0x08 */
+  __IO uint32_t ISR;        /*!< RTC initialization and status register,                    Address offset: 0x0C */
+  __IO uint32_t PRER;       /*!< RTC prescaler register,                                    Address offset: 0x10 */
+  __IO uint32_t WUTR;       /*!< RTC wakeup timer register,                                 Address offset: 0x14 */
+       uint32_t reserved;   /*!< Reserved  */
+  __IO uint32_t ALRMAR;     /*!< RTC alarm A register,                                      Address offset: 0x1C */
+  __IO uint32_t ALRMBR;     /*!< RTC alarm B register,                                      Address offset: 0x20 */
+  __IO uint32_t WPR;        /*!< RTC write protection register,                             Address offset: 0x24 */
+  __IO uint32_t SSR;        /*!< RTC sub second register,                                   Address offset: 0x28 */
+  __IO uint32_t SHIFTR;     /*!< RTC shift control register,                                Address offset: 0x2C */
+  __IO uint32_t TSTR;       /*!< RTC time stamp time register,                              Address offset: 0x30 */
+  __IO uint32_t TSDR;       /*!< RTC time stamp date register,                              Address offset: 0x34 */
+  __IO uint32_t TSSSR;      /*!< RTC time-stamp sub second register,                        Address offset: 0x38 */
+  __IO uint32_t CALR;       /*!< RTC calibration register,                                  Address offset: 0x3C */
+  __IO uint32_t TAMPCR;     /*!< RTC tamper configuration register,                         Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;   /*!< RTC alarm A sub second register,                           Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;   /*!< RTC alarm B sub second register,                           Address offset: 0x48 */
+  __IO uint32_t OR;         /*!< RTC option register,                                       Address offset: 0x4C */
+  __IO uint32_t BKP0R;      /*!< RTC backup register 0,                                     Address offset: 0x50 */
+  __IO uint32_t BKP1R;      /*!< RTC backup register 1,                                     Address offset: 0x54 */
+  __IO uint32_t BKP2R;      /*!< RTC backup register 2,                                     Address offset: 0x58 */
+  __IO uint32_t BKP3R;      /*!< RTC backup register 3,                                     Address offset: 0x5C */
+  __IO uint32_t BKP4R;      /*!< RTC backup register 4,                                     Address offset: 0x60 */
+  __IO uint32_t BKP5R;      /*!< RTC backup register 5,                                     Address offset: 0x64 */
+  __IO uint32_t BKP6R;      /*!< RTC backup register 6,                                     Address offset: 0x68 */
+  __IO uint32_t BKP7R;      /*!< RTC backup register 7,                                     Address offset: 0x6C */
+  __IO uint32_t BKP8R;      /*!< RTC backup register 8,                                     Address offset: 0x70 */
+  __IO uint32_t BKP9R;      /*!< RTC backup register 9,                                     Address offset: 0x74 */
+  __IO uint32_t BKP10R;     /*!< RTC backup register 10,                                    Address offset: 0x78 */
+  __IO uint32_t BKP11R;     /*!< RTC backup register 11,                                    Address offset: 0x7C */
+  __IO uint32_t BKP12R;     /*!< RTC backup register 12,                                    Address offset: 0x80 */
+  __IO uint32_t BKP13R;     /*!< RTC backup register 13,                                    Address offset: 0x84 */
+  __IO uint32_t BKP14R;     /*!< RTC backup register 14,                                    Address offset: 0x88 */
+  __IO uint32_t BKP15R;     /*!< RTC backup register 15,                                    Address offset: 0x8C */
+  __IO uint32_t BKP16R;     /*!< RTC backup register 16,                                    Address offset: 0x90 */
+  __IO uint32_t BKP17R;     /*!< RTC backup register 17,                                    Address offset: 0x94 */
+  __IO uint32_t BKP18R;     /*!< RTC backup register 18,                                    Address offset: 0x98 */
+  __IO uint32_t BKP19R;     /*!< RTC backup register 19,                                    Address offset: 0x9C */
+  __IO uint32_t BKP20R;     /*!< RTC backup register 20,                                    Address offset: 0xA0 */
+  __IO uint32_t BKP21R;     /*!< RTC backup register 21,                                    Address offset: 0xA4 */
+  __IO uint32_t BKP22R;     /*!< RTC backup register 22,                                    Address offset: 0xA8 */
+  __IO uint32_t BKP23R;     /*!< RTC backup register 23,                                    Address offset: 0xAC */
+  __IO uint32_t BKP24R;     /*!< RTC backup register 24,                                    Address offset: 0xB0 */
+  __IO uint32_t BKP25R;     /*!< RTC backup register 25,                                    Address offset: 0xB4 */
+  __IO uint32_t BKP26R;     /*!< RTC backup register 26,                                    Address offset: 0xB8 */
+  __IO uint32_t BKP27R;     /*!< RTC backup register 27,                                    Address offset: 0xBC */
+  __IO uint32_t BKP28R;     /*!< RTC backup register 28,                                    Address offset: 0xC0 */
+  __IO uint32_t BKP29R;     /*!< RTC backup register 29,                                    Address offset: 0xC4 */
+  __IO uint32_t BKP30R;     /*!< RTC backup register 30,                                    Address offset: 0xC8 */
+  __IO uint32_t BKP31R;     /*!< RTC backup register 31,                                    Address offset: 0xCC */
+} RTC_TypeDef;
+
+
+/**
+  * @brief Serial Audio Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
+} SAI_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
+  __IO uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
+  __IO uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
+  __IO uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
+  __IO uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
+  __IO uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
+  __IO uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
+} SAI_Block_TypeDef;
+
+/**
+  * @brief SPDIF-RX Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t   CR;           /*!< Control register,                   Address offset: 0x00 */
+  __IO uint32_t   IMR;          /*!< Interrupt mask register,            Address offset: 0x04 */
+  __IO uint32_t   SR;           /*!< Status register,                    Address offset: 0x08 */
+  __IO uint32_t   IFCR;         /*!< Interrupt Flag Clear register,      Address offset: 0x0C */
+  __IO uint32_t   DR;           /*!< Data input register,                Address offset: 0x10 */
+  __IO uint32_t   CSR;          /*!< Channel Status register,            Address offset: 0x14 */
+  __IO uint32_t   DIR;          /*!< Debug Information register,         Address offset: 0x18 */
+} SPDIFRX_TypeDef;
+
+
+/**
+  * @brief SD host Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t POWER;          /*!< SDMMC power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;          /*!< SDMMClock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;            /*!< SDMMC argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;            /*!< SDMMC command register,          Address offset: 0x0C */
+  __I uint32_t  RESPCMD;        /*!< SDMMC command response register, Address offset: 0x10 */
+  __I uint32_t  RESP1;          /*!< SDMMC response 1 register,       Address offset: 0x14 */
+  __I uint32_t  RESP2;          /*!< SDMMC response 2 register,       Address offset: 0x18 */
+  __I uint32_t  RESP3;          /*!< SDMMC response 3 register,       Address offset: 0x1C */
+  __I uint32_t  RESP4;          /*!< SDMMC response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;         /*!< SDMMC data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;           /*!< SDMMC data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;          /*!< SDMMC data control register,     Address offset: 0x2C */
+  __I uint32_t  DCOUNT;         /*!< SDMMC data counter register,     Address offset: 0x30 */
+  __I uint32_t  STA;            /*!< SDMMC status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;            /*!< SDMMC interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;           /*!< SDMMC mask register,             Address offset: 0x3C */
+  uint32_t      RESERVED0[2];   /*!< Reserved, 0x40-0x44                                  */
+  __I uint32_t  FIFOCNT;        /*!< SDMMC FIFO counter register,     Address offset: 0x48 */
+  uint32_t      RESERVED1[13];  /*!< Reserved, 0x4C-0x7C                                  */
+  __IO uint32_t FIFO;           /*!< SDMMC data FIFO register,        Address offset: 0x80 */
+} SDMMC_TypeDef;
+
+/**
+  * @brief Serial Peripheral Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+} SPI_TypeDef;
+
+/**
+  * @brief QUAD Serial Peripheral Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
+  __IO uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
+  __IO uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
+  __IO uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
+  __IO uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
+  __IO uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
+  __IO uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
+  __IO uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
+  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
+  __IO uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
+  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
+} QUADSPI_TypeDef;
+
+/**
+  * @brief TIM
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CCMR3;       /*!< TIM capture/compare mode register 3,      Address offset: 0x54 */
+  __IO uint32_t CCR5;        /*!< TIM capture/compare mode register5,       Address offset: 0x58 */
+  __IO uint32_t CCR6;        /*!< TIM capture/compare mode register6,       Address offset: 0x5C */
+
+} TIM_TypeDef;
+
+/**
+  * @brief LPTIMIMER
+  */
+typedef struct
+{
+  __IO uint32_t ISR;      /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;      /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;      /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;     /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;      /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;      /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;      /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t OR;       /*!< LPTIM Option register,                              Address offset: 0x20 */
+} LPTIM_TypeDef;
+
+
+/**
+  * @brief Universal Synchronous Asynchronous Receiver Transmitter
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;    /*!< USART Control register 1,                 Address offset: 0x00 */
+  __IO uint32_t CR2;    /*!< USART Control register 2,                 Address offset: 0x04 */
+  __IO uint32_t CR3;    /*!< USART Control register 3,                 Address offset: 0x08 */
+  __IO uint32_t BRR;    /*!< USART Baud rate register,                 Address offset: 0x0C */
+  __IO uint32_t GTPR;   /*!< USART Guard time and prescaler register,  Address offset: 0x10 */
+  __IO uint32_t RTOR;   /*!< USART Receiver Time Out register,         Address offset: 0x14 */
+  __IO uint32_t RQR;    /*!< USART Request register,                   Address offset: 0x18 */
+  __IO uint32_t ISR;    /*!< USART Interrupt and status register,      Address offset: 0x1C */
+  __IO uint32_t ICR;    /*!< USART Interrupt flag Clear register,      Address offset: 0x20 */
+  __IO uint32_t RDR;    /*!< USART Receive Data register,              Address offset: 0x24 */
+  __IO uint32_t TDR;    /*!< USART Transmit Data register,             Address offset: 0x28 */
+} USART_TypeDef;
+
+
+/**
+  * @brief Window WATCHDOG
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+} WWDG_TypeDef;
+
+/**
+  * @brief RNG
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+} RNG_TypeDef;
+
+/**
+  * @}
+  */
+
+/**
+  * @brief USB_OTG_Core_Registers
+  */
+typedef struct
+{
+ __IO uint32_t GOTGCTL;               /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  uint32_t Reserved30[2];             /*!< Reserved                                     030h */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
+  uint32_t  Reserved5[3];             /*!< Reserved                                040h-048h */
+  __IO uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
+  uint32_t  Reserved6;                /*!< Reserved                                     050h */
+  __IO uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
+  __IO uint32_t GPWRDN;               /*!< Power Down Register                          058h */
+  __IO uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
+   __IO uint32_t GADPCTL;             /*!< ADP Timer, Control and Status Register       60Ch */
+    uint32_t  Reserved43[39];         /*!< Reserved                                058h-0FFh */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO */
+} USB_OTG_GlobalTypeDef;
+
+
+/**
+  * @brief USB_OTG_device_Registers
+  */
+typedef struct
+{
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  uint32_t Reserved0C;           /*!< Reserved                     80Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  uint32_t  Reserved20;          /*!< Reserved                     820h */
+  uint32_t Reserved9;            /*!< Reserved                     824h */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  uint32_t Reserved40;           /*!< dedicated EP mask            840h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+} USB_OTG_DeviceTypeDef;
+
+
+/**
+  * @brief USB_OTG_IN_Endpoint-Specific_Register
+  */
+typedef struct
+{
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
+} USB_OTG_INEndpointTypeDef;
+
+
+/**
+  * @brief USB_OTG_OUT_Endpoint-Specific_Registers
+  */
+typedef struct
+{
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
+} USB_OTG_OUTEndpointTypeDef;
+
+
+/**
+  * @brief USB_OTG_Host_Mode_Register_Structures
+  */
+typedef struct
+{
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  uint32_t Reserved40C;           /*!< Reserved                             40Ch */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+} USB_OTG_HostTypeDef;
+
+/**
+  * @brief USB_OTG_Host_Channel_Specific_Registers
+  */
+typedef struct
+{
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  uint32_t Reserved[2];           /*!< Reserved                                      */
+} USB_OTG_HostChannelTypeDef;
+/**
+  * @}
+  */
+
+
+/** @addtogroup Peripheral_memory_map
+  * @{
+  */
+#define RAMITCM_BASE           ((uint32_t)0x00000000) /*!< Base address of :16KB RAM reserved for CPU execution/instruction accessible over ITCM   */
+#define FLASHITCM_BASE         ((uint32_t)0x00200000) /*!< Base address of :(up to 1 MB) embedded FLASH memory  accessible over ITCM               */
+#define FLASHAXI_BASE          ((uint32_t)0x08000000) /*!< Base address of : (up to 1 MB) embedded FLASH memory accessible over AXI                */
+#define RAMDTCM_BASE           ((uint32_t)0x20000000) /*!< Base address of : 64KB system data RAM accessible over DTCM                             */
+#define SRAM1_BASE             ((uint32_t)0x20010000) /*!< Base address of : 240KB RAM1 accessible over AXI/AHB                                    */
+#define SRAM2_BASE             ((uint32_t)0x2004C000) /*!< Base address of : 16KB RAM2 accessible over AXI/AHB                                     */
+#define PERIPH_BASE            ((uint32_t)0x40000000) /*!< Base address of : AHB/ABP Peripherals                                                   */
+#define BKPSRAM_BASE           ((uint32_t)0x40024000) /*!< Base address of : Backup SRAM(4 KB)                                                     */
+#define QSPI_BASE              ((uint32_t)0x90000000) /*!< Base address of : QSPI memories  accessible over AXI                                    */
+#define FMC_R_BASE             ((uint32_t)0xA0000000) /*!< Base address of : FMC Control registers                                                 */
+#define QSPI_R_BASE            ((uint32_t)0xA0001000) /*!< Base address of : QSPI Control  registers                                               */
+#define FLASH_END              ((uint32_t)0x080FFFFF) /*!< FLASH end address */
+
+/* Legacy define */
+#define FLASH_BASE     FLASHAXI_BASE
+
+/*!< Peripheral memory map */
+#define APB1PERIPH_BASE        PERIPH_BASE
+#define APB2PERIPH_BASE       (PERIPH_BASE + 0x00010000)
+#define AHB1PERIPH_BASE       (PERIPH_BASE + 0x00020000)
+#define AHB2PERIPH_BASE       (PERIPH_BASE + 0x10000000)
+
+/*!< APB1 peripherals */
+#define TIM2_BASE             (APB1PERIPH_BASE + 0x0000)
+#define TIM3_BASE             (APB1PERIPH_BASE + 0x0400)
+#define TIM4_BASE             (APB1PERIPH_BASE + 0x0800)
+#define TIM5_BASE             (APB1PERIPH_BASE + 0x0C00)
+#define TIM6_BASE             (APB1PERIPH_BASE + 0x1000)
+#define TIM7_BASE             (APB1PERIPH_BASE + 0x1400)
+#define TIM12_BASE            (APB1PERIPH_BASE + 0x1800)
+#define TIM13_BASE            (APB1PERIPH_BASE + 0x1C00)
+#define TIM14_BASE            (APB1PERIPH_BASE + 0x2000)
+#define LPTIM1_BASE           (APB1PERIPH_BASE + 0x2400)
+#define RTC_BASE              (APB1PERIPH_BASE + 0x2800)
+#define WWDG_BASE             (APB1PERIPH_BASE + 0x2C00)
+#define IWDG_BASE             (APB1PERIPH_BASE + 0x3000)
+#define SPI2_BASE             (APB1PERIPH_BASE + 0x3800)
+#define SPI3_BASE             (APB1PERIPH_BASE + 0x3C00)
+#define SPDIFRX_BASE          (APB1PERIPH_BASE + 0x4000)
+#define USART2_BASE           (APB1PERIPH_BASE + 0x4400)
+#define USART3_BASE           (APB1PERIPH_BASE + 0x4800)
+#define UART4_BASE            (APB1PERIPH_BASE + 0x4C00)
+#define UART5_BASE            (APB1PERIPH_BASE + 0x5000)
+#define I2C1_BASE             (APB1PERIPH_BASE + 0x5400)
+#define I2C2_BASE             (APB1PERIPH_BASE + 0x5800)
+#define I2C3_BASE             (APB1PERIPH_BASE + 0x5C00)
+#define I2C4_BASE             (APB1PERIPH_BASE + 0x6000)
+#define CAN1_BASE             (APB1PERIPH_BASE + 0x6400)
+#define CAN2_BASE             (APB1PERIPH_BASE + 0x6800)
+#define CEC_BASE              (APB1PERIPH_BASE + 0x6C00)
+#define PWR_BASE              (APB1PERIPH_BASE + 0x7000)
+#define DAC_BASE              (APB1PERIPH_BASE + 0x7400)
+#define UART7_BASE            (APB1PERIPH_BASE + 0x7800)
+#define UART8_BASE            (APB1PERIPH_BASE + 0x7C00)
+
+/*!< APB2 peripherals */
+#define TIM1_BASE             (APB2PERIPH_BASE + 0x0000)
+#define TIM8_BASE             (APB2PERIPH_BASE + 0x0400)
+#define USART1_BASE           (APB2PERIPH_BASE + 0x1000)
+#define USART6_BASE           (APB2PERIPH_BASE + 0x1400)
+#define ADC1_BASE             (APB2PERIPH_BASE + 0x2000)
+#define ADC2_BASE             (APB2PERIPH_BASE + 0x2100)
+#define ADC3_BASE             (APB2PERIPH_BASE + 0x2200)
+#define ADC_BASE              (APB2PERIPH_BASE + 0x2300)
+#define SDMMC1_BASE           (APB2PERIPH_BASE + 0x2C00)
+#define SPI1_BASE             (APB2PERIPH_BASE + 0x3000)
+#define SPI4_BASE             (APB2PERIPH_BASE + 0x3400)
+#define SYSCFG_BASE           (APB2PERIPH_BASE + 0x3800)
+#define EXTI_BASE             (APB2PERIPH_BASE + 0x3C00)
+#define TIM9_BASE             (APB2PERIPH_BASE + 0x4000)
+#define TIM10_BASE            (APB2PERIPH_BASE + 0x4400)
+#define TIM11_BASE            (APB2PERIPH_BASE + 0x4800)
+#define SPI5_BASE             (APB2PERIPH_BASE + 0x5000)
+#define SPI6_BASE             (APB2PERIPH_BASE + 0x5400)
+#define SAI1_BASE             (APB2PERIPH_BASE + 0x5800)
+#define SAI2_BASE             (APB2PERIPH_BASE + 0x5C00)
+#define SAI1_Block_A_BASE     (SAI1_BASE + 0x004)
+#define SAI1_Block_B_BASE     (SAI1_BASE + 0x024)
+#define SAI2_Block_A_BASE     (SAI2_BASE + 0x004)
+#define SAI2_Block_B_BASE     (SAI2_BASE + 0x024)
+/*!< AHB1 peripherals */
+#define GPIOA_BASE            (AHB1PERIPH_BASE + 0x0000)
+#define GPIOB_BASE            (AHB1PERIPH_BASE + 0x0400)
+#define GPIOC_BASE            (AHB1PERIPH_BASE + 0x0800)
+#define GPIOD_BASE            (AHB1PERIPH_BASE + 0x0C00)
+#define GPIOE_BASE            (AHB1PERIPH_BASE + 0x1000)
+#define GPIOF_BASE            (AHB1PERIPH_BASE + 0x1400)
+#define GPIOG_BASE            (AHB1PERIPH_BASE + 0x1800)
+#define GPIOH_BASE            (AHB1PERIPH_BASE + 0x1C00)
+#define GPIOI_BASE            (AHB1PERIPH_BASE + 0x2000)
+#define GPIOJ_BASE            (AHB1PERIPH_BASE + 0x2400)
+#define GPIOK_BASE            (AHB1PERIPH_BASE + 0x2800)
+#define CRC_BASE              (AHB1PERIPH_BASE + 0x3000)
+#define RCC_BASE              (AHB1PERIPH_BASE + 0x3800)
+#define FLASH_R_BASE          (AHB1PERIPH_BASE + 0x3C00)
+#define DMA1_BASE             (AHB1PERIPH_BASE + 0x6000)
+#define DMA1_Stream0_BASE     (DMA1_BASE + 0x010)
+#define DMA1_Stream1_BASE     (DMA1_BASE + 0x028)
+#define DMA1_Stream2_BASE     (DMA1_BASE + 0x040)
+#define DMA1_Stream3_BASE     (DMA1_BASE + 0x058)
+#define DMA1_Stream4_BASE     (DMA1_BASE + 0x070)
+#define DMA1_Stream5_BASE     (DMA1_BASE + 0x088)
+#define DMA1_Stream6_BASE     (DMA1_BASE + 0x0A0)
+#define DMA1_Stream7_BASE     (DMA1_BASE + 0x0B8)
+#define DMA2_BASE             (AHB1PERIPH_BASE + 0x6400)
+#define DMA2_Stream0_BASE     (DMA2_BASE + 0x010)
+#define DMA2_Stream1_BASE     (DMA2_BASE + 0x028)
+#define DMA2_Stream2_BASE     (DMA2_BASE + 0x040)
+#define DMA2_Stream3_BASE     (DMA2_BASE + 0x058)
+#define DMA2_Stream4_BASE     (DMA2_BASE + 0x070)
+#define DMA2_Stream5_BASE     (DMA2_BASE + 0x088)
+#define DMA2_Stream6_BASE     (DMA2_BASE + 0x0A0)
+#define DMA2_Stream7_BASE     (DMA2_BASE + 0x0B8)
+#define ETH_BASE              (AHB1PERIPH_BASE + 0x8000)
+#define ETH_MAC_BASE          (ETH_BASE)
+#define ETH_MMC_BASE          (ETH_BASE + 0x0100)
+#define ETH_PTP_BASE          (ETH_BASE + 0x0700)
+#define ETH_DMA_BASE          (ETH_BASE + 0x1000)
+#define DMA2D_BASE            (AHB1PERIPH_BASE + 0xB000)
+/*!< AHB2 peripherals */
+#define DCMI_BASE             (AHB2PERIPH_BASE + 0x50000)
+#define RNG_BASE              (AHB2PERIPH_BASE + 0x60800)
+/*!< FMC Bankx registers base address */
+#define FMC_Bank1_R_BASE      (FMC_R_BASE + 0x0000)
+#define FMC_Bank1E_R_BASE     (FMC_R_BASE + 0x0104)
+#define FMC_Bank3_R_BASE      (FMC_R_BASE + 0x0080)
+#define FMC_Bank5_6_R_BASE    (FMC_R_BASE + 0x0140)
+
+/* Debug MCU registers base address */
+#define DBGMCU_BASE           ((uint32_t )0xE0042000)
+
+/*!< USB registers base address */
+#define USB_OTG_HS_PERIPH_BASE               ((uint32_t )0x40040000)
+#define USB_OTG_FS_PERIPH_BASE               ((uint32_t )0x50000000)
+
+#define USB_OTG_GLOBAL_BASE                  ((uint32_t )0x000)
+#define USB_OTG_DEVICE_BASE                  ((uint32_t )0x800)
+#define USB_OTG_IN_ENDPOINT_BASE             ((uint32_t )0x900)
+#define USB_OTG_OUT_ENDPOINT_BASE            ((uint32_t )0xB00)
+#define USB_OTG_EP_REG_SIZE                  ((uint32_t )0x20)
+#define USB_OTG_HOST_BASE                    ((uint32_t )0x400)
+#define USB_OTG_HOST_PORT_BASE               ((uint32_t )0x440)
+#define USB_OTG_HOST_CHANNEL_BASE            ((uint32_t )0x500)
+#define USB_OTG_HOST_CHANNEL_SIZE            ((uint32_t )0x20)
+#define USB_OTG_PCGCCTL_BASE                 ((uint32_t )0xE00)
+#define USB_OTG_FIFO_BASE                    ((uint32_t )0x1000)
+#define USB_OTG_FIFO_SIZE                    ((uint32_t )0x1000)
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_declaration
+  * @{
+  */
+#define TIM2                ((TIM_TypeDef *) TIM2_BASE)
+#define TIM3                ((TIM_TypeDef *) TIM3_BASE)
+#define TIM4                ((TIM_TypeDef *) TIM4_BASE)
+#define TIM5                ((TIM_TypeDef *) TIM5_BASE)
+#define TIM6                ((TIM_TypeDef *) TIM6_BASE)
+#define TIM7                ((TIM_TypeDef *) TIM7_BASE)
+#define TIM12               ((TIM_TypeDef *) TIM12_BASE)
+#define TIM13               ((TIM_TypeDef *) TIM13_BASE)
+#define TIM14               ((TIM_TypeDef *) TIM14_BASE)
+#define LPTIM1              ((LPTIM_TypeDef *) LPTIM1_BASE)
+#define RTC                 ((RTC_TypeDef *) RTC_BASE)
+#define WWDG                ((WWDG_TypeDef *) WWDG_BASE)
+#define IWDG                ((IWDG_TypeDef *) IWDG_BASE)
+#define SPI2                ((SPI_TypeDef *) SPI2_BASE)
+#define SPI3                ((SPI_TypeDef *) SPI3_BASE)
+#define SPDIFRX             ((SPDIFRX_TypeDef *) SPDIFRX_BASE)
+#define USART2              ((USART_TypeDef *) USART2_BASE)
+#define USART3              ((USART_TypeDef *) USART3_BASE)
+#define UART4               ((USART_TypeDef *) UART4_BASE)
+#define UART5               ((USART_TypeDef *) UART5_BASE)
+#define I2C1                ((I2C_TypeDef *) I2C1_BASE)
+#define I2C2                ((I2C_TypeDef *) I2C2_BASE)
+#define I2C3                ((I2C_TypeDef *) I2C3_BASE)
+#define I2C4                ((I2C_TypeDef *) I2C4_BASE)
+#define CAN1                ((CAN_TypeDef *) CAN1_BASE)
+#define CAN2                ((CAN_TypeDef *) CAN2_BASE)
+#define CEC                 ((CEC_TypeDef *) CEC_BASE)
+#define PWR                 ((PWR_TypeDef *) PWR_BASE)
+#define DAC                 ((DAC_TypeDef *) DAC_BASE)
+#define UART7               ((USART_TypeDef *) UART7_BASE)
+#define UART8               ((USART_TypeDef *) UART8_BASE)
+#define TIM1                ((TIM_TypeDef *) TIM1_BASE)
+#define TIM8                ((TIM_TypeDef *) TIM8_BASE)
+#define USART1              ((USART_TypeDef *) USART1_BASE)
+#define USART6              ((USART_TypeDef *) USART6_BASE)
+#define ADC                 ((ADC_Common_TypeDef *) ADC_BASE)
+#define ADC1                ((ADC_TypeDef *) ADC1_BASE)
+#define ADC2                ((ADC_TypeDef *) ADC2_BASE)
+#define ADC3                ((ADC_TypeDef *) ADC3_BASE)
+#define SDMMC1              ((SDMMC_TypeDef *) SDMMC1_BASE)
+#define SPI1                ((SPI_TypeDef *) SPI1_BASE)
+#define SPI4                ((SPI_TypeDef *) SPI4_BASE)
+#define SYSCFG              ((SYSCFG_TypeDef *) SYSCFG_BASE)
+#define EXTI                ((EXTI_TypeDef *) EXTI_BASE)
+#define TIM9                ((TIM_TypeDef *) TIM9_BASE)
+#define TIM10               ((TIM_TypeDef *) TIM10_BASE)
+#define TIM11               ((TIM_TypeDef *) TIM11_BASE)
+#define SPI5                ((SPI_TypeDef *) SPI5_BASE)
+#define SPI6                ((SPI_TypeDef *) SPI6_BASE)
+#define SAI1                ((SAI_TypeDef *) SAI1_BASE)
+#define SAI2                ((SAI_TypeDef *) SAI2_BASE)
+#define SAI1_Block_A        ((SAI_Block_TypeDef *)SAI1_Block_A_BASE)
+#define SAI1_Block_B        ((SAI_Block_TypeDef *)SAI1_Block_B_BASE)
+#define SAI2_Block_A        ((SAI_Block_TypeDef *)SAI2_Block_A_BASE)
+#define SAI2_Block_B        ((SAI_Block_TypeDef *)SAI2_Block_B_BASE)
+#define GPIOA               ((GPIO_TypeDef *) GPIOA_BASE)
+#define GPIOB               ((GPIO_TypeDef *) GPIOB_BASE)
+#define GPIOC               ((GPIO_TypeDef *) GPIOC_BASE)
+#define GPIOD               ((GPIO_TypeDef *) GPIOD_BASE)
+#define GPIOE               ((GPIO_TypeDef *) GPIOE_BASE)
+#define GPIOF               ((GPIO_TypeDef *) GPIOF_BASE)
+#define GPIOG               ((GPIO_TypeDef *) GPIOG_BASE)
+#define GPIOH               ((GPIO_TypeDef *) GPIOH_BASE)
+#define GPIOI               ((GPIO_TypeDef *) GPIOI_BASE)
+#define GPIOJ               ((GPIO_TypeDef *) GPIOJ_BASE)
+#define GPIOK               ((GPIO_TypeDef *) GPIOK_BASE)
+#define CRC                 ((CRC_TypeDef *) CRC_BASE)
+#define RCC                 ((RCC_TypeDef *) RCC_BASE)
+#define FLASH               ((FLASH_TypeDef *) FLASH_R_BASE)
+#define DMA1                ((DMA_TypeDef *) DMA1_BASE)
+#define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
+#define DMA1_Stream1        ((DMA_Stream_TypeDef *) DMA1_Stream1_BASE)
+#define DMA1_Stream2        ((DMA_Stream_TypeDef *) DMA1_Stream2_BASE)
+#define DMA1_Stream3        ((DMA_Stream_TypeDef *) DMA1_Stream3_BASE)
+#define DMA1_Stream4        ((DMA_Stream_TypeDef *) DMA1_Stream4_BASE)
+#define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
+#define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
+#define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
+#define DMA2                ((DMA_TypeDef *) DMA2_BASE)
+#define DMA2_Stream0        ((DMA_Stream_TypeDef *) DMA2_Stream0_BASE)
+#define DMA2_Stream1        ((DMA_Stream_TypeDef *) DMA2_Stream1_BASE)
+#define DMA2_Stream2        ((DMA_Stream_TypeDef *) DMA2_Stream2_BASE)
+#define DMA2_Stream3        ((DMA_Stream_TypeDef *) DMA2_Stream3_BASE)
+#define DMA2_Stream4        ((DMA_Stream_TypeDef *) DMA2_Stream4_BASE)
+#define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
+#define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
+#define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define ETH                 ((ETH_TypeDef *) ETH_BASE)
+#define DMA2D               ((DMA2D_TypeDef *)DMA2D_BASE)
+#define DCMI                ((DCMI_TypeDef *) DCMI_BASE)
+#define RNG                 ((RNG_TypeDef *) RNG_BASE)
+#define FMC_Bank1           ((FMC_Bank1_TypeDef *) FMC_Bank1_R_BASE)
+#define FMC_Bank1E          ((FMC_Bank1E_TypeDef *) FMC_Bank1E_R_BASE)
+#define FMC_Bank3           ((FMC_Bank3_TypeDef *) FMC_Bank3_R_BASE)
+#define FMC_Bank5_6         ((FMC_Bank5_6_TypeDef *) FMC_Bank5_6_R_BASE)
+#define QUADSPI             ((QUADSPI_TypeDef *) QSPI_R_BASE)
+#define DBGMCU              ((DBGMCU_TypeDef *) DBGMCU_BASE)
+#define USB_OTG_FS          ((USB_OTG_GlobalTypeDef *) USB_OTG_FS_PERIPH_BASE)
+#define USB_OTG_HS          ((USB_OTG_GlobalTypeDef *) USB_OTG_HS_PERIPH_BASE)
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_constants
+  * @{
+  */
+
+  /** @addtogroup Peripheral_Registers_Bits_Definition
+  * @{
+  */
+
+/******************************************************************************/
+/*                         Peripheral Registers_Bits_Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Analog to Digital Converter                         */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for ADC_SR register  ********************/
+#define  ADC_SR_AWD                          ((uint32_t)0x00000001)        /*!<Analog watchdog flag                                 */
+#define  ADC_SR_EOC                          ((uint32_t)0x00000002)        /*!<End of conversion                                    */
+#define  ADC_SR_JEOC                         ((uint32_t)0x00000004)        /*!<Injected channel end of conversion                   */
+#define  ADC_SR_JSTRT                        ((uint32_t)0x00000008)        /*!<Injected channel Start flag                          */
+#define  ADC_SR_STRT                         ((uint32_t)0x00000010)        /*!<Regular channel Start flag                           */
+#define  ADC_SR_OVR                          ((uint32_t)0x00000020)        /*!<Overrun flag                                         */
+
+/*******************  Bit definition for ADC_CR1 register  ********************/
+#define  ADC_CR1_AWDCH                       ((uint32_t)0x0000001F)        /*!<AWDCH[4:0] bits (Analog watchdog channel select bits) */
+#define  ADC_CR1_AWDCH_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_CR1_AWDCH_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_CR1_AWDCH_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_CR1_AWDCH_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_CR1_AWDCH_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_CR1_EOCIE                       ((uint32_t)0x00000020)        /*!<Interrupt enable for EOC                             */
+#define  ADC_CR1_AWDIE                       ((uint32_t)0x00000040)        /*!<AAnalog Watchdog interrupt enable                    */
+#define  ADC_CR1_JEOCIE                      ((uint32_t)0x00000080)        /*!<Interrupt enable for injected channels               */
+#define  ADC_CR1_SCAN                        ((uint32_t)0x00000100)        /*!<Scan mode */
+#define  ADC_CR1_AWDSGL                      ((uint32_t)0x00000200)        /*!<Enable the watchdog on a single channel in scan mode */
+#define  ADC_CR1_JAUTO                       ((uint32_t)0x00000400)        /*!<Automatic injected group conversion                  */
+#define  ADC_CR1_DISCEN                      ((uint32_t)0x00000800)        /*!<Discontinuous mode on regular channels               */
+#define  ADC_CR1_JDISCEN                     ((uint32_t)0x00001000)        /*!<Discontinuous mode on injected channels              */
+#define  ADC_CR1_DISCNUM                     ((uint32_t)0x0000E000)        /*!<DISCNUM[2:0] bits (Discontinuous mode channel count) */
+#define  ADC_CR1_DISCNUM_0                   ((uint32_t)0x00002000)        /*!<Bit 0 */
+#define  ADC_CR1_DISCNUM_1                   ((uint32_t)0x00004000)        /*!<Bit 1 */
+#define  ADC_CR1_DISCNUM_2                   ((uint32_t)0x00008000)        /*!<Bit 2 */
+#define  ADC_CR1_JAWDEN                      ((uint32_t)0x00400000)        /*!<Analog watchdog enable on injected channels          */
+#define  ADC_CR1_AWDEN                       ((uint32_t)0x00800000)        /*!<Analog watchdog enable on regular channels           */
+#define  ADC_CR1_RES                         ((uint32_t)0x03000000)        /*!<RES[2:0] bits (Resolution)                           */
+#define  ADC_CR1_RES_0                       ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  ADC_CR1_RES_1                       ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  ADC_CR1_OVRIE                       ((uint32_t)0x04000000)         /*!<overrun interrupt enable */
+
+/*******************  Bit definition for ADC_CR2 register  ********************/
+#define  ADC_CR2_ADON                        ((uint32_t)0x00000001)        /*!<A/D Converter ON / OFF                                       */
+#define  ADC_CR2_CONT                        ((uint32_t)0x00000002)        /*!<Continuous Conversion                                        */
+#define  ADC_CR2_DMA                         ((uint32_t)0x00000100)        /*!<Direct Memory access mode                                    */
+#define  ADC_CR2_DDS                         ((uint32_t)0x00000200)        /*!<DMA disable selection (Single ADC)                           */
+#define  ADC_CR2_EOCS                        ((uint32_t)0x00000400)        /*!<End of conversion selection                                  */
+#define  ADC_CR2_ALIGN                       ((uint32_t)0x00000800)        /*!<Data Alignment                                               */
+#define  ADC_CR2_JEXTSEL                     ((uint32_t)0x000F0000)        /*!<JEXTSEL[3:0] bits (External event select for injected group) */
+#define  ADC_CR2_JEXTSEL_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  ADC_CR2_JEXTSEL_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  ADC_CR2_JEXTSEL_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  ADC_CR2_JEXTSEL_3                   ((uint32_t)0x00080000)        /*!<Bit 3 */
+#define  ADC_CR2_JEXTEN                      ((uint32_t)0x00300000)        /*!<JEXTEN[1:0] bits (External Trigger Conversion mode for injected channelsp) */
+#define  ADC_CR2_JEXTEN_0                    ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_CR2_JEXTEN_1                    ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  ADC_CR2_JSWSTART                    ((uint32_t)0x00400000)        /*!<Start Conversion of injected channels */
+#define  ADC_CR2_EXTSEL                      ((uint32_t)0x0F000000)        /*!<EXTSEL[3:0] bits (External Event Select for regular group) */
+#define  ADC_CR2_EXTSEL_0                    ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  ADC_CR2_EXTSEL_1                    ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  ADC_CR2_EXTSEL_2                    ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  ADC_CR2_EXTSEL_3                    ((uint32_t)0x08000000)        /*!<Bit 3 */
+#define  ADC_CR2_EXTEN                       ((uint32_t)0x30000000)        /*!<EXTEN[1:0] bits (External Trigger Conversion mode for regular channelsp) */
+#define  ADC_CR2_EXTEN_0                     ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  ADC_CR2_EXTEN_1                     ((uint32_t)0x20000000)        /*!<Bit 1 */
+#define  ADC_CR2_SWSTART                     ((uint32_t)0x40000000)        /*!<Start Conversion of regular channels */
+
+/******************  Bit definition for ADC_SMPR1 register  *******************/
+#define  ADC_SMPR1_SMP10                     ((uint32_t)0x00000007)        /*!<SMP10[2:0] bits (Channel 10 Sample time selection) */
+#define  ADC_SMPR1_SMP10_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP10_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP10_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP11                     ((uint32_t)0x00000038)        /*!<SMP11[2:0] bits (Channel 11 Sample time selection) */
+#define  ADC_SMPR1_SMP11_0                   ((uint32_t)0x00000008)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP11_1                   ((uint32_t)0x00000010)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP11_2                   ((uint32_t)0x00000020)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP12                     ((uint32_t)0x000001C0)        /*!<SMP12[2:0] bits (Channel 12 Sample time selection) */
+#define  ADC_SMPR1_SMP12_0                   ((uint32_t)0x00000040)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP12_1                   ((uint32_t)0x00000080)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP12_2                   ((uint32_t)0x00000100)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP13                     ((uint32_t)0x00000E00)        /*!<SMP13[2:0] bits (Channel 13 Sample time selection) */
+#define  ADC_SMPR1_SMP13_0                   ((uint32_t)0x00000200)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP13_1                   ((uint32_t)0x00000400)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP13_2                   ((uint32_t)0x00000800)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP14                     ((uint32_t)0x00007000)        /*!<SMP14[2:0] bits (Channel 14 Sample time selection) */
+#define  ADC_SMPR1_SMP14_0                   ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP14_1                   ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP14_2                   ((uint32_t)0x00004000)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP15                     ((uint32_t)0x00038000)        /*!<SMP15[2:0] bits (Channel 15 Sample time selection) */
+#define  ADC_SMPR1_SMP15_0                   ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP15_1                   ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP15_2                   ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP16                     ((uint32_t)0x001C0000)        /*!<SMP16[2:0] bits (Channel 16 Sample time selection) */
+#define  ADC_SMPR1_SMP16_0                   ((uint32_t)0x00040000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP16_1                   ((uint32_t)0x00080000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP16_2                   ((uint32_t)0x00100000)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP17                     ((uint32_t)0x00E00000)        /*!<SMP17[2:0] bits (Channel 17 Sample time selection) */
+#define  ADC_SMPR1_SMP17_0                   ((uint32_t)0x00200000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP17_1                   ((uint32_t)0x00400000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP17_2                   ((uint32_t)0x00800000)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP18                     ((uint32_t)0x07000000)        /*!<SMP18[2:0] bits (Channel 18 Sample time selection) */
+#define  ADC_SMPR1_SMP18_0                   ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP18_1                   ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP18_2                   ((uint32_t)0x04000000)        /*!<Bit 2 */
+
+/******************  Bit definition for ADC_SMPR2 register  *******************/
+#define  ADC_SMPR2_SMP0                      ((uint32_t)0x00000007)        /*!<SMP0[2:0] bits (Channel 0 Sample time selection) */
+#define  ADC_SMPR2_SMP0_0                    ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP0_1                    ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP0_2                    ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP1                      ((uint32_t)0x00000038)        /*!<SMP1[2:0] bits (Channel 1 Sample time selection) */
+#define  ADC_SMPR2_SMP1_0                    ((uint32_t)0x00000008)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP1_1                    ((uint32_t)0x00000010)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP1_2                    ((uint32_t)0x00000020)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP2                      ((uint32_t)0x000001C0)        /*!<SMP2[2:0] bits (Channel 2 Sample time selection) */
+#define  ADC_SMPR2_SMP2_0                    ((uint32_t)0x00000040)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP2_1                    ((uint32_t)0x00000080)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP2_2                    ((uint32_t)0x00000100)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP3                      ((uint32_t)0x00000E00)        /*!<SMP3[2:0] bits (Channel 3 Sample time selection) */
+#define  ADC_SMPR2_SMP3_0                    ((uint32_t)0x00000200)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP3_1                    ((uint32_t)0x00000400)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP3_2                    ((uint32_t)0x00000800)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP4                      ((uint32_t)0x00007000)        /*!<SMP4[2:0] bits (Channel 4 Sample time selection) */
+#define  ADC_SMPR2_SMP4_0                    ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP4_1                    ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP4_2                    ((uint32_t)0x00004000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP5                      ((uint32_t)0x00038000)        /*!<SMP5[2:0] bits (Channel 5 Sample time selection) */
+#define  ADC_SMPR2_SMP5_0                    ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP5_1                    ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP5_2                    ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP6                      ((uint32_t)0x001C0000)        /*!<SMP6[2:0] bits (Channel 6 Sample time selection) */
+#define  ADC_SMPR2_SMP6_0                    ((uint32_t)0x00040000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP6_1                    ((uint32_t)0x00080000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP6_2                    ((uint32_t)0x00100000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP7                      ((uint32_t)0x00E00000)        /*!<SMP7[2:0] bits (Channel 7 Sample time selection) */
+#define  ADC_SMPR2_SMP7_0                    ((uint32_t)0x00200000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP7_1                    ((uint32_t)0x00400000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP7_2                    ((uint32_t)0x00800000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP8                      ((uint32_t)0x07000000)        /*!<SMP8[2:0] bits (Channel 8 Sample time selection) */
+#define  ADC_SMPR2_SMP8_0                    ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP8_1                    ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP8_2                    ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP9                      ((uint32_t)0x38000000)        /*!<SMP9[2:0] bits (Channel 9 Sample time selection) */
+#define  ADC_SMPR2_SMP9_0                    ((uint32_t)0x08000000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP9_1                    ((uint32_t)0x10000000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP9_2                    ((uint32_t)0x20000000)        /*!<Bit 2 */
+
+/******************  Bit definition for ADC_JOFR1 register  *******************/
+#define  ADC_JOFR1_JOFFSET1                  ((uint32_t)0x0FFF)            /*!<Data offset for injected channel 1 */
+
+/******************  Bit definition for ADC_JOFR2 register  *******************/
+#define  ADC_JOFR2_JOFFSET2                  ((uint32_t)0x0FFF)            /*!<Data offset for injected channel 2 */
+
+/******************  Bit definition for ADC_JOFR3 register  *******************/
+#define  ADC_JOFR3_JOFFSET3                  ((uint32_t)0x0FFF)            /*!<Data offset for injected channel 3 */
+
+/******************  Bit definition for ADC_JOFR4 register  *******************/
+#define  ADC_JOFR4_JOFFSET4                  ((uint32_t)0x0FFF)            /*!<Data offset for injected channel 4 */
+
+/*******************  Bit definition for ADC_HTR register  ********************/
+#define  ADC_HTR_HT                          ((uint32_t)0x0FFF)            /*!<Analog watchdog high threshold */
+
+/*******************  Bit definition for ADC_LTR register  ********************/
+#define  ADC_LTR_LT                          ((uint32_t)0x0FFF)            /*!<Analog watchdog low threshold */
+
+/*******************  Bit definition for ADC_SQR1 register  *******************/
+#define  ADC_SQR1_SQ13                       ((uint32_t)0x0000001F)        /*!<SQ13[4:0] bits (13th conversion in regular sequence) */
+#define  ADC_SQR1_SQ13_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SQR1_SQ13_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SQR1_SQ13_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SQR1_SQ13_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_SQR1_SQ13_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_SQR1_SQ14                       ((uint32_t)0x000003E0)        /*!<SQ14[4:0] bits (14th conversion in regular sequence) */
+#define  ADC_SQR1_SQ14_0                     ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  ADC_SQR1_SQ14_1                     ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  ADC_SQR1_SQ14_2                     ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  ADC_SQR1_SQ14_3                     ((uint32_t)0x00000100)        /*!<Bit 3 */
+#define  ADC_SQR1_SQ14_4                     ((uint32_t)0x00000200)        /*!<Bit 4 */
+#define  ADC_SQR1_SQ15                       ((uint32_t)0x00007C00)        /*!<SQ15[4:0] bits (15th conversion in regular sequence) */
+#define  ADC_SQR1_SQ15_0                     ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  ADC_SQR1_SQ15_1                     ((uint32_t)0x00000800)        /*!<Bit 1 */
+#define  ADC_SQR1_SQ15_2                     ((uint32_t)0x00001000)        /*!<Bit 2 */
+#define  ADC_SQR1_SQ15_3                     ((uint32_t)0x00002000)        /*!<Bit 3 */
+#define  ADC_SQR1_SQ15_4                     ((uint32_t)0x00004000)        /*!<Bit 4 */
+#define  ADC_SQR1_SQ16                       ((uint32_t)0x000F8000)        /*!<SQ16[4:0] bits (16th conversion in regular sequence) */
+#define  ADC_SQR1_SQ16_0                     ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SQR1_SQ16_1                     ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SQR1_SQ16_2                     ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SQR1_SQ16_3                     ((uint32_t)0x00040000)        /*!<Bit 3 */
+#define  ADC_SQR1_SQ16_4                     ((uint32_t)0x00080000)        /*!<Bit 4 */
+#define  ADC_SQR1_L                          ((uint32_t)0x00F00000)        /*!<L[3:0] bits (Regular channel sequence length) */
+#define  ADC_SQR1_L_0                        ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_SQR1_L_1                        ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  ADC_SQR1_L_2                        ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  ADC_SQR1_L_3                        ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+/*******************  Bit definition for ADC_SQR2 register  *******************/
+#define  ADC_SQR2_SQ7                        ((uint32_t)0x0000001F)        /*!<SQ7[4:0] bits (7th conversion in regular sequence) */
+#define  ADC_SQR2_SQ7_0                      ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ7_1                      ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ7_2                      ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ7_3                      ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ7_4                      ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ8                        ((uint32_t)0x000003E0)        /*!<SQ8[4:0] bits (8th conversion in regular sequence) */
+#define  ADC_SQR2_SQ8_0                      ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ8_1                      ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ8_2                      ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ8_3                      ((uint32_t)0x00000100)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ8_4                      ((uint32_t)0x00000200)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ9                        ((uint32_t)0x00007C00)        /*!<SQ9[4:0] bits (9th conversion in regular sequence) */
+#define  ADC_SQR2_SQ9_0                      ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ9_1                      ((uint32_t)0x00000800)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ9_2                      ((uint32_t)0x00001000)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ9_3                      ((uint32_t)0x00002000)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ9_4                      ((uint32_t)0x00004000)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ10                       ((uint32_t)0x000F8000)        /*!<SQ10[4:0] bits (10th conversion in regular sequence) */
+#define  ADC_SQR2_SQ10_0                     ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ10_1                     ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ10_2                     ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ10_3                     ((uint32_t)0x00040000)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ10_4                     ((uint32_t)0x00080000)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ11                       ((uint32_t)0x01F00000)        /*!<SQ11[4:0] bits (11th conversion in regular sequence) */
+#define  ADC_SQR2_SQ11_0                     ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ11_1                     ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ11_2                     ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ11_3                     ((uint32_t)0x00800000)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ11_4                     ((uint32_t)0x01000000)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ12                       ((uint32_t)0x3E000000)        /*!<SQ12[4:0] bits (12th conversion in regular sequence) */
+#define  ADC_SQR2_SQ12_0                     ((uint32_t)0x02000000)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ12_1                     ((uint32_t)0x04000000)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ12_2                     ((uint32_t)0x08000000)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ12_3                     ((uint32_t)0x10000000)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ12_4                     ((uint32_t)0x20000000)        /*!<Bit 4 */
+
+/*******************  Bit definition for ADC_SQR3 register  *******************/
+#define  ADC_SQR3_SQ1                        ((uint32_t)0x0000001F)        /*!<SQ1[4:0] bits (1st conversion in regular sequence) */
+#define  ADC_SQR3_SQ1_0                      ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ1_1                      ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ1_2                      ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ1_3                      ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ1_4                      ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ2                        ((uint32_t)0x000003E0)        /*!<SQ2[4:0] bits (2nd conversion in regular sequence) */
+#define  ADC_SQR3_SQ2_0                      ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ2_1                      ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ2_2                      ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ2_3                      ((uint32_t)0x00000100)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ2_4                      ((uint32_t)0x00000200)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ3                        ((uint32_t)0x00007C00)        /*!<SQ3[4:0] bits (3rd conversion in regular sequence) */
+#define  ADC_SQR3_SQ3_0                      ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ3_1                      ((uint32_t)0x00000800)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ3_2                      ((uint32_t)0x00001000)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ3_3                      ((uint32_t)0x00002000)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ3_4                      ((uint32_t)0x00004000)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ4                        ((uint32_t)0x000F8000)        /*!<SQ4[4:0] bits (4th conversion in regular sequence) */
+#define  ADC_SQR3_SQ4_0                      ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ4_1                      ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ4_2                      ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ4_3                      ((uint32_t)0x00040000)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ4_4                      ((uint32_t)0x00080000)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ5                        ((uint32_t)0x01F00000)        /*!<SQ5[4:0] bits (5th conversion in regular sequence) */
+#define  ADC_SQR3_SQ5_0                      ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ5_1                      ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ5_2                      ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ5_3                      ((uint32_t)0x00800000)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ5_4                      ((uint32_t)0x01000000)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ6                        ((uint32_t)0x3E000000)        /*!<SQ6[4:0] bits (6th conversion in regular sequence) */
+#define  ADC_SQR3_SQ6_0                      ((uint32_t)0x02000000)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ6_1                      ((uint32_t)0x04000000)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ6_2                      ((uint32_t)0x08000000)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ6_3                      ((uint32_t)0x10000000)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ6_4                      ((uint32_t)0x20000000)        /*!<Bit 4 */
+
+/*******************  Bit definition for ADC_JSQR register  *******************/
+#define  ADC_JSQR_JSQ1                       ((uint32_t)0x0000001F)        /*!<JSQ1[4:0] bits (1st conversion in injected sequence) */
+#define  ADC_JSQR_JSQ1_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_JSQR_JSQ1_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_JSQR_JSQ1_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_JSQR_JSQ1_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_JSQR_JSQ1_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_JSQR_JSQ2                       ((uint32_t)0x000003E0)        /*!<JSQ2[4:0] bits (2nd conversion in injected sequence) */
+#define  ADC_JSQR_JSQ2_0                     ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  ADC_JSQR_JSQ2_1                     ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  ADC_JSQR_JSQ2_2                     ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  ADC_JSQR_JSQ2_3                     ((uint32_t)0x00000100)        /*!<Bit 3 */
+#define  ADC_JSQR_JSQ2_4                     ((uint32_t)0x00000200)        /*!<Bit 4 */
+#define  ADC_JSQR_JSQ3                       ((uint32_t)0x00007C00)        /*!<JSQ3[4:0] bits (3rd conversion in injected sequence) */
+#define  ADC_JSQR_JSQ3_0                     ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  ADC_JSQR_JSQ3_1                     ((uint32_t)0x00000800)        /*!<Bit 1 */
+#define  ADC_JSQR_JSQ3_2                     ((uint32_t)0x00001000)        /*!<Bit 2 */
+#define  ADC_JSQR_JSQ3_3                     ((uint32_t)0x00002000)        /*!<Bit 3 */
+#define  ADC_JSQR_JSQ3_4                     ((uint32_t)0x00004000)        /*!<Bit 4 */
+#define  ADC_JSQR_JSQ4                       ((uint32_t)0x000F8000)        /*!<JSQ4[4:0] bits (4th conversion in injected sequence) */
+#define  ADC_JSQR_JSQ4_0                     ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_JSQR_JSQ4_1                     ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_JSQR_JSQ4_2                     ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_JSQR_JSQ4_3                     ((uint32_t)0x00040000)        /*!<Bit 3 */
+#define  ADC_JSQR_JSQ4_4                     ((uint32_t)0x00080000)        /*!<Bit 4 */
+#define  ADC_JSQR_JL                         ((uint32_t)0x00300000)        /*!<JL[1:0] bits (Injected Sequence length) */
+#define  ADC_JSQR_JL_0                       ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_JSQR_JL_1                       ((uint32_t)0x00200000)        /*!<Bit 1 */
+
+/*******************  Bit definition for ADC_JDR1 register  *******************/
+#define  ADC_JDR1_JDATA                      ((uint16_t)0xFFFF)            /*!<Injected data */
+
+/*******************  Bit definition for ADC_JDR2 register  *******************/
+#define  ADC_JDR2_JDATA                      ((uint16_t)0xFFFF)            /*!<Injected data */
+
+/*******************  Bit definition for ADC_JDR3 register  *******************/
+#define  ADC_JDR3_JDATA                      ((uint16_t)0xFFFF)            /*!<Injected data */
+
+/*******************  Bit definition for ADC_JDR4 register  *******************/
+#define  ADC_JDR4_JDATA                      ((uint16_t)0xFFFF)            /*!<Injected data */
+
+/********************  Bit definition for ADC_DR register  ********************/
+#define  ADC_DR_DATA                         ((uint32_t)0x0000FFFF)        /*!<Regular data */
+#define  ADC_DR_ADC2DATA                     ((uint32_t)0xFFFF0000)        /*!<ADC2 data */
+
+/*******************  Bit definition for ADC_CSR register  ********************/
+#define  ADC_CSR_AWD1                        ((uint32_t)0x00000001)        /*!<ADC1 Analog watchdog flag               */
+#define  ADC_CSR_EOC1                        ((uint32_t)0x00000002)        /*!<ADC1 End of conversion                  */
+#define  ADC_CSR_JEOC1                       ((uint32_t)0x00000004)        /*!<ADC1 Injected channel end of conversion */
+#define  ADC_CSR_JSTRT1                      ((uint32_t)0x00000008)        /*!<ADC1 Injected channel Start flag        */
+#define  ADC_CSR_STRT1                       ((uint32_t)0x00000010)        /*!<ADC1 Regular channel Start flag         */
+#define  ADC_CSR_DOVR1                       ((uint32_t)0x00000020)        /*!<ADC1 DMA overrun  flag                  */
+#define  ADC_CSR_AWD2                        ((uint32_t)0x00000100)        /*!<ADC2 Analog watchdog flag               */
+#define  ADC_CSR_EOC2                        ((uint32_t)0x00000200)        /*!<ADC2 End of conversion                  */
+#define  ADC_CSR_JEOC2                       ((uint32_t)0x00000400)        /*!<ADC2 Injected channel end of conversion */
+#define  ADC_CSR_JSTRT2                      ((uint32_t)0x00000800)        /*!<ADC2 Injected channel Start flag        */
+#define  ADC_CSR_STRT2                       ((uint32_t)0x00001000)        /*!<ADC2 Regular channel Start flag         */
+#define  ADC_CSR_DOVR2                       ((uint32_t)0x00002000)        /*!<ADC2 DMA overrun  flag                  */
+#define  ADC_CSR_AWD3                        ((uint32_t)0x00010000)        /*!<ADC3 Analog watchdog flag               */
+#define  ADC_CSR_EOC3                        ((uint32_t)0x00020000)        /*!<ADC3 End of conversion                  */
+#define  ADC_CSR_JEOC3                       ((uint32_t)0x00040000)        /*!<ADC3 Injected channel end of conversion */
+#define  ADC_CSR_JSTRT3                      ((uint32_t)0x00080000)        /*!<ADC3 Injected channel Start flag        */
+#define  ADC_CSR_STRT3                       ((uint32_t)0x00100000)        /*!<ADC3 Regular channel Start flag         */
+#define  ADC_CSR_DOVR3                       ((uint32_t)0x00200000)        /*!<ADC3 DMA overrun  flag                  */
+
+/*******************  Bit definition for ADC_CCR register  ********************/
+#define  ADC_CCR_MULTI                       ((uint32_t)0x0000001F)        /*!<MULTI[4:0] bits (Multi-ADC mode selection) */
+#define  ADC_CCR_MULTI_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_CCR_MULTI_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_CCR_MULTI_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_CCR_MULTI_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_CCR_MULTI_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_CCR_DELAY                       ((uint32_t)0x00000F00)        /*!<DELAY[3:0] bits (Delay between 2 sampling phases) */
+#define  ADC_CCR_DELAY_0                     ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  ADC_CCR_DELAY_1                     ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  ADC_CCR_DELAY_2                     ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  ADC_CCR_DELAY_3                     ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  ADC_CCR_DDS                         ((uint32_t)0x00002000)        /*!<DMA disable selection (Multi-ADC mode) */
+#define  ADC_CCR_DMA                         ((uint32_t)0x0000C000)        /*!<DMA[1:0] bits (Direct Memory Access mode for multimode) */
+#define  ADC_CCR_DMA_0                       ((uint32_t)0x00004000)        /*!<Bit 0 */
+#define  ADC_CCR_DMA_1                       ((uint32_t)0x00008000)        /*!<Bit 1 */
+#define  ADC_CCR_ADCPRE                      ((uint32_t)0x00030000)        /*!<ADCPRE[1:0] bits (ADC prescaler) */
+#define  ADC_CCR_ADCPRE_0                    ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  ADC_CCR_ADCPRE_1                    ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  ADC_CCR_VBATE                       ((uint32_t)0x00400000)        /*!<VBAT Enable */
+#define  ADC_CCR_TSVREFE                     ((uint32_t)0x00800000)        /*!<Temperature Sensor and VREFINT Enable */
+
+/*******************  Bit definition for ADC_CDR register  ********************/
+#define  ADC_CDR_DATA1                      ((uint32_t)0x0000FFFF)         /*!<1st data of a pair of regular conversions */
+#define  ADC_CDR_DATA2                      ((uint32_t)0xFFFF0000)         /*!<2nd data of a pair of regular conversions */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Controller Area Network                            */
+/*                                                                            */
+/******************************************************************************/
+/*!<CAN control and status registers */
+/*******************  Bit definition for CAN_MCR register  ********************/
+#define  CAN_MCR_INRQ                        ((uint32_t)0x00000001)        /*!<Initialization Request            */
+#define  CAN_MCR_SLEEP                       ((uint32_t)0x00000002)        /*!<Sleep Mode Request                */
+#define  CAN_MCR_TXFP                        ((uint32_t)0x00000004)        /*!<Transmit FIFO Priority            */
+#define  CAN_MCR_RFLM                        ((uint32_t)0x00000008)        /*!<Receive FIFO Locked Mode          */
+#define  CAN_MCR_NART                        ((uint32_t)0x00000010)        /*!<No Automatic Retransmission       */
+#define  CAN_MCR_AWUM                        ((uint32_t)0x00000020)        /*!<Automatic Wakeup Mode             */
+#define  CAN_MCR_ABOM                        ((uint32_t)0x00000040)        /*!<Automatic Bus-Off Management      */
+#define  CAN_MCR_TTCM                        ((uint32_t)0x00000080)        /*!<Time Triggered Communication Mode */
+#define  CAN_MCR_RESET                       ((uint32_t)0x00008000)        /*!<bxCAN software master reset       */
+
+/*******************  Bit definition for CAN_MSR register  ********************/
+#define  CAN_MSR_INAK                        ((uint32_t)0x00000001)        /*!<Initialization Acknowledge  */
+#define  CAN_MSR_SLAK                        ((uint32_t)0x00000002)        /*!<Sleep Acknowledge           */
+#define  CAN_MSR_ERRI                        ((uint32_t)0x00000004)        /*!<Error Interrupt             */
+#define  CAN_MSR_WKUI                        ((uint32_t)0x00000008)        /*!<Wakeup Interrupt            */
+#define  CAN_MSR_SLAKI                       ((uint32_t)0x00000010)        /*!<Sleep Acknowledge Interrupt */
+#define  CAN_MSR_TXM                         ((uint32_t)0x00000100)        /*!<Transmit Mode               */
+#define  CAN_MSR_RXM                         ((uint32_t)0x00000200)        /*!<Receive Mode                */
+#define  CAN_MSR_SAMP                        ((uint32_t)0x00000400)        /*!<Last Sample Point           */
+#define  CAN_MSR_RX                          ((uint32_t)0x00000800)        /*!<CAN Rx Signal               */
+
+/*******************  Bit definition for CAN_TSR register  ********************/
+#define  CAN_TSR_RQCP0                       ((uint32_t)0x00000001)        /*!<Request Completed Mailbox0      */
+#define  CAN_TSR_TXOK0                       ((uint32_t)0x00000002)        /*!<Transmission OK of Mailbox0     */
+#define  CAN_TSR_ALST0                       ((uint32_t)0x00000004)        /*!<Arbitration Lost for Mailbox0   */
+#define  CAN_TSR_TERR0                       ((uint32_t)0x00000008)        /*!<Transmission Error of Mailbox0  */
+#define  CAN_TSR_ABRQ0                       ((uint32_t)0x00000080)        /*!<Abort Request for Mailbox0      */
+#define  CAN_TSR_RQCP1                       ((uint32_t)0x00000100)        /*!<Request Completed Mailbox1      */
+#define  CAN_TSR_TXOK1                       ((uint32_t)0x00000200)        /*!<Transmission OK of Mailbox1     */
+#define  CAN_TSR_ALST1                       ((uint32_t)0x00000400)        /*!<Arbitration Lost for Mailbox1   */
+#define  CAN_TSR_TERR1                       ((uint32_t)0x00000800)        /*!<Transmission Error of Mailbox1  */
+#define  CAN_TSR_ABRQ1                       ((uint32_t)0x00008000)        /*!<Abort Request for Mailbox 1     */
+#define  CAN_TSR_RQCP2                       ((uint32_t)0x00010000)        /*!<Request Completed Mailbox2      */
+#define  CAN_TSR_TXOK2                       ((uint32_t)0x00020000)        /*!<Transmission OK of Mailbox 2    */
+#define  CAN_TSR_ALST2                       ((uint32_t)0x00040000)        /*!<Arbitration Lost for mailbox 2  */
+#define  CAN_TSR_TERR2                       ((uint32_t)0x00080000)        /*!<Transmission Error of Mailbox 2 */
+#define  CAN_TSR_ABRQ2                       ((uint32_t)0x00800000)        /*!<Abort Request for Mailbox 2     */
+#define  CAN_TSR_CODE                        ((uint32_t)0x03000000)        /*!<Mailbox Code                    */
+
+#define  CAN_TSR_TME                         ((uint32_t)0x1C000000)        /*!<TME[2:0] bits */
+#define  CAN_TSR_TME0                        ((uint32_t)0x04000000)        /*!<Transmit Mailbox 0 Empty */
+#define  CAN_TSR_TME1                        ((uint32_t)0x08000000)        /*!<Transmit Mailbox 1 Empty */
+#define  CAN_TSR_TME2                        ((uint32_t)0x10000000)        /*!<Transmit Mailbox 2 Empty */
+
+#define  CAN_TSR_LOW                         ((uint32_t)0xE0000000)        /*!<LOW[2:0] bits */
+#define  CAN_TSR_LOW0                        ((uint32_t)0x20000000)        /*!<Lowest Priority Flag for Mailbox 0 */
+#define  CAN_TSR_LOW1                        ((uint32_t)0x40000000)        /*!<Lowest Priority Flag for Mailbox 1 */
+#define  CAN_TSR_LOW2                        ((uint32_t)0x80000000)        /*!<Lowest Priority Flag for Mailbox 2 */
+
+/*******************  Bit definition for CAN_RF0R register  *******************/
+#define  CAN_RF0R_FMP0                       ((uint32_t)0x00000003)        /*!<FIFO 0 Message Pending        */
+#define  CAN_RF0R_FULL0                      ((uint32_t)0x00000008)        /*!<FIFO 0 Full                   */
+#define  CAN_RF0R_FOVR0                      ((uint32_t)0x00000010)        /*!<FIFO 0 Overrun                */
+#define  CAN_RF0R_RFOM0                      ((uint32_t)0x00000020)        /*!<Release FIFO 0 Output Mailbox */
+
+/*******************  Bit definition for CAN_RF1R register  *******************/
+#define  CAN_RF1R_FMP1                       ((uint32_t)0x00000003)        /*!<FIFO 1 Message Pending        */
+#define  CAN_RF1R_FULL1                      ((uint32_t)0x00000008)        /*!<FIFO 1 Full                   */
+#define  CAN_RF1R_FOVR1                      ((uint32_t)0x00000010)        /*!<FIFO 1 Overrun                */
+#define  CAN_RF1R_RFOM1                      ((uint32_t)0x00000020)        /*!<Release FIFO 1 Output Mailbox */
+
+/********************  Bit definition for CAN_IER register  *******************/
+#define  CAN_IER_TMEIE                       ((uint32_t)0x00000001)        /*!<Transmit Mailbox Empty Interrupt Enable */
+#define  CAN_IER_FMPIE0                      ((uint32_t)0x00000002)        /*!<FIFO Message Pending Interrupt Enable   */
+#define  CAN_IER_FFIE0                       ((uint32_t)0x00000004)        /*!<FIFO Full Interrupt Enable              */
+#define  CAN_IER_FOVIE0                      ((uint32_t)0x00000008)        /*!<FIFO Overrun Interrupt Enable           */
+#define  CAN_IER_FMPIE1                      ((uint32_t)0x00000010)        /*!<FIFO Message Pending Interrupt Enable   */
+#define  CAN_IER_FFIE1                       ((uint32_t)0x00000020)        /*!<FIFO Full Interrupt Enable              */
+#define  CAN_IER_FOVIE1                      ((uint32_t)0x00000040)        /*!<FIFO Overrun Interrupt Enable           */
+#define  CAN_IER_EWGIE                       ((uint32_t)0x00000100)        /*!<Error Warning Interrupt Enable          */
+#define  CAN_IER_EPVIE                       ((uint32_t)0x00000200)        /*!<Error Passive Interrupt Enable          */
+#define  CAN_IER_BOFIE                       ((uint32_t)0x00000400)        /*!<Bus-Off Interrupt Enable                */
+#define  CAN_IER_LECIE                       ((uint32_t)0x00000800)        /*!<Last Error Code Interrupt Enable        */
+#define  CAN_IER_ERRIE                       ((uint32_t)0x00008000)        /*!<Error Interrupt Enable                  */
+#define  CAN_IER_WKUIE                       ((uint32_t)0x00010000)        /*!<Wakeup Interrupt Enable                 */
+#define  CAN_IER_SLKIE                       ((uint32_t)0x00020000)        /*!<Sleep Interrupt Enable                  */
+
+/********************  Bit definition for CAN_ESR register  *******************/
+#define  CAN_ESR_EWGF                        ((uint32_t)0x00000001)        /*!<Error Warning Flag */
+#define  CAN_ESR_EPVF                        ((uint32_t)0x00000002)        /*!<Error Passive Flag */
+#define  CAN_ESR_BOFF                        ((uint32_t)0x00000004)        /*!<Bus-Off Flag */
+
+#define  CAN_ESR_LEC                         ((uint32_t)0x00000070)        /*!<LEC[2:0] bits (Last Error Code) */
+#define  CAN_ESR_LEC_0                       ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  CAN_ESR_LEC_1                       ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  CAN_ESR_LEC_2                       ((uint32_t)0x00000040)        /*!<Bit 2 */
+
+#define  CAN_ESR_TEC                         ((uint32_t)0x00FF0000)        /*!<Least significant byte of the 9-bit Transmit Error Counter */
+#define  CAN_ESR_REC                         ((uint32_t)0xFF000000)        /*!<Receive Error Counter */
+
+/*******************  Bit definition for CAN_BTR register  ********************/
+#define  CAN_BTR_BRP                         ((uint32_t)0x000003FF)        /*!<Baud Rate Prescaler           */
+#define  CAN_BTR_TS1                         ((uint32_t)0x000F0000)        /*!<Time Segment 1                */
+#define  CAN_BTR_TS1_0                       ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  CAN_BTR_TS1_1                       ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  CAN_BTR_TS1_2                       ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  CAN_BTR_TS1_3                       ((uint32_t)0x00080000)        /*!<Bit 3 */
+#define  CAN_BTR_TS2                         ((uint32_t)0x00700000)        /*!<Time Segment 2                */
+#define  CAN_BTR_TS2_0                       ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  CAN_BTR_TS2_1                       ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  CAN_BTR_TS2_2                       ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  CAN_BTR_SJW                         ((uint32_t)0x03000000)        /*!<Resynchronization Jump Width  */
+#define  CAN_BTR_SJW_0                       ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  CAN_BTR_SJW_1                       ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  CAN_BTR_LBKM                        ((uint32_t)0x40000000)        /*!<Loop Back Mode (Debug)        */
+#define  CAN_BTR_SILM                        ((uint32_t)0x80000000)        /*!<Silent Mode                   */
+
+/*!<Mailbox registers */
+/******************  Bit definition for CAN_TI0R register  ********************/
+#define  CAN_TI0R_TXRQ                       ((uint32_t)0x00000001)        /*!<Transmit Mailbox Request                   */
+#define  CAN_TI0R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_TI0R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_TI0R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended Identifier                        */
+#define  CAN_TI0R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/******************  Bit definition for CAN_TDT0R register  *******************/
+#define  CAN_TDT0R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code     */
+#define  CAN_TDT0R_TGT                       ((uint32_t)0x00000100)        /*!<Transmit Global Time */
+#define  CAN_TDT0R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp   */
+
+/******************  Bit definition for CAN_TDL0R register  *******************/
+#define  CAN_TDL0R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_TDL0R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_TDL0R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_TDL0R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/******************  Bit definition for CAN_TDH0R register  *******************/
+#define  CAN_TDH0R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_TDH0R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_TDH0R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_TDH0R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*******************  Bit definition for CAN_TI1R register  *******************/
+#define  CAN_TI1R_TXRQ                       ((uint32_t)0x00000001)        /*!<Transmit Mailbox Request                   */
+#define  CAN_TI1R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_TI1R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_TI1R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended Identifier                        */
+#define  CAN_TI1R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_TDT1R register  ******************/
+#define  CAN_TDT1R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code     */
+#define  CAN_TDT1R_TGT                       ((uint32_t)0x00000100)        /*!<Transmit Global Time */
+#define  CAN_TDT1R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp   */
+
+/*******************  Bit definition for CAN_TDL1R register  ******************/
+#define  CAN_TDL1R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_TDL1R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_TDL1R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_TDL1R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/*******************  Bit definition for CAN_TDH1R register  ******************/
+#define  CAN_TDH1R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_TDH1R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_TDH1R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_TDH1R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*******************  Bit definition for CAN_TI2R register  *******************/
+#define  CAN_TI2R_TXRQ                       ((uint32_t)0x00000001)        /*!<Transmit Mailbox Request                   */
+#define  CAN_TI2R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_TI2R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_TI2R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended identifier                        */
+#define  CAN_TI2R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_TDT2R register  ******************/
+#define  CAN_TDT2R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code      */
+#define  CAN_TDT2R_TGT                       ((uint32_t)0x00000100)        /*!<Transmit Global Time  */
+#define  CAN_TDT2R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp    */
+
+/*******************  Bit definition for CAN_TDL2R register  ******************/
+#define  CAN_TDL2R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_TDL2R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_TDL2R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_TDL2R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/*******************  Bit definition for CAN_TDH2R register  ******************/
+#define  CAN_TDH2R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_TDH2R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_TDH2R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_TDH2R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*******************  Bit definition for CAN_RI0R register  *******************/
+#define  CAN_RI0R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_RI0R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_RI0R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended Identifier                        */
+#define  CAN_RI0R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_RDT0R register  ******************/
+#define  CAN_RDT0R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code */
+#define  CAN_RDT0R_FMI                       ((uint32_t)0x0000FF00)        /*!<Filter Match Index */
+#define  CAN_RDT0R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp */
+
+/*******************  Bit definition for CAN_RDL0R register  ******************/
+#define  CAN_RDL0R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_RDL0R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_RDL0R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_RDL0R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/*******************  Bit definition for CAN_RDH0R register  ******************/
+#define  CAN_RDH0R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_RDH0R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_RDH0R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_RDH0R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*******************  Bit definition for CAN_RI1R register  *******************/
+#define  CAN_RI1R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_RI1R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_RI1R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended identifier                        */
+#define  CAN_RI1R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_RDT1R register  ******************/
+#define  CAN_RDT1R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code   */
+#define  CAN_RDT1R_FMI                       ((uint32_t)0x0000FF00)        /*!<Filter Match Index */
+#define  CAN_RDT1R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp */
+
+/*******************  Bit definition for CAN_RDL1R register  ******************/
+#define  CAN_RDL1R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_RDL1R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_RDL1R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_RDL1R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/*******************  Bit definition for CAN_RDH1R register  ******************/
+#define  CAN_RDH1R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_RDH1R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_RDH1R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_RDH1R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*!<CAN filter registers */
+/*******************  Bit definition for CAN_FMR register  ********************/
+#define  CAN_FMR_FINIT                       ((uint8_t)0x01)               /*!<Filter Init Mode */
+#define  CAN_FMR_CAN2SB                      ((uint32_t)0x00003F00)        /*!<CAN2 start bank */
+
+/*******************  Bit definition for CAN_FM1R register  *******************/
+#define  CAN_FM1R_FBM                        ((uint32_t)0x3FFF)            /*!<Filter Mode */
+#define  CAN_FM1R_FBM0                       ((uint32_t)0x0001)            /*!<Filter Init Mode bit 0  */
+#define  CAN_FM1R_FBM1                       ((uint32_t)0x0002)            /*!<Filter Init Mode bit 1  */
+#define  CAN_FM1R_FBM2                       ((uint32_t)0x0004)            /*!<Filter Init Mode bit 2  */
+#define  CAN_FM1R_FBM3                       ((uint32_t)0x0008)            /*!<Filter Init Mode bit 3  */
+#define  CAN_FM1R_FBM4                       ((uint32_t)0x0010)            /*!<Filter Init Mode bit 4  */
+#define  CAN_FM1R_FBM5                       ((uint32_t)0x0020)            /*!<Filter Init Mode bit 5  */
+#define  CAN_FM1R_FBM6                       ((uint32_t)0x0040)            /*!<Filter Init Mode bit 6  */
+#define  CAN_FM1R_FBM7                       ((uint32_t)0x0080)            /*!<Filter Init Mode bit 7  */
+#define  CAN_FM1R_FBM8                       ((uint32_t)0x0100)            /*!<Filter Init Mode bit 8  */
+#define  CAN_FM1R_FBM9                       ((uint32_t)0x0200)            /*!<Filter Init Mode bit 9  */
+#define  CAN_FM1R_FBM10                      ((uint32_t)0x0400)            /*!<Filter Init Mode bit 10 */
+#define  CAN_FM1R_FBM11                      ((uint32_t)0x0800)            /*!<Filter Init Mode bit 11 */
+#define  CAN_FM1R_FBM12                      ((uint32_t)0x1000)            /*!<Filter Init Mode bit 12 */
+#define  CAN_FM1R_FBM13                      ((uint32_t)0x2000)            /*!<Filter Init Mode bit 13 */
+
+/*******************  Bit definition for CAN_FS1R register  *******************/
+#define  CAN_FS1R_FSC                        ((uint32_t)0x00003FFF)        /*!<Filter Scale Configuration        */
+#define  CAN_FS1R_FSC0                       ((uint32_t)0x00000001)        /*!<Filter Scale Configuration bit 0  */
+#define  CAN_FS1R_FSC1                       ((uint32_t)0x00000002)        /*!<Filter Scale Configuration bit 1  */
+#define  CAN_FS1R_FSC2                       ((uint32_t)0x00000004)        /*!<Filter Scale Configuration bit 2  */
+#define  CAN_FS1R_FSC3                       ((uint32_t)0x00000008)        /*!<Filter Scale Configuration bit 3  */
+#define  CAN_FS1R_FSC4                       ((uint32_t)0x00000010)        /*!<Filter Scale Configuration bit 4  */
+#define  CAN_FS1R_FSC5                       ((uint32_t)0x00000020)        /*!<Filter Scale Configuration bit 5  */
+#define  CAN_FS1R_FSC6                       ((uint32_t)0x00000040)        /*!<Filter Scale Configuration bit 6  */
+#define  CAN_FS1R_FSC7                       ((uint32_t)0x00000080)        /*!<Filter Scale Configuration bit 7  */
+#define  CAN_FS1R_FSC8                       ((uint32_t)0x00000100)        /*!<Filter Scale Configuration bit 8  */
+#define  CAN_FS1R_FSC9                       ((uint32_t)0x00000200)        /*!<Filter Scale Configuration bit 9  */
+#define  CAN_FS1R_FSC10                      ((uint32_t)0x00000400)        /*!<Filter Scale Configuration bit 10 */
+#define  CAN_FS1R_FSC11                      ((uint32_t)0x00000800)        /*!<Filter Scale Configuration bit 11 */
+#define  CAN_FS1R_FSC12                      ((uint32_t)0x00001000)        /*!<Filter Scale Configuration bit 12 */
+#define  CAN_FS1R_FSC13                      ((uint32_t)0x00002000)        /*!<Filter Scale Configuration bit 13 */
+
+/******************  Bit definition for CAN_FFA1R register  *******************/
+#define  CAN_FFA1R_FFA                       ((uint32_t)0x00003FFF)        /*!<Filter FIFO Assignment */
+#define  CAN_FFA1R_FFA0                      ((uint32_t)0x00000001)        /*!<Filter FIFO Assignment for Filter 0 */
+#define  CAN_FFA1R_FFA1                      ((uint32_t)0x00000002)        /*!<Filter FIFO Assignment for Filter 1 */
+#define  CAN_FFA1R_FFA2                      ((uint32_t)0x00000004)        /*!<Filter FIFO Assignment for Filter 2 */
+#define  CAN_FFA1R_FFA3                      ((uint32_t)0x00000008)        /*!<Filter FIFO Assignment for Filter 3 */
+#define  CAN_FFA1R_FFA4                      ((uint32_t)0x00000010)        /*!<Filter FIFO Assignment for Filter 4 */
+#define  CAN_FFA1R_FFA5                      ((uint32_t)0x00000020)        /*!<Filter FIFO Assignment for Filter 5 */
+#define  CAN_FFA1R_FFA6                      ((uint32_t)0x00000040)        /*!<Filter FIFO Assignment for Filter 6 */
+#define  CAN_FFA1R_FFA7                      ((uint32_t)0x00000080)        /*!<Filter FIFO Assignment for Filter 7 */
+#define  CAN_FFA1R_FFA8                      ((uint32_t)0x00000100)        /*!<Filter FIFO Assignment for Filter 8 */
+#define  CAN_FFA1R_FFA9                      ((uint32_t)0x00000200)        /*!<Filter FIFO Assignment for Filter 9 */
+#define  CAN_FFA1R_FFA10                     ((uint32_t)0x00000400)        /*!<Filter FIFO Assignment for Filter 10 */
+#define  CAN_FFA1R_FFA11                     ((uint32_t)0x00000800)        /*!<Filter FIFO Assignment for Filter 11 */
+#define  CAN_FFA1R_FFA12                     ((uint32_t)0x00001000)        /*!<Filter FIFO Assignment for Filter 12 */
+#define  CAN_FFA1R_FFA13                     ((uint32_t)0x00002000)        /*!<Filter FIFO Assignment for Filter 13 */
+
+/*******************  Bit definition for CAN_FA1R register  *******************/
+#define  CAN_FA1R_FACT                       ((uint32_t)0x00003FFF)        /*!<Filter Active    */
+#define  CAN_FA1R_FACT0                      ((uint32_t)0x00000001)        /*!<Filter 0 Active  */
+#define  CAN_FA1R_FACT1                      ((uint32_t)0x00000002)        /*!<Filter 1 Active  */
+#define  CAN_FA1R_FACT2                      ((uint32_t)0x00000004)        /*!<Filter 2 Active  */
+#define  CAN_FA1R_FACT3                      ((uint32_t)0x00000008)        /*!<Filter 3 Active  */
+#define  CAN_FA1R_FACT4                      ((uint32_t)0x00000010)        /*!<Filter 4 Active  */
+#define  CAN_FA1R_FACT5                      ((uint32_t)0x00000020)        /*!<Filter 5 Active  */
+#define  CAN_FA1R_FACT6                      ((uint32_t)0x00000040)        /*!<Filter 6 Active  */
+#define  CAN_FA1R_FACT7                      ((uint32_t)0x00000080)        /*!<Filter 7 Active  */
+#define  CAN_FA1R_FACT8                      ((uint32_t)0x00000100)        /*!<Filter 8 Active  */
+#define  CAN_FA1R_FACT9                      ((uint32_t)0x00000200)        /*!<Filter 9 Active  */
+#define  CAN_FA1R_FACT10                     ((uint32_t)0x00000400)        /*!<Filter 10 Active */
+#define  CAN_FA1R_FACT11                     ((uint32_t)0x00000800)        /*!<Filter 11 Active */
+#define  CAN_FA1R_FACT12                     ((uint32_t)0x00001000)        /*!<Filter 12 Active */
+#define  CAN_FA1R_FACT13                     ((uint32_t)0x00002000)        /*!<Filter 13 Active */
+
+/*******************  Bit definition for CAN_F0R1 register  *******************/
+#define  CAN_F0R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F0R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F0R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F0R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F0R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F0R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F0R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F0R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F0R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F0R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F0R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F0R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F0R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F0R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F0R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F0R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F0R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F0R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F0R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F0R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F0R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F0R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F0R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F0R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F0R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F0R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F0R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F0R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F0R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F0R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F0R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F0R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F1R1 register  *******************/
+#define  CAN_F1R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F1R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F1R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F1R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F1R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F1R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F1R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F1R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F1R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F1R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F1R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F1R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F1R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F1R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F1R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F1R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F1R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F1R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F1R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F1R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F1R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F1R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F1R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F1R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F1R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F1R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F1R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F1R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F1R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F1R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F1R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F1R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F2R1 register  *******************/
+#define  CAN_F2R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F2R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F2R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F2R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F2R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F2R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F2R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F2R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F2R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F2R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F2R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F2R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F2R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F2R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F2R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F2R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F2R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F2R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F2R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F2R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F2R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F2R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F2R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F2R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F2R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F2R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F2R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F2R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F2R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F2R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F2R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F2R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F3R1 register  *******************/
+#define  CAN_F3R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F3R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F3R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F3R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F3R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F3R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F3R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F3R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F3R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F3R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F3R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F3R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F3R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F3R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F3R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F3R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F3R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F3R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F3R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F3R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F3R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F3R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F3R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F3R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F3R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F3R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F3R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F3R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F3R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F3R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F3R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F3R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F4R1 register  *******************/
+#define  CAN_F4R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F4R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F4R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F4R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F4R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F4R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F4R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F4R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F4R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F4R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F4R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F4R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F4R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F4R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F4R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F4R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F4R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F4R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F4R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F4R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F4R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F4R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F4R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F4R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F4R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F4R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F4R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F4R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F4R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F4R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F4R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F4R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F5R1 register  *******************/
+#define  CAN_F5R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F5R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F5R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F5R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F5R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F5R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F5R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F5R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F5R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F5R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F5R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F5R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F5R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F5R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F5R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F5R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F5R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F5R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F5R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F5R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F5R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F5R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F5R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F5R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F5R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F5R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F5R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F5R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F5R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F5R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F5R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F5R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F6R1 register  *******************/
+#define  CAN_F6R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F6R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F6R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F6R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F6R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F6R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F6R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F6R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F6R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F6R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F6R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F6R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F6R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F6R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F6R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F6R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F6R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F6R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F6R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F6R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F6R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F6R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F6R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F6R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F6R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F6R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F6R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F6R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F6R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F6R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F6R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F6R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F7R1 register  *******************/
+#define  CAN_F7R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F7R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F7R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F7R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F7R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F7R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F7R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F7R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F7R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F7R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F7R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F7R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F7R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F7R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F7R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F7R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F7R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F7R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F7R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F7R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F7R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F7R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F7R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F7R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F7R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F7R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F7R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F7R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F7R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F7R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F7R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F7R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F8R1 register  *******************/
+#define  CAN_F8R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F8R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F8R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F8R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F8R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F8R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F8R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F8R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F8R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F8R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F8R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F8R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F8R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F8R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F8R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F8R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F8R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F8R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F8R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F8R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F8R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F8R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F8R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F8R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F8R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F8R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F8R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F8R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F8R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F8R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F8R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F8R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F9R1 register  *******************/
+#define  CAN_F9R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F9R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F9R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F9R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F9R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F9R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F9R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F9R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F9R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F9R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F9R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F9R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F9R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F9R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F9R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F9R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F9R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F9R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F9R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F9R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F9R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F9R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F9R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F9R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F9R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F9R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F9R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F9R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F9R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F9R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F9R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F9R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F10R1 register  ******************/
+#define  CAN_F10R1_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F10R1_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F10R1_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F10R1_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F10R1_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F10R1_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F10R1_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F10R1_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F10R1_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F10R1_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F10R1_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F10R1_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F10R1_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F10R1_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F10R1_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F10R1_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F10R1_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F10R1_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F10R1_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F10R1_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F10R1_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F10R1_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F10R1_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F10R1_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F10R1_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F10R1_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F10R1_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F10R1_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F10R1_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F10R1_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F10R1_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F10R1_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F11R1 register  ******************/
+#define  CAN_F11R1_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F11R1_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F11R1_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F11R1_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F11R1_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F11R1_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F11R1_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F11R1_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F11R1_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F11R1_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F11R1_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F11R1_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F11R1_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F11R1_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F11R1_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F11R1_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F11R1_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F11R1_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F11R1_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F11R1_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F11R1_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F11R1_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F11R1_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F11R1_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F11R1_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F11R1_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F11R1_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F11R1_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F11R1_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F11R1_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F11R1_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F11R1_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F12R1 register  ******************/
+#define  CAN_F12R1_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F12R1_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F12R1_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F12R1_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F12R1_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F12R1_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F12R1_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F12R1_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F12R1_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F12R1_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F12R1_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F12R1_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F12R1_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F12R1_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F12R1_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F12R1_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F12R1_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F12R1_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F12R1_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F12R1_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F12R1_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F12R1_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F12R1_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F12R1_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F12R1_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F12R1_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F12R1_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F12R1_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F12R1_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F12R1_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F12R1_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F12R1_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F13R1 register  ******************/
+#define  CAN_F13R1_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F13R1_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F13R1_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F13R1_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F13R1_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F13R1_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F13R1_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F13R1_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F13R1_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F13R1_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F13R1_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F13R1_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F13R1_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F13R1_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F13R1_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F13R1_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F13R1_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F13R1_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F13R1_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F13R1_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F13R1_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F13R1_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F13R1_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F13R1_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F13R1_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F13R1_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F13R1_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F13R1_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F13R1_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F13R1_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F13R1_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F13R1_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F0R2 register  *******************/
+#define  CAN_F0R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F0R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F0R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F0R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F0R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F0R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F0R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F0R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F0R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F0R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F0R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F0R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F0R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F0R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F0R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F0R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F0R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F0R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F0R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F0R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F0R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F0R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F0R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F0R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F0R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F0R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F0R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F0R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F0R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F0R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F0R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F0R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F1R2 register  *******************/
+#define  CAN_F1R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F1R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F1R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F1R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F1R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F1R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F1R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F1R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F1R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F1R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F1R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F1R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F1R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F1R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F1R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F1R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F1R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F1R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F1R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F1R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F1R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F1R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F1R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F1R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F1R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F1R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F1R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F1R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F1R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F1R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F1R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F1R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F2R2 register  *******************/
+#define  CAN_F2R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F2R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F2R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F2R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F2R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F2R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F2R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F2R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F2R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F2R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F2R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F2R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F2R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F2R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F2R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F2R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F2R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F2R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F2R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F2R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F2R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F2R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F2R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F2R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F2R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F2R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F2R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F2R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F2R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F2R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F2R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F2R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F3R2 register  *******************/
+#define  CAN_F3R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F3R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F3R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F3R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F3R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F3R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F3R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F3R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F3R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F3R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F3R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F3R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F3R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F3R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F3R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F3R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F3R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F3R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F3R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F3R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F3R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F3R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F3R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F3R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F3R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F3R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F3R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F3R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F3R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F3R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F3R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F3R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F4R2 register  *******************/
+#define  CAN_F4R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F4R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F4R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F4R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F4R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F4R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F4R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F4R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F4R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F4R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F4R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F4R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F4R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F4R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F4R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F4R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F4R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F4R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F4R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F4R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F4R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F4R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F4R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F4R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F4R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F4R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F4R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F4R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F4R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F4R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F4R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F4R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F5R2 register  *******************/
+#define  CAN_F5R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F5R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F5R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F5R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F5R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F5R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F5R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F5R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F5R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F5R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F5R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F5R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F5R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F5R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F5R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F5R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F5R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F5R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F5R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F5R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F5R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F5R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F5R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F5R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F5R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F5R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F5R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F5R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F5R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F5R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F5R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F5R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F6R2 register  *******************/
+#define  CAN_F6R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F6R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F6R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F6R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F6R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F6R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F6R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F6R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F6R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F6R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F6R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F6R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F6R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F6R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F6R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F6R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F6R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F6R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F6R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F6R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F6R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F6R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F6R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F6R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F6R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F6R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F6R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F6R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F6R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F6R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F6R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F6R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F7R2 register  *******************/
+#define  CAN_F7R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F7R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F7R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F7R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F7R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F7R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F7R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F7R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F7R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F7R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F7R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F7R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F7R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F7R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F7R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F7R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F7R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F7R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F7R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F7R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F7R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F7R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F7R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F7R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F7R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F7R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F7R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F7R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F7R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F7R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F7R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F7R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F8R2 register  *******************/
+#define  CAN_F8R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F8R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F8R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F8R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F8R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F8R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F8R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F8R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F8R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F8R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F8R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F8R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F8R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F8R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F8R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F8R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F8R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F8R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F8R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F8R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F8R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F8R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F8R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F8R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F8R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F8R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F8R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F8R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F8R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F8R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F8R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F8R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F9R2 register  *******************/
+#define  CAN_F9R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F9R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F9R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F9R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F9R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F9R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F9R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F9R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F9R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F9R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F9R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F9R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F9R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F9R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F9R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F9R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F9R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F9R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F9R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F9R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F9R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F9R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F9R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F9R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F9R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F9R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F9R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F9R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F9R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F9R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F9R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F9R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F10R2 register  ******************/
+#define  CAN_F10R2_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F10R2_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F10R2_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F10R2_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F10R2_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F10R2_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F10R2_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F10R2_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F10R2_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F10R2_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F10R2_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F10R2_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F10R2_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F10R2_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F10R2_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F10R2_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F10R2_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F10R2_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F10R2_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F10R2_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F10R2_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F10R2_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F10R2_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F10R2_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F10R2_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F10R2_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F10R2_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F10R2_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F10R2_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F10R2_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F10R2_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F10R2_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F11R2 register  ******************/
+#define  CAN_F11R2_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F11R2_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F11R2_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F11R2_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F11R2_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F11R2_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F11R2_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F11R2_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F11R2_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F11R2_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F11R2_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F11R2_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F11R2_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F11R2_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F11R2_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F11R2_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F11R2_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F11R2_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F11R2_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F11R2_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F11R2_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F11R2_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F11R2_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F11R2_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F11R2_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F11R2_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F11R2_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F11R2_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F11R2_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F11R2_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F11R2_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F11R2_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F12R2 register  ******************/
+#define  CAN_F12R2_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F12R2_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F12R2_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F12R2_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F12R2_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F12R2_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F12R2_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F12R2_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F12R2_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F12R2_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F12R2_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F12R2_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F12R2_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F12R2_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F12R2_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F12R2_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F12R2_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F12R2_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F12R2_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F12R2_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F12R2_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F12R2_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F12R2_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F12R2_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F12R2_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F12R2_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F12R2_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F12R2_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F12R2_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F12R2_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F12R2_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F12R2_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F13R2 register  ******************/
+#define  CAN_F13R2_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F13R2_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F13R2_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F13R2_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F13R2_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F13R2_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F13R2_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F13R2_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F13R2_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F13R2_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F13R2_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F13R2_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F13R2_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F13R2_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F13R2_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F13R2_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F13R2_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F13R2_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F13R2_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F13R2_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F13R2_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F13R2_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F13R2_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F13R2_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F13R2_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F13R2_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F13R2_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F13R2_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F13R2_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F13R2_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F13R2_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F13R2_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 HDMI-CEC (CEC)                             */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for CEC_CR register  *********************/
+#define  CEC_CR_CECEN                        ((uint32_t)0x00000001)       /*!< CEC Enable                         */
+#define  CEC_CR_TXSOM                        ((uint32_t)0x00000002)       /*!< CEC Tx Start Of Message            */
+#define  CEC_CR_TXEOM                        ((uint32_t)0x00000004)       /*!< CEC Tx End Of Message              */
+
+/*******************  Bit definition for CEC_CFGR register  *******************/
+#define  CEC_CFGR_SFT                        ((uint32_t)0x00000007)       /*!< CEC Signal Free Time               */
+#define  CEC_CFGR_RXTOL                      ((uint32_t)0x00000008)       /*!< CEC Tolerance                      */
+#define  CEC_CFGR_BRESTP                     ((uint32_t)0x00000010)       /*!< CEC Rx Stop                        */
+#define  CEC_CFGR_BREGEN                     ((uint32_t)0x00000020)       /*!< CEC Bit Rising Error generation    */
+#define  CEC_CFGR_LBPEGEN                    ((uint32_t)0x00000040)       /*!< CEC Long Period Error generation   */
+#define  CEC_CFGR_BRDNOGEN                   ((uint32_t)0x00000080)       /*!< CEC Broadcast no Error generation  */
+#define  CEC_CFGR_SFTOPT                     ((uint32_t)0x00000100)       /*!< CEC Signal Free Time optional      */
+#define  CEC_CFGR_OAR                        ((uint32_t)0x7FFF0000)       /*!< CEC Own Address                    */
+#define  CEC_CFGR_LSTN                       ((uint32_t)0x80000000)       /*!< CEC Listen mode                    */
+
+/*******************  Bit definition for CEC_TXDR register  *******************/
+#define  CEC_TXDR_TXD                        ((uint32_t)0x000000FF)       /*!< CEC Tx Data                        */
+
+/*******************  Bit definition for CEC_RXDR register  *******************/
+#define  CEC_TXDR_RXD                        ((uint32_t)0x000000FF)       /*!< CEC Rx Data                        */
+
+/*******************  Bit definition for CEC_ISR register  ********************/
+#define  CEC_ISR_RXBR                        ((uint32_t)0x00000001)       /*!< CEC Rx-Byte Received                   */
+#define  CEC_ISR_RXEND                       ((uint32_t)0x00000002)       /*!< CEC End Of Reception                   */
+#define  CEC_ISR_RXOVR                       ((uint32_t)0x00000004)       /*!< CEC Rx-Overrun                         */
+#define  CEC_ISR_BRE                         ((uint32_t)0x00000008)       /*!< CEC Rx Bit Rising Error                */
+#define  CEC_ISR_SBPE                        ((uint32_t)0x00000010)       /*!< CEC Rx Short Bit period Error          */
+#define  CEC_ISR_LBPE                        ((uint32_t)0x00000020)       /*!< CEC Rx Long Bit period Error           */
+#define  CEC_ISR_RXACKE                      ((uint32_t)0x00000040)       /*!< CEC Rx Missing Acknowledge             */
+#define  CEC_ISR_ARBLST                      ((uint32_t)0x00000080)       /*!< CEC Arbitration Lost                   */
+#define  CEC_ISR_TXBR                        ((uint32_t)0x00000100)       /*!< CEC Tx Byte Request                    */
+#define  CEC_ISR_TXEND                       ((uint32_t)0x00000200)       /*!< CEC End of Transmission                */
+#define  CEC_ISR_TXUDR                       ((uint32_t)0x00000400)       /*!< CEC Tx-Buffer Underrun                 */
+#define  CEC_ISR_TXERR                       ((uint32_t)0x00000800)       /*!< CEC Tx-Error                           */
+#define  CEC_ISR_TXACKE                      ((uint32_t)0x00001000)       /*!< CEC Tx Missing Acknowledge             */
+
+/*******************  Bit definition for CEC_IER register  ********************/
+#define  CEC_IER_RXBRIE                      ((uint32_t)0x00000001)       /*!< CEC Rx-Byte Received IT Enable         */
+#define  CEC_IER_RXENDIE                     ((uint32_t)0x00000002)       /*!< CEC End Of Reception IT Enable         */
+#define  CEC_IER_RXOVRIE                     ((uint32_t)0x00000004)       /*!< CEC Rx-Overrun IT Enable               */
+#define  CEC_IER_BREIE                       ((uint32_t)0x00000008)       /*!< CEC Rx Bit Rising Error IT Enable      */
+#define  CEC_IER_SBPEIE                      ((uint32_t)0x00000010)       /*!< CEC Rx Short Bit period Error IT Enable*/
+#define  CEC_IER_LBPEIE                      ((uint32_t)0x00000020)       /*!< CEC Rx Long Bit period Error IT Enable */
+#define  CEC_IER_RXACKEIE                    ((uint32_t)0x00000040)       /*!< CEC Rx Missing Acknowledge IT Enable   */
+#define  CEC_IER_ARBLSTIE                    ((uint32_t)0x00000080)       /*!< CEC Arbitration Lost IT Enable         */
+#define  CEC_IER_TXBRIE                      ((uint32_t)0x00000100)       /*!< CEC Tx Byte Request  IT Enable         */
+#define  CEC_IER_TXENDIE                     ((uint32_t)0x00000200)       /*!< CEC End of Transmission IT Enable      */
+#define  CEC_IER_TXUDRIE                     ((uint32_t)0x00000400)       /*!< CEC Tx-Buffer Underrun IT Enable       */
+#define  CEC_IER_TXERRIE                     ((uint32_t)0x00000800)       /*!< CEC Tx-Error IT Enable                 */
+#define  CEC_IER_TXACKEIE                    ((uint32_t)0x00001000)       /*!< CEC Tx Missing Acknowledge IT Enable   */
+
+/******************************************************************************/
+/*                                                                            */
+/*                          CRC calculation unit                              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for CRC_DR register  *********************/
+#define  CRC_DR_DR                           ((uint32_t)0xFFFFFFFF)     /*!< Data register bits */
+
+/*******************  Bit definition for CRC_IDR register  ********************/
+#define  CRC_IDR_IDR                         ((uint32_t)0x000000FF)     /*!< General-purpose 8-bit data register bits */
+
+/********************  Bit definition for CRC_CR register  ********************/
+#define  CRC_CR_RESET                        ((uint32_t)0x00000001)     /*!< RESET the CRC computation unit bit */
+#define  CRC_CR_POLYSIZE                     ((uint32_t)0x00000018)     /*!< Polynomial size bits               */
+#define  CRC_CR_POLYSIZE_0                   ((uint32_t)0x00000008)     /*!< Polynomial size bit 0              */
+#define  CRC_CR_POLYSIZE_1                   ((uint32_t)0x00000010)     /*!< Polynomial size bit 1              */
+#define  CRC_CR_REV_IN                       ((uint32_t)0x00000060)     /*!< REV_IN Reverse Input Data bits     */
+#define  CRC_CR_REV_IN_0                     ((uint32_t)0x00000020)     /*!< Bit 0 */
+#define  CRC_CR_REV_IN_1                     ((uint32_t)0x00000040)     /*!< Bit 1 */
+#define  CRC_CR_REV_OUT                      ((uint32_t)0x00000080)     /*!< REV_OUT Reverse Output Data bits   */
+
+/*******************  Bit definition for CRC_INIT register  *******************/
+#define  CRC_INIT_INIT                       ((uint32_t)0xFFFFFFFF)     /*!< Initial CRC value bits         */
+
+/*******************  Bit definition for CRC_POL register  ********************/
+#define  CRC_POL_POL                         ((uint32_t)0xFFFFFFFF)     /*!< Coefficients of the polynomial */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Digital to Analog Converter                           */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DAC_CR register  ********************/
+#define  DAC_CR_EN1                          ((uint32_t)0x00000001)        /*!<DAC channel1 enable                         */
+#define  DAC_CR_BOFF1                        ((uint32_t)0x00000002)        /*!<DAC channel1 output buffer disable          */
+#define  DAC_CR_TEN1                         ((uint32_t)0x00000004)        /*!<DAC channel1 Trigger enable                 */
+
+#define  DAC_CR_TSEL1                        ((uint32_t)0x00000038)        /*!<TSEL1[2:0] (DAC channel1 Trigger selection) */
+#define  DAC_CR_TSEL1_0                      ((uint32_t)0x00000008)        /*!<Bit 0 */
+#define  DAC_CR_TSEL1_1                      ((uint32_t)0x00000010)        /*!<Bit 1 */
+#define  DAC_CR_TSEL1_2                      ((uint32_t)0x00000020)        /*!<Bit 2 */
+
+#define  DAC_CR_WAVE1                        ((uint32_t)0x000000C0)        /*!<WAVE1[1:0] (DAC channel1 noise/triangle wave generation enable) */
+#define  DAC_CR_WAVE1_0                      ((uint32_t)0x00000040)        /*!<Bit 0 */
+#define  DAC_CR_WAVE1_1                      ((uint32_t)0x00000080)        /*!<Bit 1 */
+
+#define  DAC_CR_MAMP1                        ((uint32_t)0x00000F00)        /*!<MAMP1[3:0] (DAC channel1 Mask/Amplitude selector) */
+#define  DAC_CR_MAMP1_0                      ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  DAC_CR_MAMP1_1                      ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  DAC_CR_MAMP1_2                      ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  DAC_CR_MAMP1_3                      ((uint32_t)0x00000800)        /*!<Bit 3 */
+
+#define  DAC_CR_DMAEN1                       ((uint32_t)0x00001000)        /*!<DAC channel1 DMA enable                     */
+#define  DAC_CR_EN2                          ((uint32_t)0x00010000)        /*!<DAC channel2 enable                         */
+#define  DAC_CR_BOFF2                        ((uint32_t)0x00020000)        /*!<DAC channel2 output buffer disable          */
+#define  DAC_CR_TEN2                         ((uint32_t)0x00040000)        /*!<DAC channel2 Trigger enable                 */
+
+#define  DAC_CR_TSEL2                        ((uint32_t)0x00380000)        /*!<TSEL2[2:0] (DAC channel2 Trigger selection) */
+#define  DAC_CR_TSEL2_0                      ((uint32_t)0x00080000)        /*!<Bit 0 */
+#define  DAC_CR_TSEL2_1                      ((uint32_t)0x00100000)        /*!<Bit 1 */
+#define  DAC_CR_TSEL2_2                      ((uint32_t)0x00200000)        /*!<Bit 2 */
+
+#define  DAC_CR_WAVE2                        ((uint32_t)0x00C00000)        /*!<WAVE2[1:0] (DAC channel2 noise/triangle wave generation enable) */
+#define  DAC_CR_WAVE2_0                      ((uint32_t)0x00400000)        /*!<Bit 0 */
+#define  DAC_CR_WAVE2_1                      ((uint32_t)0x00800000)        /*!<Bit 1 */
+
+#define  DAC_CR_MAMP2                        ((uint32_t)0x0F000000)        /*!<MAMP2[3:0] (DAC channel2 Mask/Amplitude selector) */
+#define  DAC_CR_MAMP2_0                      ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  DAC_CR_MAMP2_1                      ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  DAC_CR_MAMP2_2                      ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  DAC_CR_MAMP2_3                      ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  DAC_CR_DMAEN2                       ((uint32_t)0x10000000)        /*!<DAC channel2 DMA enabled */
+
+/*****************  Bit definition for DAC_SWTRIGR register  ******************/
+#define  DAC_SWTRIGR_SWTRIG1                 ((uint32_t)0x01)               /*!<DAC channel1 software trigger */
+#define  DAC_SWTRIGR_SWTRIG2                 ((uint32_t)0x02)               /*!<DAC channel2 software trigger */
+
+/*****************  Bit definition for DAC_DHR12R1 register  ******************/
+#define  DAC_DHR12R1_DACC1DHR                ((uint32_t)0x0FFF)            /*!<DAC channel1 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12L1 register  ******************/
+#define  DAC_DHR12L1_DACC1DHR                ((uint32_t)0xFFF0)            /*!<DAC channel1 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8R1 register  ******************/
+#define  DAC_DHR8R1_DACC1DHR                 ((uint32_t)0xFF)               /*!<DAC channel1 8-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12R2 register  ******************/
+#define  DAC_DHR12R2_DACC2DHR                ((uint32_t)0x0FFF)            /*!<DAC channel2 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12L2 register  ******************/
+#define  DAC_DHR12L2_DACC2DHR                ((uint32_t)0xFFF0)            /*!<DAC channel2 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8R2 register  ******************/
+#define  DAC_DHR8R2_DACC2DHR                 ((uint32_t)0xFF)               /*!<DAC channel2 8-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12RD register  ******************/
+#define  DAC_DHR12RD_DACC1DHR                ((uint32_t)0x00000FFF)        /*!<DAC channel1 12-bit Right aligned data */
+#define  DAC_DHR12RD_DACC2DHR                ((uint32_t)0x0FFF0000)        /*!<DAC channel2 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12LD register  ******************/
+#define  DAC_DHR12LD_DACC1DHR                ((uint32_t)0x0000FFF0)        /*!<DAC channel1 12-bit Left aligned data */
+#define  DAC_DHR12LD_DACC2DHR                ((uint32_t)0xFFF00000)        /*!<DAC channel2 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8RD register  ******************/
+#define  DAC_DHR8RD_DACC1DHR                 ((uint32_t)0x00FF)            /*!<DAC channel1 8-bit Right aligned data */
+#define  DAC_DHR8RD_DACC2DHR                 ((uint32_t)0xFF00)            /*!<DAC channel2 8-bit Right aligned data */
+
+/*******************  Bit definition for DAC_DOR1 register  *******************/
+#define  DAC_DOR1_DACC1DOR                   ((uint32_t)0x0FFF)            /*!<DAC channel1 data output */
+
+/*******************  Bit definition for DAC_DOR2 register  *******************/
+#define  DAC_DOR2_DACC2DOR                   ((uint32_t)0x0FFF)            /*!<DAC channel2 data output */
+
+/********************  Bit definition for DAC_SR register  ********************/
+#define  DAC_SR_DMAUDR1                      ((uint32_t)0x00002000)        /*!<DAC channel1 DMA underrun flag */
+#define  DAC_SR_DMAUDR2                      ((uint32_t)0x20000000)        /*!<DAC channel2 DMA underrun flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 Debug MCU                                  */
+/*                                                                            */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    DCMI                                    */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DCMI_CR register  ******************/
+#define DCMI_CR_CAPTURE                      ((uint32_t)0x00000001)
+#define DCMI_CR_CM                           ((uint32_t)0x00000002)
+#define DCMI_CR_CROP                         ((uint32_t)0x00000004)
+#define DCMI_CR_JPEG                         ((uint32_t)0x00000008)
+#define DCMI_CR_ESS                          ((uint32_t)0x00000010)
+#define DCMI_CR_PCKPOL                       ((uint32_t)0x00000020)
+#define DCMI_CR_HSPOL                        ((uint32_t)0x00000040)
+#define DCMI_CR_VSPOL                        ((uint32_t)0x00000080)
+#define DCMI_CR_FCRC_0                       ((uint32_t)0x00000100)
+#define DCMI_CR_FCRC_1                       ((uint32_t)0x00000200)
+#define DCMI_CR_EDM_0                        ((uint32_t)0x00000400)
+#define DCMI_CR_EDM_1                        ((uint32_t)0x00000800)
+#define DCMI_CR_CRE                          ((uint32_t)0x00001000)
+#define DCMI_CR_ENABLE                       ((uint32_t)0x00004000)
+#define DCMI_CR_BSM                          ((uint32_t)0x00030000)
+#define DCMI_CR_BSM_0                        ((uint32_t)0x00010000)
+#define DCMI_CR_BSM_1                        ((uint32_t)0x00020000)
+#define DCMI_CR_OEBS                         ((uint32_t)0x00040000)
+#define DCMI_CR_LSM                          ((uint32_t)0x00080000)
+#define DCMI_CR_OELS                         ((uint32_t)0x00100000)
+
+/********************  Bits definition for DCMI_SR register  ******************/
+#define DCMI_SR_HSYNC                        ((uint32_t)0x00000001)
+#define DCMI_SR_VSYNC                        ((uint32_t)0x00000002)
+#define DCMI_SR_FNE                          ((uint32_t)0x00000004)
+
+/********************  Bits definition for DCMI_RISR register  ****************/
+#define DCMI_RISR_FRAME_RIS                  ((uint32_t)0x00000001)
+#define DCMI_RISR_OVF_RIS                    ((uint32_t)0x00000002)
+#define DCMI_RISR_ERR_RIS                    ((uint32_t)0x00000004)
+#define DCMI_RISR_VSYNC_RIS                  ((uint32_t)0x00000008)
+#define DCMI_RISR_LINE_RIS                   ((uint32_t)0x00000010)
+
+/********************  Bits definition for DCMI_IER register  *****************/
+#define DCMI_IER_FRAME_IE                    ((uint32_t)0x00000001)
+#define DCMI_IER_OVF_IE                      ((uint32_t)0x00000002)
+#define DCMI_IER_ERR_IE                      ((uint32_t)0x00000004)
+#define DCMI_IER_VSYNC_IE                    ((uint32_t)0x00000008)
+#define DCMI_IER_LINE_IE                     ((uint32_t)0x00000010)
+
+/********************  Bits definition for DCMI_MISR register  ****************/
+#define DCMI_MISR_FRAME_MIS                  ((uint32_t)0x00000001)
+#define DCMI_MISR_OVF_MIS                    ((uint32_t)0x00000002)
+#define DCMI_MISR_ERR_MIS                    ((uint32_t)0x00000004)
+#define DCMI_MISR_VSYNC_MIS                  ((uint32_t)0x00000008)
+#define DCMI_MISR_LINE_MIS                   ((uint32_t)0x00000010)
+
+/********************  Bits definition for DCMI_ICR register  *****************/
+#define DCMI_ICR_FRAME_ISC                   ((uint32_t)0x00000001)
+#define DCMI_ICR_OVF_ISC                     ((uint32_t)0x00000002)
+#define DCMI_ICR_ERR_ISC                     ((uint32_t)0x00000004)
+#define DCMI_ICR_VSYNC_ISC                   ((uint32_t)0x00000008)
+#define DCMI_ICR_LINE_ISC                    ((uint32_t)0x00000010)
+
+/******************************************************************************/
+/*                                                                            */
+/*                             DMA Controller                                 */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DMA_SxCR register  *****************/
+#define DMA_SxCR_CHSEL                       ((uint32_t)0x0E000000)
+#define DMA_SxCR_CHSEL_0                     ((uint32_t)0x02000000)
+#define DMA_SxCR_CHSEL_1                     ((uint32_t)0x04000000)
+#define DMA_SxCR_CHSEL_2                     ((uint32_t)0x08000000)
+#define DMA_SxCR_MBURST                      ((uint32_t)0x01800000)
+#define DMA_SxCR_MBURST_0                    ((uint32_t)0x00800000)
+#define DMA_SxCR_MBURST_1                    ((uint32_t)0x01000000)
+#define DMA_SxCR_PBURST                      ((uint32_t)0x00600000)
+#define DMA_SxCR_PBURST_0                    ((uint32_t)0x00200000)
+#define DMA_SxCR_PBURST_1                    ((uint32_t)0x00400000)
+#define DMA_SxCR_ACK                         ((uint32_t)0x00100000)
+#define DMA_SxCR_CT                          ((uint32_t)0x00080000)
+#define DMA_SxCR_DBM                         ((uint32_t)0x00040000)
+#define DMA_SxCR_PL                          ((uint32_t)0x00030000)
+#define DMA_SxCR_PL_0                        ((uint32_t)0x00010000)
+#define DMA_SxCR_PL_1                        ((uint32_t)0x00020000)
+#define DMA_SxCR_PINCOS                      ((uint32_t)0x00008000)
+#define DMA_SxCR_MSIZE                       ((uint32_t)0x00006000)
+#define DMA_SxCR_MSIZE_0                     ((uint32_t)0x00002000)
+#define DMA_SxCR_MSIZE_1                     ((uint32_t)0x00004000)
+#define DMA_SxCR_PSIZE                       ((uint32_t)0x00001800)
+#define DMA_SxCR_PSIZE_0                     ((uint32_t)0x00000800)
+#define DMA_SxCR_PSIZE_1                     ((uint32_t)0x00001000)
+#define DMA_SxCR_MINC                        ((uint32_t)0x00000400)
+#define DMA_SxCR_PINC                        ((uint32_t)0x00000200)
+#define DMA_SxCR_CIRC                        ((uint32_t)0x00000100)
+#define DMA_SxCR_DIR                         ((uint32_t)0x000000C0)
+#define DMA_SxCR_DIR_0                       ((uint32_t)0x00000040)
+#define DMA_SxCR_DIR_1                       ((uint32_t)0x00000080)
+#define DMA_SxCR_PFCTRL                      ((uint32_t)0x00000020)
+#define DMA_SxCR_TCIE                        ((uint32_t)0x00000010)
+#define DMA_SxCR_HTIE                        ((uint32_t)0x00000008)
+#define DMA_SxCR_TEIE                        ((uint32_t)0x00000004)
+#define DMA_SxCR_DMEIE                       ((uint32_t)0x00000002)
+#define DMA_SxCR_EN                          ((uint32_t)0x00000001)
+
+/********************  Bits definition for DMA_SxCNDTR register  **************/
+#define DMA_SxNDT                            ((uint32_t)0x0000FFFF)
+#define DMA_SxNDT_0                          ((uint32_t)0x00000001)
+#define DMA_SxNDT_1                          ((uint32_t)0x00000002)
+#define DMA_SxNDT_2                          ((uint32_t)0x00000004)
+#define DMA_SxNDT_3                          ((uint32_t)0x00000008)
+#define DMA_SxNDT_4                          ((uint32_t)0x00000010)
+#define DMA_SxNDT_5                          ((uint32_t)0x00000020)
+#define DMA_SxNDT_6                          ((uint32_t)0x00000040)
+#define DMA_SxNDT_7                          ((uint32_t)0x00000080)
+#define DMA_SxNDT_8                          ((uint32_t)0x00000100)
+#define DMA_SxNDT_9                          ((uint32_t)0x00000200)
+#define DMA_SxNDT_10                         ((uint32_t)0x00000400)
+#define DMA_SxNDT_11                         ((uint32_t)0x00000800)
+#define DMA_SxNDT_12                         ((uint32_t)0x00001000)
+#define DMA_SxNDT_13                         ((uint32_t)0x00002000)
+#define DMA_SxNDT_14                         ((uint32_t)0x00004000)
+#define DMA_SxNDT_15                         ((uint32_t)0x00008000)
+
+/********************  Bits definition for DMA_SxFCR register  ****************/
+#define DMA_SxFCR_FEIE                       ((uint32_t)0x00000080)
+#define DMA_SxFCR_FS                         ((uint32_t)0x00000038)
+#define DMA_SxFCR_FS_0                       ((uint32_t)0x00000008)
+#define DMA_SxFCR_FS_1                       ((uint32_t)0x00000010)
+#define DMA_SxFCR_FS_2                       ((uint32_t)0x00000020)
+#define DMA_SxFCR_DMDIS                      ((uint32_t)0x00000004)
+#define DMA_SxFCR_FTH                        ((uint32_t)0x00000003)
+#define DMA_SxFCR_FTH_0                      ((uint32_t)0x00000001)
+#define DMA_SxFCR_FTH_1                      ((uint32_t)0x00000002)
+
+/********************  Bits definition for DMA_LISR register  *****************/
+#define DMA_LISR_TCIF3                       ((uint32_t)0x08000000)
+#define DMA_LISR_HTIF3                       ((uint32_t)0x04000000)
+#define DMA_LISR_TEIF3                       ((uint32_t)0x02000000)
+#define DMA_LISR_DMEIF3                      ((uint32_t)0x01000000)
+#define DMA_LISR_FEIF3                       ((uint32_t)0x00400000)
+#define DMA_LISR_TCIF2                       ((uint32_t)0x00200000)
+#define DMA_LISR_HTIF2                       ((uint32_t)0x00100000)
+#define DMA_LISR_TEIF2                       ((uint32_t)0x00080000)
+#define DMA_LISR_DMEIF2                      ((uint32_t)0x00040000)
+#define DMA_LISR_FEIF2                       ((uint32_t)0x00010000)
+#define DMA_LISR_TCIF1                       ((uint32_t)0x00000800)
+#define DMA_LISR_HTIF1                       ((uint32_t)0x00000400)
+#define DMA_LISR_TEIF1                       ((uint32_t)0x00000200)
+#define DMA_LISR_DMEIF1                      ((uint32_t)0x00000100)
+#define DMA_LISR_FEIF1                       ((uint32_t)0x00000040)
+#define DMA_LISR_TCIF0                       ((uint32_t)0x00000020)
+#define DMA_LISR_HTIF0                       ((uint32_t)0x00000010)
+#define DMA_LISR_TEIF0                       ((uint32_t)0x00000008)
+#define DMA_LISR_DMEIF0                      ((uint32_t)0x00000004)
+#define DMA_LISR_FEIF0                       ((uint32_t)0x00000001)
+
+/********************  Bits definition for DMA_HISR register  *****************/
+#define DMA_HISR_TCIF7                       ((uint32_t)0x08000000)
+#define DMA_HISR_HTIF7                       ((uint32_t)0x04000000)
+#define DMA_HISR_TEIF7                       ((uint32_t)0x02000000)
+#define DMA_HISR_DMEIF7                      ((uint32_t)0x01000000)
+#define DMA_HISR_FEIF7                       ((uint32_t)0x00400000)
+#define DMA_HISR_TCIF6                       ((uint32_t)0x00200000)
+#define DMA_HISR_HTIF6                       ((uint32_t)0x00100000)
+#define DMA_HISR_TEIF6                       ((uint32_t)0x00080000)
+#define DMA_HISR_DMEIF6                      ((uint32_t)0x00040000)
+#define DMA_HISR_FEIF6                       ((uint32_t)0x00010000)
+#define DMA_HISR_TCIF5                       ((uint32_t)0x00000800)
+#define DMA_HISR_HTIF5                       ((uint32_t)0x00000400)
+#define DMA_HISR_TEIF5                       ((uint32_t)0x00000200)
+#define DMA_HISR_DMEIF5                      ((uint32_t)0x00000100)
+#define DMA_HISR_FEIF5                       ((uint32_t)0x00000040)
+#define DMA_HISR_TCIF4                       ((uint32_t)0x00000020)
+#define DMA_HISR_HTIF4                       ((uint32_t)0x00000010)
+#define DMA_HISR_TEIF4                       ((uint32_t)0x00000008)
+#define DMA_HISR_DMEIF4                      ((uint32_t)0x00000004)
+#define DMA_HISR_FEIF4                       ((uint32_t)0x00000001)
+
+/********************  Bits definition for DMA_LIFCR register  ****************/
+#define DMA_LIFCR_CTCIF3                     ((uint32_t)0x08000000)
+#define DMA_LIFCR_CHTIF3                     ((uint32_t)0x04000000)
+#define DMA_LIFCR_CTEIF3                     ((uint32_t)0x02000000)
+#define DMA_LIFCR_CDMEIF3                    ((uint32_t)0x01000000)
+#define DMA_LIFCR_CFEIF3                     ((uint32_t)0x00400000)
+#define DMA_LIFCR_CTCIF2                     ((uint32_t)0x00200000)
+#define DMA_LIFCR_CHTIF2                     ((uint32_t)0x00100000)
+#define DMA_LIFCR_CTEIF2                     ((uint32_t)0x00080000)
+#define DMA_LIFCR_CDMEIF2                    ((uint32_t)0x00040000)
+#define DMA_LIFCR_CFEIF2                     ((uint32_t)0x00010000)
+#define DMA_LIFCR_CTCIF1                     ((uint32_t)0x00000800)
+#define DMA_LIFCR_CHTIF1                     ((uint32_t)0x00000400)
+#define DMA_LIFCR_CTEIF1                     ((uint32_t)0x00000200)
+#define DMA_LIFCR_CDMEIF1                    ((uint32_t)0x00000100)
+#define DMA_LIFCR_CFEIF1                     ((uint32_t)0x00000040)
+#define DMA_LIFCR_CTCIF0                     ((uint32_t)0x00000020)
+#define DMA_LIFCR_CHTIF0                     ((uint32_t)0x00000010)
+#define DMA_LIFCR_CTEIF0                     ((uint32_t)0x00000008)
+#define DMA_LIFCR_CDMEIF0                    ((uint32_t)0x00000004)
+#define DMA_LIFCR_CFEIF0                     ((uint32_t)0x00000001)
+
+/********************  Bits definition for DMA_HIFCR  register  ****************/
+#define DMA_HIFCR_CTCIF7                     ((uint32_t)0x08000000)
+#define DMA_HIFCR_CHTIF7                     ((uint32_t)0x04000000)
+#define DMA_HIFCR_CTEIF7                     ((uint32_t)0x02000000)
+#define DMA_HIFCR_CDMEIF7                    ((uint32_t)0x01000000)
+#define DMA_HIFCR_CFEIF7                     ((uint32_t)0x00400000)
+#define DMA_HIFCR_CTCIF6                     ((uint32_t)0x00200000)
+#define DMA_HIFCR_CHTIF6                     ((uint32_t)0x00100000)
+#define DMA_HIFCR_CTEIF6                     ((uint32_t)0x00080000)
+#define DMA_HIFCR_CDMEIF6                    ((uint32_t)0x00040000)
+#define DMA_HIFCR_CFEIF6                     ((uint32_t)0x00010000)
+#define DMA_HIFCR_CTCIF5                     ((uint32_t)0x00000800)
+#define DMA_HIFCR_CHTIF5                     ((uint32_t)0x00000400)
+#define DMA_HIFCR_CTEIF5                     ((uint32_t)0x00000200)
+#define DMA_HIFCR_CDMEIF5                    ((uint32_t)0x00000100)
+#define DMA_HIFCR_CFEIF5                     ((uint32_t)0x00000040)
+#define DMA_HIFCR_CTCIF4                     ((uint32_t)0x00000020)
+#define DMA_HIFCR_CHTIF4                     ((uint32_t)0x00000010)
+#define DMA_HIFCR_CTEIF4                     ((uint32_t)0x00000008)
+#define DMA_HIFCR_CDMEIF4                    ((uint32_t)0x00000004)
+#define DMA_HIFCR_CFEIF4                     ((uint32_t)0x00000001)
+
+/******************************************************************************/
+/*                                                                            */
+/*                         AHB Master DMA2D Controller (DMA2D)                */
+/*                                                                            */
+/******************************************************************************/
+
+/********************  Bit definition for DMA2D_CR register  ******************/
+
+#define DMA2D_CR_START                     ((uint32_t)0x00000001)               /*!< Start transfer                          */
+#define DMA2D_CR_SUSP                      ((uint32_t)0x00000002)               /*!< Suspend transfer                        */
+#define DMA2D_CR_ABORT                     ((uint32_t)0x00000004)               /*!< Abort transfer                          */
+#define DMA2D_CR_TEIE                      ((uint32_t)0x00000100)               /*!< Transfer Error Interrupt Enable         */
+#define DMA2D_CR_TCIE                      ((uint32_t)0x00000200)               /*!< Transfer Complete Interrupt Enable      */
+#define DMA2D_CR_TWIE                      ((uint32_t)0x00000400)               /*!< Transfer Watermark Interrupt Enable     */
+#define DMA2D_CR_CAEIE                     ((uint32_t)0x00000800)               /*!< CLUT Access Error Interrupt Enable      */
+#define DMA2D_CR_CTCIE                     ((uint32_t)0x00001000)               /*!< CLUT Transfer Complete Interrupt Enable */
+#define DMA2D_CR_CEIE                      ((uint32_t)0x00002000)               /*!< Configuration Error Interrupt Enable    */
+#define DMA2D_CR_MODE                      ((uint32_t)0x00030000)               /*!< DMA2D Mode                              */
+
+/********************  Bit definition for DMA2D_ISR register  *****************/
+
+#define DMA2D_ISR_TEIF                     ((uint32_t)0x00000001)               /*!< Transfer Error Interrupt Flag         */
+#define DMA2D_ISR_TCIF                     ((uint32_t)0x00000002)               /*!< Transfer Complete Interrupt Flag      */
+#define DMA2D_ISR_TWIF                     ((uint32_t)0x00000004)               /*!< Transfer Watermark Interrupt Flag     */
+#define DMA2D_ISR_CAEIF                    ((uint32_t)0x00000008)               /*!< CLUT Access Error Interrupt Flag      */
+#define DMA2D_ISR_CTCIF                    ((uint32_t)0x00000010)               /*!< CLUT Transfer Complete Interrupt Flag */
+#define DMA2D_ISR_CEIF                     ((uint32_t)0x00000020)               /*!< Configuration Error Interrupt Flag    */
+
+/********************  Bit definition for DMA2D_IFSR register  ****************/
+
+#define DMA2D_IFSR_CTEIF                   ((uint32_t)0x00000001)               /*!< Clears Transfer Error Interrupt Flag         */
+#define DMA2D_IFSR_CTCIF                   ((uint32_t)0x00000002)               /*!< Clears Transfer Complete Interrupt Flag      */
+#define DMA2D_IFSR_CTWIF                   ((uint32_t)0x00000004)               /*!< Clears Transfer Watermark Interrupt Flag     */
+#define DMA2D_IFSR_CCAEIF                  ((uint32_t)0x00000008)               /*!< Clears CLUT Access Error Interrupt Flag      */
+#define DMA2D_IFSR_CCTCIF                  ((uint32_t)0x00000010)               /*!< Clears CLUT Transfer Complete Interrupt Flag */
+#define DMA2D_IFSR_CCEIF                   ((uint32_t)0x00000020)               /*!< Clears Configuration Error Interrupt Flag    */
+
+/********************  Bit definition for DMA2D_FGMAR register  ***************/
+
+#define DMA2D_FGMAR_MA                     ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_FGOR register  ****************/
+
+#define DMA2D_FGOR_LO                      ((uint32_t)0x00003FFF)               /*!< Line Offset */
+
+/********************  Bit definition for DMA2D_BGMAR register  ***************/
+
+#define DMA2D_BGMAR_MA                     ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_BGOR register  ****************/
+
+#define DMA2D_BGOR_LO                      ((uint32_t)0x00003FFF)               /*!< Line Offset */
+
+/********************  Bit definition for DMA2D_FGPFCCR register  *************/
+
+#define DMA2D_FGPFCCR_CM                   ((uint32_t)0x0000000F)               /*!< Color mode      */
+#define DMA2D_FGPFCCR_CCM                  ((uint32_t)0x00000010)               /*!< CLUT Color mode */
+#define DMA2D_FGPFCCR_START                ((uint32_t)0x00000020)               /*!< Start           */
+#define DMA2D_FGPFCCR_CS                   ((uint32_t)0x0000FF00)               /*!< CLUT size       */
+#define DMA2D_FGPFCCR_AM                   ((uint32_t)0x00030000)               /*!< Alpha mode      */
+#define DMA2D_FGPFCCR_ALPHA                ((uint32_t)0xFF000000)               /*!< Alpha value     */
+
+/********************  Bit definition for DMA2D_FGCOLR register  **************/
+
+#define DMA2D_FGCOLR_BLUE                  ((uint32_t)0x000000FF)               /*!< Blue Value  */
+#define DMA2D_FGCOLR_GREEN                 ((uint32_t)0x0000FF00)               /*!< Green Value */
+#define DMA2D_FGCOLR_RED                   ((uint32_t)0x00FF0000)               /*!< Red Value   */
+
+/********************  Bit definition for DMA2D_BGPFCCR register  *************/
+
+#define DMA2D_BGPFCCR_CM                   ((uint32_t)0x0000000F)               /*!< Color mode      */
+#define DMA2D_BGPFCCR_CCM                  ((uint32_t)0x00000010)               /*!< CLUT Color mode */
+#define DMA2D_BGPFCCR_START                ((uint32_t)0x00000020)               /*!< Start           */
+#define DMA2D_BGPFCCR_CS                   ((uint32_t)0x0000FF00)               /*!< CLUT size       */
+#define DMA2D_BGPFCCR_AM                   ((uint32_t)0x00030000)               /*!< Alpha Mode      */
+#define DMA2D_BGPFCCR_ALPHA                ((uint32_t)0xFF000000)               /*!< Alpha value     */
+
+/********************  Bit definition for DMA2D_BGCOLR register  **************/
+
+#define DMA2D_BGCOLR_BLUE                  ((uint32_t)0x000000FF)               /*!< Blue Value  */
+#define DMA2D_BGCOLR_GREEN                 ((uint32_t)0x0000FF00)               /*!< Green Value */
+#define DMA2D_BGCOLR_RED                   ((uint32_t)0x00FF0000)               /*!< Red Value   */
+
+/********************  Bit definition for DMA2D_FGCMAR register  **************/
+
+#define DMA2D_FGCMAR_MA                    ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_BGCMAR register  **************/
+
+#define DMA2D_BGCMAR_MA                    ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_OPFCCR register  **************/
+
+#define DMA2D_OPFCCR_CM                    ((uint32_t)0x00000007)               /*!< Color mode */
+
+/********************  Bit definition for DMA2D_OCOLR register  ***************/
+
+/*!<Mode_ARGB8888/RGB888 */
+
+#define DMA2D_OCOLR_BLUE_1                 ((uint32_t)0x000000FF)               /*!< BLUE Value          */
+#define DMA2D_OCOLR_GREEN_1                ((uint32_t)0x0000FF00)               /*!< GREEN Value         */
+#define DMA2D_OCOLR_RED_1                  ((uint32_t)0x00FF0000)               /*!< Red Value           */
+#define DMA2D_OCOLR_ALPHA_1                ((uint32_t)0xFF000000)               /*!< Alpha Channel Value */
+
+/*!<Mode_RGB565 */
+#define DMA2D_OCOLR_BLUE_2                 ((uint32_t)0x0000001F)               /*!< BLUE Value   */
+#define DMA2D_OCOLR_GREEN_2                ((uint32_t)0x000007E0)               /*!< GREEN Value  */
+#define DMA2D_OCOLR_RED_2                  ((uint32_t)0x0000F800)               /*!< Red Value    */
+
+/*!<Mode_ARGB1555 */
+#define DMA2D_OCOLR_BLUE_3                 ((uint32_t)0x0000001F)               /*!< BLUE Value          */
+#define DMA2D_OCOLR_GREEN_3                ((uint32_t)0x000003E0)               /*!< GREEN Value         */
+#define DMA2D_OCOLR_RED_3                  ((uint32_t)0x00007C00)               /*!< Red Value           */
+#define DMA2D_OCOLR_ALPHA_3                ((uint32_t)0x00008000)               /*!< Alpha Channel Value */
+
+/*!<Mode_ARGB4444 */
+#define DMA2D_OCOLR_BLUE_4                 ((uint32_t)0x0000000F)               /*!< BLUE Value          */
+#define DMA2D_OCOLR_GREEN_4                ((uint32_t)0x000000F0)               /*!< GREEN Value         */
+#define DMA2D_OCOLR_RED_4                  ((uint32_t)0x00000F00)               /*!< Red Value           */
+#define DMA2D_OCOLR_ALPHA_4                ((uint32_t)0x0000F000)               /*!< Alpha Channel Value */
+
+/********************  Bit definition for DMA2D_OMAR register  ****************/
+
+#define DMA2D_OMAR_MA                      ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_OOR register  *****************/
+
+#define DMA2D_OOR_LO                       ((uint32_t)0x00003FFF)               /*!< Line Offset */
+
+/********************  Bit definition for DMA2D_NLR register  *****************/
+
+#define DMA2D_NLR_NL                       ((uint32_t)0x0000FFFF)               /*!< Number of Lines */
+#define DMA2D_NLR_PL                       ((uint32_t)0x3FFF0000)               /*!< Pixel per Lines */
+
+/********************  Bit definition for DMA2D_LWR register  *****************/
+
+#define DMA2D_LWR_LW                       ((uint32_t)0x0000FFFF)               /*!< Line Watermark */
+
+/********************  Bit definition for DMA2D_AMTCR register  ***************/
+
+#define DMA2D_AMTCR_EN                     ((uint32_t)0x00000001)               /*!< Enable    */
+#define DMA2D_AMTCR_DT                     ((uint32_t)0x0000FF00)               /*!< Dead Time */
+
+
+
+/********************  Bit definition for DMA2D_FGCLUT register  **************/
+
+/********************  Bit definition for DMA2D_BGCLUT register  **************/
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                    External Interrupt/Event Controller                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for EXTI_IMR register  *******************/
+#define  EXTI_IMR_MR0                        ((uint32_t)0x00000001)        /*!< Interrupt Mask on line 0 */
+#define  EXTI_IMR_MR1                        ((uint32_t)0x00000002)        /*!< Interrupt Mask on line 1 */
+#define  EXTI_IMR_MR2                        ((uint32_t)0x00000004)        /*!< Interrupt Mask on line 2 */
+#define  EXTI_IMR_MR3                        ((uint32_t)0x00000008)        /*!< Interrupt Mask on line 3 */
+#define  EXTI_IMR_MR4                        ((uint32_t)0x00000010)        /*!< Interrupt Mask on line 4 */
+#define  EXTI_IMR_MR5                        ((uint32_t)0x00000020)        /*!< Interrupt Mask on line 5 */
+#define  EXTI_IMR_MR6                        ((uint32_t)0x00000040)        /*!< Interrupt Mask on line 6 */
+#define  EXTI_IMR_MR7                        ((uint32_t)0x00000080)        /*!< Interrupt Mask on line 7 */
+#define  EXTI_IMR_MR8                        ((uint32_t)0x00000100)        /*!< Interrupt Mask on line 8 */
+#define  EXTI_IMR_MR9                        ((uint32_t)0x00000200)        /*!< Interrupt Mask on line 9 */
+#define  EXTI_IMR_MR10                       ((uint32_t)0x00000400)        /*!< Interrupt Mask on line 10 */
+#define  EXTI_IMR_MR11                       ((uint32_t)0x00000800)        /*!< Interrupt Mask on line 11 */
+#define  EXTI_IMR_MR12                       ((uint32_t)0x00001000)        /*!< Interrupt Mask on line 12 */
+#define  EXTI_IMR_MR13                       ((uint32_t)0x00002000)        /*!< Interrupt Mask on line 13 */
+#define  EXTI_IMR_MR14                       ((uint32_t)0x00004000)        /*!< Interrupt Mask on line 14 */
+#define  EXTI_IMR_MR15                       ((uint32_t)0x00008000)        /*!< Interrupt Mask on line 15 */
+#define  EXTI_IMR_MR16                       ((uint32_t)0x00010000)        /*!< Interrupt Mask on line 16 */
+#define  EXTI_IMR_MR17                       ((uint32_t)0x00020000)        /*!< Interrupt Mask on line 17 */
+#define  EXTI_IMR_MR18                       ((uint32_t)0x00040000)        /*!< Interrupt Mask on line 18 */
+#define  EXTI_IMR_MR19                       ((uint32_t)0x00080000)        /*!< Interrupt Mask on line 19 */
+#define  EXTI_IMR_MR20                       ((uint32_t)0x00100000)        /*!< Interrupt Mask on line 20 */
+#define  EXTI_IMR_MR21                       ((uint32_t)0x00200000)        /*!< Interrupt Mask on line 21 */
+#define  EXTI_IMR_MR22                       ((uint32_t)0x00400000)        /*!< Interrupt Mask on line 22 */
+#define  EXTI_IMR_MR23                       ((uint32_t)0x00800000)        /*!< Interrupt Mask on line 23 */
+
+/*******************  Bit definition for EXTI_EMR register  *******************/
+#define  EXTI_EMR_MR0                        ((uint32_t)0x00000001)        /*!< Event Mask on line 0 */
+#define  EXTI_EMR_MR1                        ((uint32_t)0x00000002)        /*!< Event Mask on line 1 */
+#define  EXTI_EMR_MR2                        ((uint32_t)0x00000004)        /*!< Event Mask on line 2 */
+#define  EXTI_EMR_MR3                        ((uint32_t)0x00000008)        /*!< Event Mask on line 3 */
+#define  EXTI_EMR_MR4                        ((uint32_t)0x00000010)        /*!< Event Mask on line 4 */
+#define  EXTI_EMR_MR5                        ((uint32_t)0x00000020)        /*!< Event Mask on line 5 */
+#define  EXTI_EMR_MR6                        ((uint32_t)0x00000040)        /*!< Event Mask on line 6 */
+#define  EXTI_EMR_MR7                        ((uint32_t)0x00000080)        /*!< Event Mask on line 7 */
+#define  EXTI_EMR_MR8                        ((uint32_t)0x00000100)        /*!< Event Mask on line 8 */
+#define  EXTI_EMR_MR9                        ((uint32_t)0x00000200)        /*!< Event Mask on line 9 */
+#define  EXTI_EMR_MR10                       ((uint32_t)0x00000400)        /*!< Event Mask on line 10 */
+#define  EXTI_EMR_MR11                       ((uint32_t)0x00000800)        /*!< Event Mask on line 11 */
+#define  EXTI_EMR_MR12                       ((uint32_t)0x00001000)        /*!< Event Mask on line 12 */
+#define  EXTI_EMR_MR13                       ((uint32_t)0x00002000)        /*!< Event Mask on line 13 */
+#define  EXTI_EMR_MR14                       ((uint32_t)0x00004000)        /*!< Event Mask on line 14 */
+#define  EXTI_EMR_MR15                       ((uint32_t)0x00008000)        /*!< Event Mask on line 15 */
+#define  EXTI_EMR_MR16                       ((uint32_t)0x00010000)        /*!< Event Mask on line 16 */
+#define  EXTI_EMR_MR17                       ((uint32_t)0x00020000)        /*!< Event Mask on line 17 */
+#define  EXTI_EMR_MR18                       ((uint32_t)0x00040000)        /*!< Event Mask on line 18 */
+#define  EXTI_EMR_MR19                       ((uint32_t)0x00080000)        /*!< Event Mask on line 19 */
+#define  EXTI_EMR_MR20                       ((uint32_t)0x00100000)        /*!< Event Mask on line 20 */
+#define  EXTI_EMR_MR21                       ((uint32_t)0x00200000)        /*!< Event Mask on line 21 */
+#define  EXTI_EMR_MR22                       ((uint32_t)0x00400000)        /*!< Event Mask on line 22 */
+#define  EXTI_EMR_MR23                       ((uint32_t)0x00800000)        /*!< Event Mask on line 23 */
+
+/******************  Bit definition for EXTI_RTSR register  *******************/
+#define  EXTI_RTSR_TR0                       ((uint32_t)0x00000001)        /*!< Rising trigger event configuration bit of line 0 */
+#define  EXTI_RTSR_TR1                       ((uint32_t)0x00000002)        /*!< Rising trigger event configuration bit of line 1 */
+#define  EXTI_RTSR_TR2                       ((uint32_t)0x00000004)        /*!< Rising trigger event configuration bit of line 2 */
+#define  EXTI_RTSR_TR3                       ((uint32_t)0x00000008)        /*!< Rising trigger event configuration bit of line 3 */
+#define  EXTI_RTSR_TR4                       ((uint32_t)0x00000010)        /*!< Rising trigger event configuration bit of line 4 */
+#define  EXTI_RTSR_TR5                       ((uint32_t)0x00000020)        /*!< Rising trigger event configuration bit of line 5 */
+#define  EXTI_RTSR_TR6                       ((uint32_t)0x00000040)        /*!< Rising trigger event configuration bit of line 6 */
+#define  EXTI_RTSR_TR7                       ((uint32_t)0x00000080)        /*!< Rising trigger event configuration bit of line 7 */
+#define  EXTI_RTSR_TR8                       ((uint32_t)0x00000100)        /*!< Rising trigger event configuration bit of line 8 */
+#define  EXTI_RTSR_TR9                       ((uint32_t)0x00000200)        /*!< Rising trigger event configuration bit of line 9 */
+#define  EXTI_RTSR_TR10                      ((uint32_t)0x00000400)        /*!< Rising trigger event configuration bit of line 10 */
+#define  EXTI_RTSR_TR11                      ((uint32_t)0x00000800)        /*!< Rising trigger event configuration bit of line 11 */
+#define  EXTI_RTSR_TR12                      ((uint32_t)0x00001000)        /*!< Rising trigger event configuration bit of line 12 */
+#define  EXTI_RTSR_TR13                      ((uint32_t)0x00002000)        /*!< Rising trigger event configuration bit of line 13 */
+#define  EXTI_RTSR_TR14                      ((uint32_t)0x00004000)        /*!< Rising trigger event configuration bit of line 14 */
+#define  EXTI_RTSR_TR15                      ((uint32_t)0x00008000)        /*!< Rising trigger event configuration bit of line 15 */
+#define  EXTI_RTSR_TR16                      ((uint32_t)0x00010000)        /*!< Rising trigger event configuration bit of line 16 */
+#define  EXTI_RTSR_TR17                      ((uint32_t)0x00020000)        /*!< Rising trigger event configuration bit of line 17 */
+#define  EXTI_RTSR_TR18                      ((uint32_t)0x00040000)        /*!< Rising trigger event configuration bit of line 18 */
+#define  EXTI_RTSR_TR19                      ((uint32_t)0x00080000)        /*!< Rising trigger event configuration bit of line 19 */
+#define  EXTI_RTSR_TR20                      ((uint32_t)0x00100000)        /*!< Rising trigger event configuration bit of line 20 */
+#define  EXTI_RTSR_TR21                      ((uint32_t)0x00200000)        /*!< Rising trigger event configuration bit of line 21 */
+#define  EXTI_RTSR_TR22                      ((uint32_t)0x00400000)        /*!< Rising trigger event configuration bit of line 22 */
+#define  EXTI_RTSR_TR23                      ((uint32_t)0x00800000)        /*!< Rising trigger event configuration bit of line 23 */
+
+/******************  Bit definition for EXTI_FTSR register  *******************/
+#define  EXTI_FTSR_TR0                       ((uint32_t)0x00000001)        /*!< Falling trigger event configuration bit of line 0 */
+#define  EXTI_FTSR_TR1                       ((uint32_t)0x00000002)        /*!< Falling trigger event configuration bit of line 1 */
+#define  EXTI_FTSR_TR2                       ((uint32_t)0x00000004)        /*!< Falling trigger event configuration bit of line 2 */
+#define  EXTI_FTSR_TR3                       ((uint32_t)0x00000008)        /*!< Falling trigger event configuration bit of line 3 */
+#define  EXTI_FTSR_TR4                       ((uint32_t)0x00000010)        /*!< Falling trigger event configuration bit of line 4 */
+#define  EXTI_FTSR_TR5                       ((uint32_t)0x00000020)        /*!< Falling trigger event configuration bit of line 5 */
+#define  EXTI_FTSR_TR6                       ((uint32_t)0x00000040)        /*!< Falling trigger event configuration bit of line 6 */
+#define  EXTI_FTSR_TR7                       ((uint32_t)0x00000080)        /*!< Falling trigger event configuration bit of line 7 */
+#define  EXTI_FTSR_TR8                       ((uint32_t)0x00000100)        /*!< Falling trigger event configuration bit of line 8 */
+#define  EXTI_FTSR_TR9                       ((uint32_t)0x00000200)        /*!< Falling trigger event configuration bit of line 9 */
+#define  EXTI_FTSR_TR10                      ((uint32_t)0x00000400)        /*!< Falling trigger event configuration bit of line 10 */
+#define  EXTI_FTSR_TR11                      ((uint32_t)0x00000800)        /*!< Falling trigger event configuration bit of line 11 */
+#define  EXTI_FTSR_TR12                      ((uint32_t)0x00001000)        /*!< Falling trigger event configuration bit of line 12 */
+#define  EXTI_FTSR_TR13                      ((uint32_t)0x00002000)        /*!< Falling trigger event configuration bit of line 13 */
+#define  EXTI_FTSR_TR14                      ((uint32_t)0x00004000)        /*!< Falling trigger event configuration bit of line 14 */
+#define  EXTI_FTSR_TR15                      ((uint32_t)0x00008000)        /*!< Falling trigger event configuration bit of line 15 */
+#define  EXTI_FTSR_TR16                      ((uint32_t)0x00010000)        /*!< Falling trigger event configuration bit of line 16 */
+#define  EXTI_FTSR_TR17                      ((uint32_t)0x00020000)        /*!< Falling trigger event configuration bit of line 17 */
+#define  EXTI_FTSR_TR18                      ((uint32_t)0x00040000)        /*!< Falling trigger event configuration bit of line 18 */
+#define  EXTI_FTSR_TR19                      ((uint32_t)0x00080000)        /*!< Falling trigger event configuration bit of line 19 */
+#define  EXTI_FTSR_TR20                      ((uint32_t)0x00100000)        /*!< Falling trigger event configuration bit of line 20 */
+#define  EXTI_FTSR_TR21                      ((uint32_t)0x00200000)        /*!< Falling trigger event configuration bit of line 21 */
+#define  EXTI_FTSR_TR22                      ((uint32_t)0x00400000)        /*!< Falling trigger event configuration bit of line 22 */
+#define  EXTI_FTSR_TR23                      ((uint32_t)0x00800000)        /*!< Falling trigger event configuration bit of line 23 */
+
+/******************  Bit definition for EXTI_SWIER register  ******************/
+#define  EXTI_SWIER_SWIER0                   ((uint32_t)0x00000001)        /*!< Software Interrupt on line 0 */
+#define  EXTI_SWIER_SWIER1                   ((uint32_t)0x00000002)        /*!< Software Interrupt on line 1 */
+#define  EXTI_SWIER_SWIER2                   ((uint32_t)0x00000004)        /*!< Software Interrupt on line 2 */
+#define  EXTI_SWIER_SWIER3                   ((uint32_t)0x00000008)        /*!< Software Interrupt on line 3 */
+#define  EXTI_SWIER_SWIER4                   ((uint32_t)0x00000010)        /*!< Software Interrupt on line 4 */
+#define  EXTI_SWIER_SWIER5                   ((uint32_t)0x00000020)        /*!< Software Interrupt on line 5 */
+#define  EXTI_SWIER_SWIER6                   ((uint32_t)0x00000040)        /*!< Software Interrupt on line 6 */
+#define  EXTI_SWIER_SWIER7                   ((uint32_t)0x00000080)        /*!< Software Interrupt on line 7 */
+#define  EXTI_SWIER_SWIER8                   ((uint32_t)0x00000100)        /*!< Software Interrupt on line 8 */
+#define  EXTI_SWIER_SWIER9                   ((uint32_t)0x00000200)        /*!< Software Interrupt on line 9 */
+#define  EXTI_SWIER_SWIER10                  ((uint32_t)0x00000400)        /*!< Software Interrupt on line 10 */
+#define  EXTI_SWIER_SWIER11                  ((uint32_t)0x00000800)        /*!< Software Interrupt on line 11 */
+#define  EXTI_SWIER_SWIER12                  ((uint32_t)0x00001000)        /*!< Software Interrupt on line 12 */
+#define  EXTI_SWIER_SWIER13                  ((uint32_t)0x00002000)        /*!< Software Interrupt on line 13 */
+#define  EXTI_SWIER_SWIER14                  ((uint32_t)0x00004000)        /*!< Software Interrupt on line 14 */
+#define  EXTI_SWIER_SWIER15                  ((uint32_t)0x00008000)        /*!< Software Interrupt on line 15 */
+#define  EXTI_SWIER_SWIER16                  ((uint32_t)0x00010000)        /*!< Software Interrupt on line 16 */
+#define  EXTI_SWIER_SWIER17                  ((uint32_t)0x00020000)        /*!< Software Interrupt on line 17 */
+#define  EXTI_SWIER_SWIER18                  ((uint32_t)0x00040000)        /*!< Software Interrupt on line 18 */
+#define  EXTI_SWIER_SWIER19                  ((uint32_t)0x00080000)        /*!< Software Interrupt on line 19 */
+#define  EXTI_SWIER_SWIER20                  ((uint32_t)0x00100000)        /*!< Software Interrupt on line 20 */
+#define  EXTI_SWIER_SWIER21                  ((uint32_t)0x00200000)        /*!< Software Interrupt on line 21 */
+#define  EXTI_SWIER_SWIER22                  ((uint32_t)0x00400000)        /*!< Software Interrupt on line 22 */
+#define  EXTI_SWIER_SWIER23                  ((uint32_t)0x00800000)        /*!< Software Interrupt on line 23 */
+
+/*******************  Bit definition for EXTI_PR register  ********************/
+#define  EXTI_PR_PR0                         ((uint32_t)0x00000001)        /*!< Pending bit for line 0 */
+#define  EXTI_PR_PR1                         ((uint32_t)0x00000002)        /*!< Pending bit for line 1 */
+#define  EXTI_PR_PR2                         ((uint32_t)0x00000004)        /*!< Pending bit for line 2 */
+#define  EXTI_PR_PR3                         ((uint32_t)0x00000008)        /*!< Pending bit for line 3 */
+#define  EXTI_PR_PR4                         ((uint32_t)0x00000010)        /*!< Pending bit for line 4 */
+#define  EXTI_PR_PR5                         ((uint32_t)0x00000020)        /*!< Pending bit for line 5 */
+#define  EXTI_PR_PR6                         ((uint32_t)0x00000040)        /*!< Pending bit for line 6 */
+#define  EXTI_PR_PR7                         ((uint32_t)0x00000080)        /*!< Pending bit for line 7 */
+#define  EXTI_PR_PR8                         ((uint32_t)0x00000100)        /*!< Pending bit for line 8 */
+#define  EXTI_PR_PR9                         ((uint32_t)0x00000200)        /*!< Pending bit for line 9 */
+#define  EXTI_PR_PR10                        ((uint32_t)0x00000400)        /*!< Pending bit for line 10 */
+#define  EXTI_PR_PR11                        ((uint32_t)0x00000800)        /*!< Pending bit for line 11 */
+#define  EXTI_PR_PR12                        ((uint32_t)0x00001000)        /*!< Pending bit for line 12 */
+#define  EXTI_PR_PR13                        ((uint32_t)0x00002000)        /*!< Pending bit for line 13 */
+#define  EXTI_PR_PR14                        ((uint32_t)0x00004000)        /*!< Pending bit for line 14 */
+#define  EXTI_PR_PR15                        ((uint32_t)0x00008000)        /*!< Pending bit for line 15 */
+#define  EXTI_PR_PR16                        ((uint32_t)0x00010000)        /*!< Pending bit for line 16 */
+#define  EXTI_PR_PR17                        ((uint32_t)0x00020000)        /*!< Pending bit for line 17 */
+#define  EXTI_PR_PR18                        ((uint32_t)0x00040000)        /*!< Pending bit for line 18 */
+#define  EXTI_PR_PR19                        ((uint32_t)0x00080000)        /*!< Pending bit for line 19 */
+#define  EXTI_PR_PR20                        ((uint32_t)0x00100000)        /*!< Pending bit for line 20 */
+#define  EXTI_PR_PR21                        ((uint32_t)0x00200000)        /*!< Pending bit for line 21 */
+#define  EXTI_PR_PR22                        ((uint32_t)0x00400000)        /*!< Pending bit for line 22 */
+#define  EXTI_PR_PR23                        ((uint32_t)0x00800000)        /*!< Pending bit for line 23 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    FLASH                                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bits definition for FLASH_ACR register  *****************/
+#define FLASH_ACR_LATENCY                    ((uint32_t)0x0000000F)
+#define FLASH_ACR_LATENCY_0WS                ((uint32_t)0x00000000)
+#define FLASH_ACR_LATENCY_1WS                ((uint32_t)0x00000001)
+#define FLASH_ACR_LATENCY_2WS                ((uint32_t)0x00000002)
+#define FLASH_ACR_LATENCY_3WS                ((uint32_t)0x00000003)
+#define FLASH_ACR_LATENCY_4WS                ((uint32_t)0x00000004)
+#define FLASH_ACR_LATENCY_5WS                ((uint32_t)0x00000005)
+#define FLASH_ACR_LATENCY_6WS                ((uint32_t)0x00000006)
+#define FLASH_ACR_LATENCY_7WS                ((uint32_t)0x00000007)
+#define FLASH_ACR_LATENCY_8WS                ((uint32_t)0x00000008)
+#define FLASH_ACR_LATENCY_9WS                ((uint32_t)0x00000009)
+#define FLASH_ACR_LATENCY_10WS               ((uint32_t)0x0000000A)
+#define FLASH_ACR_LATENCY_11WS               ((uint32_t)0x0000000B)
+#define FLASH_ACR_LATENCY_12WS               ((uint32_t)0x0000000C)
+#define FLASH_ACR_LATENCY_13WS               ((uint32_t)0x0000000D)
+#define FLASH_ACR_LATENCY_14WS               ((uint32_t)0x0000000E)
+#define FLASH_ACR_LATENCY_15WS               ((uint32_t)0x0000000F)
+#define FLASH_ACR_PRFTEN                     ((uint32_t)0x00000100)
+#define FLASH_ACR_ARTEN                      ((uint32_t)0x00000200)
+#define FLASH_ACR_ARTRST                     ((uint32_t)0x00000800)
+
+/*******************  Bits definition for FLASH_SR register  ******************/
+#define FLASH_SR_EOP                         ((uint32_t)0x00000001)
+#define FLASH_SR_OPERR                       ((uint32_t)0x00000002)
+#define FLASH_SR_WRPERR                      ((uint32_t)0x00000010)
+#define FLASH_SR_PGAERR                      ((uint32_t)0x00000020)
+#define FLASH_SR_PGPERR                      ((uint32_t)0x00000040)
+#define FLASH_SR_ERSERR                      ((uint32_t)0x00000080)
+#define FLASH_SR_BSY                         ((uint32_t)0x00010000)
+
+/*******************  Bits definition for FLASH_CR register  ******************/
+#define FLASH_CR_PG                          ((uint32_t)0x00000001)
+#define FLASH_CR_SER                         ((uint32_t)0x00000002)
+#define FLASH_CR_MER                         ((uint32_t)0x00000004)
+#define FLASH_CR_SNB                         ((uint32_t)0x00000078)
+#define FLASH_CR_SNB_0                       ((uint32_t)0x00000008)
+#define FLASH_CR_SNB_1                       ((uint32_t)0x00000010)
+#define FLASH_CR_SNB_2                       ((uint32_t)0x00000020)
+#define FLASH_CR_SNB_3                       ((uint32_t)0x00000040)
+#define FLASH_CR_PSIZE                       ((uint32_t)0x00000300)
+#define FLASH_CR_PSIZE_0                     ((uint32_t)0x00000100)
+#define FLASH_CR_PSIZE_1                     ((uint32_t)0x00000200)
+#define FLASH_CR_STRT                        ((uint32_t)0x00010000)
+#define FLASH_CR_EOPIE                       ((uint32_t)0x01000000)
+#define FLASH_CR_ERRIE                       ((uint32_t)0x02000000)
+#define FLASH_CR_LOCK                        ((uint32_t)0x80000000)
+
+/*******************  Bits definition for FLASH_OPTCR register  ***************/
+#define FLASH_OPTCR_OPTLOCK                 ((uint32_t)0x00000001)
+#define FLASH_OPTCR_OPTSTRT                 ((uint32_t)0x00000002)
+#define FLASH_OPTCR_BOR_LEV                 ((uint32_t)0x0000000C)
+#define FLASH_OPTCR_BOR_LEV_0               ((uint32_t)0x00000004)
+#define FLASH_OPTCR_BOR_LEV_1               ((uint32_t)0x00000008)
+#define FLASH_OPTCR_WWDG_SW                 ((uint32_t)0x00000010)
+#define FLASH_OPTCR_IWDG_SW                 ((uint32_t)0x00000020)
+#define FLASH_OPTCR_nRST_STOP               ((uint32_t)0x00000040)
+#define FLASH_OPTCR_nRST_STDBY              ((uint32_t)0x00000080)
+#define FLASH_OPTCR_RDP                     ((uint32_t)0x0000FF00)
+#define FLASH_OPTCR_RDP_0                   ((uint32_t)0x00000100)
+#define FLASH_OPTCR_RDP_1                   ((uint32_t)0x00000200)
+#define FLASH_OPTCR_RDP_2                   ((uint32_t)0x00000400)
+#define FLASH_OPTCR_RDP_3                   ((uint32_t)0x00000800)
+#define FLASH_OPTCR_RDP_4                   ((uint32_t)0x00001000)
+#define FLASH_OPTCR_RDP_5                   ((uint32_t)0x00002000)
+#define FLASH_OPTCR_RDP_6                   ((uint32_t)0x00004000)
+#define FLASH_OPTCR_RDP_7                   ((uint32_t)0x00008000)
+#define FLASH_OPTCR_nWRP                    ((uint32_t)0x00FF0000)
+#define FLASH_OPTCR_nWRP_0                  ((uint32_t)0x00010000)
+#define FLASH_OPTCR_nWRP_1                  ((uint32_t)0x00020000)
+#define FLASH_OPTCR_nWRP_2                  ((uint32_t)0x00040000)
+#define FLASH_OPTCR_nWRP_3                  ((uint32_t)0x00080000)
+#define FLASH_OPTCR_nWRP_4                  ((uint32_t)0x00100000)
+#define FLASH_OPTCR_nWRP_5                  ((uint32_t)0x00200000)
+#define FLASH_OPTCR_nWRP_6                  ((uint32_t)0x00400000)
+#define FLASH_OPTCR_nWRP_7                  ((uint32_t)0x00800000)
+#define FLASH_OPTCR_IWDG_STDBY              ((uint32_t)0x40000000)
+#define FLASH_OPTCR_IWDG_STOP               ((uint32_t)0x80000000)
+
+/*******************  Bits definition for FLASH_OPTCR1 register  ***************/
+#define FLASH_OPTCR1_BOOT_ADD0              ((uint32_t)0x0000FFFF)
+#define FLASH_OPTCR1_BOOT_ADD1              ((uint32_t)0xFFFF0000)
+
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          Flexible Memory Controller                        */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for FMC_BCR1 register  *******************/
+#define  FMC_BCR1_MBKEN                     ((uint32_t)0x00000001)        /*!<Memory bank enable bit                 */
+#define  FMC_BCR1_MUXEN                     ((uint32_t)0x00000002)        /*!<Address/data multiplexing enable bit   */
+
+#define  FMC_BCR1_MTYP                      ((uint32_t)0x0000000C)        /*!<MTYP[1:0] bits (Memory type)           */
+#define  FMC_BCR1_MTYP_0                    ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_BCR1_MTYP_1                    ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_BCR1_MWID                      ((uint32_t)0x00000030)        /*!<MWID[1:0] bits (Memory data bus width) */
+#define  FMC_BCR1_MWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BCR1_MWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_BCR1_FACCEN                    ((uint32_t)0x00000040)        /*!<Flash access enable        */
+#define  FMC_BCR1_BURSTEN                   ((uint32_t)0x00000100)        /*!<Burst enable bit           */
+#define  FMC_BCR1_WAITPOL                   ((uint32_t)0x00000200)        /*!<Wait signal polarity bit   */
+#define  FMC_BCR1_WRAPMOD                   ((uint32_t)0x00000400)        /*!<Wrapped burst mode support */
+#define  FMC_BCR1_WAITCFG                   ((uint32_t)0x00000800)        /*!<Wait timing configuration  */
+#define  FMC_BCR1_WREN                      ((uint32_t)0x00001000)        /*!<Write enable bit           */
+#define  FMC_BCR1_WAITEN                    ((uint32_t)0x00002000)        /*!<Wait enable bit            */
+#define  FMC_BCR1_EXTMOD                    ((uint32_t)0x00004000)        /*!<Extended mode enable       */
+#define  FMC_BCR1_ASYNCWAIT                 ((uint32_t)0x00008000)        /*!<Asynchronous wait          */
+#define  FMC_BCR1_CPSIZE                     ((uint32_t)0x00070000)        /*!<CRAM page size             */
+#define  FMC_BCR1_CPSIZE_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BCR1_CPSIZE_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BCR1_CPSIZE_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BCR1_CBURSTRW                  ((uint32_t)0x00080000)        /*!<Write burst enable         */
+#define  FMC_BCR1_CCLKEN                    ((uint32_t)0x00100000)        /*!<Continous clock enable     */
+#define  FMC_BCR1_WFDIS                     ((uint32_t)0x00200000)        /*!<Write FIFO Disable         */
+
+/******************  Bit definition for FMC_BCR2 register  *******************/
+#define  FMC_BCR2_MBKEN                     ((uint32_t)0x00000001)        /*!<Memory bank enable bit                 */
+#define  FMC_BCR2_MUXEN                     ((uint32_t)0x00000002)        /*!<Address/data multiplexing enable bit   */
+
+#define  FMC_BCR2_MTYP                      ((uint32_t)0x0000000C)        /*!<MTYP[1:0] bits (Memory type)           */
+#define  FMC_BCR2_MTYP_0                    ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_BCR2_MTYP_1                    ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_BCR2_MWID                      ((uint32_t)0x00000030)        /*!<MWID[1:0] bits (Memory data bus width) */
+#define  FMC_BCR2_MWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BCR2_MWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_BCR2_FACCEN                    ((uint32_t)0x00000040)        /*!<Flash access enable        */
+#define  FMC_BCR2_BURSTEN                   ((uint32_t)0x00000100)        /*!<Burst enable bit           */
+#define  FMC_BCR2_WAITPOL                   ((uint32_t)0x00000200)        /*!<Wait signal polarity bit   */
+#define  FMC_BCR2_WRAPMOD                   ((uint32_t)0x00000400)        /*!<Wrapped burst mode support */
+#define  FMC_BCR2_WAITCFG                   ((uint32_t)0x00000800)        /*!<Wait timing configuration  */
+#define  FMC_BCR2_WREN                      ((uint32_t)0x00001000)        /*!<Write enable bit           */
+#define  FMC_BCR2_WAITEN                    ((uint32_t)0x00002000)        /*!<Wait enable bit            */
+#define  FMC_BCR2_EXTMOD                    ((uint32_t)0x00004000)        /*!<Extended mode enable       */
+#define  FMC_BCR2_ASYNCWAIT                 ((uint32_t)0x00008000)        /*!<Asynchronous wait          */
+#define  FMC_BCR2_CPSIZE                     ((uint32_t)0x00070000)        /*!<CRAM page size             */
+#define  FMC_BCR2_CPSIZE_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BCR2_CPSIZE_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BCR2_CPSIZE_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BCR2_CBURSTRW                  ((uint32_t)0x00080000)        /*!<Write burst enable         */
+
+/******************  Bit definition for FMC_BCR3 register  *******************/
+#define  FMC_BCR3_MBKEN                     ((uint32_t)0x00000001)        /*!<Memory bank enable bit                 */
+#define  FMC_BCR3_MUXEN                     ((uint32_t)0x00000002)        /*!<Address/data multiplexing enable bit   */
+
+#define  FMC_BCR3_MTYP                      ((uint32_t)0x0000000C)        /*!<MTYP[1:0] bits (Memory type)           */
+#define  FMC_BCR3_MTYP_0                    ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_BCR3_MTYP_1                    ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_BCR3_MWID                      ((uint32_t)0x00000030)        /*!<MWID[1:0] bits (Memory data bus width) */
+#define  FMC_BCR3_MWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BCR3_MWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_BCR3_FACCEN                    ((uint32_t)0x00000040)        /*!<Flash access enable        */
+#define  FMC_BCR3_BURSTEN                   ((uint32_t)0x00000100)        /*!<Burst enable bit           */
+#define  FMC_BCR3_WAITPOL                   ((uint32_t)0x00000200)        /*!<Wait signal polarity bit   */
+#define  FMC_BCR3_WRAPMOD                   ((uint32_t)0x00000400)        /*!<Wrapped burst mode support */
+#define  FMC_BCR3_WAITCFG                   ((uint32_t)0x00000800)        /*!<Wait timing configuration  */
+#define  FMC_BCR3_WREN                      ((uint32_t)0x00001000)        /*!<Write enable bit           */
+#define  FMC_BCR3_WAITEN                    ((uint32_t)0x00002000)        /*!<Wait enable bit            */
+#define  FMC_BCR3_EXTMOD                    ((uint32_t)0x00004000)        /*!<Extended mode enable       */
+#define  FMC_BCR3_ASYNCWAIT                 ((uint32_t)0x00008000)        /*!<Asynchronous wait          */
+#define  FMC_BCR3_CPSIZE                     ((uint32_t)0x00070000)        /*!<CRAM page size             */
+#define  FMC_BCR3_CPSIZE_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BCR3_CPSIZE_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BCR3_CPSIZE_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BCR3_CBURSTRW                  ((uint32_t)0x00080000)        /*!<Write burst enable         */
+
+/******************  Bit definition for FMC_BCR4 register  *******************/
+#define  FMC_BCR4_MBKEN                     ((uint32_t)0x00000001)        /*!<Memory bank enable bit                 */
+#define  FMC_BCR4_MUXEN                     ((uint32_t)0x00000002)        /*!<Address/data multiplexing enable bit   */
+
+#define  FMC_BCR4_MTYP                      ((uint32_t)0x0000000C)        /*!<MTYP[1:0] bits (Memory type)           */
+#define  FMC_BCR4_MTYP_0                    ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_BCR4_MTYP_1                    ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_BCR4_MWID                      ((uint32_t)0x00000030)        /*!<MWID[1:0] bits (Memory data bus width) */
+#define  FMC_BCR4_MWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BCR4_MWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_BCR4_FACCEN                    ((uint32_t)0x00000040)        /*!<Flash access enable        */
+#define  FMC_BCR4_BURSTEN                   ((uint32_t)0x00000100)        /*!<Burst enable bit           */
+#define  FMC_BCR4_WAITPOL                   ((uint32_t)0x00000200)        /*!<Wait signal polarity bit   */
+#define  FMC_BCR4_WRAPMOD                   ((uint32_t)0x00000400)        /*!<Wrapped burst mode support */
+#define  FMC_BCR4_WAITCFG                   ((uint32_t)0x00000800)        /*!<Wait timing configuration  */
+#define  FMC_BCR4_WREN                      ((uint32_t)0x00001000)        /*!<Write enable bit           */
+#define  FMC_BCR4_WAITEN                    ((uint32_t)0x00002000)        /*!<Wait enable bit            */
+#define  FMC_BCR4_EXTMOD                    ((uint32_t)0x00004000)        /*!<Extended mode enable       */
+#define  FMC_BCR4_ASYNCWAIT                 ((uint32_t)0x00008000)        /*!<Asynchronous wait          */
+#define  FMC_BCR4_CPSIZE                     ((uint32_t)0x00070000)        /*!<CRAM page size             */
+#define  FMC_BCR4_CPSIZE_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BCR4_CPSIZE_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BCR4_CPSIZE_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BCR4_CBURSTRW                  ((uint32_t)0x00080000)        /*!<Write burst enable         */
+
+/******************  Bit definition for FMC_BTR1 register  ******************/
+#define  FMC_BTR1_ADDSET                    ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BTR1_ADDSET_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BTR1_ADDSET_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BTR1_ADDSET_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BTR1_ADDSET_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BTR1_ADDHLD                    ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration)  */
+#define  FMC_BTR1_ADDHLD_0                  ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BTR1_ADDHLD_1                  ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BTR1_ADDHLD_2                  ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BTR1_ADDHLD_3                  ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BTR1_DATAST                    ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BTR1_DATAST_0                  ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BTR1_DATAST_1                  ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BTR1_DATAST_2                  ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BTR1_DATAST_3                  ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BTR1_DATAST_4                  ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BTR1_DATAST_5                  ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BTR1_DATAST_6                  ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BTR1_DATAST_7                  ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BTR1_BUSTURN                   ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BTR1_BUSTURN_0                 ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BTR1_BUSTURN_1                 ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BTR1_BUSTURN_2                 ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BTR1_BUSTURN_3                 ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BTR1_CLKDIV                    ((uint32_t)0x00F00000)        /*!<CLKDIV[3:0] bits (Clock divide ratio) */
+#define  FMC_BTR1_CLKDIV_0                  ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_BTR1_CLKDIV_1                  ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_BTR1_CLKDIV_2                  ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  FMC_BTR1_CLKDIV_3                  ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+#define  FMC_BTR1_DATLAT                    ((uint32_t)0x0F000000)        /*!<DATLA[3:0] bits (Data latency) */
+#define  FMC_BTR1_DATLAT_0                  ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_BTR1_DATLAT_1                  ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_BTR1_DATLAT_2                  ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_BTR1_DATLAT_3                  ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  FMC_BTR1_ACCMOD                    ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BTR1_ACCMOD_0                  ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BTR1_ACCMOD_1                  ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BTR2 register  *******************/
+#define  FMC_BTR2_ADDSET                    ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BTR2_ADDSET_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BTR2_ADDSET_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BTR2_ADDSET_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BTR2_ADDSET_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BTR2_ADDHLD                    ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BTR2_ADDHLD_0                  ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BTR2_ADDHLD_1                  ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BTR2_ADDHLD_2                  ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BTR2_ADDHLD_3                  ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BTR2_DATAST                    ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BTR2_DATAST_0                  ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BTR2_DATAST_1                  ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BTR2_DATAST_2                  ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BTR2_DATAST_3                  ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BTR2_DATAST_4                  ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BTR2_DATAST_5                  ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BTR2_DATAST_6                  ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BTR2_DATAST_7                  ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BTR2_BUSTURN                   ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BTR2_BUSTURN_0                 ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BTR2_BUSTURN_1                 ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BTR2_BUSTURN_2                 ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BTR2_BUSTURN_3                 ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BTR2_CLKDIV                    ((uint32_t)0x00F00000)        /*!<CLKDIV[3:0] bits (Clock divide ratio) */
+#define  FMC_BTR2_CLKDIV_0                  ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_BTR2_CLKDIV_1                  ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_BTR2_CLKDIV_2                  ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  FMC_BTR2_CLKDIV_3                  ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+#define  FMC_BTR2_DATLAT                    ((uint32_t)0x0F000000)        /*!<DATLA[3:0] bits (Data latency) */
+#define  FMC_BTR2_DATLAT_0                  ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_BTR2_DATLAT_1                  ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_BTR2_DATLAT_2                  ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_BTR2_DATLAT_3                  ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  FMC_BTR2_ACCMOD                    ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BTR2_ACCMOD_0                  ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BTR2_ACCMOD_1                  ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/*******************  Bit definition for FMC_BTR3 register  *******************/
+#define  FMC_BTR3_ADDSET                    ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BTR3_ADDSET_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BTR3_ADDSET_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BTR3_ADDSET_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BTR3_ADDSET_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BTR3_ADDHLD                    ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BTR3_ADDHLD_0                  ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BTR3_ADDHLD_1                  ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BTR3_ADDHLD_2                  ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BTR3_ADDHLD_3                  ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BTR3_DATAST                    ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BTR3_DATAST_0                  ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BTR3_DATAST_1                  ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BTR3_DATAST_2                  ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BTR3_DATAST_3                  ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BTR3_DATAST_4                  ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BTR3_DATAST_5                  ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BTR3_DATAST_6                  ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BTR3_DATAST_7                  ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BTR3_BUSTURN                   ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BTR3_BUSTURN_0                 ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BTR3_BUSTURN_1                 ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BTR3_BUSTURN_2                 ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BTR3_BUSTURN_3                 ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BTR3_CLKDIV                    ((uint32_t)0x00F00000)        /*!<CLKDIV[3:0] bits (Clock divide ratio) */
+#define  FMC_BTR3_CLKDIV_0                  ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_BTR3_CLKDIV_1                  ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_BTR3_CLKDIV_2                  ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  FMC_BTR3_CLKDIV_3                  ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+#define  FMC_BTR3_DATLAT                    ((uint32_t)0x0F000000)        /*!<DATLA[3:0] bits (Data latency) */
+#define  FMC_BTR3_DATLAT_0                  ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_BTR3_DATLAT_1                  ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_BTR3_DATLAT_2                  ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_BTR3_DATLAT_3                  ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  FMC_BTR3_ACCMOD                    ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BTR3_ACCMOD_0                  ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BTR3_ACCMOD_1                  ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BTR4 register  *******************/
+#define  FMC_BTR4_ADDSET                    ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BTR4_ADDSET_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BTR4_ADDSET_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BTR4_ADDSET_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BTR4_ADDSET_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BTR4_ADDHLD                    ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BTR4_ADDHLD_0                  ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BTR4_ADDHLD_1                  ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BTR4_ADDHLD_2                  ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BTR4_ADDHLD_3                  ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BTR4_DATAST                    ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BTR4_DATAST_0                  ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BTR4_DATAST_1                  ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BTR4_DATAST_2                  ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BTR4_DATAST_3                  ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BTR4_DATAST_4                  ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BTR4_DATAST_5                  ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BTR4_DATAST_6                  ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BTR4_DATAST_7                  ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BTR4_BUSTURN                   ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BTR4_BUSTURN_0                 ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BTR4_BUSTURN_1                 ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BTR4_BUSTURN_2                 ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BTR4_BUSTURN_3                 ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BTR4_CLKDIV                    ((uint32_t)0x00F00000)        /*!<CLKDIV[3:0] bits (Clock divide ratio) */
+#define  FMC_BTR4_CLKDIV_0                  ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_BTR4_CLKDIV_1                  ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_BTR4_CLKDIV_2                  ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  FMC_BTR4_CLKDIV_3                  ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+#define  FMC_BTR4_DATLAT                    ((uint32_t)0x0F000000)        /*!<DATLA[3:0] bits (Data latency) */
+#define  FMC_BTR4_DATLAT_0                  ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_BTR4_DATLAT_1                  ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_BTR4_DATLAT_2                  ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_BTR4_DATLAT_3                  ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  FMC_BTR4_ACCMOD                    ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BTR4_ACCMOD_0                  ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BTR4_ACCMOD_1                  ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BWTR1 register  ******************/
+#define  FMC_BWTR1_ADDSET                   ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BWTR1_ADDSET_0                 ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BWTR1_ADDSET_1                 ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BWTR1_ADDSET_2                 ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BWTR1_ADDSET_3                 ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BWTR1_ADDHLD                   ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BWTR1_ADDHLD_0                 ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BWTR1_ADDHLD_1                 ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BWTR1_ADDHLD_2                 ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BWTR1_ADDHLD_3                 ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BWTR1_DATAST                   ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BWTR1_DATAST_0                 ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BWTR1_DATAST_1                 ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BWTR1_DATAST_2                 ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BWTR1_DATAST_3                 ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BWTR1_DATAST_4                 ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BWTR1_DATAST_5                 ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BWTR1_DATAST_6                 ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BWTR1_DATAST_7                 ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BWTR1_BUSTURN                  ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BWTR1_BUSTURN_0                ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BWTR1_BUSTURN_1                ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BWTR1_BUSTURN_2                ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BWTR1_BUSTURN_3                ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BWTR1_ACCMOD                   ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BWTR1_ACCMOD_0                 ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BWTR1_ACCMOD_1                 ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BWTR2 register  ******************/
+#define  FMC_BWTR2_ADDSET                   ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BWTR2_ADDSET_0                 ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BWTR2_ADDSET_1                 ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BWTR2_ADDSET_2                 ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BWTR2_ADDSET_3                 ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BWTR2_ADDHLD                   ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BWTR2_ADDHLD_0                 ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BWTR2_ADDHLD_1                 ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BWTR2_ADDHLD_2                 ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BWTR2_ADDHLD_3                 ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BWTR2_DATAST                   ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BWTR2_DATAST_0                 ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BWTR2_DATAST_1                 ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BWTR2_DATAST_2                 ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BWTR2_DATAST_3                 ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BWTR2_DATAST_4                 ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BWTR2_DATAST_5                 ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BWTR2_DATAST_6                 ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BWTR2_DATAST_7                 ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BWTR2_BUSTURN                  ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BWTR2_BUSTURN_0                ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BWTR2_BUSTURN_1                ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BWTR2_BUSTURN_2                ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BWTR2_BUSTURN_3                ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BWTR2_ACCMOD                   ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BWTR2_ACCMOD_0                 ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BWTR2_ACCMOD_1                 ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BWTR3 register  ******************/
+#define  FMC_BWTR3_ADDSET                   ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BWTR3_ADDSET_0                 ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BWTR3_ADDSET_1                 ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BWTR3_ADDSET_2                 ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BWTR3_ADDSET_3                 ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BWTR3_ADDHLD                   ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BWTR3_ADDHLD_0                 ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BWTR3_ADDHLD_1                 ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BWTR3_ADDHLD_2                 ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BWTR3_ADDHLD_3                 ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BWTR3_DATAST                   ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BWTR3_DATAST_0                 ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BWTR3_DATAST_1                 ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BWTR3_DATAST_2                 ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BWTR3_DATAST_3                 ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BWTR3_DATAST_4                 ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BWTR3_DATAST_5                 ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BWTR3_DATAST_6                 ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BWTR3_DATAST_7                 ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BWTR3_BUSTURN                  ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BWTR3_BUSTURN_0                ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BWTR3_BUSTURN_1                ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BWTR3_BUSTURN_2                ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BWTR3_BUSTURN_3                ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BWTR3_ACCMOD                   ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BWTR3_ACCMOD_0                 ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BWTR3_ACCMOD_1                 ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BWTR4 register  ******************/
+#define  FMC_BWTR4_ADDSET                   ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BWTR4_ADDSET_0                 ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BWTR4_ADDSET_1                 ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BWTR4_ADDSET_2                 ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BWTR4_ADDSET_3                 ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BWTR4_ADDHLD                   ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BWTR4_ADDHLD_0                 ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BWTR4_ADDHLD_1                 ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BWTR4_ADDHLD_2                 ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BWTR4_ADDHLD_3                 ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BWTR4_DATAST                   ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BWTR4_DATAST_0                 ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BWTR4_DATAST_1                 ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BWTR4_DATAST_2                 ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BWTR4_DATAST_3                 ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BWTR4_DATAST_4                 ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BWTR4_DATAST_5                 ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BWTR4_DATAST_6                 ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BWTR4_DATAST_7                 ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BWTR4_BUSTURN                  ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BWTR4_BUSTURN_0                ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BWTR4_BUSTURN_1                ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BWTR4_BUSTURN_2                ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BWTR4_BUSTURN_3                ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BWTR4_ACCMOD                   ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BWTR4_ACCMOD_0                 ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BWTR4_ACCMOD_1                 ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_PCR register  *******************/
+#define  FMC_PCR_PWAITEN                   ((uint32_t)0x00000002)        /*!<Wait feature enable bit                   */
+#define  FMC_PCR_PBKEN                     ((uint32_t)0x00000004)        /*!<PC Card/NAND Flash memory bank enable bit */
+#define  FMC_PCR_PTYP                      ((uint32_t)0x00000008)        /*!<Memory type                               */
+
+#define  FMC_PCR_PWID                      ((uint32_t)0x00000030)        /*!<PWID[1:0] bits (NAND Flash databus width) */
+#define  FMC_PCR_PWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_PCR_PWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_PCR_ECCEN                     ((uint32_t)0x00000040)        /*!<ECC computation logic enable bit          */
+
+#define  FMC_PCR_TCLR                      ((uint32_t)0x00001E00)        /*!<TCLR[3:0] bits (CLE to RE delay)          */
+#define  FMC_PCR_TCLR_0                    ((uint32_t)0x00000200)        /*!<Bit 0 */
+#define  FMC_PCR_TCLR_1                    ((uint32_t)0x00000400)        /*!<Bit 1 */
+#define  FMC_PCR_TCLR_2                    ((uint32_t)0x00000800)        /*!<Bit 2 */
+#define  FMC_PCR_TCLR_3                    ((uint32_t)0x00001000)        /*!<Bit 3 */
+
+#define  FMC_PCR_TAR                       ((uint32_t)0x0001E000)        /*!<TAR[3:0] bits (ALE to RE delay)           */
+#define  FMC_PCR_TAR_0                     ((uint32_t)0x00002000)        /*!<Bit 0 */
+#define  FMC_PCR_TAR_1                     ((uint32_t)0x00004000)        /*!<Bit 1 */
+#define  FMC_PCR_TAR_2                     ((uint32_t)0x00008000)        /*!<Bit 2 */
+#define  FMC_PCR_TAR_3                     ((uint32_t)0x00010000)        /*!<Bit 3 */
+
+#define  FMC_PCR_ECCPS                     ((uint32_t)0x000E0000)        /*!<ECCPS[2:0] bits (ECC page size)           */
+#define  FMC_PCR_ECCPS_0                   ((uint32_t)0x00020000)        /*!<Bit 0 */
+#define  FMC_PCR_ECCPS_1                   ((uint32_t)0x00040000)        /*!<Bit 1 */
+#define  FMC_PCR_ECCPS_2                   ((uint32_t)0x00080000)        /*!<Bit 2 */
+
+/*******************  Bit definition for FMC_SR register  *******************/
+#define  FMC_SR_IRS                        ((uint32_t)0x01)              /*!<Interrupt Rising Edge status                */
+#define  FMC_SR_ILS                        ((uint32_t)0x02)              /*!<Interrupt Level status                      */
+#define  FMC_SR_IFS                        ((uint32_t)0x04)              /*!<Interrupt Falling Edge status               */
+#define  FMC_SR_IREN                       ((uint32_t)0x08)              /*!<Interrupt Rising Edge detection Enable bit  */
+#define  FMC_SR_ILEN                       ((uint32_t)0x10)              /*!<Interrupt Level detection Enable bit        */
+#define  FMC_SR_IFEN                       ((uint32_t)0x20)              /*!<Interrupt Falling Edge detection Enable bit */
+#define  FMC_SR_FEMPT                      ((uint32_t)0x40)              /*!<FIFO empty                                  */
+
+/******************  Bit definition for FMC_PMEM register  ******************/
+#define  FMC_PMEM_MEMSET3                  ((uint32_t)0x000000FF)        /*!<MEMSET3[7:0] bits (Common memory 3 setup time) */
+#define  FMC_PMEM_MEMSET3_0                ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_PMEM_MEMSET3_1                ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_PMEM_MEMSET3_2                ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_PMEM_MEMSET3_3                ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  FMC_PMEM_MEMSET3_4                ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  FMC_PMEM_MEMSET3_5                ((uint32_t)0x00000020)        /*!<Bit 5 */
+#define  FMC_PMEM_MEMSET3_6                ((uint32_t)0x00000040)        /*!<Bit 6 */
+#define  FMC_PMEM_MEMSET3_7                ((uint32_t)0x00000080)        /*!<Bit 7 */
+
+#define  FMC_PMEM_MEMWAIT3                 ((uint32_t)0x0000FF00)        /*!<MEMWAIT3[7:0] bits (Common memory 3 wait time) */
+#define  FMC_PMEM_MEMWAIT3_0               ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_PMEM_MEMWAIT3_1               ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_PMEM_MEMWAIT3_2               ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_PMEM_MEMWAIT3_3               ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_PMEM_MEMWAIT3_4               ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_PMEM_MEMWAIT3_5               ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_PMEM_MEMWAIT3_6               ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_PMEM_MEMWAIT3_7               ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_PMEM_MEMHOLD3                 ((uint32_t)0x00FF0000)        /*!<MEMHOLD3[7:0] bits (Common memory 3 hold time) */
+#define  FMC_PMEM_MEMHOLD3_0               ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_PMEM_MEMHOLD3_1               ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_PMEM_MEMHOLD3_2               ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_PMEM_MEMHOLD3_3               ((uint32_t)0x00080000)        /*!<Bit 3 */
+#define  FMC_PMEM_MEMHOLD3_4               ((uint32_t)0x00100000)        /*!<Bit 4 */
+#define  FMC_PMEM_MEMHOLD3_5               ((uint32_t)0x00200000)        /*!<Bit 5 */
+#define  FMC_PMEM_MEMHOLD3_6               ((uint32_t)0x00400000)        /*!<Bit 6 */
+#define  FMC_PMEM_MEMHOLD3_7               ((uint32_t)0x00800000)        /*!<Bit 7 */
+
+#define  FMC_PMEM_MEMHIZ3                  ((uint32_t)0xFF000000)        /*!<MEMHIZ3[7:0] bits (Common memory 3 databus HiZ time) */
+#define  FMC_PMEM_MEMHIZ3_0                ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_PMEM_MEMHIZ3_1                ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_PMEM_MEMHIZ3_2                ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_PMEM_MEMHIZ3_3                ((uint32_t)0x08000000)        /*!<Bit 3 */
+#define  FMC_PMEM_MEMHIZ3_4                ((uint32_t)0x10000000)        /*!<Bit 4 */
+#define  FMC_PMEM_MEMHIZ3_5                ((uint32_t)0x20000000)        /*!<Bit 5 */
+#define  FMC_PMEM_MEMHIZ3_6                ((uint32_t)0x40000000)        /*!<Bit 6 */
+#define  FMC_PMEM_MEMHIZ3_7                ((uint32_t)0x80000000)        /*!<Bit 7 */
+
+/******************  Bit definition for FMC_PATT register  ******************/
+#define  FMC_PATT_ATTSET3                  ((uint32_t)0x000000FF)        /*!<ATTSET3[7:0] bits (Attribute memory 3 setup time) */
+#define  FMC_PATT_ATTSET3_0                ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_PATT_ATTSET3_1                ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_PATT_ATTSET3_2                ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_PATT_ATTSET3_3                ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  FMC_PATT_ATTSET3_4                ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  FMC_PATT_ATTSET3_5                ((uint32_t)0x00000020)        /*!<Bit 5 */
+#define  FMC_PATT_ATTSET3_6                ((uint32_t)0x00000040)        /*!<Bit 6 */
+#define  FMC_PATT_ATTSET3_7                ((uint32_t)0x00000080)        /*!<Bit 7 */
+
+#define  FMC_PATT_ATTWAIT3                 ((uint32_t)0x0000FF00)        /*!<ATTWAIT3[7:0] bits (Attribute memory 3 wait time) */
+#define  FMC_PATT_ATTWAIT3_0               ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_PATT_ATTWAIT3_1               ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_PATT_ATTWAIT3_2               ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_PATT_ATTWAIT3_3               ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_PATT_ATTWAIT3_4               ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_PATT_ATTWAIT3_5               ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_PATT_ATTWAIT3_6               ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_PATT_ATTWAIT3_7               ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_PATT_ATTHOLD3                 ((uint32_t)0x00FF0000)        /*!<ATTHOLD3[7:0] bits (Attribute memory 3 hold time) */
+#define  FMC_PATT_ATTHOLD3_0               ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_PATT_ATTHOLD3_1               ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_PATT_ATTHOLD3_2               ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_PATT_ATTHOLD3_3               ((uint32_t)0x00080000)        /*!<Bit 3 */
+#define  FMC_PATT_ATTHOLD3_4               ((uint32_t)0x00100000)        /*!<Bit 4 */
+#define  FMC_PATT_ATTHOLD3_5               ((uint32_t)0x00200000)        /*!<Bit 5 */
+#define  FMC_PATT_ATTHOLD3_6               ((uint32_t)0x00400000)        /*!<Bit 6 */
+#define  FMC_PATT_ATTHOLD3_7               ((uint32_t)0x00800000)        /*!<Bit 7 */
+
+#define  FMC_PATT_ATTHIZ3                  ((uint32_t)0xFF000000)        /*!<ATTHIZ3[7:0] bits (Attribute memory 3 databus HiZ time) */
+#define  FMC_PATT_ATTHIZ3_0                ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_PATT_ATTHIZ3_1                ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_PATT_ATTHIZ3_2                ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_PATT_ATTHIZ3_3                ((uint32_t)0x08000000)        /*!<Bit 3 */
+#define  FMC_PATT_ATTHIZ3_4                ((uint32_t)0x10000000)        /*!<Bit 4 */
+#define  FMC_PATT_ATTHIZ3_5                ((uint32_t)0x20000000)        /*!<Bit 5 */
+#define  FMC_PATT_ATTHIZ3_6                ((uint32_t)0x40000000)        /*!<Bit 6 */
+#define  FMC_PATT_ATTHIZ3_7                ((uint32_t)0x80000000)        /*!<Bit 7 */
+
+/******************  Bit definition for FMC_ECCR register  ******************/
+#define  FMC_ECCR_ECC3                     ((uint32_t)0xFFFFFFFF)        /*!<ECC result */
+
+/******************  Bit definition for FMC_SDCR1 register  ******************/
+#define  FMC_SDCR1_NC                       ((uint32_t)0x00000003)        /*!<NC[1:0] bits (Number of column bits) */
+#define  FMC_SDCR1_NC_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDCR1_NC_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_NR                       ((uint32_t)0x0000000C)        /*!<NR[1:0] bits (Number of row bits) */
+#define  FMC_SDCR1_NR_0                     ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_SDCR1_NR_1                     ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_MWID                     ((uint32_t)0x00000030)        /*!<NR[1:0] bits (Number of row bits) */
+#define  FMC_SDCR1_MWID_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_SDCR1_MWID_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_NB                       ((uint32_t)0x00000040)        /*!<Number of internal bank */
+
+#define  FMC_SDCR1_CAS                      ((uint32_t)0x00000180)        /*!<CAS[1:0] bits (CAS latency) */
+#define  FMC_SDCR1_CAS_0                    ((uint32_t)0x00000080)        /*!<Bit 0 */
+#define  FMC_SDCR1_CAS_1                    ((uint32_t)0x00000100)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_WP                       ((uint32_t)0x00000200)        /*!<Write protection */
+
+#define  FMC_SDCR1_SDCLK                    ((uint32_t)0x00000C00)        /*!<SDRAM clock configuration */
+#define  FMC_SDCR1_SDCLK_0                  ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  FMC_SDCR1_SDCLK_1                  ((uint32_t)0x00000800)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_RBURST                   ((uint32_t)0x00001000)        /*!<Read burst */
+
+#define  FMC_SDCR1_RPIPE                    ((uint32_t)0x00006000)        /*!<Write protection */
+#define  FMC_SDCR1_RPIPE_0                  ((uint32_t)0x00002000)        /*!<Bit 0 */
+#define  FMC_SDCR1_RPIPE_1                  ((uint32_t)0x00004000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_SDCR2 register  ******************/
+#define  FMC_SDCR2_NC                       ((uint32_t)0x00000003)        /*!<NC[1:0] bits (Number of column bits) */
+#define  FMC_SDCR2_NC_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDCR2_NC_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_NR                       ((uint32_t)0x0000000C)        /*!<NR[1:0] bits (Number of row bits) */
+#define  FMC_SDCR2_NR_0                     ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_SDCR2_NR_1                     ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_MWID                     ((uint32_t)0x00000030)        /*!<NR[1:0] bits (Number of row bits) */
+#define  FMC_SDCR2_MWID_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_SDCR2_MWID_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_NB                       ((uint32_t)0x00000040)        /*!<Number of internal bank */
+
+#define  FMC_SDCR2_CAS                      ((uint32_t)0x00000180)        /*!<CAS[1:0] bits (CAS latency) */
+#define  FMC_SDCR2_CAS_0                    ((uint32_t)0x00000080)        /*!<Bit 0 */
+#define  FMC_SDCR2_CAS_1                    ((uint32_t)0x00000100)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_WP                       ((uint32_t)0x00000200)        /*!<Write protection */
+
+#define  FMC_SDCR2_SDCLK                    ((uint32_t)0x00000C00)        /*!<SDCLK[1:0] (SDRAM clock configuration) */
+#define  FMC_SDCR2_SDCLK_0                  ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  FMC_SDCR2_SDCLK_1                  ((uint32_t)0x00000800)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_RBURST                   ((uint32_t)0x00001000)        /*!<Read burst */
+
+#define  FMC_SDCR2_RPIPE                    ((uint32_t)0x00006000)        /*!<RPIPE[1:0](Read pipe) */
+#define  FMC_SDCR2_RPIPE_0                  ((uint32_t)0x00002000)        /*!<Bit 0 */
+#define  FMC_SDCR2_RPIPE_1                  ((uint32_t)0x00004000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_SDTR1 register  ******************/
+#define  FMC_SDTR1_TMRD                     ((uint32_t)0x0000000F)        /*!<TMRD[3:0] bits (Load mode register to active) */
+#define  FMC_SDTR1_TMRD_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDTR1_TMRD_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_SDTR1_TMRD_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_SDTR1_TMRD_3                   ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_SDTR1_TXSR                     ((uint32_t)0x000000F0)        /*!<TXSR[3:0] bits (Exit self refresh) */
+#define  FMC_SDTR1_TXSR_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_SDTR1_TXSR_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_SDTR1_TXSR_2                   ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_SDTR1_TXSR_3                   ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_SDTR1_TRAS                     ((uint32_t)0x00000F00)        /*!<TRAS[3:0] bits (Self refresh time) */
+#define  FMC_SDTR1_TRAS_0                   ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_SDTR1_TRAS_1                   ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_SDTR1_TRAS_2                   ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_SDTR1_TRAS_3                   ((uint32_t)0x00000800)        /*!<Bit 3 */
+
+#define  FMC_SDTR1_TRC                      ((uint32_t)0x0000F000)        /*!<TRC[2:0] bits (Row cycle delay) */
+#define  FMC_SDTR1_TRC_0                    ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  FMC_SDTR1_TRC_1                    ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  FMC_SDTR1_TRC_2                    ((uint32_t)0x00004000)        /*!<Bit 2 */
+
+#define  FMC_SDTR1_TWR                      ((uint32_t)0x000F0000)        /*!<TRC[2:0] bits (Write recovery delay) */
+#define  FMC_SDTR1_TWR_0                    ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_SDTR1_TWR_1                    ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_SDTR1_TWR_2                    ((uint32_t)0x00040000)        /*!<Bit 2 */
+
+#define  FMC_SDTR1_TRP                      ((uint32_t)0x00F00000)        /*!<TRP[2:0] bits (Row precharge delay) */
+#define  FMC_SDTR1_TRP_0                    ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_SDTR1_TRP_1                    ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_SDTR1_TRP_2                    ((uint32_t)0x00400000)        /*!<Bit 2 */
+
+#define  FMC_SDTR1_TRCD                     ((uint32_t)0x0F000000)        /*!<TRP[2:0] bits (Row to column delay) */
+#define  FMC_SDTR1_TRCD_0                   ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_SDTR1_TRCD_1                   ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_SDTR1_TRCD_2                   ((uint32_t)0x04000000)        /*!<Bit 2 */
+
+/******************  Bit definition for FMC_SDTR2 register  ******************/
+#define  FMC_SDTR2_TMRD                     ((uint32_t)0x0000000F)        /*!<TMRD[3:0] bits (Load mode register to active) */
+#define  FMC_SDTR2_TMRD_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDTR2_TMRD_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_SDTR2_TMRD_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_SDTR2_TMRD_3                   ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_SDTR2_TXSR                     ((uint32_t)0x000000F0)        /*!<TXSR[3:0] bits (Exit self refresh) */
+#define  FMC_SDTR2_TXSR_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_SDTR2_TXSR_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_SDTR2_TXSR_2                   ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_SDTR2_TXSR_3                   ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_SDTR2_TRAS                     ((uint32_t)0x00000F00)        /*!<TRAS[3:0] bits (Self refresh time) */
+#define  FMC_SDTR2_TRAS_0                   ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_SDTR2_TRAS_1                   ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_SDTR2_TRAS_2                   ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_SDTR2_TRAS_3                   ((uint32_t)0x00000800)        /*!<Bit 3 */
+
+#define  FMC_SDTR2_TRC                      ((uint32_t)0x0000F000)        /*!<TRC[2:0] bits (Row cycle delay) */
+#define  FMC_SDTR2_TRC_0                    ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  FMC_SDTR2_TRC_1                    ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  FMC_SDTR2_TRC_2                    ((uint32_t)0x00004000)        /*!<Bit 2 */
+
+#define  FMC_SDTR2_TWR                      ((uint32_t)0x000F0000)        /*!<TRC[2:0] bits (Write recovery delay) */
+#define  FMC_SDTR2_TWR_0                    ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_SDTR2_TWR_1                    ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_SDTR2_TWR_2                    ((uint32_t)0x00040000)        /*!<Bit 2 */
+
+#define  FMC_SDTR2_TRP                      ((uint32_t)0x00F00000)        /*!<TRP[2:0] bits (Row precharge delay) */
+#define  FMC_SDTR2_TRP_0                    ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_SDTR2_TRP_1                    ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_SDTR2_TRP_2                    ((uint32_t)0x00400000)        /*!<Bit 2 */
+
+#define  FMC_SDTR2_TRCD                     ((uint32_t)0x0F000000)        /*!<TRP[2:0] bits (Row to column delay) */
+#define  FMC_SDTR2_TRCD_0                   ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_SDTR2_TRCD_1                   ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_SDTR2_TRCD_2                   ((uint32_t)0x04000000)        /*!<Bit 2 */
+
+/******************  Bit definition for FMC_SDCMR register  ******************/
+#define  FMC_SDCMR_MODE                     ((uint32_t)0x00000007)        /*!<MODE[2:0] bits (Command mode) */
+#define  FMC_SDCMR_MODE_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDCMR_MODE_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_SDCMR_MODE_2                   ((uint32_t)0x00000003)        /*!<Bit 2 */
+
+#define  FMC_SDCMR_CTB2                     ((uint32_t)0x00000008)        /*!<Command target 2 */
+
+#define  FMC_SDCMR_CTB1                     ((uint32_t)0x00000010)        /*!<Command target 1 */
+
+#define  FMC_SDCMR_NRFS                     ((uint32_t)0x000001E0)        /*!<NRFS[3:0] bits (Number of auto-refresh) */
+#define  FMC_SDCMR_NRFS_0                   ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  FMC_SDCMR_NRFS_1                   ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  FMC_SDCMR_NRFS_2                   ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  FMC_SDCMR_NRFS_3                   ((uint32_t)0x00000100)        /*!<Bit 3 */
+
+#define  FMC_SDCMR_MRD                      ((uint32_t)0x003FFE00)        /*!<MRD[12:0] bits (Mode register definition) */
+
+/******************  Bit definition for FMC_SDRTR register  ******************/
+#define  FMC_SDRTR_CRE                      ((uint32_t)0x00000001)        /*!<Clear refresh error flag */
+
+#define  FMC_SDRTR_COUNT                    ((uint32_t)0x00003FFE)        /*!<COUNT[12:0] bits (Refresh timer count) */
+
+#define  FMC_SDRTR_REIE                     ((uint32_t)0x00004000)        /*!<RES interupt enable */
+
+/******************  Bit definition for FMC_SDSR register  ******************/
+#define  FMC_SDSR_RE                        ((uint32_t)0x00000001)        /*!<Refresh error flag */
+
+#define  FMC_SDSR_MODES1                    ((uint32_t)0x00000006)        /*!<MODES1[1:0]bits (Status mode for bank 1) */
+#define  FMC_SDSR_MODES1_0                  ((uint32_t)0x00000002)        /*!<Bit 0 */
+#define  FMC_SDSR_MODES1_1                  ((uint32_t)0x00000004)        /*!<Bit 1 */
+
+#define  FMC_SDSR_MODES2                    ((uint32_t)0x00000018)        /*!<MODES2[1:0]bits (Status mode for bank 2) */
+#define  FMC_SDSR_MODES2_0                  ((uint32_t)0x00000008)        /*!<Bit 0 */
+#define  FMC_SDSR_MODES2_1                  ((uint32_t)0x00000010)        /*!<Bit 1 */
+
+#define  FMC_SDSR_BUSY                      ((uint32_t)0x00000020)        /*!<Busy status */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            General Purpose I/O                             */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bits definition for GPIO_MODER register  *****************/
+#define GPIO_MODER_MODER0                    ((uint32_t)0x00000003)
+#define GPIO_MODER_MODER0_0                  ((uint32_t)0x00000001)
+#define GPIO_MODER_MODER0_1                  ((uint32_t)0x00000002)
+
+#define GPIO_MODER_MODER1                    ((uint32_t)0x0000000C)
+#define GPIO_MODER_MODER1_0                  ((uint32_t)0x00000004)
+#define GPIO_MODER_MODER1_1                  ((uint32_t)0x00000008)
+
+#define GPIO_MODER_MODER2                    ((uint32_t)0x00000030)
+#define GPIO_MODER_MODER2_0                  ((uint32_t)0x00000010)
+#define GPIO_MODER_MODER2_1                  ((uint32_t)0x00000020)
+
+#define GPIO_MODER_MODER3                    ((uint32_t)0x000000C0)
+#define GPIO_MODER_MODER3_0                  ((uint32_t)0x00000040)
+#define GPIO_MODER_MODER3_1                  ((uint32_t)0x00000080)
+
+#define GPIO_MODER_MODER4                    ((uint32_t)0x00000300)
+#define GPIO_MODER_MODER4_0                  ((uint32_t)0x00000100)
+#define GPIO_MODER_MODER4_1                  ((uint32_t)0x00000200)
+
+#define GPIO_MODER_MODER5                    ((uint32_t)0x00000C00)
+#define GPIO_MODER_MODER5_0                  ((uint32_t)0x00000400)
+#define GPIO_MODER_MODER5_1                  ((uint32_t)0x00000800)
+
+#define GPIO_MODER_MODER6                    ((uint32_t)0x00003000)
+#define GPIO_MODER_MODER6_0                  ((uint32_t)0x00001000)
+#define GPIO_MODER_MODER6_1                  ((uint32_t)0x00002000)
+
+#define GPIO_MODER_MODER7                    ((uint32_t)0x0000C000)
+#define GPIO_MODER_MODER7_0                  ((uint32_t)0x00004000)
+#define GPIO_MODER_MODER7_1                  ((uint32_t)0x00008000)
+
+#define GPIO_MODER_MODER8                    ((uint32_t)0x00030000)
+#define GPIO_MODER_MODER8_0                  ((uint32_t)0x00010000)
+#define GPIO_MODER_MODER8_1                  ((uint32_t)0x00020000)
+
+#define GPIO_MODER_MODER9                    ((uint32_t)0x000C0000)
+#define GPIO_MODER_MODER9_0                  ((uint32_t)0x00040000)
+#define GPIO_MODER_MODER9_1                  ((uint32_t)0x00080000)
+
+#define GPIO_MODER_MODER10                   ((uint32_t)0x00300000)
+#define GPIO_MODER_MODER10_0                 ((uint32_t)0x00100000)
+#define GPIO_MODER_MODER10_1                 ((uint32_t)0x00200000)
+
+#define GPIO_MODER_MODER11                   ((uint32_t)0x00C00000)
+#define GPIO_MODER_MODER11_0                 ((uint32_t)0x00400000)
+#define GPIO_MODER_MODER11_1                 ((uint32_t)0x00800000)
+
+#define GPIO_MODER_MODER12                   ((uint32_t)0x03000000)
+#define GPIO_MODER_MODER12_0                 ((uint32_t)0x01000000)
+#define GPIO_MODER_MODER12_1                 ((uint32_t)0x02000000)
+
+#define GPIO_MODER_MODER13                   ((uint32_t)0x0C000000)
+#define GPIO_MODER_MODER13_0                 ((uint32_t)0x04000000)
+#define GPIO_MODER_MODER13_1                 ((uint32_t)0x08000000)
+
+#define GPIO_MODER_MODER14                   ((uint32_t)0x30000000)
+#define GPIO_MODER_MODER14_0                 ((uint32_t)0x10000000)
+#define GPIO_MODER_MODER14_1                 ((uint32_t)0x20000000)
+
+#define GPIO_MODER_MODER15                   ((uint32_t)0xC0000000)
+#define GPIO_MODER_MODER15_0                 ((uint32_t)0x40000000)
+#define GPIO_MODER_MODER15_1                 ((uint32_t)0x80000000)
+
+/******************  Bits definition for GPIO_OTYPER register  ****************/
+#define GPIO_OTYPER_OT_0                     ((uint32_t)0x00000001)
+#define GPIO_OTYPER_OT_1                     ((uint32_t)0x00000002)
+#define GPIO_OTYPER_OT_2                     ((uint32_t)0x00000004)
+#define GPIO_OTYPER_OT_3                     ((uint32_t)0x00000008)
+#define GPIO_OTYPER_OT_4                     ((uint32_t)0x00000010)
+#define GPIO_OTYPER_OT_5                     ((uint32_t)0x00000020)
+#define GPIO_OTYPER_OT_6                     ((uint32_t)0x00000040)
+#define GPIO_OTYPER_OT_7                     ((uint32_t)0x00000080)
+#define GPIO_OTYPER_OT_8                     ((uint32_t)0x00000100)
+#define GPIO_OTYPER_OT_9                     ((uint32_t)0x00000200)
+#define GPIO_OTYPER_OT_10                    ((uint32_t)0x00000400)
+#define GPIO_OTYPER_OT_11                    ((uint32_t)0x00000800)
+#define GPIO_OTYPER_OT_12                    ((uint32_t)0x00001000)
+#define GPIO_OTYPER_OT_13                    ((uint32_t)0x00002000)
+#define GPIO_OTYPER_OT_14                    ((uint32_t)0x00004000)
+#define GPIO_OTYPER_OT_15                    ((uint32_t)0x00008000)
+
+/******************  Bits definition for GPIO_OSPEEDR register  ***************/
+#define GPIO_OSPEEDER_OSPEEDR0               ((uint32_t)0x00000003)
+#define GPIO_OSPEEDER_OSPEEDR0_0             ((uint32_t)0x00000001)
+#define GPIO_OSPEEDER_OSPEEDR0_1             ((uint32_t)0x00000002)
+
+#define GPIO_OSPEEDER_OSPEEDR1               ((uint32_t)0x0000000C)
+#define GPIO_OSPEEDER_OSPEEDR1_0             ((uint32_t)0x00000004)
+#define GPIO_OSPEEDER_OSPEEDR1_1             ((uint32_t)0x00000008)
+
+#define GPIO_OSPEEDER_OSPEEDR2               ((uint32_t)0x00000030)
+#define GPIO_OSPEEDER_OSPEEDR2_0             ((uint32_t)0x00000010)
+#define GPIO_OSPEEDER_OSPEEDR2_1             ((uint32_t)0x00000020)
+
+#define GPIO_OSPEEDER_OSPEEDR3               ((uint32_t)0x000000C0)
+#define GPIO_OSPEEDER_OSPEEDR3_0             ((uint32_t)0x00000040)
+#define GPIO_OSPEEDER_OSPEEDR3_1             ((uint32_t)0x00000080)
+
+#define GPIO_OSPEEDER_OSPEEDR4               ((uint32_t)0x00000300)
+#define GPIO_OSPEEDER_OSPEEDR4_0             ((uint32_t)0x00000100)
+#define GPIO_OSPEEDER_OSPEEDR4_1             ((uint32_t)0x00000200)
+
+#define GPIO_OSPEEDER_OSPEEDR5               ((uint32_t)0x00000C00)
+#define GPIO_OSPEEDER_OSPEEDR5_0             ((uint32_t)0x00000400)
+#define GPIO_OSPEEDER_OSPEEDR5_1             ((uint32_t)0x00000800)
+
+#define GPIO_OSPEEDER_OSPEEDR6               ((uint32_t)0x00003000)
+#define GPIO_OSPEEDER_OSPEEDR6_0             ((uint32_t)0x00001000)
+#define GPIO_OSPEEDER_OSPEEDR6_1             ((uint32_t)0x00002000)
+
+#define GPIO_OSPEEDER_OSPEEDR7               ((uint32_t)0x0000C000)
+#define GPIO_OSPEEDER_OSPEEDR7_0             ((uint32_t)0x00004000)
+#define GPIO_OSPEEDER_OSPEEDR7_1             ((uint32_t)0x00008000)
+
+#define GPIO_OSPEEDER_OSPEEDR8               ((uint32_t)0x00030000)
+#define GPIO_OSPEEDER_OSPEEDR8_0             ((uint32_t)0x00010000)
+#define GPIO_OSPEEDER_OSPEEDR8_1             ((uint32_t)0x00020000)
+
+#define GPIO_OSPEEDER_OSPEEDR9               ((uint32_t)0x000C0000)
+#define GPIO_OSPEEDER_OSPEEDR9_0             ((uint32_t)0x00040000)
+#define GPIO_OSPEEDER_OSPEEDR9_1             ((uint32_t)0x00080000)
+
+#define GPIO_OSPEEDER_OSPEEDR10              ((uint32_t)0x00300000)
+#define GPIO_OSPEEDER_OSPEEDR10_0            ((uint32_t)0x00100000)
+#define GPIO_OSPEEDER_OSPEEDR10_1            ((uint32_t)0x00200000)
+
+#define GPIO_OSPEEDER_OSPEEDR11              ((uint32_t)0x00C00000)
+#define GPIO_OSPEEDER_OSPEEDR11_0            ((uint32_t)0x00400000)
+#define GPIO_OSPEEDER_OSPEEDR11_1            ((uint32_t)0x00800000)
+
+#define GPIO_OSPEEDER_OSPEEDR12              ((uint32_t)0x03000000)
+#define GPIO_OSPEEDER_OSPEEDR12_0            ((uint32_t)0x01000000)
+#define GPIO_OSPEEDER_OSPEEDR12_1            ((uint32_t)0x02000000)
+
+#define GPIO_OSPEEDER_OSPEEDR13              ((uint32_t)0x0C000000)
+#define GPIO_OSPEEDER_OSPEEDR13_0            ((uint32_t)0x04000000)
+#define GPIO_OSPEEDER_OSPEEDR13_1            ((uint32_t)0x08000000)
+
+#define GPIO_OSPEEDER_OSPEEDR14              ((uint32_t)0x30000000)
+#define GPIO_OSPEEDER_OSPEEDR14_0            ((uint32_t)0x10000000)
+#define GPIO_OSPEEDER_OSPEEDR14_1            ((uint32_t)0x20000000)
+
+#define GPIO_OSPEEDER_OSPEEDR15              ((uint32_t)0xC0000000)
+#define GPIO_OSPEEDER_OSPEEDR15_0            ((uint32_t)0x40000000)
+#define GPIO_OSPEEDER_OSPEEDR15_1            ((uint32_t)0x80000000)
+
+/******************  Bits definition for GPIO_PUPDR register  *****************/
+#define GPIO_PUPDR_PUPDR0                    ((uint32_t)0x00000003)
+#define GPIO_PUPDR_PUPDR0_0                  ((uint32_t)0x00000001)
+#define GPIO_PUPDR_PUPDR0_1                  ((uint32_t)0x00000002)
+
+#define GPIO_PUPDR_PUPDR1                    ((uint32_t)0x0000000C)
+#define GPIO_PUPDR_PUPDR1_0                  ((uint32_t)0x00000004)
+#define GPIO_PUPDR_PUPDR1_1                  ((uint32_t)0x00000008)
+
+#define GPIO_PUPDR_PUPDR2                    ((uint32_t)0x00000030)
+#define GPIO_PUPDR_PUPDR2_0                  ((uint32_t)0x00000010)
+#define GPIO_PUPDR_PUPDR2_1                  ((uint32_t)0x00000020)
+
+#define GPIO_PUPDR_PUPDR3                    ((uint32_t)0x000000C0)
+#define GPIO_PUPDR_PUPDR3_0                  ((uint32_t)0x00000040)
+#define GPIO_PUPDR_PUPDR3_1                  ((uint32_t)0x00000080)
+
+#define GPIO_PUPDR_PUPDR4                    ((uint32_t)0x00000300)
+#define GPIO_PUPDR_PUPDR4_0                  ((uint32_t)0x00000100)
+#define GPIO_PUPDR_PUPDR4_1                  ((uint32_t)0x00000200)
+
+#define GPIO_PUPDR_PUPDR5                    ((uint32_t)0x00000C00)
+#define GPIO_PUPDR_PUPDR5_0                  ((uint32_t)0x00000400)
+#define GPIO_PUPDR_PUPDR5_1                  ((uint32_t)0x00000800)
+
+#define GPIO_PUPDR_PUPDR6                    ((uint32_t)0x00003000)
+#define GPIO_PUPDR_PUPDR6_0                  ((uint32_t)0x00001000)
+#define GPIO_PUPDR_PUPDR6_1                  ((uint32_t)0x00002000)
+
+#define GPIO_PUPDR_PUPDR7                    ((uint32_t)0x0000C000)
+#define GPIO_PUPDR_PUPDR7_0                  ((uint32_t)0x00004000)
+#define GPIO_PUPDR_PUPDR7_1                  ((uint32_t)0x00008000)
+
+#define GPIO_PUPDR_PUPDR8                    ((uint32_t)0x00030000)
+#define GPIO_PUPDR_PUPDR8_0                  ((uint32_t)0x00010000)
+#define GPIO_PUPDR_PUPDR8_1                  ((uint32_t)0x00020000)
+
+#define GPIO_PUPDR_PUPDR9                    ((uint32_t)0x000C0000)
+#define GPIO_PUPDR_PUPDR9_0                  ((uint32_t)0x00040000)
+#define GPIO_PUPDR_PUPDR9_1                  ((uint32_t)0x00080000)
+
+#define GPIO_PUPDR_PUPDR10                   ((uint32_t)0x00300000)
+#define GPIO_PUPDR_PUPDR10_0                 ((uint32_t)0x00100000)
+#define GPIO_PUPDR_PUPDR10_1                 ((uint32_t)0x00200000)
+
+#define GPIO_PUPDR_PUPDR11                   ((uint32_t)0x00C00000)
+#define GPIO_PUPDR_PUPDR11_0                 ((uint32_t)0x00400000)
+#define GPIO_PUPDR_PUPDR11_1                 ((uint32_t)0x00800000)
+
+#define GPIO_PUPDR_PUPDR12                   ((uint32_t)0x03000000)
+#define GPIO_PUPDR_PUPDR12_0                 ((uint32_t)0x01000000)
+#define GPIO_PUPDR_PUPDR12_1                 ((uint32_t)0x02000000)
+
+#define GPIO_PUPDR_PUPDR13                   ((uint32_t)0x0C000000)
+#define GPIO_PUPDR_PUPDR13_0                 ((uint32_t)0x04000000)
+#define GPIO_PUPDR_PUPDR13_1                 ((uint32_t)0x08000000)
+
+#define GPIO_PUPDR_PUPDR14                   ((uint32_t)0x30000000)
+#define GPIO_PUPDR_PUPDR14_0                 ((uint32_t)0x10000000)
+#define GPIO_PUPDR_PUPDR14_1                 ((uint32_t)0x20000000)
+
+#define GPIO_PUPDR_PUPDR15                   ((uint32_t)0xC0000000)
+#define GPIO_PUPDR_PUPDR15_0                 ((uint32_t)0x40000000)
+#define GPIO_PUPDR_PUPDR15_1                 ((uint32_t)0x80000000)
+
+/******************  Bits definition for GPIO_IDR register  *******************/
+#define GPIO_IDR_IDR_0                       ((uint32_t)0x00000001)
+#define GPIO_IDR_IDR_1                       ((uint32_t)0x00000002)
+#define GPIO_IDR_IDR_2                       ((uint32_t)0x00000004)
+#define GPIO_IDR_IDR_3                       ((uint32_t)0x00000008)
+#define GPIO_IDR_IDR_4                       ((uint32_t)0x00000010)
+#define GPIO_IDR_IDR_5                       ((uint32_t)0x00000020)
+#define GPIO_IDR_IDR_6                       ((uint32_t)0x00000040)
+#define GPIO_IDR_IDR_7                       ((uint32_t)0x00000080)
+#define GPIO_IDR_IDR_8                       ((uint32_t)0x00000100)
+#define GPIO_IDR_IDR_9                       ((uint32_t)0x00000200)
+#define GPIO_IDR_IDR_10                      ((uint32_t)0x00000400)
+#define GPIO_IDR_IDR_11                      ((uint32_t)0x00000800)
+#define GPIO_IDR_IDR_12                      ((uint32_t)0x00001000)
+#define GPIO_IDR_IDR_13                      ((uint32_t)0x00002000)
+#define GPIO_IDR_IDR_14                      ((uint32_t)0x00004000)
+#define GPIO_IDR_IDR_15                      ((uint32_t)0x00008000)
+
+/******************  Bits definition for GPIO_ODR register  *******************/
+#define GPIO_ODR_ODR_0                       ((uint32_t)0x00000001)
+#define GPIO_ODR_ODR_1                       ((uint32_t)0x00000002)
+#define GPIO_ODR_ODR_2                       ((uint32_t)0x00000004)
+#define GPIO_ODR_ODR_3                       ((uint32_t)0x00000008)
+#define GPIO_ODR_ODR_4                       ((uint32_t)0x00000010)
+#define GPIO_ODR_ODR_5                       ((uint32_t)0x00000020)
+#define GPIO_ODR_ODR_6                       ((uint32_t)0x00000040)
+#define GPIO_ODR_ODR_7                       ((uint32_t)0x00000080)
+#define GPIO_ODR_ODR_8                       ((uint32_t)0x00000100)
+#define GPIO_ODR_ODR_9                       ((uint32_t)0x00000200)
+#define GPIO_ODR_ODR_10                      ((uint32_t)0x00000400)
+#define GPIO_ODR_ODR_11                      ((uint32_t)0x00000800)
+#define GPIO_ODR_ODR_12                      ((uint32_t)0x00001000)
+#define GPIO_ODR_ODR_13                      ((uint32_t)0x00002000)
+#define GPIO_ODR_ODR_14                      ((uint32_t)0x00004000)
+#define GPIO_ODR_ODR_15                      ((uint32_t)0x00008000)
+
+/******************  Bits definition for GPIO_BSRR register  ******************/
+#define GPIO_BSRR_BS_0                       ((uint32_t)0x00000001)
+#define GPIO_BSRR_BS_1                       ((uint32_t)0x00000002)
+#define GPIO_BSRR_BS_2                       ((uint32_t)0x00000004)
+#define GPIO_BSRR_BS_3                       ((uint32_t)0x00000008)
+#define GPIO_BSRR_BS_4                       ((uint32_t)0x00000010)
+#define GPIO_BSRR_BS_5                       ((uint32_t)0x00000020)
+#define GPIO_BSRR_BS_6                       ((uint32_t)0x00000040)
+#define GPIO_BSRR_BS_7                       ((uint32_t)0x00000080)
+#define GPIO_BSRR_BS_8                       ((uint32_t)0x00000100)
+#define GPIO_BSRR_BS_9                       ((uint32_t)0x00000200)
+#define GPIO_BSRR_BS_10                      ((uint32_t)0x00000400)
+#define GPIO_BSRR_BS_11                      ((uint32_t)0x00000800)
+#define GPIO_BSRR_BS_12                      ((uint32_t)0x00001000)
+#define GPIO_BSRR_BS_13                      ((uint32_t)0x00002000)
+#define GPIO_BSRR_BS_14                      ((uint32_t)0x00004000)
+#define GPIO_BSRR_BS_15                      ((uint32_t)0x00008000)
+#define GPIO_BSRR_BR_0                       ((uint32_t)0x00010000)
+#define GPIO_BSRR_BR_1                       ((uint32_t)0x00020000)
+#define GPIO_BSRR_BR_2                       ((uint32_t)0x00040000)
+#define GPIO_BSRR_BR_3                       ((uint32_t)0x00080000)
+#define GPIO_BSRR_BR_4                       ((uint32_t)0x00100000)
+#define GPIO_BSRR_BR_5                       ((uint32_t)0x00200000)
+#define GPIO_BSRR_BR_6                       ((uint32_t)0x00400000)
+#define GPIO_BSRR_BR_7                       ((uint32_t)0x00800000)
+#define GPIO_BSRR_BR_8                       ((uint32_t)0x01000000)
+#define GPIO_BSRR_BR_9                       ((uint32_t)0x02000000)
+#define GPIO_BSRR_BR_10                      ((uint32_t)0x04000000)
+#define GPIO_BSRR_BR_11                      ((uint32_t)0x08000000)
+#define GPIO_BSRR_BR_12                      ((uint32_t)0x10000000)
+#define GPIO_BSRR_BR_13                      ((uint32_t)0x20000000)
+#define GPIO_BSRR_BR_14                      ((uint32_t)0x40000000)
+#define GPIO_BSRR_BR_15                      ((uint32_t)0x80000000)
+
+/****************** Bit definition for GPIO_LCKR register *********************/
+#define GPIO_LCKR_LCK0                       ((uint32_t)0x00000001)
+#define GPIO_LCKR_LCK1                       ((uint32_t)0x00000002)
+#define GPIO_LCKR_LCK2                       ((uint32_t)0x00000004)
+#define GPIO_LCKR_LCK3                       ((uint32_t)0x00000008)
+#define GPIO_LCKR_LCK4                       ((uint32_t)0x00000010)
+#define GPIO_LCKR_LCK5                       ((uint32_t)0x00000020)
+#define GPIO_LCKR_LCK6                       ((uint32_t)0x00000040)
+#define GPIO_LCKR_LCK7                       ((uint32_t)0x00000080)
+#define GPIO_LCKR_LCK8                       ((uint32_t)0x00000100)
+#define GPIO_LCKR_LCK9                       ((uint32_t)0x00000200)
+#define GPIO_LCKR_LCK10                      ((uint32_t)0x00000400)
+#define GPIO_LCKR_LCK11                      ((uint32_t)0x00000800)
+#define GPIO_LCKR_LCK12                      ((uint32_t)0x00001000)
+#define GPIO_LCKR_LCK13                      ((uint32_t)0x00002000)
+#define GPIO_LCKR_LCK14                      ((uint32_t)0x00004000)
+#define GPIO_LCKR_LCK15                      ((uint32_t)0x00008000)
+#define GPIO_LCKR_LCKK                       ((uint32_t)0x00010000)
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Inter-integrated Circuit Interface (I2C)              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for I2C_CR1 register  *******************/
+#define  I2C_CR1_PE                          ((uint32_t)0x00000001)        /*!< Peripheral enable                   */
+#define  I2C_CR1_TXIE                        ((uint32_t)0x00000002)        /*!< TX interrupt enable                 */
+#define  I2C_CR1_RXIE                        ((uint32_t)0x00000004)        /*!< RX interrupt enable                 */
+#define  I2C_CR1_ADDRIE                      ((uint32_t)0x00000008)        /*!< Address match interrupt enable      */
+#define  I2C_CR1_NACKIE                      ((uint32_t)0x00000010)        /*!< NACK received interrupt enable      */
+#define  I2C_CR1_STOPIE                      ((uint32_t)0x00000020)        /*!< STOP detection interrupt enable     */
+#define  I2C_CR1_TCIE                        ((uint32_t)0x00000040)        /*!< Transfer complete interrupt enable  */
+#define  I2C_CR1_ERRIE                       ((uint32_t)0x00000080)        /*!< Errors interrupt enable             */
+#define  I2C_CR1_DFN                         ((uint32_t)0x00000F00)        /*!< Digital noise filter                */
+#define  I2C_CR1_ANFOFF                      ((uint32_t)0x00001000)        /*!< Analog noise filter OFF             */
+#define  I2C_CR1_SWRST                       ((uint32_t)0x00002000)        /*!< Software reset                      */
+#define  I2C_CR1_TXDMAEN                     ((uint32_t)0x00004000)        /*!< DMA transmission requests enable    */
+#define  I2C_CR1_RXDMAEN                     ((uint32_t)0x00008000)        /*!< DMA reception requests enable       */
+#define  I2C_CR1_SBC                         ((uint32_t)0x00010000)        /*!< Slave byte control                  */
+#define  I2C_CR1_NOSTRETCH                   ((uint32_t)0x00020000)        /*!< Clock stretching disable            */
+#define  I2C_CR1_WUPEN                       ((uint32_t)0x00040000)        /*!< Wakeup from STOP enable             */
+#define  I2C_CR1_GCEN                        ((uint32_t)0x00080000)        /*!< General call enable                 */
+#define  I2C_CR1_SMBHEN                      ((uint32_t)0x00100000)        /*!< SMBus host address enable           */
+#define  I2C_CR1_SMBDEN                      ((uint32_t)0x00200000)        /*!< SMBus device default address enable */
+#define  I2C_CR1_ALERTEN                     ((uint32_t)0x00400000)        /*!< SMBus alert enable                  */
+#define  I2C_CR1_PECEN                       ((uint32_t)0x00800000)        /*!< PEC enable                          */
+
+/******************  Bit definition for I2C_CR2 register  ********************/
+#define  I2C_CR2_SADD                        ((uint32_t)0x000003FF)        /*!< Slave address (master mode)                             */
+#define  I2C_CR2_RD_WRN                      ((uint32_t)0x00000400)        /*!< Transfer direction (master mode)                        */
+#define  I2C_CR2_ADD10                       ((uint32_t)0x00000800)        /*!< 10-bit addressing mode (master mode)                    */
+#define  I2C_CR2_HEAD10R                     ((uint32_t)0x00001000)        /*!< 10-bit address header only read direction (master mode) */
+#define  I2C_CR2_START                       ((uint32_t)0x00002000)        /*!< START generation                                        */
+#define  I2C_CR2_STOP                        ((uint32_t)0x00004000)        /*!< STOP generation (master mode)                           */
+#define  I2C_CR2_NACK                        ((uint32_t)0x00008000)        /*!< NACK generation (slave mode)                            */
+#define  I2C_CR2_NBYTES                      ((uint32_t)0x00FF0000)        /*!< Number of bytes                                         */
+#define  I2C_CR2_RELOAD                      ((uint32_t)0x01000000)        /*!< NBYTES reload mode                                      */
+#define  I2C_CR2_AUTOEND                     ((uint32_t)0x02000000)        /*!< Automatic end mode (master mode)                        */
+#define  I2C_CR2_PECBYTE                     ((uint32_t)0x04000000)        /*!< Packet error checking byte                              */
+
+/*******************  Bit definition for I2C_OAR1 register  ******************/
+#define  I2C_OAR1_OA1                        ((uint32_t)0x000003FF)        /*!< Interface own address 1   */
+#define  I2C_OAR1_OA1MODE                    ((uint32_t)0x00000400)        /*!< Own address 1 10-bit mode */
+#define  I2C_OAR1_OA1EN                      ((uint32_t)0x00008000)        /*!< Own address 1 enable      */
+
+/*******************  Bit definition for I2C_OAR2 register  ******************/
+#define  I2C_OAR2_OA2                        ((uint32_t)0x000000FE)        /*!< Interface own address 2 */
+#define  I2C_OAR2_OA2MSK                     ((uint32_t)0x00000700)        /*!< Own address 2 masks     */
+#define  I2C_OAR2_OA2NOMASK                  ((uint32_t)0x00000000)        /*!< No mask */
+#define  I2C_OAR2_OA2MASK01                  ((uint32_t)0x00000100)        /*!< OA2[1] is masked, Only OA2[7:2] are compared */
+#define  I2C_OAR2_OA2MASK02                  ((uint32_t)0x00000200)        /*!< OA2[2:1] is masked, Only OA2[7:3] are compared */
+#define  I2C_OAR2_OA2MASK03                  ((uint32_t)0x00000300)        /*!< OA2[3:1] is masked, Only OA2[7:4] are compared */
+#define  I2C_OAR2_OA2MASK04                  ((uint32_t)0x00000400)        /*!< OA2[4:1] is masked, Only OA2[7:5] are compared */
+#define  I2C_OAR2_OA2MASK05                  ((uint32_t)0x00000500)        /*!< OA2[5:1] is masked, Only OA2[7:6] are compared */
+#define  I2C_OAR2_OA2MASK06                  ((uint32_t)0x00000600)        /*!< OA2[6:1] is masked, Only OA2[7] are compared */
+#define  I2C_OAR2_OA2MASK07                  ((uint32_t)0x00000700)        /*!< OA2[7:1] is masked, No comparison is done */
+#define  I2C_OAR2_OA2EN                      ((uint32_t)0x00008000)        /*!< Own address 2 enable    */
+
+/*******************  Bit definition for I2C_TIMINGR register *******************/
+#define  I2C_TIMINGR_SCLL                    ((uint32_t)0x000000FF)        /*!< SCL low period (master mode)  */
+#define  I2C_TIMINGR_SCLH                    ((uint32_t)0x0000FF00)        /*!< SCL high period (master mode) */
+#define  I2C_TIMINGR_SDADEL                  ((uint32_t)0x000F0000)        /*!< Data hold time                */
+#define  I2C_TIMINGR_SCLDEL                  ((uint32_t)0x00F00000)        /*!< Data setup time               */
+#define  I2C_TIMINGR_PRESC                   ((uint32_t)0xF0000000)        /*!< Timings prescaler             */
+
+/******************* Bit definition for I2C_TIMEOUTR register *******************/
+#define  I2C_TIMEOUTR_TIMEOUTA               ((uint32_t)0x00000FFF)        /*!< Bus timeout A                 */
+#define  I2C_TIMEOUTR_TIDLE                  ((uint32_t)0x00001000)        /*!< Idle clock timeout detection  */
+#define  I2C_TIMEOUTR_TIMOUTEN               ((uint32_t)0x00008000)        /*!< Clock timeout enable          */
+#define  I2C_TIMEOUTR_TIMEOUTB               ((uint32_t)0x0FFF0000)        /*!< Bus timeout B                 */
+#define  I2C_TIMEOUTR_TEXTEN                 ((uint32_t)0x80000000)        /*!< Extended clock timeout enable */
+
+/******************  Bit definition for I2C_ISR register  *********************/
+#define  I2C_ISR_TXE                         ((uint32_t)0x00000001)        /*!< Transmit data register empty    */
+#define  I2C_ISR_TXIS                        ((uint32_t)0x00000002)        /*!< Transmit interrupt status       */
+#define  I2C_ISR_RXNE                        ((uint32_t)0x00000004)        /*!< Receive data register not empty */
+#define  I2C_ISR_ADDR                        ((uint32_t)0x00000008)        /*!< Address matched (slave mode)    */
+#define  I2C_ISR_NACKF                       ((uint32_t)0x00000010)        /*!< NACK received flag              */
+#define  I2C_ISR_STOPF                       ((uint32_t)0x00000020)        /*!< STOP detection flag             */
+#define  I2C_ISR_TC                          ((uint32_t)0x00000040)        /*!< Transfer complete (master mode) */
+#define  I2C_ISR_TCR                         ((uint32_t)0x00000080)        /*!< Transfer complete reload        */
+#define  I2C_ISR_BERR                        ((uint32_t)0x00000100)        /*!< Bus error                       */
+#define  I2C_ISR_ARLO                        ((uint32_t)0x00000200)        /*!< Arbitration lost                */
+#define  I2C_ISR_OVR                         ((uint32_t)0x00000400)        /*!< Overrun/Underrun                */
+#define  I2C_ISR_PECERR                      ((uint32_t)0x00000800)        /*!< PEC error in reception          */
+#define  I2C_ISR_TIMEOUT                     ((uint32_t)0x00001000)        /*!< Timeout or Tlow detection flag  */
+#define  I2C_ISR_ALERT                       ((uint32_t)0x00002000)        /*!< SMBus alert                     */
+#define  I2C_ISR_BUSY                        ((uint32_t)0x00008000)        /*!< Bus busy                        */
+#define  I2C_ISR_DIR                         ((uint32_t)0x00010000)        /*!< Transfer direction (slave mode) */
+#define  I2C_ISR_ADDCODE                     ((uint32_t)0x00FE0000)        /*!< Address match code (slave mode) */
+
+/******************  Bit definition for I2C_ICR register  *********************/
+#define  I2C_ICR_ADDRCF                      ((uint32_t)0x00000008)        /*!< Address matched clear flag      */
+#define  I2C_ICR_NACKCF                      ((uint32_t)0x00000010)        /*!< NACK clear flag                 */
+#define  I2C_ICR_STOPCF                      ((uint32_t)0x00000020)        /*!< STOP detection clear flag       */
+#define  I2C_ICR_BERRCF                      ((uint32_t)0x00000100)        /*!< Bus error clear flag            */
+#define  I2C_ICR_ARLOCF                      ((uint32_t)0x00000200)        /*!< Arbitration lost clear flag     */
+#define  I2C_ICR_OVRCF                       ((uint32_t)0x00000400)        /*!< Overrun/Underrun clear flag     */
+#define  I2C_ICR_PECCF                       ((uint32_t)0x00000800)        /*!< PAC error clear flag            */
+#define  I2C_ICR_TIMOUTCF                    ((uint32_t)0x00001000)        /*!< Timeout clear flag              */
+#define  I2C_ICR_ALERTCF                     ((uint32_t)0x00002000)        /*!< Alert clear flag                */
+
+/******************  Bit definition for I2C_PECR register  *********************/
+#define  I2C_PECR_PEC                        ((uint32_t)0x000000FF)        /*!< PEC register        */
+
+/******************  Bit definition for I2C_RXDR register  *********************/
+#define  I2C_RXDR_RXDATA                     ((uint32_t)0x000000FF)        /*!< 8-bit receive data  */
+
+/******************  Bit definition for I2C_TXDR register  *********************/
+#define  I2C_TXDR_TXDATA                     ((uint32_t)0x000000FF)        /*!< 8-bit transmit data */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Independent WATCHDOG                             */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define  IWDG_KR_KEY                         ((uint32_t)0xFFFF)            /*!<Key value (write only, read 0000h)  */
+
+/*******************  Bit definition for IWDG_PR register  ********************/
+#define  IWDG_PR_PR                          ((uint32_t)0x07)               /*!<PR[2:0] (Prescaler divider)         */
+#define  IWDG_PR_PR_0                        ((uint32_t)0x01)               /*!<Bit 0 */
+#define  IWDG_PR_PR_1                        ((uint32_t)0x02)               /*!<Bit 1 */
+#define  IWDG_PR_PR_2                        ((uint32_t)0x04)               /*!<Bit 2 */
+
+/*******************  Bit definition for IWDG_RLR register  *******************/
+#define  IWDG_RLR_RL                         ((uint32_t)0x0FFF)            /*!<Watchdog counter reload value        */
+
+/*******************  Bit definition for IWDG_SR register  ********************/
+#define  IWDG_SR_PVU                         ((uint32_t)0x01)               /*!< Watchdog prescaler value update */
+#define  IWDG_SR_RVU                         ((uint32_t)0x02)               /*!< Watchdog counter reload value update */
+#define  IWDG_SR_WVU                         ((uint32_t)0x04)               /*!< Watchdog counter window value update */
+
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define  IWDG_WINR_WIN                       ((uint32_t)0x0FFF)             /*!< Watchdog counter window value */
+
+/******************************************************************************/
+/*                                                                            */
+/*                             Power Control                                  */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for PWR_CR1 register  ********************/
+#define  PWR_CR1_LPDS                         ((uint32_t)0x00000001)     /*!< Low-Power Deepsleep                 */
+#define  PWR_CR1_PDDS                         ((uint32_t)0x00000002)     /*!< Power Down Deepsleep                */
+#define  PWR_CR1_CSBF                         ((uint32_t)0x00000008)     /*!< Clear Standby Flag                  */
+#define  PWR_CR1_PVDE                         ((uint32_t)0x00000010)     /*!< Power Voltage Detector Enable       */
+
+#define  PWR_CR1_PLS                          ((uint32_t)0x000000E0)     /*!< PLS[2:0] bits (PVD Level Selection) */
+#define  PWR_CR1_PLS_0                        ((uint32_t)0x00000020)     /*!< Bit 0 */
+#define  PWR_CR1_PLS_1                        ((uint32_t)0x00000040)     /*!< Bit 1 */
+#define  PWR_CR1_PLS_2                        ((uint32_t)0x00000080)     /*!< Bit 2 */
+
+/*!< PVD level configuration */
+#define  PWR_CR1_PLS_LEV0                     ((uint32_t)0x00000000)     /*!< PVD level 0 */
+#define  PWR_CR1_PLS_LEV1                     ((uint32_t)0x00000020)     /*!< PVD level 1 */
+#define  PWR_CR1_PLS_LEV2                     ((uint32_t)0x00000040)     /*!< PVD level 2 */
+#define  PWR_CR1_PLS_LEV3                     ((uint32_t)0x00000060)     /*!< PVD level 3 */
+#define  PWR_CR1_PLS_LEV4                     ((uint32_t)0x00000080)     /*!< PVD level 4 */
+#define  PWR_CR1_PLS_LEV5                     ((uint32_t)0x000000A0)     /*!< PVD level 5 */
+#define  PWR_CR1_PLS_LEV6                     ((uint32_t)0x000000C0)     /*!< PVD level 6 */
+#define  PWR_CR1_PLS_LEV7                     ((uint32_t)0x000000E0)     /*!< PVD level 7 */
+
+#define  PWR_CR1_DBP                          ((uint32_t)0x00000100)     /*!< Disable Backup Domain write protection                     */
+#define  PWR_CR1_FPDS                         ((uint32_t)0x00000200)     /*!< Flash power down in Stop mode                              */
+
+#define  PWR_CR1_LPUDS                        ((uint32_t)0x00000400)     /*!< Low-power regulator in deepsleep under-drive mode          */
+#define  PWR_CR1_MRUDS                        ((uint32_t)0x00000800)     /*!< Main regulator in deepsleep under-drive mode               */
+
+#define  PWR_CR1_ADCDC1                       ((uint32_t)0x00002000)     /*!< Refer to AN4073 on how to use this bit */
+
+#define  PWR_CR1_VOS                          ((uint32_t)0x0000C000)     /*!< VOS[1:0] bits (Regulator voltage scaling output selection) */
+#define  PWR_CR1_VOS_0                        ((uint32_t)0x00004000)     /*!< Bit 0 */
+#define  PWR_CR1_VOS_1                        ((uint32_t)0x00008000)     /*!< Bit 1 */
+
+#define  PWR_CR1_ODEN                         ((uint32_t)0x00010000)     /*!< Over Drive enable                   */
+#define  PWR_CR1_ODSWEN                       ((uint32_t)0x00020000)     /*!< Over Drive switch enabled           */
+#define  PWR_CR1_UDEN                         ((uint32_t)0x000C0000)     /*!< Under Drive enable in stop mode     */
+#define  PWR_CR1_UDEN_0                       ((uint32_t)0x00040000)     /*!< Bit 0                               */
+#define  PWR_CR1_UDEN_1                       ((uint32_t)0x00080000)     /*!< Bit 1                               */
+
+/*******************  Bit definition for PWR_CSR1 register  ********************/
+#define  PWR_CSR1_WUIF                        ((uint32_t)0x00000001)     /*!< Wake up internal Flag                            */
+#define  PWR_CSR1_SBF                         ((uint32_t)0x00000002)     /*!< Standby Flag                                     */
+#define  PWR_CSR1_PVDO                        ((uint32_t)0x00000004)     /*!< PVD Output                                       */
+#define  PWR_CSR1_BRR                         ((uint32_t)0x00000008)     /*!< Backup regulator ready                           */
+#define  PWR_CSR1_BRE                         ((uint32_t)0x00000200)     /*!< Backup regulator enable                          */
+#define  PWR_CSR1_VOSRDY                      ((uint32_t)0x00004000)     /*!< Regulator voltage scaling output selection ready */
+
+#define  PWR_CSR1_ODRDY                       ((uint32_t)0x00010000)     /*!< Over Drive generator ready                       */
+#define  PWR_CSR1_ODSWRDY                     ((uint32_t)0x00020000)     /*!< Over Drive Switch ready                          */
+#define  PWR_CSR1_UDSWRDY                     ((uint32_t)0x000C0000)     /*!< Under Drive ready                                */
+
+/********************  Bit definition for PWR_CR2 register  ********************/
+#define  PWR_CR2_CWUPF1                         ((uint32_t)0x00000001)     /*!< Clear Wakeup Pin Flag for PA0      */
+#define  PWR_CR2_CWUPF2                         ((uint32_t)0x00000002)     /*!< Clear Wakeup Pin Flag for PA2      */
+#define  PWR_CR2_CWUPF3                         ((uint32_t)0x00000004)     /*!< Clear Wakeup Pin Flag for PC1      */
+#define  PWR_CR2_CWUPF4                         ((uint32_t)0x00000008)     /*!< Clear Wakeup Pin Flag for PC13     */
+#define  PWR_CR2_CWUPF5                         ((uint32_t)0x00000010)     /*!< Clear Wakeup Pin Flag for PI8      */
+#define  PWR_CR2_CWUPF6                         ((uint32_t)0x00000020)     /*!< Clear Wakeup Pin Flag for PI11     */
+
+#define  PWR_CR2_WUPP1                          ((uint32_t)0x00000100)     /*!< Wakeup Pin Polarity bit for PA0    */
+#define  PWR_CR2_WUPP2                          ((uint32_t)0x00000200)     /*!< Wakeup Pin Polarity bit for PA2    */
+#define  PWR_CR2_WUPP3                          ((uint32_t)0x00000400)     /*!< Wakeup Pin Polarity bit for PC1    */
+#define  PWR_CR2_WUPP4                          ((uint32_t)0x00000800)     /*!< Wakeup Pin Polarity bit for PC13   */
+#define  PWR_CR2_WUPP5                          ((uint32_t)0x00001000)     /*!< Wakeup Pin Polarity bit for PI8    */
+#define  PWR_CR2_WUPP6                          ((uint32_t)0x00002000)     /*!< Wakeup Pin Polarity bit for PI11   */
+
+/*******************  Bit definition for PWR_CSR2 register  ********************/
+#define  PWR_CSR2_WUPF1                         ((uint32_t)0x00000001)     /*!< Wakeup Pin Flag for PA0            */
+#define  PWR_CSR2_WUPF2                         ((uint32_t)0x00000002)     /*!< Wakeup Pin Flag for PA2            */
+#define  PWR_CSR2_WUPF3                         ((uint32_t)0x00000004)     /*!< Wakeup Pin Flag for PC1            */
+#define  PWR_CSR2_WUPF4                         ((uint32_t)0x00000008)     /*!< Wakeup Pin Flag for PC13           */
+#define  PWR_CSR2_WUPF5                         ((uint32_t)0x00000010)     /*!< Wakeup Pin Flag for PI8            */
+#define  PWR_CSR2_WUPF6                         ((uint32_t)0x00000020)     /*!< Wakeup Pin Flag for PI11           */
+
+#define  PWR_CSR2_EWUP1                         ((uint32_t)0x00000100)     /*!< Enable Wakeup Pin PA0              */
+#define  PWR_CSR2_EWUP2                         ((uint32_t)0x00000200)     /*!< Enable Wakeup Pin PA2              */
+#define  PWR_CSR2_EWUP3                         ((uint32_t)0x00000400)     /*!< Enable Wakeup Pin PC1              */
+#define  PWR_CSR2_EWUP4                         ((uint32_t)0x00000800)     /*!< Enable Wakeup Pin PC13             */
+#define  PWR_CSR2_EWUP5                         ((uint32_t)0x00001000)     /*!< Enable Wakeup Pin PI8              */
+#define  PWR_CSR2_EWUP6                         ((uint32_t)0x00002000)     /*!< Enable Wakeup Pin PI11             */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    QUADSPI                                 */
+/*                                                                            */
+/******************************************************************************/
+/*****************  Bit definition for QUADSPI_CR register  *******************/
+#define  QUADSPI_CR_EN                           ((uint32_t)0x00000001)            /*!< Enable                            */
+#define  QUADSPI_CR_ABORT                        ((uint32_t)0x00000002)            /*!< Abort request                     */
+#define  QUADSPI_CR_DMAEN                        ((uint32_t)0x00000004)            /*!< DMA Enable                        */
+#define  QUADSPI_CR_TCEN                         ((uint32_t)0x00000008)            /*!< Timeout Counter Enable            */
+#define  QUADSPI_CR_SSHIFT                       ((uint32_t)0x00000010)            /*!< Sample Shift                      */
+#define  QUADSPI_CR_DFM                          ((uint32_t)0x00000040)            /*!< Dual Flash Mode                   */
+#define  QUADSPI_CR_FSEL                         ((uint32_t)0x00000080)            /*!< Flash Select                      */
+#define  QUADSPI_CR_FTHRES                       ((uint32_t)0x00000F00)            /*!< FTHRES[3:0] FIFO Level            */
+#define  QUADSPI_CR_FTHRES_0                     ((uint32_t)0x00000100)            /*!< Bit 0 */
+#define  QUADSPI_CR_FTHRES_1                     ((uint32_t)0x00000200)            /*!< Bit 1 */
+#define  QUADSPI_CR_FTHRES_2                     ((uint32_t)0x00000400)            /*!< Bit 2 */
+#define  QUADSPI_CR_FTHRES_3                     ((uint32_t)0x00000800)            /*!< Bit 3 */
+#define  QUADSPI_CR_TEIE                         ((uint32_t)0x00010000)            /*!< Transfer Error Interrupt Enable    */
+#define  QUADSPI_CR_TCIE                         ((uint32_t)0x00020000)            /*!< Transfer Complete Interrupt Enable */
+#define  QUADSPI_CR_FTIE                         ((uint32_t)0x00040000)            /*!< FIFO Threshold Interrupt Enable    */
+#define  QUADSPI_CR_SMIE                         ((uint32_t)0x00080000)            /*!< Status Match Interrupt Enable      */
+#define  QUADSPI_CR_TOIE                         ((uint32_t)0x00100000)            /*!< TimeOut Interrupt Enable           */
+#define  QUADSPI_CR_APMS                         ((uint32_t)0x00400000)            /*!< Bit 1                              */
+#define  QUADSPI_CR_PMM                          ((uint32_t)0x00800000)            /*!< Polling Match Mode                 */
+#define  QUADSPI_CR_PRESCALER                    ((uint32_t)0xFF000000)            /*!< PRESCALER[7:0] Clock prescaler     */
+#define  QUADSPI_CR_PRESCALER_0                  ((uint32_t)0x01000000)            /*!< Bit 0 */
+#define  QUADSPI_CR_PRESCALER_1                  ((uint32_t)0x02000000)            /*!< Bit 1 */
+#define  QUADSPI_CR_PRESCALER_2                  ((uint32_t)0x04000000)            /*!< Bit 2 */
+#define  QUADSPI_CR_PRESCALER_3                  ((uint32_t)0x08000000)            /*!< Bit 3 */
+#define  QUADSPI_CR_PRESCALER_4                  ((uint32_t)0x10000000)            /*!< Bit 4 */
+#define  QUADSPI_CR_PRESCALER_5                  ((uint32_t)0x20000000)            /*!< Bit 5 */
+#define  QUADSPI_CR_PRESCALER_6                  ((uint32_t)0x40000000)            /*!< Bit 6 */
+#define  QUADSPI_CR_PRESCALER_7                  ((uint32_t)0x80000000)            /*!< Bit 7 */
+
+/*****************  Bit definition for QUADSPI_DCR register  ******************/
+#define  QUADSPI_DCR_CKMODE                      ((uint32_t)0x00000001)            /*!< Mode 0 / Mode 3                 */
+#define  QUADSPI_DCR_CSHT                        ((uint32_t)0x00000700)            /*!< CSHT[2:0]: ChipSelect High Time */
+#define  QUADSPI_DCR_CSHT_0                      ((uint32_t)0x00000100)            /*!< Bit 0 */
+#define  QUADSPI_DCR_CSHT_1                      ((uint32_t)0x00000200)            /*!< Bit 1 */
+#define  QUADSPI_DCR_CSHT_2                      ((uint32_t)0x00000400)            /*!< Bit 2 */
+#define  QUADSPI_DCR_FSIZE                       ((uint32_t)0x001F0000)            /*!< FSIZE[4:0]: Flash Size          */
+#define  QUADSPI_DCR_FSIZE_0                     ((uint32_t)0x00010000)            /*!< Bit 0 */
+#define  QUADSPI_DCR_FSIZE_1                     ((uint32_t)0x00020000)            /*!< Bit 1 */
+#define  QUADSPI_DCR_FSIZE_2                     ((uint32_t)0x00040000)            /*!< Bit 2 */
+#define  QUADSPI_DCR_FSIZE_3                     ((uint32_t)0x00080000)            /*!< Bit 3 */
+#define  QUADSPI_DCR_FSIZE_4                     ((uint32_t)0x00100000)            /*!< Bit 4 */
+
+/******************  Bit definition for QUADSPI_SR register  *******************/
+#define  QUADSPI_SR_TEF                          ((uint32_t)0x00000001)             /*!< Transfer Error Flag    */
+#define  QUADSPI_SR_TCF                          ((uint32_t)0x00000002)             /*!< Transfer Complete Flag */
+#define  QUADSPI_SR_FTF                          ((uint32_t)0x00000004)             /*!< FIFO Threshlod Flag    */
+#define  QUADSPI_SR_SMF                          ((uint32_t)0x00000008)             /*!< Status Match Flag      */
+#define  QUADSPI_SR_TOF                          ((uint32_t)0x00000010)             /*!< Timeout Flag           */
+#define  QUADSPI_SR_BUSY                         ((uint32_t)0x00000020)             /*!< Busy                   */
+#define  QUADSPI_SR_FLEVEL                       ((uint32_t)0x00001F00)             /*!< FIFO Threshlod Flag    */
+#define  QUADSPI_SR_FLEVEL_0                     ((uint32_t)0x00000100)             /*!< Bit 0 */
+#define  QUADSPI_SR_FLEVEL_1                     ((uint32_t)0x00000200)             /*!< Bit 1 */
+#define  QUADSPI_SR_FLEVEL_2                     ((uint32_t)0x00000400)             /*!< Bit 2 */
+#define  QUADSPI_SR_FLEVEL_3                     ((uint32_t)0x00000800)             /*!< Bit 3 */
+#define  QUADSPI_SR_FLEVEL_4                     ((uint32_t)0x00001000)             /*!< Bit 4 */
+
+/******************  Bit definition for QUADSPI_FCR register  ******************/
+#define  QUADSPI_FCR_CTEF                        ((uint32_t)0x00000001)             /*!< Clear Transfer Error Flag    */
+#define  QUADSPI_FCR_CTCF                        ((uint32_t)0x00000002)             /*!< Clear Transfer Complete Flag */
+#define  QUADSPI_FCR_CSMF                        ((uint32_t)0x00000008)             /*!< Clear Status Match Flag      */
+#define  QUADSPI_FCR_CTOF                        ((uint32_t)0x00000010)             /*!< Clear Timeout Flag           */
+
+/******************  Bit definition for QUADSPI_DLR register  ******************/
+#define  QUADSPI_DLR_DL                        ((uint32_t)0xFFFFFFFF)               /*!< DL[31:0]: Data Length */
+
+/******************  Bit definition for QUADSPI_CCR register  ******************/
+#define  QUADSPI_CCR_INSTRUCTION                  ((uint32_t)0x000000FF)            /*!< INSTRUCTION[7:0]: Instruction    */
+#define  QUADSPI_CCR_INSTRUCTION_0                ((uint32_t)0x00000001)            /*!< Bit 0 */
+#define  QUADSPI_CCR_INSTRUCTION_1                ((uint32_t)0x00000002)            /*!< Bit 1 */
+#define  QUADSPI_CCR_INSTRUCTION_2                ((uint32_t)0x00000004)            /*!< Bit 2 */
+#define  QUADSPI_CCR_INSTRUCTION_3                ((uint32_t)0x00000008)            /*!< Bit 3 */
+#define  QUADSPI_CCR_INSTRUCTION_4                ((uint32_t)0x00000010)            /*!< Bit 4 */
+#define  QUADSPI_CCR_INSTRUCTION_5                ((uint32_t)0x00000020)            /*!< Bit 5 */
+#define  QUADSPI_CCR_INSTRUCTION_6                ((uint32_t)0x00000040)            /*!< Bit 6 */
+#define  QUADSPI_CCR_INSTRUCTION_7                ((uint32_t)0x00000080)            /*!< Bit 7 */
+#define  QUADSPI_CCR_IMODE                        ((uint32_t)0x00000300)            /*!< IMODE[1:0]: Instruction Mode      */
+#define  QUADSPI_CCR_IMODE_0                      ((uint32_t)0x00000100)            /*!< Bit 0 */
+#define  QUADSPI_CCR_IMODE_1                      ((uint32_t)0x00000200)            /*!< Bit 1 */
+#define  QUADSPI_CCR_ADMODE                       ((uint32_t)0x00000C00)            /*!< ADMODE[1:0]: Address Mode         */
+#define  QUADSPI_CCR_ADMODE_0                     ((uint32_t)0x00000400)            /*!< Bit 0 */
+#define  QUADSPI_CCR_ADMODE_1                     ((uint32_t)0x00000800)            /*!< Bit 1 */
+#define  QUADSPI_CCR_ADSIZE                       ((uint32_t)0x00003000)            /*!< ADSIZE[1:0]: Address Size         */
+#define  QUADSPI_CCR_ADSIZE_0                     ((uint32_t)0x00001000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_ADSIZE_1                     ((uint32_t)0x00002000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_ABMODE                       ((uint32_t)0x0000C000)            /*!< ABMODE[1:0]: Alternate Bytes Mode */
+#define  QUADSPI_CCR_ABMODE_0                     ((uint32_t)0x00004000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_ABMODE_1                     ((uint32_t)0x00008000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_ABSIZE                       ((uint32_t)0x00030000)            /*!< ABSIZE[1:0]: Instruction Mode     */
+#define  QUADSPI_CCR_ABSIZE_0                     ((uint32_t)0x00010000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_ABSIZE_1                     ((uint32_t)0x00020000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_DCYC                         ((uint32_t)0x007C0000)            /*!< DCYC[4:0]: Dummy Cycles           */
+#define  QUADSPI_CCR_DCYC_0                       ((uint32_t)0x00040000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_DCYC_1                       ((uint32_t)0x00080000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_DCYC_2                       ((uint32_t)0x00100000)            /*!< Bit 2 */
+#define  QUADSPI_CCR_DCYC_3                       ((uint32_t)0x00200000)            /*!< Bit 3 */
+#define  QUADSPI_CCR_DCYC_4                       ((uint32_t)0x00400000)            /*!< Bit 4 */
+#define  QUADSPI_CCR_DMODE                        ((uint32_t)0x03000000)            /*!< DMODE[1:0]: Data Mode              */
+#define  QUADSPI_CCR_DMODE_0                      ((uint32_t)0x01000000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_DMODE_1                      ((uint32_t)0x02000000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_FMODE                        ((uint32_t)0x0C000000)            /*!< FMODE[1:0]: Functional Mode        */
+#define  QUADSPI_CCR_FMODE_0                      ((uint32_t)0x04000000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_FMODE_1                      ((uint32_t)0x08000000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_SIOO                         ((uint32_t)0x10000000)            /*!< SIOO: Send Instruction Only Once Mode */
+#define  QUADSPI_CCR_DHHC                         ((uint32_t)0x40000000)            /*!< DHHC: Delay Half Hclk Cycle           */
+#define  QUADSPI_CCR_DDRM                         ((uint32_t)0x80000000)            /*!< DDRM: Double Data Rate Mode           */
+/******************  Bit definition for QUADSPI_AR register  *******************/
+#define  QUADSPI_AR_ADDRESS                       ((uint32_t)0xFFFFFFFF)            /*!< ADDRESS[31:0]: Address */
+
+/******************  Bit definition for QUADSPI_ABR register  ******************/
+#define  QUADSPI_ABR_ALTERNATE                    ((uint32_t)0xFFFFFFFF)            /*!< ALTERNATE[31:0]: Alternate Bytes */
+
+/******************  Bit definition for QUADSPI_DR register  *******************/
+#define  QUADSPI_DR_DATA                          ((uint32_t)0xFFFFFFFF)            /*!< DATA[31:0]: Data */
+
+/******************  Bit definition for QUADSPI_PSMKR register  ****************/
+#define  QUADSPI_PSMKR_MASK                       ((uint32_t)0xFFFFFFFF)            /*!< MASK[31:0]: Status Mask */
+
+/******************  Bit definition for QUADSPI_PSMAR register  ****************/
+#define  QUADSPI_PSMAR_MATCH                      ((uint32_t)0xFFFFFFFF)            /*!< MATCH[31:0]: Status Match */
+
+/******************  Bit definition for QUADSPI_PIR register  *****************/
+#define  QUADSPI_PIR_INTERVAL                     ((uint32_t)0x0000FFFF)            /*!< INTERVAL[15:0]: Polling Interval */
+
+/******************  Bit definition for QUADSPI_LPTR register  *****************/
+#define  QUADSPI_LPTR_TIMEOUT                     ((uint32_t)0x0000FFFF)            /*!< TIMEOUT[15:0]: Timeout period */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Reset and Clock Control            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for RCC_CR register  ********************/
+#define  RCC_CR_HSION                        ((uint32_t)0x00000001)
+#define  RCC_CR_HSIRDY                       ((uint32_t)0x00000002)
+
+#define  RCC_CR_HSITRIM                      ((uint32_t)0x000000F8)
+#define  RCC_CR_HSITRIM_0                    ((uint32_t)0x00000008) /*!<Bit 0 */
+#define  RCC_CR_HSITRIM_1                    ((uint32_t)0x00000010) /*!<Bit 1 */
+#define  RCC_CR_HSITRIM_2                    ((uint32_t)0x00000020) /*!<Bit 2 */
+#define  RCC_CR_HSITRIM_3                    ((uint32_t)0x00000040) /*!<Bit 3 */
+#define  RCC_CR_HSITRIM_4                    ((uint32_t)0x00000080) /*!<Bit 4 */
+
+#define  RCC_CR_HSICAL                       ((uint32_t)0x0000FF00)
+#define  RCC_CR_HSICAL_0                     ((uint32_t)0x00000100) /*!<Bit 0 */
+#define  RCC_CR_HSICAL_1                     ((uint32_t)0x00000200) /*!<Bit 1 */
+#define  RCC_CR_HSICAL_2                     ((uint32_t)0x00000400) /*!<Bit 2 */
+#define  RCC_CR_HSICAL_3                     ((uint32_t)0x00000800) /*!<Bit 3 */
+#define  RCC_CR_HSICAL_4                     ((uint32_t)0x00001000) /*!<Bit 4 */
+#define  RCC_CR_HSICAL_5                     ((uint32_t)0x00002000) /*!<Bit 5 */
+#define  RCC_CR_HSICAL_6                     ((uint32_t)0x00004000) /*!<Bit 6 */
+#define  RCC_CR_HSICAL_7                     ((uint32_t)0x00008000) /*!<Bit 7 */
+
+#define  RCC_CR_HSEON                        ((uint32_t)0x00010000)
+#define  RCC_CR_HSERDY                       ((uint32_t)0x00020000)
+#define  RCC_CR_HSEBYP                       ((uint32_t)0x00040000)
+#define  RCC_CR_CSSON                        ((uint32_t)0x00080000)
+#define  RCC_CR_PLLON                        ((uint32_t)0x01000000)
+#define  RCC_CR_PLLRDY                       ((uint32_t)0x02000000)
+#define  RCC_CR_PLLI2SON                     ((uint32_t)0x04000000)
+#define  RCC_CR_PLLI2SRDY                    ((uint32_t)0x08000000)
+#define  RCC_CR_PLLSAION                     ((uint32_t)0x10000000)
+#define  RCC_CR_PLLSAIRDY                    ((uint32_t)0x20000000)
+
+/********************  Bit definition for RCC_PLLCFGR register  ***************/
+#define  RCC_PLLCFGR_PLLM                    ((uint32_t)0x0000003F)
+#define  RCC_PLLCFGR_PLLM_0                  ((uint32_t)0x00000001)
+#define  RCC_PLLCFGR_PLLM_1                  ((uint32_t)0x00000002)
+#define  RCC_PLLCFGR_PLLM_2                  ((uint32_t)0x00000004)
+#define  RCC_PLLCFGR_PLLM_3                  ((uint32_t)0x00000008)
+#define  RCC_PLLCFGR_PLLM_4                  ((uint32_t)0x00000010)
+#define  RCC_PLLCFGR_PLLM_5                  ((uint32_t)0x00000020)
+
+#define  RCC_PLLCFGR_PLLN                     ((uint32_t)0x00007FC0)
+#define  RCC_PLLCFGR_PLLN_0                   ((uint32_t)0x00000040)
+#define  RCC_PLLCFGR_PLLN_1                   ((uint32_t)0x00000080)
+#define  RCC_PLLCFGR_PLLN_2                   ((uint32_t)0x00000100)
+#define  RCC_PLLCFGR_PLLN_3                   ((uint32_t)0x00000200)
+#define  RCC_PLLCFGR_PLLN_4                   ((uint32_t)0x00000400)
+#define  RCC_PLLCFGR_PLLN_5                   ((uint32_t)0x00000800)
+#define  RCC_PLLCFGR_PLLN_6                   ((uint32_t)0x00001000)
+#define  RCC_PLLCFGR_PLLN_7                   ((uint32_t)0x00002000)
+#define  RCC_PLLCFGR_PLLN_8                   ((uint32_t)0x00004000)
+
+#define  RCC_PLLCFGR_PLLP                    ((uint32_t)0x00030000)
+#define  RCC_PLLCFGR_PLLP_0                  ((uint32_t)0x00010000)
+#define  RCC_PLLCFGR_PLLP_1                  ((uint32_t)0x00020000)
+
+#define  RCC_PLLCFGR_PLLSRC                  ((uint32_t)0x00400000)
+#define  RCC_PLLCFGR_PLLSRC_HSE              ((uint32_t)0x00400000)
+#define  RCC_PLLCFGR_PLLSRC_HSI              ((uint32_t)0x00000000)
+
+#define  RCC_PLLCFGR_PLLQ                    ((uint32_t)0x0F000000)
+#define  RCC_PLLCFGR_PLLQ_0                  ((uint32_t)0x01000000)
+#define  RCC_PLLCFGR_PLLQ_1                  ((uint32_t)0x02000000)
+#define  RCC_PLLCFGR_PLLQ_2                  ((uint32_t)0x04000000)
+#define  RCC_PLLCFGR_PLLQ_3                  ((uint32_t)0x08000000)
+
+/********************  Bit definition for RCC_CFGR register  ******************/
+/*!< SW configuration */
+#define  RCC_CFGR_SW                         ((uint32_t)0x00000003)        /*!< SW[1:0] bits (System clock Switch) */
+#define  RCC_CFGR_SW_0                       ((uint32_t)0x00000001)        /*!< Bit 0 */
+#define  RCC_CFGR_SW_1                       ((uint32_t)0x00000002)        /*!< Bit 1 */
+
+#define  RCC_CFGR_SW_HSI                     ((uint32_t)0x00000000)        /*!< HSI selected as system clock */
+#define  RCC_CFGR_SW_HSE                     ((uint32_t)0x00000001)        /*!< HSE selected as system clock */
+#define  RCC_CFGR_SW_PLL                     ((uint32_t)0x00000002)        /*!< PLL selected as system clock */
+
+/*!< SWS configuration */
+#define  RCC_CFGR_SWS                        ((uint32_t)0x0000000C)        /*!< SWS[1:0] bits (System Clock Switch Status) */
+#define  RCC_CFGR_SWS_0                      ((uint32_t)0x00000004)        /*!< Bit 0 */
+#define  RCC_CFGR_SWS_1                      ((uint32_t)0x00000008)        /*!< Bit 1 */
+
+#define  RCC_CFGR_SWS_HSI                    ((uint32_t)0x00000000)        /*!< HSI oscillator used as system clock */
+#define  RCC_CFGR_SWS_HSE                    ((uint32_t)0x00000004)        /*!< HSE oscillator used as system clock */
+#define  RCC_CFGR_SWS_PLL                    ((uint32_t)0x00000008)        /*!< PLL used as system clock */
+
+/*!< HPRE configuration */
+#define  RCC_CFGR_HPRE                       ((uint32_t)0x000000F0)        /*!< HPRE[3:0] bits (AHB prescaler) */
+#define  RCC_CFGR_HPRE_0                     ((uint32_t)0x00000010)        /*!< Bit 0 */
+#define  RCC_CFGR_HPRE_1                     ((uint32_t)0x00000020)        /*!< Bit 1 */
+#define  RCC_CFGR_HPRE_2                     ((uint32_t)0x00000040)        /*!< Bit 2 */
+#define  RCC_CFGR_HPRE_3                     ((uint32_t)0x00000080)        /*!< Bit 3 */
+
+#define  RCC_CFGR_HPRE_DIV1                  ((uint32_t)0x00000000)        /*!< SYSCLK not divided */
+#define  RCC_CFGR_HPRE_DIV2                  ((uint32_t)0x00000080)        /*!< SYSCLK divided by 2 */
+#define  RCC_CFGR_HPRE_DIV4                  ((uint32_t)0x00000090)        /*!< SYSCLK divided by 4 */
+#define  RCC_CFGR_HPRE_DIV8                  ((uint32_t)0x000000A0)        /*!< SYSCLK divided by 8 */
+#define  RCC_CFGR_HPRE_DIV16                 ((uint32_t)0x000000B0)        /*!< SYSCLK divided by 16 */
+#define  RCC_CFGR_HPRE_DIV64                 ((uint32_t)0x000000C0)        /*!< SYSCLK divided by 64 */
+#define  RCC_CFGR_HPRE_DIV128                ((uint32_t)0x000000D0)        /*!< SYSCLK divided by 128 */
+#define  RCC_CFGR_HPRE_DIV256                ((uint32_t)0x000000E0)        /*!< SYSCLK divided by 256 */
+#define  RCC_CFGR_HPRE_DIV512                ((uint32_t)0x000000F0)        /*!< SYSCLK divided by 512 */
+
+/*!< PPRE1 configuration */
+#define  RCC_CFGR_PPRE1                      ((uint32_t)0x00001C00)        /*!< PRE1[2:0] bits (APB1 prescaler) */
+#define  RCC_CFGR_PPRE1_0                    ((uint32_t)0x00000400)        /*!< Bit 0 */
+#define  RCC_CFGR_PPRE1_1                    ((uint32_t)0x00000800)        /*!< Bit 1 */
+#define  RCC_CFGR_PPRE1_2                    ((uint32_t)0x00001000)        /*!< Bit 2 */
+
+#define  RCC_CFGR_PPRE1_DIV1                 ((uint32_t)0x00000000)        /*!< HCLK not divided */
+#define  RCC_CFGR_PPRE1_DIV2                 ((uint32_t)0x00001000)        /*!< HCLK divided by 2 */
+#define  RCC_CFGR_PPRE1_DIV4                 ((uint32_t)0x00001400)        /*!< HCLK divided by 4 */
+#define  RCC_CFGR_PPRE1_DIV8                 ((uint32_t)0x00001800)        /*!< HCLK divided by 8 */
+#define  RCC_CFGR_PPRE1_DIV16                ((uint32_t)0x00001C00)        /*!< HCLK divided by 16 */
+
+/*!< PPRE2 configuration */
+#define  RCC_CFGR_PPRE2                      ((uint32_t)0x0000E000)        /*!< PRE2[2:0] bits (APB2 prescaler) */
+#define  RCC_CFGR_PPRE2_0                    ((uint32_t)0x00002000)        /*!< Bit 0 */
+#define  RCC_CFGR_PPRE2_1                    ((uint32_t)0x00004000)        /*!< Bit 1 */
+#define  RCC_CFGR_PPRE2_2                    ((uint32_t)0x00008000)        /*!< Bit 2 */
+
+#define  RCC_CFGR_PPRE2_DIV1                 ((uint32_t)0x00000000)        /*!< HCLK not divided */
+#define  RCC_CFGR_PPRE2_DIV2                 ((uint32_t)0x00008000)        /*!< HCLK divided by 2 */
+#define  RCC_CFGR_PPRE2_DIV4                 ((uint32_t)0x0000A000)        /*!< HCLK divided by 4 */
+#define  RCC_CFGR_PPRE2_DIV8                 ((uint32_t)0x0000C000)        /*!< HCLK divided by 8 */
+#define  RCC_CFGR_PPRE2_DIV16                ((uint32_t)0x0000E000)        /*!< HCLK divided by 16 */
+
+/*!< RTCPRE configuration */
+#define  RCC_CFGR_RTCPRE                     ((uint32_t)0x001F0000)
+#define  RCC_CFGR_RTCPRE_0                   ((uint32_t)0x00010000)
+#define  RCC_CFGR_RTCPRE_1                   ((uint32_t)0x00020000)
+#define  RCC_CFGR_RTCPRE_2                   ((uint32_t)0x00040000)
+#define  RCC_CFGR_RTCPRE_3                   ((uint32_t)0x00080000)
+#define  RCC_CFGR_RTCPRE_4                   ((uint32_t)0x00100000)
+
+/*!< MCO1 configuration */
+#define  RCC_CFGR_MCO1                       ((uint32_t)0x00600000)
+#define  RCC_CFGR_MCO1_0                     ((uint32_t)0x00200000)
+#define  RCC_CFGR_MCO1_1                     ((uint32_t)0x00400000)
+
+#define  RCC_CFGR_I2SSRC                     ((uint32_t)0x00800000)
+
+#define  RCC_CFGR_MCO1PRE                    ((uint32_t)0x07000000)
+#define  RCC_CFGR_MCO1PRE_0                  ((uint32_t)0x01000000)
+#define  RCC_CFGR_MCO1PRE_1                  ((uint32_t)0x02000000)
+#define  RCC_CFGR_MCO1PRE_2                  ((uint32_t)0x04000000)
+
+#define  RCC_CFGR_MCO2PRE                    ((uint32_t)0x38000000)
+#define  RCC_CFGR_MCO2PRE_0                  ((uint32_t)0x08000000)
+#define  RCC_CFGR_MCO2PRE_1                  ((uint32_t)0x10000000)
+#define  RCC_CFGR_MCO2PRE_2                  ((uint32_t)0x20000000)
+
+#define  RCC_CFGR_MCO2                       ((uint32_t)0xC0000000)
+#define  RCC_CFGR_MCO2_0                     ((uint32_t)0x40000000)
+#define  RCC_CFGR_MCO2_1                     ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_CIR register  *******************/
+#define  RCC_CIR_LSIRDYF                     ((uint32_t)0x00000001)
+#define  RCC_CIR_LSERDYF                     ((uint32_t)0x00000002)
+#define  RCC_CIR_HSIRDYF                     ((uint32_t)0x00000004)
+#define  RCC_CIR_HSERDYF                     ((uint32_t)0x00000008)
+#define  RCC_CIR_PLLRDYF                     ((uint32_t)0x00000010)
+#define  RCC_CIR_PLLI2SRDYF                  ((uint32_t)0x00000020)
+#define  RCC_CIR_PLLSAIRDYF                  ((uint32_t)0x00000040)
+#define  RCC_CIR_CSSF                        ((uint32_t)0x00000080)
+#define  RCC_CIR_LSIRDYIE                    ((uint32_t)0x00000100)
+#define  RCC_CIR_LSERDYIE                    ((uint32_t)0x00000200)
+#define  RCC_CIR_HSIRDYIE                    ((uint32_t)0x00000400)
+#define  RCC_CIR_HSERDYIE                    ((uint32_t)0x00000800)
+#define  RCC_CIR_PLLRDYIE                    ((uint32_t)0x00001000)
+#define  RCC_CIR_PLLI2SRDYIE                 ((uint32_t)0x00002000)
+#define  RCC_CIR_PLLSAIRDYIE                 ((uint32_t)0x00004000)
+#define  RCC_CIR_LSIRDYC                     ((uint32_t)0x00010000)
+#define  RCC_CIR_LSERDYC                     ((uint32_t)0x00020000)
+#define  RCC_CIR_HSIRDYC                     ((uint32_t)0x00040000)
+#define  RCC_CIR_HSERDYC                     ((uint32_t)0x00080000)
+#define  RCC_CIR_PLLRDYC                     ((uint32_t)0x00100000)
+#define  RCC_CIR_PLLI2SRDYC                  ((uint32_t)0x00200000)
+#define  RCC_CIR_PLLSAIRDYC                  ((uint32_t)0x00400000)
+#define  RCC_CIR_CSSC                        ((uint32_t)0x00800000)
+
+/********************  Bit definition for RCC_AHB1RSTR register  **************/
+#define  RCC_AHB1RSTR_GPIOARST               ((uint32_t)0x00000001)
+#define  RCC_AHB1RSTR_GPIOBRST               ((uint32_t)0x00000002)
+#define  RCC_AHB1RSTR_GPIOCRST               ((uint32_t)0x00000004)
+#define  RCC_AHB1RSTR_GPIODRST               ((uint32_t)0x00000008)
+#define  RCC_AHB1RSTR_GPIOERST               ((uint32_t)0x00000010)
+#define  RCC_AHB1RSTR_GPIOFRST               ((uint32_t)0x00000020)
+#define  RCC_AHB1RSTR_GPIOGRST               ((uint32_t)0x00000040)
+#define  RCC_AHB1RSTR_GPIOHRST               ((uint32_t)0x00000080)
+#define  RCC_AHB1RSTR_GPIOIRST               ((uint32_t)0x00000100)
+#define  RCC_AHB1RSTR_GPIOJRST               ((uint32_t)0x00000200)
+#define  RCC_AHB1RSTR_GPIOKRST               ((uint32_t)0x00000400)
+#define  RCC_AHB1RSTR_CRCRST                 ((uint32_t)0x00001000)
+#define  RCC_AHB1RSTR_DMA1RST                ((uint32_t)0x00200000)
+#define  RCC_AHB1RSTR_DMA2RST                ((uint32_t)0x00400000)
+#define  RCC_AHB1RSTR_DMA2DRST               ((uint32_t)0x00800000)
+#define  RCC_AHB1RSTR_ETHMACRST              ((uint32_t)0x02000000)
+#define  RCC_AHB1RSTR_OTGHRST                ((uint32_t)0x20000000)
+
+/********************  Bit definition for RCC_AHB2RSTR register  **************/
+#define  RCC_AHB2RSTR_DCMIRST                ((uint32_t)0x00000001)
+#define  RCC_AHB2RSTR_RNGRST                 ((uint32_t)0x00000040)
+#define  RCC_AHB2RSTR_OTGFSRST               ((uint32_t)0x00000080)
+
+/********************  Bit definition for RCC_AHB3RSTR register  **************/
+
+#define  RCC_AHB3RSTR_FMCRST                ((uint32_t)0x00000001)
+#define  RCC_AHB3RSTR_QSPIRST               ((uint32_t)0x00000002)
+
+/********************  Bit definition for RCC_APB1RSTR register  **************/
+#define  RCC_APB1RSTR_TIM2RST                ((uint32_t)0x00000001)
+#define  RCC_APB1RSTR_TIM3RST                ((uint32_t)0x00000002)
+#define  RCC_APB1RSTR_TIM4RST                ((uint32_t)0x00000004)
+#define  RCC_APB1RSTR_TIM5RST                ((uint32_t)0x00000008)
+#define  RCC_APB1RSTR_TIM6RST                ((uint32_t)0x00000010)
+#define  RCC_APB1RSTR_TIM7RST                ((uint32_t)0x00000020)
+#define  RCC_APB1RSTR_TIM12RST               ((uint32_t)0x00000040)
+#define  RCC_APB1RSTR_TIM13RST               ((uint32_t)0x00000080)
+#define  RCC_APB1RSTR_TIM14RST               ((uint32_t)0x00000100)
+#define  RCC_APB1RSTR_LPTIM1RST              ((uint32_t)0x00000200)
+#define  RCC_APB1RSTR_WWDGRST                ((uint32_t)0x00000800)
+#define  RCC_APB1RSTR_SPI2RST                ((uint32_t)0x00004000)
+#define  RCC_APB1RSTR_SPI3RST                ((uint32_t)0x00008000)
+#define  RCC_APB1RSTR_SPDIFRXRST             ((uint32_t)0x00010000)
+#define  RCC_APB1RSTR_USART2RST              ((uint32_t)0x00020000)
+#define  RCC_APB1RSTR_USART3RST              ((uint32_t)0x00040000)
+#define  RCC_APB1RSTR_UART4RST               ((uint32_t)0x00080000)
+#define  RCC_APB1RSTR_UART5RST               ((uint32_t)0x00100000)
+#define  RCC_APB1RSTR_I2C1RST                ((uint32_t)0x00200000)
+#define  RCC_APB1RSTR_I2C2RST                ((uint32_t)0x00400000)
+#define  RCC_APB1RSTR_I2C3RST                ((uint32_t)0x00800000)
+#define  RCC_APB1RSTR_I2C4RST                ((uint32_t)0x01000000)
+#define  RCC_APB1RSTR_CAN1RST                ((uint32_t)0x02000000)
+#define  RCC_APB1RSTR_CAN2RST                ((uint32_t)0x04000000)
+#define  RCC_APB1RSTR_CECRST                 ((uint32_t)0x08000000)
+#define  RCC_APB1RSTR_PWRRST                 ((uint32_t)0x10000000)
+#define  RCC_APB1RSTR_DACRST                 ((uint32_t)0x20000000)
+#define  RCC_APB1RSTR_UART7RST               ((uint32_t)0x40000000)
+#define  RCC_APB1RSTR_UART8RST               ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_APB2RSTR register  **************/
+#define  RCC_APB2RSTR_TIM1RST                ((uint32_t)0x00000001)
+#define  RCC_APB2RSTR_TIM8RST                ((uint32_t)0x00000002)
+#define  RCC_APB2RSTR_USART1RST              ((uint32_t)0x00000010)
+#define  RCC_APB2RSTR_USART6RST              ((uint32_t)0x00000020)
+#define  RCC_APB2RSTR_ADCRST                 ((uint32_t)0x00000100)
+#define  RCC_APB2RSTR_SDMMC1RST              ((uint32_t)0x00000800)
+#define  RCC_APB2RSTR_SPI1RST                ((uint32_t)0x00001000)
+#define  RCC_APB2RSTR_SPI4RST                ((uint32_t)0x00002000)
+#define  RCC_APB2RSTR_SYSCFGRST              ((uint32_t)0x00004000)
+#define  RCC_APB2RSTR_TIM9RST                ((uint32_t)0x00010000)
+#define  RCC_APB2RSTR_TIM10RST               ((uint32_t)0x00020000)
+#define  RCC_APB2RSTR_TIM11RST               ((uint32_t)0x00040000)
+#define  RCC_APB2RSTR_SPI5RST                ((uint32_t)0x00100000)
+#define  RCC_APB2RSTR_SPI6RST                ((uint32_t)0x00200000)
+#define  RCC_APB2RSTR_SAI1RST                ((uint32_t)0x00400000)
+#define  RCC_APB2RSTR_SAI2RST                ((uint32_t)0x00800000)
+
+/********************  Bit definition for RCC_AHB1ENR register  ***************/
+#define  RCC_AHB1ENR_GPIOAEN                 ((uint32_t)0x00000001)
+#define  RCC_AHB1ENR_GPIOBEN                 ((uint32_t)0x00000002)
+#define  RCC_AHB1ENR_GPIOCEN                 ((uint32_t)0x00000004)
+#define  RCC_AHB1ENR_GPIODEN                 ((uint32_t)0x00000008)
+#define  RCC_AHB1ENR_GPIOEEN                 ((uint32_t)0x00000010)
+#define  RCC_AHB1ENR_GPIOFEN                 ((uint32_t)0x00000020)
+#define  RCC_AHB1ENR_GPIOGEN                 ((uint32_t)0x00000040)
+#define  RCC_AHB1ENR_GPIOHEN                 ((uint32_t)0x00000080)
+#define  RCC_AHB1ENR_GPIOIEN                 ((uint32_t)0x00000100)
+#define  RCC_AHB1ENR_GPIOJEN                 ((uint32_t)0x00000200)
+#define  RCC_AHB1ENR_GPIOKEN                 ((uint32_t)0x00000400)
+#define  RCC_AHB1ENR_CRCEN                   ((uint32_t)0x00001000)
+#define  RCC_AHB1ENR_BKPSRAMEN               ((uint32_t)0x00040000)
+#define  RCC_AHB1ENR_DTCMRAMEN               ((uint32_t)0x00100000)
+#define  RCC_AHB1ENR_DMA1EN                  ((uint32_t)0x00200000)
+#define  RCC_AHB1ENR_DMA2EN                  ((uint32_t)0x00400000)
+#define  RCC_AHB1ENR_DMA2DEN                 ((uint32_t)0x00800000)
+#define  RCC_AHB1ENR_ETHMACEN                ((uint32_t)0x02000000)
+#define  RCC_AHB1ENR_ETHMACTXEN              ((uint32_t)0x04000000)
+#define  RCC_AHB1ENR_ETHMACRXEN              ((uint32_t)0x08000000)
+#define  RCC_AHB1ENR_ETHMACPTPEN             ((uint32_t)0x10000000)
+#define  RCC_AHB1ENR_OTGHSEN                 ((uint32_t)0x20000000)
+#define  RCC_AHB1ENR_OTGHSULPIEN             ((uint32_t)0x40000000)
+
+/********************  Bit definition for RCC_AHB2ENR register  ***************/
+#define  RCC_AHB2ENR_DCMIEN                  ((uint32_t)0x00000001)
+#define  RCC_AHB2ENR_RNGEN                   ((uint32_t)0x00000040)
+#define  RCC_AHB2ENR_OTGFSEN                 ((uint32_t)0x00000080)
+
+/********************  Bit definition for RCC_AHB3ENR register  ***************/
+
+#define  RCC_AHB3ENR_FMCEN                  ((uint32_t)0x00000001)
+#define  RCC_AHB3ENR_QSPIEN                 ((uint32_t)0x00000002)
+
+/********************  Bit definition for RCC_APB1ENR register  ***************/
+#define  RCC_APB1ENR_TIM2EN                  ((uint32_t)0x00000001)
+#define  RCC_APB1ENR_TIM3EN                  ((uint32_t)0x00000002)
+#define  RCC_APB1ENR_TIM4EN                  ((uint32_t)0x00000004)
+#define  RCC_APB1ENR_TIM5EN                  ((uint32_t)0x00000008)
+#define  RCC_APB1ENR_TIM6EN                  ((uint32_t)0x00000010)
+#define  RCC_APB1ENR_TIM7EN                  ((uint32_t)0x00000020)
+#define  RCC_APB1ENR_TIM12EN                 ((uint32_t)0x00000040)
+#define  RCC_APB1ENR_TIM13EN                 ((uint32_t)0x00000080)
+#define  RCC_APB1ENR_TIM14EN                 ((uint32_t)0x00000100)
+#define  RCC_APB1ENR_LPTIM1EN                ((uint32_t)0x00000200)
+#define  RCC_APB1ENR_WWDGEN                  ((uint32_t)0x00000800)
+#define  RCC_APB1ENR_SPI2EN                  ((uint32_t)0x00004000)
+#define  RCC_APB1ENR_SPI3EN                  ((uint32_t)0x00008000)
+#define  RCC_APB1ENR_SPDIFRXEN               ((uint32_t)0x00010000)
+#define  RCC_APB1ENR_USART2EN                ((uint32_t)0x00020000)
+#define  RCC_APB1ENR_USART3EN                ((uint32_t)0x00040000)
+#define  RCC_APB1ENR_UART4EN                 ((uint32_t)0x00080000)
+#define  RCC_APB1ENR_UART5EN                 ((uint32_t)0x00100000)
+#define  RCC_APB1ENR_I2C1EN                  ((uint32_t)0x00200000)
+#define  RCC_APB1ENR_I2C2EN                  ((uint32_t)0x00400000)
+#define  RCC_APB1ENR_I2C3EN                  ((uint32_t)0x00800000)
+#define  RCC_APB1ENR_I2C4EN                  ((uint32_t)0x01000000)
+#define  RCC_APB1ENR_CAN1EN                  ((uint32_t)0x02000000)
+#define  RCC_APB1ENR_CAN2EN                  ((uint32_t)0x04000000)
+#define  RCC_APB1ENR_CECEN                   ((uint32_t)0x08000000)
+#define  RCC_APB1ENR_PWREN                   ((uint32_t)0x10000000)
+#define  RCC_APB1ENR_DACEN                   ((uint32_t)0x20000000)
+#define  RCC_APB1ENR_UART7EN                 ((uint32_t)0x40000000)
+#define  RCC_APB1ENR_UART8EN                 ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_APB2ENR register  ***************/
+#define  RCC_APB2ENR_TIM1EN                  ((uint32_t)0x00000001)
+#define  RCC_APB2ENR_TIM8EN                  ((uint32_t)0x00000002)
+#define  RCC_APB2ENR_USART1EN                ((uint32_t)0x00000010)
+#define  RCC_APB2ENR_USART6EN                ((uint32_t)0x00000020)
+#define  RCC_APB2ENR_ADC1EN                  ((uint32_t)0x00000100)
+#define  RCC_APB2ENR_ADC2EN                  ((uint32_t)0x00000200)
+#define  RCC_APB2ENR_ADC3EN                  ((uint32_t)0x00000400)
+#define  RCC_APB2ENR_SDMMC1EN                ((uint32_t)0x00000800)
+#define  RCC_APB2ENR_SPI1EN                  ((uint32_t)0x00001000)
+#define  RCC_APB2ENR_SPI4EN                  ((uint32_t)0x00002000)
+#define  RCC_APB2ENR_SYSCFGEN                ((uint32_t)0x00004000)
+#define  RCC_APB2ENR_TIM9EN                  ((uint32_t)0x00010000)
+#define  RCC_APB2ENR_TIM10EN                 ((uint32_t)0x00020000)
+#define  RCC_APB2ENR_TIM11EN                 ((uint32_t)0x00040000)
+#define  RCC_APB2ENR_SPI5EN                  ((uint32_t)0x00100000)
+#define  RCC_APB2ENR_SPI6EN                  ((uint32_t)0x00200000)
+#define  RCC_APB2ENR_SAI1EN                  ((uint32_t)0x00400000)
+#define  RCC_APB2ENR_SAI2EN                  ((uint32_t)0x00800000)
+
+/********************  Bit definition for RCC_AHB1LPENR register  *************/
+#define  RCC_AHB1LPENR_GPIOALPEN             ((uint32_t)0x00000001)
+#define  RCC_AHB1LPENR_GPIOBLPEN             ((uint32_t)0x00000002)
+#define  RCC_AHB1LPENR_GPIOCLPEN             ((uint32_t)0x00000004)
+#define  RCC_AHB1LPENR_GPIODLPEN             ((uint32_t)0x00000008)
+#define  RCC_AHB1LPENR_GPIOELPEN             ((uint32_t)0x00000010)
+#define  RCC_AHB1LPENR_GPIOFLPEN             ((uint32_t)0x00000020)
+#define  RCC_AHB1LPENR_GPIOGLPEN             ((uint32_t)0x00000040)
+#define  RCC_AHB1LPENR_GPIOHLPEN             ((uint32_t)0x00000080)
+#define  RCC_AHB1LPENR_GPIOILPEN             ((uint32_t)0x00000100)
+#define  RCC_AHB1LPENR_GPIOJLPEN             ((uint32_t)0x00000200)
+#define  RCC_AHB1LPENR_GPIOKLPEN             ((uint32_t)0x00000400)
+
+#define  RCC_AHB1LPENR_CRCLPEN               ((uint32_t)0x00001000)
+#define  RCC_AHB1LPENR_AXILPEN               ((uint32_t)0x00002000)
+#define  RCC_AHB1LPENR_FLITFLPEN             ((uint32_t)0x00008000)
+#define  RCC_AHB1LPENR_SRAM1LPEN             ((uint32_t)0x00010000)
+#define  RCC_AHB1LPENR_SRAM2LPEN             ((uint32_t)0x00020000)
+#define  RCC_AHB1LPENR_BKPSRAMLPEN           ((uint32_t)0x00040000)
+#define  RCC_AHB1LPENR_DTCMLPEN              ((uint32_t)0x00100000)
+#define  RCC_AHB1LPENR_DMA1LPEN              ((uint32_t)0x00200000)
+#define  RCC_AHB1LPENR_DMA2LPEN              ((uint32_t)0x00400000)
+#define  RCC_AHB1LPENR_DMA2DLPEN             ((uint32_t)0x00800000)
+#define  RCC_AHB1LPENR_ETHMACLPEN            ((uint32_t)0x02000000)
+#define  RCC_AHB1LPENR_ETHMACTXLPEN          ((uint32_t)0x04000000)
+#define  RCC_AHB1LPENR_ETHMACRXLPEN          ((uint32_t)0x08000000)
+#define  RCC_AHB1LPENR_ETHMACPTPLPEN         ((uint32_t)0x10000000)
+#define  RCC_AHB1LPENR_OTGHSLPEN             ((uint32_t)0x20000000)
+#define  RCC_AHB1LPENR_OTGHSULPILPEN         ((uint32_t)0x40000000)
+
+/********************  Bit definition for RCC_AHB2LPENR register  *************/
+#define  RCC_AHB2LPENR_DCMILPEN              ((uint32_t)0x00000001)
+#define  RCC_AHB2LPENR_RNGLPEN               ((uint32_t)0x00000040)
+#define  RCC_AHB2LPENR_OTGFSLPEN             ((uint32_t)0x00000080)
+
+/********************  Bit definition for RCC_AHB3LPENR register  *************/
+#define  RCC_AHB3LPENR_FMCLPEN              ((uint32_t)0x00000001)
+#define  RCC_AHB3LPENR_QSPILPEN             ((uint32_t)0x00000002)
+/********************  Bit definition for RCC_APB1LPENR register  *************/
+#define  RCC_APB1LPENR_TIM2LPEN              ((uint32_t)0x00000001)
+#define  RCC_APB1LPENR_TIM3LPEN              ((uint32_t)0x00000002)
+#define  RCC_APB1LPENR_TIM4LPEN              ((uint32_t)0x00000004)
+#define  RCC_APB1LPENR_TIM5LPEN              ((uint32_t)0x00000008)
+#define  RCC_APB1LPENR_TIM6LPEN              ((uint32_t)0x00000010)
+#define  RCC_APB1LPENR_TIM7LPEN              ((uint32_t)0x00000020)
+#define  RCC_APB1LPENR_TIM12LPEN             ((uint32_t)0x00000040)
+#define  RCC_APB1LPENR_TIM13LPEN             ((uint32_t)0x00000080)
+#define  RCC_APB1LPENR_TIM14LPEN             ((uint32_t)0x00000100)
+#define  RCC_APB1LPENR_LPTIM1LPEN            ((uint32_t)0x00000200)
+#define  RCC_APB1LPENR_WWDGLPEN              ((uint32_t)0x00000800)
+#define  RCC_APB1LPENR_SPI2LPEN              ((uint32_t)0x00004000)
+#define  RCC_APB1LPENR_SPI3LPEN              ((uint32_t)0x00008000)
+#define  RCC_APB1LPENR_SPDIFRXLPEN           ((uint32_t)0x00010000)
+#define  RCC_APB1LPENR_USART2LPEN            ((uint32_t)0x00020000)
+#define  RCC_APB1LPENR_USART3LPEN            ((uint32_t)0x00040000)
+#define  RCC_APB1LPENR_UART4LPEN             ((uint32_t)0x00080000)
+#define  RCC_APB1LPENR_UART5LPEN             ((uint32_t)0x00100000)
+#define  RCC_APB1LPENR_I2C1LPEN              ((uint32_t)0x00200000)
+#define  RCC_APB1LPENR_I2C2LPEN              ((uint32_t)0x00400000)
+#define  RCC_APB1LPENR_I2C3LPEN              ((uint32_t)0x00800000)
+#define  RCC_APB1LPENR_I2C4LPEN              ((uint32_t)0x01000000)
+#define  RCC_APB1LPENR_CAN1LPEN              ((uint32_t)0x02000000)
+#define  RCC_APB1LPENR_CAN2LPEN              ((uint32_t)0x04000000)
+#define  RCC_APB1LPENR_CECLPEN               ((uint32_t)0x08000000)
+#define  RCC_APB1LPENR_PWRLPEN               ((uint32_t)0x10000000)
+#define  RCC_APB1LPENR_DACLPEN               ((uint32_t)0x20000000)
+#define  RCC_APB1LPENR_UART7LPEN             ((uint32_t)0x40000000)
+#define  RCC_APB1LPENR_UART8LPEN             ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_APB2LPENR register  *************/
+#define  RCC_APB2LPENR_TIM1LPEN              ((uint32_t)0x00000001)
+#define  RCC_APB2LPENR_TIM8LPEN              ((uint32_t)0x00000002)
+#define  RCC_APB2LPENR_USART1LPEN            ((uint32_t)0x00000010)
+#define  RCC_APB2LPENR_USART6LPEN            ((uint32_t)0x00000020)
+#define  RCC_APB2LPENR_ADC1LPEN              ((uint32_t)0x00000100)
+#define  RCC_APB2LPENR_ADC2LPEN              ((uint32_t)0x00000200)
+#define  RCC_APB2LPENR_ADC3LPEN              ((uint32_t)0x00000400)
+#define  RCC_APB2LPENR_SDMMC1LPEN            ((uint32_t)0x00000800)
+#define  RCC_APB2LPENR_SPI1LPEN              ((uint32_t)0x00001000)
+#define  RCC_APB2LPENR_SPI4LPEN              ((uint32_t)0x00002000)
+#define  RCC_APB2LPENR_SYSCFGLPEN            ((uint32_t)0x00004000)
+#define  RCC_APB2LPENR_TIM9LPEN              ((uint32_t)0x00010000)
+#define  RCC_APB2LPENR_TIM10LPEN             ((uint32_t)0x00020000)
+#define  RCC_APB2LPENR_TIM11LPEN             ((uint32_t)0x00040000)
+#define  RCC_APB2LPENR_SPI5LPEN              ((uint32_t)0x00100000)
+#define  RCC_APB2LPENR_SPI6LPEN              ((uint32_t)0x00200000)
+#define  RCC_APB2LPENR_SAI1LPEN              ((uint32_t)0x00400000)
+#define  RCC_APB2LPENR_SAI2LPEN              ((uint32_t)0x00800000)
+
+/********************  Bit definition for RCC_BDCR register  ******************/
+#define  RCC_BDCR_LSEON                      ((uint32_t)0x00000001)
+#define  RCC_BDCR_LSERDY                     ((uint32_t)0x00000002)
+#define  RCC_BDCR_LSEBYP                     ((uint32_t)0x00000004)
+#define  RCC_BDCR_LSEDRV                     ((uint32_t)0x00000018)
+#define  RCC_BDCR_LSEDRV_0                   ((uint32_t)0x00000008)
+#define  RCC_BDCR_LSEDRV_1                   ((uint32_t)0x00000010)
+#define  RCC_BDCR_RTCSEL                     ((uint32_t)0x00000300)
+#define  RCC_BDCR_RTCSEL_0                   ((uint32_t)0x00000100)
+#define  RCC_BDCR_RTCSEL_1                   ((uint32_t)0x00000200)
+#define  RCC_BDCR_RTCEN                      ((uint32_t)0x00008000)
+#define  RCC_BDCR_BDRST                      ((uint32_t)0x00010000)
+
+/********************  Bit definition for RCC_CSR register  *******************/
+#define  RCC_CSR_LSION                       ((uint32_t)0x00000001)
+#define  RCC_CSR_LSIRDY                      ((uint32_t)0x00000002)
+#define  RCC_CSR_RMVF                        ((uint32_t)0x01000000)
+#define  RCC_CSR_BORRSTF                     ((uint32_t)0x02000000)
+#define  RCC_CSR_PINRSTF                     ((uint32_t)0x04000000)
+#define  RCC_CSR_PORRSTF                     ((uint32_t)0x08000000)
+#define  RCC_CSR_SFTRSTF                     ((uint32_t)0x10000000)
+#define  RCC_CSR_IWDGRSTF                    ((uint32_t)0x20000000)
+#define  RCC_CSR_WWDGRSTF                    ((uint32_t)0x40000000)
+#define  RCC_CSR_LPWRRSTF                    ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_SSCGR register  *****************/
+#define  RCC_SSCGR_MODPER                    ((uint32_t)0x00001FFF)
+#define  RCC_SSCGR_INCSTEP                   ((uint32_t)0x0FFFE000)
+#define  RCC_SSCGR_SPREADSEL                 ((uint32_t)0x40000000)
+#define  RCC_SSCGR_SSCGEN                    ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_PLLI2SCFGR register  ************/
+#define  RCC_PLLI2SCFGR_PLLI2SN              ((uint32_t)0x00007FC0)
+#define  RCC_PLLI2SCFGR_PLLI2SN_0            ((uint32_t)0x00000040)
+#define  RCC_PLLI2SCFGR_PLLI2SN_1            ((uint32_t)0x00000080)
+#define  RCC_PLLI2SCFGR_PLLI2SN_2            ((uint32_t)0x00000100)
+#define  RCC_PLLI2SCFGR_PLLI2SN_3            ((uint32_t)0x00000200)
+#define  RCC_PLLI2SCFGR_PLLI2SN_4            ((uint32_t)0x00000400)
+#define  RCC_PLLI2SCFGR_PLLI2SN_5            ((uint32_t)0x00000800)
+#define  RCC_PLLI2SCFGR_PLLI2SN_6            ((uint32_t)0x00001000)
+#define  RCC_PLLI2SCFGR_PLLI2SN_7            ((uint32_t)0x00002000)
+#define  RCC_PLLI2SCFGR_PLLI2SN_8            ((uint32_t)0x00004000)
+
+#define  RCC_PLLI2SCFGR_PLLI2SP              ((uint32_t)0x00030000)
+#define  RCC_PLLI2SCFGR_PLLI2SP_0            ((uint32_t)0x00010000)
+#define  RCC_PLLI2SCFGR_PLLI2SP_1            ((uint32_t)0x00020000)
+
+#define  RCC_PLLI2SCFGR_PLLI2SQ              ((uint32_t)0x0F000000)
+#define  RCC_PLLI2SCFGR_PLLI2SQ_0            ((uint32_t)0x01000000)
+#define  RCC_PLLI2SCFGR_PLLI2SQ_1            ((uint32_t)0x02000000)
+#define  RCC_PLLI2SCFGR_PLLI2SQ_2            ((uint32_t)0x04000000)
+#define  RCC_PLLI2SCFGR_PLLI2SQ_3            ((uint32_t)0x08000000)
+
+#define  RCC_PLLI2SCFGR_PLLI2SR              ((uint32_t)0x70000000)
+#define  RCC_PLLI2SCFGR_PLLI2SR_0            ((uint32_t)0x10000000)
+#define  RCC_PLLI2SCFGR_PLLI2SR_1            ((uint32_t)0x20000000)
+#define  RCC_PLLI2SCFGR_PLLI2SR_2            ((uint32_t)0x40000000)
+
+/********************  Bit definition for RCC_PLLSAICFGR register  ************/
+#define  RCC_PLLSAICFGR_PLLSAIN              ((uint32_t)0x00007FC0)
+#define  RCC_PLLSAICFGR_PLLSAIN_0            ((uint32_t)0x00000040)
+#define  RCC_PLLSAICFGR_PLLSAIN_1            ((uint32_t)0x00000080)
+#define  RCC_PLLSAICFGR_PLLSAIN_2            ((uint32_t)0x00000100)
+#define  RCC_PLLSAICFGR_PLLSAIN_3            ((uint32_t)0x00000200)
+#define  RCC_PLLSAICFGR_PLLSAIN_4            ((uint32_t)0x00000400)
+#define  RCC_PLLSAICFGR_PLLSAIN_5            ((uint32_t)0x00000800)
+#define  RCC_PLLSAICFGR_PLLSAIN_6            ((uint32_t)0x00001000)
+#define  RCC_PLLSAICFGR_PLLSAIN_7            ((uint32_t)0x00002000)
+#define  RCC_PLLSAICFGR_PLLSAIN_8            ((uint32_t)0x00004000)
+
+#define  RCC_PLLSAICFGR_PLLSAIP              ((uint32_t)0x00030000)
+#define  RCC_PLLSAICFGR_PLLSAIP_0            ((uint32_t)0x00010000)
+#define  RCC_PLLSAICFGR_PLLSAIP_1            ((uint32_t)0x00020000)
+
+#define  RCC_PLLSAICFGR_PLLSAIQ              ((uint32_t)0x0F000000)
+#define  RCC_PLLSAICFGR_PLLSAIQ_0            ((uint32_t)0x01000000)
+#define  RCC_PLLSAICFGR_PLLSAIQ_1            ((uint32_t)0x02000000)
+#define  RCC_PLLSAICFGR_PLLSAIQ_2            ((uint32_t)0x04000000)
+#define  RCC_PLLSAICFGR_PLLSAIQ_3            ((uint32_t)0x08000000)
+
+#define  RCC_PLLSAICFGR_PLLSAIR              ((uint32_t)0x70000000)
+#define  RCC_PLLSAICFGR_PLLSAIR_0            ((uint32_t)0x10000000)
+#define  RCC_PLLSAICFGR_PLLSAIR_1            ((uint32_t)0x20000000)
+#define  RCC_PLLSAICFGR_PLLSAIR_2            ((uint32_t)0x40000000)
+
+/********************  Bit definition for RCC_DCKCFGR1 register  ***************/
+#define  RCC_DCKCFGR1_PLLI2SDIVQ              ((uint32_t)0x0000001F)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_0            ((uint32_t)0x00000001)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_1            ((uint32_t)0x00000002)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_2            ((uint32_t)0x00000004)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_3            ((uint32_t)0x00000008)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_4            ((uint32_t)0x00000010)
+
+#define  RCC_DCKCFGR1_PLLSAIDIVQ              ((uint32_t)0x00001F00)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_0            ((uint32_t)0x00000100)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_1            ((uint32_t)0x00000200)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_2            ((uint32_t)0x00000400)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_3            ((uint32_t)0x00000800)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_4            ((uint32_t)0x00001000)
+
+#define  RCC_DCKCFGR1_PLLSAIDIVR              ((uint32_t)0x00030000)
+#define  RCC_DCKCFGR1_PLLSAIDIVR_0            ((uint32_t)0x00010000)
+#define  RCC_DCKCFGR1_PLLSAIDIVR_1            ((uint32_t)0x00020000)
+
+#define  RCC_DCKCFGR1_SAI1SEL                 ((uint32_t)0x00300000)
+#define  RCC_DCKCFGR1_SAI1SEL_0               ((uint32_t)0x00100000)
+#define  RCC_DCKCFGR1_SAI1SEL_1               ((uint32_t)0x00200000)
+
+#define  RCC_DCKCFGR1_SAI2SEL                 ((uint32_t)0x00C00000)
+#define  RCC_DCKCFGR1_SAI2SEL_0               ((uint32_t)0x00400000)
+#define  RCC_DCKCFGR1_SAI2SEL_1               ((uint32_t)0x00800000)
+
+#define  RCC_DCKCFGR1_TIMPRE                  ((uint32_t)0x01000000)
+
+/********************  Bit definition for RCC_DCKCFGR2 register  ***************/
+#define  RCC_DCKCFGR2_USART1SEL              ((uint32_t)0x00000003)
+#define  RCC_DCKCFGR2_USART1SEL_0            ((uint32_t)0x00000001)
+#define  RCC_DCKCFGR2_USART1SEL_1            ((uint32_t)0x00000002)
+#define  RCC_DCKCFGR2_USART2SEL              ((uint32_t)0x0000000C)
+#define  RCC_DCKCFGR2_USART2SEL_0            ((uint32_t)0x00000004)
+#define  RCC_DCKCFGR2_USART2SEL_1            ((uint32_t)0x00000008)
+#define  RCC_DCKCFGR2_USART3SEL              ((uint32_t)0x00000030)
+#define  RCC_DCKCFGR2_USART3SEL_0            ((uint32_t)0x00000010)
+#define  RCC_DCKCFGR2_USART3SEL_1            ((uint32_t)0x00000020)
+#define  RCC_DCKCFGR2_UART4SEL               ((uint32_t)0x000000C0)
+#define  RCC_DCKCFGR2_UART4SEL_0             ((uint32_t)0x00000040)
+#define  RCC_DCKCFGR2_UART4SEL_1             ((uint32_t)0x00000080)
+#define  RCC_DCKCFGR2_UART5SEL               ((uint32_t)0x00000300)
+#define  RCC_DCKCFGR2_UART5SEL_0             ((uint32_t)0x00000100)
+#define  RCC_DCKCFGR2_UART5SEL_1             ((uint32_t)0x00000200)
+#define  RCC_DCKCFGR2_USART6SEL              ((uint32_t)0x00000C00)
+#define  RCC_DCKCFGR2_USART6SEL_0            ((uint32_t)0x00000400)
+#define  RCC_DCKCFGR2_USART6SEL_1            ((uint32_t)0x00000800)
+#define  RCC_DCKCFGR2_UART7SEL               ((uint32_t)0x00003000)
+#define  RCC_DCKCFGR2_UART7SEL_0             ((uint32_t)0x00001000)
+#define  RCC_DCKCFGR2_UART7SEL_1             ((uint32_t)0x00002000)
+#define  RCC_DCKCFGR2_UART8SEL               ((uint32_t)0x0000C000)
+#define  RCC_DCKCFGR2_UART8SEL_0             ((uint32_t)0x00004000)
+#define  RCC_DCKCFGR2_UART8SEL_1             ((uint32_t)0x00008000)
+#define  RCC_DCKCFGR2_I2C1SEL                ((uint32_t)0x00030000)
+#define  RCC_DCKCFGR2_I2C1SEL_0              ((uint32_t)0x00010000)
+#define  RCC_DCKCFGR2_I2C1SEL_1              ((uint32_t)0x00020000)
+#define  RCC_DCKCFGR2_I2C2SEL                ((uint32_t)0x000C0000)
+#define  RCC_DCKCFGR2_I2C2SEL_0              ((uint32_t)0x00040000)
+#define  RCC_DCKCFGR2_I2C2SEL_1              ((uint32_t)0x00080000)
+#define  RCC_DCKCFGR2_I2C3SEL                ((uint32_t)0x00300000)
+#define  RCC_DCKCFGR2_I2C3SEL_0              ((uint32_t)0x00100000)
+#define  RCC_DCKCFGR2_I2C3SEL_1              ((uint32_t)0x00200000)
+#define  RCC_DCKCFGR2_I2C4SEL                ((uint32_t)0x00C00000)
+#define  RCC_DCKCFGR2_I2C4SEL_0              ((uint32_t)0x00400000)
+#define  RCC_DCKCFGR2_I2C4SEL_1              ((uint32_t)0x00800000)
+#define  RCC_DCKCFGR2_LPTIM1SEL              ((uint32_t)0x03000000)
+#define  RCC_DCKCFGR2_LPTIM1SEL_0            ((uint32_t)0x01000000)
+#define  RCC_DCKCFGR2_LPTIM1SEL_1            ((uint32_t)0x02000000)
+#define  RCC_DCKCFGR2_CECSEL                 ((uint32_t)0x04000000)
+#define  RCC_DCKCFGR2_CK48MSEL               ((uint32_t)0x08000000)
+#define  RCC_DCKCFGR2_SDMMC1SEL              ((uint32_t)0x10000000)
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    RNG                                     */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for RNG_CR register  *******************/
+#define RNG_CR_RNGEN                         ((uint32_t)0x00000004)
+#define RNG_CR_IE                            ((uint32_t)0x00000008)
+
+/********************  Bits definition for RNG_SR register  *******************/
+#define RNG_SR_DRDY                          ((uint32_t)0x00000001)
+#define RNG_SR_CECS                          ((uint32_t)0x00000002)
+#define RNG_SR_SECS                          ((uint32_t)0x00000004)
+#define RNG_SR_CEIS                          ((uint32_t)0x00000020)
+#define RNG_SR_SEIS                          ((uint32_t)0x00000040)
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Real-Time Clock (RTC)                            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for RTC_TR register  *******************/
+#define RTC_TR_PM                            ((uint32_t)0x00400000)
+#define RTC_TR_HT                            ((uint32_t)0x00300000)
+#define RTC_TR_HT_0                          ((uint32_t)0x00100000)
+#define RTC_TR_HT_1                          ((uint32_t)0x00200000)
+#define RTC_TR_HU                            ((uint32_t)0x000F0000)
+#define RTC_TR_HU_0                          ((uint32_t)0x00010000)
+#define RTC_TR_HU_1                          ((uint32_t)0x00020000)
+#define RTC_TR_HU_2                          ((uint32_t)0x00040000)
+#define RTC_TR_HU_3                          ((uint32_t)0x00080000)
+#define RTC_TR_MNT                           ((uint32_t)0x00007000)
+#define RTC_TR_MNT_0                         ((uint32_t)0x00001000)
+#define RTC_TR_MNT_1                         ((uint32_t)0x00002000)
+#define RTC_TR_MNT_2                         ((uint32_t)0x00004000)
+#define RTC_TR_MNU                           ((uint32_t)0x00000F00)
+#define RTC_TR_MNU_0                         ((uint32_t)0x00000100)
+#define RTC_TR_MNU_1                         ((uint32_t)0x00000200)
+#define RTC_TR_MNU_2                         ((uint32_t)0x00000400)
+#define RTC_TR_MNU_3                         ((uint32_t)0x00000800)
+#define RTC_TR_ST                            ((uint32_t)0x00000070)
+#define RTC_TR_ST_0                          ((uint32_t)0x00000010)
+#define RTC_TR_ST_1                          ((uint32_t)0x00000020)
+#define RTC_TR_ST_2                          ((uint32_t)0x00000040)
+#define RTC_TR_SU                            ((uint32_t)0x0000000F)
+#define RTC_TR_SU_0                          ((uint32_t)0x00000001)
+#define RTC_TR_SU_1                          ((uint32_t)0x00000002)
+#define RTC_TR_SU_2                          ((uint32_t)0x00000004)
+#define RTC_TR_SU_3                          ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_DR register  *******************/
+#define RTC_DR_YT                            ((uint32_t)0x00F00000)
+#define RTC_DR_YT_0                          ((uint32_t)0x00100000)
+#define RTC_DR_YT_1                          ((uint32_t)0x00200000)
+#define RTC_DR_YT_2                          ((uint32_t)0x00400000)
+#define RTC_DR_YT_3                          ((uint32_t)0x00800000)
+#define RTC_DR_YU                            ((uint32_t)0x000F0000)
+#define RTC_DR_YU_0                          ((uint32_t)0x00010000)
+#define RTC_DR_YU_1                          ((uint32_t)0x00020000)
+#define RTC_DR_YU_2                          ((uint32_t)0x00040000)
+#define RTC_DR_YU_3                          ((uint32_t)0x00080000)
+#define RTC_DR_WDU                           ((uint32_t)0x0000E000)
+#define RTC_DR_WDU_0                         ((uint32_t)0x00002000)
+#define RTC_DR_WDU_1                         ((uint32_t)0x00004000)
+#define RTC_DR_WDU_2                         ((uint32_t)0x00008000)
+#define RTC_DR_MT                            ((uint32_t)0x00001000)
+#define RTC_DR_MU                            ((uint32_t)0x00000F00)
+#define RTC_DR_MU_0                          ((uint32_t)0x00000100)
+#define RTC_DR_MU_1                          ((uint32_t)0x00000200)
+#define RTC_DR_MU_2                          ((uint32_t)0x00000400)
+#define RTC_DR_MU_3                          ((uint32_t)0x00000800)
+#define RTC_DR_DT                            ((uint32_t)0x00000030)
+#define RTC_DR_DT_0                          ((uint32_t)0x00000010)
+#define RTC_DR_DT_1                          ((uint32_t)0x00000020)
+#define RTC_DR_DU                            ((uint32_t)0x0000000F)
+#define RTC_DR_DU_0                          ((uint32_t)0x00000001)
+#define RTC_DR_DU_1                          ((uint32_t)0x00000002)
+#define RTC_DR_DU_2                          ((uint32_t)0x00000004)
+#define RTC_DR_DU_3                          ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_CR register  *******************/
+#define RTC_CR_ITSE                          ((uint32_t)0x01000000)
+#define RTC_CR_COE                           ((uint32_t)0x00800000)
+#define RTC_CR_OSEL                          ((uint32_t)0x00600000)
+#define RTC_CR_OSEL_0                        ((uint32_t)0x00200000)
+#define RTC_CR_OSEL_1                        ((uint32_t)0x00400000)
+#define RTC_CR_POL                           ((uint32_t)0x00100000)
+#define RTC_CR_COSEL                         ((uint32_t)0x00080000)
+#define RTC_CR_BCK                           ((uint32_t)0x00040000)
+#define RTC_CR_SUB1H                         ((uint32_t)0x00020000)
+#define RTC_CR_ADD1H                         ((uint32_t)0x00010000)
+#define RTC_CR_TSIE                          ((uint32_t)0x00008000)
+#define RTC_CR_WUTIE                         ((uint32_t)0x00004000)
+#define RTC_CR_ALRBIE                        ((uint32_t)0x00002000)
+#define RTC_CR_ALRAIE                        ((uint32_t)0x00001000)
+#define RTC_CR_TSE                           ((uint32_t)0x00000800)
+#define RTC_CR_WUTE                          ((uint32_t)0x00000400)
+#define RTC_CR_ALRBE                         ((uint32_t)0x00000200)
+#define RTC_CR_ALRAE                         ((uint32_t)0x00000100)
+#define RTC_CR_FMT                           ((uint32_t)0x00000040)
+#define RTC_CR_BYPSHAD                       ((uint32_t)0x00000020)
+#define RTC_CR_REFCKON                       ((uint32_t)0x00000010)
+#define RTC_CR_TSEDGE                        ((uint32_t)0x00000008)
+#define RTC_CR_WUCKSEL                       ((uint32_t)0x00000007)
+#define RTC_CR_WUCKSEL_0                     ((uint32_t)0x00000001)
+#define RTC_CR_WUCKSEL_1                     ((uint32_t)0x00000002)
+#define RTC_CR_WUCKSEL_2                     ((uint32_t)0x00000004)
+
+/********************  Bits definition for RTC_ISR register  ******************/
+#define RTC_ISR_ITSF                         ((uint32_t)0x00020000)
+#define RTC_ISR_RECALPF                      ((uint32_t)0x00010000)
+#define RTC_ISR_TAMP3F                       ((uint32_t)0x00008000)
+#define RTC_ISR_TAMP2F                       ((uint32_t)0x00004000)
+#define RTC_ISR_TAMP1F                       ((uint32_t)0x00002000)
+#define RTC_ISR_TSOVF                        ((uint32_t)0x00001000)
+#define RTC_ISR_TSF                          ((uint32_t)0x00000800)
+#define RTC_ISR_WUTF                         ((uint32_t)0x00000400)
+#define RTC_ISR_ALRBF                        ((uint32_t)0x00000200)
+#define RTC_ISR_ALRAF                        ((uint32_t)0x00000100)
+#define RTC_ISR_INIT                         ((uint32_t)0x00000080)
+#define RTC_ISR_INITF                        ((uint32_t)0x00000040)
+#define RTC_ISR_RSF                          ((uint32_t)0x00000020)
+#define RTC_ISR_INITS                        ((uint32_t)0x00000010)
+#define RTC_ISR_SHPF                         ((uint32_t)0x00000008)
+#define RTC_ISR_WUTWF                        ((uint32_t)0x00000004)
+#define RTC_ISR_ALRBWF                       ((uint32_t)0x00000002)
+#define RTC_ISR_ALRAWF                       ((uint32_t)0x00000001)
+
+/********************  Bits definition for RTC_PRER register  *****************/
+#define RTC_PRER_PREDIV_A                    ((uint32_t)0x007F0000)
+#define RTC_PRER_PREDIV_S                    ((uint32_t)0x00007FFF)
+
+/********************  Bits definition for RTC_WUTR register  *****************/
+#define RTC_WUTR_WUT                         ((uint32_t)0x0000FFFF)
+
+/********************  Bits definition for RTC_ALRMAR register  ***************/
+#define RTC_ALRMAR_MSK4                      ((uint32_t)0x80000000)
+#define RTC_ALRMAR_WDSEL                     ((uint32_t)0x40000000)
+#define RTC_ALRMAR_DT                        ((uint32_t)0x30000000)
+#define RTC_ALRMAR_DT_0                      ((uint32_t)0x10000000)
+#define RTC_ALRMAR_DT_1                      ((uint32_t)0x20000000)
+#define RTC_ALRMAR_DU                        ((uint32_t)0x0F000000)
+#define RTC_ALRMAR_DU_0                      ((uint32_t)0x01000000)
+#define RTC_ALRMAR_DU_1                      ((uint32_t)0x02000000)
+#define RTC_ALRMAR_DU_2                      ((uint32_t)0x04000000)
+#define RTC_ALRMAR_DU_3                      ((uint32_t)0x08000000)
+#define RTC_ALRMAR_MSK3                      ((uint32_t)0x00800000)
+#define RTC_ALRMAR_PM                        ((uint32_t)0x00400000)
+#define RTC_ALRMAR_HT                        ((uint32_t)0x00300000)
+#define RTC_ALRMAR_HT_0                      ((uint32_t)0x00100000)
+#define RTC_ALRMAR_HT_1                      ((uint32_t)0x00200000)
+#define RTC_ALRMAR_HU                        ((uint32_t)0x000F0000)
+#define RTC_ALRMAR_HU_0                      ((uint32_t)0x00010000)
+#define RTC_ALRMAR_HU_1                      ((uint32_t)0x00020000)
+#define RTC_ALRMAR_HU_2                      ((uint32_t)0x00040000)
+#define RTC_ALRMAR_HU_3                      ((uint32_t)0x00080000)
+#define RTC_ALRMAR_MSK2                      ((uint32_t)0x00008000)
+#define RTC_ALRMAR_MNT                       ((uint32_t)0x00007000)
+#define RTC_ALRMAR_MNT_0                     ((uint32_t)0x00001000)
+#define RTC_ALRMAR_MNT_1                     ((uint32_t)0x00002000)
+#define RTC_ALRMAR_MNT_2                     ((uint32_t)0x00004000)
+#define RTC_ALRMAR_MNU                       ((uint32_t)0x00000F00)
+#define RTC_ALRMAR_MNU_0                     ((uint32_t)0x00000100)
+#define RTC_ALRMAR_MNU_1                     ((uint32_t)0x00000200)
+#define RTC_ALRMAR_MNU_2                     ((uint32_t)0x00000400)
+#define RTC_ALRMAR_MNU_3                     ((uint32_t)0x00000800)
+#define RTC_ALRMAR_MSK1                      ((uint32_t)0x00000080)
+#define RTC_ALRMAR_ST                        ((uint32_t)0x00000070)
+#define RTC_ALRMAR_ST_0                      ((uint32_t)0x00000010)
+#define RTC_ALRMAR_ST_1                      ((uint32_t)0x00000020)
+#define RTC_ALRMAR_ST_2                      ((uint32_t)0x00000040)
+#define RTC_ALRMAR_SU                        ((uint32_t)0x0000000F)
+#define RTC_ALRMAR_SU_0                      ((uint32_t)0x00000001)
+#define RTC_ALRMAR_SU_1                      ((uint32_t)0x00000002)
+#define RTC_ALRMAR_SU_2                      ((uint32_t)0x00000004)
+#define RTC_ALRMAR_SU_3                      ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_ALRMBR register  ***************/
+#define RTC_ALRMBR_MSK4                      ((uint32_t)0x80000000)
+#define RTC_ALRMBR_WDSEL                     ((uint32_t)0x40000000)
+#define RTC_ALRMBR_DT                        ((uint32_t)0x30000000)
+#define RTC_ALRMBR_DT_0                      ((uint32_t)0x10000000)
+#define RTC_ALRMBR_DT_1                      ((uint32_t)0x20000000)
+#define RTC_ALRMBR_DU                        ((uint32_t)0x0F000000)
+#define RTC_ALRMBR_DU_0                      ((uint32_t)0x01000000)
+#define RTC_ALRMBR_DU_1                      ((uint32_t)0x02000000)
+#define RTC_ALRMBR_DU_2                      ((uint32_t)0x04000000)
+#define RTC_ALRMBR_DU_3                      ((uint32_t)0x08000000)
+#define RTC_ALRMBR_MSK3                      ((uint32_t)0x00800000)
+#define RTC_ALRMBR_PM                        ((uint32_t)0x00400000)
+#define RTC_ALRMBR_HT                        ((uint32_t)0x00300000)
+#define RTC_ALRMBR_HT_0                      ((uint32_t)0x00100000)
+#define RTC_ALRMBR_HT_1                      ((uint32_t)0x00200000)
+#define RTC_ALRMBR_HU                        ((uint32_t)0x000F0000)
+#define RTC_ALRMBR_HU_0                      ((uint32_t)0x00010000)
+#define RTC_ALRMBR_HU_1                      ((uint32_t)0x00020000)
+#define RTC_ALRMBR_HU_2                      ((uint32_t)0x00040000)
+#define RTC_ALRMBR_HU_3                      ((uint32_t)0x00080000)
+#define RTC_ALRMBR_MSK2                      ((uint32_t)0x00008000)
+#define RTC_ALRMBR_MNT                       ((uint32_t)0x00007000)
+#define RTC_ALRMBR_MNT_0                     ((uint32_t)0x00001000)
+#define RTC_ALRMBR_MNT_1                     ((uint32_t)0x00002000)
+#define RTC_ALRMBR_MNT_2                     ((uint32_t)0x00004000)
+#define RTC_ALRMBR_MNU                       ((uint32_t)0x00000F00)
+#define RTC_ALRMBR_MNU_0                     ((uint32_t)0x00000100)
+#define RTC_ALRMBR_MNU_1                     ((uint32_t)0x00000200)
+#define RTC_ALRMBR_MNU_2                     ((uint32_t)0x00000400)
+#define RTC_ALRMBR_MNU_3                     ((uint32_t)0x00000800)
+#define RTC_ALRMBR_MSK1                      ((uint32_t)0x00000080)
+#define RTC_ALRMBR_ST                        ((uint32_t)0x00000070)
+#define RTC_ALRMBR_ST_0                      ((uint32_t)0x00000010)
+#define RTC_ALRMBR_ST_1                      ((uint32_t)0x00000020)
+#define RTC_ALRMBR_ST_2                      ((uint32_t)0x00000040)
+#define RTC_ALRMBR_SU                        ((uint32_t)0x0000000F)
+#define RTC_ALRMBR_SU_0                      ((uint32_t)0x00000001)
+#define RTC_ALRMBR_SU_1                      ((uint32_t)0x00000002)
+#define RTC_ALRMBR_SU_2                      ((uint32_t)0x00000004)
+#define RTC_ALRMBR_SU_3                      ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_WPR register  ******************/
+#define RTC_WPR_KEY                          ((uint32_t)0x000000FF)
+
+/********************  Bits definition for RTC_SSR register  ******************/
+#define RTC_SSR_SS                           ((uint32_t)0x0000FFFF)
+
+/********************  Bits definition for RTC_SHIFTR register  ***************/
+#define RTC_SHIFTR_SUBFS                     ((uint32_t)0x00007FFF)
+#define RTC_SHIFTR_ADD1S                     ((uint32_t)0x80000000)
+
+/********************  Bits definition for RTC_TSTR register  *****************/
+#define RTC_TSTR_PM                          ((uint32_t)0x00400000)
+#define RTC_TSTR_HT                          ((uint32_t)0x00300000)
+#define RTC_TSTR_HT_0                        ((uint32_t)0x00100000)
+#define RTC_TSTR_HT_1                        ((uint32_t)0x00200000)
+#define RTC_TSTR_HU                          ((uint32_t)0x000F0000)
+#define RTC_TSTR_HU_0                        ((uint32_t)0x00010000)
+#define RTC_TSTR_HU_1                        ((uint32_t)0x00020000)
+#define RTC_TSTR_HU_2                        ((uint32_t)0x00040000)
+#define RTC_TSTR_HU_3                        ((uint32_t)0x00080000)
+#define RTC_TSTR_MNT                         ((uint32_t)0x00007000)
+#define RTC_TSTR_MNT_0                       ((uint32_t)0x00001000)
+#define RTC_TSTR_MNT_1                       ((uint32_t)0x00002000)
+#define RTC_TSTR_MNT_2                       ((uint32_t)0x00004000)
+#define RTC_TSTR_MNU                         ((uint32_t)0x00000F00)
+#define RTC_TSTR_MNU_0                       ((uint32_t)0x00000100)
+#define RTC_TSTR_MNU_1                       ((uint32_t)0x00000200)
+#define RTC_TSTR_MNU_2                       ((uint32_t)0x00000400)
+#define RTC_TSTR_MNU_3                       ((uint32_t)0x00000800)
+#define RTC_TSTR_ST                          ((uint32_t)0x00000070)
+#define RTC_TSTR_ST_0                        ((uint32_t)0x00000010)
+#define RTC_TSTR_ST_1                        ((uint32_t)0x00000020)
+#define RTC_TSTR_ST_2                        ((uint32_t)0x00000040)
+#define RTC_TSTR_SU                          ((uint32_t)0x0000000F)
+#define RTC_TSTR_SU_0                        ((uint32_t)0x00000001)
+#define RTC_TSTR_SU_1                        ((uint32_t)0x00000002)
+#define RTC_TSTR_SU_2                        ((uint32_t)0x00000004)
+#define RTC_TSTR_SU_3                        ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_TSDR register  *****************/
+#define RTC_TSDR_WDU                         ((uint32_t)0x0000E000)
+#define RTC_TSDR_WDU_0                       ((uint32_t)0x00002000)
+#define RTC_TSDR_WDU_1                       ((uint32_t)0x00004000)
+#define RTC_TSDR_WDU_2                       ((uint32_t)0x00008000)
+#define RTC_TSDR_MT                          ((uint32_t)0x00001000)
+#define RTC_TSDR_MU                          ((uint32_t)0x00000F00)
+#define RTC_TSDR_MU_0                        ((uint32_t)0x00000100)
+#define RTC_TSDR_MU_1                        ((uint32_t)0x00000200)
+#define RTC_TSDR_MU_2                        ((uint32_t)0x00000400)
+#define RTC_TSDR_MU_3                        ((uint32_t)0x00000800)
+#define RTC_TSDR_DT                          ((uint32_t)0x00000030)
+#define RTC_TSDR_DT_0                        ((uint32_t)0x00000010)
+#define RTC_TSDR_DT_1                        ((uint32_t)0x00000020)
+#define RTC_TSDR_DU                          ((uint32_t)0x0000000F)
+#define RTC_TSDR_DU_0                        ((uint32_t)0x00000001)
+#define RTC_TSDR_DU_1                        ((uint32_t)0x00000002)
+#define RTC_TSDR_DU_2                        ((uint32_t)0x00000004)
+#define RTC_TSDR_DU_3                        ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_TSSSR register  ****************/
+#define RTC_TSSSR_SS                         ((uint32_t)0x0000FFFF)
+
+/********************  Bits definition for RTC_CAL register  *****************/
+#define RTC_CALR_CALP                        ((uint32_t)0x00008000)
+#define RTC_CALR_CALW8                       ((uint32_t)0x00004000)
+#define RTC_CALR_CALW16                      ((uint32_t)0x00002000)
+#define RTC_CALR_CALM                        ((uint32_t)0x000001FF)
+#define RTC_CALR_CALM_0                      ((uint32_t)0x00000001)
+#define RTC_CALR_CALM_1                      ((uint32_t)0x00000002)
+#define RTC_CALR_CALM_2                      ((uint32_t)0x00000004)
+#define RTC_CALR_CALM_3                      ((uint32_t)0x00000008)
+#define RTC_CALR_CALM_4                      ((uint32_t)0x00000010)
+#define RTC_CALR_CALM_5                      ((uint32_t)0x00000020)
+#define RTC_CALR_CALM_6                      ((uint32_t)0x00000040)
+#define RTC_CALR_CALM_7                      ((uint32_t)0x00000080)
+#define RTC_CALR_CALM_8                      ((uint32_t)0x00000100)
+
+/********************  Bits definition for RTC_TAMPCR register  ****************/
+#define RTC_TAMPCR_TAMP3MF                    ((uint32_t)0x01000000)
+#define RTC_TAMPCR_TAMP3NOERASE               ((uint32_t)0x00800000)
+#define RTC_TAMPCR_TAMP3IE                    ((uint32_t)0x00400000)
+#define RTC_TAMPCR_TAMP2MF                    ((uint32_t)0x00200000)
+#define RTC_TAMPCR_TAMP2NOERASE               ((uint32_t)0x00100000)
+#define RTC_TAMPCR_TAMP2IE                    ((uint32_t)0x00080000)
+#define RTC_TAMPCR_TAMP1MF                    ((uint32_t)0x00040000)
+#define RTC_TAMPCR_TAMP1NOERASE               ((uint32_t)0x00020000)
+#define RTC_TAMPCR_TAMP1IE                    ((uint32_t)0x00010000)
+#define RTC_TAMPCR_TAMPPUDIS                  ((uint32_t)0x00008000)
+#define RTC_TAMPCR_TAMPPRCH                   ((uint32_t)0x00006000)
+#define RTC_TAMPCR_TAMPPRCH_0                 ((uint32_t)0x00002000)
+#define RTC_TAMPCR_TAMPPRCH_1                 ((uint32_t)0x00004000)
+#define RTC_TAMPCR_TAMPFLT                    ((uint32_t)0x00001800)
+#define RTC_TAMPCR_TAMPFLT_0                  ((uint32_t)0x00000800)
+#define RTC_TAMPCR_TAMPFLT_1                  ((uint32_t)0x00001000)
+#define RTC_TAMPCR_TAMPFREQ                   ((uint32_t)0x00000700)
+#define RTC_TAMPCR_TAMPFREQ_0                 ((uint32_t)0x00000100)
+#define RTC_TAMPCR_TAMPFREQ_1                 ((uint32_t)0x00000200)
+#define RTC_TAMPCR_TAMPFREQ_2                 ((uint32_t)0x00000400)
+#define RTC_TAMPCR_TAMPTS                     ((uint32_t)0x00000080)
+#define RTC_TAMPCR_TAMP3_TRG                  ((uint32_t)0x00000040)
+#define RTC_TAMPCR_TAMP3E                     ((uint32_t)0x00000020)
+#define RTC_TAMPCR_TAMP2_TRG                   ((uint32_t)0x00000010)
+#define RTC_TAMPCR_TAMP2E                     ((uint32_t)0x00000008)
+#define RTC_TAMPCR_TAMPIE                     ((uint32_t)0x00000004)
+#define RTC_TAMPCR_TAMP1_TRG                   ((uint32_t)0x00000002)
+#define RTC_TAMPCR_TAMP1E                     ((uint32_t)0x00000001)
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMASSR_MASKSS                  ((uint32_t)0x0F000000)
+#define RTC_ALRMASSR_MASKSS_0                ((uint32_t)0x01000000)
+#define RTC_ALRMASSR_MASKSS_1                ((uint32_t)0x02000000)
+#define RTC_ALRMASSR_MASKSS_2                ((uint32_t)0x04000000)
+#define RTC_ALRMASSR_MASKSS_3                ((uint32_t)0x08000000)
+#define RTC_ALRMASSR_SS                      ((uint32_t)0x00007FFF)
+
+/********************  Bits definition for RTC_ALRMBSSR register  *************/
+#define RTC_ALRMBSSR_MASKSS                  ((uint32_t)0x0F000000)
+#define RTC_ALRMBSSR_MASKSS_0                ((uint32_t)0x01000000)
+#define RTC_ALRMBSSR_MASKSS_1                ((uint32_t)0x02000000)
+#define RTC_ALRMBSSR_MASKSS_2                ((uint32_t)0x04000000)
+#define RTC_ALRMBSSR_MASKSS_3                ((uint32_t)0x08000000)
+#define RTC_ALRMBSSR_SS                      ((uint32_t)0x00007FFF)
+
+/********************  Bits definition for RTC_OR register  ****************/
+#define RTC_OR_TSINSEL                      ((uint32_t)0x00000006)
+#define RTC_OR_TSINSEL_0                    ((uint32_t)0x00000002)
+#define RTC_OR_TSINSEL_1                    ((uint32_t)0x00000004)
+#define RTC_OR_ALARMTYPE                    ((uint32_t)0x00000008)
+
+
+/********************  Bits definition for RTC_BKP0R register  ****************/
+#define RTC_BKP0R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP1R register  ****************/
+#define RTC_BKP1R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP2R register  ****************/
+#define RTC_BKP2R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP3R register  ****************/
+#define RTC_BKP3R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP4R register  ****************/
+#define RTC_BKP4R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP5R register  ****************/
+#define RTC_BKP5R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP6R register  ****************/
+#define RTC_BKP6R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP7R register  ****************/
+#define RTC_BKP7R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP8R register  ****************/
+#define RTC_BKP8R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP9R register  ****************/
+#define RTC_BKP9R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP10R register  ***************/
+#define RTC_BKP10R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP11R register  ***************/
+#define RTC_BKP11R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP12R register  ***************/
+#define RTC_BKP12R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP13R register  ***************/
+#define RTC_BKP13R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP14R register  ***************/
+#define RTC_BKP14R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP15R register  ***************/
+#define RTC_BKP15R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP16R register  ***************/
+#define RTC_BKP16R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP17R register  ***************/
+#define RTC_BKP17R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP18R register  ***************/
+#define RTC_BKP18R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP19R register  ***************/
+#define RTC_BKP19R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP20R register  ***************/
+#define RTC_BKP20R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP21R register  ***************/
+#define RTC_BKP21R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP22R register  ***************/
+#define RTC_BKP22R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP23R register  ***************/
+#define RTC_BKP23R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP24R register  ***************/
+#define RTC_BKP24R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP25R register  ***************/
+#define RTC_BKP25R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP26R register  ***************/
+#define RTC_BKP26R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP27R register  ***************/
+#define RTC_BKP27R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP28R register  ***************/
+#define RTC_BKP28R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP29R register  ***************/
+#define RTC_BKP29R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP30R register  ***************/
+#define RTC_BKP30R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP31R register  ***************/
+#define RTC_BKP31R                           ((uint32_t)0xFFFFFFFF)
+
+/******************** Number of backup registers ******************************/
+#define RTC_BKP_NUMBER                       ((uint32_t)0x00000020)
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          Serial Audio Interface                            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for SAI_GCR register  *******************/
+#define  SAI_GCR_SYNCIN                  ((uint32_t)0x00000003)        /*!<SYNCIN[1:0] bits (Synchronization Inputs)   */
+#define  SAI_GCR_SYNCIN_0                ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_GCR_SYNCIN_1                ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  SAI_GCR_SYNCOUT                 ((uint32_t)0x00000030)        /*!<SYNCOUT[1:0] bits (Synchronization Outputs) */
+#define  SAI_GCR_SYNCOUT_0               ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  SAI_GCR_SYNCOUT_1               ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+/*******************  Bit definition for SAI_xCR1 register  *******************/
+#define  SAI_xCR1_MODE                    ((uint32_t)0x00000003)        /*!<MODE[1:0] bits (Audio Block Mode)           */
+#define  SAI_xCR1_MODE_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_xCR1_MODE_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  SAI_xCR1_PRTCFG                  ((uint32_t)0x0000000C)        /*!<PRTCFG[1:0] bits (Protocol Configuration)   */
+#define  SAI_xCR1_PRTCFG_0                ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  SAI_xCR1_PRTCFG_1                ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  SAI_xCR1_DS                      ((uint32_t)0x000000E0)        /*!<DS[1:0] bits (Data Size) */
+#define  SAI_xCR1_DS_0                    ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  SAI_xCR1_DS_1                    ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  SAI_xCR1_DS_2                    ((uint32_t)0x00000080)        /*!<Bit 2 */
+
+#define  SAI_xCR1_LSBFIRST                ((uint32_t)0x00000100)        /*!<LSB First Configuration  */
+#define  SAI_xCR1_CKSTR                   ((uint32_t)0x00000200)        /*!<ClocK STRobing edge      */
+
+#define  SAI_xCR1_SYNCEN                  ((uint32_t)0x00000C00)        /*!<SYNCEN[1:0](SYNChronization ENable) */
+#define  SAI_xCR1_SYNCEN_0                ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  SAI_xCR1_SYNCEN_1                ((uint32_t)0x00000800)        /*!<Bit 1 */
+
+#define  SAI_xCR1_MONO                    ((uint32_t)0x00001000)        /*!<Mono mode                  */
+#define  SAI_xCR1_OUTDRIV                 ((uint32_t)0x00002000)        /*!<Output Drive               */
+#define  SAI_xCR1_SAIEN                   ((uint32_t)0x00010000)        /*!<Audio Block enable         */
+#define  SAI_xCR1_DMAEN                   ((uint32_t)0x00020000)        /*!<DMA enable                 */
+#define  SAI_xCR1_NODIV                   ((uint32_t)0x00080000)        /*!<No Divider Configuration   */
+
+#define  SAI_xCR1_MCKDIV                  ((uint32_t)0x00F00000)        /*!<MCKDIV[3:0] (Master ClocK Divider)  */
+#define  SAI_xCR1_MCKDIV_0                ((uint32_t)0x00100000)        /*!<Bit 0  */
+#define  SAI_xCR1_MCKDIV_1                ((uint32_t)0x00200000)        /*!<Bit 1  */
+#define  SAI_xCR1_MCKDIV_2                ((uint32_t)0x00400000)        /*!<Bit 2  */
+#define  SAI_xCR1_MCKDIV_3                ((uint32_t)0x00800000)        /*!<Bit 3  */
+
+/*******************  Bit definition for SAI_xCR2 register  *******************/
+#define  SAI_xCR2_FTH                     ((uint32_t)0x00000007)        /*!<FTH[2:0](Fifo THreshold)  */
+#define  SAI_xCR2_FTH_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_xCR2_FTH_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  SAI_xCR2_FTH_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
+
+#define  SAI_xCR2_FFLUSH                  ((uint32_t)0x00000008)        /*!<Fifo FLUSH                       */
+#define  SAI_xCR2_TRIS                    ((uint32_t)0x00000010)        /*!<TRIState Management on data line */
+#define  SAI_xCR2_MUTE                    ((uint32_t)0x00000020)        /*!<Mute mode                        */
+#define  SAI_xCR2_MUTEVAL                 ((uint32_t)0x00000040)        /*!<Muate value                      */
+
+#define  SAI_xCR2_MUTECNT                  ((uint32_t)0x00001F80)       /*!<MUTECNT[5:0] (MUTE counter) */
+#define  SAI_xCR2_MUTECNT_0               ((uint32_t)0x00000080)        /*!<Bit 0 */
+#define  SAI_xCR2_MUTECNT_1               ((uint32_t)0x00000100)        /*!<Bit 1 */
+#define  SAI_xCR2_MUTECNT_2               ((uint32_t)0x00000200)        /*!<Bit 2 */
+#define  SAI_xCR2_MUTECNT_3               ((uint32_t)0x00000400)        /*!<Bit 3 */
+#define  SAI_xCR2_MUTECNT_4               ((uint32_t)0x00000800)        /*!<Bit 4 */
+#define  SAI_xCR2_MUTECNT_5               ((uint32_t)0x00001000)        /*!<Bit 5 */
+
+#define  SAI_xCR2_CPL                     ((uint32_t)0x00080000)        /*!< Complement Bit             */
+
+#define  SAI_xCR2_COMP                    ((uint32_t)0x0000C000)        /*!<COMP[1:0] (Companding mode) */
+#define  SAI_xCR2_COMP_0                  ((uint32_t)0x00004000)        /*!<Bit 0 */
+#define  SAI_xCR2_COMP_1                  ((uint32_t)0x00008000)        /*!<Bit 1 */
+
+/******************  Bit definition for SAI_xFRCR register  *******************/
+#define  SAI_xFRCR_FRL                    ((uint32_t)0x000000FF)        /*!<FRL[1:0](Frame length)  */
+#define  SAI_xFRCR_FRL_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_xFRCR_FRL_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  SAI_xFRCR_FRL_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  SAI_xFRCR_FRL_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  SAI_xFRCR_FRL_4                  ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  SAI_xFRCR_FRL_5                  ((uint32_t)0x00000020)        /*!<Bit 5 */
+#define  SAI_xFRCR_FRL_6                  ((uint32_t)0x00000040)        /*!<Bit 6 */
+#define  SAI_xFRCR_FRL_7                  ((uint32_t)0x00000080)        /*!<Bit 7 */
+
+#define  SAI_xFRCR_FSALL                  ((uint32_t)0x00007F00)        /*!<FRL[1:0] (Frame synchronization active level length)  */
+#define  SAI_xFRCR_FSALL_0                ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  SAI_xFRCR_FSALL_1                ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  SAI_xFRCR_FSALL_2                ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  SAI_xFRCR_FSALL_3                ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  SAI_xFRCR_FSALL_4                ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  SAI_xFRCR_FSALL_5                ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  SAI_xFRCR_FSALL_6                ((uint32_t)0x00004000)        /*!<Bit 6 */
+
+#define  SAI_xFRCR_FSDEF                  ((uint32_t)0x00010000)        /*!< Frame Synchronization Definition */
+#define  SAI_xFRCR_FSPO                   ((uint32_t)0x00020000)        /*!<Frame Synchronization POLarity    */
+#define  SAI_xFRCR_FSOFF                  ((uint32_t)0x00040000)        /*!<Frame Synchronization OFFset      */
+
+/******************  Bit definition for SAI_xSLOTR register  *******************/
+#define  SAI_xSLOTR_FBOFF                 ((uint32_t)0x0000001F)        /*!<FRL[4:0](First Bit Offset)  */
+#define  SAI_xSLOTR_FBOFF_0               ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_xSLOTR_FBOFF_1               ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  SAI_xSLOTR_FBOFF_2               ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  SAI_xSLOTR_FBOFF_3               ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  SAI_xSLOTR_FBOFF_4               ((uint32_t)0x00000010)        /*!<Bit 4 */
+
+#define  SAI_xSLOTR_SLOTSZ                ((uint32_t)0x000000C0)        /*!<SLOTSZ[1:0] (Slot size)  */
+#define  SAI_xSLOTR_SLOTSZ_0              ((uint32_t)0x00000040)        /*!<Bit 0 */
+#define  SAI_xSLOTR_SLOTSZ_1              ((uint32_t)0x00000080)        /*!<Bit 1 */
+
+#define  SAI_xSLOTR_NBSLOT                ((uint32_t)0x00000F00)        /*!<NBSLOT[3:0] (Number of Slot in audio Frame)  */
+#define  SAI_xSLOTR_NBSLOT_0              ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  SAI_xSLOTR_NBSLOT_1              ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  SAI_xSLOTR_NBSLOT_2              ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  SAI_xSLOTR_NBSLOT_3              ((uint32_t)0x00000800)        /*!<Bit 3 */
+
+#define  SAI_xSLOTR_SLOTEN                ((uint32_t)0xFFFF0000)        /*!<SLOTEN[15:0] (Slot Enable)  */
+
+/*******************  Bit definition for SAI_xIMR register  *******************/
+#define  SAI_xIMR_OVRUDRIE                ((uint32_t)0x00000001)        /*!<Overrun underrun interrupt enable                              */
+#define  SAI_xIMR_MUTEDETIE               ((uint32_t)0x00000002)        /*!<Mute detection interrupt enable                                */
+#define  SAI_xIMR_WCKCFGIE                ((uint32_t)0x00000004)        /*!<Wrong Clock Configuration interrupt enable                     */
+#define  SAI_xIMR_FREQIE                  ((uint32_t)0x00000008)        /*!<FIFO request interrupt enable                                  */
+#define  SAI_xIMR_CNRDYIE                 ((uint32_t)0x00000010)        /*!<Codec not ready interrupt enable                               */
+#define  SAI_xIMR_AFSDETIE                ((uint32_t)0x00000020)        /*!<Anticipated frame synchronization detection interrupt enable   */
+#define  SAI_xIMR_LFSDETIE                ((uint32_t)0x00000040)        /*!<Late frame synchronization detection interrupt enable          */
+
+/********************  Bit definition for SAI_xSR register  *******************/
+#define  SAI_xSR_OVRUDR                   ((uint32_t)0x00000001)         /*!<Overrun underrun                               */
+#define  SAI_xSR_MUTEDET                  ((uint32_t)0x00000002)         /*!<Mute detection                                 */
+#define  SAI_xSR_WCKCFG                   ((uint32_t)0x00000004)         /*!<Wrong Clock Configuration                      */
+#define  SAI_xSR_FREQ                     ((uint32_t)0x00000008)         /*!<FIFO request                                   */
+#define  SAI_xSR_CNRDY                    ((uint32_t)0x00000010)         /*!<Codec not ready                                */
+#define  SAI_xSR_AFSDET                   ((uint32_t)0x00000020)         /*!<Anticipated frame synchronization detection    */
+#define  SAI_xSR_LFSDET                   ((uint32_t)0x00000040)         /*!<Late frame synchronization detection           */
+
+#define  SAI_xSR_FLVL                     ((uint32_t)0x00070000)         /*!<FLVL[2:0] (FIFO Level Threshold)               */
+#define  SAI_xSR_FLVL_0                   ((uint32_t)0x00010000)         /*!<Bit 0 */
+#define  SAI_xSR_FLVL_1                   ((uint32_t)0x00020000)         /*!<Bit 1 */
+#define  SAI_xSR_FLVL_2                   ((uint32_t)0x00040000)         /*!<Bit 2 */
+
+/******************  Bit definition for SAI_xCLRFR register  ******************/
+#define  SAI_xCLRFR_COVRUDR               ((uint32_t)0x00000001)        /*!<Clear Overrun underrun                               */
+#define  SAI_xCLRFR_CMUTEDET              ((uint32_t)0x00000002)        /*!<Clear Mute detection                                 */
+#define  SAI_xCLRFR_CWCKCFG               ((uint32_t)0x00000004)        /*!<Clear Wrong Clock Configuration                      */
+#define  SAI_xCLRFR_CFREQ                 ((uint32_t)0x00000008)        /*!<Clear FIFO request                                   */
+#define  SAI_xCLRFR_CCNRDY                ((uint32_t)0x00000010)        /*!<Clear Codec not ready                                */
+#define  SAI_xCLRFR_CAFSDET               ((uint32_t)0x00000020)        /*!<Clear Anticipated frame synchronization detection    */
+#define  SAI_xCLRFR_CLFSDET               ((uint32_t)0x00000040)        /*!<Clear Late frame synchronization detection           */
+
+/******************  Bit definition for SAI_xDR register  *********************/
+#define  SAI_xDR_DATA                     ((uint32_t)0xFFFFFFFF)
+
+/******************************************************************************/
+/*                                                                            */
+/*                              SPDIF-RX Interface                            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for SPDIF_CR register  *******************/
+#define  SPDIFRX_CR_SPDIFEN                  ((uint32_t)0x00000003)        /*!<Peripheral Block Enable                      */
+#define  SPDIFRX_CR_RXDMAEN                  ((uint32_t)0x00000004)        /*!<Receiver DMA Enable for data flow            */
+#define  SPDIFRX_CR_RXSTEO                   ((uint32_t)0x00000008)        /*!<Stereo Mode                                  */
+#define  SPDIFRX_CR_DRFMT                    ((uint32_t)0x00000030)        /*!<RX Data format                               */
+#define  SPDIFRX_CR_PMSK                     ((uint32_t)0x00000040)        /*!<Mask Parity error bit                        */
+#define  SPDIFRX_CR_VMSK                     ((uint32_t)0x00000080)        /*!<Mask of Validity bit                         */
+#define  SPDIFRX_CR_CUMSK                    ((uint32_t)0x00000100)        /*!<Mask of channel status and user bits         */
+#define  SPDIFRX_CR_PTMSK                    ((uint32_t)0x00000200)        /*!<Mask of Preamble Type bits                   */
+#define  SPDIFRX_CR_CBDMAEN                  ((uint32_t)0x00000400)        /*!<Control Buffer DMA ENable for control flow   */
+#define  SPDIFRX_CR_CHSEL                    ((uint32_t)0x00000800)        /*!<Channel Selection                            */
+#define  SPDIFRX_CR_NBTR                     ((uint32_t)0x00003000)        /*!<Maximum allowed re-tries during synchronization phase */
+#define  SPDIFRX_CR_WFA                      ((uint32_t)0x00004000)        /*!<Wait For Activity     */
+#define  SPDIFRX_CR_INSEL                    ((uint32_t)0x00070000)        /*!<SPDIF input selection */
+
+/*******************  Bit definition for SPDIFRX_IMR register  *******************/
+#define  SPDIFRX_IMR_RXNEIE                   ((uint32_t)0x00000001)        /*!<RXNE interrupt enable                              */
+#define  SPDIFRX_IMR_CSRNEIE                  ((uint32_t)0x00000002)        /*!<Control Buffer Ready Interrupt Enable              */
+#define  SPDIFRX_IMR_PERRIE                   ((uint32_t)0x00000004)        /*!<Parity error interrupt enable                      */
+#define  SPDIFRX_IMR_OVRIE                    ((uint32_t)0x00000008)        /*!<Overrun error Interrupt Enable                     */
+#define  SPDIFRX_IMR_SBLKIE                   ((uint32_t)0x00000010)        /*!<Synchronization Block Detected Interrupt Enable    */
+#define  SPDIFRX_IMR_SYNCDIE                  ((uint32_t)0x00000020)        /*!<Synchronization Done                               */
+#define  SPDIFRX_IMR_IFEIE                    ((uint32_t)0x00000040)        /*!<Serial Interface Error Interrupt Enable            */
+
+/*******************  Bit definition for SPDIFRX_SR register  *******************/
+#define  SPDIFRX_SR_RXNE                   ((uint32_t)0x00000001)       /*!<Read data register not empty                          */
+#define  SPDIFRX_SR_CSRNE                  ((uint32_t)0x00000002)       /*!<The Control Buffer register is not empty              */
+#define  SPDIFRX_SR_PERR                   ((uint32_t)0x00000004)       /*!<Parity error                                          */
+#define  SPDIFRX_SR_OVR                    ((uint32_t)0x00000008)       /*!<Overrun error                                         */
+#define  SPDIFRX_SR_SBD                    ((uint32_t)0x00000010)       /*!<Synchronization Block Detected                        */
+#define  SPDIFRX_SR_SYNCD                  ((uint32_t)0x00000020)       /*!<Synchronization Done                                  */
+#define  SPDIFRX_SR_FERR                   ((uint32_t)0x00000040)       /*!<Framing error                                         */
+#define  SPDIFRX_SR_SERR                   ((uint32_t)0x00000080)       /*!<Synchronization error                                 */
+#define  SPDIFRX_SR_TERR                   ((uint32_t)0x00000100)       /*!<Time-out error                                        */
+#define  SPDIFRX_SR_WIDTH5                 ((uint32_t)0x7FFF0000)       /*!<Duration of 5 symbols counted with spdif_clk          */
+
+/*******************  Bit definition for SPDIFRX_IFCR register  *******************/
+#define  SPDIFRX_IFCR_PERRCF               ((uint32_t)0x00000004)       /*!<Clears the Parity error flag                         */
+#define  SPDIFRX_IFCR_OVRCF                ((uint32_t)0x00000008)       /*!<Clears the Overrun error flag                        */
+#define  SPDIFRX_IFCR_SBDCF                ((uint32_t)0x00000010)       /*!<Clears the Synchronization Block Detected flag       */
+#define  SPDIFRX_IFCR_SYNCDCF              ((uint32_t)0x00000020)       /*!<Clears the Synchronization Done flag                 */
+
+/*******************  Bit definition for SPDIFRX_DR register  (DRFMT = 0b00 case) *******************/
+#define  SPDIFRX_DR0_DR                    ((uint32_t)0x00FFFFFF)        /*!<Data value            */
+#define  SPDIFRX_DR0_PE                    ((uint32_t)0x01000000)        /*!<Parity Error bit      */
+#define  SPDIFRX_DR0_V                     ((uint32_t)0x02000000)        /*!<Validity bit          */
+#define  SPDIFRX_DR0_U                     ((uint32_t)0x04000000)        /*!<User bit              */
+#define  SPDIFRX_DR0_C                     ((uint32_t)0x08000000)        /*!<Channel Status bit    */
+#define  SPDIFRX_DR0_PT                    ((uint32_t)0x30000000)        /*!<Preamble Type         */
+
+/*******************  Bit definition for SPDIFRX_DR register  (DRFMT = 0b01 case) *******************/
+#define  SPDIFRX_DR1_DR                    ((uint32_t)0xFFFFFF00)        /*!<Data value            */
+#define  SPDIFRX_DR1_PT                    ((uint32_t)0x00000030)        /*!<Preamble Type         */
+#define  SPDIFRX_DR1_C                     ((uint32_t)0x00000008)        /*!<Channel Status bit    */
+#define  SPDIFRX_DR1_U                     ((uint32_t)0x00000004)        /*!<User bit              */
+#define  SPDIFRX_DR1_V                     ((uint32_t)0x00000002)        /*!<Validity bit          */
+#define  SPDIFRX_DR1_PE                    ((uint32_t)0x00000001)        /*!<Parity Error bit      */
+
+/*******************  Bit definition for SPDIFRX_DR register  (DRFMT = 0b10 case) *******************/
+#define  SPDIFRX_DR1_DRNL1                 ((uint32_t)0xFFFF0000)        /*!<Data value Channel B      */
+#define  SPDIFRX_DR1_DRNL2                 ((uint32_t)0x0000FFFF)        /*!<Data value Channel A      */
+
+/*******************  Bit definition for SPDIFRX_CSR register   *******************/
+#define  SPDIFRX_CSR_USR                     ((uint32_t)0x0000FFFF)        /*!<User data information           */
+#define  SPDIFRX_CSR_CS                      ((uint32_t)0x00FF0000)        /*!<Channel A status information    */
+#define  SPDIFRX_CSR_SOB                     ((uint32_t)0x01000000)        /*!<Start Of Block                  */
+
+/*******************  Bit definition for SPDIFRX_DIR register    *******************/
+#define  SPDIFRX_DIR_THI                 ((uint32_t)0x000013FF)        /*!<Threshold LOW      */
+#define  SPDIFRX_DIR_TLO                 ((uint32_t)0x1FFF0000)        /*!<Threshold HIGH     */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          SD host Interface                                 */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for SDMMC_POWER register  ******************/
+#define  SDMMC_POWER_PWRCTRL                  ((uint32_t)0x03)               /*!<PWRCTRL[1:0] bits (Power supply control bits) */
+#define  SDMMC_POWER_PWRCTRL_0                ((uint32_t)0x01)               /*!<Bit 0 */
+#define  SDMMC_POWER_PWRCTRL_1                ((uint32_t)0x02)               /*!<Bit 1 */
+
+/******************  Bit definition for SDMMC_CLKCR register  ******************/
+#define  SDMMC_CLKCR_CLKDIV                   ((uint32_t)0x00FF)            /*!<Clock divide factor             */
+#define  SDMMC_CLKCR_CLKEN                    ((uint32_t)0x0100)            /*!<Clock enable bit                */
+#define  SDMMC_CLKCR_PWRSAV                   ((uint32_t)0x0200)            /*!<Power saving configuration bit  */
+#define  SDMMC_CLKCR_BYPASS                   ((uint32_t)0x0400)            /*!<Clock divider bypass enable bit */
+
+#define  SDMMC_CLKCR_WIDBUS                   ((uint32_t)0x1800)            /*!<WIDBUS[1:0] bits (Wide bus mode enable bit) */
+#define  SDMMC_CLKCR_WIDBUS_0                 ((uint32_t)0x0800)            /*!<Bit 0 */
+#define  SDMMC_CLKCR_WIDBUS_1                 ((uint32_t)0x1000)            /*!<Bit 1 */
+
+#define  SDMMC_CLKCR_NEGEDGE                  ((uint32_t)0x2000)            /*!<SDMMC_CK dephasing selection bit */
+#define  SDMMC_CLKCR_HWFC_EN                  ((uint32_t)0x4000)            /*!<HW Flow Control enable          */
+
+/*******************  Bit definition for SDMMC_ARG register  *******************/
+#define  SDMMC_ARG_CMDARG                     ((uint32_t)0xFFFFFFFF)            /*!<Command argument */
+
+/*******************  Bit definition for SDMMC_CMD register  *******************/
+#define  SDMMC_CMD_CMDINDEX                   ((uint32_t)0x003F)            /*!<Command Index                               */
+
+#define  SDMMC_CMD_WAITRESP                   ((uint32_t)0x00C0)            /*!<WAITRESP[1:0] bits (Wait for response bits) */
+#define  SDMMC_CMD_WAITRESP_0                 ((uint32_t)0x0040)            /*!< Bit 0 */
+#define  SDMMC_CMD_WAITRESP_1                 ((uint32_t)0x0080)            /*!< Bit 1 */
+
+#define  SDMMC_CMD_WAITINT                    ((uint32_t)0x0100)            /*!<CPSM Waits for Interrupt Request                               */
+#define  SDMMC_CMD_WAITPEND                   ((uint32_t)0x0200)            /*!<CPSM Waits for ends of data transfer (CmdPend internal signal) */
+#define  SDMMC_CMD_CPSMEN                     ((uint32_t)0x0400)            /*!<Command path state machine (CPSM) Enable bit                   */
+#define  SDMMC_CMD_SDIOSUSPEND                ((uint32_t)0x0800)            /*!<SD I/O suspend command                                         */
+
+/*****************  Bit definition for SDMMC_RESPCMD register  *****************/
+#define  SDMMC_RESPCMD_RESPCMD                ((uint32_t)0x3F)               /*!<Response command index */
+
+/******************  Bit definition for SDMMC_RESP0 register  ******************/
+#define  SDMMC_RESP0_CARDSTATUS0              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_RESP1 register  ******************/
+#define  SDMMC_RESP1_CARDSTATUS1              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_RESP2 register  ******************/
+#define  SDMMC_RESP2_CARDSTATUS2              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_RESP3 register  ******************/
+#define  SDMMC_RESP3_CARDSTATUS3              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_RESP4 register  ******************/
+#define  SDMMC_RESP4_CARDSTATUS4              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_DTIMER register  *****************/
+#define  SDMMC_DTIMER_DATATIME                ((uint32_t)0xFFFFFFFF)        /*!<Data timeout period. */
+
+/******************  Bit definition for SDMMC_DLEN register  *******************/
+#define  SDMMC_DLEN_DATALENGTH                ((uint32_t)0x01FFFFFF)        /*!<Data length value    */
+
+/******************  Bit definition for SDMMC_DCTRL register  ******************/
+#define  SDMMC_DCTRL_DTEN                     ((uint32_t)0x0001)            /*!<Data transfer enabled bit         */
+#define  SDMMC_DCTRL_DTDIR                    ((uint32_t)0x0002)            /*!<Data transfer direction selection */
+#define  SDMMC_DCTRL_DTMODE                   ((uint32_t)0x0004)            /*!<Data transfer mode selection      */
+#define  SDMMC_DCTRL_DMAEN                    ((uint32_t)0x0008)            /*!<DMA enabled bit                   */
+
+#define  SDMMC_DCTRL_DBLOCKSIZE               ((uint32_t)0x00F0)            /*!<DBLOCKSIZE[3:0] bits (Data block size) */
+#define  SDMMC_DCTRL_DBLOCKSIZE_0             ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  SDMMC_DCTRL_DBLOCKSIZE_1             ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  SDMMC_DCTRL_DBLOCKSIZE_2             ((uint32_t)0x0040)            /*!<Bit 2 */
+#define  SDMMC_DCTRL_DBLOCKSIZE_3             ((uint32_t)0x0080)            /*!<Bit 3 */
+
+#define  SDMMC_DCTRL_RWSTART                  ((uint32_t)0x0100)            /*!<Read wait start         */
+#define  SDMMC_DCTRL_RWSTOP                   ((uint32_t)0x0200)            /*!<Read wait stop          */
+#define  SDMMC_DCTRL_RWMOD                    ((uint32_t)0x0400)            /*!<Read wait mode          */
+#define  SDMMC_DCTRL_SDIOEN                   ((uint32_t)0x0800)            /*!<SD I/O enable functions */
+
+/******************  Bit definition for SDMMC_DCOUNT register  *****************/
+#define  SDMMC_DCOUNT_DATACOUNT               ((uint32_t)0x01FFFFFF)        /*!<Data count value */
+
+/******************  Bit definition for SDMMC_STA register  ********************/
+#define  SDMMC_STA_CCRCFAIL                   ((uint32_t)0x00000001)        /*!<Command response received (CRC check failed)  */
+#define  SDMMC_STA_DCRCFAIL                   ((uint32_t)0x00000002)        /*!<Data block sent/received (CRC check failed)   */
+#define  SDMMC_STA_CTIMEOUT                   ((uint32_t)0x00000004)        /*!<Command response timeout                      */
+#define  SDMMC_STA_DTIMEOUT                   ((uint32_t)0x00000008)        /*!<Data timeout                                  */
+#define  SDMMC_STA_TXUNDERR                   ((uint32_t)0x00000010)        /*!<Transmit FIFO underrun error                  */
+#define  SDMMC_STA_RXOVERR                    ((uint32_t)0x00000020)        /*!<Received FIFO overrun error                   */
+#define  SDMMC_STA_CMDREND                    ((uint32_t)0x00000040)        /*!<Command response received (CRC check passed)  */
+#define  SDMMC_STA_CMDSENT                    ((uint32_t)0x00000080)        /*!<Command sent (no response required)           */
+#define  SDMMC_STA_DATAEND                    ((uint32_t)0x00000100)        /*!<Data end (data counter, SDIDCOUNT, is zero)   */
+#define  SDMMC_STA_DBCKEND                    ((uint32_t)0x00000400)        /*!<Data block sent/received (CRC check passed)   */
+#define  SDMMC_STA_CMDACT                     ((uint32_t)0x00000800)        /*!<Command transfer in progress                  */
+#define  SDMMC_STA_TXACT                      ((uint32_t)0x00001000)        /*!<Data transmit in progress                     */
+#define  SDMMC_STA_RXACT                      ((uint32_t)0x00002000)        /*!<Data receive in progress                      */
+#define  SDMMC_STA_TXFIFOHE                   ((uint32_t)0x00004000)        /*!<Transmit FIFO Half Empty: at least 8 words can be written into the FIFO */
+#define  SDMMC_STA_RXFIFOHF                   ((uint32_t)0x00008000)        /*!<Receive FIFO Half Full: there are at least 8 words in the FIFO */
+#define  SDMMC_STA_TXFIFOF                    ((uint32_t)0x00010000)        /*!<Transmit FIFO full                            */
+#define  SDMMC_STA_RXFIFOF                    ((uint32_t)0x00020000)        /*!<Receive FIFO full                             */
+#define  SDMMC_STA_TXFIFOE                    ((uint32_t)0x00040000)        /*!<Transmit FIFO empty                           */
+#define  SDMMC_STA_RXFIFOE                    ((uint32_t)0x00080000)        /*!<Receive FIFO empty                            */
+#define  SDMMC_STA_TXDAVL                     ((uint32_t)0x00100000)        /*!<Data available in transmit FIFO               */
+#define  SDMMC_STA_RXDAVL                     ((uint32_t)0x00200000)        /*!<Data available in receive FIFO                */
+#define  SDMMC_STA_SDIOIT                     ((uint32_t)0x00400000)        /*!<SDMMC interrupt received                       */
+
+/*******************  Bit definition for SDMMC_ICR register  *******************/
+#define  SDMMC_ICR_CCRCFAILC                  ((uint32_t)0x00000001)        /*!<CCRCFAIL flag clear bit */
+#define  SDMMC_ICR_DCRCFAILC                  ((uint32_t)0x00000002)        /*!<DCRCFAIL flag clear bit */
+#define  SDMMC_ICR_CTIMEOUTC                  ((uint32_t)0x00000004)        /*!<CTIMEOUT flag clear bit */
+#define  SDMMC_ICR_DTIMEOUTC                  ((uint32_t)0x00000008)        /*!<DTIMEOUT flag clear bit */
+#define  SDMMC_ICR_TXUNDERRC                  ((uint32_t)0x00000010)        /*!<TXUNDERR flag clear bit */
+#define  SDMMC_ICR_RXOVERRC                   ((uint32_t)0x00000020)        /*!<RXOVERR flag clear bit  */
+#define  SDMMC_ICR_CMDRENDC                   ((uint32_t)0x00000040)        /*!<CMDREND flag clear bit  */
+#define  SDMMC_ICR_CMDSENTC                   ((uint32_t)0x00000080)        /*!<CMDSENT flag clear bit  */
+#define  SDMMC_ICR_DATAENDC                   ((uint32_t)0x00000100)        /*!<DATAEND flag clear bit  */
+#define  SDMMC_ICR_DBCKENDC                   ((uint32_t)0x00000400)        /*!<DBCKEND flag clear bit  */
+#define  SDMMC_ICR_SDIOITC                    ((uint32_t)0x00400000)        /*!<SDMMCIT flag clear bit   */
+
+/******************  Bit definition for SDMMC_MASK register  *******************/
+#define  SDMMC_MASK_CCRCFAILIE                ((uint32_t)0x00000001)        /*!<Command CRC Fail Interrupt Enable          */
+#define  SDMMC_MASK_DCRCFAILIE                ((uint32_t)0x00000002)        /*!<Data CRC Fail Interrupt Enable             */
+#define  SDMMC_MASK_CTIMEOUTIE                ((uint32_t)0x00000004)        /*!<Command TimeOut Interrupt Enable           */
+#define  SDMMC_MASK_DTIMEOUTIE                ((uint32_t)0x00000008)        /*!<Data TimeOut Interrupt Enable              */
+#define  SDMMC_MASK_TXUNDERRIE                ((uint32_t)0x00000010)        /*!<Tx FIFO UnderRun Error Interrupt Enable    */
+#define  SDMMC_MASK_RXOVERRIE                 ((uint32_t)0x00000020)        /*!<Rx FIFO OverRun Error Interrupt Enable     */
+#define  SDMMC_MASK_CMDRENDIE                 ((uint32_t)0x00000040)        /*!<Command Response Received Interrupt Enable */
+#define  SDMMC_MASK_CMDSENTIE                 ((uint32_t)0x00000080)        /*!<Command Sent Interrupt Enable              */
+#define  SDMMC_MASK_DATAENDIE                 ((uint32_t)0x00000100)        /*!<Data End Interrupt Enable                  */
+#define  SDMMC_MASK_DBCKENDIE                 ((uint32_t)0x00000400)        /*!<Data Block End Interrupt Enable            */
+#define  SDMMC_MASK_CMDACTIE                  ((uint32_t)0x00000800)        /*!<CCommand Acting Interrupt Enable           */
+#define  SDMMC_MASK_TXACTIE                   ((uint32_t)0x00001000)        /*!<Data Transmit Acting Interrupt Enable      */
+#define  SDMMC_MASK_RXACTIE                   ((uint32_t)0x00002000)        /*!<Data receive acting interrupt enabled      */
+#define  SDMMC_MASK_TXFIFOHEIE                ((uint32_t)0x00004000)        /*!<Tx FIFO Half Empty interrupt Enable        */
+#define  SDMMC_MASK_RXFIFOHFIE                ((uint32_t)0x00008000)        /*!<Rx FIFO Half Full interrupt Enable         */
+#define  SDMMC_MASK_TXFIFOFIE                 ((uint32_t)0x00010000)        /*!<Tx FIFO Full interrupt Enable              */
+#define  SDMMC_MASK_RXFIFOFIE                 ((uint32_t)0x00020000)        /*!<Rx FIFO Full interrupt Enable              */
+#define  SDMMC_MASK_TXFIFOEIE                 ((uint32_t)0x00040000)        /*!<Tx FIFO Empty interrupt Enable             */
+#define  SDMMC_MASK_RXFIFOEIE                 ((uint32_t)0x00080000)        /*!<Rx FIFO Empty interrupt Enable             */
+#define  SDMMC_MASK_TXDAVLIE                  ((uint32_t)0x00100000)        /*!<Data available in Tx FIFO interrupt Enable */
+#define  SDMMC_MASK_RXDAVLIE                  ((uint32_t)0x00200000)        /*!<Data available in Rx FIFO interrupt Enable */
+#define  SDMMC_MASK_SDIOITIE                  ((uint32_t)0x00400000)        /*!<SDMMC Mode Interrupt Received interrupt Enable */
+
+/*****************  Bit definition for SDMMC_FIFOCNT register  *****************/
+#define  SDMMC_FIFOCNT_FIFOCOUNT              ((uint32_t)0x00FFFFFF)        /*!<Remaining number of words to be written to or read from the FIFO */
+
+/******************  Bit definition for SDMMC_FIFO register  *******************/
+#define  SDMMC_FIFO_FIFODATA                  ((uint32_t)0xFFFFFFFF)        /*!<Receive and transmit FIFO data */
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Serial Peripheral Interface (SPI)                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for SPI_CR1 register  ********************/
+#define  SPI_CR1_CPHA                        ((uint32_t)0x00000001)        /*!< Clock Phase                        */
+#define  SPI_CR1_CPOL                        ((uint32_t)0x00000002)        /*!< Clock Polarity                     */
+#define  SPI_CR1_MSTR                        ((uint32_t)0x00000004)        /*!< Master Selection                   */
+#define  SPI_CR1_BR                          ((uint32_t)0x00000038)        /*!< BR[2:0] bits (Baud Rate Control)   */
+#define  SPI_CR1_BR_0                        ((uint32_t)0x00000008)        /*!< Bit 0 */
+#define  SPI_CR1_BR_1                        ((uint32_t)0x00000010)        /*!< Bit 1 */
+#define  SPI_CR1_BR_2                        ((uint32_t)0x00000020)        /*!< Bit 2 */
+#define  SPI_CR1_SPE                         ((uint32_t)0x00000040)        /*!< SPI Enable                          */
+#define  SPI_CR1_LSBFIRST                    ((uint32_t)0x00000080)        /*!< Frame Format                        */
+#define  SPI_CR1_SSI                         ((uint32_t)0x00000100)        /*!< Internal slave select               */
+#define  SPI_CR1_SSM                         ((uint32_t)0x00000200)        /*!< Software slave management           */
+#define  SPI_CR1_RXONLY                      ((uint32_t)0x00000400)        /*!< Receive only                        */
+#define  SPI_CR1_CRCL                        ((uint32_t)0x00000800)        /*!< CRC Length                          */
+#define  SPI_CR1_CRCNEXT                     ((uint32_t)0x00001000)        /*!< Transmit CRC next                   */
+#define  SPI_CR1_CRCEN                       ((uint32_t)0x00002000)        /*!< Hardware CRC calculation enable     */
+#define  SPI_CR1_BIDIOE                      ((uint32_t)0x00004000)        /*!< Output enable in bidirectional mode */
+#define  SPI_CR1_BIDIMODE                    ((uint32_t)0x00008000)        /*!< Bidirectional data mode enable      */
+
+/*******************  Bit definition for SPI_CR2 register  ********************/
+#define  SPI_CR2_RXDMAEN                     ((uint32_t)0x00000001)        /*!< Rx Buffer DMA Enable                 */
+#define  SPI_CR2_TXDMAEN                     ((uint32_t)0x00000002)        /*!< Tx Buffer DMA Enable                 */
+#define  SPI_CR2_SSOE                        ((uint32_t)0x00000004)        /*!< SS Output Enable                     */
+#define  SPI_CR2_NSSP                        ((uint32_t)0x00000008)        /*!< NSS pulse management Enable          */
+#define  SPI_CR2_FRF                         ((uint32_t)0x00000010)        /*!< Frame Format Enable                  */
+#define  SPI_CR2_ERRIE                       ((uint32_t)0x00000020)        /*!< Error Interrupt Enable               */
+#define  SPI_CR2_RXNEIE                      ((uint32_t)0x00000040)        /*!< RX buffer Not Empty Interrupt Enable */
+#define  SPI_CR2_TXEIE                       ((uint32_t)0x00000080)        /*!< Tx buffer Empty Interrupt Enable     */
+#define  SPI_CR2_DS                          ((uint32_t)0x00000F00)        /*!< DS[3:0] Data Size                    */
+#define  SPI_CR2_DS_0                        ((uint32_t)0x00000100)        /*!< Bit 0 */
+#define  SPI_CR2_DS_1                        ((uint32_t)0x00000200)        /*!< Bit 1 */
+#define  SPI_CR2_DS_2                        ((uint32_t)0x00000400)        /*!< Bit 2 */
+#define  SPI_CR2_DS_3                        ((uint32_t)0x00000800)        /*!< Bit 3 */
+#define  SPI_CR2_FRXTH                       ((uint32_t)0x00001000)        /*!< FIFO reception Threshold           */
+#define  SPI_CR2_LDMARX                      ((uint32_t)0x00002000)        /*!< Last DMA transfer for reception    */
+#define  SPI_CR2_LDMATX                      ((uint32_t)0x00004000)        /*!< Last DMA transfer for transmission */
+
+/********************  Bit definition for SPI_SR register  ********************/
+#define  SPI_SR_RXNE                         ((uint32_t)0x00000001)        /*!< Receive buffer Not Empty  */
+#define  SPI_SR_TXE                          ((uint32_t)0x00000002)        /*!< Transmit buffer Empty     */
+#define  SPI_SR_CHSIDE                       ((uint32_t)0x00000004)        /*!< Channel side              */
+#define  SPI_SR_UDR                          ((uint32_t)0x00000008)        /*!< Underrun flag             */
+#define  SPI_SR_CRCERR                       ((uint32_t)0x00000010)        /*!< CRC Error flag            */
+#define  SPI_SR_MODF                         ((uint32_t)0x00000020)        /*!< Mode fault                */
+#define  SPI_SR_OVR                          ((uint32_t)0x00000040)        /*!< Overrun flag              */
+#define  SPI_SR_BSY                          ((uint32_t)0x00000080)        /*!< Busy flag                 */
+#define  SPI_SR_FRE                          ((uint32_t)0x00000100)        /*!< TI frame format error     */
+#define  SPI_SR_FRLVL                        ((uint32_t)0x00000600)        /*!< FIFO Reception Level      */
+#define  SPI_SR_FRLVL_0                      ((uint32_t)0x00000200)        /*!< Bit 0 */
+#define  SPI_SR_FRLVL_1                      ((uint32_t)0x00000400)        /*!< Bit 1 */
+#define  SPI_SR_FTLVL                        ((uint32_t)0x00001800)        /*!< FIFO Transmission Level   */
+#define  SPI_SR_FTLVL_0                      ((uint32_t)0x00000800)        /*!< Bit 0 */
+#define  SPI_SR_FTLVL_1                      ((uint32_t)0x00001000)        /*!< Bit 1 */
+
+/********************  Bit definition for SPI_DR register  ********************/
+#define  SPI_DR_DR                           ((uint32_t)0xFFFF)            /*!< Data Register */
+
+/*******************  Bit definition for SPI_CRCPR register  ******************/
+#define  SPI_CRCPR_CRCPOLY                   ((uint32_t)0xFFFF)            /*!< CRC polynomial register */
+
+/******************  Bit definition for SPI_RXCRCR register  ******************/
+#define  SPI_RXCRCR_RXCRC                    ((uint32_t)0xFFFF)            /*!< Rx CRC Register */
+
+/******************  Bit definition for SPI_TXCRCR register  ******************/
+#define  SPI_TXCRCR_TXCRC                    ((uint32_t)0xFFFF)            /*!< Tx CRC Register */
+
+/******************  Bit definition for SPI_I2SCFGR register  *****************/
+#define  SPI_I2SCFGR_CHLEN                   ((uint32_t)0x00000001)        /*!<Channel length (number of bits per audio channel) */
+#define  SPI_I2SCFGR_DATLEN                  ((uint32_t)0x00000006)        /*!<DATLEN[1:0] bits (Data length to be transferred)  */
+#define  SPI_I2SCFGR_DATLEN_0                ((uint32_t)0x00000002)        /*!<Bit 0 */
+#define  SPI_I2SCFGR_DATLEN_1                ((uint32_t)0x00000004)        /*!<Bit 1 */
+#define  SPI_I2SCFGR_CKPOL                   ((uint32_t)0x00000008)        /*!<steady state clock polarity                       */
+#define  SPI_I2SCFGR_I2SSTD                  ((uint32_t)0x00000030)        /*!<I2SSTD[1:0] bits (I2S standard selection)         */
+#define  SPI_I2SCFGR_I2SSTD_0                ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  SPI_I2SCFGR_I2SSTD_1                ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  SPI_I2SCFGR_PCMSYNC                 ((uint32_t)0x00000080)        /*!<PCM frame synchronization                         */
+#define  SPI_I2SCFGR_I2SCFG                  ((uint32_t)0x00000300)        /*!<I2SCFG[1:0] bits (I2S configuration mode)         */
+#define  SPI_I2SCFGR_I2SCFG_0                ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  SPI_I2SCFGR_I2SCFG_1                ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  SPI_I2SCFGR_I2SE                    ((uint32_t)0x00000400)        /*!<I2S Enable                                        */
+#define  SPI_I2SCFGR_I2SMOD                  ((uint32_t)0x00000800)        /*!<I2S mode selection                                */
+#define  SPI_I2SCFGR_ASTRTEN                 ((uint32_t)0x00001000)        /*!<Asynchronous start enable                        */
+
+/******************  Bit definition for SPI_I2SPR register  *******************/
+#define  SPI_I2SPR_I2SDIV                    ((uint32_t)0x00FF)            /*!<I2S Linear prescaler         */
+#define  SPI_I2SPR_ODD                       ((uint32_t)0x0100)            /*!<Odd factor for the prescaler */
+#define  SPI_I2SPR_MCKOE                     ((uint32_t)0x0200)            /*!<Master Clock Output Enable   */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 SYSCFG                                     */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for SYSCFG_MEMRMP register  ***************/
+#define SYSCFG_MEMRMP_MEM_BOOT          ((uint32_t)0x00000001) /*!< Boot information after Reset */
+
+#define SYSCFG_MEMRMP_SWP_FMC          ((uint32_t)0x00000C00) /*!< FMC Memory Mapping swapping */
+#define SYSCFG_MEMRMP_SWP_FMC_0        ((uint32_t)0x00000400)
+#define SYSCFG_MEMRMP_SWP_FMC_1        ((uint32_t)0x00000800)
+
+/******************  Bit definition for SYSCFG_PMC register  ******************/
+#define SYSCFG_PMC_ADCxDC2              ((uint32_t)0x00070000) /*!< Refer to AN4073 on how to use this bit  */
+#define SYSCFG_PMC_ADC1DC2              ((uint32_t)0x00010000) /*!< Refer to AN4073 on how to use this bit  */
+#define SYSCFG_PMC_ADC2DC2              ((uint32_t)0x00020000) /*!< Refer to AN4073 on how to use this bit  */
+#define SYSCFG_PMC_ADC3DC2              ((uint32_t)0x00040000) /*!< Refer to AN4073 on how to use this bit  */
+
+#define SYSCFG_PMC_MII_RMII_SEL         ((uint32_t)0x00800000) /*!<Ethernet PHY interface selection */
+
+/*****************  Bit definition for SYSCFG_EXTICR1 register  ***************/
+#define SYSCFG_EXTICR1_EXTI0            ((uint32_t)0x000F) /*!<EXTI 0 configuration */
+#define SYSCFG_EXTICR1_EXTI1            ((uint32_t)0x00F0) /*!<EXTI 1 configuration */
+#define SYSCFG_EXTICR1_EXTI2            ((uint32_t)0x0F00) /*!<EXTI 2 configuration */
+#define SYSCFG_EXTICR1_EXTI3            ((uint32_t)0xF000) /*!<EXTI 3 configuration */
+/**
+  * @brief   EXTI0 configuration
+  */
+#define SYSCFG_EXTICR1_EXTI0_PA         ((uint32_t)0x0000) /*!<PA[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PB         ((uint32_t)0x0001) /*!<PB[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PC         ((uint32_t)0x0002) /*!<PC[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PD         ((uint32_t)0x0003) /*!<PD[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PE         ((uint32_t)0x0004) /*!<PE[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PF         ((uint32_t)0x0005) /*!<PF[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PG         ((uint32_t)0x0006) /*!<PG[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PH         ((uint32_t)0x0007) /*!<PH[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PI         ((uint32_t)0x0008) /*!<PI[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PJ         ((uint32_t)0x0009) /*!<PJ[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PK         ((uint32_t)0x000A) /*!<PK[0] pin */
+
+/**
+  * @brief   EXTI1 configuration
+  */
+#define SYSCFG_EXTICR1_EXTI1_PA         ((uint32_t)0x0000) /*!<PA[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PB         ((uint32_t)0x0010) /*!<PB[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PC         ((uint32_t)0x0020) /*!<PC[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PD         ((uint32_t)0x0030) /*!<PD[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PE         ((uint32_t)0x0040) /*!<PE[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PF         ((uint32_t)0x0050) /*!<PF[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PG         ((uint32_t)0x0060) /*!<PG[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PH         ((uint32_t)0x0070) /*!<PH[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PI         ((uint32_t)0x0080) /*!<PI[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PJ         ((uint32_t)0x0090) /*!<PJ[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PK         ((uint32_t)0x00A0) /*!<PK[1] pin */
+
+/**
+  * @brief   EXTI2 configuration
+  */
+#define SYSCFG_EXTICR1_EXTI2_PA         ((uint32_t)0x0000) /*!<PA[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PB         ((uint32_t)0x0100) /*!<PB[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PC         ((uint32_t)0x0200) /*!<PC[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PD         ((uint32_t)0x0300) /*!<PD[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PE         ((uint32_t)0x0400) /*!<PE[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PF         ((uint32_t)0x0500) /*!<PF[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PG         ((uint32_t)0x0600) /*!<PG[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PH         ((uint32_t)0x0700) /*!<PH[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PI         ((uint32_t)0x0800) /*!<PI[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PJ         ((uint32_t)0x0900) /*!<PJ[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PK         ((uint32_t)0x0A00) /*!<PK[2] pin */
+
+/**
+  * @brief   EXTI3 configuration
+  */
+#define SYSCFG_EXTICR1_EXTI3_PA         ((uint32_t)0x0000) /*!<PA[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PB         ((uint32_t)0x1000) /*!<PB[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PC         ((uint32_t)0x2000) /*!<PC[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PD         ((uint32_t)0x3000) /*!<PD[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PE         ((uint32_t)0x4000) /*!<PE[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PF         ((uint32_t)0x5000) /*!<PF[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PG         ((uint32_t)0x6000) /*!<PG[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PH         ((uint32_t)0x7000) /*!<PH[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PI         ((uint32_t)0x8000) /*!<PI[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PJ         ((uint32_t)0x9000) /*!<PJ[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PK         ((uint32_t)0xA000) /*!<PK[3] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR2 register  ***************/
+#define SYSCFG_EXTICR2_EXTI4            ((uint32_t)0x000F) /*!<EXTI 4 configuration */
+#define SYSCFG_EXTICR2_EXTI5            ((uint32_t)0x00F0) /*!<EXTI 5 configuration */
+#define SYSCFG_EXTICR2_EXTI6            ((uint32_t)0x0F00) /*!<EXTI 6 configuration */
+#define SYSCFG_EXTICR2_EXTI7            ((uint32_t)0xF000) /*!<EXTI 7 configuration */
+/**
+  * @brief   EXTI4 configuration
+  */
+#define SYSCFG_EXTICR2_EXTI4_PA         ((uint32_t)0x0000) /*!<PA[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PB         ((uint32_t)0x0001) /*!<PB[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PC         ((uint32_t)0x0002) /*!<PC[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PD         ((uint32_t)0x0003) /*!<PD[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PE         ((uint32_t)0x0004) /*!<PE[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PF         ((uint32_t)0x0005) /*!<PF[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PG         ((uint32_t)0x0006) /*!<PG[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PH         ((uint32_t)0x0007) /*!<PH[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PI         ((uint32_t)0x0008) /*!<PI[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PJ         ((uint32_t)0x0009) /*!<PJ[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PK         ((uint32_t)0x000A) /*!<PK[4] pin */
+
+/**
+  * @brief   EXTI5 configuration
+  */
+#define SYSCFG_EXTICR2_EXTI5_PA         ((uint32_t)0x0000) /*!<PA[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PB         ((uint32_t)0x0010) /*!<PB[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PC         ((uint32_t)0x0020) /*!<PC[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PD         ((uint32_t)0x0030) /*!<PD[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PE         ((uint32_t)0x0040) /*!<PE[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PF         ((uint32_t)0x0050) /*!<PF[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PG         ((uint32_t)0x0060) /*!<PG[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PH         ((uint32_t)0x0070) /*!<PH[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PI         ((uint32_t)0x0080) /*!<PI[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PJ         ((uint32_t)0x0090) /*!<PJ[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PK         ((uint32_t)0x00A0) /*!<PK[5] pin */
+
+/**
+  * @brief   EXTI6 configuration
+  */
+#define SYSCFG_EXTICR2_EXTI6_PA         ((uint32_t)0x0000) /*!<PA[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PB         ((uint32_t)0x0100) /*!<PB[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PC         ((uint32_t)0x0200) /*!<PC[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PD         ((uint32_t)0x0300) /*!<PD[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PE         ((uint32_t)0x0400) /*!<PE[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PF         ((uint32_t)0x0500) /*!<PF[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PG         ((uint32_t)0x0600) /*!<PG[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PH         ((uint32_t)0x0700) /*!<PH[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PI         ((uint32_t)0x0800) /*!<PI[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PJ         ((uint32_t)0x0900) /*!<PJ[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PK         ((uint32_t)0x0A00) /*!<PK[6] pin */
+
+/**
+  * @brief   EXTI7 configuration
+  */
+#define SYSCFG_EXTICR2_EXTI7_PA         ((uint32_t)0x0000) /*!<PA[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PB         ((uint32_t)0x1000) /*!<PB[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PC         ((uint32_t)0x2000) /*!<PC[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PD         ((uint32_t)0x3000) /*!<PD[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PE         ((uint32_t)0x4000) /*!<PE[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PF         ((uint32_t)0x5000) /*!<PF[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PG         ((uint32_t)0x6000) /*!<PG[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PH         ((uint32_t)0x7000) /*!<PH[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PI         ((uint32_t)0x8000) /*!<PI[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PJ         ((uint32_t)0x9000) /*!<PJ[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PK         ((uint32_t)0xA000) /*!<PK[7] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR3 register  ***************/
+#define SYSCFG_EXTICR3_EXTI8            ((uint32_t)0x000F) /*!<EXTI 8 configuration */
+#define SYSCFG_EXTICR3_EXTI9            ((uint32_t)0x00F0) /*!<EXTI 9 configuration */
+#define SYSCFG_EXTICR3_EXTI10           ((uint32_t)0x0F00) /*!<EXTI 10 configuration */
+#define SYSCFG_EXTICR3_EXTI11           ((uint32_t)0xF000) /*!<EXTI 11 configuration */
+
+/**
+  * @brief   EXTI8 configuration
+  */
+#define SYSCFG_EXTICR3_EXTI8_PA         ((uint32_t)0x0000) /*!<PA[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PB         ((uint32_t)0x0001) /*!<PB[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PC         ((uint32_t)0x0002) /*!<PC[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PD         ((uint32_t)0x0003) /*!<PD[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PE         ((uint32_t)0x0004) /*!<PE[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PF         ((uint32_t)0x0005) /*!<PF[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PG         ((uint32_t)0x0006) /*!<PG[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PH         ((uint32_t)0x0007) /*!<PH[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PI         ((uint32_t)0x0008) /*!<PI[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PJ         ((uint32_t)0x0009) /*!<PJ[8] pin */
+
+/**
+  * @brief   EXTI9 configuration
+  */
+#define SYSCFG_EXTICR3_EXTI9_PA         ((uint32_t)0x0000) /*!<PA[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PB         ((uint32_t)0x0010) /*!<PB[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PC         ((uint32_t)0x0020) /*!<PC[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PD         ((uint32_t)0x0030) /*!<PD[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PE         ((uint32_t)0x0040) /*!<PE[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PF         ((uint32_t)0x0050) /*!<PF[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PG         ((uint32_t)0x0060) /*!<PG[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PH         ((uint32_t)0x0070) /*!<PH[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PI         ((uint32_t)0x0080) /*!<PI[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PJ         ((uint32_t)0x0090) /*!<PJ[9] pin */
+
+/**
+  * @brief   EXTI10 configuration
+  */
+#define SYSCFG_EXTICR3_EXTI10_PA        ((uint32_t)0x0000) /*!<PA[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PB        ((uint32_t)0x0100) /*!<PB[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PC        ((uint32_t)0x0200) /*!<PC[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PD        ((uint32_t)0x0300) /*!<PD[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PE        ((uint32_t)0x0400) /*!<PE[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PF        ((uint32_t)0x0500) /*!<PF[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PG        ((uint32_t)0x0600) /*!<PG[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PH        ((uint32_t)0x0700) /*!<PH[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PI        ((uint32_t)0x0800) /*!<PI[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PJ        ((uint32_t)0x0900) /*!<PJ[10] pin */
+
+/**
+  * @brief   EXTI11 configuration
+  */
+#define SYSCFG_EXTICR3_EXTI11_PA        ((uint32_t)0x0000) /*!<PA[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PB        ((uint32_t)0x1000) /*!<PB[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PC        ((uint32_t)0x2000) /*!<PC[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PD        ((uint32_t)0x3000) /*!<PD[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PE        ((uint32_t)0x4000) /*!<PE[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PF        ((uint32_t)0x5000) /*!<PF[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PG        ((uint32_t)0x6000) /*!<PG[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PH        ((uint32_t)0x7000) /*!<PH[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PI        ((uint32_t)0x8000) /*!<PI[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PJ        ((uint32_t)0x9000) /*!<PJ[11] pin */
+
+
+/*****************  Bit definition for SYSCFG_EXTICR4 register  ***************/
+#define SYSCFG_EXTICR4_EXTI12           ((uint32_t)0x000F) /*!<EXTI 12 configuration */
+#define SYSCFG_EXTICR4_EXTI13           ((uint32_t)0x00F0) /*!<EXTI 13 configuration */
+#define SYSCFG_EXTICR4_EXTI14           ((uint32_t)0x0F00) /*!<EXTI 14 configuration */
+#define SYSCFG_EXTICR4_EXTI15           ((uint32_t)0xF000) /*!<EXTI 15 configuration */
+/**
+  * @brief   EXTI12 configuration
+  */
+#define SYSCFG_EXTICR4_EXTI12_PA        ((uint32_t)0x0000) /*!<PA[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PB        ((uint32_t)0x0001) /*!<PB[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PC        ((uint32_t)0x0002) /*!<PC[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PD        ((uint32_t)0x0003) /*!<PD[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PE        ((uint32_t)0x0004) /*!<PE[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PF        ((uint32_t)0x0005) /*!<PF[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PG        ((uint32_t)0x0006) /*!<PG[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PH        ((uint32_t)0x0007) /*!<PH[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PI        ((uint32_t)0x0008) /*!<PI[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PJ        ((uint32_t)0x0009) /*!<PJ[12] pin */
+
+/**
+  * @brief   EXTI13 configuration
+  */
+#define SYSCFG_EXTICR4_EXTI13_PA        ((uint32_t)0x0000) /*!<PA[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PB        ((uint32_t)0x0010) /*!<PB[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PC        ((uint32_t)0x0020) /*!<PC[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PD        ((uint32_t)0x0030) /*!<PD[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PE        ((uint32_t)0x0040) /*!<PE[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PF        ((uint32_t)0x0050) /*!<PF[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PG        ((uint32_t)0x0060) /*!<PG[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PH        ((uint32_t)0x0070) /*!<PH[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PI        ((uint32_t)0x0008) /*!<PI[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PJ        ((uint32_t)0x0009) /*!<PJ[13] pin */
+
+/**
+  * @brief   EXTI14 configuration
+  */
+#define SYSCFG_EXTICR4_EXTI14_PA        ((uint32_t)0x0000) /*!<PA[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PB        ((uint32_t)0x0100) /*!<PB[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PC        ((uint32_t)0x0200) /*!<PC[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PD        ((uint32_t)0x0300) /*!<PD[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PE        ((uint32_t)0x0400) /*!<PE[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PF        ((uint32_t)0x0500) /*!<PF[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PG        ((uint32_t)0x0600) /*!<PG[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PH        ((uint32_t)0x0700) /*!<PH[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PI        ((uint32_t)0x0800) /*!<PI[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PJ        ((uint32_t)0x0900) /*!<PJ[14] pin */
+
+/**
+  * @brief   EXTI15 configuration
+  */
+#define SYSCFG_EXTICR4_EXTI15_PA        ((uint32_t)0x0000) /*!<PA[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PB        ((uint32_t)0x1000) /*!<PB[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PC        ((uint32_t)0x2000) /*!<PC[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PD        ((uint32_t)0x3000) /*!<PD[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PE        ((uint32_t)0x4000) /*!<PE[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PF        ((uint32_t)0x5000) /*!<PF[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PG        ((uint32_t)0x6000) /*!<PG[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PH        ((uint32_t)0x7000) /*!<PH[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PI        ((uint32_t)0x8000) /*!<PI[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PJ        ((uint32_t)0x9000) /*!<PJ[15] pin */
+
+/******************  Bit definition for SYSCFG_CMPCR register  ****************/
+#define SYSCFG_CMPCR_CMP_PD             ((uint32_t)0x00000001) /*!<Compensation cell power-down */
+#define SYSCFG_CMPCR_READY              ((uint32_t)0x00000100) /*!<Compensation cell ready flag*/
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    TIM                                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TIM_CR1 register  ********************/
+#define  TIM_CR1_CEN                         ((uint32_t)0x0001)            /*!<Counter enable        */
+#define  TIM_CR1_UDIS                        ((uint32_t)0x0002)            /*!<Update disable        */
+#define  TIM_CR1_URS                         ((uint32_t)0x0004)            /*!<Update request source */
+#define  TIM_CR1_OPM                         ((uint32_t)0x0008)            /*!<One pulse mode        */
+#define  TIM_CR1_DIR                         ((uint32_t)0x0010)            /*!<Direction             */
+
+#define  TIM_CR1_CMS                         ((uint32_t)0x0060)            /*!<CMS[1:0] bits (Center-aligned mode selection) */
+#define  TIM_CR1_CMS_0                       ((uint32_t)0x0020)            /*!<Bit 0 */
+#define  TIM_CR1_CMS_1                       ((uint32_t)0x0040)            /*!<Bit 1 */
+
+#define  TIM_CR1_ARPE                        ((uint32_t)0x0080)            /*!<Auto-reload preload enable     */
+
+#define  TIM_CR1_CKD                         ((uint32_t)0x0300)            /*!<CKD[1:0] bits (clock division) */
+#define  TIM_CR1_CKD_0                       ((uint32_t)0x0100)            /*!<Bit 0 */
+#define  TIM_CR1_CKD_1                       ((uint32_t)0x0200)            /*!<Bit 1 */
+#define  TIM_CR1_UIFREMAP                    ((uint32_t)0x0800)            /*!<UIF status bit */
+
+/*******************  Bit definition for TIM_CR2 register  ********************/
+#define  TIM_CR2_CCPC                        ((uint32_t)0x00000001)            /*!<Capture/Compare Preloaded Control        */
+#define  TIM_CR2_CCUS                        ((uint32_t)0x00000004)            /*!<Capture/Compare Control Update Selection */
+#define  TIM_CR2_CCDS                        ((uint32_t)0x00000008)            /*!<Capture/Compare DMA Selection            */
+
+#define  TIM_CR2_OIS5                        ((uint32_t)0x00010000)            /*!<Output Idle state 4 (OC4 output) */
+#define  TIM_CR2_OIS6                        ((uint32_t)0x00040000)            /*!<Output Idle state 4 (OC4 output) */
+
+#define  TIM_CR2_MMS                         ((uint32_t)0x0070)            /*!<MMS[2:0] bits (Master Mode Selection) */
+#define  TIM_CR2_MMS_0                       ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  TIM_CR2_MMS_1                       ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  TIM_CR2_MMS_2                       ((uint32_t)0x0040)            /*!<Bit 2 */
+
+#define  TIM_CR2_MMS2                        ((uint32_t)0x00F00000)            /*!<MMS[2:0] bits (Master Mode Selection) */
+#define  TIM_CR2_MMS2_0                      ((uint32_t)0x00100000)            /*!<Bit 0 */
+#define  TIM_CR2_MMS2_1                      ((uint32_t)0x00200000)            /*!<Bit 1 */
+#define  TIM_CR2_MMS2_2                      ((uint32_t)0x00400000)            /*!<Bit 2 */
+#define  TIM_CR2_MMS2_3                      ((uint32_t)0x00800000)            /*!<Bit 2 */
+
+#define  TIM_CR2_TI1S                        ((uint32_t)0x0080)            /*!<TI1 Selection */
+#define  TIM_CR2_OIS1                        ((uint32_t)0x0100)            /*!<Output Idle state 1 (OC1 output)  */
+#define  TIM_CR2_OIS1N                       ((uint32_t)0x0200)            /*!<Output Idle state 1 (OC1N output) */
+#define  TIM_CR2_OIS2                        ((uint32_t)0x0400)            /*!<Output Idle state 2 (OC2 output)  */
+#define  TIM_CR2_OIS2N                       ((uint32_t)0x0800)            /*!<Output Idle state 2 (OC2N output) */
+#define  TIM_CR2_OIS3                        ((uint32_t)0x1000)            /*!<Output Idle state 3 (OC3 output)  */
+#define  TIM_CR2_OIS3N                       ((uint32_t)0x2000)            /*!<Output Idle state 3 (OC3N output) */
+#define  TIM_CR2_OIS4                        ((uint32_t)0x4000)            /*!<Output Idle state 4 (OC4 output)  */
+
+/*******************  Bit definition for TIM_SMCR register  *******************/
+#define  TIM_SMCR_SMS                        ((uint32_t)0x00010007)            /*!<SMS[2:0] bits (Slave mode selection)    */
+#define  TIM_SMCR_SMS_0                      ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_SMCR_SMS_1                      ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define  TIM_SMCR_SMS_2                      ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define  TIM_SMCR_SMS_3                      ((uint32_t)0x00010000)            /*!<Bit 3 */
+#define  TIM_SMCR_OCCS                       ((uint32_t)0x00000008)            /*!< OCREF clear selection */
+
+#define  TIM_SMCR_TS                         ((uint32_t)0x0070)            /*!<TS[2:0] bits (Trigger selection)        */
+#define  TIM_SMCR_TS_0                       ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  TIM_SMCR_TS_1                       ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  TIM_SMCR_TS_2                       ((uint32_t)0x0040)            /*!<Bit 2 */
+
+#define  TIM_SMCR_MSM                        ((uint32_t)0x0080)            /*!<Master/slave mode                       */
+
+#define  TIM_SMCR_ETF                        ((uint32_t)0x0F00)            /*!<ETF[3:0] bits (External trigger filter) */
+#define  TIM_SMCR_ETF_0                      ((uint32_t)0x0100)            /*!<Bit 0 */
+#define  TIM_SMCR_ETF_1                      ((uint32_t)0x0200)            /*!<Bit 1 */
+#define  TIM_SMCR_ETF_2                      ((uint32_t)0x0400)            /*!<Bit 2 */
+#define  TIM_SMCR_ETF_3                      ((uint32_t)0x0800)            /*!<Bit 3 */
+
+#define  TIM_SMCR_ETPS                       ((uint32_t)0x3000)            /*!<ETPS[1:0] bits (External trigger prescaler) */
+#define  TIM_SMCR_ETPS_0                     ((uint32_t)0x1000)            /*!<Bit 0 */
+#define  TIM_SMCR_ETPS_1                     ((uint32_t)0x2000)            /*!<Bit 1 */
+
+
+#define  TIM_SMCR_ECE                        ((uint32_t)0x4000)            /*!<External clock enable     */
+#define  TIM_SMCR_ETP                        ((uint32_t)0x8000)            /*!<External trigger polarity */
+
+/*******************  Bit definition for TIM_DIER register  *******************/
+#define  TIM_DIER_UIE                        ((uint32_t)0x0001)            /*!<Update interrupt enable */
+#define  TIM_DIER_CC1IE                      ((uint32_t)0x0002)            /*!<Capture/Compare 1 interrupt enable   */
+#define  TIM_DIER_CC2IE                      ((uint32_t)0x0004)            /*!<Capture/Compare 2 interrupt enable   */
+#define  TIM_DIER_CC3IE                      ((uint32_t)0x0008)            /*!<Capture/Compare 3 interrupt enable   */
+#define  TIM_DIER_CC4IE                      ((uint32_t)0x0010)            /*!<Capture/Compare 4 interrupt enable   */
+#define  TIM_DIER_COMIE                      ((uint32_t)0x0020)            /*!<COM interrupt enable                 */
+#define  TIM_DIER_TIE                        ((uint32_t)0x0040)            /*!<Trigger interrupt enable             */
+#define  TIM_DIER_BIE                        ((uint32_t)0x0080)            /*!<Break interrupt enable               */
+#define  TIM_DIER_UDE                        ((uint32_t)0x0100)            /*!<Update DMA request enable            */
+#define  TIM_DIER_CC1DE                      ((uint32_t)0x0200)            /*!<Capture/Compare 1 DMA request enable */
+#define  TIM_DIER_CC2DE                      ((uint32_t)0x0400)            /*!<Capture/Compare 2 DMA request enable */
+#define  TIM_DIER_CC3DE                      ((uint32_t)0x0800)            /*!<Capture/Compare 3 DMA request enable */
+#define  TIM_DIER_CC4DE                      ((uint32_t)0x1000)            /*!<Capture/Compare 4 DMA request enable */
+#define  TIM_DIER_COMDE                      ((uint32_t)0x2000)            /*!<COM DMA request enable               */
+#define  TIM_DIER_TDE                        ((uint32_t)0x4000)            /*!<Trigger DMA request enable           */
+
+/********************  Bit definition for TIM_SR register  ********************/
+#define  TIM_SR_UIF                          ((uint32_t)0x0001)            /*!<Update interrupt Flag              */
+#define  TIM_SR_CC1IF                        ((uint32_t)0x0002)            /*!<Capture/Compare 1 interrupt Flag   */
+#define  TIM_SR_CC2IF                        ((uint32_t)0x0004)            /*!<Capture/Compare 2 interrupt Flag   */
+#define  TIM_SR_CC3IF                        ((uint32_t)0x0008)            /*!<Capture/Compare 3 interrupt Flag   */
+#define  TIM_SR_CC4IF                        ((uint32_t)0x0010)            /*!<Capture/Compare 4 interrupt Flag   */
+#define  TIM_SR_COMIF                        ((uint32_t)0x0020)            /*!<COM interrupt Flag                 */
+#define  TIM_SR_TIF                          ((uint32_t)0x0040)            /*!<Trigger interrupt Flag             */
+#define  TIM_SR_BIF                          ((uint32_t)0x0080)            /*!<Break interrupt Flag               */
+#define  TIM_SR_B2IF                         ((uint32_t)0x0100)            /*!<Break2 interrupt Flag               */
+#define  TIM_SR_CC1OF                        ((uint32_t)0x0200)            /*!<Capture/Compare 1 Overcapture Flag */
+#define  TIM_SR_CC2OF                        ((uint32_t)0x0400)            /*!<Capture/Compare 2 Overcapture Flag */
+#define  TIM_SR_CC3OF                        ((uint32_t)0x0800)            /*!<Capture/Compare 3 Overcapture Flag */
+#define  TIM_SR_CC4OF                        ((uint32_t)0x1000)            /*!<Capture/Compare 4 Overcapture Flag */
+
+/*******************  Bit definition for TIM_EGR register  ********************/
+#define  TIM_EGR_UG                          ((uint32_t)0x00000001)               /*!<Update Generation                         */
+#define  TIM_EGR_CC1G                        ((uint32_t)0x00000002)               /*!<Capture/Compare 1 Generation              */
+#define  TIM_EGR_CC2G                        ((uint32_t)0x00000004)               /*!<Capture/Compare 2 Generation              */
+#define  TIM_EGR_CC3G                        ((uint32_t)0x00000008)               /*!<Capture/Compare 3 Generation              */
+#define  TIM_EGR_CC4G                        ((uint32_t)0x00000010)               /*!<Capture/Compare 4 Generation              */
+#define  TIM_EGR_COMG                        ((uint32_t)0x00000020)               /*!<Capture/Compare Control Update Generation */
+#define  TIM_EGR_TG                          ((uint32_t)0x00000040)               /*!<Trigger Generation                        */
+#define  TIM_EGR_BG                          ((uint32_t)0x00000080)               /*!<Break Generation                          */
+#define  TIM_EGR_B2G                         ((uint32_t)0x00000100)              /*!<Break2 Generation                          */
+
+/******************  Bit definition for TIM_CCMR1 register  *******************/
+#define  TIM_CCMR1_CC1S                      ((uint32_t)0x00000003)            /*!<CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define  TIM_CCMR1_CC1S_0                    ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_CCMR1_CC1S_1                    ((uint32_t)0x00000002)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_OC1FE                     ((uint32_t)0x00000004)            /*!<Output Compare 1 Fast enable                 */
+#define  TIM_CCMR1_OC1PE                     ((uint32_t)0x00000008)            /*!<Output Compare 1 Preload enable              */
+
+#define  TIM_CCMR1_OC1M                      ((uint32_t)0x00010070)            /*!<OC1M[2:0] bits (Output Compare 1 Mode)       */
+#define  TIM_CCMR1_OC1M_0                    ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  TIM_CCMR1_OC1M_1                    ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  TIM_CCMR1_OC1M_2                    ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define  TIM_CCMR1_OC1M_3                    ((uint32_t)0x00010000)            /*!<Bit 3 */
+
+#define  TIM_CCMR1_OC1CE                     ((uint32_t)0x00000080)            /*!<Output Compare 1Clear Enable                 */
+
+#define  TIM_CCMR1_CC2S                      ((uint32_t)0x00000300)            /*!<CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define  TIM_CCMR1_CC2S_0                    ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  TIM_CCMR1_CC2S_1                    ((uint32_t)0x00000200)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_OC2FE                     ((uint32_t)0x00000400)            /*!<Output Compare 2 Fast enable                 */
+#define  TIM_CCMR1_OC2PE                     ((uint32_t)0x00000800)            /*!<Output Compare 2 Preload enable              */
+
+#define  TIM_CCMR1_OC2M                      ((uint32_t)0x01007000)            /*!<OC2M[2:0] bits (Output Compare 2 Mode)       */
+#define  TIM_CCMR1_OC2M_0                    ((uint32_t)0x00001000)            /*!<Bit 0 */
+#define  TIM_CCMR1_OC2M_1                    ((uint32_t)0x00002000)            /*!<Bit 1 */
+#define  TIM_CCMR1_OC2M_2                    ((uint32_t)0x00004000)            /*!<Bit 2 */
+#define  TIM_CCMR1_OC2M_3                    ((uint32_t)0x01000000)            /*!<Bit 3 */
+
+#define  TIM_CCMR1_OC2CE                     ((uint32_t)0x00008000)            /*!<Output Compare 2 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+
+#define  TIM_CCMR1_IC1PSC                    ((uint32_t)0x000C)            /*!<IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define  TIM_CCMR1_IC1PSC_0                  ((uint32_t)0x0004)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC1PSC_1                  ((uint32_t)0x0008)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_IC1F                      ((uint32_t)0x00F0)            /*!<IC1F[3:0] bits (Input Capture 1 Filter)      */
+#define  TIM_CCMR1_IC1F_0                    ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC1F_1                    ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  TIM_CCMR1_IC1F_2                    ((uint32_t)0x0040)            /*!<Bit 2 */
+#define  TIM_CCMR1_IC1F_3                    ((uint32_t)0x0080)            /*!<Bit 3 */
+
+#define  TIM_CCMR1_IC2PSC                    ((uint32_t)0x0C00)            /*!<IC2PSC[1:0] bits (Input Capture 2 Prescaler)  */
+#define  TIM_CCMR1_IC2PSC_0                  ((uint32_t)0x0400)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC2PSC_1                  ((uint32_t)0x0800)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_IC2F                      ((uint32_t)0xF000)            /*!<IC2F[3:0] bits (Input Capture 2 Filter)       */
+#define  TIM_CCMR1_IC2F_0                    ((uint32_t)0x1000)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC2F_1                    ((uint32_t)0x2000)            /*!<Bit 1 */
+#define  TIM_CCMR1_IC2F_2                    ((uint32_t)0x4000)            /*!<Bit 2 */
+#define  TIM_CCMR1_IC2F_3                    ((uint32_t)0x8000)            /*!<Bit 3 */
+
+/******************  Bit definition for TIM_CCMR2 register  *******************/
+#define  TIM_CCMR2_CC3S                      ((uint32_t)0x00000003)        /*!<CC3S[1:0] bits (Capture/Compare 3 Selection)  */
+#define  TIM_CCMR2_CC3S_0                    ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  TIM_CCMR2_CC3S_1                    ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  TIM_CCMR2_OC3FE                     ((uint32_t)0x00000004)        /*!<Output Compare 3 Fast enable           */
+#define  TIM_CCMR2_OC3PE                     ((uint32_t)0x00000008)        /*!<Output Compare 3 Preload enable        */
+
+#define  TIM_CCMR2_OC3M                      ((uint32_t)0x00010070)        /*!<OC3M[2:0] bits (Output Compare 3 Mode) */
+#define  TIM_CCMR2_OC3M_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  TIM_CCMR2_OC3M_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  TIM_CCMR2_OC3M_2                    ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  TIM_CCMR2_OC3M_3                    ((uint32_t)0x00010000)        /*!<Bit 3 */
+
+
+
+#define  TIM_CCMR2_OC3CE                     ((uint32_t)0x00000080)        /*!<Output Compare 3 Clear Enable */
+
+#define  TIM_CCMR2_CC4S                      ((uint32_t)0x00000300)        /*!<CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define  TIM_CCMR2_CC4S_0                    ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  TIM_CCMR2_CC4S_1                    ((uint32_t)0x00000200)        /*!<Bit 1 */
+
+#define  TIM_CCMR2_OC4FE                     ((uint32_t)0x00000400)        /*!<Output Compare 4 Fast enable    */
+#define  TIM_CCMR2_OC4PE                     ((uint32_t)0x00000800)        /*!<Output Compare 4 Preload enable */
+
+#define  TIM_CCMR2_OC4M                      ((uint32_t)0x01007000)        /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define  TIM_CCMR2_OC4M_0                    ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  TIM_CCMR2_OC4M_1                    ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  TIM_CCMR2_OC4M_2                    ((uint32_t)0x00004000)        /*!<Bit 2 */
+#define  TIM_CCMR2_OC4M_3                    ((uint32_t)0x01000000)        /*!<Bit 3 */
+
+#define  TIM_CCMR2_OC4CE                     ((uint32_t)0x8000)            /*!<Output Compare 4 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+
+#define  TIM_CCMR2_IC3PSC                    ((uint32_t)0x000C)            /*!<IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define  TIM_CCMR2_IC3PSC_0                  ((uint32_t)0x0004)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC3PSC_1                  ((uint32_t)0x0008)            /*!<Bit 1 */
+
+#define  TIM_CCMR2_IC3F                      ((uint32_t)0x00F0)            /*!<IC3F[3:0] bits (Input Capture 3 Filter) */
+#define  TIM_CCMR2_IC3F_0                    ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC3F_1                    ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  TIM_CCMR2_IC3F_2                    ((uint32_t)0x0040)            /*!<Bit 2 */
+#define  TIM_CCMR2_IC3F_3                    ((uint32_t)0x0080)            /*!<Bit 3 */
+
+#define  TIM_CCMR2_IC4PSC                    ((uint32_t)0x0C00)            /*!<IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define  TIM_CCMR2_IC4PSC_0                  ((uint32_t)0x0400)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC4PSC_1                  ((uint32_t)0x0800)            /*!<Bit 1 */
+
+#define  TIM_CCMR2_IC4F                      ((uint32_t)0xF000)            /*!<IC4F[3:0] bits (Input Capture 4 Filter) */
+#define  TIM_CCMR2_IC4F_0                    ((uint32_t)0x1000)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC4F_1                    ((uint32_t)0x2000)            /*!<Bit 1 */
+#define  TIM_CCMR2_IC4F_2                    ((uint32_t)0x4000)            /*!<Bit 2 */
+#define  TIM_CCMR2_IC4F_3                    ((uint32_t)0x8000)            /*!<Bit 3 */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define  TIM_CCER_CC1E                       ((uint32_t)0x00000001)            /*!<Capture/Compare 1 output enable */
+#define  TIM_CCER_CC1P                       ((uint32_t)0x00000002)            /*!<Capture/Compare 1 output Polarity */
+#define  TIM_CCER_CC1NE                      ((uint32_t)0x00000004)            /*!<Capture/Compare 1 Complementary output enable */
+#define  TIM_CCER_CC1NP                      ((uint32_t)0x00000008)            /*!<Capture/Compare 1 Complementary output Polarity */
+#define  TIM_CCER_CC2E                       ((uint32_t)0x00000010)            /*!<Capture/Compare 2 output enable */
+#define  TIM_CCER_CC2P                       ((uint32_t)0x00000020)            /*!<Capture/Compare 2 output Polarity */
+#define  TIM_CCER_CC2NE                      ((uint32_t)0x00000040)            /*!<Capture/Compare 2 Complementary output enable */
+#define  TIM_CCER_CC2NP                      ((uint32_t)0x00000080)            /*!<Capture/Compare 2 Complementary output Polarity */
+#define  TIM_CCER_CC3E                       ((uint32_t)0x00000100)            /*!<Capture/Compare 3 output enable */
+#define  TIM_CCER_CC3P                       ((uint32_t)0x00000200)            /*!<Capture/Compare 3 output Polarity */
+#define  TIM_CCER_CC3NE                      ((uint32_t)0x00000400)            /*!<Capture/Compare 3 Complementary output enable */
+#define  TIM_CCER_CC3NP                      ((uint32_t)0x00000800)            /*!<Capture/Compare 3 Complementary output Polarity */
+#define  TIM_CCER_CC4E                       ((uint32_t)0x00001000)            /*!<Capture/Compare 4 output enable */
+#define  TIM_CCER_CC4P                       ((uint32_t)0x00002000)            /*!<Capture/Compare 4 output Polarity */
+#define  TIM_CCER_CC4NP                      ((uint32_t)0x00008000)            /*!<Capture/Compare 4 Complementary output Polarity */
+#define  TIM_CCER_CC5E                       ((uint32_t)0x00010000)            /*!<Capture/Compare 5 output enable */
+#define  TIM_CCER_CC5P                       ((uint32_t)0x00020000)            /*!<Capture/Compare 5 output Polarity */
+#define  TIM_CCER_CC6E                       ((uint32_t)0x00100000)            /*!<Capture/Compare 6 output enable */
+#define  TIM_CCER_CC6P                       ((uint32_t)0x00200000)            /*!<Capture/Compare 6 output Polarity */
+
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define  TIM_CNT_CNT                         ((uint32_t)0xFFFF)            /*!<Counter Value            */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define  TIM_PSC_PSC                         ((uint32_t)0xFFFF)            /*!<Prescaler Value          */
+
+/*******************  Bit definition for TIM_ARR register  ********************/
+#define  TIM_ARR_ARR                         ((uint32_t)0xFFFF)            /*!<actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RCR register  ********************/
+#define  TIM_RCR_REP                         ((uint8_t)0xFF)               /*!<Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CCR1 register  *******************/
+#define  TIM_CCR1_CCR1                       ((uint32_t)0xFFFF)            /*!<Capture/Compare 1 Value  */
+
+/*******************  Bit definition for TIM_CCR2 register  *******************/
+#define  TIM_CCR2_CCR2                       ((uint32_t)0xFFFF)            /*!<Capture/Compare 2 Value  */
+
+/*******************  Bit definition for TIM_CCR3 register  *******************/
+#define  TIM_CCR3_CCR3                       ((uint32_t)0xFFFF)            /*!<Capture/Compare 3 Value  */
+
+/*******************  Bit definition for TIM_CCR4 register  *******************/
+#define  TIM_CCR4_CCR4                       ((uint32_t)0xFFFF)            /*!<Capture/Compare 4 Value  */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define  TIM_BDTR_DTG                        ((uint32_t)0x000000FF)            /*!<DTG[0:7] bits (Dead-Time Generator set-up) */
+#define  TIM_BDTR_DTG_0                      ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_BDTR_DTG_1                      ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define  TIM_BDTR_DTG_2                      ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define  TIM_BDTR_DTG_3                      ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define  TIM_BDTR_DTG_4                      ((uint32_t)0x00000010)            /*!<Bit 4 */
+#define  TIM_BDTR_DTG_5                      ((uint32_t)0x00000020)            /*!<Bit 5 */
+#define  TIM_BDTR_DTG_6                      ((uint32_t)0x00000040)            /*!<Bit 6 */
+#define  TIM_BDTR_DTG_7                      ((uint32_t)0x00000080)            /*!<Bit 7 */
+
+#define  TIM_BDTR_LOCK                       ((uint32_t)0x00000300)            /*!<LOCK[1:0] bits (Lock Configuration) */
+#define  TIM_BDTR_LOCK_0                     ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  TIM_BDTR_LOCK_1                     ((uint32_t)0x00000200)            /*!<Bit 1 */
+
+#define  TIM_BDTR_OSSI                       ((uint32_t)0x00000400)            /*!<Off-State Selection for Idle mode */
+#define  TIM_BDTR_OSSR                       ((uint32_t)0x00000800)            /*!<Off-State Selection for Run mode  */
+#define  TIM_BDTR_BKE                        ((uint32_t)0x00001000)            /*!<Break enable                      */
+#define  TIM_BDTR_BKP                        ((uint32_t)0x00002000)            /*!<Break Polarity                    */
+#define  TIM_BDTR_AOE                        ((uint32_t)0x00004000)            /*!<Automatic Output enable           */
+#define  TIM_BDTR_MOE                        ((uint32_t)0x00008000)            /*!<Main Output enable                */
+#define  TIM_BDTR_BKF                        ((uint32_t)0x000F0000)            /*!<Break Filter for Break1 */
+#define  TIM_BDTR_BK2F                       ((uint32_t)0x00F00000)            /*!<Break Filter for Break2 */
+#define  TIM_BDTR_BK2E                       ((uint32_t)0x01000000)            /*!<Break enable for Break2 */
+#define  TIM_BDTR_BK2P                       ((uint32_t)0x02000000)            /*!<Break Polarity for Break2 */
+
+/*******************  Bit definition for TIM_DCR register  ********************/
+#define  TIM_DCR_DBA                         ((uint32_t)0x001F)            /*!<DBA[4:0] bits (DMA Base Address) */
+#define  TIM_DCR_DBA_0                       ((uint32_t)0x0001)            /*!<Bit 0 */
+#define  TIM_DCR_DBA_1                       ((uint32_t)0x0002)            /*!<Bit 1 */
+#define  TIM_DCR_DBA_2                       ((uint32_t)0x0004)            /*!<Bit 2 */
+#define  TIM_DCR_DBA_3                       ((uint32_t)0x0008)            /*!<Bit 3 */
+#define  TIM_DCR_DBA_4                       ((uint32_t)0x0010)            /*!<Bit 4 */
+
+#define  TIM_DCR_DBL                         ((uint32_t)0x1F00)            /*!<DBL[4:0] bits (DMA Burst Length) */
+#define  TIM_DCR_DBL_0                       ((uint32_t)0x0100)            /*!<Bit 0 */
+#define  TIM_DCR_DBL_1                       ((uint32_t)0x0200)            /*!<Bit 1 */
+#define  TIM_DCR_DBL_2                       ((uint32_t)0x0400)            /*!<Bit 2 */
+#define  TIM_DCR_DBL_3                       ((uint32_t)0x0800)            /*!<Bit 3 */
+#define  TIM_DCR_DBL_4                       ((uint32_t)0x1000)            /*!<Bit 4 */
+
+/*******************  Bit definition for TIM_DMAR register  *******************/
+#define  TIM_DMAR_DMAB                       ((uint32_t)0xFFFF)            /*!<DMA register for burst accesses                    */
+
+/*******************  Bit definition for TIM_OR register  *********************/
+#define TIM_OR_TI4_RMP                       ((uint32_t)0x00C0)            /*!<TI4_RMP[1:0] bits (TIM5 Input 4 remap)             */
+#define TIM_OR_TI4_RMP_0                     ((uint32_t)0x0040)            /*!<Bit 0 */
+#define TIM_OR_TI4_RMP_1                     ((uint32_t)0x0080)            /*!<Bit 1 */
+#define TIM_OR_ITR1_RMP                      ((uint32_t)0x0C00)            /*!<ITR1_RMP[1:0] bits (TIM2 Internal trigger 1 remap) */
+#define TIM_OR_ITR1_RMP_0                    ((uint32_t)0x0400)            /*!<Bit 0 */
+#define TIM_OR_ITR1_RMP_1                    ((uint32_t)0x0800)            /*!<Bit 1 */
+
+/******************  Bit definition for TIM_CCMR3 register  *******************/
+#define  TIM_CCMR3_OC5FE                     ((uint32_t)0x00000004)            /*!<Output Compare 5 Fast enable */
+#define  TIM_CCMR3_OC5PE                     ((uint32_t)0x00000008)            /*!<Output Compare 5 Preload enable */
+
+#define  TIM_CCMR3_OC5M                      ((uint32_t)0x00010070)            /*!<OC5M[2:0] bits (Output Compare 5 Mode) */
+#define  TIM_CCMR3_OC5M_0                    ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  TIM_CCMR3_OC5M_1                    ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  TIM_CCMR3_OC5M_2                    ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define  TIM_CCMR3_OC5M_3                    ((uint32_t)0x00010000)            /*!<Bit 3 */
+
+#define  TIM_CCMR3_OC5CE                     ((uint32_t)0x00000080)            /*!<Output Compare 5 Clear Enable */
+
+#define  TIM_CCMR3_OC6FE                     ((uint32_t)0x00000400)            /*!<Output Compare 4 Fast enable */
+#define  TIM_CCMR3_OC6PE                     ((uint32_t)0x00000800)            /*!<Output Compare 4 Preload enable */
+
+#define  TIM_CCMR3_OC6M                      ((uint32_t)0x01007000)            /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define  TIM_CCMR3_OC6M_0                    ((uint32_t)0x00001000)            /*!<Bit 0 */
+#define  TIM_CCMR3_OC6M_1                    ((uint32_t)0x00002000)            /*!<Bit 1 */
+#define  TIM_CCMR3_OC6M_2                    ((uint32_t)0x00004000)            /*!<Bit 2 */
+#define  TIM_CCMR3_OC6M_3                    ((uint32_t)0x01000000)            /*!<Bit 3 */
+
+#define  TIM_CCMR3_OC6CE                     ((uint32_t)0x00008000)            /*!<Output Compare 4 Clear Enable */
+
+/*******************  Bit definition for TIM_CCR5 register  *******************/
+#define  TIM_CCR5_CCR5                       ((uint32_t)0xFFFFFFFF)        /*!<Capture/Compare 5 Value */
+#define  TIM_CCR5_GC5C1                      ((uint32_t)0x20000000)        /*!<Group Channel 5 and Channel 1 */
+#define  TIM_CCR5_GC5C2                      ((uint32_t)0x40000000)        /*!<Group Channel 5 and Channel 2 */
+#define  TIM_CCR5_GC5C3                      ((uint32_t)0x80000000)        /*!<Group Channel 5 and Channel 3 */
+
+/*******************  Bit definition for TIM_CCR6 register  *******************/
+#define  TIM_CCR6_CCR6                       ((uint16_t)0xFFFF)            /*!<Capture/Compare 6 Value */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Low Power Timer (LPTIM)                            */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for LPTIM_ISR register  *******************/
+#define  LPTIM_ISR_CMPM                         ((uint32_t)0x00000001)            /*!< Compare match                       */
+#define  LPTIM_ISR_ARRM                         ((uint32_t)0x00000002)            /*!< Autoreload match                    */
+#define  LPTIM_ISR_EXTTRIG                      ((uint32_t)0x00000004)            /*!< External trigger edge event         */
+#define  LPTIM_ISR_CMPOK                        ((uint32_t)0x00000008)            /*!< Compare register update OK          */
+#define  LPTIM_ISR_ARROK                        ((uint32_t)0x00000010)            /*!< Autoreload register update OK       */
+#define  LPTIM_ISR_UP                           ((uint32_t)0x00000020)            /*!< Counter direction change down to up */
+#define  LPTIM_ISR_DOWN                         ((uint32_t)0x00000040)            /*!< Counter direction change up to down */
+
+/******************  Bit definition for LPTIM_ICR register  *******************/
+#define  LPTIM_ICR_CMPMCF                       ((uint32_t)0x00000001)            /*!< Compare match Clear Flag                       */
+#define  LPTIM_ICR_ARRMCF                       ((uint32_t)0x00000002)            /*!< Autoreload match Clear Flag                    */
+#define  LPTIM_ICR_EXTTRIGCF                    ((uint32_t)0x00000004)            /*!< External trigger edge event Clear Flag         */
+#define  LPTIM_ICR_CMPOKCF                      ((uint32_t)0x00000008)            /*!< Compare register update OK Clear Flag          */
+#define  LPTIM_ICR_ARROKCF                      ((uint32_t)0x00000010)            /*!< Autoreload register update OK Clear Flag       */
+#define  LPTIM_ICR_UPCF                         ((uint32_t)0x00000020)            /*!< Counter direction change down to up Clear Flag */
+#define  LPTIM_ICR_DOWNCF                       ((uint32_t)0x00000040)            /*!< Counter direction change up to down Clear Flag */
+
+/******************  Bit definition for LPTIM_IER register ********************/
+#define  LPTIM_IER_CMPMIE                       ((uint32_t)0x00000001)            /*!< Compare match Interrupt Enable                       */
+#define  LPTIM_IER_ARRMIE                       ((uint32_t)0x00000002)            /*!< Autoreload match Interrupt Enable                    */
+#define  LPTIM_IER_EXTTRIGIE                    ((uint32_t)0x00000004)            /*!< External trigger edge event Interrupt Enable         */
+#define  LPTIM_IER_CMPOKIE                      ((uint32_t)0x00000008)            /*!< Compare register update OK Interrupt Enable          */
+#define  LPTIM_IER_ARROKIE                      ((uint32_t)0x00000010)            /*!< Autoreload register update OK Interrupt Enable       */
+#define  LPTIM_IER_UPIE                         ((uint32_t)0x00000020)            /*!< Counter direction change down to up Interrupt Enable */
+#define  LPTIM_IER_DOWNIE                       ((uint32_t)0x00000040)            /*!< Counter direction change up to down Interrupt Enable */
+
+/******************  Bit definition for LPTIM_CFGR register *******************/
+#define  LPTIM_CFGR_CKSEL                       ((uint32_t)0x00000001)             /*!< Clock selector */
+
+#define  LPTIM_CFGR_CKPOL                       ((uint32_t)0x00000006)             /*!< CKPOL[1:0] bits (Clock polarity) */
+#define  LPTIM_CFGR_CKPOL_0                     ((uint32_t)0x00000002)             /*!< Bit 0 */
+#define  LPTIM_CFGR_CKPOL_1                     ((uint32_t)0x00000004)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_CKFLT                       ((uint32_t)0x00000018)             /*!< CKFLT[1:0] bits (Configurable digital filter for external clock) */
+#define  LPTIM_CFGR_CKFLT_0                     ((uint32_t)0x00000008)             /*!< Bit 0 */
+#define  LPTIM_CFGR_CKFLT_1                     ((uint32_t)0x00000010)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_TRGFLT                      ((uint32_t)0x000000C0)             /*!< TRGFLT[1:0] bits (Configurable digital filter for trigger) */
+#define  LPTIM_CFGR_TRGFLT_0                    ((uint32_t)0x00000040)             /*!< Bit 0 */
+#define  LPTIM_CFGR_TRGFLT_1                    ((uint32_t)0x00000080)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_PRESC                       ((uint32_t)0x00000E00)             /*!< PRESC[2:0] bits (Clock prescaler) */
+#define  LPTIM_CFGR_PRESC_0                     ((uint32_t)0x00000200)             /*!< Bit 0 */
+#define  LPTIM_CFGR_PRESC_1                     ((uint32_t)0x00000400)             /*!< Bit 1 */
+#define  LPTIM_CFGR_PRESC_2                     ((uint32_t)0x00000800)             /*!< Bit 2 */
+
+#define  LPTIM_CFGR_TRIGSEL                     ((uint32_t)0x0000E000)             /*!< TRIGSEL[2:0]] bits (Trigger selector) */
+#define  LPTIM_CFGR_TRIGSEL_0                   ((uint32_t)0x00002000)             /*!< Bit 0 */
+#define  LPTIM_CFGR_TRIGSEL_1                   ((uint32_t)0x00004000)             /*!< Bit 1 */
+#define  LPTIM_CFGR_TRIGSEL_2                   ((uint32_t)0x00008000)             /*!< Bit 2 */
+
+#define  LPTIM_CFGR_TRIGEN                      ((uint32_t)0x00060000)             /*!< TRIGEN[1:0] bits (Trigger enable and polarity) */
+#define  LPTIM_CFGR_TRIGEN_0                    ((uint32_t)0x00020000)             /*!< Bit 0 */
+#define  LPTIM_CFGR_TRIGEN_1                    ((uint32_t)0x00040000)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_TIMOUT                      ((uint32_t)0x00080000)             /*!< Timout enable           */
+#define  LPTIM_CFGR_WAVE                        ((uint32_t)0x00100000)             /*!< Waveform shape          */
+#define  LPTIM_CFGR_WAVPOL                      ((uint32_t)0x00200000)             /*!< Waveform shape polarity */
+#define  LPTIM_CFGR_PRELOAD                     ((uint32_t)0x00400000)             /*!< Reg update mode         */
+#define  LPTIM_CFGR_COUNTMODE                   ((uint32_t)0x00800000)             /*!< Counter mode enable     */
+#define  LPTIM_CFGR_ENC                         ((uint32_t)0x01000000)             /*!< Encoder mode enable     */
+
+/******************  Bit definition for LPTIM_CR register  ********************/
+#define  LPTIM_CR_ENABLE                        ((uint32_t)0x00000001)             /*!< LPTIMer enable                 */
+#define  LPTIM_CR_SNGSTRT                       ((uint32_t)0x00080002)             /*!< Timer start in single mode     */
+#define  LPTIM_CR_CNTSTRT                       ((uint32_t)0x00000004)             /*!< Timer start in continuous mode */
+
+/******************  Bit definition for LPTIM_CMP register  *******************/
+#define  LPTIM_CMP_CMP                          ((uint32_t)0x0000FFFF)             /*!< Compare register     */
+
+/******************  Bit definition for LPTIM_ARR register  *******************/
+#define  LPTIM_ARR_ARR                          ((uint32_t)0x0000FFFF)             /*!< Auto reload register */
+
+/******************  Bit definition for LPTIM_CNT register  *******************/
+#define  LPTIM_CNT_CNT                          ((uint32_t)0x0000FFFF)             /*!< Counter register     */
+/******************************************************************************/
+/*                                                                            */
+/*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for USART_CR1 register  *******************/
+#define  USART_CR1_UE                        ((uint32_t)0x00000001)            /*!< USART Enable                                    */
+#define  USART_CR1_RE                        ((uint32_t)0x00000004)            /*!< Receiver Enable                                 */
+#define  USART_CR1_TE                        ((uint32_t)0x00000008)            /*!< Transmitter Enable                              */
+#define  USART_CR1_IDLEIE                    ((uint32_t)0x00000010)            /*!< IDLE Interrupt Enable                           */
+#define  USART_CR1_RXNEIE                    ((uint32_t)0x00000020)            /*!< RXNE Interrupt Enable                           */
+#define  USART_CR1_TCIE                      ((uint32_t)0x00000040)            /*!< Transmission Complete Interrupt Enable          */
+#define  USART_CR1_TXEIE                     ((uint32_t)0x00000080)            /*!< TXE Interrupt Enable                            */
+#define  USART_CR1_PEIE                      ((uint32_t)0x00000100)            /*!< PE Interrupt Enable                             */
+#define  USART_CR1_PS                        ((uint32_t)0x00000200)            /*!< Parity Selection                                */
+#define  USART_CR1_PCE                       ((uint32_t)0x00000400)            /*!< Parity Control Enable                           */
+#define  USART_CR1_WAKE                      ((uint32_t)0x00000800)            /*!< Receiver Wakeup method                          */
+#define  USART_CR1_M                         ((uint32_t)0x10001000)            /*!< Word length                                     */
+#define  USART_CR1_M_0                       ((uint32_t)0x00001000)            /*!< Word length - Bit 0                             */
+#define  USART_CR1_MME                       ((uint32_t)0x00002000)            /*!< Mute Mode Enable                                */
+#define  USART_CR1_CMIE                      ((uint32_t)0x00004000)            /*!< Character match interrupt enable                */
+#define  USART_CR1_OVER8                     ((uint32_t)0x00008000)            /*!< Oversampling by 8-bit or 16-bit mode            */
+#define  USART_CR1_DEDT                      ((uint32_t)0x001F0000)            /*!< DEDT[4:0] bits (Driver Enable Deassertion Time) */
+#define  USART_CR1_DEDT_0                    ((uint32_t)0x00010000)            /*!< Bit 0 */
+#define  USART_CR1_DEDT_1                    ((uint32_t)0x00020000)            /*!< Bit 1 */
+#define  USART_CR1_DEDT_2                    ((uint32_t)0x00040000)            /*!< Bit 2 */
+#define  USART_CR1_DEDT_3                    ((uint32_t)0x00080000)            /*!< Bit 3 */
+#define  USART_CR1_DEDT_4                    ((uint32_t)0x00100000)            /*!< Bit 4 */
+#define  USART_CR1_DEAT                      ((uint32_t)0x03E00000)            /*!< DEAT[4:0] bits (Driver Enable Assertion Time)   */
+#define  USART_CR1_DEAT_0                    ((uint32_t)0x00200000)            /*!< Bit 0 */
+#define  USART_CR1_DEAT_1                    ((uint32_t)0x00400000)            /*!< Bit 1 */
+#define  USART_CR1_DEAT_2                    ((uint32_t)0x00800000)            /*!< Bit 2 */
+#define  USART_CR1_DEAT_3                    ((uint32_t)0x01000000)            /*!< Bit 3 */
+#define  USART_CR1_DEAT_4                    ((uint32_t)0x02000000)            /*!< Bit 4 */
+#define  USART_CR1_RTOIE                     ((uint32_t)0x04000000)            /*!< Receive Time Out interrupt enable */
+#define  USART_CR1_EOBIE                     ((uint32_t)0x08000000)            /*!< End of Block interrupt enable     */
+#define  USART_CR1_M_1                       ((uint32_t)0x10000000)            /*!< Word length - Bit 1               */
+
+/******************  Bit definition for USART_CR2 register  *******************/
+#define  USART_CR2_ADDM7                     ((uint32_t)0x00000010)            /*!< 7-bit or 4-bit Address Detection       */
+#define  USART_CR2_LBDL                      ((uint32_t)0x00000020)            /*!< LIN Break Detection Length             */
+#define  USART_CR2_LBDIE                     ((uint32_t)0x00000040)            /*!< LIN Break Detection Interrupt Enable   */
+#define  USART_CR2_LBCL                      ((uint32_t)0x00000100)            /*!< Last Bit Clock pulse                   */
+#define  USART_CR2_CPHA                      ((uint32_t)0x00000200)            /*!< Clock Phase                            */
+#define  USART_CR2_CPOL                      ((uint32_t)0x00000400)            /*!< Clock Polarity                         */
+#define  USART_CR2_CLKEN                     ((uint32_t)0x00000800)            /*!< Clock Enable                           */
+#define  USART_CR2_STOP                      ((uint32_t)0x00003000)            /*!< STOP[1:0] bits (STOP bits)             */
+#define  USART_CR2_STOP_0                    ((uint32_t)0x00001000)            /*!< Bit 0 */
+#define  USART_CR2_STOP_1                    ((uint32_t)0x00002000)            /*!< Bit 1 */
+#define  USART_CR2_LINEN                     ((uint32_t)0x00004000)            /*!< LIN mode enable                        */
+#define  USART_CR2_SWAP                      ((uint32_t)0x00008000)            /*!< SWAP TX/RX pins                        */
+#define  USART_CR2_RXINV                     ((uint32_t)0x00010000)            /*!< RX pin active level inversion          */
+#define  USART_CR2_TXINV                     ((uint32_t)0x00020000)            /*!< TX pin active level inversion          */
+#define  USART_CR2_DATAINV                   ((uint32_t)0x00040000)            /*!< Binary data inversion                  */
+#define  USART_CR2_MSBFIRST                  ((uint32_t)0x00080000)            /*!< Most Significant Bit First             */
+#define  USART_CR2_ABREN                     ((uint32_t)0x00100000)            /*!< Auto Baud-Rate Enable                  */
+#define  USART_CR2_ABRMODE                   ((uint32_t)0x00600000)            /*!< ABRMOD[1:0] bits (Auto Baud-Rate Mode) */
+#define  USART_CR2_ABRMODE_0                 ((uint32_t)0x00200000)            /*!< Bit 0 */
+#define  USART_CR2_ABRMODE_1                 ((uint32_t)0x00400000)            /*!< Bit 1 */
+#define  USART_CR2_RTOEN                     ((uint32_t)0x00800000)            /*!< Receiver Time-Out enable  */
+#define  USART_CR2_ADD                       ((uint32_t)0xFF000000)            /*!< Address of the USART node */
+
+/******************  Bit definition for USART_CR3 register  *******************/
+#define  USART_CR3_EIE                       ((uint32_t)0x00000001)            /*!< Error Interrupt Enable                         */
+#define  USART_CR3_IREN                      ((uint32_t)0x00000002)            /*!< IrDA mode Enable                               */
+#define  USART_CR3_IRLP                      ((uint32_t)0x00000004)            /*!< IrDA Low-Power                                 */
+#define  USART_CR3_HDSEL                     ((uint32_t)0x00000008)            /*!< Half-Duplex Selection                          */
+#define  USART_CR3_NACK                      ((uint32_t)0x00000010)            /*!< SmartCard NACK enable                          */
+#define  USART_CR3_SCEN                      ((uint32_t)0x00000020)            /*!< SmartCard mode enable                          */
+#define  USART_CR3_DMAR                      ((uint32_t)0x00000040)            /*!< DMA Enable Receiver                            */
+#define  USART_CR3_DMAT                      ((uint32_t)0x00000080)            /*!< DMA Enable Transmitter                         */
+#define  USART_CR3_RTSE                      ((uint32_t)0x00000100)            /*!< RTS Enable                                     */
+#define  USART_CR3_CTSE                      ((uint32_t)0x00000200)            /*!< CTS Enable                                     */
+#define  USART_CR3_CTSIE                     ((uint32_t)0x00000400)            /*!< CTS Interrupt Enable                           */
+#define  USART_CR3_ONEBIT                    ((uint32_t)0x00000800)            /*!< One sample bit method enable                   */
+#define  USART_CR3_OVRDIS                    ((uint32_t)0x00001000)            /*!< Overrun Disable                                */
+#define  USART_CR3_DDRE                      ((uint32_t)0x00002000)            /*!< DMA Disable on Reception Error                 */
+#define  USART_CR3_DEM                       ((uint32_t)0x00004000)            /*!< Driver Enable Mode                             */
+#define  USART_CR3_DEP                       ((uint32_t)0x00008000)            /*!< Driver Enable Polarity Selection               */
+#define  USART_CR3_SCARCNT                   ((uint32_t)0x000E0000)            /*!< SCARCNT[2:0] bits (SmartCard Auto-Retry Count) */
+#define  USART_CR3_SCARCNT_0                 ((uint32_t)0x00020000)            /*!< Bit 0 */
+#define  USART_CR3_SCARCNT_1                 ((uint32_t)0x00040000)            /*!< Bit 1 */
+#define  USART_CR3_SCARCNT_2                 ((uint32_t)0x00080000)            /*!< Bit 2 */
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define  USART_BRR_DIV_FRACTION              ((uint32_t)0x000F)                /*!< Fraction of USARTDIV */
+#define  USART_BRR_DIV_MANTISSA              ((uint32_t)0xFFF0)                /*!< Mantissa of USARTDIV */
+
+/******************  Bit definition for USART_GTPR register  ******************/
+#define  USART_GTPR_PSC                      ((uint32_t)0x00FF)                /*!< PSC[7:0] bits (Prescaler value) */
+#define  USART_GTPR_GT                       ((uint32_t)0xFF00)                /*!< GT[7:0] bits (Guard time value) */
+
+
+/*******************  Bit definition for USART_RTOR register  *****************/
+#define  USART_RTOR_RTO                      ((uint32_t)0x00FFFFFF)            /*!< Receiver Time Out Value */
+#define  USART_RTOR_BLEN                     ((uint32_t)0xFF000000)            /*!< Block Length */
+
+/*******************  Bit definition for USART_RQR register  ******************/
+#define  USART_RQR_ABRRQ                     ((uint32_t)0x0001)                /*!< Auto-Baud Rate Request      */
+#define  USART_RQR_SBKRQ                     ((uint32_t)0x0002)                /*!< Send Break Request          */
+#define  USART_RQR_MMRQ                      ((uint32_t)0x0004)                /*!< Mute Mode Request           */
+#define  USART_RQR_RXFRQ                     ((uint32_t)0x0008)                /*!< Receive Data flush Request  */
+#define  USART_RQR_TXFRQ                     ((uint32_t)0x0010)                /*!< Transmit data flush Request */
+
+/*******************  Bit definition for USART_ISR register  ******************/
+#define  USART_ISR_PE                        ((uint32_t)0x00000001)            /*!< Parity Error                        */
+#define  USART_ISR_FE                        ((uint32_t)0x00000002)            /*!< Framing Error                       */
+#define  USART_ISR_NE                        ((uint32_t)0x00000004)            /*!< Noise detected Flag                 */
+#define  USART_ISR_ORE                       ((uint32_t)0x00000008)            /*!< OverRun Error                       */
+#define  USART_ISR_IDLE                      ((uint32_t)0x00000010)            /*!< IDLE line detected                  */
+#define  USART_ISR_RXNE                      ((uint32_t)0x00000020)            /*!< Read Data Register Not Empty        */
+#define  USART_ISR_TC                        ((uint32_t)0x00000040)            /*!< Transmission Complete               */
+#define  USART_ISR_TXE                       ((uint32_t)0x00000080)            /*!< Transmit Data Register Empty        */
+#define  USART_ISR_LBD                       ((uint32_t)0x00000100)            /*!< LIN Break Detection Flag            */
+#define  USART_ISR_CTSIF                     ((uint32_t)0x00000200)            /*!< CTS interrupt flag                  */
+#define  USART_ISR_CTS                       ((uint32_t)0x00000400)            /*!< CTS flag                            */
+#define  USART_ISR_RTOF                      ((uint32_t)0x00000800)            /*!< Receiver Time Out                   */
+#define  USART_ISR_EOBF                      ((uint32_t)0x00001000)            /*!< End Of Block Flag                   */
+#define  USART_ISR_ABRE                      ((uint32_t)0x00004000)            /*!< Auto-Baud Rate Error                */
+#define  USART_ISR_ABRF                      ((uint32_t)0x00008000)            /*!< Auto-Baud Rate Flag                 */
+#define  USART_ISR_BUSY                      ((uint32_t)0x00010000)            /*!< Busy Flag                           */
+#define  USART_ISR_CMF                       ((uint32_t)0x00020000)            /*!< Character Match Flag                */
+#define  USART_ISR_SBKF                      ((uint32_t)0x00040000)            /*!< Send Break Flag                     */
+#define  USART_ISR_RWU                       ((uint32_t)0x00080000)            /*!< Receive Wake Up from mute mode Flag */
+#define  USART_ISR_WUF                       ((uint32_t)0x00100000)            /*!< Wake Up from stop mode Flag         */
+#define  USART_ISR_TEACK                     ((uint32_t)0x00200000)            /*!< Transmit Enable Acknowledge Flag    */
+#define  USART_ISR_REACK                     ((uint32_t)0x00400000)            /*!< Receive Enable Acknowledge Flag     */
+
+/*******************  Bit definition for USART_ICR register  ******************/
+#define  USART_ICR_PECF                      ((uint32_t)0x00000001)            /*!< Parity Error Clear Flag             */
+#define  USART_ICR_FECF                      ((uint32_t)0x00000002)            /*!< Framing Error Clear Flag            */
+#define  USART_ICR_NCF                       ((uint32_t)0x00000004)            /*!< Noise detected Clear Flag           */
+#define  USART_ICR_ORECF                     ((uint32_t)0x00000008)            /*!< OverRun Error Clear Flag            */
+#define  USART_ICR_IDLECF                    ((uint32_t)0x00000010)            /*!< IDLE line detected Clear Flag       */
+#define  USART_ICR_TCCF                      ((uint32_t)0x00000040)            /*!< Transmission Complete Clear Flag    */
+#define  USART_ICR_LBDCF                     ((uint32_t)0x00000100)            /*!< LIN Break Detection Clear Flag      */
+#define  USART_ICR_CTSCF                     ((uint32_t)0x00000200)            /*!< CTS Interrupt Clear Flag            */
+#define  USART_ICR_RTOCF                     ((uint32_t)0x00000800)            /*!< Receiver Time Out Clear Flag        */
+#define  USART_ICR_EOBCF                     ((uint32_t)0x00001000)            /*!< End Of Block Clear Flag             */
+#define  USART_ICR_CMCF                      ((uint32_t)0x00020000)            /*!< Character Match Clear Flag          */
+#define  USART_ICR_WUCF                      ((uint32_t)0x00100000)            /*!< Wake Up from stop mode Clear Flag   */
+
+/*******************  Bit definition for USART_RDR register  ******************/
+#define  USART_RDR_RDR                       ((uint32_t)0x01FF)                /*!< RDR[8:0] bits (Receive Data value) */
+
+/*******************  Bit definition for USART_TDR register  ******************/
+#define  USART_TDR_TDR                       ((uint32_t)0x01FF)                /*!< TDR[8:0] bits (Transmit Data value) */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            Window WATCHDOG                                 */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for WWDG_CR register  ********************/
+#define  WWDG_CR_T                           ((uint32_t)0x7F)               /*!<T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define  WWDG_CR_T0                          ((uint32_t)0x01)               /*!<Bit 0 */
+#define  WWDG_CR_T1                          ((uint32_t)0x02)               /*!<Bit 1 */
+#define  WWDG_CR_T2                          ((uint32_t)0x04)               /*!<Bit 2 */
+#define  WWDG_CR_T3                          ((uint32_t)0x08)               /*!<Bit 3 */
+#define  WWDG_CR_T4                          ((uint32_t)0x10)               /*!<Bit 4 */
+#define  WWDG_CR_T5                          ((uint32_t)0x20)               /*!<Bit 5 */
+#define  WWDG_CR_T6                          ((uint32_t)0x40)               /*!<Bit 6 */
+
+#define  WWDG_CR_WDGA                        ((uint32_t)0x80)               /*!<Activation bit */
+
+/*******************  Bit definition for WWDG_CFR register  *******************/
+#define  WWDG_CFR_W                          ((uint32_t)0x007F)            /*!<W[6:0] bits (7-bit window value) */
+#define  WWDG_CFR_W0                         ((uint32_t)0x0001)            /*!<Bit 0 */
+#define  WWDG_CFR_W1                         ((uint32_t)0x0002)            /*!<Bit 1 */
+#define  WWDG_CFR_W2                         ((uint32_t)0x0004)            /*!<Bit 2 */
+#define  WWDG_CFR_W3                         ((uint32_t)0x0008)            /*!<Bit 3 */
+#define  WWDG_CFR_W4                         ((uint32_t)0x0010)            /*!<Bit 4 */
+#define  WWDG_CFR_W5                         ((uint32_t)0x0020)            /*!<Bit 5 */
+#define  WWDG_CFR_W6                         ((uint32_t)0x0040)            /*!<Bit 6 */
+
+#define  WWDG_CFR_WDGTB                      ((uint32_t)0x0180)            /*!<WDGTB[1:0] bits (Timer Base) */
+#define  WWDG_CFR_WDGTB0                     ((uint32_t)0x0080)            /*!<Bit 0 */
+#define  WWDG_CFR_WDGTB1                     ((uint32_t)0x0100)            /*!<Bit 1 */
+
+#define  WWDG_CFR_EWI                        ((uint32_t)0x0200)            /*!<Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_SR register  ********************/
+#define  WWDG_SR_EWIF                        ((uint32_t)0x01)               /*!<Early Wakeup Interrupt Flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                DBG                                         */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DBGMCU_IDCODE register  *************/
+#define  DBGMCU_IDCODE_DEV_ID                ((uint32_t)0x00000FFF)
+#define  DBGMCU_IDCODE_REV_ID                ((uint32_t)0xFFFF0000)
+
+/********************  Bit definition for DBGMCU_CR register  *****************/
+#define  DBGMCU_CR_DBG_SLEEP                 ((uint32_t)0x00000001)
+#define  DBGMCU_CR_DBG_STOP                  ((uint32_t)0x00000002)
+#define  DBGMCU_CR_DBG_STANDBY               ((uint32_t)0x00000004)
+#define  DBGMCU_CR_TRACE_IOEN                ((uint32_t)0x00000020)
+
+#define  DBGMCU_CR_TRACE_MODE                ((uint32_t)0x000000C0)
+#define  DBGMCU_CR_TRACE_MODE_0              ((uint32_t)0x00000040) /*!<Bit 0 */
+#define  DBGMCU_CR_TRACE_MODE_1              ((uint32_t)0x00000080) /*!<Bit 1 */
+
+/********************  Bit definition for DBGMCU_APB1_FZ register  ************/
+#define  DBGMCU_APB1_FZ_DBG_TIM2_STOP            ((uint32_t)0x00000001)
+#define  DBGMCU_APB1_FZ_DBG_TIM3_STOP            ((uint32_t)0x00000002)
+#define  DBGMCU_APB1_FZ_DBG_TIM4_STOP            ((uint32_t)0x00000004)
+#define  DBGMCU_APB1_FZ_DBG_TIM5_STOP            ((uint32_t)0x00000008)
+#define  DBGMCU_APB1_FZ_DBG_TIM6_STOP            ((uint32_t)0x00000010)
+#define  DBGMCU_APB1_FZ_DBG_TIM7_STOP            ((uint32_t)0x00000020)
+#define  DBGMCU_APB1_FZ_DBG_TIM12_STOP           ((uint32_t)0x00000040)
+#define  DBGMCU_APB1_FZ_DBG_TIM13_STOP           ((uint32_t)0x00000080)
+#define  DBGMCU_APB1_FZ_DBG_TIM14_STOP           ((uint32_t)0x00000100)
+#define  DBGMCU_APB1_FZ_DBG_RTC_STOP             ((uint32_t)0x00000400)
+#define  DBGMCU_APB1_FZ_DBG_WWDG_STOP            ((uint32_t)0x00000800)
+#define  DBGMCU_APB1_FZ_DBG_IWDG_STOP            ((uint32_t)0x00001000)
+#define  DBGMCU_APB1_FZ_DBG_I2C1_SMBUS_TIMEOUT   ((uint32_t)0x00200000)
+#define  DBGMCU_APB1_FZ_DBG_I2C2_SMBUS_TIMEOUT   ((uint32_t)0x00400000)
+#define  DBGMCU_APB1_FZ_DBG_I2C3_SMBUS_TIMEOUT   ((uint32_t)0x00800000)
+#define  DBGMCU_APB1_FZ_DBG_CAN1_STOP            ((uint32_t)0x02000000)
+#define  DBGMCU_APB1_FZ_DBG_CAN2_STOP            ((uint32_t)0x04000000)
+
+/********************  Bit definition for DBGMCU_APB2_FZ register  ************/
+#define  DBGMCU_APB1_FZ_DBG_TIM1_STOP        ((uint32_t)0x00000001)
+#define  DBGMCU_APB1_FZ_DBG_TIM8_STOP        ((uint32_t)0x00000002)
+#define  DBGMCU_APB1_FZ_DBG_TIM9_STOP        ((uint32_t)0x00010000)
+#define  DBGMCU_APB1_FZ_DBG_TIM10_STOP       ((uint32_t)0x00020000)
+#define  DBGMCU_APB1_FZ_DBG_TIM11_STOP       ((uint32_t)0x00040000)
+
+/******************************************************************************/
+/*                                                                            */
+/*                Ethernet MAC Registers bits definitions                     */
+/*                                                                            */
+/******************************************************************************/
+/* Bit definition for Ethernet MAC Control Register register */
+#define ETH_MACCR_WD      ((uint32_t)0x00800000)  /* Watchdog disable */
+#define ETH_MACCR_JD      ((uint32_t)0x00400000)  /* Jabber disable */
+#define ETH_MACCR_IFG     ((uint32_t)0x000E0000)  /* Inter-frame gap */
+#define ETH_MACCR_IFG_96Bit     ((uint32_t)0x00000000)  /* Minimum IFG between frames during transmission is 96Bit */
+  #define ETH_MACCR_IFG_88Bit     ((uint32_t)0x00020000)  /* Minimum IFG between frames during transmission is 88Bit */
+  #define ETH_MACCR_IFG_80Bit     ((uint32_t)0x00040000)  /* Minimum IFG between frames during transmission is 80Bit */
+  #define ETH_MACCR_IFG_72Bit     ((uint32_t)0x00060000)  /* Minimum IFG between frames during transmission is 72Bit */
+  #define ETH_MACCR_IFG_64Bit     ((uint32_t)0x00080000)  /* Minimum IFG between frames during transmission is 64Bit */
+  #define ETH_MACCR_IFG_56Bit     ((uint32_t)0x000A0000)  /* Minimum IFG between frames during transmission is 56Bit */
+  #define ETH_MACCR_IFG_48Bit     ((uint32_t)0x000C0000)  /* Minimum IFG between frames during transmission is 48Bit */
+  #define ETH_MACCR_IFG_40Bit     ((uint32_t)0x000E0000)  /* Minimum IFG between frames during transmission is 40Bit */
+#define ETH_MACCR_CSD     ((uint32_t)0x00010000)  /* Carrier sense disable (during transmission) */
+#define ETH_MACCR_FES     ((uint32_t)0x00004000)  /* Fast ethernet speed */
+#define ETH_MACCR_ROD     ((uint32_t)0x00002000)  /* Receive own disable */
+#define ETH_MACCR_LM      ((uint32_t)0x00001000)  /* loopback mode */
+#define ETH_MACCR_DM      ((uint32_t)0x00000800)  /* Duplex mode */
+#define ETH_MACCR_IPCO    ((uint32_t)0x00000400)  /* IP Checksum offload */
+#define ETH_MACCR_RD      ((uint32_t)0x00000200)  /* Retry disable */
+#define ETH_MACCR_APCS    ((uint32_t)0x00000080)  /* Automatic Pad/CRC stripping */
+#define ETH_MACCR_BL      ((uint32_t)0x00000060)  /* Back-off limit: random integer number (r) of slot time delays before rescheduling
+                                                       a transmission attempt during retries after a collision: 0 =< r <2^k */
+  #define ETH_MACCR_BL_10    ((uint32_t)0x00000000)  /* k = min (n, 10) */
+  #define ETH_MACCR_BL_8     ((uint32_t)0x00000020)  /* k = min (n, 8) */
+  #define ETH_MACCR_BL_4     ((uint32_t)0x00000040)  /* k = min (n, 4) */
+  #define ETH_MACCR_BL_1     ((uint32_t)0x00000060)  /* k = min (n, 1) */
+#define ETH_MACCR_DC      ((uint32_t)0x00000010)  /* Defferal check */
+#define ETH_MACCR_TE      ((uint32_t)0x00000008)  /* Transmitter enable */
+#define ETH_MACCR_RE      ((uint32_t)0x00000004)  /* Receiver enable */
+
+/* Bit definition for Ethernet MAC Frame Filter Register */
+#define ETH_MACFFR_RA     ((uint32_t)0x80000000)  /* Receive all */
+#define ETH_MACFFR_HPF    ((uint32_t)0x00000400)  /* Hash or perfect filter */
+#define ETH_MACFFR_SAF    ((uint32_t)0x00000200)  /* Source address filter enable */
+#define ETH_MACFFR_SAIF   ((uint32_t)0x00000100)  /* SA inverse filtering */
+#define ETH_MACFFR_PCF    ((uint32_t)0x000000C0)  /* Pass control frames: 3 cases */
+  #define ETH_MACFFR_PCF_BlockAll                ((uint32_t)0x00000040)  /* MAC filters all control frames from reaching the application */
+  #define ETH_MACFFR_PCF_ForwardAll              ((uint32_t)0x00000080)  /* MAC forwards all control frames to application even if they fail the Address Filter */
+  #define ETH_MACFFR_PCF_ForwardPassedAddrFilter ((uint32_t)0x000000C0)  /* MAC forwards control frames that pass the Address Filter. */
+#define ETH_MACFFR_BFD    ((uint32_t)0x00000020)  /* Broadcast frame disable */
+#define ETH_MACFFR_PAM    ((uint32_t)0x00000010)  /* Pass all mutlicast */
+#define ETH_MACFFR_DAIF   ((uint32_t)0x00000008)  /* DA Inverse filtering */
+#define ETH_MACFFR_HM     ((uint32_t)0x00000004)  /* Hash multicast */
+#define ETH_MACFFR_HU     ((uint32_t)0x00000002)  /* Hash unicast */
+#define ETH_MACFFR_PM     ((uint32_t)0x00000001)  /* Promiscuous mode */
+
+/* Bit definition for Ethernet MAC Hash Table High Register */
+#define ETH_MACHTHR_HTH   ((uint32_t)0xFFFFFFFF)  /* Hash table high */
+
+/* Bit definition for Ethernet MAC Hash Table Low Register */
+#define ETH_MACHTLR_HTL   ((uint32_t)0xFFFFFFFF)  /* Hash table low */
+
+/* Bit definition for Ethernet MAC MII Address Register */
+#define ETH_MACMIIAR_PA   ((uint32_t)0x0000F800)  /* Physical layer address */
+#define ETH_MACMIIAR_MR   ((uint32_t)0x000007C0)  /* MII register in the selected PHY */
+#define ETH_MACMIIAR_CR   ((uint32_t)0x0000001C)  /* CR clock range: 6 cases */
+  #define ETH_MACMIIAR_CR_Div42   ((uint32_t)0x00000000)  /* HCLK:60-100 MHz; MDC clock= HCLK/42 */
+  #define ETH_MACMIIAR_CR_Div62   ((uint32_t)0x00000004)  /* HCLK:100-150 MHz; MDC clock= HCLK/62 */
+  #define ETH_MACMIIAR_CR_Div16   ((uint32_t)0x00000008)  /* HCLK:20-35 MHz; MDC clock= HCLK/16 */
+  #define ETH_MACMIIAR_CR_Div26   ((uint32_t)0x0000000C)  /* HCLK:35-60 MHz; MDC clock= HCLK/26 */
+  #define ETH_MACMIIAR_CR_Div102  ((uint32_t)0x00000010)  /* HCLK:150-168 MHz; MDC clock= HCLK/102 */
+#define ETH_MACMIIAR_MW   ((uint32_t)0x00000002)  /* MII write */
+#define ETH_MACMIIAR_MB   ((uint32_t)0x00000001)  /* MII busy */
+
+/* Bit definition for Ethernet MAC MII Data Register */
+#define ETH_MACMIIDR_MD   ((uint32_t)0x0000FFFF)  /* MII data: read/write data from/to PHY */
+
+/* Bit definition for Ethernet MAC Flow Control Register */
+#define ETH_MACFCR_PT     ((uint32_t)0xFFFF0000)  /* Pause time */
+#define ETH_MACFCR_ZQPD   ((uint32_t)0x00000080)  /* Zero-quanta pause disable */
+#define ETH_MACFCR_PLT    ((uint32_t)0x00000030)  /* Pause low threshold: 4 cases */
+  #define ETH_MACFCR_PLT_Minus4   ((uint32_t)0x00000000)  /* Pause time minus 4 slot times */
+  #define ETH_MACFCR_PLT_Minus28  ((uint32_t)0x00000010)  /* Pause time minus 28 slot times */
+  #define ETH_MACFCR_PLT_Minus144 ((uint32_t)0x00000020)  /* Pause time minus 144 slot times */
+  #define ETH_MACFCR_PLT_Minus256 ((uint32_t)0x00000030)  /* Pause time minus 256 slot times */
+#define ETH_MACFCR_UPFD   ((uint32_t)0x00000008)  /* Unicast pause frame detect */
+#define ETH_MACFCR_RFCE   ((uint32_t)0x00000004)  /* Receive flow control enable */
+#define ETH_MACFCR_TFCE   ((uint32_t)0x00000002)  /* Transmit flow control enable */
+#define ETH_MACFCR_FCBBPA ((uint32_t)0x00000001)  /* Flow control busy/backpressure activate */
+
+/* Bit definition for Ethernet MAC VLAN Tag Register */
+#define ETH_MACVLANTR_VLANTC ((uint32_t)0x00010000)  /* 12-bit VLAN tag comparison */
+#define ETH_MACVLANTR_VLANTI ((uint32_t)0x0000FFFF)  /* VLAN tag identifier (for receive frames) */
+
+/* Bit definition for Ethernet MAC Remote Wake-UpFrame Filter Register */
+#define ETH_MACRWUFFR_D   ((uint32_t)0xFFFFFFFF)  /* Wake-up frame filter register data */
+/* Eight sequential Writes to this address (offset 0x28) will write all Wake-UpFrame Filter Registers.
+   Eight sequential Reads from this address (offset 0x28) will read all Wake-UpFrame Filter Registers. */
+/* Wake-UpFrame Filter Reg0 : Filter 0 Byte Mask
+   Wake-UpFrame Filter Reg1 : Filter 1 Byte Mask
+   Wake-UpFrame Filter Reg2 : Filter 2 Byte Mask
+   Wake-UpFrame Filter Reg3 : Filter 3 Byte Mask
+   Wake-UpFrame Filter Reg4 : RSVD - Filter3 Command - RSVD - Filter2 Command -
+                              RSVD - Filter1 Command - RSVD - Filter0 Command
+   Wake-UpFrame Filter Re5 : Filter3 Offset - Filter2 Offset - Filter1 Offset - Filter0 Offset
+   Wake-UpFrame Filter Re6 : Filter1 CRC16 - Filter0 CRC16
+   Wake-UpFrame Filter Re7 : Filter3 CRC16 - Filter2 CRC16 */
+
+/* Bit definition for Ethernet MAC PMT Control and Status Register */
+#define ETH_MACPMTCSR_WFFRPR ((uint32_t)0x80000000)  /* Wake-Up Frame Filter Register Pointer Reset */
+#define ETH_MACPMTCSR_GU     ((uint32_t)0x00000200)  /* Global Unicast */
+#define ETH_MACPMTCSR_WFR    ((uint32_t)0x00000040)  /* Wake-Up Frame Received */
+#define ETH_MACPMTCSR_MPR    ((uint32_t)0x00000020)  /* Magic Packet Received */
+#define ETH_MACPMTCSR_WFE    ((uint32_t)0x00000004)  /* Wake-Up Frame Enable */
+#define ETH_MACPMTCSR_MPE    ((uint32_t)0x00000002)  /* Magic Packet Enable */
+#define ETH_MACPMTCSR_PD     ((uint32_t)0x00000001)  /* Power Down */
+
+/* Bit definition for Ethernet MAC Status Register */
+#define ETH_MACSR_TSTS      ((uint32_t)0x00000200)  /* Time stamp trigger status */
+#define ETH_MACSR_MMCTS     ((uint32_t)0x00000040)  /* MMC transmit status */
+#define ETH_MACSR_MMMCRS    ((uint32_t)0x00000020)  /* MMC receive status */
+#define ETH_MACSR_MMCS      ((uint32_t)0x00000010)  /* MMC status */
+#define ETH_MACSR_PMTS      ((uint32_t)0x00000008)  /* PMT status */
+
+/* Bit definition for Ethernet MAC Interrupt Mask Register */
+#define ETH_MACIMR_TSTIM     ((uint32_t)0x00000200)  /* Time stamp trigger interrupt mask */
+#define ETH_MACIMR_PMTIM     ((uint32_t)0x00000008)  /* PMT interrupt mask */
+
+/* Bit definition for Ethernet MAC Address0 High Register */
+#define ETH_MACA0HR_MACA0H   ((uint32_t)0x0000FFFF)  /* MAC address0 high */
+
+/* Bit definition for Ethernet MAC Address0 Low Register */
+#define ETH_MACA0LR_MACA0L   ((uint32_t)0xFFFFFFFF)  /* MAC address0 low */
+
+/* Bit definition for Ethernet MAC Address1 High Register */
+#define ETH_MACA1HR_AE       ((uint32_t)0x80000000)  /* Address enable */
+#define ETH_MACA1HR_SA       ((uint32_t)0x40000000)  /* Source address */
+#define ETH_MACA1HR_MBC      ((uint32_t)0x3F000000)  /* Mask byte control: bits to mask for comparison of the MAC Address bytes */
+  #define ETH_MACA1HR_MBC_HBits15_8    ((uint32_t)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+  #define ETH_MACA1HR_MBC_HBits7_0     ((uint32_t)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+  #define ETH_MACA1HR_MBC_LBits31_24   ((uint32_t)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+  #define ETH_MACA1HR_MBC_LBits23_16   ((uint32_t)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+  #define ETH_MACA1HR_MBC_LBits15_8    ((uint32_t)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+  #define ETH_MACA1HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [7:0] */
+#define ETH_MACA1HR_MACA1H   ((uint32_t)0x0000FFFF)  /* MAC address1 high */
+
+/* Bit definition for Ethernet MAC Address1 Low Register */
+#define ETH_MACA1LR_MACA1L   ((uint32_t)0xFFFFFFFF)  /* MAC address1 low */
+
+/* Bit definition for Ethernet MAC Address2 High Register */
+#define ETH_MACA2HR_AE       ((uint32_t)0x80000000)  /* Address enable */
+#define ETH_MACA2HR_SA       ((uint32_t)0x40000000)  /* Source address */
+#define ETH_MACA2HR_MBC      ((uint32_t)0x3F000000)  /* Mask byte control */
+  #define ETH_MACA2HR_MBC_HBits15_8    ((uint32_t)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+  #define ETH_MACA2HR_MBC_HBits7_0     ((uint32_t)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+  #define ETH_MACA2HR_MBC_LBits31_24   ((uint32_t)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+  #define ETH_MACA2HR_MBC_LBits23_16   ((uint32_t)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+  #define ETH_MACA2HR_MBC_LBits15_8    ((uint32_t)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+  #define ETH_MACA2HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [70] */
+#define ETH_MACA2HR_MACA2H   ((uint32_t)0x0000FFFF)  /* MAC address1 high */
+
+/* Bit definition for Ethernet MAC Address2 Low Register */
+#define ETH_MACA2LR_MACA2L   ((uint32_t)0xFFFFFFFF)  /* MAC address2 low */
+
+/* Bit definition for Ethernet MAC Address3 High Register */
+#define ETH_MACA3HR_AE       ((uint32_t)0x80000000)  /* Address enable */
+#define ETH_MACA3HR_SA       ((uint32_t)0x40000000)  /* Source address */
+#define ETH_MACA3HR_MBC      ((uint32_t)0x3F000000)  /* Mask byte control */
+  #define ETH_MACA3HR_MBC_HBits15_8    ((uint32_t)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+  #define ETH_MACA3HR_MBC_HBits7_0     ((uint32_t)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+  #define ETH_MACA3HR_MBC_LBits31_24   ((uint32_t)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+  #define ETH_MACA3HR_MBC_LBits23_16   ((uint32_t)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+  #define ETH_MACA3HR_MBC_LBits15_8    ((uint32_t)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+  #define ETH_MACA3HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [70] */
+#define ETH_MACA3HR_MACA3H   ((uint32_t)0x0000FFFF)  /* MAC address3 high */
+
+/* Bit definition for Ethernet MAC Address3 Low Register */
+#define ETH_MACA3LR_MACA3L   ((uint32_t)0xFFFFFFFF)  /* MAC address3 low */
+
+/******************************************************************************/
+/*                Ethernet MMC Registers bits definition                      */
+/******************************************************************************/
+
+/* Bit definition for Ethernet MMC Contol Register */
+#define ETH_MMCCR_MCFHP      ((uint32_t)0x00000020)  /* MMC counter Full-Half preset */
+#define ETH_MMCCR_MCP        ((uint32_t)0x00000010)  /* MMC counter preset */
+#define ETH_MMCCR_MCF        ((uint32_t)0x00000008)  /* MMC Counter Freeze */
+#define ETH_MMCCR_ROR        ((uint32_t)0x00000004)  /* Reset on Read */
+#define ETH_MMCCR_CSR        ((uint32_t)0x00000002)  /* Counter Stop Rollover */
+#define ETH_MMCCR_CR         ((uint32_t)0x00000001)  /* Counters Reset */
+
+/* Bit definition for Ethernet MMC Receive Interrupt Register */
+#define ETH_MMCRIR_RGUFS     ((uint32_t)0x00020000)  /* Set when Rx good unicast frames counter reaches half the maximum value */
+#define ETH_MMCRIR_RFAES     ((uint32_t)0x00000040)  /* Set when Rx alignment error counter reaches half the maximum value */
+#define ETH_MMCRIR_RFCES     ((uint32_t)0x00000020)  /* Set when Rx crc error counter reaches half the maximum value */
+
+/* Bit definition for Ethernet MMC Transmit Interrupt Register */
+#define ETH_MMCTIR_TGFS      ((uint32_t)0x00200000)  /* Set when Tx good frame count counter reaches half the maximum value */
+#define ETH_MMCTIR_TGFMSCS   ((uint32_t)0x00008000)  /* Set when Tx good multi col counter reaches half the maximum value */
+#define ETH_MMCTIR_TGFSCS    ((uint32_t)0x00004000)  /* Set when Tx good single col counter reaches half the maximum value */
+
+/* Bit definition for Ethernet MMC Receive Interrupt Mask Register */
+#define ETH_MMCRIMR_RGUFM    ((uint32_t)0x00020000)  /* Mask the interrupt when Rx good unicast frames counter reaches half the maximum value */
+#define ETH_MMCRIMR_RFAEM    ((uint32_t)0x00000040)  /* Mask the interrupt when when Rx alignment error counter reaches half the maximum value */
+#define ETH_MMCRIMR_RFCEM    ((uint32_t)0x00000020)  /* Mask the interrupt when Rx crc error counter reaches half the maximum value */
+
+/* Bit definition for Ethernet MMC Transmit Interrupt Mask Register */
+#define ETH_MMCTIMR_TGFM     ((uint32_t)0x00200000)  /* Mask the interrupt when Tx good frame count counter reaches half the maximum value */
+#define ETH_MMCTIMR_TGFMSCM  ((uint32_t)0x00008000)  /* Mask the interrupt when Tx good multi col counter reaches half the maximum value */
+#define ETH_MMCTIMR_TGFSCM   ((uint32_t)0x00004000)  /* Mask the interrupt when Tx good single col counter reaches half the maximum value */
+
+/* Bit definition for Ethernet MMC Transmitted Good Frames after Single Collision Counter Register */
+#define ETH_MMCTGFSCCR_TGFSCC     ((uint32_t)0xFFFFFFFF)  /* Number of successfully transmitted frames after a single collision in Half-duplex mode. */
+
+/* Bit definition for Ethernet MMC Transmitted Good Frames after More than a Single Collision Counter Register */
+#define ETH_MMCTGFMSCCR_TGFMSCC   ((uint32_t)0xFFFFFFFF)  /* Number of successfully transmitted frames after more than a single collision in Half-duplex mode. */
+
+/* Bit definition for Ethernet MMC Transmitted Good Frames Counter Register */
+#define ETH_MMCTGFCR_TGFC    ((uint32_t)0xFFFFFFFF)  /* Number of good frames transmitted. */
+
+/* Bit definition for Ethernet MMC Received Frames with CRC Error Counter Register */
+#define ETH_MMCRFCECR_RFCEC  ((uint32_t)0xFFFFFFFF)  /* Number of frames received with CRC error. */
+
+/* Bit definition for Ethernet MMC Received Frames with Alignement Error Counter Register */
+#define ETH_MMCRFAECR_RFAEC  ((uint32_t)0xFFFFFFFF)  /* Number of frames received with alignment (dribble) error */
+
+/* Bit definition for Ethernet MMC Received Good Unicast Frames Counter Register */
+#define ETH_MMCRGUFCR_RGUFC  ((uint32_t)0xFFFFFFFF)  /* Number of good unicast frames received. */
+
+/******************************************************************************/
+/*               Ethernet PTP Registers bits definition                       */
+/******************************************************************************/
+
+/* Bit definition for Ethernet PTP Time Stamp Contol Register */
+#define ETH_PTPTSCR_TSCNT       ((uint32_t)0x00030000)  /* Time stamp clock node type */
+#define ETH_PTPTSSR_TSSMRME     ((uint32_t)0x00008000)  /* Time stamp snapshot for message relevant to master enable */
+#define ETH_PTPTSSR_TSSEME      ((uint32_t)0x00004000)  /* Time stamp snapshot for event message enable */
+#define ETH_PTPTSSR_TSSIPV4FE   ((uint32_t)0x00002000)  /* Time stamp snapshot for IPv4 frames enable */
+#define ETH_PTPTSSR_TSSIPV6FE   ((uint32_t)0x00001000)  /* Time stamp snapshot for IPv6 frames enable */
+#define ETH_PTPTSSR_TSSPTPOEFE  ((uint32_t)0x00000800)  /* Time stamp snapshot for PTP over ethernet frames enable */
+#define ETH_PTPTSSR_TSPTPPSV2E  ((uint32_t)0x00000400)  /* Time stamp PTP packet snooping for version2 format enable */
+#define ETH_PTPTSSR_TSSSR       ((uint32_t)0x00000200)  /* Time stamp Sub-seconds rollover */
+#define ETH_PTPTSSR_TSSARFE     ((uint32_t)0x00000100)  /* Time stamp snapshot for all received frames enable */
+
+#define ETH_PTPTSCR_TSARU    ((uint32_t)0x00000020)  /* Addend register update */
+#define ETH_PTPTSCR_TSITE    ((uint32_t)0x00000010)  /* Time stamp interrupt trigger enable */
+#define ETH_PTPTSCR_TSSTU    ((uint32_t)0x00000008)  /* Time stamp update */
+#define ETH_PTPTSCR_TSSTI    ((uint32_t)0x00000004)  /* Time stamp initialize */
+#define ETH_PTPTSCR_TSFCU    ((uint32_t)0x00000002)  /* Time stamp fine or coarse update */
+#define ETH_PTPTSCR_TSE      ((uint32_t)0x00000001)  /* Time stamp enable */
+
+/* Bit definition for Ethernet PTP Sub-Second Increment Register */
+#define ETH_PTPSSIR_STSSI    ((uint32_t)0x000000FF)  /* System time Sub-second increment value */
+
+/* Bit definition for Ethernet PTP Time Stamp High Register */
+#define ETH_PTPTSHR_STS      ((uint32_t)0xFFFFFFFF)  /* System Time second */
+
+/* Bit definition for Ethernet PTP Time Stamp Low Register */
+#define ETH_PTPTSLR_STPNS    ((uint32_t)0x80000000)  /* System Time Positive or negative time */
+#define ETH_PTPTSLR_STSS     ((uint32_t)0x7FFFFFFF)  /* System Time sub-seconds */
+
+/* Bit definition for Ethernet PTP Time Stamp High Update Register */
+#define ETH_PTPTSHUR_TSUS    ((uint32_t)0xFFFFFFFF)  /* Time stamp update seconds */
+
+/* Bit definition for Ethernet PTP Time Stamp Low Update Register */
+#define ETH_PTPTSLUR_TSUPNS  ((uint32_t)0x80000000)  /* Time stamp update Positive or negative time */
+#define ETH_PTPTSLUR_TSUSS   ((uint32_t)0x7FFFFFFF)  /* Time stamp update sub-seconds */
+
+/* Bit definition for Ethernet PTP Time Stamp Addend Register */
+#define ETH_PTPTSAR_TSA      ((uint32_t)0xFFFFFFFF)  /* Time stamp addend */
+
+/* Bit definition for Ethernet PTP Target Time High Register */
+#define ETH_PTPTTHR_TTSH     ((uint32_t)0xFFFFFFFF)  /* Target time stamp high */
+
+/* Bit definition for Ethernet PTP Target Time Low Register */
+#define ETH_PTPTTLR_TTSL     ((uint32_t)0xFFFFFFFF)  /* Target time stamp low */
+
+/* Bit definition for Ethernet PTP Time Stamp Status Register */
+#define ETH_PTPTSSR_TSTTR    ((uint32_t)0x00000020)  /* Time stamp target time reached */
+#define ETH_PTPTSSR_TSSO     ((uint32_t)0x00000010)  /* Time stamp seconds overflow */
+
+/******************************************************************************/
+/*                 Ethernet DMA Registers bits definition                     */
+/******************************************************************************/
+
+/* Bit definition for Ethernet DMA Bus Mode Register */
+#define ETH_DMABMR_AAB       ((uint32_t)0x02000000)  /* Address-Aligned beats */
+#define ETH_DMABMR_FPM        ((uint32_t)0x01000000)  /* 4xPBL mode */
+#define ETH_DMABMR_USP       ((uint32_t)0x00800000)  /* Use separate PBL */
+#define ETH_DMABMR_RDP       ((uint32_t)0x007E0000)  /* RxDMA PBL */
+  #define ETH_DMABMR_RDP_1Beat    ((uint32_t)0x00020000)  /* maximum number of beats to be transferred in one RxDMA transaction is 1 */
+  #define ETH_DMABMR_RDP_2Beat    ((uint32_t)0x00040000)  /* maximum number of beats to be transferred in one RxDMA transaction is 2 */
+  #define ETH_DMABMR_RDP_4Beat    ((uint32_t)0x00080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
+  #define ETH_DMABMR_RDP_8Beat    ((uint32_t)0x00100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
+  #define ETH_DMABMR_RDP_16Beat   ((uint32_t)0x00200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
+  #define ETH_DMABMR_RDP_32Beat   ((uint32_t)0x00400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
+  #define ETH_DMABMR_RDP_4xPBL_4Beat   ((uint32_t)0x01020000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
+  #define ETH_DMABMR_RDP_4xPBL_8Beat   ((uint32_t)0x01040000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
+  #define ETH_DMABMR_RDP_4xPBL_16Beat  ((uint32_t)0x01080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
+  #define ETH_DMABMR_RDP_4xPBL_32Beat  ((uint32_t)0x01100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
+  #define ETH_DMABMR_RDP_4xPBL_64Beat  ((uint32_t)0x01200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 64 */
+  #define ETH_DMABMR_RDP_4xPBL_128Beat ((uint32_t)0x01400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 128 */
+#define ETH_DMABMR_FB        ((uint32_t)0x00010000)  /* Fixed Burst */
+#define ETH_DMABMR_RTPR      ((uint32_t)0x0000C000)  /* Rx Tx priority ratio */
+  #define ETH_DMABMR_RTPR_1_1     ((uint32_t)0x00000000)  /* Rx Tx priority ratio */
+  #define ETH_DMABMR_RTPR_2_1     ((uint32_t)0x00004000)  /* Rx Tx priority ratio */
+  #define ETH_DMABMR_RTPR_3_1     ((uint32_t)0x00008000)  /* Rx Tx priority ratio */
+  #define ETH_DMABMR_RTPR_4_1     ((uint32_t)0x0000C000)  /* Rx Tx priority ratio */
+#define ETH_DMABMR_PBL    ((uint32_t)0x00003F00)  /* Programmable burst length */
+  #define ETH_DMABMR_PBL_1Beat    ((uint32_t)0x00000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
+  #define ETH_DMABMR_PBL_2Beat    ((uint32_t)0x00000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
+  #define ETH_DMABMR_PBL_4Beat    ((uint32_t)0x00000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+  #define ETH_DMABMR_PBL_8Beat    ((uint32_t)0x00000800)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+  #define ETH_DMABMR_PBL_16Beat   ((uint32_t)0x00001000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+  #define ETH_DMABMR_PBL_32Beat   ((uint32_t)0x00002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+  #define ETH_DMABMR_PBL_4xPBL_4Beat   ((uint32_t)0x01000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+  #define ETH_DMABMR_PBL_4xPBL_8Beat   ((uint32_t)0x01000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+  #define ETH_DMABMR_PBL_4xPBL_16Beat  ((uint32_t)0x01000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+  #define ETH_DMABMR_PBL_4xPBL_32Beat  ((uint32_t)0x01000800)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+  #define ETH_DMABMR_PBL_4xPBL_64Beat  ((uint32_t)0x01001000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
+  #define ETH_DMABMR_PBL_4xPBL_128Beat ((uint32_t)0x01002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
+#define ETH_DMABMR_EDE       ((uint32_t)0x00000080)  /* Enhanced Descriptor Enable */
+#define ETH_DMABMR_DSL       ((uint32_t)0x0000007C)  /* Descriptor Skip Length */
+#define ETH_DMABMR_DA        ((uint32_t)0x00000002)  /* DMA arbitration scheme */
+#define ETH_DMABMR_SR        ((uint32_t)0x00000001)  /* Software reset */
+
+/* Bit definition for Ethernet DMA Transmit Poll Demand Register */
+#define ETH_DMATPDR_TPD      ((uint32_t)0xFFFFFFFF)  /* Transmit poll demand */
+
+/* Bit definition for Ethernet DMA Receive Poll Demand Register */
+#define ETH_DMARPDR_RPD      ((uint32_t)0xFFFFFFFF)  /* Receive poll demand  */
+
+/* Bit definition for Ethernet DMA Receive Descriptor List Address Register */
+#define ETH_DMARDLAR_SRL     ((uint32_t)0xFFFFFFFF)  /* Start of receive list */
+
+/* Bit definition for Ethernet DMA Transmit Descriptor List Address Register */
+#define ETH_DMATDLAR_STL     ((uint32_t)0xFFFFFFFF)  /* Start of transmit list */
+
+/* Bit definition for Ethernet DMA Status Register */
+#define ETH_DMASR_TSTS       ((uint32_t)0x20000000)  /* Time-stamp trigger status */
+#define ETH_DMASR_PMTS       ((uint32_t)0x10000000)  /* PMT status */
+#define ETH_DMASR_MMCS       ((uint32_t)0x08000000)  /* MMC status */
+#define ETH_DMASR_EBS        ((uint32_t)0x03800000)  /* Error bits status */
+  /* combination with EBS[2:0] for GetFlagStatus function */
+  #define ETH_DMASR_EBS_DescAccess      ((uint32_t)0x02000000)  /* Error bits 0-data buffer, 1-desc. access */
+  #define ETH_DMASR_EBS_ReadTransf      ((uint32_t)0x01000000)  /* Error bits 0-write trnsf, 1-read transfr */
+  #define ETH_DMASR_EBS_DataTransfTx    ((uint32_t)0x00800000)  /* Error bits 0-Rx DMA, 1-Tx DMA */
+#define ETH_DMASR_TPS         ((uint32_t)0x00700000)  /* Transmit process state */
+  #define ETH_DMASR_TPS_Stopped         ((uint32_t)0x00000000)  /* Stopped - Reset or Stop Tx Command issued  */
+  #define ETH_DMASR_TPS_Fetching        ((uint32_t)0x00100000)  /* Running - fetching the Tx descriptor */
+  #define ETH_DMASR_TPS_Waiting         ((uint32_t)0x00200000)  /* Running - waiting for status */
+  #define ETH_DMASR_TPS_Reading         ((uint32_t)0x00300000)  /* Running - reading the data from host memory */
+  #define ETH_DMASR_TPS_Suspended       ((uint32_t)0x00600000)  /* Suspended - Tx Descriptor unavailabe */
+  #define ETH_DMASR_TPS_Closing         ((uint32_t)0x00700000)  /* Running - closing Rx descriptor */
+#define ETH_DMASR_RPS         ((uint32_t)0x000E0000)  /* Receive process state */
+  #define ETH_DMASR_RPS_Stopped         ((uint32_t)0x00000000)  /* Stopped - Reset or Stop Rx Command issued */
+  #define ETH_DMASR_RPS_Fetching        ((uint32_t)0x00020000)  /* Running - fetching the Rx descriptor */
+  #define ETH_DMASR_RPS_Waiting         ((uint32_t)0x00060000)  /* Running - waiting for packet */
+  #define ETH_DMASR_RPS_Suspended       ((uint32_t)0x00080000)  /* Suspended - Rx Descriptor unavailable */
+  #define ETH_DMASR_RPS_Closing         ((uint32_t)0x000A0000)  /* Running - closing descriptor */
+  #define ETH_DMASR_RPS_Queuing         ((uint32_t)0x000E0000)  /* Running - queuing the recieve frame into host memory */
+#define ETH_DMASR_NIS        ((uint32_t)0x00010000)  /* Normal interrupt summary */
+#define ETH_DMASR_AIS        ((uint32_t)0x00008000)  /* Abnormal interrupt summary */
+#define ETH_DMASR_ERS        ((uint32_t)0x00004000)  /* Early receive status */
+#define ETH_DMASR_FBES       ((uint32_t)0x00002000)  /* Fatal bus error status */
+#define ETH_DMASR_ETS        ((uint32_t)0x00000400)  /* Early transmit status */
+#define ETH_DMASR_RWTS       ((uint32_t)0x00000200)  /* Receive watchdog timeout status */
+#define ETH_DMASR_RPSS       ((uint32_t)0x00000100)  /* Receive process stopped status */
+#define ETH_DMASR_RBUS       ((uint32_t)0x00000080)  /* Receive buffer unavailable status */
+#define ETH_DMASR_RS         ((uint32_t)0x00000040)  /* Receive status */
+#define ETH_DMASR_TUS        ((uint32_t)0x00000020)  /* Transmit underflow status */
+#define ETH_DMASR_ROS        ((uint32_t)0x00000010)  /* Receive overflow status */
+#define ETH_DMASR_TJTS       ((uint32_t)0x00000008)  /* Transmit jabber timeout status */
+#define ETH_DMASR_TBUS       ((uint32_t)0x00000004)  /* Transmit buffer unavailable status */
+#define ETH_DMASR_TPSS       ((uint32_t)0x00000002)  /* Transmit process stopped status */
+#define ETH_DMASR_TS         ((uint32_t)0x00000001)  /* Transmit status */
+
+/* Bit definition for Ethernet DMA Operation Mode Register */
+#define ETH_DMAOMR_DTCEFD    ((uint32_t)0x04000000)  /* Disable Dropping of TCP/IP checksum error frames */
+#define ETH_DMAOMR_RSF       ((uint32_t)0x02000000)  /* Receive store and forward */
+#define ETH_DMAOMR_DFRF      ((uint32_t)0x01000000)  /* Disable flushing of received frames */
+#define ETH_DMAOMR_TSF       ((uint32_t)0x00200000)  /* Transmit store and forward */
+#define ETH_DMAOMR_FTF       ((uint32_t)0x00100000)  /* Flush transmit FIFO */
+#define ETH_DMAOMR_TTC       ((uint32_t)0x0001C000)  /* Transmit threshold control */
+  #define ETH_DMAOMR_TTC_64Bytes       ((uint32_t)0x00000000)  /* threshold level of the MTL Transmit FIFO is 64 Bytes */
+  #define ETH_DMAOMR_TTC_128Bytes      ((uint32_t)0x00004000)  /* threshold level of the MTL Transmit FIFO is 128 Bytes */
+  #define ETH_DMAOMR_TTC_192Bytes      ((uint32_t)0x00008000)  /* threshold level of the MTL Transmit FIFO is 192 Bytes */
+  #define ETH_DMAOMR_TTC_256Bytes      ((uint32_t)0x0000C000)  /* threshold level of the MTL Transmit FIFO is 256 Bytes */
+  #define ETH_DMAOMR_TTC_40Bytes       ((uint32_t)0x00010000)  /* threshold level of the MTL Transmit FIFO is 40 Bytes */
+  #define ETH_DMAOMR_TTC_32Bytes       ((uint32_t)0x00014000)  /* threshold level of the MTL Transmit FIFO is 32 Bytes */
+  #define ETH_DMAOMR_TTC_24Bytes       ((uint32_t)0x00018000)  /* threshold level of the MTL Transmit FIFO is 24 Bytes */
+  #define ETH_DMAOMR_TTC_16Bytes       ((uint32_t)0x0001C000)  /* threshold level of the MTL Transmit FIFO is 16 Bytes */
+#define ETH_DMAOMR_ST        ((uint32_t)0x00002000)  /* Start/stop transmission command */
+#define ETH_DMAOMR_FEF       ((uint32_t)0x00000080)  /* Forward error frames */
+#define ETH_DMAOMR_FUGF      ((uint32_t)0x00000040)  /* Forward undersized good frames */
+#define ETH_DMAOMR_RTC       ((uint32_t)0x00000018)  /* receive threshold control */
+  #define ETH_DMAOMR_RTC_64Bytes       ((uint32_t)0x00000000)  /* threshold level of the MTL Receive FIFO is 64 Bytes */
+  #define ETH_DMAOMR_RTC_32Bytes       ((uint32_t)0x00000008)  /* threshold level of the MTL Receive FIFO is 32 Bytes */
+  #define ETH_DMAOMR_RTC_96Bytes       ((uint32_t)0x00000010)  /* threshold level of the MTL Receive FIFO is 96 Bytes */
+  #define ETH_DMAOMR_RTC_128Bytes      ((uint32_t)0x00000018)  /* threshold level of the MTL Receive FIFO is 128 Bytes */
+#define ETH_DMAOMR_OSF       ((uint32_t)0x00000004)  /* operate on second frame */
+#define ETH_DMAOMR_SR        ((uint32_t)0x00000002)  /* Start/stop receive */
+
+/* Bit definition for Ethernet DMA Interrupt Enable Register */
+#define ETH_DMAIER_NISE      ((uint32_t)0x00010000)  /* Normal interrupt summary enable */
+#define ETH_DMAIER_AISE      ((uint32_t)0x00008000)  /* Abnormal interrupt summary enable */
+#define ETH_DMAIER_ERIE      ((uint32_t)0x00004000)  /* Early receive interrupt enable */
+#define ETH_DMAIER_FBEIE     ((uint32_t)0x00002000)  /* Fatal bus error interrupt enable */
+#define ETH_DMAIER_ETIE      ((uint32_t)0x00000400)  /* Early transmit interrupt enable */
+#define ETH_DMAIER_RWTIE     ((uint32_t)0x00000200)  /* Receive watchdog timeout interrupt enable */
+#define ETH_DMAIER_RPSIE     ((uint32_t)0x00000100)  /* Receive process stopped interrupt enable */
+#define ETH_DMAIER_RBUIE     ((uint32_t)0x00000080)  /* Receive buffer unavailable interrupt enable */
+#define ETH_DMAIER_RIE       ((uint32_t)0x00000040)  /* Receive interrupt enable */
+#define ETH_DMAIER_TUIE      ((uint32_t)0x00000020)  /* Transmit Underflow interrupt enable */
+#define ETH_DMAIER_ROIE      ((uint32_t)0x00000010)  /* Receive Overflow interrupt enable */
+#define ETH_DMAIER_TJTIE     ((uint32_t)0x00000008)  /* Transmit jabber timeout interrupt enable */
+#define ETH_DMAIER_TBUIE     ((uint32_t)0x00000004)  /* Transmit buffer unavailable interrupt enable */
+#define ETH_DMAIER_TPSIE     ((uint32_t)0x00000002)  /* Transmit process stopped interrupt enable */
+#define ETH_DMAIER_TIE       ((uint32_t)0x00000001)  /* Transmit interrupt enable */
+
+/* Bit definition for Ethernet DMA Missed Frame and Buffer Overflow Counter Register */
+#define ETH_DMAMFBOCR_OFOC   ((uint32_t)0x10000000)  /* Overflow bit for FIFO overflow counter */
+#define ETH_DMAMFBOCR_MFA    ((uint32_t)0x0FFE0000)  /* Number of frames missed by the application */
+#define ETH_DMAMFBOCR_OMFC   ((uint32_t)0x00010000)  /* Overflow bit for missed frame counter */
+#define ETH_DMAMFBOCR_MFC    ((uint32_t)0x0000FFFF)  /* Number of frames missed by the controller */
+
+/* Bit definition for Ethernet DMA Current Host Transmit Descriptor Register */
+#define ETH_DMACHTDR_HTDAP   ((uint32_t)0xFFFFFFFF)  /* Host transmit descriptor address pointer */
+
+/* Bit definition for Ethernet DMA Current Host Receive Descriptor Register */
+#define ETH_DMACHRDR_HRDAP   ((uint32_t)0xFFFFFFFF)  /* Host receive descriptor address pointer */
+
+/* Bit definition for Ethernet DMA Current Host Transmit Buffer Address Register */
+#define ETH_DMACHTBAR_HTBAP  ((uint32_t)0xFFFFFFFF)  /* Host transmit buffer address pointer */
+
+/* Bit definition for Ethernet DMA Current Host Receive Buffer Address Register */
+#define ETH_DMACHRBAR_HRBAP  ((uint32_t)0xFFFFFFFF)  /* Host receive buffer address pointer */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                       USB_OTG                              */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for USB_OTG_GOTGCTL register  ********************/
+#define USB_OTG_GOTGCTL_SRQSCS                  ((uint32_t)0x00000001)         /*!< Session request success */
+#define USB_OTG_GOTGCTL_SRQ                     ((uint32_t)0x00000002)         /*!< Session request */
+#define USB_OTG_GOTGCTL_VBVALOEN                ((uint32_t)0x00000004)         /*!< VBUS valid override enable */
+#define USB_OTG_GOTGCTL_VBVALOVAL               ((uint32_t)0x00000008)         /*!< VBUS valid override value */
+#define USB_OTG_GOTGCTL_AVALOEN                 ((uint32_t)0x00000010)         /*!< A-peripheral session valid override enable */
+#define USB_OTG_GOTGCTL_AVALOVAL                ((uint32_t)0x00000020)         /*!< A-peripheral session valid override value */
+#define USB_OTG_GOTGCTL_BVALOEN                 ((uint32_t)0x00000040)         /*!< B-peripheral session valid override enable */
+#define USB_OTG_GOTGCTL_BVALOVAL                ((uint32_t)0x00000080)         /*!< B-peripheral session valid override value  */
+#define USB_OTG_GOTGCTL_HNGSCS                  ((uint32_t)0x00000100)         /*!< Host set HNP enable */
+#define USB_OTG_GOTGCTL_HNPRQ                   ((uint32_t)0x00000200)         /*!< HNP request */
+#define USB_OTG_GOTGCTL_HSHNPEN                 ((uint32_t)0x00000400)         /*!< Host set HNP enable */
+#define USB_OTG_GOTGCTL_DHNPEN                  ((uint32_t)0x00000800)         /*!< Device HNP enabled */
+#define USB_OTG_GOTGCTL_EHEN                    ((uint32_t)0x00001000)         /*!< Embedded host enable */
+#define USB_OTG_GOTGCTL_CIDSTS                  ((uint32_t)0x00010000)         /*!< Connector ID status */
+#define USB_OTG_GOTGCTL_DBCT                    ((uint32_t)0x00020000)         /*!< Long/short debounce time */
+#define USB_OTG_GOTGCTL_ASVLD                   ((uint32_t)0x00040000)         /*!< A-session valid  */
+#define USB_OTG_GOTGCTL_BSESVLD                 ((uint32_t)0x00080000)         /*!< B-session valid */
+#define USB_OTG_GOTGCTL_OTGVER                  ((uint32_t)0x00100000)         /*!< OTG version  */
+
+/********************  Bit definition for USB_OTG_HCFG register  ********************/
+#define USB_OTG_HCFG_FSLSPCS                 ((uint32_t)0x00000003)            /*!< FS/LS PHY clock select  */
+#define USB_OTG_HCFG_FSLSPCS_0               ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_HCFG_FSLSPCS_1               ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_HCFG_FSLSS                   ((uint32_t)0x00000004)            /*!< FS- and LS-only support */
+
+/********************  Bit definition for USB_OTG_DCFG register  ********************/
+#define USB_OTG_DCFG_DSPD                    ((uint32_t)0x00000003)            /*!< Device speed */
+#define USB_OTG_DCFG_DSPD_0                  ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_DCFG_DSPD_1                  ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_DCFG_NZLSOHSK                ((uint32_t)0x00000004)            /*!< Nonzero-length status OUT handshake */
+
+#define USB_OTG_DCFG_DAD                     ((uint32_t)0x000007F0)            /*!< Device address */
+#define USB_OTG_DCFG_DAD_0                   ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define USB_OTG_DCFG_DAD_1                   ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define USB_OTG_DCFG_DAD_2                   ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define USB_OTG_DCFG_DAD_3                   ((uint32_t)0x00000080)            /*!<Bit 3 */
+#define USB_OTG_DCFG_DAD_4                   ((uint32_t)0x00000100)            /*!<Bit 4 */
+#define USB_OTG_DCFG_DAD_5                   ((uint32_t)0x00000200)            /*!<Bit 5 */
+#define USB_OTG_DCFG_DAD_6                   ((uint32_t)0x00000400)            /*!<Bit 6 */
+
+#define USB_OTG_DCFG_PFIVL                   ((uint32_t)0x00001800)            /*!< Periodic (micro)frame interval */
+#define USB_OTG_DCFG_PFIVL_0                 ((uint32_t)0x00000800)            /*!<Bit 0 */
+#define USB_OTG_DCFG_PFIVL_1                 ((uint32_t)0x00001000)            /*!<Bit 1 */
+
+#define USB_OTG_DCFG_PERSCHIVL               ((uint32_t)0x03000000)            /*!< Periodic scheduling interval */
+#define USB_OTG_DCFG_PERSCHIVL_0             ((uint32_t)0x01000000)            /*!<Bit 0 */
+#define USB_OTG_DCFG_PERSCHIVL_1             ((uint32_t)0x02000000)            /*!<Bit 1 */
+
+/********************  Bit definition for USB_OTG_PCGCR register  ********************/
+#define USB_OTG_PCGCR_STPPCLK                 ((uint32_t)0x00000001)            /*!< Stop PHY clock */
+#define USB_OTG_PCGCR_GATEHCLK                ((uint32_t)0x00000002)            /*!< Gate HCLK */
+#define USB_OTG_PCGCR_PHYSUSP                 ((uint32_t)0x00000010)            /*!< PHY suspended */
+
+/********************  Bit definition for USB_OTG_GOTGINT register  ********************/
+#define USB_OTG_GOTGINT_SEDET                   ((uint32_t)0x00000004)            /*!< Session end detected                   */
+#define USB_OTG_GOTGINT_SRSSCHG                 ((uint32_t)0x00000100)            /*!< Session request success status change  */
+#define USB_OTG_GOTGINT_HNSSCHG                 ((uint32_t)0x00000200)            /*!< Host negotiation success status change */
+#define USB_OTG_GOTGINT_HNGDET                  ((uint32_t)0x00020000)            /*!< Host negotiation detected              */
+#define USB_OTG_GOTGINT_ADTOCHG                 ((uint32_t)0x00040000)            /*!< A-device timeout change                */
+#define USB_OTG_GOTGINT_DBCDNE                  ((uint32_t)0x00080000)            /*!< Debounce done                          */
+#define USB_OTG_GOTGINT_IDCHNG                  ((uint32_t)0x00100000)            /*!< Change in ID pin input value           */
+
+/********************  Bit definition for USB_OTG_DCTL register  ********************/
+#define USB_OTG_DCTL_RWUSIG                  ((uint32_t)0x00000001)            /*!< Remote wakeup signaling */
+#define USB_OTG_DCTL_SDIS                    ((uint32_t)0x00000002)            /*!< Soft disconnect         */
+#define USB_OTG_DCTL_GINSTS                  ((uint32_t)0x00000004)            /*!< Global IN NAK status    */
+#define USB_OTG_DCTL_GONSTS                  ((uint32_t)0x00000008)            /*!< Global OUT NAK status   */
+
+#define USB_OTG_DCTL_TCTL                    ((uint32_t)0x00000070)            /*!< Test control */
+#define USB_OTG_DCTL_TCTL_0                  ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define USB_OTG_DCTL_TCTL_1                  ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define USB_OTG_DCTL_TCTL_2                  ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define USB_OTG_DCTL_SGINAK                  ((uint32_t)0x00000080)            /*!< Set global IN NAK         */
+#define USB_OTG_DCTL_CGINAK                  ((uint32_t)0x00000100)            /*!< Clear global IN NAK       */
+#define USB_OTG_DCTL_SGONAK                  ((uint32_t)0x00000200)            /*!< Set global OUT NAK        */
+#define USB_OTG_DCTL_CGONAK                  ((uint32_t)0x00000400)            /*!< Clear global OUT NAK      */
+#define USB_OTG_DCTL_POPRGDNE                ((uint32_t)0x00000800)            /*!< Power-on programming done */
+
+/********************  Bit definition for USB_OTG_HFIR register  ********************/
+#define USB_OTG_HFIR_FRIVL                   ((uint32_t)0x0000FFFF)            /*!< Frame interval */
+
+/********************  Bit definition for USB_OTG_HFNUM register  ********************/
+#define USB_OTG_HFNUM_FRNUM                   ((uint32_t)0x0000FFFF)            /*!< Frame number         */
+#define USB_OTG_HFNUM_FTREM                   ((uint32_t)0xFFFF0000)            /*!< Frame time remaining */
+
+/********************  Bit definition for USB_OTG_DSTS register  ********************/
+#define USB_OTG_DSTS_SUSPSTS                 ((uint32_t)0x00000001)            /*!< Suspend status   */
+
+#define USB_OTG_DSTS_ENUMSPD                 ((uint32_t)0x00000006)            /*!< Enumerated speed */
+#define USB_OTG_DSTS_ENUMSPD_0               ((uint32_t)0x00000002)            /*!<Bit 0 */
+#define USB_OTG_DSTS_ENUMSPD_1               ((uint32_t)0x00000004)            /*!<Bit 1 */
+#define USB_OTG_DSTS_EERR                    ((uint32_t)0x00000008)            /*!< Erratic error     */
+#define USB_OTG_DSTS_FNSOF                   ((uint32_t)0x003FFF00)            /*!< Frame number of the received SOF */
+
+/********************  Bit definition for USB_OTG_GAHBCFG register  ********************/
+#define USB_OTG_GAHBCFG_GINT                    ((uint32_t)0x00000001)            /*!< Global interrupt mask */
+#define USB_OTG_GAHBCFG_HBSTLEN                 ((uint32_t)0x0000001E)            /*!< Burst length/type */
+#define USB_OTG_GAHBCFG_HBSTLEN_0               ((uint32_t)0x00000002)            /*!<Bit 0 */
+#define USB_OTG_GAHBCFG_HBSTLEN_1               ((uint32_t)0x00000004)            /*!<Bit 1 */
+#define USB_OTG_GAHBCFG_HBSTLEN_2               ((uint32_t)0x00000008)            /*!<Bit 2 */
+#define USB_OTG_GAHBCFG_HBSTLEN_3               ((uint32_t)0x00000010)            /*!<Bit 3 */
+#define USB_OTG_GAHBCFG_DMAEN                   ((uint32_t)0x00000020)            /*!< DMA enable */
+#define USB_OTG_GAHBCFG_TXFELVL                 ((uint32_t)0x00000080)            /*!< TxFIFO empty level */
+#define USB_OTG_GAHBCFG_PTXFELVL                ((uint32_t)0x00000100)            /*!< Periodic TxFIFO empty level */
+
+/********************  Bit definition for USB_OTG_GUSBCFG register  ********************/
+#define USB_OTG_GUSBCFG_TOCAL                   ((uint32_t)0x00000007)            /*!< FS timeout calibration */
+#define USB_OTG_GUSBCFG_TOCAL_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_GUSBCFG_TOCAL_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_GUSBCFG_TOCAL_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_GUSBCFG_PHYSEL                  ((uint32_t)0x00000040)            /*!< USB 2.0 high-speed ULPI PHY or USB 1.1 full-speed serial transceiver select */
+#define USB_OTG_GUSBCFG_SRPCAP                  ((uint32_t)0x00000100)            /*!< SRP-capable */
+#define USB_OTG_GUSBCFG_HNPCAP                  ((uint32_t)0x00000200)            /*!< HNP-capable */
+#define USB_OTG_GUSBCFG_TRDT                    ((uint32_t)0x00003C00)            /*!< USB turnaround time */
+#define USB_OTG_GUSBCFG_TRDT_0                  ((uint32_t)0x00000400)            /*!<Bit 0 */
+#define USB_OTG_GUSBCFG_TRDT_1                  ((uint32_t)0x00000800)            /*!<Bit 1 */
+#define USB_OTG_GUSBCFG_TRDT_2                  ((uint32_t)0x00001000)            /*!<Bit 2 */
+#define USB_OTG_GUSBCFG_TRDT_3                  ((uint32_t)0x00002000)            /*!<Bit 3 */
+#define USB_OTG_GUSBCFG_PHYLPCS                 ((uint32_t)0x00008000)            /*!< PHY Low-power clock select */
+#define USB_OTG_GUSBCFG_ULPIFSLS                ((uint32_t)0x00020000)            /*!< ULPI FS/LS select               */
+#define USB_OTG_GUSBCFG_ULPIAR                  ((uint32_t)0x00040000)            /*!< ULPI Auto-resume                */
+#define USB_OTG_GUSBCFG_ULPICSM                 ((uint32_t)0x00080000)            /*!< ULPI Clock SuspendM             */
+#define USB_OTG_GUSBCFG_ULPIEVBUSD              ((uint32_t)0x00100000)            /*!< ULPI External VBUS Drive        */
+#define USB_OTG_GUSBCFG_ULPIEVBUSI              ((uint32_t)0x00200000)            /*!< ULPI external VBUS indicator    */
+#define USB_OTG_GUSBCFG_TSDPS                   ((uint32_t)0x00400000)            /*!< TermSel DLine pulsing selection */
+#define USB_OTG_GUSBCFG_PCCI                    ((uint32_t)0x00800000)            /*!< Indicator complement            */
+#define USB_OTG_GUSBCFG_PTCI                    ((uint32_t)0x01000000)            /*!< Indicator pass through          */
+#define USB_OTG_GUSBCFG_ULPIIPD                 ((uint32_t)0x02000000)            /*!< ULPI interface protect disable  */
+#define USB_OTG_GUSBCFG_FHMOD                   ((uint32_t)0x20000000)            /*!< Forced host mode                */
+#define USB_OTG_GUSBCFG_FDMOD                   ((uint32_t)0x40000000)            /*!< Forced peripheral mode          */
+#define USB_OTG_GUSBCFG_CTXPKT                  ((uint32_t)0x80000000)            /*!< Corrupt Tx packet               */
+
+/********************  Bit definition for USB_OTG_GRSTCTL register  ********************/
+#define USB_OTG_GRSTCTL_CSRST                   ((uint32_t)0x00000001)            /*!< Core soft reset          */
+#define USB_OTG_GRSTCTL_HSRST                   ((uint32_t)0x00000002)            /*!< HCLK soft reset          */
+#define USB_OTG_GRSTCTL_FCRST                   ((uint32_t)0x00000004)            /*!< Host frame counter reset */
+#define USB_OTG_GRSTCTL_RXFFLSH                 ((uint32_t)0x00000010)            /*!< RxFIFO flush             */
+#define USB_OTG_GRSTCTL_TXFFLSH                 ((uint32_t)0x00000020)            /*!< TxFIFO flush             */
+#define USB_OTG_GRSTCTL_TXFNUM                  ((uint32_t)0x000007C0)            /*!< TxFIFO number */
+#define USB_OTG_GRSTCTL_TXFNUM_0                ((uint32_t)0x00000040)            /*!<Bit 0 */
+#define USB_OTG_GRSTCTL_TXFNUM_1                ((uint32_t)0x00000080)            /*!<Bit 1 */
+#define USB_OTG_GRSTCTL_TXFNUM_2                ((uint32_t)0x00000100)            /*!<Bit 2 */
+#define USB_OTG_GRSTCTL_TXFNUM_3                ((uint32_t)0x00000200)            /*!<Bit 3 */
+#define USB_OTG_GRSTCTL_TXFNUM_4                ((uint32_t)0x00000400)            /*!<Bit 4 */
+#define USB_OTG_GRSTCTL_DMAREQ                  ((uint32_t)0x40000000)            /*!< DMA request signal */
+#define USB_OTG_GRSTCTL_AHBIDL                  ((uint32_t)0x80000000)            /*!< AHB master idle */
+
+/********************  Bit definition for USB_OTG_DIEPMSK register  ********************/
+#define USB_OTG_DIEPMSK_XFRCM                   ((uint32_t)0x00000001)            /*!< Transfer completed interrupt mask                 */
+#define USB_OTG_DIEPMSK_EPDM                    ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt mask                  */
+#define USB_OTG_DIEPMSK_TOM                     ((uint32_t)0x00000008)            /*!< Timeout condition mask (nonisochronous endpoints) */
+#define USB_OTG_DIEPMSK_ITTXFEMSK               ((uint32_t)0x00000010)            /*!< IN token received when TxFIFO empty mask          */
+#define USB_OTG_DIEPMSK_INEPNMM                 ((uint32_t)0x00000020)            /*!< IN token received with EP mismatch mask           */
+#define USB_OTG_DIEPMSK_INEPNEM                 ((uint32_t)0x00000040)            /*!< IN endpoint NAK effective mask                    */
+#define USB_OTG_DIEPMSK_TXFURM                  ((uint32_t)0x00000100)            /*!< FIFO underrun mask                                */
+#define USB_OTG_DIEPMSK_BIM                     ((uint32_t)0x00000200)            /*!< BNA interrupt mask                                */
+
+/********************  Bit definition for USB_OTG_HPTXSTS register  ********************/
+#define USB_OTG_HPTXSTS_PTXFSAVL                ((uint32_t)0x0000FFFF)            /*!< Periodic transmit data FIFO space available     */
+#define USB_OTG_HPTXSTS_PTXQSAV                 ((uint32_t)0x00FF0000)            /*!< Periodic transmit request queue space available */
+#define USB_OTG_HPTXSTS_PTXQSAV_0               ((uint32_t)0x00010000)            /*!<Bit 0 */
+#define USB_OTG_HPTXSTS_PTXQSAV_1               ((uint32_t)0x00020000)            /*!<Bit 1 */
+#define USB_OTG_HPTXSTS_PTXQSAV_2               ((uint32_t)0x00040000)            /*!<Bit 2 */
+#define USB_OTG_HPTXSTS_PTXQSAV_3               ((uint32_t)0x00080000)            /*!<Bit 3 */
+#define USB_OTG_HPTXSTS_PTXQSAV_4               ((uint32_t)0x00100000)            /*!<Bit 4 */
+#define USB_OTG_HPTXSTS_PTXQSAV_5               ((uint32_t)0x00200000)            /*!<Bit 5 */
+#define USB_OTG_HPTXSTS_PTXQSAV_6               ((uint32_t)0x00400000)            /*!<Bit 6 */
+#define USB_OTG_HPTXSTS_PTXQSAV_7               ((uint32_t)0x00800000)            /*!<Bit 7 */
+
+#define USB_OTG_HPTXSTS_PTXQTOP                 ((uint32_t)0xFF000000)            /*!< Top of the periodic transmit request queue */
+#define USB_OTG_HPTXSTS_PTXQTOP_0               ((uint32_t)0x01000000)            /*!<Bit 0 */
+#define USB_OTG_HPTXSTS_PTXQTOP_1               ((uint32_t)0x02000000)            /*!<Bit 1 */
+#define USB_OTG_HPTXSTS_PTXQTOP_2               ((uint32_t)0x04000000)            /*!<Bit 2 */
+#define USB_OTG_HPTXSTS_PTXQTOP_3               ((uint32_t)0x08000000)            /*!<Bit 3 */
+#define USB_OTG_HPTXSTS_PTXQTOP_4               ((uint32_t)0x10000000)            /*!<Bit 4 */
+#define USB_OTG_HPTXSTS_PTXQTOP_5               ((uint32_t)0x20000000)            /*!<Bit 5 */
+#define USB_OTG_HPTXSTS_PTXQTOP_6               ((uint32_t)0x40000000)            /*!<Bit 6 */
+#define USB_OTG_HPTXSTS_PTXQTOP_7               ((uint32_t)0x80000000)            /*!<Bit 7 */
+
+/********************  Bit definition for USB_OTG_HAINT register  ********************/
+#define USB_OTG_HAINT_HAINT                   ((uint32_t)0x0000FFFF)            /*!< Channel interrupts */
+
+/********************  Bit definition for USB_OTG_DOEPMSK register  ********************/
+#define USB_OTG_DOEPMSK_XFRCM                   ((uint32_t)0x00000001)            /*!< Transfer completed interrupt mask */
+#define USB_OTG_DOEPMSK_EPDM                    ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt mask               */
+#define USB_OTG_DOEPMSK_STUPM                   ((uint32_t)0x00000008)            /*!< SETUP phase done mask                          */
+#define USB_OTG_DOEPMSK_OTEPDM                  ((uint32_t)0x00000010)            /*!< OUT token received when endpoint disabled mask */
+#define USB_OTG_DOEPMSK_B2BSTUP                 ((uint32_t)0x00000040)            /*!< Back-to-back SETUP packets received mask       */
+#define USB_OTG_DOEPMSK_OPEM                    ((uint32_t)0x00000100)            /*!< OUT packet error mask                          */
+#define USB_OTG_DOEPMSK_BOIM                    ((uint32_t)0x00000200)            /*!< BNA interrupt mask                             */
+
+/********************  Bit definition for USB_OTG_GINTSTS register  ********************/
+#define USB_OTG_GINTSTS_CMOD                    ((uint32_t)0x00000001)            /*!< Current mode of operation                      */
+#define USB_OTG_GINTSTS_MMIS                    ((uint32_t)0x00000002)            /*!< Mode mismatch interrupt                        */
+#define USB_OTG_GINTSTS_OTGINT                  ((uint32_t)0x00000004)            /*!< OTG interrupt                                  */
+#define USB_OTG_GINTSTS_SOF                     ((uint32_t)0x00000008)            /*!< Start of frame                                 */
+#define USB_OTG_GINTSTS_RXFLVL                  ((uint32_t)0x00000010)            /*!< RxFIFO nonempty                                */
+#define USB_OTG_GINTSTS_NPTXFE                  ((uint32_t)0x00000020)            /*!< Nonperiodic TxFIFO empty                       */
+#define USB_OTG_GINTSTS_GINAKEFF                ((uint32_t)0x00000040)            /*!< Global IN nonperiodic NAK effective            */
+#define USB_OTG_GINTSTS_BOUTNAKEFF              ((uint32_t)0x00000080)            /*!< Global OUT NAK effective                       */
+#define USB_OTG_GINTSTS_ESUSP                   ((uint32_t)0x00000400)            /*!< Early suspend                                  */
+#define USB_OTG_GINTSTS_USBSUSP                 ((uint32_t)0x00000800)            /*!< USB suspend                                    */
+#define USB_OTG_GINTSTS_USBRST                  ((uint32_t)0x00001000)            /*!< USB reset                                      */
+#define USB_OTG_GINTSTS_ENUMDNE                 ((uint32_t)0x00002000)            /*!< Enumeration done                               */
+#define USB_OTG_GINTSTS_ISOODRP                 ((uint32_t)0x00004000)            /*!< Isochronous OUT packet dropped interrupt       */
+#define USB_OTG_GINTSTS_EOPF                    ((uint32_t)0x00008000)            /*!< End of periodic frame interrupt                */
+#define USB_OTG_GINTSTS_IEPINT                  ((uint32_t)0x00040000)            /*!< IN endpoint interrupt                          */
+#define USB_OTG_GINTSTS_OEPINT                  ((uint32_t)0x00080000)            /*!< OUT endpoint interrupt                         */
+#define USB_OTG_GINTSTS_IISOIXFR                ((uint32_t)0x00100000)            /*!< Incomplete isochronous IN transfer             */
+#define USB_OTG_GINTSTS_PXFR_INCOMPISOOUT       ((uint32_t)0x00200000)            /*!< Incomplete periodic transfer                   */
+#define USB_OTG_GINTSTS_DATAFSUSP               ((uint32_t)0x00400000)            /*!< Data fetch suspended                           */
+#define USB_OTG_GINTSTS_RSTDET                  ((uint32_t)0x00800000)            /*!< Reset detected interrupt                       */
+#define USB_OTG_GINTSTS_HPRTINT                 ((uint32_t)0x01000000)            /*!< Host port interrupt                            */
+#define USB_OTG_GINTSTS_HCINT                   ((uint32_t)0x02000000)            /*!< Host channels interrupt                        */
+#define USB_OTG_GINTSTS_PTXFE                   ((uint32_t)0x04000000)            /*!< Periodic TxFIFO empty                          */
+#define USB_OTG_GINTSTS_LPMINT                  ((uint32_t)0x08000000)            /*!< LPM interrupt                                  */
+#define USB_OTG_GINTSTS_CIDSCHG                 ((uint32_t)0x10000000)            /*!< Connector ID status change                     */
+#define USB_OTG_GINTSTS_DISCINT                 ((uint32_t)0x20000000)            /*!< Disconnect detected interrupt                  */
+#define USB_OTG_GINTSTS_SRQINT                  ((uint32_t)0x40000000)            /*!< Session request/new session detected interrupt */
+#define USB_OTG_GINTSTS_WKUINT                  ((uint32_t)0x80000000)            /*!< Resume/remote wakeup detected interrupt        */
+
+/********************  Bit definition for USB_OTG_GINTMSK register  ********************/
+#define USB_OTG_GINTMSK_MMISM                   ((uint32_t)0x00000002)            /*!< Mode mismatch interrupt mask                        */
+#define USB_OTG_GINTMSK_OTGINT                  ((uint32_t)0x00000004)            /*!< OTG interrupt mask                                  */
+#define USB_OTG_GINTMSK_SOFM                    ((uint32_t)0x00000008)            /*!< Start of frame mask                                 */
+#define USB_OTG_GINTMSK_RXFLVLM                 ((uint32_t)0x00000010)            /*!< Receive FIFO nonempty mask                          */
+#define USB_OTG_GINTMSK_NPTXFEM                 ((uint32_t)0x00000020)            /*!< Nonperiodic TxFIFO empty mask                       */
+#define USB_OTG_GINTMSK_GINAKEFFM               ((uint32_t)0x00000040)            /*!< Global nonperiodic IN NAK effective mask            */
+#define USB_OTG_GINTMSK_GONAKEFFM               ((uint32_t)0x00000080)            /*!< Global OUT NAK effective mask                       */
+#define USB_OTG_GINTMSK_ESUSPM                  ((uint32_t)0x00000400)            /*!< Early suspend mask                                  */
+#define USB_OTG_GINTMSK_USBSUSPM                ((uint32_t)0x00000800)            /*!< USB suspend mask                                    */
+#define USB_OTG_GINTMSK_USBRST                  ((uint32_t)0x00001000)            /*!< USB reset mask                                      */
+#define USB_OTG_GINTMSK_ENUMDNEM                ((uint32_t)0x00002000)            /*!< Enumeration done mask                               */
+#define USB_OTG_GINTMSK_ISOODRPM                ((uint32_t)0x00004000)            /*!< Isochronous OUT packet dropped interrupt mask       */
+#define USB_OTG_GINTMSK_EOPFM                   ((uint32_t)0x00008000)            /*!< End of periodic frame interrupt mask                */
+#define USB_OTG_GINTMSK_EPMISM                  ((uint32_t)0x00020000)            /*!< Endpoint mismatch interrupt mask                    */
+#define USB_OTG_GINTMSK_IEPINT                  ((uint32_t)0x00040000)            /*!< IN endpoints interrupt mask                         */
+#define USB_OTG_GINTMSK_OEPINT                  ((uint32_t)0x00080000)            /*!< OUT endpoints interrupt mask                        */
+#define USB_OTG_GINTMSK_IISOIXFRM               ((uint32_t)0x00100000)            /*!< Incomplete isochronous IN transfer mask             */
+#define USB_OTG_GINTMSK_PXFRM_IISOOXFRM         ((uint32_t)0x00200000)            /*!< Incomplete periodic transfer mask                   */
+#define USB_OTG_GINTMSK_FSUSPM                  ((uint32_t)0x00400000)            /*!< Data fetch suspended mask                           */
+#define USB_OTG_GINTMSK_RSTDEM                  ((uint32_t)0x00800000)            /*!< Reset detected interrupt mask                      */
+#define USB_OTG_GINTMSK_PRTIM                   ((uint32_t)0x01000000)            /*!< Host port interrupt mask                            */
+#define USB_OTG_GINTMSK_HCIM                    ((uint32_t)0x02000000)            /*!< Host channels interrupt mask                        */
+#define USB_OTG_GINTMSK_PTXFEM                  ((uint32_t)0x04000000)            /*!< Periodic TxFIFO empty mask                          */
+#define USB_OTG_GINTMSK_LPMINTM                 ((uint32_t)0x08000000)            /*!< LPM interrupt Mask                                  */
+#define USB_OTG_GINTMSK_CIDSCHGM                ((uint32_t)0x10000000)            /*!< Connector ID status change mask                     */
+#define USB_OTG_GINTMSK_DISCINT                 ((uint32_t)0x20000000)            /*!< Disconnect detected interrupt mask                  */
+#define USB_OTG_GINTMSK_SRQIM                   ((uint32_t)0x40000000)            /*!< Session request/new session detected interrupt mask */
+#define USB_OTG_GINTMSK_WUIM                    ((uint32_t)0x80000000)            /*!< Resume/remote wakeup detected interrupt mask        */
+
+/********************  Bit definition for USB_OTG_DAINT register  ********************/
+#define USB_OTG_DAINT_IEPINT                  ((uint32_t)0x0000FFFF)            /*!< IN endpoint interrupt bits  */
+#define USB_OTG_DAINT_OEPINT                  ((uint32_t)0xFFFF0000)            /*!< OUT endpoint interrupt bits */
+
+/********************  Bit definition for USB_OTG_HAINTMSK register  ********************/
+#define USB_OTG_HAINTMSK_HAINTM                  ((uint32_t)0x0000FFFF)            /*!< Channel interrupt mask */
+
+/********************  Bit definition for USB_OTG_GRXSTSP register  ********************/
+#define USB_OTG_GRXSTSP_EPNUM                    ((uint32_t)0x0000000F)            /*!< IN EP interrupt mask bits  */
+#define USB_OTG_GRXSTSP_BCNT                     ((uint32_t)0x00007FF0)            /*!< OUT EP interrupt mask bits */
+#define USB_OTG_GRXSTSP_DPID                     ((uint32_t)0x00018000)            /*!< OUT EP interrupt mask bits */
+#define USB_OTG_GRXSTSP_PKTSTS                   ((uint32_t)0x001E0000)            /*!< OUT EP interrupt mask bits */
+
+/********************  Bit definition for USB_OTG_DAINTMSK register  ********************/
+#define USB_OTG_DAINTMSK_IEPM                    ((uint32_t)0x0000FFFF)            /*!< IN EP interrupt mask bits */
+#define USB_OTG_DAINTMSK_OEPM                    ((uint32_t)0xFFFF0000)            /*!< OUT EP interrupt mask bits */
+
+/********************  Bit definition for OTG register  ********************/
+
+#define USB_OTG_CHNUM                   ((uint32_t)0x0000000F)            /*!< Channel number */
+#define USB_OTG_CHNUM_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_CHNUM_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_CHNUM_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_CHNUM_3                 ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define USB_OTG_BCNT                    ((uint32_t)0x00007FF0)            /*!< Byte count */
+
+#define USB_OTG_DPID                    ((uint32_t)0x00018000)            /*!< Data PID */
+#define USB_OTG_DPID_0                  ((uint32_t)0x00008000)            /*!<Bit 0 */
+#define USB_OTG_DPID_1                  ((uint32_t)0x00010000)            /*!<Bit 1 */
+
+#define USB_OTG_PKTSTS                  ((uint32_t)0x001E0000)            /*!< Packet status */
+#define USB_OTG_PKTSTS_0                ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define USB_OTG_PKTSTS_1                ((uint32_t)0x00040000)            /*!<Bit 1 */
+#define USB_OTG_PKTSTS_2                ((uint32_t)0x00080000)            /*!<Bit 2 */
+#define USB_OTG_PKTSTS_3                ((uint32_t)0x00100000)            /*!<Bit 3 */
+
+#define USB_OTG_EPNUM                   ((uint32_t)0x0000000F)            /*!< Endpoint number */
+#define USB_OTG_EPNUM_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_EPNUM_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_EPNUM_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_EPNUM_3                 ((uint32_t)0x00000008)            /*!<Bit 3 */
+
+#define USB_OTG_FRMNUM                  ((uint32_t)0x01E00000)            /*!< Frame number */
+#define USB_OTG_FRMNUM_0                ((uint32_t)0x00200000)            /*!<Bit 0 */
+#define USB_OTG_FRMNUM_1                ((uint32_t)0x00400000)            /*!<Bit 1 */
+#define USB_OTG_FRMNUM_2                ((uint32_t)0x00800000)            /*!<Bit 2 */
+#define USB_OTG_FRMNUM_3                ((uint32_t)0x01000000)            /*!<Bit 3 */
+
+/********************  Bit definition for OTG register  ********************/
+
+#define USB_OTG_CHNUM                   ((uint32_t)0x0000000F)            /*!< Channel number */
+#define USB_OTG_CHNUM_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_CHNUM_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_CHNUM_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_CHNUM_3                 ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define USB_OTG_BCNT                    ((uint32_t)0x00007FF0)            /*!< Byte count */
+
+#define USB_OTG_DPID                    ((uint32_t)0x00018000)            /*!< Data PID */
+#define USB_OTG_DPID_0                  ((uint32_t)0x00008000)            /*!<Bit 0 */
+#define USB_OTG_DPID_1                  ((uint32_t)0x00010000)            /*!<Bit 1 */
+
+#define USB_OTG_PKTSTS                  ((uint32_t)0x001E0000)            /*!< Packet status */
+#define USB_OTG_PKTSTS_0                ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define USB_OTG_PKTSTS_1                ((uint32_t)0x00040000)            /*!<Bit 1 */
+#define USB_OTG_PKTSTS_2                ((uint32_t)0x00080000)            /*!<Bit 2 */
+#define USB_OTG_PKTSTS_3                ((uint32_t)0x00100000)            /*!<Bit 3 */
+
+#define USB_OTG_EPNUM                   ((uint32_t)0x0000000F)            /*!< Endpoint number */
+#define USB_OTG_EPNUM_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_EPNUM_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_EPNUM_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_EPNUM_3                 ((uint32_t)0x00000008)            /*!<Bit 3 */
+
+#define USB_OTG_FRMNUM                  ((uint32_t)0x01E00000)            /*!< Frame number */
+#define USB_OTG_FRMNUM_0                ((uint32_t)0x00200000)            /*!<Bit 0 */
+#define USB_OTG_FRMNUM_1                ((uint32_t)0x00400000)            /*!<Bit 1 */
+#define USB_OTG_FRMNUM_2                ((uint32_t)0x00800000)            /*!<Bit 2 */
+#define USB_OTG_FRMNUM_3                ((uint32_t)0x01000000)            /*!<Bit 3 */
+
+/********************  Bit definition for USB_OTG_GRXFSIZ register  ********************/
+#define USB_OTG_GRXFSIZ_RXFD            ((uint32_t)0x0000FFFF)            /*!< RxFIFO depth */
+
+/********************  Bit definition for USB_OTG_DVBUSDIS register  ********************/
+#define USB_OTG_DVBUSDIS_VBUSDT         ((uint32_t)0x0000FFFF)            /*!< Device VBUS discharge time */
+
+/********************  Bit definition for OTG register  ********************/
+#define USB_OTG_NPTXFSA                 ((uint32_t)0x0000FFFF)            /*!< Nonperiodic transmit RAM start address */
+#define USB_OTG_NPTXFD                  ((uint32_t)0xFFFF0000)            /*!< Nonperiodic TxFIFO depth               */
+#define USB_OTG_TX0FSA                  ((uint32_t)0x0000FFFF)            /*!< Endpoint 0 transmit RAM start address  */
+#define USB_OTG_TX0FD                   ((uint32_t)0xFFFF0000)            /*!< Endpoint 0 TxFIFO depth                */
+
+/********************  Bit definition for USB_OTG_DVBUSPULSE register  ********************/
+#define USB_OTG_DVBUSPULSE_DVBUSP                  ((uint32_t)0x00000FFF)            /*!< Device VBUS pulsing time */
+
+/********************  Bit definition for USB_OTG_GNPTXSTS register  ********************/
+#define USB_OTG_GNPTXSTS_NPTXFSAV                ((uint32_t)0x0000FFFF)            /*!< Nonperiodic TxFIFO space available */
+
+#define USB_OTG_GNPTXSTS_NPTQXSAV                ((uint32_t)0x00FF0000)            /*!< Nonperiodic transmit request queue space available */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_0              ((uint32_t)0x00010000)            /*!<Bit 0 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_1              ((uint32_t)0x00020000)            /*!<Bit 1 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_2              ((uint32_t)0x00040000)            /*!<Bit 2 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_3              ((uint32_t)0x00080000)            /*!<Bit 3 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_4              ((uint32_t)0x00100000)            /*!<Bit 4 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_5              ((uint32_t)0x00200000)            /*!<Bit 5 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_6              ((uint32_t)0x00400000)            /*!<Bit 6 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_7              ((uint32_t)0x00800000)            /*!<Bit 7 */
+
+#define USB_OTG_GNPTXSTS_NPTXQTOP                ((uint32_t)0x7F000000)            /*!< Top of the nonperiodic transmit request queue */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_0              ((uint32_t)0x01000000)            /*!<Bit 0 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_1              ((uint32_t)0x02000000)            /*!<Bit 1 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_2              ((uint32_t)0x04000000)            /*!<Bit 2 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_3              ((uint32_t)0x08000000)            /*!<Bit 3 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_4              ((uint32_t)0x10000000)            /*!<Bit 4 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_5              ((uint32_t)0x20000000)            /*!<Bit 5 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_6              ((uint32_t)0x40000000)            /*!<Bit 6 */
+
+/********************  Bit definition for USB_OTG_DTHRCTL register  ********************/
+#define USB_OTG_DTHRCTL_NONISOTHREN             ((uint32_t)0x00000001)            /*!< Nonisochronous IN endpoints threshold enable */
+#define USB_OTG_DTHRCTL_ISOTHREN                ((uint32_t)0x00000002)            /*!< ISO IN endpoint threshold enable */
+
+#define USB_OTG_DTHRCTL_TXTHRLEN                ((uint32_t)0x000007FC)            /*!< Transmit threshold length */
+#define USB_OTG_DTHRCTL_TXTHRLEN_0              ((uint32_t)0x00000004)            /*!<Bit 0 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_1              ((uint32_t)0x00000008)            /*!<Bit 1 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_2              ((uint32_t)0x00000010)            /*!<Bit 2 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_3              ((uint32_t)0x00000020)            /*!<Bit 3 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_4              ((uint32_t)0x00000040)            /*!<Bit 4 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_5              ((uint32_t)0x00000080)            /*!<Bit 5 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_6              ((uint32_t)0x00000100)            /*!<Bit 6 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_7              ((uint32_t)0x00000200)            /*!<Bit 7 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_8              ((uint32_t)0x00000400)            /*!<Bit 8 */
+#define USB_OTG_DTHRCTL_RXTHREN                 ((uint32_t)0x00010000)            /*!< Receive threshold enable */
+
+#define USB_OTG_DTHRCTL_RXTHRLEN                ((uint32_t)0x03FE0000)            /*!< Receive threshold length */
+#define USB_OTG_DTHRCTL_RXTHRLEN_0              ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_1              ((uint32_t)0x00040000)            /*!<Bit 1 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_2              ((uint32_t)0x00080000)            /*!<Bit 2 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_3              ((uint32_t)0x00100000)            /*!<Bit 3 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_4              ((uint32_t)0x00200000)            /*!<Bit 4 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_5              ((uint32_t)0x00400000)            /*!<Bit 5 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_6              ((uint32_t)0x00800000)            /*!<Bit 6 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_7              ((uint32_t)0x01000000)            /*!<Bit 7 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_8              ((uint32_t)0x02000000)            /*!<Bit 8 */
+#define USB_OTG_DTHRCTL_ARPEN                   ((uint32_t)0x08000000)            /*!< Arbiter parking enable */
+
+/********************  Bit definition for USB_OTG_DIEPEMPMSK register  ********************/
+#define USB_OTG_DIEPEMPMSK_INEPTXFEM               ((uint32_t)0x0000FFFF)         /*!< IN EP Tx FIFO empty interrupt mask bits */
+
+/********************  Bit definition for USB_OTG_DEACHINT register  ********************/
+#define USB_OTG_DEACHINT_IEP1INT                 ((uint32_t)0x00000002)           /*!< IN endpoint 1interrupt bit   */
+#define USB_OTG_DEACHINT_OEP1INT                 ((uint32_t)0x00020000)           /*!< OUT endpoint 1 interrupt bit */
+
+/********************  Bit definition for USB_OTG_GCCFG register  ********************/
+#define USB_OTG_GCCFG_PWRDWN                 ((uint32_t)0x00010000)              /*!< Power down */
+#define USB_OTG_GCCFG_VBDEN                  ((uint32_t)0x00200000)              /*!< USB VBUS Detection Enable */
+
+/********************  Bit definition for USB_OTG_GPWRDN) register  ********************/
+#define USB_OTG_GPWRDN_ADPMEN                 ((uint32_t)0x00000001)             /*!< ADP module enable */
+#define USB_OTG_GPWRDN_ADPIF                  ((uint32_t)0x00800000)             /*!< ADP Interrupt flag */
+
+/********************  Bit definition for USB_OTG_DEACHINTMSK register  ********************/
+#define USB_OTG_DEACHINTMSK_IEP1INTM          ((uint32_t)0x00000002)            /*!< IN Endpoint 1 interrupt mask bit  */
+#define USB_OTG_DEACHINTMSK_OEP1INTM          ((uint32_t)0x00020000)            /*!< OUT Endpoint 1 interrupt mask bit */
+
+/********************  Bit definition for USB_OTG_CID register  ********************/
+#define USB_OTG_CID_PRODUCT_ID               ((uint32_t)0xFFFFFFFF)            /*!< Product ID field */
+
+/********************  Bit definition for USB_OTG_GLPMCFG register  ********************/
+#define  USB_OTG_GLPMCFG_LPMEN               ((uint32_t)0x00000001)            /*!< LPM support enable                                     */
+#define  USB_OTG_GLPMCFG_LPMACK              ((uint32_t)0x00000002)            /*!< LPM Token acknowledge enable                           */
+#define  USB_OTG_GLPMCFG_BESL                ((uint32_t)0x0000003C)            /*!< BESL value received with last ACKed LPM Token          */
+#define  USB_OTG_GLPMCFG_REMWAKE             ((uint32_t)0x00000040)            /*!< bRemoteWake value received with last ACKed LPM Token   */
+#define  USB_OTG_GLPMCFG_L1SSEN              ((uint32_t)0x00000080)            /*!< L1 shallow sleep enable                                */
+#define  USB_OTG_GLPMCFG_BESLTHRS            ((uint32_t)0x00000F00)            /*!< BESL threshold                                         */
+#define  USB_OTG_GLPMCFG_L1DSEN              ((uint32_t)0x00001000)            /*!< L1 deep sleep enable                                   */
+#define  USB_OTG_GLPMCFG_LPMRSP              ((uint32_t)0x00006000)            /*!< LPM response                                           */
+#define  USB_OTG_GLPMCFG_SLPSTS              ((uint32_t)0x00008000)            /*!< Port sleep status                                      */
+#define  USB_OTG_GLPMCFG_L1RSMOK             ((uint32_t)0x00010000)            /*!< Sleep State Resume OK                                  */
+#define  USB_OTG_GLPMCFG_LPMCHIDX            ((uint32_t)0x001E0000)            /*!< LPM Channel Index                                      */
+#define  USB_OTG_GLPMCFG_LPMRCNT             ((uint32_t)0x00E00000)            /*!< LPM retry count                                        */
+#define  USB_OTG_GLPMCFG_SNDLPM              ((uint32_t)0x01000000)            /*!< Send LPM transaction                                   */
+#define  USB_OTG_GLPMCFG_LPMRCNTSTS          ((uint32_t)0x0E000000)            /*!< LPM retry count status                                 */
+#define  USB_OTG_GLPMCFG_ENBESL              ((uint32_t)0x10000000)            /*!< Enable best effort service latency                     */
+
+/********************  Bit definition for USB_OTG_DIEPEACHMSK1 register  ********************/
+#define USB_OTG_DIEPEACHMSK1_XFRCM           ((uint32_t)0x00000001)            /*!< Transfer completed interrupt mask                 */
+#define USB_OTG_DIEPEACHMSK1_EPDM            ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt mask                  */
+#define USB_OTG_DIEPEACHMSK1_TOM             ((uint32_t)0x00000008)            /*!< Timeout condition mask (nonisochronous endpoints) */
+#define USB_OTG_DIEPEACHMSK1_ITTXFEMSK       ((uint32_t)0x00000010)            /*!< IN token received when TxFIFO empty mask          */
+#define USB_OTG_DIEPEACHMSK1_INEPNMM         ((uint32_t)0x00000020)            /*!< IN token received with EP mismatch mask           */
+#define USB_OTG_DIEPEACHMSK1_INEPNEM         ((uint32_t)0x00000040)            /*!< IN endpoint NAK effective mask                    */
+#define USB_OTG_DIEPEACHMSK1_TXFURM          ((uint32_t)0x00000100)            /*!< FIFO underrun mask                                */
+#define USB_OTG_DIEPEACHMSK1_BIM             ((uint32_t)0x00000200)            /*!< BNA interrupt mask                                */
+#define USB_OTG_DIEPEACHMSK1_NAKM            ((uint32_t)0x00002000)            /*!< NAK interrupt mask                                */
+
+/********************  Bit definition for USB_OTG_HPRT register  ********************/
+#define USB_OTG_HPRT_PCSTS                   ((uint32_t)0x00000001)            /*!< Port connect status        */
+#define USB_OTG_HPRT_PCDET                   ((uint32_t)0x00000002)            /*!< Port connect detected      */
+#define USB_OTG_HPRT_PENA                    ((uint32_t)0x00000004)            /*!< Port enable                */
+#define USB_OTG_HPRT_PENCHNG                 ((uint32_t)0x00000008)            /*!< Port enable/disable change */
+#define USB_OTG_HPRT_POCA                    ((uint32_t)0x00000010)            /*!< Port overcurrent active    */
+#define USB_OTG_HPRT_POCCHNG                 ((uint32_t)0x00000020)            /*!< Port overcurrent change    */
+#define USB_OTG_HPRT_PRES                    ((uint32_t)0x00000040)            /*!< Port resume                */
+#define USB_OTG_HPRT_PSUSP                   ((uint32_t)0x00000080)            /*!< Port suspend               */
+#define USB_OTG_HPRT_PRST                    ((uint32_t)0x00000100)            /*!< Port reset                 */
+
+#define USB_OTG_HPRT_PLSTS                   ((uint32_t)0x00000C00)            /*!< Port line status           */
+#define USB_OTG_HPRT_PLSTS_0                 ((uint32_t)0x00000400)            /*!<Bit 0 */
+#define USB_OTG_HPRT_PLSTS_1                 ((uint32_t)0x00000800)            /*!<Bit 1 */
+#define USB_OTG_HPRT_PPWR                    ((uint32_t)0x00001000)            /*!< Port power                 */
+
+#define USB_OTG_HPRT_PTCTL                   ((uint32_t)0x0001E000)            /*!< Port test control          */
+#define USB_OTG_HPRT_PTCTL_0                 ((uint32_t)0x00002000)            /*!<Bit 0 */
+#define USB_OTG_HPRT_PTCTL_1                 ((uint32_t)0x00004000)            /*!<Bit 1 */
+#define USB_OTG_HPRT_PTCTL_2                 ((uint32_t)0x00008000)            /*!<Bit 2 */
+#define USB_OTG_HPRT_PTCTL_3                 ((uint32_t)0x00010000)            /*!<Bit 3 */
+
+#define USB_OTG_HPRT_PSPD                    ((uint32_t)0x00060000)            /*!< Port speed                 */
+#define USB_OTG_HPRT_PSPD_0                  ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define USB_OTG_HPRT_PSPD_1                  ((uint32_t)0x00040000)            /*!<Bit 1 */
+
+/********************  Bit definition for USB_OTG_DOEPEACHMSK1 register  ********************/
+#define USB_OTG_DOEPEACHMSK1_XFRCM                   ((uint32_t)0x00000001)            /*!< Transfer completed interrupt mask         */
+#define USB_OTG_DOEPEACHMSK1_EPDM                    ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt mask          */
+#define USB_OTG_DOEPEACHMSK1_TOM                     ((uint32_t)0x00000008)            /*!< Timeout condition mask                    */
+#define USB_OTG_DOEPEACHMSK1_ITTXFEMSK               ((uint32_t)0x00000010)            /*!< IN token received when TxFIFO empty mask  */
+#define USB_OTG_DOEPEACHMSK1_INEPNMM                 ((uint32_t)0x00000020)            /*!< IN token received with EP mismatch mask   */
+#define USB_OTG_DOEPEACHMSK1_INEPNEM                 ((uint32_t)0x00000040)            /*!< IN endpoint NAK effective mask            */
+#define USB_OTG_DOEPEACHMSK1_TXFURM                  ((uint32_t)0x00000100)            /*!< OUT packet error mask                     */
+#define USB_OTG_DOEPEACHMSK1_BIM                     ((uint32_t)0x00000200)            /*!< BNA interrupt mask                        */
+#define USB_OTG_DOEPEACHMSK1_BERRM                   ((uint32_t)0x00001000)            /*!< Bubble error interrupt mask               */
+#define USB_OTG_DOEPEACHMSK1_NAKM                    ((uint32_t)0x00002000)            /*!< NAK interrupt mask                        */
+#define USB_OTG_DOEPEACHMSK1_NYETM                   ((uint32_t)0x00004000)            /*!< NYET interrupt mask                       */
+
+/********************  Bit definition for USB_OTG_HPTXFSIZ register  ********************/
+#define USB_OTG_HPTXFSIZ_PTXSA                   ((uint32_t)0x0000FFFF)            /*!< Host periodic TxFIFO start address            */
+#define USB_OTG_HPTXFSIZ_PTXFD                   ((uint32_t)0xFFFF0000)            /*!< Host periodic TxFIFO depth                    */
+
+/********************  Bit definition for USB_OTG_DIEPCTL register  ********************/
+#define USB_OTG_DIEPCTL_MPSIZ                   ((uint32_t)0x000007FF)            /*!< Maximum packet size              */
+#define USB_OTG_DIEPCTL_USBAEP                  ((uint32_t)0x00008000)            /*!< USB active endpoint              */
+#define USB_OTG_DIEPCTL_EONUM_DPID              ((uint32_t)0x00010000)            /*!< Even/odd frame                   */
+#define USB_OTG_DIEPCTL_NAKSTS                  ((uint32_t)0x00020000)            /*!< NAK status                       */
+
+#define USB_OTG_DIEPCTL_EPTYP                   ((uint32_t)0x000C0000)            /*!< Endpoint type                    */
+#define USB_OTG_DIEPCTL_EPTYP_0                 ((uint32_t)0x00040000)            /*!<Bit 0 */
+#define USB_OTG_DIEPCTL_EPTYP_1                 ((uint32_t)0x00080000)            /*!<Bit 1 */
+#define USB_OTG_DIEPCTL_STALL                   ((uint32_t)0x00200000)            /*!< STALL handshake                  */
+
+#define USB_OTG_DIEPCTL_TXFNUM                  ((uint32_t)0x03C00000)            /*!< TxFIFO number                    */
+#define USB_OTG_DIEPCTL_TXFNUM_0                ((uint32_t)0x00400000)            /*!<Bit 0 */
+#define USB_OTG_DIEPCTL_TXFNUM_1                ((uint32_t)0x00800000)            /*!<Bit 1 */
+#define USB_OTG_DIEPCTL_TXFNUM_2                ((uint32_t)0x01000000)            /*!<Bit 2 */
+#define USB_OTG_DIEPCTL_TXFNUM_3                ((uint32_t)0x02000000)            /*!<Bit 3 */
+#define USB_OTG_DIEPCTL_CNAK                    ((uint32_t)0x04000000)            /*!< Clear NAK                        */
+#define USB_OTG_DIEPCTL_SNAK                    ((uint32_t)0x08000000)            /*!< Set NAK */
+#define USB_OTG_DIEPCTL_SD0PID_SEVNFRM          ((uint32_t)0x10000000)            /*!< Set DATA0 PID                    */
+#define USB_OTG_DIEPCTL_SODDFRM                 ((uint32_t)0x20000000)            /*!< Set odd frame                    */
+#define USB_OTG_DIEPCTL_EPDIS                   ((uint32_t)0x40000000)            /*!< Endpoint disable                 */
+#define USB_OTG_DIEPCTL_EPENA                   ((uint32_t)0x80000000)            /*!< Endpoint enable                  */
+
+/********************  Bit definition for USB_OTG_HCCHAR register  ********************/
+#define USB_OTG_HCCHAR_MPSIZ                   ((uint32_t)0x000007FF)            /*!< Maximum packet size */
+
+#define USB_OTG_HCCHAR_EPNUM                   ((uint32_t)0x00007800)            /*!< Endpoint number */
+#define USB_OTG_HCCHAR_EPNUM_0                 ((uint32_t)0x00000800)            /*!<Bit 0 */
+#define USB_OTG_HCCHAR_EPNUM_1                 ((uint32_t)0x00001000)            /*!<Bit 1 */
+#define USB_OTG_HCCHAR_EPNUM_2                 ((uint32_t)0x00002000)            /*!<Bit 2 */
+#define USB_OTG_HCCHAR_EPNUM_3                 ((uint32_t)0x00004000)            /*!<Bit 3 */
+#define USB_OTG_HCCHAR_EPDIR                   ((uint32_t)0x00008000)            /*!< Endpoint direction */
+#define USB_OTG_HCCHAR_LSDEV                   ((uint32_t)0x00020000)            /*!< Low-speed device */
+
+#define USB_OTG_HCCHAR_EPTYP                   ((uint32_t)0x000C0000)            /*!< Endpoint type */
+#define USB_OTG_HCCHAR_EPTYP_0                 ((uint32_t)0x00040000)            /*!<Bit 0 */
+#define USB_OTG_HCCHAR_EPTYP_1                 ((uint32_t)0x00080000)            /*!<Bit 1 */
+
+#define USB_OTG_HCCHAR_MC                      ((uint32_t)0x00300000)            /*!< Multi Count (MC) / Error Count (EC) */
+#define USB_OTG_HCCHAR_MC_0                    ((uint32_t)0x00100000)            /*!<Bit 0 */
+#define USB_OTG_HCCHAR_MC_1                    ((uint32_t)0x00200000)            /*!<Bit 1 */
+
+#define USB_OTG_HCCHAR_DAD                     ((uint32_t)0x1FC00000)            /*!< Device address */
+#define USB_OTG_HCCHAR_DAD_0                   ((uint32_t)0x00400000)            /*!<Bit 0 */
+#define USB_OTG_HCCHAR_DAD_1                   ((uint32_t)0x00800000)            /*!<Bit 1 */
+#define USB_OTG_HCCHAR_DAD_2                   ((uint32_t)0x01000000)            /*!<Bit 2 */
+#define USB_OTG_HCCHAR_DAD_3                   ((uint32_t)0x02000000)            /*!<Bit 3 */
+#define USB_OTG_HCCHAR_DAD_4                   ((uint32_t)0x04000000)            /*!<Bit 4 */
+#define USB_OTG_HCCHAR_DAD_5                   ((uint32_t)0x08000000)            /*!<Bit 5 */
+#define USB_OTG_HCCHAR_DAD_6                   ((uint32_t)0x10000000)            /*!<Bit 6 */
+#define USB_OTG_HCCHAR_ODDFRM                  ((uint32_t)0x20000000)            /*!< Odd frame */
+#define USB_OTG_HCCHAR_CHDIS                   ((uint32_t)0x40000000)            /*!< Channel disable */
+#define USB_OTG_HCCHAR_CHENA                   ((uint32_t)0x80000000)            /*!< Channel enable */
+
+/********************  Bit definition for USB_OTG_HCSPLT register  ********************/
+
+#define USB_OTG_HCSPLT_PRTADDR                 ((uint32_t)0x0000007F)            /*!< Port address */
+#define USB_OTG_HCSPLT_PRTADDR_0               ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_HCSPLT_PRTADDR_1               ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_HCSPLT_PRTADDR_2               ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_HCSPLT_PRTADDR_3               ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define USB_OTG_HCSPLT_PRTADDR_4               ((uint32_t)0x00000010)            /*!<Bit 4 */
+#define USB_OTG_HCSPLT_PRTADDR_5               ((uint32_t)0x00000020)            /*!<Bit 5 */
+#define USB_OTG_HCSPLT_PRTADDR_6               ((uint32_t)0x00000040)            /*!<Bit 6 */
+
+#define USB_OTG_HCSPLT_HUBADDR                 ((uint32_t)0x00003F80)            /*!< Hub address */
+#define USB_OTG_HCSPLT_HUBADDR_0               ((uint32_t)0x00000080)            /*!<Bit 0 */
+#define USB_OTG_HCSPLT_HUBADDR_1               ((uint32_t)0x00000100)            /*!<Bit 1 */
+#define USB_OTG_HCSPLT_HUBADDR_2               ((uint32_t)0x00000200)            /*!<Bit 2 */
+#define USB_OTG_HCSPLT_HUBADDR_3               ((uint32_t)0x00000400)            /*!<Bit 3 */
+#define USB_OTG_HCSPLT_HUBADDR_4               ((uint32_t)0x00000800)            /*!<Bit 4 */
+#define USB_OTG_HCSPLT_HUBADDR_5               ((uint32_t)0x00001000)            /*!<Bit 5 */
+#define USB_OTG_HCSPLT_HUBADDR_6               ((uint32_t)0x00002000)            /*!<Bit 6 */
+
+#define USB_OTG_HCSPLT_XACTPOS                 ((uint32_t)0x0000C000)            /*!< XACTPOS */
+#define USB_OTG_HCSPLT_XACTPOS_0               ((uint32_t)0x00004000)            /*!<Bit 0 */
+#define USB_OTG_HCSPLT_XACTPOS_1               ((uint32_t)0x00008000)            /*!<Bit 1 */
+#define USB_OTG_HCSPLT_COMPLSPLT               ((uint32_t)0x00010000)            /*!< Do complete split */
+#define USB_OTG_HCSPLT_SPLITEN                 ((uint32_t)0x80000000)            /*!< Split enable */
+
+/********************  Bit definition for USB_OTG_HCINT register  ********************/
+#define USB_OTG_HCINT_XFRC                    ((uint32_t)0x00000001)            /*!< Transfer completed */
+#define USB_OTG_HCINT_CHH                     ((uint32_t)0x00000002)            /*!< Channel halted */
+#define USB_OTG_HCINT_AHBERR                  ((uint32_t)0x00000004)            /*!< AHB error */
+#define USB_OTG_HCINT_STALL                   ((uint32_t)0x00000008)            /*!< STALL response received interrupt */
+#define USB_OTG_HCINT_NAK                     ((uint32_t)0x00000010)            /*!< NAK response received interrupt */
+#define USB_OTG_HCINT_ACK                     ((uint32_t)0x00000020)            /*!< ACK response received/transmitted interrupt */
+#define USB_OTG_HCINT_NYET                    ((uint32_t)0x00000040)            /*!< Response received interrupt */
+#define USB_OTG_HCINT_TXERR                   ((uint32_t)0x00000080)            /*!< Transaction error */
+#define USB_OTG_HCINT_BBERR                   ((uint32_t)0x00000100)            /*!< Babble error */
+#define USB_OTG_HCINT_FRMOR                   ((uint32_t)0x00000200)            /*!< Frame overrun */
+#define USB_OTG_HCINT_DTERR                   ((uint32_t)0x00000400)            /*!< Data toggle error */
+
+/********************  Bit definition for USB_OTG_DIEPINT register  ********************/
+#define USB_OTG_DIEPINT_XFRC                    ((uint32_t)0x00000001)            /*!< Transfer completed interrupt */
+#define USB_OTG_DIEPINT_EPDISD                  ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt */
+#define USB_OTG_DIEPINT_TOC                     ((uint32_t)0x00000008)            /*!< Timeout condition */
+#define USB_OTG_DIEPINT_ITTXFE                  ((uint32_t)0x00000010)            /*!< IN token received when TxFIFO is empty */
+#define USB_OTG_DIEPINT_INEPNE                  ((uint32_t)0x00000040)            /*!< IN endpoint NAK effective */
+#define USB_OTG_DIEPINT_TXFE                    ((uint32_t)0x00000080)            /*!< Transmit FIFO empty */
+#define USB_OTG_DIEPINT_TXFIFOUDRN              ((uint32_t)0x00000100)            /*!< Transmit Fifo Underrun */
+#define USB_OTG_DIEPINT_BNA                     ((uint32_t)0x00000200)            /*!< Buffer not available interrupt */
+#define USB_OTG_DIEPINT_PKTDRPSTS               ((uint32_t)0x00000800)            /*!< Packet dropped status */
+#define USB_OTG_DIEPINT_BERR                    ((uint32_t)0x00001000)            /*!< Babble error interrupt */
+#define USB_OTG_DIEPINT_NAK                     ((uint32_t)0x00002000)            /*!< NAK interrupt */
+
+/********************  Bit definition for USB_OTG_HCINTMSK register  ********************/
+#define USB_OTG_HCINTMSK_XFRCM                   ((uint32_t)0x00000001)            /*!< Transfer completed mask */
+#define USB_OTG_HCINTMSK_CHHM                    ((uint32_t)0x00000002)            /*!< Channel halted mask */
+#define USB_OTG_HCINTMSK_AHBERR                  ((uint32_t)0x00000004)            /*!< AHB error */
+#define USB_OTG_HCINTMSK_STALLM                  ((uint32_t)0x00000008)            /*!< STALL response received interrupt mask */
+#define USB_OTG_HCINTMSK_NAKM                    ((uint32_t)0x00000010)            /*!< NAK response received interrupt mask */
+#define USB_OTG_HCINTMSK_ACKM                    ((uint32_t)0x00000020)            /*!< ACK response received/transmitted interrupt mask */
+#define USB_OTG_HCINTMSK_NYET                    ((uint32_t)0x00000040)            /*!< response received interrupt mask */
+#define USB_OTG_HCINTMSK_TXERRM                  ((uint32_t)0x00000080)            /*!< Transaction error mask */
+#define USB_OTG_HCINTMSK_BBERRM                  ((uint32_t)0x00000100)            /*!< Babble error mask */
+#define USB_OTG_HCINTMSK_FRMORM                  ((uint32_t)0x00000200)            /*!< Frame overrun mask */
+#define USB_OTG_HCINTMSK_DTERRM                  ((uint32_t)0x00000400)            /*!< Data toggle error mask */
+
+/********************  Bit definition for USB_OTG_DIEPTSIZ register  ********************/
+
+#define USB_OTG_DIEPTSIZ_XFRSIZ                  ((uint32_t)0x0007FFFF)            /*!< Transfer size */
+#define USB_OTG_DIEPTSIZ_PKTCNT                  ((uint32_t)0x1FF80000)            /*!< Packet count */
+#define USB_OTG_DIEPTSIZ_MULCNT                  ((uint32_t)0x60000000)            /*!< Packet count */
+/********************  Bit definition for USB_OTG_HCTSIZ register  ********************/
+#define USB_OTG_HCTSIZ_XFRSIZ                    ((uint32_t)0x0007FFFF)            /*!< Transfer size */
+#define USB_OTG_HCTSIZ_PKTCNT                    ((uint32_t)0x1FF80000)            /*!< Packet count */
+#define USB_OTG_HCTSIZ_DOPING                    ((uint32_t)0x80000000)            /*!< Do PING */
+#define USB_OTG_HCTSIZ_DPID                      ((uint32_t)0x60000000)            /*!< Data PID */
+#define USB_OTG_HCTSIZ_DPID_0                    ((uint32_t)0x20000000)            /*!<Bit 0 */
+#define USB_OTG_HCTSIZ_DPID_1                    ((uint32_t)0x40000000)            /*!<Bit 1 */
+
+/********************  Bit definition for USB_OTG_DIEPDMA register  ********************/
+#define USB_OTG_DIEPDMA_DMAADDR                  ((uint32_t)0xFFFFFFFF)            /*!< DMA address */
+
+/********************  Bit definition for USB_OTG_HCDMA register  ********************/
+#define USB_OTG_HCDMA_DMAADDR                    ((uint32_t)0xFFFFFFFF)            /*!< DMA address */
+
+/********************  Bit definition for USB_OTG_DTXFSTS register  ********************/
+#define USB_OTG_DTXFSTS_INEPTFSAV                ((uint32_t)0x0000FFFF)            /*!< IN endpoint TxFIFO space available */
+
+/********************  Bit definition for USB_OTG_DIEPTXF register  ********************/
+#define USB_OTG_DIEPTXF_INEPTXSA                 ((uint32_t)0x0000FFFF)            /*!< IN endpoint FIFOx transmit RAM start address */
+#define USB_OTG_DIEPTXF_INEPTXFD                 ((uint32_t)0xFFFF0000)            /*!< IN endpoint TxFIFO depth */
+
+/********************  Bit definition for USB_OTG_DOEPCTL register  ********************/
+#define USB_OTG_DOEPCTL_MPSIZ                     ((uint32_t)0x000007FF)            /*!< Maximum packet size */          /*!<Bit 1 */
+#define USB_OTG_DOEPCTL_USBAEP                    ((uint32_t)0x00008000)            /*!< USB active endpoint */
+#define USB_OTG_DOEPCTL_NAKSTS                    ((uint32_t)0x00020000)            /*!< NAK status */
+#define USB_OTG_DOEPCTL_SD0PID_SEVNFRM            ((uint32_t)0x10000000)            /*!< Set DATA0 PID */
+#define USB_OTG_DOEPCTL_SODDFRM                   ((uint32_t)0x20000000)            /*!< Set odd frame */
+#define USB_OTG_DOEPCTL_EPTYP                     ((uint32_t)0x000C0000)            /*!< Endpoint type */
+#define USB_OTG_DOEPCTL_EPTYP_0                   ((uint32_t)0x00040000)            /*!<Bit 0 */
+#define USB_OTG_DOEPCTL_EPTYP_1                   ((uint32_t)0x00080000)            /*!<Bit 1 */
+#define USB_OTG_DOEPCTL_SNPM                      ((uint32_t)0x00100000)            /*!< Snoop mode */
+#define USB_OTG_DOEPCTL_STALL                     ((uint32_t)0x00200000)            /*!< STALL handshake */
+#define USB_OTG_DOEPCTL_CNAK                      ((uint32_t)0x04000000)            /*!< Clear NAK */
+#define USB_OTG_DOEPCTL_SNAK                      ((uint32_t)0x08000000)            /*!< Set NAK */
+#define USB_OTG_DOEPCTL_EPDIS                     ((uint32_t)0x40000000)            /*!< Endpoint disable */
+#define USB_OTG_DOEPCTL_EPENA                     ((uint32_t)0x80000000)            /*!< Endpoint enable */
+
+/********************  Bit definition for USB_OTG_DOEPINT register  ********************/
+#define USB_OTG_DOEPINT_XFRC                    ((uint32_t)0x00000001)            /*!< Transfer completed interrupt */
+#define USB_OTG_DOEPINT_EPDISD                  ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt */
+#define USB_OTG_DOEPINT_STUP                    ((uint32_t)0x00000008)            /*!< SETUP phase done */
+#define USB_OTG_DOEPINT_OTEPDIS                 ((uint32_t)0x00000010)            /*!< OUT token received when endpoint disabled */
+#define USB_OTG_DOEPINT_B2BSTUP                 ((uint32_t)0x00000040)            /*!< Back-to-back SETUP packets received */
+#define USB_OTG_DOEPINT_NYET                    ((uint32_t)0x00004000)            /*!< NYET interrupt */
+
+/********************  Bit definition for USB_OTG_DOEPTSIZ register  ********************/
+#define USB_OTG_DOEPTSIZ_XFRSIZ                  ((uint32_t)0x0007FFFF)            /*!< Transfer size */
+#define USB_OTG_DOEPTSIZ_PKTCNT                  ((uint32_t)0x1FF80000)            /*!< Packet count */
+
+#define USB_OTG_DOEPTSIZ_STUPCNT                 ((uint32_t)0x60000000)            /*!< SETUP packet count */
+#define USB_OTG_DOEPTSIZ_STUPCNT_0               ((uint32_t)0x20000000)            /*!<Bit 0 */
+#define USB_OTG_DOEPTSIZ_STUPCNT_1               ((uint32_t)0x40000000)            /*!<Bit 1 */
+
+/********************  Bit definition for PCGCCTL register  ********************/
+#define USB_OTG_PCGCCTL_STOPCLK                 ((uint32_t)0x00000001)            /*!< SETUP packet count */
+#define USB_OTG_PCGCCTL_GATECLK                 ((uint32_t)0x00000002)            /*!<Bit 0 */
+#define USB_OTG_PCGCCTL_PHYSUSP                 ((uint32_t)0x00000010)            /*!<Bit 1 */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+
+/******************************* ADC Instances ********************************/
+#define IS_ADC_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == ADC1) || \
+                                       ((__INSTANCE__) == ADC2) || \
+                                       ((__INSTANCE__) == ADC3))
+
+/******************************* CAN Instances ********************************/
+#define IS_CAN_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == CAN1) || \
+                                       ((__INSTANCE__) == CAN2))
+
+/******************************* CRC Instances ********************************/
+#define IS_CRC_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == CRC)
+
+/******************************* DAC Instances ********************************/
+#define IS_DAC_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == DAC)
+
+/******************************* DCMI Instances *******************************/
+#define IS_DCMI_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == DCMI)
+
+/******************************* DMA2D Instances *******************************/
+#define IS_DMA2D_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == DMA2D)
+
+/******************************** DMA Instances *******************************/
+#define IS_DMA_STREAM_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == DMA1_Stream0) || \
+                                              ((__INSTANCE__) == DMA1_Stream1) || \
+                                              ((__INSTANCE__) == DMA1_Stream2) || \
+                                              ((__INSTANCE__) == DMA1_Stream3) || \
+                                              ((__INSTANCE__) == DMA1_Stream4) || \
+                                              ((__INSTANCE__) == DMA1_Stream5) || \
+                                              ((__INSTANCE__) == DMA1_Stream6) || \
+                                              ((__INSTANCE__) == DMA1_Stream7) || \
+                                              ((__INSTANCE__) == DMA2_Stream0) || \
+                                              ((__INSTANCE__) == DMA2_Stream1) || \
+                                              ((__INSTANCE__) == DMA2_Stream2) || \
+                                              ((__INSTANCE__) == DMA2_Stream3) || \
+                                              ((__INSTANCE__) == DMA2_Stream4) || \
+                                              ((__INSTANCE__) == DMA2_Stream5) || \
+                                              ((__INSTANCE__) == DMA2_Stream6) || \
+                                              ((__INSTANCE__) == DMA2_Stream7))
+
+/******************************* GPIO Instances *******************************/
+#define IS_GPIO_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == GPIOA) || \
+                                        ((__INSTANCE__) == GPIOB) || \
+                                        ((__INSTANCE__) == GPIOC) || \
+                                        ((__INSTANCE__) == GPIOD) || \
+                                        ((__INSTANCE__) == GPIOE) || \
+                                        ((__INSTANCE__) == GPIOF) || \
+                                        ((__INSTANCE__) == GPIOG) || \
+                                        ((__INSTANCE__) == GPIOH) || \
+                                        ((__INSTANCE__) == GPIOI) || \
+                                        ((__INSTANCE__) == GPIOJ) || \
+                                        ((__INSTANCE__) == GPIOK))
+
+#define IS_GPIO_AF_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == GPIOA) || \
+                                        ((__INSTANCE__) == GPIOB) || \
+                                        ((__INSTANCE__) == GPIOC) || \
+                                        ((__INSTANCE__) == GPIOD) || \
+                                        ((__INSTANCE__) == GPIOE) || \
+                                        ((__INSTANCE__) == GPIOF) || \
+                                        ((__INSTANCE__) == GPIOG) || \
+                                        ((__INSTANCE__) == GPIOH) || \
+                                        ((__INSTANCE__) == GPIOI) || \
+                                        ((__INSTANCE__) == GPIOJ) || \
+                                        ((__INSTANCE__) == GPIOK))
+
+/****************************** CEC Instances *********************************/
+#define IS_CEC_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == CEC)
+
+/****************************** QSPI Instances *********************************/
+#define IS_QSPI_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == QUADSPI)
+
+
+/******************************** I2C Instances *******************************/
+#define IS_I2C_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == I2C1) || \
+                                       ((__INSTANCE__) == I2C2) || \
+                                       ((__INSTANCE__) == I2C3) || \
+                                       ((__INSTANCE__) == I2C4))
+
+/******************************** I2S Instances *******************************/
+#define IS_I2S_ALL_INSTANCE(__INSTANCE__)  (((__INSTANCE__) == SPI1) || \
+                                    ((__INSTANCE__) == SPI2) || \
+                                    ((__INSTANCE__) == SPI3))
+
+/******************************* LPTIM Instances ********************************/
+#define IS_LPTIM_INSTANCE(__INSTANCE__) ((__INSTANCE__) == LPTIM1)
+
+/******************************* RNG Instances ********************************/
+#define IS_RNG_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == RNG)
+
+/****************************** RTC Instances *********************************/
+#define IS_RTC_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == RTC)
+
+/******************************* SAI Instances ********************************/
+#define IS_SAI_BLOCK_PERIPH(__PERIPH__) (((__PERIPH__) == SAI1_Block_A) || \
+                                     ((__PERIPH__) == SAI1_Block_B) || \
+                                     ((__PERIPH__) == SAI2_Block_A) || \
+                                     ((__PERIPH__) == SAI2_Block_B))
+
+
+/******************************** SDMMC Instances *******************************/
+#define IS_SDMMC_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == SDMMC1)
+
+
+/****************************** SPDIFRX Instances *********************************/
+#define IS_SPDIFRX_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == SPDIFRX)
+
+/******************************** SPI Instances *******************************/
+#define IS_SPI_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == SPI1) || \
+                                       ((__INSTANCE__) == SPI2) || \
+                                       ((__INSTANCE__) == SPI3) || \
+                                       ((__INSTANCE__) == SPI4) || \
+                                       ((__INSTANCE__) == SPI5) || \
+                                       ((__INSTANCE__) == SPI6))
+
+/****************** TIM Instances : All supported instances *******************/
+#define IS_TIM_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1)   || \
+                                   ((__INSTANCE__) == TIM2)   || \
+                                   ((__INSTANCE__) == TIM3)   || \
+                                   ((__INSTANCE__) == TIM4)   || \
+                                   ((__INSTANCE__) == TIM5)   || \
+                                   ((__INSTANCE__) == TIM6)   || \
+                                   ((__INSTANCE__) == TIM7)   || \
+                                   ((__INSTANCE__) == TIM8)   || \
+                                   ((__INSTANCE__) == TIM9)   || \
+                                   ((__INSTANCE__) == TIM10)  || \
+                                   ((__INSTANCE__) == TIM11)  || \
+                                   ((__INSTANCE__) == TIM12)  || \
+                                   ((__INSTANCE__) == TIM13)  || \
+                                   ((__INSTANCE__) == TIM14))
+
+/************* TIM Instances : at least 1 capture/compare channel *************/
+#define IS_TIM_CC1_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == TIM1)  || \
+                                         ((__INSTANCE__) == TIM2)  || \
+                                         ((__INSTANCE__) == TIM3)  || \
+                                         ((__INSTANCE__) == TIM4)  || \
+                                         ((__INSTANCE__) == TIM5)  || \
+                                         ((__INSTANCE__) == TIM8)  || \
+                                         ((__INSTANCE__) == TIM9)  || \
+                                         ((__INSTANCE__) == TIM10) || \
+                                         ((__INSTANCE__) == TIM11) || \
+                                         ((__INSTANCE__) == TIM12) || \
+                                         ((__INSTANCE__) == TIM13) || \
+                                         ((__INSTANCE__) == TIM14))
+
+/************ TIM Instances : at least 2 capture/compare channels *************/
+#define IS_TIM_CC2_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == TIM1)  || \
+                                         ((__INSTANCE__) == TIM2)  || \
+                                         ((__INSTANCE__) == TIM3)  || \
+                                         ((__INSTANCE__) == TIM4)  || \
+                                         ((__INSTANCE__) == TIM5)  || \
+                                         ((__INSTANCE__) == TIM8)  || \
+                                         ((__INSTANCE__) == TIM9)  || \
+                                         ((__INSTANCE__) == TIM12))
+
+/************ TIM Instances : at least 3 capture/compare channels *************/
+#define IS_TIM_CC3_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == TIM1) || \
+                                         ((__INSTANCE__) == TIM2) || \
+                                         ((__INSTANCE__) == TIM3) || \
+                                         ((__INSTANCE__) == TIM4) || \
+                                         ((__INSTANCE__) == TIM5) || \
+                                         ((__INSTANCE__) == TIM8))
+
+/************ TIM Instances : at least 4 capture/compare channels *************/
+#define IS_TIM_CC4_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                       ((__INSTANCE__) == TIM2) || \
+                                       ((__INSTANCE__) == TIM3) || \
+                                       ((__INSTANCE__) == TIM4) || \
+                                       ((__INSTANCE__) == TIM5) || \
+                                       ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting combined 3-phase PWM mode ******/
+#define IS_TIM_COMBINED3PHASEPWM_INSTANCE(__INSTANCE__) \
+                                       (((__INSTANCE__) == TIM1)    || \
+                                        ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting OCxREF clear *******************/
+#define IS_TIM_OCXREF_CLEAR_INSTANCE(__INSTANCE__)\
+                                  (((__INSTANCE__) == TIM1)    || \
+                                   ((__INSTANCE__) == TIM2)    || \
+                                   ((__INSTANCE__) == TIM3)    || \
+                                   ((__INSTANCE__) == TIM4)    || \
+                                   ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting external clock mode 1 for TIX inputs*/
+#define IS_TIM_CLOCKSOURCE_TIX_INSTANCE(__INSTANCE__)\
+                                                 (((__INSTANCE__) == TIM1)    || \
+                                                  ((__INSTANCE__) == TIM2)    || \
+                                                  ((__INSTANCE__) == TIM3)    || \
+                                                  ((__INSTANCE__) == TIM4)    || \
+                                                  ((__INSTANCE__) == TIM5)    || \
+                                                  ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting internal trigger inputs(ITRX) *******/
+#define IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(__INSTANCE__)\
+                                                   (((__INSTANCE__) == TIM1)    || \
+                                                    ((__INSTANCE__) == TIM2)    || \
+                                                    ((__INSTANCE__) == TIM3)    || \
+                                                    ((__INSTANCE__) == TIM4)    || \
+                                                    ((__INSTANCE__) == TIM5)    || \
+                                                    ((__INSTANCE__) == TIM8))
+/****************** TIM Instances : at least 5 capture/compare channels *******/
+#define IS_TIM_CC5_INSTANCE(__INSTANCE__)\
+  (((__INSTANCE__) == TIM1)    || \
+   ((__INSTANCE__) == TIM8) )
+
+/****************** TIM Instances : at least 6 capture/compare channels *******/
+#define IS_TIM_CC6_INSTANCE(__INSTANCE__)\
+  (((__INSTANCE__) == TIM1)    || \
+   ((__INSTANCE__) == TIM8))
+
+
+/******************** TIM Instances : Advanced-control timers *****************/
+#define IS_TIM_ADVANCED_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                            ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting 2 break inputs *****************/
+#define IS_TIM_BREAK_INSTANCE(__INSTANCE__)\
+  (((__INSTANCE__) == TIM1)    || \
+   ((__INSTANCE__) == TIM8))
+
+/******************* TIM Instances : Timer input XOR function *****************/
+#define IS_TIM_XOR_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == TIM1) || \
+                                         ((__INSTANCE__) == TIM2) || \
+                                         ((__INSTANCE__) == TIM3) || \
+                                         ((__INSTANCE__) == TIM4) || \
+                                         ((__INSTANCE__) == TIM5) || \
+                                         ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : DMA requests generation (UDE) *************/
+#define IS_TIM_DMA_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                       ((__INSTANCE__) == TIM2) || \
+                                       ((__INSTANCE__) == TIM3) || \
+                                       ((__INSTANCE__) == TIM4) || \
+                                       ((__INSTANCE__) == TIM5) || \
+                                       ((__INSTANCE__) == TIM6) || \
+                                       ((__INSTANCE__) == TIM7) || \
+                                       ((__INSTANCE__) == TIM8))
+
+/************ TIM Instances : DMA requests generation (CCxDE) *****************/
+#define IS_TIM_DMA_CC_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                          ((__INSTANCE__) == TIM2) || \
+                                          ((__INSTANCE__) == TIM3) || \
+                                          ((__INSTANCE__) == TIM4) || \
+                                          ((__INSTANCE__) == TIM5) || \
+                                          ((__INSTANCE__) == TIM8))
+
+/************ TIM Instances : DMA requests generation (COMDE) *****************/
+#define IS_TIM_CCDMA_INSTANCE(__INSTANCE__)  (((__INSTANCE__) == TIM1) || \
+                                          ((__INSTANCE__) == TIM2) || \
+                                          ((__INSTANCE__) == TIM3) || \
+                                          ((__INSTANCE__) == TIM4) || \
+                                          ((__INSTANCE__) == TIM5) || \
+                                          ((__INSTANCE__) == TIM8))
+
+/******************** TIM Instances : DMA burst feature ***********************/
+#define IS_TIM_DMABURST_INSTANCE(__INSTANCE__)  (((__INSTANCE__) == TIM1) || \
+                                             ((__INSTANCE__) == TIM2) || \
+                                             ((__INSTANCE__) == TIM3) || \
+                                             ((__INSTANCE__) == TIM4) || \
+                                             ((__INSTANCE__) == TIM5) || \
+                                             ((__INSTANCE__) == TIM8))
+
+/****** TIM Instances : master mode available (TIMx_CR2.MMS available )********/
+#define IS_TIM_MASTER_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                          ((__INSTANCE__) == TIM2) || \
+                                          ((__INSTANCE__) == TIM3) || \
+                                          ((__INSTANCE__) == TIM4) || \
+                                          ((__INSTANCE__) == TIM5) || \
+                                          ((__INSTANCE__) == TIM6) || \
+                                          ((__INSTANCE__) == TIM7) || \
+                                          ((__INSTANCE__) == TIM8) || \
+                                          ((__INSTANCE__) == TIM13) || \
+                                          ((__INSTANCE__) == TIM14))
+
+/*********** TIM Instances : Slave mode available (TIMx_SMCR available )*******/
+#define IS_TIM_SLAVE_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                         ((__INSTANCE__) == TIM2) || \
+                                         ((__INSTANCE__) == TIM3) || \
+                                         ((__INSTANCE__) == TIM4) || \
+                                         ((__INSTANCE__) == TIM5) || \
+                                         ((__INSTANCE__) == TIM8) || \
+                                         ((__INSTANCE__) == TIM9) || \
+                                         ((__INSTANCE__) == TIM12))
+
+/********************** TIM Instances : 32 bit Counter ************************/
+#define IS_TIM_32B_COUNTER_INSTANCE(__INSTANCE__)(((__INSTANCE__) == TIM2) || \
+                                              ((__INSTANCE__) == TIM5))
+
+/***************** TIM Instances : external trigger input available ************/
+#define IS_TIM_ETR_INSTANCE(__INSTANCE__)  (((__INSTANCE__) == TIM1) || \
+                                        ((__INSTANCE__) == TIM2) || \
+                                        ((__INSTANCE__) == TIM3) || \
+                                        ((__INSTANCE__) == TIM4) || \
+                                        ((__INSTANCE__) == TIM5) || \
+                                        ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : remapping capability **********************/
+#define IS_TIM_REMAP_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM2)  || \
+                                         ((__INSTANCE__) == TIM5)  || \
+                                         ((__INSTANCE__) == TIM11))
+
+/******************* TIM Instances : output(s) available **********************/
+#define IS_TIM_CCX_INSTANCE(__INSTANCE__, __CHANNEL__) \
+    ((((__INSTANCE__) == TIM1) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM2) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM3) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM4) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM5) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM8) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM9) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM10) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM11) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM12) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM13) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM14) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1))))
+
+/************ TIM Instances : complementary output(s) available ***************/
+#define IS_TIM_CCXN_INSTANCE(__INSTANCE__, __CHANNEL__) \
+   ((((__INSTANCE__) == TIM1) &&                    \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||           \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||           \
+      ((__CHANNEL__) == TIM_CHANNEL_3)))            \
+    ||                                          \
+    (((__INSTANCE__) == TIM8) &&                    \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||           \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||           \
+      ((__CHANNEL__) == TIM_CHANNEL_3))))
+
+/****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
+#define IS_TIM_TRGO2_INSTANCE(__INSTANCE__)\
+  (((__INSTANCE__) == TIM1)    || \
+   ((__INSTANCE__) == TIM8) )
+
+/****************** TIM Instances : supporting synchronization ****************/
+#define IS_TIM_SYNCHRO_INSTANCE(__INSTANCE__)\
+    (((__INSTANCE__) == TIM1)    || \
+     ((__INSTANCE__) == TIM2)    || \
+     ((__INSTANCE__) == TIM3)    || \
+     ((__INSTANCE__) == TIM4)    || \
+     ((__INSTANCE__) == TIM5)    || \
+     ((__INSTANCE__) == TIM6)    || \
+     ((__INSTANCE__) == TIM7)    || \
+     ((__INSTANCE__) == TIM8))
+
+/******************** USART Instances : Synchronous mode **********************/
+#define IS_USART_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                     ((__INSTANCE__) == USART2) || \
+                                     ((__INSTANCE__) == USART3) || \
+                                     ((__INSTANCE__) == USART6))
+
+/******************** UART Instances : Asynchronous mode **********************/
+#define IS_UART_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                    ((__INSTANCE__) == USART2) || \
+                                    ((__INSTANCE__) == USART3) || \
+                                    ((__INSTANCE__) == UART4)  || \
+                                    ((__INSTANCE__) == UART5)  || \
+                                    ((__INSTANCE__) == USART6) || \
+                                    ((__INSTANCE__) == UART7)  || \
+                                    ((__INSTANCE__) == UART8))
+
+/****************** UART Instances : Hardware Flow control ********************/
+#define IS_UART_HWFLOW_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                    ((__INSTANCE__) == USART2) || \
+                                    ((__INSTANCE__) == USART3) || \
+                                    ((__INSTANCE__) == UART4)  || \
+                                    ((__INSTANCE__) == UART5)  || \
+                                    ((__INSTANCE__) == USART6) || \
+                                    ((__INSTANCE__) == UART7)  || \
+                                    ((__INSTANCE__) == UART8))
+
+/********************* UART Instances : Smart card mode ***********************/
+#define IS_SMARTCARD_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                         ((__INSTANCE__) == USART2) || \
+                                         ((__INSTANCE__) == USART3) || \
+                                         ((__INSTANCE__) == USART6))
+
+/*********************** UART Instances : IRDA mode ***************************/
+#define IS_IRDA_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                    ((__INSTANCE__) == USART2) || \
+                                    ((__INSTANCE__) == USART3) || \
+                                    ((__INSTANCE__) == UART4)  || \
+                                    ((__INSTANCE__) == UART5)  || \
+                                    ((__INSTANCE__) == USART6) || \
+                                    ((__INSTANCE__) == UART7)  || \
+                                    ((__INSTANCE__) == UART8))
+
+/****************************** IWDG Instances ********************************/
+#define IS_IWDG_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == IWDG)
+
+/****************************** WWDG Instances ********************************/
+#define IS_WWDG_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == WWDG)
+
+
+/******************************************************************************/
+/*  For a painless codes migration between the STM32F7xx device product       */
+/*  lines, the aliases defined below are put in place to overcome the         */
+/*  differences in the interrupt handlers and IRQn definitions.               */
+/*  No need to update developed interrupt code when moving across             */
+/*  product lines within the same STM32F7 Family                              */
+/******************************************************************************/
+
+/* Aliases for __IRQn */
+#define HASH_RNG_IRQn              RNG_IRQn
+
+/* Aliases for __IRQHandler */
+#define HASH_RNG_IRQHandler        RNG_IRQHandler
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32F745xx_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/cmsis/devinc/stm32f746xx.h
+++ b/stmhal/cmsis/devinc/stm32f746xx.h
@@ -1,0 +1,9445 @@
+/**
+  ******************************************************************************
+  * @file    stm32f746xx.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   CMSIS STM32F746xx Device Peripheral Access Layer Header File.
+  *
+  *          This file contains:
+  *           - Data structures and the address mapping for all peripherals
+  *           - Peripheral's registers declarations and bits definition
+  *           - Macros to access peripheral’s registers hardware
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS_Device
+  * @{
+  */
+
+/** @addtogroup stm32f746xx
+  * @{
+  */
+
+#ifndef __STM32F746xx_H
+#define __STM32F746xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Configuration_section_for_CMSIS
+  * @{
+  */
+
+/**
+ * @brief STM32F7xx Interrupt Number Definition, according to the selected device
+ *        in @ref Library_configuration_section
+ */
+typedef enum IRQn
+{
+/******  Cortex-M7 Processor Exceptions Numbers ****************************************************************/
+  NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                          */
+  MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M7 Memory Management Interrupt                           */
+  BusFault_IRQn               = -11,    /*!< 5 Cortex-M7 Bus Fault Interrupt                                   */
+  UsageFault_IRQn             = -10,    /*!< 6 Cortex-M7 Usage Fault Interrupt                                 */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M7 SV Call Interrupt                                    */
+  DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M7 Debug Monitor Interrupt                              */
+  PendSV_IRQn                 = -2,     /*!< 14 Cortex-M7 Pend SV Interrupt                                    */
+  SysTick_IRQn                = -1,     /*!< 15 Cortex-M7 System Tick Interrupt                                */
+/******  STM32 specific Interrupt Numbers **********************************************************************/
+  WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
+  PVD_IRQn                    = 1,      /*!< PVD through EXTI Line detection Interrupt                         */
+  TAMP_STAMP_IRQn             = 2,      /*!< Tamper and TimeStamp interrupts through the EXTI line             */
+  RTC_WKUP_IRQn               = 3,      /*!< RTC Wakeup interrupt through the EXTI line                        */
+  FLASH_IRQn                  = 4,      /*!< FLASH global Interrupt                                            */
+  RCC_IRQn                    = 5,      /*!< RCC global Interrupt                                              */
+  EXTI0_IRQn                  = 6,      /*!< EXTI Line0 Interrupt                                              */
+  EXTI1_IRQn                  = 7,      /*!< EXTI Line1 Interrupt                                              */
+  EXTI2_IRQn                  = 8,      /*!< EXTI Line2 Interrupt                                              */
+  EXTI3_IRQn                  = 9,      /*!< EXTI Line3 Interrupt                                              */
+  EXTI4_IRQn                  = 10,     /*!< EXTI Line4 Interrupt                                              */
+  DMA1_Stream0_IRQn           = 11,     /*!< DMA1 Stream 0 global Interrupt                                    */
+  DMA1_Stream1_IRQn           = 12,     /*!< DMA1 Stream 1 global Interrupt                                    */
+  DMA1_Stream2_IRQn           = 13,     /*!< DMA1 Stream 2 global Interrupt                                    */
+  DMA1_Stream3_IRQn           = 14,     /*!< DMA1 Stream 3 global Interrupt                                    */
+  DMA1_Stream4_IRQn           = 15,     /*!< DMA1 Stream 4 global Interrupt                                    */
+  DMA1_Stream5_IRQn           = 16,     /*!< DMA1 Stream 5 global Interrupt                                    */
+  DMA1_Stream6_IRQn           = 17,     /*!< DMA1 Stream 6 global Interrupt                                    */
+  ADC_IRQn                    = 18,     /*!< ADC1, ADC2 and ADC3 global Interrupts                             */
+  CAN1_TX_IRQn                = 19,     /*!< CAN1 TX Interrupt                                                 */
+  CAN1_RX0_IRQn               = 20,     /*!< CAN1 RX0 Interrupt                                                */
+  CAN1_RX1_IRQn               = 21,     /*!< CAN1 RX1 Interrupt                                                */
+  CAN1_SCE_IRQn               = 22,     /*!< CAN1 SCE Interrupt                                                */
+  EXTI9_5_IRQn                = 23,     /*!< External Line[9:5] Interrupts                                     */
+  TIM1_BRK_TIM9_IRQn          = 24,     /*!< TIM1 Break interrupt and TIM9 global interrupt                    */
+  TIM1_UP_TIM10_IRQn          = 25,     /*!< TIM1 Update Interrupt and TIM10 global interrupt                  */
+  TIM1_TRG_COM_TIM11_IRQn     = 26,     /*!< TIM1 Trigger and Commutation Interrupt and TIM11 global interrupt */
+  TIM1_CC_IRQn                = 27,     /*!< TIM1 Capture Compare Interrupt                                    */
+  TIM2_IRQn                   = 28,     /*!< TIM2 global Interrupt                                             */
+  TIM3_IRQn                   = 29,     /*!< TIM3 global Interrupt                                             */
+  TIM4_IRQn                   = 30,     /*!< TIM4 global Interrupt                                             */
+  I2C1_EV_IRQn                = 31,     /*!< I2C1 Event Interrupt                                              */
+  I2C1_ER_IRQn                = 32,     /*!< I2C1 Error Interrupt                                              */
+  I2C2_EV_IRQn                = 33,     /*!< I2C2 Event Interrupt                                              */
+  I2C2_ER_IRQn                = 34,     /*!< I2C2 Error Interrupt                                              */
+  SPI1_IRQn                   = 35,     /*!< SPI1 global Interrupt                                             */
+  SPI2_IRQn                   = 36,     /*!< SPI2 global Interrupt                                             */
+  USART1_IRQn                 = 37,     /*!< USART1 global Interrupt                                           */
+  USART2_IRQn                 = 38,     /*!< USART2 global Interrupt                                           */
+  USART3_IRQn                 = 39,     /*!< USART3 global Interrupt                                           */
+  EXTI15_10_IRQn              = 40,     /*!< External Line[15:10] Interrupts                                   */
+  RTC_Alarm_IRQn              = 41,     /*!< RTC Alarm (A and B) through EXTI Line Interrupt                   */
+  OTG_FS_WKUP_IRQn            = 42,     /*!< USB OTG FS Wakeup through EXTI line interrupt                     */
+  TIM8_BRK_TIM12_IRQn         = 43,     /*!< TIM8 Break Interrupt and TIM12 global interrupt                   */
+  TIM8_UP_TIM13_IRQn          = 44,     /*!< TIM8 Update Interrupt and TIM13 global interrupt                  */
+  TIM8_TRG_COM_TIM14_IRQn     = 45,     /*!< TIM8 Trigger and Commutation Interrupt and TIM14 global interrupt */
+  TIM8_CC_IRQn                = 46,     /*!< TIM8 Capture Compare Interrupt                                    */
+  DMA1_Stream7_IRQn           = 47,     /*!< DMA1 Stream7 Interrupt                                            */
+  FMC_IRQn                    = 48,     /*!< FMC global Interrupt                                              */
+  SDMMC1_IRQn                 = 49,     /*!< SDMMC1 global Interrupt                                             */
+  TIM5_IRQn                   = 50,     /*!< TIM5 global Interrupt                                             */
+  SPI3_IRQn                   = 51,     /*!< SPI3 global Interrupt                                             */
+  UART4_IRQn                  = 52,     /*!< UART4 global Interrupt                                            */
+  UART5_IRQn                  = 53,     /*!< UART5 global Interrupt                                            */
+  TIM6_DAC_IRQn               = 54,     /*!< TIM6 global and DAC1&2 underrun error  interrupts                 */
+  TIM7_IRQn                   = 55,     /*!< TIM7 global interrupt                                             */
+  DMA2_Stream0_IRQn           = 56,     /*!< DMA2 Stream 0 global Interrupt                                    */
+  DMA2_Stream1_IRQn           = 57,     /*!< DMA2 Stream 1 global Interrupt                                    */
+  DMA2_Stream2_IRQn           = 58,     /*!< DMA2 Stream 2 global Interrupt                                    */
+  DMA2_Stream3_IRQn           = 59,     /*!< DMA2 Stream 3 global Interrupt                                    */
+  DMA2_Stream4_IRQn           = 60,     /*!< DMA2 Stream 4 global Interrupt                                    */
+  ETH_IRQn                    = 61,     /*!< Ethernet global Interrupt                                         */
+  ETH_WKUP_IRQn               = 62,     /*!< Ethernet Wakeup through EXTI line Interrupt                       */
+  CAN2_TX_IRQn                = 63,     /*!< CAN2 TX Interrupt                                                 */
+  CAN2_RX0_IRQn               = 64,     /*!< CAN2 RX0 Interrupt                                                */
+  CAN2_RX1_IRQn               = 65,     /*!< CAN2 RX1 Interrupt                                                */
+  CAN2_SCE_IRQn               = 66,     /*!< CAN2 SCE Interrupt                                                */
+  OTG_FS_IRQn                 = 67,     /*!< USB OTG FS global Interrupt                                       */
+  DMA2_Stream5_IRQn           = 68,     /*!< DMA2 Stream 5 global interrupt                                    */
+  DMA2_Stream6_IRQn           = 69,     /*!< DMA2 Stream 6 global interrupt                                    */
+  DMA2_Stream7_IRQn           = 70,     /*!< DMA2 Stream 7 global interrupt                                    */
+  USART6_IRQn                 = 71,     /*!< USART6 global interrupt                                           */
+  I2C3_EV_IRQn                = 72,     /*!< I2C3 event interrupt                                              */
+  I2C3_ER_IRQn                = 73,     /*!< I2C3 error interrupt                                              */
+  OTG_HS_EP1_OUT_IRQn         = 74,     /*!< USB OTG HS End Point 1 Out global interrupt                       */
+  OTG_HS_EP1_IN_IRQn          = 75,     /*!< USB OTG HS End Point 1 In global interrupt                        */
+  OTG_HS_WKUP_IRQn            = 76,     /*!< USB OTG HS Wakeup through EXTI interrupt                          */
+  OTG_HS_IRQn                 = 77,     /*!< USB OTG HS global interrupt                                       */
+  DCMI_IRQn                   = 78,     /*!< DCMI global interrupt                                             */
+  RNG_IRQn                    = 80,     /*!< RNG global interrupt                                              */
+  FPU_IRQn                    = 81,     /*!< FPU global interrupt                                              */
+  UART7_IRQn                  = 82,     /*!< UART7 global interrupt                                            */
+  UART8_IRQn                  = 83,     /*!< UART8 global interrupt                                            */
+  SPI4_IRQn                   = 84,     /*!< SPI4 global Interrupt                                             */
+  SPI5_IRQn                   = 85,     /*!< SPI5 global Interrupt                                             */
+  SPI6_IRQn                   = 86,     /*!< SPI6 global Interrupt                                             */
+  SAI1_IRQn                   = 87,     /*!< SAI1 global Interrupt                                             */
+  LTDC_IRQn                   = 88,     /*!< LTDC global Interrupt                                             */
+  LTDC_ER_IRQn                = 89,     /*!< LTDC Error global Interrupt                                       */
+  DMA2D_IRQn                  = 90,     /*!< DMA2D global Interrupt                                            */
+  SAI2_IRQn                   = 91,     /*!< SAI2 global Interrupt                                             */
+  QUADSPI_IRQn                = 92,     /*!< Quad SPI global interrupt                                         */
+  LPTIM1_IRQn                 = 93,     /*!< LP TIM1 interrupt                                                 */
+  CEC_IRQn                    = 94,     /*!< HDMI-CEC global Interrupt                                         */
+  I2C4_EV_IRQn                = 95,     /*!< I2C4 Event Interrupt                                              */
+  I2C4_ER_IRQn                = 96,     /*!< I2C4 Error Interrupt                                              */
+  SPDIF_RX_IRQn               = 97      /*!< SPDIF-RX global Interrupt                                         */
+} IRQn_Type;
+
+/**
+  * @}
+  */
+
+/**
+ * @brief Configuration of the Cortex-M7 Processor and Core Peripherals
+ */
+#define __CM7_REV                 0x0000   /*!< Cortex-M7 revision r0p1                       */
+#define __MPU_PRESENT             1       /*!< CM7 provides an MPU                           */
+#define __NVIC_PRIO_BITS          4       /*!< CM7 uses 4 Bits for the Priority Levels       */
+#define __Vendor_SysTickConfig    0       /*!< Set to 1 if different SysTick Config is used  */
+#define __FPU_PRESENT             1       /*!< FPU present                                   */
+#define __ICACHE_PRESENT          1       /*!< CM7 instruction cache present                 */
+#define __DCACHE_PRESENT          1       /*!< CM7 data cache present                        */
+#include "core_cm7.h"                 /*!< Cortex-M7 processor and core peripherals      */
+
+
+#include "system_stm32f7xx.h"
+#include <stdint.h>
+
+/** @addtogroup Peripheral_registers_structures
+  * @{
+  */
+
+/**
+  * @brief Analog to Digital Converter
+  */
+
+typedef struct
+{
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+} ADC_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
+                             AND triple modes,                            Address offset: ADC1 base address + 0x308 */
+} ADC_Common_TypeDef;
+
+
+/**
+  * @brief Controller Area Network TxMailBox
+  */
+
+typedef struct
+{
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
+} CAN_TxMailBox_TypeDef;
+
+/**
+  * @brief Controller Area Network FIFOMailBox
+  */
+
+typedef struct
+{
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+} CAN_FIFOMailBox_TypeDef;
+
+/**
+  * @brief Controller Area Network FilterRegister
+  */
+
+typedef struct
+{
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
+} CAN_FilterRegister_TypeDef;
+
+/**
+  * @brief Controller Area Network
+  */
+
+typedef struct
+{
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
+  CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
+  CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
+  uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */
+  CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
+} CAN_TypeDef;
+
+/**
+  * @brief HDMI-CEC
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;           /*!< CEC control register,                                       Address offset:0x00 */
+  __IO uint32_t CFGR;         /*!< CEC configuration register,                                 Address offset:0x04 */
+  __IO uint32_t TXDR;         /*!< CEC Tx data register ,                                      Address offset:0x08 */
+  __IO uint32_t RXDR;         /*!< CEC Rx Data Register,                                       Address offset:0x0C */
+  __IO uint32_t ISR;          /*!< CEC Interrupt and Status Register,                          Address offset:0x10 */
+  __IO uint32_t IER;          /*!< CEC interrupt enable register,                              Address offset:0x14 */
+}CEC_TypeDef;
+
+
+/**
+  * @brief CRC calculation unit
+  */
+
+typedef struct
+{
+  __IO uint32_t  DR;          /*!< CRC Data register,                           Address offset: 0x00 */
+  __IO uint8_t   IDR;         /*!< CRC Independent data register,               Address offset: 0x04 */
+  uint8_t        RESERVED0;   /*!< Reserved, 0x05                                                    */
+  uint16_t       RESERVED1;   /*!< Reserved, 0x06                                                    */
+  __IO uint32_t  CR;          /*!< CRC Control register,                        Address offset: 0x08 */
+  uint32_t       RESERVED2;   /*!< Reserved,                                                    0x0C */
+  __IO uint32_t  INIT;        /*!< Initial CRC value register,                  Address offset: 0x10 */
+  __IO uint32_t  POL;         /*!< CRC polynomial register,                     Address offset: 0x14 */
+} CRC_TypeDef;
+
+/**
+  * @brief Digital to Analog Converter
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+} DAC_TypeDef;
+
+/**
+  * @brief Debug MCU
+  */
+
+typedef struct
+{
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+}DBGMCU_TypeDef;
+
+/**
+  * @brief DCMI
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
+  __IO uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
+  __IO uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
+  __IO uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
+  __IO uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
+  __IO uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
+  __IO uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
+  __IO uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
+  __IO uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
+  __IO uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
+  __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
+} DCMI_TypeDef;
+
+/**
+  * @brief DMA Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+} DMA_Stream_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+} DMA_TypeDef;
+
+
+/**
+  * @brief DMA2D Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
+  __IO uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
+  __IO uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
+  __IO uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
+  __IO uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
+  __IO uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
+  __IO uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
+  __IO uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
+  __IO uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
+  __IO uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
+  __IO uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
+  __IO uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
+  __IO uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
+  __IO uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
+  __IO uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
+  __IO uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
+  __IO uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
+  __IO uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
+  __IO uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
+  __IO uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
+  uint32_t      RESERVED[236]; /*!< Reserved, 0x50-0x3FF */
+  __IO uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
+  __IO uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
+} DMA2D_TypeDef;
+
+
+/**
+  * @brief Ethernet MAC
+  */
+
+typedef struct
+{
+  __IO uint32_t MACCR;
+  __IO uint32_t MACFFR;
+  __IO uint32_t MACHTHR;
+  __IO uint32_t MACHTLR;
+  __IO uint32_t MACMIIAR;
+  __IO uint32_t MACMIIDR;
+  __IO uint32_t MACFCR;
+  __IO uint32_t MACVLANTR;             /*    8 */
+  uint32_t      RESERVED0[2];
+  __IO uint32_t MACRWUFFR;             /*   11 */
+  __IO uint32_t MACPMTCSR;
+  uint32_t      RESERVED1[2];
+  __IO uint32_t MACSR;                 /*   15 */
+  __IO uint32_t MACIMR;
+  __IO uint32_t MACA0HR;
+  __IO uint32_t MACA0LR;
+  __IO uint32_t MACA1HR;
+  __IO uint32_t MACA1LR;
+  __IO uint32_t MACA2HR;
+  __IO uint32_t MACA2LR;
+  __IO uint32_t MACA3HR;
+  __IO uint32_t MACA3LR;               /*   24 */
+  uint32_t      RESERVED2[40];
+  __IO uint32_t MMCCR;                 /*   65 */
+  __IO uint32_t MMCRIR;
+  __IO uint32_t MMCTIR;
+  __IO uint32_t MMCRIMR;
+  __IO uint32_t MMCTIMR;               /*   69 */
+  uint32_t      RESERVED3[14];
+  __IO uint32_t MMCTGFSCCR;            /*   84 */
+  __IO uint32_t MMCTGFMSCCR;
+  uint32_t      RESERVED4[5];
+  __IO uint32_t MMCTGFCR;
+  uint32_t      RESERVED5[10];
+  __IO uint32_t MMCRFCECR;
+  __IO uint32_t MMCRFAECR;
+  uint32_t      RESERVED6[10];
+  __IO uint32_t MMCRGUFCR;
+  uint32_t      RESERVED7[334];
+  __IO uint32_t PTPTSCR;
+  __IO uint32_t PTPSSIR;
+  __IO uint32_t PTPTSHR;
+  __IO uint32_t PTPTSLR;
+  __IO uint32_t PTPTSHUR;
+  __IO uint32_t PTPTSLUR;
+  __IO uint32_t PTPTSAR;
+  __IO uint32_t PTPTTHR;
+  __IO uint32_t PTPTTLR;
+  __IO uint32_t RESERVED8;
+  __IO uint32_t PTPTSSR;
+  uint32_t      RESERVED9[565];
+  __IO uint32_t DMABMR;
+  __IO uint32_t DMATPDR;
+  __IO uint32_t DMARPDR;
+  __IO uint32_t DMARDLAR;
+  __IO uint32_t DMATDLAR;
+  __IO uint32_t DMASR;
+  __IO uint32_t DMAOMR;
+  __IO uint32_t DMAIER;
+  __IO uint32_t DMAMFBOCR;
+  __IO uint32_t DMARSWTR;
+  uint32_t      RESERVED10[8];
+  __IO uint32_t DMACHTDR;
+  __IO uint32_t DMACHRDR;
+  __IO uint32_t DMACHTBAR;
+  __IO uint32_t DMACHRBAR;
+} ETH_TypeDef;
+
+/**
+  * @brief External Interrupt/Event Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+} EXTI_TypeDef;
+
+/**
+  * @brief FLASH Registers
+  */
+
+typedef struct
+{
+  __IO uint32_t ACR;      /*!< FLASH access control register,     Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,                Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,         Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,             Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,            Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,    Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1 ,  Address offset: 0x18 */
+} FLASH_TypeDef;
+
+
+
+/**
+  * @brief Flexible Memory Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
+} FMC_Bank1_TypeDef;
+
+/**
+  * @brief Flexible Memory Controller Bank1E
+  */
+
+typedef struct
+{
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+} FMC_Bank1E_TypeDef;
+
+/**
+  * @brief Flexible Memory Controller Bank3
+  */
+
+typedef struct
+{
+  __IO uint32_t PCR;        /*!< NAND Flash control register,                       Address offset: 0x80 */
+  __IO uint32_t SR;         /*!< NAND Flash FIFO status and interrupt register,     Address offset: 0x84 */
+  __IO uint32_t PMEM;       /*!< NAND Flash Common memory space timing register,    Address offset: 0x88 */
+  __IO uint32_t PATT;       /*!< NAND Flash Attribute memory space timing register, Address offset: 0x8C */
+  uint32_t      RESERVED0;  /*!< Reserved, 0x90                                                          */
+  __IO uint32_t ECCR;       /*!< NAND Flash ECC result registers,                   Address offset: 0x94 */
+} FMC_Bank3_TypeDef;
+
+/**
+  * @brief Flexible Memory Controller Bank5_6
+  */
+
+typedef struct
+{
+  __IO uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
+  __IO uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
+  __IO uint32_t SDCMR;       /*!< SDRAM Command Mode register,    Address offset: 0x150  */
+  __IO uint32_t SDRTR;       /*!< SDRAM Refresh Timer register,   Address offset: 0x154  */
+  __IO uint32_t SDSR;        /*!< SDRAM Status register,          Address offset: 0x158  */
+} FMC_Bank5_6_TypeDef;
+
+
+/**
+  * @brief General Purpose I/O
+  */
+
+typedef struct
+{
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+} GPIO_TypeDef;
+
+/**
+  * @brief System configuration controller
+  */
+
+typedef struct
+{
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+} SYSCFG_TypeDef;
+
+/**
+  * @brief Inter-integrated Circuit Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< I2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;      /*!< I2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;     /*!< I2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;     /*!< I2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;  /*!< I2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR; /*!< I2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;      /*!< I2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;      /*!< I2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;     /*!< I2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;     /*!< I2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;     /*!< I2C Transmit data register,        Address offset: 0x28 */
+} I2C_TypeDef;
+
+/**
+  * @brief Independent WATCHDOG
+  */
+
+typedef struct
+{
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t WINR; /*!< IWDG Window register,    Address offset: 0x10 */
+} IWDG_TypeDef;
+
+
+/**
+  * @brief LCD-TFT Display Controller
+  */
+
+typedef struct
+{
+  uint32_t      RESERVED0[2];  /*!< Reserved, 0x00-0x04 */
+  __IO uint32_t SSCR;          /*!< LTDC Synchronization Size Configuration Register,    Address offset: 0x08 */
+  __IO uint32_t BPCR;          /*!< LTDC Back Porch Configuration Register,              Address offset: 0x0C */
+  __IO uint32_t AWCR;          /*!< LTDC Active Width Configuration Register,            Address offset: 0x10 */
+  __IO uint32_t TWCR;          /*!< LTDC Total Width Configuration Register,             Address offset: 0x14 */
+  __IO uint32_t GCR;           /*!< LTDC Global Control Register,                        Address offset: 0x18 */
+  uint32_t      RESERVED1[2];  /*!< Reserved, 0x1C-0x20 */
+  __IO uint32_t SRCR;          /*!< LTDC Shadow Reload Configuration Register,           Address offset: 0x24 */
+  uint32_t      RESERVED2[1];  /*!< Reserved, 0x28 */
+  __IO uint32_t BCCR;          /*!< LTDC Background Color Configuration Register,        Address offset: 0x2C */
+  uint32_t      RESERVED3[1];  /*!< Reserved, 0x30 */
+  __IO uint32_t IER;           /*!< LTDC Interrupt Enable Register,                      Address offset: 0x34 */
+  __IO uint32_t ISR;           /*!< LTDC Interrupt Status Register,                      Address offset: 0x38 */
+  __IO uint32_t ICR;           /*!< LTDC Interrupt Clear Register,                       Address offset: 0x3C */
+  __IO uint32_t LIPCR;         /*!< LTDC Line Interrupt Position Configuration Register, Address offset: 0x40 */
+  __IO uint32_t CPSR;          /*!< LTDC Current Position Status Register,               Address offset: 0x44 */
+  __IO uint32_t CDSR;         /*!< LTDC Current Display Status Register,                 Address offset: 0x48 */
+} LTDC_TypeDef;
+
+/**
+  * @brief LCD-TFT Display layer x Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;            /*!< LTDC Layerx Control Register                                  Address offset: 0x84 */
+  __IO uint32_t WHPCR;         /*!< LTDC Layerx Window Horizontal Position Configuration Register Address offset: 0x88 */
+  __IO uint32_t WVPCR;         /*!< LTDC Layerx Window Vertical Position Configuration Register   Address offset: 0x8C */
+  __IO uint32_t CKCR;          /*!< LTDC Layerx Color Keying Configuration Register               Address offset: 0x90 */
+  __IO uint32_t PFCR;          /*!< LTDC Layerx Pixel Format Configuration Register               Address offset: 0x94 */
+  __IO uint32_t CACR;          /*!< LTDC Layerx Constant Alpha Configuration Register             Address offset: 0x98 */
+  __IO uint32_t DCCR;          /*!< LTDC Layerx Default Color Configuration Register              Address offset: 0x9C */
+  __IO uint32_t BFCR;          /*!< LTDC Layerx Blending Factors Configuration Register           Address offset: 0xA0 */
+  uint32_t      RESERVED0[2];  /*!< Reserved */
+  __IO uint32_t CFBAR;         /*!< LTDC Layerx Color Frame Buffer Address Register               Address offset: 0xAC */
+  __IO uint32_t CFBLR;         /*!< LTDC Layerx Color Frame Buffer Length Register                Address offset: 0xB0 */
+  __IO uint32_t CFBLNR;        /*!< LTDC Layerx ColorFrame Buffer Line Number Register            Address offset: 0xB4 */
+  uint32_t      RESERVED1[3];  /*!< Reserved */
+  __IO uint32_t CLUTWR;         /*!< LTDC Layerx CLUT Write Register                              Address offset: 0x144 */
+
+} LTDC_Layer_TypeDef;
+
+
+/**
+  * @brief Power Control
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;   /*!< PWR power control register 1,        Address offset: 0x00 */
+  __IO uint32_t CSR1;  /*!< PWR power control/status register 2, Address offset: 0x04 */
+  __IO uint32_t CR2;   /*!< PWR power control register 2,        Address offset: 0x08 */
+  __IO uint32_t CSR2;  /*!< PWR power control/status register 2, Address offset: 0x0C */
+} PWR_TypeDef;
+
+
+/**
+  * @brief Reset and Clock Control
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
+  __IO uint32_t DCKCFGR1;      /*!< RCC Dedicated Clocks configuration register1,                 Address offset: 0x8C */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x90 */
+
+} RCC_TypeDef;
+
+/**
+  * @brief Real-Time Clock
+  */
+
+typedef struct
+{
+  __IO uint32_t TR;         /*!< RTC time register,                                         Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< RTC date register,                                         Address offset: 0x04 */
+  __IO uint32_t CR;         /*!< RTC control register,                                      Address offset: 0x08 */
+  __IO uint32_t ISR;        /*!< RTC initialization and status register,                    Address offset: 0x0C */
+  __IO uint32_t PRER;       /*!< RTC prescaler register,                                    Address offset: 0x10 */
+  __IO uint32_t WUTR;       /*!< RTC wakeup timer register,                                 Address offset: 0x14 */
+       uint32_t reserved;   /*!< Reserved  */
+  __IO uint32_t ALRMAR;     /*!< RTC alarm A register,                                      Address offset: 0x1C */
+  __IO uint32_t ALRMBR;     /*!< RTC alarm B register,                                      Address offset: 0x20 */
+  __IO uint32_t WPR;        /*!< RTC write protection register,                             Address offset: 0x24 */
+  __IO uint32_t SSR;        /*!< RTC sub second register,                                   Address offset: 0x28 */
+  __IO uint32_t SHIFTR;     /*!< RTC shift control register,                                Address offset: 0x2C */
+  __IO uint32_t TSTR;       /*!< RTC time stamp time register,                              Address offset: 0x30 */
+  __IO uint32_t TSDR;       /*!< RTC time stamp date register,                              Address offset: 0x34 */
+  __IO uint32_t TSSSR;      /*!< RTC time-stamp sub second register,                        Address offset: 0x38 */
+  __IO uint32_t CALR;       /*!< RTC calibration register,                                  Address offset: 0x3C */
+  __IO uint32_t TAMPCR;     /*!< RTC tamper configuration register,                         Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;   /*!< RTC alarm A sub second register,                           Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;   /*!< RTC alarm B sub second register,                           Address offset: 0x48 */
+  __IO uint32_t OR;         /*!< RTC option register,                                       Address offset: 0x4C */
+  __IO uint32_t BKP0R;      /*!< RTC backup register 0,                                     Address offset: 0x50 */
+  __IO uint32_t BKP1R;      /*!< RTC backup register 1,                                     Address offset: 0x54 */
+  __IO uint32_t BKP2R;      /*!< RTC backup register 2,                                     Address offset: 0x58 */
+  __IO uint32_t BKP3R;      /*!< RTC backup register 3,                                     Address offset: 0x5C */
+  __IO uint32_t BKP4R;      /*!< RTC backup register 4,                                     Address offset: 0x60 */
+  __IO uint32_t BKP5R;      /*!< RTC backup register 5,                                     Address offset: 0x64 */
+  __IO uint32_t BKP6R;      /*!< RTC backup register 6,                                     Address offset: 0x68 */
+  __IO uint32_t BKP7R;      /*!< RTC backup register 7,                                     Address offset: 0x6C */
+  __IO uint32_t BKP8R;      /*!< RTC backup register 8,                                     Address offset: 0x70 */
+  __IO uint32_t BKP9R;      /*!< RTC backup register 9,                                     Address offset: 0x74 */
+  __IO uint32_t BKP10R;     /*!< RTC backup register 10,                                    Address offset: 0x78 */
+  __IO uint32_t BKP11R;     /*!< RTC backup register 11,                                    Address offset: 0x7C */
+  __IO uint32_t BKP12R;     /*!< RTC backup register 12,                                    Address offset: 0x80 */
+  __IO uint32_t BKP13R;     /*!< RTC backup register 13,                                    Address offset: 0x84 */
+  __IO uint32_t BKP14R;     /*!< RTC backup register 14,                                    Address offset: 0x88 */
+  __IO uint32_t BKP15R;     /*!< RTC backup register 15,                                    Address offset: 0x8C */
+  __IO uint32_t BKP16R;     /*!< RTC backup register 16,                                    Address offset: 0x90 */
+  __IO uint32_t BKP17R;     /*!< RTC backup register 17,                                    Address offset: 0x94 */
+  __IO uint32_t BKP18R;     /*!< RTC backup register 18,                                    Address offset: 0x98 */
+  __IO uint32_t BKP19R;     /*!< RTC backup register 19,                                    Address offset: 0x9C */
+  __IO uint32_t BKP20R;     /*!< RTC backup register 20,                                    Address offset: 0xA0 */
+  __IO uint32_t BKP21R;     /*!< RTC backup register 21,                                    Address offset: 0xA4 */
+  __IO uint32_t BKP22R;     /*!< RTC backup register 22,                                    Address offset: 0xA8 */
+  __IO uint32_t BKP23R;     /*!< RTC backup register 23,                                    Address offset: 0xAC */
+  __IO uint32_t BKP24R;     /*!< RTC backup register 24,                                    Address offset: 0xB0 */
+  __IO uint32_t BKP25R;     /*!< RTC backup register 25,                                    Address offset: 0xB4 */
+  __IO uint32_t BKP26R;     /*!< RTC backup register 26,                                    Address offset: 0xB8 */
+  __IO uint32_t BKP27R;     /*!< RTC backup register 27,                                    Address offset: 0xBC */
+  __IO uint32_t BKP28R;     /*!< RTC backup register 28,                                    Address offset: 0xC0 */
+  __IO uint32_t BKP29R;     /*!< RTC backup register 29,                                    Address offset: 0xC4 */
+  __IO uint32_t BKP30R;     /*!< RTC backup register 30,                                    Address offset: 0xC8 */
+  __IO uint32_t BKP31R;     /*!< RTC backup register 31,                                    Address offset: 0xCC */
+} RTC_TypeDef;
+
+
+/**
+  * @brief Serial Audio Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
+} SAI_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
+  __IO uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
+  __IO uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
+  __IO uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
+  __IO uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
+  __IO uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
+  __IO uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
+} SAI_Block_TypeDef;
+
+/**
+  * @brief SPDIF-RX Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t   CR;           /*!< Control register,                   Address offset: 0x00 */
+  __IO uint32_t   IMR;          /*!< Interrupt mask register,            Address offset: 0x04 */
+  __IO uint32_t   SR;           /*!< Status register,                    Address offset: 0x08 */
+  __IO uint32_t   IFCR;         /*!< Interrupt Flag Clear register,      Address offset: 0x0C */
+  __IO uint32_t   DR;           /*!< Data input register,                Address offset: 0x10 */
+  __IO uint32_t   CSR;          /*!< Channel Status register,            Address offset: 0x14 */
+  __IO uint32_t   DIR;          /*!< Debug Information register,         Address offset: 0x18 */
+} SPDIFRX_TypeDef;
+
+
+/**
+  * @brief SD host Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t POWER;          /*!< SDMMC power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;          /*!< SDMMClock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;            /*!< SDMMC argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;            /*!< SDMMC command register,          Address offset: 0x0C */
+  __I uint32_t  RESPCMD;        /*!< SDMMC command response register, Address offset: 0x10 */
+  __I uint32_t  RESP1;          /*!< SDMMC response 1 register,       Address offset: 0x14 */
+  __I uint32_t  RESP2;          /*!< SDMMC response 2 register,       Address offset: 0x18 */
+  __I uint32_t  RESP3;          /*!< SDMMC response 3 register,       Address offset: 0x1C */
+  __I uint32_t  RESP4;          /*!< SDMMC response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;         /*!< SDMMC data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;           /*!< SDMMC data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;          /*!< SDMMC data control register,     Address offset: 0x2C */
+  __I uint32_t  DCOUNT;         /*!< SDMMC data counter register,     Address offset: 0x30 */
+  __I uint32_t  STA;            /*!< SDMMC status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;            /*!< SDMMC interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;           /*!< SDMMC mask register,             Address offset: 0x3C */
+  uint32_t      RESERVED0[2];   /*!< Reserved, 0x40-0x44                                  */
+  __I uint32_t  FIFOCNT;        /*!< SDMMC FIFO counter register,     Address offset: 0x48 */
+  uint32_t      RESERVED1[13];  /*!< Reserved, 0x4C-0x7C                                  */
+  __IO uint32_t FIFO;           /*!< SDMMC data FIFO register,        Address offset: 0x80 */
+} SDMMC_TypeDef;
+
+/**
+  * @brief Serial Peripheral Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+} SPI_TypeDef;
+
+/**
+  * @brief QUAD Serial Peripheral Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
+  __IO uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
+  __IO uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
+  __IO uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
+  __IO uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
+  __IO uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
+  __IO uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
+  __IO uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
+  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
+  __IO uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
+  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
+} QUADSPI_TypeDef;
+
+/**
+  * @brief TIM
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CCMR3;       /*!< TIM capture/compare mode register 3,      Address offset: 0x54 */
+  __IO uint32_t CCR5;        /*!< TIM capture/compare mode register5,       Address offset: 0x58 */
+  __IO uint32_t CCR6;        /*!< TIM capture/compare mode register6,       Address offset: 0x5C */
+
+} TIM_TypeDef;
+
+/**
+  * @brief LPTIMIMER
+  */
+typedef struct
+{
+  __IO uint32_t ISR;      /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;      /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;      /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;     /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;      /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;      /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;      /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t OR;       /*!< LPTIM Option register,                              Address offset: 0x20 */
+} LPTIM_TypeDef;
+
+
+/**
+  * @brief Universal Synchronous Asynchronous Receiver Transmitter
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;    /*!< USART Control register 1,                 Address offset: 0x00 */
+  __IO uint32_t CR2;    /*!< USART Control register 2,                 Address offset: 0x04 */
+  __IO uint32_t CR3;    /*!< USART Control register 3,                 Address offset: 0x08 */
+  __IO uint32_t BRR;    /*!< USART Baud rate register,                 Address offset: 0x0C */
+  __IO uint32_t GTPR;   /*!< USART Guard time and prescaler register,  Address offset: 0x10 */
+  __IO uint32_t RTOR;   /*!< USART Receiver Time Out register,         Address offset: 0x14 */
+  __IO uint32_t RQR;    /*!< USART Request register,                   Address offset: 0x18 */
+  __IO uint32_t ISR;    /*!< USART Interrupt and status register,      Address offset: 0x1C */
+  __IO uint32_t ICR;    /*!< USART Interrupt flag Clear register,      Address offset: 0x20 */
+  __IO uint32_t RDR;    /*!< USART Receive Data register,              Address offset: 0x24 */
+  __IO uint32_t TDR;    /*!< USART Transmit Data register,             Address offset: 0x28 */
+} USART_TypeDef;
+
+
+/**
+  * @brief Window WATCHDOG
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+} WWDG_TypeDef;
+
+/**
+  * @brief RNG
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+} RNG_TypeDef;
+
+/**
+  * @}
+  */
+
+/**
+  * @brief USB_OTG_Core_Registers
+  */
+typedef struct
+{
+ __IO uint32_t GOTGCTL;               /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  uint32_t Reserved30[2];             /*!< Reserved                                     030h */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
+  uint32_t  Reserved5[3];             /*!< Reserved                                040h-048h */
+  __IO uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
+  uint32_t  Reserved6;                /*!< Reserved                                     050h */
+  __IO uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
+  __IO uint32_t GPWRDN;               /*!< Power Down Register                          058h */
+  __IO uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
+   __IO uint32_t GADPCTL;             /*!< ADP Timer, Control and Status Register       60Ch */
+    uint32_t  Reserved43[39];         /*!< Reserved                                058h-0FFh */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO */
+} USB_OTG_GlobalTypeDef;
+
+
+/**
+  * @brief USB_OTG_device_Registers
+  */
+typedef struct
+{
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  uint32_t Reserved0C;           /*!< Reserved                     80Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  uint32_t  Reserved20;          /*!< Reserved                     820h */
+  uint32_t Reserved9;            /*!< Reserved                     824h */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  uint32_t Reserved40;           /*!< dedicated EP mask            840h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+} USB_OTG_DeviceTypeDef;
+
+
+/**
+  * @brief USB_OTG_IN_Endpoint-Specific_Register
+  */
+typedef struct
+{
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
+} USB_OTG_INEndpointTypeDef;
+
+
+/**
+  * @brief USB_OTG_OUT_Endpoint-Specific_Registers
+  */
+typedef struct
+{
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
+} USB_OTG_OUTEndpointTypeDef;
+
+
+/**
+  * @brief USB_OTG_Host_Mode_Register_Structures
+  */
+typedef struct
+{
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  uint32_t Reserved40C;           /*!< Reserved                             40Ch */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+} USB_OTG_HostTypeDef;
+
+/**
+  * @brief USB_OTG_Host_Channel_Specific_Registers
+  */
+typedef struct
+{
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  uint32_t Reserved[2];           /*!< Reserved                                      */
+} USB_OTG_HostChannelTypeDef;
+/**
+  * @}
+  */
+
+
+/** @addtogroup Peripheral_memory_map
+  * @{
+  */
+#define RAMITCM_BASE           ((uint32_t)0x00000000) /*!< Base address of :16KB RAM reserved for CPU execution/instruction accessible over ITCM   */
+#define FLASHITCM_BASE         ((uint32_t)0x00200000) /*!< Base address of :(up to 1 MB) embedded FLASH memory  accessible over ITCM               */
+#define FLASHAXI_BASE          ((uint32_t)0x08000000) /*!< Base address of : (up to 1 MB) embedded FLASH memory accessible over AXI                */
+#define RAMDTCM_BASE           ((uint32_t)0x20000000) /*!< Base address of : 64KB system data RAM accessible over DTCM                             */
+#define SRAM1_BASE             ((uint32_t)0x20010000) /*!< Base address of : 240KB RAM1 accessible over AXI/AHB                                    */
+#define SRAM2_BASE             ((uint32_t)0x2004C000) /*!< Base address of : 16KB RAM2 accessible over AXI/AHB                                     */
+#define PERIPH_BASE            ((uint32_t)0x40000000) /*!< Base address of : AHB/ABP Peripherals                                                   */
+#define BKPSRAM_BASE           ((uint32_t)0x40024000) /*!< Base address of : Backup SRAM(4 KB)                                                     */
+#define QSPI_BASE              ((uint32_t)0x90000000) /*!< Base address of : QSPI memories  accessible over AXI                                    */
+#define FMC_R_BASE             ((uint32_t)0xA0000000) /*!< Base address of : FMC Control registers                                                 */
+#define QSPI_R_BASE            ((uint32_t)0xA0001000) /*!< Base address of : QSPI Control  registers                                               */
+#define FLASH_END              ((uint32_t)0x080FFFFF) /*!< FLASH end address */
+
+/* Legacy define */
+#define FLASH_BASE     FLASHAXI_BASE
+
+/*!< Peripheral memory map */
+#define APB1PERIPH_BASE        PERIPH_BASE
+#define APB2PERIPH_BASE       (PERIPH_BASE + 0x00010000)
+#define AHB1PERIPH_BASE       (PERIPH_BASE + 0x00020000)
+#define AHB2PERIPH_BASE       (PERIPH_BASE + 0x10000000)
+
+/*!< APB1 peripherals */
+#define TIM2_BASE             (APB1PERIPH_BASE + 0x0000)
+#define TIM3_BASE             (APB1PERIPH_BASE + 0x0400)
+#define TIM4_BASE             (APB1PERIPH_BASE + 0x0800)
+#define TIM5_BASE             (APB1PERIPH_BASE + 0x0C00)
+#define TIM6_BASE             (APB1PERIPH_BASE + 0x1000)
+#define TIM7_BASE             (APB1PERIPH_BASE + 0x1400)
+#define TIM12_BASE            (APB1PERIPH_BASE + 0x1800)
+#define TIM13_BASE            (APB1PERIPH_BASE + 0x1C00)
+#define TIM14_BASE            (APB1PERIPH_BASE + 0x2000)
+#define LPTIM1_BASE           (APB1PERIPH_BASE + 0x2400)
+#define RTC_BASE              (APB1PERIPH_BASE + 0x2800)
+#define WWDG_BASE             (APB1PERIPH_BASE + 0x2C00)
+#define IWDG_BASE             (APB1PERIPH_BASE + 0x3000)
+#define SPI2_BASE             (APB1PERIPH_BASE + 0x3800)
+#define SPI3_BASE             (APB1PERIPH_BASE + 0x3C00)
+#define SPDIFRX_BASE          (APB1PERIPH_BASE + 0x4000)
+#define USART2_BASE           (APB1PERIPH_BASE + 0x4400)
+#define USART3_BASE           (APB1PERIPH_BASE + 0x4800)
+#define UART4_BASE            (APB1PERIPH_BASE + 0x4C00)
+#define UART5_BASE            (APB1PERIPH_BASE + 0x5000)
+#define I2C1_BASE             (APB1PERIPH_BASE + 0x5400)
+#define I2C2_BASE             (APB1PERIPH_BASE + 0x5800)
+#define I2C3_BASE             (APB1PERIPH_BASE + 0x5C00)
+#define I2C4_BASE             (APB1PERIPH_BASE + 0x6000)
+#define CAN1_BASE             (APB1PERIPH_BASE + 0x6400)
+#define CAN2_BASE             (APB1PERIPH_BASE + 0x6800)
+#define CEC_BASE              (APB1PERIPH_BASE + 0x6C00)
+#define PWR_BASE              (APB1PERIPH_BASE + 0x7000)
+#define DAC_BASE              (APB1PERIPH_BASE + 0x7400)
+#define UART7_BASE            (APB1PERIPH_BASE + 0x7800)
+#define UART8_BASE            (APB1PERIPH_BASE + 0x7C00)
+
+/*!< APB2 peripherals */
+#define TIM1_BASE             (APB2PERIPH_BASE + 0x0000)
+#define TIM8_BASE             (APB2PERIPH_BASE + 0x0400)
+#define USART1_BASE           (APB2PERIPH_BASE + 0x1000)
+#define USART6_BASE           (APB2PERIPH_BASE + 0x1400)
+#define ADC1_BASE             (APB2PERIPH_BASE + 0x2000)
+#define ADC2_BASE             (APB2PERIPH_BASE + 0x2100)
+#define ADC3_BASE             (APB2PERIPH_BASE + 0x2200)
+#define ADC_BASE              (APB2PERIPH_BASE + 0x2300)
+#define SDMMC1_BASE           (APB2PERIPH_BASE + 0x2C00)
+#define SPI1_BASE             (APB2PERIPH_BASE + 0x3000)
+#define SPI4_BASE             (APB2PERIPH_BASE + 0x3400)
+#define SYSCFG_BASE           (APB2PERIPH_BASE + 0x3800)
+#define EXTI_BASE             (APB2PERIPH_BASE + 0x3C00)
+#define TIM9_BASE             (APB2PERIPH_BASE + 0x4000)
+#define TIM10_BASE            (APB2PERIPH_BASE + 0x4400)
+#define TIM11_BASE            (APB2PERIPH_BASE + 0x4800)
+#define SPI5_BASE             (APB2PERIPH_BASE + 0x5000)
+#define SPI6_BASE             (APB2PERIPH_BASE + 0x5400)
+#define SAI1_BASE             (APB2PERIPH_BASE + 0x5800)
+#define SAI2_BASE             (APB2PERIPH_BASE + 0x5C00)
+#define SAI1_Block_A_BASE     (SAI1_BASE + 0x004)
+#define SAI1_Block_B_BASE     (SAI1_BASE + 0x024)
+#define SAI2_Block_A_BASE     (SAI2_BASE + 0x004)
+#define SAI2_Block_B_BASE     (SAI2_BASE + 0x024)
+#define LTDC_BASE             (APB2PERIPH_BASE + 0x6800)
+#define LTDC_Layer1_BASE      (LTDC_BASE + 0x84)
+#define LTDC_Layer2_BASE      (LTDC_BASE + 0x104)
+/*!< AHB1 peripherals */
+#define GPIOA_BASE            (AHB1PERIPH_BASE + 0x0000)
+#define GPIOB_BASE            (AHB1PERIPH_BASE + 0x0400)
+#define GPIOC_BASE            (AHB1PERIPH_BASE + 0x0800)
+#define GPIOD_BASE            (AHB1PERIPH_BASE + 0x0C00)
+#define GPIOE_BASE            (AHB1PERIPH_BASE + 0x1000)
+#define GPIOF_BASE            (AHB1PERIPH_BASE + 0x1400)
+#define GPIOG_BASE            (AHB1PERIPH_BASE + 0x1800)
+#define GPIOH_BASE            (AHB1PERIPH_BASE + 0x1C00)
+#define GPIOI_BASE            (AHB1PERIPH_BASE + 0x2000)
+#define GPIOJ_BASE            (AHB1PERIPH_BASE + 0x2400)
+#define GPIOK_BASE            (AHB1PERIPH_BASE + 0x2800)
+#define CRC_BASE              (AHB1PERIPH_BASE + 0x3000)
+#define RCC_BASE              (AHB1PERIPH_BASE + 0x3800)
+#define FLASH_R_BASE          (AHB1PERIPH_BASE + 0x3C00)
+#define DMA1_BASE             (AHB1PERIPH_BASE + 0x6000)
+#define DMA1_Stream0_BASE     (DMA1_BASE + 0x010)
+#define DMA1_Stream1_BASE     (DMA1_BASE + 0x028)
+#define DMA1_Stream2_BASE     (DMA1_BASE + 0x040)
+#define DMA1_Stream3_BASE     (DMA1_BASE + 0x058)
+#define DMA1_Stream4_BASE     (DMA1_BASE + 0x070)
+#define DMA1_Stream5_BASE     (DMA1_BASE + 0x088)
+#define DMA1_Stream6_BASE     (DMA1_BASE + 0x0A0)
+#define DMA1_Stream7_BASE     (DMA1_BASE + 0x0B8)
+#define DMA2_BASE             (AHB1PERIPH_BASE + 0x6400)
+#define DMA2_Stream0_BASE     (DMA2_BASE + 0x010)
+#define DMA2_Stream1_BASE     (DMA2_BASE + 0x028)
+#define DMA2_Stream2_BASE     (DMA2_BASE + 0x040)
+#define DMA2_Stream3_BASE     (DMA2_BASE + 0x058)
+#define DMA2_Stream4_BASE     (DMA2_BASE + 0x070)
+#define DMA2_Stream5_BASE     (DMA2_BASE + 0x088)
+#define DMA2_Stream6_BASE     (DMA2_BASE + 0x0A0)
+#define DMA2_Stream7_BASE     (DMA2_BASE + 0x0B8)
+#define ETH_BASE              (AHB1PERIPH_BASE + 0x8000)
+#define ETH_MAC_BASE          (ETH_BASE)
+#define ETH_MMC_BASE          (ETH_BASE + 0x0100)
+#define ETH_PTP_BASE          (ETH_BASE + 0x0700)
+#define ETH_DMA_BASE          (ETH_BASE + 0x1000)
+#define DMA2D_BASE            (AHB1PERIPH_BASE + 0xB000)
+/*!< AHB2 peripherals */
+#define DCMI_BASE             (AHB2PERIPH_BASE + 0x50000)
+#define RNG_BASE              (AHB2PERIPH_BASE + 0x60800)
+/*!< FMC Bankx registers base address */
+#define FMC_Bank1_R_BASE      (FMC_R_BASE + 0x0000)
+#define FMC_Bank1E_R_BASE     (FMC_R_BASE + 0x0104)
+#define FMC_Bank3_R_BASE      (FMC_R_BASE + 0x0080)
+#define FMC_Bank5_6_R_BASE    (FMC_R_BASE + 0x0140)
+
+/* Debug MCU registers base address */
+#define DBGMCU_BASE           ((uint32_t )0xE0042000)
+
+/*!< USB registers base address */
+#define USB_OTG_HS_PERIPH_BASE               ((uint32_t )0x40040000)
+#define USB_OTG_FS_PERIPH_BASE               ((uint32_t )0x50000000)
+
+#define USB_OTG_GLOBAL_BASE                  ((uint32_t )0x000)
+#define USB_OTG_DEVICE_BASE                  ((uint32_t )0x800)
+#define USB_OTG_IN_ENDPOINT_BASE             ((uint32_t )0x900)
+#define USB_OTG_OUT_ENDPOINT_BASE            ((uint32_t )0xB00)
+#define USB_OTG_EP_REG_SIZE                  ((uint32_t )0x20)
+#define USB_OTG_HOST_BASE                    ((uint32_t )0x400)
+#define USB_OTG_HOST_PORT_BASE               ((uint32_t )0x440)
+#define USB_OTG_HOST_CHANNEL_BASE            ((uint32_t )0x500)
+#define USB_OTG_HOST_CHANNEL_SIZE            ((uint32_t )0x20)
+#define USB_OTG_PCGCCTL_BASE                 ((uint32_t )0xE00)
+#define USB_OTG_FIFO_BASE                    ((uint32_t )0x1000)
+#define USB_OTG_FIFO_SIZE                    ((uint32_t )0x1000)
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_declaration
+  * @{
+  */
+#define TIM2                ((TIM_TypeDef *) TIM2_BASE)
+#define TIM3                ((TIM_TypeDef *) TIM3_BASE)
+#define TIM4                ((TIM_TypeDef *) TIM4_BASE)
+#define TIM5                ((TIM_TypeDef *) TIM5_BASE)
+#define TIM6                ((TIM_TypeDef *) TIM6_BASE)
+#define TIM7                ((TIM_TypeDef *) TIM7_BASE)
+#define TIM12               ((TIM_TypeDef *) TIM12_BASE)
+#define TIM13               ((TIM_TypeDef *) TIM13_BASE)
+#define TIM14               ((TIM_TypeDef *) TIM14_BASE)
+#define LPTIM1              ((LPTIM_TypeDef *) LPTIM1_BASE)
+#define RTC                 ((RTC_TypeDef *) RTC_BASE)
+#define WWDG                ((WWDG_TypeDef *) WWDG_BASE)
+#define IWDG                ((IWDG_TypeDef *) IWDG_BASE)
+#define SPI2                ((SPI_TypeDef *) SPI2_BASE)
+#define SPI3                ((SPI_TypeDef *) SPI3_BASE)
+#define SPDIFRX             ((SPDIFRX_TypeDef *) SPDIFRX_BASE)
+#define USART2              ((USART_TypeDef *) USART2_BASE)
+#define USART3              ((USART_TypeDef *) USART3_BASE)
+#define UART4               ((USART_TypeDef *) UART4_BASE)
+#define UART5               ((USART_TypeDef *) UART5_BASE)
+#define I2C1                ((I2C_TypeDef *) I2C1_BASE)
+#define I2C2                ((I2C_TypeDef *) I2C2_BASE)
+#define I2C3                ((I2C_TypeDef *) I2C3_BASE)
+#define I2C4                ((I2C_TypeDef *) I2C4_BASE)
+#define CAN1                ((CAN_TypeDef *) CAN1_BASE)
+#define CAN2                ((CAN_TypeDef *) CAN2_BASE)
+#define CEC                 ((CEC_TypeDef *) CEC_BASE)
+#define PWR                 ((PWR_TypeDef *) PWR_BASE)
+#define DAC                 ((DAC_TypeDef *) DAC_BASE)
+#define UART7               ((USART_TypeDef *) UART7_BASE)
+#define UART8               ((USART_TypeDef *) UART8_BASE)
+#define TIM1                ((TIM_TypeDef *) TIM1_BASE)
+#define TIM8                ((TIM_TypeDef *) TIM8_BASE)
+#define USART1              ((USART_TypeDef *) USART1_BASE)
+#define USART6              ((USART_TypeDef *) USART6_BASE)
+#define ADC                 ((ADC_Common_TypeDef *) ADC_BASE)
+#define ADC1                ((ADC_TypeDef *) ADC1_BASE)
+#define ADC2                ((ADC_TypeDef *) ADC2_BASE)
+#define ADC3                ((ADC_TypeDef *) ADC3_BASE)
+#define SDMMC1              ((SDMMC_TypeDef *) SDMMC1_BASE)
+#define SPI1                ((SPI_TypeDef *) SPI1_BASE)
+#define SPI4                ((SPI_TypeDef *) SPI4_BASE)
+#define SYSCFG              ((SYSCFG_TypeDef *) SYSCFG_BASE)
+#define EXTI                ((EXTI_TypeDef *) EXTI_BASE)
+#define TIM9                ((TIM_TypeDef *) TIM9_BASE)
+#define TIM10               ((TIM_TypeDef *) TIM10_BASE)
+#define TIM11               ((TIM_TypeDef *) TIM11_BASE)
+#define SPI5                ((SPI_TypeDef *) SPI5_BASE)
+#define SPI6                ((SPI_TypeDef *) SPI6_BASE)
+#define SAI1                ((SAI_TypeDef *) SAI1_BASE)
+#define SAI2                ((SAI_TypeDef *) SAI2_BASE)
+#define SAI1_Block_A        ((SAI_Block_TypeDef *)SAI1_Block_A_BASE)
+#define SAI1_Block_B        ((SAI_Block_TypeDef *)SAI1_Block_B_BASE)
+#define SAI2_Block_A        ((SAI_Block_TypeDef *)SAI2_Block_A_BASE)
+#define SAI2_Block_B        ((SAI_Block_TypeDef *)SAI2_Block_B_BASE)
+#define LTDC                ((LTDC_TypeDef *)LTDC_BASE)
+#define LTDC_Layer1         ((LTDC_Layer_TypeDef *)LTDC_Layer1_BASE)
+#define LTDC_Layer2         ((LTDC_Layer_TypeDef *)LTDC_Layer2_BASE)
+#define GPIOA               ((GPIO_TypeDef *) GPIOA_BASE)
+#define GPIOB               ((GPIO_TypeDef *) GPIOB_BASE)
+#define GPIOC               ((GPIO_TypeDef *) GPIOC_BASE)
+#define GPIOD               ((GPIO_TypeDef *) GPIOD_BASE)
+#define GPIOE               ((GPIO_TypeDef *) GPIOE_BASE)
+#define GPIOF               ((GPIO_TypeDef *) GPIOF_BASE)
+#define GPIOG               ((GPIO_TypeDef *) GPIOG_BASE)
+#define GPIOH               ((GPIO_TypeDef *) GPIOH_BASE)
+#define GPIOI               ((GPIO_TypeDef *) GPIOI_BASE)
+#define GPIOJ               ((GPIO_TypeDef *) GPIOJ_BASE)
+#define GPIOK               ((GPIO_TypeDef *) GPIOK_BASE)
+#define CRC                 ((CRC_TypeDef *) CRC_BASE)
+#define RCC                 ((RCC_TypeDef *) RCC_BASE)
+#define FLASH               ((FLASH_TypeDef *) FLASH_R_BASE)
+#define DMA1                ((DMA_TypeDef *) DMA1_BASE)
+#define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
+#define DMA1_Stream1        ((DMA_Stream_TypeDef *) DMA1_Stream1_BASE)
+#define DMA1_Stream2        ((DMA_Stream_TypeDef *) DMA1_Stream2_BASE)
+#define DMA1_Stream3        ((DMA_Stream_TypeDef *) DMA1_Stream3_BASE)
+#define DMA1_Stream4        ((DMA_Stream_TypeDef *) DMA1_Stream4_BASE)
+#define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
+#define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
+#define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
+#define DMA2                ((DMA_TypeDef *) DMA2_BASE)
+#define DMA2_Stream0        ((DMA_Stream_TypeDef *) DMA2_Stream0_BASE)
+#define DMA2_Stream1        ((DMA_Stream_TypeDef *) DMA2_Stream1_BASE)
+#define DMA2_Stream2        ((DMA_Stream_TypeDef *) DMA2_Stream2_BASE)
+#define DMA2_Stream3        ((DMA_Stream_TypeDef *) DMA2_Stream3_BASE)
+#define DMA2_Stream4        ((DMA_Stream_TypeDef *) DMA2_Stream4_BASE)
+#define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
+#define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
+#define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define ETH                 ((ETH_TypeDef *) ETH_BASE)
+#define DMA2D               ((DMA2D_TypeDef *)DMA2D_BASE)
+#define DCMI                ((DCMI_TypeDef *) DCMI_BASE)
+#define RNG                 ((RNG_TypeDef *) RNG_BASE)
+#define FMC_Bank1           ((FMC_Bank1_TypeDef *) FMC_Bank1_R_BASE)
+#define FMC_Bank1E          ((FMC_Bank1E_TypeDef *) FMC_Bank1E_R_BASE)
+#define FMC_Bank3           ((FMC_Bank3_TypeDef *) FMC_Bank3_R_BASE)
+#define FMC_Bank5_6         ((FMC_Bank5_6_TypeDef *) FMC_Bank5_6_R_BASE)
+#define QUADSPI             ((QUADSPI_TypeDef *) QSPI_R_BASE)
+#define DBGMCU              ((DBGMCU_TypeDef *) DBGMCU_BASE)
+#define USB_OTG_FS          ((USB_OTG_GlobalTypeDef *) USB_OTG_FS_PERIPH_BASE)
+#define USB_OTG_HS          ((USB_OTG_GlobalTypeDef *) USB_OTG_HS_PERIPH_BASE)
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_constants
+  * @{
+  */
+
+  /** @addtogroup Peripheral_Registers_Bits_Definition
+  * @{
+  */
+
+/******************************************************************************/
+/*                         Peripheral Registers_Bits_Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Analog to Digital Converter                         */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for ADC_SR register  ********************/
+#define  ADC_SR_AWD                          ((uint32_t)0x00000001)        /*!<Analog watchdog flag                                 */
+#define  ADC_SR_EOC                          ((uint32_t)0x00000002)        /*!<End of conversion                                    */
+#define  ADC_SR_JEOC                         ((uint32_t)0x00000004)        /*!<Injected channel end of conversion                   */
+#define  ADC_SR_JSTRT                        ((uint32_t)0x00000008)        /*!<Injected channel Start flag                          */
+#define  ADC_SR_STRT                         ((uint32_t)0x00000010)        /*!<Regular channel Start flag                           */
+#define  ADC_SR_OVR                          ((uint32_t)0x00000020)        /*!<Overrun flag                                         */
+
+/*******************  Bit definition for ADC_CR1 register  ********************/
+#define  ADC_CR1_AWDCH                       ((uint32_t)0x0000001F)        /*!<AWDCH[4:0] bits (Analog watchdog channel select bits) */
+#define  ADC_CR1_AWDCH_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_CR1_AWDCH_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_CR1_AWDCH_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_CR1_AWDCH_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_CR1_AWDCH_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_CR1_EOCIE                       ((uint32_t)0x00000020)        /*!<Interrupt enable for EOC                             */
+#define  ADC_CR1_AWDIE                       ((uint32_t)0x00000040)        /*!<AAnalog Watchdog interrupt enable                    */
+#define  ADC_CR1_JEOCIE                      ((uint32_t)0x00000080)        /*!<Interrupt enable for injected channels               */
+#define  ADC_CR1_SCAN                        ((uint32_t)0x00000100)        /*!<Scan mode */
+#define  ADC_CR1_AWDSGL                      ((uint32_t)0x00000200)        /*!<Enable the watchdog on a single channel in scan mode */
+#define  ADC_CR1_JAUTO                       ((uint32_t)0x00000400)        /*!<Automatic injected group conversion                  */
+#define  ADC_CR1_DISCEN                      ((uint32_t)0x00000800)        /*!<Discontinuous mode on regular channels               */
+#define  ADC_CR1_JDISCEN                     ((uint32_t)0x00001000)        /*!<Discontinuous mode on injected channels              */
+#define  ADC_CR1_DISCNUM                     ((uint32_t)0x0000E000)        /*!<DISCNUM[2:0] bits (Discontinuous mode channel count) */
+#define  ADC_CR1_DISCNUM_0                   ((uint32_t)0x00002000)        /*!<Bit 0 */
+#define  ADC_CR1_DISCNUM_1                   ((uint32_t)0x00004000)        /*!<Bit 1 */
+#define  ADC_CR1_DISCNUM_2                   ((uint32_t)0x00008000)        /*!<Bit 2 */
+#define  ADC_CR1_JAWDEN                      ((uint32_t)0x00400000)        /*!<Analog watchdog enable on injected channels          */
+#define  ADC_CR1_AWDEN                       ((uint32_t)0x00800000)        /*!<Analog watchdog enable on regular channels           */
+#define  ADC_CR1_RES                         ((uint32_t)0x03000000)        /*!<RES[2:0] bits (Resolution)                           */
+#define  ADC_CR1_RES_0                       ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  ADC_CR1_RES_1                       ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  ADC_CR1_OVRIE                       ((uint32_t)0x04000000)         /*!<overrun interrupt enable */
+
+/*******************  Bit definition for ADC_CR2 register  ********************/
+#define  ADC_CR2_ADON                        ((uint32_t)0x00000001)        /*!<A/D Converter ON / OFF                                       */
+#define  ADC_CR2_CONT                        ((uint32_t)0x00000002)        /*!<Continuous Conversion                                        */
+#define  ADC_CR2_DMA                         ((uint32_t)0x00000100)        /*!<Direct Memory access mode                                    */
+#define  ADC_CR2_DDS                         ((uint32_t)0x00000200)        /*!<DMA disable selection (Single ADC)                           */
+#define  ADC_CR2_EOCS                        ((uint32_t)0x00000400)        /*!<End of conversion selection                                  */
+#define  ADC_CR2_ALIGN                       ((uint32_t)0x00000800)        /*!<Data Alignment                                               */
+#define  ADC_CR2_JEXTSEL                     ((uint32_t)0x000F0000)        /*!<JEXTSEL[3:0] bits (External event select for injected group) */
+#define  ADC_CR2_JEXTSEL_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  ADC_CR2_JEXTSEL_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  ADC_CR2_JEXTSEL_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  ADC_CR2_JEXTSEL_3                   ((uint32_t)0x00080000)        /*!<Bit 3 */
+#define  ADC_CR2_JEXTEN                      ((uint32_t)0x00300000)        /*!<JEXTEN[1:0] bits (External Trigger Conversion mode for injected channelsp) */
+#define  ADC_CR2_JEXTEN_0                    ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_CR2_JEXTEN_1                    ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  ADC_CR2_JSWSTART                    ((uint32_t)0x00400000)        /*!<Start Conversion of injected channels */
+#define  ADC_CR2_EXTSEL                      ((uint32_t)0x0F000000)        /*!<EXTSEL[3:0] bits (External Event Select for regular group) */
+#define  ADC_CR2_EXTSEL_0                    ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  ADC_CR2_EXTSEL_1                    ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  ADC_CR2_EXTSEL_2                    ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  ADC_CR2_EXTSEL_3                    ((uint32_t)0x08000000)        /*!<Bit 3 */
+#define  ADC_CR2_EXTEN                       ((uint32_t)0x30000000)        /*!<EXTEN[1:0] bits (External Trigger Conversion mode for regular channelsp) */
+#define  ADC_CR2_EXTEN_0                     ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  ADC_CR2_EXTEN_1                     ((uint32_t)0x20000000)        /*!<Bit 1 */
+#define  ADC_CR2_SWSTART                     ((uint32_t)0x40000000)        /*!<Start Conversion of regular channels */
+
+/******************  Bit definition for ADC_SMPR1 register  *******************/
+#define  ADC_SMPR1_SMP10                     ((uint32_t)0x00000007)        /*!<SMP10[2:0] bits (Channel 10 Sample time selection) */
+#define  ADC_SMPR1_SMP10_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP10_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP10_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP11                     ((uint32_t)0x00000038)        /*!<SMP11[2:0] bits (Channel 11 Sample time selection) */
+#define  ADC_SMPR1_SMP11_0                   ((uint32_t)0x00000008)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP11_1                   ((uint32_t)0x00000010)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP11_2                   ((uint32_t)0x00000020)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP12                     ((uint32_t)0x000001C0)        /*!<SMP12[2:0] bits (Channel 12 Sample time selection) */
+#define  ADC_SMPR1_SMP12_0                   ((uint32_t)0x00000040)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP12_1                   ((uint32_t)0x00000080)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP12_2                   ((uint32_t)0x00000100)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP13                     ((uint32_t)0x00000E00)        /*!<SMP13[2:0] bits (Channel 13 Sample time selection) */
+#define  ADC_SMPR1_SMP13_0                   ((uint32_t)0x00000200)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP13_1                   ((uint32_t)0x00000400)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP13_2                   ((uint32_t)0x00000800)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP14                     ((uint32_t)0x00007000)        /*!<SMP14[2:0] bits (Channel 14 Sample time selection) */
+#define  ADC_SMPR1_SMP14_0                   ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP14_1                   ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP14_2                   ((uint32_t)0x00004000)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP15                     ((uint32_t)0x00038000)        /*!<SMP15[2:0] bits (Channel 15 Sample time selection) */
+#define  ADC_SMPR1_SMP15_0                   ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP15_1                   ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP15_2                   ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP16                     ((uint32_t)0x001C0000)        /*!<SMP16[2:0] bits (Channel 16 Sample time selection) */
+#define  ADC_SMPR1_SMP16_0                   ((uint32_t)0x00040000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP16_1                   ((uint32_t)0x00080000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP16_2                   ((uint32_t)0x00100000)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP17                     ((uint32_t)0x00E00000)        /*!<SMP17[2:0] bits (Channel 17 Sample time selection) */
+#define  ADC_SMPR1_SMP17_0                   ((uint32_t)0x00200000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP17_1                   ((uint32_t)0x00400000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP17_2                   ((uint32_t)0x00800000)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP18                     ((uint32_t)0x07000000)        /*!<SMP18[2:0] bits (Channel 18 Sample time selection) */
+#define  ADC_SMPR1_SMP18_0                   ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP18_1                   ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP18_2                   ((uint32_t)0x04000000)        /*!<Bit 2 */
+
+/******************  Bit definition for ADC_SMPR2 register  *******************/
+#define  ADC_SMPR2_SMP0                      ((uint32_t)0x00000007)        /*!<SMP0[2:0] bits (Channel 0 Sample time selection) */
+#define  ADC_SMPR2_SMP0_0                    ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP0_1                    ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP0_2                    ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP1                      ((uint32_t)0x00000038)        /*!<SMP1[2:0] bits (Channel 1 Sample time selection) */
+#define  ADC_SMPR2_SMP1_0                    ((uint32_t)0x00000008)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP1_1                    ((uint32_t)0x00000010)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP1_2                    ((uint32_t)0x00000020)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP2                      ((uint32_t)0x000001C0)        /*!<SMP2[2:0] bits (Channel 2 Sample time selection) */
+#define  ADC_SMPR2_SMP2_0                    ((uint32_t)0x00000040)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP2_1                    ((uint32_t)0x00000080)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP2_2                    ((uint32_t)0x00000100)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP3                      ((uint32_t)0x00000E00)        /*!<SMP3[2:0] bits (Channel 3 Sample time selection) */
+#define  ADC_SMPR2_SMP3_0                    ((uint32_t)0x00000200)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP3_1                    ((uint32_t)0x00000400)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP3_2                    ((uint32_t)0x00000800)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP4                      ((uint32_t)0x00007000)        /*!<SMP4[2:0] bits (Channel 4 Sample time selection) */
+#define  ADC_SMPR2_SMP4_0                    ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP4_1                    ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP4_2                    ((uint32_t)0x00004000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP5                      ((uint32_t)0x00038000)        /*!<SMP5[2:0] bits (Channel 5 Sample time selection) */
+#define  ADC_SMPR2_SMP5_0                    ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP5_1                    ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP5_2                    ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP6                      ((uint32_t)0x001C0000)        /*!<SMP6[2:0] bits (Channel 6 Sample time selection) */
+#define  ADC_SMPR2_SMP6_0                    ((uint32_t)0x00040000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP6_1                    ((uint32_t)0x00080000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP6_2                    ((uint32_t)0x00100000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP7                      ((uint32_t)0x00E00000)        /*!<SMP7[2:0] bits (Channel 7 Sample time selection) */
+#define  ADC_SMPR2_SMP7_0                    ((uint32_t)0x00200000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP7_1                    ((uint32_t)0x00400000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP7_2                    ((uint32_t)0x00800000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP8                      ((uint32_t)0x07000000)        /*!<SMP8[2:0] bits (Channel 8 Sample time selection) */
+#define  ADC_SMPR2_SMP8_0                    ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP8_1                    ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP8_2                    ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP9                      ((uint32_t)0x38000000)        /*!<SMP9[2:0] bits (Channel 9 Sample time selection) */
+#define  ADC_SMPR2_SMP9_0                    ((uint32_t)0x08000000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP9_1                    ((uint32_t)0x10000000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP9_2                    ((uint32_t)0x20000000)        /*!<Bit 2 */
+
+/******************  Bit definition for ADC_JOFR1 register  *******************/
+#define  ADC_JOFR1_JOFFSET1                  ((uint32_t)0x0FFF)            /*!<Data offset for injected channel 1 */
+
+/******************  Bit definition for ADC_JOFR2 register  *******************/
+#define  ADC_JOFR2_JOFFSET2                  ((uint32_t)0x0FFF)            /*!<Data offset for injected channel 2 */
+
+/******************  Bit definition for ADC_JOFR3 register  *******************/
+#define  ADC_JOFR3_JOFFSET3                  ((uint32_t)0x0FFF)            /*!<Data offset for injected channel 3 */
+
+/******************  Bit definition for ADC_JOFR4 register  *******************/
+#define  ADC_JOFR4_JOFFSET4                  ((uint32_t)0x0FFF)            /*!<Data offset for injected channel 4 */
+
+/*******************  Bit definition for ADC_HTR register  ********************/
+#define  ADC_HTR_HT                          ((uint32_t)0x0FFF)            /*!<Analog watchdog high threshold */
+
+/*******************  Bit definition for ADC_LTR register  ********************/
+#define  ADC_LTR_LT                          ((uint32_t)0x0FFF)            /*!<Analog watchdog low threshold */
+
+/*******************  Bit definition for ADC_SQR1 register  *******************/
+#define  ADC_SQR1_SQ13                       ((uint32_t)0x0000001F)        /*!<SQ13[4:0] bits (13th conversion in regular sequence) */
+#define  ADC_SQR1_SQ13_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SQR1_SQ13_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SQR1_SQ13_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SQR1_SQ13_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_SQR1_SQ13_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_SQR1_SQ14                       ((uint32_t)0x000003E0)        /*!<SQ14[4:0] bits (14th conversion in regular sequence) */
+#define  ADC_SQR1_SQ14_0                     ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  ADC_SQR1_SQ14_1                     ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  ADC_SQR1_SQ14_2                     ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  ADC_SQR1_SQ14_3                     ((uint32_t)0x00000100)        /*!<Bit 3 */
+#define  ADC_SQR1_SQ14_4                     ((uint32_t)0x00000200)        /*!<Bit 4 */
+#define  ADC_SQR1_SQ15                       ((uint32_t)0x00007C00)        /*!<SQ15[4:0] bits (15th conversion in regular sequence) */
+#define  ADC_SQR1_SQ15_0                     ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  ADC_SQR1_SQ15_1                     ((uint32_t)0x00000800)        /*!<Bit 1 */
+#define  ADC_SQR1_SQ15_2                     ((uint32_t)0x00001000)        /*!<Bit 2 */
+#define  ADC_SQR1_SQ15_3                     ((uint32_t)0x00002000)        /*!<Bit 3 */
+#define  ADC_SQR1_SQ15_4                     ((uint32_t)0x00004000)        /*!<Bit 4 */
+#define  ADC_SQR1_SQ16                       ((uint32_t)0x000F8000)        /*!<SQ16[4:0] bits (16th conversion in regular sequence) */
+#define  ADC_SQR1_SQ16_0                     ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SQR1_SQ16_1                     ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SQR1_SQ16_2                     ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SQR1_SQ16_3                     ((uint32_t)0x00040000)        /*!<Bit 3 */
+#define  ADC_SQR1_SQ16_4                     ((uint32_t)0x00080000)        /*!<Bit 4 */
+#define  ADC_SQR1_L                          ((uint32_t)0x00F00000)        /*!<L[3:0] bits (Regular channel sequence length) */
+#define  ADC_SQR1_L_0                        ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_SQR1_L_1                        ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  ADC_SQR1_L_2                        ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  ADC_SQR1_L_3                        ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+/*******************  Bit definition for ADC_SQR2 register  *******************/
+#define  ADC_SQR2_SQ7                        ((uint32_t)0x0000001F)        /*!<SQ7[4:0] bits (7th conversion in regular sequence) */
+#define  ADC_SQR2_SQ7_0                      ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ7_1                      ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ7_2                      ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ7_3                      ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ7_4                      ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ8                        ((uint32_t)0x000003E0)        /*!<SQ8[4:0] bits (8th conversion in regular sequence) */
+#define  ADC_SQR2_SQ8_0                      ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ8_1                      ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ8_2                      ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ8_3                      ((uint32_t)0x00000100)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ8_4                      ((uint32_t)0x00000200)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ9                        ((uint32_t)0x00007C00)        /*!<SQ9[4:0] bits (9th conversion in regular sequence) */
+#define  ADC_SQR2_SQ9_0                      ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ9_1                      ((uint32_t)0x00000800)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ9_2                      ((uint32_t)0x00001000)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ9_3                      ((uint32_t)0x00002000)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ9_4                      ((uint32_t)0x00004000)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ10                       ((uint32_t)0x000F8000)        /*!<SQ10[4:0] bits (10th conversion in regular sequence) */
+#define  ADC_SQR2_SQ10_0                     ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ10_1                     ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ10_2                     ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ10_3                     ((uint32_t)0x00040000)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ10_4                     ((uint32_t)0x00080000)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ11                       ((uint32_t)0x01F00000)        /*!<SQ11[4:0] bits (11th conversion in regular sequence) */
+#define  ADC_SQR2_SQ11_0                     ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ11_1                     ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ11_2                     ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ11_3                     ((uint32_t)0x00800000)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ11_4                     ((uint32_t)0x01000000)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ12                       ((uint32_t)0x3E000000)        /*!<SQ12[4:0] bits (12th conversion in regular sequence) */
+#define  ADC_SQR2_SQ12_0                     ((uint32_t)0x02000000)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ12_1                     ((uint32_t)0x04000000)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ12_2                     ((uint32_t)0x08000000)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ12_3                     ((uint32_t)0x10000000)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ12_4                     ((uint32_t)0x20000000)        /*!<Bit 4 */
+
+/*******************  Bit definition for ADC_SQR3 register  *******************/
+#define  ADC_SQR3_SQ1                        ((uint32_t)0x0000001F)        /*!<SQ1[4:0] bits (1st conversion in regular sequence) */
+#define  ADC_SQR3_SQ1_0                      ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ1_1                      ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ1_2                      ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ1_3                      ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ1_4                      ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ2                        ((uint32_t)0x000003E0)        /*!<SQ2[4:0] bits (2nd conversion in regular sequence) */
+#define  ADC_SQR3_SQ2_0                      ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ2_1                      ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ2_2                      ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ2_3                      ((uint32_t)0x00000100)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ2_4                      ((uint32_t)0x00000200)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ3                        ((uint32_t)0x00007C00)        /*!<SQ3[4:0] bits (3rd conversion in regular sequence) */
+#define  ADC_SQR3_SQ3_0                      ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ3_1                      ((uint32_t)0x00000800)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ3_2                      ((uint32_t)0x00001000)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ3_3                      ((uint32_t)0x00002000)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ3_4                      ((uint32_t)0x00004000)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ4                        ((uint32_t)0x000F8000)        /*!<SQ4[4:0] bits (4th conversion in regular sequence) */
+#define  ADC_SQR3_SQ4_0                      ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ4_1                      ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ4_2                      ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ4_3                      ((uint32_t)0x00040000)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ4_4                      ((uint32_t)0x00080000)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ5                        ((uint32_t)0x01F00000)        /*!<SQ5[4:0] bits (5th conversion in regular sequence) */
+#define  ADC_SQR3_SQ5_0                      ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ5_1                      ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ5_2                      ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ5_3                      ((uint32_t)0x00800000)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ5_4                      ((uint32_t)0x01000000)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ6                        ((uint32_t)0x3E000000)        /*!<SQ6[4:0] bits (6th conversion in regular sequence) */
+#define  ADC_SQR3_SQ6_0                      ((uint32_t)0x02000000)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ6_1                      ((uint32_t)0x04000000)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ6_2                      ((uint32_t)0x08000000)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ6_3                      ((uint32_t)0x10000000)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ6_4                      ((uint32_t)0x20000000)        /*!<Bit 4 */
+
+/*******************  Bit definition for ADC_JSQR register  *******************/
+#define  ADC_JSQR_JSQ1                       ((uint32_t)0x0000001F)        /*!<JSQ1[4:0] bits (1st conversion in injected sequence) */
+#define  ADC_JSQR_JSQ1_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_JSQR_JSQ1_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_JSQR_JSQ1_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_JSQR_JSQ1_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_JSQR_JSQ1_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_JSQR_JSQ2                       ((uint32_t)0x000003E0)        /*!<JSQ2[4:0] bits (2nd conversion in injected sequence) */
+#define  ADC_JSQR_JSQ2_0                     ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  ADC_JSQR_JSQ2_1                     ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  ADC_JSQR_JSQ2_2                     ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  ADC_JSQR_JSQ2_3                     ((uint32_t)0x00000100)        /*!<Bit 3 */
+#define  ADC_JSQR_JSQ2_4                     ((uint32_t)0x00000200)        /*!<Bit 4 */
+#define  ADC_JSQR_JSQ3                       ((uint32_t)0x00007C00)        /*!<JSQ3[4:0] bits (3rd conversion in injected sequence) */
+#define  ADC_JSQR_JSQ3_0                     ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  ADC_JSQR_JSQ3_1                     ((uint32_t)0x00000800)        /*!<Bit 1 */
+#define  ADC_JSQR_JSQ3_2                     ((uint32_t)0x00001000)        /*!<Bit 2 */
+#define  ADC_JSQR_JSQ3_3                     ((uint32_t)0x00002000)        /*!<Bit 3 */
+#define  ADC_JSQR_JSQ3_4                     ((uint32_t)0x00004000)        /*!<Bit 4 */
+#define  ADC_JSQR_JSQ4                       ((uint32_t)0x000F8000)        /*!<JSQ4[4:0] bits (4th conversion in injected sequence) */
+#define  ADC_JSQR_JSQ4_0                     ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_JSQR_JSQ4_1                     ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_JSQR_JSQ4_2                     ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_JSQR_JSQ4_3                     ((uint32_t)0x00040000)        /*!<Bit 3 */
+#define  ADC_JSQR_JSQ4_4                     ((uint32_t)0x00080000)        /*!<Bit 4 */
+#define  ADC_JSQR_JL                         ((uint32_t)0x00300000)        /*!<JL[1:0] bits (Injected Sequence length) */
+#define  ADC_JSQR_JL_0                       ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_JSQR_JL_1                       ((uint32_t)0x00200000)        /*!<Bit 1 */
+
+/*******************  Bit definition for ADC_JDR1 register  *******************/
+#define  ADC_JDR1_JDATA                      ((uint16_t)0xFFFF)            /*!<Injected data */
+
+/*******************  Bit definition for ADC_JDR2 register  *******************/
+#define  ADC_JDR2_JDATA                      ((uint16_t)0xFFFF)            /*!<Injected data */
+
+/*******************  Bit definition for ADC_JDR3 register  *******************/
+#define  ADC_JDR3_JDATA                      ((uint16_t)0xFFFF)            /*!<Injected data */
+
+/*******************  Bit definition for ADC_JDR4 register  *******************/
+#define  ADC_JDR4_JDATA                      ((uint16_t)0xFFFF)            /*!<Injected data */
+
+/********************  Bit definition for ADC_DR register  ********************/
+#define  ADC_DR_DATA                         ((uint32_t)0x0000FFFF)        /*!<Regular data */
+#define  ADC_DR_ADC2DATA                     ((uint32_t)0xFFFF0000)        /*!<ADC2 data */
+
+/*******************  Bit definition for ADC_CSR register  ********************/
+#define  ADC_CSR_AWD1                        ((uint32_t)0x00000001)        /*!<ADC1 Analog watchdog flag               */
+#define  ADC_CSR_EOC1                        ((uint32_t)0x00000002)        /*!<ADC1 End of conversion                  */
+#define  ADC_CSR_JEOC1                       ((uint32_t)0x00000004)        /*!<ADC1 Injected channel end of conversion */
+#define  ADC_CSR_JSTRT1                      ((uint32_t)0x00000008)        /*!<ADC1 Injected channel Start flag        */
+#define  ADC_CSR_STRT1                       ((uint32_t)0x00000010)        /*!<ADC1 Regular channel Start flag         */
+#define  ADC_CSR_DOVR1                       ((uint32_t)0x00000020)        /*!<ADC1 DMA overrun  flag                  */
+#define  ADC_CSR_AWD2                        ((uint32_t)0x00000100)        /*!<ADC2 Analog watchdog flag               */
+#define  ADC_CSR_EOC2                        ((uint32_t)0x00000200)        /*!<ADC2 End of conversion                  */
+#define  ADC_CSR_JEOC2                       ((uint32_t)0x00000400)        /*!<ADC2 Injected channel end of conversion */
+#define  ADC_CSR_JSTRT2                      ((uint32_t)0x00000800)        /*!<ADC2 Injected channel Start flag        */
+#define  ADC_CSR_STRT2                       ((uint32_t)0x00001000)        /*!<ADC2 Regular channel Start flag         */
+#define  ADC_CSR_DOVR2                       ((uint32_t)0x00002000)        /*!<ADC2 DMA overrun  flag                  */
+#define  ADC_CSR_AWD3                        ((uint32_t)0x00010000)        /*!<ADC3 Analog watchdog flag               */
+#define  ADC_CSR_EOC3                        ((uint32_t)0x00020000)        /*!<ADC3 End of conversion                  */
+#define  ADC_CSR_JEOC3                       ((uint32_t)0x00040000)        /*!<ADC3 Injected channel end of conversion */
+#define  ADC_CSR_JSTRT3                      ((uint32_t)0x00080000)        /*!<ADC3 Injected channel Start flag        */
+#define  ADC_CSR_STRT3                       ((uint32_t)0x00100000)        /*!<ADC3 Regular channel Start flag         */
+#define  ADC_CSR_DOVR3                       ((uint32_t)0x00200000)        /*!<ADC3 DMA overrun  flag                  */
+
+/*******************  Bit definition for ADC_CCR register  ********************/
+#define  ADC_CCR_MULTI                       ((uint32_t)0x0000001F)        /*!<MULTI[4:0] bits (Multi-ADC mode selection) */
+#define  ADC_CCR_MULTI_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_CCR_MULTI_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_CCR_MULTI_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_CCR_MULTI_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_CCR_MULTI_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_CCR_DELAY                       ((uint32_t)0x00000F00)        /*!<DELAY[3:0] bits (Delay between 2 sampling phases) */
+#define  ADC_CCR_DELAY_0                     ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  ADC_CCR_DELAY_1                     ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  ADC_CCR_DELAY_2                     ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  ADC_CCR_DELAY_3                     ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  ADC_CCR_DDS                         ((uint32_t)0x00002000)        /*!<DMA disable selection (Multi-ADC mode) */
+#define  ADC_CCR_DMA                         ((uint32_t)0x0000C000)        /*!<DMA[1:0] bits (Direct Memory Access mode for multimode) */
+#define  ADC_CCR_DMA_0                       ((uint32_t)0x00004000)        /*!<Bit 0 */
+#define  ADC_CCR_DMA_1                       ((uint32_t)0x00008000)        /*!<Bit 1 */
+#define  ADC_CCR_ADCPRE                      ((uint32_t)0x00030000)        /*!<ADCPRE[1:0] bits (ADC prescaler) */
+#define  ADC_CCR_ADCPRE_0                    ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  ADC_CCR_ADCPRE_1                    ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  ADC_CCR_VBATE                       ((uint32_t)0x00400000)        /*!<VBAT Enable */
+#define  ADC_CCR_TSVREFE                     ((uint32_t)0x00800000)        /*!<Temperature Sensor and VREFINT Enable */
+
+/*******************  Bit definition for ADC_CDR register  ********************/
+#define  ADC_CDR_DATA1                      ((uint32_t)0x0000FFFF)         /*!<1st data of a pair of regular conversions */
+#define  ADC_CDR_DATA2                      ((uint32_t)0xFFFF0000)         /*!<2nd data of a pair of regular conversions */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Controller Area Network                            */
+/*                                                                            */
+/******************************************************************************/
+/*!<CAN control and status registers */
+/*******************  Bit definition for CAN_MCR register  ********************/
+#define  CAN_MCR_INRQ                        ((uint32_t)0x00000001)        /*!<Initialization Request            */
+#define  CAN_MCR_SLEEP                       ((uint32_t)0x00000002)        /*!<Sleep Mode Request                */
+#define  CAN_MCR_TXFP                        ((uint32_t)0x00000004)        /*!<Transmit FIFO Priority            */
+#define  CAN_MCR_RFLM                        ((uint32_t)0x00000008)        /*!<Receive FIFO Locked Mode          */
+#define  CAN_MCR_NART                        ((uint32_t)0x00000010)        /*!<No Automatic Retransmission       */
+#define  CAN_MCR_AWUM                        ((uint32_t)0x00000020)        /*!<Automatic Wakeup Mode             */
+#define  CAN_MCR_ABOM                        ((uint32_t)0x00000040)        /*!<Automatic Bus-Off Management      */
+#define  CAN_MCR_TTCM                        ((uint32_t)0x00000080)        /*!<Time Triggered Communication Mode */
+#define  CAN_MCR_RESET                       ((uint32_t)0x00008000)        /*!<bxCAN software master reset       */
+
+/*******************  Bit definition for CAN_MSR register  ********************/
+#define  CAN_MSR_INAK                        ((uint32_t)0x00000001)        /*!<Initialization Acknowledge  */
+#define  CAN_MSR_SLAK                        ((uint32_t)0x00000002)        /*!<Sleep Acknowledge           */
+#define  CAN_MSR_ERRI                        ((uint32_t)0x00000004)        /*!<Error Interrupt             */
+#define  CAN_MSR_WKUI                        ((uint32_t)0x00000008)        /*!<Wakeup Interrupt            */
+#define  CAN_MSR_SLAKI                       ((uint32_t)0x00000010)        /*!<Sleep Acknowledge Interrupt */
+#define  CAN_MSR_TXM                         ((uint32_t)0x00000100)        /*!<Transmit Mode               */
+#define  CAN_MSR_RXM                         ((uint32_t)0x00000200)        /*!<Receive Mode                */
+#define  CAN_MSR_SAMP                        ((uint32_t)0x00000400)        /*!<Last Sample Point           */
+#define  CAN_MSR_RX                          ((uint32_t)0x00000800)        /*!<CAN Rx Signal               */
+
+/*******************  Bit definition for CAN_TSR register  ********************/
+#define  CAN_TSR_RQCP0                       ((uint32_t)0x00000001)        /*!<Request Completed Mailbox0      */
+#define  CAN_TSR_TXOK0                       ((uint32_t)0x00000002)        /*!<Transmission OK of Mailbox0     */
+#define  CAN_TSR_ALST0                       ((uint32_t)0x00000004)        /*!<Arbitration Lost for Mailbox0   */
+#define  CAN_TSR_TERR0                       ((uint32_t)0x00000008)        /*!<Transmission Error of Mailbox0  */
+#define  CAN_TSR_ABRQ0                       ((uint32_t)0x00000080)        /*!<Abort Request for Mailbox0      */
+#define  CAN_TSR_RQCP1                       ((uint32_t)0x00000100)        /*!<Request Completed Mailbox1      */
+#define  CAN_TSR_TXOK1                       ((uint32_t)0x00000200)        /*!<Transmission OK of Mailbox1     */
+#define  CAN_TSR_ALST1                       ((uint32_t)0x00000400)        /*!<Arbitration Lost for Mailbox1   */
+#define  CAN_TSR_TERR1                       ((uint32_t)0x00000800)        /*!<Transmission Error of Mailbox1  */
+#define  CAN_TSR_ABRQ1                       ((uint32_t)0x00008000)        /*!<Abort Request for Mailbox 1     */
+#define  CAN_TSR_RQCP2                       ((uint32_t)0x00010000)        /*!<Request Completed Mailbox2      */
+#define  CAN_TSR_TXOK2                       ((uint32_t)0x00020000)        /*!<Transmission OK of Mailbox 2    */
+#define  CAN_TSR_ALST2                       ((uint32_t)0x00040000)        /*!<Arbitration Lost for mailbox 2  */
+#define  CAN_TSR_TERR2                       ((uint32_t)0x00080000)        /*!<Transmission Error of Mailbox 2 */
+#define  CAN_TSR_ABRQ2                       ((uint32_t)0x00800000)        /*!<Abort Request for Mailbox 2     */
+#define  CAN_TSR_CODE                        ((uint32_t)0x03000000)        /*!<Mailbox Code                    */
+
+#define  CAN_TSR_TME                         ((uint32_t)0x1C000000)        /*!<TME[2:0] bits */
+#define  CAN_TSR_TME0                        ((uint32_t)0x04000000)        /*!<Transmit Mailbox 0 Empty */
+#define  CAN_TSR_TME1                        ((uint32_t)0x08000000)        /*!<Transmit Mailbox 1 Empty */
+#define  CAN_TSR_TME2                        ((uint32_t)0x10000000)        /*!<Transmit Mailbox 2 Empty */
+
+#define  CAN_TSR_LOW                         ((uint32_t)0xE0000000)        /*!<LOW[2:0] bits */
+#define  CAN_TSR_LOW0                        ((uint32_t)0x20000000)        /*!<Lowest Priority Flag for Mailbox 0 */
+#define  CAN_TSR_LOW1                        ((uint32_t)0x40000000)        /*!<Lowest Priority Flag for Mailbox 1 */
+#define  CAN_TSR_LOW2                        ((uint32_t)0x80000000)        /*!<Lowest Priority Flag for Mailbox 2 */
+
+/*******************  Bit definition for CAN_RF0R register  *******************/
+#define  CAN_RF0R_FMP0                       ((uint32_t)0x00000003)        /*!<FIFO 0 Message Pending        */
+#define  CAN_RF0R_FULL0                      ((uint32_t)0x00000008)        /*!<FIFO 0 Full                   */
+#define  CAN_RF0R_FOVR0                      ((uint32_t)0x00000010)        /*!<FIFO 0 Overrun                */
+#define  CAN_RF0R_RFOM0                      ((uint32_t)0x00000020)        /*!<Release FIFO 0 Output Mailbox */
+
+/*******************  Bit definition for CAN_RF1R register  *******************/
+#define  CAN_RF1R_FMP1                       ((uint32_t)0x00000003)        /*!<FIFO 1 Message Pending        */
+#define  CAN_RF1R_FULL1                      ((uint32_t)0x00000008)        /*!<FIFO 1 Full                   */
+#define  CAN_RF1R_FOVR1                      ((uint32_t)0x00000010)        /*!<FIFO 1 Overrun                */
+#define  CAN_RF1R_RFOM1                      ((uint32_t)0x00000020)        /*!<Release FIFO 1 Output Mailbox */
+
+/********************  Bit definition for CAN_IER register  *******************/
+#define  CAN_IER_TMEIE                       ((uint32_t)0x00000001)        /*!<Transmit Mailbox Empty Interrupt Enable */
+#define  CAN_IER_FMPIE0                      ((uint32_t)0x00000002)        /*!<FIFO Message Pending Interrupt Enable   */
+#define  CAN_IER_FFIE0                       ((uint32_t)0x00000004)        /*!<FIFO Full Interrupt Enable              */
+#define  CAN_IER_FOVIE0                      ((uint32_t)0x00000008)        /*!<FIFO Overrun Interrupt Enable           */
+#define  CAN_IER_FMPIE1                      ((uint32_t)0x00000010)        /*!<FIFO Message Pending Interrupt Enable   */
+#define  CAN_IER_FFIE1                       ((uint32_t)0x00000020)        /*!<FIFO Full Interrupt Enable              */
+#define  CAN_IER_FOVIE1                      ((uint32_t)0x00000040)        /*!<FIFO Overrun Interrupt Enable           */
+#define  CAN_IER_EWGIE                       ((uint32_t)0x00000100)        /*!<Error Warning Interrupt Enable          */
+#define  CAN_IER_EPVIE                       ((uint32_t)0x00000200)        /*!<Error Passive Interrupt Enable          */
+#define  CAN_IER_BOFIE                       ((uint32_t)0x00000400)        /*!<Bus-Off Interrupt Enable                */
+#define  CAN_IER_LECIE                       ((uint32_t)0x00000800)        /*!<Last Error Code Interrupt Enable        */
+#define  CAN_IER_ERRIE                       ((uint32_t)0x00008000)        /*!<Error Interrupt Enable                  */
+#define  CAN_IER_WKUIE                       ((uint32_t)0x00010000)        /*!<Wakeup Interrupt Enable                 */
+#define  CAN_IER_SLKIE                       ((uint32_t)0x00020000)        /*!<Sleep Interrupt Enable                  */
+
+/********************  Bit definition for CAN_ESR register  *******************/
+#define  CAN_ESR_EWGF                        ((uint32_t)0x00000001)        /*!<Error Warning Flag */
+#define  CAN_ESR_EPVF                        ((uint32_t)0x00000002)        /*!<Error Passive Flag */
+#define  CAN_ESR_BOFF                        ((uint32_t)0x00000004)        /*!<Bus-Off Flag */
+
+#define  CAN_ESR_LEC                         ((uint32_t)0x00000070)        /*!<LEC[2:0] bits (Last Error Code) */
+#define  CAN_ESR_LEC_0                       ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  CAN_ESR_LEC_1                       ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  CAN_ESR_LEC_2                       ((uint32_t)0x00000040)        /*!<Bit 2 */
+
+#define  CAN_ESR_TEC                         ((uint32_t)0x00FF0000)        /*!<Least significant byte of the 9-bit Transmit Error Counter */
+#define  CAN_ESR_REC                         ((uint32_t)0xFF000000)        /*!<Receive Error Counter */
+
+/*******************  Bit definition for CAN_BTR register  ********************/
+#define  CAN_BTR_BRP                         ((uint32_t)0x000003FF)        /*!<Baud Rate Prescaler           */
+#define  CAN_BTR_TS1                         ((uint32_t)0x000F0000)        /*!<Time Segment 1                */
+#define  CAN_BTR_TS1_0                       ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  CAN_BTR_TS1_1                       ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  CAN_BTR_TS1_2                       ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  CAN_BTR_TS1_3                       ((uint32_t)0x00080000)        /*!<Bit 3 */
+#define  CAN_BTR_TS2                         ((uint32_t)0x00700000)        /*!<Time Segment 2                */
+#define  CAN_BTR_TS2_0                       ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  CAN_BTR_TS2_1                       ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  CAN_BTR_TS2_2                       ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  CAN_BTR_SJW                         ((uint32_t)0x03000000)        /*!<Resynchronization Jump Width  */
+#define  CAN_BTR_SJW_0                       ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  CAN_BTR_SJW_1                       ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  CAN_BTR_LBKM                        ((uint32_t)0x40000000)        /*!<Loop Back Mode (Debug)        */
+#define  CAN_BTR_SILM                        ((uint32_t)0x80000000)        /*!<Silent Mode                   */
+
+/*!<Mailbox registers */
+/******************  Bit definition for CAN_TI0R register  ********************/
+#define  CAN_TI0R_TXRQ                       ((uint32_t)0x00000001)        /*!<Transmit Mailbox Request                   */
+#define  CAN_TI0R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_TI0R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_TI0R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended Identifier                        */
+#define  CAN_TI0R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/******************  Bit definition for CAN_TDT0R register  *******************/
+#define  CAN_TDT0R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code     */
+#define  CAN_TDT0R_TGT                       ((uint32_t)0x00000100)        /*!<Transmit Global Time */
+#define  CAN_TDT0R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp   */
+
+/******************  Bit definition for CAN_TDL0R register  *******************/
+#define  CAN_TDL0R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_TDL0R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_TDL0R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_TDL0R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/******************  Bit definition for CAN_TDH0R register  *******************/
+#define  CAN_TDH0R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_TDH0R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_TDH0R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_TDH0R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*******************  Bit definition for CAN_TI1R register  *******************/
+#define  CAN_TI1R_TXRQ                       ((uint32_t)0x00000001)        /*!<Transmit Mailbox Request                   */
+#define  CAN_TI1R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_TI1R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_TI1R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended Identifier                        */
+#define  CAN_TI1R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_TDT1R register  ******************/
+#define  CAN_TDT1R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code     */
+#define  CAN_TDT1R_TGT                       ((uint32_t)0x00000100)        /*!<Transmit Global Time */
+#define  CAN_TDT1R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp   */
+
+/*******************  Bit definition for CAN_TDL1R register  ******************/
+#define  CAN_TDL1R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_TDL1R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_TDL1R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_TDL1R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/*******************  Bit definition for CAN_TDH1R register  ******************/
+#define  CAN_TDH1R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_TDH1R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_TDH1R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_TDH1R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*******************  Bit definition for CAN_TI2R register  *******************/
+#define  CAN_TI2R_TXRQ                       ((uint32_t)0x00000001)        /*!<Transmit Mailbox Request                   */
+#define  CAN_TI2R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_TI2R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_TI2R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended identifier                        */
+#define  CAN_TI2R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_TDT2R register  ******************/
+#define  CAN_TDT2R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code      */
+#define  CAN_TDT2R_TGT                       ((uint32_t)0x00000100)        /*!<Transmit Global Time  */
+#define  CAN_TDT2R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp    */
+
+/*******************  Bit definition for CAN_TDL2R register  ******************/
+#define  CAN_TDL2R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_TDL2R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_TDL2R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_TDL2R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/*******************  Bit definition for CAN_TDH2R register  ******************/
+#define  CAN_TDH2R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_TDH2R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_TDH2R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_TDH2R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*******************  Bit definition for CAN_RI0R register  *******************/
+#define  CAN_RI0R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_RI0R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_RI0R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended Identifier                        */
+#define  CAN_RI0R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_RDT0R register  ******************/
+#define  CAN_RDT0R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code */
+#define  CAN_RDT0R_FMI                       ((uint32_t)0x0000FF00)        /*!<Filter Match Index */
+#define  CAN_RDT0R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp */
+
+/*******************  Bit definition for CAN_RDL0R register  ******************/
+#define  CAN_RDL0R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_RDL0R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_RDL0R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_RDL0R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/*******************  Bit definition for CAN_RDH0R register  ******************/
+#define  CAN_RDH0R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_RDH0R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_RDH0R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_RDH0R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*******************  Bit definition for CAN_RI1R register  *******************/
+#define  CAN_RI1R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_RI1R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_RI1R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended identifier                        */
+#define  CAN_RI1R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_RDT1R register  ******************/
+#define  CAN_RDT1R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code   */
+#define  CAN_RDT1R_FMI                       ((uint32_t)0x0000FF00)        /*!<Filter Match Index */
+#define  CAN_RDT1R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp */
+
+/*******************  Bit definition for CAN_RDL1R register  ******************/
+#define  CAN_RDL1R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_RDL1R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_RDL1R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_RDL1R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/*******************  Bit definition for CAN_RDH1R register  ******************/
+#define  CAN_RDH1R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_RDH1R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_RDH1R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_RDH1R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*!<CAN filter registers */
+/*******************  Bit definition for CAN_FMR register  ********************/
+#define  CAN_FMR_FINIT                       ((uint8_t)0x01)               /*!<Filter Init Mode */
+#define  CAN_FMR_CAN2SB                      ((uint32_t)0x00003F00)        /*!<CAN2 start bank */
+
+/*******************  Bit definition for CAN_FM1R register  *******************/
+#define  CAN_FM1R_FBM                        ((uint32_t)0x3FFF)            /*!<Filter Mode */
+#define  CAN_FM1R_FBM0                       ((uint32_t)0x0001)            /*!<Filter Init Mode bit 0  */
+#define  CAN_FM1R_FBM1                       ((uint32_t)0x0002)            /*!<Filter Init Mode bit 1  */
+#define  CAN_FM1R_FBM2                       ((uint32_t)0x0004)            /*!<Filter Init Mode bit 2  */
+#define  CAN_FM1R_FBM3                       ((uint32_t)0x0008)            /*!<Filter Init Mode bit 3  */
+#define  CAN_FM1R_FBM4                       ((uint32_t)0x0010)            /*!<Filter Init Mode bit 4  */
+#define  CAN_FM1R_FBM5                       ((uint32_t)0x0020)            /*!<Filter Init Mode bit 5  */
+#define  CAN_FM1R_FBM6                       ((uint32_t)0x0040)            /*!<Filter Init Mode bit 6  */
+#define  CAN_FM1R_FBM7                       ((uint32_t)0x0080)            /*!<Filter Init Mode bit 7  */
+#define  CAN_FM1R_FBM8                       ((uint32_t)0x0100)            /*!<Filter Init Mode bit 8  */
+#define  CAN_FM1R_FBM9                       ((uint32_t)0x0200)            /*!<Filter Init Mode bit 9  */
+#define  CAN_FM1R_FBM10                      ((uint32_t)0x0400)            /*!<Filter Init Mode bit 10 */
+#define  CAN_FM1R_FBM11                      ((uint32_t)0x0800)            /*!<Filter Init Mode bit 11 */
+#define  CAN_FM1R_FBM12                      ((uint32_t)0x1000)            /*!<Filter Init Mode bit 12 */
+#define  CAN_FM1R_FBM13                      ((uint32_t)0x2000)            /*!<Filter Init Mode bit 13 */
+
+/*******************  Bit definition for CAN_FS1R register  *******************/
+#define  CAN_FS1R_FSC                        ((uint32_t)0x00003FFF)        /*!<Filter Scale Configuration        */
+#define  CAN_FS1R_FSC0                       ((uint32_t)0x00000001)        /*!<Filter Scale Configuration bit 0  */
+#define  CAN_FS1R_FSC1                       ((uint32_t)0x00000002)        /*!<Filter Scale Configuration bit 1  */
+#define  CAN_FS1R_FSC2                       ((uint32_t)0x00000004)        /*!<Filter Scale Configuration bit 2  */
+#define  CAN_FS1R_FSC3                       ((uint32_t)0x00000008)        /*!<Filter Scale Configuration bit 3  */
+#define  CAN_FS1R_FSC4                       ((uint32_t)0x00000010)        /*!<Filter Scale Configuration bit 4  */
+#define  CAN_FS1R_FSC5                       ((uint32_t)0x00000020)        /*!<Filter Scale Configuration bit 5  */
+#define  CAN_FS1R_FSC6                       ((uint32_t)0x00000040)        /*!<Filter Scale Configuration bit 6  */
+#define  CAN_FS1R_FSC7                       ((uint32_t)0x00000080)        /*!<Filter Scale Configuration bit 7  */
+#define  CAN_FS1R_FSC8                       ((uint32_t)0x00000100)        /*!<Filter Scale Configuration bit 8  */
+#define  CAN_FS1R_FSC9                       ((uint32_t)0x00000200)        /*!<Filter Scale Configuration bit 9  */
+#define  CAN_FS1R_FSC10                      ((uint32_t)0x00000400)        /*!<Filter Scale Configuration bit 10 */
+#define  CAN_FS1R_FSC11                      ((uint32_t)0x00000800)        /*!<Filter Scale Configuration bit 11 */
+#define  CAN_FS1R_FSC12                      ((uint32_t)0x00001000)        /*!<Filter Scale Configuration bit 12 */
+#define  CAN_FS1R_FSC13                      ((uint32_t)0x00002000)        /*!<Filter Scale Configuration bit 13 */
+
+/******************  Bit definition for CAN_FFA1R register  *******************/
+#define  CAN_FFA1R_FFA                       ((uint32_t)0x00003FFF)        /*!<Filter FIFO Assignment */
+#define  CAN_FFA1R_FFA0                      ((uint32_t)0x00000001)        /*!<Filter FIFO Assignment for Filter 0 */
+#define  CAN_FFA1R_FFA1                      ((uint32_t)0x00000002)        /*!<Filter FIFO Assignment for Filter 1 */
+#define  CAN_FFA1R_FFA2                      ((uint32_t)0x00000004)        /*!<Filter FIFO Assignment for Filter 2 */
+#define  CAN_FFA1R_FFA3                      ((uint32_t)0x00000008)        /*!<Filter FIFO Assignment for Filter 3 */
+#define  CAN_FFA1R_FFA4                      ((uint32_t)0x00000010)        /*!<Filter FIFO Assignment for Filter 4 */
+#define  CAN_FFA1R_FFA5                      ((uint32_t)0x00000020)        /*!<Filter FIFO Assignment for Filter 5 */
+#define  CAN_FFA1R_FFA6                      ((uint32_t)0x00000040)        /*!<Filter FIFO Assignment for Filter 6 */
+#define  CAN_FFA1R_FFA7                      ((uint32_t)0x00000080)        /*!<Filter FIFO Assignment for Filter 7 */
+#define  CAN_FFA1R_FFA8                      ((uint32_t)0x00000100)        /*!<Filter FIFO Assignment for Filter 8 */
+#define  CAN_FFA1R_FFA9                      ((uint32_t)0x00000200)        /*!<Filter FIFO Assignment for Filter 9 */
+#define  CAN_FFA1R_FFA10                     ((uint32_t)0x00000400)        /*!<Filter FIFO Assignment for Filter 10 */
+#define  CAN_FFA1R_FFA11                     ((uint32_t)0x00000800)        /*!<Filter FIFO Assignment for Filter 11 */
+#define  CAN_FFA1R_FFA12                     ((uint32_t)0x00001000)        /*!<Filter FIFO Assignment for Filter 12 */
+#define  CAN_FFA1R_FFA13                     ((uint32_t)0x00002000)        /*!<Filter FIFO Assignment for Filter 13 */
+
+/*******************  Bit definition for CAN_FA1R register  *******************/
+#define  CAN_FA1R_FACT                       ((uint32_t)0x00003FFF)        /*!<Filter Active    */
+#define  CAN_FA1R_FACT0                      ((uint32_t)0x00000001)        /*!<Filter 0 Active  */
+#define  CAN_FA1R_FACT1                      ((uint32_t)0x00000002)        /*!<Filter 1 Active  */
+#define  CAN_FA1R_FACT2                      ((uint32_t)0x00000004)        /*!<Filter 2 Active  */
+#define  CAN_FA1R_FACT3                      ((uint32_t)0x00000008)        /*!<Filter 3 Active  */
+#define  CAN_FA1R_FACT4                      ((uint32_t)0x00000010)        /*!<Filter 4 Active  */
+#define  CAN_FA1R_FACT5                      ((uint32_t)0x00000020)        /*!<Filter 5 Active  */
+#define  CAN_FA1R_FACT6                      ((uint32_t)0x00000040)        /*!<Filter 6 Active  */
+#define  CAN_FA1R_FACT7                      ((uint32_t)0x00000080)        /*!<Filter 7 Active  */
+#define  CAN_FA1R_FACT8                      ((uint32_t)0x00000100)        /*!<Filter 8 Active  */
+#define  CAN_FA1R_FACT9                      ((uint32_t)0x00000200)        /*!<Filter 9 Active  */
+#define  CAN_FA1R_FACT10                     ((uint32_t)0x00000400)        /*!<Filter 10 Active */
+#define  CAN_FA1R_FACT11                     ((uint32_t)0x00000800)        /*!<Filter 11 Active */
+#define  CAN_FA1R_FACT12                     ((uint32_t)0x00001000)        /*!<Filter 12 Active */
+#define  CAN_FA1R_FACT13                     ((uint32_t)0x00002000)        /*!<Filter 13 Active */
+
+/*******************  Bit definition for CAN_F0R1 register  *******************/
+#define  CAN_F0R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F0R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F0R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F0R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F0R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F0R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F0R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F0R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F0R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F0R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F0R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F0R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F0R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F0R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F0R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F0R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F0R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F0R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F0R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F0R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F0R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F0R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F0R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F0R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F0R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F0R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F0R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F0R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F0R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F0R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F0R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F0R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F1R1 register  *******************/
+#define  CAN_F1R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F1R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F1R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F1R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F1R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F1R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F1R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F1R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F1R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F1R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F1R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F1R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F1R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F1R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F1R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F1R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F1R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F1R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F1R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F1R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F1R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F1R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F1R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F1R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F1R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F1R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F1R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F1R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F1R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F1R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F1R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F1R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F2R1 register  *******************/
+#define  CAN_F2R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F2R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F2R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F2R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F2R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F2R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F2R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F2R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F2R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F2R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F2R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F2R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F2R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F2R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F2R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F2R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F2R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F2R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F2R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F2R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F2R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F2R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F2R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F2R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F2R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F2R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F2R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F2R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F2R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F2R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F2R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F2R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F3R1 register  *******************/
+#define  CAN_F3R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F3R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F3R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F3R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F3R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F3R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F3R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F3R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F3R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F3R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F3R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F3R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F3R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F3R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F3R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F3R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F3R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F3R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F3R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F3R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F3R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F3R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F3R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F3R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F3R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F3R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F3R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F3R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F3R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F3R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F3R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F3R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F4R1 register  *******************/
+#define  CAN_F4R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F4R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F4R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F4R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F4R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F4R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F4R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F4R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F4R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F4R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F4R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F4R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F4R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F4R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F4R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F4R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F4R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F4R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F4R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F4R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F4R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F4R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F4R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F4R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F4R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F4R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F4R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F4R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F4R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F4R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F4R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F4R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F5R1 register  *******************/
+#define  CAN_F5R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F5R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F5R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F5R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F5R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F5R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F5R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F5R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F5R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F5R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F5R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F5R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F5R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F5R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F5R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F5R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F5R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F5R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F5R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F5R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F5R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F5R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F5R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F5R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F5R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F5R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F5R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F5R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F5R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F5R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F5R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F5R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F6R1 register  *******************/
+#define  CAN_F6R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F6R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F6R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F6R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F6R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F6R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F6R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F6R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F6R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F6R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F6R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F6R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F6R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F6R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F6R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F6R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F6R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F6R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F6R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F6R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F6R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F6R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F6R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F6R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F6R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F6R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F6R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F6R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F6R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F6R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F6R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F6R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F7R1 register  *******************/
+#define  CAN_F7R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F7R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F7R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F7R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F7R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F7R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F7R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F7R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F7R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F7R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F7R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F7R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F7R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F7R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F7R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F7R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F7R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F7R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F7R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F7R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F7R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F7R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F7R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F7R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F7R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F7R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F7R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F7R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F7R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F7R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F7R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F7R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F8R1 register  *******************/
+#define  CAN_F8R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F8R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F8R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F8R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F8R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F8R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F8R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F8R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F8R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F8R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F8R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F8R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F8R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F8R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F8R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F8R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F8R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F8R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F8R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F8R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F8R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F8R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F8R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F8R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F8R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F8R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F8R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F8R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F8R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F8R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F8R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F8R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F9R1 register  *******************/
+#define  CAN_F9R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F9R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F9R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F9R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F9R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F9R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F9R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F9R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F9R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F9R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F9R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F9R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F9R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F9R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F9R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F9R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F9R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F9R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F9R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F9R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F9R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F9R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F9R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F9R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F9R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F9R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F9R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F9R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F9R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F9R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F9R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F9R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F10R1 register  ******************/
+#define  CAN_F10R1_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F10R1_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F10R1_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F10R1_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F10R1_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F10R1_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F10R1_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F10R1_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F10R1_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F10R1_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F10R1_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F10R1_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F10R1_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F10R1_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F10R1_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F10R1_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F10R1_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F10R1_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F10R1_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F10R1_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F10R1_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F10R1_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F10R1_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F10R1_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F10R1_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F10R1_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F10R1_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F10R1_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F10R1_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F10R1_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F10R1_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F10R1_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F11R1 register  ******************/
+#define  CAN_F11R1_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F11R1_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F11R1_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F11R1_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F11R1_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F11R1_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F11R1_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F11R1_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F11R1_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F11R1_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F11R1_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F11R1_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F11R1_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F11R1_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F11R1_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F11R1_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F11R1_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F11R1_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F11R1_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F11R1_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F11R1_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F11R1_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F11R1_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F11R1_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F11R1_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F11R1_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F11R1_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F11R1_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F11R1_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F11R1_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F11R1_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F11R1_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F12R1 register  ******************/
+#define  CAN_F12R1_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F12R1_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F12R1_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F12R1_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F12R1_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F12R1_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F12R1_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F12R1_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F12R1_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F12R1_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F12R1_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F12R1_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F12R1_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F12R1_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F12R1_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F12R1_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F12R1_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F12R1_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F12R1_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F12R1_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F12R1_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F12R1_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F12R1_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F12R1_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F12R1_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F12R1_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F12R1_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F12R1_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F12R1_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F12R1_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F12R1_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F12R1_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F13R1 register  ******************/
+#define  CAN_F13R1_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F13R1_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F13R1_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F13R1_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F13R1_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F13R1_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F13R1_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F13R1_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F13R1_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F13R1_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F13R1_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F13R1_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F13R1_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F13R1_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F13R1_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F13R1_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F13R1_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F13R1_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F13R1_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F13R1_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F13R1_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F13R1_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F13R1_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F13R1_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F13R1_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F13R1_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F13R1_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F13R1_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F13R1_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F13R1_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F13R1_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F13R1_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F0R2 register  *******************/
+#define  CAN_F0R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F0R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F0R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F0R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F0R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F0R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F0R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F0R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F0R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F0R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F0R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F0R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F0R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F0R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F0R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F0R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F0R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F0R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F0R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F0R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F0R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F0R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F0R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F0R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F0R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F0R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F0R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F0R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F0R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F0R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F0R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F0R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F1R2 register  *******************/
+#define  CAN_F1R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F1R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F1R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F1R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F1R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F1R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F1R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F1R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F1R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F1R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F1R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F1R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F1R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F1R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F1R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F1R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F1R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F1R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F1R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F1R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F1R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F1R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F1R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F1R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F1R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F1R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F1R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F1R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F1R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F1R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F1R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F1R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F2R2 register  *******************/
+#define  CAN_F2R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F2R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F2R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F2R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F2R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F2R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F2R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F2R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F2R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F2R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F2R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F2R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F2R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F2R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F2R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F2R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F2R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F2R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F2R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F2R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F2R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F2R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F2R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F2R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F2R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F2R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F2R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F2R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F2R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F2R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F2R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F2R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F3R2 register  *******************/
+#define  CAN_F3R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F3R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F3R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F3R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F3R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F3R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F3R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F3R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F3R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F3R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F3R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F3R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F3R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F3R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F3R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F3R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F3R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F3R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F3R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F3R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F3R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F3R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F3R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F3R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F3R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F3R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F3R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F3R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F3R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F3R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F3R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F3R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F4R2 register  *******************/
+#define  CAN_F4R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F4R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F4R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F4R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F4R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F4R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F4R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F4R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F4R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F4R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F4R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F4R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F4R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F4R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F4R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F4R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F4R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F4R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F4R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F4R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F4R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F4R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F4R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F4R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F4R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F4R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F4R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F4R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F4R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F4R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F4R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F4R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F5R2 register  *******************/
+#define  CAN_F5R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F5R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F5R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F5R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F5R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F5R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F5R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F5R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F5R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F5R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F5R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F5R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F5R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F5R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F5R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F5R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F5R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F5R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F5R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F5R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F5R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F5R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F5R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F5R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F5R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F5R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F5R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F5R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F5R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F5R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F5R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F5R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F6R2 register  *******************/
+#define  CAN_F6R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F6R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F6R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F6R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F6R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F6R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F6R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F6R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F6R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F6R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F6R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F6R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F6R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F6R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F6R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F6R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F6R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F6R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F6R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F6R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F6R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F6R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F6R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F6R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F6R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F6R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F6R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F6R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F6R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F6R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F6R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F6R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F7R2 register  *******************/
+#define  CAN_F7R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F7R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F7R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F7R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F7R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F7R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F7R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F7R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F7R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F7R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F7R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F7R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F7R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F7R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F7R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F7R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F7R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F7R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F7R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F7R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F7R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F7R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F7R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F7R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F7R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F7R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F7R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F7R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F7R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F7R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F7R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F7R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F8R2 register  *******************/
+#define  CAN_F8R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F8R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F8R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F8R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F8R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F8R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F8R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F8R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F8R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F8R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F8R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F8R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F8R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F8R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F8R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F8R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F8R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F8R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F8R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F8R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F8R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F8R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F8R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F8R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F8R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F8R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F8R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F8R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F8R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F8R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F8R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F8R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F9R2 register  *******************/
+#define  CAN_F9R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F9R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F9R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F9R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F9R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F9R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F9R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F9R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F9R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F9R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F9R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F9R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F9R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F9R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F9R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F9R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F9R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F9R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F9R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F9R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F9R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F9R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F9R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F9R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F9R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F9R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F9R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F9R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F9R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F9R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F9R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F9R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F10R2 register  ******************/
+#define  CAN_F10R2_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F10R2_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F10R2_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F10R2_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F10R2_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F10R2_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F10R2_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F10R2_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F10R2_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F10R2_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F10R2_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F10R2_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F10R2_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F10R2_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F10R2_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F10R2_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F10R2_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F10R2_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F10R2_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F10R2_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F10R2_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F10R2_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F10R2_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F10R2_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F10R2_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F10R2_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F10R2_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F10R2_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F10R2_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F10R2_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F10R2_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F10R2_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F11R2 register  ******************/
+#define  CAN_F11R2_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F11R2_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F11R2_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F11R2_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F11R2_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F11R2_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F11R2_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F11R2_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F11R2_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F11R2_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F11R2_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F11R2_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F11R2_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F11R2_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F11R2_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F11R2_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F11R2_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F11R2_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F11R2_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F11R2_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F11R2_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F11R2_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F11R2_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F11R2_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F11R2_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F11R2_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F11R2_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F11R2_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F11R2_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F11R2_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F11R2_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F11R2_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F12R2 register  ******************/
+#define  CAN_F12R2_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F12R2_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F12R2_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F12R2_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F12R2_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F12R2_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F12R2_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F12R2_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F12R2_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F12R2_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F12R2_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F12R2_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F12R2_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F12R2_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F12R2_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F12R2_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F12R2_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F12R2_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F12R2_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F12R2_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F12R2_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F12R2_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F12R2_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F12R2_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F12R2_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F12R2_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F12R2_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F12R2_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F12R2_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F12R2_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F12R2_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F12R2_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F13R2 register  ******************/
+#define  CAN_F13R2_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F13R2_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F13R2_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F13R2_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F13R2_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F13R2_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F13R2_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F13R2_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F13R2_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F13R2_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F13R2_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F13R2_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F13R2_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F13R2_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F13R2_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F13R2_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F13R2_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F13R2_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F13R2_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F13R2_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F13R2_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F13R2_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F13R2_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F13R2_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F13R2_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F13R2_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F13R2_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F13R2_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F13R2_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F13R2_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F13R2_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F13R2_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 HDMI-CEC (CEC)                             */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for CEC_CR register  *********************/
+#define  CEC_CR_CECEN                        ((uint32_t)0x00000001)       /*!< CEC Enable                         */
+#define  CEC_CR_TXSOM                        ((uint32_t)0x00000002)       /*!< CEC Tx Start Of Message            */
+#define  CEC_CR_TXEOM                        ((uint32_t)0x00000004)       /*!< CEC Tx End Of Message              */
+
+/*******************  Bit definition for CEC_CFGR register  *******************/
+#define  CEC_CFGR_SFT                        ((uint32_t)0x00000007)       /*!< CEC Signal Free Time               */
+#define  CEC_CFGR_RXTOL                      ((uint32_t)0x00000008)       /*!< CEC Tolerance                      */
+#define  CEC_CFGR_BRESTP                     ((uint32_t)0x00000010)       /*!< CEC Rx Stop                        */
+#define  CEC_CFGR_BREGEN                     ((uint32_t)0x00000020)       /*!< CEC Bit Rising Error generation    */
+#define  CEC_CFGR_LBPEGEN                    ((uint32_t)0x00000040)       /*!< CEC Long Period Error generation   */
+#define  CEC_CFGR_BRDNOGEN                   ((uint32_t)0x00000080)       /*!< CEC Broadcast no Error generation  */
+#define  CEC_CFGR_SFTOPT                     ((uint32_t)0x00000100)       /*!< CEC Signal Free Time optional      */
+#define  CEC_CFGR_OAR                        ((uint32_t)0x7FFF0000)       /*!< CEC Own Address                    */
+#define  CEC_CFGR_LSTN                       ((uint32_t)0x80000000)       /*!< CEC Listen mode                    */
+
+/*******************  Bit definition for CEC_TXDR register  *******************/
+#define  CEC_TXDR_TXD                        ((uint32_t)0x000000FF)       /*!< CEC Tx Data                        */
+
+/*******************  Bit definition for CEC_RXDR register  *******************/
+#define  CEC_TXDR_RXD                        ((uint32_t)0x000000FF)       /*!< CEC Rx Data                        */
+
+/*******************  Bit definition for CEC_ISR register  ********************/
+#define  CEC_ISR_RXBR                        ((uint32_t)0x00000001)       /*!< CEC Rx-Byte Received                   */
+#define  CEC_ISR_RXEND                       ((uint32_t)0x00000002)       /*!< CEC End Of Reception                   */
+#define  CEC_ISR_RXOVR                       ((uint32_t)0x00000004)       /*!< CEC Rx-Overrun                         */
+#define  CEC_ISR_BRE                         ((uint32_t)0x00000008)       /*!< CEC Rx Bit Rising Error                */
+#define  CEC_ISR_SBPE                        ((uint32_t)0x00000010)       /*!< CEC Rx Short Bit period Error          */
+#define  CEC_ISR_LBPE                        ((uint32_t)0x00000020)       /*!< CEC Rx Long Bit period Error           */
+#define  CEC_ISR_RXACKE                      ((uint32_t)0x00000040)       /*!< CEC Rx Missing Acknowledge             */
+#define  CEC_ISR_ARBLST                      ((uint32_t)0x00000080)       /*!< CEC Arbitration Lost                   */
+#define  CEC_ISR_TXBR                        ((uint32_t)0x00000100)       /*!< CEC Tx Byte Request                    */
+#define  CEC_ISR_TXEND                       ((uint32_t)0x00000200)       /*!< CEC End of Transmission                */
+#define  CEC_ISR_TXUDR                       ((uint32_t)0x00000400)       /*!< CEC Tx-Buffer Underrun                 */
+#define  CEC_ISR_TXERR                       ((uint32_t)0x00000800)       /*!< CEC Tx-Error                           */
+#define  CEC_ISR_TXACKE                      ((uint32_t)0x00001000)       /*!< CEC Tx Missing Acknowledge             */
+
+/*******************  Bit definition for CEC_IER register  ********************/
+#define  CEC_IER_RXBRIE                      ((uint32_t)0x00000001)       /*!< CEC Rx-Byte Received IT Enable         */
+#define  CEC_IER_RXENDIE                     ((uint32_t)0x00000002)       /*!< CEC End Of Reception IT Enable         */
+#define  CEC_IER_RXOVRIE                     ((uint32_t)0x00000004)       /*!< CEC Rx-Overrun IT Enable               */
+#define  CEC_IER_BREIE                       ((uint32_t)0x00000008)       /*!< CEC Rx Bit Rising Error IT Enable      */
+#define  CEC_IER_SBPEIE                      ((uint32_t)0x00000010)       /*!< CEC Rx Short Bit period Error IT Enable*/
+#define  CEC_IER_LBPEIE                      ((uint32_t)0x00000020)       /*!< CEC Rx Long Bit period Error IT Enable */
+#define  CEC_IER_RXACKEIE                    ((uint32_t)0x00000040)       /*!< CEC Rx Missing Acknowledge IT Enable   */
+#define  CEC_IER_ARBLSTIE                    ((uint32_t)0x00000080)       /*!< CEC Arbitration Lost IT Enable         */
+#define  CEC_IER_TXBRIE                      ((uint32_t)0x00000100)       /*!< CEC Tx Byte Request  IT Enable         */
+#define  CEC_IER_TXENDIE                     ((uint32_t)0x00000200)       /*!< CEC End of Transmission IT Enable      */
+#define  CEC_IER_TXUDRIE                     ((uint32_t)0x00000400)       /*!< CEC Tx-Buffer Underrun IT Enable       */
+#define  CEC_IER_TXERRIE                     ((uint32_t)0x00000800)       /*!< CEC Tx-Error IT Enable                 */
+#define  CEC_IER_TXACKEIE                    ((uint32_t)0x00001000)       /*!< CEC Tx Missing Acknowledge IT Enable   */
+
+/******************************************************************************/
+/*                                                                            */
+/*                          CRC calculation unit                              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for CRC_DR register  *********************/
+#define  CRC_DR_DR                           ((uint32_t)0xFFFFFFFF)     /*!< Data register bits */
+
+/*******************  Bit definition for CRC_IDR register  ********************/
+#define  CRC_IDR_IDR                         ((uint32_t)0x000000FF)     /*!< General-purpose 8-bit data register bits */
+
+/********************  Bit definition for CRC_CR register  ********************/
+#define  CRC_CR_RESET                        ((uint32_t)0x00000001)     /*!< RESET the CRC computation unit bit */
+#define  CRC_CR_POLYSIZE                     ((uint32_t)0x00000018)     /*!< Polynomial size bits               */
+#define  CRC_CR_POLYSIZE_0                   ((uint32_t)0x00000008)     /*!< Polynomial size bit 0              */
+#define  CRC_CR_POLYSIZE_1                   ((uint32_t)0x00000010)     /*!< Polynomial size bit 1              */
+#define  CRC_CR_REV_IN                       ((uint32_t)0x00000060)     /*!< REV_IN Reverse Input Data bits     */
+#define  CRC_CR_REV_IN_0                     ((uint32_t)0x00000020)     /*!< Bit 0 */
+#define  CRC_CR_REV_IN_1                     ((uint32_t)0x00000040)     /*!< Bit 1 */
+#define  CRC_CR_REV_OUT                      ((uint32_t)0x00000080)     /*!< REV_OUT Reverse Output Data bits   */
+
+/*******************  Bit definition for CRC_INIT register  *******************/
+#define  CRC_INIT_INIT                       ((uint32_t)0xFFFFFFFF)     /*!< Initial CRC value bits         */
+
+/*******************  Bit definition for CRC_POL register  ********************/
+#define  CRC_POL_POL                         ((uint32_t)0xFFFFFFFF)     /*!< Coefficients of the polynomial */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Digital to Analog Converter                           */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DAC_CR register  ********************/
+#define  DAC_CR_EN1                          ((uint32_t)0x00000001)        /*!<DAC channel1 enable                         */
+#define  DAC_CR_BOFF1                        ((uint32_t)0x00000002)        /*!<DAC channel1 output buffer disable          */
+#define  DAC_CR_TEN1                         ((uint32_t)0x00000004)        /*!<DAC channel1 Trigger enable                 */
+
+#define  DAC_CR_TSEL1                        ((uint32_t)0x00000038)        /*!<TSEL1[2:0] (DAC channel1 Trigger selection) */
+#define  DAC_CR_TSEL1_0                      ((uint32_t)0x00000008)        /*!<Bit 0 */
+#define  DAC_CR_TSEL1_1                      ((uint32_t)0x00000010)        /*!<Bit 1 */
+#define  DAC_CR_TSEL1_2                      ((uint32_t)0x00000020)        /*!<Bit 2 */
+
+#define  DAC_CR_WAVE1                        ((uint32_t)0x000000C0)        /*!<WAVE1[1:0] (DAC channel1 noise/triangle wave generation enable) */
+#define  DAC_CR_WAVE1_0                      ((uint32_t)0x00000040)        /*!<Bit 0 */
+#define  DAC_CR_WAVE1_1                      ((uint32_t)0x00000080)        /*!<Bit 1 */
+
+#define  DAC_CR_MAMP1                        ((uint32_t)0x00000F00)        /*!<MAMP1[3:0] (DAC channel1 Mask/Amplitude selector) */
+#define  DAC_CR_MAMP1_0                      ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  DAC_CR_MAMP1_1                      ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  DAC_CR_MAMP1_2                      ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  DAC_CR_MAMP1_3                      ((uint32_t)0x00000800)        /*!<Bit 3 */
+
+#define  DAC_CR_DMAEN1                       ((uint32_t)0x00001000)        /*!<DAC channel1 DMA enable                     */
+#define  DAC_CR_EN2                          ((uint32_t)0x00010000)        /*!<DAC channel2 enable                         */
+#define  DAC_CR_BOFF2                        ((uint32_t)0x00020000)        /*!<DAC channel2 output buffer disable          */
+#define  DAC_CR_TEN2                         ((uint32_t)0x00040000)        /*!<DAC channel2 Trigger enable                 */
+
+#define  DAC_CR_TSEL2                        ((uint32_t)0x00380000)        /*!<TSEL2[2:0] (DAC channel2 Trigger selection) */
+#define  DAC_CR_TSEL2_0                      ((uint32_t)0x00080000)        /*!<Bit 0 */
+#define  DAC_CR_TSEL2_1                      ((uint32_t)0x00100000)        /*!<Bit 1 */
+#define  DAC_CR_TSEL2_2                      ((uint32_t)0x00200000)        /*!<Bit 2 */
+
+#define  DAC_CR_WAVE2                        ((uint32_t)0x00C00000)        /*!<WAVE2[1:0] (DAC channel2 noise/triangle wave generation enable) */
+#define  DAC_CR_WAVE2_0                      ((uint32_t)0x00400000)        /*!<Bit 0 */
+#define  DAC_CR_WAVE2_1                      ((uint32_t)0x00800000)        /*!<Bit 1 */
+
+#define  DAC_CR_MAMP2                        ((uint32_t)0x0F000000)        /*!<MAMP2[3:0] (DAC channel2 Mask/Amplitude selector) */
+#define  DAC_CR_MAMP2_0                      ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  DAC_CR_MAMP2_1                      ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  DAC_CR_MAMP2_2                      ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  DAC_CR_MAMP2_3                      ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  DAC_CR_DMAEN2                       ((uint32_t)0x10000000)        /*!<DAC channel2 DMA enabled */
+
+/*****************  Bit definition for DAC_SWTRIGR register  ******************/
+#define  DAC_SWTRIGR_SWTRIG1                 ((uint32_t)0x01)               /*!<DAC channel1 software trigger */
+#define  DAC_SWTRIGR_SWTRIG2                 ((uint32_t)0x02)               /*!<DAC channel2 software trigger */
+
+/*****************  Bit definition for DAC_DHR12R1 register  ******************/
+#define  DAC_DHR12R1_DACC1DHR                ((uint32_t)0x0FFF)            /*!<DAC channel1 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12L1 register  ******************/
+#define  DAC_DHR12L1_DACC1DHR                ((uint32_t)0xFFF0)            /*!<DAC channel1 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8R1 register  ******************/
+#define  DAC_DHR8R1_DACC1DHR                 ((uint32_t)0xFF)               /*!<DAC channel1 8-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12R2 register  ******************/
+#define  DAC_DHR12R2_DACC2DHR                ((uint32_t)0x0FFF)            /*!<DAC channel2 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12L2 register  ******************/
+#define  DAC_DHR12L2_DACC2DHR                ((uint32_t)0xFFF0)            /*!<DAC channel2 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8R2 register  ******************/
+#define  DAC_DHR8R2_DACC2DHR                 ((uint32_t)0xFF)               /*!<DAC channel2 8-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12RD register  ******************/
+#define  DAC_DHR12RD_DACC1DHR                ((uint32_t)0x00000FFF)        /*!<DAC channel1 12-bit Right aligned data */
+#define  DAC_DHR12RD_DACC2DHR                ((uint32_t)0x0FFF0000)        /*!<DAC channel2 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12LD register  ******************/
+#define  DAC_DHR12LD_DACC1DHR                ((uint32_t)0x0000FFF0)        /*!<DAC channel1 12-bit Left aligned data */
+#define  DAC_DHR12LD_DACC2DHR                ((uint32_t)0xFFF00000)        /*!<DAC channel2 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8RD register  ******************/
+#define  DAC_DHR8RD_DACC1DHR                 ((uint32_t)0x00FF)            /*!<DAC channel1 8-bit Right aligned data */
+#define  DAC_DHR8RD_DACC2DHR                 ((uint32_t)0xFF00)            /*!<DAC channel2 8-bit Right aligned data */
+
+/*******************  Bit definition for DAC_DOR1 register  *******************/
+#define  DAC_DOR1_DACC1DOR                   ((uint32_t)0x0FFF)            /*!<DAC channel1 data output */
+
+/*******************  Bit definition for DAC_DOR2 register  *******************/
+#define  DAC_DOR2_DACC2DOR                   ((uint32_t)0x0FFF)            /*!<DAC channel2 data output */
+
+/********************  Bit definition for DAC_SR register  ********************/
+#define  DAC_SR_DMAUDR1                      ((uint32_t)0x00002000)        /*!<DAC channel1 DMA underrun flag */
+#define  DAC_SR_DMAUDR2                      ((uint32_t)0x20000000)        /*!<DAC channel2 DMA underrun flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 Debug MCU                                  */
+/*                                                                            */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    DCMI                                    */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DCMI_CR register  ******************/
+#define DCMI_CR_CAPTURE                      ((uint32_t)0x00000001)
+#define DCMI_CR_CM                           ((uint32_t)0x00000002)
+#define DCMI_CR_CROP                         ((uint32_t)0x00000004)
+#define DCMI_CR_JPEG                         ((uint32_t)0x00000008)
+#define DCMI_CR_ESS                          ((uint32_t)0x00000010)
+#define DCMI_CR_PCKPOL                       ((uint32_t)0x00000020)
+#define DCMI_CR_HSPOL                        ((uint32_t)0x00000040)
+#define DCMI_CR_VSPOL                        ((uint32_t)0x00000080)
+#define DCMI_CR_FCRC_0                       ((uint32_t)0x00000100)
+#define DCMI_CR_FCRC_1                       ((uint32_t)0x00000200)
+#define DCMI_CR_EDM_0                        ((uint32_t)0x00000400)
+#define DCMI_CR_EDM_1                        ((uint32_t)0x00000800)
+#define DCMI_CR_CRE                          ((uint32_t)0x00001000)
+#define DCMI_CR_ENABLE                       ((uint32_t)0x00004000)
+#define DCMI_CR_BSM                          ((uint32_t)0x00030000)
+#define DCMI_CR_BSM_0                        ((uint32_t)0x00010000)
+#define DCMI_CR_BSM_1                        ((uint32_t)0x00020000)
+#define DCMI_CR_OEBS                         ((uint32_t)0x00040000)
+#define DCMI_CR_LSM                          ((uint32_t)0x00080000)
+#define DCMI_CR_OELS                         ((uint32_t)0x00100000)
+
+/********************  Bits definition for DCMI_SR register  ******************/
+#define DCMI_SR_HSYNC                        ((uint32_t)0x00000001)
+#define DCMI_SR_VSYNC                        ((uint32_t)0x00000002)
+#define DCMI_SR_FNE                          ((uint32_t)0x00000004)
+
+/********************  Bits definition for DCMI_RISR register  ****************/
+#define DCMI_RISR_FRAME_RIS                  ((uint32_t)0x00000001)
+#define DCMI_RISR_OVF_RIS                    ((uint32_t)0x00000002)
+#define DCMI_RISR_ERR_RIS                    ((uint32_t)0x00000004)
+#define DCMI_RISR_VSYNC_RIS                  ((uint32_t)0x00000008)
+#define DCMI_RISR_LINE_RIS                   ((uint32_t)0x00000010)
+
+/********************  Bits definition for DCMI_IER register  *****************/
+#define DCMI_IER_FRAME_IE                    ((uint32_t)0x00000001)
+#define DCMI_IER_OVF_IE                      ((uint32_t)0x00000002)
+#define DCMI_IER_ERR_IE                      ((uint32_t)0x00000004)
+#define DCMI_IER_VSYNC_IE                    ((uint32_t)0x00000008)
+#define DCMI_IER_LINE_IE                     ((uint32_t)0x00000010)
+
+/********************  Bits definition for DCMI_MISR register  ****************/
+#define DCMI_MISR_FRAME_MIS                  ((uint32_t)0x00000001)
+#define DCMI_MISR_OVF_MIS                    ((uint32_t)0x00000002)
+#define DCMI_MISR_ERR_MIS                    ((uint32_t)0x00000004)
+#define DCMI_MISR_VSYNC_MIS                  ((uint32_t)0x00000008)
+#define DCMI_MISR_LINE_MIS                   ((uint32_t)0x00000010)
+
+/********************  Bits definition for DCMI_ICR register  *****************/
+#define DCMI_ICR_FRAME_ISC                   ((uint32_t)0x00000001)
+#define DCMI_ICR_OVF_ISC                     ((uint32_t)0x00000002)
+#define DCMI_ICR_ERR_ISC                     ((uint32_t)0x00000004)
+#define DCMI_ICR_VSYNC_ISC                   ((uint32_t)0x00000008)
+#define DCMI_ICR_LINE_ISC                    ((uint32_t)0x00000010)
+
+/******************************************************************************/
+/*                                                                            */
+/*                             DMA Controller                                 */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DMA_SxCR register  *****************/
+#define DMA_SxCR_CHSEL                       ((uint32_t)0x0E000000)
+#define DMA_SxCR_CHSEL_0                     ((uint32_t)0x02000000)
+#define DMA_SxCR_CHSEL_1                     ((uint32_t)0x04000000)
+#define DMA_SxCR_CHSEL_2                     ((uint32_t)0x08000000)
+#define DMA_SxCR_MBURST                      ((uint32_t)0x01800000)
+#define DMA_SxCR_MBURST_0                    ((uint32_t)0x00800000)
+#define DMA_SxCR_MBURST_1                    ((uint32_t)0x01000000)
+#define DMA_SxCR_PBURST                      ((uint32_t)0x00600000)
+#define DMA_SxCR_PBURST_0                    ((uint32_t)0x00200000)
+#define DMA_SxCR_PBURST_1                    ((uint32_t)0x00400000)
+#define DMA_SxCR_ACK                         ((uint32_t)0x00100000)
+#define DMA_SxCR_CT                          ((uint32_t)0x00080000)
+#define DMA_SxCR_DBM                         ((uint32_t)0x00040000)
+#define DMA_SxCR_PL                          ((uint32_t)0x00030000)
+#define DMA_SxCR_PL_0                        ((uint32_t)0x00010000)
+#define DMA_SxCR_PL_1                        ((uint32_t)0x00020000)
+#define DMA_SxCR_PINCOS                      ((uint32_t)0x00008000)
+#define DMA_SxCR_MSIZE                       ((uint32_t)0x00006000)
+#define DMA_SxCR_MSIZE_0                     ((uint32_t)0x00002000)
+#define DMA_SxCR_MSIZE_1                     ((uint32_t)0x00004000)
+#define DMA_SxCR_PSIZE                       ((uint32_t)0x00001800)
+#define DMA_SxCR_PSIZE_0                     ((uint32_t)0x00000800)
+#define DMA_SxCR_PSIZE_1                     ((uint32_t)0x00001000)
+#define DMA_SxCR_MINC                        ((uint32_t)0x00000400)
+#define DMA_SxCR_PINC                        ((uint32_t)0x00000200)
+#define DMA_SxCR_CIRC                        ((uint32_t)0x00000100)
+#define DMA_SxCR_DIR                         ((uint32_t)0x000000C0)
+#define DMA_SxCR_DIR_0                       ((uint32_t)0x00000040)
+#define DMA_SxCR_DIR_1                       ((uint32_t)0x00000080)
+#define DMA_SxCR_PFCTRL                      ((uint32_t)0x00000020)
+#define DMA_SxCR_TCIE                        ((uint32_t)0x00000010)
+#define DMA_SxCR_HTIE                        ((uint32_t)0x00000008)
+#define DMA_SxCR_TEIE                        ((uint32_t)0x00000004)
+#define DMA_SxCR_DMEIE                       ((uint32_t)0x00000002)
+#define DMA_SxCR_EN                          ((uint32_t)0x00000001)
+
+/********************  Bits definition for DMA_SxCNDTR register  **************/
+#define DMA_SxNDT                            ((uint32_t)0x0000FFFF)
+#define DMA_SxNDT_0                          ((uint32_t)0x00000001)
+#define DMA_SxNDT_1                          ((uint32_t)0x00000002)
+#define DMA_SxNDT_2                          ((uint32_t)0x00000004)
+#define DMA_SxNDT_3                          ((uint32_t)0x00000008)
+#define DMA_SxNDT_4                          ((uint32_t)0x00000010)
+#define DMA_SxNDT_5                          ((uint32_t)0x00000020)
+#define DMA_SxNDT_6                          ((uint32_t)0x00000040)
+#define DMA_SxNDT_7                          ((uint32_t)0x00000080)
+#define DMA_SxNDT_8                          ((uint32_t)0x00000100)
+#define DMA_SxNDT_9                          ((uint32_t)0x00000200)
+#define DMA_SxNDT_10                         ((uint32_t)0x00000400)
+#define DMA_SxNDT_11                         ((uint32_t)0x00000800)
+#define DMA_SxNDT_12                         ((uint32_t)0x00001000)
+#define DMA_SxNDT_13                         ((uint32_t)0x00002000)
+#define DMA_SxNDT_14                         ((uint32_t)0x00004000)
+#define DMA_SxNDT_15                         ((uint32_t)0x00008000)
+
+/********************  Bits definition for DMA_SxFCR register  ****************/
+#define DMA_SxFCR_FEIE                       ((uint32_t)0x00000080)
+#define DMA_SxFCR_FS                         ((uint32_t)0x00000038)
+#define DMA_SxFCR_FS_0                       ((uint32_t)0x00000008)
+#define DMA_SxFCR_FS_1                       ((uint32_t)0x00000010)
+#define DMA_SxFCR_FS_2                       ((uint32_t)0x00000020)
+#define DMA_SxFCR_DMDIS                      ((uint32_t)0x00000004)
+#define DMA_SxFCR_FTH                        ((uint32_t)0x00000003)
+#define DMA_SxFCR_FTH_0                      ((uint32_t)0x00000001)
+#define DMA_SxFCR_FTH_1                      ((uint32_t)0x00000002)
+
+/********************  Bits definition for DMA_LISR register  *****************/
+#define DMA_LISR_TCIF3                       ((uint32_t)0x08000000)
+#define DMA_LISR_HTIF3                       ((uint32_t)0x04000000)
+#define DMA_LISR_TEIF3                       ((uint32_t)0x02000000)
+#define DMA_LISR_DMEIF3                      ((uint32_t)0x01000000)
+#define DMA_LISR_FEIF3                       ((uint32_t)0x00400000)
+#define DMA_LISR_TCIF2                       ((uint32_t)0x00200000)
+#define DMA_LISR_HTIF2                       ((uint32_t)0x00100000)
+#define DMA_LISR_TEIF2                       ((uint32_t)0x00080000)
+#define DMA_LISR_DMEIF2                      ((uint32_t)0x00040000)
+#define DMA_LISR_FEIF2                       ((uint32_t)0x00010000)
+#define DMA_LISR_TCIF1                       ((uint32_t)0x00000800)
+#define DMA_LISR_HTIF1                       ((uint32_t)0x00000400)
+#define DMA_LISR_TEIF1                       ((uint32_t)0x00000200)
+#define DMA_LISR_DMEIF1                      ((uint32_t)0x00000100)
+#define DMA_LISR_FEIF1                       ((uint32_t)0x00000040)
+#define DMA_LISR_TCIF0                       ((uint32_t)0x00000020)
+#define DMA_LISR_HTIF0                       ((uint32_t)0x00000010)
+#define DMA_LISR_TEIF0                       ((uint32_t)0x00000008)
+#define DMA_LISR_DMEIF0                      ((uint32_t)0x00000004)
+#define DMA_LISR_FEIF0                       ((uint32_t)0x00000001)
+
+/********************  Bits definition for DMA_HISR register  *****************/
+#define DMA_HISR_TCIF7                       ((uint32_t)0x08000000)
+#define DMA_HISR_HTIF7                       ((uint32_t)0x04000000)
+#define DMA_HISR_TEIF7                       ((uint32_t)0x02000000)
+#define DMA_HISR_DMEIF7                      ((uint32_t)0x01000000)
+#define DMA_HISR_FEIF7                       ((uint32_t)0x00400000)
+#define DMA_HISR_TCIF6                       ((uint32_t)0x00200000)
+#define DMA_HISR_HTIF6                       ((uint32_t)0x00100000)
+#define DMA_HISR_TEIF6                       ((uint32_t)0x00080000)
+#define DMA_HISR_DMEIF6                      ((uint32_t)0x00040000)
+#define DMA_HISR_FEIF6                       ((uint32_t)0x00010000)
+#define DMA_HISR_TCIF5                       ((uint32_t)0x00000800)
+#define DMA_HISR_HTIF5                       ((uint32_t)0x00000400)
+#define DMA_HISR_TEIF5                       ((uint32_t)0x00000200)
+#define DMA_HISR_DMEIF5                      ((uint32_t)0x00000100)
+#define DMA_HISR_FEIF5                       ((uint32_t)0x00000040)
+#define DMA_HISR_TCIF4                       ((uint32_t)0x00000020)
+#define DMA_HISR_HTIF4                       ((uint32_t)0x00000010)
+#define DMA_HISR_TEIF4                       ((uint32_t)0x00000008)
+#define DMA_HISR_DMEIF4                      ((uint32_t)0x00000004)
+#define DMA_HISR_FEIF4                       ((uint32_t)0x00000001)
+
+/********************  Bits definition for DMA_LIFCR register  ****************/
+#define DMA_LIFCR_CTCIF3                     ((uint32_t)0x08000000)
+#define DMA_LIFCR_CHTIF3                     ((uint32_t)0x04000000)
+#define DMA_LIFCR_CTEIF3                     ((uint32_t)0x02000000)
+#define DMA_LIFCR_CDMEIF3                    ((uint32_t)0x01000000)
+#define DMA_LIFCR_CFEIF3                     ((uint32_t)0x00400000)
+#define DMA_LIFCR_CTCIF2                     ((uint32_t)0x00200000)
+#define DMA_LIFCR_CHTIF2                     ((uint32_t)0x00100000)
+#define DMA_LIFCR_CTEIF2                     ((uint32_t)0x00080000)
+#define DMA_LIFCR_CDMEIF2                    ((uint32_t)0x00040000)
+#define DMA_LIFCR_CFEIF2                     ((uint32_t)0x00010000)
+#define DMA_LIFCR_CTCIF1                     ((uint32_t)0x00000800)
+#define DMA_LIFCR_CHTIF1                     ((uint32_t)0x00000400)
+#define DMA_LIFCR_CTEIF1                     ((uint32_t)0x00000200)
+#define DMA_LIFCR_CDMEIF1                    ((uint32_t)0x00000100)
+#define DMA_LIFCR_CFEIF1                     ((uint32_t)0x00000040)
+#define DMA_LIFCR_CTCIF0                     ((uint32_t)0x00000020)
+#define DMA_LIFCR_CHTIF0                     ((uint32_t)0x00000010)
+#define DMA_LIFCR_CTEIF0                     ((uint32_t)0x00000008)
+#define DMA_LIFCR_CDMEIF0                    ((uint32_t)0x00000004)
+#define DMA_LIFCR_CFEIF0                     ((uint32_t)0x00000001)
+
+/********************  Bits definition for DMA_HIFCR  register  ****************/
+#define DMA_HIFCR_CTCIF7                     ((uint32_t)0x08000000)
+#define DMA_HIFCR_CHTIF7                     ((uint32_t)0x04000000)
+#define DMA_HIFCR_CTEIF7                     ((uint32_t)0x02000000)
+#define DMA_HIFCR_CDMEIF7                    ((uint32_t)0x01000000)
+#define DMA_HIFCR_CFEIF7                     ((uint32_t)0x00400000)
+#define DMA_HIFCR_CTCIF6                     ((uint32_t)0x00200000)
+#define DMA_HIFCR_CHTIF6                     ((uint32_t)0x00100000)
+#define DMA_HIFCR_CTEIF6                     ((uint32_t)0x00080000)
+#define DMA_HIFCR_CDMEIF6                    ((uint32_t)0x00040000)
+#define DMA_HIFCR_CFEIF6                     ((uint32_t)0x00010000)
+#define DMA_HIFCR_CTCIF5                     ((uint32_t)0x00000800)
+#define DMA_HIFCR_CHTIF5                     ((uint32_t)0x00000400)
+#define DMA_HIFCR_CTEIF5                     ((uint32_t)0x00000200)
+#define DMA_HIFCR_CDMEIF5                    ((uint32_t)0x00000100)
+#define DMA_HIFCR_CFEIF5                     ((uint32_t)0x00000040)
+#define DMA_HIFCR_CTCIF4                     ((uint32_t)0x00000020)
+#define DMA_HIFCR_CHTIF4                     ((uint32_t)0x00000010)
+#define DMA_HIFCR_CTEIF4                     ((uint32_t)0x00000008)
+#define DMA_HIFCR_CDMEIF4                    ((uint32_t)0x00000004)
+#define DMA_HIFCR_CFEIF4                     ((uint32_t)0x00000001)
+
+/******************************************************************************/
+/*                                                                            */
+/*                         AHB Master DMA2D Controller (DMA2D)                */
+/*                                                                            */
+/******************************************************************************/
+
+/********************  Bit definition for DMA2D_CR register  ******************/
+
+#define DMA2D_CR_START                     ((uint32_t)0x00000001)               /*!< Start transfer                          */
+#define DMA2D_CR_SUSP                      ((uint32_t)0x00000002)               /*!< Suspend transfer                        */
+#define DMA2D_CR_ABORT                     ((uint32_t)0x00000004)               /*!< Abort transfer                          */
+#define DMA2D_CR_TEIE                      ((uint32_t)0x00000100)               /*!< Transfer Error Interrupt Enable         */
+#define DMA2D_CR_TCIE                      ((uint32_t)0x00000200)               /*!< Transfer Complete Interrupt Enable      */
+#define DMA2D_CR_TWIE                      ((uint32_t)0x00000400)               /*!< Transfer Watermark Interrupt Enable     */
+#define DMA2D_CR_CAEIE                     ((uint32_t)0x00000800)               /*!< CLUT Access Error Interrupt Enable      */
+#define DMA2D_CR_CTCIE                     ((uint32_t)0x00001000)               /*!< CLUT Transfer Complete Interrupt Enable */
+#define DMA2D_CR_CEIE                      ((uint32_t)0x00002000)               /*!< Configuration Error Interrupt Enable    */
+#define DMA2D_CR_MODE                      ((uint32_t)0x00030000)               /*!< DMA2D Mode                              */
+
+/********************  Bit definition for DMA2D_ISR register  *****************/
+
+#define DMA2D_ISR_TEIF                     ((uint32_t)0x00000001)               /*!< Transfer Error Interrupt Flag         */
+#define DMA2D_ISR_TCIF                     ((uint32_t)0x00000002)               /*!< Transfer Complete Interrupt Flag      */
+#define DMA2D_ISR_TWIF                     ((uint32_t)0x00000004)               /*!< Transfer Watermark Interrupt Flag     */
+#define DMA2D_ISR_CAEIF                    ((uint32_t)0x00000008)               /*!< CLUT Access Error Interrupt Flag      */
+#define DMA2D_ISR_CTCIF                    ((uint32_t)0x00000010)               /*!< CLUT Transfer Complete Interrupt Flag */
+#define DMA2D_ISR_CEIF                     ((uint32_t)0x00000020)               /*!< Configuration Error Interrupt Flag    */
+
+/********************  Bit definition for DMA2D_IFSR register  ****************/
+
+#define DMA2D_IFSR_CTEIF                   ((uint32_t)0x00000001)               /*!< Clears Transfer Error Interrupt Flag         */
+#define DMA2D_IFSR_CTCIF                   ((uint32_t)0x00000002)               /*!< Clears Transfer Complete Interrupt Flag      */
+#define DMA2D_IFSR_CTWIF                   ((uint32_t)0x00000004)               /*!< Clears Transfer Watermark Interrupt Flag     */
+#define DMA2D_IFSR_CCAEIF                  ((uint32_t)0x00000008)               /*!< Clears CLUT Access Error Interrupt Flag      */
+#define DMA2D_IFSR_CCTCIF                  ((uint32_t)0x00000010)               /*!< Clears CLUT Transfer Complete Interrupt Flag */
+#define DMA2D_IFSR_CCEIF                   ((uint32_t)0x00000020)               /*!< Clears Configuration Error Interrupt Flag    */
+
+/********************  Bit definition for DMA2D_FGMAR register  ***************/
+
+#define DMA2D_FGMAR_MA                     ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_FGOR register  ****************/
+
+#define DMA2D_FGOR_LO                      ((uint32_t)0x00003FFF)               /*!< Line Offset */
+
+/********************  Bit definition for DMA2D_BGMAR register  ***************/
+
+#define DMA2D_BGMAR_MA                     ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_BGOR register  ****************/
+
+#define DMA2D_BGOR_LO                      ((uint32_t)0x00003FFF)               /*!< Line Offset */
+
+/********************  Bit definition for DMA2D_FGPFCCR register  *************/
+
+#define DMA2D_FGPFCCR_CM                   ((uint32_t)0x0000000F)               /*!< Color mode      */
+#define DMA2D_FGPFCCR_CCM                  ((uint32_t)0x00000010)               /*!< CLUT Color mode */
+#define DMA2D_FGPFCCR_START                ((uint32_t)0x00000020)               /*!< Start           */
+#define DMA2D_FGPFCCR_CS                   ((uint32_t)0x0000FF00)               /*!< CLUT size       */
+#define DMA2D_FGPFCCR_AM                   ((uint32_t)0x00030000)               /*!< Alpha mode      */
+#define DMA2D_FGPFCCR_ALPHA                ((uint32_t)0xFF000000)               /*!< Alpha value     */
+
+/********************  Bit definition for DMA2D_FGCOLR register  **************/
+
+#define DMA2D_FGCOLR_BLUE                  ((uint32_t)0x000000FF)               /*!< Blue Value  */
+#define DMA2D_FGCOLR_GREEN                 ((uint32_t)0x0000FF00)               /*!< Green Value */
+#define DMA2D_FGCOLR_RED                   ((uint32_t)0x00FF0000)               /*!< Red Value   */
+
+/********************  Bit definition for DMA2D_BGPFCCR register  *************/
+
+#define DMA2D_BGPFCCR_CM                   ((uint32_t)0x0000000F)               /*!< Color mode      */
+#define DMA2D_BGPFCCR_CCM                  ((uint32_t)0x00000010)               /*!< CLUT Color mode */
+#define DMA2D_BGPFCCR_START                ((uint32_t)0x00000020)               /*!< Start           */
+#define DMA2D_BGPFCCR_CS                   ((uint32_t)0x0000FF00)               /*!< CLUT size       */
+#define DMA2D_BGPFCCR_AM                   ((uint32_t)0x00030000)               /*!< Alpha Mode      */
+#define DMA2D_BGPFCCR_ALPHA                ((uint32_t)0xFF000000)               /*!< Alpha value     */
+
+/********************  Bit definition for DMA2D_BGCOLR register  **************/
+
+#define DMA2D_BGCOLR_BLUE                  ((uint32_t)0x000000FF)               /*!< Blue Value  */
+#define DMA2D_BGCOLR_GREEN                 ((uint32_t)0x0000FF00)               /*!< Green Value */
+#define DMA2D_BGCOLR_RED                   ((uint32_t)0x00FF0000)               /*!< Red Value   */
+
+/********************  Bit definition for DMA2D_FGCMAR register  **************/
+
+#define DMA2D_FGCMAR_MA                    ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_BGCMAR register  **************/
+
+#define DMA2D_BGCMAR_MA                    ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_OPFCCR register  **************/
+
+#define DMA2D_OPFCCR_CM                    ((uint32_t)0x00000007)               /*!< Color mode */
+
+/********************  Bit definition for DMA2D_OCOLR register  ***************/
+
+/*!<Mode_ARGB8888/RGB888 */
+
+#define DMA2D_OCOLR_BLUE_1                 ((uint32_t)0x000000FF)               /*!< BLUE Value          */
+#define DMA2D_OCOLR_GREEN_1                ((uint32_t)0x0000FF00)               /*!< GREEN Value         */
+#define DMA2D_OCOLR_RED_1                  ((uint32_t)0x00FF0000)               /*!< Red Value           */
+#define DMA2D_OCOLR_ALPHA_1                ((uint32_t)0xFF000000)               /*!< Alpha Channel Value */
+
+/*!<Mode_RGB565 */
+#define DMA2D_OCOLR_BLUE_2                 ((uint32_t)0x0000001F)               /*!< BLUE Value   */
+#define DMA2D_OCOLR_GREEN_2                ((uint32_t)0x000007E0)               /*!< GREEN Value  */
+#define DMA2D_OCOLR_RED_2                  ((uint32_t)0x0000F800)               /*!< Red Value    */
+
+/*!<Mode_ARGB1555 */
+#define DMA2D_OCOLR_BLUE_3                 ((uint32_t)0x0000001F)               /*!< BLUE Value          */
+#define DMA2D_OCOLR_GREEN_3                ((uint32_t)0x000003E0)               /*!< GREEN Value         */
+#define DMA2D_OCOLR_RED_3                  ((uint32_t)0x00007C00)               /*!< Red Value           */
+#define DMA2D_OCOLR_ALPHA_3                ((uint32_t)0x00008000)               /*!< Alpha Channel Value */
+
+/*!<Mode_ARGB4444 */
+#define DMA2D_OCOLR_BLUE_4                 ((uint32_t)0x0000000F)               /*!< BLUE Value          */
+#define DMA2D_OCOLR_GREEN_4                ((uint32_t)0x000000F0)               /*!< GREEN Value         */
+#define DMA2D_OCOLR_RED_4                  ((uint32_t)0x00000F00)               /*!< Red Value           */
+#define DMA2D_OCOLR_ALPHA_4                ((uint32_t)0x0000F000)               /*!< Alpha Channel Value */
+
+/********************  Bit definition for DMA2D_OMAR register  ****************/
+
+#define DMA2D_OMAR_MA                      ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_OOR register  *****************/
+
+#define DMA2D_OOR_LO                       ((uint32_t)0x00003FFF)               /*!< Line Offset */
+
+/********************  Bit definition for DMA2D_NLR register  *****************/
+
+#define DMA2D_NLR_NL                       ((uint32_t)0x0000FFFF)               /*!< Number of Lines */
+#define DMA2D_NLR_PL                       ((uint32_t)0x3FFF0000)               /*!< Pixel per Lines */
+
+/********************  Bit definition for DMA2D_LWR register  *****************/
+
+#define DMA2D_LWR_LW                       ((uint32_t)0x0000FFFF)               /*!< Line Watermark */
+
+/********************  Bit definition for DMA2D_AMTCR register  ***************/
+
+#define DMA2D_AMTCR_EN                     ((uint32_t)0x00000001)               /*!< Enable    */
+#define DMA2D_AMTCR_DT                     ((uint32_t)0x0000FF00)               /*!< Dead Time */
+
+
+
+/********************  Bit definition for DMA2D_FGCLUT register  **************/
+
+/********************  Bit definition for DMA2D_BGCLUT register  **************/
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                    External Interrupt/Event Controller                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for EXTI_IMR register  *******************/
+#define  EXTI_IMR_MR0                        ((uint32_t)0x00000001)        /*!< Interrupt Mask on line 0 */
+#define  EXTI_IMR_MR1                        ((uint32_t)0x00000002)        /*!< Interrupt Mask on line 1 */
+#define  EXTI_IMR_MR2                        ((uint32_t)0x00000004)        /*!< Interrupt Mask on line 2 */
+#define  EXTI_IMR_MR3                        ((uint32_t)0x00000008)        /*!< Interrupt Mask on line 3 */
+#define  EXTI_IMR_MR4                        ((uint32_t)0x00000010)        /*!< Interrupt Mask on line 4 */
+#define  EXTI_IMR_MR5                        ((uint32_t)0x00000020)        /*!< Interrupt Mask on line 5 */
+#define  EXTI_IMR_MR6                        ((uint32_t)0x00000040)        /*!< Interrupt Mask on line 6 */
+#define  EXTI_IMR_MR7                        ((uint32_t)0x00000080)        /*!< Interrupt Mask on line 7 */
+#define  EXTI_IMR_MR8                        ((uint32_t)0x00000100)        /*!< Interrupt Mask on line 8 */
+#define  EXTI_IMR_MR9                        ((uint32_t)0x00000200)        /*!< Interrupt Mask on line 9 */
+#define  EXTI_IMR_MR10                       ((uint32_t)0x00000400)        /*!< Interrupt Mask on line 10 */
+#define  EXTI_IMR_MR11                       ((uint32_t)0x00000800)        /*!< Interrupt Mask on line 11 */
+#define  EXTI_IMR_MR12                       ((uint32_t)0x00001000)        /*!< Interrupt Mask on line 12 */
+#define  EXTI_IMR_MR13                       ((uint32_t)0x00002000)        /*!< Interrupt Mask on line 13 */
+#define  EXTI_IMR_MR14                       ((uint32_t)0x00004000)        /*!< Interrupt Mask on line 14 */
+#define  EXTI_IMR_MR15                       ((uint32_t)0x00008000)        /*!< Interrupt Mask on line 15 */
+#define  EXTI_IMR_MR16                       ((uint32_t)0x00010000)        /*!< Interrupt Mask on line 16 */
+#define  EXTI_IMR_MR17                       ((uint32_t)0x00020000)        /*!< Interrupt Mask on line 17 */
+#define  EXTI_IMR_MR18                       ((uint32_t)0x00040000)        /*!< Interrupt Mask on line 18 */
+#define  EXTI_IMR_MR19                       ((uint32_t)0x00080000)        /*!< Interrupt Mask on line 19 */
+#define  EXTI_IMR_MR20                       ((uint32_t)0x00100000)        /*!< Interrupt Mask on line 20 */
+#define  EXTI_IMR_MR21                       ((uint32_t)0x00200000)        /*!< Interrupt Mask on line 21 */
+#define  EXTI_IMR_MR22                       ((uint32_t)0x00400000)        /*!< Interrupt Mask on line 22 */
+#define  EXTI_IMR_MR23                       ((uint32_t)0x00800000)        /*!< Interrupt Mask on line 23 */
+
+/*******************  Bit definition for EXTI_EMR register  *******************/
+#define  EXTI_EMR_MR0                        ((uint32_t)0x00000001)        /*!< Event Mask on line 0 */
+#define  EXTI_EMR_MR1                        ((uint32_t)0x00000002)        /*!< Event Mask on line 1 */
+#define  EXTI_EMR_MR2                        ((uint32_t)0x00000004)        /*!< Event Mask on line 2 */
+#define  EXTI_EMR_MR3                        ((uint32_t)0x00000008)        /*!< Event Mask on line 3 */
+#define  EXTI_EMR_MR4                        ((uint32_t)0x00000010)        /*!< Event Mask on line 4 */
+#define  EXTI_EMR_MR5                        ((uint32_t)0x00000020)        /*!< Event Mask on line 5 */
+#define  EXTI_EMR_MR6                        ((uint32_t)0x00000040)        /*!< Event Mask on line 6 */
+#define  EXTI_EMR_MR7                        ((uint32_t)0x00000080)        /*!< Event Mask on line 7 */
+#define  EXTI_EMR_MR8                        ((uint32_t)0x00000100)        /*!< Event Mask on line 8 */
+#define  EXTI_EMR_MR9                        ((uint32_t)0x00000200)        /*!< Event Mask on line 9 */
+#define  EXTI_EMR_MR10                       ((uint32_t)0x00000400)        /*!< Event Mask on line 10 */
+#define  EXTI_EMR_MR11                       ((uint32_t)0x00000800)        /*!< Event Mask on line 11 */
+#define  EXTI_EMR_MR12                       ((uint32_t)0x00001000)        /*!< Event Mask on line 12 */
+#define  EXTI_EMR_MR13                       ((uint32_t)0x00002000)        /*!< Event Mask on line 13 */
+#define  EXTI_EMR_MR14                       ((uint32_t)0x00004000)        /*!< Event Mask on line 14 */
+#define  EXTI_EMR_MR15                       ((uint32_t)0x00008000)        /*!< Event Mask on line 15 */
+#define  EXTI_EMR_MR16                       ((uint32_t)0x00010000)        /*!< Event Mask on line 16 */
+#define  EXTI_EMR_MR17                       ((uint32_t)0x00020000)        /*!< Event Mask on line 17 */
+#define  EXTI_EMR_MR18                       ((uint32_t)0x00040000)        /*!< Event Mask on line 18 */
+#define  EXTI_EMR_MR19                       ((uint32_t)0x00080000)        /*!< Event Mask on line 19 */
+#define  EXTI_EMR_MR20                       ((uint32_t)0x00100000)        /*!< Event Mask on line 20 */
+#define  EXTI_EMR_MR21                       ((uint32_t)0x00200000)        /*!< Event Mask on line 21 */
+#define  EXTI_EMR_MR22                       ((uint32_t)0x00400000)        /*!< Event Mask on line 22 */
+#define  EXTI_EMR_MR23                       ((uint32_t)0x00800000)        /*!< Event Mask on line 23 */
+
+/******************  Bit definition for EXTI_RTSR register  *******************/
+#define  EXTI_RTSR_TR0                       ((uint32_t)0x00000001)        /*!< Rising trigger event configuration bit of line 0 */
+#define  EXTI_RTSR_TR1                       ((uint32_t)0x00000002)        /*!< Rising trigger event configuration bit of line 1 */
+#define  EXTI_RTSR_TR2                       ((uint32_t)0x00000004)        /*!< Rising trigger event configuration bit of line 2 */
+#define  EXTI_RTSR_TR3                       ((uint32_t)0x00000008)        /*!< Rising trigger event configuration bit of line 3 */
+#define  EXTI_RTSR_TR4                       ((uint32_t)0x00000010)        /*!< Rising trigger event configuration bit of line 4 */
+#define  EXTI_RTSR_TR5                       ((uint32_t)0x00000020)        /*!< Rising trigger event configuration bit of line 5 */
+#define  EXTI_RTSR_TR6                       ((uint32_t)0x00000040)        /*!< Rising trigger event configuration bit of line 6 */
+#define  EXTI_RTSR_TR7                       ((uint32_t)0x00000080)        /*!< Rising trigger event configuration bit of line 7 */
+#define  EXTI_RTSR_TR8                       ((uint32_t)0x00000100)        /*!< Rising trigger event configuration bit of line 8 */
+#define  EXTI_RTSR_TR9                       ((uint32_t)0x00000200)        /*!< Rising trigger event configuration bit of line 9 */
+#define  EXTI_RTSR_TR10                      ((uint32_t)0x00000400)        /*!< Rising trigger event configuration bit of line 10 */
+#define  EXTI_RTSR_TR11                      ((uint32_t)0x00000800)        /*!< Rising trigger event configuration bit of line 11 */
+#define  EXTI_RTSR_TR12                      ((uint32_t)0x00001000)        /*!< Rising trigger event configuration bit of line 12 */
+#define  EXTI_RTSR_TR13                      ((uint32_t)0x00002000)        /*!< Rising trigger event configuration bit of line 13 */
+#define  EXTI_RTSR_TR14                      ((uint32_t)0x00004000)        /*!< Rising trigger event configuration bit of line 14 */
+#define  EXTI_RTSR_TR15                      ((uint32_t)0x00008000)        /*!< Rising trigger event configuration bit of line 15 */
+#define  EXTI_RTSR_TR16                      ((uint32_t)0x00010000)        /*!< Rising trigger event configuration bit of line 16 */
+#define  EXTI_RTSR_TR17                      ((uint32_t)0x00020000)        /*!< Rising trigger event configuration bit of line 17 */
+#define  EXTI_RTSR_TR18                      ((uint32_t)0x00040000)        /*!< Rising trigger event configuration bit of line 18 */
+#define  EXTI_RTSR_TR19                      ((uint32_t)0x00080000)        /*!< Rising trigger event configuration bit of line 19 */
+#define  EXTI_RTSR_TR20                      ((uint32_t)0x00100000)        /*!< Rising trigger event configuration bit of line 20 */
+#define  EXTI_RTSR_TR21                      ((uint32_t)0x00200000)        /*!< Rising trigger event configuration bit of line 21 */
+#define  EXTI_RTSR_TR22                      ((uint32_t)0x00400000)        /*!< Rising trigger event configuration bit of line 22 */
+#define  EXTI_RTSR_TR23                      ((uint32_t)0x00800000)        /*!< Rising trigger event configuration bit of line 23 */
+
+/******************  Bit definition for EXTI_FTSR register  *******************/
+#define  EXTI_FTSR_TR0                       ((uint32_t)0x00000001)        /*!< Falling trigger event configuration bit of line 0 */
+#define  EXTI_FTSR_TR1                       ((uint32_t)0x00000002)        /*!< Falling trigger event configuration bit of line 1 */
+#define  EXTI_FTSR_TR2                       ((uint32_t)0x00000004)        /*!< Falling trigger event configuration bit of line 2 */
+#define  EXTI_FTSR_TR3                       ((uint32_t)0x00000008)        /*!< Falling trigger event configuration bit of line 3 */
+#define  EXTI_FTSR_TR4                       ((uint32_t)0x00000010)        /*!< Falling trigger event configuration bit of line 4 */
+#define  EXTI_FTSR_TR5                       ((uint32_t)0x00000020)        /*!< Falling trigger event configuration bit of line 5 */
+#define  EXTI_FTSR_TR6                       ((uint32_t)0x00000040)        /*!< Falling trigger event configuration bit of line 6 */
+#define  EXTI_FTSR_TR7                       ((uint32_t)0x00000080)        /*!< Falling trigger event configuration bit of line 7 */
+#define  EXTI_FTSR_TR8                       ((uint32_t)0x00000100)        /*!< Falling trigger event configuration bit of line 8 */
+#define  EXTI_FTSR_TR9                       ((uint32_t)0x00000200)        /*!< Falling trigger event configuration bit of line 9 */
+#define  EXTI_FTSR_TR10                      ((uint32_t)0x00000400)        /*!< Falling trigger event configuration bit of line 10 */
+#define  EXTI_FTSR_TR11                      ((uint32_t)0x00000800)        /*!< Falling trigger event configuration bit of line 11 */
+#define  EXTI_FTSR_TR12                      ((uint32_t)0x00001000)        /*!< Falling trigger event configuration bit of line 12 */
+#define  EXTI_FTSR_TR13                      ((uint32_t)0x00002000)        /*!< Falling trigger event configuration bit of line 13 */
+#define  EXTI_FTSR_TR14                      ((uint32_t)0x00004000)        /*!< Falling trigger event configuration bit of line 14 */
+#define  EXTI_FTSR_TR15                      ((uint32_t)0x00008000)        /*!< Falling trigger event configuration bit of line 15 */
+#define  EXTI_FTSR_TR16                      ((uint32_t)0x00010000)        /*!< Falling trigger event configuration bit of line 16 */
+#define  EXTI_FTSR_TR17                      ((uint32_t)0x00020000)        /*!< Falling trigger event configuration bit of line 17 */
+#define  EXTI_FTSR_TR18                      ((uint32_t)0x00040000)        /*!< Falling trigger event configuration bit of line 18 */
+#define  EXTI_FTSR_TR19                      ((uint32_t)0x00080000)        /*!< Falling trigger event configuration bit of line 19 */
+#define  EXTI_FTSR_TR20                      ((uint32_t)0x00100000)        /*!< Falling trigger event configuration bit of line 20 */
+#define  EXTI_FTSR_TR21                      ((uint32_t)0x00200000)        /*!< Falling trigger event configuration bit of line 21 */
+#define  EXTI_FTSR_TR22                      ((uint32_t)0x00400000)        /*!< Falling trigger event configuration bit of line 22 */
+#define  EXTI_FTSR_TR23                      ((uint32_t)0x00800000)        /*!< Falling trigger event configuration bit of line 23 */
+
+/******************  Bit definition for EXTI_SWIER register  ******************/
+#define  EXTI_SWIER_SWIER0                   ((uint32_t)0x00000001)        /*!< Software Interrupt on line 0 */
+#define  EXTI_SWIER_SWIER1                   ((uint32_t)0x00000002)        /*!< Software Interrupt on line 1 */
+#define  EXTI_SWIER_SWIER2                   ((uint32_t)0x00000004)        /*!< Software Interrupt on line 2 */
+#define  EXTI_SWIER_SWIER3                   ((uint32_t)0x00000008)        /*!< Software Interrupt on line 3 */
+#define  EXTI_SWIER_SWIER4                   ((uint32_t)0x00000010)        /*!< Software Interrupt on line 4 */
+#define  EXTI_SWIER_SWIER5                   ((uint32_t)0x00000020)        /*!< Software Interrupt on line 5 */
+#define  EXTI_SWIER_SWIER6                   ((uint32_t)0x00000040)        /*!< Software Interrupt on line 6 */
+#define  EXTI_SWIER_SWIER7                   ((uint32_t)0x00000080)        /*!< Software Interrupt on line 7 */
+#define  EXTI_SWIER_SWIER8                   ((uint32_t)0x00000100)        /*!< Software Interrupt on line 8 */
+#define  EXTI_SWIER_SWIER9                   ((uint32_t)0x00000200)        /*!< Software Interrupt on line 9 */
+#define  EXTI_SWIER_SWIER10                  ((uint32_t)0x00000400)        /*!< Software Interrupt on line 10 */
+#define  EXTI_SWIER_SWIER11                  ((uint32_t)0x00000800)        /*!< Software Interrupt on line 11 */
+#define  EXTI_SWIER_SWIER12                  ((uint32_t)0x00001000)        /*!< Software Interrupt on line 12 */
+#define  EXTI_SWIER_SWIER13                  ((uint32_t)0x00002000)        /*!< Software Interrupt on line 13 */
+#define  EXTI_SWIER_SWIER14                  ((uint32_t)0x00004000)        /*!< Software Interrupt on line 14 */
+#define  EXTI_SWIER_SWIER15                  ((uint32_t)0x00008000)        /*!< Software Interrupt on line 15 */
+#define  EXTI_SWIER_SWIER16                  ((uint32_t)0x00010000)        /*!< Software Interrupt on line 16 */
+#define  EXTI_SWIER_SWIER17                  ((uint32_t)0x00020000)        /*!< Software Interrupt on line 17 */
+#define  EXTI_SWIER_SWIER18                  ((uint32_t)0x00040000)        /*!< Software Interrupt on line 18 */
+#define  EXTI_SWIER_SWIER19                  ((uint32_t)0x00080000)        /*!< Software Interrupt on line 19 */
+#define  EXTI_SWIER_SWIER20                  ((uint32_t)0x00100000)        /*!< Software Interrupt on line 20 */
+#define  EXTI_SWIER_SWIER21                  ((uint32_t)0x00200000)        /*!< Software Interrupt on line 21 */
+#define  EXTI_SWIER_SWIER22                  ((uint32_t)0x00400000)        /*!< Software Interrupt on line 22 */
+#define  EXTI_SWIER_SWIER23                  ((uint32_t)0x00800000)        /*!< Software Interrupt on line 23 */
+
+/*******************  Bit definition for EXTI_PR register  ********************/
+#define  EXTI_PR_PR0                         ((uint32_t)0x00000001)        /*!< Pending bit for line 0 */
+#define  EXTI_PR_PR1                         ((uint32_t)0x00000002)        /*!< Pending bit for line 1 */
+#define  EXTI_PR_PR2                         ((uint32_t)0x00000004)        /*!< Pending bit for line 2 */
+#define  EXTI_PR_PR3                         ((uint32_t)0x00000008)        /*!< Pending bit for line 3 */
+#define  EXTI_PR_PR4                         ((uint32_t)0x00000010)        /*!< Pending bit for line 4 */
+#define  EXTI_PR_PR5                         ((uint32_t)0x00000020)        /*!< Pending bit for line 5 */
+#define  EXTI_PR_PR6                         ((uint32_t)0x00000040)        /*!< Pending bit for line 6 */
+#define  EXTI_PR_PR7                         ((uint32_t)0x00000080)        /*!< Pending bit for line 7 */
+#define  EXTI_PR_PR8                         ((uint32_t)0x00000100)        /*!< Pending bit for line 8 */
+#define  EXTI_PR_PR9                         ((uint32_t)0x00000200)        /*!< Pending bit for line 9 */
+#define  EXTI_PR_PR10                        ((uint32_t)0x00000400)        /*!< Pending bit for line 10 */
+#define  EXTI_PR_PR11                        ((uint32_t)0x00000800)        /*!< Pending bit for line 11 */
+#define  EXTI_PR_PR12                        ((uint32_t)0x00001000)        /*!< Pending bit for line 12 */
+#define  EXTI_PR_PR13                        ((uint32_t)0x00002000)        /*!< Pending bit for line 13 */
+#define  EXTI_PR_PR14                        ((uint32_t)0x00004000)        /*!< Pending bit for line 14 */
+#define  EXTI_PR_PR15                        ((uint32_t)0x00008000)        /*!< Pending bit for line 15 */
+#define  EXTI_PR_PR16                        ((uint32_t)0x00010000)        /*!< Pending bit for line 16 */
+#define  EXTI_PR_PR17                        ((uint32_t)0x00020000)        /*!< Pending bit for line 17 */
+#define  EXTI_PR_PR18                        ((uint32_t)0x00040000)        /*!< Pending bit for line 18 */
+#define  EXTI_PR_PR19                        ((uint32_t)0x00080000)        /*!< Pending bit for line 19 */
+#define  EXTI_PR_PR20                        ((uint32_t)0x00100000)        /*!< Pending bit for line 20 */
+#define  EXTI_PR_PR21                        ((uint32_t)0x00200000)        /*!< Pending bit for line 21 */
+#define  EXTI_PR_PR22                        ((uint32_t)0x00400000)        /*!< Pending bit for line 22 */
+#define  EXTI_PR_PR23                        ((uint32_t)0x00800000)        /*!< Pending bit for line 23 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    FLASH                                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bits definition for FLASH_ACR register  *****************/
+#define FLASH_ACR_LATENCY                    ((uint32_t)0x0000000F)
+#define FLASH_ACR_LATENCY_0WS                ((uint32_t)0x00000000)
+#define FLASH_ACR_LATENCY_1WS                ((uint32_t)0x00000001)
+#define FLASH_ACR_LATENCY_2WS                ((uint32_t)0x00000002)
+#define FLASH_ACR_LATENCY_3WS                ((uint32_t)0x00000003)
+#define FLASH_ACR_LATENCY_4WS                ((uint32_t)0x00000004)
+#define FLASH_ACR_LATENCY_5WS                ((uint32_t)0x00000005)
+#define FLASH_ACR_LATENCY_6WS                ((uint32_t)0x00000006)
+#define FLASH_ACR_LATENCY_7WS                ((uint32_t)0x00000007)
+#define FLASH_ACR_LATENCY_8WS                ((uint32_t)0x00000008)
+#define FLASH_ACR_LATENCY_9WS                ((uint32_t)0x00000009)
+#define FLASH_ACR_LATENCY_10WS               ((uint32_t)0x0000000A)
+#define FLASH_ACR_LATENCY_11WS               ((uint32_t)0x0000000B)
+#define FLASH_ACR_LATENCY_12WS               ((uint32_t)0x0000000C)
+#define FLASH_ACR_LATENCY_13WS               ((uint32_t)0x0000000D)
+#define FLASH_ACR_LATENCY_14WS               ((uint32_t)0x0000000E)
+#define FLASH_ACR_LATENCY_15WS               ((uint32_t)0x0000000F)
+#define FLASH_ACR_PRFTEN                     ((uint32_t)0x00000100)
+#define FLASH_ACR_ARTEN                      ((uint32_t)0x00000200)
+#define FLASH_ACR_ARTRST                     ((uint32_t)0x00000800)
+
+/*******************  Bits definition for FLASH_SR register  ******************/
+#define FLASH_SR_EOP                         ((uint32_t)0x00000001)
+#define FLASH_SR_OPERR                       ((uint32_t)0x00000002)
+#define FLASH_SR_WRPERR                      ((uint32_t)0x00000010)
+#define FLASH_SR_PGAERR                      ((uint32_t)0x00000020)
+#define FLASH_SR_PGPERR                      ((uint32_t)0x00000040)
+#define FLASH_SR_ERSERR                      ((uint32_t)0x00000080)
+#define FLASH_SR_BSY                         ((uint32_t)0x00010000)
+
+/*******************  Bits definition for FLASH_CR register  ******************/
+#define FLASH_CR_PG                          ((uint32_t)0x00000001)
+#define FLASH_CR_SER                         ((uint32_t)0x00000002)
+#define FLASH_CR_MER                         ((uint32_t)0x00000004)
+#define FLASH_CR_SNB                         ((uint32_t)0x00000078)
+#define FLASH_CR_SNB_0                       ((uint32_t)0x00000008)
+#define FLASH_CR_SNB_1                       ((uint32_t)0x00000010)
+#define FLASH_CR_SNB_2                       ((uint32_t)0x00000020)
+#define FLASH_CR_SNB_3                       ((uint32_t)0x00000040)
+#define FLASH_CR_PSIZE                       ((uint32_t)0x00000300)
+#define FLASH_CR_PSIZE_0                     ((uint32_t)0x00000100)
+#define FLASH_CR_PSIZE_1                     ((uint32_t)0x00000200)
+#define FLASH_CR_STRT                        ((uint32_t)0x00010000)
+#define FLASH_CR_EOPIE                       ((uint32_t)0x01000000)
+#define FLASH_CR_ERRIE                       ((uint32_t)0x02000000)
+#define FLASH_CR_LOCK                        ((uint32_t)0x80000000)
+
+/*******************  Bits definition for FLASH_OPTCR register  ***************/
+#define FLASH_OPTCR_OPTLOCK                 ((uint32_t)0x00000001)
+#define FLASH_OPTCR_OPTSTRT                 ((uint32_t)0x00000002)
+#define FLASH_OPTCR_BOR_LEV                 ((uint32_t)0x0000000C)
+#define FLASH_OPTCR_BOR_LEV_0               ((uint32_t)0x00000004)
+#define FLASH_OPTCR_BOR_LEV_1               ((uint32_t)0x00000008)
+#define FLASH_OPTCR_WWDG_SW                 ((uint32_t)0x00000010)
+#define FLASH_OPTCR_IWDG_SW                 ((uint32_t)0x00000020)
+#define FLASH_OPTCR_nRST_STOP               ((uint32_t)0x00000040)
+#define FLASH_OPTCR_nRST_STDBY              ((uint32_t)0x00000080)
+#define FLASH_OPTCR_RDP                     ((uint32_t)0x0000FF00)
+#define FLASH_OPTCR_RDP_0                   ((uint32_t)0x00000100)
+#define FLASH_OPTCR_RDP_1                   ((uint32_t)0x00000200)
+#define FLASH_OPTCR_RDP_2                   ((uint32_t)0x00000400)
+#define FLASH_OPTCR_RDP_3                   ((uint32_t)0x00000800)
+#define FLASH_OPTCR_RDP_4                   ((uint32_t)0x00001000)
+#define FLASH_OPTCR_RDP_5                   ((uint32_t)0x00002000)
+#define FLASH_OPTCR_RDP_6                   ((uint32_t)0x00004000)
+#define FLASH_OPTCR_RDP_7                   ((uint32_t)0x00008000)
+#define FLASH_OPTCR_nWRP                    ((uint32_t)0x00FF0000)
+#define FLASH_OPTCR_nWRP_0                  ((uint32_t)0x00010000)
+#define FLASH_OPTCR_nWRP_1                  ((uint32_t)0x00020000)
+#define FLASH_OPTCR_nWRP_2                  ((uint32_t)0x00040000)
+#define FLASH_OPTCR_nWRP_3                  ((uint32_t)0x00080000)
+#define FLASH_OPTCR_nWRP_4                  ((uint32_t)0x00100000)
+#define FLASH_OPTCR_nWRP_5                  ((uint32_t)0x00200000)
+#define FLASH_OPTCR_nWRP_6                  ((uint32_t)0x00400000)
+#define FLASH_OPTCR_nWRP_7                  ((uint32_t)0x00800000)
+#define FLASH_OPTCR_IWDG_STDBY              ((uint32_t)0x40000000)
+#define FLASH_OPTCR_IWDG_STOP               ((uint32_t)0x80000000)
+
+/*******************  Bits definition for FLASH_OPTCR1 register  ***************/
+#define FLASH_OPTCR1_BOOT_ADD0              ((uint32_t)0x0000FFFF)
+#define FLASH_OPTCR1_BOOT_ADD1              ((uint32_t)0xFFFF0000)
+
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          Flexible Memory Controller                        */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for FMC_BCR1 register  *******************/
+#define  FMC_BCR1_MBKEN                     ((uint32_t)0x00000001)        /*!<Memory bank enable bit                 */
+#define  FMC_BCR1_MUXEN                     ((uint32_t)0x00000002)        /*!<Address/data multiplexing enable bit   */
+
+#define  FMC_BCR1_MTYP                      ((uint32_t)0x0000000C)        /*!<MTYP[1:0] bits (Memory type)           */
+#define  FMC_BCR1_MTYP_0                    ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_BCR1_MTYP_1                    ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_BCR1_MWID                      ((uint32_t)0x00000030)        /*!<MWID[1:0] bits (Memory data bus width) */
+#define  FMC_BCR1_MWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BCR1_MWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_BCR1_FACCEN                    ((uint32_t)0x00000040)        /*!<Flash access enable        */
+#define  FMC_BCR1_BURSTEN                   ((uint32_t)0x00000100)        /*!<Burst enable bit           */
+#define  FMC_BCR1_WAITPOL                   ((uint32_t)0x00000200)        /*!<Wait signal polarity bit   */
+#define  FMC_BCR1_WRAPMOD                   ((uint32_t)0x00000400)        /*!<Wrapped burst mode support */
+#define  FMC_BCR1_WAITCFG                   ((uint32_t)0x00000800)        /*!<Wait timing configuration  */
+#define  FMC_BCR1_WREN                      ((uint32_t)0x00001000)        /*!<Write enable bit           */
+#define  FMC_BCR1_WAITEN                    ((uint32_t)0x00002000)        /*!<Wait enable bit            */
+#define  FMC_BCR1_EXTMOD                    ((uint32_t)0x00004000)        /*!<Extended mode enable       */
+#define  FMC_BCR1_ASYNCWAIT                 ((uint32_t)0x00008000)        /*!<Asynchronous wait          */
+#define  FMC_BCR1_CPSIZE                     ((uint32_t)0x00070000)        /*!<CRAM page size             */
+#define  FMC_BCR1_CPSIZE_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BCR1_CPSIZE_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BCR1_CPSIZE_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BCR1_CBURSTRW                  ((uint32_t)0x00080000)        /*!<Write burst enable         */
+#define  FMC_BCR1_CCLKEN                    ((uint32_t)0x00100000)        /*!<Continous clock enable     */
+#define  FMC_BCR1_WFDIS                     ((uint32_t)0x00200000)        /*!<Write FIFO Disable         */
+
+/******************  Bit definition for FMC_BCR2 register  *******************/
+#define  FMC_BCR2_MBKEN                     ((uint32_t)0x00000001)        /*!<Memory bank enable bit                 */
+#define  FMC_BCR2_MUXEN                     ((uint32_t)0x00000002)        /*!<Address/data multiplexing enable bit   */
+
+#define  FMC_BCR2_MTYP                      ((uint32_t)0x0000000C)        /*!<MTYP[1:0] bits (Memory type)           */
+#define  FMC_BCR2_MTYP_0                    ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_BCR2_MTYP_1                    ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_BCR2_MWID                      ((uint32_t)0x00000030)        /*!<MWID[1:0] bits (Memory data bus width) */
+#define  FMC_BCR2_MWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BCR2_MWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_BCR2_FACCEN                    ((uint32_t)0x00000040)        /*!<Flash access enable        */
+#define  FMC_BCR2_BURSTEN                   ((uint32_t)0x00000100)        /*!<Burst enable bit           */
+#define  FMC_BCR2_WAITPOL                   ((uint32_t)0x00000200)        /*!<Wait signal polarity bit   */
+#define  FMC_BCR2_WRAPMOD                   ((uint32_t)0x00000400)        /*!<Wrapped burst mode support */
+#define  FMC_BCR2_WAITCFG                   ((uint32_t)0x00000800)        /*!<Wait timing configuration  */
+#define  FMC_BCR2_WREN                      ((uint32_t)0x00001000)        /*!<Write enable bit           */
+#define  FMC_BCR2_WAITEN                    ((uint32_t)0x00002000)        /*!<Wait enable bit            */
+#define  FMC_BCR2_EXTMOD                    ((uint32_t)0x00004000)        /*!<Extended mode enable       */
+#define  FMC_BCR2_ASYNCWAIT                 ((uint32_t)0x00008000)        /*!<Asynchronous wait          */
+#define  FMC_BCR2_CPSIZE                     ((uint32_t)0x00070000)        /*!<CRAM page size             */
+#define  FMC_BCR2_CPSIZE_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BCR2_CPSIZE_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BCR2_CPSIZE_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BCR2_CBURSTRW                  ((uint32_t)0x00080000)        /*!<Write burst enable         */
+
+/******************  Bit definition for FMC_BCR3 register  *******************/
+#define  FMC_BCR3_MBKEN                     ((uint32_t)0x00000001)        /*!<Memory bank enable bit                 */
+#define  FMC_BCR3_MUXEN                     ((uint32_t)0x00000002)        /*!<Address/data multiplexing enable bit   */
+
+#define  FMC_BCR3_MTYP                      ((uint32_t)0x0000000C)        /*!<MTYP[1:0] bits (Memory type)           */
+#define  FMC_BCR3_MTYP_0                    ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_BCR3_MTYP_1                    ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_BCR3_MWID                      ((uint32_t)0x00000030)        /*!<MWID[1:0] bits (Memory data bus width) */
+#define  FMC_BCR3_MWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BCR3_MWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_BCR3_FACCEN                    ((uint32_t)0x00000040)        /*!<Flash access enable        */
+#define  FMC_BCR3_BURSTEN                   ((uint32_t)0x00000100)        /*!<Burst enable bit           */
+#define  FMC_BCR3_WAITPOL                   ((uint32_t)0x00000200)        /*!<Wait signal polarity bit   */
+#define  FMC_BCR3_WRAPMOD                   ((uint32_t)0x00000400)        /*!<Wrapped burst mode support */
+#define  FMC_BCR3_WAITCFG                   ((uint32_t)0x00000800)        /*!<Wait timing configuration  */
+#define  FMC_BCR3_WREN                      ((uint32_t)0x00001000)        /*!<Write enable bit           */
+#define  FMC_BCR3_WAITEN                    ((uint32_t)0x00002000)        /*!<Wait enable bit            */
+#define  FMC_BCR3_EXTMOD                    ((uint32_t)0x00004000)        /*!<Extended mode enable       */
+#define  FMC_BCR3_ASYNCWAIT                 ((uint32_t)0x00008000)        /*!<Asynchronous wait          */
+#define  FMC_BCR3_CPSIZE                     ((uint32_t)0x00070000)        /*!<CRAM page size             */
+#define  FMC_BCR3_CPSIZE_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BCR3_CPSIZE_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BCR3_CPSIZE_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BCR3_CBURSTRW                  ((uint32_t)0x00080000)        /*!<Write burst enable         */
+
+/******************  Bit definition for FMC_BCR4 register  *******************/
+#define  FMC_BCR4_MBKEN                     ((uint32_t)0x00000001)        /*!<Memory bank enable bit                 */
+#define  FMC_BCR4_MUXEN                     ((uint32_t)0x00000002)        /*!<Address/data multiplexing enable bit   */
+
+#define  FMC_BCR4_MTYP                      ((uint32_t)0x0000000C)        /*!<MTYP[1:0] bits (Memory type)           */
+#define  FMC_BCR4_MTYP_0                    ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_BCR4_MTYP_1                    ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_BCR4_MWID                      ((uint32_t)0x00000030)        /*!<MWID[1:0] bits (Memory data bus width) */
+#define  FMC_BCR4_MWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BCR4_MWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_BCR4_FACCEN                    ((uint32_t)0x00000040)        /*!<Flash access enable        */
+#define  FMC_BCR4_BURSTEN                   ((uint32_t)0x00000100)        /*!<Burst enable bit           */
+#define  FMC_BCR4_WAITPOL                   ((uint32_t)0x00000200)        /*!<Wait signal polarity bit   */
+#define  FMC_BCR4_WRAPMOD                   ((uint32_t)0x00000400)        /*!<Wrapped burst mode support */
+#define  FMC_BCR4_WAITCFG                   ((uint32_t)0x00000800)        /*!<Wait timing configuration  */
+#define  FMC_BCR4_WREN                      ((uint32_t)0x00001000)        /*!<Write enable bit           */
+#define  FMC_BCR4_WAITEN                    ((uint32_t)0x00002000)        /*!<Wait enable bit            */
+#define  FMC_BCR4_EXTMOD                    ((uint32_t)0x00004000)        /*!<Extended mode enable       */
+#define  FMC_BCR4_ASYNCWAIT                 ((uint32_t)0x00008000)        /*!<Asynchronous wait          */
+#define  FMC_BCR4_CPSIZE                     ((uint32_t)0x00070000)        /*!<CRAM page size             */
+#define  FMC_BCR4_CPSIZE_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BCR4_CPSIZE_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BCR4_CPSIZE_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BCR4_CBURSTRW                  ((uint32_t)0x00080000)        /*!<Write burst enable         */
+
+/******************  Bit definition for FMC_BTR1 register  ******************/
+#define  FMC_BTR1_ADDSET                    ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BTR1_ADDSET_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BTR1_ADDSET_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BTR1_ADDSET_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BTR1_ADDSET_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BTR1_ADDHLD                    ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration)  */
+#define  FMC_BTR1_ADDHLD_0                  ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BTR1_ADDHLD_1                  ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BTR1_ADDHLD_2                  ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BTR1_ADDHLD_3                  ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BTR1_DATAST                    ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BTR1_DATAST_0                  ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BTR1_DATAST_1                  ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BTR1_DATAST_2                  ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BTR1_DATAST_3                  ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BTR1_DATAST_4                  ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BTR1_DATAST_5                  ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BTR1_DATAST_6                  ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BTR1_DATAST_7                  ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BTR1_BUSTURN                   ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BTR1_BUSTURN_0                 ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BTR1_BUSTURN_1                 ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BTR1_BUSTURN_2                 ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BTR1_BUSTURN_3                 ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BTR1_CLKDIV                    ((uint32_t)0x00F00000)        /*!<CLKDIV[3:0] bits (Clock divide ratio) */
+#define  FMC_BTR1_CLKDIV_0                  ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_BTR1_CLKDIV_1                  ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_BTR1_CLKDIV_2                  ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  FMC_BTR1_CLKDIV_3                  ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+#define  FMC_BTR1_DATLAT                    ((uint32_t)0x0F000000)        /*!<DATLA[3:0] bits (Data latency) */
+#define  FMC_BTR1_DATLAT_0                  ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_BTR1_DATLAT_1                  ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_BTR1_DATLAT_2                  ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_BTR1_DATLAT_3                  ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  FMC_BTR1_ACCMOD                    ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BTR1_ACCMOD_0                  ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BTR1_ACCMOD_1                  ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BTR2 register  *******************/
+#define  FMC_BTR2_ADDSET                    ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BTR2_ADDSET_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BTR2_ADDSET_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BTR2_ADDSET_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BTR2_ADDSET_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BTR2_ADDHLD                    ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BTR2_ADDHLD_0                  ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BTR2_ADDHLD_1                  ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BTR2_ADDHLD_2                  ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BTR2_ADDHLD_3                  ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BTR2_DATAST                    ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BTR2_DATAST_0                  ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BTR2_DATAST_1                  ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BTR2_DATAST_2                  ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BTR2_DATAST_3                  ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BTR2_DATAST_4                  ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BTR2_DATAST_5                  ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BTR2_DATAST_6                  ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BTR2_DATAST_7                  ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BTR2_BUSTURN                   ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BTR2_BUSTURN_0                 ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BTR2_BUSTURN_1                 ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BTR2_BUSTURN_2                 ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BTR2_BUSTURN_3                 ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BTR2_CLKDIV                    ((uint32_t)0x00F00000)        /*!<CLKDIV[3:0] bits (Clock divide ratio) */
+#define  FMC_BTR2_CLKDIV_0                  ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_BTR2_CLKDIV_1                  ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_BTR2_CLKDIV_2                  ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  FMC_BTR2_CLKDIV_3                  ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+#define  FMC_BTR2_DATLAT                    ((uint32_t)0x0F000000)        /*!<DATLA[3:0] bits (Data latency) */
+#define  FMC_BTR2_DATLAT_0                  ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_BTR2_DATLAT_1                  ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_BTR2_DATLAT_2                  ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_BTR2_DATLAT_3                  ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  FMC_BTR2_ACCMOD                    ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BTR2_ACCMOD_0                  ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BTR2_ACCMOD_1                  ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/*******************  Bit definition for FMC_BTR3 register  *******************/
+#define  FMC_BTR3_ADDSET                    ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BTR3_ADDSET_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BTR3_ADDSET_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BTR3_ADDSET_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BTR3_ADDSET_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BTR3_ADDHLD                    ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BTR3_ADDHLD_0                  ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BTR3_ADDHLD_1                  ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BTR3_ADDHLD_2                  ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BTR3_ADDHLD_3                  ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BTR3_DATAST                    ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BTR3_DATAST_0                  ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BTR3_DATAST_1                  ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BTR3_DATAST_2                  ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BTR3_DATAST_3                  ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BTR3_DATAST_4                  ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BTR3_DATAST_5                  ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BTR3_DATAST_6                  ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BTR3_DATAST_7                  ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BTR3_BUSTURN                   ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BTR3_BUSTURN_0                 ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BTR3_BUSTURN_1                 ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BTR3_BUSTURN_2                 ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BTR3_BUSTURN_3                 ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BTR3_CLKDIV                    ((uint32_t)0x00F00000)        /*!<CLKDIV[3:0] bits (Clock divide ratio) */
+#define  FMC_BTR3_CLKDIV_0                  ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_BTR3_CLKDIV_1                  ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_BTR3_CLKDIV_2                  ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  FMC_BTR3_CLKDIV_3                  ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+#define  FMC_BTR3_DATLAT                    ((uint32_t)0x0F000000)        /*!<DATLA[3:0] bits (Data latency) */
+#define  FMC_BTR3_DATLAT_0                  ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_BTR3_DATLAT_1                  ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_BTR3_DATLAT_2                  ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_BTR3_DATLAT_3                  ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  FMC_BTR3_ACCMOD                    ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BTR3_ACCMOD_0                  ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BTR3_ACCMOD_1                  ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BTR4 register  *******************/
+#define  FMC_BTR4_ADDSET                    ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BTR4_ADDSET_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BTR4_ADDSET_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BTR4_ADDSET_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BTR4_ADDSET_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BTR4_ADDHLD                    ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BTR4_ADDHLD_0                  ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BTR4_ADDHLD_1                  ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BTR4_ADDHLD_2                  ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BTR4_ADDHLD_3                  ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BTR4_DATAST                    ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BTR4_DATAST_0                  ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BTR4_DATAST_1                  ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BTR4_DATAST_2                  ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BTR4_DATAST_3                  ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BTR4_DATAST_4                  ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BTR4_DATAST_5                  ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BTR4_DATAST_6                  ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BTR4_DATAST_7                  ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BTR4_BUSTURN                   ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BTR4_BUSTURN_0                 ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BTR4_BUSTURN_1                 ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BTR4_BUSTURN_2                 ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BTR4_BUSTURN_3                 ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BTR4_CLKDIV                    ((uint32_t)0x00F00000)        /*!<CLKDIV[3:0] bits (Clock divide ratio) */
+#define  FMC_BTR4_CLKDIV_0                  ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_BTR4_CLKDIV_1                  ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_BTR4_CLKDIV_2                  ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  FMC_BTR4_CLKDIV_3                  ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+#define  FMC_BTR4_DATLAT                    ((uint32_t)0x0F000000)        /*!<DATLA[3:0] bits (Data latency) */
+#define  FMC_BTR4_DATLAT_0                  ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_BTR4_DATLAT_1                  ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_BTR4_DATLAT_2                  ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_BTR4_DATLAT_3                  ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  FMC_BTR4_ACCMOD                    ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BTR4_ACCMOD_0                  ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BTR4_ACCMOD_1                  ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BWTR1 register  ******************/
+#define  FMC_BWTR1_ADDSET                   ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BWTR1_ADDSET_0                 ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BWTR1_ADDSET_1                 ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BWTR1_ADDSET_2                 ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BWTR1_ADDSET_3                 ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BWTR1_ADDHLD                   ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BWTR1_ADDHLD_0                 ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BWTR1_ADDHLD_1                 ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BWTR1_ADDHLD_2                 ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BWTR1_ADDHLD_3                 ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BWTR1_DATAST                   ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BWTR1_DATAST_0                 ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BWTR1_DATAST_1                 ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BWTR1_DATAST_2                 ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BWTR1_DATAST_3                 ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BWTR1_DATAST_4                 ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BWTR1_DATAST_5                 ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BWTR1_DATAST_6                 ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BWTR1_DATAST_7                 ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BWTR1_BUSTURN                  ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BWTR1_BUSTURN_0                ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BWTR1_BUSTURN_1                ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BWTR1_BUSTURN_2                ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BWTR1_BUSTURN_3                ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BWTR1_ACCMOD                   ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BWTR1_ACCMOD_0                 ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BWTR1_ACCMOD_1                 ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BWTR2 register  ******************/
+#define  FMC_BWTR2_ADDSET                   ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BWTR2_ADDSET_0                 ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BWTR2_ADDSET_1                 ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BWTR2_ADDSET_2                 ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BWTR2_ADDSET_3                 ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BWTR2_ADDHLD                   ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BWTR2_ADDHLD_0                 ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BWTR2_ADDHLD_1                 ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BWTR2_ADDHLD_2                 ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BWTR2_ADDHLD_3                 ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BWTR2_DATAST                   ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BWTR2_DATAST_0                 ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BWTR2_DATAST_1                 ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BWTR2_DATAST_2                 ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BWTR2_DATAST_3                 ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BWTR2_DATAST_4                 ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BWTR2_DATAST_5                 ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BWTR2_DATAST_6                 ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BWTR2_DATAST_7                 ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BWTR2_BUSTURN                  ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BWTR2_BUSTURN_0                ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BWTR2_BUSTURN_1                ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BWTR2_BUSTURN_2                ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BWTR2_BUSTURN_3                ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BWTR2_ACCMOD                   ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BWTR2_ACCMOD_0                 ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BWTR2_ACCMOD_1                 ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BWTR3 register  ******************/
+#define  FMC_BWTR3_ADDSET                   ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BWTR3_ADDSET_0                 ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BWTR3_ADDSET_1                 ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BWTR3_ADDSET_2                 ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BWTR3_ADDSET_3                 ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BWTR3_ADDHLD                   ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BWTR3_ADDHLD_0                 ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BWTR3_ADDHLD_1                 ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BWTR3_ADDHLD_2                 ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BWTR3_ADDHLD_3                 ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BWTR3_DATAST                   ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BWTR3_DATAST_0                 ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BWTR3_DATAST_1                 ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BWTR3_DATAST_2                 ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BWTR3_DATAST_3                 ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BWTR3_DATAST_4                 ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BWTR3_DATAST_5                 ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BWTR3_DATAST_6                 ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BWTR3_DATAST_7                 ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BWTR3_BUSTURN                  ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BWTR3_BUSTURN_0                ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BWTR3_BUSTURN_1                ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BWTR3_BUSTURN_2                ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BWTR3_BUSTURN_3                ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BWTR3_ACCMOD                   ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BWTR3_ACCMOD_0                 ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BWTR3_ACCMOD_1                 ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BWTR4 register  ******************/
+#define  FMC_BWTR4_ADDSET                   ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BWTR4_ADDSET_0                 ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BWTR4_ADDSET_1                 ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BWTR4_ADDSET_2                 ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BWTR4_ADDSET_3                 ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BWTR4_ADDHLD                   ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BWTR4_ADDHLD_0                 ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BWTR4_ADDHLD_1                 ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BWTR4_ADDHLD_2                 ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BWTR4_ADDHLD_3                 ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BWTR4_DATAST                   ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BWTR4_DATAST_0                 ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BWTR4_DATAST_1                 ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BWTR4_DATAST_2                 ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BWTR4_DATAST_3                 ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BWTR4_DATAST_4                 ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BWTR4_DATAST_5                 ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BWTR4_DATAST_6                 ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BWTR4_DATAST_7                 ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BWTR4_BUSTURN                  ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BWTR4_BUSTURN_0                ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BWTR4_BUSTURN_1                ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BWTR4_BUSTURN_2                ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BWTR4_BUSTURN_3                ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BWTR4_ACCMOD                   ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BWTR4_ACCMOD_0                 ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BWTR4_ACCMOD_1                 ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_PCR register  *******************/
+#define  FMC_PCR_PWAITEN                   ((uint32_t)0x00000002)        /*!<Wait feature enable bit                   */
+#define  FMC_PCR_PBKEN                     ((uint32_t)0x00000004)        /*!<PC Card/NAND Flash memory bank enable bit */
+#define  FMC_PCR_PTYP                      ((uint32_t)0x00000008)        /*!<Memory type                               */
+
+#define  FMC_PCR_PWID                      ((uint32_t)0x00000030)        /*!<PWID[1:0] bits (NAND Flash databus width) */
+#define  FMC_PCR_PWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_PCR_PWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_PCR_ECCEN                     ((uint32_t)0x00000040)        /*!<ECC computation logic enable bit          */
+
+#define  FMC_PCR_TCLR                      ((uint32_t)0x00001E00)        /*!<TCLR[3:0] bits (CLE to RE delay)          */
+#define  FMC_PCR_TCLR_0                    ((uint32_t)0x00000200)        /*!<Bit 0 */
+#define  FMC_PCR_TCLR_1                    ((uint32_t)0x00000400)        /*!<Bit 1 */
+#define  FMC_PCR_TCLR_2                    ((uint32_t)0x00000800)        /*!<Bit 2 */
+#define  FMC_PCR_TCLR_3                    ((uint32_t)0x00001000)        /*!<Bit 3 */
+
+#define  FMC_PCR_TAR                       ((uint32_t)0x0001E000)        /*!<TAR[3:0] bits (ALE to RE delay)           */
+#define  FMC_PCR_TAR_0                     ((uint32_t)0x00002000)        /*!<Bit 0 */
+#define  FMC_PCR_TAR_1                     ((uint32_t)0x00004000)        /*!<Bit 1 */
+#define  FMC_PCR_TAR_2                     ((uint32_t)0x00008000)        /*!<Bit 2 */
+#define  FMC_PCR_TAR_3                     ((uint32_t)0x00010000)        /*!<Bit 3 */
+
+#define  FMC_PCR_ECCPS                     ((uint32_t)0x000E0000)        /*!<ECCPS[2:0] bits (ECC page size)           */
+#define  FMC_PCR_ECCPS_0                   ((uint32_t)0x00020000)        /*!<Bit 0 */
+#define  FMC_PCR_ECCPS_1                   ((uint32_t)0x00040000)        /*!<Bit 1 */
+#define  FMC_PCR_ECCPS_2                   ((uint32_t)0x00080000)        /*!<Bit 2 */
+
+/*******************  Bit definition for FMC_SR register  *******************/
+#define  FMC_SR_IRS                        ((uint32_t)0x01)              /*!<Interrupt Rising Edge status                */
+#define  FMC_SR_ILS                        ((uint32_t)0x02)              /*!<Interrupt Level status                      */
+#define  FMC_SR_IFS                        ((uint32_t)0x04)              /*!<Interrupt Falling Edge status               */
+#define  FMC_SR_IREN                       ((uint32_t)0x08)              /*!<Interrupt Rising Edge detection Enable bit  */
+#define  FMC_SR_ILEN                       ((uint32_t)0x10)              /*!<Interrupt Level detection Enable bit        */
+#define  FMC_SR_IFEN                       ((uint32_t)0x20)              /*!<Interrupt Falling Edge detection Enable bit */
+#define  FMC_SR_FEMPT                      ((uint32_t)0x40)              /*!<FIFO empty                                  */
+
+/******************  Bit definition for FMC_PMEM register  ******************/
+#define  FMC_PMEM_MEMSET3                  ((uint32_t)0x000000FF)        /*!<MEMSET3[7:0] bits (Common memory 3 setup time) */
+#define  FMC_PMEM_MEMSET3_0                ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_PMEM_MEMSET3_1                ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_PMEM_MEMSET3_2                ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_PMEM_MEMSET3_3                ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  FMC_PMEM_MEMSET3_4                ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  FMC_PMEM_MEMSET3_5                ((uint32_t)0x00000020)        /*!<Bit 5 */
+#define  FMC_PMEM_MEMSET3_6                ((uint32_t)0x00000040)        /*!<Bit 6 */
+#define  FMC_PMEM_MEMSET3_7                ((uint32_t)0x00000080)        /*!<Bit 7 */
+
+#define  FMC_PMEM_MEMWAIT3                 ((uint32_t)0x0000FF00)        /*!<MEMWAIT3[7:0] bits (Common memory 3 wait time) */
+#define  FMC_PMEM_MEMWAIT3_0               ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_PMEM_MEMWAIT3_1               ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_PMEM_MEMWAIT3_2               ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_PMEM_MEMWAIT3_3               ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_PMEM_MEMWAIT3_4               ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_PMEM_MEMWAIT3_5               ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_PMEM_MEMWAIT3_6               ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_PMEM_MEMWAIT3_7               ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_PMEM_MEMHOLD3                 ((uint32_t)0x00FF0000)        /*!<MEMHOLD3[7:0] bits (Common memory 3 hold time) */
+#define  FMC_PMEM_MEMHOLD3_0               ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_PMEM_MEMHOLD3_1               ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_PMEM_MEMHOLD3_2               ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_PMEM_MEMHOLD3_3               ((uint32_t)0x00080000)        /*!<Bit 3 */
+#define  FMC_PMEM_MEMHOLD3_4               ((uint32_t)0x00100000)        /*!<Bit 4 */
+#define  FMC_PMEM_MEMHOLD3_5               ((uint32_t)0x00200000)        /*!<Bit 5 */
+#define  FMC_PMEM_MEMHOLD3_6               ((uint32_t)0x00400000)        /*!<Bit 6 */
+#define  FMC_PMEM_MEMHOLD3_7               ((uint32_t)0x00800000)        /*!<Bit 7 */
+
+#define  FMC_PMEM_MEMHIZ3                  ((uint32_t)0xFF000000)        /*!<MEMHIZ3[7:0] bits (Common memory 3 databus HiZ time) */
+#define  FMC_PMEM_MEMHIZ3_0                ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_PMEM_MEMHIZ3_1                ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_PMEM_MEMHIZ3_2                ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_PMEM_MEMHIZ3_3                ((uint32_t)0x08000000)        /*!<Bit 3 */
+#define  FMC_PMEM_MEMHIZ3_4                ((uint32_t)0x10000000)        /*!<Bit 4 */
+#define  FMC_PMEM_MEMHIZ3_5                ((uint32_t)0x20000000)        /*!<Bit 5 */
+#define  FMC_PMEM_MEMHIZ3_6                ((uint32_t)0x40000000)        /*!<Bit 6 */
+#define  FMC_PMEM_MEMHIZ3_7                ((uint32_t)0x80000000)        /*!<Bit 7 */
+
+/******************  Bit definition for FMC_PATT register  ******************/
+#define  FMC_PATT_ATTSET3                  ((uint32_t)0x000000FF)        /*!<ATTSET3[7:0] bits (Attribute memory 3 setup time) */
+#define  FMC_PATT_ATTSET3_0                ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_PATT_ATTSET3_1                ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_PATT_ATTSET3_2                ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_PATT_ATTSET3_3                ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  FMC_PATT_ATTSET3_4                ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  FMC_PATT_ATTSET3_5                ((uint32_t)0x00000020)        /*!<Bit 5 */
+#define  FMC_PATT_ATTSET3_6                ((uint32_t)0x00000040)        /*!<Bit 6 */
+#define  FMC_PATT_ATTSET3_7                ((uint32_t)0x00000080)        /*!<Bit 7 */
+
+#define  FMC_PATT_ATTWAIT3                 ((uint32_t)0x0000FF00)        /*!<ATTWAIT3[7:0] bits (Attribute memory 3 wait time) */
+#define  FMC_PATT_ATTWAIT3_0               ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_PATT_ATTWAIT3_1               ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_PATT_ATTWAIT3_2               ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_PATT_ATTWAIT3_3               ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_PATT_ATTWAIT3_4               ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_PATT_ATTWAIT3_5               ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_PATT_ATTWAIT3_6               ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_PATT_ATTWAIT3_7               ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_PATT_ATTHOLD3                 ((uint32_t)0x00FF0000)        /*!<ATTHOLD3[7:0] bits (Attribute memory 3 hold time) */
+#define  FMC_PATT_ATTHOLD3_0               ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_PATT_ATTHOLD3_1               ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_PATT_ATTHOLD3_2               ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_PATT_ATTHOLD3_3               ((uint32_t)0x00080000)        /*!<Bit 3 */
+#define  FMC_PATT_ATTHOLD3_4               ((uint32_t)0x00100000)        /*!<Bit 4 */
+#define  FMC_PATT_ATTHOLD3_5               ((uint32_t)0x00200000)        /*!<Bit 5 */
+#define  FMC_PATT_ATTHOLD3_6               ((uint32_t)0x00400000)        /*!<Bit 6 */
+#define  FMC_PATT_ATTHOLD3_7               ((uint32_t)0x00800000)        /*!<Bit 7 */
+
+#define  FMC_PATT_ATTHIZ3                  ((uint32_t)0xFF000000)        /*!<ATTHIZ3[7:0] bits (Attribute memory 3 databus HiZ time) */
+#define  FMC_PATT_ATTHIZ3_0                ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_PATT_ATTHIZ3_1                ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_PATT_ATTHIZ3_2                ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_PATT_ATTHIZ3_3                ((uint32_t)0x08000000)        /*!<Bit 3 */
+#define  FMC_PATT_ATTHIZ3_4                ((uint32_t)0x10000000)        /*!<Bit 4 */
+#define  FMC_PATT_ATTHIZ3_5                ((uint32_t)0x20000000)        /*!<Bit 5 */
+#define  FMC_PATT_ATTHIZ3_6                ((uint32_t)0x40000000)        /*!<Bit 6 */
+#define  FMC_PATT_ATTHIZ3_7                ((uint32_t)0x80000000)        /*!<Bit 7 */
+
+/******************  Bit definition for FMC_ECCR register  ******************/
+#define  FMC_ECCR_ECC3                     ((uint32_t)0xFFFFFFFF)        /*!<ECC result */
+
+/******************  Bit definition for FMC_SDCR1 register  ******************/
+#define  FMC_SDCR1_NC                       ((uint32_t)0x00000003)        /*!<NC[1:0] bits (Number of column bits) */
+#define  FMC_SDCR1_NC_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDCR1_NC_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_NR                       ((uint32_t)0x0000000C)        /*!<NR[1:0] bits (Number of row bits) */
+#define  FMC_SDCR1_NR_0                     ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_SDCR1_NR_1                     ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_MWID                     ((uint32_t)0x00000030)        /*!<NR[1:0] bits (Number of row bits) */
+#define  FMC_SDCR1_MWID_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_SDCR1_MWID_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_NB                       ((uint32_t)0x00000040)        /*!<Number of internal bank */
+
+#define  FMC_SDCR1_CAS                      ((uint32_t)0x00000180)        /*!<CAS[1:0] bits (CAS latency) */
+#define  FMC_SDCR1_CAS_0                    ((uint32_t)0x00000080)        /*!<Bit 0 */
+#define  FMC_SDCR1_CAS_1                    ((uint32_t)0x00000100)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_WP                       ((uint32_t)0x00000200)        /*!<Write protection */
+
+#define  FMC_SDCR1_SDCLK                    ((uint32_t)0x00000C00)        /*!<SDRAM clock configuration */
+#define  FMC_SDCR1_SDCLK_0                  ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  FMC_SDCR1_SDCLK_1                  ((uint32_t)0x00000800)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_RBURST                   ((uint32_t)0x00001000)        /*!<Read burst */
+
+#define  FMC_SDCR1_RPIPE                    ((uint32_t)0x00006000)        /*!<Write protection */
+#define  FMC_SDCR1_RPIPE_0                  ((uint32_t)0x00002000)        /*!<Bit 0 */
+#define  FMC_SDCR1_RPIPE_1                  ((uint32_t)0x00004000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_SDCR2 register  ******************/
+#define  FMC_SDCR2_NC                       ((uint32_t)0x00000003)        /*!<NC[1:0] bits (Number of column bits) */
+#define  FMC_SDCR2_NC_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDCR2_NC_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_NR                       ((uint32_t)0x0000000C)        /*!<NR[1:0] bits (Number of row bits) */
+#define  FMC_SDCR2_NR_0                     ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_SDCR2_NR_1                     ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_MWID                     ((uint32_t)0x00000030)        /*!<NR[1:0] bits (Number of row bits) */
+#define  FMC_SDCR2_MWID_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_SDCR2_MWID_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_NB                       ((uint32_t)0x00000040)        /*!<Number of internal bank */
+
+#define  FMC_SDCR2_CAS                      ((uint32_t)0x00000180)        /*!<CAS[1:0] bits (CAS latency) */
+#define  FMC_SDCR2_CAS_0                    ((uint32_t)0x00000080)        /*!<Bit 0 */
+#define  FMC_SDCR2_CAS_1                    ((uint32_t)0x00000100)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_WP                       ((uint32_t)0x00000200)        /*!<Write protection */
+
+#define  FMC_SDCR2_SDCLK                    ((uint32_t)0x00000C00)        /*!<SDCLK[1:0] (SDRAM clock configuration) */
+#define  FMC_SDCR2_SDCLK_0                  ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  FMC_SDCR2_SDCLK_1                  ((uint32_t)0x00000800)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_RBURST                   ((uint32_t)0x00001000)        /*!<Read burst */
+
+#define  FMC_SDCR2_RPIPE                    ((uint32_t)0x00006000)        /*!<RPIPE[1:0](Read pipe) */
+#define  FMC_SDCR2_RPIPE_0                  ((uint32_t)0x00002000)        /*!<Bit 0 */
+#define  FMC_SDCR2_RPIPE_1                  ((uint32_t)0x00004000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_SDTR1 register  ******************/
+#define  FMC_SDTR1_TMRD                     ((uint32_t)0x0000000F)        /*!<TMRD[3:0] bits (Load mode register to active) */
+#define  FMC_SDTR1_TMRD_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDTR1_TMRD_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_SDTR1_TMRD_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_SDTR1_TMRD_3                   ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_SDTR1_TXSR                     ((uint32_t)0x000000F0)        /*!<TXSR[3:0] bits (Exit self refresh) */
+#define  FMC_SDTR1_TXSR_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_SDTR1_TXSR_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_SDTR1_TXSR_2                   ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_SDTR1_TXSR_3                   ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_SDTR1_TRAS                     ((uint32_t)0x00000F00)        /*!<TRAS[3:0] bits (Self refresh time) */
+#define  FMC_SDTR1_TRAS_0                   ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_SDTR1_TRAS_1                   ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_SDTR1_TRAS_2                   ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_SDTR1_TRAS_3                   ((uint32_t)0x00000800)        /*!<Bit 3 */
+
+#define  FMC_SDTR1_TRC                      ((uint32_t)0x0000F000)        /*!<TRC[2:0] bits (Row cycle delay) */
+#define  FMC_SDTR1_TRC_0                    ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  FMC_SDTR1_TRC_1                    ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  FMC_SDTR1_TRC_2                    ((uint32_t)0x00004000)        /*!<Bit 2 */
+
+#define  FMC_SDTR1_TWR                      ((uint32_t)0x000F0000)        /*!<TRC[2:0] bits (Write recovery delay) */
+#define  FMC_SDTR1_TWR_0                    ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_SDTR1_TWR_1                    ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_SDTR1_TWR_2                    ((uint32_t)0x00040000)        /*!<Bit 2 */
+
+#define  FMC_SDTR1_TRP                      ((uint32_t)0x00F00000)        /*!<TRP[2:0] bits (Row precharge delay) */
+#define  FMC_SDTR1_TRP_0                    ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_SDTR1_TRP_1                    ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_SDTR1_TRP_2                    ((uint32_t)0x00400000)        /*!<Bit 2 */
+
+#define  FMC_SDTR1_TRCD                     ((uint32_t)0x0F000000)        /*!<TRP[2:0] bits (Row to column delay) */
+#define  FMC_SDTR1_TRCD_0                   ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_SDTR1_TRCD_1                   ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_SDTR1_TRCD_2                   ((uint32_t)0x04000000)        /*!<Bit 2 */
+
+/******************  Bit definition for FMC_SDTR2 register  ******************/
+#define  FMC_SDTR2_TMRD                     ((uint32_t)0x0000000F)        /*!<TMRD[3:0] bits (Load mode register to active) */
+#define  FMC_SDTR2_TMRD_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDTR2_TMRD_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_SDTR2_TMRD_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_SDTR2_TMRD_3                   ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_SDTR2_TXSR                     ((uint32_t)0x000000F0)        /*!<TXSR[3:0] bits (Exit self refresh) */
+#define  FMC_SDTR2_TXSR_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_SDTR2_TXSR_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_SDTR2_TXSR_2                   ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_SDTR2_TXSR_3                   ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_SDTR2_TRAS                     ((uint32_t)0x00000F00)        /*!<TRAS[3:0] bits (Self refresh time) */
+#define  FMC_SDTR2_TRAS_0                   ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_SDTR2_TRAS_1                   ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_SDTR2_TRAS_2                   ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_SDTR2_TRAS_3                   ((uint32_t)0x00000800)        /*!<Bit 3 */
+
+#define  FMC_SDTR2_TRC                      ((uint32_t)0x0000F000)        /*!<TRC[2:0] bits (Row cycle delay) */
+#define  FMC_SDTR2_TRC_0                    ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  FMC_SDTR2_TRC_1                    ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  FMC_SDTR2_TRC_2                    ((uint32_t)0x00004000)        /*!<Bit 2 */
+
+#define  FMC_SDTR2_TWR                      ((uint32_t)0x000F0000)        /*!<TRC[2:0] bits (Write recovery delay) */
+#define  FMC_SDTR2_TWR_0                    ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_SDTR2_TWR_1                    ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_SDTR2_TWR_2                    ((uint32_t)0x00040000)        /*!<Bit 2 */
+
+#define  FMC_SDTR2_TRP                      ((uint32_t)0x00F00000)        /*!<TRP[2:0] bits (Row precharge delay) */
+#define  FMC_SDTR2_TRP_0                    ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_SDTR2_TRP_1                    ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_SDTR2_TRP_2                    ((uint32_t)0x00400000)        /*!<Bit 2 */
+
+#define  FMC_SDTR2_TRCD                     ((uint32_t)0x0F000000)        /*!<TRP[2:0] bits (Row to column delay) */
+#define  FMC_SDTR2_TRCD_0                   ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_SDTR2_TRCD_1                   ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_SDTR2_TRCD_2                   ((uint32_t)0x04000000)        /*!<Bit 2 */
+
+/******************  Bit definition for FMC_SDCMR register  ******************/
+#define  FMC_SDCMR_MODE                     ((uint32_t)0x00000007)        /*!<MODE[2:0] bits (Command mode) */
+#define  FMC_SDCMR_MODE_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDCMR_MODE_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_SDCMR_MODE_2                   ((uint32_t)0x00000003)        /*!<Bit 2 */
+
+#define  FMC_SDCMR_CTB2                     ((uint32_t)0x00000008)        /*!<Command target 2 */
+
+#define  FMC_SDCMR_CTB1                     ((uint32_t)0x00000010)        /*!<Command target 1 */
+
+#define  FMC_SDCMR_NRFS                     ((uint32_t)0x000001E0)        /*!<NRFS[3:0] bits (Number of auto-refresh) */
+#define  FMC_SDCMR_NRFS_0                   ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  FMC_SDCMR_NRFS_1                   ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  FMC_SDCMR_NRFS_2                   ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  FMC_SDCMR_NRFS_3                   ((uint32_t)0x00000100)        /*!<Bit 3 */
+
+#define  FMC_SDCMR_MRD                      ((uint32_t)0x003FFE00)        /*!<MRD[12:0] bits (Mode register definition) */
+
+/******************  Bit definition for FMC_SDRTR register  ******************/
+#define  FMC_SDRTR_CRE                      ((uint32_t)0x00000001)        /*!<Clear refresh error flag */
+
+#define  FMC_SDRTR_COUNT                    ((uint32_t)0x00003FFE)        /*!<COUNT[12:0] bits (Refresh timer count) */
+
+#define  FMC_SDRTR_REIE                     ((uint32_t)0x00004000)        /*!<RES interupt enable */
+
+/******************  Bit definition for FMC_SDSR register  ******************/
+#define  FMC_SDSR_RE                        ((uint32_t)0x00000001)        /*!<Refresh error flag */
+
+#define  FMC_SDSR_MODES1                    ((uint32_t)0x00000006)        /*!<MODES1[1:0]bits (Status mode for bank 1) */
+#define  FMC_SDSR_MODES1_0                  ((uint32_t)0x00000002)        /*!<Bit 0 */
+#define  FMC_SDSR_MODES1_1                  ((uint32_t)0x00000004)        /*!<Bit 1 */
+
+#define  FMC_SDSR_MODES2                    ((uint32_t)0x00000018)        /*!<MODES2[1:0]bits (Status mode for bank 2) */
+#define  FMC_SDSR_MODES2_0                  ((uint32_t)0x00000008)        /*!<Bit 0 */
+#define  FMC_SDSR_MODES2_1                  ((uint32_t)0x00000010)        /*!<Bit 1 */
+
+#define  FMC_SDSR_BUSY                      ((uint32_t)0x00000020)        /*!<Busy status */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            General Purpose I/O                             */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bits definition for GPIO_MODER register  *****************/
+#define GPIO_MODER_MODER0                    ((uint32_t)0x00000003)
+#define GPIO_MODER_MODER0_0                  ((uint32_t)0x00000001)
+#define GPIO_MODER_MODER0_1                  ((uint32_t)0x00000002)
+
+#define GPIO_MODER_MODER1                    ((uint32_t)0x0000000C)
+#define GPIO_MODER_MODER1_0                  ((uint32_t)0x00000004)
+#define GPIO_MODER_MODER1_1                  ((uint32_t)0x00000008)
+
+#define GPIO_MODER_MODER2                    ((uint32_t)0x00000030)
+#define GPIO_MODER_MODER2_0                  ((uint32_t)0x00000010)
+#define GPIO_MODER_MODER2_1                  ((uint32_t)0x00000020)
+
+#define GPIO_MODER_MODER3                    ((uint32_t)0x000000C0)
+#define GPIO_MODER_MODER3_0                  ((uint32_t)0x00000040)
+#define GPIO_MODER_MODER3_1                  ((uint32_t)0x00000080)
+
+#define GPIO_MODER_MODER4                    ((uint32_t)0x00000300)
+#define GPIO_MODER_MODER4_0                  ((uint32_t)0x00000100)
+#define GPIO_MODER_MODER4_1                  ((uint32_t)0x00000200)
+
+#define GPIO_MODER_MODER5                    ((uint32_t)0x00000C00)
+#define GPIO_MODER_MODER5_0                  ((uint32_t)0x00000400)
+#define GPIO_MODER_MODER5_1                  ((uint32_t)0x00000800)
+
+#define GPIO_MODER_MODER6                    ((uint32_t)0x00003000)
+#define GPIO_MODER_MODER6_0                  ((uint32_t)0x00001000)
+#define GPIO_MODER_MODER6_1                  ((uint32_t)0x00002000)
+
+#define GPIO_MODER_MODER7                    ((uint32_t)0x0000C000)
+#define GPIO_MODER_MODER7_0                  ((uint32_t)0x00004000)
+#define GPIO_MODER_MODER7_1                  ((uint32_t)0x00008000)
+
+#define GPIO_MODER_MODER8                    ((uint32_t)0x00030000)
+#define GPIO_MODER_MODER8_0                  ((uint32_t)0x00010000)
+#define GPIO_MODER_MODER8_1                  ((uint32_t)0x00020000)
+
+#define GPIO_MODER_MODER9                    ((uint32_t)0x000C0000)
+#define GPIO_MODER_MODER9_0                  ((uint32_t)0x00040000)
+#define GPIO_MODER_MODER9_1                  ((uint32_t)0x00080000)
+
+#define GPIO_MODER_MODER10                   ((uint32_t)0x00300000)
+#define GPIO_MODER_MODER10_0                 ((uint32_t)0x00100000)
+#define GPIO_MODER_MODER10_1                 ((uint32_t)0x00200000)
+
+#define GPIO_MODER_MODER11                   ((uint32_t)0x00C00000)
+#define GPIO_MODER_MODER11_0                 ((uint32_t)0x00400000)
+#define GPIO_MODER_MODER11_1                 ((uint32_t)0x00800000)
+
+#define GPIO_MODER_MODER12                   ((uint32_t)0x03000000)
+#define GPIO_MODER_MODER12_0                 ((uint32_t)0x01000000)
+#define GPIO_MODER_MODER12_1                 ((uint32_t)0x02000000)
+
+#define GPIO_MODER_MODER13                   ((uint32_t)0x0C000000)
+#define GPIO_MODER_MODER13_0                 ((uint32_t)0x04000000)
+#define GPIO_MODER_MODER13_1                 ((uint32_t)0x08000000)
+
+#define GPIO_MODER_MODER14                   ((uint32_t)0x30000000)
+#define GPIO_MODER_MODER14_0                 ((uint32_t)0x10000000)
+#define GPIO_MODER_MODER14_1                 ((uint32_t)0x20000000)
+
+#define GPIO_MODER_MODER15                   ((uint32_t)0xC0000000)
+#define GPIO_MODER_MODER15_0                 ((uint32_t)0x40000000)
+#define GPIO_MODER_MODER15_1                 ((uint32_t)0x80000000)
+
+/******************  Bits definition for GPIO_OTYPER register  ****************/
+#define GPIO_OTYPER_OT_0                     ((uint32_t)0x00000001)
+#define GPIO_OTYPER_OT_1                     ((uint32_t)0x00000002)
+#define GPIO_OTYPER_OT_2                     ((uint32_t)0x00000004)
+#define GPIO_OTYPER_OT_3                     ((uint32_t)0x00000008)
+#define GPIO_OTYPER_OT_4                     ((uint32_t)0x00000010)
+#define GPIO_OTYPER_OT_5                     ((uint32_t)0x00000020)
+#define GPIO_OTYPER_OT_6                     ((uint32_t)0x00000040)
+#define GPIO_OTYPER_OT_7                     ((uint32_t)0x00000080)
+#define GPIO_OTYPER_OT_8                     ((uint32_t)0x00000100)
+#define GPIO_OTYPER_OT_9                     ((uint32_t)0x00000200)
+#define GPIO_OTYPER_OT_10                    ((uint32_t)0x00000400)
+#define GPIO_OTYPER_OT_11                    ((uint32_t)0x00000800)
+#define GPIO_OTYPER_OT_12                    ((uint32_t)0x00001000)
+#define GPIO_OTYPER_OT_13                    ((uint32_t)0x00002000)
+#define GPIO_OTYPER_OT_14                    ((uint32_t)0x00004000)
+#define GPIO_OTYPER_OT_15                    ((uint32_t)0x00008000)
+
+/******************  Bits definition for GPIO_OSPEEDR register  ***************/
+#define GPIO_OSPEEDER_OSPEEDR0               ((uint32_t)0x00000003)
+#define GPIO_OSPEEDER_OSPEEDR0_0             ((uint32_t)0x00000001)
+#define GPIO_OSPEEDER_OSPEEDR0_1             ((uint32_t)0x00000002)
+
+#define GPIO_OSPEEDER_OSPEEDR1               ((uint32_t)0x0000000C)
+#define GPIO_OSPEEDER_OSPEEDR1_0             ((uint32_t)0x00000004)
+#define GPIO_OSPEEDER_OSPEEDR1_1             ((uint32_t)0x00000008)
+
+#define GPIO_OSPEEDER_OSPEEDR2               ((uint32_t)0x00000030)
+#define GPIO_OSPEEDER_OSPEEDR2_0             ((uint32_t)0x00000010)
+#define GPIO_OSPEEDER_OSPEEDR2_1             ((uint32_t)0x00000020)
+
+#define GPIO_OSPEEDER_OSPEEDR3               ((uint32_t)0x000000C0)
+#define GPIO_OSPEEDER_OSPEEDR3_0             ((uint32_t)0x00000040)
+#define GPIO_OSPEEDER_OSPEEDR3_1             ((uint32_t)0x00000080)
+
+#define GPIO_OSPEEDER_OSPEEDR4               ((uint32_t)0x00000300)
+#define GPIO_OSPEEDER_OSPEEDR4_0             ((uint32_t)0x00000100)
+#define GPIO_OSPEEDER_OSPEEDR4_1             ((uint32_t)0x00000200)
+
+#define GPIO_OSPEEDER_OSPEEDR5               ((uint32_t)0x00000C00)
+#define GPIO_OSPEEDER_OSPEEDR5_0             ((uint32_t)0x00000400)
+#define GPIO_OSPEEDER_OSPEEDR5_1             ((uint32_t)0x00000800)
+
+#define GPIO_OSPEEDER_OSPEEDR6               ((uint32_t)0x00003000)
+#define GPIO_OSPEEDER_OSPEEDR6_0             ((uint32_t)0x00001000)
+#define GPIO_OSPEEDER_OSPEEDR6_1             ((uint32_t)0x00002000)
+
+#define GPIO_OSPEEDER_OSPEEDR7               ((uint32_t)0x0000C000)
+#define GPIO_OSPEEDER_OSPEEDR7_0             ((uint32_t)0x00004000)
+#define GPIO_OSPEEDER_OSPEEDR7_1             ((uint32_t)0x00008000)
+
+#define GPIO_OSPEEDER_OSPEEDR8               ((uint32_t)0x00030000)
+#define GPIO_OSPEEDER_OSPEEDR8_0             ((uint32_t)0x00010000)
+#define GPIO_OSPEEDER_OSPEEDR8_1             ((uint32_t)0x00020000)
+
+#define GPIO_OSPEEDER_OSPEEDR9               ((uint32_t)0x000C0000)
+#define GPIO_OSPEEDER_OSPEEDR9_0             ((uint32_t)0x00040000)
+#define GPIO_OSPEEDER_OSPEEDR9_1             ((uint32_t)0x00080000)
+
+#define GPIO_OSPEEDER_OSPEEDR10              ((uint32_t)0x00300000)
+#define GPIO_OSPEEDER_OSPEEDR10_0            ((uint32_t)0x00100000)
+#define GPIO_OSPEEDER_OSPEEDR10_1            ((uint32_t)0x00200000)
+
+#define GPIO_OSPEEDER_OSPEEDR11              ((uint32_t)0x00C00000)
+#define GPIO_OSPEEDER_OSPEEDR11_0            ((uint32_t)0x00400000)
+#define GPIO_OSPEEDER_OSPEEDR11_1            ((uint32_t)0x00800000)
+
+#define GPIO_OSPEEDER_OSPEEDR12              ((uint32_t)0x03000000)
+#define GPIO_OSPEEDER_OSPEEDR12_0            ((uint32_t)0x01000000)
+#define GPIO_OSPEEDER_OSPEEDR12_1            ((uint32_t)0x02000000)
+
+#define GPIO_OSPEEDER_OSPEEDR13              ((uint32_t)0x0C000000)
+#define GPIO_OSPEEDER_OSPEEDR13_0            ((uint32_t)0x04000000)
+#define GPIO_OSPEEDER_OSPEEDR13_1            ((uint32_t)0x08000000)
+
+#define GPIO_OSPEEDER_OSPEEDR14              ((uint32_t)0x30000000)
+#define GPIO_OSPEEDER_OSPEEDR14_0            ((uint32_t)0x10000000)
+#define GPIO_OSPEEDER_OSPEEDR14_1            ((uint32_t)0x20000000)
+
+#define GPIO_OSPEEDER_OSPEEDR15              ((uint32_t)0xC0000000)
+#define GPIO_OSPEEDER_OSPEEDR15_0            ((uint32_t)0x40000000)
+#define GPIO_OSPEEDER_OSPEEDR15_1            ((uint32_t)0x80000000)
+
+/******************  Bits definition for GPIO_PUPDR register  *****************/
+#define GPIO_PUPDR_PUPDR0                    ((uint32_t)0x00000003)
+#define GPIO_PUPDR_PUPDR0_0                  ((uint32_t)0x00000001)
+#define GPIO_PUPDR_PUPDR0_1                  ((uint32_t)0x00000002)
+
+#define GPIO_PUPDR_PUPDR1                    ((uint32_t)0x0000000C)
+#define GPIO_PUPDR_PUPDR1_0                  ((uint32_t)0x00000004)
+#define GPIO_PUPDR_PUPDR1_1                  ((uint32_t)0x00000008)
+
+#define GPIO_PUPDR_PUPDR2                    ((uint32_t)0x00000030)
+#define GPIO_PUPDR_PUPDR2_0                  ((uint32_t)0x00000010)
+#define GPIO_PUPDR_PUPDR2_1                  ((uint32_t)0x00000020)
+
+#define GPIO_PUPDR_PUPDR3                    ((uint32_t)0x000000C0)
+#define GPIO_PUPDR_PUPDR3_0                  ((uint32_t)0x00000040)
+#define GPIO_PUPDR_PUPDR3_1                  ((uint32_t)0x00000080)
+
+#define GPIO_PUPDR_PUPDR4                    ((uint32_t)0x00000300)
+#define GPIO_PUPDR_PUPDR4_0                  ((uint32_t)0x00000100)
+#define GPIO_PUPDR_PUPDR4_1                  ((uint32_t)0x00000200)
+
+#define GPIO_PUPDR_PUPDR5                    ((uint32_t)0x00000C00)
+#define GPIO_PUPDR_PUPDR5_0                  ((uint32_t)0x00000400)
+#define GPIO_PUPDR_PUPDR5_1                  ((uint32_t)0x00000800)
+
+#define GPIO_PUPDR_PUPDR6                    ((uint32_t)0x00003000)
+#define GPIO_PUPDR_PUPDR6_0                  ((uint32_t)0x00001000)
+#define GPIO_PUPDR_PUPDR6_1                  ((uint32_t)0x00002000)
+
+#define GPIO_PUPDR_PUPDR7                    ((uint32_t)0x0000C000)
+#define GPIO_PUPDR_PUPDR7_0                  ((uint32_t)0x00004000)
+#define GPIO_PUPDR_PUPDR7_1                  ((uint32_t)0x00008000)
+
+#define GPIO_PUPDR_PUPDR8                    ((uint32_t)0x00030000)
+#define GPIO_PUPDR_PUPDR8_0                  ((uint32_t)0x00010000)
+#define GPIO_PUPDR_PUPDR8_1                  ((uint32_t)0x00020000)
+
+#define GPIO_PUPDR_PUPDR9                    ((uint32_t)0x000C0000)
+#define GPIO_PUPDR_PUPDR9_0                  ((uint32_t)0x00040000)
+#define GPIO_PUPDR_PUPDR9_1                  ((uint32_t)0x00080000)
+
+#define GPIO_PUPDR_PUPDR10                   ((uint32_t)0x00300000)
+#define GPIO_PUPDR_PUPDR10_0                 ((uint32_t)0x00100000)
+#define GPIO_PUPDR_PUPDR10_1                 ((uint32_t)0x00200000)
+
+#define GPIO_PUPDR_PUPDR11                   ((uint32_t)0x00C00000)
+#define GPIO_PUPDR_PUPDR11_0                 ((uint32_t)0x00400000)
+#define GPIO_PUPDR_PUPDR11_1                 ((uint32_t)0x00800000)
+
+#define GPIO_PUPDR_PUPDR12                   ((uint32_t)0x03000000)
+#define GPIO_PUPDR_PUPDR12_0                 ((uint32_t)0x01000000)
+#define GPIO_PUPDR_PUPDR12_1                 ((uint32_t)0x02000000)
+
+#define GPIO_PUPDR_PUPDR13                   ((uint32_t)0x0C000000)
+#define GPIO_PUPDR_PUPDR13_0                 ((uint32_t)0x04000000)
+#define GPIO_PUPDR_PUPDR13_1                 ((uint32_t)0x08000000)
+
+#define GPIO_PUPDR_PUPDR14                   ((uint32_t)0x30000000)
+#define GPIO_PUPDR_PUPDR14_0                 ((uint32_t)0x10000000)
+#define GPIO_PUPDR_PUPDR14_1                 ((uint32_t)0x20000000)
+
+#define GPIO_PUPDR_PUPDR15                   ((uint32_t)0xC0000000)
+#define GPIO_PUPDR_PUPDR15_0                 ((uint32_t)0x40000000)
+#define GPIO_PUPDR_PUPDR15_1                 ((uint32_t)0x80000000)
+
+/******************  Bits definition for GPIO_IDR register  *******************/
+#define GPIO_IDR_IDR_0                       ((uint32_t)0x00000001)
+#define GPIO_IDR_IDR_1                       ((uint32_t)0x00000002)
+#define GPIO_IDR_IDR_2                       ((uint32_t)0x00000004)
+#define GPIO_IDR_IDR_3                       ((uint32_t)0x00000008)
+#define GPIO_IDR_IDR_4                       ((uint32_t)0x00000010)
+#define GPIO_IDR_IDR_5                       ((uint32_t)0x00000020)
+#define GPIO_IDR_IDR_6                       ((uint32_t)0x00000040)
+#define GPIO_IDR_IDR_7                       ((uint32_t)0x00000080)
+#define GPIO_IDR_IDR_8                       ((uint32_t)0x00000100)
+#define GPIO_IDR_IDR_9                       ((uint32_t)0x00000200)
+#define GPIO_IDR_IDR_10                      ((uint32_t)0x00000400)
+#define GPIO_IDR_IDR_11                      ((uint32_t)0x00000800)
+#define GPIO_IDR_IDR_12                      ((uint32_t)0x00001000)
+#define GPIO_IDR_IDR_13                      ((uint32_t)0x00002000)
+#define GPIO_IDR_IDR_14                      ((uint32_t)0x00004000)
+#define GPIO_IDR_IDR_15                      ((uint32_t)0x00008000)
+
+/******************  Bits definition for GPIO_ODR register  *******************/
+#define GPIO_ODR_ODR_0                       ((uint32_t)0x00000001)
+#define GPIO_ODR_ODR_1                       ((uint32_t)0x00000002)
+#define GPIO_ODR_ODR_2                       ((uint32_t)0x00000004)
+#define GPIO_ODR_ODR_3                       ((uint32_t)0x00000008)
+#define GPIO_ODR_ODR_4                       ((uint32_t)0x00000010)
+#define GPIO_ODR_ODR_5                       ((uint32_t)0x00000020)
+#define GPIO_ODR_ODR_6                       ((uint32_t)0x00000040)
+#define GPIO_ODR_ODR_7                       ((uint32_t)0x00000080)
+#define GPIO_ODR_ODR_8                       ((uint32_t)0x00000100)
+#define GPIO_ODR_ODR_9                       ((uint32_t)0x00000200)
+#define GPIO_ODR_ODR_10                      ((uint32_t)0x00000400)
+#define GPIO_ODR_ODR_11                      ((uint32_t)0x00000800)
+#define GPIO_ODR_ODR_12                      ((uint32_t)0x00001000)
+#define GPIO_ODR_ODR_13                      ((uint32_t)0x00002000)
+#define GPIO_ODR_ODR_14                      ((uint32_t)0x00004000)
+#define GPIO_ODR_ODR_15                      ((uint32_t)0x00008000)
+
+/******************  Bits definition for GPIO_BSRR register  ******************/
+#define GPIO_BSRR_BS_0                       ((uint32_t)0x00000001)
+#define GPIO_BSRR_BS_1                       ((uint32_t)0x00000002)
+#define GPIO_BSRR_BS_2                       ((uint32_t)0x00000004)
+#define GPIO_BSRR_BS_3                       ((uint32_t)0x00000008)
+#define GPIO_BSRR_BS_4                       ((uint32_t)0x00000010)
+#define GPIO_BSRR_BS_5                       ((uint32_t)0x00000020)
+#define GPIO_BSRR_BS_6                       ((uint32_t)0x00000040)
+#define GPIO_BSRR_BS_7                       ((uint32_t)0x00000080)
+#define GPIO_BSRR_BS_8                       ((uint32_t)0x00000100)
+#define GPIO_BSRR_BS_9                       ((uint32_t)0x00000200)
+#define GPIO_BSRR_BS_10                      ((uint32_t)0x00000400)
+#define GPIO_BSRR_BS_11                      ((uint32_t)0x00000800)
+#define GPIO_BSRR_BS_12                      ((uint32_t)0x00001000)
+#define GPIO_BSRR_BS_13                      ((uint32_t)0x00002000)
+#define GPIO_BSRR_BS_14                      ((uint32_t)0x00004000)
+#define GPIO_BSRR_BS_15                      ((uint32_t)0x00008000)
+#define GPIO_BSRR_BR_0                       ((uint32_t)0x00010000)
+#define GPIO_BSRR_BR_1                       ((uint32_t)0x00020000)
+#define GPIO_BSRR_BR_2                       ((uint32_t)0x00040000)
+#define GPIO_BSRR_BR_3                       ((uint32_t)0x00080000)
+#define GPIO_BSRR_BR_4                       ((uint32_t)0x00100000)
+#define GPIO_BSRR_BR_5                       ((uint32_t)0x00200000)
+#define GPIO_BSRR_BR_6                       ((uint32_t)0x00400000)
+#define GPIO_BSRR_BR_7                       ((uint32_t)0x00800000)
+#define GPIO_BSRR_BR_8                       ((uint32_t)0x01000000)
+#define GPIO_BSRR_BR_9                       ((uint32_t)0x02000000)
+#define GPIO_BSRR_BR_10                      ((uint32_t)0x04000000)
+#define GPIO_BSRR_BR_11                      ((uint32_t)0x08000000)
+#define GPIO_BSRR_BR_12                      ((uint32_t)0x10000000)
+#define GPIO_BSRR_BR_13                      ((uint32_t)0x20000000)
+#define GPIO_BSRR_BR_14                      ((uint32_t)0x40000000)
+#define GPIO_BSRR_BR_15                      ((uint32_t)0x80000000)
+
+/****************** Bit definition for GPIO_LCKR register *********************/
+#define GPIO_LCKR_LCK0                       ((uint32_t)0x00000001)
+#define GPIO_LCKR_LCK1                       ((uint32_t)0x00000002)
+#define GPIO_LCKR_LCK2                       ((uint32_t)0x00000004)
+#define GPIO_LCKR_LCK3                       ((uint32_t)0x00000008)
+#define GPIO_LCKR_LCK4                       ((uint32_t)0x00000010)
+#define GPIO_LCKR_LCK5                       ((uint32_t)0x00000020)
+#define GPIO_LCKR_LCK6                       ((uint32_t)0x00000040)
+#define GPIO_LCKR_LCK7                       ((uint32_t)0x00000080)
+#define GPIO_LCKR_LCK8                       ((uint32_t)0x00000100)
+#define GPIO_LCKR_LCK9                       ((uint32_t)0x00000200)
+#define GPIO_LCKR_LCK10                      ((uint32_t)0x00000400)
+#define GPIO_LCKR_LCK11                      ((uint32_t)0x00000800)
+#define GPIO_LCKR_LCK12                      ((uint32_t)0x00001000)
+#define GPIO_LCKR_LCK13                      ((uint32_t)0x00002000)
+#define GPIO_LCKR_LCK14                      ((uint32_t)0x00004000)
+#define GPIO_LCKR_LCK15                      ((uint32_t)0x00008000)
+#define GPIO_LCKR_LCKK                       ((uint32_t)0x00010000)
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Inter-integrated Circuit Interface (I2C)              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for I2C_CR1 register  *******************/
+#define  I2C_CR1_PE                          ((uint32_t)0x00000001)        /*!< Peripheral enable                   */
+#define  I2C_CR1_TXIE                        ((uint32_t)0x00000002)        /*!< TX interrupt enable                 */
+#define  I2C_CR1_RXIE                        ((uint32_t)0x00000004)        /*!< RX interrupt enable                 */
+#define  I2C_CR1_ADDRIE                      ((uint32_t)0x00000008)        /*!< Address match interrupt enable      */
+#define  I2C_CR1_NACKIE                      ((uint32_t)0x00000010)        /*!< NACK received interrupt enable      */
+#define  I2C_CR1_STOPIE                      ((uint32_t)0x00000020)        /*!< STOP detection interrupt enable     */
+#define  I2C_CR1_TCIE                        ((uint32_t)0x00000040)        /*!< Transfer complete interrupt enable  */
+#define  I2C_CR1_ERRIE                       ((uint32_t)0x00000080)        /*!< Errors interrupt enable             */
+#define  I2C_CR1_DFN                         ((uint32_t)0x00000F00)        /*!< Digital noise filter                */
+#define  I2C_CR1_ANFOFF                      ((uint32_t)0x00001000)        /*!< Analog noise filter OFF             */
+#define  I2C_CR1_SWRST                       ((uint32_t)0x00002000)        /*!< Software reset                      */
+#define  I2C_CR1_TXDMAEN                     ((uint32_t)0x00004000)        /*!< DMA transmission requests enable    */
+#define  I2C_CR1_RXDMAEN                     ((uint32_t)0x00008000)        /*!< DMA reception requests enable       */
+#define  I2C_CR1_SBC                         ((uint32_t)0x00010000)        /*!< Slave byte control                  */
+#define  I2C_CR1_NOSTRETCH                   ((uint32_t)0x00020000)        /*!< Clock stretching disable            */
+#define  I2C_CR1_WUPEN                       ((uint32_t)0x00040000)        /*!< Wakeup from STOP enable             */
+#define  I2C_CR1_GCEN                        ((uint32_t)0x00080000)        /*!< General call enable                 */
+#define  I2C_CR1_SMBHEN                      ((uint32_t)0x00100000)        /*!< SMBus host address enable           */
+#define  I2C_CR1_SMBDEN                      ((uint32_t)0x00200000)        /*!< SMBus device default address enable */
+#define  I2C_CR1_ALERTEN                     ((uint32_t)0x00400000)        /*!< SMBus alert enable                  */
+#define  I2C_CR1_PECEN                       ((uint32_t)0x00800000)        /*!< PEC enable                          */
+
+/******************  Bit definition for I2C_CR2 register  ********************/
+#define  I2C_CR2_SADD                        ((uint32_t)0x000003FF)        /*!< Slave address (master mode)                             */
+#define  I2C_CR2_RD_WRN                      ((uint32_t)0x00000400)        /*!< Transfer direction (master mode)                        */
+#define  I2C_CR2_ADD10                       ((uint32_t)0x00000800)        /*!< 10-bit addressing mode (master mode)                    */
+#define  I2C_CR2_HEAD10R                     ((uint32_t)0x00001000)        /*!< 10-bit address header only read direction (master mode) */
+#define  I2C_CR2_START                       ((uint32_t)0x00002000)        /*!< START generation                                        */
+#define  I2C_CR2_STOP                        ((uint32_t)0x00004000)        /*!< STOP generation (master mode)                           */
+#define  I2C_CR2_NACK                        ((uint32_t)0x00008000)        /*!< NACK generation (slave mode)                            */
+#define  I2C_CR2_NBYTES                      ((uint32_t)0x00FF0000)        /*!< Number of bytes                                         */
+#define  I2C_CR2_RELOAD                      ((uint32_t)0x01000000)        /*!< NBYTES reload mode                                      */
+#define  I2C_CR2_AUTOEND                     ((uint32_t)0x02000000)        /*!< Automatic end mode (master mode)                        */
+#define  I2C_CR2_PECBYTE                     ((uint32_t)0x04000000)        /*!< Packet error checking byte                              */
+
+/*******************  Bit definition for I2C_OAR1 register  ******************/
+#define  I2C_OAR1_OA1                        ((uint32_t)0x000003FF)        /*!< Interface own address 1   */
+#define  I2C_OAR1_OA1MODE                    ((uint32_t)0x00000400)        /*!< Own address 1 10-bit mode */
+#define  I2C_OAR1_OA1EN                      ((uint32_t)0x00008000)        /*!< Own address 1 enable      */
+
+/*******************  Bit definition for I2C_OAR2 register  ******************/
+#define  I2C_OAR2_OA2                        ((uint32_t)0x000000FE)        /*!< Interface own address 2 */
+#define  I2C_OAR2_OA2MSK                     ((uint32_t)0x00000700)        /*!< Own address 2 masks     */
+#define  I2C_OAR2_OA2NOMASK                  ((uint32_t)0x00000000)        /*!< No mask */
+#define  I2C_OAR2_OA2MASK01                  ((uint32_t)0x00000100)        /*!< OA2[1] is masked, Only OA2[7:2] are compared */
+#define  I2C_OAR2_OA2MASK02                  ((uint32_t)0x00000200)        /*!< OA2[2:1] is masked, Only OA2[7:3] are compared */
+#define  I2C_OAR2_OA2MASK03                  ((uint32_t)0x00000300)        /*!< OA2[3:1] is masked, Only OA2[7:4] are compared */
+#define  I2C_OAR2_OA2MASK04                  ((uint32_t)0x00000400)        /*!< OA2[4:1] is masked, Only OA2[7:5] are compared */
+#define  I2C_OAR2_OA2MASK05                  ((uint32_t)0x00000500)        /*!< OA2[5:1] is masked, Only OA2[7:6] are compared */
+#define  I2C_OAR2_OA2MASK06                  ((uint32_t)0x00000600)        /*!< OA2[6:1] is masked, Only OA2[7] are compared */
+#define  I2C_OAR2_OA2MASK07                  ((uint32_t)0x00000700)        /*!< OA2[7:1] is masked, No comparison is done */
+#define  I2C_OAR2_OA2EN                      ((uint32_t)0x00008000)        /*!< Own address 2 enable    */
+
+/*******************  Bit definition for I2C_TIMINGR register *******************/
+#define  I2C_TIMINGR_SCLL                    ((uint32_t)0x000000FF)        /*!< SCL low period (master mode)  */
+#define  I2C_TIMINGR_SCLH                    ((uint32_t)0x0000FF00)        /*!< SCL high period (master mode) */
+#define  I2C_TIMINGR_SDADEL                  ((uint32_t)0x000F0000)        /*!< Data hold time                */
+#define  I2C_TIMINGR_SCLDEL                  ((uint32_t)0x00F00000)        /*!< Data setup time               */
+#define  I2C_TIMINGR_PRESC                   ((uint32_t)0xF0000000)        /*!< Timings prescaler             */
+
+/******************* Bit definition for I2C_TIMEOUTR register *******************/
+#define  I2C_TIMEOUTR_TIMEOUTA               ((uint32_t)0x00000FFF)        /*!< Bus timeout A                 */
+#define  I2C_TIMEOUTR_TIDLE                  ((uint32_t)0x00001000)        /*!< Idle clock timeout detection  */
+#define  I2C_TIMEOUTR_TIMOUTEN               ((uint32_t)0x00008000)        /*!< Clock timeout enable          */
+#define  I2C_TIMEOUTR_TIMEOUTB               ((uint32_t)0x0FFF0000)        /*!< Bus timeout B                 */
+#define  I2C_TIMEOUTR_TEXTEN                 ((uint32_t)0x80000000)        /*!< Extended clock timeout enable */
+
+/******************  Bit definition for I2C_ISR register  *********************/
+#define  I2C_ISR_TXE                         ((uint32_t)0x00000001)        /*!< Transmit data register empty    */
+#define  I2C_ISR_TXIS                        ((uint32_t)0x00000002)        /*!< Transmit interrupt status       */
+#define  I2C_ISR_RXNE                        ((uint32_t)0x00000004)        /*!< Receive data register not empty */
+#define  I2C_ISR_ADDR                        ((uint32_t)0x00000008)        /*!< Address matched (slave mode)    */
+#define  I2C_ISR_NACKF                       ((uint32_t)0x00000010)        /*!< NACK received flag              */
+#define  I2C_ISR_STOPF                       ((uint32_t)0x00000020)        /*!< STOP detection flag             */
+#define  I2C_ISR_TC                          ((uint32_t)0x00000040)        /*!< Transfer complete (master mode) */
+#define  I2C_ISR_TCR                         ((uint32_t)0x00000080)        /*!< Transfer complete reload        */
+#define  I2C_ISR_BERR                        ((uint32_t)0x00000100)        /*!< Bus error                       */
+#define  I2C_ISR_ARLO                        ((uint32_t)0x00000200)        /*!< Arbitration lost                */
+#define  I2C_ISR_OVR                         ((uint32_t)0x00000400)        /*!< Overrun/Underrun                */
+#define  I2C_ISR_PECERR                      ((uint32_t)0x00000800)        /*!< PEC error in reception          */
+#define  I2C_ISR_TIMEOUT                     ((uint32_t)0x00001000)        /*!< Timeout or Tlow detection flag  */
+#define  I2C_ISR_ALERT                       ((uint32_t)0x00002000)        /*!< SMBus alert                     */
+#define  I2C_ISR_BUSY                        ((uint32_t)0x00008000)        /*!< Bus busy                        */
+#define  I2C_ISR_DIR                         ((uint32_t)0x00010000)        /*!< Transfer direction (slave mode) */
+#define  I2C_ISR_ADDCODE                     ((uint32_t)0x00FE0000)        /*!< Address match code (slave mode) */
+
+/******************  Bit definition for I2C_ICR register  *********************/
+#define  I2C_ICR_ADDRCF                      ((uint32_t)0x00000008)        /*!< Address matched clear flag      */
+#define  I2C_ICR_NACKCF                      ((uint32_t)0x00000010)        /*!< NACK clear flag                 */
+#define  I2C_ICR_STOPCF                      ((uint32_t)0x00000020)        /*!< STOP detection clear flag       */
+#define  I2C_ICR_BERRCF                      ((uint32_t)0x00000100)        /*!< Bus error clear flag            */
+#define  I2C_ICR_ARLOCF                      ((uint32_t)0x00000200)        /*!< Arbitration lost clear flag     */
+#define  I2C_ICR_OVRCF                       ((uint32_t)0x00000400)        /*!< Overrun/Underrun clear flag     */
+#define  I2C_ICR_PECCF                       ((uint32_t)0x00000800)        /*!< PAC error clear flag            */
+#define  I2C_ICR_TIMOUTCF                    ((uint32_t)0x00001000)        /*!< Timeout clear flag              */
+#define  I2C_ICR_ALERTCF                     ((uint32_t)0x00002000)        /*!< Alert clear flag                */
+
+/******************  Bit definition for I2C_PECR register  *********************/
+#define  I2C_PECR_PEC                        ((uint32_t)0x000000FF)        /*!< PEC register        */
+
+/******************  Bit definition for I2C_RXDR register  *********************/
+#define  I2C_RXDR_RXDATA                     ((uint32_t)0x000000FF)        /*!< 8-bit receive data  */
+
+/******************  Bit definition for I2C_TXDR register  *********************/
+#define  I2C_TXDR_TXDATA                     ((uint32_t)0x000000FF)        /*!< 8-bit transmit data */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Independent WATCHDOG                             */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define  IWDG_KR_KEY                         ((uint32_t)0xFFFF)            /*!<Key value (write only, read 0000h)  */
+
+/*******************  Bit definition for IWDG_PR register  ********************/
+#define  IWDG_PR_PR                          ((uint32_t)0x07)               /*!<PR[2:0] (Prescaler divider)         */
+#define  IWDG_PR_PR_0                        ((uint32_t)0x01)               /*!<Bit 0 */
+#define  IWDG_PR_PR_1                        ((uint32_t)0x02)               /*!<Bit 1 */
+#define  IWDG_PR_PR_2                        ((uint32_t)0x04)               /*!<Bit 2 */
+
+/*******************  Bit definition for IWDG_RLR register  *******************/
+#define  IWDG_RLR_RL                         ((uint32_t)0x0FFF)            /*!<Watchdog counter reload value        */
+
+/*******************  Bit definition for IWDG_SR register  ********************/
+#define  IWDG_SR_PVU                         ((uint32_t)0x01)               /*!< Watchdog prescaler value update */
+#define  IWDG_SR_RVU                         ((uint32_t)0x02)               /*!< Watchdog counter reload value update */
+#define  IWDG_SR_WVU                         ((uint32_t)0x04)               /*!< Watchdog counter window value update */
+
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define  IWDG_WINR_WIN                       ((uint32_t)0x0FFF)             /*!< Watchdog counter window value */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      LCD-TFT Display Controller (LTDC)                     */
+/*                                                                            */
+/******************************************************************************/
+
+/********************  Bit definition for LTDC_SSCR register  *****************/
+
+#define LTDC_SSCR_VSH                       ((uint32_t)0x000007FF)              /*!< Vertical Synchronization Height  */
+#define LTDC_SSCR_HSW                       ((uint32_t)0x0FFF0000)              /*!< Horizontal Synchronization Width */
+
+/********************  Bit definition for LTDC_BPCR register  *****************/
+
+#define LTDC_BPCR_AVBP                      ((uint32_t)0x000007FF)              /*!< Accumulated Vertical Back Porch   */
+#define LTDC_BPCR_AHBP                      ((uint32_t)0x0FFF0000)              /*!< Accumulated Horizontal Back Porch */
+
+/********************  Bit definition for LTDC_AWCR register  *****************/
+
+#define LTDC_AWCR_AAH                       ((uint32_t)0x000007FF)              /*!< Accumulated Active heigh */
+#define LTDC_AWCR_AAW                       ((uint32_t)0x0FFF0000)              /*!< Accumulated Active Width */
+
+/********************  Bit definition for LTDC_TWCR register  *****************/
+
+#define LTDC_TWCR_TOTALH                    ((uint32_t)0x000007FF)              /*!< Total Heigh */
+#define LTDC_TWCR_TOTALW                    ((uint32_t)0x0FFF0000)              /*!< Total Width */
+
+/********************  Bit definition for LTDC_GCR register  ******************/
+
+#define LTDC_GCR_LTDCEN                     ((uint32_t)0x00000001)              /*!< LCD-TFT controller enable bit       */
+#define LTDC_GCR_DBW                        ((uint32_t)0x00000070)              /*!< Dither Blue Width                   */
+#define LTDC_GCR_DGW                        ((uint32_t)0x00000700)              /*!< Dither Green Width                  */
+#define LTDC_GCR_DRW                        ((uint32_t)0x00007000)              /*!< Dither Red Width                    */
+#define LTDC_GCR_DTEN                       ((uint32_t)0x00010000)              /*!< Dither Enable                       */
+#define LTDC_GCR_PCPOL                      ((uint32_t)0x10000000)              /*!< Pixel Clock Polarity                */
+#define LTDC_GCR_DEPOL                      ((uint32_t)0x20000000)              /*!< Data Enable Polarity                */
+#define LTDC_GCR_VSPOL                      ((uint32_t)0x40000000)              /*!< Vertical Synchronization Polarity   */
+#define LTDC_GCR_HSPOL                      ((uint32_t)0x80000000)              /*!< Horizontal Synchronization Polarity */
+
+/********************  Bit definition for LTDC_SRCR register  *****************/
+
+#define LTDC_SRCR_IMR                      ((uint32_t)0x00000001)               /*!< Immediate Reload         */
+#define LTDC_SRCR_VBR                      ((uint32_t)0x00000002)               /*!< Vertical Blanking Reload */
+
+/********************  Bit definition for LTDC_BCCR register  *****************/
+
+#define LTDC_BCCR_BCBLUE                    ((uint32_t)0x000000FF)              /*!< Background Blue value  */
+#define LTDC_BCCR_BCGREEN                   ((uint32_t)0x0000FF00)              /*!< Background Green value */
+#define LTDC_BCCR_BCRED                     ((uint32_t)0x00FF0000)              /*!< Background Red value   */
+
+/********************  Bit definition for LTDC_IER register  ******************/
+
+#define LTDC_IER_LIE                        ((uint32_t)0x00000001)              /*!< Line Interrupt Enable            */
+#define LTDC_IER_FUIE                       ((uint32_t)0x00000002)              /*!< FIFO Underrun Interrupt Enable   */
+#define LTDC_IER_TERRIE                     ((uint32_t)0x00000004)              /*!< Transfer Error Interrupt Enable  */
+#define LTDC_IER_RRIE                       ((uint32_t)0x00000008)              /*!< Register Reload interrupt enable */
+
+/********************  Bit definition for LTDC_ISR register  ******************/
+
+#define LTDC_ISR_LIF                        ((uint32_t)0x00000001)              /*!< Line Interrupt Flag */
+#define LTDC_ISR_FUIF                       ((uint32_t)0x00000002)              /*!< FIFO Underrun Interrupt Flag */
+#define LTDC_ISR_TERRIF                     ((uint32_t)0x00000004)              /*!< Transfer Error Interrupt Flag */
+#define LTDC_ISR_RRIF                       ((uint32_t)0x00000008)              /*!< Register Reload interrupt Flag */
+
+/********************  Bit definition for LTDC_ICR register  ******************/
+
+#define LTDC_ICR_CLIF                       ((uint32_t)0x00000001)              /*!< Clears the Line Interrupt Flag */
+#define LTDC_ICR_CFUIF                      ((uint32_t)0x00000002)              /*!< Clears the FIFO Underrun Interrupt Flag */
+#define LTDC_ICR_CTERRIF                    ((uint32_t)0x00000004)              /*!< Clears the Transfer Error Interrupt Flag */
+#define LTDC_ICR_CRRIF                      ((uint32_t)0x00000008)              /*!< Clears Register Reload interrupt Flag */
+
+/********************  Bit definition for LTDC_LIPCR register  ****************/
+
+#define LTDC_LIPCR_LIPOS                    ((uint32_t)0x000007FF)              /*!< Line Interrupt Position */
+
+/********************  Bit definition for LTDC_CPSR register  *****************/
+
+#define LTDC_CPSR_CYPOS                     ((uint32_t)0x0000FFFF)              /*!< Current Y Position */
+#define LTDC_CPSR_CXPOS                     ((uint32_t)0xFFFF0000)              /*!< Current X Position */
+
+/********************  Bit definition for LTDC_CDSR register  *****************/
+
+#define LTDC_CDSR_VDES                      ((uint32_t)0x00000001)              /*!< Vertical Data Enable Status       */
+#define LTDC_CDSR_HDES                      ((uint32_t)0x00000002)              /*!< Horizontal Data Enable Status     */
+#define LTDC_CDSR_VSYNCS                    ((uint32_t)0x00000004)              /*!< Vertical Synchronization Status   */
+#define LTDC_CDSR_HSYNCS                    ((uint32_t)0x00000008)              /*!< Horizontal Synchronization Status */
+
+/********************  Bit definition for LTDC_LxCR register  *****************/
+
+#define LTDC_LxCR_LEN                       ((uint32_t)0x00000001)              /*!< Layer Enable              */
+#define LTDC_LxCR_COLKEN                    ((uint32_t)0x00000002)              /*!< Color Keying Enable       */
+#define LTDC_LxCR_CLUTEN                    ((uint32_t)0x00000010)              /*!< Color Lockup Table Enable */
+
+/********************  Bit definition for LTDC_LxWHPCR register  **************/
+
+#define LTDC_LxWHPCR_WHSTPOS                ((uint32_t)0x00000FFF)              /*!< Window Horizontal Start Position */
+#define LTDC_LxWHPCR_WHSPPOS                ((uint32_t)0xFFFF0000)              /*!< Window Horizontal Stop Position  */
+
+/********************  Bit definition for LTDC_LxWVPCR register  **************/
+
+#define LTDC_LxWVPCR_WVSTPOS                ((uint32_t)0x00000FFF)              /*!< Window Vertical Start Position */
+#define LTDC_LxWVPCR_WVSPPOS                ((uint32_t)0xFFFF0000)              /*!< Window Vertical Stop Position  */
+
+/********************  Bit definition for LTDC_LxCKCR register  ***************/
+
+#define LTDC_LxCKCR_CKBLUE                  ((uint32_t)0x000000FF)              /*!< Color Key Blue value  */
+#define LTDC_LxCKCR_CKGREEN                 ((uint32_t)0x0000FF00)              /*!< Color Key Green value */
+#define LTDC_LxCKCR_CKRED                   ((uint32_t)0x00FF0000)              /*!< Color Key Red value   */
+
+/********************  Bit definition for LTDC_LxPFCR register  ***************/
+
+#define LTDC_LxPFCR_PF                      ((uint32_t)0x00000007)              /*!< Pixel Format */
+
+/********************  Bit definition for LTDC_LxCACR register  ***************/
+
+#define LTDC_LxCACR_CONSTA                  ((uint32_t)0x000000FF)              /*!< Constant Alpha */
+
+/********************  Bit definition for LTDC_LxDCCR register  ***************/
+
+#define LTDC_LxDCCR_DCBLUE                  ((uint32_t)0x000000FF)              /*!< Default Color Blue  */
+#define LTDC_LxDCCR_DCGREEN                 ((uint32_t)0x0000FF00)              /*!< Default Color Green */
+#define LTDC_LxDCCR_DCRED                   ((uint32_t)0x00FF0000)              /*!< Default Color Red   */
+#define LTDC_LxDCCR_DCALPHA                 ((uint32_t)0xFF000000)              /*!< Default Color Alpha */
+
+/********************  Bit definition for LTDC_LxBFCR register  ***************/
+
+#define LTDC_LxBFCR_BF2                     ((uint32_t)0x00000007)              /*!< Blending Factor 2 */
+#define LTDC_LxBFCR_BF1                     ((uint32_t)0x00000700)              /*!< Blending Factor 1 */
+
+/********************  Bit definition for LTDC_LxCFBAR register  **************/
+
+#define LTDC_LxCFBAR_CFBADD                 ((uint32_t)0xFFFFFFFF)              /*!< Color Frame Buffer Start Address */
+
+/********************  Bit definition for LTDC_LxCFBLR register  **************/
+
+#define LTDC_LxCFBLR_CFBLL                  ((uint32_t)0x00001FFF)              /*!< Color Frame Buffer Line Length    */
+#define LTDC_LxCFBLR_CFBP                   ((uint32_t)0x1FFF0000)              /*!< Color Frame Buffer Pitch in bytes */
+
+/********************  Bit definition for LTDC_LxCFBLNR register  *************/
+
+#define LTDC_LxCFBLNR_CFBLNBR               ((uint32_t)0x000007FF)              /*!< Frame Buffer Line Number */
+
+/********************  Bit definition for LTDC_LxCLUTWR register  *************/
+
+#define LTDC_LxCLUTWR_BLUE                  ((uint32_t)0x000000FF)              /*!< Blue value   */
+#define LTDC_LxCLUTWR_GREEN                 ((uint32_t)0x0000FF00)              /*!< Green value  */
+#define LTDC_LxCLUTWR_RED                   ((uint32_t)0x00FF0000)              /*!< Red value    */
+#define LTDC_LxCLUTWR_CLUTADD               ((uint32_t)0xFF000000)              /*!< CLUT address */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                             Power Control                                  */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for PWR_CR1 register  ********************/
+#define  PWR_CR1_LPDS                         ((uint32_t)0x00000001)     /*!< Low-Power Deepsleep                 */
+#define  PWR_CR1_PDDS                         ((uint32_t)0x00000002)     /*!< Power Down Deepsleep                */
+#define  PWR_CR1_CSBF                         ((uint32_t)0x00000008)     /*!< Clear Standby Flag                  */
+#define  PWR_CR1_PVDE                         ((uint32_t)0x00000010)     /*!< Power Voltage Detector Enable       */
+
+#define  PWR_CR1_PLS                          ((uint32_t)0x000000E0)     /*!< PLS[2:0] bits (PVD Level Selection) */
+#define  PWR_CR1_PLS_0                        ((uint32_t)0x00000020)     /*!< Bit 0 */
+#define  PWR_CR1_PLS_1                        ((uint32_t)0x00000040)     /*!< Bit 1 */
+#define  PWR_CR1_PLS_2                        ((uint32_t)0x00000080)     /*!< Bit 2 */
+
+/*!< PVD level configuration */
+#define  PWR_CR1_PLS_LEV0                     ((uint32_t)0x00000000)     /*!< PVD level 0 */
+#define  PWR_CR1_PLS_LEV1                     ((uint32_t)0x00000020)     /*!< PVD level 1 */
+#define  PWR_CR1_PLS_LEV2                     ((uint32_t)0x00000040)     /*!< PVD level 2 */
+#define  PWR_CR1_PLS_LEV3                     ((uint32_t)0x00000060)     /*!< PVD level 3 */
+#define  PWR_CR1_PLS_LEV4                     ((uint32_t)0x00000080)     /*!< PVD level 4 */
+#define  PWR_CR1_PLS_LEV5                     ((uint32_t)0x000000A0)     /*!< PVD level 5 */
+#define  PWR_CR1_PLS_LEV6                     ((uint32_t)0x000000C0)     /*!< PVD level 6 */
+#define  PWR_CR1_PLS_LEV7                     ((uint32_t)0x000000E0)     /*!< PVD level 7 */
+
+#define  PWR_CR1_DBP                          ((uint32_t)0x00000100)     /*!< Disable Backup Domain write protection                     */
+#define  PWR_CR1_FPDS                         ((uint32_t)0x00000200)     /*!< Flash power down in Stop mode                              */
+
+#define  PWR_CR1_LPUDS                        ((uint32_t)0x00000400)     /*!< Low-power regulator in deepsleep under-drive mode          */
+#define  PWR_CR1_MRUDS                        ((uint32_t)0x00000800)     /*!< Main regulator in deepsleep under-drive mode               */
+
+#define  PWR_CR1_ADCDC1                       ((uint32_t)0x00002000)     /*!< Refer to AN4073 on how to use this bit */
+
+#define  PWR_CR1_VOS                          ((uint32_t)0x0000C000)     /*!< VOS[1:0] bits (Regulator voltage scaling output selection) */
+#define  PWR_CR1_VOS_0                        ((uint32_t)0x00004000)     /*!< Bit 0 */
+#define  PWR_CR1_VOS_1                        ((uint32_t)0x00008000)     /*!< Bit 1 */
+
+#define  PWR_CR1_ODEN                         ((uint32_t)0x00010000)     /*!< Over Drive enable                   */
+#define  PWR_CR1_ODSWEN                       ((uint32_t)0x00020000)     /*!< Over Drive switch enabled           */
+#define  PWR_CR1_UDEN                         ((uint32_t)0x000C0000)     /*!< Under Drive enable in stop mode     */
+#define  PWR_CR1_UDEN_0                       ((uint32_t)0x00040000)     /*!< Bit 0                               */
+#define  PWR_CR1_UDEN_1                       ((uint32_t)0x00080000)     /*!< Bit 1                               */
+
+/*******************  Bit definition for PWR_CSR1 register  ********************/
+#define  PWR_CSR1_WUIF                        ((uint32_t)0x00000001)     /*!< Wake up internal Flag                            */
+#define  PWR_CSR1_SBF                         ((uint32_t)0x00000002)     /*!< Standby Flag                                     */
+#define  PWR_CSR1_PVDO                        ((uint32_t)0x00000004)     /*!< PVD Output                                       */
+#define  PWR_CSR1_BRR                         ((uint32_t)0x00000008)     /*!< Backup regulator ready                           */
+#define  PWR_CSR1_BRE                         ((uint32_t)0x00000200)     /*!< Backup regulator enable                          */
+#define  PWR_CSR1_VOSRDY                      ((uint32_t)0x00004000)     /*!< Regulator voltage scaling output selection ready */
+
+#define  PWR_CSR1_ODRDY                       ((uint32_t)0x00010000)     /*!< Over Drive generator ready                       */
+#define  PWR_CSR1_ODSWRDY                     ((uint32_t)0x00020000)     /*!< Over Drive Switch ready                          */
+#define  PWR_CSR1_UDSWRDY                     ((uint32_t)0x000C0000)     /*!< Under Drive ready                                */
+
+/********************  Bit definition for PWR_CR2 register  ********************/
+#define  PWR_CR2_CWUPF1                         ((uint32_t)0x00000001)     /*!< Clear Wakeup Pin Flag for PA0      */
+#define  PWR_CR2_CWUPF2                         ((uint32_t)0x00000002)     /*!< Clear Wakeup Pin Flag for PA2      */
+#define  PWR_CR2_CWUPF3                         ((uint32_t)0x00000004)     /*!< Clear Wakeup Pin Flag for PC1      */
+#define  PWR_CR2_CWUPF4                         ((uint32_t)0x00000008)     /*!< Clear Wakeup Pin Flag for PC13     */
+#define  PWR_CR2_CWUPF5                         ((uint32_t)0x00000010)     /*!< Clear Wakeup Pin Flag for PI8      */
+#define  PWR_CR2_CWUPF6                         ((uint32_t)0x00000020)     /*!< Clear Wakeup Pin Flag for PI11     */
+
+#define  PWR_CR2_WUPP1                          ((uint32_t)0x00000100)     /*!< Wakeup Pin Polarity bit for PA0    */
+#define  PWR_CR2_WUPP2                          ((uint32_t)0x00000200)     /*!< Wakeup Pin Polarity bit for PA2    */
+#define  PWR_CR2_WUPP3                          ((uint32_t)0x00000400)     /*!< Wakeup Pin Polarity bit for PC1    */
+#define  PWR_CR2_WUPP4                          ((uint32_t)0x00000800)     /*!< Wakeup Pin Polarity bit for PC13   */
+#define  PWR_CR2_WUPP5                          ((uint32_t)0x00001000)     /*!< Wakeup Pin Polarity bit for PI8    */
+#define  PWR_CR2_WUPP6                          ((uint32_t)0x00002000)     /*!< Wakeup Pin Polarity bit for PI11   */
+
+/*******************  Bit definition for PWR_CSR2 register  ********************/
+#define  PWR_CSR2_WUPF1                         ((uint32_t)0x00000001)     /*!< Wakeup Pin Flag for PA0            */
+#define  PWR_CSR2_WUPF2                         ((uint32_t)0x00000002)     /*!< Wakeup Pin Flag for PA2            */
+#define  PWR_CSR2_WUPF3                         ((uint32_t)0x00000004)     /*!< Wakeup Pin Flag for PC1            */
+#define  PWR_CSR2_WUPF4                         ((uint32_t)0x00000008)     /*!< Wakeup Pin Flag for PC13           */
+#define  PWR_CSR2_WUPF5                         ((uint32_t)0x00000010)     /*!< Wakeup Pin Flag for PI8            */
+#define  PWR_CSR2_WUPF6                         ((uint32_t)0x00000020)     /*!< Wakeup Pin Flag for PI11           */
+
+#define  PWR_CSR2_EWUP1                         ((uint32_t)0x00000100)     /*!< Enable Wakeup Pin PA0              */
+#define  PWR_CSR2_EWUP2                         ((uint32_t)0x00000200)     /*!< Enable Wakeup Pin PA2              */
+#define  PWR_CSR2_EWUP3                         ((uint32_t)0x00000400)     /*!< Enable Wakeup Pin PC1              */
+#define  PWR_CSR2_EWUP4                         ((uint32_t)0x00000800)     /*!< Enable Wakeup Pin PC13             */
+#define  PWR_CSR2_EWUP5                         ((uint32_t)0x00001000)     /*!< Enable Wakeup Pin PI8              */
+#define  PWR_CSR2_EWUP6                         ((uint32_t)0x00002000)     /*!< Enable Wakeup Pin PI11             */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    QUADSPI                                 */
+/*                                                                            */
+/******************************************************************************/
+/*****************  Bit definition for QUADSPI_CR register  *******************/
+#define  QUADSPI_CR_EN                           ((uint32_t)0x00000001)            /*!< Enable                            */
+#define  QUADSPI_CR_ABORT                        ((uint32_t)0x00000002)            /*!< Abort request                     */
+#define  QUADSPI_CR_DMAEN                        ((uint32_t)0x00000004)            /*!< DMA Enable                        */
+#define  QUADSPI_CR_TCEN                         ((uint32_t)0x00000008)            /*!< Timeout Counter Enable            */
+#define  QUADSPI_CR_SSHIFT                       ((uint32_t)0x00000010)            /*!< Sample Shift                      */
+#define  QUADSPI_CR_DFM                          ((uint32_t)0x00000040)            /*!< Dual Flash Mode                   */
+#define  QUADSPI_CR_FSEL                         ((uint32_t)0x00000080)            /*!< Flash Select                      */
+#define  QUADSPI_CR_FTHRES                       ((uint32_t)0x00000F00)            /*!< FTHRES[3:0] FIFO Level            */
+#define  QUADSPI_CR_FTHRES_0                     ((uint32_t)0x00000100)            /*!< Bit 0 */
+#define  QUADSPI_CR_FTHRES_1                     ((uint32_t)0x00000200)            /*!< Bit 1 */
+#define  QUADSPI_CR_FTHRES_2                     ((uint32_t)0x00000400)            /*!< Bit 2 */
+#define  QUADSPI_CR_FTHRES_3                     ((uint32_t)0x00000800)            /*!< Bit 3 */
+#define  QUADSPI_CR_TEIE                         ((uint32_t)0x00010000)            /*!< Transfer Error Interrupt Enable    */
+#define  QUADSPI_CR_TCIE                         ((uint32_t)0x00020000)            /*!< Transfer Complete Interrupt Enable */
+#define  QUADSPI_CR_FTIE                         ((uint32_t)0x00040000)            /*!< FIFO Threshold Interrupt Enable    */
+#define  QUADSPI_CR_SMIE                         ((uint32_t)0x00080000)            /*!< Status Match Interrupt Enable      */
+#define  QUADSPI_CR_TOIE                         ((uint32_t)0x00100000)            /*!< TimeOut Interrupt Enable           */
+#define  QUADSPI_CR_APMS                         ((uint32_t)0x00400000)            /*!< Bit 1                              */
+#define  QUADSPI_CR_PMM                          ((uint32_t)0x00800000)            /*!< Polling Match Mode                 */
+#define  QUADSPI_CR_PRESCALER                    ((uint32_t)0xFF000000)            /*!< PRESCALER[7:0] Clock prescaler     */
+#define  QUADSPI_CR_PRESCALER_0                  ((uint32_t)0x01000000)            /*!< Bit 0 */
+#define  QUADSPI_CR_PRESCALER_1                  ((uint32_t)0x02000000)            /*!< Bit 1 */
+#define  QUADSPI_CR_PRESCALER_2                  ((uint32_t)0x04000000)            /*!< Bit 2 */
+#define  QUADSPI_CR_PRESCALER_3                  ((uint32_t)0x08000000)            /*!< Bit 3 */
+#define  QUADSPI_CR_PRESCALER_4                  ((uint32_t)0x10000000)            /*!< Bit 4 */
+#define  QUADSPI_CR_PRESCALER_5                  ((uint32_t)0x20000000)            /*!< Bit 5 */
+#define  QUADSPI_CR_PRESCALER_6                  ((uint32_t)0x40000000)            /*!< Bit 6 */
+#define  QUADSPI_CR_PRESCALER_7                  ((uint32_t)0x80000000)            /*!< Bit 7 */
+
+/*****************  Bit definition for QUADSPI_DCR register  ******************/
+#define  QUADSPI_DCR_CKMODE                      ((uint32_t)0x00000001)            /*!< Mode 0 / Mode 3                 */
+#define  QUADSPI_DCR_CSHT                        ((uint32_t)0x00000700)            /*!< CSHT[2:0]: ChipSelect High Time */
+#define  QUADSPI_DCR_CSHT_0                      ((uint32_t)0x00000100)            /*!< Bit 0 */
+#define  QUADSPI_DCR_CSHT_1                      ((uint32_t)0x00000200)            /*!< Bit 1 */
+#define  QUADSPI_DCR_CSHT_2                      ((uint32_t)0x00000400)            /*!< Bit 2 */
+#define  QUADSPI_DCR_FSIZE                       ((uint32_t)0x001F0000)            /*!< FSIZE[4:0]: Flash Size          */
+#define  QUADSPI_DCR_FSIZE_0                     ((uint32_t)0x00010000)            /*!< Bit 0 */
+#define  QUADSPI_DCR_FSIZE_1                     ((uint32_t)0x00020000)            /*!< Bit 1 */
+#define  QUADSPI_DCR_FSIZE_2                     ((uint32_t)0x00040000)            /*!< Bit 2 */
+#define  QUADSPI_DCR_FSIZE_3                     ((uint32_t)0x00080000)            /*!< Bit 3 */
+#define  QUADSPI_DCR_FSIZE_4                     ((uint32_t)0x00100000)            /*!< Bit 4 */
+
+/******************  Bit definition for QUADSPI_SR register  *******************/
+#define  QUADSPI_SR_TEF                          ((uint32_t)0x00000001)             /*!< Transfer Error Flag    */
+#define  QUADSPI_SR_TCF                          ((uint32_t)0x00000002)             /*!< Transfer Complete Flag */
+#define  QUADSPI_SR_FTF                          ((uint32_t)0x00000004)             /*!< FIFO Threshlod Flag    */
+#define  QUADSPI_SR_SMF                          ((uint32_t)0x00000008)             /*!< Status Match Flag      */
+#define  QUADSPI_SR_TOF                          ((uint32_t)0x00000010)             /*!< Timeout Flag           */
+#define  QUADSPI_SR_BUSY                         ((uint32_t)0x00000020)             /*!< Busy                   */
+#define  QUADSPI_SR_FLEVEL                       ((uint32_t)0x00001F00)             /*!< FIFO Threshlod Flag    */
+#define  QUADSPI_SR_FLEVEL_0                     ((uint32_t)0x00000100)             /*!< Bit 0 */
+#define  QUADSPI_SR_FLEVEL_1                     ((uint32_t)0x00000200)             /*!< Bit 1 */
+#define  QUADSPI_SR_FLEVEL_2                     ((uint32_t)0x00000400)             /*!< Bit 2 */
+#define  QUADSPI_SR_FLEVEL_3                     ((uint32_t)0x00000800)             /*!< Bit 3 */
+#define  QUADSPI_SR_FLEVEL_4                     ((uint32_t)0x00001000)             /*!< Bit 4 */
+
+/******************  Bit definition for QUADSPI_FCR register  ******************/
+#define  QUADSPI_FCR_CTEF                        ((uint32_t)0x00000001)             /*!< Clear Transfer Error Flag    */
+#define  QUADSPI_FCR_CTCF                        ((uint32_t)0x00000002)             /*!< Clear Transfer Complete Flag */
+#define  QUADSPI_FCR_CSMF                        ((uint32_t)0x00000008)             /*!< Clear Status Match Flag      */
+#define  QUADSPI_FCR_CTOF                        ((uint32_t)0x00000010)             /*!< Clear Timeout Flag           */
+
+/******************  Bit definition for QUADSPI_DLR register  ******************/
+#define  QUADSPI_DLR_DL                        ((uint32_t)0xFFFFFFFF)               /*!< DL[31:0]: Data Length */
+
+/******************  Bit definition for QUADSPI_CCR register  ******************/
+#define  QUADSPI_CCR_INSTRUCTION                  ((uint32_t)0x000000FF)            /*!< INSTRUCTION[7:0]: Instruction    */
+#define  QUADSPI_CCR_INSTRUCTION_0                ((uint32_t)0x00000001)            /*!< Bit 0 */
+#define  QUADSPI_CCR_INSTRUCTION_1                ((uint32_t)0x00000002)            /*!< Bit 1 */
+#define  QUADSPI_CCR_INSTRUCTION_2                ((uint32_t)0x00000004)            /*!< Bit 2 */
+#define  QUADSPI_CCR_INSTRUCTION_3                ((uint32_t)0x00000008)            /*!< Bit 3 */
+#define  QUADSPI_CCR_INSTRUCTION_4                ((uint32_t)0x00000010)            /*!< Bit 4 */
+#define  QUADSPI_CCR_INSTRUCTION_5                ((uint32_t)0x00000020)            /*!< Bit 5 */
+#define  QUADSPI_CCR_INSTRUCTION_6                ((uint32_t)0x00000040)            /*!< Bit 6 */
+#define  QUADSPI_CCR_INSTRUCTION_7                ((uint32_t)0x00000080)            /*!< Bit 7 */
+#define  QUADSPI_CCR_IMODE                        ((uint32_t)0x00000300)            /*!< IMODE[1:0]: Instruction Mode      */
+#define  QUADSPI_CCR_IMODE_0                      ((uint32_t)0x00000100)            /*!< Bit 0 */
+#define  QUADSPI_CCR_IMODE_1                      ((uint32_t)0x00000200)            /*!< Bit 1 */
+#define  QUADSPI_CCR_ADMODE                       ((uint32_t)0x00000C00)            /*!< ADMODE[1:0]: Address Mode         */
+#define  QUADSPI_CCR_ADMODE_0                     ((uint32_t)0x00000400)            /*!< Bit 0 */
+#define  QUADSPI_CCR_ADMODE_1                     ((uint32_t)0x00000800)            /*!< Bit 1 */
+#define  QUADSPI_CCR_ADSIZE                       ((uint32_t)0x00003000)            /*!< ADSIZE[1:0]: Address Size         */
+#define  QUADSPI_CCR_ADSIZE_0                     ((uint32_t)0x00001000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_ADSIZE_1                     ((uint32_t)0x00002000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_ABMODE                       ((uint32_t)0x0000C000)            /*!< ABMODE[1:0]: Alternate Bytes Mode */
+#define  QUADSPI_CCR_ABMODE_0                     ((uint32_t)0x00004000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_ABMODE_1                     ((uint32_t)0x00008000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_ABSIZE                       ((uint32_t)0x00030000)            /*!< ABSIZE[1:0]: Instruction Mode     */
+#define  QUADSPI_CCR_ABSIZE_0                     ((uint32_t)0x00010000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_ABSIZE_1                     ((uint32_t)0x00020000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_DCYC                         ((uint32_t)0x007C0000)            /*!< DCYC[4:0]: Dummy Cycles           */
+#define  QUADSPI_CCR_DCYC_0                       ((uint32_t)0x00040000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_DCYC_1                       ((uint32_t)0x00080000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_DCYC_2                       ((uint32_t)0x00100000)            /*!< Bit 2 */
+#define  QUADSPI_CCR_DCYC_3                       ((uint32_t)0x00200000)            /*!< Bit 3 */
+#define  QUADSPI_CCR_DCYC_4                       ((uint32_t)0x00400000)            /*!< Bit 4 */
+#define  QUADSPI_CCR_DMODE                        ((uint32_t)0x03000000)            /*!< DMODE[1:0]: Data Mode              */
+#define  QUADSPI_CCR_DMODE_0                      ((uint32_t)0x01000000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_DMODE_1                      ((uint32_t)0x02000000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_FMODE                        ((uint32_t)0x0C000000)            /*!< FMODE[1:0]: Functional Mode        */
+#define  QUADSPI_CCR_FMODE_0                      ((uint32_t)0x04000000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_FMODE_1                      ((uint32_t)0x08000000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_SIOO                         ((uint32_t)0x10000000)            /*!< SIOO: Send Instruction Only Once Mode */
+#define  QUADSPI_CCR_DHHC                         ((uint32_t)0x40000000)            /*!< DHHC: Delay Half Hclk Cycle           */
+#define  QUADSPI_CCR_DDRM                         ((uint32_t)0x80000000)            /*!< DDRM: Double Data Rate Mode           */
+/******************  Bit definition for QUADSPI_AR register  *******************/
+#define  QUADSPI_AR_ADDRESS                       ((uint32_t)0xFFFFFFFF)            /*!< ADDRESS[31:0]: Address */
+
+/******************  Bit definition for QUADSPI_ABR register  ******************/
+#define  QUADSPI_ABR_ALTERNATE                    ((uint32_t)0xFFFFFFFF)            /*!< ALTERNATE[31:0]: Alternate Bytes */
+
+/******************  Bit definition for QUADSPI_DR register  *******************/
+#define  QUADSPI_DR_DATA                          ((uint32_t)0xFFFFFFFF)            /*!< DATA[31:0]: Data */
+
+/******************  Bit definition for QUADSPI_PSMKR register  ****************/
+#define  QUADSPI_PSMKR_MASK                       ((uint32_t)0xFFFFFFFF)            /*!< MASK[31:0]: Status Mask */
+
+/******************  Bit definition for QUADSPI_PSMAR register  ****************/
+#define  QUADSPI_PSMAR_MATCH                      ((uint32_t)0xFFFFFFFF)            /*!< MATCH[31:0]: Status Match */
+
+/******************  Bit definition for QUADSPI_PIR register  *****************/
+#define  QUADSPI_PIR_INTERVAL                     ((uint32_t)0x0000FFFF)            /*!< INTERVAL[15:0]: Polling Interval */
+
+/******************  Bit definition for QUADSPI_LPTR register  *****************/
+#define  QUADSPI_LPTR_TIMEOUT                     ((uint32_t)0x0000FFFF)            /*!< TIMEOUT[15:0]: Timeout period */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Reset and Clock Control            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for RCC_CR register  ********************/
+#define  RCC_CR_HSION                        ((uint32_t)0x00000001)
+#define  RCC_CR_HSIRDY                       ((uint32_t)0x00000002)
+
+#define  RCC_CR_HSITRIM                      ((uint32_t)0x000000F8)
+#define  RCC_CR_HSITRIM_0                    ((uint32_t)0x00000008) /*!<Bit 0 */
+#define  RCC_CR_HSITRIM_1                    ((uint32_t)0x00000010) /*!<Bit 1 */
+#define  RCC_CR_HSITRIM_2                    ((uint32_t)0x00000020) /*!<Bit 2 */
+#define  RCC_CR_HSITRIM_3                    ((uint32_t)0x00000040) /*!<Bit 3 */
+#define  RCC_CR_HSITRIM_4                    ((uint32_t)0x00000080) /*!<Bit 4 */
+
+#define  RCC_CR_HSICAL                       ((uint32_t)0x0000FF00)
+#define  RCC_CR_HSICAL_0                     ((uint32_t)0x00000100) /*!<Bit 0 */
+#define  RCC_CR_HSICAL_1                     ((uint32_t)0x00000200) /*!<Bit 1 */
+#define  RCC_CR_HSICAL_2                     ((uint32_t)0x00000400) /*!<Bit 2 */
+#define  RCC_CR_HSICAL_3                     ((uint32_t)0x00000800) /*!<Bit 3 */
+#define  RCC_CR_HSICAL_4                     ((uint32_t)0x00001000) /*!<Bit 4 */
+#define  RCC_CR_HSICAL_5                     ((uint32_t)0x00002000) /*!<Bit 5 */
+#define  RCC_CR_HSICAL_6                     ((uint32_t)0x00004000) /*!<Bit 6 */
+#define  RCC_CR_HSICAL_7                     ((uint32_t)0x00008000) /*!<Bit 7 */
+
+#define  RCC_CR_HSEON                        ((uint32_t)0x00010000)
+#define  RCC_CR_HSERDY                       ((uint32_t)0x00020000)
+#define  RCC_CR_HSEBYP                       ((uint32_t)0x00040000)
+#define  RCC_CR_CSSON                        ((uint32_t)0x00080000)
+#define  RCC_CR_PLLON                        ((uint32_t)0x01000000)
+#define  RCC_CR_PLLRDY                       ((uint32_t)0x02000000)
+#define  RCC_CR_PLLI2SON                     ((uint32_t)0x04000000)
+#define  RCC_CR_PLLI2SRDY                    ((uint32_t)0x08000000)
+#define  RCC_CR_PLLSAION                     ((uint32_t)0x10000000)
+#define  RCC_CR_PLLSAIRDY                    ((uint32_t)0x20000000)
+
+/********************  Bit definition for RCC_PLLCFGR register  ***************/
+#define  RCC_PLLCFGR_PLLM                    ((uint32_t)0x0000003F)
+#define  RCC_PLLCFGR_PLLM_0                  ((uint32_t)0x00000001)
+#define  RCC_PLLCFGR_PLLM_1                  ((uint32_t)0x00000002)
+#define  RCC_PLLCFGR_PLLM_2                  ((uint32_t)0x00000004)
+#define  RCC_PLLCFGR_PLLM_3                  ((uint32_t)0x00000008)
+#define  RCC_PLLCFGR_PLLM_4                  ((uint32_t)0x00000010)
+#define  RCC_PLLCFGR_PLLM_5                  ((uint32_t)0x00000020)
+
+#define  RCC_PLLCFGR_PLLN                     ((uint32_t)0x00007FC0)
+#define  RCC_PLLCFGR_PLLN_0                   ((uint32_t)0x00000040)
+#define  RCC_PLLCFGR_PLLN_1                   ((uint32_t)0x00000080)
+#define  RCC_PLLCFGR_PLLN_2                   ((uint32_t)0x00000100)
+#define  RCC_PLLCFGR_PLLN_3                   ((uint32_t)0x00000200)
+#define  RCC_PLLCFGR_PLLN_4                   ((uint32_t)0x00000400)
+#define  RCC_PLLCFGR_PLLN_5                   ((uint32_t)0x00000800)
+#define  RCC_PLLCFGR_PLLN_6                   ((uint32_t)0x00001000)
+#define  RCC_PLLCFGR_PLLN_7                   ((uint32_t)0x00002000)
+#define  RCC_PLLCFGR_PLLN_8                   ((uint32_t)0x00004000)
+
+#define  RCC_PLLCFGR_PLLP                    ((uint32_t)0x00030000)
+#define  RCC_PLLCFGR_PLLP_0                  ((uint32_t)0x00010000)
+#define  RCC_PLLCFGR_PLLP_1                  ((uint32_t)0x00020000)
+
+#define  RCC_PLLCFGR_PLLSRC                  ((uint32_t)0x00400000)
+#define  RCC_PLLCFGR_PLLSRC_HSE              ((uint32_t)0x00400000)
+#define  RCC_PLLCFGR_PLLSRC_HSI              ((uint32_t)0x00000000)
+
+#define  RCC_PLLCFGR_PLLQ                    ((uint32_t)0x0F000000)
+#define  RCC_PLLCFGR_PLLQ_0                  ((uint32_t)0x01000000)
+#define  RCC_PLLCFGR_PLLQ_1                  ((uint32_t)0x02000000)
+#define  RCC_PLLCFGR_PLLQ_2                  ((uint32_t)0x04000000)
+#define  RCC_PLLCFGR_PLLQ_3                  ((uint32_t)0x08000000)
+
+/********************  Bit definition for RCC_CFGR register  ******************/
+/*!< SW configuration */
+#define  RCC_CFGR_SW                         ((uint32_t)0x00000003)        /*!< SW[1:0] bits (System clock Switch) */
+#define  RCC_CFGR_SW_0                       ((uint32_t)0x00000001)        /*!< Bit 0 */
+#define  RCC_CFGR_SW_1                       ((uint32_t)0x00000002)        /*!< Bit 1 */
+
+#define  RCC_CFGR_SW_HSI                     ((uint32_t)0x00000000)        /*!< HSI selected as system clock */
+#define  RCC_CFGR_SW_HSE                     ((uint32_t)0x00000001)        /*!< HSE selected as system clock */
+#define  RCC_CFGR_SW_PLL                     ((uint32_t)0x00000002)        /*!< PLL selected as system clock */
+
+/*!< SWS configuration */
+#define  RCC_CFGR_SWS                        ((uint32_t)0x0000000C)        /*!< SWS[1:0] bits (System Clock Switch Status) */
+#define  RCC_CFGR_SWS_0                      ((uint32_t)0x00000004)        /*!< Bit 0 */
+#define  RCC_CFGR_SWS_1                      ((uint32_t)0x00000008)        /*!< Bit 1 */
+
+#define  RCC_CFGR_SWS_HSI                    ((uint32_t)0x00000000)        /*!< HSI oscillator used as system clock */
+#define  RCC_CFGR_SWS_HSE                    ((uint32_t)0x00000004)        /*!< HSE oscillator used as system clock */
+#define  RCC_CFGR_SWS_PLL                    ((uint32_t)0x00000008)        /*!< PLL used as system clock */
+
+/*!< HPRE configuration */
+#define  RCC_CFGR_HPRE                       ((uint32_t)0x000000F0)        /*!< HPRE[3:0] bits (AHB prescaler) */
+#define  RCC_CFGR_HPRE_0                     ((uint32_t)0x00000010)        /*!< Bit 0 */
+#define  RCC_CFGR_HPRE_1                     ((uint32_t)0x00000020)        /*!< Bit 1 */
+#define  RCC_CFGR_HPRE_2                     ((uint32_t)0x00000040)        /*!< Bit 2 */
+#define  RCC_CFGR_HPRE_3                     ((uint32_t)0x00000080)        /*!< Bit 3 */
+
+#define  RCC_CFGR_HPRE_DIV1                  ((uint32_t)0x00000000)        /*!< SYSCLK not divided */
+#define  RCC_CFGR_HPRE_DIV2                  ((uint32_t)0x00000080)        /*!< SYSCLK divided by 2 */
+#define  RCC_CFGR_HPRE_DIV4                  ((uint32_t)0x00000090)        /*!< SYSCLK divided by 4 */
+#define  RCC_CFGR_HPRE_DIV8                  ((uint32_t)0x000000A0)        /*!< SYSCLK divided by 8 */
+#define  RCC_CFGR_HPRE_DIV16                 ((uint32_t)0x000000B0)        /*!< SYSCLK divided by 16 */
+#define  RCC_CFGR_HPRE_DIV64                 ((uint32_t)0x000000C0)        /*!< SYSCLK divided by 64 */
+#define  RCC_CFGR_HPRE_DIV128                ((uint32_t)0x000000D0)        /*!< SYSCLK divided by 128 */
+#define  RCC_CFGR_HPRE_DIV256                ((uint32_t)0x000000E0)        /*!< SYSCLK divided by 256 */
+#define  RCC_CFGR_HPRE_DIV512                ((uint32_t)0x000000F0)        /*!< SYSCLK divided by 512 */
+
+/*!< PPRE1 configuration */
+#define  RCC_CFGR_PPRE1                      ((uint32_t)0x00001C00)        /*!< PRE1[2:0] bits (APB1 prescaler) */
+#define  RCC_CFGR_PPRE1_0                    ((uint32_t)0x00000400)        /*!< Bit 0 */
+#define  RCC_CFGR_PPRE1_1                    ((uint32_t)0x00000800)        /*!< Bit 1 */
+#define  RCC_CFGR_PPRE1_2                    ((uint32_t)0x00001000)        /*!< Bit 2 */
+
+#define  RCC_CFGR_PPRE1_DIV1                 ((uint32_t)0x00000000)        /*!< HCLK not divided */
+#define  RCC_CFGR_PPRE1_DIV2                 ((uint32_t)0x00001000)        /*!< HCLK divided by 2 */
+#define  RCC_CFGR_PPRE1_DIV4                 ((uint32_t)0x00001400)        /*!< HCLK divided by 4 */
+#define  RCC_CFGR_PPRE1_DIV8                 ((uint32_t)0x00001800)        /*!< HCLK divided by 8 */
+#define  RCC_CFGR_PPRE1_DIV16                ((uint32_t)0x00001C00)        /*!< HCLK divided by 16 */
+
+/*!< PPRE2 configuration */
+#define  RCC_CFGR_PPRE2                      ((uint32_t)0x0000E000)        /*!< PRE2[2:0] bits (APB2 prescaler) */
+#define  RCC_CFGR_PPRE2_0                    ((uint32_t)0x00002000)        /*!< Bit 0 */
+#define  RCC_CFGR_PPRE2_1                    ((uint32_t)0x00004000)        /*!< Bit 1 */
+#define  RCC_CFGR_PPRE2_2                    ((uint32_t)0x00008000)        /*!< Bit 2 */
+
+#define  RCC_CFGR_PPRE2_DIV1                 ((uint32_t)0x00000000)        /*!< HCLK not divided */
+#define  RCC_CFGR_PPRE2_DIV2                 ((uint32_t)0x00008000)        /*!< HCLK divided by 2 */
+#define  RCC_CFGR_PPRE2_DIV4                 ((uint32_t)0x0000A000)        /*!< HCLK divided by 4 */
+#define  RCC_CFGR_PPRE2_DIV8                 ((uint32_t)0x0000C000)        /*!< HCLK divided by 8 */
+#define  RCC_CFGR_PPRE2_DIV16                ((uint32_t)0x0000E000)        /*!< HCLK divided by 16 */
+
+/*!< RTCPRE configuration */
+#define  RCC_CFGR_RTCPRE                     ((uint32_t)0x001F0000)
+#define  RCC_CFGR_RTCPRE_0                   ((uint32_t)0x00010000)
+#define  RCC_CFGR_RTCPRE_1                   ((uint32_t)0x00020000)
+#define  RCC_CFGR_RTCPRE_2                   ((uint32_t)0x00040000)
+#define  RCC_CFGR_RTCPRE_3                   ((uint32_t)0x00080000)
+#define  RCC_CFGR_RTCPRE_4                   ((uint32_t)0x00100000)
+
+/*!< MCO1 configuration */
+#define  RCC_CFGR_MCO1                       ((uint32_t)0x00600000)
+#define  RCC_CFGR_MCO1_0                     ((uint32_t)0x00200000)
+#define  RCC_CFGR_MCO1_1                     ((uint32_t)0x00400000)
+
+#define  RCC_CFGR_I2SSRC                     ((uint32_t)0x00800000)
+
+#define  RCC_CFGR_MCO1PRE                    ((uint32_t)0x07000000)
+#define  RCC_CFGR_MCO1PRE_0                  ((uint32_t)0x01000000)
+#define  RCC_CFGR_MCO1PRE_1                  ((uint32_t)0x02000000)
+#define  RCC_CFGR_MCO1PRE_2                  ((uint32_t)0x04000000)
+
+#define  RCC_CFGR_MCO2PRE                    ((uint32_t)0x38000000)
+#define  RCC_CFGR_MCO2PRE_0                  ((uint32_t)0x08000000)
+#define  RCC_CFGR_MCO2PRE_1                  ((uint32_t)0x10000000)
+#define  RCC_CFGR_MCO2PRE_2                  ((uint32_t)0x20000000)
+
+#define  RCC_CFGR_MCO2                       ((uint32_t)0xC0000000)
+#define  RCC_CFGR_MCO2_0                     ((uint32_t)0x40000000)
+#define  RCC_CFGR_MCO2_1                     ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_CIR register  *******************/
+#define  RCC_CIR_LSIRDYF                     ((uint32_t)0x00000001)
+#define  RCC_CIR_LSERDYF                     ((uint32_t)0x00000002)
+#define  RCC_CIR_HSIRDYF                     ((uint32_t)0x00000004)
+#define  RCC_CIR_HSERDYF                     ((uint32_t)0x00000008)
+#define  RCC_CIR_PLLRDYF                     ((uint32_t)0x00000010)
+#define  RCC_CIR_PLLI2SRDYF                  ((uint32_t)0x00000020)
+#define  RCC_CIR_PLLSAIRDYF                  ((uint32_t)0x00000040)
+#define  RCC_CIR_CSSF                        ((uint32_t)0x00000080)
+#define  RCC_CIR_LSIRDYIE                    ((uint32_t)0x00000100)
+#define  RCC_CIR_LSERDYIE                    ((uint32_t)0x00000200)
+#define  RCC_CIR_HSIRDYIE                    ((uint32_t)0x00000400)
+#define  RCC_CIR_HSERDYIE                    ((uint32_t)0x00000800)
+#define  RCC_CIR_PLLRDYIE                    ((uint32_t)0x00001000)
+#define  RCC_CIR_PLLI2SRDYIE                 ((uint32_t)0x00002000)
+#define  RCC_CIR_PLLSAIRDYIE                 ((uint32_t)0x00004000)
+#define  RCC_CIR_LSIRDYC                     ((uint32_t)0x00010000)
+#define  RCC_CIR_LSERDYC                     ((uint32_t)0x00020000)
+#define  RCC_CIR_HSIRDYC                     ((uint32_t)0x00040000)
+#define  RCC_CIR_HSERDYC                     ((uint32_t)0x00080000)
+#define  RCC_CIR_PLLRDYC                     ((uint32_t)0x00100000)
+#define  RCC_CIR_PLLI2SRDYC                  ((uint32_t)0x00200000)
+#define  RCC_CIR_PLLSAIRDYC                  ((uint32_t)0x00400000)
+#define  RCC_CIR_CSSC                        ((uint32_t)0x00800000)
+
+/********************  Bit definition for RCC_AHB1RSTR register  **************/
+#define  RCC_AHB1RSTR_GPIOARST               ((uint32_t)0x00000001)
+#define  RCC_AHB1RSTR_GPIOBRST               ((uint32_t)0x00000002)
+#define  RCC_AHB1RSTR_GPIOCRST               ((uint32_t)0x00000004)
+#define  RCC_AHB1RSTR_GPIODRST               ((uint32_t)0x00000008)
+#define  RCC_AHB1RSTR_GPIOERST               ((uint32_t)0x00000010)
+#define  RCC_AHB1RSTR_GPIOFRST               ((uint32_t)0x00000020)
+#define  RCC_AHB1RSTR_GPIOGRST               ((uint32_t)0x00000040)
+#define  RCC_AHB1RSTR_GPIOHRST               ((uint32_t)0x00000080)
+#define  RCC_AHB1RSTR_GPIOIRST               ((uint32_t)0x00000100)
+#define  RCC_AHB1RSTR_GPIOJRST               ((uint32_t)0x00000200)
+#define  RCC_AHB1RSTR_GPIOKRST               ((uint32_t)0x00000400)
+#define  RCC_AHB1RSTR_CRCRST                 ((uint32_t)0x00001000)
+#define  RCC_AHB1RSTR_DMA1RST                ((uint32_t)0x00200000)
+#define  RCC_AHB1RSTR_DMA2RST                ((uint32_t)0x00400000)
+#define  RCC_AHB1RSTR_DMA2DRST               ((uint32_t)0x00800000)
+#define  RCC_AHB1RSTR_ETHMACRST              ((uint32_t)0x02000000)
+#define  RCC_AHB1RSTR_OTGHRST                ((uint32_t)0x20000000)
+
+/********************  Bit definition for RCC_AHB2RSTR register  **************/
+#define  RCC_AHB2RSTR_DCMIRST                ((uint32_t)0x00000001)
+#define  RCC_AHB2RSTR_RNGRST                 ((uint32_t)0x00000040)
+#define  RCC_AHB2RSTR_OTGFSRST               ((uint32_t)0x00000080)
+
+/********************  Bit definition for RCC_AHB3RSTR register  **************/
+
+#define  RCC_AHB3RSTR_FMCRST                ((uint32_t)0x00000001)
+#define  RCC_AHB3RSTR_QSPIRST               ((uint32_t)0x00000002)
+
+/********************  Bit definition for RCC_APB1RSTR register  **************/
+#define  RCC_APB1RSTR_TIM2RST                ((uint32_t)0x00000001)
+#define  RCC_APB1RSTR_TIM3RST                ((uint32_t)0x00000002)
+#define  RCC_APB1RSTR_TIM4RST                ((uint32_t)0x00000004)
+#define  RCC_APB1RSTR_TIM5RST                ((uint32_t)0x00000008)
+#define  RCC_APB1RSTR_TIM6RST                ((uint32_t)0x00000010)
+#define  RCC_APB1RSTR_TIM7RST                ((uint32_t)0x00000020)
+#define  RCC_APB1RSTR_TIM12RST               ((uint32_t)0x00000040)
+#define  RCC_APB1RSTR_TIM13RST               ((uint32_t)0x00000080)
+#define  RCC_APB1RSTR_TIM14RST               ((uint32_t)0x00000100)
+#define  RCC_APB1RSTR_LPTIM1RST              ((uint32_t)0x00000200)
+#define  RCC_APB1RSTR_WWDGRST                ((uint32_t)0x00000800)
+#define  RCC_APB1RSTR_SPI2RST                ((uint32_t)0x00004000)
+#define  RCC_APB1RSTR_SPI3RST                ((uint32_t)0x00008000)
+#define  RCC_APB1RSTR_SPDIFRXRST             ((uint32_t)0x00010000)
+#define  RCC_APB1RSTR_USART2RST              ((uint32_t)0x00020000)
+#define  RCC_APB1RSTR_USART3RST              ((uint32_t)0x00040000)
+#define  RCC_APB1RSTR_UART4RST               ((uint32_t)0x00080000)
+#define  RCC_APB1RSTR_UART5RST               ((uint32_t)0x00100000)
+#define  RCC_APB1RSTR_I2C1RST                ((uint32_t)0x00200000)
+#define  RCC_APB1RSTR_I2C2RST                ((uint32_t)0x00400000)
+#define  RCC_APB1RSTR_I2C3RST                ((uint32_t)0x00800000)
+#define  RCC_APB1RSTR_I2C4RST                ((uint32_t)0x01000000)
+#define  RCC_APB1RSTR_CAN1RST                ((uint32_t)0x02000000)
+#define  RCC_APB1RSTR_CAN2RST                ((uint32_t)0x04000000)
+#define  RCC_APB1RSTR_CECRST                 ((uint32_t)0x08000000)
+#define  RCC_APB1RSTR_PWRRST                 ((uint32_t)0x10000000)
+#define  RCC_APB1RSTR_DACRST                 ((uint32_t)0x20000000)
+#define  RCC_APB1RSTR_UART7RST               ((uint32_t)0x40000000)
+#define  RCC_APB1RSTR_UART8RST               ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_APB2RSTR register  **************/
+#define  RCC_APB2RSTR_TIM1RST                ((uint32_t)0x00000001)
+#define  RCC_APB2RSTR_TIM8RST                ((uint32_t)0x00000002)
+#define  RCC_APB2RSTR_USART1RST              ((uint32_t)0x00000010)
+#define  RCC_APB2RSTR_USART6RST              ((uint32_t)0x00000020)
+#define  RCC_APB2RSTR_ADCRST                 ((uint32_t)0x00000100)
+#define  RCC_APB2RSTR_SDMMC1RST              ((uint32_t)0x00000800)
+#define  RCC_APB2RSTR_SPI1RST                ((uint32_t)0x00001000)
+#define  RCC_APB2RSTR_SPI4RST                ((uint32_t)0x00002000)
+#define  RCC_APB2RSTR_SYSCFGRST              ((uint32_t)0x00004000)
+#define  RCC_APB2RSTR_TIM9RST                ((uint32_t)0x00010000)
+#define  RCC_APB2RSTR_TIM10RST               ((uint32_t)0x00020000)
+#define  RCC_APB2RSTR_TIM11RST               ((uint32_t)0x00040000)
+#define  RCC_APB2RSTR_SPI5RST                ((uint32_t)0x00100000)
+#define  RCC_APB2RSTR_SPI6RST                ((uint32_t)0x00200000)
+#define  RCC_APB2RSTR_SAI1RST                ((uint32_t)0x00400000)
+#define  RCC_APB2RSTR_SAI2RST                ((uint32_t)0x00800000)
+#define  RCC_APB2RSTR_LTDCRST                ((uint32_t)0x04000000)
+
+/********************  Bit definition for RCC_AHB1ENR register  ***************/
+#define  RCC_AHB1ENR_GPIOAEN                 ((uint32_t)0x00000001)
+#define  RCC_AHB1ENR_GPIOBEN                 ((uint32_t)0x00000002)
+#define  RCC_AHB1ENR_GPIOCEN                 ((uint32_t)0x00000004)
+#define  RCC_AHB1ENR_GPIODEN                 ((uint32_t)0x00000008)
+#define  RCC_AHB1ENR_GPIOEEN                 ((uint32_t)0x00000010)
+#define  RCC_AHB1ENR_GPIOFEN                 ((uint32_t)0x00000020)
+#define  RCC_AHB1ENR_GPIOGEN                 ((uint32_t)0x00000040)
+#define  RCC_AHB1ENR_GPIOHEN                 ((uint32_t)0x00000080)
+#define  RCC_AHB1ENR_GPIOIEN                 ((uint32_t)0x00000100)
+#define  RCC_AHB1ENR_GPIOJEN                 ((uint32_t)0x00000200)
+#define  RCC_AHB1ENR_GPIOKEN                 ((uint32_t)0x00000400)
+#define  RCC_AHB1ENR_CRCEN                   ((uint32_t)0x00001000)
+#define  RCC_AHB1ENR_BKPSRAMEN               ((uint32_t)0x00040000)
+#define  RCC_AHB1ENR_DTCMRAMEN               ((uint32_t)0x00100000)
+#define  RCC_AHB1ENR_DMA1EN                  ((uint32_t)0x00200000)
+#define  RCC_AHB1ENR_DMA2EN                  ((uint32_t)0x00400000)
+#define  RCC_AHB1ENR_DMA2DEN                 ((uint32_t)0x00800000)
+#define  RCC_AHB1ENR_ETHMACEN                ((uint32_t)0x02000000)
+#define  RCC_AHB1ENR_ETHMACTXEN              ((uint32_t)0x04000000)
+#define  RCC_AHB1ENR_ETHMACRXEN              ((uint32_t)0x08000000)
+#define  RCC_AHB1ENR_ETHMACPTPEN             ((uint32_t)0x10000000)
+#define  RCC_AHB1ENR_OTGHSEN                 ((uint32_t)0x20000000)
+#define  RCC_AHB1ENR_OTGHSULPIEN             ((uint32_t)0x40000000)
+
+/********************  Bit definition for RCC_AHB2ENR register  ***************/
+#define  RCC_AHB2ENR_DCMIEN                  ((uint32_t)0x00000001)
+#define  RCC_AHB2ENR_RNGEN                   ((uint32_t)0x00000040)
+#define  RCC_AHB2ENR_OTGFSEN                 ((uint32_t)0x00000080)
+
+/********************  Bit definition for RCC_AHB3ENR register  ***************/
+
+#define  RCC_AHB3ENR_FMCEN                  ((uint32_t)0x00000001)
+#define  RCC_AHB3ENR_QSPIEN                 ((uint32_t)0x00000002)
+
+/********************  Bit definition for RCC_APB1ENR register  ***************/
+#define  RCC_APB1ENR_TIM2EN                  ((uint32_t)0x00000001)
+#define  RCC_APB1ENR_TIM3EN                  ((uint32_t)0x00000002)
+#define  RCC_APB1ENR_TIM4EN                  ((uint32_t)0x00000004)
+#define  RCC_APB1ENR_TIM5EN                  ((uint32_t)0x00000008)
+#define  RCC_APB1ENR_TIM6EN                  ((uint32_t)0x00000010)
+#define  RCC_APB1ENR_TIM7EN                  ((uint32_t)0x00000020)
+#define  RCC_APB1ENR_TIM12EN                 ((uint32_t)0x00000040)
+#define  RCC_APB1ENR_TIM13EN                 ((uint32_t)0x00000080)
+#define  RCC_APB1ENR_TIM14EN                 ((uint32_t)0x00000100)
+#define  RCC_APB1ENR_LPTIM1EN                ((uint32_t)0x00000200)
+#define  RCC_APB1ENR_WWDGEN                  ((uint32_t)0x00000800)
+#define  RCC_APB1ENR_SPI2EN                  ((uint32_t)0x00004000)
+#define  RCC_APB1ENR_SPI3EN                  ((uint32_t)0x00008000)
+#define  RCC_APB1ENR_SPDIFRXEN               ((uint32_t)0x00010000)
+#define  RCC_APB1ENR_USART2EN                ((uint32_t)0x00020000)
+#define  RCC_APB1ENR_USART3EN                ((uint32_t)0x00040000)
+#define  RCC_APB1ENR_UART4EN                 ((uint32_t)0x00080000)
+#define  RCC_APB1ENR_UART5EN                 ((uint32_t)0x00100000)
+#define  RCC_APB1ENR_I2C1EN                  ((uint32_t)0x00200000)
+#define  RCC_APB1ENR_I2C2EN                  ((uint32_t)0x00400000)
+#define  RCC_APB1ENR_I2C3EN                  ((uint32_t)0x00800000)
+#define  RCC_APB1ENR_I2C4EN                  ((uint32_t)0x01000000)
+#define  RCC_APB1ENR_CAN1EN                  ((uint32_t)0x02000000)
+#define  RCC_APB1ENR_CAN2EN                  ((uint32_t)0x04000000)
+#define  RCC_APB1ENR_CECEN                   ((uint32_t)0x08000000)
+#define  RCC_APB1ENR_PWREN                   ((uint32_t)0x10000000)
+#define  RCC_APB1ENR_DACEN                   ((uint32_t)0x20000000)
+#define  RCC_APB1ENR_UART7EN                 ((uint32_t)0x40000000)
+#define  RCC_APB1ENR_UART8EN                 ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_APB2ENR register  ***************/
+#define  RCC_APB2ENR_TIM1EN                  ((uint32_t)0x00000001)
+#define  RCC_APB2ENR_TIM8EN                  ((uint32_t)0x00000002)
+#define  RCC_APB2ENR_USART1EN                ((uint32_t)0x00000010)
+#define  RCC_APB2ENR_USART6EN                ((uint32_t)0x00000020)
+#define  RCC_APB2ENR_ADC1EN                  ((uint32_t)0x00000100)
+#define  RCC_APB2ENR_ADC2EN                  ((uint32_t)0x00000200)
+#define  RCC_APB2ENR_ADC3EN                  ((uint32_t)0x00000400)
+#define  RCC_APB2ENR_SDMMC1EN                ((uint32_t)0x00000800)
+#define  RCC_APB2ENR_SPI1EN                  ((uint32_t)0x00001000)
+#define  RCC_APB2ENR_SPI4EN                  ((uint32_t)0x00002000)
+#define  RCC_APB2ENR_SYSCFGEN                ((uint32_t)0x00004000)
+#define  RCC_APB2ENR_TIM9EN                  ((uint32_t)0x00010000)
+#define  RCC_APB2ENR_TIM10EN                 ((uint32_t)0x00020000)
+#define  RCC_APB2ENR_TIM11EN                 ((uint32_t)0x00040000)
+#define  RCC_APB2ENR_SPI5EN                  ((uint32_t)0x00100000)
+#define  RCC_APB2ENR_SPI6EN                  ((uint32_t)0x00200000)
+#define  RCC_APB2ENR_SAI1EN                  ((uint32_t)0x00400000)
+#define  RCC_APB2ENR_SAI2EN                  ((uint32_t)0x00800000)
+#define  RCC_APB2ENR_LTDCEN                  ((uint32_t)0x04000000)
+
+/********************  Bit definition for RCC_AHB1LPENR register  *************/
+#define  RCC_AHB1LPENR_GPIOALPEN             ((uint32_t)0x00000001)
+#define  RCC_AHB1LPENR_GPIOBLPEN             ((uint32_t)0x00000002)
+#define  RCC_AHB1LPENR_GPIOCLPEN             ((uint32_t)0x00000004)
+#define  RCC_AHB1LPENR_GPIODLPEN             ((uint32_t)0x00000008)
+#define  RCC_AHB1LPENR_GPIOELPEN             ((uint32_t)0x00000010)
+#define  RCC_AHB1LPENR_GPIOFLPEN             ((uint32_t)0x00000020)
+#define  RCC_AHB1LPENR_GPIOGLPEN             ((uint32_t)0x00000040)
+#define  RCC_AHB1LPENR_GPIOHLPEN             ((uint32_t)0x00000080)
+#define  RCC_AHB1LPENR_GPIOILPEN             ((uint32_t)0x00000100)
+#define  RCC_AHB1LPENR_GPIOJLPEN             ((uint32_t)0x00000200)
+#define  RCC_AHB1LPENR_GPIOKLPEN             ((uint32_t)0x00000400)
+
+#define  RCC_AHB1LPENR_CRCLPEN               ((uint32_t)0x00001000)
+#define  RCC_AHB1LPENR_AXILPEN               ((uint32_t)0x00002000)
+#define  RCC_AHB1LPENR_FLITFLPEN             ((uint32_t)0x00008000)
+#define  RCC_AHB1LPENR_SRAM1LPEN             ((uint32_t)0x00010000)
+#define  RCC_AHB1LPENR_SRAM2LPEN             ((uint32_t)0x00020000)
+#define  RCC_AHB1LPENR_BKPSRAMLPEN           ((uint32_t)0x00040000)
+#define  RCC_AHB1LPENR_DTCMLPEN              ((uint32_t)0x00100000)
+#define  RCC_AHB1LPENR_DMA1LPEN              ((uint32_t)0x00200000)
+#define  RCC_AHB1LPENR_DMA2LPEN              ((uint32_t)0x00400000)
+#define  RCC_AHB1LPENR_DMA2DLPEN             ((uint32_t)0x00800000)
+#define  RCC_AHB1LPENR_ETHMACLPEN            ((uint32_t)0x02000000)
+#define  RCC_AHB1LPENR_ETHMACTXLPEN          ((uint32_t)0x04000000)
+#define  RCC_AHB1LPENR_ETHMACRXLPEN          ((uint32_t)0x08000000)
+#define  RCC_AHB1LPENR_ETHMACPTPLPEN         ((uint32_t)0x10000000)
+#define  RCC_AHB1LPENR_OTGHSLPEN             ((uint32_t)0x20000000)
+#define  RCC_AHB1LPENR_OTGHSULPILPEN         ((uint32_t)0x40000000)
+
+/********************  Bit definition for RCC_AHB2LPENR register  *************/
+#define  RCC_AHB2LPENR_DCMILPEN              ((uint32_t)0x00000001)
+#define  RCC_AHB2LPENR_RNGLPEN               ((uint32_t)0x00000040)
+#define  RCC_AHB2LPENR_OTGFSLPEN             ((uint32_t)0x00000080)
+
+/********************  Bit definition for RCC_AHB3LPENR register  *************/
+#define  RCC_AHB3LPENR_FMCLPEN              ((uint32_t)0x00000001)
+#define  RCC_AHB3LPENR_QSPILPEN             ((uint32_t)0x00000002)
+/********************  Bit definition for RCC_APB1LPENR register  *************/
+#define  RCC_APB1LPENR_TIM2LPEN              ((uint32_t)0x00000001)
+#define  RCC_APB1LPENR_TIM3LPEN              ((uint32_t)0x00000002)
+#define  RCC_APB1LPENR_TIM4LPEN              ((uint32_t)0x00000004)
+#define  RCC_APB1LPENR_TIM5LPEN              ((uint32_t)0x00000008)
+#define  RCC_APB1LPENR_TIM6LPEN              ((uint32_t)0x00000010)
+#define  RCC_APB1LPENR_TIM7LPEN              ((uint32_t)0x00000020)
+#define  RCC_APB1LPENR_TIM12LPEN             ((uint32_t)0x00000040)
+#define  RCC_APB1LPENR_TIM13LPEN             ((uint32_t)0x00000080)
+#define  RCC_APB1LPENR_TIM14LPEN             ((uint32_t)0x00000100)
+#define  RCC_APB1LPENR_LPTIM1LPEN            ((uint32_t)0x00000200)
+#define  RCC_APB1LPENR_WWDGLPEN              ((uint32_t)0x00000800)
+#define  RCC_APB1LPENR_SPI2LPEN              ((uint32_t)0x00004000)
+#define  RCC_APB1LPENR_SPI3LPEN              ((uint32_t)0x00008000)
+#define  RCC_APB1LPENR_SPDIFRXLPEN           ((uint32_t)0x00010000)
+#define  RCC_APB1LPENR_USART2LPEN            ((uint32_t)0x00020000)
+#define  RCC_APB1LPENR_USART3LPEN            ((uint32_t)0x00040000)
+#define  RCC_APB1LPENR_UART4LPEN             ((uint32_t)0x00080000)
+#define  RCC_APB1LPENR_UART5LPEN             ((uint32_t)0x00100000)
+#define  RCC_APB1LPENR_I2C1LPEN              ((uint32_t)0x00200000)
+#define  RCC_APB1LPENR_I2C2LPEN              ((uint32_t)0x00400000)
+#define  RCC_APB1LPENR_I2C3LPEN              ((uint32_t)0x00800000)
+#define  RCC_APB1LPENR_I2C4LPEN              ((uint32_t)0x01000000)
+#define  RCC_APB1LPENR_CAN1LPEN              ((uint32_t)0x02000000)
+#define  RCC_APB1LPENR_CAN2LPEN              ((uint32_t)0x04000000)
+#define  RCC_APB1LPENR_CECLPEN               ((uint32_t)0x08000000)
+#define  RCC_APB1LPENR_PWRLPEN               ((uint32_t)0x10000000)
+#define  RCC_APB1LPENR_DACLPEN               ((uint32_t)0x20000000)
+#define  RCC_APB1LPENR_UART7LPEN             ((uint32_t)0x40000000)
+#define  RCC_APB1LPENR_UART8LPEN             ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_APB2LPENR register  *************/
+#define  RCC_APB2LPENR_TIM1LPEN              ((uint32_t)0x00000001)
+#define  RCC_APB2LPENR_TIM8LPEN              ((uint32_t)0x00000002)
+#define  RCC_APB2LPENR_USART1LPEN            ((uint32_t)0x00000010)
+#define  RCC_APB2LPENR_USART6LPEN            ((uint32_t)0x00000020)
+#define  RCC_APB2LPENR_ADC1LPEN              ((uint32_t)0x00000100)
+#define  RCC_APB2LPENR_ADC2LPEN              ((uint32_t)0x00000200)
+#define  RCC_APB2LPENR_ADC3LPEN              ((uint32_t)0x00000400)
+#define  RCC_APB2LPENR_SDMMC1LPEN            ((uint32_t)0x00000800)
+#define  RCC_APB2LPENR_SPI1LPEN              ((uint32_t)0x00001000)
+#define  RCC_APB2LPENR_SPI4LPEN              ((uint32_t)0x00002000)
+#define  RCC_APB2LPENR_SYSCFGLPEN            ((uint32_t)0x00004000)
+#define  RCC_APB2LPENR_TIM9LPEN              ((uint32_t)0x00010000)
+#define  RCC_APB2LPENR_TIM10LPEN             ((uint32_t)0x00020000)
+#define  RCC_APB2LPENR_TIM11LPEN             ((uint32_t)0x00040000)
+#define  RCC_APB2LPENR_SPI5LPEN              ((uint32_t)0x00100000)
+#define  RCC_APB2LPENR_SPI6LPEN              ((uint32_t)0x00200000)
+#define  RCC_APB2LPENR_SAI1LPEN              ((uint32_t)0x00400000)
+#define  RCC_APB2LPENR_SAI2LPEN              ((uint32_t)0x00800000)
+#define  RCC_APB2LPENR_LTDCLPEN              ((uint32_t)0x04000000)
+
+/********************  Bit definition for RCC_BDCR register  ******************/
+#define  RCC_BDCR_LSEON                      ((uint32_t)0x00000001)
+#define  RCC_BDCR_LSERDY                     ((uint32_t)0x00000002)
+#define  RCC_BDCR_LSEBYP                     ((uint32_t)0x00000004)
+#define  RCC_BDCR_LSEDRV                     ((uint32_t)0x00000018)
+#define  RCC_BDCR_LSEDRV_0                   ((uint32_t)0x00000008)
+#define  RCC_BDCR_LSEDRV_1                   ((uint32_t)0x00000010)
+#define  RCC_BDCR_RTCSEL                     ((uint32_t)0x00000300)
+#define  RCC_BDCR_RTCSEL_0                   ((uint32_t)0x00000100)
+#define  RCC_BDCR_RTCSEL_1                   ((uint32_t)0x00000200)
+#define  RCC_BDCR_RTCEN                      ((uint32_t)0x00008000)
+#define  RCC_BDCR_BDRST                      ((uint32_t)0x00010000)
+
+/********************  Bit definition for RCC_CSR register  *******************/
+#define  RCC_CSR_LSION                       ((uint32_t)0x00000001)
+#define  RCC_CSR_LSIRDY                      ((uint32_t)0x00000002)
+#define  RCC_CSR_RMVF                        ((uint32_t)0x01000000)
+#define  RCC_CSR_BORRSTF                     ((uint32_t)0x02000000)
+#define  RCC_CSR_PINRSTF                     ((uint32_t)0x04000000)
+#define  RCC_CSR_PORRSTF                     ((uint32_t)0x08000000)
+#define  RCC_CSR_SFTRSTF                     ((uint32_t)0x10000000)
+#define  RCC_CSR_IWDGRSTF                    ((uint32_t)0x20000000)
+#define  RCC_CSR_WWDGRSTF                    ((uint32_t)0x40000000)
+#define  RCC_CSR_LPWRRSTF                    ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_SSCGR register  *****************/
+#define  RCC_SSCGR_MODPER                    ((uint32_t)0x00001FFF)
+#define  RCC_SSCGR_INCSTEP                   ((uint32_t)0x0FFFE000)
+#define  RCC_SSCGR_SPREADSEL                 ((uint32_t)0x40000000)
+#define  RCC_SSCGR_SSCGEN                    ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_PLLI2SCFGR register  ************/
+#define  RCC_PLLI2SCFGR_PLLI2SN              ((uint32_t)0x00007FC0)
+#define  RCC_PLLI2SCFGR_PLLI2SN_0            ((uint32_t)0x00000040)
+#define  RCC_PLLI2SCFGR_PLLI2SN_1            ((uint32_t)0x00000080)
+#define  RCC_PLLI2SCFGR_PLLI2SN_2            ((uint32_t)0x00000100)
+#define  RCC_PLLI2SCFGR_PLLI2SN_3            ((uint32_t)0x00000200)
+#define  RCC_PLLI2SCFGR_PLLI2SN_4            ((uint32_t)0x00000400)
+#define  RCC_PLLI2SCFGR_PLLI2SN_5            ((uint32_t)0x00000800)
+#define  RCC_PLLI2SCFGR_PLLI2SN_6            ((uint32_t)0x00001000)
+#define  RCC_PLLI2SCFGR_PLLI2SN_7            ((uint32_t)0x00002000)
+#define  RCC_PLLI2SCFGR_PLLI2SN_8            ((uint32_t)0x00004000)
+
+#define  RCC_PLLI2SCFGR_PLLI2SP              ((uint32_t)0x00030000)
+#define  RCC_PLLI2SCFGR_PLLI2SP_0            ((uint32_t)0x00010000)
+#define  RCC_PLLI2SCFGR_PLLI2SP_1            ((uint32_t)0x00020000)
+
+#define  RCC_PLLI2SCFGR_PLLI2SQ              ((uint32_t)0x0F000000)
+#define  RCC_PLLI2SCFGR_PLLI2SQ_0            ((uint32_t)0x01000000)
+#define  RCC_PLLI2SCFGR_PLLI2SQ_1            ((uint32_t)0x02000000)
+#define  RCC_PLLI2SCFGR_PLLI2SQ_2            ((uint32_t)0x04000000)
+#define  RCC_PLLI2SCFGR_PLLI2SQ_3            ((uint32_t)0x08000000)
+
+#define  RCC_PLLI2SCFGR_PLLI2SR              ((uint32_t)0x70000000)
+#define  RCC_PLLI2SCFGR_PLLI2SR_0            ((uint32_t)0x10000000)
+#define  RCC_PLLI2SCFGR_PLLI2SR_1            ((uint32_t)0x20000000)
+#define  RCC_PLLI2SCFGR_PLLI2SR_2            ((uint32_t)0x40000000)
+
+/********************  Bit definition for RCC_PLLSAICFGR register  ************/
+#define  RCC_PLLSAICFGR_PLLSAIN              ((uint32_t)0x00007FC0)
+#define  RCC_PLLSAICFGR_PLLSAIN_0            ((uint32_t)0x00000040)
+#define  RCC_PLLSAICFGR_PLLSAIN_1            ((uint32_t)0x00000080)
+#define  RCC_PLLSAICFGR_PLLSAIN_2            ((uint32_t)0x00000100)
+#define  RCC_PLLSAICFGR_PLLSAIN_3            ((uint32_t)0x00000200)
+#define  RCC_PLLSAICFGR_PLLSAIN_4            ((uint32_t)0x00000400)
+#define  RCC_PLLSAICFGR_PLLSAIN_5            ((uint32_t)0x00000800)
+#define  RCC_PLLSAICFGR_PLLSAIN_6            ((uint32_t)0x00001000)
+#define  RCC_PLLSAICFGR_PLLSAIN_7            ((uint32_t)0x00002000)
+#define  RCC_PLLSAICFGR_PLLSAIN_8            ((uint32_t)0x00004000)
+
+#define  RCC_PLLSAICFGR_PLLSAIP              ((uint32_t)0x00030000)
+#define  RCC_PLLSAICFGR_PLLSAIP_0            ((uint32_t)0x00010000)
+#define  RCC_PLLSAICFGR_PLLSAIP_1            ((uint32_t)0x00020000)
+
+#define  RCC_PLLSAICFGR_PLLSAIQ              ((uint32_t)0x0F000000)
+#define  RCC_PLLSAICFGR_PLLSAIQ_0            ((uint32_t)0x01000000)
+#define  RCC_PLLSAICFGR_PLLSAIQ_1            ((uint32_t)0x02000000)
+#define  RCC_PLLSAICFGR_PLLSAIQ_2            ((uint32_t)0x04000000)
+#define  RCC_PLLSAICFGR_PLLSAIQ_3            ((uint32_t)0x08000000)
+
+#define  RCC_PLLSAICFGR_PLLSAIR              ((uint32_t)0x70000000)
+#define  RCC_PLLSAICFGR_PLLSAIR_0            ((uint32_t)0x10000000)
+#define  RCC_PLLSAICFGR_PLLSAIR_1            ((uint32_t)0x20000000)
+#define  RCC_PLLSAICFGR_PLLSAIR_2            ((uint32_t)0x40000000)
+
+/********************  Bit definition for RCC_DCKCFGR1 register  ***************/
+#define  RCC_DCKCFGR1_PLLI2SDIVQ              ((uint32_t)0x0000001F)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_0            ((uint32_t)0x00000001)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_1            ((uint32_t)0x00000002)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_2            ((uint32_t)0x00000004)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_3            ((uint32_t)0x00000008)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_4            ((uint32_t)0x00000010)
+
+#define  RCC_DCKCFGR1_PLLSAIDIVQ              ((uint32_t)0x00001F00)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_0            ((uint32_t)0x00000100)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_1            ((uint32_t)0x00000200)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_2            ((uint32_t)0x00000400)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_3            ((uint32_t)0x00000800)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_4            ((uint32_t)0x00001000)
+
+#define  RCC_DCKCFGR1_PLLSAIDIVR              ((uint32_t)0x00030000)
+#define  RCC_DCKCFGR1_PLLSAIDIVR_0            ((uint32_t)0x00010000)
+#define  RCC_DCKCFGR1_PLLSAIDIVR_1            ((uint32_t)0x00020000)
+
+#define  RCC_DCKCFGR1_SAI1SEL                 ((uint32_t)0x00300000)
+#define  RCC_DCKCFGR1_SAI1SEL_0               ((uint32_t)0x00100000)
+#define  RCC_DCKCFGR1_SAI1SEL_1               ((uint32_t)0x00200000)
+
+#define  RCC_DCKCFGR1_SAI2SEL                 ((uint32_t)0x00C00000)
+#define  RCC_DCKCFGR1_SAI2SEL_0               ((uint32_t)0x00400000)
+#define  RCC_DCKCFGR1_SAI2SEL_1               ((uint32_t)0x00800000)
+
+#define  RCC_DCKCFGR1_TIMPRE                  ((uint32_t)0x01000000)
+
+/********************  Bit definition for RCC_DCKCFGR2 register  ***************/
+#define  RCC_DCKCFGR2_USART1SEL              ((uint32_t)0x00000003)
+#define  RCC_DCKCFGR2_USART1SEL_0            ((uint32_t)0x00000001)
+#define  RCC_DCKCFGR2_USART1SEL_1            ((uint32_t)0x00000002)
+#define  RCC_DCKCFGR2_USART2SEL              ((uint32_t)0x0000000C)
+#define  RCC_DCKCFGR2_USART2SEL_0            ((uint32_t)0x00000004)
+#define  RCC_DCKCFGR2_USART2SEL_1            ((uint32_t)0x00000008)
+#define  RCC_DCKCFGR2_USART3SEL              ((uint32_t)0x00000030)
+#define  RCC_DCKCFGR2_USART3SEL_0            ((uint32_t)0x00000010)
+#define  RCC_DCKCFGR2_USART3SEL_1            ((uint32_t)0x00000020)
+#define  RCC_DCKCFGR2_UART4SEL               ((uint32_t)0x000000C0)
+#define  RCC_DCKCFGR2_UART4SEL_0             ((uint32_t)0x00000040)
+#define  RCC_DCKCFGR2_UART4SEL_1             ((uint32_t)0x00000080)
+#define  RCC_DCKCFGR2_UART5SEL               ((uint32_t)0x00000300)
+#define  RCC_DCKCFGR2_UART5SEL_0             ((uint32_t)0x00000100)
+#define  RCC_DCKCFGR2_UART5SEL_1             ((uint32_t)0x00000200)
+#define  RCC_DCKCFGR2_USART6SEL              ((uint32_t)0x00000C00)
+#define  RCC_DCKCFGR2_USART6SEL_0            ((uint32_t)0x00000400)
+#define  RCC_DCKCFGR2_USART6SEL_1            ((uint32_t)0x00000800)
+#define  RCC_DCKCFGR2_UART7SEL               ((uint32_t)0x00003000)
+#define  RCC_DCKCFGR2_UART7SEL_0             ((uint32_t)0x00001000)
+#define  RCC_DCKCFGR2_UART7SEL_1             ((uint32_t)0x00002000)
+#define  RCC_DCKCFGR2_UART8SEL               ((uint32_t)0x0000C000)
+#define  RCC_DCKCFGR2_UART8SEL_0             ((uint32_t)0x00004000)
+#define  RCC_DCKCFGR2_UART8SEL_1             ((uint32_t)0x00008000)
+#define  RCC_DCKCFGR2_I2C1SEL                ((uint32_t)0x00030000)
+#define  RCC_DCKCFGR2_I2C1SEL_0              ((uint32_t)0x00010000)
+#define  RCC_DCKCFGR2_I2C1SEL_1              ((uint32_t)0x00020000)
+#define  RCC_DCKCFGR2_I2C2SEL                ((uint32_t)0x000C0000)
+#define  RCC_DCKCFGR2_I2C2SEL_0              ((uint32_t)0x00040000)
+#define  RCC_DCKCFGR2_I2C2SEL_1              ((uint32_t)0x00080000)
+#define  RCC_DCKCFGR2_I2C3SEL                ((uint32_t)0x00300000)
+#define  RCC_DCKCFGR2_I2C3SEL_0              ((uint32_t)0x00100000)
+#define  RCC_DCKCFGR2_I2C3SEL_1              ((uint32_t)0x00200000)
+#define  RCC_DCKCFGR2_I2C4SEL                ((uint32_t)0x00C00000)
+#define  RCC_DCKCFGR2_I2C4SEL_0              ((uint32_t)0x00400000)
+#define  RCC_DCKCFGR2_I2C4SEL_1              ((uint32_t)0x00800000)
+#define  RCC_DCKCFGR2_LPTIM1SEL              ((uint32_t)0x03000000)
+#define  RCC_DCKCFGR2_LPTIM1SEL_0            ((uint32_t)0x01000000)
+#define  RCC_DCKCFGR2_LPTIM1SEL_1            ((uint32_t)0x02000000)
+#define  RCC_DCKCFGR2_CECSEL                 ((uint32_t)0x04000000)
+#define  RCC_DCKCFGR2_CK48MSEL               ((uint32_t)0x08000000)
+#define  RCC_DCKCFGR2_SDMMC1SEL              ((uint32_t)0x10000000)
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    RNG                                     */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for RNG_CR register  *******************/
+#define RNG_CR_RNGEN                         ((uint32_t)0x00000004)
+#define RNG_CR_IE                            ((uint32_t)0x00000008)
+
+/********************  Bits definition for RNG_SR register  *******************/
+#define RNG_SR_DRDY                          ((uint32_t)0x00000001)
+#define RNG_SR_CECS                          ((uint32_t)0x00000002)
+#define RNG_SR_SECS                          ((uint32_t)0x00000004)
+#define RNG_SR_CEIS                          ((uint32_t)0x00000020)
+#define RNG_SR_SEIS                          ((uint32_t)0x00000040)
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Real-Time Clock (RTC)                            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for RTC_TR register  *******************/
+#define RTC_TR_PM                            ((uint32_t)0x00400000)
+#define RTC_TR_HT                            ((uint32_t)0x00300000)
+#define RTC_TR_HT_0                          ((uint32_t)0x00100000)
+#define RTC_TR_HT_1                          ((uint32_t)0x00200000)
+#define RTC_TR_HU                            ((uint32_t)0x000F0000)
+#define RTC_TR_HU_0                          ((uint32_t)0x00010000)
+#define RTC_TR_HU_1                          ((uint32_t)0x00020000)
+#define RTC_TR_HU_2                          ((uint32_t)0x00040000)
+#define RTC_TR_HU_3                          ((uint32_t)0x00080000)
+#define RTC_TR_MNT                           ((uint32_t)0x00007000)
+#define RTC_TR_MNT_0                         ((uint32_t)0x00001000)
+#define RTC_TR_MNT_1                         ((uint32_t)0x00002000)
+#define RTC_TR_MNT_2                         ((uint32_t)0x00004000)
+#define RTC_TR_MNU                           ((uint32_t)0x00000F00)
+#define RTC_TR_MNU_0                         ((uint32_t)0x00000100)
+#define RTC_TR_MNU_1                         ((uint32_t)0x00000200)
+#define RTC_TR_MNU_2                         ((uint32_t)0x00000400)
+#define RTC_TR_MNU_3                         ((uint32_t)0x00000800)
+#define RTC_TR_ST                            ((uint32_t)0x00000070)
+#define RTC_TR_ST_0                          ((uint32_t)0x00000010)
+#define RTC_TR_ST_1                          ((uint32_t)0x00000020)
+#define RTC_TR_ST_2                          ((uint32_t)0x00000040)
+#define RTC_TR_SU                            ((uint32_t)0x0000000F)
+#define RTC_TR_SU_0                          ((uint32_t)0x00000001)
+#define RTC_TR_SU_1                          ((uint32_t)0x00000002)
+#define RTC_TR_SU_2                          ((uint32_t)0x00000004)
+#define RTC_TR_SU_3                          ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_DR register  *******************/
+#define RTC_DR_YT                            ((uint32_t)0x00F00000)
+#define RTC_DR_YT_0                          ((uint32_t)0x00100000)
+#define RTC_DR_YT_1                          ((uint32_t)0x00200000)
+#define RTC_DR_YT_2                          ((uint32_t)0x00400000)
+#define RTC_DR_YT_3                          ((uint32_t)0x00800000)
+#define RTC_DR_YU                            ((uint32_t)0x000F0000)
+#define RTC_DR_YU_0                          ((uint32_t)0x00010000)
+#define RTC_DR_YU_1                          ((uint32_t)0x00020000)
+#define RTC_DR_YU_2                          ((uint32_t)0x00040000)
+#define RTC_DR_YU_3                          ((uint32_t)0x00080000)
+#define RTC_DR_WDU                           ((uint32_t)0x0000E000)
+#define RTC_DR_WDU_0                         ((uint32_t)0x00002000)
+#define RTC_DR_WDU_1                         ((uint32_t)0x00004000)
+#define RTC_DR_WDU_2                         ((uint32_t)0x00008000)
+#define RTC_DR_MT                            ((uint32_t)0x00001000)
+#define RTC_DR_MU                            ((uint32_t)0x00000F00)
+#define RTC_DR_MU_0                          ((uint32_t)0x00000100)
+#define RTC_DR_MU_1                          ((uint32_t)0x00000200)
+#define RTC_DR_MU_2                          ((uint32_t)0x00000400)
+#define RTC_DR_MU_3                          ((uint32_t)0x00000800)
+#define RTC_DR_DT                            ((uint32_t)0x00000030)
+#define RTC_DR_DT_0                          ((uint32_t)0x00000010)
+#define RTC_DR_DT_1                          ((uint32_t)0x00000020)
+#define RTC_DR_DU                            ((uint32_t)0x0000000F)
+#define RTC_DR_DU_0                          ((uint32_t)0x00000001)
+#define RTC_DR_DU_1                          ((uint32_t)0x00000002)
+#define RTC_DR_DU_2                          ((uint32_t)0x00000004)
+#define RTC_DR_DU_3                          ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_CR register  *******************/
+#define RTC_CR_ITSE                          ((uint32_t)0x01000000)
+#define RTC_CR_COE                           ((uint32_t)0x00800000)
+#define RTC_CR_OSEL                          ((uint32_t)0x00600000)
+#define RTC_CR_OSEL_0                        ((uint32_t)0x00200000)
+#define RTC_CR_OSEL_1                        ((uint32_t)0x00400000)
+#define RTC_CR_POL                           ((uint32_t)0x00100000)
+#define RTC_CR_COSEL                         ((uint32_t)0x00080000)
+#define RTC_CR_BCK                           ((uint32_t)0x00040000)
+#define RTC_CR_SUB1H                         ((uint32_t)0x00020000)
+#define RTC_CR_ADD1H                         ((uint32_t)0x00010000)
+#define RTC_CR_TSIE                          ((uint32_t)0x00008000)
+#define RTC_CR_WUTIE                         ((uint32_t)0x00004000)
+#define RTC_CR_ALRBIE                        ((uint32_t)0x00002000)
+#define RTC_CR_ALRAIE                        ((uint32_t)0x00001000)
+#define RTC_CR_TSE                           ((uint32_t)0x00000800)
+#define RTC_CR_WUTE                          ((uint32_t)0x00000400)
+#define RTC_CR_ALRBE                         ((uint32_t)0x00000200)
+#define RTC_CR_ALRAE                         ((uint32_t)0x00000100)
+#define RTC_CR_FMT                           ((uint32_t)0x00000040)
+#define RTC_CR_BYPSHAD                       ((uint32_t)0x00000020)
+#define RTC_CR_REFCKON                       ((uint32_t)0x00000010)
+#define RTC_CR_TSEDGE                        ((uint32_t)0x00000008)
+#define RTC_CR_WUCKSEL                       ((uint32_t)0x00000007)
+#define RTC_CR_WUCKSEL_0                     ((uint32_t)0x00000001)
+#define RTC_CR_WUCKSEL_1                     ((uint32_t)0x00000002)
+#define RTC_CR_WUCKSEL_2                     ((uint32_t)0x00000004)
+
+/********************  Bits definition for RTC_ISR register  ******************/
+#define RTC_ISR_ITSF                         ((uint32_t)0x00020000)
+#define RTC_ISR_RECALPF                      ((uint32_t)0x00010000)
+#define RTC_ISR_TAMP3F                       ((uint32_t)0x00008000)
+#define RTC_ISR_TAMP2F                       ((uint32_t)0x00004000)
+#define RTC_ISR_TAMP1F                       ((uint32_t)0x00002000)
+#define RTC_ISR_TSOVF                        ((uint32_t)0x00001000)
+#define RTC_ISR_TSF                          ((uint32_t)0x00000800)
+#define RTC_ISR_WUTF                         ((uint32_t)0x00000400)
+#define RTC_ISR_ALRBF                        ((uint32_t)0x00000200)
+#define RTC_ISR_ALRAF                        ((uint32_t)0x00000100)
+#define RTC_ISR_INIT                         ((uint32_t)0x00000080)
+#define RTC_ISR_INITF                        ((uint32_t)0x00000040)
+#define RTC_ISR_RSF                          ((uint32_t)0x00000020)
+#define RTC_ISR_INITS                        ((uint32_t)0x00000010)
+#define RTC_ISR_SHPF                         ((uint32_t)0x00000008)
+#define RTC_ISR_WUTWF                        ((uint32_t)0x00000004)
+#define RTC_ISR_ALRBWF                       ((uint32_t)0x00000002)
+#define RTC_ISR_ALRAWF                       ((uint32_t)0x00000001)
+
+/********************  Bits definition for RTC_PRER register  *****************/
+#define RTC_PRER_PREDIV_A                    ((uint32_t)0x007F0000)
+#define RTC_PRER_PREDIV_S                    ((uint32_t)0x00007FFF)
+
+/********************  Bits definition for RTC_WUTR register  *****************/
+#define RTC_WUTR_WUT                         ((uint32_t)0x0000FFFF)
+
+/********************  Bits definition for RTC_ALRMAR register  ***************/
+#define RTC_ALRMAR_MSK4                      ((uint32_t)0x80000000)
+#define RTC_ALRMAR_WDSEL                     ((uint32_t)0x40000000)
+#define RTC_ALRMAR_DT                        ((uint32_t)0x30000000)
+#define RTC_ALRMAR_DT_0                      ((uint32_t)0x10000000)
+#define RTC_ALRMAR_DT_1                      ((uint32_t)0x20000000)
+#define RTC_ALRMAR_DU                        ((uint32_t)0x0F000000)
+#define RTC_ALRMAR_DU_0                      ((uint32_t)0x01000000)
+#define RTC_ALRMAR_DU_1                      ((uint32_t)0x02000000)
+#define RTC_ALRMAR_DU_2                      ((uint32_t)0x04000000)
+#define RTC_ALRMAR_DU_3                      ((uint32_t)0x08000000)
+#define RTC_ALRMAR_MSK3                      ((uint32_t)0x00800000)
+#define RTC_ALRMAR_PM                        ((uint32_t)0x00400000)
+#define RTC_ALRMAR_HT                        ((uint32_t)0x00300000)
+#define RTC_ALRMAR_HT_0                      ((uint32_t)0x00100000)
+#define RTC_ALRMAR_HT_1                      ((uint32_t)0x00200000)
+#define RTC_ALRMAR_HU                        ((uint32_t)0x000F0000)
+#define RTC_ALRMAR_HU_0                      ((uint32_t)0x00010000)
+#define RTC_ALRMAR_HU_1                      ((uint32_t)0x00020000)
+#define RTC_ALRMAR_HU_2                      ((uint32_t)0x00040000)
+#define RTC_ALRMAR_HU_3                      ((uint32_t)0x00080000)
+#define RTC_ALRMAR_MSK2                      ((uint32_t)0x00008000)
+#define RTC_ALRMAR_MNT                       ((uint32_t)0x00007000)
+#define RTC_ALRMAR_MNT_0                     ((uint32_t)0x00001000)
+#define RTC_ALRMAR_MNT_1                     ((uint32_t)0x00002000)
+#define RTC_ALRMAR_MNT_2                     ((uint32_t)0x00004000)
+#define RTC_ALRMAR_MNU                       ((uint32_t)0x00000F00)
+#define RTC_ALRMAR_MNU_0                     ((uint32_t)0x00000100)
+#define RTC_ALRMAR_MNU_1                     ((uint32_t)0x00000200)
+#define RTC_ALRMAR_MNU_2                     ((uint32_t)0x00000400)
+#define RTC_ALRMAR_MNU_3                     ((uint32_t)0x00000800)
+#define RTC_ALRMAR_MSK1                      ((uint32_t)0x00000080)
+#define RTC_ALRMAR_ST                        ((uint32_t)0x00000070)
+#define RTC_ALRMAR_ST_0                      ((uint32_t)0x00000010)
+#define RTC_ALRMAR_ST_1                      ((uint32_t)0x00000020)
+#define RTC_ALRMAR_ST_2                      ((uint32_t)0x00000040)
+#define RTC_ALRMAR_SU                        ((uint32_t)0x0000000F)
+#define RTC_ALRMAR_SU_0                      ((uint32_t)0x00000001)
+#define RTC_ALRMAR_SU_1                      ((uint32_t)0x00000002)
+#define RTC_ALRMAR_SU_2                      ((uint32_t)0x00000004)
+#define RTC_ALRMAR_SU_3                      ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_ALRMBR register  ***************/
+#define RTC_ALRMBR_MSK4                      ((uint32_t)0x80000000)
+#define RTC_ALRMBR_WDSEL                     ((uint32_t)0x40000000)
+#define RTC_ALRMBR_DT                        ((uint32_t)0x30000000)
+#define RTC_ALRMBR_DT_0                      ((uint32_t)0x10000000)
+#define RTC_ALRMBR_DT_1                      ((uint32_t)0x20000000)
+#define RTC_ALRMBR_DU                        ((uint32_t)0x0F000000)
+#define RTC_ALRMBR_DU_0                      ((uint32_t)0x01000000)
+#define RTC_ALRMBR_DU_1                      ((uint32_t)0x02000000)
+#define RTC_ALRMBR_DU_2                      ((uint32_t)0x04000000)
+#define RTC_ALRMBR_DU_3                      ((uint32_t)0x08000000)
+#define RTC_ALRMBR_MSK3                      ((uint32_t)0x00800000)
+#define RTC_ALRMBR_PM                        ((uint32_t)0x00400000)
+#define RTC_ALRMBR_HT                        ((uint32_t)0x00300000)
+#define RTC_ALRMBR_HT_0                      ((uint32_t)0x00100000)
+#define RTC_ALRMBR_HT_1                      ((uint32_t)0x00200000)
+#define RTC_ALRMBR_HU                        ((uint32_t)0x000F0000)
+#define RTC_ALRMBR_HU_0                      ((uint32_t)0x00010000)
+#define RTC_ALRMBR_HU_1                      ((uint32_t)0x00020000)
+#define RTC_ALRMBR_HU_2                      ((uint32_t)0x00040000)
+#define RTC_ALRMBR_HU_3                      ((uint32_t)0x00080000)
+#define RTC_ALRMBR_MSK2                      ((uint32_t)0x00008000)
+#define RTC_ALRMBR_MNT                       ((uint32_t)0x00007000)
+#define RTC_ALRMBR_MNT_0                     ((uint32_t)0x00001000)
+#define RTC_ALRMBR_MNT_1                     ((uint32_t)0x00002000)
+#define RTC_ALRMBR_MNT_2                     ((uint32_t)0x00004000)
+#define RTC_ALRMBR_MNU                       ((uint32_t)0x00000F00)
+#define RTC_ALRMBR_MNU_0                     ((uint32_t)0x00000100)
+#define RTC_ALRMBR_MNU_1                     ((uint32_t)0x00000200)
+#define RTC_ALRMBR_MNU_2                     ((uint32_t)0x00000400)
+#define RTC_ALRMBR_MNU_3                     ((uint32_t)0x00000800)
+#define RTC_ALRMBR_MSK1                      ((uint32_t)0x00000080)
+#define RTC_ALRMBR_ST                        ((uint32_t)0x00000070)
+#define RTC_ALRMBR_ST_0                      ((uint32_t)0x00000010)
+#define RTC_ALRMBR_ST_1                      ((uint32_t)0x00000020)
+#define RTC_ALRMBR_ST_2                      ((uint32_t)0x00000040)
+#define RTC_ALRMBR_SU                        ((uint32_t)0x0000000F)
+#define RTC_ALRMBR_SU_0                      ((uint32_t)0x00000001)
+#define RTC_ALRMBR_SU_1                      ((uint32_t)0x00000002)
+#define RTC_ALRMBR_SU_2                      ((uint32_t)0x00000004)
+#define RTC_ALRMBR_SU_3                      ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_WPR register  ******************/
+#define RTC_WPR_KEY                          ((uint32_t)0x000000FF)
+
+/********************  Bits definition for RTC_SSR register  ******************/
+#define RTC_SSR_SS                           ((uint32_t)0x0000FFFF)
+
+/********************  Bits definition for RTC_SHIFTR register  ***************/
+#define RTC_SHIFTR_SUBFS                     ((uint32_t)0x00007FFF)
+#define RTC_SHIFTR_ADD1S                     ((uint32_t)0x80000000)
+
+/********************  Bits definition for RTC_TSTR register  *****************/
+#define RTC_TSTR_PM                          ((uint32_t)0x00400000)
+#define RTC_TSTR_HT                          ((uint32_t)0x00300000)
+#define RTC_TSTR_HT_0                        ((uint32_t)0x00100000)
+#define RTC_TSTR_HT_1                        ((uint32_t)0x00200000)
+#define RTC_TSTR_HU                          ((uint32_t)0x000F0000)
+#define RTC_TSTR_HU_0                        ((uint32_t)0x00010000)
+#define RTC_TSTR_HU_1                        ((uint32_t)0x00020000)
+#define RTC_TSTR_HU_2                        ((uint32_t)0x00040000)
+#define RTC_TSTR_HU_3                        ((uint32_t)0x00080000)
+#define RTC_TSTR_MNT                         ((uint32_t)0x00007000)
+#define RTC_TSTR_MNT_0                       ((uint32_t)0x00001000)
+#define RTC_TSTR_MNT_1                       ((uint32_t)0x00002000)
+#define RTC_TSTR_MNT_2                       ((uint32_t)0x00004000)
+#define RTC_TSTR_MNU                         ((uint32_t)0x00000F00)
+#define RTC_TSTR_MNU_0                       ((uint32_t)0x00000100)
+#define RTC_TSTR_MNU_1                       ((uint32_t)0x00000200)
+#define RTC_TSTR_MNU_2                       ((uint32_t)0x00000400)
+#define RTC_TSTR_MNU_3                       ((uint32_t)0x00000800)
+#define RTC_TSTR_ST                          ((uint32_t)0x00000070)
+#define RTC_TSTR_ST_0                        ((uint32_t)0x00000010)
+#define RTC_TSTR_ST_1                        ((uint32_t)0x00000020)
+#define RTC_TSTR_ST_2                        ((uint32_t)0x00000040)
+#define RTC_TSTR_SU                          ((uint32_t)0x0000000F)
+#define RTC_TSTR_SU_0                        ((uint32_t)0x00000001)
+#define RTC_TSTR_SU_1                        ((uint32_t)0x00000002)
+#define RTC_TSTR_SU_2                        ((uint32_t)0x00000004)
+#define RTC_TSTR_SU_3                        ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_TSDR register  *****************/
+#define RTC_TSDR_WDU                         ((uint32_t)0x0000E000)
+#define RTC_TSDR_WDU_0                       ((uint32_t)0x00002000)
+#define RTC_TSDR_WDU_1                       ((uint32_t)0x00004000)
+#define RTC_TSDR_WDU_2                       ((uint32_t)0x00008000)
+#define RTC_TSDR_MT                          ((uint32_t)0x00001000)
+#define RTC_TSDR_MU                          ((uint32_t)0x00000F00)
+#define RTC_TSDR_MU_0                        ((uint32_t)0x00000100)
+#define RTC_TSDR_MU_1                        ((uint32_t)0x00000200)
+#define RTC_TSDR_MU_2                        ((uint32_t)0x00000400)
+#define RTC_TSDR_MU_3                        ((uint32_t)0x00000800)
+#define RTC_TSDR_DT                          ((uint32_t)0x00000030)
+#define RTC_TSDR_DT_0                        ((uint32_t)0x00000010)
+#define RTC_TSDR_DT_1                        ((uint32_t)0x00000020)
+#define RTC_TSDR_DU                          ((uint32_t)0x0000000F)
+#define RTC_TSDR_DU_0                        ((uint32_t)0x00000001)
+#define RTC_TSDR_DU_1                        ((uint32_t)0x00000002)
+#define RTC_TSDR_DU_2                        ((uint32_t)0x00000004)
+#define RTC_TSDR_DU_3                        ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_TSSSR register  ****************/
+#define RTC_TSSSR_SS                         ((uint32_t)0x0000FFFF)
+
+/********************  Bits definition for RTC_CAL register  *****************/
+#define RTC_CALR_CALP                        ((uint32_t)0x00008000)
+#define RTC_CALR_CALW8                       ((uint32_t)0x00004000)
+#define RTC_CALR_CALW16                      ((uint32_t)0x00002000)
+#define RTC_CALR_CALM                        ((uint32_t)0x000001FF)
+#define RTC_CALR_CALM_0                      ((uint32_t)0x00000001)
+#define RTC_CALR_CALM_1                      ((uint32_t)0x00000002)
+#define RTC_CALR_CALM_2                      ((uint32_t)0x00000004)
+#define RTC_CALR_CALM_3                      ((uint32_t)0x00000008)
+#define RTC_CALR_CALM_4                      ((uint32_t)0x00000010)
+#define RTC_CALR_CALM_5                      ((uint32_t)0x00000020)
+#define RTC_CALR_CALM_6                      ((uint32_t)0x00000040)
+#define RTC_CALR_CALM_7                      ((uint32_t)0x00000080)
+#define RTC_CALR_CALM_8                      ((uint32_t)0x00000100)
+
+/********************  Bits definition for RTC_TAMPCR register  ****************/
+#define RTC_TAMPCR_TAMP3MF                    ((uint32_t)0x01000000)
+#define RTC_TAMPCR_TAMP3NOERASE               ((uint32_t)0x00800000)
+#define RTC_TAMPCR_TAMP3IE                    ((uint32_t)0x00400000)
+#define RTC_TAMPCR_TAMP2MF                    ((uint32_t)0x00200000)
+#define RTC_TAMPCR_TAMP2NOERASE               ((uint32_t)0x00100000)
+#define RTC_TAMPCR_TAMP2IE                    ((uint32_t)0x00080000)
+#define RTC_TAMPCR_TAMP1MF                    ((uint32_t)0x00040000)
+#define RTC_TAMPCR_TAMP1NOERASE               ((uint32_t)0x00020000)
+#define RTC_TAMPCR_TAMP1IE                    ((uint32_t)0x00010000)
+#define RTC_TAMPCR_TAMPPUDIS                  ((uint32_t)0x00008000)
+#define RTC_TAMPCR_TAMPPRCH                   ((uint32_t)0x00006000)
+#define RTC_TAMPCR_TAMPPRCH_0                 ((uint32_t)0x00002000)
+#define RTC_TAMPCR_TAMPPRCH_1                 ((uint32_t)0x00004000)
+#define RTC_TAMPCR_TAMPFLT                    ((uint32_t)0x00001800)
+#define RTC_TAMPCR_TAMPFLT_0                  ((uint32_t)0x00000800)
+#define RTC_TAMPCR_TAMPFLT_1                  ((uint32_t)0x00001000)
+#define RTC_TAMPCR_TAMPFREQ                   ((uint32_t)0x00000700)
+#define RTC_TAMPCR_TAMPFREQ_0                 ((uint32_t)0x00000100)
+#define RTC_TAMPCR_TAMPFREQ_1                 ((uint32_t)0x00000200)
+#define RTC_TAMPCR_TAMPFREQ_2                 ((uint32_t)0x00000400)
+#define RTC_TAMPCR_TAMPTS                     ((uint32_t)0x00000080)
+#define RTC_TAMPCR_TAMP3_TRG                  ((uint32_t)0x00000040)
+#define RTC_TAMPCR_TAMP3E                     ((uint32_t)0x00000020)
+#define RTC_TAMPCR_TAMP2_TRG                   ((uint32_t)0x00000010)
+#define RTC_TAMPCR_TAMP2E                     ((uint32_t)0x00000008)
+#define RTC_TAMPCR_TAMPIE                     ((uint32_t)0x00000004)
+#define RTC_TAMPCR_TAMP1_TRG                   ((uint32_t)0x00000002)
+#define RTC_TAMPCR_TAMP1E                     ((uint32_t)0x00000001)
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMASSR_MASKSS                  ((uint32_t)0x0F000000)
+#define RTC_ALRMASSR_MASKSS_0                ((uint32_t)0x01000000)
+#define RTC_ALRMASSR_MASKSS_1                ((uint32_t)0x02000000)
+#define RTC_ALRMASSR_MASKSS_2                ((uint32_t)0x04000000)
+#define RTC_ALRMASSR_MASKSS_3                ((uint32_t)0x08000000)
+#define RTC_ALRMASSR_SS                      ((uint32_t)0x00007FFF)
+
+/********************  Bits definition for RTC_ALRMBSSR register  *************/
+#define RTC_ALRMBSSR_MASKSS                  ((uint32_t)0x0F000000)
+#define RTC_ALRMBSSR_MASKSS_0                ((uint32_t)0x01000000)
+#define RTC_ALRMBSSR_MASKSS_1                ((uint32_t)0x02000000)
+#define RTC_ALRMBSSR_MASKSS_2                ((uint32_t)0x04000000)
+#define RTC_ALRMBSSR_MASKSS_3                ((uint32_t)0x08000000)
+#define RTC_ALRMBSSR_SS                      ((uint32_t)0x00007FFF)
+
+/********************  Bits definition for RTC_OR register  ****************/
+#define RTC_OR_TSINSEL                      ((uint32_t)0x00000006)
+#define RTC_OR_TSINSEL_0                    ((uint32_t)0x00000002)
+#define RTC_OR_TSINSEL_1                    ((uint32_t)0x00000004)
+#define RTC_OR_ALARMTYPE                    ((uint32_t)0x00000008)
+
+
+/********************  Bits definition for RTC_BKP0R register  ****************/
+#define RTC_BKP0R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP1R register  ****************/
+#define RTC_BKP1R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP2R register  ****************/
+#define RTC_BKP2R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP3R register  ****************/
+#define RTC_BKP3R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP4R register  ****************/
+#define RTC_BKP4R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP5R register  ****************/
+#define RTC_BKP5R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP6R register  ****************/
+#define RTC_BKP6R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP7R register  ****************/
+#define RTC_BKP7R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP8R register  ****************/
+#define RTC_BKP8R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP9R register  ****************/
+#define RTC_BKP9R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP10R register  ***************/
+#define RTC_BKP10R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP11R register  ***************/
+#define RTC_BKP11R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP12R register  ***************/
+#define RTC_BKP12R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP13R register  ***************/
+#define RTC_BKP13R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP14R register  ***************/
+#define RTC_BKP14R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP15R register  ***************/
+#define RTC_BKP15R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP16R register  ***************/
+#define RTC_BKP16R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP17R register  ***************/
+#define RTC_BKP17R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP18R register  ***************/
+#define RTC_BKP18R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP19R register  ***************/
+#define RTC_BKP19R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP20R register  ***************/
+#define RTC_BKP20R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP21R register  ***************/
+#define RTC_BKP21R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP22R register  ***************/
+#define RTC_BKP22R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP23R register  ***************/
+#define RTC_BKP23R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP24R register  ***************/
+#define RTC_BKP24R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP25R register  ***************/
+#define RTC_BKP25R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP26R register  ***************/
+#define RTC_BKP26R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP27R register  ***************/
+#define RTC_BKP27R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP28R register  ***************/
+#define RTC_BKP28R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP29R register  ***************/
+#define RTC_BKP29R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP30R register  ***************/
+#define RTC_BKP30R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP31R register  ***************/
+#define RTC_BKP31R                           ((uint32_t)0xFFFFFFFF)
+
+/******************** Number of backup registers ******************************/
+#define RTC_BKP_NUMBER                       ((uint32_t)0x00000020)
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          Serial Audio Interface                            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for SAI_GCR register  *******************/
+#define  SAI_GCR_SYNCIN                  ((uint32_t)0x00000003)        /*!<SYNCIN[1:0] bits (Synchronization Inputs)   */
+#define  SAI_GCR_SYNCIN_0                ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_GCR_SYNCIN_1                ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  SAI_GCR_SYNCOUT                 ((uint32_t)0x00000030)        /*!<SYNCOUT[1:0] bits (Synchronization Outputs) */
+#define  SAI_GCR_SYNCOUT_0               ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  SAI_GCR_SYNCOUT_1               ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+/*******************  Bit definition for SAI_xCR1 register  *******************/
+#define  SAI_xCR1_MODE                    ((uint32_t)0x00000003)        /*!<MODE[1:0] bits (Audio Block Mode)           */
+#define  SAI_xCR1_MODE_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_xCR1_MODE_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  SAI_xCR1_PRTCFG                  ((uint32_t)0x0000000C)        /*!<PRTCFG[1:0] bits (Protocol Configuration)   */
+#define  SAI_xCR1_PRTCFG_0                ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  SAI_xCR1_PRTCFG_1                ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  SAI_xCR1_DS                      ((uint32_t)0x000000E0)        /*!<DS[1:0] bits (Data Size) */
+#define  SAI_xCR1_DS_0                    ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  SAI_xCR1_DS_1                    ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  SAI_xCR1_DS_2                    ((uint32_t)0x00000080)        /*!<Bit 2 */
+
+#define  SAI_xCR1_LSBFIRST                ((uint32_t)0x00000100)        /*!<LSB First Configuration  */
+#define  SAI_xCR1_CKSTR                   ((uint32_t)0x00000200)        /*!<ClocK STRobing edge      */
+
+#define  SAI_xCR1_SYNCEN                  ((uint32_t)0x00000C00)        /*!<SYNCEN[1:0](SYNChronization ENable) */
+#define  SAI_xCR1_SYNCEN_0                ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  SAI_xCR1_SYNCEN_1                ((uint32_t)0x00000800)        /*!<Bit 1 */
+
+#define  SAI_xCR1_MONO                    ((uint32_t)0x00001000)        /*!<Mono mode                  */
+#define  SAI_xCR1_OUTDRIV                 ((uint32_t)0x00002000)        /*!<Output Drive               */
+#define  SAI_xCR1_SAIEN                   ((uint32_t)0x00010000)        /*!<Audio Block enable         */
+#define  SAI_xCR1_DMAEN                   ((uint32_t)0x00020000)        /*!<DMA enable                 */
+#define  SAI_xCR1_NODIV                   ((uint32_t)0x00080000)        /*!<No Divider Configuration   */
+
+#define  SAI_xCR1_MCKDIV                  ((uint32_t)0x00F00000)        /*!<MCKDIV[3:0] (Master ClocK Divider)  */
+#define  SAI_xCR1_MCKDIV_0                ((uint32_t)0x00100000)        /*!<Bit 0  */
+#define  SAI_xCR1_MCKDIV_1                ((uint32_t)0x00200000)        /*!<Bit 1  */
+#define  SAI_xCR1_MCKDIV_2                ((uint32_t)0x00400000)        /*!<Bit 2  */
+#define  SAI_xCR1_MCKDIV_3                ((uint32_t)0x00800000)        /*!<Bit 3  */
+
+/*******************  Bit definition for SAI_xCR2 register  *******************/
+#define  SAI_xCR2_FTH                     ((uint32_t)0x00000007)        /*!<FTH[2:0](Fifo THreshold)  */
+#define  SAI_xCR2_FTH_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_xCR2_FTH_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  SAI_xCR2_FTH_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
+
+#define  SAI_xCR2_FFLUSH                  ((uint32_t)0x00000008)        /*!<Fifo FLUSH                       */
+#define  SAI_xCR2_TRIS                    ((uint32_t)0x00000010)        /*!<TRIState Management on data line */
+#define  SAI_xCR2_MUTE                    ((uint32_t)0x00000020)        /*!<Mute mode                        */
+#define  SAI_xCR2_MUTEVAL                 ((uint32_t)0x00000040)        /*!<Muate value                      */
+
+#define  SAI_xCR2_MUTECNT                  ((uint32_t)0x00001F80)       /*!<MUTECNT[5:0] (MUTE counter) */
+#define  SAI_xCR2_MUTECNT_0               ((uint32_t)0x00000080)        /*!<Bit 0 */
+#define  SAI_xCR2_MUTECNT_1               ((uint32_t)0x00000100)        /*!<Bit 1 */
+#define  SAI_xCR2_MUTECNT_2               ((uint32_t)0x00000200)        /*!<Bit 2 */
+#define  SAI_xCR2_MUTECNT_3               ((uint32_t)0x00000400)        /*!<Bit 3 */
+#define  SAI_xCR2_MUTECNT_4               ((uint32_t)0x00000800)        /*!<Bit 4 */
+#define  SAI_xCR2_MUTECNT_5               ((uint32_t)0x00001000)        /*!<Bit 5 */
+
+#define  SAI_xCR2_CPL                     ((uint32_t)0x00080000)        /*!< Complement Bit             */
+
+#define  SAI_xCR2_COMP                    ((uint32_t)0x0000C000)        /*!<COMP[1:0] (Companding mode) */
+#define  SAI_xCR2_COMP_0                  ((uint32_t)0x00004000)        /*!<Bit 0 */
+#define  SAI_xCR2_COMP_1                  ((uint32_t)0x00008000)        /*!<Bit 1 */
+
+/******************  Bit definition for SAI_xFRCR register  *******************/
+#define  SAI_xFRCR_FRL                    ((uint32_t)0x000000FF)        /*!<FRL[1:0](Frame length)  */
+#define  SAI_xFRCR_FRL_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_xFRCR_FRL_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  SAI_xFRCR_FRL_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  SAI_xFRCR_FRL_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  SAI_xFRCR_FRL_4                  ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  SAI_xFRCR_FRL_5                  ((uint32_t)0x00000020)        /*!<Bit 5 */
+#define  SAI_xFRCR_FRL_6                  ((uint32_t)0x00000040)        /*!<Bit 6 */
+#define  SAI_xFRCR_FRL_7                  ((uint32_t)0x00000080)        /*!<Bit 7 */
+
+#define  SAI_xFRCR_FSALL                  ((uint32_t)0x00007F00)        /*!<FRL[1:0] (Frame synchronization active level length)  */
+#define  SAI_xFRCR_FSALL_0                ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  SAI_xFRCR_FSALL_1                ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  SAI_xFRCR_FSALL_2                ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  SAI_xFRCR_FSALL_3                ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  SAI_xFRCR_FSALL_4                ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  SAI_xFRCR_FSALL_5                ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  SAI_xFRCR_FSALL_6                ((uint32_t)0x00004000)        /*!<Bit 6 */
+
+#define  SAI_xFRCR_FSDEF                  ((uint32_t)0x00010000)        /*!< Frame Synchronization Definition */
+#define  SAI_xFRCR_FSPO                   ((uint32_t)0x00020000)        /*!<Frame Synchronization POLarity    */
+#define  SAI_xFRCR_FSOFF                  ((uint32_t)0x00040000)        /*!<Frame Synchronization OFFset      */
+
+/******************  Bit definition for SAI_xSLOTR register  *******************/
+#define  SAI_xSLOTR_FBOFF                 ((uint32_t)0x0000001F)        /*!<FRL[4:0](First Bit Offset)  */
+#define  SAI_xSLOTR_FBOFF_0               ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_xSLOTR_FBOFF_1               ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  SAI_xSLOTR_FBOFF_2               ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  SAI_xSLOTR_FBOFF_3               ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  SAI_xSLOTR_FBOFF_4               ((uint32_t)0x00000010)        /*!<Bit 4 */
+
+#define  SAI_xSLOTR_SLOTSZ                ((uint32_t)0x000000C0)        /*!<SLOTSZ[1:0] (Slot size)  */
+#define  SAI_xSLOTR_SLOTSZ_0              ((uint32_t)0x00000040)        /*!<Bit 0 */
+#define  SAI_xSLOTR_SLOTSZ_1              ((uint32_t)0x00000080)        /*!<Bit 1 */
+
+#define  SAI_xSLOTR_NBSLOT                ((uint32_t)0x00000F00)        /*!<NBSLOT[3:0] (Number of Slot in audio Frame)  */
+#define  SAI_xSLOTR_NBSLOT_0              ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  SAI_xSLOTR_NBSLOT_1              ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  SAI_xSLOTR_NBSLOT_2              ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  SAI_xSLOTR_NBSLOT_3              ((uint32_t)0x00000800)        /*!<Bit 3 */
+
+#define  SAI_xSLOTR_SLOTEN                ((uint32_t)0xFFFF0000)        /*!<SLOTEN[15:0] (Slot Enable)  */
+
+/*******************  Bit definition for SAI_xIMR register  *******************/
+#define  SAI_xIMR_OVRUDRIE                ((uint32_t)0x00000001)        /*!<Overrun underrun interrupt enable                              */
+#define  SAI_xIMR_MUTEDETIE               ((uint32_t)0x00000002)        /*!<Mute detection interrupt enable                                */
+#define  SAI_xIMR_WCKCFGIE                ((uint32_t)0x00000004)        /*!<Wrong Clock Configuration interrupt enable                     */
+#define  SAI_xIMR_FREQIE                  ((uint32_t)0x00000008)        /*!<FIFO request interrupt enable                                  */
+#define  SAI_xIMR_CNRDYIE                 ((uint32_t)0x00000010)        /*!<Codec not ready interrupt enable                               */
+#define  SAI_xIMR_AFSDETIE                ((uint32_t)0x00000020)        /*!<Anticipated frame synchronization detection interrupt enable   */
+#define  SAI_xIMR_LFSDETIE                ((uint32_t)0x00000040)        /*!<Late frame synchronization detection interrupt enable          */
+
+/********************  Bit definition for SAI_xSR register  *******************/
+#define  SAI_xSR_OVRUDR                   ((uint32_t)0x00000001)         /*!<Overrun underrun                               */
+#define  SAI_xSR_MUTEDET                  ((uint32_t)0x00000002)         /*!<Mute detection                                 */
+#define  SAI_xSR_WCKCFG                   ((uint32_t)0x00000004)         /*!<Wrong Clock Configuration                      */
+#define  SAI_xSR_FREQ                     ((uint32_t)0x00000008)         /*!<FIFO request                                   */
+#define  SAI_xSR_CNRDY                    ((uint32_t)0x00000010)         /*!<Codec not ready                                */
+#define  SAI_xSR_AFSDET                   ((uint32_t)0x00000020)         /*!<Anticipated frame synchronization detection    */
+#define  SAI_xSR_LFSDET                   ((uint32_t)0x00000040)         /*!<Late frame synchronization detection           */
+
+#define  SAI_xSR_FLVL                     ((uint32_t)0x00070000)         /*!<FLVL[2:0] (FIFO Level Threshold)               */
+#define  SAI_xSR_FLVL_0                   ((uint32_t)0x00010000)         /*!<Bit 0 */
+#define  SAI_xSR_FLVL_1                   ((uint32_t)0x00020000)         /*!<Bit 1 */
+#define  SAI_xSR_FLVL_2                   ((uint32_t)0x00040000)         /*!<Bit 2 */
+
+/******************  Bit definition for SAI_xCLRFR register  ******************/
+#define  SAI_xCLRFR_COVRUDR               ((uint32_t)0x00000001)        /*!<Clear Overrun underrun                               */
+#define  SAI_xCLRFR_CMUTEDET              ((uint32_t)0x00000002)        /*!<Clear Mute detection                                 */
+#define  SAI_xCLRFR_CWCKCFG               ((uint32_t)0x00000004)        /*!<Clear Wrong Clock Configuration                      */
+#define  SAI_xCLRFR_CFREQ                 ((uint32_t)0x00000008)        /*!<Clear FIFO request                                   */
+#define  SAI_xCLRFR_CCNRDY                ((uint32_t)0x00000010)        /*!<Clear Codec not ready                                */
+#define  SAI_xCLRFR_CAFSDET               ((uint32_t)0x00000020)        /*!<Clear Anticipated frame synchronization detection    */
+#define  SAI_xCLRFR_CLFSDET               ((uint32_t)0x00000040)        /*!<Clear Late frame synchronization detection           */
+
+/******************  Bit definition for SAI_xDR register  *********************/
+#define  SAI_xDR_DATA                     ((uint32_t)0xFFFFFFFF)
+
+/******************************************************************************/
+/*                                                                            */
+/*                              SPDIF-RX Interface                            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for SPDIF_CR register  *******************/
+#define  SPDIFRX_CR_SPDIFEN                  ((uint32_t)0x00000003)        /*!<Peripheral Block Enable                      */
+#define  SPDIFRX_CR_RXDMAEN                  ((uint32_t)0x00000004)        /*!<Receiver DMA Enable for data flow            */
+#define  SPDIFRX_CR_RXSTEO                   ((uint32_t)0x00000008)        /*!<Stereo Mode                                  */
+#define  SPDIFRX_CR_DRFMT                    ((uint32_t)0x00000030)        /*!<RX Data format                               */
+#define  SPDIFRX_CR_PMSK                     ((uint32_t)0x00000040)        /*!<Mask Parity error bit                        */
+#define  SPDIFRX_CR_VMSK                     ((uint32_t)0x00000080)        /*!<Mask of Validity bit                         */
+#define  SPDIFRX_CR_CUMSK                    ((uint32_t)0x00000100)        /*!<Mask of channel status and user bits         */
+#define  SPDIFRX_CR_PTMSK                    ((uint32_t)0x00000200)        /*!<Mask of Preamble Type bits                   */
+#define  SPDIFRX_CR_CBDMAEN                  ((uint32_t)0x00000400)        /*!<Control Buffer DMA ENable for control flow   */
+#define  SPDIFRX_CR_CHSEL                    ((uint32_t)0x00000800)        /*!<Channel Selection                            */
+#define  SPDIFRX_CR_NBTR                     ((uint32_t)0x00003000)        /*!<Maximum allowed re-tries during synchronization phase */
+#define  SPDIFRX_CR_WFA                      ((uint32_t)0x00004000)        /*!<Wait For Activity     */
+#define  SPDIFRX_CR_INSEL                    ((uint32_t)0x00070000)        /*!<SPDIF input selection */
+
+/*******************  Bit definition for SPDIFRX_IMR register  *******************/
+#define  SPDIFRX_IMR_RXNEIE                   ((uint32_t)0x00000001)        /*!<RXNE interrupt enable                              */
+#define  SPDIFRX_IMR_CSRNEIE                  ((uint32_t)0x00000002)        /*!<Control Buffer Ready Interrupt Enable              */
+#define  SPDIFRX_IMR_PERRIE                   ((uint32_t)0x00000004)        /*!<Parity error interrupt enable                      */
+#define  SPDIFRX_IMR_OVRIE                    ((uint32_t)0x00000008)        /*!<Overrun error Interrupt Enable                     */
+#define  SPDIFRX_IMR_SBLKIE                   ((uint32_t)0x00000010)        /*!<Synchronization Block Detected Interrupt Enable    */
+#define  SPDIFRX_IMR_SYNCDIE                  ((uint32_t)0x00000020)        /*!<Synchronization Done                               */
+#define  SPDIFRX_IMR_IFEIE                    ((uint32_t)0x00000040)        /*!<Serial Interface Error Interrupt Enable            */
+
+/*******************  Bit definition for SPDIFRX_SR register  *******************/
+#define  SPDIFRX_SR_RXNE                   ((uint32_t)0x00000001)       /*!<Read data register not empty                          */
+#define  SPDIFRX_SR_CSRNE                  ((uint32_t)0x00000002)       /*!<The Control Buffer register is not empty              */
+#define  SPDIFRX_SR_PERR                   ((uint32_t)0x00000004)       /*!<Parity error                                          */
+#define  SPDIFRX_SR_OVR                    ((uint32_t)0x00000008)       /*!<Overrun error                                         */
+#define  SPDIFRX_SR_SBD                    ((uint32_t)0x00000010)       /*!<Synchronization Block Detected                        */
+#define  SPDIFRX_SR_SYNCD                  ((uint32_t)0x00000020)       /*!<Synchronization Done                                  */
+#define  SPDIFRX_SR_FERR                   ((uint32_t)0x00000040)       /*!<Framing error                                         */
+#define  SPDIFRX_SR_SERR                   ((uint32_t)0x00000080)       /*!<Synchronization error                                 */
+#define  SPDIFRX_SR_TERR                   ((uint32_t)0x00000100)       /*!<Time-out error                                        */
+#define  SPDIFRX_SR_WIDTH5                 ((uint32_t)0x7FFF0000)       /*!<Duration of 5 symbols counted with spdif_clk          */
+
+/*******************  Bit definition for SPDIFRX_IFCR register  *******************/
+#define  SPDIFRX_IFCR_PERRCF               ((uint32_t)0x00000004)       /*!<Clears the Parity error flag                         */
+#define  SPDIFRX_IFCR_OVRCF                ((uint32_t)0x00000008)       /*!<Clears the Overrun error flag                        */
+#define  SPDIFRX_IFCR_SBDCF                ((uint32_t)0x00000010)       /*!<Clears the Synchronization Block Detected flag       */
+#define  SPDIFRX_IFCR_SYNCDCF              ((uint32_t)0x00000020)       /*!<Clears the Synchronization Done flag                 */
+
+/*******************  Bit definition for SPDIFRX_DR register  (DRFMT = 0b00 case) *******************/
+#define  SPDIFRX_DR0_DR                    ((uint32_t)0x00FFFFFF)        /*!<Data value            */
+#define  SPDIFRX_DR0_PE                    ((uint32_t)0x01000000)        /*!<Parity Error bit      */
+#define  SPDIFRX_DR0_V                     ((uint32_t)0x02000000)        /*!<Validity bit          */
+#define  SPDIFRX_DR0_U                     ((uint32_t)0x04000000)        /*!<User bit              */
+#define  SPDIFRX_DR0_C                     ((uint32_t)0x08000000)        /*!<Channel Status bit    */
+#define  SPDIFRX_DR0_PT                    ((uint32_t)0x30000000)        /*!<Preamble Type         */
+
+/*******************  Bit definition for SPDIFRX_DR register  (DRFMT = 0b01 case) *******************/
+#define  SPDIFRX_DR1_DR                    ((uint32_t)0xFFFFFF00)        /*!<Data value            */
+#define  SPDIFRX_DR1_PT                    ((uint32_t)0x00000030)        /*!<Preamble Type         */
+#define  SPDIFRX_DR1_C                     ((uint32_t)0x00000008)        /*!<Channel Status bit    */
+#define  SPDIFRX_DR1_U                     ((uint32_t)0x00000004)        /*!<User bit              */
+#define  SPDIFRX_DR1_V                     ((uint32_t)0x00000002)        /*!<Validity bit          */
+#define  SPDIFRX_DR1_PE                    ((uint32_t)0x00000001)        /*!<Parity Error bit      */
+
+/*******************  Bit definition for SPDIFRX_DR register  (DRFMT = 0b10 case) *******************/
+#define  SPDIFRX_DR1_DRNL1                 ((uint32_t)0xFFFF0000)        /*!<Data value Channel B      */
+#define  SPDIFRX_DR1_DRNL2                 ((uint32_t)0x0000FFFF)        /*!<Data value Channel A      */
+
+/*******************  Bit definition for SPDIFRX_CSR register   *******************/
+#define  SPDIFRX_CSR_USR                     ((uint32_t)0x0000FFFF)        /*!<User data information           */
+#define  SPDIFRX_CSR_CS                      ((uint32_t)0x00FF0000)        /*!<Channel A status information    */
+#define  SPDIFRX_CSR_SOB                     ((uint32_t)0x01000000)        /*!<Start Of Block                  */
+
+/*******************  Bit definition for SPDIFRX_DIR register    *******************/
+#define  SPDIFRX_DIR_THI                 ((uint32_t)0x000013FF)        /*!<Threshold LOW      */
+#define  SPDIFRX_DIR_TLO                 ((uint32_t)0x1FFF0000)        /*!<Threshold HIGH     */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          SD host Interface                                 */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for SDMMC_POWER register  ******************/
+#define  SDMMC_POWER_PWRCTRL                  ((uint32_t)0x03)               /*!<PWRCTRL[1:0] bits (Power supply control bits) */
+#define  SDMMC_POWER_PWRCTRL_0                ((uint32_t)0x01)               /*!<Bit 0 */
+#define  SDMMC_POWER_PWRCTRL_1                ((uint32_t)0x02)               /*!<Bit 1 */
+
+/******************  Bit definition for SDMMC_CLKCR register  ******************/
+#define  SDMMC_CLKCR_CLKDIV                   ((uint32_t)0x00FF)            /*!<Clock divide factor             */
+#define  SDMMC_CLKCR_CLKEN                    ((uint32_t)0x0100)            /*!<Clock enable bit                */
+#define  SDMMC_CLKCR_PWRSAV                   ((uint32_t)0x0200)            /*!<Power saving configuration bit  */
+#define  SDMMC_CLKCR_BYPASS                   ((uint32_t)0x0400)            /*!<Clock divider bypass enable bit */
+
+#define  SDMMC_CLKCR_WIDBUS                   ((uint32_t)0x1800)            /*!<WIDBUS[1:0] bits (Wide bus mode enable bit) */
+#define  SDMMC_CLKCR_WIDBUS_0                 ((uint32_t)0x0800)            /*!<Bit 0 */
+#define  SDMMC_CLKCR_WIDBUS_1                 ((uint32_t)0x1000)            /*!<Bit 1 */
+
+#define  SDMMC_CLKCR_NEGEDGE                  ((uint32_t)0x2000)            /*!<SDMMC_CK dephasing selection bit */
+#define  SDMMC_CLKCR_HWFC_EN                  ((uint32_t)0x4000)            /*!<HW Flow Control enable          */
+
+/*******************  Bit definition for SDMMC_ARG register  *******************/
+#define  SDMMC_ARG_CMDARG                     ((uint32_t)0xFFFFFFFF)            /*!<Command argument */
+
+/*******************  Bit definition for SDMMC_CMD register  *******************/
+#define  SDMMC_CMD_CMDINDEX                   ((uint32_t)0x003F)            /*!<Command Index                               */
+
+#define  SDMMC_CMD_WAITRESP                   ((uint32_t)0x00C0)            /*!<WAITRESP[1:0] bits (Wait for response bits) */
+#define  SDMMC_CMD_WAITRESP_0                 ((uint32_t)0x0040)            /*!< Bit 0 */
+#define  SDMMC_CMD_WAITRESP_1                 ((uint32_t)0x0080)            /*!< Bit 1 */
+
+#define  SDMMC_CMD_WAITINT                    ((uint32_t)0x0100)            /*!<CPSM Waits for Interrupt Request                               */
+#define  SDMMC_CMD_WAITPEND                   ((uint32_t)0x0200)            /*!<CPSM Waits for ends of data transfer (CmdPend internal signal) */
+#define  SDMMC_CMD_CPSMEN                     ((uint32_t)0x0400)            /*!<Command path state machine (CPSM) Enable bit                   */
+#define  SDMMC_CMD_SDIOSUSPEND                ((uint32_t)0x0800)            /*!<SD I/O suspend command                                         */
+
+/*****************  Bit definition for SDMMC_RESPCMD register  *****************/
+#define  SDMMC_RESPCMD_RESPCMD                ((uint32_t)0x3F)               /*!<Response command index */
+
+/******************  Bit definition for SDMMC_RESP0 register  ******************/
+#define  SDMMC_RESP0_CARDSTATUS0              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_RESP1 register  ******************/
+#define  SDMMC_RESP1_CARDSTATUS1              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_RESP2 register  ******************/
+#define  SDMMC_RESP2_CARDSTATUS2              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_RESP3 register  ******************/
+#define  SDMMC_RESP3_CARDSTATUS3              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_RESP4 register  ******************/
+#define  SDMMC_RESP4_CARDSTATUS4              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_DTIMER register  *****************/
+#define  SDMMC_DTIMER_DATATIME                ((uint32_t)0xFFFFFFFF)        /*!<Data timeout period. */
+
+/******************  Bit definition for SDMMC_DLEN register  *******************/
+#define  SDMMC_DLEN_DATALENGTH                ((uint32_t)0x01FFFFFF)        /*!<Data length value    */
+
+/******************  Bit definition for SDMMC_DCTRL register  ******************/
+#define  SDMMC_DCTRL_DTEN                     ((uint32_t)0x0001)            /*!<Data transfer enabled bit         */
+#define  SDMMC_DCTRL_DTDIR                    ((uint32_t)0x0002)            /*!<Data transfer direction selection */
+#define  SDMMC_DCTRL_DTMODE                   ((uint32_t)0x0004)            /*!<Data transfer mode selection      */
+#define  SDMMC_DCTRL_DMAEN                    ((uint32_t)0x0008)            /*!<DMA enabled bit                   */
+
+#define  SDMMC_DCTRL_DBLOCKSIZE               ((uint32_t)0x00F0)            /*!<DBLOCKSIZE[3:0] bits (Data block size) */
+#define  SDMMC_DCTRL_DBLOCKSIZE_0             ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  SDMMC_DCTRL_DBLOCKSIZE_1             ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  SDMMC_DCTRL_DBLOCKSIZE_2             ((uint32_t)0x0040)            /*!<Bit 2 */
+#define  SDMMC_DCTRL_DBLOCKSIZE_3             ((uint32_t)0x0080)            /*!<Bit 3 */
+
+#define  SDMMC_DCTRL_RWSTART                  ((uint32_t)0x0100)            /*!<Read wait start         */
+#define  SDMMC_DCTRL_RWSTOP                   ((uint32_t)0x0200)            /*!<Read wait stop          */
+#define  SDMMC_DCTRL_RWMOD                    ((uint32_t)0x0400)            /*!<Read wait mode          */
+#define  SDMMC_DCTRL_SDIOEN                   ((uint32_t)0x0800)            /*!<SD I/O enable functions */
+
+/******************  Bit definition for SDMMC_DCOUNT register  *****************/
+#define  SDMMC_DCOUNT_DATACOUNT               ((uint32_t)0x01FFFFFF)        /*!<Data count value */
+
+/******************  Bit definition for SDMMC_STA register  ********************/
+#define  SDMMC_STA_CCRCFAIL                   ((uint32_t)0x00000001)        /*!<Command response received (CRC check failed)  */
+#define  SDMMC_STA_DCRCFAIL                   ((uint32_t)0x00000002)        /*!<Data block sent/received (CRC check failed)   */
+#define  SDMMC_STA_CTIMEOUT                   ((uint32_t)0x00000004)        /*!<Command response timeout                      */
+#define  SDMMC_STA_DTIMEOUT                   ((uint32_t)0x00000008)        /*!<Data timeout                                  */
+#define  SDMMC_STA_TXUNDERR                   ((uint32_t)0x00000010)        /*!<Transmit FIFO underrun error                  */
+#define  SDMMC_STA_RXOVERR                    ((uint32_t)0x00000020)        /*!<Received FIFO overrun error                   */
+#define  SDMMC_STA_CMDREND                    ((uint32_t)0x00000040)        /*!<Command response received (CRC check passed)  */
+#define  SDMMC_STA_CMDSENT                    ((uint32_t)0x00000080)        /*!<Command sent (no response required)           */
+#define  SDMMC_STA_DATAEND                    ((uint32_t)0x00000100)        /*!<Data end (data counter, SDIDCOUNT, is zero)   */
+#define  SDMMC_STA_DBCKEND                    ((uint32_t)0x00000400)        /*!<Data block sent/received (CRC check passed)   */
+#define  SDMMC_STA_CMDACT                     ((uint32_t)0x00000800)        /*!<Command transfer in progress                  */
+#define  SDMMC_STA_TXACT                      ((uint32_t)0x00001000)        /*!<Data transmit in progress                     */
+#define  SDMMC_STA_RXACT                      ((uint32_t)0x00002000)        /*!<Data receive in progress                      */
+#define  SDMMC_STA_TXFIFOHE                   ((uint32_t)0x00004000)        /*!<Transmit FIFO Half Empty: at least 8 words can be written into the FIFO */
+#define  SDMMC_STA_RXFIFOHF                   ((uint32_t)0x00008000)        /*!<Receive FIFO Half Full: there are at least 8 words in the FIFO */
+#define  SDMMC_STA_TXFIFOF                    ((uint32_t)0x00010000)        /*!<Transmit FIFO full                            */
+#define  SDMMC_STA_RXFIFOF                    ((uint32_t)0x00020000)        /*!<Receive FIFO full                             */
+#define  SDMMC_STA_TXFIFOE                    ((uint32_t)0x00040000)        /*!<Transmit FIFO empty                           */
+#define  SDMMC_STA_RXFIFOE                    ((uint32_t)0x00080000)        /*!<Receive FIFO empty                            */
+#define  SDMMC_STA_TXDAVL                     ((uint32_t)0x00100000)        /*!<Data available in transmit FIFO               */
+#define  SDMMC_STA_RXDAVL                     ((uint32_t)0x00200000)        /*!<Data available in receive FIFO                */
+#define  SDMMC_STA_SDIOIT                     ((uint32_t)0x00400000)        /*!<SDMMC interrupt received                       */
+
+/*******************  Bit definition for SDMMC_ICR register  *******************/
+#define  SDMMC_ICR_CCRCFAILC                  ((uint32_t)0x00000001)        /*!<CCRCFAIL flag clear bit */
+#define  SDMMC_ICR_DCRCFAILC                  ((uint32_t)0x00000002)        /*!<DCRCFAIL flag clear bit */
+#define  SDMMC_ICR_CTIMEOUTC                  ((uint32_t)0x00000004)        /*!<CTIMEOUT flag clear bit */
+#define  SDMMC_ICR_DTIMEOUTC                  ((uint32_t)0x00000008)        /*!<DTIMEOUT flag clear bit */
+#define  SDMMC_ICR_TXUNDERRC                  ((uint32_t)0x00000010)        /*!<TXUNDERR flag clear bit */
+#define  SDMMC_ICR_RXOVERRC                   ((uint32_t)0x00000020)        /*!<RXOVERR flag clear bit  */
+#define  SDMMC_ICR_CMDRENDC                   ((uint32_t)0x00000040)        /*!<CMDREND flag clear bit  */
+#define  SDMMC_ICR_CMDSENTC                   ((uint32_t)0x00000080)        /*!<CMDSENT flag clear bit  */
+#define  SDMMC_ICR_DATAENDC                   ((uint32_t)0x00000100)        /*!<DATAEND flag clear bit  */
+#define  SDMMC_ICR_DBCKENDC                   ((uint32_t)0x00000400)        /*!<DBCKEND flag clear bit  */
+#define  SDMMC_ICR_SDIOITC                    ((uint32_t)0x00400000)        /*!<SDMMCIT flag clear bit   */
+
+/******************  Bit definition for SDMMC_MASK register  *******************/
+#define  SDMMC_MASK_CCRCFAILIE                ((uint32_t)0x00000001)        /*!<Command CRC Fail Interrupt Enable          */
+#define  SDMMC_MASK_DCRCFAILIE                ((uint32_t)0x00000002)        /*!<Data CRC Fail Interrupt Enable             */
+#define  SDMMC_MASK_CTIMEOUTIE                ((uint32_t)0x00000004)        /*!<Command TimeOut Interrupt Enable           */
+#define  SDMMC_MASK_DTIMEOUTIE                ((uint32_t)0x00000008)        /*!<Data TimeOut Interrupt Enable              */
+#define  SDMMC_MASK_TXUNDERRIE                ((uint32_t)0x00000010)        /*!<Tx FIFO UnderRun Error Interrupt Enable    */
+#define  SDMMC_MASK_RXOVERRIE                 ((uint32_t)0x00000020)        /*!<Rx FIFO OverRun Error Interrupt Enable     */
+#define  SDMMC_MASK_CMDRENDIE                 ((uint32_t)0x00000040)        /*!<Command Response Received Interrupt Enable */
+#define  SDMMC_MASK_CMDSENTIE                 ((uint32_t)0x00000080)        /*!<Command Sent Interrupt Enable              */
+#define  SDMMC_MASK_DATAENDIE                 ((uint32_t)0x00000100)        /*!<Data End Interrupt Enable                  */
+#define  SDMMC_MASK_DBCKENDIE                 ((uint32_t)0x00000400)        /*!<Data Block End Interrupt Enable            */
+#define  SDMMC_MASK_CMDACTIE                  ((uint32_t)0x00000800)        /*!<CCommand Acting Interrupt Enable           */
+#define  SDMMC_MASK_TXACTIE                   ((uint32_t)0x00001000)        /*!<Data Transmit Acting Interrupt Enable      */
+#define  SDMMC_MASK_RXACTIE                   ((uint32_t)0x00002000)        /*!<Data receive acting interrupt enabled      */
+#define  SDMMC_MASK_TXFIFOHEIE                ((uint32_t)0x00004000)        /*!<Tx FIFO Half Empty interrupt Enable        */
+#define  SDMMC_MASK_RXFIFOHFIE                ((uint32_t)0x00008000)        /*!<Rx FIFO Half Full interrupt Enable         */
+#define  SDMMC_MASK_TXFIFOFIE                 ((uint32_t)0x00010000)        /*!<Tx FIFO Full interrupt Enable              */
+#define  SDMMC_MASK_RXFIFOFIE                 ((uint32_t)0x00020000)        /*!<Rx FIFO Full interrupt Enable              */
+#define  SDMMC_MASK_TXFIFOEIE                 ((uint32_t)0x00040000)        /*!<Tx FIFO Empty interrupt Enable             */
+#define  SDMMC_MASK_RXFIFOEIE                 ((uint32_t)0x00080000)        /*!<Rx FIFO Empty interrupt Enable             */
+#define  SDMMC_MASK_TXDAVLIE                  ((uint32_t)0x00100000)        /*!<Data available in Tx FIFO interrupt Enable */
+#define  SDMMC_MASK_RXDAVLIE                  ((uint32_t)0x00200000)        /*!<Data available in Rx FIFO interrupt Enable */
+#define  SDMMC_MASK_SDIOITIE                  ((uint32_t)0x00400000)        /*!<SDMMC Mode Interrupt Received interrupt Enable */
+
+/*****************  Bit definition for SDMMC_FIFOCNT register  *****************/
+#define  SDMMC_FIFOCNT_FIFOCOUNT              ((uint32_t)0x00FFFFFF)        /*!<Remaining number of words to be written to or read from the FIFO */
+
+/******************  Bit definition for SDMMC_FIFO register  *******************/
+#define  SDMMC_FIFO_FIFODATA                  ((uint32_t)0xFFFFFFFF)        /*!<Receive and transmit FIFO data */
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Serial Peripheral Interface (SPI)                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for SPI_CR1 register  ********************/
+#define  SPI_CR1_CPHA                        ((uint32_t)0x00000001)        /*!< Clock Phase                        */
+#define  SPI_CR1_CPOL                        ((uint32_t)0x00000002)        /*!< Clock Polarity                     */
+#define  SPI_CR1_MSTR                        ((uint32_t)0x00000004)        /*!< Master Selection                   */
+#define  SPI_CR1_BR                          ((uint32_t)0x00000038)        /*!< BR[2:0] bits (Baud Rate Control)   */
+#define  SPI_CR1_BR_0                        ((uint32_t)0x00000008)        /*!< Bit 0 */
+#define  SPI_CR1_BR_1                        ((uint32_t)0x00000010)        /*!< Bit 1 */
+#define  SPI_CR1_BR_2                        ((uint32_t)0x00000020)        /*!< Bit 2 */
+#define  SPI_CR1_SPE                         ((uint32_t)0x00000040)        /*!< SPI Enable                          */
+#define  SPI_CR1_LSBFIRST                    ((uint32_t)0x00000080)        /*!< Frame Format                        */
+#define  SPI_CR1_SSI                         ((uint32_t)0x00000100)        /*!< Internal slave select               */
+#define  SPI_CR1_SSM                         ((uint32_t)0x00000200)        /*!< Software slave management           */
+#define  SPI_CR1_RXONLY                      ((uint32_t)0x00000400)        /*!< Receive only                        */
+#define  SPI_CR1_CRCL                        ((uint32_t)0x00000800)        /*!< CRC Length                          */
+#define  SPI_CR1_CRCNEXT                     ((uint32_t)0x00001000)        /*!< Transmit CRC next                   */
+#define  SPI_CR1_CRCEN                       ((uint32_t)0x00002000)        /*!< Hardware CRC calculation enable     */
+#define  SPI_CR1_BIDIOE                      ((uint32_t)0x00004000)        /*!< Output enable in bidirectional mode */
+#define  SPI_CR1_BIDIMODE                    ((uint32_t)0x00008000)        /*!< Bidirectional data mode enable      */
+
+/*******************  Bit definition for SPI_CR2 register  ********************/
+#define  SPI_CR2_RXDMAEN                     ((uint32_t)0x00000001)        /*!< Rx Buffer DMA Enable                 */
+#define  SPI_CR2_TXDMAEN                     ((uint32_t)0x00000002)        /*!< Tx Buffer DMA Enable                 */
+#define  SPI_CR2_SSOE                        ((uint32_t)0x00000004)        /*!< SS Output Enable                     */
+#define  SPI_CR2_NSSP                        ((uint32_t)0x00000008)        /*!< NSS pulse management Enable          */
+#define  SPI_CR2_FRF                         ((uint32_t)0x00000010)        /*!< Frame Format Enable                  */
+#define  SPI_CR2_ERRIE                       ((uint32_t)0x00000020)        /*!< Error Interrupt Enable               */
+#define  SPI_CR2_RXNEIE                      ((uint32_t)0x00000040)        /*!< RX buffer Not Empty Interrupt Enable */
+#define  SPI_CR2_TXEIE                       ((uint32_t)0x00000080)        /*!< Tx buffer Empty Interrupt Enable     */
+#define  SPI_CR2_DS                          ((uint32_t)0x00000F00)        /*!< DS[3:0] Data Size                    */
+#define  SPI_CR2_DS_0                        ((uint32_t)0x00000100)        /*!< Bit 0 */
+#define  SPI_CR2_DS_1                        ((uint32_t)0x00000200)        /*!< Bit 1 */
+#define  SPI_CR2_DS_2                        ((uint32_t)0x00000400)        /*!< Bit 2 */
+#define  SPI_CR2_DS_3                        ((uint32_t)0x00000800)        /*!< Bit 3 */
+#define  SPI_CR2_FRXTH                       ((uint32_t)0x00001000)        /*!< FIFO reception Threshold           */
+#define  SPI_CR2_LDMARX                      ((uint32_t)0x00002000)        /*!< Last DMA transfer for reception    */
+#define  SPI_CR2_LDMATX                      ((uint32_t)0x00004000)        /*!< Last DMA transfer for transmission */
+
+/********************  Bit definition for SPI_SR register  ********************/
+#define  SPI_SR_RXNE                         ((uint32_t)0x00000001)        /*!< Receive buffer Not Empty  */
+#define  SPI_SR_TXE                          ((uint32_t)0x00000002)        /*!< Transmit buffer Empty     */
+#define  SPI_SR_CHSIDE                       ((uint32_t)0x00000004)        /*!< Channel side              */
+#define  SPI_SR_UDR                          ((uint32_t)0x00000008)        /*!< Underrun flag             */
+#define  SPI_SR_CRCERR                       ((uint32_t)0x00000010)        /*!< CRC Error flag            */
+#define  SPI_SR_MODF                         ((uint32_t)0x00000020)        /*!< Mode fault                */
+#define  SPI_SR_OVR                          ((uint32_t)0x00000040)        /*!< Overrun flag              */
+#define  SPI_SR_BSY                          ((uint32_t)0x00000080)        /*!< Busy flag                 */
+#define  SPI_SR_FRE                          ((uint32_t)0x00000100)        /*!< TI frame format error     */
+#define  SPI_SR_FRLVL                        ((uint32_t)0x00000600)        /*!< FIFO Reception Level      */
+#define  SPI_SR_FRLVL_0                      ((uint32_t)0x00000200)        /*!< Bit 0 */
+#define  SPI_SR_FRLVL_1                      ((uint32_t)0x00000400)        /*!< Bit 1 */
+#define  SPI_SR_FTLVL                        ((uint32_t)0x00001800)        /*!< FIFO Transmission Level   */
+#define  SPI_SR_FTLVL_0                      ((uint32_t)0x00000800)        /*!< Bit 0 */
+#define  SPI_SR_FTLVL_1                      ((uint32_t)0x00001000)        /*!< Bit 1 */
+
+/********************  Bit definition for SPI_DR register  ********************/
+#define  SPI_DR_DR                           ((uint32_t)0xFFFF)            /*!< Data Register */
+
+/*******************  Bit definition for SPI_CRCPR register  ******************/
+#define  SPI_CRCPR_CRCPOLY                   ((uint32_t)0xFFFF)            /*!< CRC polynomial register */
+
+/******************  Bit definition for SPI_RXCRCR register  ******************/
+#define  SPI_RXCRCR_RXCRC                    ((uint32_t)0xFFFF)            /*!< Rx CRC Register */
+
+/******************  Bit definition for SPI_TXCRCR register  ******************/
+#define  SPI_TXCRCR_TXCRC                    ((uint32_t)0xFFFF)            /*!< Tx CRC Register */
+
+/******************  Bit definition for SPI_I2SCFGR register  *****************/
+#define  SPI_I2SCFGR_CHLEN                   ((uint32_t)0x00000001)        /*!<Channel length (number of bits per audio channel) */
+#define  SPI_I2SCFGR_DATLEN                  ((uint32_t)0x00000006)        /*!<DATLEN[1:0] bits (Data length to be transferred)  */
+#define  SPI_I2SCFGR_DATLEN_0                ((uint32_t)0x00000002)        /*!<Bit 0 */
+#define  SPI_I2SCFGR_DATLEN_1                ((uint32_t)0x00000004)        /*!<Bit 1 */
+#define  SPI_I2SCFGR_CKPOL                   ((uint32_t)0x00000008)        /*!<steady state clock polarity                       */
+#define  SPI_I2SCFGR_I2SSTD                  ((uint32_t)0x00000030)        /*!<I2SSTD[1:0] bits (I2S standard selection)         */
+#define  SPI_I2SCFGR_I2SSTD_0                ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  SPI_I2SCFGR_I2SSTD_1                ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  SPI_I2SCFGR_PCMSYNC                 ((uint32_t)0x00000080)        /*!<PCM frame synchronization                         */
+#define  SPI_I2SCFGR_I2SCFG                  ((uint32_t)0x00000300)        /*!<I2SCFG[1:0] bits (I2S configuration mode)         */
+#define  SPI_I2SCFGR_I2SCFG_0                ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  SPI_I2SCFGR_I2SCFG_1                ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  SPI_I2SCFGR_I2SE                    ((uint32_t)0x00000400)        /*!<I2S Enable                                        */
+#define  SPI_I2SCFGR_I2SMOD                  ((uint32_t)0x00000800)        /*!<I2S mode selection                                */
+#define  SPI_I2SCFGR_ASTRTEN                 ((uint32_t)0x00001000)        /*!<Asynchronous start enable                        */
+
+/******************  Bit definition for SPI_I2SPR register  *******************/
+#define  SPI_I2SPR_I2SDIV                    ((uint32_t)0x00FF)            /*!<I2S Linear prescaler         */
+#define  SPI_I2SPR_ODD                       ((uint32_t)0x0100)            /*!<Odd factor for the prescaler */
+#define  SPI_I2SPR_MCKOE                     ((uint32_t)0x0200)            /*!<Master Clock Output Enable   */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 SYSCFG                                     */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for SYSCFG_MEMRMP register  ***************/
+#define SYSCFG_MEMRMP_MEM_BOOT          ((uint32_t)0x00000001) /*!< Boot information after Reset */
+
+#define SYSCFG_MEMRMP_SWP_FMC          ((uint32_t)0x00000C00) /*!< FMC Memory Mapping swapping */
+#define SYSCFG_MEMRMP_SWP_FMC_0        ((uint32_t)0x00000400)
+#define SYSCFG_MEMRMP_SWP_FMC_1        ((uint32_t)0x00000800)
+
+/******************  Bit definition for SYSCFG_PMC register  ******************/
+#define SYSCFG_PMC_ADCxDC2              ((uint32_t)0x00070000) /*!< Refer to AN4073 on how to use this bit  */
+#define SYSCFG_PMC_ADC1DC2              ((uint32_t)0x00010000) /*!< Refer to AN4073 on how to use this bit  */
+#define SYSCFG_PMC_ADC2DC2              ((uint32_t)0x00020000) /*!< Refer to AN4073 on how to use this bit  */
+#define SYSCFG_PMC_ADC3DC2              ((uint32_t)0x00040000) /*!< Refer to AN4073 on how to use this bit  */
+
+#define SYSCFG_PMC_MII_RMII_SEL         ((uint32_t)0x00800000) /*!<Ethernet PHY interface selection */
+
+/*****************  Bit definition for SYSCFG_EXTICR1 register  ***************/
+#define SYSCFG_EXTICR1_EXTI0            ((uint32_t)0x000F) /*!<EXTI 0 configuration */
+#define SYSCFG_EXTICR1_EXTI1            ((uint32_t)0x00F0) /*!<EXTI 1 configuration */
+#define SYSCFG_EXTICR1_EXTI2            ((uint32_t)0x0F00) /*!<EXTI 2 configuration */
+#define SYSCFG_EXTICR1_EXTI3            ((uint32_t)0xF000) /*!<EXTI 3 configuration */
+/**
+  * @brief   EXTI0 configuration
+  */
+#define SYSCFG_EXTICR1_EXTI0_PA         ((uint32_t)0x0000) /*!<PA[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PB         ((uint32_t)0x0001) /*!<PB[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PC         ((uint32_t)0x0002) /*!<PC[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PD         ((uint32_t)0x0003) /*!<PD[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PE         ((uint32_t)0x0004) /*!<PE[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PF         ((uint32_t)0x0005) /*!<PF[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PG         ((uint32_t)0x0006) /*!<PG[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PH         ((uint32_t)0x0007) /*!<PH[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PI         ((uint32_t)0x0008) /*!<PI[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PJ         ((uint32_t)0x0009) /*!<PJ[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PK         ((uint32_t)0x000A) /*!<PK[0] pin */
+
+/**
+  * @brief   EXTI1 configuration
+  */
+#define SYSCFG_EXTICR1_EXTI1_PA         ((uint32_t)0x0000) /*!<PA[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PB         ((uint32_t)0x0010) /*!<PB[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PC         ((uint32_t)0x0020) /*!<PC[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PD         ((uint32_t)0x0030) /*!<PD[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PE         ((uint32_t)0x0040) /*!<PE[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PF         ((uint32_t)0x0050) /*!<PF[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PG         ((uint32_t)0x0060) /*!<PG[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PH         ((uint32_t)0x0070) /*!<PH[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PI         ((uint32_t)0x0080) /*!<PI[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PJ         ((uint32_t)0x0090) /*!<PJ[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PK         ((uint32_t)0x00A0) /*!<PK[1] pin */
+
+/**
+  * @brief   EXTI2 configuration
+  */
+#define SYSCFG_EXTICR1_EXTI2_PA         ((uint32_t)0x0000) /*!<PA[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PB         ((uint32_t)0x0100) /*!<PB[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PC         ((uint32_t)0x0200) /*!<PC[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PD         ((uint32_t)0x0300) /*!<PD[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PE         ((uint32_t)0x0400) /*!<PE[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PF         ((uint32_t)0x0500) /*!<PF[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PG         ((uint32_t)0x0600) /*!<PG[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PH         ((uint32_t)0x0700) /*!<PH[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PI         ((uint32_t)0x0800) /*!<PI[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PJ         ((uint32_t)0x0900) /*!<PJ[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PK         ((uint32_t)0x0A00) /*!<PK[2] pin */
+
+/**
+  * @brief   EXTI3 configuration
+  */
+#define SYSCFG_EXTICR1_EXTI3_PA         ((uint32_t)0x0000) /*!<PA[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PB         ((uint32_t)0x1000) /*!<PB[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PC         ((uint32_t)0x2000) /*!<PC[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PD         ((uint32_t)0x3000) /*!<PD[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PE         ((uint32_t)0x4000) /*!<PE[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PF         ((uint32_t)0x5000) /*!<PF[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PG         ((uint32_t)0x6000) /*!<PG[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PH         ((uint32_t)0x7000) /*!<PH[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PI         ((uint32_t)0x8000) /*!<PI[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PJ         ((uint32_t)0x9000) /*!<PJ[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PK         ((uint32_t)0xA000) /*!<PK[3] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR2 register  ***************/
+#define SYSCFG_EXTICR2_EXTI4            ((uint32_t)0x000F) /*!<EXTI 4 configuration */
+#define SYSCFG_EXTICR2_EXTI5            ((uint32_t)0x00F0) /*!<EXTI 5 configuration */
+#define SYSCFG_EXTICR2_EXTI6            ((uint32_t)0x0F00) /*!<EXTI 6 configuration */
+#define SYSCFG_EXTICR2_EXTI7            ((uint32_t)0xF000) /*!<EXTI 7 configuration */
+/**
+  * @brief   EXTI4 configuration
+  */
+#define SYSCFG_EXTICR2_EXTI4_PA         ((uint32_t)0x0000) /*!<PA[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PB         ((uint32_t)0x0001) /*!<PB[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PC         ((uint32_t)0x0002) /*!<PC[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PD         ((uint32_t)0x0003) /*!<PD[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PE         ((uint32_t)0x0004) /*!<PE[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PF         ((uint32_t)0x0005) /*!<PF[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PG         ((uint32_t)0x0006) /*!<PG[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PH         ((uint32_t)0x0007) /*!<PH[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PI         ((uint32_t)0x0008) /*!<PI[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PJ         ((uint32_t)0x0009) /*!<PJ[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PK         ((uint32_t)0x000A) /*!<PK[4] pin */
+
+/**
+  * @brief   EXTI5 configuration
+  */
+#define SYSCFG_EXTICR2_EXTI5_PA         ((uint32_t)0x0000) /*!<PA[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PB         ((uint32_t)0x0010) /*!<PB[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PC         ((uint32_t)0x0020) /*!<PC[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PD         ((uint32_t)0x0030) /*!<PD[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PE         ((uint32_t)0x0040) /*!<PE[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PF         ((uint32_t)0x0050) /*!<PF[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PG         ((uint32_t)0x0060) /*!<PG[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PH         ((uint32_t)0x0070) /*!<PH[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PI         ((uint32_t)0x0080) /*!<PI[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PJ         ((uint32_t)0x0090) /*!<PJ[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PK         ((uint32_t)0x00A0) /*!<PK[5] pin */
+
+/**
+  * @brief   EXTI6 configuration
+  */
+#define SYSCFG_EXTICR2_EXTI6_PA         ((uint32_t)0x0000) /*!<PA[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PB         ((uint32_t)0x0100) /*!<PB[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PC         ((uint32_t)0x0200) /*!<PC[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PD         ((uint32_t)0x0300) /*!<PD[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PE         ((uint32_t)0x0400) /*!<PE[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PF         ((uint32_t)0x0500) /*!<PF[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PG         ((uint32_t)0x0600) /*!<PG[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PH         ((uint32_t)0x0700) /*!<PH[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PI         ((uint32_t)0x0800) /*!<PI[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PJ         ((uint32_t)0x0900) /*!<PJ[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PK         ((uint32_t)0x0A00) /*!<PK[6] pin */
+
+/**
+  * @brief   EXTI7 configuration
+  */
+#define SYSCFG_EXTICR2_EXTI7_PA         ((uint32_t)0x0000) /*!<PA[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PB         ((uint32_t)0x1000) /*!<PB[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PC         ((uint32_t)0x2000) /*!<PC[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PD         ((uint32_t)0x3000) /*!<PD[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PE         ((uint32_t)0x4000) /*!<PE[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PF         ((uint32_t)0x5000) /*!<PF[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PG         ((uint32_t)0x6000) /*!<PG[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PH         ((uint32_t)0x7000) /*!<PH[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PI         ((uint32_t)0x8000) /*!<PI[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PJ         ((uint32_t)0x9000) /*!<PJ[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PK         ((uint32_t)0xA000) /*!<PK[7] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR3 register  ***************/
+#define SYSCFG_EXTICR3_EXTI8            ((uint32_t)0x000F) /*!<EXTI 8 configuration */
+#define SYSCFG_EXTICR3_EXTI9            ((uint32_t)0x00F0) /*!<EXTI 9 configuration */
+#define SYSCFG_EXTICR3_EXTI10           ((uint32_t)0x0F00) /*!<EXTI 10 configuration */
+#define SYSCFG_EXTICR3_EXTI11           ((uint32_t)0xF000) /*!<EXTI 11 configuration */
+
+/**
+  * @brief   EXTI8 configuration
+  */
+#define SYSCFG_EXTICR3_EXTI8_PA         ((uint32_t)0x0000) /*!<PA[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PB         ((uint32_t)0x0001) /*!<PB[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PC         ((uint32_t)0x0002) /*!<PC[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PD         ((uint32_t)0x0003) /*!<PD[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PE         ((uint32_t)0x0004) /*!<PE[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PF         ((uint32_t)0x0005) /*!<PF[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PG         ((uint32_t)0x0006) /*!<PG[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PH         ((uint32_t)0x0007) /*!<PH[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PI         ((uint32_t)0x0008) /*!<PI[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PJ         ((uint32_t)0x0009) /*!<PJ[8] pin */
+
+/**
+  * @brief   EXTI9 configuration
+  */
+#define SYSCFG_EXTICR3_EXTI9_PA         ((uint32_t)0x0000) /*!<PA[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PB         ((uint32_t)0x0010) /*!<PB[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PC         ((uint32_t)0x0020) /*!<PC[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PD         ((uint32_t)0x0030) /*!<PD[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PE         ((uint32_t)0x0040) /*!<PE[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PF         ((uint32_t)0x0050) /*!<PF[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PG         ((uint32_t)0x0060) /*!<PG[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PH         ((uint32_t)0x0070) /*!<PH[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PI         ((uint32_t)0x0080) /*!<PI[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PJ         ((uint32_t)0x0090) /*!<PJ[9] pin */
+
+/**
+  * @brief   EXTI10 configuration
+  */
+#define SYSCFG_EXTICR3_EXTI10_PA        ((uint32_t)0x0000) /*!<PA[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PB        ((uint32_t)0x0100) /*!<PB[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PC        ((uint32_t)0x0200) /*!<PC[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PD        ((uint32_t)0x0300) /*!<PD[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PE        ((uint32_t)0x0400) /*!<PE[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PF        ((uint32_t)0x0500) /*!<PF[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PG        ((uint32_t)0x0600) /*!<PG[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PH        ((uint32_t)0x0700) /*!<PH[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PI        ((uint32_t)0x0800) /*!<PI[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PJ        ((uint32_t)0x0900) /*!<PJ[10] pin */
+
+/**
+  * @brief   EXTI11 configuration
+  */
+#define SYSCFG_EXTICR3_EXTI11_PA        ((uint32_t)0x0000) /*!<PA[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PB        ((uint32_t)0x1000) /*!<PB[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PC        ((uint32_t)0x2000) /*!<PC[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PD        ((uint32_t)0x3000) /*!<PD[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PE        ((uint32_t)0x4000) /*!<PE[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PF        ((uint32_t)0x5000) /*!<PF[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PG        ((uint32_t)0x6000) /*!<PG[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PH        ((uint32_t)0x7000) /*!<PH[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PI        ((uint32_t)0x8000) /*!<PI[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PJ        ((uint32_t)0x9000) /*!<PJ[11] pin */
+
+
+/*****************  Bit definition for SYSCFG_EXTICR4 register  ***************/
+#define SYSCFG_EXTICR4_EXTI12           ((uint32_t)0x000F) /*!<EXTI 12 configuration */
+#define SYSCFG_EXTICR4_EXTI13           ((uint32_t)0x00F0) /*!<EXTI 13 configuration */
+#define SYSCFG_EXTICR4_EXTI14           ((uint32_t)0x0F00) /*!<EXTI 14 configuration */
+#define SYSCFG_EXTICR4_EXTI15           ((uint32_t)0xF000) /*!<EXTI 15 configuration */
+/**
+  * @brief   EXTI12 configuration
+  */
+#define SYSCFG_EXTICR4_EXTI12_PA        ((uint32_t)0x0000) /*!<PA[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PB        ((uint32_t)0x0001) /*!<PB[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PC        ((uint32_t)0x0002) /*!<PC[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PD        ((uint32_t)0x0003) /*!<PD[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PE        ((uint32_t)0x0004) /*!<PE[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PF        ((uint32_t)0x0005) /*!<PF[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PG        ((uint32_t)0x0006) /*!<PG[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PH        ((uint32_t)0x0007) /*!<PH[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PI        ((uint32_t)0x0008) /*!<PI[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PJ        ((uint32_t)0x0009) /*!<PJ[12] pin */
+
+/**
+  * @brief   EXTI13 configuration
+  */
+#define SYSCFG_EXTICR4_EXTI13_PA        ((uint32_t)0x0000) /*!<PA[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PB        ((uint32_t)0x0010) /*!<PB[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PC        ((uint32_t)0x0020) /*!<PC[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PD        ((uint32_t)0x0030) /*!<PD[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PE        ((uint32_t)0x0040) /*!<PE[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PF        ((uint32_t)0x0050) /*!<PF[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PG        ((uint32_t)0x0060) /*!<PG[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PH        ((uint32_t)0x0070) /*!<PH[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PI        ((uint32_t)0x0008) /*!<PI[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PJ        ((uint32_t)0x0009) /*!<PJ[13] pin */
+
+/**
+  * @brief   EXTI14 configuration
+  */
+#define SYSCFG_EXTICR4_EXTI14_PA        ((uint32_t)0x0000) /*!<PA[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PB        ((uint32_t)0x0100) /*!<PB[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PC        ((uint32_t)0x0200) /*!<PC[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PD        ((uint32_t)0x0300) /*!<PD[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PE        ((uint32_t)0x0400) /*!<PE[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PF        ((uint32_t)0x0500) /*!<PF[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PG        ((uint32_t)0x0600) /*!<PG[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PH        ((uint32_t)0x0700) /*!<PH[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PI        ((uint32_t)0x0800) /*!<PI[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PJ        ((uint32_t)0x0900) /*!<PJ[14] pin */
+
+/**
+  * @brief   EXTI15 configuration
+  */
+#define SYSCFG_EXTICR4_EXTI15_PA        ((uint32_t)0x0000) /*!<PA[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PB        ((uint32_t)0x1000) /*!<PB[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PC        ((uint32_t)0x2000) /*!<PC[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PD        ((uint32_t)0x3000) /*!<PD[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PE        ((uint32_t)0x4000) /*!<PE[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PF        ((uint32_t)0x5000) /*!<PF[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PG        ((uint32_t)0x6000) /*!<PG[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PH        ((uint32_t)0x7000) /*!<PH[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PI        ((uint32_t)0x8000) /*!<PI[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PJ        ((uint32_t)0x9000) /*!<PJ[15] pin */
+
+/******************  Bit definition for SYSCFG_CMPCR register  ****************/
+#define SYSCFG_CMPCR_CMP_PD             ((uint32_t)0x00000001) /*!<Compensation cell power-down */
+#define SYSCFG_CMPCR_READY              ((uint32_t)0x00000100) /*!<Compensation cell ready flag*/
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    TIM                                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TIM_CR1 register  ********************/
+#define  TIM_CR1_CEN                         ((uint32_t)0x0001)            /*!<Counter enable        */
+#define  TIM_CR1_UDIS                        ((uint32_t)0x0002)            /*!<Update disable        */
+#define  TIM_CR1_URS                         ((uint32_t)0x0004)            /*!<Update request source */
+#define  TIM_CR1_OPM                         ((uint32_t)0x0008)            /*!<One pulse mode        */
+#define  TIM_CR1_DIR                         ((uint32_t)0x0010)            /*!<Direction             */
+
+#define  TIM_CR1_CMS                         ((uint32_t)0x0060)            /*!<CMS[1:0] bits (Center-aligned mode selection) */
+#define  TIM_CR1_CMS_0                       ((uint32_t)0x0020)            /*!<Bit 0 */
+#define  TIM_CR1_CMS_1                       ((uint32_t)0x0040)            /*!<Bit 1 */
+
+#define  TIM_CR1_ARPE                        ((uint32_t)0x0080)            /*!<Auto-reload preload enable     */
+
+#define  TIM_CR1_CKD                         ((uint32_t)0x0300)            /*!<CKD[1:0] bits (clock division) */
+#define  TIM_CR1_CKD_0                       ((uint32_t)0x0100)            /*!<Bit 0 */
+#define  TIM_CR1_CKD_1                       ((uint32_t)0x0200)            /*!<Bit 1 */
+#define  TIM_CR1_UIFREMAP                    ((uint32_t)0x0800)            /*!<UIF status bit */
+
+/*******************  Bit definition for TIM_CR2 register  ********************/
+#define  TIM_CR2_CCPC                        ((uint32_t)0x00000001)            /*!<Capture/Compare Preloaded Control        */
+#define  TIM_CR2_CCUS                        ((uint32_t)0x00000004)            /*!<Capture/Compare Control Update Selection */
+#define  TIM_CR2_CCDS                        ((uint32_t)0x00000008)            /*!<Capture/Compare DMA Selection            */
+
+#define  TIM_CR2_OIS5                        ((uint32_t)0x00010000)            /*!<Output Idle state 4 (OC4 output) */
+#define  TIM_CR2_OIS6                        ((uint32_t)0x00040000)            /*!<Output Idle state 4 (OC4 output) */
+
+#define  TIM_CR2_MMS                         ((uint32_t)0x0070)            /*!<MMS[2:0] bits (Master Mode Selection) */
+#define  TIM_CR2_MMS_0                       ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  TIM_CR2_MMS_1                       ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  TIM_CR2_MMS_2                       ((uint32_t)0x0040)            /*!<Bit 2 */
+
+#define  TIM_CR2_MMS2                        ((uint32_t)0x00F00000)            /*!<MMS[2:0] bits (Master Mode Selection) */
+#define  TIM_CR2_MMS2_0                      ((uint32_t)0x00100000)            /*!<Bit 0 */
+#define  TIM_CR2_MMS2_1                      ((uint32_t)0x00200000)            /*!<Bit 1 */
+#define  TIM_CR2_MMS2_2                      ((uint32_t)0x00400000)            /*!<Bit 2 */
+#define  TIM_CR2_MMS2_3                      ((uint32_t)0x00800000)            /*!<Bit 2 */
+
+#define  TIM_CR2_TI1S                        ((uint32_t)0x0080)            /*!<TI1 Selection */
+#define  TIM_CR2_OIS1                        ((uint32_t)0x0100)            /*!<Output Idle state 1 (OC1 output)  */
+#define  TIM_CR2_OIS1N                       ((uint32_t)0x0200)            /*!<Output Idle state 1 (OC1N output) */
+#define  TIM_CR2_OIS2                        ((uint32_t)0x0400)            /*!<Output Idle state 2 (OC2 output)  */
+#define  TIM_CR2_OIS2N                       ((uint32_t)0x0800)            /*!<Output Idle state 2 (OC2N output) */
+#define  TIM_CR2_OIS3                        ((uint32_t)0x1000)            /*!<Output Idle state 3 (OC3 output)  */
+#define  TIM_CR2_OIS3N                       ((uint32_t)0x2000)            /*!<Output Idle state 3 (OC3N output) */
+#define  TIM_CR2_OIS4                        ((uint32_t)0x4000)            /*!<Output Idle state 4 (OC4 output)  */
+
+/*******************  Bit definition for TIM_SMCR register  *******************/
+#define  TIM_SMCR_SMS                        ((uint32_t)0x00010007)            /*!<SMS[2:0] bits (Slave mode selection)    */
+#define  TIM_SMCR_SMS_0                      ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_SMCR_SMS_1                      ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define  TIM_SMCR_SMS_2                      ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define  TIM_SMCR_SMS_3                      ((uint32_t)0x00010000)            /*!<Bit 3 */
+#define  TIM_SMCR_OCCS                       ((uint32_t)0x00000008)            /*!< OCREF clear selection */
+
+#define  TIM_SMCR_TS                         ((uint32_t)0x0070)            /*!<TS[2:0] bits (Trigger selection)        */
+#define  TIM_SMCR_TS_0                       ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  TIM_SMCR_TS_1                       ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  TIM_SMCR_TS_2                       ((uint32_t)0x0040)            /*!<Bit 2 */
+
+#define  TIM_SMCR_MSM                        ((uint32_t)0x0080)            /*!<Master/slave mode                       */
+
+#define  TIM_SMCR_ETF                        ((uint32_t)0x0F00)            /*!<ETF[3:0] bits (External trigger filter) */
+#define  TIM_SMCR_ETF_0                      ((uint32_t)0x0100)            /*!<Bit 0 */
+#define  TIM_SMCR_ETF_1                      ((uint32_t)0x0200)            /*!<Bit 1 */
+#define  TIM_SMCR_ETF_2                      ((uint32_t)0x0400)            /*!<Bit 2 */
+#define  TIM_SMCR_ETF_3                      ((uint32_t)0x0800)            /*!<Bit 3 */
+
+#define  TIM_SMCR_ETPS                       ((uint32_t)0x3000)            /*!<ETPS[1:0] bits (External trigger prescaler) */
+#define  TIM_SMCR_ETPS_0                     ((uint32_t)0x1000)            /*!<Bit 0 */
+#define  TIM_SMCR_ETPS_1                     ((uint32_t)0x2000)            /*!<Bit 1 */
+
+
+#define  TIM_SMCR_ECE                        ((uint32_t)0x4000)            /*!<External clock enable     */
+#define  TIM_SMCR_ETP                        ((uint32_t)0x8000)            /*!<External trigger polarity */
+
+/*******************  Bit definition for TIM_DIER register  *******************/
+#define  TIM_DIER_UIE                        ((uint32_t)0x0001)            /*!<Update interrupt enable */
+#define  TIM_DIER_CC1IE                      ((uint32_t)0x0002)            /*!<Capture/Compare 1 interrupt enable   */
+#define  TIM_DIER_CC2IE                      ((uint32_t)0x0004)            /*!<Capture/Compare 2 interrupt enable   */
+#define  TIM_DIER_CC3IE                      ((uint32_t)0x0008)            /*!<Capture/Compare 3 interrupt enable   */
+#define  TIM_DIER_CC4IE                      ((uint32_t)0x0010)            /*!<Capture/Compare 4 interrupt enable   */
+#define  TIM_DIER_COMIE                      ((uint32_t)0x0020)            /*!<COM interrupt enable                 */
+#define  TIM_DIER_TIE                        ((uint32_t)0x0040)            /*!<Trigger interrupt enable             */
+#define  TIM_DIER_BIE                        ((uint32_t)0x0080)            /*!<Break interrupt enable               */
+#define  TIM_DIER_UDE                        ((uint32_t)0x0100)            /*!<Update DMA request enable            */
+#define  TIM_DIER_CC1DE                      ((uint32_t)0x0200)            /*!<Capture/Compare 1 DMA request enable */
+#define  TIM_DIER_CC2DE                      ((uint32_t)0x0400)            /*!<Capture/Compare 2 DMA request enable */
+#define  TIM_DIER_CC3DE                      ((uint32_t)0x0800)            /*!<Capture/Compare 3 DMA request enable */
+#define  TIM_DIER_CC4DE                      ((uint32_t)0x1000)            /*!<Capture/Compare 4 DMA request enable */
+#define  TIM_DIER_COMDE                      ((uint32_t)0x2000)            /*!<COM DMA request enable               */
+#define  TIM_DIER_TDE                        ((uint32_t)0x4000)            /*!<Trigger DMA request enable           */
+
+/********************  Bit definition for TIM_SR register  ********************/
+#define  TIM_SR_UIF                          ((uint32_t)0x0001)            /*!<Update interrupt Flag              */
+#define  TIM_SR_CC1IF                        ((uint32_t)0x0002)            /*!<Capture/Compare 1 interrupt Flag   */
+#define  TIM_SR_CC2IF                        ((uint32_t)0x0004)            /*!<Capture/Compare 2 interrupt Flag   */
+#define  TIM_SR_CC3IF                        ((uint32_t)0x0008)            /*!<Capture/Compare 3 interrupt Flag   */
+#define  TIM_SR_CC4IF                        ((uint32_t)0x0010)            /*!<Capture/Compare 4 interrupt Flag   */
+#define  TIM_SR_COMIF                        ((uint32_t)0x0020)            /*!<COM interrupt Flag                 */
+#define  TIM_SR_TIF                          ((uint32_t)0x0040)            /*!<Trigger interrupt Flag             */
+#define  TIM_SR_BIF                          ((uint32_t)0x0080)            /*!<Break interrupt Flag               */
+#define  TIM_SR_B2IF                         ((uint32_t)0x0100)            /*!<Break2 interrupt Flag               */
+#define  TIM_SR_CC1OF                        ((uint32_t)0x0200)            /*!<Capture/Compare 1 Overcapture Flag */
+#define  TIM_SR_CC2OF                        ((uint32_t)0x0400)            /*!<Capture/Compare 2 Overcapture Flag */
+#define  TIM_SR_CC3OF                        ((uint32_t)0x0800)            /*!<Capture/Compare 3 Overcapture Flag */
+#define  TIM_SR_CC4OF                        ((uint32_t)0x1000)            /*!<Capture/Compare 4 Overcapture Flag */
+
+/*******************  Bit definition for TIM_EGR register  ********************/
+#define  TIM_EGR_UG                          ((uint32_t)0x00000001)               /*!<Update Generation                         */
+#define  TIM_EGR_CC1G                        ((uint32_t)0x00000002)               /*!<Capture/Compare 1 Generation              */
+#define  TIM_EGR_CC2G                        ((uint32_t)0x00000004)               /*!<Capture/Compare 2 Generation              */
+#define  TIM_EGR_CC3G                        ((uint32_t)0x00000008)               /*!<Capture/Compare 3 Generation              */
+#define  TIM_EGR_CC4G                        ((uint32_t)0x00000010)               /*!<Capture/Compare 4 Generation              */
+#define  TIM_EGR_COMG                        ((uint32_t)0x00000020)               /*!<Capture/Compare Control Update Generation */
+#define  TIM_EGR_TG                          ((uint32_t)0x00000040)               /*!<Trigger Generation                        */
+#define  TIM_EGR_BG                          ((uint32_t)0x00000080)               /*!<Break Generation                          */
+#define  TIM_EGR_B2G                         ((uint32_t)0x00000100)              /*!<Break2 Generation                          */
+
+/******************  Bit definition for TIM_CCMR1 register  *******************/
+#define  TIM_CCMR1_CC1S                      ((uint32_t)0x00000003)            /*!<CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define  TIM_CCMR1_CC1S_0                    ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_CCMR1_CC1S_1                    ((uint32_t)0x00000002)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_OC1FE                     ((uint32_t)0x00000004)            /*!<Output Compare 1 Fast enable                 */
+#define  TIM_CCMR1_OC1PE                     ((uint32_t)0x00000008)            /*!<Output Compare 1 Preload enable              */
+
+#define  TIM_CCMR1_OC1M                      ((uint32_t)0x00010070)            /*!<OC1M[2:0] bits (Output Compare 1 Mode)       */
+#define  TIM_CCMR1_OC1M_0                    ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  TIM_CCMR1_OC1M_1                    ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  TIM_CCMR1_OC1M_2                    ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define  TIM_CCMR1_OC1M_3                    ((uint32_t)0x00010000)            /*!<Bit 3 */
+
+#define  TIM_CCMR1_OC1CE                     ((uint32_t)0x00000080)            /*!<Output Compare 1Clear Enable                 */
+
+#define  TIM_CCMR1_CC2S                      ((uint32_t)0x00000300)            /*!<CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define  TIM_CCMR1_CC2S_0                    ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  TIM_CCMR1_CC2S_1                    ((uint32_t)0x00000200)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_OC2FE                     ((uint32_t)0x00000400)            /*!<Output Compare 2 Fast enable                 */
+#define  TIM_CCMR1_OC2PE                     ((uint32_t)0x00000800)            /*!<Output Compare 2 Preload enable              */
+
+#define  TIM_CCMR1_OC2M                      ((uint32_t)0x01007000)            /*!<OC2M[2:0] bits (Output Compare 2 Mode)       */
+#define  TIM_CCMR1_OC2M_0                    ((uint32_t)0x00001000)            /*!<Bit 0 */
+#define  TIM_CCMR1_OC2M_1                    ((uint32_t)0x00002000)            /*!<Bit 1 */
+#define  TIM_CCMR1_OC2M_2                    ((uint32_t)0x00004000)            /*!<Bit 2 */
+#define  TIM_CCMR1_OC2M_3                    ((uint32_t)0x01000000)            /*!<Bit 3 */
+
+#define  TIM_CCMR1_OC2CE                     ((uint32_t)0x00008000)            /*!<Output Compare 2 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+
+#define  TIM_CCMR1_IC1PSC                    ((uint32_t)0x000C)            /*!<IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define  TIM_CCMR1_IC1PSC_0                  ((uint32_t)0x0004)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC1PSC_1                  ((uint32_t)0x0008)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_IC1F                      ((uint32_t)0x00F0)            /*!<IC1F[3:0] bits (Input Capture 1 Filter)      */
+#define  TIM_CCMR1_IC1F_0                    ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC1F_1                    ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  TIM_CCMR1_IC1F_2                    ((uint32_t)0x0040)            /*!<Bit 2 */
+#define  TIM_CCMR1_IC1F_3                    ((uint32_t)0x0080)            /*!<Bit 3 */
+
+#define  TIM_CCMR1_IC2PSC                    ((uint32_t)0x0C00)            /*!<IC2PSC[1:0] bits (Input Capture 2 Prescaler)  */
+#define  TIM_CCMR1_IC2PSC_0                  ((uint32_t)0x0400)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC2PSC_1                  ((uint32_t)0x0800)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_IC2F                      ((uint32_t)0xF000)            /*!<IC2F[3:0] bits (Input Capture 2 Filter)       */
+#define  TIM_CCMR1_IC2F_0                    ((uint32_t)0x1000)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC2F_1                    ((uint32_t)0x2000)            /*!<Bit 1 */
+#define  TIM_CCMR1_IC2F_2                    ((uint32_t)0x4000)            /*!<Bit 2 */
+#define  TIM_CCMR1_IC2F_3                    ((uint32_t)0x8000)            /*!<Bit 3 */
+
+/******************  Bit definition for TIM_CCMR2 register  *******************/
+#define  TIM_CCMR2_CC3S                      ((uint32_t)0x00000003)        /*!<CC3S[1:0] bits (Capture/Compare 3 Selection)  */
+#define  TIM_CCMR2_CC3S_0                    ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  TIM_CCMR2_CC3S_1                    ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  TIM_CCMR2_OC3FE                     ((uint32_t)0x00000004)        /*!<Output Compare 3 Fast enable           */
+#define  TIM_CCMR2_OC3PE                     ((uint32_t)0x00000008)        /*!<Output Compare 3 Preload enable        */
+
+#define  TIM_CCMR2_OC3M                      ((uint32_t)0x00010070)        /*!<OC3M[2:0] bits (Output Compare 3 Mode) */
+#define  TIM_CCMR2_OC3M_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  TIM_CCMR2_OC3M_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  TIM_CCMR2_OC3M_2                    ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  TIM_CCMR2_OC3M_3                    ((uint32_t)0x00010000)        /*!<Bit 3 */
+
+
+
+#define  TIM_CCMR2_OC3CE                     ((uint32_t)0x00000080)        /*!<Output Compare 3 Clear Enable */
+
+#define  TIM_CCMR2_CC4S                      ((uint32_t)0x00000300)        /*!<CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define  TIM_CCMR2_CC4S_0                    ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  TIM_CCMR2_CC4S_1                    ((uint32_t)0x00000200)        /*!<Bit 1 */
+
+#define  TIM_CCMR2_OC4FE                     ((uint32_t)0x00000400)        /*!<Output Compare 4 Fast enable    */
+#define  TIM_CCMR2_OC4PE                     ((uint32_t)0x00000800)        /*!<Output Compare 4 Preload enable */
+
+#define  TIM_CCMR2_OC4M                      ((uint32_t)0x01007000)        /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define  TIM_CCMR2_OC4M_0                    ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  TIM_CCMR2_OC4M_1                    ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  TIM_CCMR2_OC4M_2                    ((uint32_t)0x00004000)        /*!<Bit 2 */
+#define  TIM_CCMR2_OC4M_3                    ((uint32_t)0x01000000)        /*!<Bit 3 */
+
+#define  TIM_CCMR2_OC4CE                     ((uint32_t)0x8000)            /*!<Output Compare 4 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+
+#define  TIM_CCMR2_IC3PSC                    ((uint32_t)0x000C)            /*!<IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define  TIM_CCMR2_IC3PSC_0                  ((uint32_t)0x0004)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC3PSC_1                  ((uint32_t)0x0008)            /*!<Bit 1 */
+
+#define  TIM_CCMR2_IC3F                      ((uint32_t)0x00F0)            /*!<IC3F[3:0] bits (Input Capture 3 Filter) */
+#define  TIM_CCMR2_IC3F_0                    ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC3F_1                    ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  TIM_CCMR2_IC3F_2                    ((uint32_t)0x0040)            /*!<Bit 2 */
+#define  TIM_CCMR2_IC3F_3                    ((uint32_t)0x0080)            /*!<Bit 3 */
+
+#define  TIM_CCMR2_IC4PSC                    ((uint32_t)0x0C00)            /*!<IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define  TIM_CCMR2_IC4PSC_0                  ((uint32_t)0x0400)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC4PSC_1                  ((uint32_t)0x0800)            /*!<Bit 1 */
+
+#define  TIM_CCMR2_IC4F                      ((uint32_t)0xF000)            /*!<IC4F[3:0] bits (Input Capture 4 Filter) */
+#define  TIM_CCMR2_IC4F_0                    ((uint32_t)0x1000)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC4F_1                    ((uint32_t)0x2000)            /*!<Bit 1 */
+#define  TIM_CCMR2_IC4F_2                    ((uint32_t)0x4000)            /*!<Bit 2 */
+#define  TIM_CCMR2_IC4F_3                    ((uint32_t)0x8000)            /*!<Bit 3 */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define  TIM_CCER_CC1E                       ((uint32_t)0x00000001)            /*!<Capture/Compare 1 output enable */
+#define  TIM_CCER_CC1P                       ((uint32_t)0x00000002)            /*!<Capture/Compare 1 output Polarity */
+#define  TIM_CCER_CC1NE                      ((uint32_t)0x00000004)            /*!<Capture/Compare 1 Complementary output enable */
+#define  TIM_CCER_CC1NP                      ((uint32_t)0x00000008)            /*!<Capture/Compare 1 Complementary output Polarity */
+#define  TIM_CCER_CC2E                       ((uint32_t)0x00000010)            /*!<Capture/Compare 2 output enable */
+#define  TIM_CCER_CC2P                       ((uint32_t)0x00000020)            /*!<Capture/Compare 2 output Polarity */
+#define  TIM_CCER_CC2NE                      ((uint32_t)0x00000040)            /*!<Capture/Compare 2 Complementary output enable */
+#define  TIM_CCER_CC2NP                      ((uint32_t)0x00000080)            /*!<Capture/Compare 2 Complementary output Polarity */
+#define  TIM_CCER_CC3E                       ((uint32_t)0x00000100)            /*!<Capture/Compare 3 output enable */
+#define  TIM_CCER_CC3P                       ((uint32_t)0x00000200)            /*!<Capture/Compare 3 output Polarity */
+#define  TIM_CCER_CC3NE                      ((uint32_t)0x00000400)            /*!<Capture/Compare 3 Complementary output enable */
+#define  TIM_CCER_CC3NP                      ((uint32_t)0x00000800)            /*!<Capture/Compare 3 Complementary output Polarity */
+#define  TIM_CCER_CC4E                       ((uint32_t)0x00001000)            /*!<Capture/Compare 4 output enable */
+#define  TIM_CCER_CC4P                       ((uint32_t)0x00002000)            /*!<Capture/Compare 4 output Polarity */
+#define  TIM_CCER_CC4NP                      ((uint32_t)0x00008000)            /*!<Capture/Compare 4 Complementary output Polarity */
+#define  TIM_CCER_CC5E                       ((uint32_t)0x00010000)            /*!<Capture/Compare 5 output enable */
+#define  TIM_CCER_CC5P                       ((uint32_t)0x00020000)            /*!<Capture/Compare 5 output Polarity */
+#define  TIM_CCER_CC6E                       ((uint32_t)0x00100000)            /*!<Capture/Compare 6 output enable */
+#define  TIM_CCER_CC6P                       ((uint32_t)0x00200000)            /*!<Capture/Compare 6 output Polarity */
+
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define  TIM_CNT_CNT                         ((uint32_t)0xFFFF)            /*!<Counter Value            */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define  TIM_PSC_PSC                         ((uint32_t)0xFFFF)            /*!<Prescaler Value          */
+
+/*******************  Bit definition for TIM_ARR register  ********************/
+#define  TIM_ARR_ARR                         ((uint32_t)0xFFFF)            /*!<actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RCR register  ********************/
+#define  TIM_RCR_REP                         ((uint8_t)0xFF)               /*!<Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CCR1 register  *******************/
+#define  TIM_CCR1_CCR1                       ((uint32_t)0xFFFF)            /*!<Capture/Compare 1 Value  */
+
+/*******************  Bit definition for TIM_CCR2 register  *******************/
+#define  TIM_CCR2_CCR2                       ((uint32_t)0xFFFF)            /*!<Capture/Compare 2 Value  */
+
+/*******************  Bit definition for TIM_CCR3 register  *******************/
+#define  TIM_CCR3_CCR3                       ((uint32_t)0xFFFF)            /*!<Capture/Compare 3 Value  */
+
+/*******************  Bit definition for TIM_CCR4 register  *******************/
+#define  TIM_CCR4_CCR4                       ((uint32_t)0xFFFF)            /*!<Capture/Compare 4 Value  */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define  TIM_BDTR_DTG                        ((uint32_t)0x000000FF)            /*!<DTG[0:7] bits (Dead-Time Generator set-up) */
+#define  TIM_BDTR_DTG_0                      ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_BDTR_DTG_1                      ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define  TIM_BDTR_DTG_2                      ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define  TIM_BDTR_DTG_3                      ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define  TIM_BDTR_DTG_4                      ((uint32_t)0x00000010)            /*!<Bit 4 */
+#define  TIM_BDTR_DTG_5                      ((uint32_t)0x00000020)            /*!<Bit 5 */
+#define  TIM_BDTR_DTG_6                      ((uint32_t)0x00000040)            /*!<Bit 6 */
+#define  TIM_BDTR_DTG_7                      ((uint32_t)0x00000080)            /*!<Bit 7 */
+
+#define  TIM_BDTR_LOCK                       ((uint32_t)0x00000300)            /*!<LOCK[1:0] bits (Lock Configuration) */
+#define  TIM_BDTR_LOCK_0                     ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  TIM_BDTR_LOCK_1                     ((uint32_t)0x00000200)            /*!<Bit 1 */
+
+#define  TIM_BDTR_OSSI                       ((uint32_t)0x00000400)            /*!<Off-State Selection for Idle mode */
+#define  TIM_BDTR_OSSR                       ((uint32_t)0x00000800)            /*!<Off-State Selection for Run mode  */
+#define  TIM_BDTR_BKE                        ((uint32_t)0x00001000)            /*!<Break enable                      */
+#define  TIM_BDTR_BKP                        ((uint32_t)0x00002000)            /*!<Break Polarity                    */
+#define  TIM_BDTR_AOE                        ((uint32_t)0x00004000)            /*!<Automatic Output enable           */
+#define  TIM_BDTR_MOE                        ((uint32_t)0x00008000)            /*!<Main Output enable                */
+#define  TIM_BDTR_BKF                        ((uint32_t)0x000F0000)            /*!<Break Filter for Break1 */
+#define  TIM_BDTR_BK2F                       ((uint32_t)0x00F00000)            /*!<Break Filter for Break2 */
+#define  TIM_BDTR_BK2E                       ((uint32_t)0x01000000)            /*!<Break enable for Break2 */
+#define  TIM_BDTR_BK2P                       ((uint32_t)0x02000000)            /*!<Break Polarity for Break2 */
+
+/*******************  Bit definition for TIM_DCR register  ********************/
+#define  TIM_DCR_DBA                         ((uint32_t)0x001F)            /*!<DBA[4:0] bits (DMA Base Address) */
+#define  TIM_DCR_DBA_0                       ((uint32_t)0x0001)            /*!<Bit 0 */
+#define  TIM_DCR_DBA_1                       ((uint32_t)0x0002)            /*!<Bit 1 */
+#define  TIM_DCR_DBA_2                       ((uint32_t)0x0004)            /*!<Bit 2 */
+#define  TIM_DCR_DBA_3                       ((uint32_t)0x0008)            /*!<Bit 3 */
+#define  TIM_DCR_DBA_4                       ((uint32_t)0x0010)            /*!<Bit 4 */
+
+#define  TIM_DCR_DBL                         ((uint32_t)0x1F00)            /*!<DBL[4:0] bits (DMA Burst Length) */
+#define  TIM_DCR_DBL_0                       ((uint32_t)0x0100)            /*!<Bit 0 */
+#define  TIM_DCR_DBL_1                       ((uint32_t)0x0200)            /*!<Bit 1 */
+#define  TIM_DCR_DBL_2                       ((uint32_t)0x0400)            /*!<Bit 2 */
+#define  TIM_DCR_DBL_3                       ((uint32_t)0x0800)            /*!<Bit 3 */
+#define  TIM_DCR_DBL_4                       ((uint32_t)0x1000)            /*!<Bit 4 */
+
+/*******************  Bit definition for TIM_DMAR register  *******************/
+#define  TIM_DMAR_DMAB                       ((uint32_t)0xFFFF)            /*!<DMA register for burst accesses                    */
+
+/*******************  Bit definition for TIM_OR register  *********************/
+#define TIM_OR_TI4_RMP                       ((uint32_t)0x00C0)            /*!<TI4_RMP[1:0] bits (TIM5 Input 4 remap)             */
+#define TIM_OR_TI4_RMP_0                     ((uint32_t)0x0040)            /*!<Bit 0 */
+#define TIM_OR_TI4_RMP_1                     ((uint32_t)0x0080)            /*!<Bit 1 */
+#define TIM_OR_ITR1_RMP                      ((uint32_t)0x0C00)            /*!<ITR1_RMP[1:0] bits (TIM2 Internal trigger 1 remap) */
+#define TIM_OR_ITR1_RMP_0                    ((uint32_t)0x0400)            /*!<Bit 0 */
+#define TIM_OR_ITR1_RMP_1                    ((uint32_t)0x0800)            /*!<Bit 1 */
+
+/******************  Bit definition for TIM_CCMR3 register  *******************/
+#define  TIM_CCMR3_OC5FE                     ((uint32_t)0x00000004)            /*!<Output Compare 5 Fast enable */
+#define  TIM_CCMR3_OC5PE                     ((uint32_t)0x00000008)            /*!<Output Compare 5 Preload enable */
+
+#define  TIM_CCMR3_OC5M                      ((uint32_t)0x00010070)            /*!<OC5M[2:0] bits (Output Compare 5 Mode) */
+#define  TIM_CCMR3_OC5M_0                    ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  TIM_CCMR3_OC5M_1                    ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  TIM_CCMR3_OC5M_2                    ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define  TIM_CCMR3_OC5M_3                    ((uint32_t)0x00010000)            /*!<Bit 3 */
+
+#define  TIM_CCMR3_OC5CE                     ((uint32_t)0x00000080)            /*!<Output Compare 5 Clear Enable */
+
+#define  TIM_CCMR3_OC6FE                     ((uint32_t)0x00000400)            /*!<Output Compare 4 Fast enable */
+#define  TIM_CCMR3_OC6PE                     ((uint32_t)0x00000800)            /*!<Output Compare 4 Preload enable */
+
+#define  TIM_CCMR3_OC6M                      ((uint32_t)0x01007000)            /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define  TIM_CCMR3_OC6M_0                    ((uint32_t)0x00001000)            /*!<Bit 0 */
+#define  TIM_CCMR3_OC6M_1                    ((uint32_t)0x00002000)            /*!<Bit 1 */
+#define  TIM_CCMR3_OC6M_2                    ((uint32_t)0x00004000)            /*!<Bit 2 */
+#define  TIM_CCMR3_OC6M_3                    ((uint32_t)0x01000000)            /*!<Bit 3 */
+
+#define  TIM_CCMR3_OC6CE                     ((uint32_t)0x00008000)            /*!<Output Compare 4 Clear Enable */
+
+/*******************  Bit definition for TIM_CCR5 register  *******************/
+#define  TIM_CCR5_CCR5                       ((uint32_t)0xFFFFFFFF)        /*!<Capture/Compare 5 Value */
+#define  TIM_CCR5_GC5C1                      ((uint32_t)0x20000000)        /*!<Group Channel 5 and Channel 1 */
+#define  TIM_CCR5_GC5C2                      ((uint32_t)0x40000000)        /*!<Group Channel 5 and Channel 2 */
+#define  TIM_CCR5_GC5C3                      ((uint32_t)0x80000000)        /*!<Group Channel 5 and Channel 3 */
+
+/*******************  Bit definition for TIM_CCR6 register  *******************/
+#define  TIM_CCR6_CCR6                       ((uint16_t)0xFFFF)            /*!<Capture/Compare 6 Value */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Low Power Timer (LPTIM)                            */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for LPTIM_ISR register  *******************/
+#define  LPTIM_ISR_CMPM                         ((uint32_t)0x00000001)            /*!< Compare match                       */
+#define  LPTIM_ISR_ARRM                         ((uint32_t)0x00000002)            /*!< Autoreload match                    */
+#define  LPTIM_ISR_EXTTRIG                      ((uint32_t)0x00000004)            /*!< External trigger edge event         */
+#define  LPTIM_ISR_CMPOK                        ((uint32_t)0x00000008)            /*!< Compare register update OK          */
+#define  LPTIM_ISR_ARROK                        ((uint32_t)0x00000010)            /*!< Autoreload register update OK       */
+#define  LPTIM_ISR_UP                           ((uint32_t)0x00000020)            /*!< Counter direction change down to up */
+#define  LPTIM_ISR_DOWN                         ((uint32_t)0x00000040)            /*!< Counter direction change up to down */
+
+/******************  Bit definition for LPTIM_ICR register  *******************/
+#define  LPTIM_ICR_CMPMCF                       ((uint32_t)0x00000001)            /*!< Compare match Clear Flag                       */
+#define  LPTIM_ICR_ARRMCF                       ((uint32_t)0x00000002)            /*!< Autoreload match Clear Flag                    */
+#define  LPTIM_ICR_EXTTRIGCF                    ((uint32_t)0x00000004)            /*!< External trigger edge event Clear Flag         */
+#define  LPTIM_ICR_CMPOKCF                      ((uint32_t)0x00000008)            /*!< Compare register update OK Clear Flag          */
+#define  LPTIM_ICR_ARROKCF                      ((uint32_t)0x00000010)            /*!< Autoreload register update OK Clear Flag       */
+#define  LPTIM_ICR_UPCF                         ((uint32_t)0x00000020)            /*!< Counter direction change down to up Clear Flag */
+#define  LPTIM_ICR_DOWNCF                       ((uint32_t)0x00000040)            /*!< Counter direction change up to down Clear Flag */
+
+/******************  Bit definition for LPTIM_IER register ********************/
+#define  LPTIM_IER_CMPMIE                       ((uint32_t)0x00000001)            /*!< Compare match Interrupt Enable                       */
+#define  LPTIM_IER_ARRMIE                       ((uint32_t)0x00000002)            /*!< Autoreload match Interrupt Enable                    */
+#define  LPTIM_IER_EXTTRIGIE                    ((uint32_t)0x00000004)            /*!< External trigger edge event Interrupt Enable         */
+#define  LPTIM_IER_CMPOKIE                      ((uint32_t)0x00000008)            /*!< Compare register update OK Interrupt Enable          */
+#define  LPTIM_IER_ARROKIE                      ((uint32_t)0x00000010)            /*!< Autoreload register update OK Interrupt Enable       */
+#define  LPTIM_IER_UPIE                         ((uint32_t)0x00000020)            /*!< Counter direction change down to up Interrupt Enable */
+#define  LPTIM_IER_DOWNIE                       ((uint32_t)0x00000040)            /*!< Counter direction change up to down Interrupt Enable */
+
+/******************  Bit definition for LPTIM_CFGR register *******************/
+#define  LPTIM_CFGR_CKSEL                       ((uint32_t)0x00000001)             /*!< Clock selector */
+
+#define  LPTIM_CFGR_CKPOL                       ((uint32_t)0x00000006)             /*!< CKPOL[1:0] bits (Clock polarity) */
+#define  LPTIM_CFGR_CKPOL_0                     ((uint32_t)0x00000002)             /*!< Bit 0 */
+#define  LPTIM_CFGR_CKPOL_1                     ((uint32_t)0x00000004)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_CKFLT                       ((uint32_t)0x00000018)             /*!< CKFLT[1:0] bits (Configurable digital filter for external clock) */
+#define  LPTIM_CFGR_CKFLT_0                     ((uint32_t)0x00000008)             /*!< Bit 0 */
+#define  LPTIM_CFGR_CKFLT_1                     ((uint32_t)0x00000010)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_TRGFLT                      ((uint32_t)0x000000C0)             /*!< TRGFLT[1:0] bits (Configurable digital filter for trigger) */
+#define  LPTIM_CFGR_TRGFLT_0                    ((uint32_t)0x00000040)             /*!< Bit 0 */
+#define  LPTIM_CFGR_TRGFLT_1                    ((uint32_t)0x00000080)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_PRESC                       ((uint32_t)0x00000E00)             /*!< PRESC[2:0] bits (Clock prescaler) */
+#define  LPTIM_CFGR_PRESC_0                     ((uint32_t)0x00000200)             /*!< Bit 0 */
+#define  LPTIM_CFGR_PRESC_1                     ((uint32_t)0x00000400)             /*!< Bit 1 */
+#define  LPTIM_CFGR_PRESC_2                     ((uint32_t)0x00000800)             /*!< Bit 2 */
+
+#define  LPTIM_CFGR_TRIGSEL                     ((uint32_t)0x0000E000)             /*!< TRIGSEL[2:0]] bits (Trigger selector) */
+#define  LPTIM_CFGR_TRIGSEL_0                   ((uint32_t)0x00002000)             /*!< Bit 0 */
+#define  LPTIM_CFGR_TRIGSEL_1                   ((uint32_t)0x00004000)             /*!< Bit 1 */
+#define  LPTIM_CFGR_TRIGSEL_2                   ((uint32_t)0x00008000)             /*!< Bit 2 */
+
+#define  LPTIM_CFGR_TRIGEN                      ((uint32_t)0x00060000)             /*!< TRIGEN[1:0] bits (Trigger enable and polarity) */
+#define  LPTIM_CFGR_TRIGEN_0                    ((uint32_t)0x00020000)             /*!< Bit 0 */
+#define  LPTIM_CFGR_TRIGEN_1                    ((uint32_t)0x00040000)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_TIMOUT                      ((uint32_t)0x00080000)             /*!< Timout enable           */
+#define  LPTIM_CFGR_WAVE                        ((uint32_t)0x00100000)             /*!< Waveform shape          */
+#define  LPTIM_CFGR_WAVPOL                      ((uint32_t)0x00200000)             /*!< Waveform shape polarity */
+#define  LPTIM_CFGR_PRELOAD                     ((uint32_t)0x00400000)             /*!< Reg update mode         */
+#define  LPTIM_CFGR_COUNTMODE                   ((uint32_t)0x00800000)             /*!< Counter mode enable     */
+#define  LPTIM_CFGR_ENC                         ((uint32_t)0x01000000)             /*!< Encoder mode enable     */
+
+/******************  Bit definition for LPTIM_CR register  ********************/
+#define  LPTIM_CR_ENABLE                        ((uint32_t)0x00000001)             /*!< LPTIMer enable                 */
+#define  LPTIM_CR_SNGSTRT                       ((uint32_t)0x00080002)             /*!< Timer start in single mode     */
+#define  LPTIM_CR_CNTSTRT                       ((uint32_t)0x00000004)             /*!< Timer start in continuous mode */
+
+/******************  Bit definition for LPTIM_CMP register  *******************/
+#define  LPTIM_CMP_CMP                          ((uint32_t)0x0000FFFF)             /*!< Compare register     */
+
+/******************  Bit definition for LPTIM_ARR register  *******************/
+#define  LPTIM_ARR_ARR                          ((uint32_t)0x0000FFFF)             /*!< Auto reload register */
+
+/******************  Bit definition for LPTIM_CNT register  *******************/
+#define  LPTIM_CNT_CNT                          ((uint32_t)0x0000FFFF)             /*!< Counter register     */
+/******************************************************************************/
+/*                                                                            */
+/*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for USART_CR1 register  *******************/
+#define  USART_CR1_UE                        ((uint32_t)0x00000001)            /*!< USART Enable                                    */
+#define  USART_CR1_RE                        ((uint32_t)0x00000004)            /*!< Receiver Enable                                 */
+#define  USART_CR1_TE                        ((uint32_t)0x00000008)            /*!< Transmitter Enable                              */
+#define  USART_CR1_IDLEIE                    ((uint32_t)0x00000010)            /*!< IDLE Interrupt Enable                           */
+#define  USART_CR1_RXNEIE                    ((uint32_t)0x00000020)            /*!< RXNE Interrupt Enable                           */
+#define  USART_CR1_TCIE                      ((uint32_t)0x00000040)            /*!< Transmission Complete Interrupt Enable          */
+#define  USART_CR1_TXEIE                     ((uint32_t)0x00000080)            /*!< TXE Interrupt Enable                            */
+#define  USART_CR1_PEIE                      ((uint32_t)0x00000100)            /*!< PE Interrupt Enable                             */
+#define  USART_CR1_PS                        ((uint32_t)0x00000200)            /*!< Parity Selection                                */
+#define  USART_CR1_PCE                       ((uint32_t)0x00000400)            /*!< Parity Control Enable                           */
+#define  USART_CR1_WAKE                      ((uint32_t)0x00000800)            /*!< Receiver Wakeup method                          */
+#define  USART_CR1_M                         ((uint32_t)0x10001000)            /*!< Word length                                     */
+#define  USART_CR1_M_0                       ((uint32_t)0x00001000)            /*!< Word length - Bit 0                             */
+#define  USART_CR1_MME                       ((uint32_t)0x00002000)            /*!< Mute Mode Enable                                */
+#define  USART_CR1_CMIE                      ((uint32_t)0x00004000)            /*!< Character match interrupt enable                */
+#define  USART_CR1_OVER8                     ((uint32_t)0x00008000)            /*!< Oversampling by 8-bit or 16-bit mode            */
+#define  USART_CR1_DEDT                      ((uint32_t)0x001F0000)            /*!< DEDT[4:0] bits (Driver Enable Deassertion Time) */
+#define  USART_CR1_DEDT_0                    ((uint32_t)0x00010000)            /*!< Bit 0 */
+#define  USART_CR1_DEDT_1                    ((uint32_t)0x00020000)            /*!< Bit 1 */
+#define  USART_CR1_DEDT_2                    ((uint32_t)0x00040000)            /*!< Bit 2 */
+#define  USART_CR1_DEDT_3                    ((uint32_t)0x00080000)            /*!< Bit 3 */
+#define  USART_CR1_DEDT_4                    ((uint32_t)0x00100000)            /*!< Bit 4 */
+#define  USART_CR1_DEAT                      ((uint32_t)0x03E00000)            /*!< DEAT[4:0] bits (Driver Enable Assertion Time)   */
+#define  USART_CR1_DEAT_0                    ((uint32_t)0x00200000)            /*!< Bit 0 */
+#define  USART_CR1_DEAT_1                    ((uint32_t)0x00400000)            /*!< Bit 1 */
+#define  USART_CR1_DEAT_2                    ((uint32_t)0x00800000)            /*!< Bit 2 */
+#define  USART_CR1_DEAT_3                    ((uint32_t)0x01000000)            /*!< Bit 3 */
+#define  USART_CR1_DEAT_4                    ((uint32_t)0x02000000)            /*!< Bit 4 */
+#define  USART_CR1_RTOIE                     ((uint32_t)0x04000000)            /*!< Receive Time Out interrupt enable */
+#define  USART_CR1_EOBIE                     ((uint32_t)0x08000000)            /*!< End of Block interrupt enable     */
+#define  USART_CR1_M_1                       ((uint32_t)0x10000000)            /*!< Word length - Bit 1               */
+
+/******************  Bit definition for USART_CR2 register  *******************/
+#define  USART_CR2_ADDM7                     ((uint32_t)0x00000010)            /*!< 7-bit or 4-bit Address Detection       */
+#define  USART_CR2_LBDL                      ((uint32_t)0x00000020)            /*!< LIN Break Detection Length             */
+#define  USART_CR2_LBDIE                     ((uint32_t)0x00000040)            /*!< LIN Break Detection Interrupt Enable   */
+#define  USART_CR2_LBCL                      ((uint32_t)0x00000100)            /*!< Last Bit Clock pulse                   */
+#define  USART_CR2_CPHA                      ((uint32_t)0x00000200)            /*!< Clock Phase                            */
+#define  USART_CR2_CPOL                      ((uint32_t)0x00000400)            /*!< Clock Polarity                         */
+#define  USART_CR2_CLKEN                     ((uint32_t)0x00000800)            /*!< Clock Enable                           */
+#define  USART_CR2_STOP                      ((uint32_t)0x00003000)            /*!< STOP[1:0] bits (STOP bits)             */
+#define  USART_CR2_STOP_0                    ((uint32_t)0x00001000)            /*!< Bit 0 */
+#define  USART_CR2_STOP_1                    ((uint32_t)0x00002000)            /*!< Bit 1 */
+#define  USART_CR2_LINEN                     ((uint32_t)0x00004000)            /*!< LIN mode enable                        */
+#define  USART_CR2_SWAP                      ((uint32_t)0x00008000)            /*!< SWAP TX/RX pins                        */
+#define  USART_CR2_RXINV                     ((uint32_t)0x00010000)            /*!< RX pin active level inversion          */
+#define  USART_CR2_TXINV                     ((uint32_t)0x00020000)            /*!< TX pin active level inversion          */
+#define  USART_CR2_DATAINV                   ((uint32_t)0x00040000)            /*!< Binary data inversion                  */
+#define  USART_CR2_MSBFIRST                  ((uint32_t)0x00080000)            /*!< Most Significant Bit First             */
+#define  USART_CR2_ABREN                     ((uint32_t)0x00100000)            /*!< Auto Baud-Rate Enable                  */
+#define  USART_CR2_ABRMODE                   ((uint32_t)0x00600000)            /*!< ABRMOD[1:0] bits (Auto Baud-Rate Mode) */
+#define  USART_CR2_ABRMODE_0                 ((uint32_t)0x00200000)            /*!< Bit 0 */
+#define  USART_CR2_ABRMODE_1                 ((uint32_t)0x00400000)            /*!< Bit 1 */
+#define  USART_CR2_RTOEN                     ((uint32_t)0x00800000)            /*!< Receiver Time-Out enable  */
+#define  USART_CR2_ADD                       ((uint32_t)0xFF000000)            /*!< Address of the USART node */
+
+/******************  Bit definition for USART_CR3 register  *******************/
+#define  USART_CR3_EIE                       ((uint32_t)0x00000001)            /*!< Error Interrupt Enable                         */
+#define  USART_CR3_IREN                      ((uint32_t)0x00000002)            /*!< IrDA mode Enable                               */
+#define  USART_CR3_IRLP                      ((uint32_t)0x00000004)            /*!< IrDA Low-Power                                 */
+#define  USART_CR3_HDSEL                     ((uint32_t)0x00000008)            /*!< Half-Duplex Selection                          */
+#define  USART_CR3_NACK                      ((uint32_t)0x00000010)            /*!< SmartCard NACK enable                          */
+#define  USART_CR3_SCEN                      ((uint32_t)0x00000020)            /*!< SmartCard mode enable                          */
+#define  USART_CR3_DMAR                      ((uint32_t)0x00000040)            /*!< DMA Enable Receiver                            */
+#define  USART_CR3_DMAT                      ((uint32_t)0x00000080)            /*!< DMA Enable Transmitter                         */
+#define  USART_CR3_RTSE                      ((uint32_t)0x00000100)            /*!< RTS Enable                                     */
+#define  USART_CR3_CTSE                      ((uint32_t)0x00000200)            /*!< CTS Enable                                     */
+#define  USART_CR3_CTSIE                     ((uint32_t)0x00000400)            /*!< CTS Interrupt Enable                           */
+#define  USART_CR3_ONEBIT                    ((uint32_t)0x00000800)            /*!< One sample bit method enable                   */
+#define  USART_CR3_OVRDIS                    ((uint32_t)0x00001000)            /*!< Overrun Disable                                */
+#define  USART_CR3_DDRE                      ((uint32_t)0x00002000)            /*!< DMA Disable on Reception Error                 */
+#define  USART_CR3_DEM                       ((uint32_t)0x00004000)            /*!< Driver Enable Mode                             */
+#define  USART_CR3_DEP                       ((uint32_t)0x00008000)            /*!< Driver Enable Polarity Selection               */
+#define  USART_CR3_SCARCNT                   ((uint32_t)0x000E0000)            /*!< SCARCNT[2:0] bits (SmartCard Auto-Retry Count) */
+#define  USART_CR3_SCARCNT_0                 ((uint32_t)0x00020000)            /*!< Bit 0 */
+#define  USART_CR3_SCARCNT_1                 ((uint32_t)0x00040000)            /*!< Bit 1 */
+#define  USART_CR3_SCARCNT_2                 ((uint32_t)0x00080000)            /*!< Bit 2 */
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define  USART_BRR_DIV_FRACTION              ((uint32_t)0x000F)                /*!< Fraction of USARTDIV */
+#define  USART_BRR_DIV_MANTISSA              ((uint32_t)0xFFF0)                /*!< Mantissa of USARTDIV */
+
+/******************  Bit definition for USART_GTPR register  ******************/
+#define  USART_GTPR_PSC                      ((uint32_t)0x00FF)                /*!< PSC[7:0] bits (Prescaler value) */
+#define  USART_GTPR_GT                       ((uint32_t)0xFF00)                /*!< GT[7:0] bits (Guard time value) */
+
+
+/*******************  Bit definition for USART_RTOR register  *****************/
+#define  USART_RTOR_RTO                      ((uint32_t)0x00FFFFFF)            /*!< Receiver Time Out Value */
+#define  USART_RTOR_BLEN                     ((uint32_t)0xFF000000)            /*!< Block Length */
+
+/*******************  Bit definition for USART_RQR register  ******************/
+#define  USART_RQR_ABRRQ                     ((uint32_t)0x0001)                /*!< Auto-Baud Rate Request      */
+#define  USART_RQR_SBKRQ                     ((uint32_t)0x0002)                /*!< Send Break Request          */
+#define  USART_RQR_MMRQ                      ((uint32_t)0x0004)                /*!< Mute Mode Request           */
+#define  USART_RQR_RXFRQ                     ((uint32_t)0x0008)                /*!< Receive Data flush Request  */
+#define  USART_RQR_TXFRQ                     ((uint32_t)0x0010)                /*!< Transmit data flush Request */
+
+/*******************  Bit definition for USART_ISR register  ******************/
+#define  USART_ISR_PE                        ((uint32_t)0x00000001)            /*!< Parity Error                        */
+#define  USART_ISR_FE                        ((uint32_t)0x00000002)            /*!< Framing Error                       */
+#define  USART_ISR_NE                        ((uint32_t)0x00000004)            /*!< Noise detected Flag                 */
+#define  USART_ISR_ORE                       ((uint32_t)0x00000008)            /*!< OverRun Error                       */
+#define  USART_ISR_IDLE                      ((uint32_t)0x00000010)            /*!< IDLE line detected                  */
+#define  USART_ISR_RXNE                      ((uint32_t)0x00000020)            /*!< Read Data Register Not Empty        */
+#define  USART_ISR_TC                        ((uint32_t)0x00000040)            /*!< Transmission Complete               */
+#define  USART_ISR_TXE                       ((uint32_t)0x00000080)            /*!< Transmit Data Register Empty        */
+#define  USART_ISR_LBD                       ((uint32_t)0x00000100)            /*!< LIN Break Detection Flag            */
+#define  USART_ISR_CTSIF                     ((uint32_t)0x00000200)            /*!< CTS interrupt flag                  */
+#define  USART_ISR_CTS                       ((uint32_t)0x00000400)            /*!< CTS flag                            */
+#define  USART_ISR_RTOF                      ((uint32_t)0x00000800)            /*!< Receiver Time Out                   */
+#define  USART_ISR_EOBF                      ((uint32_t)0x00001000)            /*!< End Of Block Flag                   */
+#define  USART_ISR_ABRE                      ((uint32_t)0x00004000)            /*!< Auto-Baud Rate Error                */
+#define  USART_ISR_ABRF                      ((uint32_t)0x00008000)            /*!< Auto-Baud Rate Flag                 */
+#define  USART_ISR_BUSY                      ((uint32_t)0x00010000)            /*!< Busy Flag                           */
+#define  USART_ISR_CMF                       ((uint32_t)0x00020000)            /*!< Character Match Flag                */
+#define  USART_ISR_SBKF                      ((uint32_t)0x00040000)            /*!< Send Break Flag                     */
+#define  USART_ISR_RWU                       ((uint32_t)0x00080000)            /*!< Receive Wake Up from mute mode Flag */
+#define  USART_ISR_WUF                       ((uint32_t)0x00100000)            /*!< Wake Up from stop mode Flag         */
+#define  USART_ISR_TEACK                     ((uint32_t)0x00200000)            /*!< Transmit Enable Acknowledge Flag    */
+#define  USART_ISR_REACK                     ((uint32_t)0x00400000)            /*!< Receive Enable Acknowledge Flag     */
+
+/*******************  Bit definition for USART_ICR register  ******************/
+#define  USART_ICR_PECF                      ((uint32_t)0x00000001)            /*!< Parity Error Clear Flag             */
+#define  USART_ICR_FECF                      ((uint32_t)0x00000002)            /*!< Framing Error Clear Flag            */
+#define  USART_ICR_NCF                       ((uint32_t)0x00000004)            /*!< Noise detected Clear Flag           */
+#define  USART_ICR_ORECF                     ((uint32_t)0x00000008)            /*!< OverRun Error Clear Flag            */
+#define  USART_ICR_IDLECF                    ((uint32_t)0x00000010)            /*!< IDLE line detected Clear Flag       */
+#define  USART_ICR_TCCF                      ((uint32_t)0x00000040)            /*!< Transmission Complete Clear Flag    */
+#define  USART_ICR_LBDCF                     ((uint32_t)0x00000100)            /*!< LIN Break Detection Clear Flag      */
+#define  USART_ICR_CTSCF                     ((uint32_t)0x00000200)            /*!< CTS Interrupt Clear Flag            */
+#define  USART_ICR_RTOCF                     ((uint32_t)0x00000800)            /*!< Receiver Time Out Clear Flag        */
+#define  USART_ICR_EOBCF                     ((uint32_t)0x00001000)            /*!< End Of Block Clear Flag             */
+#define  USART_ICR_CMCF                      ((uint32_t)0x00020000)            /*!< Character Match Clear Flag          */
+#define  USART_ICR_WUCF                      ((uint32_t)0x00100000)            /*!< Wake Up from stop mode Clear Flag   */
+
+/*******************  Bit definition for USART_RDR register  ******************/
+#define  USART_RDR_RDR                       ((uint32_t)0x01FF)                /*!< RDR[8:0] bits (Receive Data value) */
+
+/*******************  Bit definition for USART_TDR register  ******************/
+#define  USART_TDR_TDR                       ((uint32_t)0x01FF)                /*!< TDR[8:0] bits (Transmit Data value) */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            Window WATCHDOG                                 */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for WWDG_CR register  ********************/
+#define  WWDG_CR_T                           ((uint32_t)0x7F)               /*!<T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define  WWDG_CR_T0                          ((uint32_t)0x01)               /*!<Bit 0 */
+#define  WWDG_CR_T1                          ((uint32_t)0x02)               /*!<Bit 1 */
+#define  WWDG_CR_T2                          ((uint32_t)0x04)               /*!<Bit 2 */
+#define  WWDG_CR_T3                          ((uint32_t)0x08)               /*!<Bit 3 */
+#define  WWDG_CR_T4                          ((uint32_t)0x10)               /*!<Bit 4 */
+#define  WWDG_CR_T5                          ((uint32_t)0x20)               /*!<Bit 5 */
+#define  WWDG_CR_T6                          ((uint32_t)0x40)               /*!<Bit 6 */
+
+#define  WWDG_CR_WDGA                        ((uint32_t)0x80)               /*!<Activation bit */
+
+/*******************  Bit definition for WWDG_CFR register  *******************/
+#define  WWDG_CFR_W                          ((uint32_t)0x007F)            /*!<W[6:0] bits (7-bit window value) */
+#define  WWDG_CFR_W0                         ((uint32_t)0x0001)            /*!<Bit 0 */
+#define  WWDG_CFR_W1                         ((uint32_t)0x0002)            /*!<Bit 1 */
+#define  WWDG_CFR_W2                         ((uint32_t)0x0004)            /*!<Bit 2 */
+#define  WWDG_CFR_W3                         ((uint32_t)0x0008)            /*!<Bit 3 */
+#define  WWDG_CFR_W4                         ((uint32_t)0x0010)            /*!<Bit 4 */
+#define  WWDG_CFR_W5                         ((uint32_t)0x0020)            /*!<Bit 5 */
+#define  WWDG_CFR_W6                         ((uint32_t)0x0040)            /*!<Bit 6 */
+
+#define  WWDG_CFR_WDGTB                      ((uint32_t)0x0180)            /*!<WDGTB[1:0] bits (Timer Base) */
+#define  WWDG_CFR_WDGTB0                     ((uint32_t)0x0080)            /*!<Bit 0 */
+#define  WWDG_CFR_WDGTB1                     ((uint32_t)0x0100)            /*!<Bit 1 */
+
+#define  WWDG_CFR_EWI                        ((uint32_t)0x0200)            /*!<Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_SR register  ********************/
+#define  WWDG_SR_EWIF                        ((uint32_t)0x01)               /*!<Early Wakeup Interrupt Flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                DBG                                         */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DBGMCU_IDCODE register  *************/
+#define  DBGMCU_IDCODE_DEV_ID                ((uint32_t)0x00000FFF)
+#define  DBGMCU_IDCODE_REV_ID                ((uint32_t)0xFFFF0000)
+
+/********************  Bit definition for DBGMCU_CR register  *****************/
+#define  DBGMCU_CR_DBG_SLEEP                 ((uint32_t)0x00000001)
+#define  DBGMCU_CR_DBG_STOP                  ((uint32_t)0x00000002)
+#define  DBGMCU_CR_DBG_STANDBY               ((uint32_t)0x00000004)
+#define  DBGMCU_CR_TRACE_IOEN                ((uint32_t)0x00000020)
+
+#define  DBGMCU_CR_TRACE_MODE                ((uint32_t)0x000000C0)
+#define  DBGMCU_CR_TRACE_MODE_0              ((uint32_t)0x00000040) /*!<Bit 0 */
+#define  DBGMCU_CR_TRACE_MODE_1              ((uint32_t)0x00000080) /*!<Bit 1 */
+
+/********************  Bit definition for DBGMCU_APB1_FZ register  ************/
+#define  DBGMCU_APB1_FZ_DBG_TIM2_STOP            ((uint32_t)0x00000001)
+#define  DBGMCU_APB1_FZ_DBG_TIM3_STOP            ((uint32_t)0x00000002)
+#define  DBGMCU_APB1_FZ_DBG_TIM4_STOP            ((uint32_t)0x00000004)
+#define  DBGMCU_APB1_FZ_DBG_TIM5_STOP            ((uint32_t)0x00000008)
+#define  DBGMCU_APB1_FZ_DBG_TIM6_STOP            ((uint32_t)0x00000010)
+#define  DBGMCU_APB1_FZ_DBG_TIM7_STOP            ((uint32_t)0x00000020)
+#define  DBGMCU_APB1_FZ_DBG_TIM12_STOP           ((uint32_t)0x00000040)
+#define  DBGMCU_APB1_FZ_DBG_TIM13_STOP           ((uint32_t)0x00000080)
+#define  DBGMCU_APB1_FZ_DBG_TIM14_STOP           ((uint32_t)0x00000100)
+#define  DBGMCU_APB1_FZ_DBG_RTC_STOP             ((uint32_t)0x00000400)
+#define  DBGMCU_APB1_FZ_DBG_WWDG_STOP            ((uint32_t)0x00000800)
+#define  DBGMCU_APB1_FZ_DBG_IWDG_STOP            ((uint32_t)0x00001000)
+#define  DBGMCU_APB1_FZ_DBG_I2C1_SMBUS_TIMEOUT   ((uint32_t)0x00200000)
+#define  DBGMCU_APB1_FZ_DBG_I2C2_SMBUS_TIMEOUT   ((uint32_t)0x00400000)
+#define  DBGMCU_APB1_FZ_DBG_I2C3_SMBUS_TIMEOUT   ((uint32_t)0x00800000)
+#define  DBGMCU_APB1_FZ_DBG_CAN1_STOP            ((uint32_t)0x02000000)
+#define  DBGMCU_APB1_FZ_DBG_CAN2_STOP            ((uint32_t)0x04000000)
+
+/********************  Bit definition for DBGMCU_APB2_FZ register  ************/
+#define  DBGMCU_APB1_FZ_DBG_TIM1_STOP        ((uint32_t)0x00000001)
+#define  DBGMCU_APB1_FZ_DBG_TIM8_STOP        ((uint32_t)0x00000002)
+#define  DBGMCU_APB1_FZ_DBG_TIM9_STOP        ((uint32_t)0x00010000)
+#define  DBGMCU_APB1_FZ_DBG_TIM10_STOP       ((uint32_t)0x00020000)
+#define  DBGMCU_APB1_FZ_DBG_TIM11_STOP       ((uint32_t)0x00040000)
+
+/******************************************************************************/
+/*                                                                            */
+/*                Ethernet MAC Registers bits definitions                     */
+/*                                                                            */
+/******************************************************************************/
+/* Bit definition for Ethernet MAC Control Register register */
+#define ETH_MACCR_WD      ((uint32_t)0x00800000)  /* Watchdog disable */
+#define ETH_MACCR_JD      ((uint32_t)0x00400000)  /* Jabber disable */
+#define ETH_MACCR_IFG     ((uint32_t)0x000E0000)  /* Inter-frame gap */
+#define ETH_MACCR_IFG_96Bit     ((uint32_t)0x00000000)  /* Minimum IFG between frames during transmission is 96Bit */
+  #define ETH_MACCR_IFG_88Bit     ((uint32_t)0x00020000)  /* Minimum IFG between frames during transmission is 88Bit */
+  #define ETH_MACCR_IFG_80Bit     ((uint32_t)0x00040000)  /* Minimum IFG between frames during transmission is 80Bit */
+  #define ETH_MACCR_IFG_72Bit     ((uint32_t)0x00060000)  /* Minimum IFG between frames during transmission is 72Bit */
+  #define ETH_MACCR_IFG_64Bit     ((uint32_t)0x00080000)  /* Minimum IFG between frames during transmission is 64Bit */
+  #define ETH_MACCR_IFG_56Bit     ((uint32_t)0x000A0000)  /* Minimum IFG between frames during transmission is 56Bit */
+  #define ETH_MACCR_IFG_48Bit     ((uint32_t)0x000C0000)  /* Minimum IFG between frames during transmission is 48Bit */
+  #define ETH_MACCR_IFG_40Bit     ((uint32_t)0x000E0000)  /* Minimum IFG between frames during transmission is 40Bit */
+#define ETH_MACCR_CSD     ((uint32_t)0x00010000)  /* Carrier sense disable (during transmission) */
+#define ETH_MACCR_FES     ((uint32_t)0x00004000)  /* Fast ethernet speed */
+#define ETH_MACCR_ROD     ((uint32_t)0x00002000)  /* Receive own disable */
+#define ETH_MACCR_LM      ((uint32_t)0x00001000)  /* loopback mode */
+#define ETH_MACCR_DM      ((uint32_t)0x00000800)  /* Duplex mode */
+#define ETH_MACCR_IPCO    ((uint32_t)0x00000400)  /* IP Checksum offload */
+#define ETH_MACCR_RD      ((uint32_t)0x00000200)  /* Retry disable */
+#define ETH_MACCR_APCS    ((uint32_t)0x00000080)  /* Automatic Pad/CRC stripping */
+#define ETH_MACCR_BL      ((uint32_t)0x00000060)  /* Back-off limit: random integer number (r) of slot time delays before rescheduling
+                                                       a transmission attempt during retries after a collision: 0 =< r <2^k */
+  #define ETH_MACCR_BL_10    ((uint32_t)0x00000000)  /* k = min (n, 10) */
+  #define ETH_MACCR_BL_8     ((uint32_t)0x00000020)  /* k = min (n, 8) */
+  #define ETH_MACCR_BL_4     ((uint32_t)0x00000040)  /* k = min (n, 4) */
+  #define ETH_MACCR_BL_1     ((uint32_t)0x00000060)  /* k = min (n, 1) */
+#define ETH_MACCR_DC      ((uint32_t)0x00000010)  /* Defferal check */
+#define ETH_MACCR_TE      ((uint32_t)0x00000008)  /* Transmitter enable */
+#define ETH_MACCR_RE      ((uint32_t)0x00000004)  /* Receiver enable */
+
+/* Bit definition for Ethernet MAC Frame Filter Register */
+#define ETH_MACFFR_RA     ((uint32_t)0x80000000)  /* Receive all */
+#define ETH_MACFFR_HPF    ((uint32_t)0x00000400)  /* Hash or perfect filter */
+#define ETH_MACFFR_SAF    ((uint32_t)0x00000200)  /* Source address filter enable */
+#define ETH_MACFFR_SAIF   ((uint32_t)0x00000100)  /* SA inverse filtering */
+#define ETH_MACFFR_PCF    ((uint32_t)0x000000C0)  /* Pass control frames: 3 cases */
+  #define ETH_MACFFR_PCF_BlockAll                ((uint32_t)0x00000040)  /* MAC filters all control frames from reaching the application */
+  #define ETH_MACFFR_PCF_ForwardAll              ((uint32_t)0x00000080)  /* MAC forwards all control frames to application even if they fail the Address Filter */
+  #define ETH_MACFFR_PCF_ForwardPassedAddrFilter ((uint32_t)0x000000C0)  /* MAC forwards control frames that pass the Address Filter. */
+#define ETH_MACFFR_BFD    ((uint32_t)0x00000020)  /* Broadcast frame disable */
+#define ETH_MACFFR_PAM    ((uint32_t)0x00000010)  /* Pass all mutlicast */
+#define ETH_MACFFR_DAIF   ((uint32_t)0x00000008)  /* DA Inverse filtering */
+#define ETH_MACFFR_HM     ((uint32_t)0x00000004)  /* Hash multicast */
+#define ETH_MACFFR_HU     ((uint32_t)0x00000002)  /* Hash unicast */
+#define ETH_MACFFR_PM     ((uint32_t)0x00000001)  /* Promiscuous mode */
+
+/* Bit definition for Ethernet MAC Hash Table High Register */
+#define ETH_MACHTHR_HTH   ((uint32_t)0xFFFFFFFF)  /* Hash table high */
+
+/* Bit definition for Ethernet MAC Hash Table Low Register */
+#define ETH_MACHTLR_HTL   ((uint32_t)0xFFFFFFFF)  /* Hash table low */
+
+/* Bit definition for Ethernet MAC MII Address Register */
+#define ETH_MACMIIAR_PA   ((uint32_t)0x0000F800)  /* Physical layer address */
+#define ETH_MACMIIAR_MR   ((uint32_t)0x000007C0)  /* MII register in the selected PHY */
+#define ETH_MACMIIAR_CR   ((uint32_t)0x0000001C)  /* CR clock range: 6 cases */
+  #define ETH_MACMIIAR_CR_Div42   ((uint32_t)0x00000000)  /* HCLK:60-100 MHz; MDC clock= HCLK/42 */
+  #define ETH_MACMIIAR_CR_Div62   ((uint32_t)0x00000004)  /* HCLK:100-150 MHz; MDC clock= HCLK/62 */
+  #define ETH_MACMIIAR_CR_Div16   ((uint32_t)0x00000008)  /* HCLK:20-35 MHz; MDC clock= HCLK/16 */
+  #define ETH_MACMIIAR_CR_Div26   ((uint32_t)0x0000000C)  /* HCLK:35-60 MHz; MDC clock= HCLK/26 */
+  #define ETH_MACMIIAR_CR_Div102  ((uint32_t)0x00000010)  /* HCLK:150-168 MHz; MDC clock= HCLK/102 */
+#define ETH_MACMIIAR_MW   ((uint32_t)0x00000002)  /* MII write */
+#define ETH_MACMIIAR_MB   ((uint32_t)0x00000001)  /* MII busy */
+
+/* Bit definition for Ethernet MAC MII Data Register */
+#define ETH_MACMIIDR_MD   ((uint32_t)0x0000FFFF)  /* MII data: read/write data from/to PHY */
+
+/* Bit definition for Ethernet MAC Flow Control Register */
+#define ETH_MACFCR_PT     ((uint32_t)0xFFFF0000)  /* Pause time */
+#define ETH_MACFCR_ZQPD   ((uint32_t)0x00000080)  /* Zero-quanta pause disable */
+#define ETH_MACFCR_PLT    ((uint32_t)0x00000030)  /* Pause low threshold: 4 cases */
+  #define ETH_MACFCR_PLT_Minus4   ((uint32_t)0x00000000)  /* Pause time minus 4 slot times */
+  #define ETH_MACFCR_PLT_Minus28  ((uint32_t)0x00000010)  /* Pause time minus 28 slot times */
+  #define ETH_MACFCR_PLT_Minus144 ((uint32_t)0x00000020)  /* Pause time minus 144 slot times */
+  #define ETH_MACFCR_PLT_Minus256 ((uint32_t)0x00000030)  /* Pause time minus 256 slot times */
+#define ETH_MACFCR_UPFD   ((uint32_t)0x00000008)  /* Unicast pause frame detect */
+#define ETH_MACFCR_RFCE   ((uint32_t)0x00000004)  /* Receive flow control enable */
+#define ETH_MACFCR_TFCE   ((uint32_t)0x00000002)  /* Transmit flow control enable */
+#define ETH_MACFCR_FCBBPA ((uint32_t)0x00000001)  /* Flow control busy/backpressure activate */
+
+/* Bit definition for Ethernet MAC VLAN Tag Register */
+#define ETH_MACVLANTR_VLANTC ((uint32_t)0x00010000)  /* 12-bit VLAN tag comparison */
+#define ETH_MACVLANTR_VLANTI ((uint32_t)0x0000FFFF)  /* VLAN tag identifier (for receive frames) */
+
+/* Bit definition for Ethernet MAC Remote Wake-UpFrame Filter Register */
+#define ETH_MACRWUFFR_D   ((uint32_t)0xFFFFFFFF)  /* Wake-up frame filter register data */
+/* Eight sequential Writes to this address (offset 0x28) will write all Wake-UpFrame Filter Registers.
+   Eight sequential Reads from this address (offset 0x28) will read all Wake-UpFrame Filter Registers. */
+/* Wake-UpFrame Filter Reg0 : Filter 0 Byte Mask
+   Wake-UpFrame Filter Reg1 : Filter 1 Byte Mask
+   Wake-UpFrame Filter Reg2 : Filter 2 Byte Mask
+   Wake-UpFrame Filter Reg3 : Filter 3 Byte Mask
+   Wake-UpFrame Filter Reg4 : RSVD - Filter3 Command - RSVD - Filter2 Command -
+                              RSVD - Filter1 Command - RSVD - Filter0 Command
+   Wake-UpFrame Filter Re5 : Filter3 Offset - Filter2 Offset - Filter1 Offset - Filter0 Offset
+   Wake-UpFrame Filter Re6 : Filter1 CRC16 - Filter0 CRC16
+   Wake-UpFrame Filter Re7 : Filter3 CRC16 - Filter2 CRC16 */
+
+/* Bit definition for Ethernet MAC PMT Control and Status Register */
+#define ETH_MACPMTCSR_WFFRPR ((uint32_t)0x80000000)  /* Wake-Up Frame Filter Register Pointer Reset */
+#define ETH_MACPMTCSR_GU     ((uint32_t)0x00000200)  /* Global Unicast */
+#define ETH_MACPMTCSR_WFR    ((uint32_t)0x00000040)  /* Wake-Up Frame Received */
+#define ETH_MACPMTCSR_MPR    ((uint32_t)0x00000020)  /* Magic Packet Received */
+#define ETH_MACPMTCSR_WFE    ((uint32_t)0x00000004)  /* Wake-Up Frame Enable */
+#define ETH_MACPMTCSR_MPE    ((uint32_t)0x00000002)  /* Magic Packet Enable */
+#define ETH_MACPMTCSR_PD     ((uint32_t)0x00000001)  /* Power Down */
+
+/* Bit definition for Ethernet MAC Status Register */
+#define ETH_MACSR_TSTS      ((uint32_t)0x00000200)  /* Time stamp trigger status */
+#define ETH_MACSR_MMCTS     ((uint32_t)0x00000040)  /* MMC transmit status */
+#define ETH_MACSR_MMMCRS    ((uint32_t)0x00000020)  /* MMC receive status */
+#define ETH_MACSR_MMCS      ((uint32_t)0x00000010)  /* MMC status */
+#define ETH_MACSR_PMTS      ((uint32_t)0x00000008)  /* PMT status */
+
+/* Bit definition for Ethernet MAC Interrupt Mask Register */
+#define ETH_MACIMR_TSTIM     ((uint32_t)0x00000200)  /* Time stamp trigger interrupt mask */
+#define ETH_MACIMR_PMTIM     ((uint32_t)0x00000008)  /* PMT interrupt mask */
+
+/* Bit definition for Ethernet MAC Address0 High Register */
+#define ETH_MACA0HR_MACA0H   ((uint32_t)0x0000FFFF)  /* MAC address0 high */
+
+/* Bit definition for Ethernet MAC Address0 Low Register */
+#define ETH_MACA0LR_MACA0L   ((uint32_t)0xFFFFFFFF)  /* MAC address0 low */
+
+/* Bit definition for Ethernet MAC Address1 High Register */
+#define ETH_MACA1HR_AE       ((uint32_t)0x80000000)  /* Address enable */
+#define ETH_MACA1HR_SA       ((uint32_t)0x40000000)  /* Source address */
+#define ETH_MACA1HR_MBC      ((uint32_t)0x3F000000)  /* Mask byte control: bits to mask for comparison of the MAC Address bytes */
+  #define ETH_MACA1HR_MBC_HBits15_8    ((uint32_t)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+  #define ETH_MACA1HR_MBC_HBits7_0     ((uint32_t)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+  #define ETH_MACA1HR_MBC_LBits31_24   ((uint32_t)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+  #define ETH_MACA1HR_MBC_LBits23_16   ((uint32_t)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+  #define ETH_MACA1HR_MBC_LBits15_8    ((uint32_t)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+  #define ETH_MACA1HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [7:0] */
+#define ETH_MACA1HR_MACA1H   ((uint32_t)0x0000FFFF)  /* MAC address1 high */
+
+/* Bit definition for Ethernet MAC Address1 Low Register */
+#define ETH_MACA1LR_MACA1L   ((uint32_t)0xFFFFFFFF)  /* MAC address1 low */
+
+/* Bit definition for Ethernet MAC Address2 High Register */
+#define ETH_MACA2HR_AE       ((uint32_t)0x80000000)  /* Address enable */
+#define ETH_MACA2HR_SA       ((uint32_t)0x40000000)  /* Source address */
+#define ETH_MACA2HR_MBC      ((uint32_t)0x3F000000)  /* Mask byte control */
+  #define ETH_MACA2HR_MBC_HBits15_8    ((uint32_t)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+  #define ETH_MACA2HR_MBC_HBits7_0     ((uint32_t)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+  #define ETH_MACA2HR_MBC_LBits31_24   ((uint32_t)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+  #define ETH_MACA2HR_MBC_LBits23_16   ((uint32_t)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+  #define ETH_MACA2HR_MBC_LBits15_8    ((uint32_t)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+  #define ETH_MACA2HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [70] */
+#define ETH_MACA2HR_MACA2H   ((uint32_t)0x0000FFFF)  /* MAC address1 high */
+
+/* Bit definition for Ethernet MAC Address2 Low Register */
+#define ETH_MACA2LR_MACA2L   ((uint32_t)0xFFFFFFFF)  /* MAC address2 low */
+
+/* Bit definition for Ethernet MAC Address3 High Register */
+#define ETH_MACA3HR_AE       ((uint32_t)0x80000000)  /* Address enable */
+#define ETH_MACA3HR_SA       ((uint32_t)0x40000000)  /* Source address */
+#define ETH_MACA3HR_MBC      ((uint32_t)0x3F000000)  /* Mask byte control */
+  #define ETH_MACA3HR_MBC_HBits15_8    ((uint32_t)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+  #define ETH_MACA3HR_MBC_HBits7_0     ((uint32_t)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+  #define ETH_MACA3HR_MBC_LBits31_24   ((uint32_t)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+  #define ETH_MACA3HR_MBC_LBits23_16   ((uint32_t)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+  #define ETH_MACA3HR_MBC_LBits15_8    ((uint32_t)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+  #define ETH_MACA3HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [70] */
+#define ETH_MACA3HR_MACA3H   ((uint32_t)0x0000FFFF)  /* MAC address3 high */
+
+/* Bit definition for Ethernet MAC Address3 Low Register */
+#define ETH_MACA3LR_MACA3L   ((uint32_t)0xFFFFFFFF)  /* MAC address3 low */
+
+/******************************************************************************/
+/*                Ethernet MMC Registers bits definition                      */
+/******************************************************************************/
+
+/* Bit definition for Ethernet MMC Contol Register */
+#define ETH_MMCCR_MCFHP      ((uint32_t)0x00000020)  /* MMC counter Full-Half preset */
+#define ETH_MMCCR_MCP        ((uint32_t)0x00000010)  /* MMC counter preset */
+#define ETH_MMCCR_MCF        ((uint32_t)0x00000008)  /* MMC Counter Freeze */
+#define ETH_MMCCR_ROR        ((uint32_t)0x00000004)  /* Reset on Read */
+#define ETH_MMCCR_CSR        ((uint32_t)0x00000002)  /* Counter Stop Rollover */
+#define ETH_MMCCR_CR         ((uint32_t)0x00000001)  /* Counters Reset */
+
+/* Bit definition for Ethernet MMC Receive Interrupt Register */
+#define ETH_MMCRIR_RGUFS     ((uint32_t)0x00020000)  /* Set when Rx good unicast frames counter reaches half the maximum value */
+#define ETH_MMCRIR_RFAES     ((uint32_t)0x00000040)  /* Set when Rx alignment error counter reaches half the maximum value */
+#define ETH_MMCRIR_RFCES     ((uint32_t)0x00000020)  /* Set when Rx crc error counter reaches half the maximum value */
+
+/* Bit definition for Ethernet MMC Transmit Interrupt Register */
+#define ETH_MMCTIR_TGFS      ((uint32_t)0x00200000)  /* Set when Tx good frame count counter reaches half the maximum value */
+#define ETH_MMCTIR_TGFMSCS   ((uint32_t)0x00008000)  /* Set when Tx good multi col counter reaches half the maximum value */
+#define ETH_MMCTIR_TGFSCS    ((uint32_t)0x00004000)  /* Set when Tx good single col counter reaches half the maximum value */
+
+/* Bit definition for Ethernet MMC Receive Interrupt Mask Register */
+#define ETH_MMCRIMR_RGUFM    ((uint32_t)0x00020000)  /* Mask the interrupt when Rx good unicast frames counter reaches half the maximum value */
+#define ETH_MMCRIMR_RFAEM    ((uint32_t)0x00000040)  /* Mask the interrupt when when Rx alignment error counter reaches half the maximum value */
+#define ETH_MMCRIMR_RFCEM    ((uint32_t)0x00000020)  /* Mask the interrupt when Rx crc error counter reaches half the maximum value */
+
+/* Bit definition for Ethernet MMC Transmit Interrupt Mask Register */
+#define ETH_MMCTIMR_TGFM     ((uint32_t)0x00200000)  /* Mask the interrupt when Tx good frame count counter reaches half the maximum value */
+#define ETH_MMCTIMR_TGFMSCM  ((uint32_t)0x00008000)  /* Mask the interrupt when Tx good multi col counter reaches half the maximum value */
+#define ETH_MMCTIMR_TGFSCM   ((uint32_t)0x00004000)  /* Mask the interrupt when Tx good single col counter reaches half the maximum value */
+
+/* Bit definition for Ethernet MMC Transmitted Good Frames after Single Collision Counter Register */
+#define ETH_MMCTGFSCCR_TGFSCC     ((uint32_t)0xFFFFFFFF)  /* Number of successfully transmitted frames after a single collision in Half-duplex mode. */
+
+/* Bit definition for Ethernet MMC Transmitted Good Frames after More than a Single Collision Counter Register */
+#define ETH_MMCTGFMSCCR_TGFMSCC   ((uint32_t)0xFFFFFFFF)  /* Number of successfully transmitted frames after more than a single collision in Half-duplex mode. */
+
+/* Bit definition for Ethernet MMC Transmitted Good Frames Counter Register */
+#define ETH_MMCTGFCR_TGFC    ((uint32_t)0xFFFFFFFF)  /* Number of good frames transmitted. */
+
+/* Bit definition for Ethernet MMC Received Frames with CRC Error Counter Register */
+#define ETH_MMCRFCECR_RFCEC  ((uint32_t)0xFFFFFFFF)  /* Number of frames received with CRC error. */
+
+/* Bit definition for Ethernet MMC Received Frames with Alignement Error Counter Register */
+#define ETH_MMCRFAECR_RFAEC  ((uint32_t)0xFFFFFFFF)  /* Number of frames received with alignment (dribble) error */
+
+/* Bit definition for Ethernet MMC Received Good Unicast Frames Counter Register */
+#define ETH_MMCRGUFCR_RGUFC  ((uint32_t)0xFFFFFFFF)  /* Number of good unicast frames received. */
+
+/******************************************************************************/
+/*               Ethernet PTP Registers bits definition                       */
+/******************************************************************************/
+
+/* Bit definition for Ethernet PTP Time Stamp Contol Register */
+#define ETH_PTPTSCR_TSCNT       ((uint32_t)0x00030000)  /* Time stamp clock node type */
+#define ETH_PTPTSSR_TSSMRME     ((uint32_t)0x00008000)  /* Time stamp snapshot for message relevant to master enable */
+#define ETH_PTPTSSR_TSSEME      ((uint32_t)0x00004000)  /* Time stamp snapshot for event message enable */
+#define ETH_PTPTSSR_TSSIPV4FE   ((uint32_t)0x00002000)  /* Time stamp snapshot for IPv4 frames enable */
+#define ETH_PTPTSSR_TSSIPV6FE   ((uint32_t)0x00001000)  /* Time stamp snapshot for IPv6 frames enable */
+#define ETH_PTPTSSR_TSSPTPOEFE  ((uint32_t)0x00000800)  /* Time stamp snapshot for PTP over ethernet frames enable */
+#define ETH_PTPTSSR_TSPTPPSV2E  ((uint32_t)0x00000400)  /* Time stamp PTP packet snooping for version2 format enable */
+#define ETH_PTPTSSR_TSSSR       ((uint32_t)0x00000200)  /* Time stamp Sub-seconds rollover */
+#define ETH_PTPTSSR_TSSARFE     ((uint32_t)0x00000100)  /* Time stamp snapshot for all received frames enable */
+
+#define ETH_PTPTSCR_TSARU    ((uint32_t)0x00000020)  /* Addend register update */
+#define ETH_PTPTSCR_TSITE    ((uint32_t)0x00000010)  /* Time stamp interrupt trigger enable */
+#define ETH_PTPTSCR_TSSTU    ((uint32_t)0x00000008)  /* Time stamp update */
+#define ETH_PTPTSCR_TSSTI    ((uint32_t)0x00000004)  /* Time stamp initialize */
+#define ETH_PTPTSCR_TSFCU    ((uint32_t)0x00000002)  /* Time stamp fine or coarse update */
+#define ETH_PTPTSCR_TSE      ((uint32_t)0x00000001)  /* Time stamp enable */
+
+/* Bit definition for Ethernet PTP Sub-Second Increment Register */
+#define ETH_PTPSSIR_STSSI    ((uint32_t)0x000000FF)  /* System time Sub-second increment value */
+
+/* Bit definition for Ethernet PTP Time Stamp High Register */
+#define ETH_PTPTSHR_STS      ((uint32_t)0xFFFFFFFF)  /* System Time second */
+
+/* Bit definition for Ethernet PTP Time Stamp Low Register */
+#define ETH_PTPTSLR_STPNS    ((uint32_t)0x80000000)  /* System Time Positive or negative time */
+#define ETH_PTPTSLR_STSS     ((uint32_t)0x7FFFFFFF)  /* System Time sub-seconds */
+
+/* Bit definition for Ethernet PTP Time Stamp High Update Register */
+#define ETH_PTPTSHUR_TSUS    ((uint32_t)0xFFFFFFFF)  /* Time stamp update seconds */
+
+/* Bit definition for Ethernet PTP Time Stamp Low Update Register */
+#define ETH_PTPTSLUR_TSUPNS  ((uint32_t)0x80000000)  /* Time stamp update Positive or negative time */
+#define ETH_PTPTSLUR_TSUSS   ((uint32_t)0x7FFFFFFF)  /* Time stamp update sub-seconds */
+
+/* Bit definition for Ethernet PTP Time Stamp Addend Register */
+#define ETH_PTPTSAR_TSA      ((uint32_t)0xFFFFFFFF)  /* Time stamp addend */
+
+/* Bit definition for Ethernet PTP Target Time High Register */
+#define ETH_PTPTTHR_TTSH     ((uint32_t)0xFFFFFFFF)  /* Target time stamp high */
+
+/* Bit definition for Ethernet PTP Target Time Low Register */
+#define ETH_PTPTTLR_TTSL     ((uint32_t)0xFFFFFFFF)  /* Target time stamp low */
+
+/* Bit definition for Ethernet PTP Time Stamp Status Register */
+#define ETH_PTPTSSR_TSTTR    ((uint32_t)0x00000020)  /* Time stamp target time reached */
+#define ETH_PTPTSSR_TSSO     ((uint32_t)0x00000010)  /* Time stamp seconds overflow */
+
+/******************************************************************************/
+/*                 Ethernet DMA Registers bits definition                     */
+/******************************************************************************/
+
+/* Bit definition for Ethernet DMA Bus Mode Register */
+#define ETH_DMABMR_AAB       ((uint32_t)0x02000000)  /* Address-Aligned beats */
+#define ETH_DMABMR_FPM        ((uint32_t)0x01000000)  /* 4xPBL mode */
+#define ETH_DMABMR_USP       ((uint32_t)0x00800000)  /* Use separate PBL */
+#define ETH_DMABMR_RDP       ((uint32_t)0x007E0000)  /* RxDMA PBL */
+  #define ETH_DMABMR_RDP_1Beat    ((uint32_t)0x00020000)  /* maximum number of beats to be transferred in one RxDMA transaction is 1 */
+  #define ETH_DMABMR_RDP_2Beat    ((uint32_t)0x00040000)  /* maximum number of beats to be transferred in one RxDMA transaction is 2 */
+  #define ETH_DMABMR_RDP_4Beat    ((uint32_t)0x00080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
+  #define ETH_DMABMR_RDP_8Beat    ((uint32_t)0x00100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
+  #define ETH_DMABMR_RDP_16Beat   ((uint32_t)0x00200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
+  #define ETH_DMABMR_RDP_32Beat   ((uint32_t)0x00400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
+  #define ETH_DMABMR_RDP_4xPBL_4Beat   ((uint32_t)0x01020000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
+  #define ETH_DMABMR_RDP_4xPBL_8Beat   ((uint32_t)0x01040000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
+  #define ETH_DMABMR_RDP_4xPBL_16Beat  ((uint32_t)0x01080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
+  #define ETH_DMABMR_RDP_4xPBL_32Beat  ((uint32_t)0x01100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
+  #define ETH_DMABMR_RDP_4xPBL_64Beat  ((uint32_t)0x01200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 64 */
+  #define ETH_DMABMR_RDP_4xPBL_128Beat ((uint32_t)0x01400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 128 */
+#define ETH_DMABMR_FB        ((uint32_t)0x00010000)  /* Fixed Burst */
+#define ETH_DMABMR_RTPR      ((uint32_t)0x0000C000)  /* Rx Tx priority ratio */
+  #define ETH_DMABMR_RTPR_1_1     ((uint32_t)0x00000000)  /* Rx Tx priority ratio */
+  #define ETH_DMABMR_RTPR_2_1     ((uint32_t)0x00004000)  /* Rx Tx priority ratio */
+  #define ETH_DMABMR_RTPR_3_1     ((uint32_t)0x00008000)  /* Rx Tx priority ratio */
+  #define ETH_DMABMR_RTPR_4_1     ((uint32_t)0x0000C000)  /* Rx Tx priority ratio */
+#define ETH_DMABMR_PBL    ((uint32_t)0x00003F00)  /* Programmable burst length */
+  #define ETH_DMABMR_PBL_1Beat    ((uint32_t)0x00000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
+  #define ETH_DMABMR_PBL_2Beat    ((uint32_t)0x00000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
+  #define ETH_DMABMR_PBL_4Beat    ((uint32_t)0x00000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+  #define ETH_DMABMR_PBL_8Beat    ((uint32_t)0x00000800)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+  #define ETH_DMABMR_PBL_16Beat   ((uint32_t)0x00001000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+  #define ETH_DMABMR_PBL_32Beat   ((uint32_t)0x00002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+  #define ETH_DMABMR_PBL_4xPBL_4Beat   ((uint32_t)0x01000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+  #define ETH_DMABMR_PBL_4xPBL_8Beat   ((uint32_t)0x01000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+  #define ETH_DMABMR_PBL_4xPBL_16Beat  ((uint32_t)0x01000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+  #define ETH_DMABMR_PBL_4xPBL_32Beat  ((uint32_t)0x01000800)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+  #define ETH_DMABMR_PBL_4xPBL_64Beat  ((uint32_t)0x01001000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
+  #define ETH_DMABMR_PBL_4xPBL_128Beat ((uint32_t)0x01002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
+#define ETH_DMABMR_EDE       ((uint32_t)0x00000080)  /* Enhanced Descriptor Enable */
+#define ETH_DMABMR_DSL       ((uint32_t)0x0000007C)  /* Descriptor Skip Length */
+#define ETH_DMABMR_DA        ((uint32_t)0x00000002)  /* DMA arbitration scheme */
+#define ETH_DMABMR_SR        ((uint32_t)0x00000001)  /* Software reset */
+
+/* Bit definition for Ethernet DMA Transmit Poll Demand Register */
+#define ETH_DMATPDR_TPD      ((uint32_t)0xFFFFFFFF)  /* Transmit poll demand */
+
+/* Bit definition for Ethernet DMA Receive Poll Demand Register */
+#define ETH_DMARPDR_RPD      ((uint32_t)0xFFFFFFFF)  /* Receive poll demand  */
+
+/* Bit definition for Ethernet DMA Receive Descriptor List Address Register */
+#define ETH_DMARDLAR_SRL     ((uint32_t)0xFFFFFFFF)  /* Start of receive list */
+
+/* Bit definition for Ethernet DMA Transmit Descriptor List Address Register */
+#define ETH_DMATDLAR_STL     ((uint32_t)0xFFFFFFFF)  /* Start of transmit list */
+
+/* Bit definition for Ethernet DMA Status Register */
+#define ETH_DMASR_TSTS       ((uint32_t)0x20000000)  /* Time-stamp trigger status */
+#define ETH_DMASR_PMTS       ((uint32_t)0x10000000)  /* PMT status */
+#define ETH_DMASR_MMCS       ((uint32_t)0x08000000)  /* MMC status */
+#define ETH_DMASR_EBS        ((uint32_t)0x03800000)  /* Error bits status */
+  /* combination with EBS[2:0] for GetFlagStatus function */
+  #define ETH_DMASR_EBS_DescAccess      ((uint32_t)0x02000000)  /* Error bits 0-data buffer, 1-desc. access */
+  #define ETH_DMASR_EBS_ReadTransf      ((uint32_t)0x01000000)  /* Error bits 0-write trnsf, 1-read transfr */
+  #define ETH_DMASR_EBS_DataTransfTx    ((uint32_t)0x00800000)  /* Error bits 0-Rx DMA, 1-Tx DMA */
+#define ETH_DMASR_TPS         ((uint32_t)0x00700000)  /* Transmit process state */
+  #define ETH_DMASR_TPS_Stopped         ((uint32_t)0x00000000)  /* Stopped - Reset or Stop Tx Command issued  */
+  #define ETH_DMASR_TPS_Fetching        ((uint32_t)0x00100000)  /* Running - fetching the Tx descriptor */
+  #define ETH_DMASR_TPS_Waiting         ((uint32_t)0x00200000)  /* Running - waiting for status */
+  #define ETH_DMASR_TPS_Reading         ((uint32_t)0x00300000)  /* Running - reading the data from host memory */
+  #define ETH_DMASR_TPS_Suspended       ((uint32_t)0x00600000)  /* Suspended - Tx Descriptor unavailabe */
+  #define ETH_DMASR_TPS_Closing         ((uint32_t)0x00700000)  /* Running - closing Rx descriptor */
+#define ETH_DMASR_RPS         ((uint32_t)0x000E0000)  /* Receive process state */
+  #define ETH_DMASR_RPS_Stopped         ((uint32_t)0x00000000)  /* Stopped - Reset or Stop Rx Command issued */
+  #define ETH_DMASR_RPS_Fetching        ((uint32_t)0x00020000)  /* Running - fetching the Rx descriptor */
+  #define ETH_DMASR_RPS_Waiting         ((uint32_t)0x00060000)  /* Running - waiting for packet */
+  #define ETH_DMASR_RPS_Suspended       ((uint32_t)0x00080000)  /* Suspended - Rx Descriptor unavailable */
+  #define ETH_DMASR_RPS_Closing         ((uint32_t)0x000A0000)  /* Running - closing descriptor */
+  #define ETH_DMASR_RPS_Queuing         ((uint32_t)0x000E0000)  /* Running - queuing the recieve frame into host memory */
+#define ETH_DMASR_NIS        ((uint32_t)0x00010000)  /* Normal interrupt summary */
+#define ETH_DMASR_AIS        ((uint32_t)0x00008000)  /* Abnormal interrupt summary */
+#define ETH_DMASR_ERS        ((uint32_t)0x00004000)  /* Early receive status */
+#define ETH_DMASR_FBES       ((uint32_t)0x00002000)  /* Fatal bus error status */
+#define ETH_DMASR_ETS        ((uint32_t)0x00000400)  /* Early transmit status */
+#define ETH_DMASR_RWTS       ((uint32_t)0x00000200)  /* Receive watchdog timeout status */
+#define ETH_DMASR_RPSS       ((uint32_t)0x00000100)  /* Receive process stopped status */
+#define ETH_DMASR_RBUS       ((uint32_t)0x00000080)  /* Receive buffer unavailable status */
+#define ETH_DMASR_RS         ((uint32_t)0x00000040)  /* Receive status */
+#define ETH_DMASR_TUS        ((uint32_t)0x00000020)  /* Transmit underflow status */
+#define ETH_DMASR_ROS        ((uint32_t)0x00000010)  /* Receive overflow status */
+#define ETH_DMASR_TJTS       ((uint32_t)0x00000008)  /* Transmit jabber timeout status */
+#define ETH_DMASR_TBUS       ((uint32_t)0x00000004)  /* Transmit buffer unavailable status */
+#define ETH_DMASR_TPSS       ((uint32_t)0x00000002)  /* Transmit process stopped status */
+#define ETH_DMASR_TS         ((uint32_t)0x00000001)  /* Transmit status */
+
+/* Bit definition for Ethernet DMA Operation Mode Register */
+#define ETH_DMAOMR_DTCEFD    ((uint32_t)0x04000000)  /* Disable Dropping of TCP/IP checksum error frames */
+#define ETH_DMAOMR_RSF       ((uint32_t)0x02000000)  /* Receive store and forward */
+#define ETH_DMAOMR_DFRF      ((uint32_t)0x01000000)  /* Disable flushing of received frames */
+#define ETH_DMAOMR_TSF       ((uint32_t)0x00200000)  /* Transmit store and forward */
+#define ETH_DMAOMR_FTF       ((uint32_t)0x00100000)  /* Flush transmit FIFO */
+#define ETH_DMAOMR_TTC       ((uint32_t)0x0001C000)  /* Transmit threshold control */
+  #define ETH_DMAOMR_TTC_64Bytes       ((uint32_t)0x00000000)  /* threshold level of the MTL Transmit FIFO is 64 Bytes */
+  #define ETH_DMAOMR_TTC_128Bytes      ((uint32_t)0x00004000)  /* threshold level of the MTL Transmit FIFO is 128 Bytes */
+  #define ETH_DMAOMR_TTC_192Bytes      ((uint32_t)0x00008000)  /* threshold level of the MTL Transmit FIFO is 192 Bytes */
+  #define ETH_DMAOMR_TTC_256Bytes      ((uint32_t)0x0000C000)  /* threshold level of the MTL Transmit FIFO is 256 Bytes */
+  #define ETH_DMAOMR_TTC_40Bytes       ((uint32_t)0x00010000)  /* threshold level of the MTL Transmit FIFO is 40 Bytes */
+  #define ETH_DMAOMR_TTC_32Bytes       ((uint32_t)0x00014000)  /* threshold level of the MTL Transmit FIFO is 32 Bytes */
+  #define ETH_DMAOMR_TTC_24Bytes       ((uint32_t)0x00018000)  /* threshold level of the MTL Transmit FIFO is 24 Bytes */
+  #define ETH_DMAOMR_TTC_16Bytes       ((uint32_t)0x0001C000)  /* threshold level of the MTL Transmit FIFO is 16 Bytes */
+#define ETH_DMAOMR_ST        ((uint32_t)0x00002000)  /* Start/stop transmission command */
+#define ETH_DMAOMR_FEF       ((uint32_t)0x00000080)  /* Forward error frames */
+#define ETH_DMAOMR_FUGF      ((uint32_t)0x00000040)  /* Forward undersized good frames */
+#define ETH_DMAOMR_RTC       ((uint32_t)0x00000018)  /* receive threshold control */
+  #define ETH_DMAOMR_RTC_64Bytes       ((uint32_t)0x00000000)  /* threshold level of the MTL Receive FIFO is 64 Bytes */
+  #define ETH_DMAOMR_RTC_32Bytes       ((uint32_t)0x00000008)  /* threshold level of the MTL Receive FIFO is 32 Bytes */
+  #define ETH_DMAOMR_RTC_96Bytes       ((uint32_t)0x00000010)  /* threshold level of the MTL Receive FIFO is 96 Bytes */
+  #define ETH_DMAOMR_RTC_128Bytes      ((uint32_t)0x00000018)  /* threshold level of the MTL Receive FIFO is 128 Bytes */
+#define ETH_DMAOMR_OSF       ((uint32_t)0x00000004)  /* operate on second frame */
+#define ETH_DMAOMR_SR        ((uint32_t)0x00000002)  /* Start/stop receive */
+
+/* Bit definition for Ethernet DMA Interrupt Enable Register */
+#define ETH_DMAIER_NISE      ((uint32_t)0x00010000)  /* Normal interrupt summary enable */
+#define ETH_DMAIER_AISE      ((uint32_t)0x00008000)  /* Abnormal interrupt summary enable */
+#define ETH_DMAIER_ERIE      ((uint32_t)0x00004000)  /* Early receive interrupt enable */
+#define ETH_DMAIER_FBEIE     ((uint32_t)0x00002000)  /* Fatal bus error interrupt enable */
+#define ETH_DMAIER_ETIE      ((uint32_t)0x00000400)  /* Early transmit interrupt enable */
+#define ETH_DMAIER_RWTIE     ((uint32_t)0x00000200)  /* Receive watchdog timeout interrupt enable */
+#define ETH_DMAIER_RPSIE     ((uint32_t)0x00000100)  /* Receive process stopped interrupt enable */
+#define ETH_DMAIER_RBUIE     ((uint32_t)0x00000080)  /* Receive buffer unavailable interrupt enable */
+#define ETH_DMAIER_RIE       ((uint32_t)0x00000040)  /* Receive interrupt enable */
+#define ETH_DMAIER_TUIE      ((uint32_t)0x00000020)  /* Transmit Underflow interrupt enable */
+#define ETH_DMAIER_ROIE      ((uint32_t)0x00000010)  /* Receive Overflow interrupt enable */
+#define ETH_DMAIER_TJTIE     ((uint32_t)0x00000008)  /* Transmit jabber timeout interrupt enable */
+#define ETH_DMAIER_TBUIE     ((uint32_t)0x00000004)  /* Transmit buffer unavailable interrupt enable */
+#define ETH_DMAIER_TPSIE     ((uint32_t)0x00000002)  /* Transmit process stopped interrupt enable */
+#define ETH_DMAIER_TIE       ((uint32_t)0x00000001)  /* Transmit interrupt enable */
+
+/* Bit definition for Ethernet DMA Missed Frame and Buffer Overflow Counter Register */
+#define ETH_DMAMFBOCR_OFOC   ((uint32_t)0x10000000)  /* Overflow bit for FIFO overflow counter */
+#define ETH_DMAMFBOCR_MFA    ((uint32_t)0x0FFE0000)  /* Number of frames missed by the application */
+#define ETH_DMAMFBOCR_OMFC   ((uint32_t)0x00010000)  /* Overflow bit for missed frame counter */
+#define ETH_DMAMFBOCR_MFC    ((uint32_t)0x0000FFFF)  /* Number of frames missed by the controller */
+
+/* Bit definition for Ethernet DMA Current Host Transmit Descriptor Register */
+#define ETH_DMACHTDR_HTDAP   ((uint32_t)0xFFFFFFFF)  /* Host transmit descriptor address pointer */
+
+/* Bit definition for Ethernet DMA Current Host Receive Descriptor Register */
+#define ETH_DMACHRDR_HRDAP   ((uint32_t)0xFFFFFFFF)  /* Host receive descriptor address pointer */
+
+/* Bit definition for Ethernet DMA Current Host Transmit Buffer Address Register */
+#define ETH_DMACHTBAR_HTBAP  ((uint32_t)0xFFFFFFFF)  /* Host transmit buffer address pointer */
+
+/* Bit definition for Ethernet DMA Current Host Receive Buffer Address Register */
+#define ETH_DMACHRBAR_HRBAP  ((uint32_t)0xFFFFFFFF)  /* Host receive buffer address pointer */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                       USB_OTG                              */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for USB_OTG_GOTGCTL register  ********************/
+#define USB_OTG_GOTGCTL_SRQSCS                  ((uint32_t)0x00000001)         /*!< Session request success */
+#define USB_OTG_GOTGCTL_SRQ                     ((uint32_t)0x00000002)         /*!< Session request */
+#define USB_OTG_GOTGCTL_VBVALOEN                ((uint32_t)0x00000004)         /*!< VBUS valid override enable */
+#define USB_OTG_GOTGCTL_VBVALOVAL               ((uint32_t)0x00000008)         /*!< VBUS valid override value */
+#define USB_OTG_GOTGCTL_AVALOEN                 ((uint32_t)0x00000010)         /*!< A-peripheral session valid override enable */
+#define USB_OTG_GOTGCTL_AVALOVAL                ((uint32_t)0x00000020)         /*!< A-peripheral session valid override value */
+#define USB_OTG_GOTGCTL_BVALOEN                 ((uint32_t)0x00000040)         /*!< B-peripheral session valid override enable */
+#define USB_OTG_GOTGCTL_BVALOVAL                ((uint32_t)0x00000080)         /*!< B-peripheral session valid override value  */
+#define USB_OTG_GOTGCTL_HNGSCS                  ((uint32_t)0x00000100)         /*!< Host set HNP enable */
+#define USB_OTG_GOTGCTL_HNPRQ                   ((uint32_t)0x00000200)         /*!< HNP request */
+#define USB_OTG_GOTGCTL_HSHNPEN                 ((uint32_t)0x00000400)         /*!< Host set HNP enable */
+#define USB_OTG_GOTGCTL_DHNPEN                  ((uint32_t)0x00000800)         /*!< Device HNP enabled */
+#define USB_OTG_GOTGCTL_EHEN                    ((uint32_t)0x00001000)         /*!< Embedded host enable */
+#define USB_OTG_GOTGCTL_CIDSTS                  ((uint32_t)0x00010000)         /*!< Connector ID status */
+#define USB_OTG_GOTGCTL_DBCT                    ((uint32_t)0x00020000)         /*!< Long/short debounce time */
+#define USB_OTG_GOTGCTL_ASVLD                   ((uint32_t)0x00040000)         /*!< A-session valid  */
+#define USB_OTG_GOTGCTL_BSESVLD                 ((uint32_t)0x00080000)         /*!< B-session valid */
+#define USB_OTG_GOTGCTL_OTGVER                  ((uint32_t)0x00100000)         /*!< OTG version  */
+
+/********************  Bit definition for USB_OTG_HCFG register  ********************/
+#define USB_OTG_HCFG_FSLSPCS                 ((uint32_t)0x00000003)            /*!< FS/LS PHY clock select  */
+#define USB_OTG_HCFG_FSLSPCS_0               ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_HCFG_FSLSPCS_1               ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_HCFG_FSLSS                   ((uint32_t)0x00000004)            /*!< FS- and LS-only support */
+
+/********************  Bit definition for USB_OTG_DCFG register  ********************/
+#define USB_OTG_DCFG_DSPD                    ((uint32_t)0x00000003)            /*!< Device speed */
+#define USB_OTG_DCFG_DSPD_0                  ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_DCFG_DSPD_1                  ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_DCFG_NZLSOHSK                ((uint32_t)0x00000004)            /*!< Nonzero-length status OUT handshake */
+
+#define USB_OTG_DCFG_DAD                     ((uint32_t)0x000007F0)            /*!< Device address */
+#define USB_OTG_DCFG_DAD_0                   ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define USB_OTG_DCFG_DAD_1                   ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define USB_OTG_DCFG_DAD_2                   ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define USB_OTG_DCFG_DAD_3                   ((uint32_t)0x00000080)            /*!<Bit 3 */
+#define USB_OTG_DCFG_DAD_4                   ((uint32_t)0x00000100)            /*!<Bit 4 */
+#define USB_OTG_DCFG_DAD_5                   ((uint32_t)0x00000200)            /*!<Bit 5 */
+#define USB_OTG_DCFG_DAD_6                   ((uint32_t)0x00000400)            /*!<Bit 6 */
+
+#define USB_OTG_DCFG_PFIVL                   ((uint32_t)0x00001800)            /*!< Periodic (micro)frame interval */
+#define USB_OTG_DCFG_PFIVL_0                 ((uint32_t)0x00000800)            /*!<Bit 0 */
+#define USB_OTG_DCFG_PFIVL_1                 ((uint32_t)0x00001000)            /*!<Bit 1 */
+
+#define USB_OTG_DCFG_PERSCHIVL               ((uint32_t)0x03000000)            /*!< Periodic scheduling interval */
+#define USB_OTG_DCFG_PERSCHIVL_0             ((uint32_t)0x01000000)            /*!<Bit 0 */
+#define USB_OTG_DCFG_PERSCHIVL_1             ((uint32_t)0x02000000)            /*!<Bit 1 */
+
+/********************  Bit definition for USB_OTG_PCGCR register  ********************/
+#define USB_OTG_PCGCR_STPPCLK                 ((uint32_t)0x00000001)            /*!< Stop PHY clock */
+#define USB_OTG_PCGCR_GATEHCLK                ((uint32_t)0x00000002)            /*!< Gate HCLK */
+#define USB_OTG_PCGCR_PHYSUSP                 ((uint32_t)0x00000010)            /*!< PHY suspended */
+
+/********************  Bit definition for USB_OTG_GOTGINT register  ********************/
+#define USB_OTG_GOTGINT_SEDET                   ((uint32_t)0x00000004)            /*!< Session end detected                   */
+#define USB_OTG_GOTGINT_SRSSCHG                 ((uint32_t)0x00000100)            /*!< Session request success status change  */
+#define USB_OTG_GOTGINT_HNSSCHG                 ((uint32_t)0x00000200)            /*!< Host negotiation success status change */
+#define USB_OTG_GOTGINT_HNGDET                  ((uint32_t)0x00020000)            /*!< Host negotiation detected              */
+#define USB_OTG_GOTGINT_ADTOCHG                 ((uint32_t)0x00040000)            /*!< A-device timeout change                */
+#define USB_OTG_GOTGINT_DBCDNE                  ((uint32_t)0x00080000)            /*!< Debounce done                          */
+#define USB_OTG_GOTGINT_IDCHNG                  ((uint32_t)0x00100000)            /*!< Change in ID pin input value           */
+
+/********************  Bit definition for USB_OTG_DCTL register  ********************/
+#define USB_OTG_DCTL_RWUSIG                  ((uint32_t)0x00000001)            /*!< Remote wakeup signaling */
+#define USB_OTG_DCTL_SDIS                    ((uint32_t)0x00000002)            /*!< Soft disconnect         */
+#define USB_OTG_DCTL_GINSTS                  ((uint32_t)0x00000004)            /*!< Global IN NAK status    */
+#define USB_OTG_DCTL_GONSTS                  ((uint32_t)0x00000008)            /*!< Global OUT NAK status   */
+
+#define USB_OTG_DCTL_TCTL                    ((uint32_t)0x00000070)            /*!< Test control */
+#define USB_OTG_DCTL_TCTL_0                  ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define USB_OTG_DCTL_TCTL_1                  ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define USB_OTG_DCTL_TCTL_2                  ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define USB_OTG_DCTL_SGINAK                  ((uint32_t)0x00000080)            /*!< Set global IN NAK         */
+#define USB_OTG_DCTL_CGINAK                  ((uint32_t)0x00000100)            /*!< Clear global IN NAK       */
+#define USB_OTG_DCTL_SGONAK                  ((uint32_t)0x00000200)            /*!< Set global OUT NAK        */
+#define USB_OTG_DCTL_CGONAK                  ((uint32_t)0x00000400)            /*!< Clear global OUT NAK      */
+#define USB_OTG_DCTL_POPRGDNE                ((uint32_t)0x00000800)            /*!< Power-on programming done */
+
+/********************  Bit definition for USB_OTG_HFIR register  ********************/
+#define USB_OTG_HFIR_FRIVL                   ((uint32_t)0x0000FFFF)            /*!< Frame interval */
+
+/********************  Bit definition for USB_OTG_HFNUM register  ********************/
+#define USB_OTG_HFNUM_FRNUM                   ((uint32_t)0x0000FFFF)            /*!< Frame number         */
+#define USB_OTG_HFNUM_FTREM                   ((uint32_t)0xFFFF0000)            /*!< Frame time remaining */
+
+/********************  Bit definition for USB_OTG_DSTS register  ********************/
+#define USB_OTG_DSTS_SUSPSTS                 ((uint32_t)0x00000001)            /*!< Suspend status   */
+
+#define USB_OTG_DSTS_ENUMSPD                 ((uint32_t)0x00000006)            /*!< Enumerated speed */
+#define USB_OTG_DSTS_ENUMSPD_0               ((uint32_t)0x00000002)            /*!<Bit 0 */
+#define USB_OTG_DSTS_ENUMSPD_1               ((uint32_t)0x00000004)            /*!<Bit 1 */
+#define USB_OTG_DSTS_EERR                    ((uint32_t)0x00000008)            /*!< Erratic error     */
+#define USB_OTG_DSTS_FNSOF                   ((uint32_t)0x003FFF00)            /*!< Frame number of the received SOF */
+
+/********************  Bit definition for USB_OTG_GAHBCFG register  ********************/
+#define USB_OTG_GAHBCFG_GINT                    ((uint32_t)0x00000001)            /*!< Global interrupt mask */
+#define USB_OTG_GAHBCFG_HBSTLEN                 ((uint32_t)0x0000001E)            /*!< Burst length/type */
+#define USB_OTG_GAHBCFG_HBSTLEN_0               ((uint32_t)0x00000002)            /*!<Bit 0 */
+#define USB_OTG_GAHBCFG_HBSTLEN_1               ((uint32_t)0x00000004)            /*!<Bit 1 */
+#define USB_OTG_GAHBCFG_HBSTLEN_2               ((uint32_t)0x00000008)            /*!<Bit 2 */
+#define USB_OTG_GAHBCFG_HBSTLEN_3               ((uint32_t)0x00000010)            /*!<Bit 3 */
+#define USB_OTG_GAHBCFG_DMAEN                   ((uint32_t)0x00000020)            /*!< DMA enable */
+#define USB_OTG_GAHBCFG_TXFELVL                 ((uint32_t)0x00000080)            /*!< TxFIFO empty level */
+#define USB_OTG_GAHBCFG_PTXFELVL                ((uint32_t)0x00000100)            /*!< Periodic TxFIFO empty level */
+
+/********************  Bit definition for USB_OTG_GUSBCFG register  ********************/
+#define USB_OTG_GUSBCFG_TOCAL                   ((uint32_t)0x00000007)            /*!< FS timeout calibration */
+#define USB_OTG_GUSBCFG_TOCAL_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_GUSBCFG_TOCAL_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_GUSBCFG_TOCAL_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_GUSBCFG_PHYSEL                  ((uint32_t)0x00000040)            /*!< USB 2.0 high-speed ULPI PHY or USB 1.1 full-speed serial transceiver select */
+#define USB_OTG_GUSBCFG_SRPCAP                  ((uint32_t)0x00000100)            /*!< SRP-capable */
+#define USB_OTG_GUSBCFG_HNPCAP                  ((uint32_t)0x00000200)            /*!< HNP-capable */
+#define USB_OTG_GUSBCFG_TRDT                    ((uint32_t)0x00003C00)            /*!< USB turnaround time */
+#define USB_OTG_GUSBCFG_TRDT_0                  ((uint32_t)0x00000400)            /*!<Bit 0 */
+#define USB_OTG_GUSBCFG_TRDT_1                  ((uint32_t)0x00000800)            /*!<Bit 1 */
+#define USB_OTG_GUSBCFG_TRDT_2                  ((uint32_t)0x00001000)            /*!<Bit 2 */
+#define USB_OTG_GUSBCFG_TRDT_3                  ((uint32_t)0x00002000)            /*!<Bit 3 */
+#define USB_OTG_GUSBCFG_PHYLPCS                 ((uint32_t)0x00008000)            /*!< PHY Low-power clock select */
+#define USB_OTG_GUSBCFG_ULPIFSLS                ((uint32_t)0x00020000)            /*!< ULPI FS/LS select               */
+#define USB_OTG_GUSBCFG_ULPIAR                  ((uint32_t)0x00040000)            /*!< ULPI Auto-resume                */
+#define USB_OTG_GUSBCFG_ULPICSM                 ((uint32_t)0x00080000)            /*!< ULPI Clock SuspendM             */
+#define USB_OTG_GUSBCFG_ULPIEVBUSD              ((uint32_t)0x00100000)            /*!< ULPI External VBUS Drive        */
+#define USB_OTG_GUSBCFG_ULPIEVBUSI              ((uint32_t)0x00200000)            /*!< ULPI external VBUS indicator    */
+#define USB_OTG_GUSBCFG_TSDPS                   ((uint32_t)0x00400000)            /*!< TermSel DLine pulsing selection */
+#define USB_OTG_GUSBCFG_PCCI                    ((uint32_t)0x00800000)            /*!< Indicator complement            */
+#define USB_OTG_GUSBCFG_PTCI                    ((uint32_t)0x01000000)            /*!< Indicator pass through          */
+#define USB_OTG_GUSBCFG_ULPIIPD                 ((uint32_t)0x02000000)            /*!< ULPI interface protect disable  */
+#define USB_OTG_GUSBCFG_FHMOD                   ((uint32_t)0x20000000)            /*!< Forced host mode                */
+#define USB_OTG_GUSBCFG_FDMOD                   ((uint32_t)0x40000000)            /*!< Forced peripheral mode          */
+#define USB_OTG_GUSBCFG_CTXPKT                  ((uint32_t)0x80000000)            /*!< Corrupt Tx packet               */
+
+/********************  Bit definition for USB_OTG_GRSTCTL register  ********************/
+#define USB_OTG_GRSTCTL_CSRST                   ((uint32_t)0x00000001)            /*!< Core soft reset          */
+#define USB_OTG_GRSTCTL_HSRST                   ((uint32_t)0x00000002)            /*!< HCLK soft reset          */
+#define USB_OTG_GRSTCTL_FCRST                   ((uint32_t)0x00000004)            /*!< Host frame counter reset */
+#define USB_OTG_GRSTCTL_RXFFLSH                 ((uint32_t)0x00000010)            /*!< RxFIFO flush             */
+#define USB_OTG_GRSTCTL_TXFFLSH                 ((uint32_t)0x00000020)            /*!< TxFIFO flush             */
+#define USB_OTG_GRSTCTL_TXFNUM                  ((uint32_t)0x000007C0)            /*!< TxFIFO number */
+#define USB_OTG_GRSTCTL_TXFNUM_0                ((uint32_t)0x00000040)            /*!<Bit 0 */
+#define USB_OTG_GRSTCTL_TXFNUM_1                ((uint32_t)0x00000080)            /*!<Bit 1 */
+#define USB_OTG_GRSTCTL_TXFNUM_2                ((uint32_t)0x00000100)            /*!<Bit 2 */
+#define USB_OTG_GRSTCTL_TXFNUM_3                ((uint32_t)0x00000200)            /*!<Bit 3 */
+#define USB_OTG_GRSTCTL_TXFNUM_4                ((uint32_t)0x00000400)            /*!<Bit 4 */
+#define USB_OTG_GRSTCTL_DMAREQ                  ((uint32_t)0x40000000)            /*!< DMA request signal */
+#define USB_OTG_GRSTCTL_AHBIDL                  ((uint32_t)0x80000000)            /*!< AHB master idle */
+
+/********************  Bit definition for USB_OTG_DIEPMSK register  ********************/
+#define USB_OTG_DIEPMSK_XFRCM                   ((uint32_t)0x00000001)            /*!< Transfer completed interrupt mask                 */
+#define USB_OTG_DIEPMSK_EPDM                    ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt mask                  */
+#define USB_OTG_DIEPMSK_TOM                     ((uint32_t)0x00000008)            /*!< Timeout condition mask (nonisochronous endpoints) */
+#define USB_OTG_DIEPMSK_ITTXFEMSK               ((uint32_t)0x00000010)            /*!< IN token received when TxFIFO empty mask          */
+#define USB_OTG_DIEPMSK_INEPNMM                 ((uint32_t)0x00000020)            /*!< IN token received with EP mismatch mask           */
+#define USB_OTG_DIEPMSK_INEPNEM                 ((uint32_t)0x00000040)            /*!< IN endpoint NAK effective mask                    */
+#define USB_OTG_DIEPMSK_TXFURM                  ((uint32_t)0x00000100)            /*!< FIFO underrun mask                                */
+#define USB_OTG_DIEPMSK_BIM                     ((uint32_t)0x00000200)            /*!< BNA interrupt mask                                */
+
+/********************  Bit definition for USB_OTG_HPTXSTS register  ********************/
+#define USB_OTG_HPTXSTS_PTXFSAVL                ((uint32_t)0x0000FFFF)            /*!< Periodic transmit data FIFO space available     */
+#define USB_OTG_HPTXSTS_PTXQSAV                 ((uint32_t)0x00FF0000)            /*!< Periodic transmit request queue space available */
+#define USB_OTG_HPTXSTS_PTXQSAV_0               ((uint32_t)0x00010000)            /*!<Bit 0 */
+#define USB_OTG_HPTXSTS_PTXQSAV_1               ((uint32_t)0x00020000)            /*!<Bit 1 */
+#define USB_OTG_HPTXSTS_PTXQSAV_2               ((uint32_t)0x00040000)            /*!<Bit 2 */
+#define USB_OTG_HPTXSTS_PTXQSAV_3               ((uint32_t)0x00080000)            /*!<Bit 3 */
+#define USB_OTG_HPTXSTS_PTXQSAV_4               ((uint32_t)0x00100000)            /*!<Bit 4 */
+#define USB_OTG_HPTXSTS_PTXQSAV_5               ((uint32_t)0x00200000)            /*!<Bit 5 */
+#define USB_OTG_HPTXSTS_PTXQSAV_6               ((uint32_t)0x00400000)            /*!<Bit 6 */
+#define USB_OTG_HPTXSTS_PTXQSAV_7               ((uint32_t)0x00800000)            /*!<Bit 7 */
+
+#define USB_OTG_HPTXSTS_PTXQTOP                 ((uint32_t)0xFF000000)            /*!< Top of the periodic transmit request queue */
+#define USB_OTG_HPTXSTS_PTXQTOP_0               ((uint32_t)0x01000000)            /*!<Bit 0 */
+#define USB_OTG_HPTXSTS_PTXQTOP_1               ((uint32_t)0x02000000)            /*!<Bit 1 */
+#define USB_OTG_HPTXSTS_PTXQTOP_2               ((uint32_t)0x04000000)            /*!<Bit 2 */
+#define USB_OTG_HPTXSTS_PTXQTOP_3               ((uint32_t)0x08000000)            /*!<Bit 3 */
+#define USB_OTG_HPTXSTS_PTXQTOP_4               ((uint32_t)0x10000000)            /*!<Bit 4 */
+#define USB_OTG_HPTXSTS_PTXQTOP_5               ((uint32_t)0x20000000)            /*!<Bit 5 */
+#define USB_OTG_HPTXSTS_PTXQTOP_6               ((uint32_t)0x40000000)            /*!<Bit 6 */
+#define USB_OTG_HPTXSTS_PTXQTOP_7               ((uint32_t)0x80000000)            /*!<Bit 7 */
+
+/********************  Bit definition for USB_OTG_HAINT register  ********************/
+#define USB_OTG_HAINT_HAINT                   ((uint32_t)0x0000FFFF)            /*!< Channel interrupts */
+
+/********************  Bit definition for USB_OTG_DOEPMSK register  ********************/
+#define USB_OTG_DOEPMSK_XFRCM                   ((uint32_t)0x00000001)            /*!< Transfer completed interrupt mask */
+#define USB_OTG_DOEPMSK_EPDM                    ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt mask               */
+#define USB_OTG_DOEPMSK_STUPM                   ((uint32_t)0x00000008)            /*!< SETUP phase done mask                          */
+#define USB_OTG_DOEPMSK_OTEPDM                  ((uint32_t)0x00000010)            /*!< OUT token received when endpoint disabled mask */
+#define USB_OTG_DOEPMSK_B2BSTUP                 ((uint32_t)0x00000040)            /*!< Back-to-back SETUP packets received mask       */
+#define USB_OTG_DOEPMSK_OPEM                    ((uint32_t)0x00000100)            /*!< OUT packet error mask                          */
+#define USB_OTG_DOEPMSK_BOIM                    ((uint32_t)0x00000200)            /*!< BNA interrupt mask                             */
+
+/********************  Bit definition for USB_OTG_GINTSTS register  ********************/
+#define USB_OTG_GINTSTS_CMOD                    ((uint32_t)0x00000001)            /*!< Current mode of operation                      */
+#define USB_OTG_GINTSTS_MMIS                    ((uint32_t)0x00000002)            /*!< Mode mismatch interrupt                        */
+#define USB_OTG_GINTSTS_OTGINT                  ((uint32_t)0x00000004)            /*!< OTG interrupt                                  */
+#define USB_OTG_GINTSTS_SOF                     ((uint32_t)0x00000008)            /*!< Start of frame                                 */
+#define USB_OTG_GINTSTS_RXFLVL                  ((uint32_t)0x00000010)            /*!< RxFIFO nonempty                                */
+#define USB_OTG_GINTSTS_NPTXFE                  ((uint32_t)0x00000020)            /*!< Nonperiodic TxFIFO empty                       */
+#define USB_OTG_GINTSTS_GINAKEFF                ((uint32_t)0x00000040)            /*!< Global IN nonperiodic NAK effective            */
+#define USB_OTG_GINTSTS_BOUTNAKEFF              ((uint32_t)0x00000080)            /*!< Global OUT NAK effective                       */
+#define USB_OTG_GINTSTS_ESUSP                   ((uint32_t)0x00000400)            /*!< Early suspend                                  */
+#define USB_OTG_GINTSTS_USBSUSP                 ((uint32_t)0x00000800)            /*!< USB suspend                                    */
+#define USB_OTG_GINTSTS_USBRST                  ((uint32_t)0x00001000)            /*!< USB reset                                      */
+#define USB_OTG_GINTSTS_ENUMDNE                 ((uint32_t)0x00002000)            /*!< Enumeration done                               */
+#define USB_OTG_GINTSTS_ISOODRP                 ((uint32_t)0x00004000)            /*!< Isochronous OUT packet dropped interrupt       */
+#define USB_OTG_GINTSTS_EOPF                    ((uint32_t)0x00008000)            /*!< End of periodic frame interrupt                */
+#define USB_OTG_GINTSTS_IEPINT                  ((uint32_t)0x00040000)            /*!< IN endpoint interrupt                          */
+#define USB_OTG_GINTSTS_OEPINT                  ((uint32_t)0x00080000)            /*!< OUT endpoint interrupt                         */
+#define USB_OTG_GINTSTS_IISOIXFR                ((uint32_t)0x00100000)            /*!< Incomplete isochronous IN transfer             */
+#define USB_OTG_GINTSTS_PXFR_INCOMPISOOUT       ((uint32_t)0x00200000)            /*!< Incomplete periodic transfer                   */
+#define USB_OTG_GINTSTS_DATAFSUSP               ((uint32_t)0x00400000)            /*!< Data fetch suspended                           */
+#define USB_OTG_GINTSTS_RSTDET                  ((uint32_t)0x00800000)            /*!< Reset detected interrupt                       */
+#define USB_OTG_GINTSTS_HPRTINT                 ((uint32_t)0x01000000)            /*!< Host port interrupt                            */
+#define USB_OTG_GINTSTS_HCINT                   ((uint32_t)0x02000000)            /*!< Host channels interrupt                        */
+#define USB_OTG_GINTSTS_PTXFE                   ((uint32_t)0x04000000)            /*!< Periodic TxFIFO empty                          */
+#define USB_OTG_GINTSTS_LPMINT                  ((uint32_t)0x08000000)            /*!< LPM interrupt                                  */
+#define USB_OTG_GINTSTS_CIDSCHG                 ((uint32_t)0x10000000)            /*!< Connector ID status change                     */
+#define USB_OTG_GINTSTS_DISCINT                 ((uint32_t)0x20000000)            /*!< Disconnect detected interrupt                  */
+#define USB_OTG_GINTSTS_SRQINT                  ((uint32_t)0x40000000)            /*!< Session request/new session detected interrupt */
+#define USB_OTG_GINTSTS_WKUINT                  ((uint32_t)0x80000000)            /*!< Resume/remote wakeup detected interrupt        */
+
+/********************  Bit definition for USB_OTG_GINTMSK register  ********************/
+#define USB_OTG_GINTMSK_MMISM                   ((uint32_t)0x00000002)            /*!< Mode mismatch interrupt mask                        */
+#define USB_OTG_GINTMSK_OTGINT                  ((uint32_t)0x00000004)            /*!< OTG interrupt mask                                  */
+#define USB_OTG_GINTMSK_SOFM                    ((uint32_t)0x00000008)            /*!< Start of frame mask                                 */
+#define USB_OTG_GINTMSK_RXFLVLM                 ((uint32_t)0x00000010)            /*!< Receive FIFO nonempty mask                          */
+#define USB_OTG_GINTMSK_NPTXFEM                 ((uint32_t)0x00000020)            /*!< Nonperiodic TxFIFO empty mask                       */
+#define USB_OTG_GINTMSK_GINAKEFFM               ((uint32_t)0x00000040)            /*!< Global nonperiodic IN NAK effective mask            */
+#define USB_OTG_GINTMSK_GONAKEFFM               ((uint32_t)0x00000080)            /*!< Global OUT NAK effective mask                       */
+#define USB_OTG_GINTMSK_ESUSPM                  ((uint32_t)0x00000400)            /*!< Early suspend mask                                  */
+#define USB_OTG_GINTMSK_USBSUSPM                ((uint32_t)0x00000800)            /*!< USB suspend mask                                    */
+#define USB_OTG_GINTMSK_USBRST                  ((uint32_t)0x00001000)            /*!< USB reset mask                                      */
+#define USB_OTG_GINTMSK_ENUMDNEM                ((uint32_t)0x00002000)            /*!< Enumeration done mask                               */
+#define USB_OTG_GINTMSK_ISOODRPM                ((uint32_t)0x00004000)            /*!< Isochronous OUT packet dropped interrupt mask       */
+#define USB_OTG_GINTMSK_EOPFM                   ((uint32_t)0x00008000)            /*!< End of periodic frame interrupt mask                */
+#define USB_OTG_GINTMSK_EPMISM                  ((uint32_t)0x00020000)            /*!< Endpoint mismatch interrupt mask                    */
+#define USB_OTG_GINTMSK_IEPINT                  ((uint32_t)0x00040000)            /*!< IN endpoints interrupt mask                         */
+#define USB_OTG_GINTMSK_OEPINT                  ((uint32_t)0x00080000)            /*!< OUT endpoints interrupt mask                        */
+#define USB_OTG_GINTMSK_IISOIXFRM               ((uint32_t)0x00100000)            /*!< Incomplete isochronous IN transfer mask             */
+#define USB_OTG_GINTMSK_PXFRM_IISOOXFRM         ((uint32_t)0x00200000)            /*!< Incomplete periodic transfer mask                   */
+#define USB_OTG_GINTMSK_FSUSPM                  ((uint32_t)0x00400000)            /*!< Data fetch suspended mask                           */
+#define USB_OTG_GINTMSK_RSTDEM                  ((uint32_t)0x00800000)            /*!< Reset detected interrupt mask                      */
+#define USB_OTG_GINTMSK_PRTIM                   ((uint32_t)0x01000000)            /*!< Host port interrupt mask                            */
+#define USB_OTG_GINTMSK_HCIM                    ((uint32_t)0x02000000)            /*!< Host channels interrupt mask                        */
+#define USB_OTG_GINTMSK_PTXFEM                  ((uint32_t)0x04000000)            /*!< Periodic TxFIFO empty mask                          */
+#define USB_OTG_GINTMSK_LPMINTM                 ((uint32_t)0x08000000)            /*!< LPM interrupt Mask                                  */
+#define USB_OTG_GINTMSK_CIDSCHGM                ((uint32_t)0x10000000)            /*!< Connector ID status change mask                     */
+#define USB_OTG_GINTMSK_DISCINT                 ((uint32_t)0x20000000)            /*!< Disconnect detected interrupt mask                  */
+#define USB_OTG_GINTMSK_SRQIM                   ((uint32_t)0x40000000)            /*!< Session request/new session detected interrupt mask */
+#define USB_OTG_GINTMSK_WUIM                    ((uint32_t)0x80000000)            /*!< Resume/remote wakeup detected interrupt mask        */
+
+/********************  Bit definition for USB_OTG_DAINT register  ********************/
+#define USB_OTG_DAINT_IEPINT                  ((uint32_t)0x0000FFFF)            /*!< IN endpoint interrupt bits  */
+#define USB_OTG_DAINT_OEPINT                  ((uint32_t)0xFFFF0000)            /*!< OUT endpoint interrupt bits */
+
+/********************  Bit definition for USB_OTG_HAINTMSK register  ********************/
+#define USB_OTG_HAINTMSK_HAINTM                  ((uint32_t)0x0000FFFF)            /*!< Channel interrupt mask */
+
+/********************  Bit definition for USB_OTG_GRXSTSP register  ********************/
+#define USB_OTG_GRXSTSP_EPNUM                    ((uint32_t)0x0000000F)            /*!< IN EP interrupt mask bits  */
+#define USB_OTG_GRXSTSP_BCNT                     ((uint32_t)0x00007FF0)            /*!< OUT EP interrupt mask bits */
+#define USB_OTG_GRXSTSP_DPID                     ((uint32_t)0x00018000)            /*!< OUT EP interrupt mask bits */
+#define USB_OTG_GRXSTSP_PKTSTS                   ((uint32_t)0x001E0000)            /*!< OUT EP interrupt mask bits */
+
+/********************  Bit definition for USB_OTG_DAINTMSK register  ********************/
+#define USB_OTG_DAINTMSK_IEPM                    ((uint32_t)0x0000FFFF)            /*!< IN EP interrupt mask bits */
+#define USB_OTG_DAINTMSK_OEPM                    ((uint32_t)0xFFFF0000)            /*!< OUT EP interrupt mask bits */
+
+/********************  Bit definition for OTG register  ********************/
+
+#define USB_OTG_CHNUM                   ((uint32_t)0x0000000F)            /*!< Channel number */
+#define USB_OTG_CHNUM_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_CHNUM_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_CHNUM_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_CHNUM_3                 ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define USB_OTG_BCNT                    ((uint32_t)0x00007FF0)            /*!< Byte count */
+
+#define USB_OTG_DPID                    ((uint32_t)0x00018000)            /*!< Data PID */
+#define USB_OTG_DPID_0                  ((uint32_t)0x00008000)            /*!<Bit 0 */
+#define USB_OTG_DPID_1                  ((uint32_t)0x00010000)            /*!<Bit 1 */
+
+#define USB_OTG_PKTSTS                  ((uint32_t)0x001E0000)            /*!< Packet status */
+#define USB_OTG_PKTSTS_0                ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define USB_OTG_PKTSTS_1                ((uint32_t)0x00040000)            /*!<Bit 1 */
+#define USB_OTG_PKTSTS_2                ((uint32_t)0x00080000)            /*!<Bit 2 */
+#define USB_OTG_PKTSTS_3                ((uint32_t)0x00100000)            /*!<Bit 3 */
+
+#define USB_OTG_EPNUM                   ((uint32_t)0x0000000F)            /*!< Endpoint number */
+#define USB_OTG_EPNUM_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_EPNUM_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_EPNUM_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_EPNUM_3                 ((uint32_t)0x00000008)            /*!<Bit 3 */
+
+#define USB_OTG_FRMNUM                  ((uint32_t)0x01E00000)            /*!< Frame number */
+#define USB_OTG_FRMNUM_0                ((uint32_t)0x00200000)            /*!<Bit 0 */
+#define USB_OTG_FRMNUM_1                ((uint32_t)0x00400000)            /*!<Bit 1 */
+#define USB_OTG_FRMNUM_2                ((uint32_t)0x00800000)            /*!<Bit 2 */
+#define USB_OTG_FRMNUM_3                ((uint32_t)0x01000000)            /*!<Bit 3 */
+
+/********************  Bit definition for OTG register  ********************/
+
+#define USB_OTG_CHNUM                   ((uint32_t)0x0000000F)            /*!< Channel number */
+#define USB_OTG_CHNUM_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_CHNUM_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_CHNUM_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_CHNUM_3                 ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define USB_OTG_BCNT                    ((uint32_t)0x00007FF0)            /*!< Byte count */
+
+#define USB_OTG_DPID                    ((uint32_t)0x00018000)            /*!< Data PID */
+#define USB_OTG_DPID_0                  ((uint32_t)0x00008000)            /*!<Bit 0 */
+#define USB_OTG_DPID_1                  ((uint32_t)0x00010000)            /*!<Bit 1 */
+
+#define USB_OTG_PKTSTS                  ((uint32_t)0x001E0000)            /*!< Packet status */
+#define USB_OTG_PKTSTS_0                ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define USB_OTG_PKTSTS_1                ((uint32_t)0x00040000)            /*!<Bit 1 */
+#define USB_OTG_PKTSTS_2                ((uint32_t)0x00080000)            /*!<Bit 2 */
+#define USB_OTG_PKTSTS_3                ((uint32_t)0x00100000)            /*!<Bit 3 */
+
+#define USB_OTG_EPNUM                   ((uint32_t)0x0000000F)            /*!< Endpoint number */
+#define USB_OTG_EPNUM_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_EPNUM_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_EPNUM_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_EPNUM_3                 ((uint32_t)0x00000008)            /*!<Bit 3 */
+
+#define USB_OTG_FRMNUM                  ((uint32_t)0x01E00000)            /*!< Frame number */
+#define USB_OTG_FRMNUM_0                ((uint32_t)0x00200000)            /*!<Bit 0 */
+#define USB_OTG_FRMNUM_1                ((uint32_t)0x00400000)            /*!<Bit 1 */
+#define USB_OTG_FRMNUM_2                ((uint32_t)0x00800000)            /*!<Bit 2 */
+#define USB_OTG_FRMNUM_3                ((uint32_t)0x01000000)            /*!<Bit 3 */
+
+/********************  Bit definition for USB_OTG_GRXFSIZ register  ********************/
+#define USB_OTG_GRXFSIZ_RXFD            ((uint32_t)0x0000FFFF)            /*!< RxFIFO depth */
+
+/********************  Bit definition for USB_OTG_DVBUSDIS register  ********************/
+#define USB_OTG_DVBUSDIS_VBUSDT         ((uint32_t)0x0000FFFF)            /*!< Device VBUS discharge time */
+
+/********************  Bit definition for OTG register  ********************/
+#define USB_OTG_NPTXFSA                 ((uint32_t)0x0000FFFF)            /*!< Nonperiodic transmit RAM start address */
+#define USB_OTG_NPTXFD                  ((uint32_t)0xFFFF0000)            /*!< Nonperiodic TxFIFO depth               */
+#define USB_OTG_TX0FSA                  ((uint32_t)0x0000FFFF)            /*!< Endpoint 0 transmit RAM start address  */
+#define USB_OTG_TX0FD                   ((uint32_t)0xFFFF0000)            /*!< Endpoint 0 TxFIFO depth                */
+
+/********************  Bit definition for USB_OTG_DVBUSPULSE register  ********************/
+#define USB_OTG_DVBUSPULSE_DVBUSP                  ((uint32_t)0x00000FFF)            /*!< Device VBUS pulsing time */
+
+/********************  Bit definition for USB_OTG_GNPTXSTS register  ********************/
+#define USB_OTG_GNPTXSTS_NPTXFSAV                ((uint32_t)0x0000FFFF)            /*!< Nonperiodic TxFIFO space available */
+
+#define USB_OTG_GNPTXSTS_NPTQXSAV                ((uint32_t)0x00FF0000)            /*!< Nonperiodic transmit request queue space available */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_0              ((uint32_t)0x00010000)            /*!<Bit 0 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_1              ((uint32_t)0x00020000)            /*!<Bit 1 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_2              ((uint32_t)0x00040000)            /*!<Bit 2 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_3              ((uint32_t)0x00080000)            /*!<Bit 3 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_4              ((uint32_t)0x00100000)            /*!<Bit 4 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_5              ((uint32_t)0x00200000)            /*!<Bit 5 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_6              ((uint32_t)0x00400000)            /*!<Bit 6 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_7              ((uint32_t)0x00800000)            /*!<Bit 7 */
+
+#define USB_OTG_GNPTXSTS_NPTXQTOP                ((uint32_t)0x7F000000)            /*!< Top of the nonperiodic transmit request queue */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_0              ((uint32_t)0x01000000)            /*!<Bit 0 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_1              ((uint32_t)0x02000000)            /*!<Bit 1 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_2              ((uint32_t)0x04000000)            /*!<Bit 2 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_3              ((uint32_t)0x08000000)            /*!<Bit 3 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_4              ((uint32_t)0x10000000)            /*!<Bit 4 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_5              ((uint32_t)0x20000000)            /*!<Bit 5 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_6              ((uint32_t)0x40000000)            /*!<Bit 6 */
+
+/********************  Bit definition for USB_OTG_DTHRCTL register  ********************/
+#define USB_OTG_DTHRCTL_NONISOTHREN             ((uint32_t)0x00000001)            /*!< Nonisochronous IN endpoints threshold enable */
+#define USB_OTG_DTHRCTL_ISOTHREN                ((uint32_t)0x00000002)            /*!< ISO IN endpoint threshold enable */
+
+#define USB_OTG_DTHRCTL_TXTHRLEN                ((uint32_t)0x000007FC)            /*!< Transmit threshold length */
+#define USB_OTG_DTHRCTL_TXTHRLEN_0              ((uint32_t)0x00000004)            /*!<Bit 0 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_1              ((uint32_t)0x00000008)            /*!<Bit 1 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_2              ((uint32_t)0x00000010)            /*!<Bit 2 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_3              ((uint32_t)0x00000020)            /*!<Bit 3 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_4              ((uint32_t)0x00000040)            /*!<Bit 4 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_5              ((uint32_t)0x00000080)            /*!<Bit 5 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_6              ((uint32_t)0x00000100)            /*!<Bit 6 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_7              ((uint32_t)0x00000200)            /*!<Bit 7 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_8              ((uint32_t)0x00000400)            /*!<Bit 8 */
+#define USB_OTG_DTHRCTL_RXTHREN                 ((uint32_t)0x00010000)            /*!< Receive threshold enable */
+
+#define USB_OTG_DTHRCTL_RXTHRLEN                ((uint32_t)0x03FE0000)            /*!< Receive threshold length */
+#define USB_OTG_DTHRCTL_RXTHRLEN_0              ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_1              ((uint32_t)0x00040000)            /*!<Bit 1 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_2              ((uint32_t)0x00080000)            /*!<Bit 2 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_3              ((uint32_t)0x00100000)            /*!<Bit 3 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_4              ((uint32_t)0x00200000)            /*!<Bit 4 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_5              ((uint32_t)0x00400000)            /*!<Bit 5 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_6              ((uint32_t)0x00800000)            /*!<Bit 6 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_7              ((uint32_t)0x01000000)            /*!<Bit 7 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_8              ((uint32_t)0x02000000)            /*!<Bit 8 */
+#define USB_OTG_DTHRCTL_ARPEN                   ((uint32_t)0x08000000)            /*!< Arbiter parking enable */
+
+/********************  Bit definition for USB_OTG_DIEPEMPMSK register  ********************/
+#define USB_OTG_DIEPEMPMSK_INEPTXFEM               ((uint32_t)0x0000FFFF)         /*!< IN EP Tx FIFO empty interrupt mask bits */
+
+/********************  Bit definition for USB_OTG_DEACHINT register  ********************/
+#define USB_OTG_DEACHINT_IEP1INT                 ((uint32_t)0x00000002)           /*!< IN endpoint 1interrupt bit   */
+#define USB_OTG_DEACHINT_OEP1INT                 ((uint32_t)0x00020000)           /*!< OUT endpoint 1 interrupt bit */
+
+/********************  Bit definition for USB_OTG_GCCFG register  ********************/
+#define USB_OTG_GCCFG_PWRDWN                 ((uint32_t)0x00010000)              /*!< Power down */
+#define USB_OTG_GCCFG_VBDEN                  ((uint32_t)0x00200000)              /*!< USB VBUS Detection Enable */
+
+/********************  Bit definition for USB_OTG_GPWRDN) register  ********************/
+#define USB_OTG_GPWRDN_ADPMEN                 ((uint32_t)0x00000001)             /*!< ADP module enable */
+#define USB_OTG_GPWRDN_ADPIF                  ((uint32_t)0x00800000)             /*!< ADP Interrupt flag */
+
+/********************  Bit definition for USB_OTG_DEACHINTMSK register  ********************/
+#define USB_OTG_DEACHINTMSK_IEP1INTM          ((uint32_t)0x00000002)            /*!< IN Endpoint 1 interrupt mask bit  */
+#define USB_OTG_DEACHINTMSK_OEP1INTM          ((uint32_t)0x00020000)            /*!< OUT Endpoint 1 interrupt mask bit */
+
+/********************  Bit definition for USB_OTG_CID register  ********************/
+#define USB_OTG_CID_PRODUCT_ID               ((uint32_t)0xFFFFFFFF)            /*!< Product ID field */
+
+/********************  Bit definition for USB_OTG_GLPMCFG register  ********************/
+#define  USB_OTG_GLPMCFG_LPMEN               ((uint32_t)0x00000001)            /*!< LPM support enable                                     */
+#define  USB_OTG_GLPMCFG_LPMACK              ((uint32_t)0x00000002)            /*!< LPM Token acknowledge enable                           */
+#define  USB_OTG_GLPMCFG_BESL                ((uint32_t)0x0000003C)            /*!< BESL value received with last ACKed LPM Token          */
+#define  USB_OTG_GLPMCFG_REMWAKE             ((uint32_t)0x00000040)            /*!< bRemoteWake value received with last ACKed LPM Token   */
+#define  USB_OTG_GLPMCFG_L1SSEN              ((uint32_t)0x00000080)            /*!< L1 shallow sleep enable                                */
+#define  USB_OTG_GLPMCFG_BESLTHRS            ((uint32_t)0x00000F00)            /*!< BESL threshold                                         */
+#define  USB_OTG_GLPMCFG_L1DSEN              ((uint32_t)0x00001000)            /*!< L1 deep sleep enable                                   */
+#define  USB_OTG_GLPMCFG_LPMRSP              ((uint32_t)0x00006000)            /*!< LPM response                                           */
+#define  USB_OTG_GLPMCFG_SLPSTS              ((uint32_t)0x00008000)            /*!< Port sleep status                                      */
+#define  USB_OTG_GLPMCFG_L1RSMOK             ((uint32_t)0x00010000)            /*!< Sleep State Resume OK                                  */
+#define  USB_OTG_GLPMCFG_LPMCHIDX            ((uint32_t)0x001E0000)            /*!< LPM Channel Index                                      */
+#define  USB_OTG_GLPMCFG_LPMRCNT             ((uint32_t)0x00E00000)            /*!< LPM retry count                                        */
+#define  USB_OTG_GLPMCFG_SNDLPM              ((uint32_t)0x01000000)            /*!< Send LPM transaction                                   */
+#define  USB_OTG_GLPMCFG_LPMRCNTSTS          ((uint32_t)0x0E000000)            /*!< LPM retry count status                                 */
+#define  USB_OTG_GLPMCFG_ENBESL              ((uint32_t)0x10000000)            /*!< Enable best effort service latency                     */
+
+/********************  Bit definition for USB_OTG_DIEPEACHMSK1 register  ********************/
+#define USB_OTG_DIEPEACHMSK1_XFRCM           ((uint32_t)0x00000001)            /*!< Transfer completed interrupt mask                 */
+#define USB_OTG_DIEPEACHMSK1_EPDM            ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt mask                  */
+#define USB_OTG_DIEPEACHMSK1_TOM             ((uint32_t)0x00000008)            /*!< Timeout condition mask (nonisochronous endpoints) */
+#define USB_OTG_DIEPEACHMSK1_ITTXFEMSK       ((uint32_t)0x00000010)            /*!< IN token received when TxFIFO empty mask          */
+#define USB_OTG_DIEPEACHMSK1_INEPNMM         ((uint32_t)0x00000020)            /*!< IN token received with EP mismatch mask           */
+#define USB_OTG_DIEPEACHMSK1_INEPNEM         ((uint32_t)0x00000040)            /*!< IN endpoint NAK effective mask                    */
+#define USB_OTG_DIEPEACHMSK1_TXFURM          ((uint32_t)0x00000100)            /*!< FIFO underrun mask                                */
+#define USB_OTG_DIEPEACHMSK1_BIM             ((uint32_t)0x00000200)            /*!< BNA interrupt mask                                */
+#define USB_OTG_DIEPEACHMSK1_NAKM            ((uint32_t)0x00002000)            /*!< NAK interrupt mask                                */
+
+/********************  Bit definition for USB_OTG_HPRT register  ********************/
+#define USB_OTG_HPRT_PCSTS                   ((uint32_t)0x00000001)            /*!< Port connect status        */
+#define USB_OTG_HPRT_PCDET                   ((uint32_t)0x00000002)            /*!< Port connect detected      */
+#define USB_OTG_HPRT_PENA                    ((uint32_t)0x00000004)            /*!< Port enable                */
+#define USB_OTG_HPRT_PENCHNG                 ((uint32_t)0x00000008)            /*!< Port enable/disable change */
+#define USB_OTG_HPRT_POCA                    ((uint32_t)0x00000010)            /*!< Port overcurrent active    */
+#define USB_OTG_HPRT_POCCHNG                 ((uint32_t)0x00000020)            /*!< Port overcurrent change    */
+#define USB_OTG_HPRT_PRES                    ((uint32_t)0x00000040)            /*!< Port resume                */
+#define USB_OTG_HPRT_PSUSP                   ((uint32_t)0x00000080)            /*!< Port suspend               */
+#define USB_OTG_HPRT_PRST                    ((uint32_t)0x00000100)            /*!< Port reset                 */
+
+#define USB_OTG_HPRT_PLSTS                   ((uint32_t)0x00000C00)            /*!< Port line status           */
+#define USB_OTG_HPRT_PLSTS_0                 ((uint32_t)0x00000400)            /*!<Bit 0 */
+#define USB_OTG_HPRT_PLSTS_1                 ((uint32_t)0x00000800)            /*!<Bit 1 */
+#define USB_OTG_HPRT_PPWR                    ((uint32_t)0x00001000)            /*!< Port power                 */
+
+#define USB_OTG_HPRT_PTCTL                   ((uint32_t)0x0001E000)            /*!< Port test control          */
+#define USB_OTG_HPRT_PTCTL_0                 ((uint32_t)0x00002000)            /*!<Bit 0 */
+#define USB_OTG_HPRT_PTCTL_1                 ((uint32_t)0x00004000)            /*!<Bit 1 */
+#define USB_OTG_HPRT_PTCTL_2                 ((uint32_t)0x00008000)            /*!<Bit 2 */
+#define USB_OTG_HPRT_PTCTL_3                 ((uint32_t)0x00010000)            /*!<Bit 3 */
+
+#define USB_OTG_HPRT_PSPD                    ((uint32_t)0x00060000)            /*!< Port speed                 */
+#define USB_OTG_HPRT_PSPD_0                  ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define USB_OTG_HPRT_PSPD_1                  ((uint32_t)0x00040000)            /*!<Bit 1 */
+
+/********************  Bit definition for USB_OTG_DOEPEACHMSK1 register  ********************/
+#define USB_OTG_DOEPEACHMSK1_XFRCM                   ((uint32_t)0x00000001)            /*!< Transfer completed interrupt mask         */
+#define USB_OTG_DOEPEACHMSK1_EPDM                    ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt mask          */
+#define USB_OTG_DOEPEACHMSK1_TOM                     ((uint32_t)0x00000008)            /*!< Timeout condition mask                    */
+#define USB_OTG_DOEPEACHMSK1_ITTXFEMSK               ((uint32_t)0x00000010)            /*!< IN token received when TxFIFO empty mask  */
+#define USB_OTG_DOEPEACHMSK1_INEPNMM                 ((uint32_t)0x00000020)            /*!< IN token received with EP mismatch mask   */
+#define USB_OTG_DOEPEACHMSK1_INEPNEM                 ((uint32_t)0x00000040)            /*!< IN endpoint NAK effective mask            */
+#define USB_OTG_DOEPEACHMSK1_TXFURM                  ((uint32_t)0x00000100)            /*!< OUT packet error mask                     */
+#define USB_OTG_DOEPEACHMSK1_BIM                     ((uint32_t)0x00000200)            /*!< BNA interrupt mask                        */
+#define USB_OTG_DOEPEACHMSK1_BERRM                   ((uint32_t)0x00001000)            /*!< Bubble error interrupt mask               */
+#define USB_OTG_DOEPEACHMSK1_NAKM                    ((uint32_t)0x00002000)            /*!< NAK interrupt mask                        */
+#define USB_OTG_DOEPEACHMSK1_NYETM                   ((uint32_t)0x00004000)            /*!< NYET interrupt mask                       */
+
+/********************  Bit definition for USB_OTG_HPTXFSIZ register  ********************/
+#define USB_OTG_HPTXFSIZ_PTXSA                   ((uint32_t)0x0000FFFF)            /*!< Host periodic TxFIFO start address            */
+#define USB_OTG_HPTXFSIZ_PTXFD                   ((uint32_t)0xFFFF0000)            /*!< Host periodic TxFIFO depth                    */
+
+/********************  Bit definition for USB_OTG_DIEPCTL register  ********************/
+#define USB_OTG_DIEPCTL_MPSIZ                   ((uint32_t)0x000007FF)            /*!< Maximum packet size              */
+#define USB_OTG_DIEPCTL_USBAEP                  ((uint32_t)0x00008000)            /*!< USB active endpoint              */
+#define USB_OTG_DIEPCTL_EONUM_DPID              ((uint32_t)0x00010000)            /*!< Even/odd frame                   */
+#define USB_OTG_DIEPCTL_NAKSTS                  ((uint32_t)0x00020000)            /*!< NAK status                       */
+
+#define USB_OTG_DIEPCTL_EPTYP                   ((uint32_t)0x000C0000)            /*!< Endpoint type                    */
+#define USB_OTG_DIEPCTL_EPTYP_0                 ((uint32_t)0x00040000)            /*!<Bit 0 */
+#define USB_OTG_DIEPCTL_EPTYP_1                 ((uint32_t)0x00080000)            /*!<Bit 1 */
+#define USB_OTG_DIEPCTL_STALL                   ((uint32_t)0x00200000)            /*!< STALL handshake                  */
+
+#define USB_OTG_DIEPCTL_TXFNUM                  ((uint32_t)0x03C00000)            /*!< TxFIFO number                    */
+#define USB_OTG_DIEPCTL_TXFNUM_0                ((uint32_t)0x00400000)            /*!<Bit 0 */
+#define USB_OTG_DIEPCTL_TXFNUM_1                ((uint32_t)0x00800000)            /*!<Bit 1 */
+#define USB_OTG_DIEPCTL_TXFNUM_2                ((uint32_t)0x01000000)            /*!<Bit 2 */
+#define USB_OTG_DIEPCTL_TXFNUM_3                ((uint32_t)0x02000000)            /*!<Bit 3 */
+#define USB_OTG_DIEPCTL_CNAK                    ((uint32_t)0x04000000)            /*!< Clear NAK                        */
+#define USB_OTG_DIEPCTL_SNAK                    ((uint32_t)0x08000000)            /*!< Set NAK */
+#define USB_OTG_DIEPCTL_SD0PID_SEVNFRM          ((uint32_t)0x10000000)            /*!< Set DATA0 PID                    */
+#define USB_OTG_DIEPCTL_SODDFRM                 ((uint32_t)0x20000000)            /*!< Set odd frame                    */
+#define USB_OTG_DIEPCTL_EPDIS                   ((uint32_t)0x40000000)            /*!< Endpoint disable                 */
+#define USB_OTG_DIEPCTL_EPENA                   ((uint32_t)0x80000000)            /*!< Endpoint enable                  */
+
+/********************  Bit definition for USB_OTG_HCCHAR register  ********************/
+#define USB_OTG_HCCHAR_MPSIZ                   ((uint32_t)0x000007FF)            /*!< Maximum packet size */
+
+#define USB_OTG_HCCHAR_EPNUM                   ((uint32_t)0x00007800)            /*!< Endpoint number */
+#define USB_OTG_HCCHAR_EPNUM_0                 ((uint32_t)0x00000800)            /*!<Bit 0 */
+#define USB_OTG_HCCHAR_EPNUM_1                 ((uint32_t)0x00001000)            /*!<Bit 1 */
+#define USB_OTG_HCCHAR_EPNUM_2                 ((uint32_t)0x00002000)            /*!<Bit 2 */
+#define USB_OTG_HCCHAR_EPNUM_3                 ((uint32_t)0x00004000)            /*!<Bit 3 */
+#define USB_OTG_HCCHAR_EPDIR                   ((uint32_t)0x00008000)            /*!< Endpoint direction */
+#define USB_OTG_HCCHAR_LSDEV                   ((uint32_t)0x00020000)            /*!< Low-speed device */
+
+#define USB_OTG_HCCHAR_EPTYP                   ((uint32_t)0x000C0000)            /*!< Endpoint type */
+#define USB_OTG_HCCHAR_EPTYP_0                 ((uint32_t)0x00040000)            /*!<Bit 0 */
+#define USB_OTG_HCCHAR_EPTYP_1                 ((uint32_t)0x00080000)            /*!<Bit 1 */
+
+#define USB_OTG_HCCHAR_MC                      ((uint32_t)0x00300000)            /*!< Multi Count (MC) / Error Count (EC) */
+#define USB_OTG_HCCHAR_MC_0                    ((uint32_t)0x00100000)            /*!<Bit 0 */
+#define USB_OTG_HCCHAR_MC_1                    ((uint32_t)0x00200000)            /*!<Bit 1 */
+
+#define USB_OTG_HCCHAR_DAD                     ((uint32_t)0x1FC00000)            /*!< Device address */
+#define USB_OTG_HCCHAR_DAD_0                   ((uint32_t)0x00400000)            /*!<Bit 0 */
+#define USB_OTG_HCCHAR_DAD_1                   ((uint32_t)0x00800000)            /*!<Bit 1 */
+#define USB_OTG_HCCHAR_DAD_2                   ((uint32_t)0x01000000)            /*!<Bit 2 */
+#define USB_OTG_HCCHAR_DAD_3                   ((uint32_t)0x02000000)            /*!<Bit 3 */
+#define USB_OTG_HCCHAR_DAD_4                   ((uint32_t)0x04000000)            /*!<Bit 4 */
+#define USB_OTG_HCCHAR_DAD_5                   ((uint32_t)0x08000000)            /*!<Bit 5 */
+#define USB_OTG_HCCHAR_DAD_6                   ((uint32_t)0x10000000)            /*!<Bit 6 */
+#define USB_OTG_HCCHAR_ODDFRM                  ((uint32_t)0x20000000)            /*!< Odd frame */
+#define USB_OTG_HCCHAR_CHDIS                   ((uint32_t)0x40000000)            /*!< Channel disable */
+#define USB_OTG_HCCHAR_CHENA                   ((uint32_t)0x80000000)            /*!< Channel enable */
+
+/********************  Bit definition for USB_OTG_HCSPLT register  ********************/
+
+#define USB_OTG_HCSPLT_PRTADDR                 ((uint32_t)0x0000007F)            /*!< Port address */
+#define USB_OTG_HCSPLT_PRTADDR_0               ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_HCSPLT_PRTADDR_1               ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_HCSPLT_PRTADDR_2               ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_HCSPLT_PRTADDR_3               ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define USB_OTG_HCSPLT_PRTADDR_4               ((uint32_t)0x00000010)            /*!<Bit 4 */
+#define USB_OTG_HCSPLT_PRTADDR_5               ((uint32_t)0x00000020)            /*!<Bit 5 */
+#define USB_OTG_HCSPLT_PRTADDR_6               ((uint32_t)0x00000040)            /*!<Bit 6 */
+
+#define USB_OTG_HCSPLT_HUBADDR                 ((uint32_t)0x00003F80)            /*!< Hub address */
+#define USB_OTG_HCSPLT_HUBADDR_0               ((uint32_t)0x00000080)            /*!<Bit 0 */
+#define USB_OTG_HCSPLT_HUBADDR_1               ((uint32_t)0x00000100)            /*!<Bit 1 */
+#define USB_OTG_HCSPLT_HUBADDR_2               ((uint32_t)0x00000200)            /*!<Bit 2 */
+#define USB_OTG_HCSPLT_HUBADDR_3               ((uint32_t)0x00000400)            /*!<Bit 3 */
+#define USB_OTG_HCSPLT_HUBADDR_4               ((uint32_t)0x00000800)            /*!<Bit 4 */
+#define USB_OTG_HCSPLT_HUBADDR_5               ((uint32_t)0x00001000)            /*!<Bit 5 */
+#define USB_OTG_HCSPLT_HUBADDR_6               ((uint32_t)0x00002000)            /*!<Bit 6 */
+
+#define USB_OTG_HCSPLT_XACTPOS                 ((uint32_t)0x0000C000)            /*!< XACTPOS */
+#define USB_OTG_HCSPLT_XACTPOS_0               ((uint32_t)0x00004000)            /*!<Bit 0 */
+#define USB_OTG_HCSPLT_XACTPOS_1               ((uint32_t)0x00008000)            /*!<Bit 1 */
+#define USB_OTG_HCSPLT_COMPLSPLT               ((uint32_t)0x00010000)            /*!< Do complete split */
+#define USB_OTG_HCSPLT_SPLITEN                 ((uint32_t)0x80000000)            /*!< Split enable */
+
+/********************  Bit definition for USB_OTG_HCINT register  ********************/
+#define USB_OTG_HCINT_XFRC                    ((uint32_t)0x00000001)            /*!< Transfer completed */
+#define USB_OTG_HCINT_CHH                     ((uint32_t)0x00000002)            /*!< Channel halted */
+#define USB_OTG_HCINT_AHBERR                  ((uint32_t)0x00000004)            /*!< AHB error */
+#define USB_OTG_HCINT_STALL                   ((uint32_t)0x00000008)            /*!< STALL response received interrupt */
+#define USB_OTG_HCINT_NAK                     ((uint32_t)0x00000010)            /*!< NAK response received interrupt */
+#define USB_OTG_HCINT_ACK                     ((uint32_t)0x00000020)            /*!< ACK response received/transmitted interrupt */
+#define USB_OTG_HCINT_NYET                    ((uint32_t)0x00000040)            /*!< Response received interrupt */
+#define USB_OTG_HCINT_TXERR                   ((uint32_t)0x00000080)            /*!< Transaction error */
+#define USB_OTG_HCINT_BBERR                   ((uint32_t)0x00000100)            /*!< Babble error */
+#define USB_OTG_HCINT_FRMOR                   ((uint32_t)0x00000200)            /*!< Frame overrun */
+#define USB_OTG_HCINT_DTERR                   ((uint32_t)0x00000400)            /*!< Data toggle error */
+
+/********************  Bit definition for USB_OTG_DIEPINT register  ********************/
+#define USB_OTG_DIEPINT_XFRC                    ((uint32_t)0x00000001)            /*!< Transfer completed interrupt */
+#define USB_OTG_DIEPINT_EPDISD                  ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt */
+#define USB_OTG_DIEPINT_TOC                     ((uint32_t)0x00000008)            /*!< Timeout condition */
+#define USB_OTG_DIEPINT_ITTXFE                  ((uint32_t)0x00000010)            /*!< IN token received when TxFIFO is empty */
+#define USB_OTG_DIEPINT_INEPNE                  ((uint32_t)0x00000040)            /*!< IN endpoint NAK effective */
+#define USB_OTG_DIEPINT_TXFE                    ((uint32_t)0x00000080)            /*!< Transmit FIFO empty */
+#define USB_OTG_DIEPINT_TXFIFOUDRN              ((uint32_t)0x00000100)            /*!< Transmit Fifo Underrun */
+#define USB_OTG_DIEPINT_BNA                     ((uint32_t)0x00000200)            /*!< Buffer not available interrupt */
+#define USB_OTG_DIEPINT_PKTDRPSTS               ((uint32_t)0x00000800)            /*!< Packet dropped status */
+#define USB_OTG_DIEPINT_BERR                    ((uint32_t)0x00001000)            /*!< Babble error interrupt */
+#define USB_OTG_DIEPINT_NAK                     ((uint32_t)0x00002000)            /*!< NAK interrupt */
+
+/********************  Bit definition for USB_OTG_HCINTMSK register  ********************/
+#define USB_OTG_HCINTMSK_XFRCM                   ((uint32_t)0x00000001)            /*!< Transfer completed mask */
+#define USB_OTG_HCINTMSK_CHHM                    ((uint32_t)0x00000002)            /*!< Channel halted mask */
+#define USB_OTG_HCINTMSK_AHBERR                  ((uint32_t)0x00000004)            /*!< AHB error */
+#define USB_OTG_HCINTMSK_STALLM                  ((uint32_t)0x00000008)            /*!< STALL response received interrupt mask */
+#define USB_OTG_HCINTMSK_NAKM                    ((uint32_t)0x00000010)            /*!< NAK response received interrupt mask */
+#define USB_OTG_HCINTMSK_ACKM                    ((uint32_t)0x00000020)            /*!< ACK response received/transmitted interrupt mask */
+#define USB_OTG_HCINTMSK_NYET                    ((uint32_t)0x00000040)            /*!< response received interrupt mask */
+#define USB_OTG_HCINTMSK_TXERRM                  ((uint32_t)0x00000080)            /*!< Transaction error mask */
+#define USB_OTG_HCINTMSK_BBERRM                  ((uint32_t)0x00000100)            /*!< Babble error mask */
+#define USB_OTG_HCINTMSK_FRMORM                  ((uint32_t)0x00000200)            /*!< Frame overrun mask */
+#define USB_OTG_HCINTMSK_DTERRM                  ((uint32_t)0x00000400)            /*!< Data toggle error mask */
+
+/********************  Bit definition for USB_OTG_DIEPTSIZ register  ********************/
+
+#define USB_OTG_DIEPTSIZ_XFRSIZ                  ((uint32_t)0x0007FFFF)            /*!< Transfer size */
+#define USB_OTG_DIEPTSIZ_PKTCNT                  ((uint32_t)0x1FF80000)            /*!< Packet count */
+#define USB_OTG_DIEPTSIZ_MULCNT                  ((uint32_t)0x60000000)            /*!< Packet count */
+/********************  Bit definition for USB_OTG_HCTSIZ register  ********************/
+#define USB_OTG_HCTSIZ_XFRSIZ                    ((uint32_t)0x0007FFFF)            /*!< Transfer size */
+#define USB_OTG_HCTSIZ_PKTCNT                    ((uint32_t)0x1FF80000)            /*!< Packet count */
+#define USB_OTG_HCTSIZ_DOPING                    ((uint32_t)0x80000000)            /*!< Do PING */
+#define USB_OTG_HCTSIZ_DPID                      ((uint32_t)0x60000000)            /*!< Data PID */
+#define USB_OTG_HCTSIZ_DPID_0                    ((uint32_t)0x20000000)            /*!<Bit 0 */
+#define USB_OTG_HCTSIZ_DPID_1                    ((uint32_t)0x40000000)            /*!<Bit 1 */
+
+/********************  Bit definition for USB_OTG_DIEPDMA register  ********************/
+#define USB_OTG_DIEPDMA_DMAADDR                  ((uint32_t)0xFFFFFFFF)            /*!< DMA address */
+
+/********************  Bit definition for USB_OTG_HCDMA register  ********************/
+#define USB_OTG_HCDMA_DMAADDR                    ((uint32_t)0xFFFFFFFF)            /*!< DMA address */
+
+/********************  Bit definition for USB_OTG_DTXFSTS register  ********************/
+#define USB_OTG_DTXFSTS_INEPTFSAV                ((uint32_t)0x0000FFFF)            /*!< IN endpoint TxFIFO space available */
+
+/********************  Bit definition for USB_OTG_DIEPTXF register  ********************/
+#define USB_OTG_DIEPTXF_INEPTXSA                 ((uint32_t)0x0000FFFF)            /*!< IN endpoint FIFOx transmit RAM start address */
+#define USB_OTG_DIEPTXF_INEPTXFD                 ((uint32_t)0xFFFF0000)            /*!< IN endpoint TxFIFO depth */
+
+/********************  Bit definition for USB_OTG_DOEPCTL register  ********************/
+#define USB_OTG_DOEPCTL_MPSIZ                     ((uint32_t)0x000007FF)            /*!< Maximum packet size */          /*!<Bit 1 */
+#define USB_OTG_DOEPCTL_USBAEP                    ((uint32_t)0x00008000)            /*!< USB active endpoint */
+#define USB_OTG_DOEPCTL_NAKSTS                    ((uint32_t)0x00020000)            /*!< NAK status */
+#define USB_OTG_DOEPCTL_SD0PID_SEVNFRM            ((uint32_t)0x10000000)            /*!< Set DATA0 PID */
+#define USB_OTG_DOEPCTL_SODDFRM                   ((uint32_t)0x20000000)            /*!< Set odd frame */
+#define USB_OTG_DOEPCTL_EPTYP                     ((uint32_t)0x000C0000)            /*!< Endpoint type */
+#define USB_OTG_DOEPCTL_EPTYP_0                   ((uint32_t)0x00040000)            /*!<Bit 0 */
+#define USB_OTG_DOEPCTL_EPTYP_1                   ((uint32_t)0x00080000)            /*!<Bit 1 */
+#define USB_OTG_DOEPCTL_SNPM                      ((uint32_t)0x00100000)            /*!< Snoop mode */
+#define USB_OTG_DOEPCTL_STALL                     ((uint32_t)0x00200000)            /*!< STALL handshake */
+#define USB_OTG_DOEPCTL_CNAK                      ((uint32_t)0x04000000)            /*!< Clear NAK */
+#define USB_OTG_DOEPCTL_SNAK                      ((uint32_t)0x08000000)            /*!< Set NAK */
+#define USB_OTG_DOEPCTL_EPDIS                     ((uint32_t)0x40000000)            /*!< Endpoint disable */
+#define USB_OTG_DOEPCTL_EPENA                     ((uint32_t)0x80000000)            /*!< Endpoint enable */
+
+/********************  Bit definition for USB_OTG_DOEPINT register  ********************/
+#define USB_OTG_DOEPINT_XFRC                    ((uint32_t)0x00000001)            /*!< Transfer completed interrupt */
+#define USB_OTG_DOEPINT_EPDISD                  ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt */
+#define USB_OTG_DOEPINT_STUP                    ((uint32_t)0x00000008)            /*!< SETUP phase done */
+#define USB_OTG_DOEPINT_OTEPDIS                 ((uint32_t)0x00000010)            /*!< OUT token received when endpoint disabled */
+#define USB_OTG_DOEPINT_B2BSTUP                 ((uint32_t)0x00000040)            /*!< Back-to-back SETUP packets received */
+#define USB_OTG_DOEPINT_NYET                    ((uint32_t)0x00004000)            /*!< NYET interrupt */
+
+/********************  Bit definition for USB_OTG_DOEPTSIZ register  ********************/
+#define USB_OTG_DOEPTSIZ_XFRSIZ                  ((uint32_t)0x0007FFFF)            /*!< Transfer size */
+#define USB_OTG_DOEPTSIZ_PKTCNT                  ((uint32_t)0x1FF80000)            /*!< Packet count */
+
+#define USB_OTG_DOEPTSIZ_STUPCNT                 ((uint32_t)0x60000000)            /*!< SETUP packet count */
+#define USB_OTG_DOEPTSIZ_STUPCNT_0               ((uint32_t)0x20000000)            /*!<Bit 0 */
+#define USB_OTG_DOEPTSIZ_STUPCNT_1               ((uint32_t)0x40000000)            /*!<Bit 1 */
+
+/********************  Bit definition for PCGCCTL register  ********************/
+#define USB_OTG_PCGCCTL_STOPCLK                 ((uint32_t)0x00000001)            /*!< SETUP packet count */
+#define USB_OTG_PCGCCTL_GATECLK                 ((uint32_t)0x00000002)            /*!<Bit 0 */
+#define USB_OTG_PCGCCTL_PHYSUSP                 ((uint32_t)0x00000010)            /*!<Bit 1 */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+
+/******************************* ADC Instances ********************************/
+#define IS_ADC_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == ADC1) || \
+                                       ((__INSTANCE__) == ADC2) || \
+                                       ((__INSTANCE__) == ADC3))
+
+/******************************* CAN Instances ********************************/
+#define IS_CAN_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == CAN1) || \
+                                       ((__INSTANCE__) == CAN2))
+
+/******************************* CRC Instances ********************************/
+#define IS_CRC_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == CRC)
+
+/******************************* DAC Instances ********************************/
+#define IS_DAC_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == DAC)
+
+/******************************* DCMI Instances *******************************/
+#define IS_DCMI_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == DCMI)
+
+/******************************* DMA2D Instances *******************************/
+#define IS_DMA2D_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == DMA2D)
+
+/******************************** DMA Instances *******************************/
+#define IS_DMA_STREAM_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == DMA1_Stream0) || \
+                                              ((__INSTANCE__) == DMA1_Stream1) || \
+                                              ((__INSTANCE__) == DMA1_Stream2) || \
+                                              ((__INSTANCE__) == DMA1_Stream3) || \
+                                              ((__INSTANCE__) == DMA1_Stream4) || \
+                                              ((__INSTANCE__) == DMA1_Stream5) || \
+                                              ((__INSTANCE__) == DMA1_Stream6) || \
+                                              ((__INSTANCE__) == DMA1_Stream7) || \
+                                              ((__INSTANCE__) == DMA2_Stream0) || \
+                                              ((__INSTANCE__) == DMA2_Stream1) || \
+                                              ((__INSTANCE__) == DMA2_Stream2) || \
+                                              ((__INSTANCE__) == DMA2_Stream3) || \
+                                              ((__INSTANCE__) == DMA2_Stream4) || \
+                                              ((__INSTANCE__) == DMA2_Stream5) || \
+                                              ((__INSTANCE__) == DMA2_Stream6) || \
+                                              ((__INSTANCE__) == DMA2_Stream7))
+
+/******************************* GPIO Instances *******************************/
+#define IS_GPIO_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == GPIOA) || \
+                                        ((__INSTANCE__) == GPIOB) || \
+                                        ((__INSTANCE__) == GPIOC) || \
+                                        ((__INSTANCE__) == GPIOD) || \
+                                        ((__INSTANCE__) == GPIOE) || \
+                                        ((__INSTANCE__) == GPIOF) || \
+                                        ((__INSTANCE__) == GPIOG) || \
+                                        ((__INSTANCE__) == GPIOH) || \
+                                        ((__INSTANCE__) == GPIOI) || \
+                                        ((__INSTANCE__) == GPIOJ) || \
+                                        ((__INSTANCE__) == GPIOK))
+
+#define IS_GPIO_AF_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == GPIOA) || \
+                                        ((__INSTANCE__) == GPIOB) || \
+                                        ((__INSTANCE__) == GPIOC) || \
+                                        ((__INSTANCE__) == GPIOD) || \
+                                        ((__INSTANCE__) == GPIOE) || \
+                                        ((__INSTANCE__) == GPIOF) || \
+                                        ((__INSTANCE__) == GPIOG) || \
+                                        ((__INSTANCE__) == GPIOH) || \
+                                        ((__INSTANCE__) == GPIOI) || \
+                                        ((__INSTANCE__) == GPIOJ) || \
+                                        ((__INSTANCE__) == GPIOK))
+
+/****************************** CEC Instances *********************************/
+#define IS_CEC_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == CEC)
+
+/****************************** QSPI Instances *********************************/
+#define IS_QSPI_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == QUADSPI)
+
+
+/******************************** I2C Instances *******************************/
+#define IS_I2C_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == I2C1) || \
+                                       ((__INSTANCE__) == I2C2) || \
+                                       ((__INSTANCE__) == I2C3) || \
+                                       ((__INSTANCE__) == I2C4))
+
+/******************************** I2S Instances *******************************/
+#define IS_I2S_ALL_INSTANCE(__INSTANCE__)  (((__INSTANCE__) == SPI1) || \
+                                    ((__INSTANCE__) == SPI2) || \
+                                    ((__INSTANCE__) == SPI3))
+
+/******************************* LPTIM Instances ********************************/
+#define IS_LPTIM_INSTANCE(__INSTANCE__) ((__INSTANCE__) == LPTIM1)
+
+/****************************** LTDC Instances ********************************/
+#define IS_LTDC_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == LTDC)
+
+/******************************* RNG Instances ********************************/
+#define IS_RNG_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == RNG)
+
+/****************************** RTC Instances *********************************/
+#define IS_RTC_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == RTC)
+
+/******************************* SAI Instances ********************************/
+#define IS_SAI_BLOCK_PERIPH(__PERIPH__) (((__PERIPH__) == SAI1_Block_A) || \
+                                     ((__PERIPH__) == SAI1_Block_B) || \
+                                     ((__PERIPH__) == SAI2_Block_A) || \
+                                     ((__PERIPH__) == SAI2_Block_B))
+
+
+/******************************** SDMMC Instances *******************************/
+#define IS_SDMMC_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == SDMMC1)
+
+
+/****************************** SPDIFRX Instances *********************************/
+#define IS_SPDIFRX_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == SPDIFRX)
+
+/******************************** SPI Instances *******************************/
+#define IS_SPI_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == SPI1) || \
+                                       ((__INSTANCE__) == SPI2) || \
+                                       ((__INSTANCE__) == SPI3) || \
+                                       ((__INSTANCE__) == SPI4) || \
+                                       ((__INSTANCE__) == SPI5) || \
+                                       ((__INSTANCE__) == SPI6))
+
+/****************** TIM Instances : All supported instances *******************/
+#define IS_TIM_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1)   || \
+                                   ((__INSTANCE__) == TIM2)   || \
+                                   ((__INSTANCE__) == TIM3)   || \
+                                   ((__INSTANCE__) == TIM4)   || \
+                                   ((__INSTANCE__) == TIM5)   || \
+                                   ((__INSTANCE__) == TIM6)   || \
+                                   ((__INSTANCE__) == TIM7)   || \
+                                   ((__INSTANCE__) == TIM8)   || \
+                                   ((__INSTANCE__) == TIM9)   || \
+                                   ((__INSTANCE__) == TIM10)  || \
+                                   ((__INSTANCE__) == TIM11)  || \
+                                   ((__INSTANCE__) == TIM12)  || \
+                                   ((__INSTANCE__) == TIM13)  || \
+                                   ((__INSTANCE__) == TIM14))
+
+/************* TIM Instances : at least 1 capture/compare channel *************/
+#define IS_TIM_CC1_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == TIM1)  || \
+                                         ((__INSTANCE__) == TIM2)  || \
+                                         ((__INSTANCE__) == TIM3)  || \
+                                         ((__INSTANCE__) == TIM4)  || \
+                                         ((__INSTANCE__) == TIM5)  || \
+                                         ((__INSTANCE__) == TIM8)  || \
+                                         ((__INSTANCE__) == TIM9)  || \
+                                         ((__INSTANCE__) == TIM10) || \
+                                         ((__INSTANCE__) == TIM11) || \
+                                         ((__INSTANCE__) == TIM12) || \
+                                         ((__INSTANCE__) == TIM13) || \
+                                         ((__INSTANCE__) == TIM14))
+
+/************ TIM Instances : at least 2 capture/compare channels *************/
+#define IS_TIM_CC2_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == TIM1)  || \
+                                         ((__INSTANCE__) == TIM2)  || \
+                                         ((__INSTANCE__) == TIM3)  || \
+                                         ((__INSTANCE__) == TIM4)  || \
+                                         ((__INSTANCE__) == TIM5)  || \
+                                         ((__INSTANCE__) == TIM8)  || \
+                                         ((__INSTANCE__) == TIM9)  || \
+                                         ((__INSTANCE__) == TIM12))
+
+/************ TIM Instances : at least 3 capture/compare channels *************/
+#define IS_TIM_CC3_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == TIM1) || \
+                                         ((__INSTANCE__) == TIM2) || \
+                                         ((__INSTANCE__) == TIM3) || \
+                                         ((__INSTANCE__) == TIM4) || \
+                                         ((__INSTANCE__) == TIM5) || \
+                                         ((__INSTANCE__) == TIM8))
+
+/************ TIM Instances : at least 4 capture/compare channels *************/
+#define IS_TIM_CC4_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                       ((__INSTANCE__) == TIM2) || \
+                                       ((__INSTANCE__) == TIM3) || \
+                                       ((__INSTANCE__) == TIM4) || \
+                                       ((__INSTANCE__) == TIM5) || \
+                                       ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting combined 3-phase PWM mode ******/
+#define IS_TIM_COMBINED3PHASEPWM_INSTANCE(__INSTANCE__) \
+                                       (((__INSTANCE__) == TIM1)    || \
+                                        ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting OCxREF clear *******************/
+#define IS_TIM_OCXREF_CLEAR_INSTANCE(__INSTANCE__)\
+                                  (((__INSTANCE__) == TIM1)    || \
+                                   ((__INSTANCE__) == TIM2)    || \
+                                   ((__INSTANCE__) == TIM3)    || \
+                                   ((__INSTANCE__) == TIM4)    || \
+                                   ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting external clock mode 1 for TIX inputs*/
+#define IS_TIM_CLOCKSOURCE_TIX_INSTANCE(__INSTANCE__)\
+                                                 (((__INSTANCE__) == TIM1)    || \
+                                                  ((__INSTANCE__) == TIM2)    || \
+                                                  ((__INSTANCE__) == TIM3)    || \
+                                                  ((__INSTANCE__) == TIM4)    || \
+                                                  ((__INSTANCE__) == TIM5)    || \
+                                                  ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting internal trigger inputs(ITRX) *******/
+#define IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(__INSTANCE__)\
+                                                   (((__INSTANCE__) == TIM1)    || \
+                                                    ((__INSTANCE__) == TIM2)    || \
+                                                    ((__INSTANCE__) == TIM3)    || \
+                                                    ((__INSTANCE__) == TIM4)    || \
+                                                    ((__INSTANCE__) == TIM5)    || \
+                                                    ((__INSTANCE__) == TIM8))
+/****************** TIM Instances : at least 5 capture/compare channels *******/
+#define IS_TIM_CC5_INSTANCE(__INSTANCE__)\
+  (((__INSTANCE__) == TIM1)    || \
+   ((__INSTANCE__) == TIM8) )
+
+/****************** TIM Instances : at least 6 capture/compare channels *******/
+#define IS_TIM_CC6_INSTANCE(__INSTANCE__)\
+  (((__INSTANCE__) == TIM1)    || \
+   ((__INSTANCE__) == TIM8))
+
+
+/******************** TIM Instances : Advanced-control timers *****************/
+#define IS_TIM_ADVANCED_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                            ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting 2 break inputs *****************/
+#define IS_TIM_BREAK_INSTANCE(__INSTANCE__)\
+  (((__INSTANCE__) == TIM1)    || \
+   ((__INSTANCE__) == TIM8))
+
+/******************* TIM Instances : Timer input XOR function *****************/
+#define IS_TIM_XOR_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == TIM1) || \
+                                         ((__INSTANCE__) == TIM2) || \
+                                         ((__INSTANCE__) == TIM3) || \
+                                         ((__INSTANCE__) == TIM4) || \
+                                         ((__INSTANCE__) == TIM5) || \
+                                         ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : DMA requests generation (UDE) *************/
+#define IS_TIM_DMA_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                       ((__INSTANCE__) == TIM2) || \
+                                       ((__INSTANCE__) == TIM3) || \
+                                       ((__INSTANCE__) == TIM4) || \
+                                       ((__INSTANCE__) == TIM5) || \
+                                       ((__INSTANCE__) == TIM6) || \
+                                       ((__INSTANCE__) == TIM7) || \
+                                       ((__INSTANCE__) == TIM8))
+
+/************ TIM Instances : DMA requests generation (CCxDE) *****************/
+#define IS_TIM_DMA_CC_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                          ((__INSTANCE__) == TIM2) || \
+                                          ((__INSTANCE__) == TIM3) || \
+                                          ((__INSTANCE__) == TIM4) || \
+                                          ((__INSTANCE__) == TIM5) || \
+                                          ((__INSTANCE__) == TIM8))
+
+/************ TIM Instances : DMA requests generation (COMDE) *****************/
+#define IS_TIM_CCDMA_INSTANCE(__INSTANCE__)  (((__INSTANCE__) == TIM1) || \
+                                          ((__INSTANCE__) == TIM2) || \
+                                          ((__INSTANCE__) == TIM3) || \
+                                          ((__INSTANCE__) == TIM4) || \
+                                          ((__INSTANCE__) == TIM5) || \
+                                          ((__INSTANCE__) == TIM8))
+
+/******************** TIM Instances : DMA burst feature ***********************/
+#define IS_TIM_DMABURST_INSTANCE(__INSTANCE__)  (((__INSTANCE__) == TIM1) || \
+                                             ((__INSTANCE__) == TIM2) || \
+                                             ((__INSTANCE__) == TIM3) || \
+                                             ((__INSTANCE__) == TIM4) || \
+                                             ((__INSTANCE__) == TIM5) || \
+                                             ((__INSTANCE__) == TIM8))
+
+/****** TIM Instances : master mode available (TIMx_CR2.MMS available )********/
+#define IS_TIM_MASTER_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                          ((__INSTANCE__) == TIM2) || \
+                                          ((__INSTANCE__) == TIM3) || \
+                                          ((__INSTANCE__) == TIM4) || \
+                                          ((__INSTANCE__) == TIM5) || \
+                                          ((__INSTANCE__) == TIM6) || \
+                                          ((__INSTANCE__) == TIM7) || \
+                                          ((__INSTANCE__) == TIM8) || \
+                                          ((__INSTANCE__) == TIM13) || \
+                                          ((__INSTANCE__) == TIM14))
+
+/*********** TIM Instances : Slave mode available (TIMx_SMCR available )*******/
+#define IS_TIM_SLAVE_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                         ((__INSTANCE__) == TIM2) || \
+                                         ((__INSTANCE__) == TIM3) || \
+                                         ((__INSTANCE__) == TIM4) || \
+                                         ((__INSTANCE__) == TIM5) || \
+                                         ((__INSTANCE__) == TIM8) || \
+                                         ((__INSTANCE__) == TIM9) || \
+                                         ((__INSTANCE__) == TIM12))
+
+/********************** TIM Instances : 32 bit Counter ************************/
+#define IS_TIM_32B_COUNTER_INSTANCE(__INSTANCE__)(((__INSTANCE__) == TIM2) || \
+                                              ((__INSTANCE__) == TIM5))
+
+/***************** TIM Instances : external trigger input available ************/
+#define IS_TIM_ETR_INSTANCE(__INSTANCE__)  (((__INSTANCE__) == TIM1) || \
+                                        ((__INSTANCE__) == TIM2) || \
+                                        ((__INSTANCE__) == TIM3) || \
+                                        ((__INSTANCE__) == TIM4) || \
+                                        ((__INSTANCE__) == TIM5) || \
+                                        ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : remapping capability **********************/
+#define IS_TIM_REMAP_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM2)  || \
+                                         ((__INSTANCE__) == TIM5)  || \
+                                         ((__INSTANCE__) == TIM11))
+
+/******************* TIM Instances : output(s) available **********************/
+#define IS_TIM_CCX_INSTANCE(__INSTANCE__, __CHANNEL__) \
+    ((((__INSTANCE__) == TIM1) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM2) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM3) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM4) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM5) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM8) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM9) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM10) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM11) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM12) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM13) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM14) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1))))
+
+/************ TIM Instances : complementary output(s) available ***************/
+#define IS_TIM_CCXN_INSTANCE(__INSTANCE__, __CHANNEL__) \
+   ((((__INSTANCE__) == TIM1) &&                    \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||           \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||           \
+      ((__CHANNEL__) == TIM_CHANNEL_3)))            \
+    ||                                          \
+    (((__INSTANCE__) == TIM8) &&                    \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||           \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||           \
+      ((__CHANNEL__) == TIM_CHANNEL_3))))
+
+/****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
+#define IS_TIM_TRGO2_INSTANCE(__INSTANCE__)\
+  (((__INSTANCE__) == TIM1)    || \
+   ((__INSTANCE__) == TIM8) )
+
+/****************** TIM Instances : supporting synchronization ****************/
+#define IS_TIM_SYNCHRO_INSTANCE(__INSTANCE__)\
+    (((__INSTANCE__) == TIM1)    || \
+     ((__INSTANCE__) == TIM2)    || \
+     ((__INSTANCE__) == TIM3)    || \
+     ((__INSTANCE__) == TIM4)    || \
+     ((__INSTANCE__) == TIM5)    || \
+     ((__INSTANCE__) == TIM6)    || \
+     ((__INSTANCE__) == TIM7)    || \
+     ((__INSTANCE__) == TIM8))
+
+/******************** USART Instances : Synchronous mode **********************/
+#define IS_USART_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                     ((__INSTANCE__) == USART2) || \
+                                     ((__INSTANCE__) == USART3) || \
+                                     ((__INSTANCE__) == USART6))
+
+/******************** UART Instances : Asynchronous mode **********************/
+#define IS_UART_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                    ((__INSTANCE__) == USART2) || \
+                                    ((__INSTANCE__) == USART3) || \
+                                    ((__INSTANCE__) == UART4)  || \
+                                    ((__INSTANCE__) == UART5)  || \
+                                    ((__INSTANCE__) == USART6) || \
+                                    ((__INSTANCE__) == UART7)  || \
+                                    ((__INSTANCE__) == UART8))
+
+/****************** UART Instances : Hardware Flow control ********************/
+#define IS_UART_HWFLOW_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                    ((__INSTANCE__) == USART2) || \
+                                    ((__INSTANCE__) == USART3) || \
+                                    ((__INSTANCE__) == UART4)  || \
+                                    ((__INSTANCE__) == UART5)  || \
+                                    ((__INSTANCE__) == USART6) || \
+                                    ((__INSTANCE__) == UART7)  || \
+                                    ((__INSTANCE__) == UART8))
+
+/********************* UART Instances : Smart card mode ***********************/
+#define IS_SMARTCARD_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                         ((__INSTANCE__) == USART2) || \
+                                         ((__INSTANCE__) == USART3) || \
+                                         ((__INSTANCE__) == USART6))
+
+/*********************** UART Instances : IRDA mode ***************************/
+#define IS_IRDA_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                    ((__INSTANCE__) == USART2) || \
+                                    ((__INSTANCE__) == USART3) || \
+                                    ((__INSTANCE__) == UART4)  || \
+                                    ((__INSTANCE__) == UART5)  || \
+                                    ((__INSTANCE__) == USART6) || \
+                                    ((__INSTANCE__) == UART7)  || \
+                                    ((__INSTANCE__) == UART8))
+
+/****************************** IWDG Instances ********************************/
+#define IS_IWDG_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == IWDG)
+
+/****************************** WWDG Instances ********************************/
+#define IS_WWDG_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == WWDG)
+
+
+/******************************************************************************/
+/*  For a painless codes migration between the STM32F7xx device product       */
+/*  lines, the aliases defined below are put in place to overcome the         */
+/*  differences in the interrupt handlers and IRQn definitions.               */
+/*  No need to update developed interrupt code when moving across             */
+/*  product lines within the same STM32F7 Family                              */
+/******************************************************************************/
+
+/* Aliases for __IRQn */
+#define HASH_RNG_IRQn              RNG_IRQn
+
+/* Aliases for __IRQHandler */
+#define HASH_RNG_IRQHandler        RNG_IRQHandler
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32F746xx_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/cmsis/devinc/stm32f756xx.h
+++ b/stmhal/cmsis/devinc/stm32f756xx.h
@@ -1,0 +1,9635 @@
+/**
+  ******************************************************************************
+  * @file    stm32f756xx.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   CMSIS STM32F756xx Device Peripheral Access Layer Header File.
+  *
+  *          This file contains:
+  *           - Data structures and the address mapping for all peripherals
+  *           - Peripheral's registers declarations and bits definition
+  *           - Macros to access peripheral’s registers hardware
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS_Device
+  * @{
+  */
+
+/** @addtogroup stm32f756xx
+  * @{
+  */
+
+#ifndef __STM32F756xx_H
+#define __STM32F756xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Configuration_section_for_CMSIS
+  * @{
+  */
+
+/**
+ * @brief STM32F7xx Interrupt Number Definition, according to the selected device
+ *        in @ref Library_configuration_section
+ */
+typedef enum
+{
+/******  Cortex-M7 Processor Exceptions Numbers ****************************************************************/
+  NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                          */
+  MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M7 Memory Management Interrupt                           */
+  BusFault_IRQn               = -11,    /*!< 5 Cortex-M7 Bus Fault Interrupt                                   */
+  UsageFault_IRQn             = -10,    /*!< 6 Cortex-M7 Usage Fault Interrupt                                 */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M7 SV Call Interrupt                                    */
+  DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M7 Debug Monitor Interrupt                              */
+  PendSV_IRQn                 = -2,     /*!< 14 Cortex-M7 Pend SV Interrupt                                    */
+  SysTick_IRQn                = -1,     /*!< 15 Cortex-M7 System Tick Interrupt                                */
+/******  STM32 specific Interrupt Numbers **********************************************************************/
+  WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
+  PVD_IRQn                    = 1,      /*!< PVD through EXTI Line detection Interrupt                         */
+  TAMP_STAMP_IRQn             = 2,      /*!< Tamper and TimeStamp interrupts through the EXTI line             */
+  RTC_WKUP_IRQn               = 3,      /*!< RTC Wakeup interrupt through the EXTI line                        */
+  FLASH_IRQn                  = 4,      /*!< FLASH global Interrupt                                            */
+  RCC_IRQn                    = 5,      /*!< RCC global Interrupt                                              */
+  EXTI0_IRQn                  = 6,      /*!< EXTI Line0 Interrupt                                              */
+  EXTI1_IRQn                  = 7,      /*!< EXTI Line1 Interrupt                                              */
+  EXTI2_IRQn                  = 8,      /*!< EXTI Line2 Interrupt                                              */
+  EXTI3_IRQn                  = 9,      /*!< EXTI Line3 Interrupt                                              */
+  EXTI4_IRQn                  = 10,     /*!< EXTI Line4 Interrupt                                              */
+  DMA1_Stream0_IRQn           = 11,     /*!< DMA1 Stream 0 global Interrupt                                    */
+  DMA1_Stream1_IRQn           = 12,     /*!< DMA1 Stream 1 global Interrupt                                    */
+  DMA1_Stream2_IRQn           = 13,     /*!< DMA1 Stream 2 global Interrupt                                    */
+  DMA1_Stream3_IRQn           = 14,     /*!< DMA1 Stream 3 global Interrupt                                    */
+  DMA1_Stream4_IRQn           = 15,     /*!< DMA1 Stream 4 global Interrupt                                    */
+  DMA1_Stream5_IRQn           = 16,     /*!< DMA1 Stream 5 global Interrupt                                    */
+  DMA1_Stream6_IRQn           = 17,     /*!< DMA1 Stream 6 global Interrupt                                    */
+  ADC_IRQn                    = 18,     /*!< ADC1, ADC2 and ADC3 global Interrupts                             */
+  CAN1_TX_IRQn                = 19,     /*!< CAN1 TX Interrupt                                                 */
+  CAN1_RX0_IRQn               = 20,     /*!< CAN1 RX0 Interrupt                                                */
+  CAN1_RX1_IRQn               = 21,     /*!< CAN1 RX1 Interrupt                                                */
+  CAN1_SCE_IRQn               = 22,     /*!< CAN1 SCE Interrupt                                                */
+  EXTI9_5_IRQn                = 23,     /*!< External Line[9:5] Interrupts                                     */
+  TIM1_BRK_TIM9_IRQn          = 24,     /*!< TIM1 Break interrupt and TIM9 global interrupt                    */
+  TIM1_UP_TIM10_IRQn          = 25,     /*!< TIM1 Update Interrupt and TIM10 global interrupt                  */
+  TIM1_TRG_COM_TIM11_IRQn     = 26,     /*!< TIM1 Trigger and Commutation Interrupt and TIM11 global interrupt */
+  TIM1_CC_IRQn                = 27,     /*!< TIM1 Capture Compare Interrupt                                    */
+  TIM2_IRQn                   = 28,     /*!< TIM2 global Interrupt                                             */
+  TIM3_IRQn                   = 29,     /*!< TIM3 global Interrupt                                             */
+  TIM4_IRQn                   = 30,     /*!< TIM4 global Interrupt                                             */
+  I2C1_EV_IRQn                = 31,     /*!< I2C1 Event Interrupt                                              */
+  I2C1_ER_IRQn                = 32,     /*!< I2C1 Error Interrupt                                              */
+  I2C2_EV_IRQn                = 33,     /*!< I2C2 Event Interrupt                                              */
+  I2C2_ER_IRQn                = 34,     /*!< I2C2 Error Interrupt                                              */
+  SPI1_IRQn                   = 35,     /*!< SPI1 global Interrupt                                             */
+  SPI2_IRQn                   = 36,     /*!< SPI2 global Interrupt                                             */
+  USART1_IRQn                 = 37,     /*!< USART1 global Interrupt                                           */
+  USART2_IRQn                 = 38,     /*!< USART2 global Interrupt                                           */
+  USART3_IRQn                 = 39,     /*!< USART3 global Interrupt                                           */
+  EXTI15_10_IRQn              = 40,     /*!< External Line[15:10] Interrupts                                   */
+  RTC_Alarm_IRQn              = 41,     /*!< RTC Alarm (A and B) through EXTI Line Interrupt                   */
+  OTG_FS_WKUP_IRQn            = 42,     /*!< USB OTG FS Wakeup through EXTI line interrupt                     */
+  TIM8_BRK_TIM12_IRQn         = 43,     /*!< TIM8 Break Interrupt and TIM12 global interrupt                   */
+  TIM8_UP_TIM13_IRQn          = 44,     /*!< TIM8 Update Interrupt and TIM13 global interrupt                  */
+  TIM8_TRG_COM_TIM14_IRQn     = 45,     /*!< TIM8 Trigger and Commutation Interrupt and TIM14 global interrupt */
+  TIM8_CC_IRQn                = 46,     /*!< TIM8 Capture Compare Interrupt                                    */
+  DMA1_Stream7_IRQn           = 47,     /*!< DMA1 Stream7 Interrupt                                            */
+  FMC_IRQn                    = 48,     /*!< FMC global Interrupt                                              */
+  SDMMC1_IRQn                 = 49,     /*!< SDMMC1 global Interrupt                                             */
+  TIM5_IRQn                   = 50,     /*!< TIM5 global Interrupt                                             */
+  SPI3_IRQn                   = 51,     /*!< SPI3 global Interrupt                                             */
+  UART4_IRQn                  = 52,     /*!< UART4 global Interrupt                                            */
+  UART5_IRQn                  = 53,     /*!< UART5 global Interrupt                                            */
+  TIM6_DAC_IRQn               = 54,     /*!< TIM6 global and DAC1&2 underrun error  interrupts                 */
+  TIM7_IRQn                   = 55,     /*!< TIM7 global interrupt                                             */
+  DMA2_Stream0_IRQn           = 56,     /*!< DMA2 Stream 0 global Interrupt                                    */
+  DMA2_Stream1_IRQn           = 57,     /*!< DMA2 Stream 1 global Interrupt                                    */
+  DMA2_Stream2_IRQn           = 58,     /*!< DMA2 Stream 2 global Interrupt                                    */
+  DMA2_Stream3_IRQn           = 59,     /*!< DMA2 Stream 3 global Interrupt                                    */
+  DMA2_Stream4_IRQn           = 60,     /*!< DMA2 Stream 4 global Interrupt                                    */
+  ETH_IRQn                    = 61,     /*!< Ethernet global Interrupt                                         */
+  ETH_WKUP_IRQn               = 62,     /*!< Ethernet Wakeup through EXTI line Interrupt                       */
+  CAN2_TX_IRQn                = 63,     /*!< CAN2 TX Interrupt                                                 */
+  CAN2_RX0_IRQn               = 64,     /*!< CAN2 RX0 Interrupt                                                */
+  CAN2_RX1_IRQn               = 65,     /*!< CAN2 RX1 Interrupt                                                */
+  CAN2_SCE_IRQn               = 66,     /*!< CAN2 SCE Interrupt                                                */
+  OTG_FS_IRQn                 = 67,     /*!< USB OTG FS global Interrupt                                       */
+  DMA2_Stream5_IRQn           = 68,     /*!< DMA2 Stream 5 global interrupt                                    */
+  DMA2_Stream6_IRQn           = 69,     /*!< DMA2 Stream 6 global interrupt                                    */
+  DMA2_Stream7_IRQn           = 70,     /*!< DMA2 Stream 7 global interrupt                                    */
+  USART6_IRQn                 = 71,     /*!< USART6 global interrupt                                           */
+  I2C3_EV_IRQn                = 72,     /*!< I2C3 event interrupt                                              */
+  I2C3_ER_IRQn                = 73,     /*!< I2C3 error interrupt                                              */
+  OTG_HS_EP1_OUT_IRQn         = 74,     /*!< USB OTG HS End Point 1 Out global interrupt                       */
+  OTG_HS_EP1_IN_IRQn          = 75,     /*!< USB OTG HS End Point 1 In global interrupt                        */
+  OTG_HS_WKUP_IRQn            = 76,     /*!< USB OTG HS Wakeup through EXTI interrupt                          */
+  OTG_HS_IRQn                 = 77,     /*!< USB OTG HS global interrupt                                       */
+  DCMI_IRQn                   = 78,     /*!< DCMI global interrupt                                             */
+  CRYP_IRQn                   = 79,     /*!< CRYP crypto global interrupt                                      */
+  HASH_RNG_IRQn               = 80,     /*!< Hash and Rng global interrupt                                     */
+  FPU_IRQn                    = 81,     /*!< FPU global interrupt                                              */
+  UART7_IRQn                  = 82,     /*!< UART7 global interrupt                                            */
+  UART8_IRQn                  = 83,     /*!< UART8 global interrupt                                            */
+  SPI4_IRQn                   = 84,     /*!< SPI4 global Interrupt                                             */
+  SPI5_IRQn                   = 85,     /*!< SPI5 global Interrupt                                             */
+  SPI6_IRQn                   = 86,     /*!< SPI6 global Interrupt                                             */
+  SAI1_IRQn                   = 87,     /*!< SAI1 global Interrupt                                             */
+  LTDC_IRQn                   = 88,     /*!< LTDC global Interrupt                                             */
+  LTDC_ER_IRQn                = 89,     /*!< LTDC Error global Interrupt                                       */
+  DMA2D_IRQn                  = 90,     /*!< DMA2D global Interrupt                                           */
+  SAI2_IRQn                   = 91,     /*!< SAI2 global Interrupt                                             */
+  QUADSPI_IRQn                = 92,     /*!< Quad SPI global interrupt                                         */
+  LPTIM1_IRQn                 = 93,     /*!< LP TIM1 interrupt                                                 */
+  CEC_IRQn                    = 94,     /*!< HDMI-CEC global Interrupt                                         */
+  I2C4_EV_IRQn                = 95,     /*!< I2C4 Event Interrupt                                              */
+  I2C4_ER_IRQn                = 96,     /*!< I2C4 Error Interrupt                                              */
+  SPDIF_RX_IRQn               = 97      /*!< SPDIF-RX global Interrupt                                         */
+} IRQn_Type;
+
+/**
+  * @}
+  */
+
+/**
+ * @brief Configuration of the Cortex-M7 Processor and Core Peripherals
+ */
+#define __CM7_REV                 0x0000   /*!< Cortex-M7 revision r0p0                       */
+#define __MPU_PRESENT             1       /*!< CM7 provides an MPU                           */
+#define __NVIC_PRIO_BITS          4       /*!< CM7 uses 4 Bits for the Priority Levels       */
+#define __Vendor_SysTickConfig    0       /*!< Set to 1 if different SysTick Config is used  */
+#define __FPU_PRESENT             1       /*!< FPU present                                   */
+#define __ICACHE_PRESENT          1       /*!< CM7 instruction cache present                 */
+#define __DCACHE_PRESENT          1       /*!< CM7 data cache present                        */
+#include "core_cm7.h"                 /*!< Cortex-M7 processor and core peripherals      */
+
+
+#include "system_stm32f7xx.h"
+#include <stdint.h>
+
+/** @addtogroup Peripheral_registers_structures
+  * @{
+  */
+
+/**
+  * @brief Analog to Digital Converter
+  */
+
+typedef struct
+{
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+} ADC_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
+                             AND triple modes,                            Address offset: ADC1 base address + 0x308 */
+} ADC_Common_TypeDef;
+
+
+/**
+  * @brief Controller Area Network TxMailBox
+  */
+
+typedef struct
+{
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
+} CAN_TxMailBox_TypeDef;
+
+/**
+  * @brief Controller Area Network FIFOMailBox
+  */
+
+typedef struct
+{
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+} CAN_FIFOMailBox_TypeDef;
+
+/**
+  * @brief Controller Area Network FilterRegister
+  */
+
+typedef struct
+{
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
+} CAN_FilterRegister_TypeDef;
+
+/**
+  * @brief Controller Area Network
+  */
+
+typedef struct
+{
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
+  CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
+  CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
+  uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */
+  CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
+} CAN_TypeDef;
+
+/**
+  * @brief HDMI-CEC
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;           /*!< CEC control register,                                       Address offset:0x00 */
+  __IO uint32_t CFGR;         /*!< CEC configuration register,                                 Address offset:0x04 */
+  __IO uint32_t TXDR;         /*!< CEC Tx data register ,                                      Address offset:0x08 */
+  __IO uint32_t RXDR;         /*!< CEC Rx Data Register,                                       Address offset:0x0C */
+  __IO uint32_t ISR;          /*!< CEC Interrupt and Status Register,                          Address offset:0x10 */
+  __IO uint32_t IER;          /*!< CEC interrupt enable register,                              Address offset:0x14 */
+}CEC_TypeDef;
+
+
+/**
+  * @brief CRC calculation unit
+  */
+
+typedef struct
+{
+  __IO uint32_t  DR;          /*!< CRC Data register,                           Address offset: 0x00 */
+  __IO uint8_t   IDR;         /*!< CRC Independent data register,               Address offset: 0x04 */
+  uint8_t        RESERVED0;   /*!< Reserved, 0x05                                                    */
+  uint16_t       RESERVED1;   /*!< Reserved, 0x06                                                    */
+  __IO uint32_t  CR;          /*!< CRC Control register,                        Address offset: 0x08 */
+  uint32_t       RESERVED2;   /*!< Reserved,                                                    0x0C */
+  __IO uint32_t  INIT;        /*!< Initial CRC value register,                  Address offset: 0x10 */
+  __IO uint32_t  POL;         /*!< CRC polynomial register,                     Address offset: 0x14 */
+} CRC_TypeDef;
+
+/**
+  * @brief Digital to Analog Converter
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+} DAC_TypeDef;
+
+/**
+  * @brief Debug MCU
+  */
+
+typedef struct
+{
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+}DBGMCU_TypeDef;
+
+/**
+  * @brief DCMI
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
+  __IO uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
+  __IO uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
+  __IO uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
+  __IO uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
+  __IO uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
+  __IO uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
+  __IO uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
+  __IO uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
+  __IO uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
+  __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
+} DCMI_TypeDef;
+
+/**
+  * @brief DMA Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+} DMA_Stream_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+} DMA_TypeDef;
+
+
+/**
+  * @brief DMA2D Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
+  __IO uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
+  __IO uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
+  __IO uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
+  __IO uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
+  __IO uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
+  __IO uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
+  __IO uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
+  __IO uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
+  __IO uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
+  __IO uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
+  __IO uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
+  __IO uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
+  __IO uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
+  __IO uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
+  __IO uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
+  __IO uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
+  __IO uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
+  __IO uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
+  __IO uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
+  uint32_t      RESERVED[236]; /*!< Reserved, 0x50-0x3FF */
+  __IO uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
+  __IO uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
+} DMA2D_TypeDef;
+
+
+/**
+  * @brief Ethernet MAC
+  */
+
+typedef struct
+{
+  __IO uint32_t MACCR;
+  __IO uint32_t MACFFR;
+  __IO uint32_t MACHTHR;
+  __IO uint32_t MACHTLR;
+  __IO uint32_t MACMIIAR;
+  __IO uint32_t MACMIIDR;
+  __IO uint32_t MACFCR;
+  __IO uint32_t MACVLANTR;             /*    8 */
+  uint32_t      RESERVED0[2];
+  __IO uint32_t MACRWUFFR;             /*   11 */
+  __IO uint32_t MACPMTCSR;
+  uint32_t      RESERVED1[2];
+  __IO uint32_t MACSR;                 /*   15 */
+  __IO uint32_t MACIMR;
+  __IO uint32_t MACA0HR;
+  __IO uint32_t MACA0LR;
+  __IO uint32_t MACA1HR;
+  __IO uint32_t MACA1LR;
+  __IO uint32_t MACA2HR;
+  __IO uint32_t MACA2LR;
+  __IO uint32_t MACA3HR;
+  __IO uint32_t MACA3LR;               /*   24 */
+  uint32_t      RESERVED2[40];
+  __IO uint32_t MMCCR;                 /*   65 */
+  __IO uint32_t MMCRIR;
+  __IO uint32_t MMCTIR;
+  __IO uint32_t MMCRIMR;
+  __IO uint32_t MMCTIMR;               /*   69 */
+  uint32_t      RESERVED3[14];
+  __IO uint32_t MMCTGFSCCR;            /*   84 */
+  __IO uint32_t MMCTGFMSCCR;
+  uint32_t      RESERVED4[5];
+  __IO uint32_t MMCTGFCR;
+  uint32_t      RESERVED5[10];
+  __IO uint32_t MMCRFCECR;
+  __IO uint32_t MMCRFAECR;
+  uint32_t      RESERVED6[10];
+  __IO uint32_t MMCRGUFCR;
+  uint32_t      RESERVED7[334];
+  __IO uint32_t PTPTSCR;
+  __IO uint32_t PTPSSIR;
+  __IO uint32_t PTPTSHR;
+  __IO uint32_t PTPTSLR;
+  __IO uint32_t PTPTSHUR;
+  __IO uint32_t PTPTSLUR;
+  __IO uint32_t PTPTSAR;
+  __IO uint32_t PTPTTHR;
+  __IO uint32_t PTPTTLR;
+  __IO uint32_t RESERVED8;
+  __IO uint32_t PTPTSSR;
+  uint32_t      RESERVED9[565];
+  __IO uint32_t DMABMR;
+  __IO uint32_t DMATPDR;
+  __IO uint32_t DMARPDR;
+  __IO uint32_t DMARDLAR;
+  __IO uint32_t DMATDLAR;
+  __IO uint32_t DMASR;
+  __IO uint32_t DMAOMR;
+  __IO uint32_t DMAIER;
+  __IO uint32_t DMAMFBOCR;
+  __IO uint32_t DMARSWTR;
+  uint32_t      RESERVED10[8];
+  __IO uint32_t DMACHTDR;
+  __IO uint32_t DMACHRDR;
+  __IO uint32_t DMACHTBAR;
+  __IO uint32_t DMACHRBAR;
+} ETH_TypeDef;
+
+/**
+  * @brief External Interrupt/Event Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+} EXTI_TypeDef;
+
+/**
+  * @brief FLASH Registers
+  */
+
+typedef struct
+{
+  __IO uint32_t ACR;      /*!< FLASH access control register,     Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,                Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,         Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,             Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,            Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,    Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1 ,  Address offset: 0x18 */
+} FLASH_TypeDef;
+
+
+
+/**
+  * @brief Flexible Memory Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
+} FMC_Bank1_TypeDef;
+
+/**
+  * @brief Flexible Memory Controller Bank1E
+  */
+
+typedef struct
+{
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+} FMC_Bank1E_TypeDef;
+
+/**
+  * @brief Flexible Memory Controller Bank3
+  */
+
+typedef struct
+{
+  __IO uint32_t PCR;        /*!< NAND Flash control register,                       Address offset: 0x80 */
+  __IO uint32_t SR;         /*!< NAND Flash FIFO status and interrupt register,     Address offset: 0x84 */
+  __IO uint32_t PMEM;       /*!< NAND Flash Common memory space timing register,    Address offset: 0x88 */
+  __IO uint32_t PATT;       /*!< NAND Flash Attribute memory space timing register, Address offset: 0x8C */
+  uint32_t      RESERVED0;  /*!< Reserved, 0x90                                                          */
+  __IO uint32_t ECCR;       /*!< NAND Flash ECC result registers,                   Address offset: 0x94 */
+} FMC_Bank3_TypeDef;
+
+/**
+  * @brief Flexible Memory Controller Bank5_6
+  */
+
+typedef struct
+{
+  __IO uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
+  __IO uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
+  __IO uint32_t SDCMR;       /*!< SDRAM Command Mode register,    Address offset: 0x150  */
+  __IO uint32_t SDRTR;       /*!< SDRAM Refresh Timer register,   Address offset: 0x154  */
+  __IO uint32_t SDSR;        /*!< SDRAM Status register,          Address offset: 0x158  */
+} FMC_Bank5_6_TypeDef;
+
+
+/**
+  * @brief General Purpose I/O
+  */
+
+typedef struct
+{
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+} GPIO_TypeDef;
+
+/**
+  * @brief System configuration controller
+  */
+
+typedef struct
+{
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+} SYSCFG_TypeDef;
+
+/**
+  * @brief Inter-integrated Circuit Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< I2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;      /*!< I2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;     /*!< I2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;     /*!< I2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;  /*!< I2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR; /*!< I2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;      /*!< I2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;      /*!< I2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;     /*!< I2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;     /*!< I2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;     /*!< I2C Transmit data register,        Address offset: 0x28 */
+} I2C_TypeDef;
+
+/**
+  * @brief Independent WATCHDOG
+  */
+
+typedef struct
+{
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t WINR; /*!< IWDG Window register,    Address offset: 0x10 */
+} IWDG_TypeDef;
+
+
+/**
+  * @brief LCD-TFT Display Controller
+  */
+
+typedef struct
+{
+  uint32_t      RESERVED0[2];  /*!< Reserved, 0x00-0x04 */
+  __IO uint32_t SSCR;          /*!< LTDC Synchronization Size Configuration Register,    Address offset: 0x08 */
+  __IO uint32_t BPCR;          /*!< LTDC Back Porch Configuration Register,              Address offset: 0x0C */
+  __IO uint32_t AWCR;          /*!< LTDC Active Width Configuration Register,            Address offset: 0x10 */
+  __IO uint32_t TWCR;          /*!< LTDC Total Width Configuration Register,             Address offset: 0x14 */
+  __IO uint32_t GCR;           /*!< LTDC Global Control Register,                        Address offset: 0x18 */
+  uint32_t      RESERVED1[2];  /*!< Reserved, 0x1C-0x20 */
+  __IO uint32_t SRCR;          /*!< LTDC Shadow Reload Configuration Register,           Address offset: 0x24 */
+  uint32_t      RESERVED2[1];  /*!< Reserved, 0x28 */
+  __IO uint32_t BCCR;          /*!< LTDC Background Color Configuration Register,        Address offset: 0x2C */
+  uint32_t      RESERVED3[1];  /*!< Reserved, 0x30 */
+  __IO uint32_t IER;           /*!< LTDC Interrupt Enable Register,                      Address offset: 0x34 */
+  __IO uint32_t ISR;           /*!< LTDC Interrupt Status Register,                      Address offset: 0x38 */
+  __IO uint32_t ICR;           /*!< LTDC Interrupt Clear Register,                       Address offset: 0x3C */
+  __IO uint32_t LIPCR;         /*!< LTDC Line Interrupt Position Configuration Register, Address offset: 0x40 */
+  __IO uint32_t CPSR;          /*!< LTDC Current Position Status Register,               Address offset: 0x44 */
+  __IO uint32_t CDSR;         /*!< LTDC Current Display Status Register,                 Address offset: 0x48 */
+} LTDC_TypeDef;
+
+/**
+  * @brief LCD-TFT Display layer x Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;            /*!< LTDC Layerx Control Register                                  Address offset: 0x84 */
+  __IO uint32_t WHPCR;         /*!< LTDC Layerx Window Horizontal Position Configuration Register Address offset: 0x88 */
+  __IO uint32_t WVPCR;         /*!< LTDC Layerx Window Vertical Position Configuration Register   Address offset: 0x8C */
+  __IO uint32_t CKCR;          /*!< LTDC Layerx Color Keying Configuration Register               Address offset: 0x90 */
+  __IO uint32_t PFCR;          /*!< LTDC Layerx Pixel Format Configuration Register               Address offset: 0x94 */
+  __IO uint32_t CACR;          /*!< LTDC Layerx Constant Alpha Configuration Register             Address offset: 0x98 */
+  __IO uint32_t DCCR;          /*!< LTDC Layerx Default Color Configuration Register              Address offset: 0x9C */
+  __IO uint32_t BFCR;          /*!< LTDC Layerx Blending Factors Configuration Register           Address offset: 0xA0 */
+  uint32_t      RESERVED0[2];  /*!< Reserved */
+  __IO uint32_t CFBAR;         /*!< LTDC Layerx Color Frame Buffer Address Register               Address offset: 0xAC */
+  __IO uint32_t CFBLR;         /*!< LTDC Layerx Color Frame Buffer Length Register                Address offset: 0xB0 */
+  __IO uint32_t CFBLNR;        /*!< LTDC Layerx ColorFrame Buffer Line Number Register            Address offset: 0xB4 */
+  uint32_t      RESERVED1[3];  /*!< Reserved */
+  __IO uint32_t CLUTWR;         /*!< LTDC Layerx CLUT Write Register                              Address offset: 0x144 */
+
+} LTDC_Layer_TypeDef;
+
+
+/**
+  * @brief Power Control
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;   /*!< PWR power control register 1,        Address offset: 0x00 */
+  __IO uint32_t CSR1;  /*!< PWR power control/status register 2, Address offset: 0x04 */
+  __IO uint32_t CR2;   /*!< PWR power control register 2,        Address offset: 0x08 */
+  __IO uint32_t CSR2;  /*!< PWR power control/status register 2, Address offset: 0x0C */
+} PWR_TypeDef;
+
+
+/**
+  * @brief Reset and Clock Control
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
+  __IO uint32_t DCKCFGR1;      /*!< RCC Dedicated Clocks configuration register1,                 Address offset: 0x8C */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x90 */
+
+} RCC_TypeDef;
+
+/**
+  * @brief Real-Time Clock
+  */
+
+typedef struct
+{
+  __IO uint32_t TR;         /*!< RTC time register,                                         Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< RTC date register,                                         Address offset: 0x04 */
+  __IO uint32_t CR;         /*!< RTC control register,                                      Address offset: 0x08 */
+  __IO uint32_t ISR;        /*!< RTC initialization and status register,                    Address offset: 0x0C */
+  __IO uint32_t PRER;       /*!< RTC prescaler register,                                    Address offset: 0x10 */
+  __IO uint32_t WUTR;       /*!< RTC wakeup timer register,                                 Address offset: 0x14 */
+       uint32_t reserved;   /*!< Reserved  */
+  __IO uint32_t ALRMAR;     /*!< RTC alarm A register,                                      Address offset: 0x1C */
+  __IO uint32_t ALRMBR;     /*!< RTC alarm B register,                                      Address offset: 0x20 */
+  __IO uint32_t WPR;        /*!< RTC write protection register,                             Address offset: 0x24 */
+  __IO uint32_t SSR;        /*!< RTC sub second register,                                   Address offset: 0x28 */
+  __IO uint32_t SHIFTR;     /*!< RTC shift control register,                                Address offset: 0x2C */
+  __IO uint32_t TSTR;       /*!< RTC time stamp time register,                              Address offset: 0x30 */
+  __IO uint32_t TSDR;       /*!< RTC time stamp date register,                              Address offset: 0x34 */
+  __IO uint32_t TSSSR;      /*!< RTC time-stamp sub second register,                        Address offset: 0x38 */
+  __IO uint32_t CALR;       /*!< RTC calibration register,                                  Address offset: 0x3C */
+  __IO uint32_t TAMPCR;     /*!< RTC tamper configuration register,                         Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;   /*!< RTC alarm A sub second register,                           Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;   /*!< RTC alarm B sub second register,                           Address offset: 0x48 */
+  __IO uint32_t OR;         /*!< RTC option register,                                       Address offset: 0x4C */
+  __IO uint32_t BKP0R;      /*!< RTC backup register 0,                                     Address offset: 0x50 */
+  __IO uint32_t BKP1R;      /*!< RTC backup register 1,                                     Address offset: 0x54 */
+  __IO uint32_t BKP2R;      /*!< RTC backup register 2,                                     Address offset: 0x58 */
+  __IO uint32_t BKP3R;      /*!< RTC backup register 3,                                     Address offset: 0x5C */
+  __IO uint32_t BKP4R;      /*!< RTC backup register 4,                                     Address offset: 0x60 */
+  __IO uint32_t BKP5R;      /*!< RTC backup register 5,                                     Address offset: 0x64 */
+  __IO uint32_t BKP6R;      /*!< RTC backup register 6,                                     Address offset: 0x68 */
+  __IO uint32_t BKP7R;      /*!< RTC backup register 7,                                     Address offset: 0x6C */
+  __IO uint32_t BKP8R;      /*!< RTC backup register 8,                                     Address offset: 0x70 */
+  __IO uint32_t BKP9R;      /*!< RTC backup register 9,                                     Address offset: 0x74 */
+  __IO uint32_t BKP10R;     /*!< RTC backup register 10,                                    Address offset: 0x78 */
+  __IO uint32_t BKP11R;     /*!< RTC backup register 11,                                    Address offset: 0x7C */
+  __IO uint32_t BKP12R;     /*!< RTC backup register 12,                                    Address offset: 0x80 */
+  __IO uint32_t BKP13R;     /*!< RTC backup register 13,                                    Address offset: 0x84 */
+  __IO uint32_t BKP14R;     /*!< RTC backup register 14,                                    Address offset: 0x88 */
+  __IO uint32_t BKP15R;     /*!< RTC backup register 15,                                    Address offset: 0x8C */
+  __IO uint32_t BKP16R;     /*!< RTC backup register 16,                                    Address offset: 0x90 */
+  __IO uint32_t BKP17R;     /*!< RTC backup register 17,                                    Address offset: 0x94 */
+  __IO uint32_t BKP18R;     /*!< RTC backup register 18,                                    Address offset: 0x98 */
+  __IO uint32_t BKP19R;     /*!< RTC backup register 19,                                    Address offset: 0x9C */
+  __IO uint32_t BKP20R;     /*!< RTC backup register 20,                                    Address offset: 0xA0 */
+  __IO uint32_t BKP21R;     /*!< RTC backup register 21,                                    Address offset: 0xA4 */
+  __IO uint32_t BKP22R;     /*!< RTC backup register 22,                                    Address offset: 0xA8 */
+  __IO uint32_t BKP23R;     /*!< RTC backup register 23,                                    Address offset: 0xAC */
+  __IO uint32_t BKP24R;     /*!< RTC backup register 24,                                    Address offset: 0xB0 */
+  __IO uint32_t BKP25R;     /*!< RTC backup register 25,                                    Address offset: 0xB4 */
+  __IO uint32_t BKP26R;     /*!< RTC backup register 26,                                    Address offset: 0xB8 */
+  __IO uint32_t BKP27R;     /*!< RTC backup register 27,                                    Address offset: 0xBC */
+  __IO uint32_t BKP28R;     /*!< RTC backup register 28,                                    Address offset: 0xC0 */
+  __IO uint32_t BKP29R;     /*!< RTC backup register 29,                                    Address offset: 0xC4 */
+  __IO uint32_t BKP30R;     /*!< RTC backup register 30,                                    Address offset: 0xC8 */
+  __IO uint32_t BKP31R;     /*!< RTC backup register 31,                                    Address offset: 0xCC */
+} RTC_TypeDef;
+
+
+/**
+  * @brief Serial Audio Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
+} SAI_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
+  __IO uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
+  __IO uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
+  __IO uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
+  __IO uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
+  __IO uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
+  __IO uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
+} SAI_Block_TypeDef;
+
+/**
+  * @brief SPDIF-RX Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t   CR;           /*!< Control register,                   Address offset: 0x00 */
+  __IO uint32_t   IMR;          /*!< Interrupt mask register,            Address offset: 0x04 */
+  __IO uint32_t   SR;           /*!< Status register,                    Address offset: 0x08 */
+  __IO uint32_t   IFCR;         /*!< Interrupt Flag Clear register,      Address offset: 0x0C */
+  __IO uint32_t   DR;           /*!< Data input register,                Address offset: 0x10 */
+  __IO uint32_t   CSR;          /*!< Channel Status register,            Address offset: 0x14 */
+  __IO uint32_t   DIR;          /*!< Debug Information register,         Address offset: 0x18 */
+} SPDIFRX_TypeDef;
+
+
+/**
+  * @brief SD host Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t POWER;          /*!< SDMMC power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;          /*!< SDMMClock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;            /*!< SDMMC argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;            /*!< SDMMC command register,          Address offset: 0x0C */
+  __I uint32_t  RESPCMD;        /*!< SDMMC command response register, Address offset: 0x10 */
+  __I uint32_t  RESP1;          /*!< SDMMC response 1 register,       Address offset: 0x14 */
+  __I uint32_t  RESP2;          /*!< SDMMC response 2 register,       Address offset: 0x18 */
+  __I uint32_t  RESP3;          /*!< SDMMC response 3 register,       Address offset: 0x1C */
+  __I uint32_t  RESP4;          /*!< SDMMC response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;         /*!< SDMMC data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;           /*!< SDMMC data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;          /*!< SDMMC data control register,     Address offset: 0x2C */
+  __I uint32_t  DCOUNT;         /*!< SDMMC data counter register,     Address offset: 0x30 */
+  __I uint32_t  STA;            /*!< SDMMC status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;            /*!< SDMMC interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;           /*!< SDMMC mask register,             Address offset: 0x3C */
+  uint32_t      RESERVED0[2];   /*!< Reserved, 0x40-0x44                                  */
+  __I uint32_t  FIFOCNT;        /*!< SDMMC FIFO counter register,     Address offset: 0x48 */
+  uint32_t      RESERVED1[13];  /*!< Reserved, 0x4C-0x7C                                  */
+  __IO uint32_t FIFO;           /*!< SDMMC data FIFO register,        Address offset: 0x80 */
+} SDMMC_TypeDef;
+
+/**
+  * @brief Serial Peripheral Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+} SPI_TypeDef;
+
+/**
+  * @brief QUAD Serial Peripheral Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
+  __IO uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
+  __IO uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
+  __IO uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
+  __IO uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
+  __IO uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
+  __IO uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
+  __IO uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
+  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
+  __IO uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
+  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
+} QUADSPI_TypeDef;
+
+/**
+  * @brief TIM
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CCMR3;       /*!< TIM capture/compare mode register 3,      Address offset: 0x54 */
+  __IO uint32_t CCR5;        /*!< TIM capture/compare mode register5,       Address offset: 0x58 */
+  __IO uint32_t CCR6;        /*!< TIM capture/compare mode register6,       Address offset: 0x5C */
+
+} TIM_TypeDef;
+
+/**
+  * @brief LPTIMIMER
+  */
+typedef struct
+{
+  __IO uint32_t ISR;      /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;      /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;      /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;     /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;      /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;      /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;      /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t OR;       /*!< LPTIM Option register,                              Address offset: 0x20 */
+} LPTIM_TypeDef;
+
+
+/**
+  * @brief Universal Synchronous Asynchronous Receiver Transmitter
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;    /*!< USART Control register 1,                 Address offset: 0x00 */
+  __IO uint32_t CR2;    /*!< USART Control register 2,                 Address offset: 0x04 */
+  __IO uint32_t CR3;    /*!< USART Control register 3,                 Address offset: 0x08 */
+  __IO uint32_t BRR;    /*!< USART Baud rate register,                 Address offset: 0x0C */
+  __IO uint32_t GTPR;   /*!< USART Guard time and prescaler register,  Address offset: 0x10 */
+  __IO uint32_t RTOR;   /*!< USART Receiver Time Out register,         Address offset: 0x14 */
+  __IO uint32_t RQR;    /*!< USART Request register,                   Address offset: 0x18 */
+  __IO uint32_t ISR;    /*!< USART Interrupt and status register,      Address offset: 0x1C */
+  __IO uint32_t ICR;    /*!< USART Interrupt flag Clear register,      Address offset: 0x20 */
+  __IO uint32_t RDR;    /*!< USART Receive Data register,              Address offset: 0x24 */
+  __IO uint32_t TDR;    /*!< USART Transmit Data register,             Address offset: 0x28 */
+} USART_TypeDef;
+
+
+/**
+  * @brief Window WATCHDOG
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+} WWDG_TypeDef;
+
+/**
+  * @brief Crypto Processor
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;         /*!< CRYP control register,                                    Address offset: 0x00 */
+  __IO uint32_t SR;         /*!< CRYP status register,                                     Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRYP data input register,                                 Address offset: 0x08 */
+  __IO uint32_t DOUT;       /*!< CRYP data output register,                                Address offset: 0x0C */
+  __IO uint32_t DMACR;      /*!< CRYP DMA control register,                                Address offset: 0x10 */
+  __IO uint32_t IMSCR;      /*!< CRYP interrupt mask set/clear register,                   Address offset: 0x14 */
+  __IO uint32_t RISR;       /*!< CRYP raw interrupt status register,                       Address offset: 0x18 */
+  __IO uint32_t MISR;       /*!< CRYP masked interrupt status register,                    Address offset: 0x1C */
+  __IO uint32_t K0LR;       /*!< CRYP key left  register 0,                                Address offset: 0x20 */
+  __IO uint32_t K0RR;       /*!< CRYP key right register 0,                                Address offset: 0x24 */
+  __IO uint32_t K1LR;       /*!< CRYP key left  register 1,                                Address offset: 0x28 */
+  __IO uint32_t K1RR;       /*!< CRYP key right register 1,                                Address offset: 0x2C */
+  __IO uint32_t K2LR;       /*!< CRYP key left  register 2,                                Address offset: 0x30 */
+  __IO uint32_t K2RR;       /*!< CRYP key right register 2,                                Address offset: 0x34 */
+  __IO uint32_t K3LR;       /*!< CRYP key left  register 3,                                Address offset: 0x38 */
+  __IO uint32_t K3RR;       /*!< CRYP key right register 3,                                Address offset: 0x3C */
+  __IO uint32_t IV0LR;      /*!< CRYP initialization vector left-word  register 0,         Address offset: 0x40 */
+  __IO uint32_t IV0RR;      /*!< CRYP initialization vector right-word register 0,         Address offset: 0x44 */
+  __IO uint32_t IV1LR;      /*!< CRYP initialization vector left-word  register 1,         Address offset: 0x48 */
+  __IO uint32_t IV1RR;      /*!< CRYP initialization vector right-word register 1,         Address offset: 0x4C */
+  __IO uint32_t CSGCMCCM0R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 0,        Address offset: 0x50 */
+  __IO uint32_t CSGCMCCM1R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 1,        Address offset: 0x54 */
+  __IO uint32_t CSGCMCCM2R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 2,        Address offset: 0x58 */
+  __IO uint32_t CSGCMCCM3R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 3,        Address offset: 0x5C */
+  __IO uint32_t CSGCMCCM4R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 4,        Address offset: 0x60 */
+  __IO uint32_t CSGCMCCM5R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 5,        Address offset: 0x64 */
+  __IO uint32_t CSGCMCCM6R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 6,        Address offset: 0x68 */
+  __IO uint32_t CSGCMCCM7R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 7,        Address offset: 0x6C */
+  __IO uint32_t CSGCM0R;    /*!< CRYP GCM/GMAC context swap register 0,                    Address offset: 0x70 */
+  __IO uint32_t CSGCM1R;    /*!< CRYP GCM/GMAC context swap register 1,                    Address offset: 0x74 */
+  __IO uint32_t CSGCM2R;    /*!< CRYP GCM/GMAC context swap register 2,                    Address offset: 0x78 */
+  __IO uint32_t CSGCM3R;    /*!< CRYP GCM/GMAC context swap register 3,                    Address offset: 0x7C */
+  __IO uint32_t CSGCM4R;    /*!< CRYP GCM/GMAC context swap register 4,                    Address offset: 0x80 */
+  __IO uint32_t CSGCM5R;    /*!< CRYP GCM/GMAC context swap register 5,                    Address offset: 0x84 */
+  __IO uint32_t CSGCM6R;    /*!< CRYP GCM/GMAC context swap register 6,                    Address offset: 0x88 */
+  __IO uint32_t CSGCM7R;    /*!< CRYP GCM/GMAC context swap register 7,                    Address offset: 0x8C */
+} CRYP_TypeDef;
+
+/**
+  * @brief HASH
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;               /*!< HASH control register,          Address offset: 0x00        */
+  __IO uint32_t DIN;              /*!< HASH data input register,       Address offset: 0x04        */
+  __IO uint32_t STR;              /*!< HASH start register,            Address offset: 0x08        */
+  __IO uint32_t HR[5];            /*!< HASH digest registers,          Address offset: 0x0C-0x1C   */
+  __IO uint32_t IMR;              /*!< HASH interrupt enable register, Address offset: 0x20        */
+  __IO uint32_t SR;               /*!< HASH status register,           Address offset: 0x24        */
+  uint32_t      RESERVED[52];     /*!< Reserved, 0x28-0xF4                                         */
+  __IO uint32_t CSR[54];          /*!< HASH context swap registers,    Address offset: 0x0F8-0x1CC */
+} HASH_TypeDef;
+
+/**
+  * @brief HASH_DIGEST
+  */
+
+typedef struct
+{
+  __IO uint32_t HR[8];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */
+} HASH_DIGEST_TypeDef;
+
+/**
+  * @brief RNG
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+} RNG_TypeDef;
+
+/**
+  * @}
+  */
+
+/**
+  * @brief USB_OTG_Core_Registers
+  */
+typedef struct
+{
+ __IO uint32_t GOTGCTL;               /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  uint32_t Reserved30[2];             /*!< Reserved                                     030h */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
+  uint32_t  Reserved5[3];             /*!< Reserved                                040h-048h */
+  __IO uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
+  uint32_t  Reserved6;                /*!< Reserved                                     050h */
+  __IO uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
+  __IO uint32_t GPWRDN;               /*!< Power Down Register                          058h */
+  __IO uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
+   __IO uint32_t GADPCTL;             /*!< ADP Timer, Control and Status Register       60Ch */
+    uint32_t  Reserved43[39];         /*!< Reserved                                058h-0FFh */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO */
+} USB_OTG_GlobalTypeDef;
+
+
+/**
+  * @brief USB_OTG_device_Registers
+  */
+typedef struct
+{
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  uint32_t Reserved0C;           /*!< Reserved                     80Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  uint32_t  Reserved20;          /*!< Reserved                     820h */
+  uint32_t Reserved9;            /*!< Reserved                     824h */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  uint32_t Reserved40;           /*!< dedicated EP mask            840h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+} USB_OTG_DeviceTypeDef;
+
+
+/**
+  * @brief USB_OTG_IN_Endpoint-Specific_Register
+  */
+typedef struct
+{
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
+} USB_OTG_INEndpointTypeDef;
+
+
+/**
+  * @brief USB_OTG_OUT_Endpoint-Specific_Registers
+  */
+typedef struct
+{
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
+} USB_OTG_OUTEndpointTypeDef;
+
+
+/**
+  * @brief USB_OTG_Host_Mode_Register_Structures
+  */
+typedef struct
+{
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  uint32_t Reserved40C;           /*!< Reserved                             40Ch */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+} USB_OTG_HostTypeDef;
+
+/**
+  * @brief USB_OTG_Host_Channel_Specific_Registers
+  */
+typedef struct
+{
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  uint32_t Reserved[2];           /*!< Reserved                                      */
+} USB_OTG_HostChannelTypeDef;
+/**
+  * @}
+  */
+
+
+/** @addtogroup Peripheral_memory_map
+  * @{
+  */
+#define RAMITCM_BASE           ((uint32_t)0x00000000) /*!< Base address of :16KB RAM reserved for CPU execution/instruction accessible over ITCM   */
+#define FLASHITCM_BASE         ((uint32_t)0x00200000) /*!< Base address of :(up to 1 MB) embedded FLASH memory  accessible over ITCM               */
+#define FLASHAXI_BASE          ((uint32_t)0x08000000) /*!< Base address of : (up to 1 MB) embedded FLASH memory accessible over AXI                */
+#define RAMDTCM_BASE           ((uint32_t)0x20000000) /*!< Base address of : 64KB system data RAM accessible over DTCM                             */
+#define SRAM1_BASE             ((uint32_t)0x20010000) /*!< Base address of : 240KB RAM1 accessible over AXI/AHB                                    */
+#define SRAM2_BASE             ((uint32_t)0x2004C000) /*!< Base address of : 16KB RAM2 accessible over AXI/AHB                                     */
+#define PERIPH_BASE            ((uint32_t)0x40000000) /*!< Base address of : AHB/ABP Peripherals                                                   */
+#define BKPSRAM_BASE           ((uint32_t)0x40024000) /*!< Base address of : Backup SRAM(4 KB)                                                     */
+#define QSPI_BASE              ((uint32_t)0x90000000) /*!< Base address of : QSPI memories  accessible over AXI                                    */
+#define FMC_R_BASE             ((uint32_t)0xA0000000) /*!< Base address of : FMC Control registers                                                 */
+#define QSPI_R_BASE            ((uint32_t)0xA0001000) /*!< Base address of : QSPI Control  registers                                               */
+#define FLASH_END              ((uint32_t)0x080FFFFF) /*!< FLASH end address */
+
+/* Legacy define */
+#define FLASH_BASE     FLASHAXI_BASE
+
+/*!< Peripheral memory map */
+#define APB1PERIPH_BASE        PERIPH_BASE
+#define APB2PERIPH_BASE       (PERIPH_BASE + 0x00010000)
+#define AHB1PERIPH_BASE       (PERIPH_BASE + 0x00020000)
+#define AHB2PERIPH_BASE       (PERIPH_BASE + 0x10000000)
+
+/*!< APB1 peripherals */
+#define TIM2_BASE             (APB1PERIPH_BASE + 0x0000)
+#define TIM3_BASE             (APB1PERIPH_BASE + 0x0400)
+#define TIM4_BASE             (APB1PERIPH_BASE + 0x0800)
+#define TIM5_BASE             (APB1PERIPH_BASE + 0x0C00)
+#define TIM6_BASE             (APB1PERIPH_BASE + 0x1000)
+#define TIM7_BASE             (APB1PERIPH_BASE + 0x1400)
+#define TIM12_BASE            (APB1PERIPH_BASE + 0x1800)
+#define TIM13_BASE            (APB1PERIPH_BASE + 0x1C00)
+#define TIM14_BASE            (APB1PERIPH_BASE + 0x2000)
+#define LPTIM1_BASE           (APB1PERIPH_BASE + 0x2400)
+#define RTC_BASE              (APB1PERIPH_BASE + 0x2800)
+#define WWDG_BASE             (APB1PERIPH_BASE + 0x2C00)
+#define IWDG_BASE             (APB1PERIPH_BASE + 0x3000)
+#define SPI2_BASE             (APB1PERIPH_BASE + 0x3800)
+#define SPI3_BASE             (APB1PERIPH_BASE + 0x3C00)
+#define SPDIFRX_BASE          (APB1PERIPH_BASE + 0x4000)
+#define USART2_BASE           (APB1PERIPH_BASE + 0x4400)
+#define USART3_BASE           (APB1PERIPH_BASE + 0x4800)
+#define UART4_BASE            (APB1PERIPH_BASE + 0x4C00)
+#define UART5_BASE            (APB1PERIPH_BASE + 0x5000)
+#define I2C1_BASE             (APB1PERIPH_BASE + 0x5400)
+#define I2C2_BASE             (APB1PERIPH_BASE + 0x5800)
+#define I2C3_BASE             (APB1PERIPH_BASE + 0x5C00)
+#define I2C4_BASE             (APB1PERIPH_BASE + 0x6000)
+#define CAN1_BASE             (APB1PERIPH_BASE + 0x6400)
+#define CAN2_BASE             (APB1PERIPH_BASE + 0x6800)
+#define CEC_BASE              (APB1PERIPH_BASE + 0x6C00)
+#define PWR_BASE              (APB1PERIPH_BASE + 0x7000)
+#define DAC_BASE              (APB1PERIPH_BASE + 0x7400)
+#define UART7_BASE            (APB1PERIPH_BASE + 0x7800)
+#define UART8_BASE            (APB1PERIPH_BASE + 0x7C00)
+
+/*!< APB2 peripherals */
+#define TIM1_BASE             (APB2PERIPH_BASE + 0x0000)
+#define TIM8_BASE             (APB2PERIPH_BASE + 0x0400)
+#define USART1_BASE           (APB2PERIPH_BASE + 0x1000)
+#define USART6_BASE           (APB2PERIPH_BASE + 0x1400)
+#define ADC1_BASE             (APB2PERIPH_BASE + 0x2000)
+#define ADC2_BASE             (APB2PERIPH_BASE + 0x2100)
+#define ADC3_BASE             (APB2PERIPH_BASE + 0x2200)
+#define ADC_BASE              (APB2PERIPH_BASE + 0x2300)
+#define SDMMC1_BASE           (APB2PERIPH_BASE + 0x2C00)
+#define SPI1_BASE             (APB2PERIPH_BASE + 0x3000)
+#define SPI4_BASE             (APB2PERIPH_BASE + 0x3400)
+#define SYSCFG_BASE           (APB2PERIPH_BASE + 0x3800)
+#define EXTI_BASE             (APB2PERIPH_BASE + 0x3C00)
+#define TIM9_BASE             (APB2PERIPH_BASE + 0x4000)
+#define TIM10_BASE            (APB2PERIPH_BASE + 0x4400)
+#define TIM11_BASE            (APB2PERIPH_BASE + 0x4800)
+#define SPI5_BASE             (APB2PERIPH_BASE + 0x5000)
+#define SPI6_BASE             (APB2PERIPH_BASE + 0x5400)
+#define SAI1_BASE             (APB2PERIPH_BASE + 0x5800)
+#define SAI2_BASE             (APB2PERIPH_BASE + 0x5C00)
+#define SAI1_Block_A_BASE     (SAI1_BASE + 0x004)
+#define SAI1_Block_B_BASE     (SAI1_BASE + 0x024)
+#define SAI2_Block_A_BASE     (SAI2_BASE + 0x004)
+#define SAI2_Block_B_BASE     (SAI2_BASE + 0x024)
+#define LTDC_BASE             (APB2PERIPH_BASE + 0x6800)
+#define LTDC_Layer1_BASE      (LTDC_BASE + 0x84)
+#define LTDC_Layer2_BASE      (LTDC_BASE + 0x104)
+/*!< AHB1 peripherals */
+#define GPIOA_BASE            (AHB1PERIPH_BASE + 0x0000)
+#define GPIOB_BASE            (AHB1PERIPH_BASE + 0x0400)
+#define GPIOC_BASE            (AHB1PERIPH_BASE + 0x0800)
+#define GPIOD_BASE            (AHB1PERIPH_BASE + 0x0C00)
+#define GPIOE_BASE            (AHB1PERIPH_BASE + 0x1000)
+#define GPIOF_BASE            (AHB1PERIPH_BASE + 0x1400)
+#define GPIOG_BASE            (AHB1PERIPH_BASE + 0x1800)
+#define GPIOH_BASE            (AHB1PERIPH_BASE + 0x1C00)
+#define GPIOI_BASE            (AHB1PERIPH_BASE + 0x2000)
+#define GPIOJ_BASE            (AHB1PERIPH_BASE + 0x2400)
+#define GPIOK_BASE            (AHB1PERIPH_BASE + 0x2800)
+#define CRC_BASE              (AHB1PERIPH_BASE + 0x3000)
+#define RCC_BASE              (AHB1PERIPH_BASE + 0x3800)
+#define FLASH_R_BASE          (AHB1PERIPH_BASE + 0x3C00)
+#define DMA1_BASE             (AHB1PERIPH_BASE + 0x6000)
+#define DMA1_Stream0_BASE     (DMA1_BASE + 0x010)
+#define DMA1_Stream1_BASE     (DMA1_BASE + 0x028)
+#define DMA1_Stream2_BASE     (DMA1_BASE + 0x040)
+#define DMA1_Stream3_BASE     (DMA1_BASE + 0x058)
+#define DMA1_Stream4_BASE     (DMA1_BASE + 0x070)
+#define DMA1_Stream5_BASE     (DMA1_BASE + 0x088)
+#define DMA1_Stream6_BASE     (DMA1_BASE + 0x0A0)
+#define DMA1_Stream7_BASE     (DMA1_BASE + 0x0B8)
+#define DMA2_BASE             (AHB1PERIPH_BASE + 0x6400)
+#define DMA2_Stream0_BASE     (DMA2_BASE + 0x010)
+#define DMA2_Stream1_BASE     (DMA2_BASE + 0x028)
+#define DMA2_Stream2_BASE     (DMA2_BASE + 0x040)
+#define DMA2_Stream3_BASE     (DMA2_BASE + 0x058)
+#define DMA2_Stream4_BASE     (DMA2_BASE + 0x070)
+#define DMA2_Stream5_BASE     (DMA2_BASE + 0x088)
+#define DMA2_Stream6_BASE     (DMA2_BASE + 0x0A0)
+#define DMA2_Stream7_BASE     (DMA2_BASE + 0x0B8)
+#define ETH_BASE              (AHB1PERIPH_BASE + 0x8000)
+#define ETH_MAC_BASE          (ETH_BASE)
+#define ETH_MMC_BASE          (ETH_BASE + 0x0100)
+#define ETH_PTP_BASE          (ETH_BASE + 0x0700)
+#define ETH_DMA_BASE          (ETH_BASE + 0x1000)
+#define DMA2D_BASE            (AHB1PERIPH_BASE + 0xB000)
+/*!< AHB2 peripherals */
+#define DCMI_BASE             (AHB2PERIPH_BASE + 0x50000)
+#define CRYP_BASE             (AHB2PERIPH_BASE + 0x60000)
+#define HASH_BASE             (AHB2PERIPH_BASE + 0x60400)
+#define HASH_DIGEST_BASE      (AHB2PERIPH_BASE + 0x60710)
+#define RNG_BASE              (AHB2PERIPH_BASE + 0x60800)
+/*!< FMC Bankx registers base address */
+#define FMC_Bank1_R_BASE      (FMC_R_BASE + 0x0000)
+#define FMC_Bank1E_R_BASE     (FMC_R_BASE + 0x0104)
+#define FMC_Bank3_R_BASE      (FMC_R_BASE + 0x0080)
+#define FMC_Bank5_6_R_BASE    (FMC_R_BASE + 0x0140)
+
+/* Debug MCU registers base address */
+#define DBGMCU_BASE           ((uint32_t )0xE0042000)
+
+/*!< USB registers base address */
+#define USB_OTG_HS_PERIPH_BASE               ((uint32_t )0x40040000)
+#define USB_OTG_FS_PERIPH_BASE               ((uint32_t )0x50000000)
+
+#define USB_OTG_GLOBAL_BASE                  ((uint32_t )0x000)
+#define USB_OTG_DEVICE_BASE                  ((uint32_t )0x800)
+#define USB_OTG_IN_ENDPOINT_BASE             ((uint32_t )0x900)
+#define USB_OTG_OUT_ENDPOINT_BASE            ((uint32_t )0xB00)
+#define USB_OTG_EP_REG_SIZE                  ((uint32_t )0x20)
+#define USB_OTG_HOST_BASE                    ((uint32_t )0x400)
+#define USB_OTG_HOST_PORT_BASE               ((uint32_t )0x440)
+#define USB_OTG_HOST_CHANNEL_BASE            ((uint32_t )0x500)
+#define USB_OTG_HOST_CHANNEL_SIZE            ((uint32_t )0x20)
+#define USB_OTG_PCGCCTL_BASE                 ((uint32_t )0xE00)
+#define USB_OTG_FIFO_BASE                    ((uint32_t )0x1000)
+#define USB_OTG_FIFO_SIZE                    ((uint32_t )0x1000)
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_declaration
+  * @{
+  */
+#define TIM2                ((TIM_TypeDef *) TIM2_BASE)
+#define TIM3                ((TIM_TypeDef *) TIM3_BASE)
+#define TIM4                ((TIM_TypeDef *) TIM4_BASE)
+#define TIM5                ((TIM_TypeDef *) TIM5_BASE)
+#define TIM6                ((TIM_TypeDef *) TIM6_BASE)
+#define TIM7                ((TIM_TypeDef *) TIM7_BASE)
+#define TIM12               ((TIM_TypeDef *) TIM12_BASE)
+#define TIM13               ((TIM_TypeDef *) TIM13_BASE)
+#define TIM14               ((TIM_TypeDef *) TIM14_BASE)
+#define LPTIM1              ((LPTIM_TypeDef *) LPTIM1_BASE)
+#define RTC                 ((RTC_TypeDef *) RTC_BASE)
+#define WWDG                ((WWDG_TypeDef *) WWDG_BASE)
+#define IWDG                ((IWDG_TypeDef *) IWDG_BASE)
+#define SPI2                ((SPI_TypeDef *) SPI2_BASE)
+#define SPI3                ((SPI_TypeDef *) SPI3_BASE)
+#define SPDIFRX             ((SPDIFRX_TypeDef *) SPDIFRX_BASE)
+#define USART2              ((USART_TypeDef *) USART2_BASE)
+#define USART3              ((USART_TypeDef *) USART3_BASE)
+#define UART4               ((USART_TypeDef *) UART4_BASE)
+#define UART5               ((USART_TypeDef *) UART5_BASE)
+#define I2C1                ((I2C_TypeDef *) I2C1_BASE)
+#define I2C2                ((I2C_TypeDef *) I2C2_BASE)
+#define I2C3                ((I2C_TypeDef *) I2C3_BASE)
+#define I2C4                ((I2C_TypeDef *) I2C4_BASE)
+#define CAN1                ((CAN_TypeDef *) CAN1_BASE)
+#define CAN2                ((CAN_TypeDef *) CAN2_BASE)
+#define CEC                 ((CEC_TypeDef *) CEC_BASE)
+#define PWR                 ((PWR_TypeDef *) PWR_BASE)
+#define DAC                 ((DAC_TypeDef *) DAC_BASE)
+#define UART7               ((USART_TypeDef *) UART7_BASE)
+#define UART8               ((USART_TypeDef *) UART8_BASE)
+#define TIM1                ((TIM_TypeDef *) TIM1_BASE)
+#define TIM8                ((TIM_TypeDef *) TIM8_BASE)
+#define USART1              ((USART_TypeDef *) USART1_BASE)
+#define USART6              ((USART_TypeDef *) USART6_BASE)
+#define ADC                 ((ADC_Common_TypeDef *) ADC_BASE)
+#define ADC1                ((ADC_TypeDef *) ADC1_BASE)
+#define ADC2                ((ADC_TypeDef *) ADC2_BASE)
+#define ADC3                ((ADC_TypeDef *) ADC3_BASE)
+#define SDMMC1              ((SDMMC_TypeDef *) SDMMC1_BASE)
+#define SPI1                ((SPI_TypeDef *) SPI1_BASE)
+#define SPI4                ((SPI_TypeDef *) SPI4_BASE)
+#define SYSCFG              ((SYSCFG_TypeDef *) SYSCFG_BASE)
+#define EXTI                ((EXTI_TypeDef *) EXTI_BASE)
+#define TIM9                ((TIM_TypeDef *) TIM9_BASE)
+#define TIM10               ((TIM_TypeDef *) TIM10_BASE)
+#define TIM11               ((TIM_TypeDef *) TIM11_BASE)
+#define SPI5                ((SPI_TypeDef *) SPI5_BASE)
+#define SPI6                ((SPI_TypeDef *) SPI6_BASE)
+#define SAI1                ((SAI_TypeDef *) SAI1_BASE)
+#define SAI2                ((SAI_TypeDef *) SAI2_BASE)
+#define SAI1_Block_A        ((SAI_Block_TypeDef *)SAI1_Block_A_BASE)
+#define SAI1_Block_B        ((SAI_Block_TypeDef *)SAI1_Block_B_BASE)
+#define SAI2_Block_A        ((SAI_Block_TypeDef *)SAI2_Block_A_BASE)
+#define SAI2_Block_B        ((SAI_Block_TypeDef *)SAI2_Block_B_BASE)
+#define LTDC                ((LTDC_TypeDef *)LTDC_BASE)
+#define LTDC_Layer1         ((LTDC_Layer_TypeDef *)LTDC_Layer1_BASE)
+#define LTDC_Layer2         ((LTDC_Layer_TypeDef *)LTDC_Layer2_BASE)
+#define GPIOA               ((GPIO_TypeDef *) GPIOA_BASE)
+#define GPIOB               ((GPIO_TypeDef *) GPIOB_BASE)
+#define GPIOC               ((GPIO_TypeDef *) GPIOC_BASE)
+#define GPIOD               ((GPIO_TypeDef *) GPIOD_BASE)
+#define GPIOE               ((GPIO_TypeDef *) GPIOE_BASE)
+#define GPIOF               ((GPIO_TypeDef *) GPIOF_BASE)
+#define GPIOG               ((GPIO_TypeDef *) GPIOG_BASE)
+#define GPIOH               ((GPIO_TypeDef *) GPIOH_BASE)
+#define GPIOI               ((GPIO_TypeDef *) GPIOI_BASE)
+#define GPIOJ               ((GPIO_TypeDef *) GPIOJ_BASE)
+#define GPIOK               ((GPIO_TypeDef *) GPIOK_BASE)
+#define CRC                 ((CRC_TypeDef *) CRC_BASE)
+#define RCC                 ((RCC_TypeDef *) RCC_BASE)
+#define FLASH               ((FLASH_TypeDef *) FLASH_R_BASE)
+#define DMA1                ((DMA_TypeDef *) DMA1_BASE)
+#define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
+#define DMA1_Stream1        ((DMA_Stream_TypeDef *) DMA1_Stream1_BASE)
+#define DMA1_Stream2        ((DMA_Stream_TypeDef *) DMA1_Stream2_BASE)
+#define DMA1_Stream3        ((DMA_Stream_TypeDef *) DMA1_Stream3_BASE)
+#define DMA1_Stream4        ((DMA_Stream_TypeDef *) DMA1_Stream4_BASE)
+#define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
+#define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
+#define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
+#define DMA2                ((DMA_TypeDef *) DMA2_BASE)
+#define DMA2_Stream0        ((DMA_Stream_TypeDef *) DMA2_Stream0_BASE)
+#define DMA2_Stream1        ((DMA_Stream_TypeDef *) DMA2_Stream1_BASE)
+#define DMA2_Stream2        ((DMA_Stream_TypeDef *) DMA2_Stream2_BASE)
+#define DMA2_Stream3        ((DMA_Stream_TypeDef *) DMA2_Stream3_BASE)
+#define DMA2_Stream4        ((DMA_Stream_TypeDef *) DMA2_Stream4_BASE)
+#define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
+#define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
+#define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define ETH                 ((ETH_TypeDef *) ETH_BASE)
+#define DMA2D               ((DMA2D_TypeDef *)DMA2D_BASE)
+#define DCMI                ((DCMI_TypeDef *) DCMI_BASE)
+#define CRYP                ((CRYP_TypeDef *) CRYP_BASE)
+#define HASH                ((HASH_TypeDef *) HASH_BASE)
+#define HASH_DIGEST         ((HASH_DIGEST_TypeDef *) HASH_DIGEST_BASE)
+#define RNG                 ((RNG_TypeDef *) RNG_BASE)
+#define FMC_Bank1           ((FMC_Bank1_TypeDef *) FMC_Bank1_R_BASE)
+#define FMC_Bank1E          ((FMC_Bank1E_TypeDef *) FMC_Bank1E_R_BASE)
+#define FMC_Bank3           ((FMC_Bank3_TypeDef *) FMC_Bank3_R_BASE)
+#define FMC_Bank5_6         ((FMC_Bank5_6_TypeDef *) FMC_Bank5_6_R_BASE)
+#define QUADSPI             ((QUADSPI_TypeDef *) QSPI_R_BASE)
+#define DBGMCU              ((DBGMCU_TypeDef *) DBGMCU_BASE)
+#define USB_OTG_FS          ((USB_OTG_GlobalTypeDef *) USB_OTG_FS_PERIPH_BASE)
+#define USB_OTG_HS          ((USB_OTG_GlobalTypeDef *) USB_OTG_HS_PERIPH_BASE)
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_constants
+  * @{
+  */
+
+  /** @addtogroup Peripheral_Registers_Bits_Definition
+  * @{
+  */
+
+/******************************************************************************/
+/*                         Peripheral Registers_Bits_Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Analog to Digital Converter                         */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for ADC_SR register  ********************/
+#define  ADC_SR_AWD                          ((uint32_t)0x00000001)        /*!<Analog watchdog flag                                 */
+#define  ADC_SR_EOC                          ((uint32_t)0x00000002)        /*!<End of conversion                                    */
+#define  ADC_SR_JEOC                         ((uint32_t)0x00000004)        /*!<Injected channel end of conversion                   */
+#define  ADC_SR_JSTRT                        ((uint32_t)0x00000008)        /*!<Injected channel Start flag                          */
+#define  ADC_SR_STRT                         ((uint32_t)0x00000010)        /*!<Regular channel Start flag                           */
+#define  ADC_SR_OVR                          ((uint32_t)0x00000020)        /*!<Overrun flag                                         */
+
+/*******************  Bit definition for ADC_CR1 register  ********************/
+#define  ADC_CR1_AWDCH                       ((uint32_t)0x0000001F)        /*!<AWDCH[4:0] bits (Analog watchdog channel select bits) */
+#define  ADC_CR1_AWDCH_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_CR1_AWDCH_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_CR1_AWDCH_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_CR1_AWDCH_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_CR1_AWDCH_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_CR1_EOCIE                       ((uint32_t)0x00000020)        /*!<Interrupt enable for EOC                             */
+#define  ADC_CR1_AWDIE                       ((uint32_t)0x00000040)        /*!<AAnalog Watchdog interrupt enable                    */
+#define  ADC_CR1_JEOCIE                      ((uint32_t)0x00000080)        /*!<Interrupt enable for injected channels               */
+#define  ADC_CR1_SCAN                        ((uint32_t)0x00000100)        /*!<Scan mode */
+#define  ADC_CR1_AWDSGL                      ((uint32_t)0x00000200)        /*!<Enable the watchdog on a single channel in scan mode */
+#define  ADC_CR1_JAUTO                       ((uint32_t)0x00000400)        /*!<Automatic injected group conversion                  */
+#define  ADC_CR1_DISCEN                      ((uint32_t)0x00000800)        /*!<Discontinuous mode on regular channels               */
+#define  ADC_CR1_JDISCEN                     ((uint32_t)0x00001000)        /*!<Discontinuous mode on injected channels              */
+#define  ADC_CR1_DISCNUM                     ((uint32_t)0x0000E000)        /*!<DISCNUM[2:0] bits (Discontinuous mode channel count) */
+#define  ADC_CR1_DISCNUM_0                   ((uint32_t)0x00002000)        /*!<Bit 0 */
+#define  ADC_CR1_DISCNUM_1                   ((uint32_t)0x00004000)        /*!<Bit 1 */
+#define  ADC_CR1_DISCNUM_2                   ((uint32_t)0x00008000)        /*!<Bit 2 */
+#define  ADC_CR1_JAWDEN                      ((uint32_t)0x00400000)        /*!<Analog watchdog enable on injected channels          */
+#define  ADC_CR1_AWDEN                       ((uint32_t)0x00800000)        /*!<Analog watchdog enable on regular channels           */
+#define  ADC_CR1_RES                         ((uint32_t)0x03000000)        /*!<RES[2:0] bits (Resolution)                           */
+#define  ADC_CR1_RES_0                       ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  ADC_CR1_RES_1                       ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  ADC_CR1_OVRIE                       ((uint32_t)0x04000000)         /*!<overrun interrupt enable */
+
+/*******************  Bit definition for ADC_CR2 register  ********************/
+#define  ADC_CR2_ADON                        ((uint32_t)0x00000001)        /*!<A/D Converter ON / OFF                                       */
+#define  ADC_CR2_CONT                        ((uint32_t)0x00000002)        /*!<Continuous Conversion                                        */
+#define  ADC_CR2_DMA                         ((uint32_t)0x00000100)        /*!<Direct Memory access mode                                    */
+#define  ADC_CR2_DDS                         ((uint32_t)0x00000200)        /*!<DMA disable selection (Single ADC)                           */
+#define  ADC_CR2_EOCS                        ((uint32_t)0x00000400)        /*!<End of conversion selection                                  */
+#define  ADC_CR2_ALIGN                       ((uint32_t)0x00000800)        /*!<Data Alignment                                               */
+#define  ADC_CR2_JEXTSEL                     ((uint32_t)0x000F0000)        /*!<JEXTSEL[3:0] bits (External event select for injected group) */
+#define  ADC_CR2_JEXTSEL_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  ADC_CR2_JEXTSEL_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  ADC_CR2_JEXTSEL_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  ADC_CR2_JEXTSEL_3                   ((uint32_t)0x00080000)        /*!<Bit 3 */
+#define  ADC_CR2_JEXTEN                      ((uint32_t)0x00300000)        /*!<JEXTEN[1:0] bits (External Trigger Conversion mode for injected channelsp) */
+#define  ADC_CR2_JEXTEN_0                    ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_CR2_JEXTEN_1                    ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  ADC_CR2_JSWSTART                    ((uint32_t)0x00400000)        /*!<Start Conversion of injected channels */
+#define  ADC_CR2_EXTSEL                      ((uint32_t)0x0F000000)        /*!<EXTSEL[3:0] bits (External Event Select for regular group) */
+#define  ADC_CR2_EXTSEL_0                    ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  ADC_CR2_EXTSEL_1                    ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  ADC_CR2_EXTSEL_2                    ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  ADC_CR2_EXTSEL_3                    ((uint32_t)0x08000000)        /*!<Bit 3 */
+#define  ADC_CR2_EXTEN                       ((uint32_t)0x30000000)        /*!<EXTEN[1:0] bits (External Trigger Conversion mode for regular channelsp) */
+#define  ADC_CR2_EXTEN_0                     ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  ADC_CR2_EXTEN_1                     ((uint32_t)0x20000000)        /*!<Bit 1 */
+#define  ADC_CR2_SWSTART                     ((uint32_t)0x40000000)        /*!<Start Conversion of regular channels */
+
+/******************  Bit definition for ADC_SMPR1 register  *******************/
+#define  ADC_SMPR1_SMP10                     ((uint32_t)0x00000007)        /*!<SMP10[2:0] bits (Channel 10 Sample time selection) */
+#define  ADC_SMPR1_SMP10_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP10_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP10_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP11                     ((uint32_t)0x00000038)        /*!<SMP11[2:0] bits (Channel 11 Sample time selection) */
+#define  ADC_SMPR1_SMP11_0                   ((uint32_t)0x00000008)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP11_1                   ((uint32_t)0x00000010)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP11_2                   ((uint32_t)0x00000020)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP12                     ((uint32_t)0x000001C0)        /*!<SMP12[2:0] bits (Channel 12 Sample time selection) */
+#define  ADC_SMPR1_SMP12_0                   ((uint32_t)0x00000040)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP12_1                   ((uint32_t)0x00000080)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP12_2                   ((uint32_t)0x00000100)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP13                     ((uint32_t)0x00000E00)        /*!<SMP13[2:0] bits (Channel 13 Sample time selection) */
+#define  ADC_SMPR1_SMP13_0                   ((uint32_t)0x00000200)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP13_1                   ((uint32_t)0x00000400)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP13_2                   ((uint32_t)0x00000800)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP14                     ((uint32_t)0x00007000)        /*!<SMP14[2:0] bits (Channel 14 Sample time selection) */
+#define  ADC_SMPR1_SMP14_0                   ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP14_1                   ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP14_2                   ((uint32_t)0x00004000)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP15                     ((uint32_t)0x00038000)        /*!<SMP15[2:0] bits (Channel 15 Sample time selection) */
+#define  ADC_SMPR1_SMP15_0                   ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP15_1                   ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP15_2                   ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP16                     ((uint32_t)0x001C0000)        /*!<SMP16[2:0] bits (Channel 16 Sample time selection) */
+#define  ADC_SMPR1_SMP16_0                   ((uint32_t)0x00040000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP16_1                   ((uint32_t)0x00080000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP16_2                   ((uint32_t)0x00100000)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP17                     ((uint32_t)0x00E00000)        /*!<SMP17[2:0] bits (Channel 17 Sample time selection) */
+#define  ADC_SMPR1_SMP17_0                   ((uint32_t)0x00200000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP17_1                   ((uint32_t)0x00400000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP17_2                   ((uint32_t)0x00800000)        /*!<Bit 2 */
+#define  ADC_SMPR1_SMP18                     ((uint32_t)0x07000000)        /*!<SMP18[2:0] bits (Channel 18 Sample time selection) */
+#define  ADC_SMPR1_SMP18_0                   ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  ADC_SMPR1_SMP18_1                   ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  ADC_SMPR1_SMP18_2                   ((uint32_t)0x04000000)        /*!<Bit 2 */
+
+/******************  Bit definition for ADC_SMPR2 register  *******************/
+#define  ADC_SMPR2_SMP0                      ((uint32_t)0x00000007)        /*!<SMP0[2:0] bits (Channel 0 Sample time selection) */
+#define  ADC_SMPR2_SMP0_0                    ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP0_1                    ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP0_2                    ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP1                      ((uint32_t)0x00000038)        /*!<SMP1[2:0] bits (Channel 1 Sample time selection) */
+#define  ADC_SMPR2_SMP1_0                    ((uint32_t)0x00000008)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP1_1                    ((uint32_t)0x00000010)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP1_2                    ((uint32_t)0x00000020)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP2                      ((uint32_t)0x000001C0)        /*!<SMP2[2:0] bits (Channel 2 Sample time selection) */
+#define  ADC_SMPR2_SMP2_0                    ((uint32_t)0x00000040)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP2_1                    ((uint32_t)0x00000080)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP2_2                    ((uint32_t)0x00000100)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP3                      ((uint32_t)0x00000E00)        /*!<SMP3[2:0] bits (Channel 3 Sample time selection) */
+#define  ADC_SMPR2_SMP3_0                    ((uint32_t)0x00000200)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP3_1                    ((uint32_t)0x00000400)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP3_2                    ((uint32_t)0x00000800)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP4                      ((uint32_t)0x00007000)        /*!<SMP4[2:0] bits (Channel 4 Sample time selection) */
+#define  ADC_SMPR2_SMP4_0                    ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP4_1                    ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP4_2                    ((uint32_t)0x00004000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP5                      ((uint32_t)0x00038000)        /*!<SMP5[2:0] bits (Channel 5 Sample time selection) */
+#define  ADC_SMPR2_SMP5_0                    ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP5_1                    ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP5_2                    ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP6                      ((uint32_t)0x001C0000)        /*!<SMP6[2:0] bits (Channel 6 Sample time selection) */
+#define  ADC_SMPR2_SMP6_0                    ((uint32_t)0x00040000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP6_1                    ((uint32_t)0x00080000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP6_2                    ((uint32_t)0x00100000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP7                      ((uint32_t)0x00E00000)        /*!<SMP7[2:0] bits (Channel 7 Sample time selection) */
+#define  ADC_SMPR2_SMP7_0                    ((uint32_t)0x00200000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP7_1                    ((uint32_t)0x00400000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP7_2                    ((uint32_t)0x00800000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP8                      ((uint32_t)0x07000000)        /*!<SMP8[2:0] bits (Channel 8 Sample time selection) */
+#define  ADC_SMPR2_SMP8_0                    ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP8_1                    ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP8_2                    ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  ADC_SMPR2_SMP9                      ((uint32_t)0x38000000)        /*!<SMP9[2:0] bits (Channel 9 Sample time selection) */
+#define  ADC_SMPR2_SMP9_0                    ((uint32_t)0x08000000)        /*!<Bit 0 */
+#define  ADC_SMPR2_SMP9_1                    ((uint32_t)0x10000000)        /*!<Bit 1 */
+#define  ADC_SMPR2_SMP9_2                    ((uint32_t)0x20000000)        /*!<Bit 2 */
+
+/******************  Bit definition for ADC_JOFR1 register  *******************/
+#define  ADC_JOFR1_JOFFSET1                  ((uint32_t)0x0FFF)            /*!<Data offset for injected channel 1 */
+
+/******************  Bit definition for ADC_JOFR2 register  *******************/
+#define  ADC_JOFR2_JOFFSET2                  ((uint32_t)0x0FFF)            /*!<Data offset for injected channel 2 */
+
+/******************  Bit definition for ADC_JOFR3 register  *******************/
+#define  ADC_JOFR3_JOFFSET3                  ((uint32_t)0x0FFF)            /*!<Data offset for injected channel 3 */
+
+/******************  Bit definition for ADC_JOFR4 register  *******************/
+#define  ADC_JOFR4_JOFFSET4                  ((uint32_t)0x0FFF)            /*!<Data offset for injected channel 4 */
+
+/*******************  Bit definition for ADC_HTR register  ********************/
+#define  ADC_HTR_HT                          ((uint32_t)0x0FFF)            /*!<Analog watchdog high threshold */
+
+/*******************  Bit definition for ADC_LTR register  ********************/
+#define  ADC_LTR_LT                          ((uint32_t)0x0FFF)            /*!<Analog watchdog low threshold */
+
+/*******************  Bit definition for ADC_SQR1 register  *******************/
+#define  ADC_SQR1_SQ13                       ((uint32_t)0x0000001F)        /*!<SQ13[4:0] bits (13th conversion in regular sequence) */
+#define  ADC_SQR1_SQ13_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SQR1_SQ13_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SQR1_SQ13_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SQR1_SQ13_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_SQR1_SQ13_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_SQR1_SQ14                       ((uint32_t)0x000003E0)        /*!<SQ14[4:0] bits (14th conversion in regular sequence) */
+#define  ADC_SQR1_SQ14_0                     ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  ADC_SQR1_SQ14_1                     ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  ADC_SQR1_SQ14_2                     ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  ADC_SQR1_SQ14_3                     ((uint32_t)0x00000100)        /*!<Bit 3 */
+#define  ADC_SQR1_SQ14_4                     ((uint32_t)0x00000200)        /*!<Bit 4 */
+#define  ADC_SQR1_SQ15                       ((uint32_t)0x00007C00)        /*!<SQ15[4:0] bits (15th conversion in regular sequence) */
+#define  ADC_SQR1_SQ15_0                     ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  ADC_SQR1_SQ15_1                     ((uint32_t)0x00000800)        /*!<Bit 1 */
+#define  ADC_SQR1_SQ15_2                     ((uint32_t)0x00001000)        /*!<Bit 2 */
+#define  ADC_SQR1_SQ15_3                     ((uint32_t)0x00002000)        /*!<Bit 3 */
+#define  ADC_SQR1_SQ15_4                     ((uint32_t)0x00004000)        /*!<Bit 4 */
+#define  ADC_SQR1_SQ16                       ((uint32_t)0x000F8000)        /*!<SQ16[4:0] bits (16th conversion in regular sequence) */
+#define  ADC_SQR1_SQ16_0                     ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SQR1_SQ16_1                     ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SQR1_SQ16_2                     ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SQR1_SQ16_3                     ((uint32_t)0x00040000)        /*!<Bit 3 */
+#define  ADC_SQR1_SQ16_4                     ((uint32_t)0x00080000)        /*!<Bit 4 */
+#define  ADC_SQR1_L                          ((uint32_t)0x00F00000)        /*!<L[3:0] bits (Regular channel sequence length) */
+#define  ADC_SQR1_L_0                        ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_SQR1_L_1                        ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  ADC_SQR1_L_2                        ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  ADC_SQR1_L_3                        ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+/*******************  Bit definition for ADC_SQR2 register  *******************/
+#define  ADC_SQR2_SQ7                        ((uint32_t)0x0000001F)        /*!<SQ7[4:0] bits (7th conversion in regular sequence) */
+#define  ADC_SQR2_SQ7_0                      ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ7_1                      ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ7_2                      ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ7_3                      ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ7_4                      ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ8                        ((uint32_t)0x000003E0)        /*!<SQ8[4:0] bits (8th conversion in regular sequence) */
+#define  ADC_SQR2_SQ8_0                      ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ8_1                      ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ8_2                      ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ8_3                      ((uint32_t)0x00000100)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ8_4                      ((uint32_t)0x00000200)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ9                        ((uint32_t)0x00007C00)        /*!<SQ9[4:0] bits (9th conversion in regular sequence) */
+#define  ADC_SQR2_SQ9_0                      ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ9_1                      ((uint32_t)0x00000800)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ9_2                      ((uint32_t)0x00001000)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ9_3                      ((uint32_t)0x00002000)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ9_4                      ((uint32_t)0x00004000)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ10                       ((uint32_t)0x000F8000)        /*!<SQ10[4:0] bits (10th conversion in regular sequence) */
+#define  ADC_SQR2_SQ10_0                     ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ10_1                     ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ10_2                     ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ10_3                     ((uint32_t)0x00040000)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ10_4                     ((uint32_t)0x00080000)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ11                       ((uint32_t)0x01F00000)        /*!<SQ11[4:0] bits (11th conversion in regular sequence) */
+#define  ADC_SQR2_SQ11_0                     ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ11_1                     ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ11_2                     ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ11_3                     ((uint32_t)0x00800000)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ11_4                     ((uint32_t)0x01000000)        /*!<Bit 4 */
+#define  ADC_SQR2_SQ12                       ((uint32_t)0x3E000000)        /*!<SQ12[4:0] bits (12th conversion in regular sequence) */
+#define  ADC_SQR2_SQ12_0                     ((uint32_t)0x02000000)        /*!<Bit 0 */
+#define  ADC_SQR2_SQ12_1                     ((uint32_t)0x04000000)        /*!<Bit 1 */
+#define  ADC_SQR2_SQ12_2                     ((uint32_t)0x08000000)        /*!<Bit 2 */
+#define  ADC_SQR2_SQ12_3                     ((uint32_t)0x10000000)        /*!<Bit 3 */
+#define  ADC_SQR2_SQ12_4                     ((uint32_t)0x20000000)        /*!<Bit 4 */
+
+/*******************  Bit definition for ADC_SQR3 register  *******************/
+#define  ADC_SQR3_SQ1                        ((uint32_t)0x0000001F)        /*!<SQ1[4:0] bits (1st conversion in regular sequence) */
+#define  ADC_SQR3_SQ1_0                      ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ1_1                      ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ1_2                      ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ1_3                      ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ1_4                      ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ2                        ((uint32_t)0x000003E0)        /*!<SQ2[4:0] bits (2nd conversion in regular sequence) */
+#define  ADC_SQR3_SQ2_0                      ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ2_1                      ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ2_2                      ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ2_3                      ((uint32_t)0x00000100)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ2_4                      ((uint32_t)0x00000200)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ3                        ((uint32_t)0x00007C00)        /*!<SQ3[4:0] bits (3rd conversion in regular sequence) */
+#define  ADC_SQR3_SQ3_0                      ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ3_1                      ((uint32_t)0x00000800)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ3_2                      ((uint32_t)0x00001000)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ3_3                      ((uint32_t)0x00002000)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ3_4                      ((uint32_t)0x00004000)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ4                        ((uint32_t)0x000F8000)        /*!<SQ4[4:0] bits (4th conversion in regular sequence) */
+#define  ADC_SQR3_SQ4_0                      ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ4_1                      ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ4_2                      ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ4_3                      ((uint32_t)0x00040000)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ4_4                      ((uint32_t)0x00080000)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ5                        ((uint32_t)0x01F00000)        /*!<SQ5[4:0] bits (5th conversion in regular sequence) */
+#define  ADC_SQR3_SQ5_0                      ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ5_1                      ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ5_2                      ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ5_3                      ((uint32_t)0x00800000)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ5_4                      ((uint32_t)0x01000000)        /*!<Bit 4 */
+#define  ADC_SQR3_SQ6                        ((uint32_t)0x3E000000)        /*!<SQ6[4:0] bits (6th conversion in regular sequence) */
+#define  ADC_SQR3_SQ6_0                      ((uint32_t)0x02000000)        /*!<Bit 0 */
+#define  ADC_SQR3_SQ6_1                      ((uint32_t)0x04000000)        /*!<Bit 1 */
+#define  ADC_SQR3_SQ6_2                      ((uint32_t)0x08000000)        /*!<Bit 2 */
+#define  ADC_SQR3_SQ6_3                      ((uint32_t)0x10000000)        /*!<Bit 3 */
+#define  ADC_SQR3_SQ6_4                      ((uint32_t)0x20000000)        /*!<Bit 4 */
+
+/*******************  Bit definition for ADC_JSQR register  *******************/
+#define  ADC_JSQR_JSQ1                       ((uint32_t)0x0000001F)        /*!<JSQ1[4:0] bits (1st conversion in injected sequence) */
+#define  ADC_JSQR_JSQ1_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_JSQR_JSQ1_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_JSQR_JSQ1_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_JSQR_JSQ1_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_JSQR_JSQ1_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_JSQR_JSQ2                       ((uint32_t)0x000003E0)        /*!<JSQ2[4:0] bits (2nd conversion in injected sequence) */
+#define  ADC_JSQR_JSQ2_0                     ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  ADC_JSQR_JSQ2_1                     ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  ADC_JSQR_JSQ2_2                     ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  ADC_JSQR_JSQ2_3                     ((uint32_t)0x00000100)        /*!<Bit 3 */
+#define  ADC_JSQR_JSQ2_4                     ((uint32_t)0x00000200)        /*!<Bit 4 */
+#define  ADC_JSQR_JSQ3                       ((uint32_t)0x00007C00)        /*!<JSQ3[4:0] bits (3rd conversion in injected sequence) */
+#define  ADC_JSQR_JSQ3_0                     ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  ADC_JSQR_JSQ3_1                     ((uint32_t)0x00000800)        /*!<Bit 1 */
+#define  ADC_JSQR_JSQ3_2                     ((uint32_t)0x00001000)        /*!<Bit 2 */
+#define  ADC_JSQR_JSQ3_3                     ((uint32_t)0x00002000)        /*!<Bit 3 */
+#define  ADC_JSQR_JSQ3_4                     ((uint32_t)0x00004000)        /*!<Bit 4 */
+#define  ADC_JSQR_JSQ4                       ((uint32_t)0x000F8000)        /*!<JSQ4[4:0] bits (4th conversion in injected sequence) */
+#define  ADC_JSQR_JSQ4_0                     ((uint32_t)0x00008000)        /*!<Bit 0 */
+#define  ADC_JSQR_JSQ4_1                     ((uint32_t)0x00010000)        /*!<Bit 1 */
+#define  ADC_JSQR_JSQ4_2                     ((uint32_t)0x00020000)        /*!<Bit 2 */
+#define  ADC_JSQR_JSQ4_3                     ((uint32_t)0x00040000)        /*!<Bit 3 */
+#define  ADC_JSQR_JSQ4_4                     ((uint32_t)0x00080000)        /*!<Bit 4 */
+#define  ADC_JSQR_JL                         ((uint32_t)0x00300000)        /*!<JL[1:0] bits (Injected Sequence length) */
+#define  ADC_JSQR_JL_0                       ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  ADC_JSQR_JL_1                       ((uint32_t)0x00200000)        /*!<Bit 1 */
+
+/*******************  Bit definition for ADC_JDR1 register  *******************/
+#define  ADC_JDR1_JDATA                      ((uint16_t)0xFFFF)            /*!<Injected data */
+
+/*******************  Bit definition for ADC_JDR2 register  *******************/
+#define  ADC_JDR2_JDATA                      ((uint16_t)0xFFFF)            /*!<Injected data */
+
+/*******************  Bit definition for ADC_JDR3 register  *******************/
+#define  ADC_JDR3_JDATA                      ((uint16_t)0xFFFF)            /*!<Injected data */
+
+/*******************  Bit definition for ADC_JDR4 register  *******************/
+#define  ADC_JDR4_JDATA                      ((uint16_t)0xFFFF)            /*!<Injected data */
+
+/********************  Bit definition for ADC_DR register  ********************/
+#define  ADC_DR_DATA                         ((uint32_t)0x0000FFFF)        /*!<Regular data */
+#define  ADC_DR_ADC2DATA                     ((uint32_t)0xFFFF0000)        /*!<ADC2 data */
+
+/*******************  Bit definition for ADC_CSR register  ********************/
+#define  ADC_CSR_AWD1                        ((uint32_t)0x00000001)        /*!<ADC1 Analog watchdog flag               */
+#define  ADC_CSR_EOC1                        ((uint32_t)0x00000002)        /*!<ADC1 End of conversion                  */
+#define  ADC_CSR_JEOC1                       ((uint32_t)0x00000004)        /*!<ADC1 Injected channel end of conversion */
+#define  ADC_CSR_JSTRT1                      ((uint32_t)0x00000008)        /*!<ADC1 Injected channel Start flag        */
+#define  ADC_CSR_STRT1                       ((uint32_t)0x00000010)        /*!<ADC1 Regular channel Start flag         */
+#define  ADC_CSR_DOVR1                       ((uint32_t)0x00000020)        /*!<ADC1 DMA overrun  flag                  */
+#define  ADC_CSR_AWD2                        ((uint32_t)0x00000100)        /*!<ADC2 Analog watchdog flag               */
+#define  ADC_CSR_EOC2                        ((uint32_t)0x00000200)        /*!<ADC2 End of conversion                  */
+#define  ADC_CSR_JEOC2                       ((uint32_t)0x00000400)        /*!<ADC2 Injected channel end of conversion */
+#define  ADC_CSR_JSTRT2                      ((uint32_t)0x00000800)        /*!<ADC2 Injected channel Start flag        */
+#define  ADC_CSR_STRT2                       ((uint32_t)0x00001000)        /*!<ADC2 Regular channel Start flag         */
+#define  ADC_CSR_DOVR2                       ((uint32_t)0x00002000)        /*!<ADC2 DMA overrun  flag                  */
+#define  ADC_CSR_AWD3                        ((uint32_t)0x00010000)        /*!<ADC3 Analog watchdog flag               */
+#define  ADC_CSR_EOC3                        ((uint32_t)0x00020000)        /*!<ADC3 End of conversion                  */
+#define  ADC_CSR_JEOC3                       ((uint32_t)0x00040000)        /*!<ADC3 Injected channel end of conversion */
+#define  ADC_CSR_JSTRT3                      ((uint32_t)0x00080000)        /*!<ADC3 Injected channel Start flag        */
+#define  ADC_CSR_STRT3                       ((uint32_t)0x00100000)        /*!<ADC3 Regular channel Start flag         */
+#define  ADC_CSR_DOVR3                       ((uint32_t)0x00200000)        /*!<ADC3 DMA overrun  flag                  */
+
+/*******************  Bit definition for ADC_CCR register  ********************/
+#define  ADC_CCR_MULTI                       ((uint32_t)0x0000001F)        /*!<MULTI[4:0] bits (Multi-ADC mode selection) */
+#define  ADC_CCR_MULTI_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  ADC_CCR_MULTI_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  ADC_CCR_MULTI_2                     ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  ADC_CCR_MULTI_3                     ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  ADC_CCR_MULTI_4                     ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  ADC_CCR_DELAY                       ((uint32_t)0x00000F00)        /*!<DELAY[3:0] bits (Delay between 2 sampling phases) */
+#define  ADC_CCR_DELAY_0                     ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  ADC_CCR_DELAY_1                     ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  ADC_CCR_DELAY_2                     ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  ADC_CCR_DELAY_3                     ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  ADC_CCR_DDS                         ((uint32_t)0x00002000)        /*!<DMA disable selection (Multi-ADC mode) */
+#define  ADC_CCR_DMA                         ((uint32_t)0x0000C000)        /*!<DMA[1:0] bits (Direct Memory Access mode for multimode) */
+#define  ADC_CCR_DMA_0                       ((uint32_t)0x00004000)        /*!<Bit 0 */
+#define  ADC_CCR_DMA_1                       ((uint32_t)0x00008000)        /*!<Bit 1 */
+#define  ADC_CCR_ADCPRE                      ((uint32_t)0x00030000)        /*!<ADCPRE[1:0] bits (ADC prescaler) */
+#define  ADC_CCR_ADCPRE_0                    ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  ADC_CCR_ADCPRE_1                    ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  ADC_CCR_VBATE                       ((uint32_t)0x00400000)        /*!<VBAT Enable */
+#define  ADC_CCR_TSVREFE                     ((uint32_t)0x00800000)        /*!<Temperature Sensor and VREFINT Enable */
+
+/*******************  Bit definition for ADC_CDR register  ********************/
+#define  ADC_CDR_DATA1                      ((uint32_t)0x0000FFFF)         /*!<1st data of a pair of regular conversions */
+#define  ADC_CDR_DATA2                      ((uint32_t)0xFFFF0000)         /*!<2nd data of a pair of regular conversions */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Controller Area Network                            */
+/*                                                                            */
+/******************************************************************************/
+/*!<CAN control and status registers */
+/*******************  Bit definition for CAN_MCR register  ********************/
+#define  CAN_MCR_INRQ                        ((uint32_t)0x00000001)        /*!<Initialization Request            */
+#define  CAN_MCR_SLEEP                       ((uint32_t)0x00000002)        /*!<Sleep Mode Request                */
+#define  CAN_MCR_TXFP                        ((uint32_t)0x00000004)        /*!<Transmit FIFO Priority            */
+#define  CAN_MCR_RFLM                        ((uint32_t)0x00000008)        /*!<Receive FIFO Locked Mode          */
+#define  CAN_MCR_NART                        ((uint32_t)0x00000010)        /*!<No Automatic Retransmission       */
+#define  CAN_MCR_AWUM                        ((uint32_t)0x00000020)        /*!<Automatic Wakeup Mode             */
+#define  CAN_MCR_ABOM                        ((uint32_t)0x00000040)        /*!<Automatic Bus-Off Management      */
+#define  CAN_MCR_TTCM                        ((uint32_t)0x00000080)        /*!<Time Triggered Communication Mode */
+#define  CAN_MCR_RESET                       ((uint32_t)0x00008000)        /*!<bxCAN software master reset       */
+
+/*******************  Bit definition for CAN_MSR register  ********************/
+#define  CAN_MSR_INAK                        ((uint32_t)0x00000001)        /*!<Initialization Acknowledge  */
+#define  CAN_MSR_SLAK                        ((uint32_t)0x00000002)        /*!<Sleep Acknowledge           */
+#define  CAN_MSR_ERRI                        ((uint32_t)0x00000004)        /*!<Error Interrupt             */
+#define  CAN_MSR_WKUI                        ((uint32_t)0x00000008)        /*!<Wakeup Interrupt            */
+#define  CAN_MSR_SLAKI                       ((uint32_t)0x00000010)        /*!<Sleep Acknowledge Interrupt */
+#define  CAN_MSR_TXM                         ((uint32_t)0x00000100)        /*!<Transmit Mode               */
+#define  CAN_MSR_RXM                         ((uint32_t)0x00000200)        /*!<Receive Mode                */
+#define  CAN_MSR_SAMP                        ((uint32_t)0x00000400)        /*!<Last Sample Point           */
+#define  CAN_MSR_RX                          ((uint32_t)0x00000800)        /*!<CAN Rx Signal               */
+
+/*******************  Bit definition for CAN_TSR register  ********************/
+#define  CAN_TSR_RQCP0                       ((uint32_t)0x00000001)        /*!<Request Completed Mailbox0      */
+#define  CAN_TSR_TXOK0                       ((uint32_t)0x00000002)        /*!<Transmission OK of Mailbox0     */
+#define  CAN_TSR_ALST0                       ((uint32_t)0x00000004)        /*!<Arbitration Lost for Mailbox0   */
+#define  CAN_TSR_TERR0                       ((uint32_t)0x00000008)        /*!<Transmission Error of Mailbox0  */
+#define  CAN_TSR_ABRQ0                       ((uint32_t)0x00000080)        /*!<Abort Request for Mailbox0      */
+#define  CAN_TSR_RQCP1                       ((uint32_t)0x00000100)        /*!<Request Completed Mailbox1      */
+#define  CAN_TSR_TXOK1                       ((uint32_t)0x00000200)        /*!<Transmission OK of Mailbox1     */
+#define  CAN_TSR_ALST1                       ((uint32_t)0x00000400)        /*!<Arbitration Lost for Mailbox1   */
+#define  CAN_TSR_TERR1                       ((uint32_t)0x00000800)        /*!<Transmission Error of Mailbox1  */
+#define  CAN_TSR_ABRQ1                       ((uint32_t)0x00008000)        /*!<Abort Request for Mailbox 1     */
+#define  CAN_TSR_RQCP2                       ((uint32_t)0x00010000)        /*!<Request Completed Mailbox2      */
+#define  CAN_TSR_TXOK2                       ((uint32_t)0x00020000)        /*!<Transmission OK of Mailbox 2    */
+#define  CAN_TSR_ALST2                       ((uint32_t)0x00040000)        /*!<Arbitration Lost for mailbox 2  */
+#define  CAN_TSR_TERR2                       ((uint32_t)0x00080000)        /*!<Transmission Error of Mailbox 2 */
+#define  CAN_TSR_ABRQ2                       ((uint32_t)0x00800000)        /*!<Abort Request for Mailbox 2     */
+#define  CAN_TSR_CODE                        ((uint32_t)0x03000000)        /*!<Mailbox Code                    */
+
+#define  CAN_TSR_TME                         ((uint32_t)0x1C000000)        /*!<TME[2:0] bits */
+#define  CAN_TSR_TME0                        ((uint32_t)0x04000000)        /*!<Transmit Mailbox 0 Empty */
+#define  CAN_TSR_TME1                        ((uint32_t)0x08000000)        /*!<Transmit Mailbox 1 Empty */
+#define  CAN_TSR_TME2                        ((uint32_t)0x10000000)        /*!<Transmit Mailbox 2 Empty */
+
+#define  CAN_TSR_LOW                         ((uint32_t)0xE0000000)        /*!<LOW[2:0] bits */
+#define  CAN_TSR_LOW0                        ((uint32_t)0x20000000)        /*!<Lowest Priority Flag for Mailbox 0 */
+#define  CAN_TSR_LOW1                        ((uint32_t)0x40000000)        /*!<Lowest Priority Flag for Mailbox 1 */
+#define  CAN_TSR_LOW2                        ((uint32_t)0x80000000)        /*!<Lowest Priority Flag for Mailbox 2 */
+
+/*******************  Bit definition for CAN_RF0R register  *******************/
+#define  CAN_RF0R_FMP0                       ((uint32_t)0x00000003)        /*!<FIFO 0 Message Pending        */
+#define  CAN_RF0R_FULL0                      ((uint32_t)0x00000008)        /*!<FIFO 0 Full                   */
+#define  CAN_RF0R_FOVR0                      ((uint32_t)0x00000010)        /*!<FIFO 0 Overrun                */
+#define  CAN_RF0R_RFOM0                      ((uint32_t)0x00000020)        /*!<Release FIFO 0 Output Mailbox */
+
+/*******************  Bit definition for CAN_RF1R register  *******************/
+#define  CAN_RF1R_FMP1                       ((uint32_t)0x00000003)        /*!<FIFO 1 Message Pending        */
+#define  CAN_RF1R_FULL1                      ((uint32_t)0x00000008)        /*!<FIFO 1 Full                   */
+#define  CAN_RF1R_FOVR1                      ((uint32_t)0x00000010)        /*!<FIFO 1 Overrun                */
+#define  CAN_RF1R_RFOM1                      ((uint32_t)0x00000020)        /*!<Release FIFO 1 Output Mailbox */
+
+/********************  Bit definition for CAN_IER register  *******************/
+#define  CAN_IER_TMEIE                       ((uint32_t)0x00000001)        /*!<Transmit Mailbox Empty Interrupt Enable */
+#define  CAN_IER_FMPIE0                      ((uint32_t)0x00000002)        /*!<FIFO Message Pending Interrupt Enable   */
+#define  CAN_IER_FFIE0                       ((uint32_t)0x00000004)        /*!<FIFO Full Interrupt Enable              */
+#define  CAN_IER_FOVIE0                      ((uint32_t)0x00000008)        /*!<FIFO Overrun Interrupt Enable           */
+#define  CAN_IER_FMPIE1                      ((uint32_t)0x00000010)        /*!<FIFO Message Pending Interrupt Enable   */
+#define  CAN_IER_FFIE1                       ((uint32_t)0x00000020)        /*!<FIFO Full Interrupt Enable              */
+#define  CAN_IER_FOVIE1                      ((uint32_t)0x00000040)        /*!<FIFO Overrun Interrupt Enable           */
+#define  CAN_IER_EWGIE                       ((uint32_t)0x00000100)        /*!<Error Warning Interrupt Enable          */
+#define  CAN_IER_EPVIE                       ((uint32_t)0x00000200)        /*!<Error Passive Interrupt Enable          */
+#define  CAN_IER_BOFIE                       ((uint32_t)0x00000400)        /*!<Bus-Off Interrupt Enable                */
+#define  CAN_IER_LECIE                       ((uint32_t)0x00000800)        /*!<Last Error Code Interrupt Enable        */
+#define  CAN_IER_ERRIE                       ((uint32_t)0x00008000)        /*!<Error Interrupt Enable                  */
+#define  CAN_IER_WKUIE                       ((uint32_t)0x00010000)        /*!<Wakeup Interrupt Enable                 */
+#define  CAN_IER_SLKIE                       ((uint32_t)0x00020000)        /*!<Sleep Interrupt Enable                  */
+
+/********************  Bit definition for CAN_ESR register  *******************/
+#define  CAN_ESR_EWGF                        ((uint32_t)0x00000001)        /*!<Error Warning Flag */
+#define  CAN_ESR_EPVF                        ((uint32_t)0x00000002)        /*!<Error Passive Flag */
+#define  CAN_ESR_BOFF                        ((uint32_t)0x00000004)        /*!<Bus-Off Flag */
+
+#define  CAN_ESR_LEC                         ((uint32_t)0x00000070)        /*!<LEC[2:0] bits (Last Error Code) */
+#define  CAN_ESR_LEC_0                       ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  CAN_ESR_LEC_1                       ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  CAN_ESR_LEC_2                       ((uint32_t)0x00000040)        /*!<Bit 2 */
+
+#define  CAN_ESR_TEC                         ((uint32_t)0x00FF0000)        /*!<Least significant byte of the 9-bit Transmit Error Counter */
+#define  CAN_ESR_REC                         ((uint32_t)0xFF000000)        /*!<Receive Error Counter */
+
+/*******************  Bit definition for CAN_BTR register  ********************/
+#define  CAN_BTR_BRP                         ((uint32_t)0x000003FF)        /*!<Baud Rate Prescaler           */
+#define  CAN_BTR_TS1                         ((uint32_t)0x000F0000)        /*!<Time Segment 1                */
+#define  CAN_BTR_TS1_0                       ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  CAN_BTR_TS1_1                       ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  CAN_BTR_TS1_2                       ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  CAN_BTR_TS1_3                       ((uint32_t)0x00080000)        /*!<Bit 3 */
+#define  CAN_BTR_TS2                         ((uint32_t)0x00700000)        /*!<Time Segment 2                */
+#define  CAN_BTR_TS2_0                       ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  CAN_BTR_TS2_1                       ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  CAN_BTR_TS2_2                       ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  CAN_BTR_SJW                         ((uint32_t)0x03000000)        /*!<Resynchronization Jump Width  */
+#define  CAN_BTR_SJW_0                       ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  CAN_BTR_SJW_1                       ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  CAN_BTR_LBKM                        ((uint32_t)0x40000000)        /*!<Loop Back Mode (Debug)        */
+#define  CAN_BTR_SILM                        ((uint32_t)0x80000000)        /*!<Silent Mode                   */
+
+/*!<Mailbox registers */
+/******************  Bit definition for CAN_TI0R register  ********************/
+#define  CAN_TI0R_TXRQ                       ((uint32_t)0x00000001)        /*!<Transmit Mailbox Request                   */
+#define  CAN_TI0R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_TI0R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_TI0R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended Identifier                        */
+#define  CAN_TI0R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/******************  Bit definition for CAN_TDT0R register  *******************/
+#define  CAN_TDT0R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code     */
+#define  CAN_TDT0R_TGT                       ((uint32_t)0x00000100)        /*!<Transmit Global Time */
+#define  CAN_TDT0R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp   */
+
+/******************  Bit definition for CAN_TDL0R register  *******************/
+#define  CAN_TDL0R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_TDL0R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_TDL0R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_TDL0R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/******************  Bit definition for CAN_TDH0R register  *******************/
+#define  CAN_TDH0R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_TDH0R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_TDH0R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_TDH0R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*******************  Bit definition for CAN_TI1R register  *******************/
+#define  CAN_TI1R_TXRQ                       ((uint32_t)0x00000001)        /*!<Transmit Mailbox Request                   */
+#define  CAN_TI1R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_TI1R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_TI1R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended Identifier                        */
+#define  CAN_TI1R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_TDT1R register  ******************/
+#define  CAN_TDT1R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code     */
+#define  CAN_TDT1R_TGT                       ((uint32_t)0x00000100)        /*!<Transmit Global Time */
+#define  CAN_TDT1R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp   */
+
+/*******************  Bit definition for CAN_TDL1R register  ******************/
+#define  CAN_TDL1R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_TDL1R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_TDL1R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_TDL1R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/*******************  Bit definition for CAN_TDH1R register  ******************/
+#define  CAN_TDH1R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_TDH1R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_TDH1R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_TDH1R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*******************  Bit definition for CAN_TI2R register  *******************/
+#define  CAN_TI2R_TXRQ                       ((uint32_t)0x00000001)        /*!<Transmit Mailbox Request                   */
+#define  CAN_TI2R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_TI2R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_TI2R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended identifier                        */
+#define  CAN_TI2R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_TDT2R register  ******************/
+#define  CAN_TDT2R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code      */
+#define  CAN_TDT2R_TGT                       ((uint32_t)0x00000100)        /*!<Transmit Global Time  */
+#define  CAN_TDT2R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp    */
+
+/*******************  Bit definition for CAN_TDL2R register  ******************/
+#define  CAN_TDL2R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_TDL2R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_TDL2R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_TDL2R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/*******************  Bit definition for CAN_TDH2R register  ******************/
+#define  CAN_TDH2R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_TDH2R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_TDH2R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_TDH2R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*******************  Bit definition for CAN_RI0R register  *******************/
+#define  CAN_RI0R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_RI0R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_RI0R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended Identifier                        */
+#define  CAN_RI0R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_RDT0R register  ******************/
+#define  CAN_RDT0R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code */
+#define  CAN_RDT0R_FMI                       ((uint32_t)0x0000FF00)        /*!<Filter Match Index */
+#define  CAN_RDT0R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp */
+
+/*******************  Bit definition for CAN_RDL0R register  ******************/
+#define  CAN_RDL0R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_RDL0R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_RDL0R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_RDL0R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/*******************  Bit definition for CAN_RDH0R register  ******************/
+#define  CAN_RDH0R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_RDH0R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_RDH0R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_RDH0R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*******************  Bit definition for CAN_RI1R register  *******************/
+#define  CAN_RI1R_RTR                        ((uint32_t)0x00000002)        /*!<Remote Transmission Request                */
+#define  CAN_RI1R_IDE                        ((uint32_t)0x00000004)        /*!<Identifier Extension                       */
+#define  CAN_RI1R_EXID                       ((uint32_t)0x001FFFF8)        /*!<Extended identifier                        */
+#define  CAN_RI1R_STID                       ((uint32_t)0xFFE00000)        /*!<Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_RDT1R register  ******************/
+#define  CAN_RDT1R_DLC                       ((uint32_t)0x0000000F)        /*!<Data Length Code   */
+#define  CAN_RDT1R_FMI                       ((uint32_t)0x0000FF00)        /*!<Filter Match Index */
+#define  CAN_RDT1R_TIME                      ((uint32_t)0xFFFF0000)        /*!<Message Time Stamp */
+
+/*******************  Bit definition for CAN_RDL1R register  ******************/
+#define  CAN_RDL1R_DATA0                     ((uint32_t)0x000000FF)        /*!<Data byte 0 */
+#define  CAN_RDL1R_DATA1                     ((uint32_t)0x0000FF00)        /*!<Data byte 1 */
+#define  CAN_RDL1R_DATA2                     ((uint32_t)0x00FF0000)        /*!<Data byte 2 */
+#define  CAN_RDL1R_DATA3                     ((uint32_t)0xFF000000)        /*!<Data byte 3 */
+
+/*******************  Bit definition for CAN_RDH1R register  ******************/
+#define  CAN_RDH1R_DATA4                     ((uint32_t)0x000000FF)        /*!<Data byte 4 */
+#define  CAN_RDH1R_DATA5                     ((uint32_t)0x0000FF00)        /*!<Data byte 5 */
+#define  CAN_RDH1R_DATA6                     ((uint32_t)0x00FF0000)        /*!<Data byte 6 */
+#define  CAN_RDH1R_DATA7                     ((uint32_t)0xFF000000)        /*!<Data byte 7 */
+
+/*!<CAN filter registers */
+/*******************  Bit definition for CAN_FMR register  ********************/
+#define  CAN_FMR_FINIT                       ((uint8_t)0x01)               /*!<Filter Init Mode */
+#define  CAN_FMR_CAN2SB                      ((uint32_t)0x00003F00)        /*!<CAN2 start bank */
+
+/*******************  Bit definition for CAN_FM1R register  *******************/
+#define  CAN_FM1R_FBM                        ((uint32_t)0x3FFF)            /*!<Filter Mode */
+#define  CAN_FM1R_FBM0                       ((uint32_t)0x0001)            /*!<Filter Init Mode bit 0  */
+#define  CAN_FM1R_FBM1                       ((uint32_t)0x0002)            /*!<Filter Init Mode bit 1  */
+#define  CAN_FM1R_FBM2                       ((uint32_t)0x0004)            /*!<Filter Init Mode bit 2  */
+#define  CAN_FM1R_FBM3                       ((uint32_t)0x0008)            /*!<Filter Init Mode bit 3  */
+#define  CAN_FM1R_FBM4                       ((uint32_t)0x0010)            /*!<Filter Init Mode bit 4  */
+#define  CAN_FM1R_FBM5                       ((uint32_t)0x0020)            /*!<Filter Init Mode bit 5  */
+#define  CAN_FM1R_FBM6                       ((uint32_t)0x0040)            /*!<Filter Init Mode bit 6  */
+#define  CAN_FM1R_FBM7                       ((uint32_t)0x0080)            /*!<Filter Init Mode bit 7  */
+#define  CAN_FM1R_FBM8                       ((uint32_t)0x0100)            /*!<Filter Init Mode bit 8  */
+#define  CAN_FM1R_FBM9                       ((uint32_t)0x0200)            /*!<Filter Init Mode bit 9  */
+#define  CAN_FM1R_FBM10                      ((uint32_t)0x0400)            /*!<Filter Init Mode bit 10 */
+#define  CAN_FM1R_FBM11                      ((uint32_t)0x0800)            /*!<Filter Init Mode bit 11 */
+#define  CAN_FM1R_FBM12                      ((uint32_t)0x1000)            /*!<Filter Init Mode bit 12 */
+#define  CAN_FM1R_FBM13                      ((uint32_t)0x2000)            /*!<Filter Init Mode bit 13 */
+
+/*******************  Bit definition for CAN_FS1R register  *******************/
+#define  CAN_FS1R_FSC                        ((uint32_t)0x00003FFF)        /*!<Filter Scale Configuration        */
+#define  CAN_FS1R_FSC0                       ((uint32_t)0x00000001)        /*!<Filter Scale Configuration bit 0  */
+#define  CAN_FS1R_FSC1                       ((uint32_t)0x00000002)        /*!<Filter Scale Configuration bit 1  */
+#define  CAN_FS1R_FSC2                       ((uint32_t)0x00000004)        /*!<Filter Scale Configuration bit 2  */
+#define  CAN_FS1R_FSC3                       ((uint32_t)0x00000008)        /*!<Filter Scale Configuration bit 3  */
+#define  CAN_FS1R_FSC4                       ((uint32_t)0x00000010)        /*!<Filter Scale Configuration bit 4  */
+#define  CAN_FS1R_FSC5                       ((uint32_t)0x00000020)        /*!<Filter Scale Configuration bit 5  */
+#define  CAN_FS1R_FSC6                       ((uint32_t)0x00000040)        /*!<Filter Scale Configuration bit 6  */
+#define  CAN_FS1R_FSC7                       ((uint32_t)0x00000080)        /*!<Filter Scale Configuration bit 7  */
+#define  CAN_FS1R_FSC8                       ((uint32_t)0x00000100)        /*!<Filter Scale Configuration bit 8  */
+#define  CAN_FS1R_FSC9                       ((uint32_t)0x00000200)        /*!<Filter Scale Configuration bit 9  */
+#define  CAN_FS1R_FSC10                      ((uint32_t)0x00000400)        /*!<Filter Scale Configuration bit 10 */
+#define  CAN_FS1R_FSC11                      ((uint32_t)0x00000800)        /*!<Filter Scale Configuration bit 11 */
+#define  CAN_FS1R_FSC12                      ((uint32_t)0x00001000)        /*!<Filter Scale Configuration bit 12 */
+#define  CAN_FS1R_FSC13                      ((uint32_t)0x00002000)        /*!<Filter Scale Configuration bit 13 */
+
+/******************  Bit definition for CAN_FFA1R register  *******************/
+#define  CAN_FFA1R_FFA                       ((uint32_t)0x00003FFF)        /*!<Filter FIFO Assignment */
+#define  CAN_FFA1R_FFA0                      ((uint32_t)0x00000001)        /*!<Filter FIFO Assignment for Filter 0 */
+#define  CAN_FFA1R_FFA1                      ((uint32_t)0x00000002)        /*!<Filter FIFO Assignment for Filter 1 */
+#define  CAN_FFA1R_FFA2                      ((uint32_t)0x00000004)        /*!<Filter FIFO Assignment for Filter 2 */
+#define  CAN_FFA1R_FFA3                      ((uint32_t)0x00000008)        /*!<Filter FIFO Assignment for Filter 3 */
+#define  CAN_FFA1R_FFA4                      ((uint32_t)0x00000010)        /*!<Filter FIFO Assignment for Filter 4 */
+#define  CAN_FFA1R_FFA5                      ((uint32_t)0x00000020)        /*!<Filter FIFO Assignment for Filter 5 */
+#define  CAN_FFA1R_FFA6                      ((uint32_t)0x00000040)        /*!<Filter FIFO Assignment for Filter 6 */
+#define  CAN_FFA1R_FFA7                      ((uint32_t)0x00000080)        /*!<Filter FIFO Assignment for Filter 7 */
+#define  CAN_FFA1R_FFA8                      ((uint32_t)0x00000100)        /*!<Filter FIFO Assignment for Filter 8 */
+#define  CAN_FFA1R_FFA9                      ((uint32_t)0x00000200)        /*!<Filter FIFO Assignment for Filter 9 */
+#define  CAN_FFA1R_FFA10                     ((uint32_t)0x00000400)        /*!<Filter FIFO Assignment for Filter 10 */
+#define  CAN_FFA1R_FFA11                     ((uint32_t)0x00000800)        /*!<Filter FIFO Assignment for Filter 11 */
+#define  CAN_FFA1R_FFA12                     ((uint32_t)0x00001000)        /*!<Filter FIFO Assignment for Filter 12 */
+#define  CAN_FFA1R_FFA13                     ((uint32_t)0x00002000)        /*!<Filter FIFO Assignment for Filter 13 */
+
+/*******************  Bit definition for CAN_FA1R register  *******************/
+#define  CAN_FA1R_FACT                       ((uint32_t)0x00003FFF)        /*!<Filter Active    */
+#define  CAN_FA1R_FACT0                      ((uint32_t)0x00000001)        /*!<Filter 0 Active  */
+#define  CAN_FA1R_FACT1                      ((uint32_t)0x00000002)        /*!<Filter 1 Active  */
+#define  CAN_FA1R_FACT2                      ((uint32_t)0x00000004)        /*!<Filter 2 Active  */
+#define  CAN_FA1R_FACT3                      ((uint32_t)0x00000008)        /*!<Filter 3 Active  */
+#define  CAN_FA1R_FACT4                      ((uint32_t)0x00000010)        /*!<Filter 4 Active  */
+#define  CAN_FA1R_FACT5                      ((uint32_t)0x00000020)        /*!<Filter 5 Active  */
+#define  CAN_FA1R_FACT6                      ((uint32_t)0x00000040)        /*!<Filter 6 Active  */
+#define  CAN_FA1R_FACT7                      ((uint32_t)0x00000080)        /*!<Filter 7 Active  */
+#define  CAN_FA1R_FACT8                      ((uint32_t)0x00000100)        /*!<Filter 8 Active  */
+#define  CAN_FA1R_FACT9                      ((uint32_t)0x00000200)        /*!<Filter 9 Active  */
+#define  CAN_FA1R_FACT10                     ((uint32_t)0x00000400)        /*!<Filter 10 Active */
+#define  CAN_FA1R_FACT11                     ((uint32_t)0x00000800)        /*!<Filter 11 Active */
+#define  CAN_FA1R_FACT12                     ((uint32_t)0x00001000)        /*!<Filter 12 Active */
+#define  CAN_FA1R_FACT13                     ((uint32_t)0x00002000)        /*!<Filter 13 Active */
+
+/*******************  Bit definition for CAN_F0R1 register  *******************/
+#define  CAN_F0R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F0R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F0R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F0R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F0R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F0R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F0R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F0R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F0R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F0R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F0R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F0R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F0R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F0R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F0R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F0R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F0R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F0R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F0R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F0R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F0R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F0R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F0R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F0R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F0R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F0R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F0R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F0R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F0R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F0R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F0R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F0R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F1R1 register  *******************/
+#define  CAN_F1R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F1R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F1R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F1R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F1R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F1R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F1R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F1R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F1R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F1R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F1R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F1R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F1R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F1R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F1R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F1R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F1R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F1R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F1R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F1R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F1R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F1R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F1R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F1R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F1R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F1R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F1R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F1R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F1R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F1R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F1R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F1R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F2R1 register  *******************/
+#define  CAN_F2R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F2R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F2R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F2R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F2R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F2R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F2R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F2R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F2R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F2R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F2R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F2R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F2R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F2R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F2R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F2R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F2R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F2R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F2R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F2R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F2R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F2R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F2R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F2R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F2R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F2R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F2R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F2R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F2R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F2R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F2R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F2R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F3R1 register  *******************/
+#define  CAN_F3R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F3R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F3R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F3R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F3R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F3R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F3R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F3R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F3R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F3R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F3R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F3R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F3R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F3R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F3R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F3R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F3R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F3R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F3R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F3R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F3R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F3R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F3R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F3R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F3R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F3R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F3R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F3R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F3R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F3R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F3R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F3R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F4R1 register  *******************/
+#define  CAN_F4R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F4R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F4R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F4R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F4R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F4R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F4R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F4R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F4R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F4R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F4R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F4R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F4R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F4R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F4R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F4R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F4R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F4R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F4R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F4R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F4R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F4R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F4R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F4R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F4R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F4R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F4R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F4R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F4R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F4R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F4R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F4R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F5R1 register  *******************/
+#define  CAN_F5R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F5R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F5R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F5R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F5R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F5R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F5R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F5R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F5R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F5R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F5R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F5R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F5R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F5R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F5R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F5R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F5R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F5R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F5R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F5R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F5R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F5R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F5R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F5R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F5R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F5R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F5R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F5R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F5R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F5R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F5R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F5R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F6R1 register  *******************/
+#define  CAN_F6R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F6R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F6R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F6R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F6R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F6R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F6R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F6R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F6R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F6R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F6R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F6R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F6R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F6R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F6R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F6R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F6R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F6R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F6R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F6R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F6R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F6R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F6R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F6R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F6R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F6R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F6R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F6R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F6R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F6R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F6R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F6R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F7R1 register  *******************/
+#define  CAN_F7R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F7R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F7R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F7R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F7R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F7R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F7R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F7R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F7R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F7R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F7R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F7R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F7R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F7R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F7R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F7R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F7R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F7R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F7R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F7R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F7R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F7R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F7R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F7R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F7R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F7R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F7R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F7R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F7R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F7R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F7R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F7R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F8R1 register  *******************/
+#define  CAN_F8R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F8R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F8R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F8R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F8R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F8R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F8R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F8R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F8R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F8R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F8R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F8R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F8R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F8R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F8R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F8R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F8R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F8R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F8R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F8R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F8R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F8R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F8R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F8R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F8R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F8R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F8R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F8R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F8R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F8R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F8R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F8R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F9R1 register  *******************/
+#define  CAN_F9R1_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F9R1_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F9R1_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F9R1_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F9R1_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F9R1_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F9R1_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F9R1_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F9R1_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F9R1_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F9R1_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F9R1_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F9R1_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F9R1_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F9R1_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F9R1_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F9R1_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F9R1_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F9R1_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F9R1_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F9R1_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F9R1_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F9R1_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F9R1_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F9R1_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F9R1_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F9R1_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F9R1_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F9R1_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F9R1_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F9R1_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F9R1_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F10R1 register  ******************/
+#define  CAN_F10R1_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F10R1_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F10R1_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F10R1_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F10R1_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F10R1_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F10R1_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F10R1_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F10R1_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F10R1_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F10R1_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F10R1_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F10R1_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F10R1_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F10R1_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F10R1_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F10R1_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F10R1_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F10R1_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F10R1_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F10R1_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F10R1_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F10R1_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F10R1_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F10R1_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F10R1_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F10R1_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F10R1_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F10R1_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F10R1_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F10R1_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F10R1_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F11R1 register  ******************/
+#define  CAN_F11R1_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F11R1_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F11R1_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F11R1_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F11R1_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F11R1_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F11R1_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F11R1_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F11R1_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F11R1_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F11R1_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F11R1_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F11R1_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F11R1_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F11R1_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F11R1_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F11R1_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F11R1_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F11R1_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F11R1_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F11R1_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F11R1_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F11R1_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F11R1_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F11R1_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F11R1_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F11R1_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F11R1_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F11R1_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F11R1_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F11R1_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F11R1_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F12R1 register  ******************/
+#define  CAN_F12R1_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F12R1_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F12R1_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F12R1_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F12R1_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F12R1_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F12R1_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F12R1_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F12R1_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F12R1_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F12R1_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F12R1_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F12R1_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F12R1_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F12R1_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F12R1_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F12R1_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F12R1_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F12R1_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F12R1_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F12R1_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F12R1_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F12R1_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F12R1_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F12R1_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F12R1_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F12R1_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F12R1_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F12R1_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F12R1_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F12R1_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F12R1_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F13R1 register  ******************/
+#define  CAN_F13R1_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F13R1_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F13R1_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F13R1_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F13R1_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F13R1_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F13R1_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F13R1_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F13R1_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F13R1_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F13R1_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F13R1_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F13R1_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F13R1_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F13R1_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F13R1_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F13R1_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F13R1_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F13R1_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F13R1_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F13R1_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F13R1_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F13R1_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F13R1_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F13R1_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F13R1_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F13R1_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F13R1_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F13R1_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F13R1_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F13R1_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F13R1_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F0R2 register  *******************/
+#define  CAN_F0R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F0R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F0R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F0R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F0R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F0R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F0R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F0R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F0R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F0R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F0R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F0R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F0R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F0R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F0R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F0R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F0R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F0R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F0R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F0R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F0R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F0R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F0R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F0R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F0R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F0R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F0R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F0R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F0R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F0R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F0R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F0R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F1R2 register  *******************/
+#define  CAN_F1R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F1R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F1R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F1R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F1R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F1R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F1R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F1R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F1R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F1R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F1R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F1R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F1R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F1R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F1R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F1R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F1R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F1R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F1R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F1R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F1R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F1R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F1R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F1R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F1R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F1R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F1R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F1R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F1R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F1R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F1R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F1R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F2R2 register  *******************/
+#define  CAN_F2R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F2R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F2R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F2R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F2R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F2R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F2R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F2R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F2R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F2R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F2R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F2R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F2R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F2R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F2R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F2R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F2R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F2R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F2R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F2R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F2R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F2R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F2R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F2R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F2R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F2R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F2R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F2R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F2R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F2R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F2R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F2R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F3R2 register  *******************/
+#define  CAN_F3R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F3R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F3R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F3R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F3R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F3R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F3R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F3R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F3R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F3R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F3R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F3R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F3R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F3R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F3R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F3R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F3R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F3R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F3R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F3R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F3R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F3R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F3R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F3R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F3R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F3R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F3R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F3R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F3R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F3R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F3R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F3R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F4R2 register  *******************/
+#define  CAN_F4R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F4R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F4R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F4R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F4R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F4R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F4R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F4R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F4R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F4R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F4R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F4R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F4R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F4R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F4R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F4R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F4R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F4R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F4R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F4R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F4R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F4R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F4R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F4R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F4R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F4R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F4R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F4R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F4R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F4R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F4R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F4R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F5R2 register  *******************/
+#define  CAN_F5R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F5R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F5R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F5R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F5R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F5R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F5R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F5R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F5R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F5R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F5R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F5R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F5R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F5R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F5R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F5R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F5R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F5R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F5R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F5R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F5R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F5R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F5R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F5R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F5R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F5R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F5R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F5R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F5R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F5R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F5R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F5R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F6R2 register  *******************/
+#define  CAN_F6R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F6R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F6R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F6R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F6R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F6R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F6R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F6R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F6R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F6R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F6R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F6R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F6R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F6R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F6R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F6R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F6R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F6R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F6R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F6R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F6R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F6R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F6R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F6R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F6R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F6R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F6R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F6R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F6R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F6R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F6R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F6R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F7R2 register  *******************/
+#define  CAN_F7R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F7R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F7R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F7R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F7R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F7R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F7R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F7R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F7R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F7R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F7R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F7R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F7R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F7R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F7R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F7R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F7R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F7R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F7R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F7R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F7R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F7R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F7R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F7R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F7R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F7R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F7R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F7R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F7R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F7R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F7R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F7R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F8R2 register  *******************/
+#define  CAN_F8R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F8R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F8R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F8R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F8R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F8R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F8R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F8R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F8R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F8R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F8R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F8R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F8R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F8R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F8R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F8R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F8R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F8R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F8R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F8R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F8R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F8R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F8R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F8R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F8R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F8R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F8R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F8R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F8R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F8R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F8R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F8R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F9R2 register  *******************/
+#define  CAN_F9R2_FB0                        ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F9R2_FB1                        ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F9R2_FB2                        ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F9R2_FB3                        ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F9R2_FB4                        ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F9R2_FB5                        ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F9R2_FB6                        ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F9R2_FB7                        ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F9R2_FB8                        ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F9R2_FB9                        ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F9R2_FB10                       ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F9R2_FB11                       ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F9R2_FB12                       ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F9R2_FB13                       ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F9R2_FB14                       ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F9R2_FB15                       ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F9R2_FB16                       ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F9R2_FB17                       ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F9R2_FB18                       ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F9R2_FB19                       ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F9R2_FB20                       ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F9R2_FB21                       ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F9R2_FB22                       ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F9R2_FB23                       ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F9R2_FB24                       ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F9R2_FB25                       ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F9R2_FB26                       ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F9R2_FB27                       ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F9R2_FB28                       ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F9R2_FB29                       ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F9R2_FB30                       ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F9R2_FB31                       ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F10R2 register  ******************/
+#define  CAN_F10R2_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F10R2_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F10R2_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F10R2_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F10R2_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F10R2_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F10R2_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F10R2_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F10R2_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F10R2_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F10R2_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F10R2_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F10R2_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F10R2_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F10R2_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F10R2_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F10R2_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F10R2_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F10R2_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F10R2_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F10R2_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F10R2_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F10R2_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F10R2_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F10R2_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F10R2_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F10R2_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F10R2_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F10R2_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F10R2_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F10R2_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F10R2_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F11R2 register  ******************/
+#define  CAN_F11R2_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F11R2_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F11R2_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F11R2_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F11R2_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F11R2_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F11R2_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F11R2_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F11R2_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F11R2_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F11R2_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F11R2_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F11R2_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F11R2_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F11R2_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F11R2_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F11R2_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F11R2_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F11R2_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F11R2_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F11R2_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F11R2_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F11R2_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F11R2_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F11R2_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F11R2_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F11R2_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F11R2_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F11R2_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F11R2_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F11R2_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F11R2_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F12R2 register  ******************/
+#define  CAN_F12R2_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F12R2_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F12R2_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F12R2_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F12R2_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F12R2_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F12R2_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F12R2_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F12R2_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F12R2_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F12R2_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F12R2_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F12R2_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F12R2_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F12R2_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F12R2_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F12R2_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F12R2_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F12R2_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F12R2_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F12R2_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F12R2_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F12R2_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F12R2_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F12R2_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F12R2_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F12R2_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F12R2_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F12R2_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F12R2_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F12R2_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F12R2_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/*******************  Bit definition for CAN_F13R2 register  ******************/
+#define  CAN_F13R2_FB0                       ((uint32_t)0x00000001)        /*!<Filter bit 0 */
+#define  CAN_F13R2_FB1                       ((uint32_t)0x00000002)        /*!<Filter bit 1 */
+#define  CAN_F13R2_FB2                       ((uint32_t)0x00000004)        /*!<Filter bit 2 */
+#define  CAN_F13R2_FB3                       ((uint32_t)0x00000008)        /*!<Filter bit 3 */
+#define  CAN_F13R2_FB4                       ((uint32_t)0x00000010)        /*!<Filter bit 4 */
+#define  CAN_F13R2_FB5                       ((uint32_t)0x00000020)        /*!<Filter bit 5 */
+#define  CAN_F13R2_FB6                       ((uint32_t)0x00000040)        /*!<Filter bit 6 */
+#define  CAN_F13R2_FB7                       ((uint32_t)0x00000080)        /*!<Filter bit 7 */
+#define  CAN_F13R2_FB8                       ((uint32_t)0x00000100)        /*!<Filter bit 8 */
+#define  CAN_F13R2_FB9                       ((uint32_t)0x00000200)        /*!<Filter bit 9 */
+#define  CAN_F13R2_FB10                      ((uint32_t)0x00000400)        /*!<Filter bit 10 */
+#define  CAN_F13R2_FB11                      ((uint32_t)0x00000800)        /*!<Filter bit 11 */
+#define  CAN_F13R2_FB12                      ((uint32_t)0x00001000)        /*!<Filter bit 12 */
+#define  CAN_F13R2_FB13                      ((uint32_t)0x00002000)        /*!<Filter bit 13 */
+#define  CAN_F13R2_FB14                      ((uint32_t)0x00004000)        /*!<Filter bit 14 */
+#define  CAN_F13R2_FB15                      ((uint32_t)0x00008000)        /*!<Filter bit 15 */
+#define  CAN_F13R2_FB16                      ((uint32_t)0x00010000)        /*!<Filter bit 16 */
+#define  CAN_F13R2_FB17                      ((uint32_t)0x00020000)        /*!<Filter bit 17 */
+#define  CAN_F13R2_FB18                      ((uint32_t)0x00040000)        /*!<Filter bit 18 */
+#define  CAN_F13R2_FB19                      ((uint32_t)0x00080000)        /*!<Filter bit 19 */
+#define  CAN_F13R2_FB20                      ((uint32_t)0x00100000)        /*!<Filter bit 20 */
+#define  CAN_F13R2_FB21                      ((uint32_t)0x00200000)        /*!<Filter bit 21 */
+#define  CAN_F13R2_FB22                      ((uint32_t)0x00400000)        /*!<Filter bit 22 */
+#define  CAN_F13R2_FB23                      ((uint32_t)0x00800000)        /*!<Filter bit 23 */
+#define  CAN_F13R2_FB24                      ((uint32_t)0x01000000)        /*!<Filter bit 24 */
+#define  CAN_F13R2_FB25                      ((uint32_t)0x02000000)        /*!<Filter bit 25 */
+#define  CAN_F13R2_FB26                      ((uint32_t)0x04000000)        /*!<Filter bit 26 */
+#define  CAN_F13R2_FB27                      ((uint32_t)0x08000000)        /*!<Filter bit 27 */
+#define  CAN_F13R2_FB28                      ((uint32_t)0x10000000)        /*!<Filter bit 28 */
+#define  CAN_F13R2_FB29                      ((uint32_t)0x20000000)        /*!<Filter bit 29 */
+#define  CAN_F13R2_FB30                      ((uint32_t)0x40000000)        /*!<Filter bit 30 */
+#define  CAN_F13R2_FB31                      ((uint32_t)0x80000000)        /*!<Filter bit 31 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 HDMI-CEC (CEC)                             */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for CEC_CR register  *********************/
+#define  CEC_CR_CECEN                        ((uint32_t)0x00000001)       /*!< CEC Enable                         */
+#define  CEC_CR_TXSOM                        ((uint32_t)0x00000002)       /*!< CEC Tx Start Of Message            */
+#define  CEC_CR_TXEOM                        ((uint32_t)0x00000004)       /*!< CEC Tx End Of Message              */
+
+/*******************  Bit definition for CEC_CFGR register  *******************/
+#define  CEC_CFGR_SFT                        ((uint32_t)0x00000007)       /*!< CEC Signal Free Time               */
+#define  CEC_CFGR_RXTOL                      ((uint32_t)0x00000008)       /*!< CEC Tolerance                      */
+#define  CEC_CFGR_BRESTP                     ((uint32_t)0x00000010)       /*!< CEC Rx Stop                        */
+#define  CEC_CFGR_BREGEN                     ((uint32_t)0x00000020)       /*!< CEC Bit Rising Error generation    */
+#define  CEC_CFGR_LBPEGEN                    ((uint32_t)0x00000040)       /*!< CEC Long Period Error generation   */
+#define  CEC_CFGR_BRDNOGEN                   ((uint32_t)0x00000080)       /*!< CEC Broadcast no Error generation  */
+#define  CEC_CFGR_SFTOPT                     ((uint32_t)0x00000100)       /*!< CEC Signal Free Time optional      */
+#define  CEC_CFGR_OAR                        ((uint32_t)0x7FFF0000)       /*!< CEC Own Address                    */
+#define  CEC_CFGR_LSTN                       ((uint32_t)0x80000000)       /*!< CEC Listen mode                    */
+
+/*******************  Bit definition for CEC_TXDR register  *******************/
+#define  CEC_TXDR_TXD                        ((uint32_t)0x000000FF)       /*!< CEC Tx Data                        */
+
+/*******************  Bit definition for CEC_RXDR register  *******************/
+#define  CEC_TXDR_RXD                        ((uint32_t)0x000000FF)       /*!< CEC Rx Data                        */
+
+/*******************  Bit definition for CEC_ISR register  ********************/
+#define  CEC_ISR_RXBR                        ((uint32_t)0x00000001)       /*!< CEC Rx-Byte Received                   */
+#define  CEC_ISR_RXEND                       ((uint32_t)0x00000002)       /*!< CEC End Of Reception                   */
+#define  CEC_ISR_RXOVR                       ((uint32_t)0x00000004)       /*!< CEC Rx-Overrun                         */
+#define  CEC_ISR_BRE                         ((uint32_t)0x00000008)       /*!< CEC Rx Bit Rising Error                */
+#define  CEC_ISR_SBPE                        ((uint32_t)0x00000010)       /*!< CEC Rx Short Bit period Error          */
+#define  CEC_ISR_LBPE                        ((uint32_t)0x00000020)       /*!< CEC Rx Long Bit period Error           */
+#define  CEC_ISR_RXACKE                      ((uint32_t)0x00000040)       /*!< CEC Rx Missing Acknowledge             */
+#define  CEC_ISR_ARBLST                      ((uint32_t)0x00000080)       /*!< CEC Arbitration Lost                   */
+#define  CEC_ISR_TXBR                        ((uint32_t)0x00000100)       /*!< CEC Tx Byte Request                    */
+#define  CEC_ISR_TXEND                       ((uint32_t)0x00000200)       /*!< CEC End of Transmission                */
+#define  CEC_ISR_TXUDR                       ((uint32_t)0x00000400)       /*!< CEC Tx-Buffer Underrun                 */
+#define  CEC_ISR_TXERR                       ((uint32_t)0x00000800)       /*!< CEC Tx-Error                           */
+#define  CEC_ISR_TXACKE                      ((uint32_t)0x00001000)       /*!< CEC Tx Missing Acknowledge             */
+
+/*******************  Bit definition for CEC_IER register  ********************/
+#define  CEC_IER_RXBRIE                      ((uint32_t)0x00000001)       /*!< CEC Rx-Byte Received IT Enable         */
+#define  CEC_IER_RXENDIE                     ((uint32_t)0x00000002)       /*!< CEC End Of Reception IT Enable         */
+#define  CEC_IER_RXOVRIE                     ((uint32_t)0x00000004)       /*!< CEC Rx-Overrun IT Enable               */
+#define  CEC_IER_BREIE                       ((uint32_t)0x00000008)       /*!< CEC Rx Bit Rising Error IT Enable      */
+#define  CEC_IER_SBPEIE                      ((uint32_t)0x00000010)       /*!< CEC Rx Short Bit period Error IT Enable*/
+#define  CEC_IER_LBPEIE                      ((uint32_t)0x00000020)       /*!< CEC Rx Long Bit period Error IT Enable */
+#define  CEC_IER_RXACKEIE                    ((uint32_t)0x00000040)       /*!< CEC Rx Missing Acknowledge IT Enable   */
+#define  CEC_IER_ARBLSTIE                    ((uint32_t)0x00000080)       /*!< CEC Arbitration Lost IT Enable         */
+#define  CEC_IER_TXBRIE                      ((uint32_t)0x00000100)       /*!< CEC Tx Byte Request  IT Enable         */
+#define  CEC_IER_TXENDIE                     ((uint32_t)0x00000200)       /*!< CEC End of Transmission IT Enable      */
+#define  CEC_IER_TXUDRIE                     ((uint32_t)0x00000400)       /*!< CEC Tx-Buffer Underrun IT Enable       */
+#define  CEC_IER_TXERRIE                     ((uint32_t)0x00000800)       /*!< CEC Tx-Error IT Enable                 */
+#define  CEC_IER_TXACKEIE                    ((uint32_t)0x00001000)       /*!< CEC Tx Missing Acknowledge IT Enable   */
+
+/******************************************************************************/
+/*                                                                            */
+/*                          CRC calculation unit                              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for CRC_DR register  *********************/
+#define  CRC_DR_DR                           ((uint32_t)0xFFFFFFFF)     /*!< Data register bits */
+
+/*******************  Bit definition for CRC_IDR register  ********************/
+#define  CRC_IDR_IDR                         ((uint32_t)0x000000FF)     /*!< General-purpose 8-bit data register bits */
+
+/********************  Bit definition for CRC_CR register  ********************/
+#define  CRC_CR_RESET                        ((uint32_t)0x00000001)     /*!< RESET the CRC computation unit bit */
+#define  CRC_CR_POLYSIZE                     ((uint32_t)0x00000018)     /*!< Polynomial size bits               */
+#define  CRC_CR_POLYSIZE_0                   ((uint32_t)0x00000008)     /*!< Polynomial size bit 0              */
+#define  CRC_CR_POLYSIZE_1                   ((uint32_t)0x00000010)     /*!< Polynomial size bit 1              */
+#define  CRC_CR_REV_IN                       ((uint32_t)0x00000060)     /*!< REV_IN Reverse Input Data bits     */
+#define  CRC_CR_REV_IN_0                     ((uint32_t)0x00000020)     /*!< Bit 0 */
+#define  CRC_CR_REV_IN_1                     ((uint32_t)0x00000040)     /*!< Bit 1 */
+#define  CRC_CR_REV_OUT                      ((uint32_t)0x00000080)     /*!< REV_OUT Reverse Output Data bits   */
+
+/*******************  Bit definition for CRC_INIT register  *******************/
+#define  CRC_INIT_INIT                       ((uint32_t)0xFFFFFFFF)     /*!< Initial CRC value bits         */
+
+/*******************  Bit definition for CRC_POL register  ********************/
+#define  CRC_POL_POL                         ((uint32_t)0xFFFFFFFF)     /*!< Coefficients of the polynomial */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                            Crypto Processor                                */
+/*                                                                            */
+/******************************************************************************/
+/******************* Bits definition for CRYP_CR register  ********************/
+#define CRYP_CR_ALGODIR                      ((uint32_t)0x00000004)
+
+#define CRYP_CR_ALGOMODE                     ((uint32_t)0x00080038)
+#define CRYP_CR_ALGOMODE_0                   ((uint32_t)0x00000008)
+#define CRYP_CR_ALGOMODE_1                   ((uint32_t)0x00000010)
+#define CRYP_CR_ALGOMODE_2                   ((uint32_t)0x00000020)
+#define CRYP_CR_ALGOMODE_TDES_ECB            ((uint32_t)0x00000000)
+#define CRYP_CR_ALGOMODE_TDES_CBC            ((uint32_t)0x00000008)
+#define CRYP_CR_ALGOMODE_DES_ECB             ((uint32_t)0x00000010)
+#define CRYP_CR_ALGOMODE_DES_CBC             ((uint32_t)0x00000018)
+#define CRYP_CR_ALGOMODE_AES_ECB             ((uint32_t)0x00000020)
+#define CRYP_CR_ALGOMODE_AES_CBC             ((uint32_t)0x00000028)
+#define CRYP_CR_ALGOMODE_AES_CTR             ((uint32_t)0x00000030)
+#define CRYP_CR_ALGOMODE_AES_KEY             ((uint32_t)0x00000038)
+
+#define CRYP_CR_DATATYPE                     ((uint32_t)0x000000C0)
+#define CRYP_CR_DATATYPE_0                   ((uint32_t)0x00000040)
+#define CRYP_CR_DATATYPE_1                   ((uint32_t)0x00000080)
+#define CRYP_CR_KEYSIZE                      ((uint32_t)0x00000300)
+#define CRYP_CR_KEYSIZE_0                    ((uint32_t)0x00000100)
+#define CRYP_CR_KEYSIZE_1                    ((uint32_t)0x00000200)
+#define CRYP_CR_FFLUSH                       ((uint32_t)0x00004000)
+#define CRYP_CR_CRYPEN                       ((uint32_t)0x00008000)
+
+#define CRYP_CR_GCM_CCMPH                    ((uint32_t)0x00030000)
+#define CRYP_CR_GCM_CCMPH_0                  ((uint32_t)0x00010000)
+#define CRYP_CR_GCM_CCMPH_1                  ((uint32_t)0x00020000)
+#define CRYP_CR_ALGOMODE_3                   ((uint32_t)0x00080000)
+
+/****************** Bits definition for CRYP_SR register  *********************/
+#define CRYP_SR_IFEM                         ((uint32_t)0x00000001)
+#define CRYP_SR_IFNF                         ((uint32_t)0x00000002)
+#define CRYP_SR_OFNE                         ((uint32_t)0x00000004)
+#define CRYP_SR_OFFU                         ((uint32_t)0x00000008)
+#define CRYP_SR_BUSY                         ((uint32_t)0x00000010)
+/****************** Bits definition for CRYP_DMACR register  ******************/
+#define CRYP_DMACR_DIEN                      ((uint32_t)0x00000001)
+#define CRYP_DMACR_DOEN                      ((uint32_t)0x00000002)
+/*****************  Bits definition for CRYP_IMSCR register  ******************/
+#define CRYP_IMSCR_INIM                      ((uint32_t)0x00000001)
+#define CRYP_IMSCR_OUTIM                     ((uint32_t)0x00000002)
+/****************** Bits definition for CRYP_RISR register  *******************/
+#define CRYP_RISR_OUTRIS                     ((uint32_t)0x00000001)
+#define CRYP_RISR_INRIS                      ((uint32_t)0x00000002)
+/****************** Bits definition for CRYP_MISR register  *******************/
+#define CRYP_MISR_INMIS                      ((uint32_t)0x00000001)
+#define CRYP_MISR_OUTMIS                     ((uint32_t)0x00000002)
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Digital to Analog Converter                           */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DAC_CR register  ********************/
+#define  DAC_CR_EN1                          ((uint32_t)0x00000001)        /*!<DAC channel1 enable                         */
+#define  DAC_CR_BOFF1                        ((uint32_t)0x00000002)        /*!<DAC channel1 output buffer disable          */
+#define  DAC_CR_TEN1                         ((uint32_t)0x00000004)        /*!<DAC channel1 Trigger enable                 */
+
+#define  DAC_CR_TSEL1                        ((uint32_t)0x00000038)        /*!<TSEL1[2:0] (DAC channel1 Trigger selection) */
+#define  DAC_CR_TSEL1_0                      ((uint32_t)0x00000008)        /*!<Bit 0 */
+#define  DAC_CR_TSEL1_1                      ((uint32_t)0x00000010)        /*!<Bit 1 */
+#define  DAC_CR_TSEL1_2                      ((uint32_t)0x00000020)        /*!<Bit 2 */
+
+#define  DAC_CR_WAVE1                        ((uint32_t)0x000000C0)        /*!<WAVE1[1:0] (DAC channel1 noise/triangle wave generation enable) */
+#define  DAC_CR_WAVE1_0                      ((uint32_t)0x00000040)        /*!<Bit 0 */
+#define  DAC_CR_WAVE1_1                      ((uint32_t)0x00000080)        /*!<Bit 1 */
+
+#define  DAC_CR_MAMP1                        ((uint32_t)0x00000F00)        /*!<MAMP1[3:0] (DAC channel1 Mask/Amplitude selector) */
+#define  DAC_CR_MAMP1_0                      ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  DAC_CR_MAMP1_1                      ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  DAC_CR_MAMP1_2                      ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  DAC_CR_MAMP1_3                      ((uint32_t)0x00000800)        /*!<Bit 3 */
+
+#define  DAC_CR_DMAEN1                       ((uint32_t)0x00001000)        /*!<DAC channel1 DMA enable                     */
+#define  DAC_CR_EN2                          ((uint32_t)0x00010000)        /*!<DAC channel2 enable                         */
+#define  DAC_CR_BOFF2                        ((uint32_t)0x00020000)        /*!<DAC channel2 output buffer disable          */
+#define  DAC_CR_TEN2                         ((uint32_t)0x00040000)        /*!<DAC channel2 Trigger enable                 */
+
+#define  DAC_CR_TSEL2                        ((uint32_t)0x00380000)        /*!<TSEL2[2:0] (DAC channel2 Trigger selection) */
+#define  DAC_CR_TSEL2_0                      ((uint32_t)0x00080000)        /*!<Bit 0 */
+#define  DAC_CR_TSEL2_1                      ((uint32_t)0x00100000)        /*!<Bit 1 */
+#define  DAC_CR_TSEL2_2                      ((uint32_t)0x00200000)        /*!<Bit 2 */
+
+#define  DAC_CR_WAVE2                        ((uint32_t)0x00C00000)        /*!<WAVE2[1:0] (DAC channel2 noise/triangle wave generation enable) */
+#define  DAC_CR_WAVE2_0                      ((uint32_t)0x00400000)        /*!<Bit 0 */
+#define  DAC_CR_WAVE2_1                      ((uint32_t)0x00800000)        /*!<Bit 1 */
+
+#define  DAC_CR_MAMP2                        ((uint32_t)0x0F000000)        /*!<MAMP2[3:0] (DAC channel2 Mask/Amplitude selector) */
+#define  DAC_CR_MAMP2_0                      ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  DAC_CR_MAMP2_1                      ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  DAC_CR_MAMP2_2                      ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  DAC_CR_MAMP2_3                      ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  DAC_CR_DMAEN2                       ((uint32_t)0x10000000)        /*!<DAC channel2 DMA enabled */
+
+/*****************  Bit definition for DAC_SWTRIGR register  ******************/
+#define  DAC_SWTRIGR_SWTRIG1                 ((uint32_t)0x01)               /*!<DAC channel1 software trigger */
+#define  DAC_SWTRIGR_SWTRIG2                 ((uint32_t)0x02)               /*!<DAC channel2 software trigger */
+
+/*****************  Bit definition for DAC_DHR12R1 register  ******************/
+#define  DAC_DHR12R1_DACC1DHR                ((uint32_t)0x0FFF)            /*!<DAC channel1 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12L1 register  ******************/
+#define  DAC_DHR12L1_DACC1DHR                ((uint32_t)0xFFF0)            /*!<DAC channel1 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8R1 register  ******************/
+#define  DAC_DHR8R1_DACC1DHR                 ((uint32_t)0xFF)               /*!<DAC channel1 8-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12R2 register  ******************/
+#define  DAC_DHR12R2_DACC2DHR                ((uint32_t)0x0FFF)            /*!<DAC channel2 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12L2 register  ******************/
+#define  DAC_DHR12L2_DACC2DHR                ((uint32_t)0xFFF0)            /*!<DAC channel2 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8R2 register  ******************/
+#define  DAC_DHR8R2_DACC2DHR                 ((uint32_t)0xFF)               /*!<DAC channel2 8-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12RD register  ******************/
+#define  DAC_DHR12RD_DACC1DHR                ((uint32_t)0x00000FFF)        /*!<DAC channel1 12-bit Right aligned data */
+#define  DAC_DHR12RD_DACC2DHR                ((uint32_t)0x0FFF0000)        /*!<DAC channel2 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12LD register  ******************/
+#define  DAC_DHR12LD_DACC1DHR                ((uint32_t)0x0000FFF0)        /*!<DAC channel1 12-bit Left aligned data */
+#define  DAC_DHR12LD_DACC2DHR                ((uint32_t)0xFFF00000)        /*!<DAC channel2 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8RD register  ******************/
+#define  DAC_DHR8RD_DACC1DHR                 ((uint32_t)0x00FF)            /*!<DAC channel1 8-bit Right aligned data */
+#define  DAC_DHR8RD_DACC2DHR                 ((uint32_t)0xFF00)            /*!<DAC channel2 8-bit Right aligned data */
+
+/*******************  Bit definition for DAC_DOR1 register  *******************/
+#define  DAC_DOR1_DACC1DOR                   ((uint32_t)0x0FFF)            /*!<DAC channel1 data output */
+
+/*******************  Bit definition for DAC_DOR2 register  *******************/
+#define  DAC_DOR2_DACC2DOR                   ((uint32_t)0x0FFF)            /*!<DAC channel2 data output */
+
+/********************  Bit definition for DAC_SR register  ********************/
+#define  DAC_SR_DMAUDR1                      ((uint32_t)0x00002000)        /*!<DAC channel1 DMA underrun flag */
+#define  DAC_SR_DMAUDR2                      ((uint32_t)0x20000000)        /*!<DAC channel2 DMA underrun flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 Debug MCU                                  */
+/*                                                                            */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    DCMI                                    */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DCMI_CR register  ******************/
+#define DCMI_CR_CAPTURE                      ((uint32_t)0x00000001)
+#define DCMI_CR_CM                           ((uint32_t)0x00000002)
+#define DCMI_CR_CROP                         ((uint32_t)0x00000004)
+#define DCMI_CR_JPEG                         ((uint32_t)0x00000008)
+#define DCMI_CR_ESS                          ((uint32_t)0x00000010)
+#define DCMI_CR_PCKPOL                       ((uint32_t)0x00000020)
+#define DCMI_CR_HSPOL                        ((uint32_t)0x00000040)
+#define DCMI_CR_VSPOL                        ((uint32_t)0x00000080)
+#define DCMI_CR_FCRC_0                       ((uint32_t)0x00000100)
+#define DCMI_CR_FCRC_1                       ((uint32_t)0x00000200)
+#define DCMI_CR_EDM_0                        ((uint32_t)0x00000400)
+#define DCMI_CR_EDM_1                        ((uint32_t)0x00000800)
+#define DCMI_CR_CRE                          ((uint32_t)0x00001000)
+#define DCMI_CR_ENABLE                       ((uint32_t)0x00004000)
+#define DCMI_CR_BSM                          ((uint32_t)0x00030000)
+#define DCMI_CR_BSM_0                        ((uint32_t)0x00010000)
+#define DCMI_CR_BSM_1                        ((uint32_t)0x00020000)
+#define DCMI_CR_OEBS                         ((uint32_t)0x00040000)
+#define DCMI_CR_LSM                          ((uint32_t)0x00080000)
+#define DCMI_CR_OELS                         ((uint32_t)0x00100000)
+
+/********************  Bits definition for DCMI_SR register  ******************/
+#define DCMI_SR_HSYNC                        ((uint32_t)0x00000001)
+#define DCMI_SR_VSYNC                        ((uint32_t)0x00000002)
+#define DCMI_SR_FNE                          ((uint32_t)0x00000004)
+
+/********************  Bits definition for DCMI_RISR register  ****************/
+#define DCMI_RISR_FRAME_RIS                  ((uint32_t)0x00000001)
+#define DCMI_RISR_OVF_RIS                    ((uint32_t)0x00000002)
+#define DCMI_RISR_ERR_RIS                    ((uint32_t)0x00000004)
+#define DCMI_RISR_VSYNC_RIS                  ((uint32_t)0x00000008)
+#define DCMI_RISR_LINE_RIS                   ((uint32_t)0x00000010)
+
+/********************  Bits definition for DCMI_IER register  *****************/
+#define DCMI_IER_FRAME_IE                    ((uint32_t)0x00000001)
+#define DCMI_IER_OVF_IE                      ((uint32_t)0x00000002)
+#define DCMI_IER_ERR_IE                      ((uint32_t)0x00000004)
+#define DCMI_IER_VSYNC_IE                    ((uint32_t)0x00000008)
+#define DCMI_IER_LINE_IE                     ((uint32_t)0x00000010)
+
+/********************  Bits definition for DCMI_MISR register  ****************/
+#define DCMI_MISR_FRAME_MIS                  ((uint32_t)0x00000001)
+#define DCMI_MISR_OVF_MIS                    ((uint32_t)0x00000002)
+#define DCMI_MISR_ERR_MIS                    ((uint32_t)0x00000004)
+#define DCMI_MISR_VSYNC_MIS                  ((uint32_t)0x00000008)
+#define DCMI_MISR_LINE_MIS                   ((uint32_t)0x00000010)
+
+/********************  Bits definition for DCMI_ICR register  *****************/
+#define DCMI_ICR_FRAME_ISC                   ((uint32_t)0x00000001)
+#define DCMI_ICR_OVF_ISC                     ((uint32_t)0x00000002)
+#define DCMI_ICR_ERR_ISC                     ((uint32_t)0x00000004)
+#define DCMI_ICR_VSYNC_ISC                   ((uint32_t)0x00000008)
+#define DCMI_ICR_LINE_ISC                    ((uint32_t)0x00000010)
+
+/******************************************************************************/
+/*                                                                            */
+/*                             DMA Controller                                 */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DMA_SxCR register  *****************/
+#define DMA_SxCR_CHSEL                       ((uint32_t)0x0E000000)
+#define DMA_SxCR_CHSEL_0                     ((uint32_t)0x02000000)
+#define DMA_SxCR_CHSEL_1                     ((uint32_t)0x04000000)
+#define DMA_SxCR_CHSEL_2                     ((uint32_t)0x08000000)
+#define DMA_SxCR_MBURST                      ((uint32_t)0x01800000)
+#define DMA_SxCR_MBURST_0                    ((uint32_t)0x00800000)
+#define DMA_SxCR_MBURST_1                    ((uint32_t)0x01000000)
+#define DMA_SxCR_PBURST                      ((uint32_t)0x00600000)
+#define DMA_SxCR_PBURST_0                    ((uint32_t)0x00200000)
+#define DMA_SxCR_PBURST_1                    ((uint32_t)0x00400000)
+#define DMA_SxCR_ACK                         ((uint32_t)0x00100000)
+#define DMA_SxCR_CT                          ((uint32_t)0x00080000)
+#define DMA_SxCR_DBM                         ((uint32_t)0x00040000)
+#define DMA_SxCR_PL                          ((uint32_t)0x00030000)
+#define DMA_SxCR_PL_0                        ((uint32_t)0x00010000)
+#define DMA_SxCR_PL_1                        ((uint32_t)0x00020000)
+#define DMA_SxCR_PINCOS                      ((uint32_t)0x00008000)
+#define DMA_SxCR_MSIZE                       ((uint32_t)0x00006000)
+#define DMA_SxCR_MSIZE_0                     ((uint32_t)0x00002000)
+#define DMA_SxCR_MSIZE_1                     ((uint32_t)0x00004000)
+#define DMA_SxCR_PSIZE                       ((uint32_t)0x00001800)
+#define DMA_SxCR_PSIZE_0                     ((uint32_t)0x00000800)
+#define DMA_SxCR_PSIZE_1                     ((uint32_t)0x00001000)
+#define DMA_SxCR_MINC                        ((uint32_t)0x00000400)
+#define DMA_SxCR_PINC                        ((uint32_t)0x00000200)
+#define DMA_SxCR_CIRC                        ((uint32_t)0x00000100)
+#define DMA_SxCR_DIR                         ((uint32_t)0x000000C0)
+#define DMA_SxCR_DIR_0                       ((uint32_t)0x00000040)
+#define DMA_SxCR_DIR_1                       ((uint32_t)0x00000080)
+#define DMA_SxCR_PFCTRL                      ((uint32_t)0x00000020)
+#define DMA_SxCR_TCIE                        ((uint32_t)0x00000010)
+#define DMA_SxCR_HTIE                        ((uint32_t)0x00000008)
+#define DMA_SxCR_TEIE                        ((uint32_t)0x00000004)
+#define DMA_SxCR_DMEIE                       ((uint32_t)0x00000002)
+#define DMA_SxCR_EN                          ((uint32_t)0x00000001)
+
+/********************  Bits definition for DMA_SxCNDTR register  **************/
+#define DMA_SxNDT                            ((uint32_t)0x0000FFFF)
+#define DMA_SxNDT_0                          ((uint32_t)0x00000001)
+#define DMA_SxNDT_1                          ((uint32_t)0x00000002)
+#define DMA_SxNDT_2                          ((uint32_t)0x00000004)
+#define DMA_SxNDT_3                          ((uint32_t)0x00000008)
+#define DMA_SxNDT_4                          ((uint32_t)0x00000010)
+#define DMA_SxNDT_5                          ((uint32_t)0x00000020)
+#define DMA_SxNDT_6                          ((uint32_t)0x00000040)
+#define DMA_SxNDT_7                          ((uint32_t)0x00000080)
+#define DMA_SxNDT_8                          ((uint32_t)0x00000100)
+#define DMA_SxNDT_9                          ((uint32_t)0x00000200)
+#define DMA_SxNDT_10                         ((uint32_t)0x00000400)
+#define DMA_SxNDT_11                         ((uint32_t)0x00000800)
+#define DMA_SxNDT_12                         ((uint32_t)0x00001000)
+#define DMA_SxNDT_13                         ((uint32_t)0x00002000)
+#define DMA_SxNDT_14                         ((uint32_t)0x00004000)
+#define DMA_SxNDT_15                         ((uint32_t)0x00008000)
+
+/********************  Bits definition for DMA_SxFCR register  ****************/
+#define DMA_SxFCR_FEIE                       ((uint32_t)0x00000080)
+#define DMA_SxFCR_FS                         ((uint32_t)0x00000038)
+#define DMA_SxFCR_FS_0                       ((uint32_t)0x00000008)
+#define DMA_SxFCR_FS_1                       ((uint32_t)0x00000010)
+#define DMA_SxFCR_FS_2                       ((uint32_t)0x00000020)
+#define DMA_SxFCR_DMDIS                      ((uint32_t)0x00000004)
+#define DMA_SxFCR_FTH                        ((uint32_t)0x00000003)
+#define DMA_SxFCR_FTH_0                      ((uint32_t)0x00000001)
+#define DMA_SxFCR_FTH_1                      ((uint32_t)0x00000002)
+
+/********************  Bits definition for DMA_LISR register  *****************/
+#define DMA_LISR_TCIF3                       ((uint32_t)0x08000000)
+#define DMA_LISR_HTIF3                       ((uint32_t)0x04000000)
+#define DMA_LISR_TEIF3                       ((uint32_t)0x02000000)
+#define DMA_LISR_DMEIF3                      ((uint32_t)0x01000000)
+#define DMA_LISR_FEIF3                       ((uint32_t)0x00400000)
+#define DMA_LISR_TCIF2                       ((uint32_t)0x00200000)
+#define DMA_LISR_HTIF2                       ((uint32_t)0x00100000)
+#define DMA_LISR_TEIF2                       ((uint32_t)0x00080000)
+#define DMA_LISR_DMEIF2                      ((uint32_t)0x00040000)
+#define DMA_LISR_FEIF2                       ((uint32_t)0x00010000)
+#define DMA_LISR_TCIF1                       ((uint32_t)0x00000800)
+#define DMA_LISR_HTIF1                       ((uint32_t)0x00000400)
+#define DMA_LISR_TEIF1                       ((uint32_t)0x00000200)
+#define DMA_LISR_DMEIF1                      ((uint32_t)0x00000100)
+#define DMA_LISR_FEIF1                       ((uint32_t)0x00000040)
+#define DMA_LISR_TCIF0                       ((uint32_t)0x00000020)
+#define DMA_LISR_HTIF0                       ((uint32_t)0x00000010)
+#define DMA_LISR_TEIF0                       ((uint32_t)0x00000008)
+#define DMA_LISR_DMEIF0                      ((uint32_t)0x00000004)
+#define DMA_LISR_FEIF0                       ((uint32_t)0x00000001)
+
+/********************  Bits definition for DMA_HISR register  *****************/
+#define DMA_HISR_TCIF7                       ((uint32_t)0x08000000)
+#define DMA_HISR_HTIF7                       ((uint32_t)0x04000000)
+#define DMA_HISR_TEIF7                       ((uint32_t)0x02000000)
+#define DMA_HISR_DMEIF7                      ((uint32_t)0x01000000)
+#define DMA_HISR_FEIF7                       ((uint32_t)0x00400000)
+#define DMA_HISR_TCIF6                       ((uint32_t)0x00200000)
+#define DMA_HISR_HTIF6                       ((uint32_t)0x00100000)
+#define DMA_HISR_TEIF6                       ((uint32_t)0x00080000)
+#define DMA_HISR_DMEIF6                      ((uint32_t)0x00040000)
+#define DMA_HISR_FEIF6                       ((uint32_t)0x00010000)
+#define DMA_HISR_TCIF5                       ((uint32_t)0x00000800)
+#define DMA_HISR_HTIF5                       ((uint32_t)0x00000400)
+#define DMA_HISR_TEIF5                       ((uint32_t)0x00000200)
+#define DMA_HISR_DMEIF5                      ((uint32_t)0x00000100)
+#define DMA_HISR_FEIF5                       ((uint32_t)0x00000040)
+#define DMA_HISR_TCIF4                       ((uint32_t)0x00000020)
+#define DMA_HISR_HTIF4                       ((uint32_t)0x00000010)
+#define DMA_HISR_TEIF4                       ((uint32_t)0x00000008)
+#define DMA_HISR_DMEIF4                      ((uint32_t)0x00000004)
+#define DMA_HISR_FEIF4                       ((uint32_t)0x00000001)
+
+/********************  Bits definition for DMA_LIFCR register  ****************/
+#define DMA_LIFCR_CTCIF3                     ((uint32_t)0x08000000)
+#define DMA_LIFCR_CHTIF3                     ((uint32_t)0x04000000)
+#define DMA_LIFCR_CTEIF3                     ((uint32_t)0x02000000)
+#define DMA_LIFCR_CDMEIF3                    ((uint32_t)0x01000000)
+#define DMA_LIFCR_CFEIF3                     ((uint32_t)0x00400000)
+#define DMA_LIFCR_CTCIF2                     ((uint32_t)0x00200000)
+#define DMA_LIFCR_CHTIF2                     ((uint32_t)0x00100000)
+#define DMA_LIFCR_CTEIF2                     ((uint32_t)0x00080000)
+#define DMA_LIFCR_CDMEIF2                    ((uint32_t)0x00040000)
+#define DMA_LIFCR_CFEIF2                     ((uint32_t)0x00010000)
+#define DMA_LIFCR_CTCIF1                     ((uint32_t)0x00000800)
+#define DMA_LIFCR_CHTIF1                     ((uint32_t)0x00000400)
+#define DMA_LIFCR_CTEIF1                     ((uint32_t)0x00000200)
+#define DMA_LIFCR_CDMEIF1                    ((uint32_t)0x00000100)
+#define DMA_LIFCR_CFEIF1                     ((uint32_t)0x00000040)
+#define DMA_LIFCR_CTCIF0                     ((uint32_t)0x00000020)
+#define DMA_LIFCR_CHTIF0                     ((uint32_t)0x00000010)
+#define DMA_LIFCR_CTEIF0                     ((uint32_t)0x00000008)
+#define DMA_LIFCR_CDMEIF0                    ((uint32_t)0x00000004)
+#define DMA_LIFCR_CFEIF0                     ((uint32_t)0x00000001)
+
+/********************  Bits definition for DMA_HIFCR  register  ****************/
+#define DMA_HIFCR_CTCIF7                     ((uint32_t)0x08000000)
+#define DMA_HIFCR_CHTIF7                     ((uint32_t)0x04000000)
+#define DMA_HIFCR_CTEIF7                     ((uint32_t)0x02000000)
+#define DMA_HIFCR_CDMEIF7                    ((uint32_t)0x01000000)
+#define DMA_HIFCR_CFEIF7                     ((uint32_t)0x00400000)
+#define DMA_HIFCR_CTCIF6                     ((uint32_t)0x00200000)
+#define DMA_HIFCR_CHTIF6                     ((uint32_t)0x00100000)
+#define DMA_HIFCR_CTEIF6                     ((uint32_t)0x00080000)
+#define DMA_HIFCR_CDMEIF6                    ((uint32_t)0x00040000)
+#define DMA_HIFCR_CFEIF6                     ((uint32_t)0x00010000)
+#define DMA_HIFCR_CTCIF5                     ((uint32_t)0x00000800)
+#define DMA_HIFCR_CHTIF5                     ((uint32_t)0x00000400)
+#define DMA_HIFCR_CTEIF5                     ((uint32_t)0x00000200)
+#define DMA_HIFCR_CDMEIF5                    ((uint32_t)0x00000100)
+#define DMA_HIFCR_CFEIF5                     ((uint32_t)0x00000040)
+#define DMA_HIFCR_CTCIF4                     ((uint32_t)0x00000020)
+#define DMA_HIFCR_CHTIF4                     ((uint32_t)0x00000010)
+#define DMA_HIFCR_CTEIF4                     ((uint32_t)0x00000008)
+#define DMA_HIFCR_CDMEIF4                    ((uint32_t)0x00000004)
+#define DMA_HIFCR_CFEIF4                     ((uint32_t)0x00000001)
+
+/******************************************************************************/
+/*                                                                            */
+/*                         AHB Master DMA2D Controller (DMA2D)                */
+/*                                                                            */
+/******************************************************************************/
+
+/********************  Bit definition for DMA2D_CR register  ******************/
+
+#define DMA2D_CR_START                     ((uint32_t)0x00000001)               /*!< Start transfer                          */
+#define DMA2D_CR_SUSP                      ((uint32_t)0x00000002)               /*!< Suspend transfer                        */
+#define DMA2D_CR_ABORT                     ((uint32_t)0x00000004)               /*!< Abort transfer                          */
+#define DMA2D_CR_TEIE                      ((uint32_t)0x00000100)               /*!< Transfer Error Interrupt Enable         */
+#define DMA2D_CR_TCIE                      ((uint32_t)0x00000200)               /*!< Transfer Complete Interrupt Enable      */
+#define DMA2D_CR_TWIE                      ((uint32_t)0x00000400)               /*!< Transfer Watermark Interrupt Enable     */
+#define DMA2D_CR_CAEIE                     ((uint32_t)0x00000800)               /*!< CLUT Access Error Interrupt Enable      */
+#define DMA2D_CR_CTCIE                     ((uint32_t)0x00001000)               /*!< CLUT Transfer Complete Interrupt Enable */
+#define DMA2D_CR_CEIE                      ((uint32_t)0x00002000)               /*!< Configuration Error Interrupt Enable    */
+#define DMA2D_CR_MODE                      ((uint32_t)0x00030000)               /*!< DMA2D Mode                              */
+
+/********************  Bit definition for DMA2D_ISR register  *****************/
+
+#define DMA2D_ISR_TEIF                     ((uint32_t)0x00000001)               /*!< Transfer Error Interrupt Flag         */
+#define DMA2D_ISR_TCIF                     ((uint32_t)0x00000002)               /*!< Transfer Complete Interrupt Flag      */
+#define DMA2D_ISR_TWIF                     ((uint32_t)0x00000004)               /*!< Transfer Watermark Interrupt Flag     */
+#define DMA2D_ISR_CAEIF                    ((uint32_t)0x00000008)               /*!< CLUT Access Error Interrupt Flag      */
+#define DMA2D_ISR_CTCIF                    ((uint32_t)0x00000010)               /*!< CLUT Transfer Complete Interrupt Flag */
+#define DMA2D_ISR_CEIF                     ((uint32_t)0x00000020)               /*!< Configuration Error Interrupt Flag    */
+
+/********************  Bit definition for DMA2D_IFSR register  ****************/
+
+#define DMA2D_IFSR_CTEIF                   ((uint32_t)0x00000001)               /*!< Clears Transfer Error Interrupt Flag         */
+#define DMA2D_IFSR_CTCIF                   ((uint32_t)0x00000002)               /*!< Clears Transfer Complete Interrupt Flag      */
+#define DMA2D_IFSR_CTWIF                   ((uint32_t)0x00000004)               /*!< Clears Transfer Watermark Interrupt Flag     */
+#define DMA2D_IFSR_CCAEIF                  ((uint32_t)0x00000008)               /*!< Clears CLUT Access Error Interrupt Flag      */
+#define DMA2D_IFSR_CCTCIF                  ((uint32_t)0x00000010)               /*!< Clears CLUT Transfer Complete Interrupt Flag */
+#define DMA2D_IFSR_CCEIF                   ((uint32_t)0x00000020)               /*!< Clears Configuration Error Interrupt Flag    */
+
+/********************  Bit definition for DMA2D_FGMAR register  ***************/
+
+#define DMA2D_FGMAR_MA                     ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_FGOR register  ****************/
+
+#define DMA2D_FGOR_LO                      ((uint32_t)0x00003FFF)               /*!< Line Offset */
+
+/********************  Bit definition for DMA2D_BGMAR register  ***************/
+
+#define DMA2D_BGMAR_MA                     ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_BGOR register  ****************/
+
+#define DMA2D_BGOR_LO                      ((uint32_t)0x00003FFF)               /*!< Line Offset */
+
+/********************  Bit definition for DMA2D_FGPFCCR register  *************/
+
+#define DMA2D_FGPFCCR_CM                   ((uint32_t)0x0000000F)               /*!< Color mode      */
+#define DMA2D_FGPFCCR_CCM                  ((uint32_t)0x00000010)               /*!< CLUT Color mode */
+#define DMA2D_FGPFCCR_START                ((uint32_t)0x00000020)               /*!< Start           */
+#define DMA2D_FGPFCCR_CS                   ((uint32_t)0x0000FF00)               /*!< CLUT size       */
+#define DMA2D_FGPFCCR_AM                   ((uint32_t)0x00030000)               /*!< Alpha mode      */
+#define DMA2D_FGPFCCR_ALPHA                ((uint32_t)0xFF000000)               /*!< Alpha value     */
+
+/********************  Bit definition for DMA2D_FGCOLR register  **************/
+
+#define DMA2D_FGCOLR_BLUE                  ((uint32_t)0x000000FF)               /*!< Blue Value  */
+#define DMA2D_FGCOLR_GREEN                 ((uint32_t)0x0000FF00)               /*!< Green Value */
+#define DMA2D_FGCOLR_RED                   ((uint32_t)0x00FF0000)               /*!< Red Value   */
+
+/********************  Bit definition for DMA2D_BGPFCCR register  *************/
+
+#define DMA2D_BGPFCCR_CM                   ((uint32_t)0x0000000F)               /*!< Color mode      */
+#define DMA2D_BGPFCCR_CCM                  ((uint32_t)0x00000010)               /*!< CLUT Color mode */
+#define DMA2D_BGPFCCR_START                ((uint32_t)0x00000020)               /*!< Start           */
+#define DMA2D_BGPFCCR_CS                   ((uint32_t)0x0000FF00)               /*!< CLUT size       */
+#define DMA2D_BGPFCCR_AM                   ((uint32_t)0x00030000)               /*!< Alpha Mode      */
+#define DMA2D_BGPFCCR_ALPHA                ((uint32_t)0xFF000000)               /*!< Alpha value     */
+
+/********************  Bit definition for DMA2D_BGCOLR register  **************/
+
+#define DMA2D_BGCOLR_BLUE                  ((uint32_t)0x000000FF)               /*!< Blue Value  */
+#define DMA2D_BGCOLR_GREEN                 ((uint32_t)0x0000FF00)               /*!< Green Value */
+#define DMA2D_BGCOLR_RED                   ((uint32_t)0x00FF0000)               /*!< Red Value   */
+
+/********************  Bit definition for DMA2D_FGCMAR register  **************/
+
+#define DMA2D_FGCMAR_MA                    ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_BGCMAR register  **************/
+
+#define DMA2D_BGCMAR_MA                    ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_OPFCCR register  **************/
+
+#define DMA2D_OPFCCR_CM                    ((uint32_t)0x00000007)               /*!< Color mode */
+
+/********************  Bit definition for DMA2D_OCOLR register  ***************/
+
+/*!<Mode_ARGB8888/RGB888 */
+
+#define DMA2D_OCOLR_BLUE_1                 ((uint32_t)0x000000FF)               /*!< BLUE Value          */
+#define DMA2D_OCOLR_GREEN_1                ((uint32_t)0x0000FF00)               /*!< GREEN Value         */
+#define DMA2D_OCOLR_RED_1                  ((uint32_t)0x00FF0000)               /*!< Red Value           */
+#define DMA2D_OCOLR_ALPHA_1                ((uint32_t)0xFF000000)               /*!< Alpha Channel Value */
+
+/*!<Mode_RGB565 */
+#define DMA2D_OCOLR_BLUE_2                 ((uint32_t)0x0000001F)               /*!< BLUE Value   */
+#define DMA2D_OCOLR_GREEN_2                ((uint32_t)0x000007E0)               /*!< GREEN Value  */
+#define DMA2D_OCOLR_RED_2                  ((uint32_t)0x0000F800)               /*!< Red Value    */
+
+/*!<Mode_ARGB1555 */
+#define DMA2D_OCOLR_BLUE_3                 ((uint32_t)0x0000001F)               /*!< BLUE Value          */
+#define DMA2D_OCOLR_GREEN_3                ((uint32_t)0x000003E0)               /*!< GREEN Value         */
+#define DMA2D_OCOLR_RED_3                  ((uint32_t)0x00007C00)               /*!< Red Value           */
+#define DMA2D_OCOLR_ALPHA_3                ((uint32_t)0x00008000)               /*!< Alpha Channel Value */
+
+/*!<Mode_ARGB4444 */
+#define DMA2D_OCOLR_BLUE_4                 ((uint32_t)0x0000000F)               /*!< BLUE Value          */
+#define DMA2D_OCOLR_GREEN_4                ((uint32_t)0x000000F0)               /*!< GREEN Value         */
+#define DMA2D_OCOLR_RED_4                  ((uint32_t)0x00000F00)               /*!< Red Value           */
+#define DMA2D_OCOLR_ALPHA_4                ((uint32_t)0x0000F000)               /*!< Alpha Channel Value */
+
+/********************  Bit definition for DMA2D_OMAR register  ****************/
+
+#define DMA2D_OMAR_MA                      ((uint32_t)0xFFFFFFFF)               /*!< Memory Address */
+
+/********************  Bit definition for DMA2D_OOR register  *****************/
+
+#define DMA2D_OOR_LO                       ((uint32_t)0x00003FFF)               /*!< Line Offset */
+
+/********************  Bit definition for DMA2D_NLR register  *****************/
+
+#define DMA2D_NLR_NL                       ((uint32_t)0x0000FFFF)               /*!< Number of Lines */
+#define DMA2D_NLR_PL                       ((uint32_t)0x3FFF0000)               /*!< Pixel per Lines */
+
+/********************  Bit definition for DMA2D_LWR register  *****************/
+
+#define DMA2D_LWR_LW                       ((uint32_t)0x0000FFFF)               /*!< Line Watermark */
+
+/********************  Bit definition for DMA2D_AMTCR register  ***************/
+
+#define DMA2D_AMTCR_EN                     ((uint32_t)0x00000001)               /*!< Enable    */
+#define DMA2D_AMTCR_DT                     ((uint32_t)0x0000FF00)               /*!< Dead Time */
+
+
+
+/********************  Bit definition for DMA2D_FGCLUT register  **************/
+
+/********************  Bit definition for DMA2D_BGCLUT register  **************/
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                    External Interrupt/Event Controller                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for EXTI_IMR register  *******************/
+#define  EXTI_IMR_MR0                        ((uint32_t)0x00000001)        /*!< Interrupt Mask on line 0 */
+#define  EXTI_IMR_MR1                        ((uint32_t)0x00000002)        /*!< Interrupt Mask on line 1 */
+#define  EXTI_IMR_MR2                        ((uint32_t)0x00000004)        /*!< Interrupt Mask on line 2 */
+#define  EXTI_IMR_MR3                        ((uint32_t)0x00000008)        /*!< Interrupt Mask on line 3 */
+#define  EXTI_IMR_MR4                        ((uint32_t)0x00000010)        /*!< Interrupt Mask on line 4 */
+#define  EXTI_IMR_MR5                        ((uint32_t)0x00000020)        /*!< Interrupt Mask on line 5 */
+#define  EXTI_IMR_MR6                        ((uint32_t)0x00000040)        /*!< Interrupt Mask on line 6 */
+#define  EXTI_IMR_MR7                        ((uint32_t)0x00000080)        /*!< Interrupt Mask on line 7 */
+#define  EXTI_IMR_MR8                        ((uint32_t)0x00000100)        /*!< Interrupt Mask on line 8 */
+#define  EXTI_IMR_MR9                        ((uint32_t)0x00000200)        /*!< Interrupt Mask on line 9 */
+#define  EXTI_IMR_MR10                       ((uint32_t)0x00000400)        /*!< Interrupt Mask on line 10 */
+#define  EXTI_IMR_MR11                       ((uint32_t)0x00000800)        /*!< Interrupt Mask on line 11 */
+#define  EXTI_IMR_MR12                       ((uint32_t)0x00001000)        /*!< Interrupt Mask on line 12 */
+#define  EXTI_IMR_MR13                       ((uint32_t)0x00002000)        /*!< Interrupt Mask on line 13 */
+#define  EXTI_IMR_MR14                       ((uint32_t)0x00004000)        /*!< Interrupt Mask on line 14 */
+#define  EXTI_IMR_MR15                       ((uint32_t)0x00008000)        /*!< Interrupt Mask on line 15 */
+#define  EXTI_IMR_MR16                       ((uint32_t)0x00010000)        /*!< Interrupt Mask on line 16 */
+#define  EXTI_IMR_MR17                       ((uint32_t)0x00020000)        /*!< Interrupt Mask on line 17 */
+#define  EXTI_IMR_MR18                       ((uint32_t)0x00040000)        /*!< Interrupt Mask on line 18 */
+#define  EXTI_IMR_MR19                       ((uint32_t)0x00080000)        /*!< Interrupt Mask on line 19 */
+#define  EXTI_IMR_MR20                       ((uint32_t)0x00100000)        /*!< Interrupt Mask on line 20 */
+#define  EXTI_IMR_MR21                       ((uint32_t)0x00200000)        /*!< Interrupt Mask on line 21 */
+#define  EXTI_IMR_MR22                       ((uint32_t)0x00400000)        /*!< Interrupt Mask on line 22 */
+#define  EXTI_IMR_MR23                       ((uint32_t)0x00800000)        /*!< Interrupt Mask on line 23 */
+
+/*******************  Bit definition for EXTI_EMR register  *******************/
+#define  EXTI_EMR_MR0                        ((uint32_t)0x00000001)        /*!< Event Mask on line 0 */
+#define  EXTI_EMR_MR1                        ((uint32_t)0x00000002)        /*!< Event Mask on line 1 */
+#define  EXTI_EMR_MR2                        ((uint32_t)0x00000004)        /*!< Event Mask on line 2 */
+#define  EXTI_EMR_MR3                        ((uint32_t)0x00000008)        /*!< Event Mask on line 3 */
+#define  EXTI_EMR_MR4                        ((uint32_t)0x00000010)        /*!< Event Mask on line 4 */
+#define  EXTI_EMR_MR5                        ((uint32_t)0x00000020)        /*!< Event Mask on line 5 */
+#define  EXTI_EMR_MR6                        ((uint32_t)0x00000040)        /*!< Event Mask on line 6 */
+#define  EXTI_EMR_MR7                        ((uint32_t)0x00000080)        /*!< Event Mask on line 7 */
+#define  EXTI_EMR_MR8                        ((uint32_t)0x00000100)        /*!< Event Mask on line 8 */
+#define  EXTI_EMR_MR9                        ((uint32_t)0x00000200)        /*!< Event Mask on line 9 */
+#define  EXTI_EMR_MR10                       ((uint32_t)0x00000400)        /*!< Event Mask on line 10 */
+#define  EXTI_EMR_MR11                       ((uint32_t)0x00000800)        /*!< Event Mask on line 11 */
+#define  EXTI_EMR_MR12                       ((uint32_t)0x00001000)        /*!< Event Mask on line 12 */
+#define  EXTI_EMR_MR13                       ((uint32_t)0x00002000)        /*!< Event Mask on line 13 */
+#define  EXTI_EMR_MR14                       ((uint32_t)0x00004000)        /*!< Event Mask on line 14 */
+#define  EXTI_EMR_MR15                       ((uint32_t)0x00008000)        /*!< Event Mask on line 15 */
+#define  EXTI_EMR_MR16                       ((uint32_t)0x00010000)        /*!< Event Mask on line 16 */
+#define  EXTI_EMR_MR17                       ((uint32_t)0x00020000)        /*!< Event Mask on line 17 */
+#define  EXTI_EMR_MR18                       ((uint32_t)0x00040000)        /*!< Event Mask on line 18 */
+#define  EXTI_EMR_MR19                       ((uint32_t)0x00080000)        /*!< Event Mask on line 19 */
+#define  EXTI_EMR_MR20                       ((uint32_t)0x00100000)        /*!< Event Mask on line 20 */
+#define  EXTI_EMR_MR21                       ((uint32_t)0x00200000)        /*!< Event Mask on line 21 */
+#define  EXTI_EMR_MR22                       ((uint32_t)0x00400000)        /*!< Event Mask on line 22 */
+#define  EXTI_EMR_MR23                       ((uint32_t)0x00800000)        /*!< Event Mask on line 23 */
+
+/******************  Bit definition for EXTI_RTSR register  *******************/
+#define  EXTI_RTSR_TR0                       ((uint32_t)0x00000001)        /*!< Rising trigger event configuration bit of line 0 */
+#define  EXTI_RTSR_TR1                       ((uint32_t)0x00000002)        /*!< Rising trigger event configuration bit of line 1 */
+#define  EXTI_RTSR_TR2                       ((uint32_t)0x00000004)        /*!< Rising trigger event configuration bit of line 2 */
+#define  EXTI_RTSR_TR3                       ((uint32_t)0x00000008)        /*!< Rising trigger event configuration bit of line 3 */
+#define  EXTI_RTSR_TR4                       ((uint32_t)0x00000010)        /*!< Rising trigger event configuration bit of line 4 */
+#define  EXTI_RTSR_TR5                       ((uint32_t)0x00000020)        /*!< Rising trigger event configuration bit of line 5 */
+#define  EXTI_RTSR_TR6                       ((uint32_t)0x00000040)        /*!< Rising trigger event configuration bit of line 6 */
+#define  EXTI_RTSR_TR7                       ((uint32_t)0x00000080)        /*!< Rising trigger event configuration bit of line 7 */
+#define  EXTI_RTSR_TR8                       ((uint32_t)0x00000100)        /*!< Rising trigger event configuration bit of line 8 */
+#define  EXTI_RTSR_TR9                       ((uint32_t)0x00000200)        /*!< Rising trigger event configuration bit of line 9 */
+#define  EXTI_RTSR_TR10                      ((uint32_t)0x00000400)        /*!< Rising trigger event configuration bit of line 10 */
+#define  EXTI_RTSR_TR11                      ((uint32_t)0x00000800)        /*!< Rising trigger event configuration bit of line 11 */
+#define  EXTI_RTSR_TR12                      ((uint32_t)0x00001000)        /*!< Rising trigger event configuration bit of line 12 */
+#define  EXTI_RTSR_TR13                      ((uint32_t)0x00002000)        /*!< Rising trigger event configuration bit of line 13 */
+#define  EXTI_RTSR_TR14                      ((uint32_t)0x00004000)        /*!< Rising trigger event configuration bit of line 14 */
+#define  EXTI_RTSR_TR15                      ((uint32_t)0x00008000)        /*!< Rising trigger event configuration bit of line 15 */
+#define  EXTI_RTSR_TR16                      ((uint32_t)0x00010000)        /*!< Rising trigger event configuration bit of line 16 */
+#define  EXTI_RTSR_TR17                      ((uint32_t)0x00020000)        /*!< Rising trigger event configuration bit of line 17 */
+#define  EXTI_RTSR_TR18                      ((uint32_t)0x00040000)        /*!< Rising trigger event configuration bit of line 18 */
+#define  EXTI_RTSR_TR19                      ((uint32_t)0x00080000)        /*!< Rising trigger event configuration bit of line 19 */
+#define  EXTI_RTSR_TR20                      ((uint32_t)0x00100000)        /*!< Rising trigger event configuration bit of line 20 */
+#define  EXTI_RTSR_TR21                      ((uint32_t)0x00200000)        /*!< Rising trigger event configuration bit of line 21 */
+#define  EXTI_RTSR_TR22                      ((uint32_t)0x00400000)        /*!< Rising trigger event configuration bit of line 22 */
+#define  EXTI_RTSR_TR23                      ((uint32_t)0x00800000)        /*!< Rising trigger event configuration bit of line 23 */
+
+/******************  Bit definition for EXTI_FTSR register  *******************/
+#define  EXTI_FTSR_TR0                       ((uint32_t)0x00000001)        /*!< Falling trigger event configuration bit of line 0 */
+#define  EXTI_FTSR_TR1                       ((uint32_t)0x00000002)        /*!< Falling trigger event configuration bit of line 1 */
+#define  EXTI_FTSR_TR2                       ((uint32_t)0x00000004)        /*!< Falling trigger event configuration bit of line 2 */
+#define  EXTI_FTSR_TR3                       ((uint32_t)0x00000008)        /*!< Falling trigger event configuration bit of line 3 */
+#define  EXTI_FTSR_TR4                       ((uint32_t)0x00000010)        /*!< Falling trigger event configuration bit of line 4 */
+#define  EXTI_FTSR_TR5                       ((uint32_t)0x00000020)        /*!< Falling trigger event configuration bit of line 5 */
+#define  EXTI_FTSR_TR6                       ((uint32_t)0x00000040)        /*!< Falling trigger event configuration bit of line 6 */
+#define  EXTI_FTSR_TR7                       ((uint32_t)0x00000080)        /*!< Falling trigger event configuration bit of line 7 */
+#define  EXTI_FTSR_TR8                       ((uint32_t)0x00000100)        /*!< Falling trigger event configuration bit of line 8 */
+#define  EXTI_FTSR_TR9                       ((uint32_t)0x00000200)        /*!< Falling trigger event configuration bit of line 9 */
+#define  EXTI_FTSR_TR10                      ((uint32_t)0x00000400)        /*!< Falling trigger event configuration bit of line 10 */
+#define  EXTI_FTSR_TR11                      ((uint32_t)0x00000800)        /*!< Falling trigger event configuration bit of line 11 */
+#define  EXTI_FTSR_TR12                      ((uint32_t)0x00001000)        /*!< Falling trigger event configuration bit of line 12 */
+#define  EXTI_FTSR_TR13                      ((uint32_t)0x00002000)        /*!< Falling trigger event configuration bit of line 13 */
+#define  EXTI_FTSR_TR14                      ((uint32_t)0x00004000)        /*!< Falling trigger event configuration bit of line 14 */
+#define  EXTI_FTSR_TR15                      ((uint32_t)0x00008000)        /*!< Falling trigger event configuration bit of line 15 */
+#define  EXTI_FTSR_TR16                      ((uint32_t)0x00010000)        /*!< Falling trigger event configuration bit of line 16 */
+#define  EXTI_FTSR_TR17                      ((uint32_t)0x00020000)        /*!< Falling trigger event configuration bit of line 17 */
+#define  EXTI_FTSR_TR18                      ((uint32_t)0x00040000)        /*!< Falling trigger event configuration bit of line 18 */
+#define  EXTI_FTSR_TR19                      ((uint32_t)0x00080000)        /*!< Falling trigger event configuration bit of line 19 */
+#define  EXTI_FTSR_TR20                      ((uint32_t)0x00100000)        /*!< Falling trigger event configuration bit of line 20 */
+#define  EXTI_FTSR_TR21                      ((uint32_t)0x00200000)        /*!< Falling trigger event configuration bit of line 21 */
+#define  EXTI_FTSR_TR22                      ((uint32_t)0x00400000)        /*!< Falling trigger event configuration bit of line 22 */
+#define  EXTI_FTSR_TR23                      ((uint32_t)0x00800000)        /*!< Falling trigger event configuration bit of line 23 */
+
+/******************  Bit definition for EXTI_SWIER register  ******************/
+#define  EXTI_SWIER_SWIER0                   ((uint32_t)0x00000001)        /*!< Software Interrupt on line 0 */
+#define  EXTI_SWIER_SWIER1                   ((uint32_t)0x00000002)        /*!< Software Interrupt on line 1 */
+#define  EXTI_SWIER_SWIER2                   ((uint32_t)0x00000004)        /*!< Software Interrupt on line 2 */
+#define  EXTI_SWIER_SWIER3                   ((uint32_t)0x00000008)        /*!< Software Interrupt on line 3 */
+#define  EXTI_SWIER_SWIER4                   ((uint32_t)0x00000010)        /*!< Software Interrupt on line 4 */
+#define  EXTI_SWIER_SWIER5                   ((uint32_t)0x00000020)        /*!< Software Interrupt on line 5 */
+#define  EXTI_SWIER_SWIER6                   ((uint32_t)0x00000040)        /*!< Software Interrupt on line 6 */
+#define  EXTI_SWIER_SWIER7                   ((uint32_t)0x00000080)        /*!< Software Interrupt on line 7 */
+#define  EXTI_SWIER_SWIER8                   ((uint32_t)0x00000100)        /*!< Software Interrupt on line 8 */
+#define  EXTI_SWIER_SWIER9                   ((uint32_t)0x00000200)        /*!< Software Interrupt on line 9 */
+#define  EXTI_SWIER_SWIER10                  ((uint32_t)0x00000400)        /*!< Software Interrupt on line 10 */
+#define  EXTI_SWIER_SWIER11                  ((uint32_t)0x00000800)        /*!< Software Interrupt on line 11 */
+#define  EXTI_SWIER_SWIER12                  ((uint32_t)0x00001000)        /*!< Software Interrupt on line 12 */
+#define  EXTI_SWIER_SWIER13                  ((uint32_t)0x00002000)        /*!< Software Interrupt on line 13 */
+#define  EXTI_SWIER_SWIER14                  ((uint32_t)0x00004000)        /*!< Software Interrupt on line 14 */
+#define  EXTI_SWIER_SWIER15                  ((uint32_t)0x00008000)        /*!< Software Interrupt on line 15 */
+#define  EXTI_SWIER_SWIER16                  ((uint32_t)0x00010000)        /*!< Software Interrupt on line 16 */
+#define  EXTI_SWIER_SWIER17                  ((uint32_t)0x00020000)        /*!< Software Interrupt on line 17 */
+#define  EXTI_SWIER_SWIER18                  ((uint32_t)0x00040000)        /*!< Software Interrupt on line 18 */
+#define  EXTI_SWIER_SWIER19                  ((uint32_t)0x00080000)        /*!< Software Interrupt on line 19 */
+#define  EXTI_SWIER_SWIER20                  ((uint32_t)0x00100000)        /*!< Software Interrupt on line 20 */
+#define  EXTI_SWIER_SWIER21                  ((uint32_t)0x00200000)        /*!< Software Interrupt on line 21 */
+#define  EXTI_SWIER_SWIER22                  ((uint32_t)0x00400000)        /*!< Software Interrupt on line 22 */
+#define  EXTI_SWIER_SWIER23                  ((uint32_t)0x00800000)        /*!< Software Interrupt on line 23 */
+
+/*******************  Bit definition for EXTI_PR register  ********************/
+#define  EXTI_PR_PR0                         ((uint32_t)0x00000001)        /*!< Pending bit for line 0 */
+#define  EXTI_PR_PR1                         ((uint32_t)0x00000002)        /*!< Pending bit for line 1 */
+#define  EXTI_PR_PR2                         ((uint32_t)0x00000004)        /*!< Pending bit for line 2 */
+#define  EXTI_PR_PR3                         ((uint32_t)0x00000008)        /*!< Pending bit for line 3 */
+#define  EXTI_PR_PR4                         ((uint32_t)0x00000010)        /*!< Pending bit for line 4 */
+#define  EXTI_PR_PR5                         ((uint32_t)0x00000020)        /*!< Pending bit for line 5 */
+#define  EXTI_PR_PR6                         ((uint32_t)0x00000040)        /*!< Pending bit for line 6 */
+#define  EXTI_PR_PR7                         ((uint32_t)0x00000080)        /*!< Pending bit for line 7 */
+#define  EXTI_PR_PR8                         ((uint32_t)0x00000100)        /*!< Pending bit for line 8 */
+#define  EXTI_PR_PR9                         ((uint32_t)0x00000200)        /*!< Pending bit for line 9 */
+#define  EXTI_PR_PR10                        ((uint32_t)0x00000400)        /*!< Pending bit for line 10 */
+#define  EXTI_PR_PR11                        ((uint32_t)0x00000800)        /*!< Pending bit for line 11 */
+#define  EXTI_PR_PR12                        ((uint32_t)0x00001000)        /*!< Pending bit for line 12 */
+#define  EXTI_PR_PR13                        ((uint32_t)0x00002000)        /*!< Pending bit for line 13 */
+#define  EXTI_PR_PR14                        ((uint32_t)0x00004000)        /*!< Pending bit for line 14 */
+#define  EXTI_PR_PR15                        ((uint32_t)0x00008000)        /*!< Pending bit for line 15 */
+#define  EXTI_PR_PR16                        ((uint32_t)0x00010000)        /*!< Pending bit for line 16 */
+#define  EXTI_PR_PR17                        ((uint32_t)0x00020000)        /*!< Pending bit for line 17 */
+#define  EXTI_PR_PR18                        ((uint32_t)0x00040000)        /*!< Pending bit for line 18 */
+#define  EXTI_PR_PR19                        ((uint32_t)0x00080000)        /*!< Pending bit for line 19 */
+#define  EXTI_PR_PR20                        ((uint32_t)0x00100000)        /*!< Pending bit for line 20 */
+#define  EXTI_PR_PR21                        ((uint32_t)0x00200000)        /*!< Pending bit for line 21 */
+#define  EXTI_PR_PR22                        ((uint32_t)0x00400000)        /*!< Pending bit for line 22 */
+#define  EXTI_PR_PR23                        ((uint32_t)0x00800000)        /*!< Pending bit for line 23 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    FLASH                                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bits definition for FLASH_ACR register  *****************/
+#define FLASH_ACR_LATENCY                    ((uint32_t)0x0000000F)
+#define FLASH_ACR_LATENCY_0WS                ((uint32_t)0x00000000)
+#define FLASH_ACR_LATENCY_1WS                ((uint32_t)0x00000001)
+#define FLASH_ACR_LATENCY_2WS                ((uint32_t)0x00000002)
+#define FLASH_ACR_LATENCY_3WS                ((uint32_t)0x00000003)
+#define FLASH_ACR_LATENCY_4WS                ((uint32_t)0x00000004)
+#define FLASH_ACR_LATENCY_5WS                ((uint32_t)0x00000005)
+#define FLASH_ACR_LATENCY_6WS                ((uint32_t)0x00000006)
+#define FLASH_ACR_LATENCY_7WS                ((uint32_t)0x00000007)
+#define FLASH_ACR_LATENCY_8WS                ((uint32_t)0x00000008)
+#define FLASH_ACR_LATENCY_9WS                ((uint32_t)0x00000009)
+#define FLASH_ACR_LATENCY_10WS               ((uint32_t)0x0000000A)
+#define FLASH_ACR_LATENCY_11WS               ((uint32_t)0x0000000B)
+#define FLASH_ACR_LATENCY_12WS               ((uint32_t)0x0000000C)
+#define FLASH_ACR_LATENCY_13WS               ((uint32_t)0x0000000D)
+#define FLASH_ACR_LATENCY_14WS               ((uint32_t)0x0000000E)
+#define FLASH_ACR_LATENCY_15WS               ((uint32_t)0x0000000F)
+#define FLASH_ACR_PRFTEN                     ((uint32_t)0x00000100)
+#define FLASH_ACR_ARTEN                      ((uint32_t)0x00000200)
+#define FLASH_ACR_ARTRST                     ((uint32_t)0x00000800)
+
+/*******************  Bits definition for FLASH_SR register  ******************/
+#define FLASH_SR_EOP                         ((uint32_t)0x00000001)
+#define FLASH_SR_OPERR                       ((uint32_t)0x00000002)
+#define FLASH_SR_WRPERR                      ((uint32_t)0x00000010)
+#define FLASH_SR_PGAERR                      ((uint32_t)0x00000020)
+#define FLASH_SR_PGPERR                      ((uint32_t)0x00000040)
+#define FLASH_SR_ERSERR                      ((uint32_t)0x00000080)
+#define FLASH_SR_BSY                         ((uint32_t)0x00010000)
+
+/*******************  Bits definition for FLASH_CR register  ******************/
+#define FLASH_CR_PG                          ((uint32_t)0x00000001)
+#define FLASH_CR_SER                         ((uint32_t)0x00000002)
+#define FLASH_CR_MER                         ((uint32_t)0x00000004)
+#define FLASH_CR_SNB                         ((uint32_t)0x00000078)
+#define FLASH_CR_SNB_0                       ((uint32_t)0x00000008)
+#define FLASH_CR_SNB_1                       ((uint32_t)0x00000010)
+#define FLASH_CR_SNB_2                       ((uint32_t)0x00000020)
+#define FLASH_CR_SNB_3                       ((uint32_t)0x00000040)
+#define FLASH_CR_PSIZE                       ((uint32_t)0x00000300)
+#define FLASH_CR_PSIZE_0                     ((uint32_t)0x00000100)
+#define FLASH_CR_PSIZE_1                     ((uint32_t)0x00000200)
+#define FLASH_CR_STRT                        ((uint32_t)0x00010000)
+#define FLASH_CR_EOPIE                       ((uint32_t)0x01000000)
+#define FLASH_CR_ERRIE                       ((uint32_t)0x02000000)
+#define FLASH_CR_LOCK                        ((uint32_t)0x80000000)
+
+/*******************  Bits definition for FLASH_OPTCR register  ***************/
+#define FLASH_OPTCR_OPTLOCK                 ((uint32_t)0x00000001)
+#define FLASH_OPTCR_OPTSTRT                 ((uint32_t)0x00000002)
+#define FLASH_OPTCR_BOR_LEV                 ((uint32_t)0x0000000C)
+#define FLASH_OPTCR_BOR_LEV_0               ((uint32_t)0x00000004)
+#define FLASH_OPTCR_BOR_LEV_1               ((uint32_t)0x00000008)
+#define FLASH_OPTCR_WWDG_SW                 ((uint32_t)0x00000010)
+#define FLASH_OPTCR_IWDG_SW                 ((uint32_t)0x00000020)
+#define FLASH_OPTCR_nRST_STOP               ((uint32_t)0x00000040)
+#define FLASH_OPTCR_nRST_STDBY              ((uint32_t)0x00000080)
+#define FLASH_OPTCR_RDP                     ((uint32_t)0x0000FF00)
+#define FLASH_OPTCR_RDP_0                   ((uint32_t)0x00000100)
+#define FLASH_OPTCR_RDP_1                   ((uint32_t)0x00000200)
+#define FLASH_OPTCR_RDP_2                   ((uint32_t)0x00000400)
+#define FLASH_OPTCR_RDP_3                   ((uint32_t)0x00000800)
+#define FLASH_OPTCR_RDP_4                   ((uint32_t)0x00001000)
+#define FLASH_OPTCR_RDP_5                   ((uint32_t)0x00002000)
+#define FLASH_OPTCR_RDP_6                   ((uint32_t)0x00004000)
+#define FLASH_OPTCR_RDP_7                   ((uint32_t)0x00008000)
+#define FLASH_OPTCR_nWRP                    ((uint32_t)0x00FF0000)
+#define FLASH_OPTCR_nWRP_0                  ((uint32_t)0x00010000)
+#define FLASH_OPTCR_nWRP_1                  ((uint32_t)0x00020000)
+#define FLASH_OPTCR_nWRP_2                  ((uint32_t)0x00040000)
+#define FLASH_OPTCR_nWRP_3                  ((uint32_t)0x00080000)
+#define FLASH_OPTCR_nWRP_4                  ((uint32_t)0x00100000)
+#define FLASH_OPTCR_nWRP_5                  ((uint32_t)0x00200000)
+#define FLASH_OPTCR_nWRP_6                  ((uint32_t)0x00400000)
+#define FLASH_OPTCR_nWRP_7                  ((uint32_t)0x00800000)
+#define FLASH_OPTCR_IWDG_STDBY              ((uint32_t)0x40000000)
+#define FLASH_OPTCR_IWDG_STOP               ((uint32_t)0x80000000)
+
+/*******************  Bits definition for FLASH_OPTCR1 register  ***************/
+#define FLASH_OPTCR1_BOOT_ADD0              ((uint32_t)0x0000FFFF)
+#define FLASH_OPTCR1_BOOT_ADD1              ((uint32_t)0xFFFF0000)
+
+/******************************************************************************/
+/*                                                                            */
+/*                          Flexible Memory Controller                        */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for FMC_BCR1 register  *******************/
+#define  FMC_BCR1_MBKEN                     ((uint32_t)0x00000001)        /*!<Memory bank enable bit                 */
+#define  FMC_BCR1_MUXEN                     ((uint32_t)0x00000002)        /*!<Address/data multiplexing enable bit   */
+
+#define  FMC_BCR1_MTYP                      ((uint32_t)0x0000000C)        /*!<MTYP[1:0] bits (Memory type)           */
+#define  FMC_BCR1_MTYP_0                    ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_BCR1_MTYP_1                    ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_BCR1_MWID                      ((uint32_t)0x00000030)        /*!<MWID[1:0] bits (Memory data bus width) */
+#define  FMC_BCR1_MWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BCR1_MWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_BCR1_FACCEN                    ((uint32_t)0x00000040)        /*!<Flash access enable        */
+#define  FMC_BCR1_BURSTEN                   ((uint32_t)0x00000100)        /*!<Burst enable bit           */
+#define  FMC_BCR1_WAITPOL                   ((uint32_t)0x00000200)        /*!<Wait signal polarity bit   */
+#define  FMC_BCR1_WRAPMOD                   ((uint32_t)0x00000400)        /*!<Wrapped burst mode support */
+#define  FMC_BCR1_WAITCFG                   ((uint32_t)0x00000800)        /*!<Wait timing configuration  */
+#define  FMC_BCR1_WREN                      ((uint32_t)0x00001000)        /*!<Write enable bit           */
+#define  FMC_BCR1_WAITEN                    ((uint32_t)0x00002000)        /*!<Wait enable bit            */
+#define  FMC_BCR1_EXTMOD                    ((uint32_t)0x00004000)        /*!<Extended mode enable       */
+#define  FMC_BCR1_ASYNCWAIT                 ((uint32_t)0x00008000)        /*!<Asynchronous wait          */
+#define  FMC_BCR1_CPSIZE                     ((uint32_t)0x00070000)        /*!<CRAM page size             */
+#define  FMC_BCR1_CPSIZE_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BCR1_CPSIZE_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BCR1_CPSIZE_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BCR1_CBURSTRW                  ((uint32_t)0x00080000)        /*!<Write burst enable         */
+#define  FMC_BCR1_CCLKEN                    ((uint32_t)0x00100000)        /*!<Continous clock enable     */
+#define  FMC_BCR1_WFDIS                     ((uint32_t)0x00200000)        /*!<Write FIFO Disable         */
+
+/******************  Bit definition for FMC_BCR2 register  *******************/
+#define  FMC_BCR2_MBKEN                     ((uint32_t)0x00000001)        /*!<Memory bank enable bit                 */
+#define  FMC_BCR2_MUXEN                     ((uint32_t)0x00000002)        /*!<Address/data multiplexing enable bit   */
+
+#define  FMC_BCR2_MTYP                      ((uint32_t)0x0000000C)        /*!<MTYP[1:0] bits (Memory type)           */
+#define  FMC_BCR2_MTYP_0                    ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_BCR2_MTYP_1                    ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_BCR2_MWID                      ((uint32_t)0x00000030)        /*!<MWID[1:0] bits (Memory data bus width) */
+#define  FMC_BCR2_MWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BCR2_MWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_BCR2_FACCEN                    ((uint32_t)0x00000040)        /*!<Flash access enable        */
+#define  FMC_BCR2_BURSTEN                   ((uint32_t)0x00000100)        /*!<Burst enable bit           */
+#define  FMC_BCR2_WAITPOL                   ((uint32_t)0x00000200)        /*!<Wait signal polarity bit   */
+#define  FMC_BCR2_WRAPMOD                   ((uint32_t)0x00000400)        /*!<Wrapped burst mode support */
+#define  FMC_BCR2_WAITCFG                   ((uint32_t)0x00000800)        /*!<Wait timing configuration  */
+#define  FMC_BCR2_WREN                      ((uint32_t)0x00001000)        /*!<Write enable bit           */
+#define  FMC_BCR2_WAITEN                    ((uint32_t)0x00002000)        /*!<Wait enable bit            */
+#define  FMC_BCR2_EXTMOD                    ((uint32_t)0x00004000)        /*!<Extended mode enable       */
+#define  FMC_BCR2_ASYNCWAIT                 ((uint32_t)0x00008000)        /*!<Asynchronous wait          */
+#define  FMC_BCR2_CPSIZE                     ((uint32_t)0x00070000)        /*!<CRAM page size             */
+#define  FMC_BCR2_CPSIZE_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BCR2_CPSIZE_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BCR2_CPSIZE_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BCR2_CBURSTRW                  ((uint32_t)0x00080000)        /*!<Write burst enable         */
+
+/******************  Bit definition for FMC_BCR3 register  *******************/
+#define  FMC_BCR3_MBKEN                     ((uint32_t)0x00000001)        /*!<Memory bank enable bit                 */
+#define  FMC_BCR3_MUXEN                     ((uint32_t)0x00000002)        /*!<Address/data multiplexing enable bit   */
+
+#define  FMC_BCR3_MTYP                      ((uint32_t)0x0000000C)        /*!<MTYP[1:0] bits (Memory type)           */
+#define  FMC_BCR3_MTYP_0                    ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_BCR3_MTYP_1                    ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_BCR3_MWID                      ((uint32_t)0x00000030)        /*!<MWID[1:0] bits (Memory data bus width) */
+#define  FMC_BCR3_MWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BCR3_MWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_BCR3_FACCEN                    ((uint32_t)0x00000040)        /*!<Flash access enable        */
+#define  FMC_BCR3_BURSTEN                   ((uint32_t)0x00000100)        /*!<Burst enable bit           */
+#define  FMC_BCR3_WAITPOL                   ((uint32_t)0x00000200)        /*!<Wait signal polarity bit   */
+#define  FMC_BCR3_WRAPMOD                   ((uint32_t)0x00000400)        /*!<Wrapped burst mode support */
+#define  FMC_BCR3_WAITCFG                   ((uint32_t)0x00000800)        /*!<Wait timing configuration  */
+#define  FMC_BCR3_WREN                      ((uint32_t)0x00001000)        /*!<Write enable bit           */
+#define  FMC_BCR3_WAITEN                    ((uint32_t)0x00002000)        /*!<Wait enable bit            */
+#define  FMC_BCR3_EXTMOD                    ((uint32_t)0x00004000)        /*!<Extended mode enable       */
+#define  FMC_BCR3_ASYNCWAIT                 ((uint32_t)0x00008000)        /*!<Asynchronous wait          */
+#define  FMC_BCR3_CPSIZE                     ((uint32_t)0x00070000)        /*!<CRAM page size             */
+#define  FMC_BCR3_CPSIZE_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BCR3_CPSIZE_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BCR3_CPSIZE_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BCR3_CBURSTRW                  ((uint32_t)0x00080000)        /*!<Write burst enable         */
+
+/******************  Bit definition for FMC_BCR4 register  *******************/
+#define  FMC_BCR4_MBKEN                     ((uint32_t)0x00000001)        /*!<Memory bank enable bit                 */
+#define  FMC_BCR4_MUXEN                     ((uint32_t)0x00000002)        /*!<Address/data multiplexing enable bit   */
+
+#define  FMC_BCR4_MTYP                      ((uint32_t)0x0000000C)        /*!<MTYP[1:0] bits (Memory type)           */
+#define  FMC_BCR4_MTYP_0                    ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_BCR4_MTYP_1                    ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_BCR4_MWID                      ((uint32_t)0x00000030)        /*!<MWID[1:0] bits (Memory data bus width) */
+#define  FMC_BCR4_MWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BCR4_MWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_BCR4_FACCEN                    ((uint32_t)0x00000040)        /*!<Flash access enable        */
+#define  FMC_BCR4_BURSTEN                   ((uint32_t)0x00000100)        /*!<Burst enable bit           */
+#define  FMC_BCR4_WAITPOL                   ((uint32_t)0x00000200)        /*!<Wait signal polarity bit   */
+#define  FMC_BCR4_WRAPMOD                   ((uint32_t)0x00000400)        /*!<Wrapped burst mode support */
+#define  FMC_BCR4_WAITCFG                   ((uint32_t)0x00000800)        /*!<Wait timing configuration  */
+#define  FMC_BCR4_WREN                      ((uint32_t)0x00001000)        /*!<Write enable bit           */
+#define  FMC_BCR4_WAITEN                    ((uint32_t)0x00002000)        /*!<Wait enable bit            */
+#define  FMC_BCR4_EXTMOD                    ((uint32_t)0x00004000)        /*!<Extended mode enable       */
+#define  FMC_BCR4_ASYNCWAIT                 ((uint32_t)0x00008000)        /*!<Asynchronous wait          */
+#define  FMC_BCR4_CPSIZE                     ((uint32_t)0x00070000)        /*!<CRAM page size             */
+#define  FMC_BCR4_CPSIZE_0                   ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BCR4_CPSIZE_1                   ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BCR4_CPSIZE_2                   ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BCR4_CBURSTRW                  ((uint32_t)0x00080000)        /*!<Write burst enable         */
+
+/******************  Bit definition for FMC_BTR1 register  ******************/
+#define  FMC_BTR1_ADDSET                    ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BTR1_ADDSET_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BTR1_ADDSET_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BTR1_ADDSET_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BTR1_ADDSET_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BTR1_ADDHLD                    ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration)  */
+#define  FMC_BTR1_ADDHLD_0                  ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BTR1_ADDHLD_1                  ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BTR1_ADDHLD_2                  ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BTR1_ADDHLD_3                  ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BTR1_DATAST                    ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BTR1_DATAST_0                  ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BTR1_DATAST_1                  ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BTR1_DATAST_2                  ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BTR1_DATAST_3                  ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BTR1_DATAST_4                  ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BTR1_DATAST_5                  ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BTR1_DATAST_6                  ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BTR1_DATAST_7                  ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BTR1_BUSTURN                   ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BTR1_BUSTURN_0                 ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BTR1_BUSTURN_1                 ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BTR1_BUSTURN_2                 ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BTR1_BUSTURN_3                 ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BTR1_CLKDIV                    ((uint32_t)0x00F00000)        /*!<CLKDIV[3:0] bits (Clock divide ratio) */
+#define  FMC_BTR1_CLKDIV_0                  ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_BTR1_CLKDIV_1                  ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_BTR1_CLKDIV_2                  ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  FMC_BTR1_CLKDIV_3                  ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+#define  FMC_BTR1_DATLAT                    ((uint32_t)0x0F000000)        /*!<DATLA[3:0] bits (Data latency) */
+#define  FMC_BTR1_DATLAT_0                  ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_BTR1_DATLAT_1                  ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_BTR1_DATLAT_2                  ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_BTR1_DATLAT_3                  ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  FMC_BTR1_ACCMOD                    ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BTR1_ACCMOD_0                  ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BTR1_ACCMOD_1                  ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BTR2 register  *******************/
+#define  FMC_BTR2_ADDSET                    ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BTR2_ADDSET_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BTR2_ADDSET_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BTR2_ADDSET_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BTR2_ADDSET_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BTR2_ADDHLD                    ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BTR2_ADDHLD_0                  ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BTR2_ADDHLD_1                  ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BTR2_ADDHLD_2                  ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BTR2_ADDHLD_3                  ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BTR2_DATAST                    ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BTR2_DATAST_0                  ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BTR2_DATAST_1                  ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BTR2_DATAST_2                  ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BTR2_DATAST_3                  ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BTR2_DATAST_4                  ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BTR2_DATAST_5                  ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BTR2_DATAST_6                  ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BTR2_DATAST_7                  ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BTR2_BUSTURN                   ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BTR2_BUSTURN_0                 ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BTR2_BUSTURN_1                 ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BTR2_BUSTURN_2                 ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BTR2_BUSTURN_3                 ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BTR2_CLKDIV                    ((uint32_t)0x00F00000)        /*!<CLKDIV[3:0] bits (Clock divide ratio) */
+#define  FMC_BTR2_CLKDIV_0                  ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_BTR2_CLKDIV_1                  ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_BTR2_CLKDIV_2                  ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  FMC_BTR2_CLKDIV_3                  ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+#define  FMC_BTR2_DATLAT                    ((uint32_t)0x0F000000)        /*!<DATLA[3:0] bits (Data latency) */
+#define  FMC_BTR2_DATLAT_0                  ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_BTR2_DATLAT_1                  ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_BTR2_DATLAT_2                  ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_BTR2_DATLAT_3                  ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  FMC_BTR2_ACCMOD                    ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BTR2_ACCMOD_0                  ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BTR2_ACCMOD_1                  ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/*******************  Bit definition for FMC_BTR3 register  *******************/
+#define  FMC_BTR3_ADDSET                    ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BTR3_ADDSET_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BTR3_ADDSET_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BTR3_ADDSET_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BTR3_ADDSET_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BTR3_ADDHLD                    ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BTR3_ADDHLD_0                  ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BTR3_ADDHLD_1                  ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BTR3_ADDHLD_2                  ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BTR3_ADDHLD_3                  ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BTR3_DATAST                    ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BTR3_DATAST_0                  ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BTR3_DATAST_1                  ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BTR3_DATAST_2                  ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BTR3_DATAST_3                  ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BTR3_DATAST_4                  ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BTR3_DATAST_5                  ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BTR3_DATAST_6                  ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BTR3_DATAST_7                  ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BTR3_BUSTURN                   ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BTR3_BUSTURN_0                 ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BTR3_BUSTURN_1                 ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BTR3_BUSTURN_2                 ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BTR3_BUSTURN_3                 ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BTR3_CLKDIV                    ((uint32_t)0x00F00000)        /*!<CLKDIV[3:0] bits (Clock divide ratio) */
+#define  FMC_BTR3_CLKDIV_0                  ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_BTR3_CLKDIV_1                  ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_BTR3_CLKDIV_2                  ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  FMC_BTR3_CLKDIV_3                  ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+#define  FMC_BTR3_DATLAT                    ((uint32_t)0x0F000000)        /*!<DATLA[3:0] bits (Data latency) */
+#define  FMC_BTR3_DATLAT_0                  ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_BTR3_DATLAT_1                  ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_BTR3_DATLAT_2                  ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_BTR3_DATLAT_3                  ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  FMC_BTR3_ACCMOD                    ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BTR3_ACCMOD_0                  ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BTR3_ACCMOD_1                  ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BTR4 register  *******************/
+#define  FMC_BTR4_ADDSET                    ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BTR4_ADDSET_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BTR4_ADDSET_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BTR4_ADDSET_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BTR4_ADDSET_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BTR4_ADDHLD                    ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BTR4_ADDHLD_0                  ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BTR4_ADDHLD_1                  ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BTR4_ADDHLD_2                  ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BTR4_ADDHLD_3                  ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BTR4_DATAST                    ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BTR4_DATAST_0                  ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BTR4_DATAST_1                  ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BTR4_DATAST_2                  ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BTR4_DATAST_3                  ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BTR4_DATAST_4                  ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BTR4_DATAST_5                  ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BTR4_DATAST_6                  ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BTR4_DATAST_7                  ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BTR4_BUSTURN                   ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BTR4_BUSTURN_0                 ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BTR4_BUSTURN_1                 ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BTR4_BUSTURN_2                 ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BTR4_BUSTURN_3                 ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BTR4_CLKDIV                    ((uint32_t)0x00F00000)        /*!<CLKDIV[3:0] bits (Clock divide ratio) */
+#define  FMC_BTR4_CLKDIV_0                  ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_BTR4_CLKDIV_1                  ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_BTR4_CLKDIV_2                  ((uint32_t)0x00400000)        /*!<Bit 2 */
+#define  FMC_BTR4_CLKDIV_3                  ((uint32_t)0x00800000)        /*!<Bit 3 */
+
+#define  FMC_BTR4_DATLAT                    ((uint32_t)0x0F000000)        /*!<DATLA[3:0] bits (Data latency) */
+#define  FMC_BTR4_DATLAT_0                  ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_BTR4_DATLAT_1                  ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_BTR4_DATLAT_2                  ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_BTR4_DATLAT_3                  ((uint32_t)0x08000000)        /*!<Bit 3 */
+
+#define  FMC_BTR4_ACCMOD                    ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BTR4_ACCMOD_0                  ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BTR4_ACCMOD_1                  ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BWTR1 register  ******************/
+#define  FMC_BWTR1_ADDSET                   ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BWTR1_ADDSET_0                 ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BWTR1_ADDSET_1                 ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BWTR1_ADDSET_2                 ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BWTR1_ADDSET_3                 ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BWTR1_ADDHLD                   ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BWTR1_ADDHLD_0                 ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BWTR1_ADDHLD_1                 ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BWTR1_ADDHLD_2                 ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BWTR1_ADDHLD_3                 ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BWTR1_DATAST                   ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BWTR1_DATAST_0                 ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BWTR1_DATAST_1                 ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BWTR1_DATAST_2                 ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BWTR1_DATAST_3                 ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BWTR1_DATAST_4                 ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BWTR1_DATAST_5                 ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BWTR1_DATAST_6                 ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BWTR1_DATAST_7                 ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BWTR1_BUSTURN                  ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BWTR1_BUSTURN_0                ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BWTR1_BUSTURN_1                ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BWTR1_BUSTURN_2                ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BWTR1_BUSTURN_3                ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BWTR1_ACCMOD                   ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BWTR1_ACCMOD_0                 ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BWTR1_ACCMOD_1                 ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BWTR2 register  ******************/
+#define  FMC_BWTR2_ADDSET                   ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BWTR2_ADDSET_0                 ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BWTR2_ADDSET_1                 ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BWTR2_ADDSET_2                 ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BWTR2_ADDSET_3                 ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BWTR2_ADDHLD                   ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BWTR2_ADDHLD_0                 ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BWTR2_ADDHLD_1                 ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BWTR2_ADDHLD_2                 ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BWTR2_ADDHLD_3                 ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BWTR2_DATAST                   ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BWTR2_DATAST_0                 ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BWTR2_DATAST_1                 ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BWTR2_DATAST_2                 ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BWTR2_DATAST_3                 ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BWTR2_DATAST_4                 ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BWTR2_DATAST_5                 ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BWTR2_DATAST_6                 ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BWTR2_DATAST_7                 ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BWTR2_BUSTURN                  ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BWTR2_BUSTURN_0                ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BWTR2_BUSTURN_1                ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BWTR2_BUSTURN_2                ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BWTR2_BUSTURN_3                ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BWTR2_ACCMOD                   ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BWTR2_ACCMOD_0                 ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BWTR2_ACCMOD_1                 ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BWTR3 register  ******************/
+#define  FMC_BWTR3_ADDSET                   ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BWTR3_ADDSET_0                 ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BWTR3_ADDSET_1                 ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BWTR3_ADDSET_2                 ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BWTR3_ADDSET_3                 ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BWTR3_ADDHLD                   ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BWTR3_ADDHLD_0                 ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BWTR3_ADDHLD_1                 ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BWTR3_ADDHLD_2                 ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BWTR3_ADDHLD_3                 ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BWTR3_DATAST                   ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BWTR3_DATAST_0                 ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BWTR3_DATAST_1                 ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BWTR3_DATAST_2                 ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BWTR3_DATAST_3                 ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BWTR3_DATAST_4                 ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BWTR3_DATAST_5                 ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BWTR3_DATAST_6                 ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BWTR3_DATAST_7                 ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BWTR3_BUSTURN                  ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BWTR3_BUSTURN_0                ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BWTR3_BUSTURN_1                ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BWTR3_BUSTURN_2                ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BWTR3_BUSTURN_3                ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BWTR3_ACCMOD                   ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BWTR3_ACCMOD_0                 ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BWTR3_ACCMOD_1                 ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_BWTR4 register  ******************/
+#define  FMC_BWTR4_ADDSET                   ((uint32_t)0x0000000F)        /*!<ADDSET[3:0] bits (Address setup phase duration) */
+#define  FMC_BWTR4_ADDSET_0                 ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_BWTR4_ADDSET_1                 ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_BWTR4_ADDSET_2                 ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_BWTR4_ADDSET_3                 ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_BWTR4_ADDHLD                   ((uint32_t)0x000000F0)        /*!<ADDHLD[3:0] bits (Address-hold phase duration) */
+#define  FMC_BWTR4_ADDHLD_0                 ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_BWTR4_ADDHLD_1                 ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_BWTR4_ADDHLD_2                 ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_BWTR4_ADDHLD_3                 ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_BWTR4_DATAST                   ((uint32_t)0x0000FF00)        /*!<DATAST [3:0] bits (Data-phase duration) */
+#define  FMC_BWTR4_DATAST_0                 ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_BWTR4_DATAST_1                 ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_BWTR4_DATAST_2                 ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_BWTR4_DATAST_3                 ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_BWTR4_DATAST_4                 ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_BWTR4_DATAST_5                 ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_BWTR4_DATAST_6                 ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_BWTR4_DATAST_7                 ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_BWTR4_BUSTURN                  ((uint32_t)0x000F0000)        /*!<BUSTURN[3:0] bits (Bus turnaround phase duration) */
+#define  FMC_BWTR4_BUSTURN_0                ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_BWTR4_BUSTURN_1                ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_BWTR4_BUSTURN_2                ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_BWTR4_BUSTURN_3                ((uint32_t)0x00080000)        /*!<Bit 3 */
+
+#define  FMC_BWTR4_ACCMOD                   ((uint32_t)0x30000000)        /*!<ACCMOD[1:0] bits (Access mode) */
+#define  FMC_BWTR4_ACCMOD_0                 ((uint32_t)0x10000000)        /*!<Bit 0 */
+#define  FMC_BWTR4_ACCMOD_1                 ((uint32_t)0x20000000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_PCR register  *******************/
+#define  FMC_PCR_PWAITEN                   ((uint32_t)0x00000002)        /*!<Wait feature enable bit                   */
+#define  FMC_PCR_PBKEN                     ((uint32_t)0x00000004)        /*!<PC Card/NAND Flash memory bank enable bit */
+#define  FMC_PCR_PTYP                      ((uint32_t)0x00000008)        /*!<Memory type                               */
+
+#define  FMC_PCR_PWID                      ((uint32_t)0x00000030)        /*!<PWID[1:0] bits (NAND Flash databus width) */
+#define  FMC_PCR_PWID_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_PCR_PWID_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_PCR_ECCEN                     ((uint32_t)0x00000040)        /*!<ECC computation logic enable bit          */
+
+#define  FMC_PCR_TCLR                      ((uint32_t)0x00001E00)        /*!<TCLR[3:0] bits (CLE to RE delay)          */
+#define  FMC_PCR_TCLR_0                    ((uint32_t)0x00000200)        /*!<Bit 0 */
+#define  FMC_PCR_TCLR_1                    ((uint32_t)0x00000400)        /*!<Bit 1 */
+#define  FMC_PCR_TCLR_2                    ((uint32_t)0x00000800)        /*!<Bit 2 */
+#define  FMC_PCR_TCLR_3                    ((uint32_t)0x00001000)        /*!<Bit 3 */
+
+#define  FMC_PCR_TAR                       ((uint32_t)0x0001E000)        /*!<TAR[3:0] bits (ALE to RE delay)           */
+#define  FMC_PCR_TAR_0                     ((uint32_t)0x00002000)        /*!<Bit 0 */
+#define  FMC_PCR_TAR_1                     ((uint32_t)0x00004000)        /*!<Bit 1 */
+#define  FMC_PCR_TAR_2                     ((uint32_t)0x00008000)        /*!<Bit 2 */
+#define  FMC_PCR_TAR_3                     ((uint32_t)0x00010000)        /*!<Bit 3 */
+
+#define  FMC_PCR_ECCPS                     ((uint32_t)0x000E0000)        /*!<ECCPS[2:0] bits (ECC page size)           */
+#define  FMC_PCR_ECCPS_0                   ((uint32_t)0x00020000)        /*!<Bit 0 */
+#define  FMC_PCR_ECCPS_1                   ((uint32_t)0x00040000)        /*!<Bit 1 */
+#define  FMC_PCR_ECCPS_2                   ((uint32_t)0x00080000)        /*!<Bit 2 */
+
+/*******************  Bit definition for FMC_SR register  *******************/
+#define  FMC_SR_IRS                        ((uint32_t)0x01)              /*!<Interrupt Rising Edge status                */
+#define  FMC_SR_ILS                        ((uint32_t)0x02)              /*!<Interrupt Level status                      */
+#define  FMC_SR_IFS                        ((uint32_t)0x04)              /*!<Interrupt Falling Edge status               */
+#define  FMC_SR_IREN                       ((uint32_t)0x08)              /*!<Interrupt Rising Edge detection Enable bit  */
+#define  FMC_SR_ILEN                       ((uint32_t)0x10)              /*!<Interrupt Level detection Enable bit        */
+#define  FMC_SR_IFEN                       ((uint32_t)0x20)              /*!<Interrupt Falling Edge detection Enable bit */
+#define  FMC_SR_FEMPT                      ((uint32_t)0x40)              /*!<FIFO empty                                  */
+
+/******************  Bit definition for FMC_PMEM register  ******************/
+#define  FMC_PMEM_MEMSET3                  ((uint32_t)0x000000FF)        /*!<MEMSET3[7:0] bits (Common memory 3 setup time) */
+#define  FMC_PMEM_MEMSET3_0                ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_PMEM_MEMSET3_1                ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_PMEM_MEMSET3_2                ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_PMEM_MEMSET3_3                ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  FMC_PMEM_MEMSET3_4                ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  FMC_PMEM_MEMSET3_5                ((uint32_t)0x00000020)        /*!<Bit 5 */
+#define  FMC_PMEM_MEMSET3_6                ((uint32_t)0x00000040)        /*!<Bit 6 */
+#define  FMC_PMEM_MEMSET3_7                ((uint32_t)0x00000080)        /*!<Bit 7 */
+
+#define  FMC_PMEM_MEMWAIT3                 ((uint32_t)0x0000FF00)        /*!<MEMWAIT3[7:0] bits (Common memory 3 wait time) */
+#define  FMC_PMEM_MEMWAIT3_0               ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_PMEM_MEMWAIT3_1               ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_PMEM_MEMWAIT3_2               ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_PMEM_MEMWAIT3_3               ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_PMEM_MEMWAIT3_4               ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_PMEM_MEMWAIT3_5               ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_PMEM_MEMWAIT3_6               ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_PMEM_MEMWAIT3_7               ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_PMEM_MEMHOLD3                 ((uint32_t)0x00FF0000)        /*!<MEMHOLD3[7:0] bits (Common memory 3 hold time) */
+#define  FMC_PMEM_MEMHOLD3_0               ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_PMEM_MEMHOLD3_1               ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_PMEM_MEMHOLD3_2               ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_PMEM_MEMHOLD3_3               ((uint32_t)0x00080000)        /*!<Bit 3 */
+#define  FMC_PMEM_MEMHOLD3_4               ((uint32_t)0x00100000)        /*!<Bit 4 */
+#define  FMC_PMEM_MEMHOLD3_5               ((uint32_t)0x00200000)        /*!<Bit 5 */
+#define  FMC_PMEM_MEMHOLD3_6               ((uint32_t)0x00400000)        /*!<Bit 6 */
+#define  FMC_PMEM_MEMHOLD3_7               ((uint32_t)0x00800000)        /*!<Bit 7 */
+
+#define  FMC_PMEM_MEMHIZ3                  ((uint32_t)0xFF000000)        /*!<MEMHIZ3[7:0] bits (Common memory 3 databus HiZ time) */
+#define  FMC_PMEM_MEMHIZ3_0                ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_PMEM_MEMHIZ3_1                ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_PMEM_MEMHIZ3_2                ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_PMEM_MEMHIZ3_3                ((uint32_t)0x08000000)        /*!<Bit 3 */
+#define  FMC_PMEM_MEMHIZ3_4                ((uint32_t)0x10000000)        /*!<Bit 4 */
+#define  FMC_PMEM_MEMHIZ3_5                ((uint32_t)0x20000000)        /*!<Bit 5 */
+#define  FMC_PMEM_MEMHIZ3_6                ((uint32_t)0x40000000)        /*!<Bit 6 */
+#define  FMC_PMEM_MEMHIZ3_7                ((uint32_t)0x80000000)        /*!<Bit 7 */
+
+/******************  Bit definition for FMC_PATT register  ******************/
+#define  FMC_PATT_ATTSET3                  ((uint32_t)0x000000FF)        /*!<ATTSET3[7:0] bits (Attribute memory 3 setup time) */
+#define  FMC_PATT_ATTSET3_0                ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_PATT_ATTSET3_1                ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_PATT_ATTSET3_2                ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_PATT_ATTSET3_3                ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  FMC_PATT_ATTSET3_4                ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  FMC_PATT_ATTSET3_5                ((uint32_t)0x00000020)        /*!<Bit 5 */
+#define  FMC_PATT_ATTSET3_6                ((uint32_t)0x00000040)        /*!<Bit 6 */
+#define  FMC_PATT_ATTSET3_7                ((uint32_t)0x00000080)        /*!<Bit 7 */
+
+#define  FMC_PATT_ATTWAIT3                 ((uint32_t)0x0000FF00)        /*!<ATTWAIT3[7:0] bits (Attribute memory 3 wait time) */
+#define  FMC_PATT_ATTWAIT3_0               ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_PATT_ATTWAIT3_1               ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_PATT_ATTWAIT3_2               ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_PATT_ATTWAIT3_3               ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  FMC_PATT_ATTWAIT3_4               ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  FMC_PATT_ATTWAIT3_5               ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  FMC_PATT_ATTWAIT3_6               ((uint32_t)0x00004000)        /*!<Bit 6 */
+#define  FMC_PATT_ATTWAIT3_7               ((uint32_t)0x00008000)        /*!<Bit 7 */
+
+#define  FMC_PATT_ATTHOLD3                 ((uint32_t)0x00FF0000)        /*!<ATTHOLD3[7:0] bits (Attribute memory 3 hold time) */
+#define  FMC_PATT_ATTHOLD3_0               ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_PATT_ATTHOLD3_1               ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_PATT_ATTHOLD3_2               ((uint32_t)0x00040000)        /*!<Bit 2 */
+#define  FMC_PATT_ATTHOLD3_3               ((uint32_t)0x00080000)        /*!<Bit 3 */
+#define  FMC_PATT_ATTHOLD3_4               ((uint32_t)0x00100000)        /*!<Bit 4 */
+#define  FMC_PATT_ATTHOLD3_5               ((uint32_t)0x00200000)        /*!<Bit 5 */
+#define  FMC_PATT_ATTHOLD3_6               ((uint32_t)0x00400000)        /*!<Bit 6 */
+#define  FMC_PATT_ATTHOLD3_7               ((uint32_t)0x00800000)        /*!<Bit 7 */
+
+#define  FMC_PATT_ATTHIZ3                  ((uint32_t)0xFF000000)        /*!<ATTHIZ3[7:0] bits (Attribute memory 3 databus HiZ time) */
+#define  FMC_PATT_ATTHIZ3_0                ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_PATT_ATTHIZ3_1                ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_PATT_ATTHIZ3_2                ((uint32_t)0x04000000)        /*!<Bit 2 */
+#define  FMC_PATT_ATTHIZ3_3                ((uint32_t)0x08000000)        /*!<Bit 3 */
+#define  FMC_PATT_ATTHIZ3_4                ((uint32_t)0x10000000)        /*!<Bit 4 */
+#define  FMC_PATT_ATTHIZ3_5                ((uint32_t)0x20000000)        /*!<Bit 5 */
+#define  FMC_PATT_ATTHIZ3_6                ((uint32_t)0x40000000)        /*!<Bit 6 */
+#define  FMC_PATT_ATTHIZ3_7                ((uint32_t)0x80000000)        /*!<Bit 7 */
+
+/******************  Bit definition for FMC_ECCR register  ******************/
+#define  FMC_ECCR_ECC3                     ((uint32_t)0xFFFFFFFF)        /*!<ECC result */
+
+/******************  Bit definition for FMC_SDCR1 register  ******************/
+#define  FMC_SDCR1_NC                       ((uint32_t)0x00000003)        /*!<NC[1:0] bits (Number of column bits) */
+#define  FMC_SDCR1_NC_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDCR1_NC_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_NR                       ((uint32_t)0x0000000C)        /*!<NR[1:0] bits (Number of row bits) */
+#define  FMC_SDCR1_NR_0                     ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_SDCR1_NR_1                     ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_MWID                     ((uint32_t)0x00000030)        /*!<NR[1:0] bits (Number of row bits) */
+#define  FMC_SDCR1_MWID_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_SDCR1_MWID_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_NB                       ((uint32_t)0x00000040)        /*!<Number of internal bank */
+
+#define  FMC_SDCR1_CAS                      ((uint32_t)0x00000180)        /*!<CAS[1:0] bits (CAS latency) */
+#define  FMC_SDCR1_CAS_0                    ((uint32_t)0x00000080)        /*!<Bit 0 */
+#define  FMC_SDCR1_CAS_1                    ((uint32_t)0x00000100)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_WP                       ((uint32_t)0x00000200)        /*!<Write protection */
+
+#define  FMC_SDCR1_SDCLK                    ((uint32_t)0x00000C00)        /*!<SDRAM clock configuration */
+#define  FMC_SDCR1_SDCLK_0                  ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  FMC_SDCR1_SDCLK_1                  ((uint32_t)0x00000800)        /*!<Bit 1 */
+
+#define  FMC_SDCR1_RBURST                   ((uint32_t)0x00001000)        /*!<Read burst */
+
+#define  FMC_SDCR1_RPIPE                    ((uint32_t)0x00006000)        /*!<Write protection */
+#define  FMC_SDCR1_RPIPE_0                  ((uint32_t)0x00002000)        /*!<Bit 0 */
+#define  FMC_SDCR1_RPIPE_1                  ((uint32_t)0x00004000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_SDCR2 register  ******************/
+#define  FMC_SDCR2_NC                       ((uint32_t)0x00000003)        /*!<NC[1:0] bits (Number of column bits) */
+#define  FMC_SDCR2_NC_0                     ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDCR2_NC_1                     ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_NR                       ((uint32_t)0x0000000C)        /*!<NR[1:0] bits (Number of row bits) */
+#define  FMC_SDCR2_NR_0                     ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  FMC_SDCR2_NR_1                     ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_MWID                     ((uint32_t)0x00000030)        /*!<NR[1:0] bits (Number of row bits) */
+#define  FMC_SDCR2_MWID_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_SDCR2_MWID_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_NB                       ((uint32_t)0x00000040)        /*!<Number of internal bank */
+
+#define  FMC_SDCR2_CAS                      ((uint32_t)0x00000180)        /*!<CAS[1:0] bits (CAS latency) */
+#define  FMC_SDCR2_CAS_0                    ((uint32_t)0x00000080)        /*!<Bit 0 */
+#define  FMC_SDCR2_CAS_1                    ((uint32_t)0x00000100)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_WP                       ((uint32_t)0x00000200)        /*!<Write protection */
+
+#define  FMC_SDCR2_SDCLK                    ((uint32_t)0x00000C00)        /*!<SDCLK[1:0] (SDRAM clock configuration) */
+#define  FMC_SDCR2_SDCLK_0                  ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  FMC_SDCR2_SDCLK_1                  ((uint32_t)0x00000800)        /*!<Bit 1 */
+
+#define  FMC_SDCR2_RBURST                   ((uint32_t)0x00001000)        /*!<Read burst */
+
+#define  FMC_SDCR2_RPIPE                    ((uint32_t)0x00006000)        /*!<RPIPE[1:0](Read pipe) */
+#define  FMC_SDCR2_RPIPE_0                  ((uint32_t)0x00002000)        /*!<Bit 0 */
+#define  FMC_SDCR2_RPIPE_1                  ((uint32_t)0x00004000)        /*!<Bit 1 */
+
+/******************  Bit definition for FMC_SDTR1 register  ******************/
+#define  FMC_SDTR1_TMRD                     ((uint32_t)0x0000000F)        /*!<TMRD[3:0] bits (Load mode register to active) */
+#define  FMC_SDTR1_TMRD_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDTR1_TMRD_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_SDTR1_TMRD_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_SDTR1_TMRD_3                   ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_SDTR1_TXSR                     ((uint32_t)0x000000F0)        /*!<TXSR[3:0] bits (Exit self refresh) */
+#define  FMC_SDTR1_TXSR_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_SDTR1_TXSR_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_SDTR1_TXSR_2                   ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_SDTR1_TXSR_3                   ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_SDTR1_TRAS                     ((uint32_t)0x00000F00)        /*!<TRAS[3:0] bits (Self refresh time) */
+#define  FMC_SDTR1_TRAS_0                   ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_SDTR1_TRAS_1                   ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_SDTR1_TRAS_2                   ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_SDTR1_TRAS_3                   ((uint32_t)0x00000800)        /*!<Bit 3 */
+
+#define  FMC_SDTR1_TRC                      ((uint32_t)0x0000F000)        /*!<TRC[2:0] bits (Row cycle delay) */
+#define  FMC_SDTR1_TRC_0                    ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  FMC_SDTR1_TRC_1                    ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  FMC_SDTR1_TRC_2                    ((uint32_t)0x00004000)        /*!<Bit 2 */
+
+#define  FMC_SDTR1_TWR                      ((uint32_t)0x000F0000)        /*!<TRC[2:0] bits (Write recovery delay) */
+#define  FMC_SDTR1_TWR_0                    ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_SDTR1_TWR_1                    ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_SDTR1_TWR_2                    ((uint32_t)0x00040000)        /*!<Bit 2 */
+
+#define  FMC_SDTR1_TRP                      ((uint32_t)0x00F00000)        /*!<TRP[2:0] bits (Row precharge delay) */
+#define  FMC_SDTR1_TRP_0                    ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_SDTR1_TRP_1                    ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_SDTR1_TRP_2                    ((uint32_t)0x00400000)        /*!<Bit 2 */
+
+#define  FMC_SDTR1_TRCD                     ((uint32_t)0x0F000000)        /*!<TRP[2:0] bits (Row to column delay) */
+#define  FMC_SDTR1_TRCD_0                   ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_SDTR1_TRCD_1                   ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_SDTR1_TRCD_2                   ((uint32_t)0x04000000)        /*!<Bit 2 */
+
+/******************  Bit definition for FMC_SDTR2 register  ******************/
+#define  FMC_SDTR2_TMRD                     ((uint32_t)0x0000000F)        /*!<TMRD[3:0] bits (Load mode register to active) */
+#define  FMC_SDTR2_TMRD_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDTR2_TMRD_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_SDTR2_TMRD_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  FMC_SDTR2_TMRD_3                   ((uint32_t)0x00000008)        /*!<Bit 3 */
+
+#define  FMC_SDTR2_TXSR                     ((uint32_t)0x000000F0)        /*!<TXSR[3:0] bits (Exit self refresh) */
+#define  FMC_SDTR2_TXSR_0                   ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  FMC_SDTR2_TXSR_1                   ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  FMC_SDTR2_TXSR_2                   ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  FMC_SDTR2_TXSR_3                   ((uint32_t)0x00000080)        /*!<Bit 3 */
+
+#define  FMC_SDTR2_TRAS                     ((uint32_t)0x00000F00)        /*!<TRAS[3:0] bits (Self refresh time) */
+#define  FMC_SDTR2_TRAS_0                   ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  FMC_SDTR2_TRAS_1                   ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  FMC_SDTR2_TRAS_2                   ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  FMC_SDTR2_TRAS_3                   ((uint32_t)0x00000800)        /*!<Bit 3 */
+
+#define  FMC_SDTR2_TRC                      ((uint32_t)0x0000F000)        /*!<TRC[2:0] bits (Row cycle delay) */
+#define  FMC_SDTR2_TRC_0                    ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  FMC_SDTR2_TRC_1                    ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  FMC_SDTR2_TRC_2                    ((uint32_t)0x00004000)        /*!<Bit 2 */
+
+#define  FMC_SDTR2_TWR                      ((uint32_t)0x000F0000)        /*!<TRC[2:0] bits (Write recovery delay) */
+#define  FMC_SDTR2_TWR_0                    ((uint32_t)0x00010000)        /*!<Bit 0 */
+#define  FMC_SDTR2_TWR_1                    ((uint32_t)0x00020000)        /*!<Bit 1 */
+#define  FMC_SDTR2_TWR_2                    ((uint32_t)0x00040000)        /*!<Bit 2 */
+
+#define  FMC_SDTR2_TRP                      ((uint32_t)0x00F00000)        /*!<TRP[2:0] bits (Row precharge delay) */
+#define  FMC_SDTR2_TRP_0                    ((uint32_t)0x00100000)        /*!<Bit 0 */
+#define  FMC_SDTR2_TRP_1                    ((uint32_t)0x00200000)        /*!<Bit 1 */
+#define  FMC_SDTR2_TRP_2                    ((uint32_t)0x00400000)        /*!<Bit 2 */
+
+#define  FMC_SDTR2_TRCD                     ((uint32_t)0x0F000000)        /*!<TRP[2:0] bits (Row to column delay) */
+#define  FMC_SDTR2_TRCD_0                   ((uint32_t)0x01000000)        /*!<Bit 0 */
+#define  FMC_SDTR2_TRCD_1                   ((uint32_t)0x02000000)        /*!<Bit 1 */
+#define  FMC_SDTR2_TRCD_2                   ((uint32_t)0x04000000)        /*!<Bit 2 */
+
+/******************  Bit definition for FMC_SDCMR register  ******************/
+#define  FMC_SDCMR_MODE                     ((uint32_t)0x00000007)        /*!<MODE[2:0] bits (Command mode) */
+#define  FMC_SDCMR_MODE_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  FMC_SDCMR_MODE_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  FMC_SDCMR_MODE_2                   ((uint32_t)0x00000003)        /*!<Bit 2 */
+
+#define  FMC_SDCMR_CTB2                     ((uint32_t)0x00000008)        /*!<Command target 2 */
+
+#define  FMC_SDCMR_CTB1                     ((uint32_t)0x00000010)        /*!<Command target 1 */
+
+#define  FMC_SDCMR_NRFS                     ((uint32_t)0x000001E0)        /*!<NRFS[3:0] bits (Number of auto-refresh) */
+#define  FMC_SDCMR_NRFS_0                   ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  FMC_SDCMR_NRFS_1                   ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  FMC_SDCMR_NRFS_2                   ((uint32_t)0x00000080)        /*!<Bit 2 */
+#define  FMC_SDCMR_NRFS_3                   ((uint32_t)0x00000100)        /*!<Bit 3 */
+
+#define  FMC_SDCMR_MRD                      ((uint32_t)0x003FFE00)        /*!<MRD[12:0] bits (Mode register definition) */
+
+/******************  Bit definition for FMC_SDRTR register  ******************/
+#define  FMC_SDRTR_CRE                      ((uint32_t)0x00000001)        /*!<Clear refresh error flag */
+
+#define  FMC_SDRTR_COUNT                    ((uint32_t)0x00003FFE)        /*!<COUNT[12:0] bits (Refresh timer count) */
+
+#define  FMC_SDRTR_REIE                     ((uint32_t)0x00004000)        /*!<RES interupt enable */
+
+/******************  Bit definition for FMC_SDSR register  ******************/
+#define  FMC_SDSR_RE                        ((uint32_t)0x00000001)        /*!<Refresh error flag */
+
+#define  FMC_SDSR_MODES1                    ((uint32_t)0x00000006)        /*!<MODES1[1:0]bits (Status mode for bank 1) */
+#define  FMC_SDSR_MODES1_0                  ((uint32_t)0x00000002)        /*!<Bit 0 */
+#define  FMC_SDSR_MODES1_1                  ((uint32_t)0x00000004)        /*!<Bit 1 */
+
+#define  FMC_SDSR_MODES2                    ((uint32_t)0x00000018)        /*!<MODES2[1:0]bits (Status mode for bank 2) */
+#define  FMC_SDSR_MODES2_0                  ((uint32_t)0x00000008)        /*!<Bit 0 */
+#define  FMC_SDSR_MODES2_1                  ((uint32_t)0x00000010)        /*!<Bit 1 */
+
+#define  FMC_SDSR_BUSY                      ((uint32_t)0x00000020)        /*!<Busy status */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            General Purpose I/O                             */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bits definition for GPIO_MODER register  *****************/
+#define GPIO_MODER_MODER0                    ((uint32_t)0x00000003)
+#define GPIO_MODER_MODER0_0                  ((uint32_t)0x00000001)
+#define GPIO_MODER_MODER0_1                  ((uint32_t)0x00000002)
+
+#define GPIO_MODER_MODER1                    ((uint32_t)0x0000000C)
+#define GPIO_MODER_MODER1_0                  ((uint32_t)0x00000004)
+#define GPIO_MODER_MODER1_1                  ((uint32_t)0x00000008)
+
+#define GPIO_MODER_MODER2                    ((uint32_t)0x00000030)
+#define GPIO_MODER_MODER2_0                  ((uint32_t)0x00000010)
+#define GPIO_MODER_MODER2_1                  ((uint32_t)0x00000020)
+
+#define GPIO_MODER_MODER3                    ((uint32_t)0x000000C0)
+#define GPIO_MODER_MODER3_0                  ((uint32_t)0x00000040)
+#define GPIO_MODER_MODER3_1                  ((uint32_t)0x00000080)
+
+#define GPIO_MODER_MODER4                    ((uint32_t)0x00000300)
+#define GPIO_MODER_MODER4_0                  ((uint32_t)0x00000100)
+#define GPIO_MODER_MODER4_1                  ((uint32_t)0x00000200)
+
+#define GPIO_MODER_MODER5                    ((uint32_t)0x00000C00)
+#define GPIO_MODER_MODER5_0                  ((uint32_t)0x00000400)
+#define GPIO_MODER_MODER5_1                  ((uint32_t)0x00000800)
+
+#define GPIO_MODER_MODER6                    ((uint32_t)0x00003000)
+#define GPIO_MODER_MODER6_0                  ((uint32_t)0x00001000)
+#define GPIO_MODER_MODER6_1                  ((uint32_t)0x00002000)
+
+#define GPIO_MODER_MODER7                    ((uint32_t)0x0000C000)
+#define GPIO_MODER_MODER7_0                  ((uint32_t)0x00004000)
+#define GPIO_MODER_MODER7_1                  ((uint32_t)0x00008000)
+
+#define GPIO_MODER_MODER8                    ((uint32_t)0x00030000)
+#define GPIO_MODER_MODER8_0                  ((uint32_t)0x00010000)
+#define GPIO_MODER_MODER8_1                  ((uint32_t)0x00020000)
+
+#define GPIO_MODER_MODER9                    ((uint32_t)0x000C0000)
+#define GPIO_MODER_MODER9_0                  ((uint32_t)0x00040000)
+#define GPIO_MODER_MODER9_1                  ((uint32_t)0x00080000)
+
+#define GPIO_MODER_MODER10                   ((uint32_t)0x00300000)
+#define GPIO_MODER_MODER10_0                 ((uint32_t)0x00100000)
+#define GPIO_MODER_MODER10_1                 ((uint32_t)0x00200000)
+
+#define GPIO_MODER_MODER11                   ((uint32_t)0x00C00000)
+#define GPIO_MODER_MODER11_0                 ((uint32_t)0x00400000)
+#define GPIO_MODER_MODER11_1                 ((uint32_t)0x00800000)
+
+#define GPIO_MODER_MODER12                   ((uint32_t)0x03000000)
+#define GPIO_MODER_MODER12_0                 ((uint32_t)0x01000000)
+#define GPIO_MODER_MODER12_1                 ((uint32_t)0x02000000)
+
+#define GPIO_MODER_MODER13                   ((uint32_t)0x0C000000)
+#define GPIO_MODER_MODER13_0                 ((uint32_t)0x04000000)
+#define GPIO_MODER_MODER13_1                 ((uint32_t)0x08000000)
+
+#define GPIO_MODER_MODER14                   ((uint32_t)0x30000000)
+#define GPIO_MODER_MODER14_0                 ((uint32_t)0x10000000)
+#define GPIO_MODER_MODER14_1                 ((uint32_t)0x20000000)
+
+#define GPIO_MODER_MODER15                   ((uint32_t)0xC0000000)
+#define GPIO_MODER_MODER15_0                 ((uint32_t)0x40000000)
+#define GPIO_MODER_MODER15_1                 ((uint32_t)0x80000000)
+
+/******************  Bits definition for GPIO_OTYPER register  ****************/
+#define GPIO_OTYPER_OT_0                     ((uint32_t)0x00000001)
+#define GPIO_OTYPER_OT_1                     ((uint32_t)0x00000002)
+#define GPIO_OTYPER_OT_2                     ((uint32_t)0x00000004)
+#define GPIO_OTYPER_OT_3                     ((uint32_t)0x00000008)
+#define GPIO_OTYPER_OT_4                     ((uint32_t)0x00000010)
+#define GPIO_OTYPER_OT_5                     ((uint32_t)0x00000020)
+#define GPIO_OTYPER_OT_6                     ((uint32_t)0x00000040)
+#define GPIO_OTYPER_OT_7                     ((uint32_t)0x00000080)
+#define GPIO_OTYPER_OT_8                     ((uint32_t)0x00000100)
+#define GPIO_OTYPER_OT_9                     ((uint32_t)0x00000200)
+#define GPIO_OTYPER_OT_10                    ((uint32_t)0x00000400)
+#define GPIO_OTYPER_OT_11                    ((uint32_t)0x00000800)
+#define GPIO_OTYPER_OT_12                    ((uint32_t)0x00001000)
+#define GPIO_OTYPER_OT_13                    ((uint32_t)0x00002000)
+#define GPIO_OTYPER_OT_14                    ((uint32_t)0x00004000)
+#define GPIO_OTYPER_OT_15                    ((uint32_t)0x00008000)
+
+/******************  Bits definition for GPIO_OSPEEDR register  ***************/
+#define GPIO_OSPEEDER_OSPEEDR0               ((uint32_t)0x00000003)
+#define GPIO_OSPEEDER_OSPEEDR0_0             ((uint32_t)0x00000001)
+#define GPIO_OSPEEDER_OSPEEDR0_1             ((uint32_t)0x00000002)
+
+#define GPIO_OSPEEDER_OSPEEDR1               ((uint32_t)0x0000000C)
+#define GPIO_OSPEEDER_OSPEEDR1_0             ((uint32_t)0x00000004)
+#define GPIO_OSPEEDER_OSPEEDR1_1             ((uint32_t)0x00000008)
+
+#define GPIO_OSPEEDER_OSPEEDR2               ((uint32_t)0x00000030)
+#define GPIO_OSPEEDER_OSPEEDR2_0             ((uint32_t)0x00000010)
+#define GPIO_OSPEEDER_OSPEEDR2_1             ((uint32_t)0x00000020)
+
+#define GPIO_OSPEEDER_OSPEEDR3               ((uint32_t)0x000000C0)
+#define GPIO_OSPEEDER_OSPEEDR3_0             ((uint32_t)0x00000040)
+#define GPIO_OSPEEDER_OSPEEDR3_1             ((uint32_t)0x00000080)
+
+#define GPIO_OSPEEDER_OSPEEDR4               ((uint32_t)0x00000300)
+#define GPIO_OSPEEDER_OSPEEDR4_0             ((uint32_t)0x00000100)
+#define GPIO_OSPEEDER_OSPEEDR4_1             ((uint32_t)0x00000200)
+
+#define GPIO_OSPEEDER_OSPEEDR5               ((uint32_t)0x00000C00)
+#define GPIO_OSPEEDER_OSPEEDR5_0             ((uint32_t)0x00000400)
+#define GPIO_OSPEEDER_OSPEEDR5_1             ((uint32_t)0x00000800)
+
+#define GPIO_OSPEEDER_OSPEEDR6               ((uint32_t)0x00003000)
+#define GPIO_OSPEEDER_OSPEEDR6_0             ((uint32_t)0x00001000)
+#define GPIO_OSPEEDER_OSPEEDR6_1             ((uint32_t)0x00002000)
+
+#define GPIO_OSPEEDER_OSPEEDR7               ((uint32_t)0x0000C000)
+#define GPIO_OSPEEDER_OSPEEDR7_0             ((uint32_t)0x00004000)
+#define GPIO_OSPEEDER_OSPEEDR7_1             ((uint32_t)0x00008000)
+
+#define GPIO_OSPEEDER_OSPEEDR8               ((uint32_t)0x00030000)
+#define GPIO_OSPEEDER_OSPEEDR8_0             ((uint32_t)0x00010000)
+#define GPIO_OSPEEDER_OSPEEDR8_1             ((uint32_t)0x00020000)
+
+#define GPIO_OSPEEDER_OSPEEDR9               ((uint32_t)0x000C0000)
+#define GPIO_OSPEEDER_OSPEEDR9_0             ((uint32_t)0x00040000)
+#define GPIO_OSPEEDER_OSPEEDR9_1             ((uint32_t)0x00080000)
+
+#define GPIO_OSPEEDER_OSPEEDR10              ((uint32_t)0x00300000)
+#define GPIO_OSPEEDER_OSPEEDR10_0            ((uint32_t)0x00100000)
+#define GPIO_OSPEEDER_OSPEEDR10_1            ((uint32_t)0x00200000)
+
+#define GPIO_OSPEEDER_OSPEEDR11              ((uint32_t)0x00C00000)
+#define GPIO_OSPEEDER_OSPEEDR11_0            ((uint32_t)0x00400000)
+#define GPIO_OSPEEDER_OSPEEDR11_1            ((uint32_t)0x00800000)
+
+#define GPIO_OSPEEDER_OSPEEDR12              ((uint32_t)0x03000000)
+#define GPIO_OSPEEDER_OSPEEDR12_0            ((uint32_t)0x01000000)
+#define GPIO_OSPEEDER_OSPEEDR12_1            ((uint32_t)0x02000000)
+
+#define GPIO_OSPEEDER_OSPEEDR13              ((uint32_t)0x0C000000)
+#define GPIO_OSPEEDER_OSPEEDR13_0            ((uint32_t)0x04000000)
+#define GPIO_OSPEEDER_OSPEEDR13_1            ((uint32_t)0x08000000)
+
+#define GPIO_OSPEEDER_OSPEEDR14              ((uint32_t)0x30000000)
+#define GPIO_OSPEEDER_OSPEEDR14_0            ((uint32_t)0x10000000)
+#define GPIO_OSPEEDER_OSPEEDR14_1            ((uint32_t)0x20000000)
+
+#define GPIO_OSPEEDER_OSPEEDR15              ((uint32_t)0xC0000000)
+#define GPIO_OSPEEDER_OSPEEDR15_0            ((uint32_t)0x40000000)
+#define GPIO_OSPEEDER_OSPEEDR15_1            ((uint32_t)0x80000000)
+
+/******************  Bits definition for GPIO_PUPDR register  *****************/
+#define GPIO_PUPDR_PUPDR0                    ((uint32_t)0x00000003)
+#define GPIO_PUPDR_PUPDR0_0                  ((uint32_t)0x00000001)
+#define GPIO_PUPDR_PUPDR0_1                  ((uint32_t)0x00000002)
+
+#define GPIO_PUPDR_PUPDR1                    ((uint32_t)0x0000000C)
+#define GPIO_PUPDR_PUPDR1_0                  ((uint32_t)0x00000004)
+#define GPIO_PUPDR_PUPDR1_1                  ((uint32_t)0x00000008)
+
+#define GPIO_PUPDR_PUPDR2                    ((uint32_t)0x00000030)
+#define GPIO_PUPDR_PUPDR2_0                  ((uint32_t)0x00000010)
+#define GPIO_PUPDR_PUPDR2_1                  ((uint32_t)0x00000020)
+
+#define GPIO_PUPDR_PUPDR3                    ((uint32_t)0x000000C0)
+#define GPIO_PUPDR_PUPDR3_0                  ((uint32_t)0x00000040)
+#define GPIO_PUPDR_PUPDR3_1                  ((uint32_t)0x00000080)
+
+#define GPIO_PUPDR_PUPDR4                    ((uint32_t)0x00000300)
+#define GPIO_PUPDR_PUPDR4_0                  ((uint32_t)0x00000100)
+#define GPIO_PUPDR_PUPDR4_1                  ((uint32_t)0x00000200)
+
+#define GPIO_PUPDR_PUPDR5                    ((uint32_t)0x00000C00)
+#define GPIO_PUPDR_PUPDR5_0                  ((uint32_t)0x00000400)
+#define GPIO_PUPDR_PUPDR5_1                  ((uint32_t)0x00000800)
+
+#define GPIO_PUPDR_PUPDR6                    ((uint32_t)0x00003000)
+#define GPIO_PUPDR_PUPDR6_0                  ((uint32_t)0x00001000)
+#define GPIO_PUPDR_PUPDR6_1                  ((uint32_t)0x00002000)
+
+#define GPIO_PUPDR_PUPDR7                    ((uint32_t)0x0000C000)
+#define GPIO_PUPDR_PUPDR7_0                  ((uint32_t)0x00004000)
+#define GPIO_PUPDR_PUPDR7_1                  ((uint32_t)0x00008000)
+
+#define GPIO_PUPDR_PUPDR8                    ((uint32_t)0x00030000)
+#define GPIO_PUPDR_PUPDR8_0                  ((uint32_t)0x00010000)
+#define GPIO_PUPDR_PUPDR8_1                  ((uint32_t)0x00020000)
+
+#define GPIO_PUPDR_PUPDR9                    ((uint32_t)0x000C0000)
+#define GPIO_PUPDR_PUPDR9_0                  ((uint32_t)0x00040000)
+#define GPIO_PUPDR_PUPDR9_1                  ((uint32_t)0x00080000)
+
+#define GPIO_PUPDR_PUPDR10                   ((uint32_t)0x00300000)
+#define GPIO_PUPDR_PUPDR10_0                 ((uint32_t)0x00100000)
+#define GPIO_PUPDR_PUPDR10_1                 ((uint32_t)0x00200000)
+
+#define GPIO_PUPDR_PUPDR11                   ((uint32_t)0x00C00000)
+#define GPIO_PUPDR_PUPDR11_0                 ((uint32_t)0x00400000)
+#define GPIO_PUPDR_PUPDR11_1                 ((uint32_t)0x00800000)
+
+#define GPIO_PUPDR_PUPDR12                   ((uint32_t)0x03000000)
+#define GPIO_PUPDR_PUPDR12_0                 ((uint32_t)0x01000000)
+#define GPIO_PUPDR_PUPDR12_1                 ((uint32_t)0x02000000)
+
+#define GPIO_PUPDR_PUPDR13                   ((uint32_t)0x0C000000)
+#define GPIO_PUPDR_PUPDR13_0                 ((uint32_t)0x04000000)
+#define GPIO_PUPDR_PUPDR13_1                 ((uint32_t)0x08000000)
+
+#define GPIO_PUPDR_PUPDR14                   ((uint32_t)0x30000000)
+#define GPIO_PUPDR_PUPDR14_0                 ((uint32_t)0x10000000)
+#define GPIO_PUPDR_PUPDR14_1                 ((uint32_t)0x20000000)
+
+#define GPIO_PUPDR_PUPDR15                   ((uint32_t)0xC0000000)
+#define GPIO_PUPDR_PUPDR15_0                 ((uint32_t)0x40000000)
+#define GPIO_PUPDR_PUPDR15_1                 ((uint32_t)0x80000000)
+
+/******************  Bits definition for GPIO_IDR register  *******************/
+#define GPIO_IDR_IDR_0                       ((uint32_t)0x00000001)
+#define GPIO_IDR_IDR_1                       ((uint32_t)0x00000002)
+#define GPIO_IDR_IDR_2                       ((uint32_t)0x00000004)
+#define GPIO_IDR_IDR_3                       ((uint32_t)0x00000008)
+#define GPIO_IDR_IDR_4                       ((uint32_t)0x00000010)
+#define GPIO_IDR_IDR_5                       ((uint32_t)0x00000020)
+#define GPIO_IDR_IDR_6                       ((uint32_t)0x00000040)
+#define GPIO_IDR_IDR_7                       ((uint32_t)0x00000080)
+#define GPIO_IDR_IDR_8                       ((uint32_t)0x00000100)
+#define GPIO_IDR_IDR_9                       ((uint32_t)0x00000200)
+#define GPIO_IDR_IDR_10                      ((uint32_t)0x00000400)
+#define GPIO_IDR_IDR_11                      ((uint32_t)0x00000800)
+#define GPIO_IDR_IDR_12                      ((uint32_t)0x00001000)
+#define GPIO_IDR_IDR_13                      ((uint32_t)0x00002000)
+#define GPIO_IDR_IDR_14                      ((uint32_t)0x00004000)
+#define GPIO_IDR_IDR_15                      ((uint32_t)0x00008000)
+
+/******************  Bits definition for GPIO_ODR register  *******************/
+#define GPIO_ODR_ODR_0                       ((uint32_t)0x00000001)
+#define GPIO_ODR_ODR_1                       ((uint32_t)0x00000002)
+#define GPIO_ODR_ODR_2                       ((uint32_t)0x00000004)
+#define GPIO_ODR_ODR_3                       ((uint32_t)0x00000008)
+#define GPIO_ODR_ODR_4                       ((uint32_t)0x00000010)
+#define GPIO_ODR_ODR_5                       ((uint32_t)0x00000020)
+#define GPIO_ODR_ODR_6                       ((uint32_t)0x00000040)
+#define GPIO_ODR_ODR_7                       ((uint32_t)0x00000080)
+#define GPIO_ODR_ODR_8                       ((uint32_t)0x00000100)
+#define GPIO_ODR_ODR_9                       ((uint32_t)0x00000200)
+#define GPIO_ODR_ODR_10                      ((uint32_t)0x00000400)
+#define GPIO_ODR_ODR_11                      ((uint32_t)0x00000800)
+#define GPIO_ODR_ODR_12                      ((uint32_t)0x00001000)
+#define GPIO_ODR_ODR_13                      ((uint32_t)0x00002000)
+#define GPIO_ODR_ODR_14                      ((uint32_t)0x00004000)
+#define GPIO_ODR_ODR_15                      ((uint32_t)0x00008000)
+
+/******************  Bits definition for GPIO_BSRR register  ******************/
+#define GPIO_BSRR_BS_0                       ((uint32_t)0x00000001)
+#define GPIO_BSRR_BS_1                       ((uint32_t)0x00000002)
+#define GPIO_BSRR_BS_2                       ((uint32_t)0x00000004)
+#define GPIO_BSRR_BS_3                       ((uint32_t)0x00000008)
+#define GPIO_BSRR_BS_4                       ((uint32_t)0x00000010)
+#define GPIO_BSRR_BS_5                       ((uint32_t)0x00000020)
+#define GPIO_BSRR_BS_6                       ((uint32_t)0x00000040)
+#define GPIO_BSRR_BS_7                       ((uint32_t)0x00000080)
+#define GPIO_BSRR_BS_8                       ((uint32_t)0x00000100)
+#define GPIO_BSRR_BS_9                       ((uint32_t)0x00000200)
+#define GPIO_BSRR_BS_10                      ((uint32_t)0x00000400)
+#define GPIO_BSRR_BS_11                      ((uint32_t)0x00000800)
+#define GPIO_BSRR_BS_12                      ((uint32_t)0x00001000)
+#define GPIO_BSRR_BS_13                      ((uint32_t)0x00002000)
+#define GPIO_BSRR_BS_14                      ((uint32_t)0x00004000)
+#define GPIO_BSRR_BS_15                      ((uint32_t)0x00008000)
+#define GPIO_BSRR_BR_0                       ((uint32_t)0x00010000)
+#define GPIO_BSRR_BR_1                       ((uint32_t)0x00020000)
+#define GPIO_BSRR_BR_2                       ((uint32_t)0x00040000)
+#define GPIO_BSRR_BR_3                       ((uint32_t)0x00080000)
+#define GPIO_BSRR_BR_4                       ((uint32_t)0x00100000)
+#define GPIO_BSRR_BR_5                       ((uint32_t)0x00200000)
+#define GPIO_BSRR_BR_6                       ((uint32_t)0x00400000)
+#define GPIO_BSRR_BR_7                       ((uint32_t)0x00800000)
+#define GPIO_BSRR_BR_8                       ((uint32_t)0x01000000)
+#define GPIO_BSRR_BR_9                       ((uint32_t)0x02000000)
+#define GPIO_BSRR_BR_10                      ((uint32_t)0x04000000)
+#define GPIO_BSRR_BR_11                      ((uint32_t)0x08000000)
+#define GPIO_BSRR_BR_12                      ((uint32_t)0x10000000)
+#define GPIO_BSRR_BR_13                      ((uint32_t)0x20000000)
+#define GPIO_BSRR_BR_14                      ((uint32_t)0x40000000)
+#define GPIO_BSRR_BR_15                      ((uint32_t)0x80000000)
+
+/****************** Bit definition for GPIO_LCKR register *********************/
+#define GPIO_LCKR_LCK0                       ((uint32_t)0x00000001)
+#define GPIO_LCKR_LCK1                       ((uint32_t)0x00000002)
+#define GPIO_LCKR_LCK2                       ((uint32_t)0x00000004)
+#define GPIO_LCKR_LCK3                       ((uint32_t)0x00000008)
+#define GPIO_LCKR_LCK4                       ((uint32_t)0x00000010)
+#define GPIO_LCKR_LCK5                       ((uint32_t)0x00000020)
+#define GPIO_LCKR_LCK6                       ((uint32_t)0x00000040)
+#define GPIO_LCKR_LCK7                       ((uint32_t)0x00000080)
+#define GPIO_LCKR_LCK8                       ((uint32_t)0x00000100)
+#define GPIO_LCKR_LCK9                       ((uint32_t)0x00000200)
+#define GPIO_LCKR_LCK10                      ((uint32_t)0x00000400)
+#define GPIO_LCKR_LCK11                      ((uint32_t)0x00000800)
+#define GPIO_LCKR_LCK12                      ((uint32_t)0x00001000)
+#define GPIO_LCKR_LCK13                      ((uint32_t)0x00002000)
+#define GPIO_LCKR_LCK14                      ((uint32_t)0x00004000)
+#define GPIO_LCKR_LCK15                      ((uint32_t)0x00008000)
+#define GPIO_LCKR_LCKK                       ((uint32_t)0x00010000)
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    HASH                                    */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bits definition for HASH_CR register  ********************/
+#define HASH_CR_INIT                         ((uint32_t)0x00000004)
+#define HASH_CR_DMAE                         ((uint32_t)0x00000008)
+#define HASH_CR_DATATYPE                     ((uint32_t)0x00000030)
+#define HASH_CR_DATATYPE_0                   ((uint32_t)0x00000010)
+#define HASH_CR_DATATYPE_1                   ((uint32_t)0x00000020)
+#define HASH_CR_MODE                         ((uint32_t)0x00000040)
+#define HASH_CR_ALGO                         ((uint32_t)0x00040080)
+#define HASH_CR_ALGO_0                       ((uint32_t)0x00000080)
+#define HASH_CR_ALGO_1                       ((uint32_t)0x00040000)
+#define HASH_CR_NBW                          ((uint32_t)0x00000F00)
+#define HASH_CR_NBW_0                        ((uint32_t)0x00000100)
+#define HASH_CR_NBW_1                        ((uint32_t)0x00000200)
+#define HASH_CR_NBW_2                        ((uint32_t)0x00000400)
+#define HASH_CR_NBW_3                        ((uint32_t)0x00000800)
+#define HASH_CR_DINNE                        ((uint32_t)0x00001000)
+#define HASH_CR_MDMAT                        ((uint32_t)0x00002000)
+#define HASH_CR_LKEY                         ((uint32_t)0x00010000)
+
+/******************  Bits definition for HASH_STR register  *******************/
+#define HASH_STR_NBLW                        ((uint32_t)0x0000001F)
+#define HASH_STR_NBLW_0                      ((uint32_t)0x00000001)
+#define HASH_STR_NBLW_1                      ((uint32_t)0x00000002)
+#define HASH_STR_NBLW_2                      ((uint32_t)0x00000004)
+#define HASH_STR_NBLW_3                      ((uint32_t)0x00000008)
+#define HASH_STR_NBLW_4                      ((uint32_t)0x00000010)
+#define HASH_STR_DCAL                        ((uint32_t)0x00000100)
+
+/* legacy defines */
+#define HASH_STR_NBW                         HASH_STR_NBLW
+#define HASH_STR_NBW_0                       HASH_STR_NBLW_0
+#define HASH_STR_NBW_1                       HASH_STR_NBLW_1
+#define HASH_STR_NBW_2                       HASH_STR_NBLW_2
+#define HASH_STR_NBW_3                       HASH_STR_NBLW_3
+#define HASH_STR_NBW_4                       HASH_STR_NBLW_4
+
+/******************  Bits definition for HASH_IMR register  *******************/
+#define HASH_IMR_DINIE                       ((uint32_t)0x00000001)
+#define HASH_IMR_DCIE                        ((uint32_t)0x00000002)
+
+/* legacy defines */
+#define HASH_IMR_DINIM                       HASH_IMR_DINIE
+#define HASH_IMR_DCIM                        HASH_IMR_DCIE
+/******************  Bits definition for HASH_SR register  ********************/
+#define HASH_SR_DINIS                        ((uint32_t)0x00000001)
+#define HASH_SR_DCIS                         ((uint32_t)0x00000002)
+#define HASH_SR_DMAS                         ((uint32_t)0x00000004)
+#define HASH_SR_BUSY                         ((uint32_t)0x00000008)
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Inter-integrated Circuit Interface (I2C)              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for I2C_CR1 register  *******************/
+#define  I2C_CR1_PE                          ((uint32_t)0x00000001)        /*!< Peripheral enable                   */
+#define  I2C_CR1_TXIE                        ((uint32_t)0x00000002)        /*!< TX interrupt enable                 */
+#define  I2C_CR1_RXIE                        ((uint32_t)0x00000004)        /*!< RX interrupt enable                 */
+#define  I2C_CR1_ADDRIE                      ((uint32_t)0x00000008)        /*!< Address match interrupt enable      */
+#define  I2C_CR1_NACKIE                      ((uint32_t)0x00000010)        /*!< NACK received interrupt enable      */
+#define  I2C_CR1_STOPIE                      ((uint32_t)0x00000020)        /*!< STOP detection interrupt enable     */
+#define  I2C_CR1_TCIE                        ((uint32_t)0x00000040)        /*!< Transfer complete interrupt enable  */
+#define  I2C_CR1_ERRIE                       ((uint32_t)0x00000080)        /*!< Errors interrupt enable             */
+#define  I2C_CR1_DFN                         ((uint32_t)0x00000F00)        /*!< Digital noise filter                */
+#define  I2C_CR1_ANFOFF                      ((uint32_t)0x00001000)        /*!< Analog noise filter OFF             */
+#define  I2C_CR1_SWRST                       ((uint32_t)0x00002000)        /*!< Software reset                      */
+#define  I2C_CR1_TXDMAEN                     ((uint32_t)0x00004000)        /*!< DMA transmission requests enable    */
+#define  I2C_CR1_RXDMAEN                     ((uint32_t)0x00008000)        /*!< DMA reception requests enable       */
+#define  I2C_CR1_SBC                         ((uint32_t)0x00010000)        /*!< Slave byte control                  */
+#define  I2C_CR1_NOSTRETCH                   ((uint32_t)0x00020000)        /*!< Clock stretching disable            */
+#define  I2C_CR1_WUPEN                       ((uint32_t)0x00040000)        /*!< Wakeup from STOP enable             */
+#define  I2C_CR1_GCEN                        ((uint32_t)0x00080000)        /*!< General call enable                 */
+#define  I2C_CR1_SMBHEN                      ((uint32_t)0x00100000)        /*!< SMBus host address enable           */
+#define  I2C_CR1_SMBDEN                      ((uint32_t)0x00200000)        /*!< SMBus device default address enable */
+#define  I2C_CR1_ALERTEN                     ((uint32_t)0x00400000)        /*!< SMBus alert enable                  */
+#define  I2C_CR1_PECEN                       ((uint32_t)0x00800000)        /*!< PEC enable                          */
+
+/******************  Bit definition for I2C_CR2 register  ********************/
+#define  I2C_CR2_SADD                        ((uint32_t)0x000003FF)        /*!< Slave address (master mode)                             */
+#define  I2C_CR2_RD_WRN                      ((uint32_t)0x00000400)        /*!< Transfer direction (master mode)                        */
+#define  I2C_CR2_ADD10                       ((uint32_t)0x00000800)        /*!< 10-bit addressing mode (master mode)                    */
+#define  I2C_CR2_HEAD10R                     ((uint32_t)0x00001000)        /*!< 10-bit address header only read direction (master mode) */
+#define  I2C_CR2_START                       ((uint32_t)0x00002000)        /*!< START generation                                        */
+#define  I2C_CR2_STOP                        ((uint32_t)0x00004000)        /*!< STOP generation (master mode)                           */
+#define  I2C_CR2_NACK                        ((uint32_t)0x00008000)        /*!< NACK generation (slave mode)                            */
+#define  I2C_CR2_NBYTES                      ((uint32_t)0x00FF0000)        /*!< Number of bytes                                         */
+#define  I2C_CR2_RELOAD                      ((uint32_t)0x01000000)        /*!< NBYTES reload mode                                      */
+#define  I2C_CR2_AUTOEND                     ((uint32_t)0x02000000)        /*!< Automatic end mode (master mode)                        */
+#define  I2C_CR2_PECBYTE                     ((uint32_t)0x04000000)        /*!< Packet error checking byte                              */
+
+/*******************  Bit definition for I2C_OAR1 register  ******************/
+#define  I2C_OAR1_OA1                        ((uint32_t)0x000003FF)        /*!< Interface own address 1   */
+#define  I2C_OAR1_OA1MODE                    ((uint32_t)0x00000400)        /*!< Own address 1 10-bit mode */
+#define  I2C_OAR1_OA1EN                      ((uint32_t)0x00008000)        /*!< Own address 1 enable      */
+
+/*******************  Bit definition for I2C_OAR2 register  ******************/
+#define  I2C_OAR2_OA2                        ((uint32_t)0x000000FE)        /*!< Interface own address 2 */
+#define  I2C_OAR2_OA2MSK                     ((uint32_t)0x00000700)        /*!< Own address 2 masks     */
+#define  I2C_OAR2_OA2NOMASK                  ((uint32_t)0x00000000)        /*!< No mask */
+#define  I2C_OAR2_OA2MASK01                  ((uint32_t)0x00000100)        /*!< OA2[1] is masked, Only OA2[7:2] are compared */
+#define  I2C_OAR2_OA2MASK02                  ((uint32_t)0x00000200)        /*!< OA2[2:1] is masked, Only OA2[7:3] are compared */
+#define  I2C_OAR2_OA2MASK03                  ((uint32_t)0x00000300)        /*!< OA2[3:1] is masked, Only OA2[7:4] are compared */
+#define  I2C_OAR2_OA2MASK04                  ((uint32_t)0x00000400)        /*!< OA2[4:1] is masked, Only OA2[7:5] are compared */
+#define  I2C_OAR2_OA2MASK05                  ((uint32_t)0x00000500)        /*!< OA2[5:1] is masked, Only OA2[7:6] are compared */
+#define  I2C_OAR2_OA2MASK06                  ((uint32_t)0x00000600)        /*!< OA2[6:1] is masked, Only OA2[7] are compared */
+#define  I2C_OAR2_OA2MASK07                  ((uint32_t)0x00000700)        /*!< OA2[7:1] is masked, No comparison is done */
+#define  I2C_OAR2_OA2EN                      ((uint32_t)0x00008000)        /*!< Own address 2 enable    */
+
+/*******************  Bit definition for I2C_TIMINGR register *******************/
+#define  I2C_TIMINGR_SCLL                    ((uint32_t)0x000000FF)        /*!< SCL low period (master mode)  */
+#define  I2C_TIMINGR_SCLH                    ((uint32_t)0x0000FF00)        /*!< SCL high period (master mode) */
+#define  I2C_TIMINGR_SDADEL                  ((uint32_t)0x000F0000)        /*!< Data hold time                */
+#define  I2C_TIMINGR_SCLDEL                  ((uint32_t)0x00F00000)        /*!< Data setup time               */
+#define  I2C_TIMINGR_PRESC                   ((uint32_t)0xF0000000)        /*!< Timings prescaler             */
+
+/******************* Bit definition for I2C_TIMEOUTR register *******************/
+#define  I2C_TIMEOUTR_TIMEOUTA               ((uint32_t)0x00000FFF)        /*!< Bus timeout A                 */
+#define  I2C_TIMEOUTR_TIDLE                  ((uint32_t)0x00001000)        /*!< Idle clock timeout detection  */
+#define  I2C_TIMEOUTR_TIMOUTEN               ((uint32_t)0x00008000)        /*!< Clock timeout enable          */
+#define  I2C_TIMEOUTR_TIMEOUTB               ((uint32_t)0x0FFF0000)        /*!< Bus timeout B                 */
+#define  I2C_TIMEOUTR_TEXTEN                 ((uint32_t)0x80000000)        /*!< Extended clock timeout enable */
+
+/******************  Bit definition for I2C_ISR register  *********************/
+#define  I2C_ISR_TXE                         ((uint32_t)0x00000001)        /*!< Transmit data register empty    */
+#define  I2C_ISR_TXIS                        ((uint32_t)0x00000002)        /*!< Transmit interrupt status       */
+#define  I2C_ISR_RXNE                        ((uint32_t)0x00000004)        /*!< Receive data register not empty */
+#define  I2C_ISR_ADDR                        ((uint32_t)0x00000008)        /*!< Address matched (slave mode)    */
+#define  I2C_ISR_NACKF                       ((uint32_t)0x00000010)        /*!< NACK received flag              */
+#define  I2C_ISR_STOPF                       ((uint32_t)0x00000020)        /*!< STOP detection flag             */
+#define  I2C_ISR_TC                          ((uint32_t)0x00000040)        /*!< Transfer complete (master mode) */
+#define  I2C_ISR_TCR                         ((uint32_t)0x00000080)        /*!< Transfer complete reload        */
+#define  I2C_ISR_BERR                        ((uint32_t)0x00000100)        /*!< Bus error                       */
+#define  I2C_ISR_ARLO                        ((uint32_t)0x00000200)        /*!< Arbitration lost                */
+#define  I2C_ISR_OVR                         ((uint32_t)0x00000400)        /*!< Overrun/Underrun                */
+#define  I2C_ISR_PECERR                      ((uint32_t)0x00000800)        /*!< PEC error in reception          */
+#define  I2C_ISR_TIMEOUT                     ((uint32_t)0x00001000)        /*!< Timeout or Tlow detection flag  */
+#define  I2C_ISR_ALERT                       ((uint32_t)0x00002000)        /*!< SMBus alert                     */
+#define  I2C_ISR_BUSY                        ((uint32_t)0x00008000)        /*!< Bus busy                        */
+#define  I2C_ISR_DIR                         ((uint32_t)0x00010000)        /*!< Transfer direction (slave mode) */
+#define  I2C_ISR_ADDCODE                     ((uint32_t)0x00FE0000)        /*!< Address match code (slave mode) */
+
+/******************  Bit definition for I2C_ICR register  *********************/
+#define  I2C_ICR_ADDRCF                      ((uint32_t)0x00000008)        /*!< Address matched clear flag      */
+#define  I2C_ICR_NACKCF                      ((uint32_t)0x00000010)        /*!< NACK clear flag                 */
+#define  I2C_ICR_STOPCF                      ((uint32_t)0x00000020)        /*!< STOP detection clear flag       */
+#define  I2C_ICR_BERRCF                      ((uint32_t)0x00000100)        /*!< Bus error clear flag            */
+#define  I2C_ICR_ARLOCF                      ((uint32_t)0x00000200)        /*!< Arbitration lost clear flag     */
+#define  I2C_ICR_OVRCF                       ((uint32_t)0x00000400)        /*!< Overrun/Underrun clear flag     */
+#define  I2C_ICR_PECCF                       ((uint32_t)0x00000800)        /*!< PAC error clear flag            */
+#define  I2C_ICR_TIMOUTCF                    ((uint32_t)0x00001000)        /*!< Timeout clear flag              */
+#define  I2C_ICR_ALERTCF                     ((uint32_t)0x00002000)        /*!< Alert clear flag                */
+
+/******************  Bit definition for I2C_PECR register  *********************/
+#define  I2C_PECR_PEC                        ((uint32_t)0x000000FF)        /*!< PEC register        */
+
+/******************  Bit definition for I2C_RXDR register  *********************/
+#define  I2C_RXDR_RXDATA                     ((uint32_t)0x000000FF)        /*!< 8-bit receive data  */
+
+/******************  Bit definition for I2C_TXDR register  *********************/
+#define  I2C_TXDR_TXDATA                     ((uint32_t)0x000000FF)        /*!< 8-bit transmit data */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Independent WATCHDOG                             */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define  IWDG_KR_KEY                         ((uint32_t)0xFFFF)            /*!<Key value (write only, read 0000h)  */
+
+/*******************  Bit definition for IWDG_PR register  ********************/
+#define  IWDG_PR_PR                          ((uint32_t)0x07)               /*!<PR[2:0] (Prescaler divider)         */
+#define  IWDG_PR_PR_0                        ((uint32_t)0x01)               /*!<Bit 0 */
+#define  IWDG_PR_PR_1                        ((uint32_t)0x02)               /*!<Bit 1 */
+#define  IWDG_PR_PR_2                        ((uint32_t)0x04)               /*!<Bit 2 */
+
+/*******************  Bit definition for IWDG_RLR register  *******************/
+#define  IWDG_RLR_RL                         ((uint32_t)0x0FFF)            /*!<Watchdog counter reload value        */
+
+/*******************  Bit definition for IWDG_SR register  ********************/
+#define  IWDG_SR_PVU                         ((uint32_t)0x01)               /*!< Watchdog prescaler value update */
+#define  IWDG_SR_RVU                         ((uint32_t)0x02)               /*!< Watchdog counter reload value update */
+#define  IWDG_SR_WVU                         ((uint32_t)0x04)               /*!< Watchdog counter window value update */
+
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define  IWDG_WINR_WIN                       ((uint32_t)0x0FFF)             /*!< Watchdog counter window value */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      LCD-TFT Display Controller (LTDC)                     */
+/*                                                                            */
+/******************************************************************************/
+
+/********************  Bit definition for LTDC_SSCR register  *****************/
+
+#define LTDC_SSCR_VSH                       ((uint32_t)0x000007FF)              /*!< Vertical Synchronization Height  */
+#define LTDC_SSCR_HSW                       ((uint32_t)0x0FFF0000)              /*!< Horizontal Synchronization Width */
+
+/********************  Bit definition for LTDC_BPCR register  *****************/
+
+#define LTDC_BPCR_AVBP                      ((uint32_t)0x000007FF)              /*!< Accumulated Vertical Back Porch   */
+#define LTDC_BPCR_AHBP                      ((uint32_t)0x0FFF0000)              /*!< Accumulated Horizontal Back Porch */
+
+/********************  Bit definition for LTDC_AWCR register  *****************/
+
+#define LTDC_AWCR_AAH                       ((uint32_t)0x000007FF)              /*!< Accumulated Active heigh */
+#define LTDC_AWCR_AAW                       ((uint32_t)0x0FFF0000)              /*!< Accumulated Active Width */
+
+/********************  Bit definition for LTDC_TWCR register  *****************/
+
+#define LTDC_TWCR_TOTALH                    ((uint32_t)0x000007FF)              /*!< Total Heigh */
+#define LTDC_TWCR_TOTALW                    ((uint32_t)0x0FFF0000)              /*!< Total Width */
+
+/********************  Bit definition for LTDC_GCR register  ******************/
+
+#define LTDC_GCR_LTDCEN                     ((uint32_t)0x00000001)              /*!< LCD-TFT controller enable bit       */
+#define LTDC_GCR_DBW                        ((uint32_t)0x00000070)              /*!< Dither Blue Width                   */
+#define LTDC_GCR_DGW                        ((uint32_t)0x00000700)              /*!< Dither Green Width                  */
+#define LTDC_GCR_DRW                        ((uint32_t)0x00007000)              /*!< Dither Red Width                    */
+#define LTDC_GCR_DTEN                       ((uint32_t)0x00010000)              /*!< Dither Enable                       */
+#define LTDC_GCR_PCPOL                      ((uint32_t)0x10000000)              /*!< Pixel Clock Polarity                */
+#define LTDC_GCR_DEPOL                      ((uint32_t)0x20000000)              /*!< Data Enable Polarity                */
+#define LTDC_GCR_VSPOL                      ((uint32_t)0x40000000)              /*!< Vertical Synchronization Polarity   */
+#define LTDC_GCR_HSPOL                      ((uint32_t)0x80000000)              /*!< Horizontal Synchronization Polarity */
+
+/********************  Bit definition for LTDC_SRCR register  *****************/
+
+#define LTDC_SRCR_IMR                      ((uint32_t)0x00000001)               /*!< Immediate Reload         */
+#define LTDC_SRCR_VBR                      ((uint32_t)0x00000002)               /*!< Vertical Blanking Reload */
+
+/********************  Bit definition for LTDC_BCCR register  *****************/
+
+#define LTDC_BCCR_BCBLUE                    ((uint32_t)0x000000FF)              /*!< Background Blue value  */
+#define LTDC_BCCR_BCGREEN                   ((uint32_t)0x0000FF00)              /*!< Background Green value */
+#define LTDC_BCCR_BCRED                     ((uint32_t)0x00FF0000)              /*!< Background Red value   */
+
+/********************  Bit definition for LTDC_IER register  ******************/
+
+#define LTDC_IER_LIE                        ((uint32_t)0x00000001)              /*!< Line Interrupt Enable            */
+#define LTDC_IER_FUIE                       ((uint32_t)0x00000002)              /*!< FIFO Underrun Interrupt Enable   */
+#define LTDC_IER_TERRIE                     ((uint32_t)0x00000004)              /*!< Transfer Error Interrupt Enable  */
+#define LTDC_IER_RRIE                       ((uint32_t)0x00000008)              /*!< Register Reload interrupt enable */
+
+/********************  Bit definition for LTDC_ISR register  ******************/
+
+#define LTDC_ISR_LIF                        ((uint32_t)0x00000001)              /*!< Line Interrupt Flag */
+#define LTDC_ISR_FUIF                       ((uint32_t)0x00000002)              /*!< FIFO Underrun Interrupt Flag */
+#define LTDC_ISR_TERRIF                     ((uint32_t)0x00000004)              /*!< Transfer Error Interrupt Flag */
+#define LTDC_ISR_RRIF                       ((uint32_t)0x00000008)              /*!< Register Reload interrupt Flag */
+
+/********************  Bit definition for LTDC_ICR register  ******************/
+
+#define LTDC_ICR_CLIF                       ((uint32_t)0x00000001)              /*!< Clears the Line Interrupt Flag */
+#define LTDC_ICR_CFUIF                      ((uint32_t)0x00000002)              /*!< Clears the FIFO Underrun Interrupt Flag */
+#define LTDC_ICR_CTERRIF                    ((uint32_t)0x00000004)              /*!< Clears the Transfer Error Interrupt Flag */
+#define LTDC_ICR_CRRIF                      ((uint32_t)0x00000008)              /*!< Clears Register Reload interrupt Flag */
+
+/********************  Bit definition for LTDC_LIPCR register  ****************/
+
+#define LTDC_LIPCR_LIPOS                    ((uint32_t)0x000007FF)              /*!< Line Interrupt Position */
+
+/********************  Bit definition for LTDC_CPSR register  *****************/
+
+#define LTDC_CPSR_CYPOS                     ((uint32_t)0x0000FFFF)              /*!< Current Y Position */
+#define LTDC_CPSR_CXPOS                     ((uint32_t)0xFFFF0000)              /*!< Current X Position */
+
+/********************  Bit definition for LTDC_CDSR register  *****************/
+
+#define LTDC_CDSR_VDES                      ((uint32_t)0x00000001)              /*!< Vertical Data Enable Status       */
+#define LTDC_CDSR_HDES                      ((uint32_t)0x00000002)              /*!< Horizontal Data Enable Status     */
+#define LTDC_CDSR_VSYNCS                    ((uint32_t)0x00000004)              /*!< Vertical Synchronization Status   */
+#define LTDC_CDSR_HSYNCS                    ((uint32_t)0x00000008)              /*!< Horizontal Synchronization Status */
+
+/********************  Bit definition for LTDC_LxCR register  *****************/
+
+#define LTDC_LxCR_LEN                       ((uint32_t)0x00000001)              /*!< Layer Enable              */
+#define LTDC_LxCR_COLKEN                    ((uint32_t)0x00000002)              /*!< Color Keying Enable       */
+#define LTDC_LxCR_CLUTEN                    ((uint32_t)0x00000010)              /*!< Color Lockup Table Enable */
+
+/********************  Bit definition for LTDC_LxWHPCR register  **************/
+
+#define LTDC_LxWHPCR_WHSTPOS                ((uint32_t)0x00000FFF)              /*!< Window Horizontal Start Position */
+#define LTDC_LxWHPCR_WHSPPOS                ((uint32_t)0xFFFF0000)              /*!< Window Horizontal Stop Position  */
+
+/********************  Bit definition for LTDC_LxWVPCR register  **************/
+
+#define LTDC_LxWVPCR_WVSTPOS                ((uint32_t)0x00000FFF)              /*!< Window Vertical Start Position */
+#define LTDC_LxWVPCR_WVSPPOS                ((uint32_t)0xFFFF0000)              /*!< Window Vertical Stop Position  */
+
+/********************  Bit definition for LTDC_LxCKCR register  ***************/
+
+#define LTDC_LxCKCR_CKBLUE                  ((uint32_t)0x000000FF)              /*!< Color Key Blue value  */
+#define LTDC_LxCKCR_CKGREEN                 ((uint32_t)0x0000FF00)              /*!< Color Key Green value */
+#define LTDC_LxCKCR_CKRED                   ((uint32_t)0x00FF0000)              /*!< Color Key Red value   */
+
+/********************  Bit definition for LTDC_LxPFCR register  ***************/
+
+#define LTDC_LxPFCR_PF                      ((uint32_t)0x00000007)              /*!< Pixel Format */
+
+/********************  Bit definition for LTDC_LxCACR register  ***************/
+
+#define LTDC_LxCACR_CONSTA                  ((uint32_t)0x000000FF)              /*!< Constant Alpha */
+
+/********************  Bit definition for LTDC_LxDCCR register  ***************/
+
+#define LTDC_LxDCCR_DCBLUE                  ((uint32_t)0x000000FF)              /*!< Default Color Blue  */
+#define LTDC_LxDCCR_DCGREEN                 ((uint32_t)0x0000FF00)              /*!< Default Color Green */
+#define LTDC_LxDCCR_DCRED                   ((uint32_t)0x00FF0000)              /*!< Default Color Red   */
+#define LTDC_LxDCCR_DCALPHA                 ((uint32_t)0xFF000000)              /*!< Default Color Alpha */
+
+/********************  Bit definition for LTDC_LxBFCR register  ***************/
+
+#define LTDC_LxBFCR_BF2                     ((uint32_t)0x00000007)              /*!< Blending Factor 2 */
+#define LTDC_LxBFCR_BF1                     ((uint32_t)0x00000700)              /*!< Blending Factor 1 */
+
+/********************  Bit definition for LTDC_LxCFBAR register  **************/
+
+#define LTDC_LxCFBAR_CFBADD                 ((uint32_t)0xFFFFFFFF)              /*!< Color Frame Buffer Start Address */
+
+/********************  Bit definition for LTDC_LxCFBLR register  **************/
+
+#define LTDC_LxCFBLR_CFBLL                  ((uint32_t)0x00001FFF)              /*!< Color Frame Buffer Line Length    */
+#define LTDC_LxCFBLR_CFBP                   ((uint32_t)0x1FFF0000)              /*!< Color Frame Buffer Pitch in bytes */
+
+/********************  Bit definition for LTDC_LxCFBLNR register  *************/
+
+#define LTDC_LxCFBLNR_CFBLNBR               ((uint32_t)0x000007FF)              /*!< Frame Buffer Line Number */
+
+/********************  Bit definition for LTDC_LxCLUTWR register  *************/
+
+#define LTDC_LxCLUTWR_BLUE                  ((uint32_t)0x000000FF)              /*!< Blue value   */
+#define LTDC_LxCLUTWR_GREEN                 ((uint32_t)0x0000FF00)              /*!< Green value  */
+#define LTDC_LxCLUTWR_RED                   ((uint32_t)0x00FF0000)              /*!< Red value    */
+#define LTDC_LxCLUTWR_CLUTADD               ((uint32_t)0xFF000000)              /*!< CLUT address */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                             Power Control                                  */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for PWR_CR1 register  ********************/
+#define  PWR_CR1_LPDS                         ((uint32_t)0x00000001)     /*!< Low-Power Deepsleep                 */
+#define  PWR_CR1_PDDS                         ((uint32_t)0x00000002)     /*!< Power Down Deepsleep                */
+#define  PWR_CR1_CSBF                         ((uint32_t)0x00000008)     /*!< Clear Standby Flag                  */
+#define  PWR_CR1_PVDE                         ((uint32_t)0x00000010)     /*!< Power Voltage Detector Enable       */
+
+#define  PWR_CR1_PLS                          ((uint32_t)0x000000E0)     /*!< PLS[2:0] bits (PVD Level Selection) */
+#define  PWR_CR1_PLS_0                        ((uint32_t)0x00000020)     /*!< Bit 0 */
+#define  PWR_CR1_PLS_1                        ((uint32_t)0x00000040)     /*!< Bit 1 */
+#define  PWR_CR1_PLS_2                        ((uint32_t)0x00000080)     /*!< Bit 2 */
+
+/*!< PVD level configuration */
+#define  PWR_CR1_PLS_LEV0                     ((uint32_t)0x00000000)     /*!< PVD level 0 */
+#define  PWR_CR1_PLS_LEV1                     ((uint32_t)0x00000020)     /*!< PVD level 1 */
+#define  PWR_CR1_PLS_LEV2                     ((uint32_t)0x00000040)     /*!< PVD level 2 */
+#define  PWR_CR1_PLS_LEV3                     ((uint32_t)0x00000060)     /*!< PVD level 3 */
+#define  PWR_CR1_PLS_LEV4                     ((uint32_t)0x00000080)     /*!< PVD level 4 */
+#define  PWR_CR1_PLS_LEV5                     ((uint32_t)0x000000A0)     /*!< PVD level 5 */
+#define  PWR_CR1_PLS_LEV6                     ((uint32_t)0x000000C0)     /*!< PVD level 6 */
+#define  PWR_CR1_PLS_LEV7                     ((uint32_t)0x000000E0)     /*!< PVD level 7 */
+
+#define  PWR_CR1_DBP                          ((uint32_t)0x00000100)     /*!< Disable Backup Domain write protection                     */
+#define  PWR_CR1_FPDS                         ((uint32_t)0x00000200)     /*!< Flash power down in Stop mode                              */
+
+#define  PWR_CR1_LPUDS                        ((uint32_t)0x00000400)     /*!< Low-power regulator in deepsleep under-drive mode          */
+#define  PWR_CR1_MRUDS                        ((uint32_t)0x00000800)     /*!< Main regulator in deepsleep under-drive mode               */
+
+#define  PWR_CR1_ADCDC1                       ((uint32_t)0x00002000)     /*!< Refer to AN4073 on how to use this bit */
+
+#define  PWR_CR1_VOS                          ((uint32_t)0x0000C000)     /*!< VOS[1:0] bits (Regulator voltage scaling output selection) */
+#define  PWR_CR1_VOS_0                        ((uint32_t)0x00004000)     /*!< Bit 0 */
+#define  PWR_CR1_VOS_1                        ((uint32_t)0x00008000)     /*!< Bit 1 */
+
+#define  PWR_CR1_ODEN                         ((uint32_t)0x00010000)     /*!< Over Drive enable                   */
+#define  PWR_CR1_ODSWEN                       ((uint32_t)0x00020000)     /*!< Over Drive switch enabled           */
+#define  PWR_CR1_UDEN                         ((uint32_t)0x000C0000)     /*!< Under Drive enable in stop mode     */
+#define  PWR_CR1_UDEN_0                       ((uint32_t)0x00040000)     /*!< Bit 0                               */
+#define  PWR_CR1_UDEN_1                       ((uint32_t)0x00080000)     /*!< Bit 1                               */
+
+/*******************  Bit definition for PWR_CSR1 register  ********************/
+#define  PWR_CSR1_WUIF                        ((uint32_t)0x00000001)     /*!< Wake up internal Flag                            */
+#define  PWR_CSR1_SBF                         ((uint32_t)0x00000002)     /*!< Standby Flag                                     */
+#define  PWR_CSR1_PVDO                        ((uint32_t)0x00000004)     /*!< PVD Output                                       */
+#define  PWR_CSR1_BRR                         ((uint32_t)0x00000008)     /*!< Backup regulator ready                           */
+#define  PWR_CSR1_BRE                         ((uint32_t)0x00000200)     /*!< Backup regulator enable                          */
+#define  PWR_CSR1_VOSRDY                      ((uint32_t)0x00004000)     /*!< Regulator voltage scaling output selection ready */
+
+#define  PWR_CSR1_ODRDY                       ((uint32_t)0x00010000)     /*!< Over Drive generator ready                       */
+#define  PWR_CSR1_ODSWRDY                     ((uint32_t)0x00020000)     /*!< Over Drive Switch ready                          */
+#define  PWR_CSR1_UDSWRDY                     ((uint32_t)0x000C0000)     /*!< Under Drive ready                                */
+
+/********************  Bit definition for PWR_CR2 register  ********************/
+#define  PWR_CR2_CWUPF1                         ((uint32_t)0x00000001)     /*!< Clear Wakeup Pin Flag for PA0      */
+#define  PWR_CR2_CWUPF2                         ((uint32_t)0x00000002)     /*!< Clear Wakeup Pin Flag for PA2      */
+#define  PWR_CR2_CWUPF3                         ((uint32_t)0x00000004)     /*!< Clear Wakeup Pin Flag for PC1      */
+#define  PWR_CR2_CWUPF4                         ((uint32_t)0x00000008)     /*!< Clear Wakeup Pin Flag for PC13     */
+#define  PWR_CR2_CWUPF5                         ((uint32_t)0x00000010)     /*!< Clear Wakeup Pin Flag for PI8      */
+#define  PWR_CR2_CWUPF6                         ((uint32_t)0x00000020)     /*!< Clear Wakeup Pin Flag for PI11     */
+
+#define  PWR_CR2_WUPP1                          ((uint32_t)0x00000100)     /*!< Wakeup Pin Polarity bit for PA0    */
+#define  PWR_CR2_WUPP2                          ((uint32_t)0x00000200)     /*!< Wakeup Pin Polarity bit for PA2    */
+#define  PWR_CR2_WUPP3                          ((uint32_t)0x00000400)     /*!< Wakeup Pin Polarity bit for PC1    */
+#define  PWR_CR2_WUPP4                          ((uint32_t)0x00000800)     /*!< Wakeup Pin Polarity bit for PC13   */
+#define  PWR_CR2_WUPP5                          ((uint32_t)0x00001000)     /*!< Wakeup Pin Polarity bit for PI8    */
+#define  PWR_CR2_WUPP6                          ((uint32_t)0x00002000)     /*!< Wakeup Pin Polarity bit for PI11   */
+
+/*******************  Bit definition for PWR_CSR2 register  ********************/
+#define  PWR_CSR2_WUPF1                         ((uint32_t)0x00000001)     /*!< Wakeup Pin Flag for PA0            */
+#define  PWR_CSR2_WUPF2                         ((uint32_t)0x00000002)     /*!< Wakeup Pin Flag for PA2            */
+#define  PWR_CSR2_WUPF3                         ((uint32_t)0x00000004)     /*!< Wakeup Pin Flag for PC1            */
+#define  PWR_CSR2_WUPF4                         ((uint32_t)0x00000008)     /*!< Wakeup Pin Flag for PC13           */
+#define  PWR_CSR2_WUPF5                         ((uint32_t)0x00000010)     /*!< Wakeup Pin Flag for PI8            */
+#define  PWR_CSR2_WUPF6                         ((uint32_t)0x00000020)     /*!< Wakeup Pin Flag for PI11           */
+
+#define  PWR_CSR2_EWUP1                         ((uint32_t)0x00000100)     /*!< Enable Wakeup Pin PA0              */
+#define  PWR_CSR2_EWUP2                         ((uint32_t)0x00000200)     /*!< Enable Wakeup Pin PA2              */
+#define  PWR_CSR2_EWUP3                         ((uint32_t)0x00000400)     /*!< Enable Wakeup Pin PC1              */
+#define  PWR_CSR2_EWUP4                         ((uint32_t)0x00000800)     /*!< Enable Wakeup Pin PC13             */
+#define  PWR_CSR2_EWUP5                         ((uint32_t)0x00001000)     /*!< Enable Wakeup Pin PI8              */
+#define  PWR_CSR2_EWUP6                         ((uint32_t)0x00002000)     /*!< Enable Wakeup Pin PI11             */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    QUADSPI                                 */
+/*                                                                            */
+/******************************************************************************/
+/*****************  Bit definition for QUADSPI_CR register  *******************/
+#define  QUADSPI_CR_EN                           ((uint32_t)0x00000001)            /*!< Enable                            */
+#define  QUADSPI_CR_ABORT                        ((uint32_t)0x00000002)            /*!< Abort request                     */
+#define  QUADSPI_CR_DMAEN                        ((uint32_t)0x00000004)            /*!< DMA Enable                        */
+#define  QUADSPI_CR_TCEN                         ((uint32_t)0x00000008)            /*!< Timeout Counter Enable            */
+#define  QUADSPI_CR_SSHIFT                       ((uint32_t)0x00000010)            /*!< Sample Shift                      */
+#define  QUADSPI_CR_DFM                          ((uint32_t)0x00000040)            /*!< Dual Flash Mode                   */
+#define  QUADSPI_CR_FSEL                         ((uint32_t)0x00000080)            /*!< Flash Select                      */
+#define  QUADSPI_CR_FTHRES                       ((uint32_t)0x00000F00)            /*!< FTHRES[3:0] FIFO Level            */
+#define  QUADSPI_CR_FTHRES_0                     ((uint32_t)0x00000100)            /*!< Bit 0 */
+#define  QUADSPI_CR_FTHRES_1                     ((uint32_t)0x00000200)            /*!< Bit 1 */
+#define  QUADSPI_CR_FTHRES_2                     ((uint32_t)0x00000400)            /*!< Bit 2 */
+#define  QUADSPI_CR_FTHRES_3                     ((uint32_t)0x00000800)            /*!< Bit 3 */
+#define  QUADSPI_CR_TEIE                         ((uint32_t)0x00010000)            /*!< Transfer Error Interrupt Enable    */
+#define  QUADSPI_CR_TCIE                         ((uint32_t)0x00020000)            /*!< Transfer Complete Interrupt Enable */
+#define  QUADSPI_CR_FTIE                         ((uint32_t)0x00040000)            /*!< FIFO Threshold Interrupt Enable    */
+#define  QUADSPI_CR_SMIE                         ((uint32_t)0x00080000)            /*!< Status Match Interrupt Enable      */
+#define  QUADSPI_CR_TOIE                         ((uint32_t)0x00100000)            /*!< TimeOut Interrupt Enable           */
+#define  QUADSPI_CR_APMS                         ((uint32_t)0x00400000)            /*!< Bit 1                              */
+#define  QUADSPI_CR_PMM                          ((uint32_t)0x00800000)            /*!< Polling Match Mode                 */
+#define  QUADSPI_CR_PRESCALER                    ((uint32_t)0xFF000000)            /*!< PRESCALER[7:0] Clock prescaler     */
+#define  QUADSPI_CR_PRESCALER_0                  ((uint32_t)0x01000000)            /*!< Bit 0 */
+#define  QUADSPI_CR_PRESCALER_1                  ((uint32_t)0x02000000)            /*!< Bit 1 */
+#define  QUADSPI_CR_PRESCALER_2                  ((uint32_t)0x04000000)            /*!< Bit 2 */
+#define  QUADSPI_CR_PRESCALER_3                  ((uint32_t)0x08000000)            /*!< Bit 3 */
+#define  QUADSPI_CR_PRESCALER_4                  ((uint32_t)0x10000000)            /*!< Bit 4 */
+#define  QUADSPI_CR_PRESCALER_5                  ((uint32_t)0x20000000)            /*!< Bit 5 */
+#define  QUADSPI_CR_PRESCALER_6                  ((uint32_t)0x40000000)            /*!< Bit 6 */
+#define  QUADSPI_CR_PRESCALER_7                  ((uint32_t)0x80000000)            /*!< Bit 7 */
+
+/*****************  Bit definition for QUADSPI_DCR register  ******************/
+#define  QUADSPI_DCR_CKMODE                      ((uint32_t)0x00000001)            /*!< Mode 0 / Mode 3                 */
+#define  QUADSPI_DCR_CSHT                        ((uint32_t)0x00000700)            /*!< CSHT[2:0]: ChipSelect High Time */
+#define  QUADSPI_DCR_CSHT_0                      ((uint32_t)0x00000100)            /*!< Bit 0 */
+#define  QUADSPI_DCR_CSHT_1                      ((uint32_t)0x00000200)            /*!< Bit 1 */
+#define  QUADSPI_DCR_CSHT_2                      ((uint32_t)0x00000400)            /*!< Bit 2 */
+#define  QUADSPI_DCR_FSIZE                       ((uint32_t)0x001F0000)            /*!< FSIZE[4:0]: Flash Size          */
+#define  QUADSPI_DCR_FSIZE_0                     ((uint32_t)0x00010000)            /*!< Bit 0 */
+#define  QUADSPI_DCR_FSIZE_1                     ((uint32_t)0x00020000)            /*!< Bit 1 */
+#define  QUADSPI_DCR_FSIZE_2                     ((uint32_t)0x00040000)            /*!< Bit 2 */
+#define  QUADSPI_DCR_FSIZE_3                     ((uint32_t)0x00080000)            /*!< Bit 3 */
+#define  QUADSPI_DCR_FSIZE_4                     ((uint32_t)0x00100000)            /*!< Bit 4 */
+
+/******************  Bit definition for QUADSPI_SR register  *******************/
+#define  QUADSPI_SR_TEF                          ((uint32_t)0x00000001)             /*!< Transfer Error Flag    */
+#define  QUADSPI_SR_TCF                          ((uint32_t)0x00000002)             /*!< Transfer Complete Flag */
+#define  QUADSPI_SR_FTF                          ((uint32_t)0x00000004)             /*!< FIFO Threshlod Flag    */
+#define  QUADSPI_SR_SMF                          ((uint32_t)0x00000008)             /*!< Status Match Flag      */
+#define  QUADSPI_SR_TOF                          ((uint32_t)0x00000010)             /*!< Timeout Flag           */
+#define  QUADSPI_SR_BUSY                         ((uint32_t)0x00000020)             /*!< Busy                   */
+#define  QUADSPI_SR_FLEVEL                       ((uint32_t)0x00001F00)             /*!< FIFO Threshlod Flag    */
+#define  QUADSPI_SR_FLEVEL_0                     ((uint32_t)0x00000100)             /*!< Bit 0 */
+#define  QUADSPI_SR_FLEVEL_1                     ((uint32_t)0x00000200)             /*!< Bit 1 */
+#define  QUADSPI_SR_FLEVEL_2                     ((uint32_t)0x00000400)             /*!< Bit 2 */
+#define  QUADSPI_SR_FLEVEL_3                     ((uint32_t)0x00000800)             /*!< Bit 3 */
+#define  QUADSPI_SR_FLEVEL_4                     ((uint32_t)0x00001000)             /*!< Bit 4 */
+
+/******************  Bit definition for QUADSPI_FCR register  ******************/
+#define  QUADSPI_FCR_CTEF                        ((uint32_t)0x00000001)             /*!< Clear Transfer Error Flag    */
+#define  QUADSPI_FCR_CTCF                        ((uint32_t)0x00000002)             /*!< Clear Transfer Complete Flag */
+#define  QUADSPI_FCR_CSMF                        ((uint32_t)0x00000008)             /*!< Clear Status Match Flag      */
+#define  QUADSPI_FCR_CTOF                        ((uint32_t)0x00000010)             /*!< Clear Timeout Flag           */
+
+/******************  Bit definition for QUADSPI_DLR register  ******************/
+#define  QUADSPI_DLR_DL                        ((uint32_t)0xFFFFFFFF)               /*!< DL[31:0]: Data Length */
+
+/******************  Bit definition for QUADSPI_CCR register  ******************/
+#define  QUADSPI_CCR_INSTRUCTION                  ((uint32_t)0x000000FF)            /*!< INSTRUCTION[7:0]: Instruction    */
+#define  QUADSPI_CCR_INSTRUCTION_0                ((uint32_t)0x00000001)            /*!< Bit 0 */
+#define  QUADSPI_CCR_INSTRUCTION_1                ((uint32_t)0x00000002)            /*!< Bit 1 */
+#define  QUADSPI_CCR_INSTRUCTION_2                ((uint32_t)0x00000004)            /*!< Bit 2 */
+#define  QUADSPI_CCR_INSTRUCTION_3                ((uint32_t)0x00000008)            /*!< Bit 3 */
+#define  QUADSPI_CCR_INSTRUCTION_4                ((uint32_t)0x00000010)            /*!< Bit 4 */
+#define  QUADSPI_CCR_INSTRUCTION_5                ((uint32_t)0x00000020)            /*!< Bit 5 */
+#define  QUADSPI_CCR_INSTRUCTION_6                ((uint32_t)0x00000040)            /*!< Bit 6 */
+#define  QUADSPI_CCR_INSTRUCTION_7                ((uint32_t)0x00000080)            /*!< Bit 7 */
+#define  QUADSPI_CCR_IMODE                        ((uint32_t)0x00000300)            /*!< IMODE[1:0]: Instruction Mode      */
+#define  QUADSPI_CCR_IMODE_0                      ((uint32_t)0x00000100)            /*!< Bit 0 */
+#define  QUADSPI_CCR_IMODE_1                      ((uint32_t)0x00000200)            /*!< Bit 1 */
+#define  QUADSPI_CCR_ADMODE                       ((uint32_t)0x00000C00)            /*!< ADMODE[1:0]: Address Mode         */
+#define  QUADSPI_CCR_ADMODE_0                     ((uint32_t)0x00000400)            /*!< Bit 0 */
+#define  QUADSPI_CCR_ADMODE_1                     ((uint32_t)0x00000800)            /*!< Bit 1 */
+#define  QUADSPI_CCR_ADSIZE                       ((uint32_t)0x00003000)            /*!< ADSIZE[1:0]: Address Size         */
+#define  QUADSPI_CCR_ADSIZE_0                     ((uint32_t)0x00001000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_ADSIZE_1                     ((uint32_t)0x00002000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_ABMODE                       ((uint32_t)0x0000C000)            /*!< ABMODE[1:0]: Alternate Bytes Mode */
+#define  QUADSPI_CCR_ABMODE_0                     ((uint32_t)0x00004000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_ABMODE_1                     ((uint32_t)0x00008000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_ABSIZE                       ((uint32_t)0x00030000)            /*!< ABSIZE[1:0]: Instruction Mode     */
+#define  QUADSPI_CCR_ABSIZE_0                     ((uint32_t)0x00010000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_ABSIZE_1                     ((uint32_t)0x00020000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_DCYC                         ((uint32_t)0x007C0000)            /*!< DCYC[4:0]: Dummy Cycles           */
+#define  QUADSPI_CCR_DCYC_0                       ((uint32_t)0x00040000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_DCYC_1                       ((uint32_t)0x00080000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_DCYC_2                       ((uint32_t)0x00100000)            /*!< Bit 2 */
+#define  QUADSPI_CCR_DCYC_3                       ((uint32_t)0x00200000)            /*!< Bit 3 */
+#define  QUADSPI_CCR_DCYC_4                       ((uint32_t)0x00400000)            /*!< Bit 4 */
+#define  QUADSPI_CCR_DMODE                        ((uint32_t)0x03000000)            /*!< DMODE[1:0]: Data Mode              */
+#define  QUADSPI_CCR_DMODE_0                      ((uint32_t)0x01000000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_DMODE_1                      ((uint32_t)0x02000000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_FMODE                        ((uint32_t)0x0C000000)            /*!< FMODE[1:0]: Functional Mode        */
+#define  QUADSPI_CCR_FMODE_0                      ((uint32_t)0x04000000)            /*!< Bit 0 */
+#define  QUADSPI_CCR_FMODE_1                      ((uint32_t)0x08000000)            /*!< Bit 1 */
+#define  QUADSPI_CCR_SIOO                         ((uint32_t)0x10000000)            /*!< SIOO: Send Instruction Only Once Mode */
+#define  QUADSPI_CCR_DHHC                         ((uint32_t)0x40000000)            /*!< DHHC: Delay Half Hclk Cycle           */
+#define  QUADSPI_CCR_DDRM                         ((uint32_t)0x80000000)            /*!< DDRM: Double Data Rate Mode           */
+/******************  Bit definition for QUADSPI_AR register  *******************/
+#define  QUADSPI_AR_ADDRESS                       ((uint32_t)0xFFFFFFFF)            /*!< ADDRESS[31:0]: Address */
+
+/******************  Bit definition for QUADSPI_ABR register  ******************/
+#define  QUADSPI_ABR_ALTERNATE                    ((uint32_t)0xFFFFFFFF)            /*!< ALTERNATE[31:0]: Alternate Bytes */
+
+/******************  Bit definition for QUADSPI_DR register  *******************/
+#define  QUADSPI_DR_DATA                          ((uint32_t)0xFFFFFFFF)            /*!< DATA[31:0]: Data */
+
+/******************  Bit definition for QUADSPI_PSMKR register  ****************/
+#define  QUADSPI_PSMKR_MASK                       ((uint32_t)0xFFFFFFFF)            /*!< MASK[31:0]: Status Mask */
+
+/******************  Bit definition for QUADSPI_PSMAR register  ****************/
+#define  QUADSPI_PSMAR_MATCH                      ((uint32_t)0xFFFFFFFF)            /*!< MATCH[31:0]: Status Match */
+
+/******************  Bit definition for QUADSPI_PIR register  *****************/
+#define  QUADSPI_PIR_INTERVAL                     ((uint32_t)0x0000FFFF)            /*!< INTERVAL[15:0]: Polling Interval */
+
+/******************  Bit definition for QUADSPI_LPTR register  *****************/
+#define  QUADSPI_LPTR_TIMEOUT                     ((uint32_t)0x0000FFFF)            /*!< TIMEOUT[15:0]: Timeout period */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Reset and Clock Control            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for RCC_CR register  ********************/
+#define  RCC_CR_HSION                        ((uint32_t)0x00000001)
+#define  RCC_CR_HSIRDY                       ((uint32_t)0x00000002)
+
+#define  RCC_CR_HSITRIM                      ((uint32_t)0x000000F8)
+#define  RCC_CR_HSITRIM_0                    ((uint32_t)0x00000008) /*!<Bit 0 */
+#define  RCC_CR_HSITRIM_1                    ((uint32_t)0x00000010) /*!<Bit 1 */
+#define  RCC_CR_HSITRIM_2                    ((uint32_t)0x00000020) /*!<Bit 2 */
+#define  RCC_CR_HSITRIM_3                    ((uint32_t)0x00000040) /*!<Bit 3 */
+#define  RCC_CR_HSITRIM_4                    ((uint32_t)0x00000080) /*!<Bit 4 */
+
+#define  RCC_CR_HSICAL                       ((uint32_t)0x0000FF00)
+#define  RCC_CR_HSICAL_0                     ((uint32_t)0x00000100) /*!<Bit 0 */
+#define  RCC_CR_HSICAL_1                     ((uint32_t)0x00000200) /*!<Bit 1 */
+#define  RCC_CR_HSICAL_2                     ((uint32_t)0x00000400) /*!<Bit 2 */
+#define  RCC_CR_HSICAL_3                     ((uint32_t)0x00000800) /*!<Bit 3 */
+#define  RCC_CR_HSICAL_4                     ((uint32_t)0x00001000) /*!<Bit 4 */
+#define  RCC_CR_HSICAL_5                     ((uint32_t)0x00002000) /*!<Bit 5 */
+#define  RCC_CR_HSICAL_6                     ((uint32_t)0x00004000) /*!<Bit 6 */
+#define  RCC_CR_HSICAL_7                     ((uint32_t)0x00008000) /*!<Bit 7 */
+
+#define  RCC_CR_HSEON                        ((uint32_t)0x00010000)
+#define  RCC_CR_HSERDY                       ((uint32_t)0x00020000)
+#define  RCC_CR_HSEBYP                       ((uint32_t)0x00040000)
+#define  RCC_CR_CSSON                        ((uint32_t)0x00080000)
+#define  RCC_CR_PLLON                        ((uint32_t)0x01000000)
+#define  RCC_CR_PLLRDY                       ((uint32_t)0x02000000)
+#define  RCC_CR_PLLI2SON                     ((uint32_t)0x04000000)
+#define  RCC_CR_PLLI2SRDY                    ((uint32_t)0x08000000)
+#define  RCC_CR_PLLSAION                     ((uint32_t)0x10000000)
+#define  RCC_CR_PLLSAIRDY                    ((uint32_t)0x20000000)
+
+/********************  Bit definition for RCC_PLLCFGR register  ***************/
+#define  RCC_PLLCFGR_PLLM                    ((uint32_t)0x0000003F)
+#define  RCC_PLLCFGR_PLLM_0                  ((uint32_t)0x00000001)
+#define  RCC_PLLCFGR_PLLM_1                  ((uint32_t)0x00000002)
+#define  RCC_PLLCFGR_PLLM_2                  ((uint32_t)0x00000004)
+#define  RCC_PLLCFGR_PLLM_3                  ((uint32_t)0x00000008)
+#define  RCC_PLLCFGR_PLLM_4                  ((uint32_t)0x00000010)
+#define  RCC_PLLCFGR_PLLM_5                  ((uint32_t)0x00000020)
+
+#define  RCC_PLLCFGR_PLLN                     ((uint32_t)0x00007FC0)
+#define  RCC_PLLCFGR_PLLN_0                   ((uint32_t)0x00000040)
+#define  RCC_PLLCFGR_PLLN_1                   ((uint32_t)0x00000080)
+#define  RCC_PLLCFGR_PLLN_2                   ((uint32_t)0x00000100)
+#define  RCC_PLLCFGR_PLLN_3                   ((uint32_t)0x00000200)
+#define  RCC_PLLCFGR_PLLN_4                   ((uint32_t)0x00000400)
+#define  RCC_PLLCFGR_PLLN_5                   ((uint32_t)0x00000800)
+#define  RCC_PLLCFGR_PLLN_6                   ((uint32_t)0x00001000)
+#define  RCC_PLLCFGR_PLLN_7                   ((uint32_t)0x00002000)
+#define  RCC_PLLCFGR_PLLN_8                   ((uint32_t)0x00004000)
+
+#define  RCC_PLLCFGR_PLLP                    ((uint32_t)0x00030000)
+#define  RCC_PLLCFGR_PLLP_0                  ((uint32_t)0x00010000)
+#define  RCC_PLLCFGR_PLLP_1                  ((uint32_t)0x00020000)
+
+#define  RCC_PLLCFGR_PLLSRC                  ((uint32_t)0x00400000)
+#define  RCC_PLLCFGR_PLLSRC_HSE              ((uint32_t)0x00400000)
+#define  RCC_PLLCFGR_PLLSRC_HSI              ((uint32_t)0x00000000)
+
+#define  RCC_PLLCFGR_PLLQ                    ((uint32_t)0x0F000000)
+#define  RCC_PLLCFGR_PLLQ_0                  ((uint32_t)0x01000000)
+#define  RCC_PLLCFGR_PLLQ_1                  ((uint32_t)0x02000000)
+#define  RCC_PLLCFGR_PLLQ_2                  ((uint32_t)0x04000000)
+#define  RCC_PLLCFGR_PLLQ_3                  ((uint32_t)0x08000000)
+
+/********************  Bit definition for RCC_CFGR register  ******************/
+/*!< SW configuration */
+#define  RCC_CFGR_SW                         ((uint32_t)0x00000003)        /*!< SW[1:0] bits (System clock Switch) */
+#define  RCC_CFGR_SW_0                       ((uint32_t)0x00000001)        /*!< Bit 0 */
+#define  RCC_CFGR_SW_1                       ((uint32_t)0x00000002)        /*!< Bit 1 */
+
+#define  RCC_CFGR_SW_HSI                     ((uint32_t)0x00000000)        /*!< HSI selected as system clock */
+#define  RCC_CFGR_SW_HSE                     ((uint32_t)0x00000001)        /*!< HSE selected as system clock */
+#define  RCC_CFGR_SW_PLL                     ((uint32_t)0x00000002)        /*!< PLL selected as system clock */
+
+/*!< SWS configuration */
+#define  RCC_CFGR_SWS                        ((uint32_t)0x0000000C)        /*!< SWS[1:0] bits (System Clock Switch Status) */
+#define  RCC_CFGR_SWS_0                      ((uint32_t)0x00000004)        /*!< Bit 0 */
+#define  RCC_CFGR_SWS_1                      ((uint32_t)0x00000008)        /*!< Bit 1 */
+
+#define  RCC_CFGR_SWS_HSI                    ((uint32_t)0x00000000)        /*!< HSI oscillator used as system clock */
+#define  RCC_CFGR_SWS_HSE                    ((uint32_t)0x00000004)        /*!< HSE oscillator used as system clock */
+#define  RCC_CFGR_SWS_PLL                    ((uint32_t)0x00000008)        /*!< PLL used as system clock */
+
+/*!< HPRE configuration */
+#define  RCC_CFGR_HPRE                       ((uint32_t)0x000000F0)        /*!< HPRE[3:0] bits (AHB prescaler) */
+#define  RCC_CFGR_HPRE_0                     ((uint32_t)0x00000010)        /*!< Bit 0 */
+#define  RCC_CFGR_HPRE_1                     ((uint32_t)0x00000020)        /*!< Bit 1 */
+#define  RCC_CFGR_HPRE_2                     ((uint32_t)0x00000040)        /*!< Bit 2 */
+#define  RCC_CFGR_HPRE_3                     ((uint32_t)0x00000080)        /*!< Bit 3 */
+
+#define  RCC_CFGR_HPRE_DIV1                  ((uint32_t)0x00000000)        /*!< SYSCLK not divided */
+#define  RCC_CFGR_HPRE_DIV2                  ((uint32_t)0x00000080)        /*!< SYSCLK divided by 2 */
+#define  RCC_CFGR_HPRE_DIV4                  ((uint32_t)0x00000090)        /*!< SYSCLK divided by 4 */
+#define  RCC_CFGR_HPRE_DIV8                  ((uint32_t)0x000000A0)        /*!< SYSCLK divided by 8 */
+#define  RCC_CFGR_HPRE_DIV16                 ((uint32_t)0x000000B0)        /*!< SYSCLK divided by 16 */
+#define  RCC_CFGR_HPRE_DIV64                 ((uint32_t)0x000000C0)        /*!< SYSCLK divided by 64 */
+#define  RCC_CFGR_HPRE_DIV128                ((uint32_t)0x000000D0)        /*!< SYSCLK divided by 128 */
+#define  RCC_CFGR_HPRE_DIV256                ((uint32_t)0x000000E0)        /*!< SYSCLK divided by 256 */
+#define  RCC_CFGR_HPRE_DIV512                ((uint32_t)0x000000F0)        /*!< SYSCLK divided by 512 */
+
+/*!< PPRE1 configuration */
+#define  RCC_CFGR_PPRE1                      ((uint32_t)0x00001C00)        /*!< PRE1[2:0] bits (APB1 prescaler) */
+#define  RCC_CFGR_PPRE1_0                    ((uint32_t)0x00000400)        /*!< Bit 0 */
+#define  RCC_CFGR_PPRE1_1                    ((uint32_t)0x00000800)        /*!< Bit 1 */
+#define  RCC_CFGR_PPRE1_2                    ((uint32_t)0x00001000)        /*!< Bit 2 */
+
+#define  RCC_CFGR_PPRE1_DIV1                 ((uint32_t)0x00000000)        /*!< HCLK not divided */
+#define  RCC_CFGR_PPRE1_DIV2                 ((uint32_t)0x00001000)        /*!< HCLK divided by 2 */
+#define  RCC_CFGR_PPRE1_DIV4                 ((uint32_t)0x00001400)        /*!< HCLK divided by 4 */
+#define  RCC_CFGR_PPRE1_DIV8                 ((uint32_t)0x00001800)        /*!< HCLK divided by 8 */
+#define  RCC_CFGR_PPRE1_DIV16                ((uint32_t)0x00001C00)        /*!< HCLK divided by 16 */
+
+/*!< PPRE2 configuration */
+#define  RCC_CFGR_PPRE2                      ((uint32_t)0x0000E000)        /*!< PRE2[2:0] bits (APB2 prescaler) */
+#define  RCC_CFGR_PPRE2_0                    ((uint32_t)0x00002000)        /*!< Bit 0 */
+#define  RCC_CFGR_PPRE2_1                    ((uint32_t)0x00004000)        /*!< Bit 1 */
+#define  RCC_CFGR_PPRE2_2                    ((uint32_t)0x00008000)        /*!< Bit 2 */
+
+#define  RCC_CFGR_PPRE2_DIV1                 ((uint32_t)0x00000000)        /*!< HCLK not divided */
+#define  RCC_CFGR_PPRE2_DIV2                 ((uint32_t)0x00008000)        /*!< HCLK divided by 2 */
+#define  RCC_CFGR_PPRE2_DIV4                 ((uint32_t)0x0000A000)        /*!< HCLK divided by 4 */
+#define  RCC_CFGR_PPRE2_DIV8                 ((uint32_t)0x0000C000)        /*!< HCLK divided by 8 */
+#define  RCC_CFGR_PPRE2_DIV16                ((uint32_t)0x0000E000)        /*!< HCLK divided by 16 */
+
+/*!< RTCPRE configuration */
+#define  RCC_CFGR_RTCPRE                     ((uint32_t)0x001F0000)
+#define  RCC_CFGR_RTCPRE_0                   ((uint32_t)0x00010000)
+#define  RCC_CFGR_RTCPRE_1                   ((uint32_t)0x00020000)
+#define  RCC_CFGR_RTCPRE_2                   ((uint32_t)0x00040000)
+#define  RCC_CFGR_RTCPRE_3                   ((uint32_t)0x00080000)
+#define  RCC_CFGR_RTCPRE_4                   ((uint32_t)0x00100000)
+
+/*!< MCO1 configuration */
+#define  RCC_CFGR_MCO1                       ((uint32_t)0x00600000)
+#define  RCC_CFGR_MCO1_0                     ((uint32_t)0x00200000)
+#define  RCC_CFGR_MCO1_1                     ((uint32_t)0x00400000)
+
+#define  RCC_CFGR_I2SSRC                     ((uint32_t)0x00800000)
+
+#define  RCC_CFGR_MCO1PRE                    ((uint32_t)0x07000000)
+#define  RCC_CFGR_MCO1PRE_0                  ((uint32_t)0x01000000)
+#define  RCC_CFGR_MCO1PRE_1                  ((uint32_t)0x02000000)
+#define  RCC_CFGR_MCO1PRE_2                  ((uint32_t)0x04000000)
+
+#define  RCC_CFGR_MCO2PRE                    ((uint32_t)0x38000000)
+#define  RCC_CFGR_MCO2PRE_0                  ((uint32_t)0x08000000)
+#define  RCC_CFGR_MCO2PRE_1                  ((uint32_t)0x10000000)
+#define  RCC_CFGR_MCO2PRE_2                  ((uint32_t)0x20000000)
+
+#define  RCC_CFGR_MCO2                       ((uint32_t)0xC0000000)
+#define  RCC_CFGR_MCO2_0                     ((uint32_t)0x40000000)
+#define  RCC_CFGR_MCO2_1                     ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_CIR register  *******************/
+#define  RCC_CIR_LSIRDYF                     ((uint32_t)0x00000001)
+#define  RCC_CIR_LSERDYF                     ((uint32_t)0x00000002)
+#define  RCC_CIR_HSIRDYF                     ((uint32_t)0x00000004)
+#define  RCC_CIR_HSERDYF                     ((uint32_t)0x00000008)
+#define  RCC_CIR_PLLRDYF                     ((uint32_t)0x00000010)
+#define  RCC_CIR_PLLI2SRDYF                  ((uint32_t)0x00000020)
+#define  RCC_CIR_PLLSAIRDYF                  ((uint32_t)0x00000040)
+#define  RCC_CIR_CSSF                        ((uint32_t)0x00000080)
+#define  RCC_CIR_LSIRDYIE                    ((uint32_t)0x00000100)
+#define  RCC_CIR_LSERDYIE                    ((uint32_t)0x00000200)
+#define  RCC_CIR_HSIRDYIE                    ((uint32_t)0x00000400)
+#define  RCC_CIR_HSERDYIE                    ((uint32_t)0x00000800)
+#define  RCC_CIR_PLLRDYIE                    ((uint32_t)0x00001000)
+#define  RCC_CIR_PLLI2SRDYIE                 ((uint32_t)0x00002000)
+#define  RCC_CIR_PLLSAIRDYIE                 ((uint32_t)0x00004000)
+#define  RCC_CIR_LSIRDYC                     ((uint32_t)0x00010000)
+#define  RCC_CIR_LSERDYC                     ((uint32_t)0x00020000)
+#define  RCC_CIR_HSIRDYC                     ((uint32_t)0x00040000)
+#define  RCC_CIR_HSERDYC                     ((uint32_t)0x00080000)
+#define  RCC_CIR_PLLRDYC                     ((uint32_t)0x00100000)
+#define  RCC_CIR_PLLI2SRDYC                  ((uint32_t)0x00200000)
+#define  RCC_CIR_PLLSAIRDYC                  ((uint32_t)0x00400000)
+#define  RCC_CIR_CSSC                        ((uint32_t)0x00800000)
+
+/********************  Bit definition for RCC_AHB1RSTR register  **************/
+#define  RCC_AHB1RSTR_GPIOARST               ((uint32_t)0x00000001)
+#define  RCC_AHB1RSTR_GPIOBRST               ((uint32_t)0x00000002)
+#define  RCC_AHB1RSTR_GPIOCRST               ((uint32_t)0x00000004)
+#define  RCC_AHB1RSTR_GPIODRST               ((uint32_t)0x00000008)
+#define  RCC_AHB1RSTR_GPIOERST               ((uint32_t)0x00000010)
+#define  RCC_AHB1RSTR_GPIOFRST               ((uint32_t)0x00000020)
+#define  RCC_AHB1RSTR_GPIOGRST               ((uint32_t)0x00000040)
+#define  RCC_AHB1RSTR_GPIOHRST               ((uint32_t)0x00000080)
+#define  RCC_AHB1RSTR_GPIOIRST               ((uint32_t)0x00000100)
+#define  RCC_AHB1RSTR_GPIOJRST               ((uint32_t)0x00000200)
+#define  RCC_AHB1RSTR_GPIOKRST               ((uint32_t)0x00000400)
+#define  RCC_AHB1RSTR_CRCRST                 ((uint32_t)0x00001000)
+#define  RCC_AHB1RSTR_DMA1RST                ((uint32_t)0x00200000)
+#define  RCC_AHB1RSTR_DMA2RST                ((uint32_t)0x00400000)
+#define  RCC_AHB1RSTR_DMA2DRST               ((uint32_t)0x00800000)
+#define  RCC_AHB1RSTR_ETHMACRST              ((uint32_t)0x02000000)
+#define  RCC_AHB1RSTR_OTGHRST                ((uint32_t)0x20000000)
+
+/********************  Bit definition for RCC_AHB2RSTR register  **************/
+#define  RCC_AHB2RSTR_DCMIRST                ((uint32_t)0x00000001)
+#define  RCC_AHB2RSTR_CRYPRST                ((uint32_t)0x00000010)
+#define  RCC_AHB2RSTR_HASHRST                ((uint32_t)0x00000020)
+#define  RCC_AHB2RSTR_RNGRST                 ((uint32_t)0x00000040)
+#define  RCC_AHB2RSTR_OTGFSRST               ((uint32_t)0x00000080)
+
+/********************  Bit definition for RCC_AHB3RSTR register  **************/
+
+#define  RCC_AHB3RSTR_FMCRST                ((uint32_t)0x00000001)
+#define  RCC_AHB3RSTR_QSPIRST               ((uint32_t)0x00000002)
+
+/********************  Bit definition for RCC_APB1RSTR register  **************/
+#define  RCC_APB1RSTR_TIM2RST                ((uint32_t)0x00000001)
+#define  RCC_APB1RSTR_TIM3RST                ((uint32_t)0x00000002)
+#define  RCC_APB1RSTR_TIM4RST                ((uint32_t)0x00000004)
+#define  RCC_APB1RSTR_TIM5RST                ((uint32_t)0x00000008)
+#define  RCC_APB1RSTR_TIM6RST                ((uint32_t)0x00000010)
+#define  RCC_APB1RSTR_TIM7RST                ((uint32_t)0x00000020)
+#define  RCC_APB1RSTR_TIM12RST               ((uint32_t)0x00000040)
+#define  RCC_APB1RSTR_TIM13RST               ((uint32_t)0x00000080)
+#define  RCC_APB1RSTR_TIM14RST               ((uint32_t)0x00000100)
+#define  RCC_APB1RSTR_LPTIM1RST              ((uint32_t)0x00000200)
+#define  RCC_APB1RSTR_WWDGRST                ((uint32_t)0x00000800)
+#define  RCC_APB1RSTR_SPI2RST                ((uint32_t)0x00004000)
+#define  RCC_APB1RSTR_SPI3RST                ((uint32_t)0x00008000)
+#define  RCC_APB1RSTR_SPDIFRXRST             ((uint32_t)0x00010000)
+#define  RCC_APB1RSTR_USART2RST              ((uint32_t)0x00020000)
+#define  RCC_APB1RSTR_USART3RST              ((uint32_t)0x00040000)
+#define  RCC_APB1RSTR_UART4RST               ((uint32_t)0x00080000)
+#define  RCC_APB1RSTR_UART5RST               ((uint32_t)0x00100000)
+#define  RCC_APB1RSTR_I2C1RST                ((uint32_t)0x00200000)
+#define  RCC_APB1RSTR_I2C2RST                ((uint32_t)0x00400000)
+#define  RCC_APB1RSTR_I2C3RST                ((uint32_t)0x00800000)
+#define  RCC_APB1RSTR_I2C4RST                ((uint32_t)0x01000000)
+#define  RCC_APB1RSTR_CAN1RST                ((uint32_t)0x02000000)
+#define  RCC_APB1RSTR_CAN2RST                ((uint32_t)0x04000000)
+#define  RCC_APB1RSTR_CECRST                 ((uint32_t)0x08000000)
+#define  RCC_APB1RSTR_PWRRST                 ((uint32_t)0x10000000)
+#define  RCC_APB1RSTR_DACRST                 ((uint32_t)0x20000000)
+#define  RCC_APB1RSTR_UART7RST               ((uint32_t)0x40000000)
+#define  RCC_APB1RSTR_UART8RST               ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_APB2RSTR register  **************/
+#define  RCC_APB2RSTR_TIM1RST                ((uint32_t)0x00000001)
+#define  RCC_APB2RSTR_TIM8RST                ((uint32_t)0x00000002)
+#define  RCC_APB2RSTR_USART1RST              ((uint32_t)0x00000010)
+#define  RCC_APB2RSTR_USART6RST              ((uint32_t)0x00000020)
+#define  RCC_APB2RSTR_ADCRST                 ((uint32_t)0x00000100)
+#define  RCC_APB2RSTR_SDMMC1RST              ((uint32_t)0x00000800)
+#define  RCC_APB2RSTR_SPI1RST                ((uint32_t)0x00001000)
+#define  RCC_APB2RSTR_SPI4RST                ((uint32_t)0x00002000)
+#define  RCC_APB2RSTR_SYSCFGRST              ((uint32_t)0x00004000)
+#define  RCC_APB2RSTR_TIM9RST                ((uint32_t)0x00010000)
+#define  RCC_APB2RSTR_TIM10RST               ((uint32_t)0x00020000)
+#define  RCC_APB2RSTR_TIM11RST               ((uint32_t)0x00040000)
+#define  RCC_APB2RSTR_SPI5RST                ((uint32_t)0x00100000)
+#define  RCC_APB2RSTR_SPI6RST                ((uint32_t)0x00200000)
+#define  RCC_APB2RSTR_SAI1RST                ((uint32_t)0x00400000)
+#define  RCC_APB2RSTR_SAI2RST                ((uint32_t)0x00800000)
+#define  RCC_APB2RSTR_LTDCRST                ((uint32_t)0x04000000)
+
+/********************  Bit definition for RCC_AHB1ENR register  ***************/
+#define  RCC_AHB1ENR_GPIOAEN                 ((uint32_t)0x00000001)
+#define  RCC_AHB1ENR_GPIOBEN                 ((uint32_t)0x00000002)
+#define  RCC_AHB1ENR_GPIOCEN                 ((uint32_t)0x00000004)
+#define  RCC_AHB1ENR_GPIODEN                 ((uint32_t)0x00000008)
+#define  RCC_AHB1ENR_GPIOEEN                 ((uint32_t)0x00000010)
+#define  RCC_AHB1ENR_GPIOFEN                 ((uint32_t)0x00000020)
+#define  RCC_AHB1ENR_GPIOGEN                 ((uint32_t)0x00000040)
+#define  RCC_AHB1ENR_GPIOHEN                 ((uint32_t)0x00000080)
+#define  RCC_AHB1ENR_GPIOIEN                 ((uint32_t)0x00000100)
+#define  RCC_AHB1ENR_GPIOJEN                 ((uint32_t)0x00000200)
+#define  RCC_AHB1ENR_GPIOKEN                 ((uint32_t)0x00000400)
+#define  RCC_AHB1ENR_CRCEN                   ((uint32_t)0x00001000)
+#define  RCC_AHB1ENR_BKPSRAMEN               ((uint32_t)0x00040000)
+#define  RCC_AHB1ENR_DTCMRAMEN               ((uint32_t)0x00100000)
+#define  RCC_AHB1ENR_DMA1EN                  ((uint32_t)0x00200000)
+#define  RCC_AHB1ENR_DMA2EN                  ((uint32_t)0x00400000)
+#define  RCC_AHB1ENR_DMA2DEN                 ((uint32_t)0x00800000)
+#define  RCC_AHB1ENR_ETHMACEN                ((uint32_t)0x02000000)
+#define  RCC_AHB1ENR_ETHMACTXEN              ((uint32_t)0x04000000)
+#define  RCC_AHB1ENR_ETHMACRXEN              ((uint32_t)0x08000000)
+#define  RCC_AHB1ENR_ETHMACPTPEN             ((uint32_t)0x10000000)
+#define  RCC_AHB1ENR_OTGHSEN                 ((uint32_t)0x20000000)
+#define  RCC_AHB1ENR_OTGHSULPIEN             ((uint32_t)0x40000000)
+
+/********************  Bit definition for RCC_AHB2ENR register  ***************/
+#define  RCC_AHB2ENR_DCMIEN                  ((uint32_t)0x00000001)
+#define  RCC_AHB2ENR_CRYPEN                  ((uint32_t)0x00000010)
+#define  RCC_AHB2ENR_HASHEN                  ((uint32_t)0x00000020)
+#define  RCC_AHB2ENR_RNGEN                   ((uint32_t)0x00000040)
+#define  RCC_AHB2ENR_OTGFSEN                 ((uint32_t)0x00000080)
+
+/********************  Bit definition for RCC_AHB3ENR register  ***************/
+
+#define  RCC_AHB3ENR_FMCEN                  ((uint32_t)0x00000001)
+#define  RCC_AHB3ENR_QSPIEN                 ((uint32_t)0x00000002)
+
+/********************  Bit definition for RCC_APB1ENR register  ***************/
+#define  RCC_APB1ENR_TIM2EN                  ((uint32_t)0x00000001)
+#define  RCC_APB1ENR_TIM3EN                  ((uint32_t)0x00000002)
+#define  RCC_APB1ENR_TIM4EN                  ((uint32_t)0x00000004)
+#define  RCC_APB1ENR_TIM5EN                  ((uint32_t)0x00000008)
+#define  RCC_APB1ENR_TIM6EN                  ((uint32_t)0x00000010)
+#define  RCC_APB1ENR_TIM7EN                  ((uint32_t)0x00000020)
+#define  RCC_APB1ENR_TIM12EN                 ((uint32_t)0x00000040)
+#define  RCC_APB1ENR_TIM13EN                 ((uint32_t)0x00000080)
+#define  RCC_APB1ENR_TIM14EN                 ((uint32_t)0x00000100)
+#define  RCC_APB1ENR_LPTIM1EN                ((uint32_t)0x00000200)
+#define  RCC_APB1ENR_WWDGEN                  ((uint32_t)0x00000800)
+#define  RCC_APB1ENR_SPI2EN                  ((uint32_t)0x00004000)
+#define  RCC_APB1ENR_SPI3EN                  ((uint32_t)0x00008000)
+#define  RCC_APB1ENR_SPDIFRXEN               ((uint32_t)0x00010000)
+#define  RCC_APB1ENR_USART2EN                ((uint32_t)0x00020000)
+#define  RCC_APB1ENR_USART3EN                ((uint32_t)0x00040000)
+#define  RCC_APB1ENR_UART4EN                 ((uint32_t)0x00080000)
+#define  RCC_APB1ENR_UART5EN                 ((uint32_t)0x00100000)
+#define  RCC_APB1ENR_I2C1EN                  ((uint32_t)0x00200000)
+#define  RCC_APB1ENR_I2C2EN                  ((uint32_t)0x00400000)
+#define  RCC_APB1ENR_I2C3EN                  ((uint32_t)0x00800000)
+#define  RCC_APB1ENR_I2C4EN                  ((uint32_t)0x01000000)
+#define  RCC_APB1ENR_CAN1EN                  ((uint32_t)0x02000000)
+#define  RCC_APB1ENR_CAN2EN                  ((uint32_t)0x04000000)
+#define  RCC_APB1ENR_CECEN                   ((uint32_t)0x08000000)
+#define  RCC_APB1ENR_PWREN                   ((uint32_t)0x10000000)
+#define  RCC_APB1ENR_DACEN                   ((uint32_t)0x20000000)
+#define  RCC_APB1ENR_UART7EN                 ((uint32_t)0x40000000)
+#define  RCC_APB1ENR_UART8EN                 ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_APB2ENR register  ***************/
+#define  RCC_APB2ENR_TIM1EN                  ((uint32_t)0x00000001)
+#define  RCC_APB2ENR_TIM8EN                  ((uint32_t)0x00000002)
+#define  RCC_APB2ENR_USART1EN                ((uint32_t)0x00000010)
+#define  RCC_APB2ENR_USART6EN                ((uint32_t)0x00000020)
+#define  RCC_APB2ENR_ADC1EN                  ((uint32_t)0x00000100)
+#define  RCC_APB2ENR_ADC2EN                  ((uint32_t)0x00000200)
+#define  RCC_APB2ENR_ADC3EN                  ((uint32_t)0x00000400)
+#define  RCC_APB2ENR_SDMMC1EN                ((uint32_t)0x00000800)
+#define  RCC_APB2ENR_SPI1EN                  ((uint32_t)0x00001000)
+#define  RCC_APB2ENR_SPI4EN                  ((uint32_t)0x00002000)
+#define  RCC_APB2ENR_SYSCFGEN                ((uint32_t)0x00004000)
+#define  RCC_APB2ENR_TIM9EN                  ((uint32_t)0x00010000)
+#define  RCC_APB2ENR_TIM10EN                 ((uint32_t)0x00020000)
+#define  RCC_APB2ENR_TIM11EN                 ((uint32_t)0x00040000)
+#define  RCC_APB2ENR_SPI5EN                  ((uint32_t)0x00100000)
+#define  RCC_APB2ENR_SPI6EN                  ((uint32_t)0x00200000)
+#define  RCC_APB2ENR_SAI1EN                  ((uint32_t)0x00400000)
+#define  RCC_APB2ENR_SAI2EN                  ((uint32_t)0x00800000)
+#define  RCC_APB2ENR_LTDCEN                  ((uint32_t)0x04000000)
+
+/********************  Bit definition for RCC_AHB1LPENR register  *************/
+#define  RCC_AHB1LPENR_GPIOALPEN             ((uint32_t)0x00000001)
+#define  RCC_AHB1LPENR_GPIOBLPEN             ((uint32_t)0x00000002)
+#define  RCC_AHB1LPENR_GPIOCLPEN             ((uint32_t)0x00000004)
+#define  RCC_AHB1LPENR_GPIODLPEN             ((uint32_t)0x00000008)
+#define  RCC_AHB1LPENR_GPIOELPEN             ((uint32_t)0x00000010)
+#define  RCC_AHB1LPENR_GPIOFLPEN             ((uint32_t)0x00000020)
+#define  RCC_AHB1LPENR_GPIOGLPEN             ((uint32_t)0x00000040)
+#define  RCC_AHB1LPENR_GPIOHLPEN             ((uint32_t)0x00000080)
+#define  RCC_AHB1LPENR_GPIOILPEN             ((uint32_t)0x00000100)
+#define  RCC_AHB1LPENR_GPIOJLPEN             ((uint32_t)0x00000200)
+#define  RCC_AHB1LPENR_GPIOKLPEN             ((uint32_t)0x00000400)
+
+#define  RCC_AHB1LPENR_CRCLPEN               ((uint32_t)0x00001000)
+#define  RCC_AHB1LPENR_AXILPEN               ((uint32_t)0x00002000)
+#define  RCC_AHB1LPENR_FLITFLPEN             ((uint32_t)0x00008000)
+#define  RCC_AHB1LPENR_SRAM1LPEN             ((uint32_t)0x00010000)
+#define  RCC_AHB1LPENR_SRAM2LPEN             ((uint32_t)0x00020000)
+#define  RCC_AHB1LPENR_BKPSRAMLPEN           ((uint32_t)0x00040000)
+#define  RCC_AHB1LPENR_DTCMLPEN              ((uint32_t)0x00100000)
+#define  RCC_AHB1LPENR_DMA1LPEN              ((uint32_t)0x00200000)
+#define  RCC_AHB1LPENR_DMA2LPEN              ((uint32_t)0x00400000)
+#define  RCC_AHB1LPENR_DMA2DLPEN             ((uint32_t)0x00800000)
+#define  RCC_AHB1LPENR_ETHMACLPEN            ((uint32_t)0x02000000)
+#define  RCC_AHB1LPENR_ETHMACTXLPEN          ((uint32_t)0x04000000)
+#define  RCC_AHB1LPENR_ETHMACRXLPEN          ((uint32_t)0x08000000)
+#define  RCC_AHB1LPENR_ETHMACPTPLPEN         ((uint32_t)0x10000000)
+#define  RCC_AHB1LPENR_OTGHSLPEN             ((uint32_t)0x20000000)
+#define  RCC_AHB1LPENR_OTGHSULPILPEN         ((uint32_t)0x40000000)
+
+/********************  Bit definition for RCC_AHB2LPENR register  *************/
+#define  RCC_AHB2LPENR_DCMILPEN              ((uint32_t)0x00000001)
+#define  RCC_AHB2LPENR_CRYPLPEN              ((uint32_t)0x00000010)
+#define  RCC_AHB2LPENR_HASHLPEN              ((uint32_t)0x00000020)
+#define  RCC_AHB2LPENR_RNGLPEN               ((uint32_t)0x00000040)
+#define  RCC_AHB2LPENR_OTGFSLPEN             ((uint32_t)0x00000080)
+
+/********************  Bit definition for RCC_AHB3LPENR register  *************/
+#define  RCC_AHB3LPENR_FMCLPEN              ((uint32_t)0x00000001)
+#define  RCC_AHB3LPENR_QSPILPEN             ((uint32_t)0x00000002)
+/********************  Bit definition for RCC_APB1LPENR register  *************/
+#define  RCC_APB1LPENR_TIM2LPEN              ((uint32_t)0x00000001)
+#define  RCC_APB1LPENR_TIM3LPEN              ((uint32_t)0x00000002)
+#define  RCC_APB1LPENR_TIM4LPEN              ((uint32_t)0x00000004)
+#define  RCC_APB1LPENR_TIM5LPEN              ((uint32_t)0x00000008)
+#define  RCC_APB1LPENR_TIM6LPEN              ((uint32_t)0x00000010)
+#define  RCC_APB1LPENR_TIM7LPEN              ((uint32_t)0x00000020)
+#define  RCC_APB1LPENR_TIM12LPEN             ((uint32_t)0x00000040)
+#define  RCC_APB1LPENR_TIM13LPEN             ((uint32_t)0x00000080)
+#define  RCC_APB1LPENR_TIM14LPEN             ((uint32_t)0x00000100)
+#define  RCC_APB1LPENR_LPTIM1LPEN            ((uint32_t)0x00000200)
+#define  RCC_APB1LPENR_WWDGLPEN              ((uint32_t)0x00000800)
+#define  RCC_APB1LPENR_SPI2LPEN              ((uint32_t)0x00004000)
+#define  RCC_APB1LPENR_SPI3LPEN              ((uint32_t)0x00008000)
+#define  RCC_APB1LPENR_SPDIFRXLPEN           ((uint32_t)0x00010000)
+#define  RCC_APB1LPENR_USART2LPEN            ((uint32_t)0x00020000)
+#define  RCC_APB1LPENR_USART3LPEN            ((uint32_t)0x00040000)
+#define  RCC_APB1LPENR_UART4LPEN             ((uint32_t)0x00080000)
+#define  RCC_APB1LPENR_UART5LPEN             ((uint32_t)0x00100000)
+#define  RCC_APB1LPENR_I2C1LPEN              ((uint32_t)0x00200000)
+#define  RCC_APB1LPENR_I2C2LPEN              ((uint32_t)0x00400000)
+#define  RCC_APB1LPENR_I2C3LPEN              ((uint32_t)0x00800000)
+#define  RCC_APB1LPENR_I2C4LPEN              ((uint32_t)0x01000000)
+#define  RCC_APB1LPENR_CAN1LPEN              ((uint32_t)0x02000000)
+#define  RCC_APB1LPENR_CAN2LPEN              ((uint32_t)0x04000000)
+#define  RCC_APB1LPENR_CECLPEN               ((uint32_t)0x08000000)
+#define  RCC_APB1LPENR_PWRLPEN               ((uint32_t)0x10000000)
+#define  RCC_APB1LPENR_DACLPEN               ((uint32_t)0x20000000)
+#define  RCC_APB1LPENR_UART7LPEN             ((uint32_t)0x40000000)
+#define  RCC_APB1LPENR_UART8LPEN             ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_APB2LPENR register  *************/
+#define  RCC_APB2LPENR_TIM1LPEN              ((uint32_t)0x00000001)
+#define  RCC_APB2LPENR_TIM8LPEN              ((uint32_t)0x00000002)
+#define  RCC_APB2LPENR_USART1LPEN            ((uint32_t)0x00000010)
+#define  RCC_APB2LPENR_USART6LPEN            ((uint32_t)0x00000020)
+#define  RCC_APB2LPENR_ADC1LPEN              ((uint32_t)0x00000100)
+#define  RCC_APB2LPENR_ADC2LPEN              ((uint32_t)0x00000200)
+#define  RCC_APB2LPENR_ADC3LPEN              ((uint32_t)0x00000400)
+#define  RCC_APB2LPENR_SDMMC1LPEN            ((uint32_t)0x00000800)
+#define  RCC_APB2LPENR_SPI1LPEN              ((uint32_t)0x00001000)
+#define  RCC_APB2LPENR_SPI4LPEN              ((uint32_t)0x00002000)
+#define  RCC_APB2LPENR_SYSCFGLPEN            ((uint32_t)0x00004000)
+#define  RCC_APB2LPENR_TIM9LPEN              ((uint32_t)0x00010000)
+#define  RCC_APB2LPENR_TIM10LPEN             ((uint32_t)0x00020000)
+#define  RCC_APB2LPENR_TIM11LPEN             ((uint32_t)0x00040000)
+#define  RCC_APB2LPENR_SPI5LPEN              ((uint32_t)0x00100000)
+#define  RCC_APB2LPENR_SPI6LPEN              ((uint32_t)0x00200000)
+#define  RCC_APB2LPENR_SAI1LPEN              ((uint32_t)0x00400000)
+#define  RCC_APB2LPENR_SAI2LPEN              ((uint32_t)0x00800000)
+#define  RCC_APB2LPENR_LTDCLPEN              ((uint32_t)0x04000000)
+
+/********************  Bit definition for RCC_BDCR register  ******************/
+#define  RCC_BDCR_LSEON                      ((uint32_t)0x00000001)
+#define  RCC_BDCR_LSERDY                     ((uint32_t)0x00000002)
+#define  RCC_BDCR_LSEBYP                     ((uint32_t)0x00000004)
+#define  RCC_BDCR_LSEDRV                     ((uint32_t)0x00000018)
+#define  RCC_BDCR_LSEDRV_0                   ((uint32_t)0x00000008)
+#define  RCC_BDCR_LSEDRV_1                   ((uint32_t)0x00000010)
+#define  RCC_BDCR_RTCSEL                     ((uint32_t)0x00000300)
+#define  RCC_BDCR_RTCSEL_0                   ((uint32_t)0x00000100)
+#define  RCC_BDCR_RTCSEL_1                   ((uint32_t)0x00000200)
+#define  RCC_BDCR_RTCEN                      ((uint32_t)0x00008000)
+#define  RCC_BDCR_BDRST                      ((uint32_t)0x00010000)
+
+/********************  Bit definition for RCC_CSR register  *******************/
+#define  RCC_CSR_LSION                       ((uint32_t)0x00000001)
+#define  RCC_CSR_LSIRDY                      ((uint32_t)0x00000002)
+#define  RCC_CSR_RMVF                        ((uint32_t)0x01000000)
+#define  RCC_CSR_BORRSTF                     ((uint32_t)0x02000000)
+#define  RCC_CSR_PINRSTF                     ((uint32_t)0x04000000)
+#define  RCC_CSR_PORRSTF                     ((uint32_t)0x08000000)
+#define  RCC_CSR_SFTRSTF                     ((uint32_t)0x10000000)
+#define  RCC_CSR_IWDGRSTF                    ((uint32_t)0x20000000)
+#define  RCC_CSR_WWDGRSTF                    ((uint32_t)0x40000000)
+#define  RCC_CSR_LPWRRSTF                    ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_SSCGR register  *****************/
+#define  RCC_SSCGR_MODPER                    ((uint32_t)0x00001FFF)
+#define  RCC_SSCGR_INCSTEP                   ((uint32_t)0x0FFFE000)
+#define  RCC_SSCGR_SPREADSEL                 ((uint32_t)0x40000000)
+#define  RCC_SSCGR_SSCGEN                    ((uint32_t)0x80000000)
+
+/********************  Bit definition for RCC_PLLI2SCFGR register  ************/
+#define  RCC_PLLI2SCFGR_PLLI2SN              ((uint32_t)0x00007FC0)
+#define  RCC_PLLI2SCFGR_PLLI2SN_0            ((uint32_t)0x00000040)
+#define  RCC_PLLI2SCFGR_PLLI2SN_1            ((uint32_t)0x00000080)
+#define  RCC_PLLI2SCFGR_PLLI2SN_2            ((uint32_t)0x00000100)
+#define  RCC_PLLI2SCFGR_PLLI2SN_3            ((uint32_t)0x00000200)
+#define  RCC_PLLI2SCFGR_PLLI2SN_4            ((uint32_t)0x00000400)
+#define  RCC_PLLI2SCFGR_PLLI2SN_5            ((uint32_t)0x00000800)
+#define  RCC_PLLI2SCFGR_PLLI2SN_6            ((uint32_t)0x00001000)
+#define  RCC_PLLI2SCFGR_PLLI2SN_7            ((uint32_t)0x00002000)
+#define  RCC_PLLI2SCFGR_PLLI2SN_8            ((uint32_t)0x00004000)
+
+#define  RCC_PLLI2SCFGR_PLLI2SP              ((uint32_t)0x00030000)
+#define  RCC_PLLI2SCFGR_PLLI2SP_0            ((uint32_t)0x00010000)
+#define  RCC_PLLI2SCFGR_PLLI2SP_1            ((uint32_t)0x00020000)
+
+#define  RCC_PLLI2SCFGR_PLLI2SQ              ((uint32_t)0x0F000000)
+#define  RCC_PLLI2SCFGR_PLLI2SQ_0            ((uint32_t)0x01000000)
+#define  RCC_PLLI2SCFGR_PLLI2SQ_1            ((uint32_t)0x02000000)
+#define  RCC_PLLI2SCFGR_PLLI2SQ_2            ((uint32_t)0x04000000)
+#define  RCC_PLLI2SCFGR_PLLI2SQ_3            ((uint32_t)0x08000000)
+
+#define  RCC_PLLI2SCFGR_PLLI2SR              ((uint32_t)0x70000000)
+#define  RCC_PLLI2SCFGR_PLLI2SR_0            ((uint32_t)0x10000000)
+#define  RCC_PLLI2SCFGR_PLLI2SR_1            ((uint32_t)0x20000000)
+#define  RCC_PLLI2SCFGR_PLLI2SR_2            ((uint32_t)0x40000000)
+
+/********************  Bit definition for RCC_PLLSAICFGR register  ************/
+#define  RCC_PLLSAICFGR_PLLSAIN              ((uint32_t)0x00007FC0)
+#define  RCC_PLLSAICFGR_PLLSAIN_0            ((uint32_t)0x00000040)
+#define  RCC_PLLSAICFGR_PLLSAIN_1            ((uint32_t)0x00000080)
+#define  RCC_PLLSAICFGR_PLLSAIN_2            ((uint32_t)0x00000100)
+#define  RCC_PLLSAICFGR_PLLSAIN_3            ((uint32_t)0x00000200)
+#define  RCC_PLLSAICFGR_PLLSAIN_4            ((uint32_t)0x00000400)
+#define  RCC_PLLSAICFGR_PLLSAIN_5            ((uint32_t)0x00000800)
+#define  RCC_PLLSAICFGR_PLLSAIN_6            ((uint32_t)0x00001000)
+#define  RCC_PLLSAICFGR_PLLSAIN_7            ((uint32_t)0x00002000)
+#define  RCC_PLLSAICFGR_PLLSAIN_8            ((uint32_t)0x00004000)
+
+#define  RCC_PLLSAICFGR_PLLSAIP              ((uint32_t)0x00030000)
+#define  RCC_PLLSAICFGR_PLLSAIP_0            ((uint32_t)0x00010000)
+#define  RCC_PLLSAICFGR_PLLSAIP_1            ((uint32_t)0x00020000)
+
+#define  RCC_PLLSAICFGR_PLLSAIQ              ((uint32_t)0x0F000000)
+#define  RCC_PLLSAICFGR_PLLSAIQ_0            ((uint32_t)0x01000000)
+#define  RCC_PLLSAICFGR_PLLSAIQ_1            ((uint32_t)0x02000000)
+#define  RCC_PLLSAICFGR_PLLSAIQ_2            ((uint32_t)0x04000000)
+#define  RCC_PLLSAICFGR_PLLSAIQ_3            ((uint32_t)0x08000000)
+
+#define  RCC_PLLSAICFGR_PLLSAIR              ((uint32_t)0x70000000)
+#define  RCC_PLLSAICFGR_PLLSAIR_0            ((uint32_t)0x10000000)
+#define  RCC_PLLSAICFGR_PLLSAIR_1            ((uint32_t)0x20000000)
+#define  RCC_PLLSAICFGR_PLLSAIR_2            ((uint32_t)0x40000000)
+
+/********************  Bit definition for RCC_DCKCFGR1 register  ***************/
+#define  RCC_DCKCFGR1_PLLI2SDIVQ              ((uint32_t)0x0000001F)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_0            ((uint32_t)0x00000001)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_1            ((uint32_t)0x00000002)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_2            ((uint32_t)0x00000004)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_3            ((uint32_t)0x00000008)
+#define  RCC_DCKCFGR1_PLLI2SDIVQ_4            ((uint32_t)0x00000010)
+
+#define  RCC_DCKCFGR1_PLLSAIDIVQ              ((uint32_t)0x00001F00)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_0            ((uint32_t)0x00000100)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_1            ((uint32_t)0x00000200)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_2            ((uint32_t)0x00000400)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_3            ((uint32_t)0x00000800)
+#define  RCC_DCKCFGR1_PLLSAIDIVQ_4            ((uint32_t)0x00001000)
+
+#define  RCC_DCKCFGR1_PLLSAIDIVR              ((uint32_t)0x00030000)
+#define  RCC_DCKCFGR1_PLLSAIDIVR_0            ((uint32_t)0x00010000)
+#define  RCC_DCKCFGR1_PLLSAIDIVR_1            ((uint32_t)0x00020000)
+
+#define  RCC_DCKCFGR1_SAI1SEL                 ((uint32_t)0x00300000)
+#define  RCC_DCKCFGR1_SAI1SEL_0               ((uint32_t)0x00100000)
+#define  RCC_DCKCFGR1_SAI1SEL_1               ((uint32_t)0x00200000)
+
+#define  RCC_DCKCFGR1_SAI2SEL                 ((uint32_t)0x00C00000)
+#define  RCC_DCKCFGR1_SAI2SEL_0               ((uint32_t)0x00400000)
+#define  RCC_DCKCFGR1_SAI2SEL_1               ((uint32_t)0x00800000)
+
+#define  RCC_DCKCFGR1_TIMPRE                  ((uint32_t)0x01000000)
+
+/********************  Bit definition for RCC_DCKCFGR2 register  ***************/
+#define  RCC_DCKCFGR2_USART1SEL              ((uint32_t)0x00000003)
+#define  RCC_DCKCFGR2_USART1SEL_0            ((uint32_t)0x00000001)
+#define  RCC_DCKCFGR2_USART1SEL_1            ((uint32_t)0x00000002)
+#define  RCC_DCKCFGR2_USART2SEL              ((uint32_t)0x0000000C)
+#define  RCC_DCKCFGR2_USART2SEL_0            ((uint32_t)0x00000004)
+#define  RCC_DCKCFGR2_USART2SEL_1            ((uint32_t)0x00000008)
+#define  RCC_DCKCFGR2_USART3SEL              ((uint32_t)0x00000030)
+#define  RCC_DCKCFGR2_USART3SEL_0            ((uint32_t)0x00000010)
+#define  RCC_DCKCFGR2_USART3SEL_1            ((uint32_t)0x00000020)
+#define  RCC_DCKCFGR2_UART4SEL               ((uint32_t)0x000000C0)
+#define  RCC_DCKCFGR2_UART4SEL_0             ((uint32_t)0x00000040)
+#define  RCC_DCKCFGR2_UART4SEL_1             ((uint32_t)0x00000080)
+#define  RCC_DCKCFGR2_UART5SEL               ((uint32_t)0x00000300)
+#define  RCC_DCKCFGR2_UART5SEL_0             ((uint32_t)0x00000100)
+#define  RCC_DCKCFGR2_UART5SEL_1             ((uint32_t)0x00000200)
+#define  RCC_DCKCFGR2_USART6SEL              ((uint32_t)0x00000C00)
+#define  RCC_DCKCFGR2_USART6SEL_0            ((uint32_t)0x00000400)
+#define  RCC_DCKCFGR2_USART6SEL_1            ((uint32_t)0x00000800)
+#define  RCC_DCKCFGR2_UART7SEL               ((uint32_t)0x00003000)
+#define  RCC_DCKCFGR2_UART7SEL_0             ((uint32_t)0x00001000)
+#define  RCC_DCKCFGR2_UART7SEL_1             ((uint32_t)0x00002000)
+#define  RCC_DCKCFGR2_UART8SEL               ((uint32_t)0x0000C000)
+#define  RCC_DCKCFGR2_UART8SEL_0             ((uint32_t)0x00004000)
+#define  RCC_DCKCFGR2_UART8SEL_1             ((uint32_t)0x00008000)
+#define  RCC_DCKCFGR2_I2C1SEL                ((uint32_t)0x00030000)
+#define  RCC_DCKCFGR2_I2C1SEL_0              ((uint32_t)0x00010000)
+#define  RCC_DCKCFGR2_I2C1SEL_1              ((uint32_t)0x00020000)
+#define  RCC_DCKCFGR2_I2C2SEL                ((uint32_t)0x000C0000)
+#define  RCC_DCKCFGR2_I2C2SEL_0              ((uint32_t)0x00040000)
+#define  RCC_DCKCFGR2_I2C2SEL_1              ((uint32_t)0x00080000)
+#define  RCC_DCKCFGR2_I2C3SEL                ((uint32_t)0x00300000)
+#define  RCC_DCKCFGR2_I2C3SEL_0              ((uint32_t)0x00100000)
+#define  RCC_DCKCFGR2_I2C3SEL_1              ((uint32_t)0x00200000)
+#define  RCC_DCKCFGR2_I2C4SEL                ((uint32_t)0x00C00000)
+#define  RCC_DCKCFGR2_I2C4SEL_0              ((uint32_t)0x00400000)
+#define  RCC_DCKCFGR2_I2C4SEL_1              ((uint32_t)0x00800000)
+#define  RCC_DCKCFGR2_LPTIM1SEL              ((uint32_t)0x03000000)
+#define  RCC_DCKCFGR2_LPTIM1SEL_0            ((uint32_t)0x01000000)
+#define  RCC_DCKCFGR2_LPTIM1SEL_1            ((uint32_t)0x02000000)
+#define  RCC_DCKCFGR2_CECSEL                 ((uint32_t)0x04000000)
+#define  RCC_DCKCFGR2_CK48MSEL               ((uint32_t)0x08000000)
+#define  RCC_DCKCFGR2_SDMMC1SEL              ((uint32_t)0x10000000)
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    RNG                                     */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for RNG_CR register  *******************/
+#define RNG_CR_RNGEN                         ((uint32_t)0x00000004)
+#define RNG_CR_IE                            ((uint32_t)0x00000008)
+
+/********************  Bits definition for RNG_SR register  *******************/
+#define RNG_SR_DRDY                          ((uint32_t)0x00000001)
+#define RNG_SR_CECS                          ((uint32_t)0x00000002)
+#define RNG_SR_SECS                          ((uint32_t)0x00000004)
+#define RNG_SR_CEIS                          ((uint32_t)0x00000020)
+#define RNG_SR_SEIS                          ((uint32_t)0x00000040)
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Real-Time Clock (RTC)                            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for RTC_TR register  *******************/
+#define RTC_TR_PM                            ((uint32_t)0x00400000)
+#define RTC_TR_HT                            ((uint32_t)0x00300000)
+#define RTC_TR_HT_0                          ((uint32_t)0x00100000)
+#define RTC_TR_HT_1                          ((uint32_t)0x00200000)
+#define RTC_TR_HU                            ((uint32_t)0x000F0000)
+#define RTC_TR_HU_0                          ((uint32_t)0x00010000)
+#define RTC_TR_HU_1                          ((uint32_t)0x00020000)
+#define RTC_TR_HU_2                          ((uint32_t)0x00040000)
+#define RTC_TR_HU_3                          ((uint32_t)0x00080000)
+#define RTC_TR_MNT                           ((uint32_t)0x00007000)
+#define RTC_TR_MNT_0                         ((uint32_t)0x00001000)
+#define RTC_TR_MNT_1                         ((uint32_t)0x00002000)
+#define RTC_TR_MNT_2                         ((uint32_t)0x00004000)
+#define RTC_TR_MNU                           ((uint32_t)0x00000F00)
+#define RTC_TR_MNU_0                         ((uint32_t)0x00000100)
+#define RTC_TR_MNU_1                         ((uint32_t)0x00000200)
+#define RTC_TR_MNU_2                         ((uint32_t)0x00000400)
+#define RTC_TR_MNU_3                         ((uint32_t)0x00000800)
+#define RTC_TR_ST                            ((uint32_t)0x00000070)
+#define RTC_TR_ST_0                          ((uint32_t)0x00000010)
+#define RTC_TR_ST_1                          ((uint32_t)0x00000020)
+#define RTC_TR_ST_2                          ((uint32_t)0x00000040)
+#define RTC_TR_SU                            ((uint32_t)0x0000000F)
+#define RTC_TR_SU_0                          ((uint32_t)0x00000001)
+#define RTC_TR_SU_1                          ((uint32_t)0x00000002)
+#define RTC_TR_SU_2                          ((uint32_t)0x00000004)
+#define RTC_TR_SU_3                          ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_DR register  *******************/
+#define RTC_DR_YT                            ((uint32_t)0x00F00000)
+#define RTC_DR_YT_0                          ((uint32_t)0x00100000)
+#define RTC_DR_YT_1                          ((uint32_t)0x00200000)
+#define RTC_DR_YT_2                          ((uint32_t)0x00400000)
+#define RTC_DR_YT_3                          ((uint32_t)0x00800000)
+#define RTC_DR_YU                            ((uint32_t)0x000F0000)
+#define RTC_DR_YU_0                          ((uint32_t)0x00010000)
+#define RTC_DR_YU_1                          ((uint32_t)0x00020000)
+#define RTC_DR_YU_2                          ((uint32_t)0x00040000)
+#define RTC_DR_YU_3                          ((uint32_t)0x00080000)
+#define RTC_DR_WDU                           ((uint32_t)0x0000E000)
+#define RTC_DR_WDU_0                         ((uint32_t)0x00002000)
+#define RTC_DR_WDU_1                         ((uint32_t)0x00004000)
+#define RTC_DR_WDU_2                         ((uint32_t)0x00008000)
+#define RTC_DR_MT                            ((uint32_t)0x00001000)
+#define RTC_DR_MU                            ((uint32_t)0x00000F00)
+#define RTC_DR_MU_0                          ((uint32_t)0x00000100)
+#define RTC_DR_MU_1                          ((uint32_t)0x00000200)
+#define RTC_DR_MU_2                          ((uint32_t)0x00000400)
+#define RTC_DR_MU_3                          ((uint32_t)0x00000800)
+#define RTC_DR_DT                            ((uint32_t)0x00000030)
+#define RTC_DR_DT_0                          ((uint32_t)0x00000010)
+#define RTC_DR_DT_1                          ((uint32_t)0x00000020)
+#define RTC_DR_DU                            ((uint32_t)0x0000000F)
+#define RTC_DR_DU_0                          ((uint32_t)0x00000001)
+#define RTC_DR_DU_1                          ((uint32_t)0x00000002)
+#define RTC_DR_DU_2                          ((uint32_t)0x00000004)
+#define RTC_DR_DU_3                          ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_CR register  *******************/
+#define RTC_CR_ITSE                          ((uint32_t)0x01000000)
+#define RTC_CR_COE                           ((uint32_t)0x00800000)
+#define RTC_CR_OSEL                          ((uint32_t)0x00600000)
+#define RTC_CR_OSEL_0                        ((uint32_t)0x00200000)
+#define RTC_CR_OSEL_1                        ((uint32_t)0x00400000)
+#define RTC_CR_POL                           ((uint32_t)0x00100000)
+#define RTC_CR_COSEL                         ((uint32_t)0x00080000)
+#define RTC_CR_BCK                           ((uint32_t)0x00040000)
+#define RTC_CR_SUB1H                         ((uint32_t)0x00020000)
+#define RTC_CR_ADD1H                         ((uint32_t)0x00010000)
+#define RTC_CR_TSIE                          ((uint32_t)0x00008000)
+#define RTC_CR_WUTIE                         ((uint32_t)0x00004000)
+#define RTC_CR_ALRBIE                        ((uint32_t)0x00002000)
+#define RTC_CR_ALRAIE                        ((uint32_t)0x00001000)
+#define RTC_CR_TSE                           ((uint32_t)0x00000800)
+#define RTC_CR_WUTE                          ((uint32_t)0x00000400)
+#define RTC_CR_ALRBE                         ((uint32_t)0x00000200)
+#define RTC_CR_ALRAE                         ((uint32_t)0x00000100)
+#define RTC_CR_FMT                           ((uint32_t)0x00000040)
+#define RTC_CR_BYPSHAD                       ((uint32_t)0x00000020)
+#define RTC_CR_REFCKON                       ((uint32_t)0x00000010)
+#define RTC_CR_TSEDGE                        ((uint32_t)0x00000008)
+#define RTC_CR_WUCKSEL                       ((uint32_t)0x00000007)
+#define RTC_CR_WUCKSEL_0                     ((uint32_t)0x00000001)
+#define RTC_CR_WUCKSEL_1                     ((uint32_t)0x00000002)
+#define RTC_CR_WUCKSEL_2                     ((uint32_t)0x00000004)
+
+/********************  Bits definition for RTC_ISR register  ******************/
+#define RTC_ISR_ITSF                         ((uint32_t)0x00020000)
+#define RTC_ISR_RECALPF                      ((uint32_t)0x00010000)
+#define RTC_ISR_TAMP3F                       ((uint32_t)0x00008000)
+#define RTC_ISR_TAMP2F                       ((uint32_t)0x00004000)
+#define RTC_ISR_TAMP1F                       ((uint32_t)0x00002000)
+#define RTC_ISR_TSOVF                        ((uint32_t)0x00001000)
+#define RTC_ISR_TSF                          ((uint32_t)0x00000800)
+#define RTC_ISR_WUTF                         ((uint32_t)0x00000400)
+#define RTC_ISR_ALRBF                        ((uint32_t)0x00000200)
+#define RTC_ISR_ALRAF                        ((uint32_t)0x00000100)
+#define RTC_ISR_INIT                         ((uint32_t)0x00000080)
+#define RTC_ISR_INITF                        ((uint32_t)0x00000040)
+#define RTC_ISR_RSF                          ((uint32_t)0x00000020)
+#define RTC_ISR_INITS                        ((uint32_t)0x00000010)
+#define RTC_ISR_SHPF                         ((uint32_t)0x00000008)
+#define RTC_ISR_WUTWF                        ((uint32_t)0x00000004)
+#define RTC_ISR_ALRBWF                       ((uint32_t)0x00000002)
+#define RTC_ISR_ALRAWF                       ((uint32_t)0x00000001)
+
+/********************  Bits definition for RTC_PRER register  *****************/
+#define RTC_PRER_PREDIV_A                    ((uint32_t)0x007F0000)
+#define RTC_PRER_PREDIV_S                    ((uint32_t)0x00007FFF)
+
+/********************  Bits definition for RTC_WUTR register  *****************/
+#define RTC_WUTR_WUT                         ((uint32_t)0x0000FFFF)
+
+/********************  Bits definition for RTC_ALRMAR register  ***************/
+#define RTC_ALRMAR_MSK4                      ((uint32_t)0x80000000)
+#define RTC_ALRMAR_WDSEL                     ((uint32_t)0x40000000)
+#define RTC_ALRMAR_DT                        ((uint32_t)0x30000000)
+#define RTC_ALRMAR_DT_0                      ((uint32_t)0x10000000)
+#define RTC_ALRMAR_DT_1                      ((uint32_t)0x20000000)
+#define RTC_ALRMAR_DU                        ((uint32_t)0x0F000000)
+#define RTC_ALRMAR_DU_0                      ((uint32_t)0x01000000)
+#define RTC_ALRMAR_DU_1                      ((uint32_t)0x02000000)
+#define RTC_ALRMAR_DU_2                      ((uint32_t)0x04000000)
+#define RTC_ALRMAR_DU_3                      ((uint32_t)0x08000000)
+#define RTC_ALRMAR_MSK3                      ((uint32_t)0x00800000)
+#define RTC_ALRMAR_PM                        ((uint32_t)0x00400000)
+#define RTC_ALRMAR_HT                        ((uint32_t)0x00300000)
+#define RTC_ALRMAR_HT_0                      ((uint32_t)0x00100000)
+#define RTC_ALRMAR_HT_1                      ((uint32_t)0x00200000)
+#define RTC_ALRMAR_HU                        ((uint32_t)0x000F0000)
+#define RTC_ALRMAR_HU_0                      ((uint32_t)0x00010000)
+#define RTC_ALRMAR_HU_1                      ((uint32_t)0x00020000)
+#define RTC_ALRMAR_HU_2                      ((uint32_t)0x00040000)
+#define RTC_ALRMAR_HU_3                      ((uint32_t)0x00080000)
+#define RTC_ALRMAR_MSK2                      ((uint32_t)0x00008000)
+#define RTC_ALRMAR_MNT                       ((uint32_t)0x00007000)
+#define RTC_ALRMAR_MNT_0                     ((uint32_t)0x00001000)
+#define RTC_ALRMAR_MNT_1                     ((uint32_t)0x00002000)
+#define RTC_ALRMAR_MNT_2                     ((uint32_t)0x00004000)
+#define RTC_ALRMAR_MNU                       ((uint32_t)0x00000F00)
+#define RTC_ALRMAR_MNU_0                     ((uint32_t)0x00000100)
+#define RTC_ALRMAR_MNU_1                     ((uint32_t)0x00000200)
+#define RTC_ALRMAR_MNU_2                     ((uint32_t)0x00000400)
+#define RTC_ALRMAR_MNU_3                     ((uint32_t)0x00000800)
+#define RTC_ALRMAR_MSK1                      ((uint32_t)0x00000080)
+#define RTC_ALRMAR_ST                        ((uint32_t)0x00000070)
+#define RTC_ALRMAR_ST_0                      ((uint32_t)0x00000010)
+#define RTC_ALRMAR_ST_1                      ((uint32_t)0x00000020)
+#define RTC_ALRMAR_ST_2                      ((uint32_t)0x00000040)
+#define RTC_ALRMAR_SU                        ((uint32_t)0x0000000F)
+#define RTC_ALRMAR_SU_0                      ((uint32_t)0x00000001)
+#define RTC_ALRMAR_SU_1                      ((uint32_t)0x00000002)
+#define RTC_ALRMAR_SU_2                      ((uint32_t)0x00000004)
+#define RTC_ALRMAR_SU_3                      ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_ALRMBR register  ***************/
+#define RTC_ALRMBR_MSK4                      ((uint32_t)0x80000000)
+#define RTC_ALRMBR_WDSEL                     ((uint32_t)0x40000000)
+#define RTC_ALRMBR_DT                        ((uint32_t)0x30000000)
+#define RTC_ALRMBR_DT_0                      ((uint32_t)0x10000000)
+#define RTC_ALRMBR_DT_1                      ((uint32_t)0x20000000)
+#define RTC_ALRMBR_DU                        ((uint32_t)0x0F000000)
+#define RTC_ALRMBR_DU_0                      ((uint32_t)0x01000000)
+#define RTC_ALRMBR_DU_1                      ((uint32_t)0x02000000)
+#define RTC_ALRMBR_DU_2                      ((uint32_t)0x04000000)
+#define RTC_ALRMBR_DU_3                      ((uint32_t)0x08000000)
+#define RTC_ALRMBR_MSK3                      ((uint32_t)0x00800000)
+#define RTC_ALRMBR_PM                        ((uint32_t)0x00400000)
+#define RTC_ALRMBR_HT                        ((uint32_t)0x00300000)
+#define RTC_ALRMBR_HT_0                      ((uint32_t)0x00100000)
+#define RTC_ALRMBR_HT_1                      ((uint32_t)0x00200000)
+#define RTC_ALRMBR_HU                        ((uint32_t)0x000F0000)
+#define RTC_ALRMBR_HU_0                      ((uint32_t)0x00010000)
+#define RTC_ALRMBR_HU_1                      ((uint32_t)0x00020000)
+#define RTC_ALRMBR_HU_2                      ((uint32_t)0x00040000)
+#define RTC_ALRMBR_HU_3                      ((uint32_t)0x00080000)
+#define RTC_ALRMBR_MSK2                      ((uint32_t)0x00008000)
+#define RTC_ALRMBR_MNT                       ((uint32_t)0x00007000)
+#define RTC_ALRMBR_MNT_0                     ((uint32_t)0x00001000)
+#define RTC_ALRMBR_MNT_1                     ((uint32_t)0x00002000)
+#define RTC_ALRMBR_MNT_2                     ((uint32_t)0x00004000)
+#define RTC_ALRMBR_MNU                       ((uint32_t)0x00000F00)
+#define RTC_ALRMBR_MNU_0                     ((uint32_t)0x00000100)
+#define RTC_ALRMBR_MNU_1                     ((uint32_t)0x00000200)
+#define RTC_ALRMBR_MNU_2                     ((uint32_t)0x00000400)
+#define RTC_ALRMBR_MNU_3                     ((uint32_t)0x00000800)
+#define RTC_ALRMBR_MSK1                      ((uint32_t)0x00000080)
+#define RTC_ALRMBR_ST                        ((uint32_t)0x00000070)
+#define RTC_ALRMBR_ST_0                      ((uint32_t)0x00000010)
+#define RTC_ALRMBR_ST_1                      ((uint32_t)0x00000020)
+#define RTC_ALRMBR_ST_2                      ((uint32_t)0x00000040)
+#define RTC_ALRMBR_SU                        ((uint32_t)0x0000000F)
+#define RTC_ALRMBR_SU_0                      ((uint32_t)0x00000001)
+#define RTC_ALRMBR_SU_1                      ((uint32_t)0x00000002)
+#define RTC_ALRMBR_SU_2                      ((uint32_t)0x00000004)
+#define RTC_ALRMBR_SU_3                      ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_WPR register  ******************/
+#define RTC_WPR_KEY                          ((uint32_t)0x000000FF)
+
+/********************  Bits definition for RTC_SSR register  ******************/
+#define RTC_SSR_SS                           ((uint32_t)0x0000FFFF)
+
+/********************  Bits definition for RTC_SHIFTR register  ***************/
+#define RTC_SHIFTR_SUBFS                     ((uint32_t)0x00007FFF)
+#define RTC_SHIFTR_ADD1S                     ((uint32_t)0x80000000)
+
+/********************  Bits definition for RTC_TSTR register  *****************/
+#define RTC_TSTR_PM                          ((uint32_t)0x00400000)
+#define RTC_TSTR_HT                          ((uint32_t)0x00300000)
+#define RTC_TSTR_HT_0                        ((uint32_t)0x00100000)
+#define RTC_TSTR_HT_1                        ((uint32_t)0x00200000)
+#define RTC_TSTR_HU                          ((uint32_t)0x000F0000)
+#define RTC_TSTR_HU_0                        ((uint32_t)0x00010000)
+#define RTC_TSTR_HU_1                        ((uint32_t)0x00020000)
+#define RTC_TSTR_HU_2                        ((uint32_t)0x00040000)
+#define RTC_TSTR_HU_3                        ((uint32_t)0x00080000)
+#define RTC_TSTR_MNT                         ((uint32_t)0x00007000)
+#define RTC_TSTR_MNT_0                       ((uint32_t)0x00001000)
+#define RTC_TSTR_MNT_1                       ((uint32_t)0x00002000)
+#define RTC_TSTR_MNT_2                       ((uint32_t)0x00004000)
+#define RTC_TSTR_MNU                         ((uint32_t)0x00000F00)
+#define RTC_TSTR_MNU_0                       ((uint32_t)0x00000100)
+#define RTC_TSTR_MNU_1                       ((uint32_t)0x00000200)
+#define RTC_TSTR_MNU_2                       ((uint32_t)0x00000400)
+#define RTC_TSTR_MNU_3                       ((uint32_t)0x00000800)
+#define RTC_TSTR_ST                          ((uint32_t)0x00000070)
+#define RTC_TSTR_ST_0                        ((uint32_t)0x00000010)
+#define RTC_TSTR_ST_1                        ((uint32_t)0x00000020)
+#define RTC_TSTR_ST_2                        ((uint32_t)0x00000040)
+#define RTC_TSTR_SU                          ((uint32_t)0x0000000F)
+#define RTC_TSTR_SU_0                        ((uint32_t)0x00000001)
+#define RTC_TSTR_SU_1                        ((uint32_t)0x00000002)
+#define RTC_TSTR_SU_2                        ((uint32_t)0x00000004)
+#define RTC_TSTR_SU_3                        ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_TSDR register  *****************/
+#define RTC_TSDR_WDU                         ((uint32_t)0x0000E000)
+#define RTC_TSDR_WDU_0                       ((uint32_t)0x00002000)
+#define RTC_TSDR_WDU_1                       ((uint32_t)0x00004000)
+#define RTC_TSDR_WDU_2                       ((uint32_t)0x00008000)
+#define RTC_TSDR_MT                          ((uint32_t)0x00001000)
+#define RTC_TSDR_MU                          ((uint32_t)0x00000F00)
+#define RTC_TSDR_MU_0                        ((uint32_t)0x00000100)
+#define RTC_TSDR_MU_1                        ((uint32_t)0x00000200)
+#define RTC_TSDR_MU_2                        ((uint32_t)0x00000400)
+#define RTC_TSDR_MU_3                        ((uint32_t)0x00000800)
+#define RTC_TSDR_DT                          ((uint32_t)0x00000030)
+#define RTC_TSDR_DT_0                        ((uint32_t)0x00000010)
+#define RTC_TSDR_DT_1                        ((uint32_t)0x00000020)
+#define RTC_TSDR_DU                          ((uint32_t)0x0000000F)
+#define RTC_TSDR_DU_0                        ((uint32_t)0x00000001)
+#define RTC_TSDR_DU_1                        ((uint32_t)0x00000002)
+#define RTC_TSDR_DU_2                        ((uint32_t)0x00000004)
+#define RTC_TSDR_DU_3                        ((uint32_t)0x00000008)
+
+/********************  Bits definition for RTC_TSSSR register  ****************/
+#define RTC_TSSSR_SS                         ((uint32_t)0x0000FFFF)
+
+/********************  Bits definition for RTC_CAL register  *****************/
+#define RTC_CALR_CALP                        ((uint32_t)0x00008000)
+#define RTC_CALR_CALW8                       ((uint32_t)0x00004000)
+#define RTC_CALR_CALW16                      ((uint32_t)0x00002000)
+#define RTC_CALR_CALM                        ((uint32_t)0x000001FF)
+#define RTC_CALR_CALM_0                      ((uint32_t)0x00000001)
+#define RTC_CALR_CALM_1                      ((uint32_t)0x00000002)
+#define RTC_CALR_CALM_2                      ((uint32_t)0x00000004)
+#define RTC_CALR_CALM_3                      ((uint32_t)0x00000008)
+#define RTC_CALR_CALM_4                      ((uint32_t)0x00000010)
+#define RTC_CALR_CALM_5                      ((uint32_t)0x00000020)
+#define RTC_CALR_CALM_6                      ((uint32_t)0x00000040)
+#define RTC_CALR_CALM_7                      ((uint32_t)0x00000080)
+#define RTC_CALR_CALM_8                      ((uint32_t)0x00000100)
+
+/********************  Bits definition for RTC_TAMPCR register  ****************/
+#define RTC_TAMPCR_TAMP3MF                    ((uint32_t)0x01000000)
+#define RTC_TAMPCR_TAMP3NOERASE               ((uint32_t)0x00800000)
+#define RTC_TAMPCR_TAMP3IE                    ((uint32_t)0x00400000)
+#define RTC_TAMPCR_TAMP2MF                    ((uint32_t)0x00200000)
+#define RTC_TAMPCR_TAMP2NOERASE               ((uint32_t)0x00100000)
+#define RTC_TAMPCR_TAMP2IE                    ((uint32_t)0x00080000)
+#define RTC_TAMPCR_TAMP1MF                    ((uint32_t)0x00040000)
+#define RTC_TAMPCR_TAMP1NOERASE               ((uint32_t)0x00020000)
+#define RTC_TAMPCR_TAMP1IE                    ((uint32_t)0x00010000)
+#define RTC_TAMPCR_TAMPPUDIS                  ((uint32_t)0x00008000)
+#define RTC_TAMPCR_TAMPPRCH                   ((uint32_t)0x00006000)
+#define RTC_TAMPCR_TAMPPRCH_0                 ((uint32_t)0x00002000)
+#define RTC_TAMPCR_TAMPPRCH_1                 ((uint32_t)0x00004000)
+#define RTC_TAMPCR_TAMPFLT                    ((uint32_t)0x00001800)
+#define RTC_TAMPCR_TAMPFLT_0                  ((uint32_t)0x00000800)
+#define RTC_TAMPCR_TAMPFLT_1                  ((uint32_t)0x00001000)
+#define RTC_TAMPCR_TAMPFREQ                   ((uint32_t)0x00000700)
+#define RTC_TAMPCR_TAMPFREQ_0                 ((uint32_t)0x00000100)
+#define RTC_TAMPCR_TAMPFREQ_1                 ((uint32_t)0x00000200)
+#define RTC_TAMPCR_TAMPFREQ_2                 ((uint32_t)0x00000400)
+#define RTC_TAMPCR_TAMPTS                     ((uint32_t)0x00000080)
+#define RTC_TAMPCR_TAMP3_TRG                  ((uint32_t)0x00000040)
+#define RTC_TAMPCR_TAMP3E                     ((uint32_t)0x00000020)
+#define RTC_TAMPCR_TAMP2_TRG                   ((uint32_t)0x00000010)
+#define RTC_TAMPCR_TAMP2E                     ((uint32_t)0x00000008)
+#define RTC_TAMPCR_TAMPIE                     ((uint32_t)0x00000004)
+#define RTC_TAMPCR_TAMP1_TRG                   ((uint32_t)0x00000002)
+#define RTC_TAMPCR_TAMP1E                     ((uint32_t)0x00000001)
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMASSR_MASKSS                  ((uint32_t)0x0F000000)
+#define RTC_ALRMASSR_MASKSS_0                ((uint32_t)0x01000000)
+#define RTC_ALRMASSR_MASKSS_1                ((uint32_t)0x02000000)
+#define RTC_ALRMASSR_MASKSS_2                ((uint32_t)0x04000000)
+#define RTC_ALRMASSR_MASKSS_3                ((uint32_t)0x08000000)
+#define RTC_ALRMASSR_SS                      ((uint32_t)0x00007FFF)
+
+/********************  Bits definition for RTC_ALRMBSSR register  *************/
+#define RTC_ALRMBSSR_MASKSS                  ((uint32_t)0x0F000000)
+#define RTC_ALRMBSSR_MASKSS_0                ((uint32_t)0x01000000)
+#define RTC_ALRMBSSR_MASKSS_1                ((uint32_t)0x02000000)
+#define RTC_ALRMBSSR_MASKSS_2                ((uint32_t)0x04000000)
+#define RTC_ALRMBSSR_MASKSS_3                ((uint32_t)0x08000000)
+#define RTC_ALRMBSSR_SS                      ((uint32_t)0x00007FFF)
+
+/********************  Bits definition for RTC_OR register  ****************/
+#define RTC_OR_TSINSEL                      ((uint32_t)0x00000006)
+#define RTC_OR_TSINSEL_0                    ((uint32_t)0x00000002)
+#define RTC_OR_TSINSEL_1                    ((uint32_t)0x00000004)
+#define RTC_OR_ALARMTYPE                    ((uint32_t)0x00000008)
+
+
+/********************  Bits definition for RTC_BKP0R register  ****************/
+#define RTC_BKP0R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP1R register  ****************/
+#define RTC_BKP1R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP2R register  ****************/
+#define RTC_BKP2R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP3R register  ****************/
+#define RTC_BKP3R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP4R register  ****************/
+#define RTC_BKP4R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP5R register  ****************/
+#define RTC_BKP5R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP6R register  ****************/
+#define RTC_BKP6R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP7R register  ****************/
+#define RTC_BKP7R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP8R register  ****************/
+#define RTC_BKP8R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP9R register  ****************/
+#define RTC_BKP9R                            ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP10R register  ***************/
+#define RTC_BKP10R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP11R register  ***************/
+#define RTC_BKP11R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP12R register  ***************/
+#define RTC_BKP12R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP13R register  ***************/
+#define RTC_BKP13R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP14R register  ***************/
+#define RTC_BKP14R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP15R register  ***************/
+#define RTC_BKP15R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP16R register  ***************/
+#define RTC_BKP16R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP17R register  ***************/
+#define RTC_BKP17R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP18R register  ***************/
+#define RTC_BKP18R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP19R register  ***************/
+#define RTC_BKP19R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP20R register  ***************/
+#define RTC_BKP20R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP21R register  ***************/
+#define RTC_BKP21R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP22R register  ***************/
+#define RTC_BKP22R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP23R register  ***************/
+#define RTC_BKP23R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP24R register  ***************/
+#define RTC_BKP24R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP25R register  ***************/
+#define RTC_BKP25R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP26R register  ***************/
+#define RTC_BKP26R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP27R register  ***************/
+#define RTC_BKP27R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP28R register  ***************/
+#define RTC_BKP28R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP29R register  ***************/
+#define RTC_BKP29R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP30R register  ***************/
+#define RTC_BKP30R                           ((uint32_t)0xFFFFFFFF)
+
+/********************  Bits definition for RTC_BKP31R register  ***************/
+#define RTC_BKP31R                           ((uint32_t)0xFFFFFFFF)
+
+/******************** Number of backup registers ******************************/
+#define RTC_BKP_NUMBER                       ((uint32_t)0x00000020)
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          Serial Audio Interface                            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for SAI_GCR register  *******************/
+#define  SAI_GCR_SYNCIN                  ((uint32_t)0x00000003)        /*!<SYNCIN[1:0] bits (Synchronization Inputs)   */
+#define  SAI_GCR_SYNCIN_0                ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_GCR_SYNCIN_1                ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  SAI_GCR_SYNCOUT                 ((uint32_t)0x00000030)        /*!<SYNCOUT[1:0] bits (Synchronization Outputs) */
+#define  SAI_GCR_SYNCOUT_0               ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  SAI_GCR_SYNCOUT_1               ((uint32_t)0x00000020)        /*!<Bit 1 */
+
+/*******************  Bit definition for SAI_xCR1 register  *******************/
+#define  SAI_xCR1_MODE                    ((uint32_t)0x00000003)        /*!<MODE[1:0] bits (Audio Block Mode)           */
+#define  SAI_xCR1_MODE_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_xCR1_MODE_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  SAI_xCR1_PRTCFG                  ((uint32_t)0x0000000C)        /*!<PRTCFG[1:0] bits (Protocol Configuration)   */
+#define  SAI_xCR1_PRTCFG_0                ((uint32_t)0x00000004)        /*!<Bit 0 */
+#define  SAI_xCR1_PRTCFG_1                ((uint32_t)0x00000008)        /*!<Bit 1 */
+
+#define  SAI_xCR1_DS                      ((uint32_t)0x000000E0)        /*!<DS[1:0] bits (Data Size) */
+#define  SAI_xCR1_DS_0                    ((uint32_t)0x00000020)        /*!<Bit 0 */
+#define  SAI_xCR1_DS_1                    ((uint32_t)0x00000040)        /*!<Bit 1 */
+#define  SAI_xCR1_DS_2                    ((uint32_t)0x00000080)        /*!<Bit 2 */
+
+#define  SAI_xCR1_LSBFIRST                ((uint32_t)0x00000100)        /*!<LSB First Configuration  */
+#define  SAI_xCR1_CKSTR                   ((uint32_t)0x00000200)        /*!<ClocK STRobing edge      */
+
+#define  SAI_xCR1_SYNCEN                  ((uint32_t)0x00000C00)        /*!<SYNCEN[1:0](SYNChronization ENable) */
+#define  SAI_xCR1_SYNCEN_0                ((uint32_t)0x00000400)        /*!<Bit 0 */
+#define  SAI_xCR1_SYNCEN_1                ((uint32_t)0x00000800)        /*!<Bit 1 */
+
+#define  SAI_xCR1_MONO                    ((uint32_t)0x00001000)        /*!<Mono mode                  */
+#define  SAI_xCR1_OUTDRIV                 ((uint32_t)0x00002000)        /*!<Output Drive               */
+#define  SAI_xCR1_SAIEN                   ((uint32_t)0x00010000)        /*!<Audio Block enable         */
+#define  SAI_xCR1_DMAEN                   ((uint32_t)0x00020000)        /*!<DMA enable                 */
+#define  SAI_xCR1_NODIV                   ((uint32_t)0x00080000)        /*!<No Divider Configuration   */
+
+#define  SAI_xCR1_MCKDIV                  ((uint32_t)0x00F00000)        /*!<MCKDIV[3:0] (Master ClocK Divider)  */
+#define  SAI_xCR1_MCKDIV_0                ((uint32_t)0x00100000)        /*!<Bit 0  */
+#define  SAI_xCR1_MCKDIV_1                ((uint32_t)0x00200000)        /*!<Bit 1  */
+#define  SAI_xCR1_MCKDIV_2                ((uint32_t)0x00400000)        /*!<Bit 2  */
+#define  SAI_xCR1_MCKDIV_3                ((uint32_t)0x00800000)        /*!<Bit 3  */
+
+/*******************  Bit definition for SAI_xCR2 register  *******************/
+#define  SAI_xCR2_FTH                     ((uint32_t)0x00000007)        /*!<FTH[2:0](Fifo THreshold)  */
+#define  SAI_xCR2_FTH_0                   ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_xCR2_FTH_1                   ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  SAI_xCR2_FTH_2                   ((uint32_t)0x00000004)        /*!<Bit 2 */
+
+#define  SAI_xCR2_FFLUSH                  ((uint32_t)0x00000008)        /*!<Fifo FLUSH                       */
+#define  SAI_xCR2_TRIS                    ((uint32_t)0x00000010)        /*!<TRIState Management on data line */
+#define  SAI_xCR2_MUTE                    ((uint32_t)0x00000020)        /*!<Mute mode                        */
+#define  SAI_xCR2_MUTEVAL                 ((uint32_t)0x00000040)        /*!<Muate value                      */
+
+#define  SAI_xCR2_MUTECNT                  ((uint32_t)0x00001F80)       /*!<MUTECNT[5:0] (MUTE counter) */
+#define  SAI_xCR2_MUTECNT_0               ((uint32_t)0x00000080)        /*!<Bit 0 */
+#define  SAI_xCR2_MUTECNT_1               ((uint32_t)0x00000100)        /*!<Bit 1 */
+#define  SAI_xCR2_MUTECNT_2               ((uint32_t)0x00000200)        /*!<Bit 2 */
+#define  SAI_xCR2_MUTECNT_3               ((uint32_t)0x00000400)        /*!<Bit 3 */
+#define  SAI_xCR2_MUTECNT_4               ((uint32_t)0x00000800)        /*!<Bit 4 */
+#define  SAI_xCR2_MUTECNT_5               ((uint32_t)0x00001000)        /*!<Bit 5 */
+
+#define  SAI_xCR2_CPL                     ((uint32_t)0x00080000)        /*!< Complement Bit             */
+
+#define  SAI_xCR2_COMP                    ((uint32_t)0x0000C000)        /*!<COMP[1:0] (Companding mode) */
+#define  SAI_xCR2_COMP_0                  ((uint32_t)0x00004000)        /*!<Bit 0 */
+#define  SAI_xCR2_COMP_1                  ((uint32_t)0x00008000)        /*!<Bit 1 */
+
+/******************  Bit definition for SAI_xFRCR register  *******************/
+#define  SAI_xFRCR_FRL                    ((uint32_t)0x000000FF)        /*!<FRL[1:0](Frame length)  */
+#define  SAI_xFRCR_FRL_0                  ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_xFRCR_FRL_1                  ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  SAI_xFRCR_FRL_2                  ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  SAI_xFRCR_FRL_3                  ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  SAI_xFRCR_FRL_4                  ((uint32_t)0x00000010)        /*!<Bit 4 */
+#define  SAI_xFRCR_FRL_5                  ((uint32_t)0x00000020)        /*!<Bit 5 */
+#define  SAI_xFRCR_FRL_6                  ((uint32_t)0x00000040)        /*!<Bit 6 */
+#define  SAI_xFRCR_FRL_7                  ((uint32_t)0x00000080)        /*!<Bit 7 */
+
+#define  SAI_xFRCR_FSALL                  ((uint32_t)0x00007F00)        /*!<FRL[1:0] (Frame synchronization active level length)  */
+#define  SAI_xFRCR_FSALL_0                ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  SAI_xFRCR_FSALL_1                ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  SAI_xFRCR_FSALL_2                ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  SAI_xFRCR_FSALL_3                ((uint32_t)0x00000800)        /*!<Bit 3 */
+#define  SAI_xFRCR_FSALL_4                ((uint32_t)0x00001000)        /*!<Bit 4 */
+#define  SAI_xFRCR_FSALL_5                ((uint32_t)0x00002000)        /*!<Bit 5 */
+#define  SAI_xFRCR_FSALL_6                ((uint32_t)0x00004000)        /*!<Bit 6 */
+
+#define  SAI_xFRCR_FSDEF                  ((uint32_t)0x00010000)        /*!< Frame Synchronization Definition */
+#define  SAI_xFRCR_FSPO                   ((uint32_t)0x00020000)        /*!<Frame Synchronization POLarity    */
+#define  SAI_xFRCR_FSOFF                  ((uint32_t)0x00040000)        /*!<Frame Synchronization OFFset      */
+
+/******************  Bit definition for SAI_xSLOTR register  *******************/
+#define  SAI_xSLOTR_FBOFF                 ((uint32_t)0x0000001F)        /*!<FRL[4:0](First Bit Offset)  */
+#define  SAI_xSLOTR_FBOFF_0               ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  SAI_xSLOTR_FBOFF_1               ((uint32_t)0x00000002)        /*!<Bit 1 */
+#define  SAI_xSLOTR_FBOFF_2               ((uint32_t)0x00000004)        /*!<Bit 2 */
+#define  SAI_xSLOTR_FBOFF_3               ((uint32_t)0x00000008)        /*!<Bit 3 */
+#define  SAI_xSLOTR_FBOFF_4               ((uint32_t)0x00000010)        /*!<Bit 4 */
+
+#define  SAI_xSLOTR_SLOTSZ                ((uint32_t)0x000000C0)        /*!<SLOTSZ[1:0] (Slot size)  */
+#define  SAI_xSLOTR_SLOTSZ_0              ((uint32_t)0x00000040)        /*!<Bit 0 */
+#define  SAI_xSLOTR_SLOTSZ_1              ((uint32_t)0x00000080)        /*!<Bit 1 */
+
+#define  SAI_xSLOTR_NBSLOT                ((uint32_t)0x00000F00)        /*!<NBSLOT[3:0] (Number of Slot in audio Frame)  */
+#define  SAI_xSLOTR_NBSLOT_0              ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  SAI_xSLOTR_NBSLOT_1              ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  SAI_xSLOTR_NBSLOT_2              ((uint32_t)0x00000400)        /*!<Bit 2 */
+#define  SAI_xSLOTR_NBSLOT_3              ((uint32_t)0x00000800)        /*!<Bit 3 */
+
+#define  SAI_xSLOTR_SLOTEN                ((uint32_t)0xFFFF0000)        /*!<SLOTEN[15:0] (Slot Enable)  */
+
+/*******************  Bit definition for SAI_xIMR register  *******************/
+#define  SAI_xIMR_OVRUDRIE                ((uint32_t)0x00000001)        /*!<Overrun underrun interrupt enable                              */
+#define  SAI_xIMR_MUTEDETIE               ((uint32_t)0x00000002)        /*!<Mute detection interrupt enable                                */
+#define  SAI_xIMR_WCKCFGIE                ((uint32_t)0x00000004)        /*!<Wrong Clock Configuration interrupt enable                     */
+#define  SAI_xIMR_FREQIE                  ((uint32_t)0x00000008)        /*!<FIFO request interrupt enable                                  */
+#define  SAI_xIMR_CNRDYIE                 ((uint32_t)0x00000010)        /*!<Codec not ready interrupt enable                               */
+#define  SAI_xIMR_AFSDETIE                ((uint32_t)0x00000020)        /*!<Anticipated frame synchronization detection interrupt enable   */
+#define  SAI_xIMR_LFSDETIE                ((uint32_t)0x00000040)        /*!<Late frame synchronization detection interrupt enable          */
+
+/********************  Bit definition for SAI_xSR register  *******************/
+#define  SAI_xSR_OVRUDR                   ((uint32_t)0x00000001)         /*!<Overrun underrun                               */
+#define  SAI_xSR_MUTEDET                  ((uint32_t)0x00000002)         /*!<Mute detection                                 */
+#define  SAI_xSR_WCKCFG                   ((uint32_t)0x00000004)         /*!<Wrong Clock Configuration                      */
+#define  SAI_xSR_FREQ                     ((uint32_t)0x00000008)         /*!<FIFO request                                   */
+#define  SAI_xSR_CNRDY                    ((uint32_t)0x00000010)         /*!<Codec not ready                                */
+#define  SAI_xSR_AFSDET                   ((uint32_t)0x00000020)         /*!<Anticipated frame synchronization detection    */
+#define  SAI_xSR_LFSDET                   ((uint32_t)0x00000040)         /*!<Late frame synchronization detection           */
+
+#define  SAI_xSR_FLVL                     ((uint32_t)0x00070000)         /*!<FLVL[2:0] (FIFO Level Threshold)               */
+#define  SAI_xSR_FLVL_0                   ((uint32_t)0x00010000)         /*!<Bit 0 */
+#define  SAI_xSR_FLVL_1                   ((uint32_t)0x00020000)         /*!<Bit 1 */
+#define  SAI_xSR_FLVL_2                   ((uint32_t)0x00040000)         /*!<Bit 2 */
+
+/******************  Bit definition for SAI_xCLRFR register  ******************/
+#define  SAI_xCLRFR_COVRUDR               ((uint32_t)0x00000001)        /*!<Clear Overrun underrun                               */
+#define  SAI_xCLRFR_CMUTEDET              ((uint32_t)0x00000002)        /*!<Clear Mute detection                                 */
+#define  SAI_xCLRFR_CWCKCFG               ((uint32_t)0x00000004)        /*!<Clear Wrong Clock Configuration                      */
+#define  SAI_xCLRFR_CFREQ                 ((uint32_t)0x00000008)        /*!<Clear FIFO request                                   */
+#define  SAI_xCLRFR_CCNRDY                ((uint32_t)0x00000010)        /*!<Clear Codec not ready                                */
+#define  SAI_xCLRFR_CAFSDET               ((uint32_t)0x00000020)        /*!<Clear Anticipated frame synchronization detection    */
+#define  SAI_xCLRFR_CLFSDET               ((uint32_t)0x00000040)        /*!<Clear Late frame synchronization detection           */
+
+/******************  Bit definition for SAI_xDR register  *********************/
+#define  SAI_xDR_DATA                     ((uint32_t)0xFFFFFFFF)
+
+/******************************************************************************/
+/*                                                                            */
+/*                              SPDIF-RX Interface                            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for SPDIF_CR register  *******************/
+#define  SPDIFRX_CR_SPDIFEN                  ((uint32_t)0x00000003)        /*!<Peripheral Block Enable                      */
+#define  SPDIFRX_CR_RXDMAEN                  ((uint32_t)0x00000004)        /*!<Receiver DMA Enable for data flow            */
+#define  SPDIFRX_CR_RXSTEO                   ((uint32_t)0x00000008)        /*!<Stereo Mode                                  */
+#define  SPDIFRX_CR_DRFMT                    ((uint32_t)0x00000030)        /*!<RX Data format                               */
+#define  SPDIFRX_CR_PMSK                     ((uint32_t)0x00000040)        /*!<Mask Parity error bit                        */
+#define  SPDIFRX_CR_VMSK                     ((uint32_t)0x00000080)        /*!<Mask of Validity bit                         */
+#define  SPDIFRX_CR_CUMSK                    ((uint32_t)0x00000100)        /*!<Mask of channel status and user bits         */
+#define  SPDIFRX_CR_PTMSK                    ((uint32_t)0x00000200)        /*!<Mask of Preamble Type bits                   */
+#define  SPDIFRX_CR_CBDMAEN                  ((uint32_t)0x00000400)        /*!<Control Buffer DMA ENable for control flow   */
+#define  SPDIFRX_CR_CHSEL                    ((uint32_t)0x00000800)        /*!<Channel Selection                            */
+#define  SPDIFRX_CR_NBTR                     ((uint32_t)0x00003000)        /*!<Maximum allowed re-tries during synchronization phase */
+#define  SPDIFRX_CR_WFA                      ((uint32_t)0x00004000)        /*!<Wait For Activity     */
+#define  SPDIFRX_CR_INSEL                    ((uint32_t)0x00070000)        /*!<SPDIF input selection */
+
+/*******************  Bit definition for SPDIFRX_IMR register  *******************/
+#define  SPDIFRX_IMR_RXNEIE                   ((uint32_t)0x00000001)        /*!<RXNE interrupt enable                              */
+#define  SPDIFRX_IMR_CSRNEIE                  ((uint32_t)0x00000002)        /*!<Control Buffer Ready Interrupt Enable              */
+#define  SPDIFRX_IMR_PERRIE                   ((uint32_t)0x00000004)        /*!<Parity error interrupt enable                      */
+#define  SPDIFRX_IMR_OVRIE                    ((uint32_t)0x00000008)        /*!<Overrun error Interrupt Enable                     */
+#define  SPDIFRX_IMR_SBLKIE                   ((uint32_t)0x00000010)        /*!<Synchronization Block Detected Interrupt Enable    */
+#define  SPDIFRX_IMR_SYNCDIE                  ((uint32_t)0x00000020)        /*!<Synchronization Done                               */
+#define  SPDIFRX_IMR_IFEIE                    ((uint32_t)0x00000040)        /*!<Serial Interface Error Interrupt Enable            */
+
+/*******************  Bit definition for SPDIFRX_SR register  *******************/
+#define  SPDIFRX_SR_RXNE                   ((uint32_t)0x00000001)       /*!<Read data register not empty                          */
+#define  SPDIFRX_SR_CSRNE                  ((uint32_t)0x00000002)       /*!<The Control Buffer register is not empty              */
+#define  SPDIFRX_SR_PERR                   ((uint32_t)0x00000004)       /*!<Parity error                                          */
+#define  SPDIFRX_SR_OVR                    ((uint32_t)0x00000008)       /*!<Overrun error                                         */
+#define  SPDIFRX_SR_SBD                    ((uint32_t)0x00000010)       /*!<Synchronization Block Detected                        */
+#define  SPDIFRX_SR_SYNCD                  ((uint32_t)0x00000020)       /*!<Synchronization Done                                  */
+#define  SPDIFRX_SR_FERR                   ((uint32_t)0x00000040)       /*!<Framing error                                         */
+#define  SPDIFRX_SR_SERR                   ((uint32_t)0x00000080)       /*!<Synchronization error                                 */
+#define  SPDIFRX_SR_TERR                   ((uint32_t)0x00000100)       /*!<Time-out error                                        */
+#define  SPDIFRX_SR_WIDTH5                 ((uint32_t)0x7FFF0000)       /*!<Duration of 5 symbols counted with spdif_clk          */
+
+/*******************  Bit definition for SPDIFRX_IFCR register  *******************/
+#define  SPDIFRX_IFCR_PERRCF               ((uint32_t)0x00000004)       /*!<Clears the Parity error flag                         */
+#define  SPDIFRX_IFCR_OVRCF                ((uint32_t)0x00000008)       /*!<Clears the Overrun error flag                        */
+#define  SPDIFRX_IFCR_SBDCF                ((uint32_t)0x00000010)       /*!<Clears the Synchronization Block Detected flag       */
+#define  SPDIFRX_IFCR_SYNCDCF              ((uint32_t)0x00000020)       /*!<Clears the Synchronization Done flag                 */
+
+/*******************  Bit definition for SPDIFRX_DR register  (DRFMT = 0b00 case) *******************/
+#define  SPDIFRX_DR0_DR                    ((uint32_t)0x00FFFFFF)        /*!<Data value            */
+#define  SPDIFRX_DR0_PE                    ((uint32_t)0x01000000)        /*!<Parity Error bit      */
+#define  SPDIFRX_DR0_V                     ((uint32_t)0x02000000)        /*!<Validity bit          */
+#define  SPDIFRX_DR0_U                     ((uint32_t)0x04000000)        /*!<User bit              */
+#define  SPDIFRX_DR0_C                     ((uint32_t)0x08000000)        /*!<Channel Status bit    */
+#define  SPDIFRX_DR0_PT                    ((uint32_t)0x30000000)        /*!<Preamble Type         */
+
+/*******************  Bit definition for SPDIFRX_DR register  (DRFMT = 0b01 case) *******************/
+#define  SPDIFRX_DR1_DR                    ((uint32_t)0xFFFFFF00)        /*!<Data value            */
+#define  SPDIFRX_DR1_PT                    ((uint32_t)0x00000030)        /*!<Preamble Type         */
+#define  SPDIFRX_DR1_C                     ((uint32_t)0x00000008)        /*!<Channel Status bit    */
+#define  SPDIFRX_DR1_U                     ((uint32_t)0x00000004)        /*!<User bit              */
+#define  SPDIFRX_DR1_V                     ((uint32_t)0x00000002)        /*!<Validity bit          */
+#define  SPDIFRX_DR1_PE                    ((uint32_t)0x00000001)        /*!<Parity Error bit      */
+
+/*******************  Bit definition for SPDIFRX_DR register  (DRFMT = 0b10 case) *******************/
+#define  SPDIFRX_DR1_DRNL1                 ((uint32_t)0xFFFF0000)        /*!<Data value Channel B      */
+#define  SPDIFRX_DR1_DRNL2                 ((uint32_t)0x0000FFFF)        /*!<Data value Channel A      */
+
+/*******************  Bit definition for SPDIFRX_CSR register   *******************/
+#define  SPDIFRX_CSR_USR                     ((uint32_t)0x0000FFFF)        /*!<User data information           */
+#define  SPDIFRX_CSR_CS                      ((uint32_t)0x00FF0000)        /*!<Channel A status information    */
+#define  SPDIFRX_CSR_SOB                     ((uint32_t)0x01000000)        /*!<Start Of Block                  */
+
+/*******************  Bit definition for SPDIFRX_DIR register    *******************/
+#define  SPDIFRX_DIR_THI                 ((uint32_t)0x000013FF)        /*!<Threshold LOW      */
+#define  SPDIFRX_DIR_TLO                 ((uint32_t)0x1FFF0000)        /*!<Threshold HIGH     */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          SD host Interface                                 */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for SDMMC_POWER register  ******************/
+#define  SDMMC_POWER_PWRCTRL                  ((uint32_t)0x03)               /*!<PWRCTRL[1:0] bits (Power supply control bits) */
+#define  SDMMC_POWER_PWRCTRL_0                ((uint32_t)0x01)               /*!<Bit 0 */
+#define  SDMMC_POWER_PWRCTRL_1                ((uint32_t)0x02)               /*!<Bit 1 */
+
+/******************  Bit definition for SDMMC_CLKCR register  ******************/
+#define  SDMMC_CLKCR_CLKDIV                   ((uint32_t)0x00FF)            /*!<Clock divide factor             */
+#define  SDMMC_CLKCR_CLKEN                    ((uint32_t)0x0100)            /*!<Clock enable bit                */
+#define  SDMMC_CLKCR_PWRSAV                   ((uint32_t)0x0200)            /*!<Power saving configuration bit  */
+#define  SDMMC_CLKCR_BYPASS                   ((uint32_t)0x0400)            /*!<Clock divider bypass enable bit */
+
+#define  SDMMC_CLKCR_WIDBUS                   ((uint32_t)0x1800)            /*!<WIDBUS[1:0] bits (Wide bus mode enable bit) */
+#define  SDMMC_CLKCR_WIDBUS_0                 ((uint32_t)0x0800)            /*!<Bit 0 */
+#define  SDMMC_CLKCR_WIDBUS_1                 ((uint32_t)0x1000)            /*!<Bit 1 */
+
+#define  SDMMC_CLKCR_NEGEDGE                  ((uint32_t)0x2000)            /*!<SDMMC_CK dephasing selection bit */
+#define  SDMMC_CLKCR_HWFC_EN                  ((uint32_t)0x4000)            /*!<HW Flow Control enable          */
+
+/*******************  Bit definition for SDMMC_ARG register  *******************/
+#define  SDMMC_ARG_CMDARG                     ((uint32_t)0xFFFFFFFF)            /*!<Command argument */
+
+/*******************  Bit definition for SDMMC_CMD register  *******************/
+#define  SDMMC_CMD_CMDINDEX                   ((uint32_t)0x003F)            /*!<Command Index                               */
+
+#define  SDMMC_CMD_WAITRESP                   ((uint32_t)0x00C0)            /*!<WAITRESP[1:0] bits (Wait for response bits) */
+#define  SDMMC_CMD_WAITRESP_0                 ((uint32_t)0x0040)            /*!< Bit 0 */
+#define  SDMMC_CMD_WAITRESP_1                 ((uint32_t)0x0080)            /*!< Bit 1 */
+
+#define  SDMMC_CMD_WAITINT                    ((uint32_t)0x0100)            /*!<CPSM Waits for Interrupt Request                               */
+#define  SDMMC_CMD_WAITPEND                   ((uint32_t)0x0200)            /*!<CPSM Waits for ends of data transfer (CmdPend internal signal) */
+#define  SDMMC_CMD_CPSMEN                     ((uint32_t)0x0400)            /*!<Command path state machine (CPSM) Enable bit                   */
+#define  SDMMC_CMD_SDIOSUSPEND                ((uint32_t)0x0800)            /*!<SD I/O suspend command                                         */
+
+/*****************  Bit definition for SDMMC_RESPCMD register  *****************/
+#define  SDMMC_RESPCMD_RESPCMD                ((uint32_t)0x3F)               /*!<Response command index */
+
+/******************  Bit definition for SDMMC_RESP0 register  ******************/
+#define  SDMMC_RESP0_CARDSTATUS0              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_RESP1 register  ******************/
+#define  SDMMC_RESP1_CARDSTATUS1              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_RESP2 register  ******************/
+#define  SDMMC_RESP2_CARDSTATUS2              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_RESP3 register  ******************/
+#define  SDMMC_RESP3_CARDSTATUS3              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_RESP4 register  ******************/
+#define  SDMMC_RESP4_CARDSTATUS4              ((uint32_t)0xFFFFFFFF)        /*!<Card Status */
+
+/******************  Bit definition for SDMMC_DTIMER register  *****************/
+#define  SDMMC_DTIMER_DATATIME                ((uint32_t)0xFFFFFFFF)        /*!<Data timeout period. */
+
+/******************  Bit definition for SDMMC_DLEN register  *******************/
+#define  SDMMC_DLEN_DATALENGTH                ((uint32_t)0x01FFFFFF)        /*!<Data length value    */
+
+/******************  Bit definition for SDMMC_DCTRL register  ******************/
+#define  SDMMC_DCTRL_DTEN                     ((uint32_t)0x0001)            /*!<Data transfer enabled bit         */
+#define  SDMMC_DCTRL_DTDIR                    ((uint32_t)0x0002)            /*!<Data transfer direction selection */
+#define  SDMMC_DCTRL_DTMODE                   ((uint32_t)0x0004)            /*!<Data transfer mode selection      */
+#define  SDMMC_DCTRL_DMAEN                    ((uint32_t)0x0008)            /*!<DMA enabled bit                   */
+
+#define  SDMMC_DCTRL_DBLOCKSIZE               ((uint32_t)0x00F0)            /*!<DBLOCKSIZE[3:0] bits (Data block size) */
+#define  SDMMC_DCTRL_DBLOCKSIZE_0             ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  SDMMC_DCTRL_DBLOCKSIZE_1             ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  SDMMC_DCTRL_DBLOCKSIZE_2             ((uint32_t)0x0040)            /*!<Bit 2 */
+#define  SDMMC_DCTRL_DBLOCKSIZE_3             ((uint32_t)0x0080)            /*!<Bit 3 */
+
+#define  SDMMC_DCTRL_RWSTART                  ((uint32_t)0x0100)            /*!<Read wait start         */
+#define  SDMMC_DCTRL_RWSTOP                   ((uint32_t)0x0200)            /*!<Read wait stop          */
+#define  SDMMC_DCTRL_RWMOD                    ((uint32_t)0x0400)            /*!<Read wait mode          */
+#define  SDMMC_DCTRL_SDIOEN                   ((uint32_t)0x0800)            /*!<SD I/O enable functions */
+
+/******************  Bit definition for SDMMC_DCOUNT register  *****************/
+#define  SDMMC_DCOUNT_DATACOUNT               ((uint32_t)0x01FFFFFF)        /*!<Data count value */
+
+/******************  Bit definition for SDMMC_STA register  ********************/
+#define  SDMMC_STA_CCRCFAIL                   ((uint32_t)0x00000001)        /*!<Command response received (CRC check failed)  */
+#define  SDMMC_STA_DCRCFAIL                   ((uint32_t)0x00000002)        /*!<Data block sent/received (CRC check failed)   */
+#define  SDMMC_STA_CTIMEOUT                   ((uint32_t)0x00000004)        /*!<Command response timeout                      */
+#define  SDMMC_STA_DTIMEOUT                   ((uint32_t)0x00000008)        /*!<Data timeout                                  */
+#define  SDMMC_STA_TXUNDERR                   ((uint32_t)0x00000010)        /*!<Transmit FIFO underrun error                  */
+#define  SDMMC_STA_RXOVERR                    ((uint32_t)0x00000020)        /*!<Received FIFO overrun error                   */
+#define  SDMMC_STA_CMDREND                    ((uint32_t)0x00000040)        /*!<Command response received (CRC check passed)  */
+#define  SDMMC_STA_CMDSENT                    ((uint32_t)0x00000080)        /*!<Command sent (no response required)           */
+#define  SDMMC_STA_DATAEND                    ((uint32_t)0x00000100)        /*!<Data end (data counter, SDIDCOUNT, is zero)   */
+#define  SDMMC_STA_DBCKEND                    ((uint32_t)0x00000400)        /*!<Data block sent/received (CRC check passed)   */
+#define  SDMMC_STA_CMDACT                     ((uint32_t)0x00000800)        /*!<Command transfer in progress                  */
+#define  SDMMC_STA_TXACT                      ((uint32_t)0x00001000)        /*!<Data transmit in progress                     */
+#define  SDMMC_STA_RXACT                      ((uint32_t)0x00002000)        /*!<Data receive in progress                      */
+#define  SDMMC_STA_TXFIFOHE                   ((uint32_t)0x00004000)        /*!<Transmit FIFO Half Empty: at least 8 words can be written into the FIFO */
+#define  SDMMC_STA_RXFIFOHF                   ((uint32_t)0x00008000)        /*!<Receive FIFO Half Full: there are at least 8 words in the FIFO */
+#define  SDMMC_STA_TXFIFOF                    ((uint32_t)0x00010000)        /*!<Transmit FIFO full                            */
+#define  SDMMC_STA_RXFIFOF                    ((uint32_t)0x00020000)        /*!<Receive FIFO full                             */
+#define  SDMMC_STA_TXFIFOE                    ((uint32_t)0x00040000)        /*!<Transmit FIFO empty                           */
+#define  SDMMC_STA_RXFIFOE                    ((uint32_t)0x00080000)        /*!<Receive FIFO empty                            */
+#define  SDMMC_STA_TXDAVL                     ((uint32_t)0x00100000)        /*!<Data available in transmit FIFO               */
+#define  SDMMC_STA_RXDAVL                     ((uint32_t)0x00200000)        /*!<Data available in receive FIFO                */
+#define  SDMMC_STA_SDIOIT                     ((uint32_t)0x00400000)        /*!<SDMMC interrupt received                       */
+
+/*******************  Bit definition for SDMMC_ICR register  *******************/
+#define  SDMMC_ICR_CCRCFAILC                  ((uint32_t)0x00000001)        /*!<CCRCFAIL flag clear bit */
+#define  SDMMC_ICR_DCRCFAILC                  ((uint32_t)0x00000002)        /*!<DCRCFAIL flag clear bit */
+#define  SDMMC_ICR_CTIMEOUTC                  ((uint32_t)0x00000004)        /*!<CTIMEOUT flag clear bit */
+#define  SDMMC_ICR_DTIMEOUTC                  ((uint32_t)0x00000008)        /*!<DTIMEOUT flag clear bit */
+#define  SDMMC_ICR_TXUNDERRC                  ((uint32_t)0x00000010)        /*!<TXUNDERR flag clear bit */
+#define  SDMMC_ICR_RXOVERRC                   ((uint32_t)0x00000020)        /*!<RXOVERR flag clear bit  */
+#define  SDMMC_ICR_CMDRENDC                   ((uint32_t)0x00000040)        /*!<CMDREND flag clear bit  */
+#define  SDMMC_ICR_CMDSENTC                   ((uint32_t)0x00000080)        /*!<CMDSENT flag clear bit  */
+#define  SDMMC_ICR_DATAENDC                   ((uint32_t)0x00000100)        /*!<DATAEND flag clear bit  */
+#define  SDMMC_ICR_DBCKENDC                   ((uint32_t)0x00000400)        /*!<DBCKEND flag clear bit  */
+#define  SDMMC_ICR_SDIOITC                    ((uint32_t)0x00400000)        /*!<SDMMCIT flag clear bit   */
+
+/******************  Bit definition for SDMMC_MASK register  *******************/
+#define  SDMMC_MASK_CCRCFAILIE                ((uint32_t)0x00000001)        /*!<Command CRC Fail Interrupt Enable          */
+#define  SDMMC_MASK_DCRCFAILIE                ((uint32_t)0x00000002)        /*!<Data CRC Fail Interrupt Enable             */
+#define  SDMMC_MASK_CTIMEOUTIE                ((uint32_t)0x00000004)        /*!<Command TimeOut Interrupt Enable           */
+#define  SDMMC_MASK_DTIMEOUTIE                ((uint32_t)0x00000008)        /*!<Data TimeOut Interrupt Enable              */
+#define  SDMMC_MASK_TXUNDERRIE                ((uint32_t)0x00000010)        /*!<Tx FIFO UnderRun Error Interrupt Enable    */
+#define  SDMMC_MASK_RXOVERRIE                 ((uint32_t)0x00000020)        /*!<Rx FIFO OverRun Error Interrupt Enable     */
+#define  SDMMC_MASK_CMDRENDIE                 ((uint32_t)0x00000040)        /*!<Command Response Received Interrupt Enable */
+#define  SDMMC_MASK_CMDSENTIE                 ((uint32_t)0x00000080)        /*!<Command Sent Interrupt Enable              */
+#define  SDMMC_MASK_DATAENDIE                 ((uint32_t)0x00000100)        /*!<Data End Interrupt Enable                  */
+#define  SDMMC_MASK_DBCKENDIE                 ((uint32_t)0x00000400)        /*!<Data Block End Interrupt Enable            */
+#define  SDMMC_MASK_CMDACTIE                  ((uint32_t)0x00000800)        /*!<CCommand Acting Interrupt Enable           */
+#define  SDMMC_MASK_TXACTIE                   ((uint32_t)0x00001000)        /*!<Data Transmit Acting Interrupt Enable      */
+#define  SDMMC_MASK_RXACTIE                   ((uint32_t)0x00002000)        /*!<Data receive acting interrupt enabled      */
+#define  SDMMC_MASK_TXFIFOHEIE                ((uint32_t)0x00004000)        /*!<Tx FIFO Half Empty interrupt Enable        */
+#define  SDMMC_MASK_RXFIFOHFIE                ((uint32_t)0x00008000)        /*!<Rx FIFO Half Full interrupt Enable         */
+#define  SDMMC_MASK_TXFIFOFIE                 ((uint32_t)0x00010000)        /*!<Tx FIFO Full interrupt Enable              */
+#define  SDMMC_MASK_RXFIFOFIE                 ((uint32_t)0x00020000)        /*!<Rx FIFO Full interrupt Enable              */
+#define  SDMMC_MASK_TXFIFOEIE                 ((uint32_t)0x00040000)        /*!<Tx FIFO Empty interrupt Enable             */
+#define  SDMMC_MASK_RXFIFOEIE                 ((uint32_t)0x00080000)        /*!<Rx FIFO Empty interrupt Enable             */
+#define  SDMMC_MASK_TXDAVLIE                  ((uint32_t)0x00100000)        /*!<Data available in Tx FIFO interrupt Enable */
+#define  SDMMC_MASK_RXDAVLIE                  ((uint32_t)0x00200000)        /*!<Data available in Rx FIFO interrupt Enable */
+#define  SDMMC_MASK_SDIOITIE                  ((uint32_t)0x00400000)        /*!<SDMMC Mode Interrupt Received interrupt Enable */
+
+/*****************  Bit definition for SDMMC_FIFOCNT register  *****************/
+#define  SDMMC_FIFOCNT_FIFOCOUNT              ((uint32_t)0x00FFFFFF)        /*!<Remaining number of words to be written to or read from the FIFO */
+
+/******************  Bit definition for SDMMC_FIFO register  *******************/
+#define  SDMMC_FIFO_FIFODATA                  ((uint32_t)0xFFFFFFFF)        /*!<Receive and transmit FIFO data */
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Serial Peripheral Interface (SPI)                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for SPI_CR1 register  ********************/
+#define  SPI_CR1_CPHA                        ((uint32_t)0x00000001)        /*!< Clock Phase                        */
+#define  SPI_CR1_CPOL                        ((uint32_t)0x00000002)        /*!< Clock Polarity                     */
+#define  SPI_CR1_MSTR                        ((uint32_t)0x00000004)        /*!< Master Selection                   */
+#define  SPI_CR1_BR                          ((uint32_t)0x00000038)        /*!< BR[2:0] bits (Baud Rate Control)   */
+#define  SPI_CR1_BR_0                        ((uint32_t)0x00000008)        /*!< Bit 0 */
+#define  SPI_CR1_BR_1                        ((uint32_t)0x00000010)        /*!< Bit 1 */
+#define  SPI_CR1_BR_2                        ((uint32_t)0x00000020)        /*!< Bit 2 */
+#define  SPI_CR1_SPE                         ((uint32_t)0x00000040)        /*!< SPI Enable                          */
+#define  SPI_CR1_LSBFIRST                    ((uint32_t)0x00000080)        /*!< Frame Format                        */
+#define  SPI_CR1_SSI                         ((uint32_t)0x00000100)        /*!< Internal slave select               */
+#define  SPI_CR1_SSM                         ((uint32_t)0x00000200)        /*!< Software slave management           */
+#define  SPI_CR1_RXONLY                      ((uint32_t)0x00000400)        /*!< Receive only                        */
+#define  SPI_CR1_CRCL                        ((uint32_t)0x00000800)        /*!< CRC Length                          */
+#define  SPI_CR1_CRCNEXT                     ((uint32_t)0x00001000)        /*!< Transmit CRC next                   */
+#define  SPI_CR1_CRCEN                       ((uint32_t)0x00002000)        /*!< Hardware CRC calculation enable     */
+#define  SPI_CR1_BIDIOE                      ((uint32_t)0x00004000)        /*!< Output enable in bidirectional mode */
+#define  SPI_CR1_BIDIMODE                    ((uint32_t)0x00008000)        /*!< Bidirectional data mode enable      */
+
+/*******************  Bit definition for SPI_CR2 register  ********************/
+#define  SPI_CR2_RXDMAEN                     ((uint32_t)0x00000001)        /*!< Rx Buffer DMA Enable                 */
+#define  SPI_CR2_TXDMAEN                     ((uint32_t)0x00000002)        /*!< Tx Buffer DMA Enable                 */
+#define  SPI_CR2_SSOE                        ((uint32_t)0x00000004)        /*!< SS Output Enable                     */
+#define  SPI_CR2_NSSP                        ((uint32_t)0x00000008)        /*!< NSS pulse management Enable          */
+#define  SPI_CR2_FRF                         ((uint32_t)0x00000010)        /*!< Frame Format Enable                  */
+#define  SPI_CR2_ERRIE                       ((uint32_t)0x00000020)        /*!< Error Interrupt Enable               */
+#define  SPI_CR2_RXNEIE                      ((uint32_t)0x00000040)        /*!< RX buffer Not Empty Interrupt Enable */
+#define  SPI_CR2_TXEIE                       ((uint32_t)0x00000080)        /*!< Tx buffer Empty Interrupt Enable     */
+#define  SPI_CR2_DS                          ((uint32_t)0x00000F00)        /*!< DS[3:0] Data Size                    */
+#define  SPI_CR2_DS_0                        ((uint32_t)0x00000100)        /*!< Bit 0 */
+#define  SPI_CR2_DS_1                        ((uint32_t)0x00000200)        /*!< Bit 1 */
+#define  SPI_CR2_DS_2                        ((uint32_t)0x00000400)        /*!< Bit 2 */
+#define  SPI_CR2_DS_3                        ((uint32_t)0x00000800)        /*!< Bit 3 */
+#define  SPI_CR2_FRXTH                       ((uint32_t)0x00001000)        /*!< FIFO reception Threshold           */
+#define  SPI_CR2_LDMARX                      ((uint32_t)0x00002000)        /*!< Last DMA transfer for reception    */
+#define  SPI_CR2_LDMATX                      ((uint32_t)0x00004000)        /*!< Last DMA transfer for transmission */
+
+/********************  Bit definition for SPI_SR register  ********************/
+#define  SPI_SR_RXNE                         ((uint32_t)0x00000001)        /*!< Receive buffer Not Empty  */
+#define  SPI_SR_TXE                          ((uint32_t)0x00000002)        /*!< Transmit buffer Empty     */
+#define  SPI_SR_CHSIDE                       ((uint32_t)0x00000004)        /*!< Channel side              */
+#define  SPI_SR_UDR                          ((uint32_t)0x00000008)        /*!< Underrun flag             */
+#define  SPI_SR_CRCERR                       ((uint32_t)0x00000010)        /*!< CRC Error flag            */
+#define  SPI_SR_MODF                         ((uint32_t)0x00000020)        /*!< Mode fault                */
+#define  SPI_SR_OVR                          ((uint32_t)0x00000040)        /*!< Overrun flag              */
+#define  SPI_SR_BSY                          ((uint32_t)0x00000080)        /*!< Busy flag                 */
+#define  SPI_SR_FRE                          ((uint32_t)0x00000100)        /*!< TI frame format error     */
+#define  SPI_SR_FRLVL                        ((uint32_t)0x00000600)        /*!< FIFO Reception Level      */
+#define  SPI_SR_FRLVL_0                      ((uint32_t)0x00000200)        /*!< Bit 0 */
+#define  SPI_SR_FRLVL_1                      ((uint32_t)0x00000400)        /*!< Bit 1 */
+#define  SPI_SR_FTLVL                        ((uint32_t)0x00001800)        /*!< FIFO Transmission Level   */
+#define  SPI_SR_FTLVL_0                      ((uint32_t)0x00000800)        /*!< Bit 0 */
+#define  SPI_SR_FTLVL_1                      ((uint32_t)0x00001000)        /*!< Bit 1 */
+
+/********************  Bit definition for SPI_DR register  ********************/
+#define  SPI_DR_DR                           ((uint32_t)0xFFFF)            /*!< Data Register */
+
+/*******************  Bit definition for SPI_CRCPR register  ******************/
+#define  SPI_CRCPR_CRCPOLY                   ((uint32_t)0xFFFF)            /*!< CRC polynomial register */
+
+/******************  Bit definition for SPI_RXCRCR register  ******************/
+#define  SPI_RXCRCR_RXCRC                    ((uint32_t)0xFFFF)            /*!< Rx CRC Register */
+
+/******************  Bit definition for SPI_TXCRCR register  ******************/
+#define  SPI_TXCRCR_TXCRC                    ((uint32_t)0xFFFF)            /*!< Tx CRC Register */
+
+/******************  Bit definition for SPI_I2SCFGR register  *****************/
+#define  SPI_I2SCFGR_CHLEN                   ((uint32_t)0x00000001)        /*!<Channel length (number of bits per audio channel) */
+#define  SPI_I2SCFGR_DATLEN                  ((uint32_t)0x00000006)        /*!<DATLEN[1:0] bits (Data length to be transferred)  */
+#define  SPI_I2SCFGR_DATLEN_0                ((uint32_t)0x00000002)        /*!<Bit 0 */
+#define  SPI_I2SCFGR_DATLEN_1                ((uint32_t)0x00000004)        /*!<Bit 1 */
+#define  SPI_I2SCFGR_CKPOL                   ((uint32_t)0x00000008)        /*!<steady state clock polarity                       */
+#define  SPI_I2SCFGR_I2SSTD                  ((uint32_t)0x00000030)        /*!<I2SSTD[1:0] bits (I2S standard selection)         */
+#define  SPI_I2SCFGR_I2SSTD_0                ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  SPI_I2SCFGR_I2SSTD_1                ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  SPI_I2SCFGR_PCMSYNC                 ((uint32_t)0x00000080)        /*!<PCM frame synchronization                         */
+#define  SPI_I2SCFGR_I2SCFG                  ((uint32_t)0x00000300)        /*!<I2SCFG[1:0] bits (I2S configuration mode)         */
+#define  SPI_I2SCFGR_I2SCFG_0                ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  SPI_I2SCFGR_I2SCFG_1                ((uint32_t)0x00000200)        /*!<Bit 1 */
+#define  SPI_I2SCFGR_I2SE                    ((uint32_t)0x00000400)        /*!<I2S Enable                                        */
+#define  SPI_I2SCFGR_I2SMOD                  ((uint32_t)0x00000800)        /*!<I2S mode selection                                */
+#define  SPI_I2SCFGR_ASTRTEN                 ((uint32_t)0x00001000)        /*!<Asynchronous start enable                        */
+
+/******************  Bit definition for SPI_I2SPR register  *******************/
+#define  SPI_I2SPR_I2SDIV                    ((uint32_t)0x00FF)            /*!<I2S Linear prescaler         */
+#define  SPI_I2SPR_ODD                       ((uint32_t)0x0100)            /*!<Odd factor for the prescaler */
+#define  SPI_I2SPR_MCKOE                     ((uint32_t)0x0200)            /*!<Master Clock Output Enable   */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 SYSCFG                                     */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for SYSCFG_MEMRMP register  ***************/
+#define SYSCFG_MEMRMP_MEM_BOOT          ((uint32_t)0x00000001) /*!< Boot information after Reset */
+
+#define SYSCFG_MEMRMP_SWP_FMC          ((uint32_t)0x00000C00) /*!< FMC Memory Mapping swapping */
+#define SYSCFG_MEMRMP_SWP_FMC_0        ((uint32_t)0x00000400)
+#define SYSCFG_MEMRMP_SWP_FMC_1        ((uint32_t)0x00000800)
+
+/******************  Bit definition for SYSCFG_PMC register  ******************/
+#define SYSCFG_PMC_ADCxDC2              ((uint32_t)0x00070000) /*!< Refer to AN4073 on how to use this bit  */
+#define SYSCFG_PMC_ADC1DC2              ((uint32_t)0x00010000) /*!< Refer to AN4073 on how to use this bit  */
+#define SYSCFG_PMC_ADC2DC2              ((uint32_t)0x00020000) /*!< Refer to AN4073 on how to use this bit  */
+#define SYSCFG_PMC_ADC3DC2              ((uint32_t)0x00040000) /*!< Refer to AN4073 on how to use this bit  */
+
+#define SYSCFG_PMC_MII_RMII_SEL         ((uint32_t)0x00800000) /*!<Ethernet PHY interface selection */
+
+/*****************  Bit definition for SYSCFG_EXTICR1 register  ***************/
+#define SYSCFG_EXTICR1_EXTI0            ((uint32_t)0x000F) /*!<EXTI 0 configuration */
+#define SYSCFG_EXTICR1_EXTI1            ((uint32_t)0x00F0) /*!<EXTI 1 configuration */
+#define SYSCFG_EXTICR1_EXTI2            ((uint32_t)0x0F00) /*!<EXTI 2 configuration */
+#define SYSCFG_EXTICR1_EXTI3            ((uint32_t)0xF000) /*!<EXTI 3 configuration */
+/**
+  * @brief   EXTI0 configuration
+  */
+#define SYSCFG_EXTICR1_EXTI0_PA         ((uint32_t)0x0000) /*!<PA[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PB         ((uint32_t)0x0001) /*!<PB[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PC         ((uint32_t)0x0002) /*!<PC[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PD         ((uint32_t)0x0003) /*!<PD[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PE         ((uint32_t)0x0004) /*!<PE[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PF         ((uint32_t)0x0005) /*!<PF[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PG         ((uint32_t)0x0006) /*!<PG[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PH         ((uint32_t)0x0007) /*!<PH[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PI         ((uint32_t)0x0008) /*!<PI[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PJ         ((uint32_t)0x0009) /*!<PJ[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PK         ((uint32_t)0x000A) /*!<PK[0] pin */
+
+/**
+  * @brief   EXTI1 configuration
+  */
+#define SYSCFG_EXTICR1_EXTI1_PA         ((uint32_t)0x0000) /*!<PA[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PB         ((uint32_t)0x0010) /*!<PB[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PC         ((uint32_t)0x0020) /*!<PC[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PD         ((uint32_t)0x0030) /*!<PD[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PE         ((uint32_t)0x0040) /*!<PE[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PF         ((uint32_t)0x0050) /*!<PF[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PG         ((uint32_t)0x0060) /*!<PG[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PH         ((uint32_t)0x0070) /*!<PH[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PI         ((uint32_t)0x0080) /*!<PI[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PJ         ((uint32_t)0x0090) /*!<PJ[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PK         ((uint32_t)0x00A0) /*!<PK[1] pin */
+
+/**
+  * @brief   EXTI2 configuration
+  */
+#define SYSCFG_EXTICR1_EXTI2_PA         ((uint32_t)0x0000) /*!<PA[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PB         ((uint32_t)0x0100) /*!<PB[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PC         ((uint32_t)0x0200) /*!<PC[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PD         ((uint32_t)0x0300) /*!<PD[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PE         ((uint32_t)0x0400) /*!<PE[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PF         ((uint32_t)0x0500) /*!<PF[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PG         ((uint32_t)0x0600) /*!<PG[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PH         ((uint32_t)0x0700) /*!<PH[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PI         ((uint32_t)0x0800) /*!<PI[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PJ         ((uint32_t)0x0900) /*!<PJ[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PK         ((uint32_t)0x0A00) /*!<PK[2] pin */
+
+/**
+  * @brief   EXTI3 configuration
+  */
+#define SYSCFG_EXTICR1_EXTI3_PA         ((uint32_t)0x0000) /*!<PA[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PB         ((uint32_t)0x1000) /*!<PB[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PC         ((uint32_t)0x2000) /*!<PC[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PD         ((uint32_t)0x3000) /*!<PD[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PE         ((uint32_t)0x4000) /*!<PE[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PF         ((uint32_t)0x5000) /*!<PF[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PG         ((uint32_t)0x6000) /*!<PG[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PH         ((uint32_t)0x7000) /*!<PH[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PI         ((uint32_t)0x8000) /*!<PI[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PJ         ((uint32_t)0x9000) /*!<PJ[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PK         ((uint32_t)0xA000) /*!<PK[3] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR2 register  ***************/
+#define SYSCFG_EXTICR2_EXTI4            ((uint32_t)0x000F) /*!<EXTI 4 configuration */
+#define SYSCFG_EXTICR2_EXTI5            ((uint32_t)0x00F0) /*!<EXTI 5 configuration */
+#define SYSCFG_EXTICR2_EXTI6            ((uint32_t)0x0F00) /*!<EXTI 6 configuration */
+#define SYSCFG_EXTICR2_EXTI7            ((uint32_t)0xF000) /*!<EXTI 7 configuration */
+/**
+  * @brief   EXTI4 configuration
+  */
+#define SYSCFG_EXTICR2_EXTI4_PA         ((uint32_t)0x0000) /*!<PA[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PB         ((uint32_t)0x0001) /*!<PB[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PC         ((uint32_t)0x0002) /*!<PC[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PD         ((uint32_t)0x0003) /*!<PD[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PE         ((uint32_t)0x0004) /*!<PE[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PF         ((uint32_t)0x0005) /*!<PF[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PG         ((uint32_t)0x0006) /*!<PG[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PH         ((uint32_t)0x0007) /*!<PH[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PI         ((uint32_t)0x0008) /*!<PI[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PJ         ((uint32_t)0x0009) /*!<PJ[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PK         ((uint32_t)0x000A) /*!<PK[4] pin */
+
+/**
+  * @brief   EXTI5 configuration
+  */
+#define SYSCFG_EXTICR2_EXTI5_PA         ((uint32_t)0x0000) /*!<PA[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PB         ((uint32_t)0x0010) /*!<PB[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PC         ((uint32_t)0x0020) /*!<PC[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PD         ((uint32_t)0x0030) /*!<PD[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PE         ((uint32_t)0x0040) /*!<PE[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PF         ((uint32_t)0x0050) /*!<PF[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PG         ((uint32_t)0x0060) /*!<PG[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PH         ((uint32_t)0x0070) /*!<PH[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PI         ((uint32_t)0x0080) /*!<PI[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PJ         ((uint32_t)0x0090) /*!<PJ[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PK         ((uint32_t)0x00A0) /*!<PK[5] pin */
+
+/**
+  * @brief   EXTI6 configuration
+  */
+#define SYSCFG_EXTICR2_EXTI6_PA         ((uint32_t)0x0000) /*!<PA[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PB         ((uint32_t)0x0100) /*!<PB[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PC         ((uint32_t)0x0200) /*!<PC[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PD         ((uint32_t)0x0300) /*!<PD[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PE         ((uint32_t)0x0400) /*!<PE[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PF         ((uint32_t)0x0500) /*!<PF[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PG         ((uint32_t)0x0600) /*!<PG[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PH         ((uint32_t)0x0700) /*!<PH[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PI         ((uint32_t)0x0800) /*!<PI[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PJ         ((uint32_t)0x0900) /*!<PJ[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PK         ((uint32_t)0x0A00) /*!<PK[6] pin */
+
+/**
+  * @brief   EXTI7 configuration
+  */
+#define SYSCFG_EXTICR2_EXTI7_PA         ((uint32_t)0x0000) /*!<PA[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PB         ((uint32_t)0x1000) /*!<PB[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PC         ((uint32_t)0x2000) /*!<PC[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PD         ((uint32_t)0x3000) /*!<PD[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PE         ((uint32_t)0x4000) /*!<PE[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PF         ((uint32_t)0x5000) /*!<PF[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PG         ((uint32_t)0x6000) /*!<PG[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PH         ((uint32_t)0x7000) /*!<PH[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PI         ((uint32_t)0x8000) /*!<PI[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PJ         ((uint32_t)0x9000) /*!<PJ[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PK         ((uint32_t)0xA000) /*!<PK[7] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR3 register  ***************/
+#define SYSCFG_EXTICR3_EXTI8            ((uint32_t)0x000F) /*!<EXTI 8 configuration */
+#define SYSCFG_EXTICR3_EXTI9            ((uint32_t)0x00F0) /*!<EXTI 9 configuration */
+#define SYSCFG_EXTICR3_EXTI10           ((uint32_t)0x0F00) /*!<EXTI 10 configuration */
+#define SYSCFG_EXTICR3_EXTI11           ((uint32_t)0xF000) /*!<EXTI 11 configuration */
+
+/**
+  * @brief   EXTI8 configuration
+  */
+#define SYSCFG_EXTICR3_EXTI8_PA         ((uint32_t)0x0000) /*!<PA[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PB         ((uint32_t)0x0001) /*!<PB[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PC         ((uint32_t)0x0002) /*!<PC[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PD         ((uint32_t)0x0003) /*!<PD[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PE         ((uint32_t)0x0004) /*!<PE[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PF         ((uint32_t)0x0005) /*!<PF[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PG         ((uint32_t)0x0006) /*!<PG[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PH         ((uint32_t)0x0007) /*!<PH[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PI         ((uint32_t)0x0008) /*!<PI[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PJ         ((uint32_t)0x0009) /*!<PJ[8] pin */
+
+/**
+  * @brief   EXTI9 configuration
+  */
+#define SYSCFG_EXTICR3_EXTI9_PA         ((uint32_t)0x0000) /*!<PA[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PB         ((uint32_t)0x0010) /*!<PB[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PC         ((uint32_t)0x0020) /*!<PC[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PD         ((uint32_t)0x0030) /*!<PD[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PE         ((uint32_t)0x0040) /*!<PE[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PF         ((uint32_t)0x0050) /*!<PF[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PG         ((uint32_t)0x0060) /*!<PG[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PH         ((uint32_t)0x0070) /*!<PH[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PI         ((uint32_t)0x0080) /*!<PI[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PJ         ((uint32_t)0x0090) /*!<PJ[9] pin */
+
+/**
+  * @brief   EXTI10 configuration
+  */
+#define SYSCFG_EXTICR3_EXTI10_PA        ((uint32_t)0x0000) /*!<PA[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PB        ((uint32_t)0x0100) /*!<PB[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PC        ((uint32_t)0x0200) /*!<PC[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PD        ((uint32_t)0x0300) /*!<PD[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PE        ((uint32_t)0x0400) /*!<PE[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PF        ((uint32_t)0x0500) /*!<PF[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PG        ((uint32_t)0x0600) /*!<PG[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PH        ((uint32_t)0x0700) /*!<PH[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PI        ((uint32_t)0x0800) /*!<PI[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PJ        ((uint32_t)0x0900) /*!<PJ[10] pin */
+
+/**
+  * @brief   EXTI11 configuration
+  */
+#define SYSCFG_EXTICR3_EXTI11_PA        ((uint32_t)0x0000) /*!<PA[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PB        ((uint32_t)0x1000) /*!<PB[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PC        ((uint32_t)0x2000) /*!<PC[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PD        ((uint32_t)0x3000) /*!<PD[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PE        ((uint32_t)0x4000) /*!<PE[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PF        ((uint32_t)0x5000) /*!<PF[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PG        ((uint32_t)0x6000) /*!<PG[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PH        ((uint32_t)0x7000) /*!<PH[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PI        ((uint32_t)0x8000) /*!<PI[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PJ        ((uint32_t)0x9000) /*!<PJ[11] pin */
+
+
+/*****************  Bit definition for SYSCFG_EXTICR4 register  ***************/
+#define SYSCFG_EXTICR4_EXTI12           ((uint32_t)0x000F) /*!<EXTI 12 configuration */
+#define SYSCFG_EXTICR4_EXTI13           ((uint32_t)0x00F0) /*!<EXTI 13 configuration */
+#define SYSCFG_EXTICR4_EXTI14           ((uint32_t)0x0F00) /*!<EXTI 14 configuration */
+#define SYSCFG_EXTICR4_EXTI15           ((uint32_t)0xF000) /*!<EXTI 15 configuration */
+/**
+  * @brief   EXTI12 configuration
+  */
+#define SYSCFG_EXTICR4_EXTI12_PA        ((uint32_t)0x0000) /*!<PA[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PB        ((uint32_t)0x0001) /*!<PB[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PC        ((uint32_t)0x0002) /*!<PC[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PD        ((uint32_t)0x0003) /*!<PD[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PE        ((uint32_t)0x0004) /*!<PE[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PF        ((uint32_t)0x0005) /*!<PF[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PG        ((uint32_t)0x0006) /*!<PG[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PH        ((uint32_t)0x0007) /*!<PH[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PI        ((uint32_t)0x0008) /*!<PI[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PJ        ((uint32_t)0x0009) /*!<PJ[12] pin */
+
+/**
+  * @brief   EXTI13 configuration
+  */
+#define SYSCFG_EXTICR4_EXTI13_PA        ((uint32_t)0x0000) /*!<PA[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PB        ((uint32_t)0x0010) /*!<PB[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PC        ((uint32_t)0x0020) /*!<PC[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PD        ((uint32_t)0x0030) /*!<PD[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PE        ((uint32_t)0x0040) /*!<PE[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PF        ((uint32_t)0x0050) /*!<PF[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PG        ((uint32_t)0x0060) /*!<PG[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PH        ((uint32_t)0x0070) /*!<PH[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PI        ((uint32_t)0x0008) /*!<PI[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PJ        ((uint32_t)0x0009) /*!<PJ[13] pin */
+
+/**
+  * @brief   EXTI14 configuration
+  */
+#define SYSCFG_EXTICR4_EXTI14_PA        ((uint32_t)0x0000) /*!<PA[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PB        ((uint32_t)0x0100) /*!<PB[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PC        ((uint32_t)0x0200) /*!<PC[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PD        ((uint32_t)0x0300) /*!<PD[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PE        ((uint32_t)0x0400) /*!<PE[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PF        ((uint32_t)0x0500) /*!<PF[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PG        ((uint32_t)0x0600) /*!<PG[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PH        ((uint32_t)0x0700) /*!<PH[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PI        ((uint32_t)0x0800) /*!<PI[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PJ        ((uint32_t)0x0900) /*!<PJ[14] pin */
+
+/**
+  * @brief   EXTI15 configuration
+  */
+#define SYSCFG_EXTICR4_EXTI15_PA        ((uint32_t)0x0000) /*!<PA[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PB        ((uint32_t)0x1000) /*!<PB[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PC        ((uint32_t)0x2000) /*!<PC[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PD        ((uint32_t)0x3000) /*!<PD[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PE        ((uint32_t)0x4000) /*!<PE[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PF        ((uint32_t)0x5000) /*!<PF[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PG        ((uint32_t)0x6000) /*!<PG[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PH        ((uint32_t)0x7000) /*!<PH[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PI        ((uint32_t)0x8000) /*!<PI[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PJ        ((uint32_t)0x9000) /*!<PJ[15] pin */
+
+/******************  Bit definition for SYSCFG_CMPCR register  ****************/
+#define SYSCFG_CMPCR_CMP_PD             ((uint32_t)0x00000001) /*!<Compensation cell power-down */
+#define SYSCFG_CMPCR_READY              ((uint32_t)0x00000100) /*!<Compensation cell ready flag*/
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    TIM                                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TIM_CR1 register  ********************/
+#define  TIM_CR1_CEN                         ((uint32_t)0x0001)            /*!<Counter enable        */
+#define  TIM_CR1_UDIS                        ((uint32_t)0x0002)            /*!<Update disable        */
+#define  TIM_CR1_URS                         ((uint32_t)0x0004)            /*!<Update request source */
+#define  TIM_CR1_OPM                         ((uint32_t)0x0008)            /*!<One pulse mode        */
+#define  TIM_CR1_DIR                         ((uint32_t)0x0010)            /*!<Direction             */
+
+#define  TIM_CR1_CMS                         ((uint32_t)0x0060)            /*!<CMS[1:0] bits (Center-aligned mode selection) */
+#define  TIM_CR1_CMS_0                       ((uint32_t)0x0020)            /*!<Bit 0 */
+#define  TIM_CR1_CMS_1                       ((uint32_t)0x0040)            /*!<Bit 1 */
+
+#define  TIM_CR1_ARPE                        ((uint32_t)0x0080)            /*!<Auto-reload preload enable     */
+
+#define  TIM_CR1_CKD                         ((uint32_t)0x0300)            /*!<CKD[1:0] bits (clock division) */
+#define  TIM_CR1_CKD_0                       ((uint32_t)0x0100)            /*!<Bit 0 */
+#define  TIM_CR1_CKD_1                       ((uint32_t)0x0200)            /*!<Bit 1 */
+#define  TIM_CR1_UIFREMAP                    ((uint32_t)0x0800)            /*!<UIF status bit */
+
+/*******************  Bit definition for TIM_CR2 register  ********************/
+#define  TIM_CR2_CCPC                        ((uint32_t)0x00000001)            /*!<Capture/Compare Preloaded Control        */
+#define  TIM_CR2_CCUS                        ((uint32_t)0x00000004)            /*!<Capture/Compare Control Update Selection */
+#define  TIM_CR2_CCDS                        ((uint32_t)0x00000008)            /*!<Capture/Compare DMA Selection            */
+
+#define  TIM_CR2_OIS5                        ((uint32_t)0x00010000)            /*!<Output Idle state 4 (OC4 output) */
+#define  TIM_CR2_OIS6                        ((uint32_t)0x00040000)            /*!<Output Idle state 4 (OC4 output) */
+
+#define  TIM_CR2_MMS                         ((uint32_t)0x0070)            /*!<MMS[2:0] bits (Master Mode Selection) */
+#define  TIM_CR2_MMS_0                       ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  TIM_CR2_MMS_1                       ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  TIM_CR2_MMS_2                       ((uint32_t)0x0040)            /*!<Bit 2 */
+
+#define  TIM_CR2_MMS2                        ((uint32_t)0x00F00000)            /*!<MMS[2:0] bits (Master Mode Selection) */
+#define  TIM_CR2_MMS2_0                      ((uint32_t)0x00100000)            /*!<Bit 0 */
+#define  TIM_CR2_MMS2_1                      ((uint32_t)0x00200000)            /*!<Bit 1 */
+#define  TIM_CR2_MMS2_2                      ((uint32_t)0x00400000)            /*!<Bit 2 */
+#define  TIM_CR2_MMS2_3                      ((uint32_t)0x00800000)            /*!<Bit 2 */
+
+#define  TIM_CR2_TI1S                        ((uint32_t)0x0080)            /*!<TI1 Selection */
+#define  TIM_CR2_OIS1                        ((uint32_t)0x0100)            /*!<Output Idle state 1 (OC1 output)  */
+#define  TIM_CR2_OIS1N                       ((uint32_t)0x0200)            /*!<Output Idle state 1 (OC1N output) */
+#define  TIM_CR2_OIS2                        ((uint32_t)0x0400)            /*!<Output Idle state 2 (OC2 output)  */
+#define  TIM_CR2_OIS2N                       ((uint32_t)0x0800)            /*!<Output Idle state 2 (OC2N output) */
+#define  TIM_CR2_OIS3                        ((uint32_t)0x1000)            /*!<Output Idle state 3 (OC3 output)  */
+#define  TIM_CR2_OIS3N                       ((uint32_t)0x2000)            /*!<Output Idle state 3 (OC3N output) */
+#define  TIM_CR2_OIS4                        ((uint32_t)0x4000)            /*!<Output Idle state 4 (OC4 output)  */
+
+/*******************  Bit definition for TIM_SMCR register  *******************/
+#define  TIM_SMCR_SMS                        ((uint32_t)0x00010007)            /*!<SMS[2:0] bits (Slave mode selection)    */
+#define  TIM_SMCR_SMS_0                      ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_SMCR_SMS_1                      ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define  TIM_SMCR_SMS_2                      ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define  TIM_SMCR_SMS_3                      ((uint32_t)0x00010000)            /*!<Bit 3 */
+#define  TIM_SMCR_OCCS                       ((uint32_t)0x00000008)            /*!< OCREF clear selection */
+
+#define  TIM_SMCR_TS                         ((uint32_t)0x0070)            /*!<TS[2:0] bits (Trigger selection)        */
+#define  TIM_SMCR_TS_0                       ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  TIM_SMCR_TS_1                       ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  TIM_SMCR_TS_2                       ((uint32_t)0x0040)            /*!<Bit 2 */
+
+#define  TIM_SMCR_MSM                        ((uint32_t)0x0080)            /*!<Master/slave mode                       */
+
+#define  TIM_SMCR_ETF                        ((uint32_t)0x0F00)            /*!<ETF[3:0] bits (External trigger filter) */
+#define  TIM_SMCR_ETF_0                      ((uint32_t)0x0100)            /*!<Bit 0 */
+#define  TIM_SMCR_ETF_1                      ((uint32_t)0x0200)            /*!<Bit 1 */
+#define  TIM_SMCR_ETF_2                      ((uint32_t)0x0400)            /*!<Bit 2 */
+#define  TIM_SMCR_ETF_3                      ((uint32_t)0x0800)            /*!<Bit 3 */
+
+#define  TIM_SMCR_ETPS                       ((uint32_t)0x3000)            /*!<ETPS[1:0] bits (External trigger prescaler) */
+#define  TIM_SMCR_ETPS_0                     ((uint32_t)0x1000)            /*!<Bit 0 */
+#define  TIM_SMCR_ETPS_1                     ((uint32_t)0x2000)            /*!<Bit 1 */
+
+
+#define  TIM_SMCR_ECE                        ((uint32_t)0x4000)            /*!<External clock enable     */
+#define  TIM_SMCR_ETP                        ((uint32_t)0x8000)            /*!<External trigger polarity */
+
+/*******************  Bit definition for TIM_DIER register  *******************/
+#define  TIM_DIER_UIE                        ((uint32_t)0x0001)            /*!<Update interrupt enable */
+#define  TIM_DIER_CC1IE                      ((uint32_t)0x0002)            /*!<Capture/Compare 1 interrupt enable   */
+#define  TIM_DIER_CC2IE                      ((uint32_t)0x0004)            /*!<Capture/Compare 2 interrupt enable   */
+#define  TIM_DIER_CC3IE                      ((uint32_t)0x0008)            /*!<Capture/Compare 3 interrupt enable   */
+#define  TIM_DIER_CC4IE                      ((uint32_t)0x0010)            /*!<Capture/Compare 4 interrupt enable   */
+#define  TIM_DIER_COMIE                      ((uint32_t)0x0020)            /*!<COM interrupt enable                 */
+#define  TIM_DIER_TIE                        ((uint32_t)0x0040)            /*!<Trigger interrupt enable             */
+#define  TIM_DIER_BIE                        ((uint32_t)0x0080)            /*!<Break interrupt enable               */
+#define  TIM_DIER_UDE                        ((uint32_t)0x0100)            /*!<Update DMA request enable            */
+#define  TIM_DIER_CC1DE                      ((uint32_t)0x0200)            /*!<Capture/Compare 1 DMA request enable */
+#define  TIM_DIER_CC2DE                      ((uint32_t)0x0400)            /*!<Capture/Compare 2 DMA request enable */
+#define  TIM_DIER_CC3DE                      ((uint32_t)0x0800)            /*!<Capture/Compare 3 DMA request enable */
+#define  TIM_DIER_CC4DE                      ((uint32_t)0x1000)            /*!<Capture/Compare 4 DMA request enable */
+#define  TIM_DIER_COMDE                      ((uint32_t)0x2000)            /*!<COM DMA request enable               */
+#define  TIM_DIER_TDE                        ((uint32_t)0x4000)            /*!<Trigger DMA request enable           */
+
+/********************  Bit definition for TIM_SR register  ********************/
+#define  TIM_SR_UIF                          ((uint32_t)0x0001)            /*!<Update interrupt Flag              */
+#define  TIM_SR_CC1IF                        ((uint32_t)0x0002)            /*!<Capture/Compare 1 interrupt Flag   */
+#define  TIM_SR_CC2IF                        ((uint32_t)0x0004)            /*!<Capture/Compare 2 interrupt Flag   */
+#define  TIM_SR_CC3IF                        ((uint32_t)0x0008)            /*!<Capture/Compare 3 interrupt Flag   */
+#define  TIM_SR_CC4IF                        ((uint32_t)0x0010)            /*!<Capture/Compare 4 interrupt Flag   */
+#define  TIM_SR_COMIF                        ((uint32_t)0x0020)            /*!<COM interrupt Flag                 */
+#define  TIM_SR_TIF                          ((uint32_t)0x0040)            /*!<Trigger interrupt Flag             */
+#define  TIM_SR_BIF                          ((uint32_t)0x0080)            /*!<Break interrupt Flag               */
+#define  TIM_SR_B2IF                         ((uint32_t)0x0100)            /*!<Break2 interrupt Flag               */
+#define  TIM_SR_CC1OF                        ((uint32_t)0x0200)            /*!<Capture/Compare 1 Overcapture Flag */
+#define  TIM_SR_CC2OF                        ((uint32_t)0x0400)            /*!<Capture/Compare 2 Overcapture Flag */
+#define  TIM_SR_CC3OF                        ((uint32_t)0x0800)            /*!<Capture/Compare 3 Overcapture Flag */
+#define  TIM_SR_CC4OF                        ((uint32_t)0x1000)            /*!<Capture/Compare 4 Overcapture Flag */
+
+/*******************  Bit definition for TIM_EGR register  ********************/
+#define  TIM_EGR_UG                          ((uint32_t)0x00000001)               /*!<Update Generation                         */
+#define  TIM_EGR_CC1G                        ((uint32_t)0x00000002)               /*!<Capture/Compare 1 Generation              */
+#define  TIM_EGR_CC2G                        ((uint32_t)0x00000004)               /*!<Capture/Compare 2 Generation              */
+#define  TIM_EGR_CC3G                        ((uint32_t)0x00000008)               /*!<Capture/Compare 3 Generation              */
+#define  TIM_EGR_CC4G                        ((uint32_t)0x00000010)               /*!<Capture/Compare 4 Generation              */
+#define  TIM_EGR_COMG                        ((uint32_t)0x00000020)               /*!<Capture/Compare Control Update Generation */
+#define  TIM_EGR_TG                          ((uint32_t)0x00000040)               /*!<Trigger Generation                        */
+#define  TIM_EGR_BG                          ((uint32_t)0x00000080)               /*!<Break Generation                          */
+#define  TIM_EGR_B2G                         ((uint32_t)0x00000100)              /*!<Break2 Generation                          */
+
+/******************  Bit definition for TIM_CCMR1 register  *******************/
+#define  TIM_CCMR1_CC1S                      ((uint32_t)0x00000003)            /*!<CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define  TIM_CCMR1_CC1S_0                    ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_CCMR1_CC1S_1                    ((uint32_t)0x00000002)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_OC1FE                     ((uint32_t)0x00000004)            /*!<Output Compare 1 Fast enable                 */
+#define  TIM_CCMR1_OC1PE                     ((uint32_t)0x00000008)            /*!<Output Compare 1 Preload enable              */
+
+#define  TIM_CCMR1_OC1M                      ((uint32_t)0x00010070)            /*!<OC1M[2:0] bits (Output Compare 1 Mode)       */
+#define  TIM_CCMR1_OC1M_0                    ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  TIM_CCMR1_OC1M_1                    ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  TIM_CCMR1_OC1M_2                    ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define  TIM_CCMR1_OC1M_3                    ((uint32_t)0x00010000)            /*!<Bit 3 */
+
+#define  TIM_CCMR1_OC1CE                     ((uint32_t)0x00000080)            /*!<Output Compare 1Clear Enable                 */
+
+#define  TIM_CCMR1_CC2S                      ((uint32_t)0x00000300)            /*!<CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define  TIM_CCMR1_CC2S_0                    ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  TIM_CCMR1_CC2S_1                    ((uint32_t)0x00000200)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_OC2FE                     ((uint32_t)0x00000400)            /*!<Output Compare 2 Fast enable                 */
+#define  TIM_CCMR1_OC2PE                     ((uint32_t)0x00000800)            /*!<Output Compare 2 Preload enable              */
+
+#define  TIM_CCMR1_OC2M                      ((uint32_t)0x01007000)            /*!<OC2M[2:0] bits (Output Compare 2 Mode)       */
+#define  TIM_CCMR1_OC2M_0                    ((uint32_t)0x00001000)            /*!<Bit 0 */
+#define  TIM_CCMR1_OC2M_1                    ((uint32_t)0x00002000)            /*!<Bit 1 */
+#define  TIM_CCMR1_OC2M_2                    ((uint32_t)0x00004000)            /*!<Bit 2 */
+#define  TIM_CCMR1_OC2M_3                    ((uint32_t)0x01000000)            /*!<Bit 3 */
+
+#define  TIM_CCMR1_OC2CE                     ((uint32_t)0x00008000)            /*!<Output Compare 2 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+
+#define  TIM_CCMR1_IC1PSC                    ((uint32_t)0x000C)            /*!<IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define  TIM_CCMR1_IC1PSC_0                  ((uint32_t)0x0004)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC1PSC_1                  ((uint32_t)0x0008)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_IC1F                      ((uint32_t)0x00F0)            /*!<IC1F[3:0] bits (Input Capture 1 Filter)      */
+#define  TIM_CCMR1_IC1F_0                    ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC1F_1                    ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  TIM_CCMR1_IC1F_2                    ((uint32_t)0x0040)            /*!<Bit 2 */
+#define  TIM_CCMR1_IC1F_3                    ((uint32_t)0x0080)            /*!<Bit 3 */
+
+#define  TIM_CCMR1_IC2PSC                    ((uint32_t)0x0C00)            /*!<IC2PSC[1:0] bits (Input Capture 2 Prescaler)  */
+#define  TIM_CCMR1_IC2PSC_0                  ((uint32_t)0x0400)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC2PSC_1                  ((uint32_t)0x0800)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_IC2F                      ((uint32_t)0xF000)            /*!<IC2F[3:0] bits (Input Capture 2 Filter)       */
+#define  TIM_CCMR1_IC2F_0                    ((uint32_t)0x1000)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC2F_1                    ((uint32_t)0x2000)            /*!<Bit 1 */
+#define  TIM_CCMR1_IC2F_2                    ((uint32_t)0x4000)            /*!<Bit 2 */
+#define  TIM_CCMR1_IC2F_3                    ((uint32_t)0x8000)            /*!<Bit 3 */
+
+/******************  Bit definition for TIM_CCMR2 register  *******************/
+#define  TIM_CCMR2_CC3S                      ((uint32_t)0x00000003)        /*!<CC3S[1:0] bits (Capture/Compare 3 Selection)  */
+#define  TIM_CCMR2_CC3S_0                    ((uint32_t)0x00000001)        /*!<Bit 0 */
+#define  TIM_CCMR2_CC3S_1                    ((uint32_t)0x00000002)        /*!<Bit 1 */
+
+#define  TIM_CCMR2_OC3FE                     ((uint32_t)0x00000004)        /*!<Output Compare 3 Fast enable           */
+#define  TIM_CCMR2_OC3PE                     ((uint32_t)0x00000008)        /*!<Output Compare 3 Preload enable        */
+
+#define  TIM_CCMR2_OC3M                      ((uint32_t)0x00010070)        /*!<OC3M[2:0] bits (Output Compare 3 Mode) */
+#define  TIM_CCMR2_OC3M_0                    ((uint32_t)0x00000010)        /*!<Bit 0 */
+#define  TIM_CCMR2_OC3M_1                    ((uint32_t)0x00000020)        /*!<Bit 1 */
+#define  TIM_CCMR2_OC3M_2                    ((uint32_t)0x00000040)        /*!<Bit 2 */
+#define  TIM_CCMR2_OC3M_3                    ((uint32_t)0x00010000)        /*!<Bit 3 */
+
+
+
+#define  TIM_CCMR2_OC3CE                     ((uint32_t)0x00000080)        /*!<Output Compare 3 Clear Enable */
+
+#define  TIM_CCMR2_CC4S                      ((uint32_t)0x00000300)        /*!<CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define  TIM_CCMR2_CC4S_0                    ((uint32_t)0x00000100)        /*!<Bit 0 */
+#define  TIM_CCMR2_CC4S_1                    ((uint32_t)0x00000200)        /*!<Bit 1 */
+
+#define  TIM_CCMR2_OC4FE                     ((uint32_t)0x00000400)        /*!<Output Compare 4 Fast enable    */
+#define  TIM_CCMR2_OC4PE                     ((uint32_t)0x00000800)        /*!<Output Compare 4 Preload enable */
+
+#define  TIM_CCMR2_OC4M                      ((uint32_t)0x01007000)        /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define  TIM_CCMR2_OC4M_0                    ((uint32_t)0x00001000)        /*!<Bit 0 */
+#define  TIM_CCMR2_OC4M_1                    ((uint32_t)0x00002000)        /*!<Bit 1 */
+#define  TIM_CCMR2_OC4M_2                    ((uint32_t)0x00004000)        /*!<Bit 2 */
+#define  TIM_CCMR2_OC4M_3                    ((uint32_t)0x01000000)        /*!<Bit 3 */
+
+#define  TIM_CCMR2_OC4CE                     ((uint32_t)0x8000)            /*!<Output Compare 4 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+
+#define  TIM_CCMR2_IC3PSC                    ((uint32_t)0x000C)            /*!<IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define  TIM_CCMR2_IC3PSC_0                  ((uint32_t)0x0004)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC3PSC_1                  ((uint32_t)0x0008)            /*!<Bit 1 */
+
+#define  TIM_CCMR2_IC3F                      ((uint32_t)0x00F0)            /*!<IC3F[3:0] bits (Input Capture 3 Filter) */
+#define  TIM_CCMR2_IC3F_0                    ((uint32_t)0x0010)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC3F_1                    ((uint32_t)0x0020)            /*!<Bit 1 */
+#define  TIM_CCMR2_IC3F_2                    ((uint32_t)0x0040)            /*!<Bit 2 */
+#define  TIM_CCMR2_IC3F_3                    ((uint32_t)0x0080)            /*!<Bit 3 */
+
+#define  TIM_CCMR2_IC4PSC                    ((uint32_t)0x0C00)            /*!<IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define  TIM_CCMR2_IC4PSC_0                  ((uint32_t)0x0400)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC4PSC_1                  ((uint32_t)0x0800)            /*!<Bit 1 */
+
+#define  TIM_CCMR2_IC4F                      ((uint32_t)0xF000)            /*!<IC4F[3:0] bits (Input Capture 4 Filter) */
+#define  TIM_CCMR2_IC4F_0                    ((uint32_t)0x1000)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC4F_1                    ((uint32_t)0x2000)            /*!<Bit 1 */
+#define  TIM_CCMR2_IC4F_2                    ((uint32_t)0x4000)            /*!<Bit 2 */
+#define  TIM_CCMR2_IC4F_3                    ((uint32_t)0x8000)            /*!<Bit 3 */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define  TIM_CCER_CC1E                       ((uint32_t)0x00000001)            /*!<Capture/Compare 1 output enable */
+#define  TIM_CCER_CC1P                       ((uint32_t)0x00000002)            /*!<Capture/Compare 1 output Polarity */
+#define  TIM_CCER_CC1NE                      ((uint32_t)0x00000004)            /*!<Capture/Compare 1 Complementary output enable */
+#define  TIM_CCER_CC1NP                      ((uint32_t)0x00000008)            /*!<Capture/Compare 1 Complementary output Polarity */
+#define  TIM_CCER_CC2E                       ((uint32_t)0x00000010)            /*!<Capture/Compare 2 output enable */
+#define  TIM_CCER_CC2P                       ((uint32_t)0x00000020)            /*!<Capture/Compare 2 output Polarity */
+#define  TIM_CCER_CC2NE                      ((uint32_t)0x00000040)            /*!<Capture/Compare 2 Complementary output enable */
+#define  TIM_CCER_CC2NP                      ((uint32_t)0x00000080)            /*!<Capture/Compare 2 Complementary output Polarity */
+#define  TIM_CCER_CC3E                       ((uint32_t)0x00000100)            /*!<Capture/Compare 3 output enable */
+#define  TIM_CCER_CC3P                       ((uint32_t)0x00000200)            /*!<Capture/Compare 3 output Polarity */
+#define  TIM_CCER_CC3NE                      ((uint32_t)0x00000400)            /*!<Capture/Compare 3 Complementary output enable */
+#define  TIM_CCER_CC3NP                      ((uint32_t)0x00000800)            /*!<Capture/Compare 3 Complementary output Polarity */
+#define  TIM_CCER_CC4E                       ((uint32_t)0x00001000)            /*!<Capture/Compare 4 output enable */
+#define  TIM_CCER_CC4P                       ((uint32_t)0x00002000)            /*!<Capture/Compare 4 output Polarity */
+#define  TIM_CCER_CC4NP                      ((uint32_t)0x00008000)            /*!<Capture/Compare 4 Complementary output Polarity */
+#define  TIM_CCER_CC5E                       ((uint32_t)0x00010000)            /*!<Capture/Compare 5 output enable */
+#define  TIM_CCER_CC5P                       ((uint32_t)0x00020000)            /*!<Capture/Compare 5 output Polarity */
+#define  TIM_CCER_CC6E                       ((uint32_t)0x00100000)            /*!<Capture/Compare 6 output enable */
+#define  TIM_CCER_CC6P                       ((uint32_t)0x00200000)            /*!<Capture/Compare 6 output Polarity */
+
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define  TIM_CNT_CNT                         ((uint32_t)0xFFFF)            /*!<Counter Value            */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define  TIM_PSC_PSC                         ((uint32_t)0xFFFF)            /*!<Prescaler Value          */
+
+/*******************  Bit definition for TIM_ARR register  ********************/
+#define  TIM_ARR_ARR                         ((uint32_t)0xFFFF)            /*!<actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RCR register  ********************/
+#define  TIM_RCR_REP                         ((uint8_t)0xFF)               /*!<Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CCR1 register  *******************/
+#define  TIM_CCR1_CCR1                       ((uint32_t)0xFFFF)            /*!<Capture/Compare 1 Value  */
+
+/*******************  Bit definition for TIM_CCR2 register  *******************/
+#define  TIM_CCR2_CCR2                       ((uint32_t)0xFFFF)            /*!<Capture/Compare 2 Value  */
+
+/*******************  Bit definition for TIM_CCR3 register  *******************/
+#define  TIM_CCR3_CCR3                       ((uint32_t)0xFFFF)            /*!<Capture/Compare 3 Value  */
+
+/*******************  Bit definition for TIM_CCR4 register  *******************/
+#define  TIM_CCR4_CCR4                       ((uint32_t)0xFFFF)            /*!<Capture/Compare 4 Value  */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define  TIM_BDTR_DTG                        ((uint32_t)0x000000FF)            /*!<DTG[0:7] bits (Dead-Time Generator set-up) */
+#define  TIM_BDTR_DTG_0                      ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_BDTR_DTG_1                      ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define  TIM_BDTR_DTG_2                      ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define  TIM_BDTR_DTG_3                      ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define  TIM_BDTR_DTG_4                      ((uint32_t)0x00000010)            /*!<Bit 4 */
+#define  TIM_BDTR_DTG_5                      ((uint32_t)0x00000020)            /*!<Bit 5 */
+#define  TIM_BDTR_DTG_6                      ((uint32_t)0x00000040)            /*!<Bit 6 */
+#define  TIM_BDTR_DTG_7                      ((uint32_t)0x00000080)            /*!<Bit 7 */
+
+#define  TIM_BDTR_LOCK                       ((uint32_t)0x00000300)            /*!<LOCK[1:0] bits (Lock Configuration) */
+#define  TIM_BDTR_LOCK_0                     ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  TIM_BDTR_LOCK_1                     ((uint32_t)0x00000200)            /*!<Bit 1 */
+
+#define  TIM_BDTR_OSSI                       ((uint32_t)0x00000400)            /*!<Off-State Selection for Idle mode */
+#define  TIM_BDTR_OSSR                       ((uint32_t)0x00000800)            /*!<Off-State Selection for Run mode  */
+#define  TIM_BDTR_BKE                        ((uint32_t)0x00001000)            /*!<Break enable                      */
+#define  TIM_BDTR_BKP                        ((uint32_t)0x00002000)            /*!<Break Polarity                    */
+#define  TIM_BDTR_AOE                        ((uint32_t)0x00004000)            /*!<Automatic Output enable           */
+#define  TIM_BDTR_MOE                        ((uint32_t)0x00008000)            /*!<Main Output enable                */
+#define  TIM_BDTR_BKF                        ((uint32_t)0x000F0000)            /*!<Break Filter for Break1 */
+#define  TIM_BDTR_BK2F                       ((uint32_t)0x00F00000)            /*!<Break Filter for Break2 */
+#define  TIM_BDTR_BK2E                       ((uint32_t)0x01000000)            /*!<Break enable for Break2 */
+#define  TIM_BDTR_BK2P                       ((uint32_t)0x02000000)            /*!<Break Polarity for Break2 */
+
+/*******************  Bit definition for TIM_DCR register  ********************/
+#define  TIM_DCR_DBA                         ((uint32_t)0x001F)            /*!<DBA[4:0] bits (DMA Base Address) */
+#define  TIM_DCR_DBA_0                       ((uint32_t)0x0001)            /*!<Bit 0 */
+#define  TIM_DCR_DBA_1                       ((uint32_t)0x0002)            /*!<Bit 1 */
+#define  TIM_DCR_DBA_2                       ((uint32_t)0x0004)            /*!<Bit 2 */
+#define  TIM_DCR_DBA_3                       ((uint32_t)0x0008)            /*!<Bit 3 */
+#define  TIM_DCR_DBA_4                       ((uint32_t)0x0010)            /*!<Bit 4 */
+
+#define  TIM_DCR_DBL                         ((uint32_t)0x1F00)            /*!<DBL[4:0] bits (DMA Burst Length) */
+#define  TIM_DCR_DBL_0                       ((uint32_t)0x0100)            /*!<Bit 0 */
+#define  TIM_DCR_DBL_1                       ((uint32_t)0x0200)            /*!<Bit 1 */
+#define  TIM_DCR_DBL_2                       ((uint32_t)0x0400)            /*!<Bit 2 */
+#define  TIM_DCR_DBL_3                       ((uint32_t)0x0800)            /*!<Bit 3 */
+#define  TIM_DCR_DBL_4                       ((uint32_t)0x1000)            /*!<Bit 4 */
+
+/*******************  Bit definition for TIM_DMAR register  *******************/
+#define  TIM_DMAR_DMAB                       ((uint32_t)0xFFFF)            /*!<DMA register for burst accesses                    */
+
+/*******************  Bit definition for TIM_OR register  *********************/
+#define TIM_OR_TI4_RMP                       ((uint32_t)0x00C0)            /*!<TI4_RMP[1:0] bits (TIM5 Input 4 remap)             */
+#define TIM_OR_TI4_RMP_0                     ((uint32_t)0x0040)            /*!<Bit 0 */
+#define TIM_OR_TI4_RMP_1                     ((uint32_t)0x0080)            /*!<Bit 1 */
+#define TIM_OR_ITR1_RMP                      ((uint32_t)0x0C00)            /*!<ITR1_RMP[1:0] bits (TIM2 Internal trigger 1 remap) */
+#define TIM_OR_ITR1_RMP_0                    ((uint32_t)0x0400)            /*!<Bit 0 */
+#define TIM_OR_ITR1_RMP_1                    ((uint32_t)0x0800)            /*!<Bit 1 */
+
+/******************  Bit definition for TIM_CCMR3 register  *******************/
+#define  TIM_CCMR3_OC5FE                     ((uint32_t)0x00000004)            /*!<Output Compare 5 Fast enable */
+#define  TIM_CCMR3_OC5PE                     ((uint32_t)0x00000008)            /*!<Output Compare 5 Preload enable */
+
+#define  TIM_CCMR3_OC5M                      ((uint32_t)0x00010070)            /*!<OC5M[2:0] bits (Output Compare 5 Mode) */
+#define  TIM_CCMR3_OC5M_0                    ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  TIM_CCMR3_OC5M_1                    ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  TIM_CCMR3_OC5M_2                    ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define  TIM_CCMR3_OC5M_3                    ((uint32_t)0x00010000)            /*!<Bit 3 */
+
+#define  TIM_CCMR3_OC5CE                     ((uint32_t)0x00000080)            /*!<Output Compare 5 Clear Enable */
+
+#define  TIM_CCMR3_OC6FE                     ((uint32_t)0x00000400)            /*!<Output Compare 4 Fast enable */
+#define  TIM_CCMR3_OC6PE                     ((uint32_t)0x00000800)            /*!<Output Compare 4 Preload enable */
+
+#define  TIM_CCMR3_OC6M                      ((uint32_t)0x01007000)            /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define  TIM_CCMR3_OC6M_0                    ((uint32_t)0x00001000)            /*!<Bit 0 */
+#define  TIM_CCMR3_OC6M_1                    ((uint32_t)0x00002000)            /*!<Bit 1 */
+#define  TIM_CCMR3_OC6M_2                    ((uint32_t)0x00004000)            /*!<Bit 2 */
+#define  TIM_CCMR3_OC6M_3                    ((uint32_t)0x01000000)            /*!<Bit 3 */
+
+#define  TIM_CCMR3_OC6CE                     ((uint32_t)0x00008000)            /*!<Output Compare 4 Clear Enable */
+
+/*******************  Bit definition for TIM_CCR5 register  *******************/
+#define  TIM_CCR5_CCR5                       ((uint32_t)0xFFFFFFFF)        /*!<Capture/Compare 5 Value */
+#define  TIM_CCR5_GC5C1                      ((uint32_t)0x20000000)        /*!<Group Channel 5 and Channel 1 */
+#define  TIM_CCR5_GC5C2                      ((uint32_t)0x40000000)        /*!<Group Channel 5 and Channel 2 */
+#define  TIM_CCR5_GC5C3                      ((uint32_t)0x80000000)        /*!<Group Channel 5 and Channel 3 */
+
+/*******************  Bit definition for TIM_CCR6 register  *******************/
+#define  TIM_CCR6_CCR6                       ((uint16_t)0xFFFF)            /*!<Capture/Compare 6 Value */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Low Power Timer (LPTIM)                            */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for LPTIM_ISR register  *******************/
+#define  LPTIM_ISR_CMPM                         ((uint32_t)0x00000001)            /*!< Compare match                       */
+#define  LPTIM_ISR_ARRM                         ((uint32_t)0x00000002)            /*!< Autoreload match                    */
+#define  LPTIM_ISR_EXTTRIG                      ((uint32_t)0x00000004)            /*!< External trigger edge event         */
+#define  LPTIM_ISR_CMPOK                        ((uint32_t)0x00000008)            /*!< Compare register update OK          */
+#define  LPTIM_ISR_ARROK                        ((uint32_t)0x00000010)            /*!< Autoreload register update OK       */
+#define  LPTIM_ISR_UP                           ((uint32_t)0x00000020)            /*!< Counter direction change down to up */
+#define  LPTIM_ISR_DOWN                         ((uint32_t)0x00000040)            /*!< Counter direction change up to down */
+
+/******************  Bit definition for LPTIM_ICR register  *******************/
+#define  LPTIM_ICR_CMPMCF                       ((uint32_t)0x00000001)            /*!< Compare match Clear Flag                       */
+#define  LPTIM_ICR_ARRMCF                       ((uint32_t)0x00000002)            /*!< Autoreload match Clear Flag                    */
+#define  LPTIM_ICR_EXTTRIGCF                    ((uint32_t)0x00000004)            /*!< External trigger edge event Clear Flag         */
+#define  LPTIM_ICR_CMPOKCF                      ((uint32_t)0x00000008)            /*!< Compare register update OK Clear Flag          */
+#define  LPTIM_ICR_ARROKCF                      ((uint32_t)0x00000010)            /*!< Autoreload register update OK Clear Flag       */
+#define  LPTIM_ICR_UPCF                         ((uint32_t)0x00000020)            /*!< Counter direction change down to up Clear Flag */
+#define  LPTIM_ICR_DOWNCF                       ((uint32_t)0x00000040)            /*!< Counter direction change up to down Clear Flag */
+
+/******************  Bit definition for LPTIM_IER register ********************/
+#define  LPTIM_IER_CMPMIE                       ((uint32_t)0x00000001)            /*!< Compare match Interrupt Enable                       */
+#define  LPTIM_IER_ARRMIE                       ((uint32_t)0x00000002)            /*!< Autoreload match Interrupt Enable                    */
+#define  LPTIM_IER_EXTTRIGIE                    ((uint32_t)0x00000004)            /*!< External trigger edge event Interrupt Enable         */
+#define  LPTIM_IER_CMPOKIE                      ((uint32_t)0x00000008)            /*!< Compare register update OK Interrupt Enable          */
+#define  LPTIM_IER_ARROKIE                      ((uint32_t)0x00000010)            /*!< Autoreload register update OK Interrupt Enable       */
+#define  LPTIM_IER_UPIE                         ((uint32_t)0x00000020)            /*!< Counter direction change down to up Interrupt Enable */
+#define  LPTIM_IER_DOWNIE                       ((uint32_t)0x00000040)            /*!< Counter direction change up to down Interrupt Enable */
+
+/******************  Bit definition for LPTIM_CFGR register *******************/
+#define  LPTIM_CFGR_CKSEL                       ((uint32_t)0x00000001)             /*!< Clock selector */
+
+#define  LPTIM_CFGR_CKPOL                       ((uint32_t)0x00000006)             /*!< CKPOL[1:0] bits (Clock polarity) */
+#define  LPTIM_CFGR_CKPOL_0                     ((uint32_t)0x00000002)             /*!< Bit 0 */
+#define  LPTIM_CFGR_CKPOL_1                     ((uint32_t)0x00000004)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_CKFLT                       ((uint32_t)0x00000018)             /*!< CKFLT[1:0] bits (Configurable digital filter for external clock) */
+#define  LPTIM_CFGR_CKFLT_0                     ((uint32_t)0x00000008)             /*!< Bit 0 */
+#define  LPTIM_CFGR_CKFLT_1                     ((uint32_t)0x00000010)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_TRGFLT                      ((uint32_t)0x000000C0)             /*!< TRGFLT[1:0] bits (Configurable digital filter for trigger) */
+#define  LPTIM_CFGR_TRGFLT_0                    ((uint32_t)0x00000040)             /*!< Bit 0 */
+#define  LPTIM_CFGR_TRGFLT_1                    ((uint32_t)0x00000080)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_PRESC                       ((uint32_t)0x00000E00)             /*!< PRESC[2:0] bits (Clock prescaler) */
+#define  LPTIM_CFGR_PRESC_0                     ((uint32_t)0x00000200)             /*!< Bit 0 */
+#define  LPTIM_CFGR_PRESC_1                     ((uint32_t)0x00000400)             /*!< Bit 1 */
+#define  LPTIM_CFGR_PRESC_2                     ((uint32_t)0x00000800)             /*!< Bit 2 */
+
+#define  LPTIM_CFGR_TRIGSEL                     ((uint32_t)0x0000E000)             /*!< TRIGSEL[2:0]] bits (Trigger selector) */
+#define  LPTIM_CFGR_TRIGSEL_0                   ((uint32_t)0x00002000)             /*!< Bit 0 */
+#define  LPTIM_CFGR_TRIGSEL_1                   ((uint32_t)0x00004000)             /*!< Bit 1 */
+#define  LPTIM_CFGR_TRIGSEL_2                   ((uint32_t)0x00008000)             /*!< Bit 2 */
+
+#define  LPTIM_CFGR_TRIGEN                      ((uint32_t)0x00060000)             /*!< TRIGEN[1:0] bits (Trigger enable and polarity) */
+#define  LPTIM_CFGR_TRIGEN_0                    ((uint32_t)0x00020000)             /*!< Bit 0 */
+#define  LPTIM_CFGR_TRIGEN_1                    ((uint32_t)0x00040000)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_TIMOUT                      ((uint32_t)0x00080000)             /*!< Timout enable           */
+#define  LPTIM_CFGR_WAVE                        ((uint32_t)0x00100000)             /*!< Waveform shape          */
+#define  LPTIM_CFGR_WAVPOL                      ((uint32_t)0x00200000)             /*!< Waveform shape polarity */
+#define  LPTIM_CFGR_PRELOAD                     ((uint32_t)0x00400000)             /*!< Reg update mode         */
+#define  LPTIM_CFGR_COUNTMODE                   ((uint32_t)0x00800000)             /*!< Counter mode enable     */
+#define  LPTIM_CFGR_ENC                         ((uint32_t)0x01000000)             /*!< Encoder mode enable     */
+
+/******************  Bit definition for LPTIM_CR register  ********************/
+#define  LPTIM_CR_ENABLE                        ((uint32_t)0x00000001)             /*!< LPTIMer enable                 */
+#define  LPTIM_CR_SNGSTRT                       ((uint32_t)0x00080002)             /*!< Timer start in single mode     */
+#define  LPTIM_CR_CNTSTRT                       ((uint32_t)0x00000004)             /*!< Timer start in continuous mode */
+
+/******************  Bit definition for LPTIM_CMP register  *******************/
+#define  LPTIM_CMP_CMP                          ((uint32_t)0x0000FFFF)             /*!< Compare register     */
+
+/******************  Bit definition for LPTIM_ARR register  *******************/
+#define  LPTIM_ARR_ARR                          ((uint32_t)0x0000FFFF)             /*!< Auto reload register */
+
+/******************  Bit definition for LPTIM_CNT register  *******************/
+#define  LPTIM_CNT_CNT                          ((uint32_t)0x0000FFFF)             /*!< Counter register     */
+/******************************************************************************/
+/*                                                                            */
+/*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for USART_CR1 register  *******************/
+#define  USART_CR1_UE                        ((uint32_t)0x00000001)            /*!< USART Enable                                    */
+#define  USART_CR1_RE                        ((uint32_t)0x00000004)            /*!< Receiver Enable                                 */
+#define  USART_CR1_TE                        ((uint32_t)0x00000008)            /*!< Transmitter Enable                              */
+#define  USART_CR1_IDLEIE                    ((uint32_t)0x00000010)            /*!< IDLE Interrupt Enable                           */
+#define  USART_CR1_RXNEIE                    ((uint32_t)0x00000020)            /*!< RXNE Interrupt Enable                           */
+#define  USART_CR1_TCIE                      ((uint32_t)0x00000040)            /*!< Transmission Complete Interrupt Enable          */
+#define  USART_CR1_TXEIE                     ((uint32_t)0x00000080)            /*!< TXE Interrupt Enable                            */
+#define  USART_CR1_PEIE                      ((uint32_t)0x00000100)            /*!< PE Interrupt Enable                             */
+#define  USART_CR1_PS                        ((uint32_t)0x00000200)            /*!< Parity Selection                                */
+#define  USART_CR1_PCE                       ((uint32_t)0x00000400)            /*!< Parity Control Enable                           */
+#define  USART_CR1_WAKE                      ((uint32_t)0x00000800)            /*!< Receiver Wakeup method                          */
+#define  USART_CR1_M                         ((uint32_t)0x10001000)            /*!< Word length                                     */
+#define  USART_CR1_M_0                       ((uint32_t)0x00001000)            /*!< Word length - Bit 0                             */
+#define  USART_CR1_MME                       ((uint32_t)0x00002000)            /*!< Mute Mode Enable                                */
+#define  USART_CR1_CMIE                      ((uint32_t)0x00004000)            /*!< Character match interrupt enable                */
+#define  USART_CR1_OVER8                     ((uint32_t)0x00008000)            /*!< Oversampling by 8-bit or 16-bit mode            */
+#define  USART_CR1_DEDT                      ((uint32_t)0x001F0000)            /*!< DEDT[4:0] bits (Driver Enable Deassertion Time) */
+#define  USART_CR1_DEDT_0                    ((uint32_t)0x00010000)            /*!< Bit 0 */
+#define  USART_CR1_DEDT_1                    ((uint32_t)0x00020000)            /*!< Bit 1 */
+#define  USART_CR1_DEDT_2                    ((uint32_t)0x00040000)            /*!< Bit 2 */
+#define  USART_CR1_DEDT_3                    ((uint32_t)0x00080000)            /*!< Bit 3 */
+#define  USART_CR1_DEDT_4                    ((uint32_t)0x00100000)            /*!< Bit 4 */
+#define  USART_CR1_DEAT                      ((uint32_t)0x03E00000)            /*!< DEAT[4:0] bits (Driver Enable Assertion Time)   */
+#define  USART_CR1_DEAT_0                    ((uint32_t)0x00200000)            /*!< Bit 0 */
+#define  USART_CR1_DEAT_1                    ((uint32_t)0x00400000)            /*!< Bit 1 */
+#define  USART_CR1_DEAT_2                    ((uint32_t)0x00800000)            /*!< Bit 2 */
+#define  USART_CR1_DEAT_3                    ((uint32_t)0x01000000)            /*!< Bit 3 */
+#define  USART_CR1_DEAT_4                    ((uint32_t)0x02000000)            /*!< Bit 4 */
+#define  USART_CR1_RTOIE                     ((uint32_t)0x04000000)            /*!< Receive Time Out interrupt enable */
+#define  USART_CR1_EOBIE                     ((uint32_t)0x08000000)            /*!< End of Block interrupt enable     */
+#define  USART_CR1_M_1                       ((uint32_t)0x10000000)            /*!< Word length - Bit 1               */
+
+/******************  Bit definition for USART_CR2 register  *******************/
+#define  USART_CR2_ADDM7                     ((uint32_t)0x00000010)            /*!< 7-bit or 4-bit Address Detection       */
+#define  USART_CR2_LBDL                      ((uint32_t)0x00000020)            /*!< LIN Break Detection Length             */
+#define  USART_CR2_LBDIE                     ((uint32_t)0x00000040)            /*!< LIN Break Detection Interrupt Enable   */
+#define  USART_CR2_LBCL                      ((uint32_t)0x00000100)            /*!< Last Bit Clock pulse                   */
+#define  USART_CR2_CPHA                      ((uint32_t)0x00000200)            /*!< Clock Phase                            */
+#define  USART_CR2_CPOL                      ((uint32_t)0x00000400)            /*!< Clock Polarity                         */
+#define  USART_CR2_CLKEN                     ((uint32_t)0x00000800)            /*!< Clock Enable                           */
+#define  USART_CR2_STOP                      ((uint32_t)0x00003000)            /*!< STOP[1:0] bits (STOP bits)             */
+#define  USART_CR2_STOP_0                    ((uint32_t)0x00001000)            /*!< Bit 0 */
+#define  USART_CR2_STOP_1                    ((uint32_t)0x00002000)            /*!< Bit 1 */
+#define  USART_CR2_LINEN                     ((uint32_t)0x00004000)            /*!< LIN mode enable                        */
+#define  USART_CR2_SWAP                      ((uint32_t)0x00008000)            /*!< SWAP TX/RX pins                        */
+#define  USART_CR2_RXINV                     ((uint32_t)0x00010000)            /*!< RX pin active level inversion          */
+#define  USART_CR2_TXINV                     ((uint32_t)0x00020000)            /*!< TX pin active level inversion          */
+#define  USART_CR2_DATAINV                   ((uint32_t)0x00040000)            /*!< Binary data inversion                  */
+#define  USART_CR2_MSBFIRST                  ((uint32_t)0x00080000)            /*!< Most Significant Bit First             */
+#define  USART_CR2_ABREN                     ((uint32_t)0x00100000)            /*!< Auto Baud-Rate Enable                  */
+#define  USART_CR2_ABRMODE                   ((uint32_t)0x00600000)            /*!< ABRMOD[1:0] bits (Auto Baud-Rate Mode) */
+#define  USART_CR2_ABRMODE_0                 ((uint32_t)0x00200000)            /*!< Bit 0 */
+#define  USART_CR2_ABRMODE_1                 ((uint32_t)0x00400000)            /*!< Bit 1 */
+#define  USART_CR2_RTOEN                     ((uint32_t)0x00800000)            /*!< Receiver Time-Out enable  */
+#define  USART_CR2_ADD                       ((uint32_t)0xFF000000)            /*!< Address of the USART node */
+
+/******************  Bit definition for USART_CR3 register  *******************/
+#define  USART_CR3_EIE                       ((uint32_t)0x00000001)            /*!< Error Interrupt Enable                         */
+#define  USART_CR3_IREN                      ((uint32_t)0x00000002)            /*!< IrDA mode Enable                               */
+#define  USART_CR3_IRLP                      ((uint32_t)0x00000004)            /*!< IrDA Low-Power                                 */
+#define  USART_CR3_HDSEL                     ((uint32_t)0x00000008)            /*!< Half-Duplex Selection                          */
+#define  USART_CR3_NACK                      ((uint32_t)0x00000010)            /*!< SmartCard NACK enable                          */
+#define  USART_CR3_SCEN                      ((uint32_t)0x00000020)            /*!< SmartCard mode enable                          */
+#define  USART_CR3_DMAR                      ((uint32_t)0x00000040)            /*!< DMA Enable Receiver                            */
+#define  USART_CR3_DMAT                      ((uint32_t)0x00000080)            /*!< DMA Enable Transmitter                         */
+#define  USART_CR3_RTSE                      ((uint32_t)0x00000100)            /*!< RTS Enable                                     */
+#define  USART_CR3_CTSE                      ((uint32_t)0x00000200)            /*!< CTS Enable                                     */
+#define  USART_CR3_CTSIE                     ((uint32_t)0x00000400)            /*!< CTS Interrupt Enable                           */
+#define  USART_CR3_ONEBIT                    ((uint32_t)0x00000800)            /*!< One sample bit method enable                   */
+#define  USART_CR3_OVRDIS                    ((uint32_t)0x00001000)            /*!< Overrun Disable                                */
+#define  USART_CR3_DDRE                      ((uint32_t)0x00002000)            /*!< DMA Disable on Reception Error                 */
+#define  USART_CR3_DEM                       ((uint32_t)0x00004000)            /*!< Driver Enable Mode                             */
+#define  USART_CR3_DEP                       ((uint32_t)0x00008000)            /*!< Driver Enable Polarity Selection               */
+#define  USART_CR3_SCARCNT                   ((uint32_t)0x000E0000)            /*!< SCARCNT[2:0] bits (SmartCard Auto-Retry Count) */
+#define  USART_CR3_SCARCNT_0                 ((uint32_t)0x00020000)            /*!< Bit 0 */
+#define  USART_CR3_SCARCNT_1                 ((uint32_t)0x00040000)            /*!< Bit 1 */
+#define  USART_CR3_SCARCNT_2                 ((uint32_t)0x00080000)            /*!< Bit 2 */
+
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define  USART_BRR_DIV_FRACTION              ((uint32_t)0x000F)                /*!< Fraction of USARTDIV */
+#define  USART_BRR_DIV_MANTISSA              ((uint32_t)0xFFF0)                /*!< Mantissa of USARTDIV */
+
+/******************  Bit definition for USART_GTPR register  ******************/
+#define  USART_GTPR_PSC                      ((uint32_t)0x00FF)                /*!< PSC[7:0] bits (Prescaler value) */
+#define  USART_GTPR_GT                       ((uint32_t)0xFF00)                /*!< GT[7:0] bits (Guard time value) */
+
+
+/*******************  Bit definition for USART_RTOR register  *****************/
+#define  USART_RTOR_RTO                      ((uint32_t)0x00FFFFFF)            /*!< Receiver Time Out Value */
+#define  USART_RTOR_BLEN                     ((uint32_t)0xFF000000)            /*!< Block Length */
+
+/*******************  Bit definition for USART_RQR register  ******************/
+#define  USART_RQR_ABRRQ                     ((uint32_t)0x0001)                /*!< Auto-Baud Rate Request      */
+#define  USART_RQR_SBKRQ                     ((uint32_t)0x0002)                /*!< Send Break Request          */
+#define  USART_RQR_MMRQ                      ((uint32_t)0x0004)                /*!< Mute Mode Request           */
+#define  USART_RQR_RXFRQ                     ((uint32_t)0x0008)                /*!< Receive Data flush Request  */
+#define  USART_RQR_TXFRQ                     ((uint32_t)0x0010)                /*!< Transmit data flush Request */
+
+/*******************  Bit definition for USART_ISR register  ******************/
+#define  USART_ISR_PE                        ((uint32_t)0x00000001)            /*!< Parity Error                        */
+#define  USART_ISR_FE                        ((uint32_t)0x00000002)            /*!< Framing Error                       */
+#define  USART_ISR_NE                        ((uint32_t)0x00000004)            /*!< Noise detected Flag                 */
+#define  USART_ISR_ORE                       ((uint32_t)0x00000008)            /*!< OverRun Error                       */
+#define  USART_ISR_IDLE                      ((uint32_t)0x00000010)            /*!< IDLE line detected                  */
+#define  USART_ISR_RXNE                      ((uint32_t)0x00000020)            /*!< Read Data Register Not Empty        */
+#define  USART_ISR_TC                        ((uint32_t)0x00000040)            /*!< Transmission Complete               */
+#define  USART_ISR_TXE                       ((uint32_t)0x00000080)            /*!< Transmit Data Register Empty        */
+#define  USART_ISR_LBD                       ((uint32_t)0x00000100)            /*!< LIN Break Detection Flag            */
+#define  USART_ISR_CTSIF                     ((uint32_t)0x00000200)            /*!< CTS interrupt flag                  */
+#define  USART_ISR_CTS                       ((uint32_t)0x00000400)            /*!< CTS flag                            */
+#define  USART_ISR_RTOF                      ((uint32_t)0x00000800)            /*!< Receiver Time Out                   */
+#define  USART_ISR_EOBF                      ((uint32_t)0x00001000)            /*!< End Of Block Flag                   */
+#define  USART_ISR_ABRE                      ((uint32_t)0x00004000)            /*!< Auto-Baud Rate Error                */
+#define  USART_ISR_ABRF                      ((uint32_t)0x00008000)            /*!< Auto-Baud Rate Flag                 */
+#define  USART_ISR_BUSY                      ((uint32_t)0x00010000)            /*!< Busy Flag                           */
+#define  USART_ISR_CMF                       ((uint32_t)0x00020000)            /*!< Character Match Flag                */
+#define  USART_ISR_SBKF                      ((uint32_t)0x00040000)            /*!< Send Break Flag                     */
+#define  USART_ISR_RWU                       ((uint32_t)0x00080000)            /*!< Receive Wake Up from mute mode Flag */
+#define  USART_ISR_WUF                       ((uint32_t)0x00100000)            /*!< Wake Up from stop mode Flag         */
+#define  USART_ISR_TEACK                     ((uint32_t)0x00200000)            /*!< Transmit Enable Acknowledge Flag    */
+#define  USART_ISR_REACK                     ((uint32_t)0x00400000)            /*!< Receive Enable Acknowledge Flag     */
+
+/*******************  Bit definition for USART_ICR register  ******************/
+#define  USART_ICR_PECF                      ((uint32_t)0x00000001)            /*!< Parity Error Clear Flag             */
+#define  USART_ICR_FECF                      ((uint32_t)0x00000002)            /*!< Framing Error Clear Flag            */
+#define  USART_ICR_NCF                       ((uint32_t)0x00000004)            /*!< Noise detected Clear Flag           */
+#define  USART_ICR_ORECF                     ((uint32_t)0x00000008)            /*!< OverRun Error Clear Flag            */
+#define  USART_ICR_IDLECF                    ((uint32_t)0x00000010)            /*!< IDLE line detected Clear Flag       */
+#define  USART_ICR_TCCF                      ((uint32_t)0x00000040)            /*!< Transmission Complete Clear Flag    */
+#define  USART_ICR_LBDCF                     ((uint32_t)0x00000100)            /*!< LIN Break Detection Clear Flag      */
+#define  USART_ICR_CTSCF                     ((uint32_t)0x00000200)            /*!< CTS Interrupt Clear Flag            */
+#define  USART_ICR_RTOCF                     ((uint32_t)0x00000800)            /*!< Receiver Time Out Clear Flag        */
+#define  USART_ICR_EOBCF                     ((uint32_t)0x00001000)            /*!< End Of Block Clear Flag             */
+#define  USART_ICR_CMCF                      ((uint32_t)0x00020000)            /*!< Character Match Clear Flag          */
+#define  USART_ICR_WUCF                      ((uint32_t)0x00100000)            /*!< Wake Up from stop mode Clear Flag   */
+
+/*******************  Bit definition for USART_RDR register  ******************/
+#define  USART_RDR_RDR                       ((uint32_t)0x01FF)                /*!< RDR[8:0] bits (Receive Data value) */
+
+/*******************  Bit definition for USART_TDR register  ******************/
+#define  USART_TDR_TDR                       ((uint32_t)0x01FF)                /*!< TDR[8:0] bits (Transmit Data value) */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            Window WATCHDOG                                 */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for WWDG_CR register  ********************/
+#define  WWDG_CR_T                           ((uint32_t)0x7F)               /*!<T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define  WWDG_CR_T0                          ((uint32_t)0x01)               /*!<Bit 0 */
+#define  WWDG_CR_T1                          ((uint32_t)0x02)               /*!<Bit 1 */
+#define  WWDG_CR_T2                          ((uint32_t)0x04)               /*!<Bit 2 */
+#define  WWDG_CR_T3                          ((uint32_t)0x08)               /*!<Bit 3 */
+#define  WWDG_CR_T4                          ((uint32_t)0x10)               /*!<Bit 4 */
+#define  WWDG_CR_T5                          ((uint32_t)0x20)               /*!<Bit 5 */
+#define  WWDG_CR_T6                          ((uint32_t)0x40)               /*!<Bit 6 */
+
+#define  WWDG_CR_WDGA                        ((uint32_t)0x80)               /*!<Activation bit */
+
+/*******************  Bit definition for WWDG_CFR register  *******************/
+#define  WWDG_CFR_W                          ((uint32_t)0x007F)            /*!<W[6:0] bits (7-bit window value) */
+#define  WWDG_CFR_W0                         ((uint32_t)0x0001)            /*!<Bit 0 */
+#define  WWDG_CFR_W1                         ((uint32_t)0x0002)            /*!<Bit 1 */
+#define  WWDG_CFR_W2                         ((uint32_t)0x0004)            /*!<Bit 2 */
+#define  WWDG_CFR_W3                         ((uint32_t)0x0008)            /*!<Bit 3 */
+#define  WWDG_CFR_W4                         ((uint32_t)0x0010)            /*!<Bit 4 */
+#define  WWDG_CFR_W5                         ((uint32_t)0x0020)            /*!<Bit 5 */
+#define  WWDG_CFR_W6                         ((uint32_t)0x0040)            /*!<Bit 6 */
+
+#define  WWDG_CFR_WDGTB                      ((uint32_t)0x0180)            /*!<WDGTB[1:0] bits (Timer Base) */
+#define  WWDG_CFR_WDGTB0                     ((uint32_t)0x0080)            /*!<Bit 0 */
+#define  WWDG_CFR_WDGTB1                     ((uint32_t)0x0100)            /*!<Bit 1 */
+
+#define  WWDG_CFR_EWI                        ((uint32_t)0x0200)            /*!<Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_SR register  ********************/
+#define  WWDG_SR_EWIF                        ((uint32_t)0x01)               /*!<Early Wakeup Interrupt Flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                DBG                                         */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DBGMCU_IDCODE register  *************/
+#define  DBGMCU_IDCODE_DEV_ID                ((uint32_t)0x00000FFF)
+#define  DBGMCU_IDCODE_REV_ID                ((uint32_t)0xFFFF0000)
+
+/********************  Bit definition for DBGMCU_CR register  *****************/
+#define  DBGMCU_CR_DBG_SLEEP                 ((uint32_t)0x00000001)
+#define  DBGMCU_CR_DBG_STOP                  ((uint32_t)0x00000002)
+#define  DBGMCU_CR_DBG_STANDBY               ((uint32_t)0x00000004)
+#define  DBGMCU_CR_TRACE_IOEN                ((uint32_t)0x00000020)
+
+#define  DBGMCU_CR_TRACE_MODE                ((uint32_t)0x000000C0)
+#define  DBGMCU_CR_TRACE_MODE_0              ((uint32_t)0x00000040) /*!<Bit 0 */
+#define  DBGMCU_CR_TRACE_MODE_1              ((uint32_t)0x00000080) /*!<Bit 1 */
+
+/********************  Bit definition for DBGMCU_APB1_FZ register  ************/
+#define  DBGMCU_APB1_FZ_DBG_TIM2_STOP            ((uint32_t)0x00000001)
+#define  DBGMCU_APB1_FZ_DBG_TIM3_STOP            ((uint32_t)0x00000002)
+#define  DBGMCU_APB1_FZ_DBG_TIM4_STOP            ((uint32_t)0x00000004)
+#define  DBGMCU_APB1_FZ_DBG_TIM5_STOP            ((uint32_t)0x00000008)
+#define  DBGMCU_APB1_FZ_DBG_TIM6_STOP            ((uint32_t)0x00000010)
+#define  DBGMCU_APB1_FZ_DBG_TIM7_STOP            ((uint32_t)0x00000020)
+#define  DBGMCU_APB1_FZ_DBG_TIM12_STOP           ((uint32_t)0x00000040)
+#define  DBGMCU_APB1_FZ_DBG_TIM13_STOP           ((uint32_t)0x00000080)
+#define  DBGMCU_APB1_FZ_DBG_TIM14_STOP           ((uint32_t)0x00000100)
+#define  DBGMCU_APB1_FZ_DBG_RTC_STOP             ((uint32_t)0x00000400)
+#define  DBGMCU_APB1_FZ_DBG_WWDG_STOP            ((uint32_t)0x00000800)
+#define  DBGMCU_APB1_FZ_DBG_IWDG_STOP            ((uint32_t)0x00001000)
+#define  DBGMCU_APB1_FZ_DBG_I2C1_SMBUS_TIMEOUT   ((uint32_t)0x00200000)
+#define  DBGMCU_APB1_FZ_DBG_I2C2_SMBUS_TIMEOUT   ((uint32_t)0x00400000)
+#define  DBGMCU_APB1_FZ_DBG_I2C3_SMBUS_TIMEOUT   ((uint32_t)0x00800000)
+#define  DBGMCU_APB1_FZ_DBG_CAN1_STOP            ((uint32_t)0x02000000)
+#define  DBGMCU_APB1_FZ_DBG_CAN2_STOP            ((uint32_t)0x04000000)
+
+/********************  Bit definition for DBGMCU_APB2_FZ register  ************/
+#define  DBGMCU_APB1_FZ_DBG_TIM1_STOP        ((uint32_t)0x00000001)
+#define  DBGMCU_APB1_FZ_DBG_TIM8_STOP        ((uint32_t)0x00000002)
+#define  DBGMCU_APB1_FZ_DBG_TIM9_STOP        ((uint32_t)0x00010000)
+#define  DBGMCU_APB1_FZ_DBG_TIM10_STOP       ((uint32_t)0x00020000)
+#define  DBGMCU_APB1_FZ_DBG_TIM11_STOP       ((uint32_t)0x00040000)
+
+/******************************************************************************/
+/*                                                                            */
+/*                Ethernet MAC Registers bits definitions                     */
+/*                                                                            */
+/******************************************************************************/
+/* Bit definition for Ethernet MAC Control Register register */
+#define ETH_MACCR_WD      ((uint32_t)0x00800000)  /* Watchdog disable */
+#define ETH_MACCR_JD      ((uint32_t)0x00400000)  /* Jabber disable */
+#define ETH_MACCR_IFG     ((uint32_t)0x000E0000)  /* Inter-frame gap */
+#define ETH_MACCR_IFG_96Bit     ((uint32_t)0x00000000)  /* Minimum IFG between frames during transmission is 96Bit */
+  #define ETH_MACCR_IFG_88Bit     ((uint32_t)0x00020000)  /* Minimum IFG between frames during transmission is 88Bit */
+  #define ETH_MACCR_IFG_80Bit     ((uint32_t)0x00040000)  /* Minimum IFG between frames during transmission is 80Bit */
+  #define ETH_MACCR_IFG_72Bit     ((uint32_t)0x00060000)  /* Minimum IFG between frames during transmission is 72Bit */
+  #define ETH_MACCR_IFG_64Bit     ((uint32_t)0x00080000)  /* Minimum IFG between frames during transmission is 64Bit */
+  #define ETH_MACCR_IFG_56Bit     ((uint32_t)0x000A0000)  /* Minimum IFG between frames during transmission is 56Bit */
+  #define ETH_MACCR_IFG_48Bit     ((uint32_t)0x000C0000)  /* Minimum IFG between frames during transmission is 48Bit */
+  #define ETH_MACCR_IFG_40Bit     ((uint32_t)0x000E0000)  /* Minimum IFG between frames during transmission is 40Bit */
+#define ETH_MACCR_CSD     ((uint32_t)0x00010000)  /* Carrier sense disable (during transmission) */
+#define ETH_MACCR_FES     ((uint32_t)0x00004000)  /* Fast ethernet speed */
+#define ETH_MACCR_ROD     ((uint32_t)0x00002000)  /* Receive own disable */
+#define ETH_MACCR_LM      ((uint32_t)0x00001000)  /* loopback mode */
+#define ETH_MACCR_DM      ((uint32_t)0x00000800)  /* Duplex mode */
+#define ETH_MACCR_IPCO    ((uint32_t)0x00000400)  /* IP Checksum offload */
+#define ETH_MACCR_RD      ((uint32_t)0x00000200)  /* Retry disable */
+#define ETH_MACCR_APCS    ((uint32_t)0x00000080)  /* Automatic Pad/CRC stripping */
+#define ETH_MACCR_BL      ((uint32_t)0x00000060)  /* Back-off limit: random integer number (r) of slot time delays before rescheduling
+                                                       a transmission attempt during retries after a collision: 0 =< r <2^k */
+  #define ETH_MACCR_BL_10    ((uint32_t)0x00000000)  /* k = min (n, 10) */
+  #define ETH_MACCR_BL_8     ((uint32_t)0x00000020)  /* k = min (n, 8) */
+  #define ETH_MACCR_BL_4     ((uint32_t)0x00000040)  /* k = min (n, 4) */
+  #define ETH_MACCR_BL_1     ((uint32_t)0x00000060)  /* k = min (n, 1) */
+#define ETH_MACCR_DC      ((uint32_t)0x00000010)  /* Defferal check */
+#define ETH_MACCR_TE      ((uint32_t)0x00000008)  /* Transmitter enable */
+#define ETH_MACCR_RE      ((uint32_t)0x00000004)  /* Receiver enable */
+
+/* Bit definition for Ethernet MAC Frame Filter Register */
+#define ETH_MACFFR_RA     ((uint32_t)0x80000000)  /* Receive all */
+#define ETH_MACFFR_HPF    ((uint32_t)0x00000400)  /* Hash or perfect filter */
+#define ETH_MACFFR_SAF    ((uint32_t)0x00000200)  /* Source address filter enable */
+#define ETH_MACFFR_SAIF   ((uint32_t)0x00000100)  /* SA inverse filtering */
+#define ETH_MACFFR_PCF    ((uint32_t)0x000000C0)  /* Pass control frames: 3 cases */
+  #define ETH_MACFFR_PCF_BlockAll                ((uint32_t)0x00000040)  /* MAC filters all control frames from reaching the application */
+  #define ETH_MACFFR_PCF_ForwardAll              ((uint32_t)0x00000080)  /* MAC forwards all control frames to application even if they fail the Address Filter */
+  #define ETH_MACFFR_PCF_ForwardPassedAddrFilter ((uint32_t)0x000000C0)  /* MAC forwards control frames that pass the Address Filter. */
+#define ETH_MACFFR_BFD    ((uint32_t)0x00000020)  /* Broadcast frame disable */
+#define ETH_MACFFR_PAM    ((uint32_t)0x00000010)  /* Pass all mutlicast */
+#define ETH_MACFFR_DAIF   ((uint32_t)0x00000008)  /* DA Inverse filtering */
+#define ETH_MACFFR_HM     ((uint32_t)0x00000004)  /* Hash multicast */
+#define ETH_MACFFR_HU     ((uint32_t)0x00000002)  /* Hash unicast */
+#define ETH_MACFFR_PM     ((uint32_t)0x00000001)  /* Promiscuous mode */
+
+/* Bit definition for Ethernet MAC Hash Table High Register */
+#define ETH_MACHTHR_HTH   ((uint32_t)0xFFFFFFFF)  /* Hash table high */
+
+/* Bit definition for Ethernet MAC Hash Table Low Register */
+#define ETH_MACHTLR_HTL   ((uint32_t)0xFFFFFFFF)  /* Hash table low */
+
+/* Bit definition for Ethernet MAC MII Address Register */
+#define ETH_MACMIIAR_PA   ((uint32_t)0x0000F800)  /* Physical layer address */
+#define ETH_MACMIIAR_MR   ((uint32_t)0x000007C0)  /* MII register in the selected PHY */
+#define ETH_MACMIIAR_CR   ((uint32_t)0x0000001C)  /* CR clock range: 6 cases */
+  #define ETH_MACMIIAR_CR_Div42   ((uint32_t)0x00000000)  /* HCLK:60-100 MHz; MDC clock= HCLK/42 */
+  #define ETH_MACMIIAR_CR_Div62   ((uint32_t)0x00000004)  /* HCLK:100-150 MHz; MDC clock= HCLK/62 */
+  #define ETH_MACMIIAR_CR_Div16   ((uint32_t)0x00000008)  /* HCLK:20-35 MHz; MDC clock= HCLK/16 */
+  #define ETH_MACMIIAR_CR_Div26   ((uint32_t)0x0000000C)  /* HCLK:35-60 MHz; MDC clock= HCLK/26 */
+  #define ETH_MACMIIAR_CR_Div102  ((uint32_t)0x00000010)  /* HCLK:150-168 MHz; MDC clock= HCLK/102 */
+#define ETH_MACMIIAR_MW   ((uint32_t)0x00000002)  /* MII write */
+#define ETH_MACMIIAR_MB   ((uint32_t)0x00000001)  /* MII busy */
+
+/* Bit definition for Ethernet MAC MII Data Register */
+#define ETH_MACMIIDR_MD   ((uint32_t)0x0000FFFF)  /* MII data: read/write data from/to PHY */
+
+/* Bit definition for Ethernet MAC Flow Control Register */
+#define ETH_MACFCR_PT     ((uint32_t)0xFFFF0000)  /* Pause time */
+#define ETH_MACFCR_ZQPD   ((uint32_t)0x00000080)  /* Zero-quanta pause disable */
+#define ETH_MACFCR_PLT    ((uint32_t)0x00000030)  /* Pause low threshold: 4 cases */
+  #define ETH_MACFCR_PLT_Minus4   ((uint32_t)0x00000000)  /* Pause time minus 4 slot times */
+  #define ETH_MACFCR_PLT_Minus28  ((uint32_t)0x00000010)  /* Pause time minus 28 slot times */
+  #define ETH_MACFCR_PLT_Minus144 ((uint32_t)0x00000020)  /* Pause time minus 144 slot times */
+  #define ETH_MACFCR_PLT_Minus256 ((uint32_t)0x00000030)  /* Pause time minus 256 slot times */
+#define ETH_MACFCR_UPFD   ((uint32_t)0x00000008)  /* Unicast pause frame detect */
+#define ETH_MACFCR_RFCE   ((uint32_t)0x00000004)  /* Receive flow control enable */
+#define ETH_MACFCR_TFCE   ((uint32_t)0x00000002)  /* Transmit flow control enable */
+#define ETH_MACFCR_FCBBPA ((uint32_t)0x00000001)  /* Flow control busy/backpressure activate */
+
+/* Bit definition for Ethernet MAC VLAN Tag Register */
+#define ETH_MACVLANTR_VLANTC ((uint32_t)0x00010000)  /* 12-bit VLAN tag comparison */
+#define ETH_MACVLANTR_VLANTI ((uint32_t)0x0000FFFF)  /* VLAN tag identifier (for receive frames) */
+
+/* Bit definition for Ethernet MAC Remote Wake-UpFrame Filter Register */
+#define ETH_MACRWUFFR_D   ((uint32_t)0xFFFFFFFF)  /* Wake-up frame filter register data */
+/* Eight sequential Writes to this address (offset 0x28) will write all Wake-UpFrame Filter Registers.
+   Eight sequential Reads from this address (offset 0x28) will read all Wake-UpFrame Filter Registers. */
+/* Wake-UpFrame Filter Reg0 : Filter 0 Byte Mask
+   Wake-UpFrame Filter Reg1 : Filter 1 Byte Mask
+   Wake-UpFrame Filter Reg2 : Filter 2 Byte Mask
+   Wake-UpFrame Filter Reg3 : Filter 3 Byte Mask
+   Wake-UpFrame Filter Reg4 : RSVD - Filter3 Command - RSVD - Filter2 Command -
+                              RSVD - Filter1 Command - RSVD - Filter0 Command
+   Wake-UpFrame Filter Re5 : Filter3 Offset - Filter2 Offset - Filter1 Offset - Filter0 Offset
+   Wake-UpFrame Filter Re6 : Filter1 CRC16 - Filter0 CRC16
+   Wake-UpFrame Filter Re7 : Filter3 CRC16 - Filter2 CRC16 */
+
+/* Bit definition for Ethernet MAC PMT Control and Status Register */
+#define ETH_MACPMTCSR_WFFRPR ((uint32_t)0x80000000)  /* Wake-Up Frame Filter Register Pointer Reset */
+#define ETH_MACPMTCSR_GU     ((uint32_t)0x00000200)  /* Global Unicast */
+#define ETH_MACPMTCSR_WFR    ((uint32_t)0x00000040)  /* Wake-Up Frame Received */
+#define ETH_MACPMTCSR_MPR    ((uint32_t)0x00000020)  /* Magic Packet Received */
+#define ETH_MACPMTCSR_WFE    ((uint32_t)0x00000004)  /* Wake-Up Frame Enable */
+#define ETH_MACPMTCSR_MPE    ((uint32_t)0x00000002)  /* Magic Packet Enable */
+#define ETH_MACPMTCSR_PD     ((uint32_t)0x00000001)  /* Power Down */
+
+/* Bit definition for Ethernet MAC Status Register */
+#define ETH_MACSR_TSTS      ((uint32_t)0x00000200)  /* Time stamp trigger status */
+#define ETH_MACSR_MMCTS     ((uint32_t)0x00000040)  /* MMC transmit status */
+#define ETH_MACSR_MMMCRS    ((uint32_t)0x00000020)  /* MMC receive status */
+#define ETH_MACSR_MMCS      ((uint32_t)0x00000010)  /* MMC status */
+#define ETH_MACSR_PMTS      ((uint32_t)0x00000008)  /* PMT status */
+
+/* Bit definition for Ethernet MAC Interrupt Mask Register */
+#define ETH_MACIMR_TSTIM     ((uint32_t)0x00000200)  /* Time stamp trigger interrupt mask */
+#define ETH_MACIMR_PMTIM     ((uint32_t)0x00000008)  /* PMT interrupt mask */
+
+/* Bit definition for Ethernet MAC Address0 High Register */
+#define ETH_MACA0HR_MACA0H   ((uint32_t)0x0000FFFF)  /* MAC address0 high */
+
+/* Bit definition for Ethernet MAC Address0 Low Register */
+#define ETH_MACA0LR_MACA0L   ((uint32_t)0xFFFFFFFF)  /* MAC address0 low */
+
+/* Bit definition for Ethernet MAC Address1 High Register */
+#define ETH_MACA1HR_AE       ((uint32_t)0x80000000)  /* Address enable */
+#define ETH_MACA1HR_SA       ((uint32_t)0x40000000)  /* Source address */
+#define ETH_MACA1HR_MBC      ((uint32_t)0x3F000000)  /* Mask byte control: bits to mask for comparison of the MAC Address bytes */
+  #define ETH_MACA1HR_MBC_HBits15_8    ((uint32_t)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+  #define ETH_MACA1HR_MBC_HBits7_0     ((uint32_t)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+  #define ETH_MACA1HR_MBC_LBits31_24   ((uint32_t)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+  #define ETH_MACA1HR_MBC_LBits23_16   ((uint32_t)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+  #define ETH_MACA1HR_MBC_LBits15_8    ((uint32_t)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+  #define ETH_MACA1HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [7:0] */
+#define ETH_MACA1HR_MACA1H   ((uint32_t)0x0000FFFF)  /* MAC address1 high */
+
+/* Bit definition for Ethernet MAC Address1 Low Register */
+#define ETH_MACA1LR_MACA1L   ((uint32_t)0xFFFFFFFF)  /* MAC address1 low */
+
+/* Bit definition for Ethernet MAC Address2 High Register */
+#define ETH_MACA2HR_AE       ((uint32_t)0x80000000)  /* Address enable */
+#define ETH_MACA2HR_SA       ((uint32_t)0x40000000)  /* Source address */
+#define ETH_MACA2HR_MBC      ((uint32_t)0x3F000000)  /* Mask byte control */
+  #define ETH_MACA2HR_MBC_HBits15_8    ((uint32_t)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+  #define ETH_MACA2HR_MBC_HBits7_0     ((uint32_t)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+  #define ETH_MACA2HR_MBC_LBits31_24   ((uint32_t)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+  #define ETH_MACA2HR_MBC_LBits23_16   ((uint32_t)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+  #define ETH_MACA2HR_MBC_LBits15_8    ((uint32_t)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+  #define ETH_MACA2HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [70] */
+#define ETH_MACA2HR_MACA2H   ((uint32_t)0x0000FFFF)  /* MAC address1 high */
+
+/* Bit definition for Ethernet MAC Address2 Low Register */
+#define ETH_MACA2LR_MACA2L   ((uint32_t)0xFFFFFFFF)  /* MAC address2 low */
+
+/* Bit definition for Ethernet MAC Address3 High Register */
+#define ETH_MACA3HR_AE       ((uint32_t)0x80000000)  /* Address enable */
+#define ETH_MACA3HR_SA       ((uint32_t)0x40000000)  /* Source address */
+#define ETH_MACA3HR_MBC      ((uint32_t)0x3F000000)  /* Mask byte control */
+  #define ETH_MACA3HR_MBC_HBits15_8    ((uint32_t)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+  #define ETH_MACA3HR_MBC_HBits7_0     ((uint32_t)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+  #define ETH_MACA3HR_MBC_LBits31_24   ((uint32_t)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+  #define ETH_MACA3HR_MBC_LBits23_16   ((uint32_t)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+  #define ETH_MACA3HR_MBC_LBits15_8    ((uint32_t)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+  #define ETH_MACA3HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [70] */
+#define ETH_MACA3HR_MACA3H   ((uint32_t)0x0000FFFF)  /* MAC address3 high */
+
+/* Bit definition for Ethernet MAC Address3 Low Register */
+#define ETH_MACA3LR_MACA3L   ((uint32_t)0xFFFFFFFF)  /* MAC address3 low */
+
+/******************************************************************************/
+/*                Ethernet MMC Registers bits definition                      */
+/******************************************************************************/
+
+/* Bit definition for Ethernet MMC Contol Register */
+#define ETH_MMCCR_MCFHP      ((uint32_t)0x00000020)  /* MMC counter Full-Half preset */
+#define ETH_MMCCR_MCP        ((uint32_t)0x00000010)  /* MMC counter preset */
+#define ETH_MMCCR_MCF        ((uint32_t)0x00000008)  /* MMC Counter Freeze */
+#define ETH_MMCCR_ROR        ((uint32_t)0x00000004)  /* Reset on Read */
+#define ETH_MMCCR_CSR        ((uint32_t)0x00000002)  /* Counter Stop Rollover */
+#define ETH_MMCCR_CR         ((uint32_t)0x00000001)  /* Counters Reset */
+
+/* Bit definition for Ethernet MMC Receive Interrupt Register */
+#define ETH_MMCRIR_RGUFS     ((uint32_t)0x00020000)  /* Set when Rx good unicast frames counter reaches half the maximum value */
+#define ETH_MMCRIR_RFAES     ((uint32_t)0x00000040)  /* Set when Rx alignment error counter reaches half the maximum value */
+#define ETH_MMCRIR_RFCES     ((uint32_t)0x00000020)  /* Set when Rx crc error counter reaches half the maximum value */
+
+/* Bit definition for Ethernet MMC Transmit Interrupt Register */
+#define ETH_MMCTIR_TGFS      ((uint32_t)0x00200000)  /* Set when Tx good frame count counter reaches half the maximum value */
+#define ETH_MMCTIR_TGFMSCS   ((uint32_t)0x00008000)  /* Set when Tx good multi col counter reaches half the maximum value */
+#define ETH_MMCTIR_TGFSCS    ((uint32_t)0x00004000)  /* Set when Tx good single col counter reaches half the maximum value */
+
+/* Bit definition for Ethernet MMC Receive Interrupt Mask Register */
+#define ETH_MMCRIMR_RGUFM    ((uint32_t)0x00020000)  /* Mask the interrupt when Rx good unicast frames counter reaches half the maximum value */
+#define ETH_MMCRIMR_RFAEM    ((uint32_t)0x00000040)  /* Mask the interrupt when when Rx alignment error counter reaches half the maximum value */
+#define ETH_MMCRIMR_RFCEM    ((uint32_t)0x00000020)  /* Mask the interrupt when Rx crc error counter reaches half the maximum value */
+
+/* Bit definition for Ethernet MMC Transmit Interrupt Mask Register */
+#define ETH_MMCTIMR_TGFM     ((uint32_t)0x00200000)  /* Mask the interrupt when Tx good frame count counter reaches half the maximum value */
+#define ETH_MMCTIMR_TGFMSCM  ((uint32_t)0x00008000)  /* Mask the interrupt when Tx good multi col counter reaches half the maximum value */
+#define ETH_MMCTIMR_TGFSCM   ((uint32_t)0x00004000)  /* Mask the interrupt when Tx good single col counter reaches half the maximum value */
+
+/* Bit definition for Ethernet MMC Transmitted Good Frames after Single Collision Counter Register */
+#define ETH_MMCTGFSCCR_TGFSCC     ((uint32_t)0xFFFFFFFF)  /* Number of successfully transmitted frames after a single collision in Half-duplex mode. */
+
+/* Bit definition for Ethernet MMC Transmitted Good Frames after More than a Single Collision Counter Register */
+#define ETH_MMCTGFMSCCR_TGFMSCC   ((uint32_t)0xFFFFFFFF)  /* Number of successfully transmitted frames after more than a single collision in Half-duplex mode. */
+
+/* Bit definition for Ethernet MMC Transmitted Good Frames Counter Register */
+#define ETH_MMCTGFCR_TGFC    ((uint32_t)0xFFFFFFFF)  /* Number of good frames transmitted. */
+
+/* Bit definition for Ethernet MMC Received Frames with CRC Error Counter Register */
+#define ETH_MMCRFCECR_RFCEC  ((uint32_t)0xFFFFFFFF)  /* Number of frames received with CRC error. */
+
+/* Bit definition for Ethernet MMC Received Frames with Alignement Error Counter Register */
+#define ETH_MMCRFAECR_RFAEC  ((uint32_t)0xFFFFFFFF)  /* Number of frames received with alignment (dribble) error */
+
+/* Bit definition for Ethernet MMC Received Good Unicast Frames Counter Register */
+#define ETH_MMCRGUFCR_RGUFC  ((uint32_t)0xFFFFFFFF)  /* Number of good unicast frames received. */
+
+/******************************************************************************/
+/*               Ethernet PTP Registers bits definition                       */
+/******************************************************************************/
+
+/* Bit definition for Ethernet PTP Time Stamp Contol Register */
+#define ETH_PTPTSCR_TSCNT       ((uint32_t)0x00030000)  /* Time stamp clock node type */
+#define ETH_PTPTSSR_TSSMRME     ((uint32_t)0x00008000)  /* Time stamp snapshot for message relevant to master enable */
+#define ETH_PTPTSSR_TSSEME      ((uint32_t)0x00004000)  /* Time stamp snapshot for event message enable */
+#define ETH_PTPTSSR_TSSIPV4FE   ((uint32_t)0x00002000)  /* Time stamp snapshot for IPv4 frames enable */
+#define ETH_PTPTSSR_TSSIPV6FE   ((uint32_t)0x00001000)  /* Time stamp snapshot for IPv6 frames enable */
+#define ETH_PTPTSSR_TSSPTPOEFE  ((uint32_t)0x00000800)  /* Time stamp snapshot for PTP over ethernet frames enable */
+#define ETH_PTPTSSR_TSPTPPSV2E  ((uint32_t)0x00000400)  /* Time stamp PTP packet snooping for version2 format enable */
+#define ETH_PTPTSSR_TSSSR       ((uint32_t)0x00000200)  /* Time stamp Sub-seconds rollover */
+#define ETH_PTPTSSR_TSSARFE     ((uint32_t)0x00000100)  /* Time stamp snapshot for all received frames enable */
+
+#define ETH_PTPTSCR_TSARU    ((uint32_t)0x00000020)  /* Addend register update */
+#define ETH_PTPTSCR_TSITE    ((uint32_t)0x00000010)  /* Time stamp interrupt trigger enable */
+#define ETH_PTPTSCR_TSSTU    ((uint32_t)0x00000008)  /* Time stamp update */
+#define ETH_PTPTSCR_TSSTI    ((uint32_t)0x00000004)  /* Time stamp initialize */
+#define ETH_PTPTSCR_TSFCU    ((uint32_t)0x00000002)  /* Time stamp fine or coarse update */
+#define ETH_PTPTSCR_TSE      ((uint32_t)0x00000001)  /* Time stamp enable */
+
+/* Bit definition for Ethernet PTP Sub-Second Increment Register */
+#define ETH_PTPSSIR_STSSI    ((uint32_t)0x000000FF)  /* System time Sub-second increment value */
+
+/* Bit definition for Ethernet PTP Time Stamp High Register */
+#define ETH_PTPTSHR_STS      ((uint32_t)0xFFFFFFFF)  /* System Time second */
+
+/* Bit definition for Ethernet PTP Time Stamp Low Register */
+#define ETH_PTPTSLR_STPNS    ((uint32_t)0x80000000)  /* System Time Positive or negative time */
+#define ETH_PTPTSLR_STSS     ((uint32_t)0x7FFFFFFF)  /* System Time sub-seconds */
+
+/* Bit definition for Ethernet PTP Time Stamp High Update Register */
+#define ETH_PTPTSHUR_TSUS    ((uint32_t)0xFFFFFFFF)  /* Time stamp update seconds */
+
+/* Bit definition for Ethernet PTP Time Stamp Low Update Register */
+#define ETH_PTPTSLUR_TSUPNS  ((uint32_t)0x80000000)  /* Time stamp update Positive or negative time */
+#define ETH_PTPTSLUR_TSUSS   ((uint32_t)0x7FFFFFFF)  /* Time stamp update sub-seconds */
+
+/* Bit definition for Ethernet PTP Time Stamp Addend Register */
+#define ETH_PTPTSAR_TSA      ((uint32_t)0xFFFFFFFF)  /* Time stamp addend */
+
+/* Bit definition for Ethernet PTP Target Time High Register */
+#define ETH_PTPTTHR_TTSH     ((uint32_t)0xFFFFFFFF)  /* Target time stamp high */
+
+/* Bit definition for Ethernet PTP Target Time Low Register */
+#define ETH_PTPTTLR_TTSL     ((uint32_t)0xFFFFFFFF)  /* Target time stamp low */
+
+/* Bit definition for Ethernet PTP Time Stamp Status Register */
+#define ETH_PTPTSSR_TSTTR    ((uint32_t)0x00000020)  /* Time stamp target time reached */
+#define ETH_PTPTSSR_TSSO     ((uint32_t)0x00000010)  /* Time stamp seconds overflow */
+
+/******************************************************************************/
+/*                 Ethernet DMA Registers bits definition                     */
+/******************************************************************************/
+
+/* Bit definition for Ethernet DMA Bus Mode Register */
+#define ETH_DMABMR_AAB       ((uint32_t)0x02000000)  /* Address-Aligned beats */
+#define ETH_DMABMR_FPM        ((uint32_t)0x01000000)  /* 4xPBL mode */
+#define ETH_DMABMR_USP       ((uint32_t)0x00800000)  /* Use separate PBL */
+#define ETH_DMABMR_RDP       ((uint32_t)0x007E0000)  /* RxDMA PBL */
+  #define ETH_DMABMR_RDP_1Beat    ((uint32_t)0x00020000)  /* maximum number of beats to be transferred in one RxDMA transaction is 1 */
+  #define ETH_DMABMR_RDP_2Beat    ((uint32_t)0x00040000)  /* maximum number of beats to be transferred in one RxDMA transaction is 2 */
+  #define ETH_DMABMR_RDP_4Beat    ((uint32_t)0x00080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
+  #define ETH_DMABMR_RDP_8Beat    ((uint32_t)0x00100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
+  #define ETH_DMABMR_RDP_16Beat   ((uint32_t)0x00200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
+  #define ETH_DMABMR_RDP_32Beat   ((uint32_t)0x00400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
+  #define ETH_DMABMR_RDP_4xPBL_4Beat   ((uint32_t)0x01020000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
+  #define ETH_DMABMR_RDP_4xPBL_8Beat   ((uint32_t)0x01040000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
+  #define ETH_DMABMR_RDP_4xPBL_16Beat  ((uint32_t)0x01080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
+  #define ETH_DMABMR_RDP_4xPBL_32Beat  ((uint32_t)0x01100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
+  #define ETH_DMABMR_RDP_4xPBL_64Beat  ((uint32_t)0x01200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 64 */
+  #define ETH_DMABMR_RDP_4xPBL_128Beat ((uint32_t)0x01400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 128 */
+#define ETH_DMABMR_FB        ((uint32_t)0x00010000)  /* Fixed Burst */
+#define ETH_DMABMR_RTPR      ((uint32_t)0x0000C000)  /* Rx Tx priority ratio */
+  #define ETH_DMABMR_RTPR_1_1     ((uint32_t)0x00000000)  /* Rx Tx priority ratio */
+  #define ETH_DMABMR_RTPR_2_1     ((uint32_t)0x00004000)  /* Rx Tx priority ratio */
+  #define ETH_DMABMR_RTPR_3_1     ((uint32_t)0x00008000)  /* Rx Tx priority ratio */
+  #define ETH_DMABMR_RTPR_4_1     ((uint32_t)0x0000C000)  /* Rx Tx priority ratio */
+#define ETH_DMABMR_PBL    ((uint32_t)0x00003F00)  /* Programmable burst length */
+  #define ETH_DMABMR_PBL_1Beat    ((uint32_t)0x00000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
+  #define ETH_DMABMR_PBL_2Beat    ((uint32_t)0x00000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
+  #define ETH_DMABMR_PBL_4Beat    ((uint32_t)0x00000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+  #define ETH_DMABMR_PBL_8Beat    ((uint32_t)0x00000800)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+  #define ETH_DMABMR_PBL_16Beat   ((uint32_t)0x00001000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+  #define ETH_DMABMR_PBL_32Beat   ((uint32_t)0x00002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+  #define ETH_DMABMR_PBL_4xPBL_4Beat   ((uint32_t)0x01000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+  #define ETH_DMABMR_PBL_4xPBL_8Beat   ((uint32_t)0x01000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+  #define ETH_DMABMR_PBL_4xPBL_16Beat  ((uint32_t)0x01000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+  #define ETH_DMABMR_PBL_4xPBL_32Beat  ((uint32_t)0x01000800)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+  #define ETH_DMABMR_PBL_4xPBL_64Beat  ((uint32_t)0x01001000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
+  #define ETH_DMABMR_PBL_4xPBL_128Beat ((uint32_t)0x01002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
+#define ETH_DMABMR_EDE       ((uint32_t)0x00000080)  /* Enhanced Descriptor Enable */
+#define ETH_DMABMR_DSL       ((uint32_t)0x0000007C)  /* Descriptor Skip Length */
+#define ETH_DMABMR_DA        ((uint32_t)0x00000002)  /* DMA arbitration scheme */
+#define ETH_DMABMR_SR        ((uint32_t)0x00000001)  /* Software reset */
+
+/* Bit definition for Ethernet DMA Transmit Poll Demand Register */
+#define ETH_DMATPDR_TPD      ((uint32_t)0xFFFFFFFF)  /* Transmit poll demand */
+
+/* Bit definition for Ethernet DMA Receive Poll Demand Register */
+#define ETH_DMARPDR_RPD      ((uint32_t)0xFFFFFFFF)  /* Receive poll demand  */
+
+/* Bit definition for Ethernet DMA Receive Descriptor List Address Register */
+#define ETH_DMARDLAR_SRL     ((uint32_t)0xFFFFFFFF)  /* Start of receive list */
+
+/* Bit definition for Ethernet DMA Transmit Descriptor List Address Register */
+#define ETH_DMATDLAR_STL     ((uint32_t)0xFFFFFFFF)  /* Start of transmit list */
+
+/* Bit definition for Ethernet DMA Status Register */
+#define ETH_DMASR_TSTS       ((uint32_t)0x20000000)  /* Time-stamp trigger status */
+#define ETH_DMASR_PMTS       ((uint32_t)0x10000000)  /* PMT status */
+#define ETH_DMASR_MMCS       ((uint32_t)0x08000000)  /* MMC status */
+#define ETH_DMASR_EBS        ((uint32_t)0x03800000)  /* Error bits status */
+  /* combination with EBS[2:0] for GetFlagStatus function */
+  #define ETH_DMASR_EBS_DescAccess      ((uint32_t)0x02000000)  /* Error bits 0-data buffer, 1-desc. access */
+  #define ETH_DMASR_EBS_ReadTransf      ((uint32_t)0x01000000)  /* Error bits 0-write trnsf, 1-read transfr */
+  #define ETH_DMASR_EBS_DataTransfTx    ((uint32_t)0x00800000)  /* Error bits 0-Rx DMA, 1-Tx DMA */
+#define ETH_DMASR_TPS         ((uint32_t)0x00700000)  /* Transmit process state */
+  #define ETH_DMASR_TPS_Stopped         ((uint32_t)0x00000000)  /* Stopped - Reset or Stop Tx Command issued  */
+  #define ETH_DMASR_TPS_Fetching        ((uint32_t)0x00100000)  /* Running - fetching the Tx descriptor */
+  #define ETH_DMASR_TPS_Waiting         ((uint32_t)0x00200000)  /* Running - waiting for status */
+  #define ETH_DMASR_TPS_Reading         ((uint32_t)0x00300000)  /* Running - reading the data from host memory */
+  #define ETH_DMASR_TPS_Suspended       ((uint32_t)0x00600000)  /* Suspended - Tx Descriptor unavailabe */
+  #define ETH_DMASR_TPS_Closing         ((uint32_t)0x00700000)  /* Running - closing Rx descriptor */
+#define ETH_DMASR_RPS         ((uint32_t)0x000E0000)  /* Receive process state */
+  #define ETH_DMASR_RPS_Stopped         ((uint32_t)0x00000000)  /* Stopped - Reset or Stop Rx Command issued */
+  #define ETH_DMASR_RPS_Fetching        ((uint32_t)0x00020000)  /* Running - fetching the Rx descriptor */
+  #define ETH_DMASR_RPS_Waiting         ((uint32_t)0x00060000)  /* Running - waiting for packet */
+  #define ETH_DMASR_RPS_Suspended       ((uint32_t)0x00080000)  /* Suspended - Rx Descriptor unavailable */
+  #define ETH_DMASR_RPS_Closing         ((uint32_t)0x000A0000)  /* Running - closing descriptor */
+  #define ETH_DMASR_RPS_Queuing         ((uint32_t)0x000E0000)  /* Running - queuing the recieve frame into host memory */
+#define ETH_DMASR_NIS        ((uint32_t)0x00010000)  /* Normal interrupt summary */
+#define ETH_DMASR_AIS        ((uint32_t)0x00008000)  /* Abnormal interrupt summary */
+#define ETH_DMASR_ERS        ((uint32_t)0x00004000)  /* Early receive status */
+#define ETH_DMASR_FBES       ((uint32_t)0x00002000)  /* Fatal bus error status */
+#define ETH_DMASR_ETS        ((uint32_t)0x00000400)  /* Early transmit status */
+#define ETH_DMASR_RWTS       ((uint32_t)0x00000200)  /* Receive watchdog timeout status */
+#define ETH_DMASR_RPSS       ((uint32_t)0x00000100)  /* Receive process stopped status */
+#define ETH_DMASR_RBUS       ((uint32_t)0x00000080)  /* Receive buffer unavailable status */
+#define ETH_DMASR_RS         ((uint32_t)0x00000040)  /* Receive status */
+#define ETH_DMASR_TUS        ((uint32_t)0x00000020)  /* Transmit underflow status */
+#define ETH_DMASR_ROS        ((uint32_t)0x00000010)  /* Receive overflow status */
+#define ETH_DMASR_TJTS       ((uint32_t)0x00000008)  /* Transmit jabber timeout status */
+#define ETH_DMASR_TBUS       ((uint32_t)0x00000004)  /* Transmit buffer unavailable status */
+#define ETH_DMASR_TPSS       ((uint32_t)0x00000002)  /* Transmit process stopped status */
+#define ETH_DMASR_TS         ((uint32_t)0x00000001)  /* Transmit status */
+
+/* Bit definition for Ethernet DMA Operation Mode Register */
+#define ETH_DMAOMR_DTCEFD    ((uint32_t)0x04000000)  /* Disable Dropping of TCP/IP checksum error frames */
+#define ETH_DMAOMR_RSF       ((uint32_t)0x02000000)  /* Receive store and forward */
+#define ETH_DMAOMR_DFRF      ((uint32_t)0x01000000)  /* Disable flushing of received frames */
+#define ETH_DMAOMR_TSF       ((uint32_t)0x00200000)  /* Transmit store and forward */
+#define ETH_DMAOMR_FTF       ((uint32_t)0x00100000)  /* Flush transmit FIFO */
+#define ETH_DMAOMR_TTC       ((uint32_t)0x0001C000)  /* Transmit threshold control */
+  #define ETH_DMAOMR_TTC_64Bytes       ((uint32_t)0x00000000)  /* threshold level of the MTL Transmit FIFO is 64 Bytes */
+  #define ETH_DMAOMR_TTC_128Bytes      ((uint32_t)0x00004000)  /* threshold level of the MTL Transmit FIFO is 128 Bytes */
+  #define ETH_DMAOMR_TTC_192Bytes      ((uint32_t)0x00008000)  /* threshold level of the MTL Transmit FIFO is 192 Bytes */
+  #define ETH_DMAOMR_TTC_256Bytes      ((uint32_t)0x0000C000)  /* threshold level of the MTL Transmit FIFO is 256 Bytes */
+  #define ETH_DMAOMR_TTC_40Bytes       ((uint32_t)0x00010000)  /* threshold level of the MTL Transmit FIFO is 40 Bytes */
+  #define ETH_DMAOMR_TTC_32Bytes       ((uint32_t)0x00014000)  /* threshold level of the MTL Transmit FIFO is 32 Bytes */
+  #define ETH_DMAOMR_TTC_24Bytes       ((uint32_t)0x00018000)  /* threshold level of the MTL Transmit FIFO is 24 Bytes */
+  #define ETH_DMAOMR_TTC_16Bytes       ((uint32_t)0x0001C000)  /* threshold level of the MTL Transmit FIFO is 16 Bytes */
+#define ETH_DMAOMR_ST        ((uint32_t)0x00002000)  /* Start/stop transmission command */
+#define ETH_DMAOMR_FEF       ((uint32_t)0x00000080)  /* Forward error frames */
+#define ETH_DMAOMR_FUGF      ((uint32_t)0x00000040)  /* Forward undersized good frames */
+#define ETH_DMAOMR_RTC       ((uint32_t)0x00000018)  /* receive threshold control */
+  #define ETH_DMAOMR_RTC_64Bytes       ((uint32_t)0x00000000)  /* threshold level of the MTL Receive FIFO is 64 Bytes */
+  #define ETH_DMAOMR_RTC_32Bytes       ((uint32_t)0x00000008)  /* threshold level of the MTL Receive FIFO is 32 Bytes */
+  #define ETH_DMAOMR_RTC_96Bytes       ((uint32_t)0x00000010)  /* threshold level of the MTL Receive FIFO is 96 Bytes */
+  #define ETH_DMAOMR_RTC_128Bytes      ((uint32_t)0x00000018)  /* threshold level of the MTL Receive FIFO is 128 Bytes */
+#define ETH_DMAOMR_OSF       ((uint32_t)0x00000004)  /* operate on second frame */
+#define ETH_DMAOMR_SR        ((uint32_t)0x00000002)  /* Start/stop receive */
+
+/* Bit definition for Ethernet DMA Interrupt Enable Register */
+#define ETH_DMAIER_NISE      ((uint32_t)0x00010000)  /* Normal interrupt summary enable */
+#define ETH_DMAIER_AISE      ((uint32_t)0x00008000)  /* Abnormal interrupt summary enable */
+#define ETH_DMAIER_ERIE      ((uint32_t)0x00004000)  /* Early receive interrupt enable */
+#define ETH_DMAIER_FBEIE     ((uint32_t)0x00002000)  /* Fatal bus error interrupt enable */
+#define ETH_DMAIER_ETIE      ((uint32_t)0x00000400)  /* Early transmit interrupt enable */
+#define ETH_DMAIER_RWTIE     ((uint32_t)0x00000200)  /* Receive watchdog timeout interrupt enable */
+#define ETH_DMAIER_RPSIE     ((uint32_t)0x00000100)  /* Receive process stopped interrupt enable */
+#define ETH_DMAIER_RBUIE     ((uint32_t)0x00000080)  /* Receive buffer unavailable interrupt enable */
+#define ETH_DMAIER_RIE       ((uint32_t)0x00000040)  /* Receive interrupt enable */
+#define ETH_DMAIER_TUIE      ((uint32_t)0x00000020)  /* Transmit Underflow interrupt enable */
+#define ETH_DMAIER_ROIE      ((uint32_t)0x00000010)  /* Receive Overflow interrupt enable */
+#define ETH_DMAIER_TJTIE     ((uint32_t)0x00000008)  /* Transmit jabber timeout interrupt enable */
+#define ETH_DMAIER_TBUIE     ((uint32_t)0x00000004)  /* Transmit buffer unavailable interrupt enable */
+#define ETH_DMAIER_TPSIE     ((uint32_t)0x00000002)  /* Transmit process stopped interrupt enable */
+#define ETH_DMAIER_TIE       ((uint32_t)0x00000001)  /* Transmit interrupt enable */
+
+/* Bit definition for Ethernet DMA Missed Frame and Buffer Overflow Counter Register */
+#define ETH_DMAMFBOCR_OFOC   ((uint32_t)0x10000000)  /* Overflow bit for FIFO overflow counter */
+#define ETH_DMAMFBOCR_MFA    ((uint32_t)0x0FFE0000)  /* Number of frames missed by the application */
+#define ETH_DMAMFBOCR_OMFC   ((uint32_t)0x00010000)  /* Overflow bit for missed frame counter */
+#define ETH_DMAMFBOCR_MFC    ((uint32_t)0x0000FFFF)  /* Number of frames missed by the controller */
+
+/* Bit definition for Ethernet DMA Current Host Transmit Descriptor Register */
+#define ETH_DMACHTDR_HTDAP   ((uint32_t)0xFFFFFFFF)  /* Host transmit descriptor address pointer */
+
+/* Bit definition for Ethernet DMA Current Host Receive Descriptor Register */
+#define ETH_DMACHRDR_HRDAP   ((uint32_t)0xFFFFFFFF)  /* Host receive descriptor address pointer */
+
+/* Bit definition for Ethernet DMA Current Host Transmit Buffer Address Register */
+#define ETH_DMACHTBAR_HTBAP  ((uint32_t)0xFFFFFFFF)  /* Host transmit buffer address pointer */
+
+/* Bit definition for Ethernet DMA Current Host Receive Buffer Address Register */
+#define ETH_DMACHRBAR_HRBAP  ((uint32_t)0xFFFFFFFF)  /* Host receive buffer address pointer */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                       USB_OTG                              */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for USB_OTG_GOTGCTL register  ********************/
+#define USB_OTG_GOTGCTL_SRQSCS                  ((uint32_t)0x00000001)         /*!< Session request success */
+#define USB_OTG_GOTGCTL_SRQ                     ((uint32_t)0x00000002)         /*!< Session request */
+#define USB_OTG_GOTGCTL_VBVALOEN                ((uint32_t)0x00000004)         /*!< VBUS valid override enable */
+#define USB_OTG_GOTGCTL_VBVALOVAL               ((uint32_t)0x00000008)         /*!< VBUS valid override value */
+#define USB_OTG_GOTGCTL_AVALOEN                 ((uint32_t)0x00000010)         /*!< A-peripheral session valid override enable */
+#define USB_OTG_GOTGCTL_AVALOVAL                ((uint32_t)0x00000020)         /*!< A-peripheral session valid override value */
+#define USB_OTG_GOTGCTL_BVALOEN                 ((uint32_t)0x00000040)         /*!< B-peripheral session valid override enable */
+#define USB_OTG_GOTGCTL_BVALOVAL                ((uint32_t)0x00000080)         /*!< B-peripheral session valid override value  */
+#define USB_OTG_GOTGCTL_HNGSCS                  ((uint32_t)0x00000100)         /*!< Host set HNP enable */
+#define USB_OTG_GOTGCTL_HNPRQ                   ((uint32_t)0x00000200)         /*!< HNP request */
+#define USB_OTG_GOTGCTL_HSHNPEN                 ((uint32_t)0x00000400)         /*!< Host set HNP enable */
+#define USB_OTG_GOTGCTL_DHNPEN                  ((uint32_t)0x00000800)         /*!< Device HNP enabled */
+#define USB_OTG_GOTGCTL_EHEN                    ((uint32_t)0x00001000)         /*!< Embedded host enable */
+#define USB_OTG_GOTGCTL_CIDSTS                  ((uint32_t)0x00010000)         /*!< Connector ID status */
+#define USB_OTG_GOTGCTL_DBCT                    ((uint32_t)0x00020000)         /*!< Long/short debounce time */
+#define USB_OTG_GOTGCTL_ASVLD                   ((uint32_t)0x00040000)         /*!< A-session valid  */
+#define USB_OTG_GOTGCTL_BSESVLD                 ((uint32_t)0x00080000)         /*!< B-session valid */
+#define USB_OTG_GOTGCTL_OTGVER                  ((uint32_t)0x00100000)         /*!< OTG version  */
+
+/********************  Bit definition for USB_OTG_HCFG register  ********************/
+#define USB_OTG_HCFG_FSLSPCS                 ((uint32_t)0x00000003)            /*!< FS/LS PHY clock select  */
+#define USB_OTG_HCFG_FSLSPCS_0               ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_HCFG_FSLSPCS_1               ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_HCFG_FSLSS                   ((uint32_t)0x00000004)            /*!< FS- and LS-only support */
+
+/********************  Bit definition for USB_OTG_DCFG register  ********************/
+#define USB_OTG_DCFG_DSPD                    ((uint32_t)0x00000003)            /*!< Device speed */
+#define USB_OTG_DCFG_DSPD_0                  ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_DCFG_DSPD_1                  ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_DCFG_NZLSOHSK                ((uint32_t)0x00000004)            /*!< Nonzero-length status OUT handshake */
+
+#define USB_OTG_DCFG_DAD                     ((uint32_t)0x000007F0)            /*!< Device address */
+#define USB_OTG_DCFG_DAD_0                   ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define USB_OTG_DCFG_DAD_1                   ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define USB_OTG_DCFG_DAD_2                   ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define USB_OTG_DCFG_DAD_3                   ((uint32_t)0x00000080)            /*!<Bit 3 */
+#define USB_OTG_DCFG_DAD_4                   ((uint32_t)0x00000100)            /*!<Bit 4 */
+#define USB_OTG_DCFG_DAD_5                   ((uint32_t)0x00000200)            /*!<Bit 5 */
+#define USB_OTG_DCFG_DAD_6                   ((uint32_t)0x00000400)            /*!<Bit 6 */
+
+#define USB_OTG_DCFG_PFIVL                   ((uint32_t)0x00001800)            /*!< Periodic (micro)frame interval */
+#define USB_OTG_DCFG_PFIVL_0                 ((uint32_t)0x00000800)            /*!<Bit 0 */
+#define USB_OTG_DCFG_PFIVL_1                 ((uint32_t)0x00001000)            /*!<Bit 1 */
+
+#define USB_OTG_DCFG_PERSCHIVL               ((uint32_t)0x03000000)            /*!< Periodic scheduling interval */
+#define USB_OTG_DCFG_PERSCHIVL_0             ((uint32_t)0x01000000)            /*!<Bit 0 */
+#define USB_OTG_DCFG_PERSCHIVL_1             ((uint32_t)0x02000000)            /*!<Bit 1 */
+
+/********************  Bit definition for USB_OTG_PCGCR register  ********************/
+#define USB_OTG_PCGCR_STPPCLK                 ((uint32_t)0x00000001)            /*!< Stop PHY clock */
+#define USB_OTG_PCGCR_GATEHCLK                ((uint32_t)0x00000002)            /*!< Gate HCLK */
+#define USB_OTG_PCGCR_PHYSUSP                 ((uint32_t)0x00000010)            /*!< PHY suspended */
+
+/********************  Bit definition for USB_OTG_GOTGINT register  ********************/
+#define USB_OTG_GOTGINT_SEDET                   ((uint32_t)0x00000004)            /*!< Session end detected                   */
+#define USB_OTG_GOTGINT_SRSSCHG                 ((uint32_t)0x00000100)            /*!< Session request success status change  */
+#define USB_OTG_GOTGINT_HNSSCHG                 ((uint32_t)0x00000200)            /*!< Host negotiation success status change */
+#define USB_OTG_GOTGINT_HNGDET                  ((uint32_t)0x00020000)            /*!< Host negotiation detected              */
+#define USB_OTG_GOTGINT_ADTOCHG                 ((uint32_t)0x00040000)            /*!< A-device timeout change                */
+#define USB_OTG_GOTGINT_DBCDNE                  ((uint32_t)0x00080000)            /*!< Debounce done                          */
+#define USB_OTG_GOTGINT_IDCHNG                  ((uint32_t)0x00100000)            /*!< Change in ID pin input value           */
+
+/********************  Bit definition for USB_OTG_DCTL register  ********************/
+#define USB_OTG_DCTL_RWUSIG                  ((uint32_t)0x00000001)            /*!< Remote wakeup signaling */
+#define USB_OTG_DCTL_SDIS                    ((uint32_t)0x00000002)            /*!< Soft disconnect         */
+#define USB_OTG_DCTL_GINSTS                  ((uint32_t)0x00000004)            /*!< Global IN NAK status    */
+#define USB_OTG_DCTL_GONSTS                  ((uint32_t)0x00000008)            /*!< Global OUT NAK status   */
+
+#define USB_OTG_DCTL_TCTL                    ((uint32_t)0x00000070)            /*!< Test control */
+#define USB_OTG_DCTL_TCTL_0                  ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define USB_OTG_DCTL_TCTL_1                  ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define USB_OTG_DCTL_TCTL_2                  ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define USB_OTG_DCTL_SGINAK                  ((uint32_t)0x00000080)            /*!< Set global IN NAK         */
+#define USB_OTG_DCTL_CGINAK                  ((uint32_t)0x00000100)            /*!< Clear global IN NAK       */
+#define USB_OTG_DCTL_SGONAK                  ((uint32_t)0x00000200)            /*!< Set global OUT NAK        */
+#define USB_OTG_DCTL_CGONAK                  ((uint32_t)0x00000400)            /*!< Clear global OUT NAK      */
+#define USB_OTG_DCTL_POPRGDNE                ((uint32_t)0x00000800)            /*!< Power-on programming done */
+
+/********************  Bit definition for USB_OTG_HFIR register  ********************/
+#define USB_OTG_HFIR_FRIVL                   ((uint32_t)0x0000FFFF)            /*!< Frame interval */
+
+/********************  Bit definition for USB_OTG_HFNUM register  ********************/
+#define USB_OTG_HFNUM_FRNUM                   ((uint32_t)0x0000FFFF)            /*!< Frame number         */
+#define USB_OTG_HFNUM_FTREM                   ((uint32_t)0xFFFF0000)            /*!< Frame time remaining */
+
+/********************  Bit definition for USB_OTG_DSTS register  ********************/
+#define USB_OTG_DSTS_SUSPSTS                 ((uint32_t)0x00000001)            /*!< Suspend status   */
+
+#define USB_OTG_DSTS_ENUMSPD                 ((uint32_t)0x00000006)            /*!< Enumerated speed */
+#define USB_OTG_DSTS_ENUMSPD_0               ((uint32_t)0x00000002)            /*!<Bit 0 */
+#define USB_OTG_DSTS_ENUMSPD_1               ((uint32_t)0x00000004)            /*!<Bit 1 */
+#define USB_OTG_DSTS_EERR                    ((uint32_t)0x00000008)            /*!< Erratic error     */
+#define USB_OTG_DSTS_FNSOF                   ((uint32_t)0x003FFF00)            /*!< Frame number of the received SOF */
+
+/********************  Bit definition for USB_OTG_GAHBCFG register  ********************/
+#define USB_OTG_GAHBCFG_GINT                    ((uint32_t)0x00000001)            /*!< Global interrupt mask */
+#define USB_OTG_GAHBCFG_HBSTLEN                 ((uint32_t)0x0000001E)            /*!< Burst length/type */
+#define USB_OTG_GAHBCFG_HBSTLEN_0               ((uint32_t)0x00000002)            /*!<Bit 0 */
+#define USB_OTG_GAHBCFG_HBSTLEN_1               ((uint32_t)0x00000004)            /*!<Bit 1 */
+#define USB_OTG_GAHBCFG_HBSTLEN_2               ((uint32_t)0x00000008)            /*!<Bit 2 */
+#define USB_OTG_GAHBCFG_HBSTLEN_3               ((uint32_t)0x00000010)            /*!<Bit 3 */
+#define USB_OTG_GAHBCFG_DMAEN                   ((uint32_t)0x00000020)            /*!< DMA enable */
+#define USB_OTG_GAHBCFG_TXFELVL                 ((uint32_t)0x00000080)            /*!< TxFIFO empty level */
+#define USB_OTG_GAHBCFG_PTXFELVL                ((uint32_t)0x00000100)            /*!< Periodic TxFIFO empty level */
+
+/********************  Bit definition for USB_OTG_GUSBCFG register  ********************/
+#define USB_OTG_GUSBCFG_TOCAL                   ((uint32_t)0x00000007)            /*!< FS timeout calibration */
+#define USB_OTG_GUSBCFG_TOCAL_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_GUSBCFG_TOCAL_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_GUSBCFG_TOCAL_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_GUSBCFG_PHYSEL                  ((uint32_t)0x00000040)            /*!< USB 2.0 high-speed ULPI PHY or USB 1.1 full-speed serial transceiver select */
+#define USB_OTG_GUSBCFG_SRPCAP                  ((uint32_t)0x00000100)            /*!< SRP-capable */
+#define USB_OTG_GUSBCFG_HNPCAP                  ((uint32_t)0x00000200)            /*!< HNP-capable */
+#define USB_OTG_GUSBCFG_TRDT                    ((uint32_t)0x00003C00)            /*!< USB turnaround time */
+#define USB_OTG_GUSBCFG_TRDT_0                  ((uint32_t)0x00000400)            /*!<Bit 0 */
+#define USB_OTG_GUSBCFG_TRDT_1                  ((uint32_t)0x00000800)            /*!<Bit 1 */
+#define USB_OTG_GUSBCFG_TRDT_2                  ((uint32_t)0x00001000)            /*!<Bit 2 */
+#define USB_OTG_GUSBCFG_TRDT_3                  ((uint32_t)0x00002000)            /*!<Bit 3 */
+#define USB_OTG_GUSBCFG_PHYLPCS                 ((uint32_t)0x00008000)            /*!< PHY Low-power clock select */
+#define USB_OTG_GUSBCFG_ULPIFSLS                ((uint32_t)0x00020000)            /*!< ULPI FS/LS select               */
+#define USB_OTG_GUSBCFG_ULPIAR                  ((uint32_t)0x00040000)            /*!< ULPI Auto-resume                */
+#define USB_OTG_GUSBCFG_ULPICSM                 ((uint32_t)0x00080000)            /*!< ULPI Clock SuspendM             */
+#define USB_OTG_GUSBCFG_ULPIEVBUSD              ((uint32_t)0x00100000)            /*!< ULPI External VBUS Drive        */
+#define USB_OTG_GUSBCFG_ULPIEVBUSI              ((uint32_t)0x00200000)            /*!< ULPI external VBUS indicator    */
+#define USB_OTG_GUSBCFG_TSDPS                   ((uint32_t)0x00400000)            /*!< TermSel DLine pulsing selection */
+#define USB_OTG_GUSBCFG_PCCI                    ((uint32_t)0x00800000)            /*!< Indicator complement            */
+#define USB_OTG_GUSBCFG_PTCI                    ((uint32_t)0x01000000)            /*!< Indicator pass through          */
+#define USB_OTG_GUSBCFG_ULPIIPD                 ((uint32_t)0x02000000)            /*!< ULPI interface protect disable  */
+#define USB_OTG_GUSBCFG_FHMOD                   ((uint32_t)0x20000000)            /*!< Forced host mode                */
+#define USB_OTG_GUSBCFG_FDMOD                   ((uint32_t)0x40000000)            /*!< Forced peripheral mode          */
+#define USB_OTG_GUSBCFG_CTXPKT                  ((uint32_t)0x80000000)            /*!< Corrupt Tx packet               */
+
+/********************  Bit definition for USB_OTG_GRSTCTL register  ********************/
+#define USB_OTG_GRSTCTL_CSRST                   ((uint32_t)0x00000001)            /*!< Core soft reset          */
+#define USB_OTG_GRSTCTL_HSRST                   ((uint32_t)0x00000002)            /*!< HCLK soft reset          */
+#define USB_OTG_GRSTCTL_FCRST                   ((uint32_t)0x00000004)            /*!< Host frame counter reset */
+#define USB_OTG_GRSTCTL_RXFFLSH                 ((uint32_t)0x00000010)            /*!< RxFIFO flush             */
+#define USB_OTG_GRSTCTL_TXFFLSH                 ((uint32_t)0x00000020)            /*!< TxFIFO flush             */
+#define USB_OTG_GRSTCTL_TXFNUM                  ((uint32_t)0x000007C0)            /*!< TxFIFO number */
+#define USB_OTG_GRSTCTL_TXFNUM_0                ((uint32_t)0x00000040)            /*!<Bit 0 */
+#define USB_OTG_GRSTCTL_TXFNUM_1                ((uint32_t)0x00000080)            /*!<Bit 1 */
+#define USB_OTG_GRSTCTL_TXFNUM_2                ((uint32_t)0x00000100)            /*!<Bit 2 */
+#define USB_OTG_GRSTCTL_TXFNUM_3                ((uint32_t)0x00000200)            /*!<Bit 3 */
+#define USB_OTG_GRSTCTL_TXFNUM_4                ((uint32_t)0x00000400)            /*!<Bit 4 */
+#define USB_OTG_GRSTCTL_DMAREQ                  ((uint32_t)0x40000000)            /*!< DMA request signal */
+#define USB_OTG_GRSTCTL_AHBIDL                  ((uint32_t)0x80000000)            /*!< AHB master idle */
+
+/********************  Bit definition for USB_OTG_DIEPMSK register  ********************/
+#define USB_OTG_DIEPMSK_XFRCM                   ((uint32_t)0x00000001)            /*!< Transfer completed interrupt mask                 */
+#define USB_OTG_DIEPMSK_EPDM                    ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt mask                  */
+#define USB_OTG_DIEPMSK_TOM                     ((uint32_t)0x00000008)            /*!< Timeout condition mask (nonisochronous endpoints) */
+#define USB_OTG_DIEPMSK_ITTXFEMSK               ((uint32_t)0x00000010)            /*!< IN token received when TxFIFO empty mask          */
+#define USB_OTG_DIEPMSK_INEPNMM                 ((uint32_t)0x00000020)            /*!< IN token received with EP mismatch mask           */
+#define USB_OTG_DIEPMSK_INEPNEM                 ((uint32_t)0x00000040)            /*!< IN endpoint NAK effective mask                    */
+#define USB_OTG_DIEPMSK_TXFURM                  ((uint32_t)0x00000100)            /*!< FIFO underrun mask                                */
+#define USB_OTG_DIEPMSK_BIM                     ((uint32_t)0x00000200)            /*!< BNA interrupt mask                                */
+
+/********************  Bit definition for USB_OTG_HPTXSTS register  ********************/
+#define USB_OTG_HPTXSTS_PTXFSAVL                ((uint32_t)0x0000FFFF)            /*!< Periodic transmit data FIFO space available     */
+#define USB_OTG_HPTXSTS_PTXQSAV                 ((uint32_t)0x00FF0000)            /*!< Periodic transmit request queue space available */
+#define USB_OTG_HPTXSTS_PTXQSAV_0               ((uint32_t)0x00010000)            /*!<Bit 0 */
+#define USB_OTG_HPTXSTS_PTXQSAV_1               ((uint32_t)0x00020000)            /*!<Bit 1 */
+#define USB_OTG_HPTXSTS_PTXQSAV_2               ((uint32_t)0x00040000)            /*!<Bit 2 */
+#define USB_OTG_HPTXSTS_PTXQSAV_3               ((uint32_t)0x00080000)            /*!<Bit 3 */
+#define USB_OTG_HPTXSTS_PTXQSAV_4               ((uint32_t)0x00100000)            /*!<Bit 4 */
+#define USB_OTG_HPTXSTS_PTXQSAV_5               ((uint32_t)0x00200000)            /*!<Bit 5 */
+#define USB_OTG_HPTXSTS_PTXQSAV_6               ((uint32_t)0x00400000)            /*!<Bit 6 */
+#define USB_OTG_HPTXSTS_PTXQSAV_7               ((uint32_t)0x00800000)            /*!<Bit 7 */
+
+#define USB_OTG_HPTXSTS_PTXQTOP                 ((uint32_t)0xFF000000)            /*!< Top of the periodic transmit request queue */
+#define USB_OTG_HPTXSTS_PTXQTOP_0               ((uint32_t)0x01000000)            /*!<Bit 0 */
+#define USB_OTG_HPTXSTS_PTXQTOP_1               ((uint32_t)0x02000000)            /*!<Bit 1 */
+#define USB_OTG_HPTXSTS_PTXQTOP_2               ((uint32_t)0x04000000)            /*!<Bit 2 */
+#define USB_OTG_HPTXSTS_PTXQTOP_3               ((uint32_t)0x08000000)            /*!<Bit 3 */
+#define USB_OTG_HPTXSTS_PTXQTOP_4               ((uint32_t)0x10000000)            /*!<Bit 4 */
+#define USB_OTG_HPTXSTS_PTXQTOP_5               ((uint32_t)0x20000000)            /*!<Bit 5 */
+#define USB_OTG_HPTXSTS_PTXQTOP_6               ((uint32_t)0x40000000)            /*!<Bit 6 */
+#define USB_OTG_HPTXSTS_PTXQTOP_7               ((uint32_t)0x80000000)            /*!<Bit 7 */
+
+/********************  Bit definition for USB_OTG_HAINT register  ********************/
+#define USB_OTG_HAINT_HAINT                   ((uint32_t)0x0000FFFF)            /*!< Channel interrupts */
+
+/********************  Bit definition for USB_OTG_DOEPMSK register  ********************/
+#define USB_OTG_DOEPMSK_XFRCM                   ((uint32_t)0x00000001)            /*!< Transfer completed interrupt mask */
+#define USB_OTG_DOEPMSK_EPDM                    ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt mask               */
+#define USB_OTG_DOEPMSK_STUPM                   ((uint32_t)0x00000008)            /*!< SETUP phase done mask                          */
+#define USB_OTG_DOEPMSK_OTEPDM                  ((uint32_t)0x00000010)            /*!< OUT token received when endpoint disabled mask */
+#define USB_OTG_DOEPMSK_B2BSTUP                 ((uint32_t)0x00000040)            /*!< Back-to-back SETUP packets received mask       */
+#define USB_OTG_DOEPMSK_OPEM                    ((uint32_t)0x00000100)            /*!< OUT packet error mask                          */
+#define USB_OTG_DOEPMSK_BOIM                    ((uint32_t)0x00000200)            /*!< BNA interrupt mask                             */
+
+/********************  Bit definition for USB_OTG_GINTSTS register  ********************/
+#define USB_OTG_GINTSTS_CMOD                    ((uint32_t)0x00000001)            /*!< Current mode of operation                      */
+#define USB_OTG_GINTSTS_MMIS                    ((uint32_t)0x00000002)            /*!< Mode mismatch interrupt                        */
+#define USB_OTG_GINTSTS_OTGINT                  ((uint32_t)0x00000004)            /*!< OTG interrupt                                  */
+#define USB_OTG_GINTSTS_SOF                     ((uint32_t)0x00000008)            /*!< Start of frame                                 */
+#define USB_OTG_GINTSTS_RXFLVL                  ((uint32_t)0x00000010)            /*!< RxFIFO nonempty                                */
+#define USB_OTG_GINTSTS_NPTXFE                  ((uint32_t)0x00000020)            /*!< Nonperiodic TxFIFO empty                       */
+#define USB_OTG_GINTSTS_GINAKEFF                ((uint32_t)0x00000040)            /*!< Global IN nonperiodic NAK effective            */
+#define USB_OTG_GINTSTS_BOUTNAKEFF              ((uint32_t)0x00000080)            /*!< Global OUT NAK effective                       */
+#define USB_OTG_GINTSTS_ESUSP                   ((uint32_t)0x00000400)            /*!< Early suspend                                  */
+#define USB_OTG_GINTSTS_USBSUSP                 ((uint32_t)0x00000800)            /*!< USB suspend                                    */
+#define USB_OTG_GINTSTS_USBRST                  ((uint32_t)0x00001000)            /*!< USB reset                                      */
+#define USB_OTG_GINTSTS_ENUMDNE                 ((uint32_t)0x00002000)            /*!< Enumeration done                               */
+#define USB_OTG_GINTSTS_ISOODRP                 ((uint32_t)0x00004000)            /*!< Isochronous OUT packet dropped interrupt       */
+#define USB_OTG_GINTSTS_EOPF                    ((uint32_t)0x00008000)            /*!< End of periodic frame interrupt                */
+#define USB_OTG_GINTSTS_IEPINT                  ((uint32_t)0x00040000)            /*!< IN endpoint interrupt                          */
+#define USB_OTG_GINTSTS_OEPINT                  ((uint32_t)0x00080000)            /*!< OUT endpoint interrupt                         */
+#define USB_OTG_GINTSTS_IISOIXFR                ((uint32_t)0x00100000)            /*!< Incomplete isochronous IN transfer             */
+#define USB_OTG_GINTSTS_PXFR_INCOMPISOOUT       ((uint32_t)0x00200000)            /*!< Incomplete periodic transfer                   */
+#define USB_OTG_GINTSTS_DATAFSUSP               ((uint32_t)0x00400000)            /*!< Data fetch suspended                           */
+#define USB_OTG_GINTSTS_RSTDET                  ((uint32_t)0x00800000)            /*!< Reset detected interrupt                       */
+#define USB_OTG_GINTSTS_HPRTINT                 ((uint32_t)0x01000000)            /*!< Host port interrupt                            */
+#define USB_OTG_GINTSTS_HCINT                   ((uint32_t)0x02000000)            /*!< Host channels interrupt                        */
+#define USB_OTG_GINTSTS_PTXFE                   ((uint32_t)0x04000000)            /*!< Periodic TxFIFO empty                          */
+#define USB_OTG_GINTSTS_LPMINT                  ((uint32_t)0x08000000)            /*!< LPM interrupt                                  */
+#define USB_OTG_GINTSTS_CIDSCHG                 ((uint32_t)0x10000000)            /*!< Connector ID status change                     */
+#define USB_OTG_GINTSTS_DISCINT                 ((uint32_t)0x20000000)            /*!< Disconnect detected interrupt                  */
+#define USB_OTG_GINTSTS_SRQINT                  ((uint32_t)0x40000000)            /*!< Session request/new session detected interrupt */
+#define USB_OTG_GINTSTS_WKUINT                  ((uint32_t)0x80000000)            /*!< Resume/remote wakeup detected interrupt        */
+
+/********************  Bit definition for USB_OTG_GINTMSK register  ********************/
+#define USB_OTG_GINTMSK_MMISM                   ((uint32_t)0x00000002)            /*!< Mode mismatch interrupt mask                        */
+#define USB_OTG_GINTMSK_OTGINT                  ((uint32_t)0x00000004)            /*!< OTG interrupt mask                                  */
+#define USB_OTG_GINTMSK_SOFM                    ((uint32_t)0x00000008)            /*!< Start of frame mask                                 */
+#define USB_OTG_GINTMSK_RXFLVLM                 ((uint32_t)0x00000010)            /*!< Receive FIFO nonempty mask                          */
+#define USB_OTG_GINTMSK_NPTXFEM                 ((uint32_t)0x00000020)            /*!< Nonperiodic TxFIFO empty mask                       */
+#define USB_OTG_GINTMSK_GINAKEFFM               ((uint32_t)0x00000040)            /*!< Global nonperiodic IN NAK effective mask            */
+#define USB_OTG_GINTMSK_GONAKEFFM               ((uint32_t)0x00000080)            /*!< Global OUT NAK effective mask                       */
+#define USB_OTG_GINTMSK_ESUSPM                  ((uint32_t)0x00000400)            /*!< Early suspend mask                                  */
+#define USB_OTG_GINTMSK_USBSUSPM                ((uint32_t)0x00000800)            /*!< USB suspend mask                                    */
+#define USB_OTG_GINTMSK_USBRST                  ((uint32_t)0x00001000)            /*!< USB reset mask                                      */
+#define USB_OTG_GINTMSK_ENUMDNEM                ((uint32_t)0x00002000)            /*!< Enumeration done mask                               */
+#define USB_OTG_GINTMSK_ISOODRPM                ((uint32_t)0x00004000)            /*!< Isochronous OUT packet dropped interrupt mask       */
+#define USB_OTG_GINTMSK_EOPFM                   ((uint32_t)0x00008000)            /*!< End of periodic frame interrupt mask                */
+#define USB_OTG_GINTMSK_EPMISM                  ((uint32_t)0x00020000)            /*!< Endpoint mismatch interrupt mask                    */
+#define USB_OTG_GINTMSK_IEPINT                  ((uint32_t)0x00040000)            /*!< IN endpoints interrupt mask                         */
+#define USB_OTG_GINTMSK_OEPINT                  ((uint32_t)0x00080000)            /*!< OUT endpoints interrupt mask                        */
+#define USB_OTG_GINTMSK_IISOIXFRM               ((uint32_t)0x00100000)            /*!< Incomplete isochronous IN transfer mask             */
+#define USB_OTG_GINTMSK_PXFRM_IISOOXFRM         ((uint32_t)0x00200000)            /*!< Incomplete periodic transfer mask                   */
+#define USB_OTG_GINTMSK_FSUSPM                  ((uint32_t)0x00400000)            /*!< Data fetch suspended mask                           */
+#define USB_OTG_GINTMSK_RSTDEM                  ((uint32_t)0x00800000)            /*!< Reset detected interrupt mask                      */
+#define USB_OTG_GINTMSK_PRTIM                   ((uint32_t)0x01000000)            /*!< Host port interrupt mask                            */
+#define USB_OTG_GINTMSK_HCIM                    ((uint32_t)0x02000000)            /*!< Host channels interrupt mask                        */
+#define USB_OTG_GINTMSK_PTXFEM                  ((uint32_t)0x04000000)            /*!< Periodic TxFIFO empty mask                          */
+#define USB_OTG_GINTMSK_LPMINTM                 ((uint32_t)0x08000000)            /*!< LPM interrupt Mask                                  */
+#define USB_OTG_GINTMSK_CIDSCHGM                ((uint32_t)0x10000000)            /*!< Connector ID status change mask                     */
+#define USB_OTG_GINTMSK_DISCINT                 ((uint32_t)0x20000000)            /*!< Disconnect detected interrupt mask                  */
+#define USB_OTG_GINTMSK_SRQIM                   ((uint32_t)0x40000000)            /*!< Session request/new session detected interrupt mask */
+#define USB_OTG_GINTMSK_WUIM                    ((uint32_t)0x80000000)            /*!< Resume/remote wakeup detected interrupt mask        */
+
+/********************  Bit definition for USB_OTG_DAINT register  ********************/
+#define USB_OTG_DAINT_IEPINT                  ((uint32_t)0x0000FFFF)            /*!< IN endpoint interrupt bits  */
+#define USB_OTG_DAINT_OEPINT                  ((uint32_t)0xFFFF0000)            /*!< OUT endpoint interrupt bits */
+
+/********************  Bit definition for USB_OTG_HAINTMSK register  ********************/
+#define USB_OTG_HAINTMSK_HAINTM                  ((uint32_t)0x0000FFFF)            /*!< Channel interrupt mask */
+
+/********************  Bit definition for USB_OTG_GRXSTSP register  ********************/
+#define USB_OTG_GRXSTSP_EPNUM                    ((uint32_t)0x0000000F)            /*!< IN EP interrupt mask bits  */
+#define USB_OTG_GRXSTSP_BCNT                     ((uint32_t)0x00007FF0)            /*!< OUT EP interrupt mask bits */
+#define USB_OTG_GRXSTSP_DPID                     ((uint32_t)0x00018000)            /*!< OUT EP interrupt mask bits */
+#define USB_OTG_GRXSTSP_PKTSTS                   ((uint32_t)0x001E0000)            /*!< OUT EP interrupt mask bits */
+
+/********************  Bit definition for USB_OTG_DAINTMSK register  ********************/
+#define USB_OTG_DAINTMSK_IEPM                    ((uint32_t)0x0000FFFF)            /*!< IN EP interrupt mask bits */
+#define USB_OTG_DAINTMSK_OEPM                    ((uint32_t)0xFFFF0000)            /*!< OUT EP interrupt mask bits */
+
+/********************  Bit definition for OTG register  ********************/
+
+#define USB_OTG_CHNUM                   ((uint32_t)0x0000000F)            /*!< Channel number */
+#define USB_OTG_CHNUM_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_CHNUM_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_CHNUM_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_CHNUM_3                 ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define USB_OTG_BCNT                    ((uint32_t)0x00007FF0)            /*!< Byte count */
+
+#define USB_OTG_DPID                    ((uint32_t)0x00018000)            /*!< Data PID */
+#define USB_OTG_DPID_0                  ((uint32_t)0x00008000)            /*!<Bit 0 */
+#define USB_OTG_DPID_1                  ((uint32_t)0x00010000)            /*!<Bit 1 */
+
+#define USB_OTG_PKTSTS                  ((uint32_t)0x001E0000)            /*!< Packet status */
+#define USB_OTG_PKTSTS_0                ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define USB_OTG_PKTSTS_1                ((uint32_t)0x00040000)            /*!<Bit 1 */
+#define USB_OTG_PKTSTS_2                ((uint32_t)0x00080000)            /*!<Bit 2 */
+#define USB_OTG_PKTSTS_3                ((uint32_t)0x00100000)            /*!<Bit 3 */
+
+#define USB_OTG_EPNUM                   ((uint32_t)0x0000000F)            /*!< Endpoint number */
+#define USB_OTG_EPNUM_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_EPNUM_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_EPNUM_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_EPNUM_3                 ((uint32_t)0x00000008)            /*!<Bit 3 */
+
+#define USB_OTG_FRMNUM                  ((uint32_t)0x01E00000)            /*!< Frame number */
+#define USB_OTG_FRMNUM_0                ((uint32_t)0x00200000)            /*!<Bit 0 */
+#define USB_OTG_FRMNUM_1                ((uint32_t)0x00400000)            /*!<Bit 1 */
+#define USB_OTG_FRMNUM_2                ((uint32_t)0x00800000)            /*!<Bit 2 */
+#define USB_OTG_FRMNUM_3                ((uint32_t)0x01000000)            /*!<Bit 3 */
+
+/********************  Bit definition for OTG register  ********************/
+
+#define USB_OTG_CHNUM                   ((uint32_t)0x0000000F)            /*!< Channel number */
+#define USB_OTG_CHNUM_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_CHNUM_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_CHNUM_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_CHNUM_3                 ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define USB_OTG_BCNT                    ((uint32_t)0x00007FF0)            /*!< Byte count */
+
+#define USB_OTG_DPID                    ((uint32_t)0x00018000)            /*!< Data PID */
+#define USB_OTG_DPID_0                  ((uint32_t)0x00008000)            /*!<Bit 0 */
+#define USB_OTG_DPID_1                  ((uint32_t)0x00010000)            /*!<Bit 1 */
+
+#define USB_OTG_PKTSTS                  ((uint32_t)0x001E0000)            /*!< Packet status */
+#define USB_OTG_PKTSTS_0                ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define USB_OTG_PKTSTS_1                ((uint32_t)0x00040000)            /*!<Bit 1 */
+#define USB_OTG_PKTSTS_2                ((uint32_t)0x00080000)            /*!<Bit 2 */
+#define USB_OTG_PKTSTS_3                ((uint32_t)0x00100000)            /*!<Bit 3 */
+
+#define USB_OTG_EPNUM                   ((uint32_t)0x0000000F)            /*!< Endpoint number */
+#define USB_OTG_EPNUM_0                 ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_EPNUM_1                 ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_EPNUM_2                 ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_EPNUM_3                 ((uint32_t)0x00000008)            /*!<Bit 3 */
+
+#define USB_OTG_FRMNUM                  ((uint32_t)0x01E00000)            /*!< Frame number */
+#define USB_OTG_FRMNUM_0                ((uint32_t)0x00200000)            /*!<Bit 0 */
+#define USB_OTG_FRMNUM_1                ((uint32_t)0x00400000)            /*!<Bit 1 */
+#define USB_OTG_FRMNUM_2                ((uint32_t)0x00800000)            /*!<Bit 2 */
+#define USB_OTG_FRMNUM_3                ((uint32_t)0x01000000)            /*!<Bit 3 */
+
+/********************  Bit definition for USB_OTG_GRXFSIZ register  ********************/
+#define USB_OTG_GRXFSIZ_RXFD            ((uint32_t)0x0000FFFF)            /*!< RxFIFO depth */
+
+/********************  Bit definition for USB_OTG_DVBUSDIS register  ********************/
+#define USB_OTG_DVBUSDIS_VBUSDT         ((uint32_t)0x0000FFFF)            /*!< Device VBUS discharge time */
+
+/********************  Bit definition for OTG register  ********************/
+#define USB_OTG_NPTXFSA                 ((uint32_t)0x0000FFFF)            /*!< Nonperiodic transmit RAM start address */
+#define USB_OTG_NPTXFD                  ((uint32_t)0xFFFF0000)            /*!< Nonperiodic TxFIFO depth               */
+#define USB_OTG_TX0FSA                  ((uint32_t)0x0000FFFF)            /*!< Endpoint 0 transmit RAM start address  */
+#define USB_OTG_TX0FD                   ((uint32_t)0xFFFF0000)            /*!< Endpoint 0 TxFIFO depth                */
+
+/********************  Bit definition for USB_OTG_DVBUSPULSE register  ********************/
+#define USB_OTG_DVBUSPULSE_DVBUSP                  ((uint32_t)0x00000FFF)            /*!< Device VBUS pulsing time */
+
+/********************  Bit definition for USB_OTG_GNPTXSTS register  ********************/
+#define USB_OTG_GNPTXSTS_NPTXFSAV                ((uint32_t)0x0000FFFF)            /*!< Nonperiodic TxFIFO space available */
+
+#define USB_OTG_GNPTXSTS_NPTQXSAV                ((uint32_t)0x00FF0000)            /*!< Nonperiodic transmit request queue space available */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_0              ((uint32_t)0x00010000)            /*!<Bit 0 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_1              ((uint32_t)0x00020000)            /*!<Bit 1 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_2              ((uint32_t)0x00040000)            /*!<Bit 2 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_3              ((uint32_t)0x00080000)            /*!<Bit 3 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_4              ((uint32_t)0x00100000)            /*!<Bit 4 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_5              ((uint32_t)0x00200000)            /*!<Bit 5 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_6              ((uint32_t)0x00400000)            /*!<Bit 6 */
+#define USB_OTG_GNPTXSTS_NPTQXSAV_7              ((uint32_t)0x00800000)            /*!<Bit 7 */
+
+#define USB_OTG_GNPTXSTS_NPTXQTOP                ((uint32_t)0x7F000000)            /*!< Top of the nonperiodic transmit request queue */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_0              ((uint32_t)0x01000000)            /*!<Bit 0 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_1              ((uint32_t)0x02000000)            /*!<Bit 1 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_2              ((uint32_t)0x04000000)            /*!<Bit 2 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_3              ((uint32_t)0x08000000)            /*!<Bit 3 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_4              ((uint32_t)0x10000000)            /*!<Bit 4 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_5              ((uint32_t)0x20000000)            /*!<Bit 5 */
+#define USB_OTG_GNPTXSTS_NPTXQTOP_6              ((uint32_t)0x40000000)            /*!<Bit 6 */
+
+/********************  Bit definition for USB_OTG_DTHRCTL register  ********************/
+#define USB_OTG_DTHRCTL_NONISOTHREN             ((uint32_t)0x00000001)            /*!< Nonisochronous IN endpoints threshold enable */
+#define USB_OTG_DTHRCTL_ISOTHREN                ((uint32_t)0x00000002)            /*!< ISO IN endpoint threshold enable */
+
+#define USB_OTG_DTHRCTL_TXTHRLEN                ((uint32_t)0x000007FC)            /*!< Transmit threshold length */
+#define USB_OTG_DTHRCTL_TXTHRLEN_0              ((uint32_t)0x00000004)            /*!<Bit 0 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_1              ((uint32_t)0x00000008)            /*!<Bit 1 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_2              ((uint32_t)0x00000010)            /*!<Bit 2 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_3              ((uint32_t)0x00000020)            /*!<Bit 3 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_4              ((uint32_t)0x00000040)            /*!<Bit 4 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_5              ((uint32_t)0x00000080)            /*!<Bit 5 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_6              ((uint32_t)0x00000100)            /*!<Bit 6 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_7              ((uint32_t)0x00000200)            /*!<Bit 7 */
+#define USB_OTG_DTHRCTL_TXTHRLEN_8              ((uint32_t)0x00000400)            /*!<Bit 8 */
+#define USB_OTG_DTHRCTL_RXTHREN                 ((uint32_t)0x00010000)            /*!< Receive threshold enable */
+
+#define USB_OTG_DTHRCTL_RXTHRLEN                ((uint32_t)0x03FE0000)            /*!< Receive threshold length */
+#define USB_OTG_DTHRCTL_RXTHRLEN_0              ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_1              ((uint32_t)0x00040000)            /*!<Bit 1 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_2              ((uint32_t)0x00080000)            /*!<Bit 2 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_3              ((uint32_t)0x00100000)            /*!<Bit 3 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_4              ((uint32_t)0x00200000)            /*!<Bit 4 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_5              ((uint32_t)0x00400000)            /*!<Bit 5 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_6              ((uint32_t)0x00800000)            /*!<Bit 6 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_7              ((uint32_t)0x01000000)            /*!<Bit 7 */
+#define USB_OTG_DTHRCTL_RXTHRLEN_8              ((uint32_t)0x02000000)            /*!<Bit 8 */
+#define USB_OTG_DTHRCTL_ARPEN                   ((uint32_t)0x08000000)            /*!< Arbiter parking enable */
+
+/********************  Bit definition for USB_OTG_DIEPEMPMSK register  ********************/
+#define USB_OTG_DIEPEMPMSK_INEPTXFEM               ((uint32_t)0x0000FFFF)         /*!< IN EP Tx FIFO empty interrupt mask bits */
+
+/********************  Bit definition for USB_OTG_DEACHINT register  ********************/
+#define USB_OTG_DEACHINT_IEP1INT                 ((uint32_t)0x00000002)           /*!< IN endpoint 1interrupt bit   */
+#define USB_OTG_DEACHINT_OEP1INT                 ((uint32_t)0x00020000)           /*!< OUT endpoint 1 interrupt bit */
+
+/********************  Bit definition for USB_OTG_GCCFG register  ********************/
+#define USB_OTG_GCCFG_PWRDWN                 ((uint32_t)0x00010000)              /*!< Power down */
+#define USB_OTG_GCCFG_VBDEN                  ((uint32_t)0x00200000)              /*!< USB VBUS Detection Enable */
+
+/********************  Bit definition for USB_OTG_GPWRDN) register  ********************/
+#define USB_OTG_GPWRDN_ADPMEN                 ((uint32_t)0x00000001)             /*!< ADP module enable */
+#define USB_OTG_GPWRDN_ADPIF                  ((uint32_t)0x00800000)             /*!< ADP Interrupt flag */
+
+/********************  Bit definition for USB_OTG_DEACHINTMSK register  ********************/
+#define USB_OTG_DEACHINTMSK_IEP1INTM          ((uint32_t)0x00000002)            /*!< IN Endpoint 1 interrupt mask bit  */
+#define USB_OTG_DEACHINTMSK_OEP1INTM          ((uint32_t)0x00020000)            /*!< OUT Endpoint 1 interrupt mask bit */
+
+/********************  Bit definition for USB_OTG_CID register  ********************/
+#define USB_OTG_CID_PRODUCT_ID               ((uint32_t)0xFFFFFFFF)            /*!< Product ID field */
+
+/********************  Bit definition for USB_OTG_GLPMCFG register  ********************/
+#define  USB_OTG_GLPMCFG_LPMEN               ((uint32_t)0x00000001)            /*!< LPM support enable                                     */
+#define  USB_OTG_GLPMCFG_LPMACK              ((uint32_t)0x00000002)            /*!< LPM Token acknowledge enable                           */
+#define  USB_OTG_GLPMCFG_BESL                ((uint32_t)0x0000003C)            /*!< BESL value received with last ACKed LPM Token          */
+#define  USB_OTG_GLPMCFG_REMWAKE             ((uint32_t)0x00000040)            /*!< bRemoteWake value received with last ACKed LPM Token   */
+#define  USB_OTG_GLPMCFG_L1SSEN              ((uint32_t)0x00000080)            /*!< L1 shallow sleep enable                                */
+#define  USB_OTG_GLPMCFG_BESLTHRS            ((uint32_t)0x00000F00)            /*!< BESL threshold                                         */
+#define  USB_OTG_GLPMCFG_L1DSEN              ((uint32_t)0x00001000)            /*!< L1 deep sleep enable                                   */
+#define  USB_OTG_GLPMCFG_LPMRSP              ((uint32_t)0x00006000)            /*!< LPM response                                           */
+#define  USB_OTG_GLPMCFG_SLPSTS              ((uint32_t)0x00008000)            /*!< Port sleep status                                      */
+#define  USB_OTG_GLPMCFG_L1RSMOK             ((uint32_t)0x00010000)            /*!< Sleep State Resume OK                                  */
+#define  USB_OTG_GLPMCFG_LPMCHIDX            ((uint32_t)0x001E0000)            /*!< LPM Channel Index                                      */
+#define  USB_OTG_GLPMCFG_LPMRCNT             ((uint32_t)0x00E00000)            /*!< LPM retry count                                        */
+#define  USB_OTG_GLPMCFG_SNDLPM              ((uint32_t)0x01000000)            /*!< Send LPM transaction                                   */
+#define  USB_OTG_GLPMCFG_LPMRCNTSTS          ((uint32_t)0x0E000000)            /*!< LPM retry count status                                 */
+#define  USB_OTG_GLPMCFG_ENBESL              ((uint32_t)0x10000000)            /*!< Enable best effort service latency                     */
+
+/********************  Bit definition for USB_OTG_DIEPEACHMSK1 register  ********************/
+#define USB_OTG_DIEPEACHMSK1_XFRCM           ((uint32_t)0x00000001)            /*!< Transfer completed interrupt mask                 */
+#define USB_OTG_DIEPEACHMSK1_EPDM            ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt mask                  */
+#define USB_OTG_DIEPEACHMSK1_TOM             ((uint32_t)0x00000008)            /*!< Timeout condition mask (nonisochronous endpoints) */
+#define USB_OTG_DIEPEACHMSK1_ITTXFEMSK       ((uint32_t)0x00000010)            /*!< IN token received when TxFIFO empty mask          */
+#define USB_OTG_DIEPEACHMSK1_INEPNMM         ((uint32_t)0x00000020)            /*!< IN token received with EP mismatch mask           */
+#define USB_OTG_DIEPEACHMSK1_INEPNEM         ((uint32_t)0x00000040)            /*!< IN endpoint NAK effective mask                    */
+#define USB_OTG_DIEPEACHMSK1_TXFURM          ((uint32_t)0x00000100)            /*!< FIFO underrun mask                                */
+#define USB_OTG_DIEPEACHMSK1_BIM             ((uint32_t)0x00000200)            /*!< BNA interrupt mask                                */
+#define USB_OTG_DIEPEACHMSK1_NAKM            ((uint32_t)0x00002000)            /*!< NAK interrupt mask                                */
+
+/********************  Bit definition for USB_OTG_HPRT register  ********************/
+#define USB_OTG_HPRT_PCSTS                   ((uint32_t)0x00000001)            /*!< Port connect status        */
+#define USB_OTG_HPRT_PCDET                   ((uint32_t)0x00000002)            /*!< Port connect detected      */
+#define USB_OTG_HPRT_PENA                    ((uint32_t)0x00000004)            /*!< Port enable                */
+#define USB_OTG_HPRT_PENCHNG                 ((uint32_t)0x00000008)            /*!< Port enable/disable change */
+#define USB_OTG_HPRT_POCA                    ((uint32_t)0x00000010)            /*!< Port overcurrent active    */
+#define USB_OTG_HPRT_POCCHNG                 ((uint32_t)0x00000020)            /*!< Port overcurrent change    */
+#define USB_OTG_HPRT_PRES                    ((uint32_t)0x00000040)            /*!< Port resume                */
+#define USB_OTG_HPRT_PSUSP                   ((uint32_t)0x00000080)            /*!< Port suspend               */
+#define USB_OTG_HPRT_PRST                    ((uint32_t)0x00000100)            /*!< Port reset                 */
+
+#define USB_OTG_HPRT_PLSTS                   ((uint32_t)0x00000C00)            /*!< Port line status           */
+#define USB_OTG_HPRT_PLSTS_0                 ((uint32_t)0x00000400)            /*!<Bit 0 */
+#define USB_OTG_HPRT_PLSTS_1                 ((uint32_t)0x00000800)            /*!<Bit 1 */
+#define USB_OTG_HPRT_PPWR                    ((uint32_t)0x00001000)            /*!< Port power                 */
+
+#define USB_OTG_HPRT_PTCTL                   ((uint32_t)0x0001E000)            /*!< Port test control          */
+#define USB_OTG_HPRT_PTCTL_0                 ((uint32_t)0x00002000)            /*!<Bit 0 */
+#define USB_OTG_HPRT_PTCTL_1                 ((uint32_t)0x00004000)            /*!<Bit 1 */
+#define USB_OTG_HPRT_PTCTL_2                 ((uint32_t)0x00008000)            /*!<Bit 2 */
+#define USB_OTG_HPRT_PTCTL_3                 ((uint32_t)0x00010000)            /*!<Bit 3 */
+
+#define USB_OTG_HPRT_PSPD                    ((uint32_t)0x00060000)            /*!< Port speed                 */
+#define USB_OTG_HPRT_PSPD_0                  ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define USB_OTG_HPRT_PSPD_1                  ((uint32_t)0x00040000)            /*!<Bit 1 */
+
+/********************  Bit definition for USB_OTG_DOEPEACHMSK1 register  ********************/
+#define USB_OTG_DOEPEACHMSK1_XFRCM                   ((uint32_t)0x00000001)            /*!< Transfer completed interrupt mask         */
+#define USB_OTG_DOEPEACHMSK1_EPDM                    ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt mask          */
+#define USB_OTG_DOEPEACHMSK1_TOM                     ((uint32_t)0x00000008)            /*!< Timeout condition mask                    */
+#define USB_OTG_DOEPEACHMSK1_ITTXFEMSK               ((uint32_t)0x00000010)            /*!< IN token received when TxFIFO empty mask  */
+#define USB_OTG_DOEPEACHMSK1_INEPNMM                 ((uint32_t)0x00000020)            /*!< IN token received with EP mismatch mask   */
+#define USB_OTG_DOEPEACHMSK1_INEPNEM                 ((uint32_t)0x00000040)            /*!< IN endpoint NAK effective mask            */
+#define USB_OTG_DOEPEACHMSK1_TXFURM                  ((uint32_t)0x00000100)            /*!< OUT packet error mask                     */
+#define USB_OTG_DOEPEACHMSK1_BIM                     ((uint32_t)0x00000200)            /*!< BNA interrupt mask                        */
+#define USB_OTG_DOEPEACHMSK1_BERRM                   ((uint32_t)0x00001000)            /*!< Bubble error interrupt mask               */
+#define USB_OTG_DOEPEACHMSK1_NAKM                    ((uint32_t)0x00002000)            /*!< NAK interrupt mask                        */
+#define USB_OTG_DOEPEACHMSK1_NYETM                   ((uint32_t)0x00004000)            /*!< NYET interrupt mask                       */
+
+/********************  Bit definition for USB_OTG_HPTXFSIZ register  ********************/
+#define USB_OTG_HPTXFSIZ_PTXSA                   ((uint32_t)0x0000FFFF)            /*!< Host periodic TxFIFO start address            */
+#define USB_OTG_HPTXFSIZ_PTXFD                   ((uint32_t)0xFFFF0000)            /*!< Host periodic TxFIFO depth                    */
+
+/********************  Bit definition for USB_OTG_DIEPCTL register  ********************/
+#define USB_OTG_DIEPCTL_MPSIZ                   ((uint32_t)0x000007FF)            /*!< Maximum packet size              */
+#define USB_OTG_DIEPCTL_USBAEP                  ((uint32_t)0x00008000)            /*!< USB active endpoint              */
+#define USB_OTG_DIEPCTL_EONUM_DPID              ((uint32_t)0x00010000)            /*!< Even/odd frame                   */
+#define USB_OTG_DIEPCTL_NAKSTS                  ((uint32_t)0x00020000)            /*!< NAK status                       */
+
+#define USB_OTG_DIEPCTL_EPTYP                   ((uint32_t)0x000C0000)            /*!< Endpoint type                    */
+#define USB_OTG_DIEPCTL_EPTYP_0                 ((uint32_t)0x00040000)            /*!<Bit 0 */
+#define USB_OTG_DIEPCTL_EPTYP_1                 ((uint32_t)0x00080000)            /*!<Bit 1 */
+#define USB_OTG_DIEPCTL_STALL                   ((uint32_t)0x00200000)            /*!< STALL handshake                  */
+
+#define USB_OTG_DIEPCTL_TXFNUM                  ((uint32_t)0x03C00000)            /*!< TxFIFO number                    */
+#define USB_OTG_DIEPCTL_TXFNUM_0                ((uint32_t)0x00400000)            /*!<Bit 0 */
+#define USB_OTG_DIEPCTL_TXFNUM_1                ((uint32_t)0x00800000)            /*!<Bit 1 */
+#define USB_OTG_DIEPCTL_TXFNUM_2                ((uint32_t)0x01000000)            /*!<Bit 2 */
+#define USB_OTG_DIEPCTL_TXFNUM_3                ((uint32_t)0x02000000)            /*!<Bit 3 */
+#define USB_OTG_DIEPCTL_CNAK                    ((uint32_t)0x04000000)            /*!< Clear NAK                        */
+#define USB_OTG_DIEPCTL_SNAK                    ((uint32_t)0x08000000)            /*!< Set NAK */
+#define USB_OTG_DIEPCTL_SD0PID_SEVNFRM          ((uint32_t)0x10000000)            /*!< Set DATA0 PID                    */
+#define USB_OTG_DIEPCTL_SODDFRM                 ((uint32_t)0x20000000)            /*!< Set odd frame                    */
+#define USB_OTG_DIEPCTL_EPDIS                   ((uint32_t)0x40000000)            /*!< Endpoint disable                 */
+#define USB_OTG_DIEPCTL_EPENA                   ((uint32_t)0x80000000)            /*!< Endpoint enable                  */
+
+/********************  Bit definition for USB_OTG_HCCHAR register  ********************/
+#define USB_OTG_HCCHAR_MPSIZ                   ((uint32_t)0x000007FF)            /*!< Maximum packet size */
+
+#define USB_OTG_HCCHAR_EPNUM                   ((uint32_t)0x00007800)            /*!< Endpoint number */
+#define USB_OTG_HCCHAR_EPNUM_0                 ((uint32_t)0x00000800)            /*!<Bit 0 */
+#define USB_OTG_HCCHAR_EPNUM_1                 ((uint32_t)0x00001000)            /*!<Bit 1 */
+#define USB_OTG_HCCHAR_EPNUM_2                 ((uint32_t)0x00002000)            /*!<Bit 2 */
+#define USB_OTG_HCCHAR_EPNUM_3                 ((uint32_t)0x00004000)            /*!<Bit 3 */
+#define USB_OTG_HCCHAR_EPDIR                   ((uint32_t)0x00008000)            /*!< Endpoint direction */
+#define USB_OTG_HCCHAR_LSDEV                   ((uint32_t)0x00020000)            /*!< Low-speed device */
+
+#define USB_OTG_HCCHAR_EPTYP                   ((uint32_t)0x000C0000)            /*!< Endpoint type */
+#define USB_OTG_HCCHAR_EPTYP_0                 ((uint32_t)0x00040000)            /*!<Bit 0 */
+#define USB_OTG_HCCHAR_EPTYP_1                 ((uint32_t)0x00080000)            /*!<Bit 1 */
+
+#define USB_OTG_HCCHAR_MC                      ((uint32_t)0x00300000)            /*!< Multi Count (MC) / Error Count (EC) */
+#define USB_OTG_HCCHAR_MC_0                    ((uint32_t)0x00100000)            /*!<Bit 0 */
+#define USB_OTG_HCCHAR_MC_1                    ((uint32_t)0x00200000)            /*!<Bit 1 */
+
+#define USB_OTG_HCCHAR_DAD                     ((uint32_t)0x1FC00000)            /*!< Device address */
+#define USB_OTG_HCCHAR_DAD_0                   ((uint32_t)0x00400000)            /*!<Bit 0 */
+#define USB_OTG_HCCHAR_DAD_1                   ((uint32_t)0x00800000)            /*!<Bit 1 */
+#define USB_OTG_HCCHAR_DAD_2                   ((uint32_t)0x01000000)            /*!<Bit 2 */
+#define USB_OTG_HCCHAR_DAD_3                   ((uint32_t)0x02000000)            /*!<Bit 3 */
+#define USB_OTG_HCCHAR_DAD_4                   ((uint32_t)0x04000000)            /*!<Bit 4 */
+#define USB_OTG_HCCHAR_DAD_5                   ((uint32_t)0x08000000)            /*!<Bit 5 */
+#define USB_OTG_HCCHAR_DAD_6                   ((uint32_t)0x10000000)            /*!<Bit 6 */
+#define USB_OTG_HCCHAR_ODDFRM                  ((uint32_t)0x20000000)            /*!< Odd frame */
+#define USB_OTG_HCCHAR_CHDIS                   ((uint32_t)0x40000000)            /*!< Channel disable */
+#define USB_OTG_HCCHAR_CHENA                   ((uint32_t)0x80000000)            /*!< Channel enable */
+
+/********************  Bit definition for USB_OTG_HCSPLT register  ********************/
+
+#define USB_OTG_HCSPLT_PRTADDR                 ((uint32_t)0x0000007F)            /*!< Port address */
+#define USB_OTG_HCSPLT_PRTADDR_0               ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define USB_OTG_HCSPLT_PRTADDR_1               ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define USB_OTG_HCSPLT_PRTADDR_2               ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define USB_OTG_HCSPLT_PRTADDR_3               ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define USB_OTG_HCSPLT_PRTADDR_4               ((uint32_t)0x00000010)            /*!<Bit 4 */
+#define USB_OTG_HCSPLT_PRTADDR_5               ((uint32_t)0x00000020)            /*!<Bit 5 */
+#define USB_OTG_HCSPLT_PRTADDR_6               ((uint32_t)0x00000040)            /*!<Bit 6 */
+
+#define USB_OTG_HCSPLT_HUBADDR                 ((uint32_t)0x00003F80)            /*!< Hub address */
+#define USB_OTG_HCSPLT_HUBADDR_0               ((uint32_t)0x00000080)            /*!<Bit 0 */
+#define USB_OTG_HCSPLT_HUBADDR_1               ((uint32_t)0x00000100)            /*!<Bit 1 */
+#define USB_OTG_HCSPLT_HUBADDR_2               ((uint32_t)0x00000200)            /*!<Bit 2 */
+#define USB_OTG_HCSPLT_HUBADDR_3               ((uint32_t)0x00000400)            /*!<Bit 3 */
+#define USB_OTG_HCSPLT_HUBADDR_4               ((uint32_t)0x00000800)            /*!<Bit 4 */
+#define USB_OTG_HCSPLT_HUBADDR_5               ((uint32_t)0x00001000)            /*!<Bit 5 */
+#define USB_OTG_HCSPLT_HUBADDR_6               ((uint32_t)0x00002000)            /*!<Bit 6 */
+
+#define USB_OTG_HCSPLT_XACTPOS                 ((uint32_t)0x0000C000)            /*!< XACTPOS */
+#define USB_OTG_HCSPLT_XACTPOS_0               ((uint32_t)0x00004000)            /*!<Bit 0 */
+#define USB_OTG_HCSPLT_XACTPOS_1               ((uint32_t)0x00008000)            /*!<Bit 1 */
+#define USB_OTG_HCSPLT_COMPLSPLT               ((uint32_t)0x00010000)            /*!< Do complete split */
+#define USB_OTG_HCSPLT_SPLITEN                 ((uint32_t)0x80000000)            /*!< Split enable */
+
+/********************  Bit definition for USB_OTG_HCINT register  ********************/
+#define USB_OTG_HCINT_XFRC                    ((uint32_t)0x00000001)            /*!< Transfer completed */
+#define USB_OTG_HCINT_CHH                     ((uint32_t)0x00000002)            /*!< Channel halted */
+#define USB_OTG_HCINT_AHBERR                  ((uint32_t)0x00000004)            /*!< AHB error */
+#define USB_OTG_HCINT_STALL                   ((uint32_t)0x00000008)            /*!< STALL response received interrupt */
+#define USB_OTG_HCINT_NAK                     ((uint32_t)0x00000010)            /*!< NAK response received interrupt */
+#define USB_OTG_HCINT_ACK                     ((uint32_t)0x00000020)            /*!< ACK response received/transmitted interrupt */
+#define USB_OTG_HCINT_NYET                    ((uint32_t)0x00000040)            /*!< Response received interrupt */
+#define USB_OTG_HCINT_TXERR                   ((uint32_t)0x00000080)            /*!< Transaction error */
+#define USB_OTG_HCINT_BBERR                   ((uint32_t)0x00000100)            /*!< Babble error */
+#define USB_OTG_HCINT_FRMOR                   ((uint32_t)0x00000200)            /*!< Frame overrun */
+#define USB_OTG_HCINT_DTERR                   ((uint32_t)0x00000400)            /*!< Data toggle error */
+
+/********************  Bit definition for USB_OTG_DIEPINT register  ********************/
+#define USB_OTG_DIEPINT_XFRC                    ((uint32_t)0x00000001)            /*!< Transfer completed interrupt */
+#define USB_OTG_DIEPINT_EPDISD                  ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt */
+#define USB_OTG_DIEPINT_TOC                     ((uint32_t)0x00000008)            /*!< Timeout condition */
+#define USB_OTG_DIEPINT_ITTXFE                  ((uint32_t)0x00000010)            /*!< IN token received when TxFIFO is empty */
+#define USB_OTG_DIEPINT_INEPNE                  ((uint32_t)0x00000040)            /*!< IN endpoint NAK effective */
+#define USB_OTG_DIEPINT_TXFE                    ((uint32_t)0x00000080)            /*!< Transmit FIFO empty */
+#define USB_OTG_DIEPINT_TXFIFOUDRN              ((uint32_t)0x00000100)            /*!< Transmit Fifo Underrun */
+#define USB_OTG_DIEPINT_BNA                     ((uint32_t)0x00000200)            /*!< Buffer not available interrupt */
+#define USB_OTG_DIEPINT_PKTDRPSTS               ((uint32_t)0x00000800)            /*!< Packet dropped status */
+#define USB_OTG_DIEPINT_BERR                    ((uint32_t)0x00001000)            /*!< Babble error interrupt */
+#define USB_OTG_DIEPINT_NAK                     ((uint32_t)0x00002000)            /*!< NAK interrupt */
+
+/********************  Bit definition for USB_OTG_HCINTMSK register  ********************/
+#define USB_OTG_HCINTMSK_XFRCM                   ((uint32_t)0x00000001)            /*!< Transfer completed mask */
+#define USB_OTG_HCINTMSK_CHHM                    ((uint32_t)0x00000002)            /*!< Channel halted mask */
+#define USB_OTG_HCINTMSK_AHBERR                  ((uint32_t)0x00000004)            /*!< AHB error */
+#define USB_OTG_HCINTMSK_STALLM                  ((uint32_t)0x00000008)            /*!< STALL response received interrupt mask */
+#define USB_OTG_HCINTMSK_NAKM                    ((uint32_t)0x00000010)            /*!< NAK response received interrupt mask */
+#define USB_OTG_HCINTMSK_ACKM                    ((uint32_t)0x00000020)            /*!< ACK response received/transmitted interrupt mask */
+#define USB_OTG_HCINTMSK_NYET                    ((uint32_t)0x00000040)            /*!< response received interrupt mask */
+#define USB_OTG_HCINTMSK_TXERRM                  ((uint32_t)0x00000080)            /*!< Transaction error mask */
+#define USB_OTG_HCINTMSK_BBERRM                  ((uint32_t)0x00000100)            /*!< Babble error mask */
+#define USB_OTG_HCINTMSK_FRMORM                  ((uint32_t)0x00000200)            /*!< Frame overrun mask */
+#define USB_OTG_HCINTMSK_DTERRM                  ((uint32_t)0x00000400)            /*!< Data toggle error mask */
+
+/********************  Bit definition for USB_OTG_DIEPTSIZ register  ********************/
+
+#define USB_OTG_DIEPTSIZ_XFRSIZ                  ((uint32_t)0x0007FFFF)            /*!< Transfer size */
+#define USB_OTG_DIEPTSIZ_PKTCNT                  ((uint32_t)0x1FF80000)            /*!< Packet count */
+#define USB_OTG_DIEPTSIZ_MULCNT                  ((uint32_t)0x60000000)            /*!< Packet count */
+/********************  Bit definition for USB_OTG_HCTSIZ register  ********************/
+#define USB_OTG_HCTSIZ_XFRSIZ                    ((uint32_t)0x0007FFFF)            /*!< Transfer size */
+#define USB_OTG_HCTSIZ_PKTCNT                    ((uint32_t)0x1FF80000)            /*!< Packet count */
+#define USB_OTG_HCTSIZ_DOPING                    ((uint32_t)0x80000000)            /*!< Do PING */
+#define USB_OTG_HCTSIZ_DPID                      ((uint32_t)0x60000000)            /*!< Data PID */
+#define USB_OTG_HCTSIZ_DPID_0                    ((uint32_t)0x20000000)            /*!<Bit 0 */
+#define USB_OTG_HCTSIZ_DPID_1                    ((uint32_t)0x40000000)            /*!<Bit 1 */
+
+/********************  Bit definition for USB_OTG_DIEPDMA register  ********************/
+#define USB_OTG_DIEPDMA_DMAADDR                  ((uint32_t)0xFFFFFFFF)            /*!< DMA address */
+
+/********************  Bit definition for USB_OTG_HCDMA register  ********************/
+#define USB_OTG_HCDMA_DMAADDR                    ((uint32_t)0xFFFFFFFF)            /*!< DMA address */
+
+/********************  Bit definition for USB_OTG_DTXFSTS register  ********************/
+#define USB_OTG_DTXFSTS_INEPTFSAV                ((uint32_t)0x0000FFFF)            /*!< IN endpoint TxFIFO space available */
+
+/********************  Bit definition for USB_OTG_DIEPTXF register  ********************/
+#define USB_OTG_DIEPTXF_INEPTXSA                 ((uint32_t)0x0000FFFF)            /*!< IN endpoint FIFOx transmit RAM start address */
+#define USB_OTG_DIEPTXF_INEPTXFD                 ((uint32_t)0xFFFF0000)            /*!< IN endpoint TxFIFO depth */
+
+/********************  Bit definition for USB_OTG_DOEPCTL register  ********************/
+#define USB_OTG_DOEPCTL_MPSIZ                     ((uint32_t)0x000007FF)            /*!< Maximum packet size */          /*!<Bit 1 */
+#define USB_OTG_DOEPCTL_USBAEP                    ((uint32_t)0x00008000)            /*!< USB active endpoint */
+#define USB_OTG_DOEPCTL_NAKSTS                    ((uint32_t)0x00020000)            /*!< NAK status */
+#define USB_OTG_DOEPCTL_SD0PID_SEVNFRM            ((uint32_t)0x10000000)            /*!< Set DATA0 PID */
+#define USB_OTG_DOEPCTL_SODDFRM                   ((uint32_t)0x20000000)            /*!< Set odd frame */
+#define USB_OTG_DOEPCTL_EPTYP                     ((uint32_t)0x000C0000)            /*!< Endpoint type */
+#define USB_OTG_DOEPCTL_EPTYP_0                   ((uint32_t)0x00040000)            /*!<Bit 0 */
+#define USB_OTG_DOEPCTL_EPTYP_1                   ((uint32_t)0x00080000)            /*!<Bit 1 */
+#define USB_OTG_DOEPCTL_SNPM                      ((uint32_t)0x00100000)            /*!< Snoop mode */
+#define USB_OTG_DOEPCTL_STALL                     ((uint32_t)0x00200000)            /*!< STALL handshake */
+#define USB_OTG_DOEPCTL_CNAK                      ((uint32_t)0x04000000)            /*!< Clear NAK */
+#define USB_OTG_DOEPCTL_SNAK                      ((uint32_t)0x08000000)            /*!< Set NAK */
+#define USB_OTG_DOEPCTL_EPDIS                     ((uint32_t)0x40000000)            /*!< Endpoint disable */
+#define USB_OTG_DOEPCTL_EPENA                     ((uint32_t)0x80000000)            /*!< Endpoint enable */
+
+/********************  Bit definition for USB_OTG_DOEPINT register  ********************/
+#define USB_OTG_DOEPINT_XFRC                    ((uint32_t)0x00000001)            /*!< Transfer completed interrupt */
+#define USB_OTG_DOEPINT_EPDISD                  ((uint32_t)0x00000002)            /*!< Endpoint disabled interrupt */
+#define USB_OTG_DOEPINT_STUP                    ((uint32_t)0x00000008)            /*!< SETUP phase done */
+#define USB_OTG_DOEPINT_OTEPDIS                 ((uint32_t)0x00000010)            /*!< OUT token received when endpoint disabled */
+#define USB_OTG_DOEPINT_B2BSTUP                 ((uint32_t)0x00000040)            /*!< Back-to-back SETUP packets received */
+#define USB_OTG_DOEPINT_NYET                    ((uint32_t)0x00004000)            /*!< NYET interrupt */
+
+/********************  Bit definition for USB_OTG_DOEPTSIZ register  ********************/
+#define USB_OTG_DOEPTSIZ_XFRSIZ                  ((uint32_t)0x0007FFFF)            /*!< Transfer size */
+#define USB_OTG_DOEPTSIZ_PKTCNT                  ((uint32_t)0x1FF80000)            /*!< Packet count */
+
+#define USB_OTG_DOEPTSIZ_STUPCNT                 ((uint32_t)0x60000000)            /*!< SETUP packet count */
+#define USB_OTG_DOEPTSIZ_STUPCNT_0               ((uint32_t)0x20000000)            /*!<Bit 0 */
+#define USB_OTG_DOEPTSIZ_STUPCNT_1               ((uint32_t)0x40000000)            /*!<Bit 1 */
+
+/********************  Bit definition for PCGCCTL register  ********************/
+#define USB_OTG_PCGCCTL_STOPCLK                 ((uint32_t)0x00000001)            /*!< SETUP packet count */
+#define USB_OTG_PCGCCTL_GATECLK                 ((uint32_t)0x00000002)            /*!<Bit 0 */
+#define USB_OTG_PCGCCTL_PHYSUSP                 ((uint32_t)0x00000010)            /*!<Bit 1 */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+
+/******************************* ADC Instances ********************************/
+#define IS_ADC_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == ADC1) || \
+                                       ((__INSTANCE__) == ADC2) || \
+                                       ((__INSTANCE__) == ADC3))
+
+/******************************* CAN Instances ********************************/
+#define IS_CAN_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == CAN1) || \
+                                       ((__INSTANCE__) == CAN2))
+
+/******************************* CRC Instances ********************************/
+#define IS_CRC_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == CRC)
+
+/******************************* DAC Instances ********************************/
+#define IS_DAC_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == DAC)
+
+/******************************* DCMI Instances *******************************/
+#define IS_DCMI_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == DCMI)
+
+/******************************* DMA2D Instances *******************************/
+#define IS_DMA2D_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == DMA2D)
+
+/******************************** DMA Instances *******************************/
+#define IS_DMA_STREAM_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == DMA1_Stream0) || \
+                                              ((__INSTANCE__) == DMA1_Stream1) || \
+                                              ((__INSTANCE__) == DMA1_Stream2) || \
+                                              ((__INSTANCE__) == DMA1_Stream3) || \
+                                              ((__INSTANCE__) == DMA1_Stream4) || \
+                                              ((__INSTANCE__) == DMA1_Stream5) || \
+                                              ((__INSTANCE__) == DMA1_Stream6) || \
+                                              ((__INSTANCE__) == DMA1_Stream7) || \
+                                              ((__INSTANCE__) == DMA2_Stream0) || \
+                                              ((__INSTANCE__) == DMA2_Stream1) || \
+                                              ((__INSTANCE__) == DMA2_Stream2) || \
+                                              ((__INSTANCE__) == DMA2_Stream3) || \
+                                              ((__INSTANCE__) == DMA2_Stream4) || \
+                                              ((__INSTANCE__) == DMA2_Stream5) || \
+                                              ((__INSTANCE__) == DMA2_Stream6) || \
+                                              ((__INSTANCE__) == DMA2_Stream7))
+
+/******************************* GPIO Instances *******************************/
+#define IS_GPIO_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == GPIOA) || \
+                                        ((__INSTANCE__) == GPIOB) || \
+                                        ((__INSTANCE__) == GPIOC) || \
+                                        ((__INSTANCE__) == GPIOD) || \
+                                        ((__INSTANCE__) == GPIOE) || \
+                                        ((__INSTANCE__) == GPIOF) || \
+                                        ((__INSTANCE__) == GPIOG) || \
+                                        ((__INSTANCE__) == GPIOH) || \
+                                        ((__INSTANCE__) == GPIOI) || \
+                                        ((__INSTANCE__) == GPIOJ) || \
+                                        ((__INSTANCE__) == GPIOK))
+
+#define IS_GPIO_AF_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == GPIOA) || \
+                                        ((__INSTANCE__) == GPIOB) || \
+                                        ((__INSTANCE__) == GPIOC) || \
+                                        ((__INSTANCE__) == GPIOD) || \
+                                        ((__INSTANCE__) == GPIOE) || \
+                                        ((__INSTANCE__) == GPIOF) || \
+                                        ((__INSTANCE__) == GPIOG) || \
+                                        ((__INSTANCE__) == GPIOH) || \
+                                        ((__INSTANCE__) == GPIOI) || \
+                                        ((__INSTANCE__) == GPIOJ) || \
+                                        ((__INSTANCE__) == GPIOK))
+
+/****************************** CEC Instances *********************************/
+#define IS_CEC_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == CEC)
+
+/****************************** QSPI Instances *********************************/
+#define IS_QSPI_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == QUADSPI)
+
+
+/******************************** I2C Instances *******************************/
+#define IS_I2C_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == I2C1) || \
+                                       ((__INSTANCE__) == I2C2) || \
+                                       ((__INSTANCE__) == I2C3) || \
+                                       ((__INSTANCE__) == I2C4))
+
+/******************************** I2S Instances *******************************/
+#define IS_I2S_ALL_INSTANCE(__INSTANCE__)  (((__INSTANCE__) == SPI1) || \
+                                    ((__INSTANCE__) == SPI2) || \
+                                    ((__INSTANCE__) == SPI3))
+
+/******************************* LPTIM Instances ********************************/
+#define IS_LPTIM_INSTANCE(__INSTANCE__) ((__INSTANCE__) == LPTIM1)
+
+/****************************** LTDC Instances ********************************/
+#define IS_LTDC_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == LTDC)
+
+/******************************* RNG Instances ********************************/
+#define IS_RNG_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == RNG)
+
+/****************************** RTC Instances *********************************/
+#define IS_RTC_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == RTC)
+
+/******************************* SAI Instances ********************************/
+#define IS_SAI_BLOCK_PERIPH(__PERIPH__) (((__PERIPH__) == SAI1_Block_A) || \
+                                     ((__PERIPH__) == SAI1_Block_B) || \
+                                     ((__PERIPH__) == SAI2_Block_A) || \
+                                     ((__PERIPH__) == SAI2_Block_B))
+
+
+/******************************** SDMMC Instances *******************************/
+#define IS_SDMMC_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == SDMMC1)
+
+
+/****************************** SPDIFRX Instances *********************************/
+#define IS_SPDIFRX_ALL_INSTANCE(__INSTANCE__) ((__INSTANCE__) == SPDIFRX)
+
+/******************************** SPI Instances *******************************/
+#define IS_SPI_ALL_INSTANCE(__INSTANCE__) (((__INSTANCE__) == SPI1) || \
+                                       ((__INSTANCE__) == SPI2) || \
+                                       ((__INSTANCE__) == SPI3) || \
+                                       ((__INSTANCE__) == SPI4) || \
+                                       ((__INSTANCE__) == SPI5) || \
+                                       ((__INSTANCE__) == SPI6))
+
+/****************** TIM Instances : All supported instances *******************/
+#define IS_TIM_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1)   || \
+                                   ((__INSTANCE__) == TIM2)   || \
+                                   ((__INSTANCE__) == TIM3)   || \
+                                   ((__INSTANCE__) == TIM4)   || \
+                                   ((__INSTANCE__) == TIM5)   || \
+                                   ((__INSTANCE__) == TIM6)   || \
+                                   ((__INSTANCE__) == TIM7)   || \
+                                   ((__INSTANCE__) == TIM8)   || \
+                                   ((__INSTANCE__) == TIM9)   || \
+                                   ((__INSTANCE__) == TIM10)  || \
+                                   ((__INSTANCE__) == TIM11)  || \
+                                   ((__INSTANCE__) == TIM12)  || \
+                                   ((__INSTANCE__) == TIM13)  || \
+                                   ((__INSTANCE__) == TIM14))
+
+/************* TIM Instances : at least 1 capture/compare channel *************/
+#define IS_TIM_CC1_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == TIM1)  || \
+                                         ((__INSTANCE__) == TIM2)  || \
+                                         ((__INSTANCE__) == TIM3)  || \
+                                         ((__INSTANCE__) == TIM4)  || \
+                                         ((__INSTANCE__) == TIM5)  || \
+                                         ((__INSTANCE__) == TIM8)  || \
+                                         ((__INSTANCE__) == TIM9)  || \
+                                         ((__INSTANCE__) == TIM10) || \
+                                         ((__INSTANCE__) == TIM11) || \
+                                         ((__INSTANCE__) == TIM12) || \
+                                         ((__INSTANCE__) == TIM13) || \
+                                         ((__INSTANCE__) == TIM14))
+
+/************ TIM Instances : at least 2 capture/compare channels *************/
+#define IS_TIM_CC2_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == TIM1)  || \
+                                         ((__INSTANCE__) == TIM2)  || \
+                                         ((__INSTANCE__) == TIM3)  || \
+                                         ((__INSTANCE__) == TIM4)  || \
+                                         ((__INSTANCE__) == TIM5)  || \
+                                         ((__INSTANCE__) == TIM8)  || \
+                                         ((__INSTANCE__) == TIM9)  || \
+                                         ((__INSTANCE__) == TIM12))
+
+/************ TIM Instances : at least 3 capture/compare channels *************/
+#define IS_TIM_CC3_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == TIM1) || \
+                                         ((__INSTANCE__) == TIM2) || \
+                                         ((__INSTANCE__) == TIM3) || \
+                                         ((__INSTANCE__) == TIM4) || \
+                                         ((__INSTANCE__) == TIM5) || \
+                                         ((__INSTANCE__) == TIM8))
+
+/************ TIM Instances : at least 4 capture/compare channels *************/
+#define IS_TIM_CC4_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                       ((__INSTANCE__) == TIM2) || \
+                                       ((__INSTANCE__) == TIM3) || \
+                                       ((__INSTANCE__) == TIM4) || \
+                                       ((__INSTANCE__) == TIM5) || \
+                                       ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting combined 3-phase PWM mode ******/
+#define IS_TIM_COMBINED3PHASEPWM_INSTANCE(__INSTANCE__) \
+                                       (((__INSTANCE__) == TIM1)    || \
+                                        ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting OCxREF clear *******************/
+#define IS_TIM_OCXREF_CLEAR_INSTANCE(__INSTANCE__)\
+                                  (((__INSTANCE__) == TIM1)    || \
+                                   ((__INSTANCE__) == TIM2)    || \
+                                   ((__INSTANCE__) == TIM3)    || \
+                                   ((__INSTANCE__) == TIM4)    || \
+                                   ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting external clock mode 1 for TIX inputs*/
+#define IS_TIM_CLOCKSOURCE_TIX_INSTANCE(__INSTANCE__)\
+                                                 (((__INSTANCE__) == TIM1)    || \
+                                                  ((__INSTANCE__) == TIM2)    || \
+                                                  ((__INSTANCE__) == TIM3)    || \
+                                                  ((__INSTANCE__) == TIM4)    || \
+                                                  ((__INSTANCE__) == TIM5)    || \
+                                                  ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting internal trigger inputs(ITRX) *******/
+#define IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(__INSTANCE__)\
+                                                   (((__INSTANCE__) == TIM1)    || \
+                                                    ((__INSTANCE__) == TIM2)    || \
+                                                    ((__INSTANCE__) == TIM3)    || \
+                                                    ((__INSTANCE__) == TIM4)    || \
+                                                    ((__INSTANCE__) == TIM5)    || \
+                                                    ((__INSTANCE__) == TIM8))
+/****************** TIM Instances : at least 5 capture/compare channels *******/
+#define IS_TIM_CC5_INSTANCE(__INSTANCE__)\
+  (((__INSTANCE__) == TIM1)    || \
+   ((__INSTANCE__) == TIM8) )
+
+/****************** TIM Instances : at least 6 capture/compare channels *******/
+#define IS_TIM_CC6_INSTANCE(__INSTANCE__)\
+  (((__INSTANCE__) == TIM1)    || \
+   ((__INSTANCE__) == TIM8))
+
+
+/******************** TIM Instances : Advanced-control timers *****************/
+#define IS_TIM_ADVANCED_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                            ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : supporting 2 break inputs *****************/
+#define IS_TIM_BREAK_INSTANCE(__INSTANCE__)\
+  (((__INSTANCE__) == TIM1)    || \
+   ((__INSTANCE__) == TIM8))
+
+/******************* TIM Instances : Timer input XOR function *****************/
+#define IS_TIM_XOR_INSTANCE(__INSTANCE__)   (((__INSTANCE__) == TIM1) || \
+                                         ((__INSTANCE__) == TIM2) || \
+                                         ((__INSTANCE__) == TIM3) || \
+                                         ((__INSTANCE__) == TIM4) || \
+                                         ((__INSTANCE__) == TIM5) || \
+                                         ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : DMA requests generation (UDE) *************/
+#define IS_TIM_DMA_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                       ((__INSTANCE__) == TIM2) || \
+                                       ((__INSTANCE__) == TIM3) || \
+                                       ((__INSTANCE__) == TIM4) || \
+                                       ((__INSTANCE__) == TIM5) || \
+                                       ((__INSTANCE__) == TIM6) || \
+                                       ((__INSTANCE__) == TIM7) || \
+                                       ((__INSTANCE__) == TIM8))
+
+/************ TIM Instances : DMA requests generation (CCxDE) *****************/
+#define IS_TIM_DMA_CC_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                          ((__INSTANCE__) == TIM2) || \
+                                          ((__INSTANCE__) == TIM3) || \
+                                          ((__INSTANCE__) == TIM4) || \
+                                          ((__INSTANCE__) == TIM5) || \
+                                          ((__INSTANCE__) == TIM8))
+
+/************ TIM Instances : DMA requests generation (COMDE) *****************/
+#define IS_TIM_CCDMA_INSTANCE(__INSTANCE__)  (((__INSTANCE__) == TIM1) || \
+                                          ((__INSTANCE__) == TIM2) || \
+                                          ((__INSTANCE__) == TIM3) || \
+                                          ((__INSTANCE__) == TIM4) || \
+                                          ((__INSTANCE__) == TIM5) || \
+                                          ((__INSTANCE__) == TIM8))
+
+/******************** TIM Instances : DMA burst feature ***********************/
+#define IS_TIM_DMABURST_INSTANCE(__INSTANCE__)  (((__INSTANCE__) == TIM1) || \
+                                             ((__INSTANCE__) == TIM2) || \
+                                             ((__INSTANCE__) == TIM3) || \
+                                             ((__INSTANCE__) == TIM4) || \
+                                             ((__INSTANCE__) == TIM5) || \
+                                             ((__INSTANCE__) == TIM8))
+
+/****** TIM Instances : master mode available (TIMx_CR2.MMS available )********/
+#define IS_TIM_MASTER_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                          ((__INSTANCE__) == TIM2) || \
+                                          ((__INSTANCE__) == TIM3) || \
+                                          ((__INSTANCE__) == TIM4) || \
+                                          ((__INSTANCE__) == TIM5) || \
+                                          ((__INSTANCE__) == TIM6) || \
+                                          ((__INSTANCE__) == TIM7) || \
+                                          ((__INSTANCE__) == TIM8) || \
+                                          ((__INSTANCE__) == TIM13) || \
+                                          ((__INSTANCE__) == TIM14))
+
+/*********** TIM Instances : Slave mode available (TIMx_SMCR available )*******/
+#define IS_TIM_SLAVE_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM1) || \
+                                         ((__INSTANCE__) == TIM2) || \
+                                         ((__INSTANCE__) == TIM3) || \
+                                         ((__INSTANCE__) == TIM4) || \
+                                         ((__INSTANCE__) == TIM5) || \
+                                         ((__INSTANCE__) == TIM8) || \
+                                         ((__INSTANCE__) == TIM9) || \
+                                         ((__INSTANCE__) == TIM12))
+
+/********************** TIM Instances : 32 bit Counter ************************/
+#define IS_TIM_32B_COUNTER_INSTANCE(__INSTANCE__)(((__INSTANCE__) == TIM2) || \
+                                              ((__INSTANCE__) == TIM5))
+
+/***************** TIM Instances : external trigger input available ************/
+#define IS_TIM_ETR_INSTANCE(__INSTANCE__)  (((__INSTANCE__) == TIM1) || \
+                                        ((__INSTANCE__) == TIM2) || \
+                                        ((__INSTANCE__) == TIM3) || \
+                                        ((__INSTANCE__) == TIM4) || \
+                                        ((__INSTANCE__) == TIM5) || \
+                                        ((__INSTANCE__) == TIM8))
+
+/****************** TIM Instances : remapping capability **********************/
+#define IS_TIM_REMAP_INSTANCE(__INSTANCE__) (((__INSTANCE__) == TIM2)  || \
+                                         ((__INSTANCE__) == TIM5)  || \
+                                         ((__INSTANCE__) == TIM11))
+
+/******************* TIM Instances : output(s) available **********************/
+#define IS_TIM_CCX_INSTANCE(__INSTANCE__, __CHANNEL__) \
+    ((((__INSTANCE__) == TIM1) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM2) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM3) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM4) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM5) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM8) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_3) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_4)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM9) &&                   \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM10) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM11) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM12) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||          \
+      ((__CHANNEL__) == TIM_CHANNEL_2)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM13) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1)))           \
+    ||                                         \
+    (((__INSTANCE__) == TIM14) &&                  \
+     (((__CHANNEL__) == TIM_CHANNEL_1))))
+
+/************ TIM Instances : complementary output(s) available ***************/
+#define IS_TIM_CCXN_INSTANCE(__INSTANCE__, __CHANNEL__) \
+   ((((__INSTANCE__) == TIM1) &&                    \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||           \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||           \
+      ((__CHANNEL__) == TIM_CHANNEL_3)))            \
+    ||                                          \
+    (((__INSTANCE__) == TIM8) &&                    \
+     (((__CHANNEL__) == TIM_CHANNEL_1) ||           \
+      ((__CHANNEL__) == TIM_CHANNEL_2) ||           \
+      ((__CHANNEL__) == TIM_CHANNEL_3))))
+
+/****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
+#define IS_TIM_TRGO2_INSTANCE(__INSTANCE__)\
+  (((__INSTANCE__) == TIM1)    || \
+   ((__INSTANCE__) == TIM8) )
+
+/****************** TIM Instances : supporting synchronization ****************/
+#define IS_TIM_SYNCHRO_INSTANCE(__INSTANCE__)\
+    (((__INSTANCE__) == TIM1)    || \
+     ((__INSTANCE__) == TIM2)    || \
+     ((__INSTANCE__) == TIM3)    || \
+     ((__INSTANCE__) == TIM4)    || \
+     ((__INSTANCE__) == TIM5)    || \
+     ((__INSTANCE__) == TIM6)    || \
+     ((__INSTANCE__) == TIM7)    || \
+     ((__INSTANCE__) == TIM8))
+
+/******************** USART Instances : Synchronous mode **********************/
+#define IS_USART_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                     ((__INSTANCE__) == USART2) || \
+                                     ((__INSTANCE__) == USART3) || \
+                                     ((__INSTANCE__) == USART6))
+
+/******************** UART Instances : Asynchronous mode **********************/
+#define IS_UART_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                    ((__INSTANCE__) == USART2) || \
+                                    ((__INSTANCE__) == USART3) || \
+                                    ((__INSTANCE__) == UART4)  || \
+                                    ((__INSTANCE__) == UART5)  || \
+                                    ((__INSTANCE__) == USART6) || \
+                                    ((__INSTANCE__) == UART7)  || \
+                                    ((__INSTANCE__) == UART8))
+
+/****************** UART Instances : Hardware Flow control ********************/
+#define IS_UART_HWFLOW_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                    ((__INSTANCE__) == USART2) || \
+                                    ((__INSTANCE__) == USART3) || \
+                                    ((__INSTANCE__) == UART4)  || \
+                                    ((__INSTANCE__) == UART5)  || \
+                                    ((__INSTANCE__) == USART6) || \
+                                    ((__INSTANCE__) == UART7)  || \
+                                    ((__INSTANCE__) == UART8))
+
+/********************* UART Instances : Smart card mode ***********************/
+#define IS_SMARTCARD_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                         ((__INSTANCE__) == USART2) || \
+                                         ((__INSTANCE__) == USART3) || \
+                                         ((__INSTANCE__) == USART6))
+
+/*********************** UART Instances : IRDA mode ***************************/
+#define IS_IRDA_INSTANCE(__INSTANCE__) (((__INSTANCE__) == USART1) || \
+                                    ((__INSTANCE__) == USART2) || \
+                                    ((__INSTANCE__) == USART3) || \
+                                    ((__INSTANCE__) == UART4)  || \
+                                    ((__INSTANCE__) == UART5)  || \
+                                    ((__INSTANCE__) == USART6) || \
+                                    ((__INSTANCE__) == UART7)  || \
+                                    ((__INSTANCE__) == UART8))
+
+/****************************** IWDG Instances ********************************/
+#define IS_IWDG_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == IWDG)
+
+/****************************** WWDG Instances ********************************/
+#define IS_WWDG_ALL_INSTANCE(__INSTANCE__)  ((__INSTANCE__) == WWDG)
+
+
+/******************************************************************************/
+/*  For a painless codes migration between the STM32F7xx device product       */
+/*  lines, the aliases defined below are put in place to overcome the         */
+/*  differences in the interrupt handlers and IRQn definitions.               */
+/*  No need to update developed interrupt code when moving across             */
+/*  product lines within the same STM32F7 Family                              */
+/******************************************************************************/
+
+/* Aliases for __IRQn */
+#define RNG_IRQn              HASH_RNG_IRQn
+
+/* Aliases for __IRQHandler */
+#define RNG_IRQHandler        HASH_RNG_IRQHandler
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32F756xx_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/cmsis/devinc/stm32f7xx.h
+++ b/stmhal/cmsis/devinc/stm32f7xx.h
@@ -1,0 +1,197 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   CMSIS STM32F7xx Device Peripheral Access Layer Header File.
+  *
+  *          The file is the unique include file that the application programmer
+  *          is using in the C source code, usually in main.c. This file contains:
+  *           - Configuration section that allows to select:
+  *              - The STM32F7xx device used in the target application
+  *              - To use or not the peripheral’s drivers in application code(i.e.
+  *                code will be based on direct access to peripheral’s registers
+  *                rather than drivers API), this option is controlled by
+  *                "#define USE_HAL_DRIVER"
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32f7xx
+  * @{
+  */
+
+#ifndef __STM32F7xx_H
+#define __STM32F7xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Library_configuration_section
+  * @{
+  */
+
+/**
+  * @brief STM32 Family
+  */
+#if !defined  (STM32F7)
+#define STM32F7
+#endif /* STM32F7 */
+
+/* Uncomment the line below according to the target STM32 device used in your
+   application
+  */
+#if !defined (STM32F756xx) && !defined (STM32F746xx) && !defined (STM32F745xx)
+  /* #define STM32F756xx */   /*!< STM32F756VG, STM32F756ZG, STM32F756ZG, STM32F756IG, STM32F756BG,
+                                   STM32F756NG Devices */
+  /* #define STM32F746xx */   /*!< STM32F746VE, STM32F746VG, STM32F746ZE, STM32F746ZG, STM32F746IE, STM32F746IG,
+                                   STM32F746BE, STM32F746BG, STM32F746NE, STM32F746NG Devices */
+  /* #define STM32F745xx */   /*!< STM32F745VE, STM32F745VG, STM32F745ZG, STM32F745ZE, STM32F745IE, STM32F745IG Devices */
+#endif
+
+/*  Tip: To avoid modifying this file each time you need to switch between these
+        devices, you can define the device in your toolchain compiler preprocessor.
+  */
+
+#if !defined  (USE_HAL_DRIVER)
+/**
+ * @brief Comment the line below if you will not use the peripherals drivers.
+   In this case, these drivers will not be included and the application code will
+   be based on direct access to peripherals registers
+   */
+  /*#define USE_HAL_DRIVER */
+#endif /* USE_HAL_DRIVER */
+
+/**
+  * @brief CMSIS Device version number V1.0.1
+  */
+#define __STM32F7xx_CMSIS_DEVICE_VERSION_MAIN   (0x01) /*!< [31:24] main version */
+#define __STM32F7xx_CMSIS_DEVICE_VERSION_SUB1   (0x00) /*!< [23:16] sub1 version */
+#define __STM32F7xx_CMSIS_DEVICE_VERSION_SUB2   (0x01) /*!< [15:8]  sub2 version */
+#define __STM32F7xx_CMSIS_DEVICE_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
+#define __STM32F7xx_CMSIS_DEVICE_VERSION        ((__STM32F7xx_CMSIS_DEVICE_VERSION_MAIN << 24)\
+                                                |(__STM32F7xx_CMSIS_DEVICE_VERSION_SUB1 << 16)\
+                                                |(__STM32F7xx_CMSIS_DEVICE_VERSION_SUB2 << 8 )\
+                                                |(__STM32F7xx_CMSIS_DEVICE_VERSION))
+/**
+  * @}
+  */
+
+/** @addtogroup Device_Included
+  * @{
+  */
+#if defined(STM32F756xx)
+  #include "stm32f756xx.h"
+#elif defined(STM32F746xx)
+  #include "stm32f746xx.h"
+#elif defined(STM32F745xx)
+  #include "stm32f745xx.h"
+#else
+ #error "Please select first the target STM32F7xx device used in your application (in stm32f7xx.h file)"
+#endif
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_types
+  * @{
+  */
+typedef enum
+{
+  RESET = 0,
+  SET = !RESET
+} FlagStatus, ITStatus;
+
+typedef enum
+{
+  DISABLE = 0,
+  ENABLE = !DISABLE
+} FunctionalState;
+#define IS_FUNCTIONAL_STATE(STATE) (((STATE) == DISABLE) || ((STATE) == ENABLE))
+
+typedef enum
+{
+  ERROR = 0,
+  SUCCESS = !ERROR
+} ErrorStatus;
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_macro
+  * @{
+  */
+#define SET_BIT(REG, BIT)     ((REG) |= (BIT))
+
+#define CLEAR_BIT(REG, BIT)   ((REG) &= ~(BIT))
+
+#define READ_BIT(REG, BIT)    ((REG) & (BIT))
+
+#define CLEAR_REG(REG)        ((REG) = (0x0))
+
+#define WRITE_REG(REG, VAL)   ((REG) = (VAL))
+
+#define READ_REG(REG)         ((REG))
+
+#define MODIFY_REG(REG, CLEARMASK, SETMASK)  WRITE_REG((REG), (((READ_REG(REG)) & (~(CLEARMASK))) | (SETMASK)))
+
+#define POSITION_VAL(VAL)     (__CLZ(__RBIT(VAL)))
+
+/**
+  * @}
+  */
+
+#ifdef USE_HAL_DRIVER
+  #include "stm32f7xx_hal_conf.h"
+#endif /* USE_HAL_DRIVER */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32F7xx_H */
+
+/**
+  * @}
+  */
+
+  /**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/cmsis/devinc/system_stm32f7xx.h
+++ b/stmhal/cmsis/devinc/system_stm32f7xx.h
@@ -1,0 +1,122 @@
+/**
+  ******************************************************************************
+  * @file    system_stm32f7xx.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   CMSIS Cortex-M7 Device System Source File for STM32F7xx devices.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32f7xx_system
+  * @{
+  */
+
+/**
+  * @brief Define to prevent recursive inclusion
+  */
+#ifndef __SYSTEM_STM32F7XX_H
+#define __SYSTEM_STM32F7XX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** @addtogroup STM32F7xx_System_Includes
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+
+/** @addtogroup STM32F7xx_System_Exported_types
+  * @{
+  */
+  /* This variable is updated in three ways:
+      1) by calling CMSIS function SystemCoreClockUpdate()
+      2) by calling HAL API function HAL_RCC_GetSysClockFreq()
+      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
+         Note: If you use this function to configure the system clock; then there
+               is no need to call the 2 first functions listed above, since SystemCoreClock
+               variable is updated automatically.
+    */
+extern uint32_t SystemCoreClock;          /*!< System Clock Frequency (Core Clock) */
+
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F7xx_System_Exported_Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F7xx_System_Exported_Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F7xx_System_Exported_Functions
+  * @{
+  */
+
+extern void SystemInit(void);
+extern void SystemCoreClockUpdate(void);
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__SYSTEM_STM32F7XX_H */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/cmsis/inc/core_cm7.h
+++ b/stmhal/cmsis/inc/core_cm7.h
@@ -1,0 +1,2397 @@
+/**************************************************************************//**
+ * @file     core_cm7.h
+ * @brief    CMSIS Cortex-M7 Core Peripheral Access Layer Header File
+ * @version  V4.10
+ * @date     18. March 2015
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2015 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#if defined ( __ICCARM__ )
+ #pragma system_include  /* treat file as system include file for MISRA check */
+#endif
+
+#ifndef __CORE_CM7_H_GENERIC
+#define __CORE_CM7_H_GENERIC
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/** \ingroup Cortex_M7
+  @{
+ */
+
+/*  CMSIS CM7 definitions */
+#define __CM7_CMSIS_VERSION_MAIN  (0x04)                                   /*!< [31:16] CMSIS HAL main version   */
+#define __CM7_CMSIS_VERSION_SUB   (0x00)                                   /*!< [15:0]  CMSIS HAL sub version    */
+#define __CM7_CMSIS_VERSION       ((__CM7_CMSIS_VERSION_MAIN << 16) | \
+                                    __CM7_CMSIS_VERSION_SUB          )     /*!< CMSIS HAL version number         */
+
+#define __CORTEX_M                (0x07)                                   /*!< Cortex-M Core                    */
+
+
+#if   defined ( __CC_ARM )
+  #define __ASM            __asm                                      /*!< asm keyword for ARM Compiler          */
+  #define __INLINE         __inline                                   /*!< inline keyword for ARM Compiler       */
+  #define __STATIC_INLINE  static __inline
+
+#elif defined ( __GNUC__ )
+  #define __ASM            __asm                                      /*!< asm keyword for GNU Compiler          */
+  #define __INLINE         inline                                     /*!< inline keyword for GNU Compiler       */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __ICCARM__ )
+  #define __ASM            __asm                                      /*!< asm keyword for IAR Compiler          */
+  #define __INLINE         inline                                     /*!< inline keyword for IAR Compiler. Only available in High optimization mode! */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __TMS470__ )
+  #define __ASM            __asm                                      /*!< asm keyword for TI CCS Compiler       */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __TASKING__ )
+  #define __ASM            __asm                                      /*!< asm keyword for TASKING Compiler      */
+  #define __INLINE         inline                                     /*!< inline keyword for TASKING Compiler   */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __CSMC__ )
+  #define __packed
+  #define __ASM            _asm                                      /*!< asm keyword for COSMIC Compiler      */
+  #define __INLINE         inline                                    /*use -pc99 on compile line !< inline keyword for COSMIC Compiler   */
+  #define __STATIC_INLINE  static inline
+
+#endif
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    For this, __FPU_PRESENT has to be checked prior to making use of FPU specific registers and functions.
+*/
+#if defined ( __CC_ARM )
+  #if defined __TARGET_FPU_VFP
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined __ARMVFP__
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __TMS470__ )
+  #if defined __TI_VFP_SUPPORT__
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined __FPU_VFP__
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __CSMC__ )		/* Cosmic */
+  #if ( __CSMC__ & 0x400)		// FPU present for parser
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+#endif
+
+#include <stdint.h>                      /* standard types definitions                      */
+#include <core_cmInstr.h>                /* Core Instruction Access                         */
+#include <core_cmFunc.h>                 /* Core Function Access                            */
+//#include <core_cmSimd.h>                 /* Compiler specific SIMD Intrinsics               */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM7_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM7_H_DEPENDANT
+#define __CORE_CM7_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM7_REV
+    #define __CM7_REV               0x0000
+    #warning "__CM7_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __ICACHE_PRESENT
+    #define __ICACHE_PRESENT          0
+    #warning "__ICACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DCACHE_PRESENT
+    #define __DCACHE_PRESENT          0
+    #warning "__DCACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DTCM_PRESENT
+    #define __DTCM_PRESENT            0
+    #warning "__DTCM_PRESENT        not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions                 */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions                 */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions                */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions              */
+
+/*@} end of group Cortex_M7 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core MPU Register
+  - Core FPU Register
+ ******************************************************************************/
+/** \defgroup CMSIS_core_register Defines and Type Definitions
+    \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/** \ingroup    CMSIS_core_register
+    \defgroup   CMSIS_CORE  Status and Control Registers
+    \brief  Core Register type definitions.
+  @{
+ */
+
+/** \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags        */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved                           */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag          */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag       */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag          */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag           */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag       */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} APSR_Type;
+
+/* APSR Register Definitions */
+#define APSR_N_Pos                         31                                             /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30                                             /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29                                             /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28                                             /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+#define APSR_Q_Pos                         27                                             /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+
+#define APSR_GE_Pos                        16                                             /*!< APSR: GE Position */
+#define APSR_GE_Msk                        (0xFUL << APSR_GE_Pos)                         /*!< APSR: GE Mask */
+
+
+/** \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number                   */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved                           */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} IPSR_Type;
+
+/* IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0                                             /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/** \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number                   */
+    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags        */
+    uint32_t _reserved1:4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0)          */
+    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0)          */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag          */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag       */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag          */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag           */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag       */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} xPSR_Type;
+
+/* xPSR Register Definitions */
+#define xPSR_N_Pos                         31                                             /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30                                             /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29                                             /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28                                             /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_Q_Pos                         27                                             /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+
+#define xPSR_IT_Pos                        25                                             /*!< xPSR: IT Position */
+#define xPSR_IT_Msk                        (3UL << xPSR_IT_Pos)                           /*!< xPSR: IT Mask */
+
+#define xPSR_T_Pos                         24                                             /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_GE_Pos                        16                                             /*!< xPSR: GE Position */
+#define xPSR_GE_Msk                        (0xFUL << xPSR_GE_Pos)                         /*!< xPSR: GE Mask */
+
+#define xPSR_ISR_Pos                        0                                             /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/** \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack to be used                   */
+    uint32_t FPCA:1;                     /*!< bit:      2  FP extension active flag           */
+    uint32_t _reserved0:29;              /*!< bit:  3..31  Reserved                           */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} CONTROL_Type;
+
+/* CONTROL Register Definitions */
+#define CONTROL_FPCA_Pos                    2                                             /*!< CONTROL: FPCA Position */
+#define CONTROL_FPCA_Msk                   (1UL << CONTROL_FPCA_Pos)                      /*!< CONTROL: FPCA Mask */
+
+#define CONTROL_SPSEL_Pos                   1                                             /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0                                             /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/** \ingroup    CMSIS_core_register
+    \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+    \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/** \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IO uint32_t ISER[8];                 /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register           */
+       uint32_t RESERVED0[24];
+  __IO uint32_t ICER[8];                 /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register         */
+       uint32_t RSERVED1[24];
+  __IO uint32_t ISPR[8];                 /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register          */
+       uint32_t RESERVED2[24];
+  __IO uint32_t ICPR[8];                 /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register        */
+       uint32_t RESERVED3[24];
+  __IO uint32_t IABR[8];                 /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register           */
+       uint32_t RESERVED4[56];
+  __IO uint8_t  IP[240];                 /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+       uint32_t RESERVED5[644];
+  __O  uint32_t STIR;                    /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register     */
+}  NVIC_Type;
+
+/* Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0                                          /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SCB     System Control Block (SCB)
+    \brief      Type definitions for the System Control Block Registers
+  @{
+ */
+
+/** \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __I  uint32_t CPUID;                   /*!< Offset: 0x000 (R/ )  CPUID Base Register                                   */
+  __IO uint32_t ICSR;                    /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register                  */
+  __IO uint32_t VTOR;                    /*!< Offset: 0x008 (R/W)  Vector Table Offset Register                          */
+  __IO uint32_t AIRCR;                   /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register      */
+  __IO uint32_t SCR;                     /*!< Offset: 0x010 (R/W)  System Control Register                               */
+  __IO uint32_t CCR;                     /*!< Offset: 0x014 (R/W)  Configuration Control Register                        */
+  __IO uint8_t  SHPR[12];                /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IO uint32_t SHCSR;                   /*!< Offset: 0x024 (R/W)  System Handler Control and State Register             */
+  __IO uint32_t CFSR;                    /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register                    */
+  __IO uint32_t HFSR;                    /*!< Offset: 0x02C (R/W)  HardFault Status Register                             */
+  __IO uint32_t DFSR;                    /*!< Offset: 0x030 (R/W)  Debug Fault Status Register                           */
+  __IO uint32_t MMFAR;                   /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register                      */
+  __IO uint32_t BFAR;                    /*!< Offset: 0x038 (R/W)  BusFault Address Register                             */
+  __IO uint32_t AFSR;                    /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register                       */
+  __I  uint32_t ID_PFR[2];               /*!< Offset: 0x040 (R/ )  Processor Feature Register                            */
+  __I  uint32_t ID_DFR;                  /*!< Offset: 0x048 (R/ )  Debug Feature Register                                */
+  __I  uint32_t ID_AFR;                  /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register                            */
+  __I  uint32_t ID_MFR[4];               /*!< Offset: 0x050 (R/ )  Memory Model Feature Register                         */
+  __I  uint32_t ID_ISAR[5];              /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register                   */
+       uint32_t RESERVED0[1];
+  __I  uint32_t CLIDR;                   /*!< Offset: 0x078 (R/ )  Cache Level ID register                               */
+  __I  uint32_t CTR;                     /*!< Offset: 0x07C (R/ )  Cache Type register                                   */
+  __I  uint32_t CCSIDR;                  /*!< Offset: 0x080 (R/ )  Cache Size ID Register                                */
+  __IO uint32_t CSSELR;                  /*!< Offset: 0x084 (R/W)  Cache Size Selection Register                         */
+  __IO uint32_t CPACR;                   /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register                   */
+       uint32_t RESERVED3[93];
+  __O  uint32_t STIR;                    /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register                 */
+       uint32_t RESERVED4[15];
+  __I  uint32_t MVFR0;                   /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0                      */
+  __I  uint32_t MVFR1;                   /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1                      */
+  __I  uint32_t MVFR2;                   /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 1                      */
+       uint32_t RESERVED5[1];
+  __O  uint32_t ICIALLU;                 /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU                         */
+       uint32_t RESERVED6[1];
+  __O  uint32_t ICIMVAU;                 /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU                      */
+  __O  uint32_t DCIMVAC;                 /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC                      */
+  __O  uint32_t DCISW;                   /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way                         */
+  __O  uint32_t DCCMVAU;                 /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU                           */
+  __O  uint32_t DCCMVAC;                 /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC                           */
+  __O  uint32_t DCCSW;                   /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way                              */
+  __O  uint32_t DCCIMVAC;                /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC            */
+  __O  uint32_t DCCISW;                  /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way               */
+       uint32_t RESERVED7[6];
+  __IO uint32_t ITCMCR;                  /*!< Offset: 0x290 (R/W)  Instruction Tightly-Coupled Memory Control Register   */
+  __IO uint32_t DTCMCR;                  /*!< Offset: 0x294 (R/W)  Data Tightly-Coupled Memory Control Registers         */
+  __IO uint32_t AHBPCR;                  /*!< Offset: 0x298 (R/W)  AHBP Control Register                                 */
+  __IO uint32_t CACR;                    /*!< Offset: 0x29C (R/W)  L1 Cache Control Register                             */
+  __IO uint32_t AHBSCR;                  /*!< Offset: 0x2A0 (R/W)  AHB Slave Control Register                            */
+       uint32_t RESERVED8[1];
+  __IO uint32_t ABFSR;                   /*!< Offset: 0x2A8 (R/W)  Auxiliary Bus Fault Status Register                   */
+} SCB_Type;
+
+/* SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24                                             /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20                                             /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16                                             /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4                                             /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0                                             /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/* SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31                                             /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28                                             /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27                                             /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26                                             /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25                                             /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23                                             /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22                                             /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12                                             /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11                                             /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0                                             /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/* SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7                                             /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/* SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16                                             /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16                                             /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15                                             /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8                                             /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2                                             /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1                                             /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+#define SCB_AIRCR_VECTRESET_Pos             0                                             /*!< SCB AIRCR: VECTRESET Position */
+#define SCB_AIRCR_VECTRESET_Msk            (1UL /*<< SCB_AIRCR_VECTRESET_Pos*/)           /*!< SCB AIRCR: VECTRESET Mask */
+
+/* SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4                                             /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2                                             /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1                                             /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/* SCB Configuration Control Register Definitions */
+#define SCB_CCR_BP_Pos                      18                                            /*!< SCB CCR: Branch prediction enable bit Position */
+#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: Branch prediction enable bit Mask */
+
+#define SCB_CCR_IC_Pos                      17                                            /*!< SCB CCR: Instruction cache enable bit Position */
+#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: Instruction cache enable bit Mask */
+
+#define SCB_CCR_DC_Pos                      16                                            /*!< SCB CCR: Cache enable bit Position */
+#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: Cache enable bit Mask */
+
+#define SCB_CCR_STKALIGN_Pos                9                                             /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8                                             /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4                                             /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3                                             /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1                                             /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+#define SCB_CCR_NONBASETHRDENA_Pos          0                                             /*!< SCB CCR: NONBASETHRDENA Position */
+#define SCB_CCR_NONBASETHRDENA_Msk         (1UL /*<< SCB_CCR_NONBASETHRDENA_Pos*/)        /*!< SCB CCR: NONBASETHRDENA Mask */
+
+/* SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_USGFAULTENA_Pos          18                                             /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17                                             /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16                                             /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15                                             /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14                                             /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13                                             /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12                                             /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11                                             /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10                                             /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8                                             /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7                                             /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3                                             /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1                                             /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0                                             /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/* SCB Configurable Fault Status Registers Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16                                             /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8                                             /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0                                             /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/* SCB Hard Fault Status Registers Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31                                             /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30                                             /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1                                             /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/* SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_EXTERNAL_Pos               4                                             /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3                                             /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2                                             /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1                                             /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0                                             /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+
+/* Cache Level ID register */
+#define SCB_CLIDR_LOUU_Pos                 27                                             /*!< SCB CLIDR: LoUU Position */
+#define SCB_CLIDR_LOUU_Msk                 (7UL << SCB_CLIDR_LOUU_Pos)                    /*!< SCB CLIDR: LoUU Mask */
+
+#define SCB_CLIDR_LOC_Pos                  24                                             /*!< SCB CLIDR: LoC Position */
+#define SCB_CLIDR_LOC_Msk                  (7UL << SCB_CLIDR_FORMAT_Pos)                  /*!< SCB CLIDR: LoC Mask */
+
+/* Cache Type register */
+#define SCB_CTR_FORMAT_Pos                 29                                             /*!< SCB CTR: Format Position */
+#define SCB_CTR_FORMAT_Msk                 (7UL << SCB_CTR_FORMAT_Pos)                    /*!< SCB CTR: Format Mask */
+
+#define SCB_CTR_CWG_Pos                    24                                             /*!< SCB CTR: CWG Position */
+#define SCB_CTR_CWG_Msk                    (0xFUL << SCB_CTR_CWG_Pos)                     /*!< SCB CTR: CWG Mask */
+
+#define SCB_CTR_ERG_Pos                    20                                             /*!< SCB CTR: ERG Position */
+#define SCB_CTR_ERG_Msk                    (0xFUL << SCB_CTR_ERG_Pos)                     /*!< SCB CTR: ERG Mask */
+
+#define SCB_CTR_DMINLINE_Pos               16                                             /*!< SCB CTR: DminLine Position */
+#define SCB_CTR_DMINLINE_Msk               (0xFUL << SCB_CTR_DMINLINE_Pos)                /*!< SCB CTR: DminLine Mask */
+
+#define SCB_CTR_IMINLINE_Pos                0                                             /*!< SCB CTR: ImInLine Position */
+#define SCB_CTR_IMINLINE_Msk               (0xFUL /*<< SCB_CTR_IMINLINE_Pos*/)            /*!< SCB CTR: ImInLine Mask */
+
+/* Cache Size ID Register */
+#define SCB_CCSIDR_WT_Pos                  31                                             /*!< SCB CCSIDR: WT Position */
+#define SCB_CCSIDR_WT_Msk                  (7UL << SCB_CCSIDR_WT_Pos)                     /*!< SCB CCSIDR: WT Mask */
+
+#define SCB_CCSIDR_WB_Pos                  30                                             /*!< SCB CCSIDR: WB Position */
+#define SCB_CCSIDR_WB_Msk                  (7UL << SCB_CCSIDR_WB_Pos)                     /*!< SCB CCSIDR: WB Mask */
+
+#define SCB_CCSIDR_RA_Pos                  29                                             /*!< SCB CCSIDR: RA Position */
+#define SCB_CCSIDR_RA_Msk                  (7UL << SCB_CCSIDR_RA_Pos)                     /*!< SCB CCSIDR: RA Mask */
+
+#define SCB_CCSIDR_WA_Pos                  28                                             /*!< SCB CCSIDR: WA Position */
+#define SCB_CCSIDR_WA_Msk                  (7UL << SCB_CCSIDR_WA_Pos)                     /*!< SCB CCSIDR: WA Mask */
+
+#define SCB_CCSIDR_NUMSETS_Pos             13                                             /*!< SCB CCSIDR: NumSets Position */
+#define SCB_CCSIDR_NUMSETS_Msk             (0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos)           /*!< SCB CCSIDR: NumSets Mask */
+
+#define SCB_CCSIDR_ASSOCIATIVITY_Pos        3                                             /*!< SCB CCSIDR: Associativity Position */
+#define SCB_CCSIDR_ASSOCIATIVITY_Msk       (0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos)      /*!< SCB CCSIDR: Associativity Mask */
+
+#define SCB_CCSIDR_LINESIZE_Pos             0                                             /*!< SCB CCSIDR: LineSize Position */
+#define SCB_CCSIDR_LINESIZE_Msk            (7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/)           /*!< SCB CCSIDR: LineSize Mask */
+
+/* Cache Size Selection Register */
+#define SCB_CSSELR_LEVEL_Pos                1                                             /*!< SCB CSSELR: Level Position */
+#define SCB_CSSELR_LEVEL_Msk               (7UL << SCB_CSSELR_LEVEL_Pos)                  /*!< SCB CSSELR: Level Mask */
+
+#define SCB_CSSELR_IND_Pos                  0                                             /*!< SCB CSSELR: InD Position */
+#define SCB_CSSELR_IND_Msk                 (1UL /*<< SCB_CSSELR_IND_Pos*/)                /*!< SCB CSSELR: InD Mask */
+
+/* SCB Software Triggered Interrupt Register */
+#define SCB_STIR_INTID_Pos                  0                                             /*!< SCB STIR: INTID Position */
+#define SCB_STIR_INTID_Msk                 (0x1FFUL /*<< SCB_STIR_INTID_Pos*/)            /*!< SCB STIR: INTID Mask */
+
+/* Instruction Tightly-Coupled Memory Control Register*/
+#define SCB_ITCMCR_SZ_Pos                   3                                             /*!< SCB ITCMCR: SZ Position */
+#define SCB_ITCMCR_SZ_Msk                  (0xFUL << SCB_ITCMCR_SZ_Pos)                   /*!< SCB ITCMCR: SZ Mask */
+
+#define SCB_ITCMCR_RETEN_Pos                2                                             /*!< SCB ITCMCR: RETEN Position */
+#define SCB_ITCMCR_RETEN_Msk               (1UL << SCB_ITCMCR_RETEN_Pos)                  /*!< SCB ITCMCR: RETEN Mask */
+
+#define SCB_ITCMCR_RMW_Pos                  1                                             /*!< SCB ITCMCR: RMW Position */
+#define SCB_ITCMCR_RMW_Msk                 (1UL << SCB_ITCMCR_RMW_Pos)                    /*!< SCB ITCMCR: RMW Mask */
+
+#define SCB_ITCMCR_EN_Pos                   0                                             /*!< SCB ITCMCR: EN Position */
+#define SCB_ITCMCR_EN_Msk                  (1UL /*<< SCB_ITCMCR_EN_Pos*/)                 /*!< SCB ITCMCR: EN Mask */
+
+/* Data Tightly-Coupled Memory Control Registers */
+#define SCB_DTCMCR_SZ_Pos                   3                                             /*!< SCB DTCMCR: SZ Position */
+#define SCB_DTCMCR_SZ_Msk                  (0xFUL << SCB_DTCMCR_SZ_Pos)                   /*!< SCB DTCMCR: SZ Mask */
+
+#define SCB_DTCMCR_RETEN_Pos                2                                             /*!< SCB DTCMCR: RETEN Position */
+#define SCB_DTCMCR_RETEN_Msk               (1UL << SCB_DTCMCR_RETEN_Pos)                   /*!< SCB DTCMCR: RETEN Mask */
+
+#define SCB_DTCMCR_RMW_Pos                  1                                             /*!< SCB DTCMCR: RMW Position */
+#define SCB_DTCMCR_RMW_Msk                 (1UL << SCB_DTCMCR_RMW_Pos)                    /*!< SCB DTCMCR: RMW Mask */
+
+#define SCB_DTCMCR_EN_Pos                   0                                             /*!< SCB DTCMCR: EN Position */
+#define SCB_DTCMCR_EN_Msk                  (1UL /*<< SCB_DTCMCR_EN_Pos*/)                 /*!< SCB DTCMCR: EN Mask */
+
+/* AHBP Control Register */
+#define SCB_AHBPCR_SZ_Pos                   1                                             /*!< SCB AHBPCR: SZ Position */
+#define SCB_AHBPCR_SZ_Msk                  (7UL << SCB_AHBPCR_SZ_Pos)                     /*!< SCB AHBPCR: SZ Mask */
+
+#define SCB_AHBPCR_EN_Pos                   0                                             /*!< SCB AHBPCR: EN Position */
+#define SCB_AHBPCR_EN_Msk                  (1UL /*<< SCB_AHBPCR_EN_Pos*/)                 /*!< SCB AHBPCR: EN Mask */
+
+/* L1 Cache Control Register */
+#define SCB_CACR_FORCEWT_Pos                2                                             /*!< SCB CACR: FORCEWT Position */
+#define SCB_CACR_FORCEWT_Msk               (1UL << SCB_CACR_FORCEWT_Pos)                  /*!< SCB CACR: FORCEWT Mask */
+
+#define SCB_CACR_ECCEN_Pos                  1                                             /*!< SCB CACR: ECCEN Position */
+#define SCB_CACR_ECCEN_Msk                 (1UL << SCB_CACR_ECCEN_Pos)                    /*!< SCB CACR: ECCEN Mask */
+
+#define SCB_CACR_SIWT_Pos                   0                                             /*!< SCB CACR: SIWT Position */
+#define SCB_CACR_SIWT_Msk                  (1UL /*<< SCB_CACR_SIWT_Pos*/)                 /*!< SCB CACR: SIWT Mask */
+
+/* AHBS control register */
+#define SCB_AHBSCR_INITCOUNT_Pos           11                                             /*!< SCB AHBSCR: INITCOUNT Position */
+#define SCB_AHBSCR_INITCOUNT_Msk           (0x1FUL << SCB_AHBPCR_INITCOUNT_Pos)           /*!< SCB AHBSCR: INITCOUNT Mask */
+
+#define SCB_AHBSCR_TPRI_Pos                 2                                             /*!< SCB AHBSCR: TPRI Position */
+#define SCB_AHBSCR_TPRI_Msk                (0x1FFUL << SCB_AHBPCR_TPRI_Pos)               /*!< SCB AHBSCR: TPRI Mask */
+
+#define SCB_AHBSCR_CTL_Pos                  0                                             /*!< SCB AHBSCR: CTL Position*/
+#define SCB_AHBSCR_CTL_Msk                 (3UL /*<< SCB_AHBPCR_CTL_Pos*/)                /*!< SCB AHBSCR: CTL Mask */
+
+/* Auxiliary Bus Fault Status Register */
+#define SCB_ABFSR_AXIMTYPE_Pos              8                                             /*!< SCB ABFSR: AXIMTYPE Position*/
+#define SCB_ABFSR_AXIMTYPE_Msk             (3UL << SCB_ABFSR_AXIMTYPE_Pos)                /*!< SCB ABFSR: AXIMTYPE Mask */
+
+#define SCB_ABFSR_EPPB_Pos                  4                                             /*!< SCB ABFSR: EPPB Position*/
+#define SCB_ABFSR_EPPB_Msk                 (1UL << SCB_ABFSR_EPPB_Pos)                    /*!< SCB ABFSR: EPPB Mask */
+
+#define SCB_ABFSR_AXIM_Pos                  3                                             /*!< SCB ABFSR: AXIM Position*/
+#define SCB_ABFSR_AXIM_Msk                 (1UL << SCB_ABFSR_AXIM_Pos)                    /*!< SCB ABFSR: AXIM Mask */
+
+#define SCB_ABFSR_AHBP_Pos                  2                                             /*!< SCB ABFSR: AHBP Position*/
+#define SCB_ABFSR_AHBP_Msk                 (1UL << SCB_ABFSR_AHBP_Pos)                    /*!< SCB ABFSR: AHBP Mask */
+
+#define SCB_ABFSR_DTCM_Pos                  1                                             /*!< SCB ABFSR: DTCM Position*/
+#define SCB_ABFSR_DTCM_Msk                 (1UL << SCB_ABFSR_DTCM_Pos)                    /*!< SCB ABFSR: DTCM Mask */
+
+#define SCB_ABFSR_ITCM_Pos                  0                                             /*!< SCB ABFSR: ITCM Position*/
+#define SCB_ABFSR_ITCM_Msk                 (1UL /*<< SCB_ABFSR_ITCM_Pos*/)                /*!< SCB ABFSR: ITCM Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SCnSCB System Controls not in SCB (SCnSCB)
+    \brief      Type definitions for the System Control and ID Register not in the SCB
+  @{
+ */
+
+/** \brief  Structure type to access the System Control and ID Register not in the SCB.
+ */
+typedef struct
+{
+       uint32_t RESERVED0[1];
+  __I  uint32_t ICTR;                    /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register      */
+  __IO uint32_t ACTLR;                   /*!< Offset: 0x008 (R/W)  Auxiliary Control Register              */
+} SCnSCB_Type;
+
+/* Interrupt Controller Type Register Definitions */
+#define SCnSCB_ICTR_INTLINESNUM_Pos         0                                          /*!< ICTR: INTLINESNUM Position */
+#define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
+
+/* Auxiliary Control Register Definitions */
+#define SCnSCB_ACTLR_DISITMATBFLUSH_Pos    12                                          /*!< ACTLR: DISITMATBFLUSH Position */
+#define SCnSCB_ACTLR_DISITMATBFLUSH_Msk    (1UL << SCnSCB_ACTLR_DISITMATBFLUSH_Pos)    /*!< ACTLR: DISITMATBFLUSH Mask */
+
+#define SCnSCB_ACTLR_DISRAMODE_Pos         11                                          /*!< ACTLR: DISRAMODE Position */
+#define SCnSCB_ACTLR_DISRAMODE_Msk         (1UL << SCnSCB_ACTLR_DISRAMODE_Pos)         /*!< ACTLR: DISRAMODE Mask */
+
+#define SCnSCB_ACTLR_FPEXCODIS_Pos         10                                          /*!< ACTLR: FPEXCODIS Position */
+#define SCnSCB_ACTLR_FPEXCODIS_Msk         (1UL << SCnSCB_ACTLR_FPEXCODIS_Pos)         /*!< ACTLR: FPEXCODIS Mask */
+
+#define SCnSCB_ACTLR_DISFOLD_Pos            2                                          /*!< ACTLR: DISFOLD Position */
+#define SCnSCB_ACTLR_DISFOLD_Msk           (1UL << SCnSCB_ACTLR_DISFOLD_Pos)           /*!< ACTLR: DISFOLD Mask */
+
+#define SCnSCB_ACTLR_DISMCYCINT_Pos         0                                          /*!< ACTLR: DISMCYCINT Position */
+#define SCnSCB_ACTLR_DISMCYCINT_Msk        (1UL /*<< SCnSCB_ACTLR_DISMCYCINT_Pos*/)    /*!< ACTLR: DISMCYCINT Mask */
+
+/*@} end of group CMSIS_SCnotSCB */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+    \brief      Type definitions for the System Timer Registers.
+  @{
+ */
+
+/** \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IO uint32_t CTRL;                    /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IO uint32_t LOAD;                    /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register       */
+  __IO uint32_t VAL;                     /*!< Offset: 0x008 (R/W)  SysTick Current Value Register      */
+  __I  uint32_t CALIB;                   /*!< Offset: 0x00C (R/ )  SysTick Calibration Register        */
+} SysTick_Type;
+
+/* SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16                                             /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2                                             /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1                                             /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0                                             /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/* SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0                                             /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/* SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0                                             /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/* SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31                                             /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30                                             /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0                                             /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+    \brief      Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/** \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __O  union
+  {
+    __O  uint8_t    u8;                  /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 8-bit                   */
+    __O  uint16_t   u16;                 /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 16-bit                  */
+    __O  uint32_t   u32;                 /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 32-bit                  */
+  }  PORT [32];                          /*!< Offset: 0x000 ( /W)  ITM Stimulus Port Registers               */
+       uint32_t RESERVED0[864];
+  __IO uint32_t TER;                     /*!< Offset: 0xE00 (R/W)  ITM Trace Enable Register                 */
+       uint32_t RESERVED1[15];
+  __IO uint32_t TPR;                     /*!< Offset: 0xE40 (R/W)  ITM Trace Privilege Register              */
+       uint32_t RESERVED2[15];
+  __IO uint32_t TCR;                     /*!< Offset: 0xE80 (R/W)  ITM Trace Control Register                */
+       uint32_t RESERVED3[29];
+  __O  uint32_t IWR;                     /*!< Offset: 0xEF8 ( /W)  ITM Integration Write Register            */
+  __I  uint32_t IRR;                     /*!< Offset: 0xEFC (R/ )  ITM Integration Read Register             */
+  __IO uint32_t IMCR;                    /*!< Offset: 0xF00 (R/W)  ITM Integration Mode Control Register     */
+       uint32_t RESERVED4[43];
+  __O  uint32_t LAR;                     /*!< Offset: 0xFB0 ( /W)  ITM Lock Access Register                  */
+  __I  uint32_t LSR;                     /*!< Offset: 0xFB4 (R/ )  ITM Lock Status Register                  */
+       uint32_t RESERVED5[6];
+  __I  uint32_t PID4;                    /*!< Offset: 0xFD0 (R/ )  ITM Peripheral Identification Register #4 */
+  __I  uint32_t PID5;                    /*!< Offset: 0xFD4 (R/ )  ITM Peripheral Identification Register #5 */
+  __I  uint32_t PID6;                    /*!< Offset: 0xFD8 (R/ )  ITM Peripheral Identification Register #6 */
+  __I  uint32_t PID7;                    /*!< Offset: 0xFDC (R/ )  ITM Peripheral Identification Register #7 */
+  __I  uint32_t PID0;                    /*!< Offset: 0xFE0 (R/ )  ITM Peripheral Identification Register #0 */
+  __I  uint32_t PID1;                    /*!< Offset: 0xFE4 (R/ )  ITM Peripheral Identification Register #1 */
+  __I  uint32_t PID2;                    /*!< Offset: 0xFE8 (R/ )  ITM Peripheral Identification Register #2 */
+  __I  uint32_t PID3;                    /*!< Offset: 0xFEC (R/ )  ITM Peripheral Identification Register #3 */
+  __I  uint32_t CID0;                    /*!< Offset: 0xFF0 (R/ )  ITM Component  Identification Register #0 */
+  __I  uint32_t CID1;                    /*!< Offset: 0xFF4 (R/ )  ITM Component  Identification Register #1 */
+  __I  uint32_t CID2;                    /*!< Offset: 0xFF8 (R/ )  ITM Component  Identification Register #2 */
+  __I  uint32_t CID3;                    /*!< Offset: 0xFFC (R/ )  ITM Component  Identification Register #3 */
+} ITM_Type;
+
+/* ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0                                             /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFUL /*<< ITM_TPR_PRIVMASK_Pos*/)            /*!< ITM TPR: PRIVMASK Mask */
+
+/* ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23                                             /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TraceBusID_Pos             16                                             /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TraceBusID_Msk             (0x7FUL << ITM_TCR_TraceBusID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10                                             /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPrescale_Pos              8                                             /*!< ITM TCR: TSPrescale Position */
+#define ITM_TCR_TSPrescale_Msk             (3UL << ITM_TCR_TSPrescale_Pos)                /*!< ITM TCR: TSPrescale Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4                                             /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3                                             /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2                                             /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1                                             /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0                                             /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+
+/* ITM Integration Write Register Definitions */
+#define ITM_IWR_ATVALIDM_Pos                0                                             /*!< ITM IWR: ATVALIDM Position */
+#define ITM_IWR_ATVALIDM_Msk               (1UL /*<< ITM_IWR_ATVALIDM_Pos*/)              /*!< ITM IWR: ATVALIDM Mask */
+
+/* ITM Integration Read Register Definitions */
+#define ITM_IRR_ATREADYM_Pos                0                                             /*!< ITM IRR: ATREADYM Position */
+#define ITM_IRR_ATREADYM_Msk               (1UL /*<< ITM_IRR_ATREADYM_Pos*/)              /*!< ITM IRR: ATREADYM Mask */
+
+/* ITM Integration Mode Control Register Definitions */
+#define ITM_IMCR_INTEGRATION_Pos            0                                             /*!< ITM IMCR: INTEGRATION Position */
+#define ITM_IMCR_INTEGRATION_Msk           (1UL /*<< ITM_IMCR_INTEGRATION_Pos*/)          /*!< ITM IMCR: INTEGRATION Mask */
+
+/* ITM Lock Status Register Definitions */
+#define ITM_LSR_ByteAcc_Pos                 2                                             /*!< ITM LSR: ByteAcc Position */
+#define ITM_LSR_ByteAcc_Msk                (1UL << ITM_LSR_ByteAcc_Pos)                   /*!< ITM LSR: ByteAcc Mask */
+
+#define ITM_LSR_Access_Pos                  1                                             /*!< ITM LSR: Access Position */
+#define ITM_LSR_Access_Msk                 (1UL << ITM_LSR_Access_Pos)                    /*!< ITM LSR: Access Mask */
+
+#define ITM_LSR_Present_Pos                 0                                             /*!< ITM LSR: Present Position */
+#define ITM_LSR_Present_Msk                (1UL /*<< ITM_LSR_Present_Pos*/)               /*!< ITM LSR: Present Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+    \brief      Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/** \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IO uint32_t CTRL;                    /*!< Offset: 0x000 (R/W)  Control Register                          */
+  __IO uint32_t CYCCNT;                  /*!< Offset: 0x004 (R/W)  Cycle Count Register                      */
+  __IO uint32_t CPICNT;                  /*!< Offset: 0x008 (R/W)  CPI Count Register                        */
+  __IO uint32_t EXCCNT;                  /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register         */
+  __IO uint32_t SLEEPCNT;                /*!< Offset: 0x010 (R/W)  Sleep Count Register                      */
+  __IO uint32_t LSUCNT;                  /*!< Offset: 0x014 (R/W)  LSU Count Register                        */
+  __IO uint32_t FOLDCNT;                 /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register         */
+  __I  uint32_t PCSR;                    /*!< Offset: 0x01C (R/ )  Program Counter Sample Register           */
+  __IO uint32_t COMP0;                   /*!< Offset: 0x020 (R/W)  Comparator Register 0                     */
+  __IO uint32_t MASK0;                   /*!< Offset: 0x024 (R/W)  Mask Register 0                           */
+  __IO uint32_t FUNCTION0;               /*!< Offset: 0x028 (R/W)  Function Register 0                       */
+       uint32_t RESERVED0[1];
+  __IO uint32_t COMP1;                   /*!< Offset: 0x030 (R/W)  Comparator Register 1                     */
+  __IO uint32_t MASK1;                   /*!< Offset: 0x034 (R/W)  Mask Register 1                           */
+  __IO uint32_t FUNCTION1;               /*!< Offset: 0x038 (R/W)  Function Register 1                       */
+       uint32_t RESERVED1[1];
+  __IO uint32_t COMP2;                   /*!< Offset: 0x040 (R/W)  Comparator Register 2                     */
+  __IO uint32_t MASK2;                   /*!< Offset: 0x044 (R/W)  Mask Register 2                           */
+  __IO uint32_t FUNCTION2;               /*!< Offset: 0x048 (R/W)  Function Register 2                       */
+       uint32_t RESERVED2[1];
+  __IO uint32_t COMP3;                   /*!< Offset: 0x050 (R/W)  Comparator Register 3                     */
+  __IO uint32_t MASK3;                   /*!< Offset: 0x054 (R/W)  Mask Register 3                           */
+  __IO uint32_t FUNCTION3;               /*!< Offset: 0x058 (R/W)  Function Register 3                       */
+       uint32_t RESERVED3[981];
+  __O  uint32_t LAR;                     /*!< Offset: 0xFB0 (  W)  Lock Access Register                      */
+  __I  uint32_t LSR;                     /*!< Offset: 0xFB4 (R  )  Lock Status Register                      */
+} DWT_Type;
+
+/* DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28                                          /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27                                          /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (0x1UL << DWT_CTRL_NOTRCPKT_Pos)            /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26                                          /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (0x1UL << DWT_CTRL_NOEXTTRIG_Pos)           /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25                                          /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (0x1UL << DWT_CTRL_NOCYCCNT_Pos)            /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24                                          /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (0x1UL << DWT_CTRL_NOPRFCNT_Pos)            /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22                                          /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (0x1UL << DWT_CTRL_CYCEVTENA_Pos)           /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21                                          /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (0x1UL << DWT_CTRL_FOLDEVTENA_Pos)          /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20                                          /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (0x1UL << DWT_CTRL_LSUEVTENA_Pos)           /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19                                          /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (0x1UL << DWT_CTRL_SLEEPEVTENA_Pos)         /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18                                          /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (0x1UL << DWT_CTRL_EXCEVTENA_Pos)           /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17                                          /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (0x1UL << DWT_CTRL_CPIEVTENA_Pos)           /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16                                          /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (0x1UL << DWT_CTRL_EXCTRCENA_Pos)           /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12                                          /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (0x1UL << DWT_CTRL_PCSAMPLENA_Pos)          /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10                                          /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9                                          /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (0x1UL << DWT_CTRL_CYCTAP_Pos)              /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5                                          /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1                                          /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0                                          /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (0x1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)       /*!< DWT CTRL: CYCCNTENA Mask */
+
+/* DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0                                          /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+
+/* DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0                                          /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+
+/* DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0                                          /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/* DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0                                          /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+
+/* DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0                                          /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/* DWT Comparator Mask Register Definitions */
+#define DWT_MASK_MASK_Pos                   0                                          /*!< DWT MASK: MASK Position */
+#define DWT_MASK_MASK_Msk                  (0x1FUL /*<< DWT_MASK_MASK_Pos*/)           /*!< DWT MASK: MASK Mask */
+
+/* DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_MATCHED_Pos           24                                          /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (0x1UL << DWT_FUNCTION_MATCHED_Pos)         /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVADDR1_Pos        16                                          /*!< DWT FUNCTION: DATAVADDR1 Position */
+#define DWT_FUNCTION_DATAVADDR1_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR1_Pos)      /*!< DWT FUNCTION: DATAVADDR1 Mask */
+
+#define DWT_FUNCTION_DATAVADDR0_Pos        12                                          /*!< DWT FUNCTION: DATAVADDR0 Position */
+#define DWT_FUNCTION_DATAVADDR0_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR0_Pos)      /*!< DWT FUNCTION: DATAVADDR0 Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10                                          /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_LNK1ENA_Pos            9                                          /*!< DWT FUNCTION: LNK1ENA Position */
+#define DWT_FUNCTION_LNK1ENA_Msk           (0x1UL << DWT_FUNCTION_LNK1ENA_Pos)         /*!< DWT FUNCTION: LNK1ENA Mask */
+
+#define DWT_FUNCTION_DATAVMATCH_Pos         8                                          /*!< DWT FUNCTION: DATAVMATCH Position */
+#define DWT_FUNCTION_DATAVMATCH_Msk        (0x1UL << DWT_FUNCTION_DATAVMATCH_Pos)      /*!< DWT FUNCTION: DATAVMATCH Mask */
+
+#define DWT_FUNCTION_CYCMATCH_Pos           7                                          /*!< DWT FUNCTION: CYCMATCH Position */
+#define DWT_FUNCTION_CYCMATCH_Msk          (0x1UL << DWT_FUNCTION_CYCMATCH_Pos)        /*!< DWT FUNCTION: CYCMATCH Mask */
+
+#define DWT_FUNCTION_EMITRANGE_Pos          5                                          /*!< DWT FUNCTION: EMITRANGE Position */
+#define DWT_FUNCTION_EMITRANGE_Msk         (0x1UL << DWT_FUNCTION_EMITRANGE_Pos)       /*!< DWT FUNCTION: EMITRANGE Mask */
+
+#define DWT_FUNCTION_FUNCTION_Pos           0                                          /*!< DWT FUNCTION: FUNCTION Position */
+#define DWT_FUNCTION_FUNCTION_Msk          (0xFUL /*<< DWT_FUNCTION_FUNCTION_Pos*/)    /*!< DWT FUNCTION: FUNCTION Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_TPI     Trace Port Interface (TPI)
+    \brief      Type definitions for the Trace Port Interface (TPI)
+  @{
+ */
+
+/** \brief  Structure type to access the Trace Port Interface Register (TPI).
+ */
+typedef struct
+{
+  __IO uint32_t SSPSR;                   /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register     */
+  __IO uint32_t CSPSR;                   /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+       uint32_t RESERVED0[2];
+  __IO uint32_t ACPR;                    /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+       uint32_t RESERVED1[55];
+  __IO uint32_t SPPR;                    /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+       uint32_t RESERVED2[131];
+  __I  uint32_t FFSR;                    /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IO uint32_t FFCR;                    /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __I  uint32_t FSCR;                    /*!< Offset: 0x308 (R/ )  Formatter Synchronization Counter Register */
+       uint32_t RESERVED3[759];
+  __I  uint32_t TRIGGER;                 /*!< Offset: 0xEE8 (R/ )  TRIGGER */
+  __I  uint32_t FIFO0;                   /*!< Offset: 0xEEC (R/ )  Integration ETM Data */
+  __I  uint32_t ITATBCTR2;               /*!< Offset: 0xEF0 (R/ )  ITATBCTR2 */
+       uint32_t RESERVED4[1];
+  __I  uint32_t ITATBCTR0;               /*!< Offset: 0xEF8 (R/ )  ITATBCTR0 */
+  __I  uint32_t FIFO1;                   /*!< Offset: 0xEFC (R/ )  Integration ITM Data */
+  __IO uint32_t ITCTRL;                  /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+       uint32_t RESERVED5[39];
+  __IO uint32_t CLAIMSET;                /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IO uint32_t CLAIMCLR;                /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+       uint32_t RESERVED7[8];
+  __I  uint32_t DEVID;                   /*!< Offset: 0xFC8 (R/ )  TPIU_DEVID */
+  __I  uint32_t DEVTYPE;                 /*!< Offset: 0xFCC (R/ )  TPIU_DEVTYPE */
+} TPI_Type;
+
+/* TPI Asynchronous Clock Prescaler Register Definitions */
+#define TPI_ACPR_PRESCALER_Pos              0                                          /*!< TPI ACPR: PRESCALER Position */
+#define TPI_ACPR_PRESCALER_Msk             (0x1FFFUL /*<< TPI_ACPR_PRESCALER_Pos*/)    /*!< TPI ACPR: PRESCALER Mask */
+
+/* TPI Selected Pin Protocol Register Definitions */
+#define TPI_SPPR_TXMODE_Pos                 0                                          /*!< TPI SPPR: TXMODE Position */
+#define TPI_SPPR_TXMODE_Msk                (0x3UL /*<< TPI_SPPR_TXMODE_Pos*/)          /*!< TPI SPPR: TXMODE Mask */
+
+/* TPI Formatter and Flush Status Register Definitions */
+#define TPI_FFSR_FtNonStop_Pos              3                                          /*!< TPI FFSR: FtNonStop Position */
+#define TPI_FFSR_FtNonStop_Msk             (0x1UL << TPI_FFSR_FtNonStop_Pos)           /*!< TPI FFSR: FtNonStop Mask */
+
+#define TPI_FFSR_TCPresent_Pos              2                                          /*!< TPI FFSR: TCPresent Position */
+#define TPI_FFSR_TCPresent_Msk             (0x1UL << TPI_FFSR_TCPresent_Pos)           /*!< TPI FFSR: TCPresent Mask */
+
+#define TPI_FFSR_FtStopped_Pos              1                                          /*!< TPI FFSR: FtStopped Position */
+#define TPI_FFSR_FtStopped_Msk             (0x1UL << TPI_FFSR_FtStopped_Pos)           /*!< TPI FFSR: FtStopped Mask */
+
+#define TPI_FFSR_FlInProg_Pos               0                                          /*!< TPI FFSR: FlInProg Position */
+#define TPI_FFSR_FlInProg_Msk              (0x1UL /*<< TPI_FFSR_FlInProg_Pos*/)        /*!< TPI FFSR: FlInProg Mask */
+
+/* TPI Formatter and Flush Control Register Definitions */
+#define TPI_FFCR_TrigIn_Pos                 8                                          /*!< TPI FFCR: TrigIn Position */
+#define TPI_FFCR_TrigIn_Msk                (0x1UL << TPI_FFCR_TrigIn_Pos)              /*!< TPI FFCR: TrigIn Mask */
+
+#define TPI_FFCR_EnFCont_Pos                1                                          /*!< TPI FFCR: EnFCont Position */
+#define TPI_FFCR_EnFCont_Msk               (0x1UL << TPI_FFCR_EnFCont_Pos)             /*!< TPI FFCR: EnFCont Mask */
+
+/* TPI TRIGGER Register Definitions */
+#define TPI_TRIGGER_TRIGGER_Pos             0                                          /*!< TPI TRIGGER: TRIGGER Position */
+#define TPI_TRIGGER_TRIGGER_Msk            (0x1UL /*<< TPI_TRIGGER_TRIGGER_Pos*/)      /*!< TPI TRIGGER: TRIGGER Mask */
+
+/* TPI Integration ETM Data Register Definitions (FIFO0) */
+#define TPI_FIFO0_ITM_ATVALID_Pos          29                                          /*!< TPI FIFO0: ITM_ATVALID Position */
+#define TPI_FIFO0_ITM_ATVALID_Msk          (0x3UL << TPI_FIFO0_ITM_ATVALID_Pos)        /*!< TPI FIFO0: ITM_ATVALID Mask */
+
+#define TPI_FIFO0_ITM_bytecount_Pos        27                                          /*!< TPI FIFO0: ITM_bytecount Position */
+#define TPI_FIFO0_ITM_bytecount_Msk        (0x3UL << TPI_FIFO0_ITM_bytecount_Pos)      /*!< TPI FIFO0: ITM_bytecount Mask */
+
+#define TPI_FIFO0_ETM_ATVALID_Pos          26                                          /*!< TPI FIFO0: ETM_ATVALID Position */
+#define TPI_FIFO0_ETM_ATVALID_Msk          (0x3UL << TPI_FIFO0_ETM_ATVALID_Pos)        /*!< TPI FIFO0: ETM_ATVALID Mask */
+
+#define TPI_FIFO0_ETM_bytecount_Pos        24                                          /*!< TPI FIFO0: ETM_bytecount Position */
+#define TPI_FIFO0_ETM_bytecount_Msk        (0x3UL << TPI_FIFO0_ETM_bytecount_Pos)      /*!< TPI FIFO0: ETM_bytecount Mask */
+
+#define TPI_FIFO0_ETM2_Pos                 16                                          /*!< TPI FIFO0: ETM2 Position */
+#define TPI_FIFO0_ETM2_Msk                 (0xFFUL << TPI_FIFO0_ETM2_Pos)              /*!< TPI FIFO0: ETM2 Mask */
+
+#define TPI_FIFO0_ETM1_Pos                  8                                          /*!< TPI FIFO0: ETM1 Position */
+#define TPI_FIFO0_ETM1_Msk                 (0xFFUL << TPI_FIFO0_ETM1_Pos)              /*!< TPI FIFO0: ETM1 Mask */
+
+#define TPI_FIFO0_ETM0_Pos                  0                                          /*!< TPI FIFO0: ETM0 Position */
+#define TPI_FIFO0_ETM0_Msk                 (0xFFUL /*<< TPI_FIFO0_ETM0_Pos*/)          /*!< TPI FIFO0: ETM0 Mask */
+
+/* TPI ITATBCTR2 Register Definitions */
+#define TPI_ITATBCTR2_ATREADY_Pos           0                                          /*!< TPI ITATBCTR2: ATREADY Position */
+#define TPI_ITATBCTR2_ATREADY_Msk          (0x1UL /*<< TPI_ITATBCTR2_ATREADY_Pos*/)    /*!< TPI ITATBCTR2: ATREADY Mask */
+
+/* TPI Integration ITM Data Register Definitions (FIFO1) */
+#define TPI_FIFO1_ITM_ATVALID_Pos          29                                          /*!< TPI FIFO1: ITM_ATVALID Position */
+#define TPI_FIFO1_ITM_ATVALID_Msk          (0x3UL << TPI_FIFO1_ITM_ATVALID_Pos)        /*!< TPI FIFO1: ITM_ATVALID Mask */
+
+#define TPI_FIFO1_ITM_bytecount_Pos        27                                          /*!< TPI FIFO1: ITM_bytecount Position */
+#define TPI_FIFO1_ITM_bytecount_Msk        (0x3UL << TPI_FIFO1_ITM_bytecount_Pos)      /*!< TPI FIFO1: ITM_bytecount Mask */
+
+#define TPI_FIFO1_ETM_ATVALID_Pos          26                                          /*!< TPI FIFO1: ETM_ATVALID Position */
+#define TPI_FIFO1_ETM_ATVALID_Msk          (0x3UL << TPI_FIFO1_ETM_ATVALID_Pos)        /*!< TPI FIFO1: ETM_ATVALID Mask */
+
+#define TPI_FIFO1_ETM_bytecount_Pos        24                                          /*!< TPI FIFO1: ETM_bytecount Position */
+#define TPI_FIFO1_ETM_bytecount_Msk        (0x3UL << TPI_FIFO1_ETM_bytecount_Pos)      /*!< TPI FIFO1: ETM_bytecount Mask */
+
+#define TPI_FIFO1_ITM2_Pos                 16                                          /*!< TPI FIFO1: ITM2 Position */
+#define TPI_FIFO1_ITM2_Msk                 (0xFFUL << TPI_FIFO1_ITM2_Pos)              /*!< TPI FIFO1: ITM2 Mask */
+
+#define TPI_FIFO1_ITM1_Pos                  8                                          /*!< TPI FIFO1: ITM1 Position */
+#define TPI_FIFO1_ITM1_Msk                 (0xFFUL << TPI_FIFO1_ITM1_Pos)              /*!< TPI FIFO1: ITM1 Mask */
+
+#define TPI_FIFO1_ITM0_Pos                  0                                          /*!< TPI FIFO1: ITM0 Position */
+#define TPI_FIFO1_ITM0_Msk                 (0xFFUL /*<< TPI_FIFO1_ITM0_Pos*/)          /*!< TPI FIFO1: ITM0 Mask */
+
+/* TPI ITATBCTR0 Register Definitions */
+#define TPI_ITATBCTR0_ATREADY_Pos           0                                          /*!< TPI ITATBCTR0: ATREADY Position */
+#define TPI_ITATBCTR0_ATREADY_Msk          (0x1UL /*<< TPI_ITATBCTR0_ATREADY_Pos*/)    /*!< TPI ITATBCTR0: ATREADY Mask */
+
+/* TPI Integration Mode Control Register Definitions */
+#define TPI_ITCTRL_Mode_Pos                 0                                          /*!< TPI ITCTRL: Mode Position */
+#define TPI_ITCTRL_Mode_Msk                (0x1UL /*<< TPI_ITCTRL_Mode_Pos*/)          /*!< TPI ITCTRL: Mode Mask */
+
+/* TPI DEVID Register Definitions */
+#define TPI_DEVID_NRZVALID_Pos             11                                          /*!< TPI DEVID: NRZVALID Position */
+#define TPI_DEVID_NRZVALID_Msk             (0x1UL << TPI_DEVID_NRZVALID_Pos)           /*!< TPI DEVID: NRZVALID Mask */
+
+#define TPI_DEVID_MANCVALID_Pos            10                                          /*!< TPI DEVID: MANCVALID Position */
+#define TPI_DEVID_MANCVALID_Msk            (0x1UL << TPI_DEVID_MANCVALID_Pos)          /*!< TPI DEVID: MANCVALID Mask */
+
+#define TPI_DEVID_PTINVALID_Pos             9                                          /*!< TPI DEVID: PTINVALID Position */
+#define TPI_DEVID_PTINVALID_Msk            (0x1UL << TPI_DEVID_PTINVALID_Pos)          /*!< TPI DEVID: PTINVALID Mask */
+
+#define TPI_DEVID_MinBufSz_Pos              6                                          /*!< TPI DEVID: MinBufSz Position */
+#define TPI_DEVID_MinBufSz_Msk             (0x7UL << TPI_DEVID_MinBufSz_Pos)           /*!< TPI DEVID: MinBufSz Mask */
+
+#define TPI_DEVID_AsynClkIn_Pos             5                                          /*!< TPI DEVID: AsynClkIn Position */
+#define TPI_DEVID_AsynClkIn_Msk            (0x1UL << TPI_DEVID_AsynClkIn_Pos)          /*!< TPI DEVID: AsynClkIn Mask */
+
+#define TPI_DEVID_NrTraceInput_Pos          0                                          /*!< TPI DEVID: NrTraceInput Position */
+#define TPI_DEVID_NrTraceInput_Msk         (0x1FUL /*<< TPI_DEVID_NrTraceInput_Pos*/)  /*!< TPI DEVID: NrTraceInput Mask */
+
+/* TPI DEVTYPE Register Definitions */
+#define TPI_DEVTYPE_MajorType_Pos           4                                          /*!< TPI DEVTYPE: MajorType Position */
+#define TPI_DEVTYPE_MajorType_Msk          (0xFUL << TPI_DEVTYPE_MajorType_Pos)        /*!< TPI DEVTYPE: MajorType Mask */
+
+#define TPI_DEVTYPE_SubType_Pos             0                                          /*!< TPI DEVTYPE: SubType Position */
+#define TPI_DEVTYPE_SubType_Msk            (0xFUL /*<< TPI_DEVTYPE_SubType_Pos*/)      /*!< TPI DEVTYPE: SubType Mask */
+
+/*@}*/ /* end of group CMSIS_TPI */
+
+
+#if (__MPU_PRESENT == 1)
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+    \brief      Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/** \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __I  uint32_t TYPE;                    /*!< Offset: 0x000 (R/ )  MPU Type Register                              */
+  __IO uint32_t CTRL;                    /*!< Offset: 0x004 (R/W)  MPU Control Register                           */
+  __IO uint32_t RNR;                     /*!< Offset: 0x008 (R/W)  MPU Region RNRber Register                     */
+  __IO uint32_t RBAR;                    /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register               */
+  __IO uint32_t RASR;                    /*!< Offset: 0x010 (R/W)  MPU Region Attribute and Size Register         */
+  __IO uint32_t RBAR_A1;                 /*!< Offset: 0x014 (R/W)  MPU Alias 1 Region Base Address Register       */
+  __IO uint32_t RASR_A1;                 /*!< Offset: 0x018 (R/W)  MPU Alias 1 Region Attribute and Size Register */
+  __IO uint32_t RBAR_A2;                 /*!< Offset: 0x01C (R/W)  MPU Alias 2 Region Base Address Register       */
+  __IO uint32_t RASR_A2;                 /*!< Offset: 0x020 (R/W)  MPU Alias 2 Region Attribute and Size Register */
+  __IO uint32_t RBAR_A3;                 /*!< Offset: 0x024 (R/W)  MPU Alias 3 Region Base Address Register       */
+  __IO uint32_t RASR_A3;                 /*!< Offset: 0x028 (R/W)  MPU Alias 3 Region Attribute and Size Register */
+} MPU_Type;
+
+/* MPU Type Register */
+#define MPU_TYPE_IREGION_Pos               16                                             /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8                                             /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0                                             /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/* MPU Control Register */
+#define MPU_CTRL_PRIVDEFENA_Pos             2                                             /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1                                             /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0                                             /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/* MPU Region Number Register */
+#define MPU_RNR_REGION_Pos                  0                                             /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/* MPU Region Base Address Register */
+#define MPU_RBAR_ADDR_Pos                   5                                             /*!< MPU RBAR: ADDR Position */
+#define MPU_RBAR_ADDR_Msk                  (0x7FFFFFFUL << MPU_RBAR_ADDR_Pos)             /*!< MPU RBAR: ADDR Mask */
+
+#define MPU_RBAR_VALID_Pos                  4                                             /*!< MPU RBAR: VALID Position */
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)                    /*!< MPU RBAR: VALID Mask */
+
+#define MPU_RBAR_REGION_Pos                 0                                             /*!< MPU RBAR: REGION Position */
+#define MPU_RBAR_REGION_Msk                (0xFUL /*<< MPU_RBAR_REGION_Pos*/)             /*!< MPU RBAR: REGION Mask */
+
+/* MPU Region Attribute and Size Register */
+#define MPU_RASR_ATTRS_Pos                 16                                             /*!< MPU RASR: MPU Region Attribute field Position */
+#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)               /*!< MPU RASR: MPU Region Attribute field Mask */
+
+#define MPU_RASR_XN_Pos                    28                                             /*!< MPU RASR: ATTRS.XN Position */
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)                       /*!< MPU RASR: ATTRS.XN Mask */
+
+#define MPU_RASR_AP_Pos                    24                                             /*!< MPU RASR: ATTRS.AP Position */
+#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)                     /*!< MPU RASR: ATTRS.AP Mask */
+
+#define MPU_RASR_TEX_Pos                   19                                             /*!< MPU RASR: ATTRS.TEX Position */
+#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)                    /*!< MPU RASR: ATTRS.TEX Mask */
+
+#define MPU_RASR_S_Pos                     18                                             /*!< MPU RASR: ATTRS.S Position */
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)                        /*!< MPU RASR: ATTRS.S Mask */
+
+#define MPU_RASR_C_Pos                     17                                             /*!< MPU RASR: ATTRS.C Position */
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)                        /*!< MPU RASR: ATTRS.C Mask */
+
+#define MPU_RASR_B_Pos                     16                                             /*!< MPU RASR: ATTRS.B Position */
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)                        /*!< MPU RASR: ATTRS.B Mask */
+
+#define MPU_RASR_SRD_Pos                    8                                             /*!< MPU RASR: Sub-Region Disable Position */
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)                   /*!< MPU RASR: Sub-Region Disable Mask */
+
+#define MPU_RASR_SIZE_Pos                   1                                             /*!< MPU RASR: Region Size Field Position */
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)                  /*!< MPU RASR: Region Size Field Mask */
+
+#define MPU_RASR_ENABLE_Pos                 0                                             /*!< MPU RASR: Region enable bit Position */
+#define MPU_RASR_ENABLE_Msk                (1UL /*<< MPU_RASR_ENABLE_Pos*/)               /*!< MPU RASR: Region enable bit Disable Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+#if (__FPU_PRESENT == 1)
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+    \brief      Type definitions for the Floating Point Unit (FPU)
+  @{
+ */
+
+/** \brief  Structure type to access the Floating Point Unit (FPU).
+ */
+typedef struct
+{
+       uint32_t RESERVED0[1];
+  __IO uint32_t FPCCR;                   /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register               */
+  __IO uint32_t FPCAR;                   /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register               */
+  __IO uint32_t FPDSCR;                  /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register        */
+  __I  uint32_t MVFR0;                   /*!< Offset: 0x010 (R/ )  Media and FP Feature Register 0                       */
+  __I  uint32_t MVFR1;                   /*!< Offset: 0x014 (R/ )  Media and FP Feature Register 1                       */
+  __I  uint32_t MVFR2;                   /*!< Offset: 0x018 (R/ )  Media and FP Feature Register 2                       */
+} FPU_Type;
+
+/* Floating-Point Context Control Register */
+#define FPU_FPCCR_ASPEN_Pos                31                                             /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+
+#define FPU_FPCCR_LSPEN_Pos                30                                             /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+
+#define FPU_FPCCR_MONRDY_Pos                8                                             /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+
+#define FPU_FPCCR_BFRDY_Pos                 6                                             /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+
+#define FPU_FPCCR_MMRDY_Pos                 5                                             /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+
+#define FPU_FPCCR_HFRDY_Pos                 4                                             /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+
+#define FPU_FPCCR_THREAD_Pos                3                                             /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+
+#define FPU_FPCCR_USER_Pos                  1                                             /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+
+#define FPU_FPCCR_LSPACT_Pos                0                                             /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL /*<< FPU_FPCCR_LSPACT_Pos*/)              /*!< FPCCR: Lazy state preservation active bit Mask */
+
+/* Floating-Point Context Address Register */
+#define FPU_FPCAR_ADDRESS_Pos               3                                             /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+
+/* Floating-Point Default Status Control Register */
+#define FPU_FPDSCR_AHP_Pos                 26                                             /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+
+#define FPU_FPDSCR_DN_Pos                  25                                             /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+
+#define FPU_FPDSCR_FZ_Pos                  24                                             /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+
+#define FPU_FPDSCR_RMode_Pos               22                                             /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+
+/* Media and FP Feature Register 0 */
+#define FPU_MVFR0_FP_rounding_modes_Pos    28                                             /*!< MVFR0: FP rounding modes bits Position */
+#define FPU_MVFR0_FP_rounding_modes_Msk    (0xFUL << FPU_MVFR0_FP_rounding_modes_Pos)     /*!< MVFR0: FP rounding modes bits Mask */
+
+#define FPU_MVFR0_Short_vectors_Pos        24                                             /*!< MVFR0: Short vectors bits Position */
+#define FPU_MVFR0_Short_vectors_Msk        (0xFUL << FPU_MVFR0_Short_vectors_Pos)         /*!< MVFR0: Short vectors bits Mask */
+
+#define FPU_MVFR0_Square_root_Pos          20                                             /*!< MVFR0: Square root bits Position */
+#define FPU_MVFR0_Square_root_Msk          (0xFUL << FPU_MVFR0_Square_root_Pos)           /*!< MVFR0: Square root bits Mask */
+
+#define FPU_MVFR0_Divide_Pos               16                                             /*!< MVFR0: Divide bits Position */
+#define FPU_MVFR0_Divide_Msk               (0xFUL << FPU_MVFR0_Divide_Pos)                /*!< MVFR0: Divide bits Mask */
+
+#define FPU_MVFR0_FP_excep_trapping_Pos    12                                             /*!< MVFR0: FP exception trapping bits Position */
+#define FPU_MVFR0_FP_excep_trapping_Msk    (0xFUL << FPU_MVFR0_FP_excep_trapping_Pos)     /*!< MVFR0: FP exception trapping bits Mask */
+
+#define FPU_MVFR0_Double_precision_Pos      8                                             /*!< MVFR0: Double-precision bits Position */
+#define FPU_MVFR0_Double_precision_Msk     (0xFUL << FPU_MVFR0_Double_precision_Pos)      /*!< MVFR0: Double-precision bits Mask */
+
+#define FPU_MVFR0_Single_precision_Pos      4                                             /*!< MVFR0: Single-precision bits Position */
+#define FPU_MVFR0_Single_precision_Msk     (0xFUL << FPU_MVFR0_Single_precision_Pos)      /*!< MVFR0: Single-precision bits Mask */
+
+#define FPU_MVFR0_A_SIMD_registers_Pos      0                                             /*!< MVFR0: A_SIMD registers bits Position */
+#define FPU_MVFR0_A_SIMD_registers_Msk     (0xFUL /*<< FPU_MVFR0_A_SIMD_registers_Pos*/)  /*!< MVFR0: A_SIMD registers bits Mask */
+
+/* Media and FP Feature Register 1 */
+#define FPU_MVFR1_FP_fused_MAC_Pos         28                                             /*!< MVFR1: FP fused MAC bits Position */
+#define FPU_MVFR1_FP_fused_MAC_Msk         (0xFUL << FPU_MVFR1_FP_fused_MAC_Pos)          /*!< MVFR1: FP fused MAC bits Mask */
+
+#define FPU_MVFR1_FP_HPFP_Pos              24                                             /*!< MVFR1: FP HPFP bits Position */
+#define FPU_MVFR1_FP_HPFP_Msk              (0xFUL << FPU_MVFR1_FP_HPFP_Pos)               /*!< MVFR1: FP HPFP bits Mask */
+
+#define FPU_MVFR1_D_NaN_mode_Pos            4                                             /*!< MVFR1: D_NaN mode bits Position */
+#define FPU_MVFR1_D_NaN_mode_Msk           (0xFUL << FPU_MVFR1_D_NaN_mode_Pos)            /*!< MVFR1: D_NaN mode bits Mask */
+
+#define FPU_MVFR1_FtZ_mode_Pos              0                                             /*!< MVFR1: FtZ mode bits Position */
+#define FPU_MVFR1_FtZ_mode_Msk             (0xFUL /*<< FPU_MVFR1_FtZ_mode_Pos*/)          /*!< MVFR1: FtZ mode bits Mask */
+
+/* Media and FP Feature Register 2 */
+
+/*@} end of group CMSIS_FPU */
+#endif
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
+    \brief      Type definitions for the Core Debug Registers
+  @{
+ */
+
+/** \brief  Structure type to access the Core Debug Register (CoreDebug).
+ */
+typedef struct
+{
+  __IO uint32_t DHCSR;                   /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register    */
+  __O  uint32_t DCRSR;                   /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register        */
+  __IO uint32_t DCRDR;                   /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register            */
+  __IO uint32_t DEMCR;                   /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+} CoreDebug_Type;
+
+/* Debug Halting Control and Status Register */
+#define CoreDebug_DHCSR_DBGKEY_Pos         16                                             /*!< CoreDebug DHCSR: DBGKEY Position */
+#define CoreDebug_DHCSR_DBGKEY_Msk         (0xFFFFUL << CoreDebug_DHCSR_DBGKEY_Pos)       /*!< CoreDebug DHCSR: DBGKEY Mask */
+
+#define CoreDebug_DHCSR_S_RESET_ST_Pos     25                                             /*!< CoreDebug DHCSR: S_RESET_ST Position */
+#define CoreDebug_DHCSR_S_RESET_ST_Msk     (1UL << CoreDebug_DHCSR_S_RESET_ST_Pos)        /*!< CoreDebug DHCSR: S_RESET_ST Mask */
+
+#define CoreDebug_DHCSR_S_RETIRE_ST_Pos    24                                             /*!< CoreDebug DHCSR: S_RETIRE_ST Position */
+#define CoreDebug_DHCSR_S_RETIRE_ST_Msk    (1UL << CoreDebug_DHCSR_S_RETIRE_ST_Pos)       /*!< CoreDebug DHCSR: S_RETIRE_ST Mask */
+
+#define CoreDebug_DHCSR_S_LOCKUP_Pos       19                                             /*!< CoreDebug DHCSR: S_LOCKUP Position */
+#define CoreDebug_DHCSR_S_LOCKUP_Msk       (1UL << CoreDebug_DHCSR_S_LOCKUP_Pos)          /*!< CoreDebug DHCSR: S_LOCKUP Mask */
+
+#define CoreDebug_DHCSR_S_SLEEP_Pos        18                                             /*!< CoreDebug DHCSR: S_SLEEP Position */
+#define CoreDebug_DHCSR_S_SLEEP_Msk        (1UL << CoreDebug_DHCSR_S_SLEEP_Pos)           /*!< CoreDebug DHCSR: S_SLEEP Mask */
+
+#define CoreDebug_DHCSR_S_HALT_Pos         17                                             /*!< CoreDebug DHCSR: S_HALT Position */
+#define CoreDebug_DHCSR_S_HALT_Msk         (1UL << CoreDebug_DHCSR_S_HALT_Pos)            /*!< CoreDebug DHCSR: S_HALT Mask */
+
+#define CoreDebug_DHCSR_S_REGRDY_Pos       16                                             /*!< CoreDebug DHCSR: S_REGRDY Position */
+#define CoreDebug_DHCSR_S_REGRDY_Msk       (1UL << CoreDebug_DHCSR_S_REGRDY_Pos)          /*!< CoreDebug DHCSR: S_REGRDY Mask */
+
+#define CoreDebug_DHCSR_C_SNAPSTALL_Pos     5                                             /*!< CoreDebug DHCSR: C_SNAPSTALL Position */
+#define CoreDebug_DHCSR_C_SNAPSTALL_Msk    (1UL << CoreDebug_DHCSR_C_SNAPSTALL_Pos)       /*!< CoreDebug DHCSR: C_SNAPSTALL Mask */
+
+#define CoreDebug_DHCSR_C_MASKINTS_Pos      3                                             /*!< CoreDebug DHCSR: C_MASKINTS Position */
+#define CoreDebug_DHCSR_C_MASKINTS_Msk     (1UL << CoreDebug_DHCSR_C_MASKINTS_Pos)        /*!< CoreDebug DHCSR: C_MASKINTS Mask */
+
+#define CoreDebug_DHCSR_C_STEP_Pos          2                                             /*!< CoreDebug DHCSR: C_STEP Position */
+#define CoreDebug_DHCSR_C_STEP_Msk         (1UL << CoreDebug_DHCSR_C_STEP_Pos)            /*!< CoreDebug DHCSR: C_STEP Mask */
+
+#define CoreDebug_DHCSR_C_HALT_Pos          1                                             /*!< CoreDebug DHCSR: C_HALT Position */
+#define CoreDebug_DHCSR_C_HALT_Msk         (1UL << CoreDebug_DHCSR_C_HALT_Pos)            /*!< CoreDebug DHCSR: C_HALT Mask */
+
+#define CoreDebug_DHCSR_C_DEBUGEN_Pos       0                                             /*!< CoreDebug DHCSR: C_DEBUGEN Position */
+#define CoreDebug_DHCSR_C_DEBUGEN_Msk      (1UL /*<< CoreDebug_DHCSR_C_DEBUGEN_Pos*/)     /*!< CoreDebug DHCSR: C_DEBUGEN Mask */
+
+/* Debug Core Register Selector Register */
+#define CoreDebug_DCRSR_REGWnR_Pos         16                                             /*!< CoreDebug DCRSR: REGWnR Position */
+#define CoreDebug_DCRSR_REGWnR_Msk         (1UL << CoreDebug_DCRSR_REGWnR_Pos)            /*!< CoreDebug DCRSR: REGWnR Mask */
+
+#define CoreDebug_DCRSR_REGSEL_Pos          0                                             /*!< CoreDebug DCRSR: REGSEL Position */
+#define CoreDebug_DCRSR_REGSEL_Msk         (0x1FUL /*<< CoreDebug_DCRSR_REGSEL_Pos*/)     /*!< CoreDebug DCRSR: REGSEL Mask */
+
+/* Debug Exception and Monitor Control Register */
+#define CoreDebug_DEMCR_TRCENA_Pos         24                                             /*!< CoreDebug DEMCR: TRCENA Position */
+#define CoreDebug_DEMCR_TRCENA_Msk         (1UL << CoreDebug_DEMCR_TRCENA_Pos)            /*!< CoreDebug DEMCR: TRCENA Mask */
+
+#define CoreDebug_DEMCR_MON_REQ_Pos        19                                             /*!< CoreDebug DEMCR: MON_REQ Position */
+#define CoreDebug_DEMCR_MON_REQ_Msk        (1UL << CoreDebug_DEMCR_MON_REQ_Pos)           /*!< CoreDebug DEMCR: MON_REQ Mask */
+
+#define CoreDebug_DEMCR_MON_STEP_Pos       18                                             /*!< CoreDebug DEMCR: MON_STEP Position */
+#define CoreDebug_DEMCR_MON_STEP_Msk       (1UL << CoreDebug_DEMCR_MON_STEP_Pos)          /*!< CoreDebug DEMCR: MON_STEP Mask */
+
+#define CoreDebug_DEMCR_MON_PEND_Pos       17                                             /*!< CoreDebug DEMCR: MON_PEND Position */
+#define CoreDebug_DEMCR_MON_PEND_Msk       (1UL << CoreDebug_DEMCR_MON_PEND_Pos)          /*!< CoreDebug DEMCR: MON_PEND Mask */
+
+#define CoreDebug_DEMCR_MON_EN_Pos         16                                             /*!< CoreDebug DEMCR: MON_EN Position */
+#define CoreDebug_DEMCR_MON_EN_Msk         (1UL << CoreDebug_DEMCR_MON_EN_Pos)            /*!< CoreDebug DEMCR: MON_EN Mask */
+
+#define CoreDebug_DEMCR_VC_HARDERR_Pos     10                                             /*!< CoreDebug DEMCR: VC_HARDERR Position */
+#define CoreDebug_DEMCR_VC_HARDERR_Msk     (1UL << CoreDebug_DEMCR_VC_HARDERR_Pos)        /*!< CoreDebug DEMCR: VC_HARDERR Mask */
+
+#define CoreDebug_DEMCR_VC_INTERR_Pos       9                                             /*!< CoreDebug DEMCR: VC_INTERR Position */
+#define CoreDebug_DEMCR_VC_INTERR_Msk      (1UL << CoreDebug_DEMCR_VC_INTERR_Pos)         /*!< CoreDebug DEMCR: VC_INTERR Mask */
+
+#define CoreDebug_DEMCR_VC_BUSERR_Pos       8                                             /*!< CoreDebug DEMCR: VC_BUSERR Position */
+#define CoreDebug_DEMCR_VC_BUSERR_Msk      (1UL << CoreDebug_DEMCR_VC_BUSERR_Pos)         /*!< CoreDebug DEMCR: VC_BUSERR Mask */
+
+#define CoreDebug_DEMCR_VC_STATERR_Pos      7                                             /*!< CoreDebug DEMCR: VC_STATERR Position */
+#define CoreDebug_DEMCR_VC_STATERR_Msk     (1UL << CoreDebug_DEMCR_VC_STATERR_Pos)        /*!< CoreDebug DEMCR: VC_STATERR Mask */
+
+#define CoreDebug_DEMCR_VC_CHKERR_Pos       6                                             /*!< CoreDebug DEMCR: VC_CHKERR Position */
+#define CoreDebug_DEMCR_VC_CHKERR_Msk      (1UL << CoreDebug_DEMCR_VC_CHKERR_Pos)         /*!< CoreDebug DEMCR: VC_CHKERR Mask */
+
+#define CoreDebug_DEMCR_VC_NOCPERR_Pos      5                                             /*!< CoreDebug DEMCR: VC_NOCPERR Position */
+#define CoreDebug_DEMCR_VC_NOCPERR_Msk     (1UL << CoreDebug_DEMCR_VC_NOCPERR_Pos)        /*!< CoreDebug DEMCR: VC_NOCPERR Mask */
+
+#define CoreDebug_DEMCR_VC_MMERR_Pos        4                                             /*!< CoreDebug DEMCR: VC_MMERR Position */
+#define CoreDebug_DEMCR_VC_MMERR_Msk       (1UL << CoreDebug_DEMCR_VC_MMERR_Pos)          /*!< CoreDebug DEMCR: VC_MMERR Mask */
+
+#define CoreDebug_DEMCR_VC_CORERESET_Pos    0                                             /*!< CoreDebug DEMCR: VC_CORERESET Position */
+#define CoreDebug_DEMCR_VC_CORERESET_Msk   (1UL /*<< CoreDebug_DEMCR_VC_CORERESET_Pos*/)  /*!< CoreDebug DEMCR: VC_CORERESET Mask */
+
+/*@} end of group CMSIS_CoreDebug */
+
+
+/** \ingroup    CMSIS_core_register
+    \defgroup   CMSIS_core_base     Core Definitions
+    \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Cortex-M4 Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address  */
+#define ITM_BASE            (0xE0000000UL)                            /*!< ITM Base Address                   */
+#define DWT_BASE            (0xE0001000UL)                            /*!< DWT Base Address                   */
+#define TPI_BASE            (0xE0040000UL)                            /*!< TPI Base Address                   */
+#define CoreDebug_BASE      (0xE000EDF0UL)                            /*!< Core Debug Base Address            */
+#define SysTick_BASE        (SCS_BASE +  0x0010UL)                    /*!< SysTick Base Address               */
+#define NVIC_BASE           (SCS_BASE +  0x0100UL)                    /*!< NVIC Base Address                  */
+#define SCB_BASE            (SCS_BASE +  0x0D00UL)                    /*!< System Control Block Base Address  */
+
+#define SCnSCB              ((SCnSCB_Type    *)     SCS_BASE      )   /*!< System control Register not in SCB */
+#define SCB                 ((SCB_Type       *)     SCB_BASE      )   /*!< SCB configuration struct           */
+#define SysTick             ((SysTick_Type   *)     SysTick_BASE  )   /*!< SysTick configuration struct       */
+#define NVIC                ((NVIC_Type      *)     NVIC_BASE     )   /*!< NVIC configuration struct          */
+#define ITM                 ((ITM_Type       *)     ITM_BASE      )   /*!< ITM configuration struct           */
+#define DWT                 ((DWT_Type       *)     DWT_BASE      )   /*!< DWT configuration struct           */
+#define TPI                 ((TPI_Type       *)     TPI_BASE      )   /*!< TPI configuration struct           */
+#define CoreDebug           ((CoreDebug_Type *)     CoreDebug_BASE)   /*!< Core Debug configuration struct    */
+
+#if (__MPU_PRESENT == 1)
+  #define MPU_BASE          (SCS_BASE +  0x0D90UL)                    /*!< Memory Protection Unit             */
+  #define MPU               ((MPU_Type       *)     MPU_BASE      )   /*!< Memory Protection Unit             */
+#endif
+
+#if (__FPU_PRESENT == 1)
+  #define FPU_BASE          (SCS_BASE +  0x0F30UL)                    /*!< Floating Point Unit                */
+  #define FPU               ((FPU_Type       *)     FPU_BASE      )   /*!< Floating Point Unit                */
+#endif
+
+/*@} */
+
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/** \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+    \brief      Functions that manage interrupts and exceptions via the NVIC.
+    @{
+ */
+
+/** \brief  Set Priority Grouping
+
+  The function sets the priority grouping field using the required unlock sequence.
+  The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+  Only values from 0..7 are used.
+  In case of a conflict between priority grouping and available
+  priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+
+    \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk));             /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << 8)                       );              /* Insert write key and priorty group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/** \brief  Get Priority Grouping
+
+  The function reads the priority grouping field from the NVIC Interrupt Controller.
+
+    \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/** \brief  Enable External Interrupt
+
+    The function enables a device-specific interrupt in the NVIC interrupt controller.
+
+    \param [in]      IRQn  External interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  NVIC->ISER[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+}
+
+
+/** \brief  Disable External Interrupt
+
+    The function disables a device-specific interrupt in the NVIC interrupt controller.
+
+    \param [in]      IRQn  External interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  NVIC->ICER[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+}
+
+
+/** \brief  Get Pending Interrupt
+
+    The function reads the pending register in the NVIC and returns the pending bit
+    for the specified interrupt.
+
+    \param [in]      IRQn  Interrupt number.
+
+    \return             0  Interrupt status is not pending.
+    \return             1  Interrupt status is pending.
+ */
+__STATIC_INLINE uint32_t NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  return((uint32_t)(((NVIC->ISPR[(((uint32_t)(int32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+}
+
+
+/** \brief  Set Pending Interrupt
+
+    The function sets the pending bit of an external interrupt.
+
+    \param [in]      IRQn  Interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->ISPR[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+}
+
+
+/** \brief  Clear Pending Interrupt
+
+    The function clears the pending bit of an external interrupt.
+
+    \param [in]      IRQn  External interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->ICPR[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+}
+
+
+/** \brief  Get Active Interrupt
+
+    The function reads the active register in NVIC and returns the active bit.
+
+    \param [in]      IRQn  Interrupt number.
+
+    \return             0  Interrupt status is not active.
+    \return             1  Interrupt status is active.
+ */
+__STATIC_INLINE uint32_t NVIC_GetActive(IRQn_Type IRQn)
+{
+  return((uint32_t)(((NVIC->IABR[(((uint32_t)(int32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+}
+
+
+/** \brief  Set Interrupt Priority
+
+    The function sets the priority of an interrupt.
+
+    \note The priority cannot be set for every core interrupt.
+
+    \param [in]      IRQn  Interrupt number.
+    \param [in]  priority  Priority to set.
+ */
+__STATIC_INLINE void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if((int32_t)IRQn < 0) {
+    SCB->SHPR[(((uint32_t)(int32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8 - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else {
+    NVIC->IP[((uint32_t)(int32_t)IRQn)]                = (uint8_t)((priority << (8 - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/** \brief  Get Interrupt Priority
+
+    The function reads the priority of an interrupt. The interrupt
+    number can be positive to specify an external (device specific)
+    interrupt, or negative to specify an internal (core) interrupt.
+
+
+    \param [in]   IRQn  Interrupt number.
+    \return             Interrupt Priority. Value is aligned automatically to the implemented
+                        priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if((int32_t)IRQn < 0) {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)(int32_t)IRQn) & 0xFUL)-4UL] >> (8 - __NVIC_PRIO_BITS)));
+  }
+  else {
+    return(((uint32_t)NVIC->IP[((uint32_t)(int32_t)IRQn)]               >> (8 - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/** \brief  Encode Priority
+
+    The function encodes the priority for an interrupt with the given priority group,
+    preemptive priority value, and subpriority value.
+    In case of a conflict between priority grouping and available
+    priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+
+    \param [in]     PriorityGroup  Used priority group.
+    \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+    \param [in]       SubPriority  Subpriority value (starting from 0).
+    \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/** \brief  Decode Priority
+
+    The function decodes an interrupt priority value with a given priority group to
+    preemptive priority value and subpriority value.
+    In case of a conflict between priority grouping and available
+    priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+
+    \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+    \param [in]     PriorityGroup  Used priority group.
+    \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+    \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* pPreemptPriority, uint32_t* pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/** \brief  System Reset
+
+    The function initiates a system reset request to reset the MCU.
+ */
+__STATIC_INLINE void NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+  while(1) { __NOP(); }                                             /* wait until reset */
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+
+/* ##########################  FPU functions  #################################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_FpuFunctions FPU Functions
+    \brief      Function that provides FPU type.
+    @{
+ */
+
+/**
+  \fn          uint32_t SCB_GetFPUType(void)
+  \brief       get FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+  uint32_t mvfr0;
+
+  mvfr0 = SCB->MVFR0;
+  if        ((mvfr0 & 0x00000FF0UL) == 0x220UL) {
+    return 2UL;           // Double + Single precision FPU
+  } else if ((mvfr0 & 0x00000FF0UL) == 0x020UL) {
+    return 1UL;           // Single precision FPU
+  } else {
+    return 0UL;           // No FPU
+  }
+}
+
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+
+/* ##########################  Cache functions  #################################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_CacheFunctions Cache Functions
+    \brief      Functions that configure Instruction and Data cache.
+    @{
+ */
+
+/* Cache Size ID Register Macros */
+#define CCSIDR_WAYS(x)         (((x) & SCB_CCSIDR_ASSOCIATIVITY_Msk) >> SCB_CCSIDR_ASSOCIATIVITY_Pos)
+#define CCSIDR_SETS(x)         (((x) & SCB_CCSIDR_NUMSETS_Msk      ) >> SCB_CCSIDR_NUMSETS_Pos      )
+#define CCSIDR_LSSHIFT(x)      (((x) & SCB_CCSIDR_LINESIZE_Msk     ) /*>> SCB_CCSIDR_LINESIZE_Pos*/ )
+
+
+/** \brief Enable I-Cache
+
+    The function turns on I-Cache
+  */
+__STATIC_INLINE void SCB_EnableICache (void)
+{
+  #if (__ICACHE_PRESENT == 1)
+    __DSB();
+    __ISB();
+    SCB->ICIALLU = 0UL;                     // invalidate I-Cache
+    SCB->CCR |=  (uint32_t)SCB_CCR_IC_Msk;  // enable I-Cache
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/** \brief Disable I-Cache
+
+    The function turns off I-Cache
+  */
+__STATIC_INLINE void SCB_DisableICache (void)
+{
+  #if (__ICACHE_PRESENT == 1)
+    __DSB();
+    __ISB();
+    SCB->CCR &= ~(uint32_t)SCB_CCR_IC_Msk;  // disable I-Cache
+    SCB->ICIALLU = 0UL;                     // invalidate I-Cache
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/** \brief Invalidate I-Cache
+
+    The function invalidates I-Cache
+  */
+__STATIC_INLINE void SCB_InvalidateICache (void)
+{
+  #if (__ICACHE_PRESENT == 1)
+    __DSB();
+    __ISB();
+    SCB->ICIALLU = 0UL;
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/** \brief Enable D-Cache
+
+    The function turns on D-Cache
+  */
+__STATIC_INLINE void SCB_EnableDCache (void)
+{
+  #if (__DCACHE_PRESENT == 1)
+    uint32_t ccsidr, sshift, wshift, sw;
+    uint32_t sets, ways;
+
+    SCB->CSSELR = (0UL << 1) | 0UL;         // Level 1 data cache
+    ccsidr  = SCB->CCSIDR;
+    sets    = (uint32_t)(CCSIDR_SETS(ccsidr));
+    sshift  = (uint32_t)(CCSIDR_LSSHIFT(ccsidr) + 4UL);
+    ways    = (uint32_t)(CCSIDR_WAYS(ccsidr));
+    wshift  = (uint32_t)((uint32_t)__CLZ(ways) & 0x1FUL);
+
+    __DSB();
+
+    do {                                   // invalidate D-Cache
+         uint32_t tmpways = ways;
+         do {
+              sw = ((tmpways << wshift) | (sets << sshift));
+              SCB->DCISW = sw;
+            } while(tmpways--);
+        } while(sets--);
+    __DSB();
+
+    SCB->CCR |=  (uint32_t)SCB_CCR_DC_Msk;   // enable D-Cache
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/** \brief Disable D-Cache
+
+    The function turns off D-Cache
+  */
+__STATIC_INLINE void SCB_DisableDCache (void)
+{
+  #if (__DCACHE_PRESENT == 1)
+    uint32_t ccsidr, sshift, wshift, sw;
+    uint32_t sets, ways;
+
+    SCB->CSSELR = (0UL << 1) | 0UL;         // Level 1 data cache
+    ccsidr  = SCB->CCSIDR;
+    sets    = (uint32_t)(CCSIDR_SETS(ccsidr));
+    sshift  = (uint32_t)(CCSIDR_LSSHIFT(ccsidr) + 4UL);
+    ways    = (uint32_t)(CCSIDR_WAYS(ccsidr));
+    wshift  = (uint32_t)((uint32_t)__CLZ(ways) & 0x1FUL);
+
+    __DSB();
+
+    SCB->CCR &= ~(uint32_t)SCB_CCR_DC_Msk;  // disable D-Cache
+
+    do {                                    // clean & invalidate D-Cache
+         uint32_t tmpways = ways;
+         do {
+              sw = ((tmpways << wshift) | (sets << sshift));
+              SCB->DCCISW = sw;
+            } while(tmpways--);
+        } while(sets--);
+
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/** \brief Invalidate D-Cache
+
+    The function invalidates D-Cache
+  */
+__STATIC_INLINE void SCB_InvalidateDCache (void)
+{
+  #if (__DCACHE_PRESENT == 1)
+    uint32_t ccsidr, sshift, wshift, sw;
+    uint32_t sets, ways;
+
+    SCB->CSSELR = (0UL << 1) | 0UL;         // Level 1 data cache
+    ccsidr  = SCB->CCSIDR;
+    sets    = (uint32_t)(CCSIDR_SETS(ccsidr));
+    sshift  = (uint32_t)(CCSIDR_LSSHIFT(ccsidr) + 4UL);
+    ways    = (uint32_t)(CCSIDR_WAYS(ccsidr));
+    wshift  = (uint32_t)((uint32_t)__CLZ(ways) & 0x1FUL);
+
+    __DSB();
+
+    do {                                    // invalidate D-Cache
+         uint32_t tmpways = ways;
+         do {
+              sw = ((tmpways << wshift) | (sets << sshift));
+              SCB->DCISW = sw;
+            } while(tmpways--);
+        } while(sets--);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/** \brief Clean D-Cache
+
+    The function cleans D-Cache
+  */
+__STATIC_INLINE void SCB_CleanDCache (void)
+{
+  #if (__DCACHE_PRESENT == 1)
+    uint32_t ccsidr, sshift, wshift, sw;
+    uint32_t sets, ways;
+
+    SCB->CSSELR = (0UL << 1) | 0UL;         // Level 1 data cache
+    ccsidr  = SCB->CCSIDR;
+    sets    = (uint32_t)(CCSIDR_SETS(ccsidr));
+    sshift  = (uint32_t)(CCSIDR_LSSHIFT(ccsidr) + 4UL);
+    ways    = (uint32_t)(CCSIDR_WAYS(ccsidr));
+    wshift  = (uint32_t)((uint32_t)__CLZ(ways) & 0x1FUL);
+
+    __DSB();
+
+    do {                                    // clean D-Cache
+         uint32_t tmpways = ways;
+         do {
+              sw = ((tmpways << wshift) | (sets << sshift));
+              SCB->DCCSW = sw;
+            } while(tmpways--);
+        } while(sets--);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/** \brief Clean & Invalidate D-Cache
+
+    The function cleans and Invalidates D-Cache
+  */
+__STATIC_INLINE void SCB_CleanInvalidateDCache (void)
+{
+  #if (__DCACHE_PRESENT == 1)
+    uint32_t ccsidr, sshift, wshift, sw;
+    uint32_t sets, ways;
+
+    SCB->CSSELR = (0UL << 1) | 0UL;         // Level 1 data cache
+    ccsidr  = SCB->CCSIDR;
+    sets    = (uint32_t)(CCSIDR_SETS(ccsidr));
+    sshift  = (uint32_t)(CCSIDR_LSSHIFT(ccsidr) + 4UL);
+    ways    = (uint32_t)(CCSIDR_WAYS(ccsidr));
+    wshift  = (uint32_t)((uint32_t)__CLZ(ways) & 0x1FUL);
+
+    __DSB();
+
+    do {                                    // clean & invalidate D-Cache
+         uint32_t tmpways = ways;
+         do {
+              sw = ((tmpways << wshift) | (sets << sshift));
+              SCB->DCCISW = sw;
+            } while(tmpways--);
+        } while(sets--);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \fn          void SCB_InvalidateDCache_by_Addr(volatile uint32_t *addr, int32_t dsize)
+  \brief       D-Cache Invalidate by address
+  \param[in]   addr    address (aligned to 32-byte boundary)
+  \param[in]   dsize   size of memory block (in number of bytes)
+*/
+__STATIC_INLINE void SCB_InvalidateDCache_by_Addr (uint32_t *addr, int32_t dsize)
+{
+  #if (__DCACHE_PRESENT == 1)
+    int32_t  op_size = dsize;
+    uint32_t op_addr = (uint32_t)addr;
+    uint32_t linesize = 32UL;               // in Cortex-M7 size of cache line is fixed to 8 words (32 bytes)
+
+    __DSB();
+
+    while (op_size > 0) {
+      SCB->DCIMVAC = op_addr;
+      op_addr +=          linesize;
+      op_size -= (int32_t)linesize;
+    }
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \fn          void SCB_CleanDCache_by_Addr(volatile uint32_t *addr, int32_t dsize)
+  \brief       D-Cache Clean by address
+  \param[in]   addr    address (aligned to 32-byte boundary)
+  \param[in]   dsize   size of memory block (in number of bytes)
+*/
+__STATIC_INLINE void SCB_CleanDCache_by_Addr (uint32_t *addr, int32_t dsize)
+{
+  #if (__DCACHE_PRESENT == 1)
+    int32_t  op_size = dsize;
+    uint32_t op_addr = (uint32_t) addr;
+    uint32_t linesize = 32UL;               // in Cortex-M7 size of cache line is fixed to 8 words (32 bytes)
+
+    __DSB();
+
+    while (op_size > 0) {
+      SCB->DCCMVAC = op_addr;
+      op_addr +=          linesize;
+      op_size -= (int32_t)linesize;
+    }
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \fn          void SCB_CleanInvalidateDCache_by_Addr(volatile uint32_t *addr, int32_t dsize)
+  \brief       D-Cache Clean and Invalidate by address
+  \param[in]   addr    address (aligned to 32-byte boundary)
+  \param[in]   dsize   size of memory block (in number of bytes)
+*/
+__STATIC_INLINE void SCB_CleanInvalidateDCache_by_Addr (uint32_t *addr, int32_t dsize)
+{
+  #if (__DCACHE_PRESENT == 1)
+    int32_t  op_size = dsize;
+    uint32_t op_addr = (uint32_t) addr;
+    uint32_t linesize = 32UL;               // in Cortex-M7 size of cache line is fixed to 8 words (32 bytes)
+
+    __DSB();
+
+    while (op_size > 0) {
+      SCB->DCCIMVAC = op_addr;
+      op_addr +=          linesize;
+      op_size -= (int32_t)linesize;
+    }
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/*@} end of CMSIS_Core_CacheFunctions */
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+    \brief      Functions that configure the System.
+  @{
+ */
+
+#if (__Vendor_SysTickConfig == 0)
+
+/** \brief  System Tick Configuration
+
+    The function initializes the System Timer and its interrupt, and starts the System Tick Timer.
+    Counter is in free running mode to generate periodic interrupts.
+
+    \param [in]  ticks  Number of ticks between two interrupts.
+
+    \return          0  Function succeeded.
+    \return          1  Function failed.
+
+    \note     When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+    function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+    must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk) { return (1UL); }    /* Reload value impossible */
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_core_DebugFunctions ITM Functions
+    \brief   Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                    /*!< External variable to receive characters.                         */
+#define                 ITM_RXBUFFER_EMPTY    0x5AA55AA5 /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/** \brief  ITM Send Character
+
+    The function transmits a character via the ITM channel 0, and
+    \li Just returns when no debugger is connected that has booked the output.
+    \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+
+    \param [in]     ch  Character to transmit.
+
+    \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0].u32 == 0UL) { __NOP(); }
+    ITM->PORT[0].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
+
+
+/** \brief  ITM Receive Character
+
+    The function inputs a character via the external variable \ref ITM_RxBuffer.
+
+    \return             Received character.
+    \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void) {
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY) {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/** \brief  ITM Check Character
+
+    The function checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+
+    \return          0  No character available.
+    \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void) {
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY) {
+    return (0);                                 /* no character available */
+  } else {
+    return (1);                                 /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM7_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/stmhal/cmsis/inc/core_cmSimd.h
+++ b/stmhal/cmsis/inc/core_cmSimd.h
@@ -1,0 +1,697 @@
+/**************************************************************************//**
+ * @file     core_cmSimd.h
+ * @brief    CMSIS Cortex-M SIMD Header File
+ * @version  V4.10
+ * @date     18. March 2015
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2014 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#if defined ( __ICCARM__ )
+ #pragma system_include  /* treat file as system include file for MISRA check */
+#endif
+
+#ifndef __CORE_CMSIMD_H
+#define __CORE_CMSIMD_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+ ******************************************************************************/
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+/** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+#if   defined ( __CC_ARM ) /*------------------RealView Compiler -----------------*/
+/* ARM armcc specific functions */
+#define __SADD8                           __sadd8
+#define __QADD8                           __qadd8
+#define __SHADD8                          __shadd8
+#define __UADD8                           __uadd8
+#define __UQADD8                          __uqadd8
+#define __UHADD8                          __uhadd8
+#define __SSUB8                           __ssub8
+#define __QSUB8                           __qsub8
+#define __SHSUB8                          __shsub8
+#define __USUB8                           __usub8
+#define __UQSUB8                          __uqsub8
+#define __UHSUB8                          __uhsub8
+#define __SADD16                          __sadd16
+#define __QADD16                          __qadd16
+#define __SHADD16                         __shadd16
+#define __UADD16                          __uadd16
+#define __UQADD16                         __uqadd16
+#define __UHADD16                         __uhadd16
+#define __SSUB16                          __ssub16
+#define __QSUB16                          __qsub16
+#define __SHSUB16                         __shsub16
+#define __USUB16                          __usub16
+#define __UQSUB16                         __uqsub16
+#define __UHSUB16                         __uhsub16
+#define __SASX                            __sasx
+#define __QASX                            __qasx
+#define __SHASX                           __shasx
+#define __UASX                            __uasx
+#define __UQASX                           __uqasx
+#define __UHASX                           __uhasx
+#define __SSAX                            __ssax
+#define __QSAX                            __qsax
+#define __SHSAX                           __shsax
+#define __USAX                            __usax
+#define __UQSAX                           __uqsax
+#define __UHSAX                           __uhsax
+#define __USAD8                           __usad8
+#define __USADA8                          __usada8
+#define __SSAT16                          __ssat16
+#define __USAT16                          __usat16
+#define __UXTB16                          __uxtb16
+#define __UXTAB16                         __uxtab16
+#define __SXTB16                          __sxtb16
+#define __SXTAB16                         __sxtab16
+#define __SMUAD                           __smuad
+#define __SMUADX                          __smuadx
+#define __SMLAD                           __smlad
+#define __SMLADX                          __smladx
+#define __SMLALD                          __smlald
+#define __SMLALDX                         __smlaldx
+#define __SMUSD                           __smusd
+#define __SMUSDX                          __smusdx
+#define __SMLSD                           __smlsd
+#define __SMLSDX                          __smlsdx
+#define __SMLSLD                          __smlsld
+#define __SMLSLDX                         __smlsldx
+#define __SEL                             __sel
+#define __QADD                            __qadd
+#define __QSUB                            __qsub
+
+#define __PKHBT(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0x0000FFFFUL) |  \
+                                           ((((uint32_t)(ARG2)) << (ARG3)) & 0xFFFF0000UL)  )
+
+#define __PKHTB(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0xFFFF0000UL) |  \
+                                           ((((uint32_t)(ARG2)) >> (ARG3)) & 0x0000FFFFUL)  )
+
+#define __SMMLA(ARG1,ARG2,ARG3)          ( (int32_t)((((int64_t)(ARG1) * (ARG2)) + \
+                                                      ((int64_t)(ARG3) << 32)      ) >> 32))
+
+
+#elif defined ( __GNUC__ ) /*------------------ GNU Compiler ---------------------*/
+/* GNU gcc specific functions */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USAD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usad8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USADA8(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("usada8 %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+#define __SSAT16(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("ssat16 %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+#define __USAT16(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("usat16 %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UXTB16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("uxtb16 %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UXTAB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uxtab16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SXTB16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SXTAB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtab16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMUAD  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smuad %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMUADX (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smuadx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMLAD (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlad %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMLADX (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smladx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint64_t __SMLALD (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   // Little endian
+  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               // Big endian
+  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint64_t __SMLALDX (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   // Little endian
+  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               // Big endian
+  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMUSD  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smusd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMUSDX (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smusdx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMLSD (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlsd %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMLSDX (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlsdx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint64_t __SMLSLD (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   // Little endian
+  __ASM volatile ("smlsld %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               // Big endian
+  __ASM volatile ("smlsld %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint64_t __SMLSLDX (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   // Little endian
+  __ASM volatile ("smlsldx %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               // Big endian
+  __ASM volatile ("smlsldx %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SEL  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sel %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QADD(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QSUB(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+#define __PKHBT(ARG1,ARG2,ARG3) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  __ASM ("pkhbt %0, %1, %2, lsl %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __PKHTB(ARG1,ARG2,ARG3) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  if (ARG3 == 0) \
+    __ASM ("pkhtb %0, %1, %2" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2)  ); \
+  else \
+    __ASM ("pkhtb %0, %1, %2, asr %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+ int32_t result;
+
+ __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+ return(result);
+}
+
+
+#elif defined ( __ICCARM__ ) /*------------------ ICC Compiler -------------------*/
+/* IAR iccarm specific functions */
+#include <cmsis_iar.h>
+
+
+#elif defined ( __TMS470__ ) /*---------------- TI CCS Compiler ------------------*/
+/* TI CCS specific functions */
+#include <cmsis_ccs.h>
+
+
+#elif defined ( __TASKING__ ) /*------------------ TASKING Compiler --------------*/
+/* TASKING carm specific functions */
+/* not yet supported */
+
+
+#elif defined ( __CSMC__ ) /*------------------ COSMIC Compiler -------------------*/
+/* Cosmic specific functions */
+#include <cmsis_csm.h>
+
+#endif
+
+/*@} end of group CMSIS_SIMD_intrinsics */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CMSIMD_H */

--- a/stmhal/hal/f7/inc/Legacy/stm32_hal_legacy.h
+++ b/stmhal/hal/f7/inc/Legacy/stm32_hal_legacy.h
@@ -1,0 +1,2515 @@
+/**
+  ******************************************************************************
+  * @file    stm32_hal_legacy.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   This file contains aliases definition for the STM32Cube HAL constants 
+  *          macros and functions maintained for legacy purpose.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32_HAL_LEGACY
+#define __STM32_HAL_LEGACY
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup HAL_AES_Aliased_Defines HAL CRYP Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define AES_FLAG_RDERR                  CRYP_FLAG_RDERR
+#define AES_FLAG_WRERR                  CRYP_FLAG_WRERR
+#define AES_CLEARFLAG_CCF               CRYP_CLEARFLAG_CCF
+#define AES_CLEARFLAG_RDERR             CRYP_CLEARFLAG_RDERR
+#define AES_CLEARFLAG_WRERR             CRYP_CLEARFLAG_WRERR
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_ADC_Aliased_Defines HAL ADC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define ADC_RESOLUTION12b               ADC_RESOLUTION_12B
+#define ADC_RESOLUTION10b               ADC_RESOLUTION_10B
+#define ADC_RESOLUTION8b                ADC_RESOLUTION_8B
+#define ADC_RESOLUTION6b                ADC_RESOLUTION_6B
+#define OVR_DATA_OVERWRITTEN            ADC_OVR_DATA_OVERWRITTEN
+#define OVR_DATA_PRESERVED              ADC_OVR_DATA_PRESERVED
+#define EOC_SINGLE_CONV                 ADC_EOC_SINGLE_CONV
+#define EOC_SEQ_CONV                    ADC_EOC_SEQ_CONV
+#define EOC_SINGLE_SEQ_CONV             ADC_EOC_SINGLE_SEQ_CONV
+#define REGULAR_GROUP                   ADC_REGULAR_GROUP
+#define INJECTED_GROUP                  ADC_INJECTED_GROUP
+#define REGULAR_INJECTED_GROUP          ADC_REGULAR_INJECTED_GROUP
+#define AWD_EVENT                       ADC_AWD_EVENT
+#define AWD1_EVENT                      ADC_AWD1_EVENT
+#define AWD2_EVENT                      ADC_AWD2_EVENT
+#define AWD3_EVENT                      ADC_AWD3_EVENT
+#define OVR_EVENT                       ADC_OVR_EVENT
+#define JQOVF_EVENT                     ADC_JQOVF_EVENT
+#define ALL_CHANNELS                    ADC_ALL_CHANNELS
+#define REGULAR_CHANNELS                ADC_REGULAR_CHANNELS
+#define INJECTED_CHANNELS               ADC_INJECTED_CHANNELS
+#define SYSCFG_FLAG_SENSOR_ADC          ADC_FLAG_SENSOR
+#define SYSCFG_FLAG_VREF_ADC            ADC_FLAG_VREFINT
+#define ADC_CLOCKPRESCALER_PCLK_DIV1    ADC_CLOCK_SYNC_PCLK_DIV1
+#define ADC_CLOCKPRESCALER_PCLK_DIV2    ADC_CLOCK_SYNC_PCLK_DIV2
+#define ADC_CLOCKPRESCALER_PCLK_DIV4    ADC_CLOCK_SYNC_PCLK_DIV4
+#define ADC_CLOCKPRESCALER_PCLK_DIV6    ADC_CLOCK_SYNC_PCLK_DIV6
+#define ADC_CLOCKPRESCALER_PCLK_DIV8    ADC_CLOCK_SYNC_PCLK_DIV8
+#define ADC_EXTERNALTRIG0_T6_TRGO       ADC_EXTERNALTRIGCONV_T6_TRGO 
+#define ADC_EXTERNALTRIG1_T21_CC2       ADC_EXTERNALTRIGCONV_T21_CC2 
+#define ADC_EXTERNALTRIG2_T2_TRGO       ADC_EXTERNALTRIGCONV_T2_TRGO 
+#define ADC_EXTERNALTRIG3_T2_CC4        ADC_EXTERNALTRIGCONV_T2_CC4  
+#define ADC_EXTERNALTRIG4_T22_TRGO      ADC_EXTERNALTRIGCONV_T22_TRGO
+#define ADC_EXTERNALTRIG7_EXT_IT11      ADC_EXTERNALTRIGCONV_EXT_IT11
+#define ADC_CLOCK_ASYNC                 ADC_CLOCK_ASYNC_DIV1
+#define ADC_EXTERNALTRIG_EDGE_NONE      ADC_EXTERNALTRIGCONVEDGE_NONE
+#define ADC_EXTERNALTRIG_EDGE_RISING    ADC_EXTERNALTRIGCONVEDGE_RISING
+#define ADC_EXTERNALTRIG_EDGE_FALLING   ADC_EXTERNALTRIGCONVEDGE_FALLING
+#define ADC_EXTERNALTRIG_EDGE_RISINGFALLING ADC_EXTERNALTRIGCONVEDGE_RISINGFALLING 
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_CEC_Aliased_Defines HAL CEC Aliased Defines maintained for legacy purpose
+  * @{
+  */ 
+  
+#define __HAL_CEC_GET_IT __HAL_CEC_GET_FLAG 
+
+/**
+  * @}
+  */   
+   
+/** @defgroup HAL_COMP_Aliased_Defines HAL COMP Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+#define COMP_WINDOWMODE_DISABLED    COMP_WINDOWMODE_DISABLE
+#define COMP_WINDOWMODE_ENABLED     COMP_WINDOWMODE_ENABLE
+#define COMP_EXTI_LINE_COMP1_EVENT  COMP_EXTI_LINE_COMP1
+#define COMP_EXTI_LINE_COMP2_EVENT  COMP_EXTI_LINE_COMP2
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_CRC_Aliased_Defines HAL CRC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+#define CRC_OUTPUTDATA_INVERSION_DISABLED    CRC_OUTPUTDATA_INVERSION_DISABLE
+#define CRC_OUTPUTDATA_INVERSION_ENABLED     CRC_OUTPUTDATA_INVERSION_ENABLE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_DAC_Aliased_Defines HAL DAC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+
+#define DAC1_CHANNEL_1                                  DAC_CHANNEL_1
+#define DAC1_CHANNEL_2                                  DAC_CHANNEL_2
+#define DAC2_CHANNEL_1                                  DAC_CHANNEL_1
+#define DAC_WAVE_NONE                                   ((uint32_t)0x00000000)
+#define DAC_WAVE_NOISE                                  ((uint32_t)DAC_CR_WAVE1_0)
+#define DAC_WAVE_TRIANGLE                               ((uint32_t)DAC_CR_WAVE1_1)                           
+#define DAC_WAVEGENERATION_NONE                         DAC_WAVE_NONE
+#define DAC_WAVEGENERATION_NOISE                        DAC_WAVE_NOISE
+#define DAC_WAVEGENERATION_TRIANGLE                     DAC_WAVE_TRIANGLE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_DMA_Aliased_Defines HAL DMA Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define HAL_REMAPDMA_ADC_DMA_CH2                DMA_REMAP_ADC_DMA_CH2       
+#define HAL_REMAPDMA_USART1_TX_DMA_CH4          DMA_REMAP_USART1_TX_DMA_CH4 
+#define HAL_REMAPDMA_USART1_RX_DMA_CH5          DMA_REMAP_USART1_RX_DMA_CH5   
+#define HAL_REMAPDMA_TIM16_DMA_CH4              DMA_REMAP_TIM16_DMA_CH4       
+#define HAL_REMAPDMA_TIM17_DMA_CH2              DMA_REMAP_TIM17_DMA_CH2       
+#define HAL_REMAPDMA_USART3_DMA_CH32            DMA_REMAP_USART3_DMA_CH32
+#define HAL_REMAPDMA_TIM16_DMA_CH6              DMA_REMAP_TIM16_DMA_CH6
+#define HAL_REMAPDMA_TIM17_DMA_CH7              DMA_REMAP_TIM17_DMA_CH7      
+#define HAL_REMAPDMA_SPI2_DMA_CH67              DMA_REMAP_SPI2_DMA_CH67  
+#define HAL_REMAPDMA_USART2_DMA_CH67            DMA_REMAP_USART2_DMA_CH67 
+#define HAL_REMAPDMA_USART3_DMA_CH32            DMA_REMAP_USART3_DMA_CH32  
+#define HAL_REMAPDMA_I2C1_DMA_CH76              DMA_REMAP_I2C1_DMA_CH76   
+#define HAL_REMAPDMA_TIM1_DMA_CH6               DMA_REMAP_TIM1_DMA_CH6     
+#define HAL_REMAPDMA_TIM2_DMA_CH7               DMA_REMAP_TIM2_DMA_CH7      
+#define HAL_REMAPDMA_TIM3_DMA_CH6               DMA_REMAP_TIM3_DMA_CH6    
+  
+#define IS_HAL_REMAPDMA                          IS_DMA_REMAP  
+#define __HAL_REMAPDMA_CHANNEL_ENABLE            __HAL_DMA_REMAP_CHANNEL_ENABLE
+#define __HAL_REMAPDMA_CHANNEL_DISABLE           __HAL_DMA_REMAP_CHANNEL_DISABLE
+  
+  
+  
+/**
+  * @}
+  */
+
+/** @defgroup HAL_FLASH_Aliased_Defines HAL FLASH Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+#define TYPEPROGRAM_BYTE              FLASH_TYPEPROGRAM_BYTE
+#define TYPEPROGRAM_HALFWORD          FLASH_TYPEPROGRAM_HALFWORD
+#define TYPEPROGRAM_WORD              FLASH_TYPEPROGRAM_WORD
+#define TYPEPROGRAM_DOUBLEWORD        FLASH_TYPEPROGRAM_DOUBLEWORD
+#define TYPEERASE_SECTORS             FLASH_TYPEERASE_SECTORS
+#define TYPEERASE_PAGES               FLASH_TYPEERASE_PAGES
+#define TYPEERASE_PAGEERASE           FLASH_TYPEERASE_PAGES
+#define TYPEERASE_MASSERASE           FLASH_TYPEERASE_MASSERASE
+#define WRPSTATE_DISABLE              OB_WRPSTATE_DISABLE
+#define WRPSTATE_ENABLE               OB_WRPSTATE_ENABLE
+#define HAL_FLASH_TIMEOUT_VALUE       FLASH_TIMEOUT_VALUE
+#define OBEX_PCROP                    OPTIONBYTE_PCROP
+#define OBEX_BOOTCONFIG               OPTIONBYTE_BOOTCONFIG
+#define PCROPSTATE_DISABLE            OB_PCROP_STATE_DISABLE
+#define PCROPSTATE_ENABLE             OB_PCROP_STATE_ENABLE
+#define TYPEERASEDATA_BYTE            FLASH_TYPEERASEDATA_BYTE
+#define TYPEERASEDATA_HALFWORD        FLASH_TYPEERASEDATA_HALFWORD
+#define TYPEERASEDATA_WORD            FLASH_TYPEERASEDATA_WORD
+#define TYPEPROGRAMDATA_BYTE          FLASH_TYPEPROGRAMDATA_BYTE
+#define TYPEPROGRAMDATA_HALFWORD      FLASH_TYPEPROGRAMDATA_HALFWORD
+#define TYPEPROGRAMDATA_WORD          FLASH_TYPEPROGRAMDATA_WORD
+#define TYPEPROGRAMDATA_FASTBYTE      FLASH_TYPEPROGRAMDATA_FASTBYTE
+#define TYPEPROGRAMDATA_FASTHALFWORD  FLASH_TYPEPROGRAMDATA_FASTHALFWORD
+#define TYPEPROGRAMDATA_FASTWORD      FLASH_TYPEPROGRAMDATA_FASTWORD
+#define PAGESIZE                      FLASH_PAGE_SIZE
+#define TYPEPROGRAM_FASTBYTE          FLASH_TYPEPROGRAM_BYTE
+#define TYPEPROGRAM_FASTHALFWORD      FLASH_TYPEPROGRAM_HALFWORD
+#define TYPEPROGRAM_FASTWORD          FLASH_TYPEPROGRAM_WORD
+#define VOLTAGE_RANGE_1               FLASH_VOLTAGE_RANGE_1
+#define VOLTAGE_RANGE_2               FLASH_VOLTAGE_RANGE_2
+#define VOLTAGE_RANGE_3               FLASH_VOLTAGE_RANGE_3
+#define VOLTAGE_RANGE_4               FLASH_VOLTAGE_RANGE_4
+#define TYPEPROGRAM_FAST              FLASH_TYPEPROGRAM_FAST
+#define TYPEPROGRAM_FAST_AND_LAST     FLASH_TYPEPROGRAM_FAST_AND_LAST
+#define WRPAREA_BANK1_AREAA           OB_WRPAREA_BANK1_AREAA
+#define WRPAREA_BANK1_AREAB           OB_WRPAREA_BANK1_AREAB
+#define WRPAREA_BANK2_AREAA           OB_WRPAREA_BANK2_AREAA
+#define WRPAREA_BANK2_AREAB           OB_WRPAREA_BANK2_AREAB
+#define IWDG_STDBY_FREEZE             OB_IWDG_STDBY_FREEZE
+#define IWDG_STDBY_ACTIVE             OB_IWDG_STDBY_RUN
+#define IWDG_STOP_FREEZE              OB_IWDG_STOP_FREEZE
+#define IWDG_STOP_ACTIVE              OB_IWDG_STOP_RUN
+#define FLASH_ERROR_NONE              HAL_FLASH_ERROR_NONE
+#define FLASH_ERROR_RD                HAL_FLASH_ERROR_RD
+#define FLASH_ERROR_PG                HAL_FLASH_ERROR_PROG
+#define FLASH_ERROR_PGP               HAL_FLASH_ERROR_PGS
+#define FLASH_ERROR_WRP               HAL_FLASH_ERROR_WRP
+#define FLASH_ERROR_OPTV              HAL_FLASH_ERROR_OPTV
+#define FLASH_ERROR_OPTVUSR           HAL_FLASH_ERROR_OPTVUSR
+#define FLASH_ERROR_PROG              HAL_FLASH_ERROR_PROG
+#define FLASH_ERROR_OP                HAL_FLASH_ERROR_OPERATION
+#define FLASH_ERROR_PGA               HAL_FLASH_ERROR_PGA
+#define FLASH_ERROR_SIZE              HAL_FLASH_ERROR_SIZE
+#define FLASH_ERROR_SIZ               HAL_FLASH_ERROR_SIZE
+#define FLASH_ERROR_PGS               HAL_FLASH_ERROR_PGS
+#define FLASH_ERROR_MIS               HAL_FLASH_ERROR_MIS
+#define FLASH_ERROR_FAST              HAL_FLASH_ERROR_FAST
+#define FLASH_ERROR_FWWERR            HAL_FLASH_ERROR_FWWERR
+#define FLASH_ERROR_NOTZERO           HAL_FLASH_ERROR_NOTZERO
+#define FLASH_ERROR_OPERATION         HAL_FLASH_ERROR_OPERATION
+#define FLASH_ERROR_ERS               HAL_FLASH_ERROR_ERS
+#define OB_WDG_SW                     OB_IWDG_SW
+#define OB_WDG_HW                     OB_IWDG_HW
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_SYSCFG_Aliased_Defines HAL SYSCFG Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+#define SYSCFG_FASTMODEPLUS_I2C_PB6    I2C_FASTMODEPLUS_PB6
+#define SYSCFG_FASTMODEPLUS_I2C_PB7    I2C_FASTMODEPLUS_PB7
+#define SYSCFG_FASTMODEPLUS_I2C_PB8    I2C_FASTMODEPLUS_PB8
+#define SYSCFG_FASTMODEPLUS_I2C_PB9    I2C_FASTMODEPLUS_PB9
+#define SYSCFG_FASTMODEPLUS_I2C1       I2C_FASTMODEPLUS_I2C1
+#define SYSCFG_FASTMODEPLUS_I2C2       I2C_FASTMODEPLUS_I2C2
+#define SYSCFG_FASTMODEPLUS_I2C3       I2C_FASTMODEPLUS_I2C3
+
+/**
+  * @}
+  */
+  
+
+/** @defgroup LL_FMC_Aliased_Defines LL FMC Aliased Defines maintained for compatibility purpose
+  * @{
+  */
+#if defined(STM32L4) || defined(STM32F7)
+#define FMC_NAND_PCC_WAIT_FEATURE_DISABLE       FMC_NAND_WAIT_FEATURE_DISABLE
+#define FMC_NAND_PCC_WAIT_FEATURE_ENABLE        FMC_NAND_WAIT_FEATURE_ENABLE
+#define FMC_NAND_PCC_MEM_BUS_WIDTH_8            FMC_NAND_MEM_BUS_WIDTH_8
+#define FMC_NAND_PCC_MEM_BUS_WIDTH_16           FMC_NAND_MEM_BUS_WIDTH_16
+#else
+#define FMC_NAND_WAIT_FEATURE_DISABLE           FMC_NAND_PCC_WAIT_FEATURE_DISABLE
+#define FMC_NAND_WAIT_FEATURE_ENABLE            FMC_NAND_PCC_WAIT_FEATURE_ENABLE
+#define FMC_NAND_MEM_BUS_WIDTH_8                FMC_NAND_PCC_MEM_BUS_WIDTH_8
+#define FMC_NAND_MEM_BUS_WIDTH_16               FMC_NAND_PCC_MEM_BUS_WIDTH_16
+#endif
+/**
+  * @}
+  */
+
+/** @defgroup LL_FSMC_Aliased_Defines LL FSMC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+#define FSMC_NORSRAM_TYPEDEF                      FSMC_NORSRAM_TypeDef
+#define FSMC_NORSRAM_EXTENDED_TYPEDEF             FSMC_NORSRAM_EXTENDED_TypeDef
+/**
+  * @}
+  */
+
+/** @defgroup HAL_GPIO_Aliased_Macros HAL GPIO Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define GET_GPIO_SOURCE                           GPIO_GET_INDEX
+#define GET_GPIO_INDEX                            GPIO_GET_INDEX
+
+#if defined(STM32F4)
+#define GPIO_AF12_SDMMC                           GPIO_AF12_SDIO
+#define GPIO_AF12_SDMMC1                          GPIO_AF12_SDIO
+#endif
+
+#if defined(STM32F7)
+#define GPIO_AF12_SDIO                            GPIO_AF12_SDMMC1
+#define GPIO_AF12_SDMMC                           GPIO_AF12_SDMMC1
+#endif
+
+#if defined(STM32L4)
+#define GPIO_AF12_SDIO                            GPIO_AF12_SDMMC1
+#define GPIO_AF12_SDMMC                           GPIO_AF12_SDMMC1
+#endif
+
+#define GPIO_AF0_LPTIM                            GPIO_AF0_LPTIM1
+#define GPIO_AF1_LPTIM                            GPIO_AF1_LPTIM1
+#define GPIO_AF2_LPTIM                            GPIO_AF2_LPTIM1
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_HRTIM_Aliased_Macros HAL HRTIM Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define HRTIM_TIMDELAYEDPROTECTION_DISABLED           HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DISABLED
+#define HRTIM_TIMDELAYEDPROTECTION_DELAYEDOUT1_EEV68  HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DELAYEDOUT1_EEV6
+#define HRTIM_TIMDELAYEDPROTECTION_DELAYEDOUT2_EEV68  HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DELAYEDOUT2_EEV6
+#define HRTIM_TIMDELAYEDPROTECTION_DELAYEDBOTH_EEV68  HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DELAYEDBOTH_EEV6
+#define HRTIM_TIMDELAYEDPROTECTION_BALANCED_EEV68     HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_BALANCED_EEV6
+#define HRTIM_TIMDELAYEDPROTECTION_DELAYEDOUT1_DEEV79 HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DELAYEDOUT1_DEEV7
+#define HRTIM_TIMDELAYEDPROTECTION_DELAYEDOUT2_DEEV79 HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DELAYEDOUT2_DEEV7
+#define HRTIM_TIMDELAYEDPROTECTION_DELAYEDBOTH_EEV79  HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DELAYEDBOTH_EEV7
+#define HRTIM_TIMDELAYEDPROTECTION_BALANCED_EEV79     HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_BALANCED_EEV7
+/**
+  * @}
+  */
+
+/** @defgroup HAL_I2C_Aliased_Defines HAL I2C Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define I2C_DUALADDRESS_DISABLED                I2C_DUALADDRESS_DISABLE
+#define I2C_DUALADDRESS_ENABLED                 I2C_DUALADDRESS_ENABLE
+#define I2C_GENERALCALL_DISABLED                I2C_GENERALCALL_DISABLE
+#define I2C_GENERALCALL_ENABLED                 I2C_GENERALCALL_ENABLE
+#define I2C_NOSTRETCH_DISABLED                  I2C_NOSTRETCH_DISABLE
+#define I2C_NOSTRETCH_ENABLED                   I2C_NOSTRETCH_ENABLE
+#define I2C_ANALOGFILTER_ENABLED                I2C_ANALOGFILTER_ENABLE
+#define I2C_ANALOGFILTER_DISABLED               I2C_ANALOGFILTER_DISABLE
+/**
+  * @}
+  */
+
+/** @defgroup HAL_IRDA_Aliased_Defines HAL IRDA Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define IRDA_ONE_BIT_SAMPLE_DISABLED            IRDA_ONE_BIT_SAMPLE_DISABLE
+#define IRDA_ONE_BIT_SAMPLE_ENABLED             IRDA_ONE_BIT_SAMPLE_ENABLE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_IWDG_Aliased_Defines HAL IWDG Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define KR_KEY_RELOAD                   IWDG_KEY_RELOAD
+#define KR_KEY_ENABLE                   IWDG_KEY_ENABLE
+#define KR_KEY_EWA                      IWDG_KEY_WRITE_ACCESS_ENABLE
+#define KR_KEY_DWA                      IWDG_KEY_WRITE_ACCESS_DISABLE
+/**
+  * @}
+  */
+
+/** @defgroup HAL_LPTIM_Aliased_Defines HAL LPTIM Aliased Defines maintained for legacy purpose
+  * @{
+  */
+
+#define LPTIM_CLOCKSAMPLETIME_DIRECTTRANSISTION LPTIM_CLOCKSAMPLETIME_DIRECTTRANSITION
+#define LPTIM_CLOCKSAMPLETIME_2TRANSISTIONS     LPTIM_CLOCKSAMPLETIME_2TRANSITIONS
+#define LPTIM_CLOCKSAMPLETIME_4TRANSISTIONS     LPTIM_CLOCKSAMPLETIME_4TRANSITIONS
+#define LPTIM_CLOCKSAMPLETIME_8TRANSISTIONS     LPTIM_CLOCKSAMPLETIME_8TRANSITIONS
+
+#define LPTIM_CLOCKPOLARITY_RISINGEDGE          LPTIM_CLOCKPOLARITY_RISING
+#define LPTIM_CLOCKPOLARITY_FALLINGEDGE         LPTIM_CLOCKPOLARITY_FALLING
+#define LPTIM_CLOCKPOLARITY_BOTHEDGES           LPTIM_CLOCKPOLARITY_RISING_FALLING
+
+#define LPTIM_TRIGSAMPLETIME_DIRECTTRANSISTION  LPTIM_TRIGSAMPLETIME_DIRECTTRANSITION
+#define LPTIM_TRIGSAMPLETIME_2TRANSISTIONS      LPTIM_TRIGSAMPLETIME_2TRANSITIONS
+#define LPTIM_TRIGSAMPLETIME_4TRANSISTIONS      LPTIM_TRIGSAMPLETIME_4TRANSITIONS
+#define LPTIM_TRIGSAMPLETIME_8TRANSISTIONS      LPTIM_TRIGSAMPLETIME_8TRANSITIONS        
+
+/* The following 3 definition have also been present in a temporary version of lptim.h */
+/* They need to be renamed also to the right name, just in case */
+#define LPTIM_TRIGSAMPLETIME_2TRANSITION        LPTIM_TRIGSAMPLETIME_2TRANSITIONS
+#define LPTIM_TRIGSAMPLETIME_4TRANSITION        LPTIM_TRIGSAMPLETIME_4TRANSITIONS
+#define LPTIM_TRIGSAMPLETIME_8TRANSITION        LPTIM_TRIGSAMPLETIME_8TRANSITIONS
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_NAND_Aliased_Defines HAL NAND Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define NAND_AddressTypedef             NAND_AddressTypeDef
+
+#define __ARRAY_ADDRESS                 ARRAY_ADDRESS
+#define __ADDR_1st_CYCLE                ADDR_1ST_CYCLE
+#define __ADDR_2nd_CYCLE                ADDR_2ND_CYCLE
+#define __ADDR_3rd_CYCLE                ADDR_3RD_CYCLE
+#define __ADDR_4th_CYCLE                ADDR_4TH_CYCLE
+/**
+  * @}
+  */
+   
+/** @defgroup HAL_NOR_Aliased_Defines HAL NOR Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define NOR_StatusTypedef              HAL_NOR_StatusTypeDef
+#define NOR_SUCCESS                    HAL_NOR_STATUS_SUCCESS
+#define NOR_ONGOING                    HAL_NOR_STATUS_ONGOING
+#define NOR_ERROR                      HAL_NOR_STATUS_ERROR
+#define NOR_TIMEOUT                    HAL_NOR_STATUS_TIMEOUT
+
+#define __NOR_WRITE                    NOR_WRITE
+#define __NOR_ADDR_SHIFT               NOR_ADDR_SHIFT
+/**
+  * @}
+  */
+
+/** @defgroup HAL_OPAMP_Aliased_Defines HAL OPAMP Aliased Defines maintained for legacy purpose
+  * @{
+  */
+
+#define OPAMP_NONINVERTINGINPUT_VP0           OPAMP_NONINVERTINGINPUT_IO0
+#define OPAMP_NONINVERTINGINPUT_VP1           OPAMP_NONINVERTINGINPUT_IO1
+#define OPAMP_NONINVERTINGINPUT_VP2           OPAMP_NONINVERTINGINPUT_IO2
+#define OPAMP_NONINVERTINGINPUT_VP3           OPAMP_NONINVERTINGINPUT_IO3
+                                              
+#define OPAMP_SEC_NONINVERTINGINPUT_VP0       OPAMP_SEC_NONINVERTINGINPUT_IO0
+#define OPAMP_SEC_NONINVERTINGINPUT_VP1       OPAMP_SEC_NONINVERTINGINPUT_IO1
+#define OPAMP_SEC_NONINVERTINGINPUT_VP2       OPAMP_SEC_NONINVERTINGINPUT_IO2
+#define OPAMP_SEC_NONINVERTINGINPUT_VP3       OPAMP_SEC_NONINVERTINGINPUT_IO3   
+
+#define OPAMP_INVERTINGINPUT_VM0              OPAMP_INVERTINGINPUT_IO0
+#define OPAMP_INVERTINGINPUT_VM1              OPAMP_INVERTINGINPUT_IO1
+
+#define IOPAMP_INVERTINGINPUT_VM0             OPAMP_INVERTINGINPUT_IO0
+#define IOPAMP_INVERTINGINPUT_VM1             OPAMP_INVERTINGINPUT_IO1
+
+#define OPAMP_SEC_INVERTINGINPUT_VM0          OPAMP_SEC_INVERTINGINPUT_IO0
+#define OPAMP_SEC_INVERTINGINPUT_VM1          OPAMP_SEC_INVERTINGINPUT_IO1    
+
+#define OPAMP_INVERTINGINPUT_VINM             OPAMP_SEC_INVERTINGINPUT_IO1
+                                                                      
+#define OPAMP_PGACONNECT_NO                   OPAMP_PGA_CONNECT_INVERTINGINPUT_NO             
+#define OPAMP_PGACONNECT_VM0                  OPAMP_PGA_CONNECT_INVERTINGINPUT_IO0            
+#define OPAMP_PGACONNECT_VM1                  OPAMP_PGA_CONNECT_INVERTINGINPUT_IO1          
+                                                        
+/**
+  * @}
+  */
+
+/** @defgroup HAL_I2S_Aliased_Defines HAL I2S Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define I2S_STANDARD_PHILLIPS      I2S_STANDARD_PHILIPS
+/**
+  * @}
+  */
+
+/** @defgroup HAL_PCCARD_Aliased_Defines HAL PCCARD Aliased Defines maintained for legacy purpose
+  * @{
+  */
+
+/* Compact Flash-ATA registers description */
+#define CF_DATA                       ATA_DATA                
+#define CF_SECTOR_COUNT               ATA_SECTOR_COUNT        
+#define CF_SECTOR_NUMBER              ATA_SECTOR_NUMBER       
+#define CF_CYLINDER_LOW               ATA_CYLINDER_LOW        
+#define CF_CYLINDER_HIGH              ATA_CYLINDER_HIGH       
+#define CF_CARD_HEAD                  ATA_CARD_HEAD           
+#define CF_STATUS_CMD                 ATA_STATUS_CMD          
+#define CF_STATUS_CMD_ALTERNATE       ATA_STATUS_CMD_ALTERNATE
+#define CF_COMMON_DATA_AREA           ATA_COMMON_DATA_AREA    
+
+/* Compact Flash-ATA commands */
+#define CF_READ_SECTOR_CMD            ATA_READ_SECTOR_CMD 
+#define CF_WRITE_SECTOR_CMD           ATA_WRITE_SECTOR_CMD
+#define CF_ERASE_SECTOR_CMD           ATA_ERASE_SECTOR_CMD
+#define CF_IDENTIFY_CMD               ATA_IDENTIFY_CMD
+
+#define PCCARD_StatusTypedef          HAL_PCCARD_StatusTypeDef
+#define PCCARD_SUCCESS                HAL_PCCARD_STATUS_SUCCESS
+#define PCCARD_ONGOING                HAL_PCCARD_STATUS_ONGOING
+#define PCCARD_ERROR                  HAL_PCCARD_STATUS_ERROR
+#define PCCARD_TIMEOUT                HAL_PCCARD_STATUS_TIMEOUT
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_RTC_Aliased_Defines HAL RTC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+#define FORMAT_BIN                  RTC_FORMAT_BIN
+#define FORMAT_BCD                  RTC_FORMAT_BCD
+
+#define RTC_ALARMSUBSECONDMASK_None     RTC_ALARMSUBSECONDMASK_NONE
+#define RTC_TAMPERERASEBACKUP_ENABLED   RTC_TAMPER_ERASE_BACKUP_ENABLE
+#define RTC_TAMPERERASEBACKUP_DISABLED  RTC_TAMPER_ERASE_BACKUP_DISABLE
+#define RTC_TAMPERMASK_FLAG_DISABLED    RTC_TAMPERMASK_FLAG_DISABLE
+#define RTC_TAMPERMASK_FLAG_ENABLED     RTC_TAMPERMASK_FLAG_ENABLE
+
+#define RTC_MASKTAMPERFLAG_DISABLED     RTC_TAMPERMASK_FLAG_DISABLE 
+#define RTC_MASKTAMPERFLAG_ENABLED      RTC_TAMPERMASK_FLAG_ENABLE 
+#define RTC_TAMPERERASEBACKUP_ENABLED   RTC_TAMPER_ERASE_BACKUP_ENABLE
+#define RTC_TAMPERERASEBACKUP_DISABLED  RTC_TAMPER_ERASE_BACKUP_DISABLE 
+#define RTC_MASKTAMPERFLAG_DISABLED     RTC_TAMPERMASK_FLAG_DISABLE 
+#define RTC_MASKTAMPERFLAG_ENABLED      RTC_TAMPERMASK_FLAG_ENABLE
+#define RTC_TAMPER1_2_INTERRUPT         RTC_ALL_TAMPER_INTERRUPT 
+#define RTC_TAMPER1_2_3_INTERRUPT       RTC_ALL_TAMPER_INTERRUPT 
+
+#define RTC_TIMESTAMPPIN_PC13  RTC_TIMESTAMPPIN_DEFAULT
+#define RTC_TIMESTAMPPIN_PA0 RTC_TIMESTAMPPIN_POS1 
+#define RTC_TIMESTAMPPIN_PI8 RTC_TIMESTAMPPIN_POS1
+#define RTC_TIMESTAMPPIN_PC1   RTC_TIMESTAMPPIN_POS2
+
+#define RTC_OUTPUT_REMAP_PC13  RTC_OUTPUT_REMAP_NONE
+#define RTC_OUTPUT_REMAP_PB14  RTC_OUTPUT_REMAP_POS1
+#define RTC_OUTPUT_REMAP_PB2   RTC_OUTPUT_REMAP_POS1
+
+#define RTC_TAMPERPIN_PC13 RTC_TAMPERPIN_DEFAULT 
+#define RTC_TAMPERPIN_PA0  RTC_TAMPERPIN_POS1 
+#define RTC_TAMPERPIN_PI8  RTC_TAMPERPIN_POS1
+
+/**
+  * @}
+  */
+
+  
+/** @defgroup HAL_SMARTCARD_Aliased_Defines HAL SMARTCARD Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define SMARTCARD_NACK_ENABLED                  SMARTCARD_NACK_ENABLE
+#define SMARTCARD_NACK_DISABLED                 SMARTCARD_NACK_DISABLE
+
+#define SMARTCARD_ONEBIT_SAMPLING_DISABLED      SMARTCARD_ONE_BIT_SAMPLE_DISABLE
+#define SMARTCARD_ONEBIT_SAMPLING_ENABLED       SMARTCARD_ONE_BIT_SAMPLE_ENABLE
+#define SMARTCARD_ONEBIT_SAMPLING_DISABLE       SMARTCARD_ONE_BIT_SAMPLE_DISABLE
+#define SMARTCARD_ONEBIT_SAMPLING_ENABLE        SMARTCARD_ONE_BIT_SAMPLE_ENABLE
+
+#define SMARTCARD_TIMEOUT_DISABLED              SMARTCARD_TIMEOUT_DISABLE
+#define SMARTCARD_TIMEOUT_ENABLED               SMARTCARD_TIMEOUT_ENABLE
+
+#define SMARTCARD_LASTBIT_DISABLED              SMARTCARD_LASTBIT_DISABLE
+#define SMARTCARD_LASTBIT_ENABLED               SMARTCARD_LASTBIT_ENABLE
+/**
+  * @}
+  */
+
+  
+  /** @defgroup HAL_SMBUS_Aliased_Defines HAL SMBUS Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define SMBUS_DUALADDRESS_DISABLED      SMBUS_DUALADDRESS_DISABLE
+#define SMBUS_DUALADDRESS_ENABLED       SMBUS_DUALADDRESS_ENABLE
+#define SMBUS_GENERALCALL_DISABLED      SMBUS_GENERALCALL_DISABLE
+#define SMBUS_GENERALCALL_ENABLED       SMBUS_GENERALCALL_ENABLE
+#define SMBUS_NOSTRETCH_DISABLED        SMBUS_NOSTRETCH_DISABLE
+#define SMBUS_NOSTRETCH_ENABLED         SMBUS_NOSTRETCH_ENABLE
+#define SMBUS_ANALOGFILTER_ENABLED      SMBUS_ANALOGFILTER_ENABLE
+#define SMBUS_ANALOGFILTER_DISABLED     SMBUS_ANALOGFILTER_DISABLE
+#define SMBUS_PEC_DISABLED              SMBUS_PEC_DISABLE
+#define SMBUS_PEC_ENABLED               SMBUS_PEC_ENABLE
+#define HAL_SMBUS_STATE_SLAVE_LISTEN    HAL_SMBUS_STATE_LISTEN
+/**
+  * @}
+  */
+  
+  /** @defgroup HAL_SPI_Aliased_Defines HAL SPI Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define SPI_TIMODE_DISABLED             SPI_TIMODE_DISABLE
+#define SPI_TIMODE_ENABLED              SPI_TIMODE_ENABLE
+
+#define SPI_CRCCALCULATION_DISABLED     SPI_CRCCALCULATION_DISABLE
+#define SPI_CRCCALCULATION_ENABLED      SPI_CRCCALCULATION_ENABLE
+
+#define SPI_NSS_PULSE_DISABLED          SPI_NSS_PULSE_DISABLE
+#define SPI_NSS_PULSE_ENABLED           SPI_NSS_PULSE_ENABLE
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_TIM_Aliased_Defines HAL TIM Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define CCER_CCxE_MASK                   TIM_CCER_CCxE_MASK
+#define CCER_CCxNE_MASK                  TIM_CCER_CCxNE_MASK
+  
+#define TIM_DMABase_CR1                  TIM_DMABASE_CR1
+#define TIM_DMABase_CR2                  TIM_DMABASE_CR2
+#define TIM_DMABase_SMCR                 TIM_DMABASE_SMCR
+#define TIM_DMABase_DIER                 TIM_DMABASE_DIER
+#define TIM_DMABase_SR                   TIM_DMABASE_SR
+#define TIM_DMABase_EGR                  TIM_DMABASE_EGR
+#define TIM_DMABase_CCMR1                TIM_DMABASE_CCMR1
+#define TIM_DMABase_CCMR2                TIM_DMABASE_CCMR2
+#define TIM_DMABase_CCER                 TIM_DMABASE_CCER
+#define TIM_DMABase_CNT                  TIM_DMABASE_CNT
+#define TIM_DMABase_PSC                  TIM_DMABASE_PSC
+#define TIM_DMABase_ARR                  TIM_DMABASE_ARR
+#define TIM_DMABase_RCR                  TIM_DMABASE_RCR
+#define TIM_DMABase_CCR1                 TIM_DMABASE_CCR1
+#define TIM_DMABase_CCR2                 TIM_DMABASE_CCR2
+#define TIM_DMABase_CCR3                 TIM_DMABASE_CCR3
+#define TIM_DMABase_CCR4                 TIM_DMABASE_CCR4
+#define TIM_DMABase_BDTR                 TIM_DMABASE_BDTR
+#define TIM_DMABase_DCR                  TIM_DMABASE_DCR
+#define TIM_DMABase_DMAR                 TIM_DMABASE_DMAR
+#define TIM_DMABase_OR1                  TIM_DMABASE_OR1
+#define TIM_DMABase_CCMR3                TIM_DMABASE_CCMR3
+#define TIM_DMABase_CCR5                 TIM_DMABASE_CCR5
+#define TIM_DMABase_CCR6                 TIM_DMABASE_CCR6
+#define TIM_DMABase_OR2                  TIM_DMABASE_OR2
+#define TIM_DMABase_OR3                  TIM_DMABASE_OR3
+#define TIM_DMABase_OR                   TIM_DMABASE_OR
+
+#define TIM_EventSource_Update           TIM_EVENTSOURCE_UPDATE
+#define TIM_EventSource_CC1              TIM_EVENTSOURCE_CC1
+#define TIM_EventSource_CC2              TIM_EVENTSOURCE_CC2
+#define TIM_EventSource_CC3              TIM_EVENTSOURCE_CC3
+#define TIM_EventSource_CC4              TIM_EVENTSOURCE_CC4
+#define TIM_EventSource_COM              TIM_EVENTSOURCE_COM
+#define TIM_EventSource_Trigger          TIM_EVENTSOURCE_TRIGGER
+#define TIM_EventSource_Break            TIM_EVENTSOURCE_BREAK
+#define TIM_EventSource_Break2           TIM_EVENTSOURCE_BREAK2
+
+#define TIM_DMABurstLength_1Transfer     TIM_DMABURSTLENGTH_1TRANSFER
+#define TIM_DMABurstLength_2Transfers    TIM_DMABURSTLENGTH_2TRANSFERS
+#define TIM_DMABurstLength_3Transfers    TIM_DMABURSTLENGTH_3TRANSFERS
+#define TIM_DMABurstLength_4Transfers    TIM_DMABURSTLENGTH_4TRANSFERS
+#define TIM_DMABurstLength_5Transfers    TIM_DMABURSTLENGTH_5TRANSFERS
+#define TIM_DMABurstLength_6Transfers    TIM_DMABURSTLENGTH_6TRANSFERS
+#define TIM_DMABurstLength_7Transfers    TIM_DMABURSTLENGTH_7TRANSFERS
+#define TIM_DMABurstLength_8Transfers    TIM_DMABURSTLENGTH_8TRANSFERS
+#define TIM_DMABurstLength_9Transfers    TIM_DMABURSTLENGTH_9TRANSFERS
+#define TIM_DMABurstLength_10Transfers   TIM_DMABURSTLENGTH_10TRANSFERS
+#define TIM_DMABurstLength_11Transfers   TIM_DMABURSTLENGTH_11TRANSFERS
+#define TIM_DMABurstLength_12Transfers   TIM_DMABURSTLENGTH_12TRANSFERS
+#define TIM_DMABurstLength_13Transfers   TIM_DMABURSTLENGTH_13TRANSFERS
+#define TIM_DMABurstLength_14Transfers   TIM_DMABURSTLENGTH_14TRANSFERS
+#define TIM_DMABurstLength_15Transfers   TIM_DMABURSTLENGTH_15TRANSFERS
+#define TIM_DMABurstLength_16Transfers   TIM_DMABURSTLENGTH_16TRANSFERS
+#define TIM_DMABurstLength_17Transfers   TIM_DMABURSTLENGTH_17TRANSFERS
+#define TIM_DMABurstLength_18Transfers   TIM_DMABURSTLENGTH_18TRANSFERS
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_TSC_Aliased_Defines HAL TSC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define TSC_SYNC_POL_FALL        TSC_SYNC_POLARITY_FALLING
+#define TSC_SYNC_POL_RISE_HIGH   TSC_SYNC_POLARITY_RISING
+/**
+  * @}
+  */
+
+/** @defgroup HAL_UART_Aliased_Defines HAL UART Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define UART_ONEBIT_SAMPLING_DISABLED   UART_ONE_BIT_SAMPLE_DISABLE
+#define UART_ONEBIT_SAMPLING_ENABLED    UART_ONE_BIT_SAMPLE_ENABLE
+#define UART_ONE_BIT_SAMPLE_DISABLED    UART_ONE_BIT_SAMPLE_DISABLE
+#define UART_ONE_BIT_SAMPLE_ENABLED     UART_ONE_BIT_SAMPLE_ENABLE
+
+#define __HAL_UART_ONEBIT_ENABLE        __HAL_UART_ONE_BIT_SAMPLE_ENABLE
+#define __HAL_UART_ONEBIT_DISABLE       __HAL_UART_ONE_BIT_SAMPLE_DISABLE
+
+#define __DIV_SAMPLING16                UART_DIV_SAMPLING16
+#define __DIVMANT_SAMPLING16            UART_DIVMANT_SAMPLING16
+#define __DIVFRAQ_SAMPLING16            UART_DIVFRAQ_SAMPLING16
+#define __UART_BRR_SAMPLING16           UART_BRR_SAMPLING16
+
+#define __DIV_SAMPLING8                 UART_DIV_SAMPLING8
+#define __DIVMANT_SAMPLING8             UART_DIVMANT_SAMPLING8
+#define __DIVFRAQ_SAMPLING8             UART_DIVFRAQ_SAMPLING8
+#define __UART_BRR_SAMPLING8            UART_BRR_SAMPLING8
+
+#define UART_WAKEUPMETHODE_IDLELINE     UART_WAKEUPMETHOD_IDLELINE
+#define UART_WAKEUPMETHODE_ADDRESSMARK  UART_WAKEUPMETHOD_ADDRESSMARK
+
+/**
+  * @}
+  */
+
+  
+/** @defgroup HAL_USART_Aliased_Defines HAL USART Aliased Defines maintained for legacy purpose
+  * @{
+  */
+
+#define USART_CLOCK_DISABLED            USART_CLOCK_DISABLE
+#define USART_CLOCK_ENABLED             USART_CLOCK_ENABLE
+
+#define USARTNACK_ENABLED               USART_NACK_ENABLE
+#define USARTNACK_DISABLED              USART_NACK_DISABLE
+/**
+  * @}
+  */
+
+/** @defgroup HAL_WWDG_Aliased_Defines HAL WWDG Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define CFR_BASE                    WWDG_CFR_BASE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_CAN_Aliased_Defines HAL CAN Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define CAN_FilterFIFO0             CAN_FILTER_FIFO0
+#define CAN_FilterFIFO1             CAN_FILTER_FIFO1
+#define CAN_IT_RQCP0                CAN_IT_TME
+#define CAN_IT_RQCP1                CAN_IT_TME
+#define CAN_IT_RQCP2                CAN_IT_TME
+#define INAK_TIMEOUT                CAN_TIMEOUT_VALUE
+#define SLAK_TIMEOUT                CAN_TIMEOUT_VALUE
+#define CAN_TXSTATUS_FAILED         ((uint8_t)0x00)
+#define CAN_TXSTATUS_OK             ((uint8_t)0x01)
+#define CAN_TXSTATUS_PENDING        ((uint8_t)0x02)
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_ETH_Aliased_Defines HAL ETH Aliased Defines maintained for legacy purpose
+  * @{
+  */
+
+#define VLAN_TAG                ETH_VLAN_TAG
+#define MIN_ETH_PAYLOAD         ETH_MIN_ETH_PAYLOAD
+#define MAX_ETH_PAYLOAD         ETH_MAX_ETH_PAYLOAD
+#define JUMBO_FRAME_PAYLOAD     ETH_JUMBO_FRAME_PAYLOAD
+#define MACMIIAR_CR_MASK        ETH_MACMIIAR_CR_MASK
+#define MACCR_CLEAR_MASK        ETH_MACCR_CLEAR_MASK
+#define MACFCR_CLEAR_MASK       ETH_MACFCR_CLEAR_MASK
+#define DMAOMR_CLEAR_MASK       ETH_DMAOMR_CLEAR_MASK
+
+#define ETH_MMCCR              ((uint32_t)0x00000100)  
+#define ETH_MMCRIR             ((uint32_t)0x00000104)  
+#define ETH_MMCTIR             ((uint32_t)0x00000108)  
+#define ETH_MMCRIMR            ((uint32_t)0x0000010C)  
+#define ETH_MMCTIMR            ((uint32_t)0x00000110)  
+#define ETH_MMCTGFSCCR         ((uint32_t)0x0000014C)  
+#define ETH_MMCTGFMSCCR        ((uint32_t)0x00000150)  
+#define ETH_MMCTGFCR           ((uint32_t)0x00000168)  
+#define ETH_MMCRFCECR          ((uint32_t)0x00000194)  
+#define ETH_MMCRFAECR          ((uint32_t)0x00000198)  
+#define ETH_MMCRGUFCR          ((uint32_t)0x000001C4) 
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_PPP_Aliased_Defines HAL PPP Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup HAL_CRYP_Aliased_Functions HAL CRYP Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define HAL_CRYP_ComputationCpltCallback     HAL_CRYPEx_ComputationCpltCallback
+/**
+  * @}
+  */  
+
+/** @defgroup HAL_HASH_Aliased_Functions HAL HASH Aliased Functions maintained for legacy purpose
+  * @{
+  */ 
+  
+#define HAL_HMAC_MD5_Finish          HAL_HASH_MD5_Finish
+#define HAL_HMAC_SHA1_Finish         HAL_HASH_SHA1_Finish
+#define HAL_HMAC_SHA224_Finish       HAL_HASH_SHA224_Finish
+#define HAL_HMAC_SHA256_Finish       HAL_HASH_SHA256_Finish
+
+/*HASH Algorithm Selection*/
+
+#define HASH_AlgoSelection_SHA1      HASH_ALGOSELECTION_SHA1 
+#define HASH_AlgoSelection_SHA224    HASH_ALGOSELECTION_SHA224
+#define HASH_AlgoSelection_SHA256    HASH_ALGOSELECTION_SHA256
+#define HASH_AlgoSelection_MD5       HASH_ALGOSELECTION_MD5
+
+#define HASH_AlgoMode_HASH         HASH_ALGOMODE_HASH 
+#define HASH_AlgoMode_HMAC         HASH_ALGOMODE_HMAC
+
+#define HASH_HMACKeyType_ShortKey  HASH_HMAC_KEYTYPE_SHORTKEY
+#define HASH_HMACKeyType_LongKey   HASH_HMAC_KEYTYPE_LONGKEY
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_Aliased_Functions HAL Generic Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define HAL_EnableDBGSleepMode HAL_DBGMCU_EnableDBGSleepMode
+#define HAL_DisableDBGSleepMode HAL_DBGMCU_DisableDBGSleepMode
+#define HAL_EnableDBGStopMode HAL_DBGMCU_EnableDBGStopMode
+#define HAL_DisableDBGStopMode HAL_DBGMCU_DisableDBGStopMode
+#define HAL_EnableDBGStandbyMode HAL_DBGMCU_EnableDBGStandbyMode
+#define HAL_DisableDBGStandbyMode HAL_DBGMCU_DisableDBGStandbyMode
+#define HAL_DBG_LowPowerConfig(Periph, cmd) (((cmd)==ENABLE)? HAL_DBGMCU_DBG_EnableLowPowerConfig(Periph) : HAL_DBGMCU_DBG_DisableLowPowerConfig(Periph))
+#define HAL_VREFINT_OutputSelect  HAL_SYSCFG_VREFINT_OutputSelect
+#define HAL_Lock_Cmd(cmd) (((cmd)==ENABLE) ? HAL_SYSCFG_Enable_Lock_VREFINT() : HAL_SYSCFG_Disable_Lock_VREFINT())
+#define HAL_VREFINT_Cmd(cmd) (((cmd)==ENABLE)? HAL_SYSCFG_EnableVREFINT() : HAL_SYSCFG_DisableVREFINT())
+#define HAL_ADC_EnableBuffer_Cmd(cmd)  (((cmd)==ENABLE) ? HAL_ADCEx_EnableVREFINT() : HAL_ADCEx_DisableVREFINT())
+#define HAL_ADC_EnableBufferSensor_Cmd(cmd) (((cmd)==ENABLE) ?  HAL_ADCEx_EnableVREFINTTempSensor() : HAL_ADCEx_DisableVREFINTTempSensor())
+/**
+  * @}
+  */
+
+/** @defgroup HAL_FLASH_Aliased_Functions HAL FLASH Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define FLASH_HalfPageProgram      HAL_FLASHEx_HalfPageProgram
+#define FLASH_EnableRunPowerDown   HAL_FLASHEx_EnableRunPowerDown
+#define FLASH_DisableRunPowerDown  HAL_FLASHEx_DisableRunPowerDown
+#define HAL_DATA_EEPROMEx_Unlock   HAL_FLASHEx_DATAEEPROM_Unlock
+#define HAL_DATA_EEPROMEx_Lock     HAL_FLASHEx_DATAEEPROM_Lock
+#define HAL_DATA_EEPROMEx_Erase    HAL_FLASHEx_DATAEEPROM_Erase
+#define HAL_DATA_EEPROMEx_Program  HAL_FLASHEx_DATAEEPROM_Program
+
+ /**
+  * @}
+  */
+
+/** @defgroup HAL_I2C_Aliased_Functions HAL I2C Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define HAL_I2CEx_AnalogFilter_Config      HAL_I2CEx_ConfigAnalogFilter
+#define HAL_I2CEx_DigitalFilter_Config     HAL_I2CEx_ConfigDigitalFilter
+
+#define HAL_I2CFastModePlusConfig(SYSCFG_I2CFastModePlus, cmd) (((cmd)==ENABLE)? HAL_I2CEx_EnableFastModePlus(SYSCFG_I2CFastModePlus): HAL_I2CEx_DisableFastModePlus(SYSCFG_I2CFastModePlus))
+ /**
+  * @}
+  */
+
+/** @defgroup HAL_PWR_Aliased HAL PWR Aliased maintained for legacy purpose
+  * @{
+  */
+#define HAL_PWR_PVDConfig                             HAL_PWR_ConfigPVD
+#define HAL_PWR_DisableBkUpReg                        HAL_PWREx_DisableBkUpReg
+#define HAL_PWR_DisableFlashPowerDown                 HAL_PWREx_DisableFlashPowerDown
+#define HAL_PWR_DisableVddio2Monitor                  HAL_PWREx_DisableVddio2Monitor
+#define HAL_PWR_EnableBkUpReg                         HAL_PWREx_EnableBkUpReg
+#define HAL_PWR_EnableFlashPowerDown                  HAL_PWREx_EnableFlashPowerDown
+#define HAL_PWR_EnableVddio2Monitor                   HAL_PWREx_EnableVddio2Monitor
+#define HAL_PWR_PVD_PVM_IRQHandler                    HAL_PWREx_PVD_PVM_IRQHandler
+#define HAL_PWR_PVDLevelConfig                        HAL_PWR_ConfigPVD
+#define HAL_PWR_Vddio2Monitor_IRQHandler              HAL_PWREx_Vddio2Monitor_IRQHandler
+#define HAL_PWR_Vddio2MonitorCallback                 HAL_PWREx_Vddio2MonitorCallback
+#define HAL_PWREx_ActivateOverDrive                   HAL_PWREx_EnableOverDrive
+#define HAL_PWREx_DeactivateOverDrive                 HAL_PWREx_DisableOverDrive
+#define HAL_PWREx_DisableSDADCAnalog                  HAL_PWREx_DisableSDADC
+#define HAL_PWREx_EnableSDADCAnalog                   HAL_PWREx_EnableSDADC
+#define HAL_PWREx_PVMConfig                           HAL_PWREx_ConfigPVM
+
+#define PWR_MODE_NORMAL                               PWR_PVD_MODE_NORMAL
+#define PWR_MODE_IT_RISING                            PWR_PVD_MODE_IT_RISING
+#define PWR_MODE_IT_FALLING                           PWR_PVD_MODE_IT_FALLING
+#define PWR_MODE_IT_RISING_FALLING                    PWR_PVD_MODE_IT_RISING_FALLING
+#define PWR_MODE_EVENT_RISING                         PWR_PVD_MODE_EVENT_RISING
+#define PWR_MODE_EVENT_FALLING                        PWR_PVD_MODE_EVENT_FALLING
+#define PWR_MODE_EVENT_RISING_FALLING                 PWR_PVD_MODE_EVENT_RISING_FALLING
+
+#define CR_OFFSET_BB                                  PWR_CR_OFFSET_BB
+#define CSR_OFFSET_BB                                 PWR_CSR_OFFSET_BB
+
+#define DBP_BitNumber                                 DBP_BIT_NUMBER
+#define PVDE_BitNumber                                PVDE_BIT_NUMBER
+#define PMODE_BitNumber                               PMODE_BIT_NUMBER
+#define EWUP_BitNumber                                EWUP_BIT_NUMBER
+#define FPDS_BitNumber                                FPDS_BIT_NUMBER
+#define ODEN_BitNumber                                ODEN_BIT_NUMBER
+#define ODSWEN_BitNumber                              ODSWEN_BIT_NUMBER
+#define MRLVDS_BitNumber                              MRLVDS_BIT_NUMBER
+#define LPLVDS_BitNumber                              LPLVDS_BIT_NUMBER
+#define BRE_BitNumber                                 BRE_BIT_NUMBER
+
+#define PWR_MODE_EVT                                  PWR_PVD_MODE_NORMAL
+ 
+ /**
+  * @}
+  */  
+  
+/** @defgroup HAL_SMBUS_Aliased_Functions HAL SMBUS Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define HAL_SMBUS_Slave_Listen_IT          HAL_SMBUS_EnableListen_IT
+#define HAL_SMBUS_SlaveAddrCallback        HAL_SMBUS_AddrCallback         
+#define HAL_SMBUS_SlaveListenCpltCallback  HAL_SMBUS_ListenCpltCallback   
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SPI_Aliased_Functions HAL SPI Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define HAL_SPI_FlushRxFifo                HAL_SPIEx_FlushRxFifo
+/**
+  * @}
+  */  
+
+/** @defgroup HAL_TIM_Aliased_Functions HAL TIM Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define HAL_TIM_DMADelayPulseCplt                       TIM_DMADelayPulseCplt
+#define HAL_TIM_DMAError                                TIM_DMAError
+#define HAL_TIM_DMACaptureCplt                          TIM_DMACaptureCplt
+#define HAL_TIMEx_DMACommutationCplt                    TIMEx_DMACommutationCplt
+/**
+  * @}
+  */
+   
+/** @defgroup HAL_UART_Aliased_Functions HAL UART Aliased Functions maintained for legacy purpose
+  * @{
+  */ 
+#define HAL_UART_WakeupCallback HAL_UARTEx_WakeupCallback
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_LTDC_Aliased_Functions HAL LTDC Aliased Functions maintained for legacy purpose
+  * @{
+  */ 
+#define HAL_LTDC_LineEvenCallback HAL_LTDC_LineEventCallback
+/**
+  * @}
+  */  
+   
+  
+   /** @defgroup HAL_PPP_Aliased_Functions HAL PPP Aliased Functions maintained for legacy purpose
+  * @{
+  */
+  
+/**
+  * @}
+  */
+
+/* Exported macros ------------------------------------------------------------*/
+
+/** @defgroup HAL_AES_Aliased_Macros HAL CRYP Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define AES_IT_CC                      CRYP_IT_CC
+#define AES_IT_ERR                     CRYP_IT_ERR
+#define AES_FLAG_CCF                   CRYP_FLAG_CCF
+/**
+  * @}
+  */  
+  
+/** @defgroup HAL_Aliased_Macros HAL Generic Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_GET_BOOT_MODE                   __HAL_SYSCFG_GET_BOOT_MODE
+#define __HAL_REMAPMEMORY_FLASH               __HAL_SYSCFG_REMAPMEMORY_FLASH
+#define __HAL_REMAPMEMORY_SYSTEMFLASH         __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH
+#define __HAL_REMAPMEMORY_SRAM                __HAL_SYSCFG_REMAPMEMORY_SRAM
+#define __HAL_REMAPMEMORY_FMC                 __HAL_SYSCFG_REMAPMEMORY_FMC
+#define __HAL_REMAPMEMORY_FMC_SDRAM           __HAL_SYSCFG_REMAPMEMORY_FMC_SDRAM 
+#define __HAL_REMAPMEMORY_FSMC                __HAL_SYSCFG_REMAPMEMORY_FSMC
+#define __HAL_REMAPMEMORY_QUADSPI             __HAL_SYSCFG_REMAPMEMORY_QUADSPI
+#define __HAL_FMC_BANK                        __HAL_SYSCFG_FMC_BANK
+#define __HAL_GET_FLAG                        __HAL_SYSCFG_GET_FLAG
+#define __HAL_CLEAR_FLAG                      __HAL_SYSCFG_CLEAR_FLAG
+#define __HAL_VREFINT_OUT_ENABLE              __HAL_SYSCFG_VREFINT_OUT_ENABLE
+#define __HAL_VREFINT_OUT_DISABLE             __HAL_SYSCFG_VREFINT_OUT_DISABLE
+
+#define SYSCFG_FLAG_VREF_READY                SYSCFG_FLAG_VREFINT_READY
+#define SYSCFG_FLAG_RC48                      RCC_FLAG_HSI48
+#define IS_SYSCFG_FASTMODEPLUS_CONFIG         IS_I2C_FASTMODEPLUS
+#define UFB_MODE_BitNumber                    UFB_MODE_BIT_NUMBER
+#define CMP_PD_BitNumber                      CMP_PD_BIT_NUMBER
+
+/**
+  * @}
+  */
+
+   
+/** @defgroup HAL_ADC_Aliased_Macros HAL ADC Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __ADC_ENABLE                                     __HAL_ADC_ENABLE
+#define __ADC_DISABLE                                    __HAL_ADC_DISABLE
+#define __HAL_ADC_ENABLING_CONDITIONS                    ADC_ENABLING_CONDITIONS
+#define __HAL_ADC_DISABLING_CONDITIONS                   ADC_DISABLING_CONDITIONS
+#define __HAL_ADC_IS_ENABLED                             ADC_IS_ENABLE
+#define __ADC_IS_ENABLED                                 ADC_IS_ENABLE
+#define __HAL_ADC_IS_SOFTWARE_START_REGULAR              ADC_IS_SOFTWARE_START_REGULAR
+#define __HAL_ADC_IS_SOFTWARE_START_INJECTED             ADC_IS_SOFTWARE_START_INJECTED
+#define __HAL_ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED
+#define __HAL_ADC_IS_CONVERSION_ONGOING_REGULAR          ADC_IS_CONVERSION_ONGOING_REGULAR
+#define __HAL_ADC_IS_CONVERSION_ONGOING_INJECTED         ADC_IS_CONVERSION_ONGOING_INJECTED
+#define __HAL_ADC_IS_CONVERSION_ONGOING                  ADC_IS_CONVERSION_ONGOING
+#define __HAL_ADC_CLEAR_ERRORCODE                        ADC_CLEAR_ERRORCODE
+
+#define __HAL_ADC_GET_RESOLUTION                         ADC_GET_RESOLUTION
+#define __HAL_ADC_JSQR_RK                                ADC_JSQR_RK
+#define __HAL_ADC_CFGR_AWD1CH                            ADC_CFGR_AWD1CH_SHIFT
+#define __HAL_ADC_CFGR_AWD23CR                           ADC_CFGR_AWD23CR
+#define __HAL_ADC_CFGR_INJECT_AUTO_CONVERSION            ADC_CFGR_INJECT_AUTO_CONVERSION
+#define __HAL_ADC_CFGR_INJECT_CONTEXT_QUEUE              ADC_CFGR_INJECT_CONTEXT_QUEUE
+#define __HAL_ADC_CFGR_INJECT_DISCCONTINUOUS             ADC_CFGR_INJECT_DISCCONTINUOUS
+#define __HAL_ADC_CFGR_REG_DISCCONTINUOUS                ADC_CFGR_REG_DISCCONTINUOUS
+#define __HAL_ADC_CFGR_DISCONTINUOUS_NUM                 ADC_CFGR_DISCONTINUOUS_NUM
+#define __HAL_ADC_CFGR_AUTOWAIT                          ADC_CFGR_AUTOWAIT
+#define __HAL_ADC_CFGR_CONTINUOUS                        ADC_CFGR_CONTINUOUS
+#define __HAL_ADC_CFGR_OVERRUN                           ADC_CFGR_OVERRUN
+#define __HAL_ADC_CFGR_DMACONTREQ                        ADC_CFGR_DMACONTREQ
+#define __HAL_ADC_CFGR_EXTSEL                            ADC_CFGR_EXTSEL_SET
+#define __HAL_ADC_JSQR_JEXTSEL                           ADC_JSQR_JEXTSEL_SET
+#define __HAL_ADC_OFR_CHANNEL                            ADC_OFR_CHANNEL
+#define __HAL_ADC_DIFSEL_CHANNEL                         ADC_DIFSEL_CHANNEL
+#define __HAL_ADC_CALFACT_DIFF_SET                       ADC_CALFACT_DIFF_SET
+#define __HAL_ADC_CALFACT_DIFF_GET                       ADC_CALFACT_DIFF_GET
+#define __HAL_ADC_TRX_HIGHTHRESHOLD                      ADC_TRX_HIGHTHRESHOLD
+
+#define __HAL_ADC_OFFSET_SHIFT_RESOLUTION                ADC_OFFSET_SHIFT_RESOLUTION
+#define __HAL_ADC_AWD1THRESHOLD_SHIFT_RESOLUTION         ADC_AWD1THRESHOLD_SHIFT_RESOLUTION
+#define __HAL_ADC_AWD23THRESHOLD_SHIFT_RESOLUTION        ADC_AWD23THRESHOLD_SHIFT_RESOLUTION
+#define __HAL_ADC_COMMON_REGISTER                        ADC_COMMON_REGISTER
+#define __HAL_ADC_COMMON_CCR_MULTI                       ADC_COMMON_CCR_MULTI
+#define __HAL_ADC_MULTIMODE_IS_ENABLED                   ADC_MULTIMODE_IS_ENABLE
+#define __ADC_MULTIMODE_IS_ENABLED                       ADC_MULTIMODE_IS_ENABLE
+#define __HAL_ADC_NONMULTIMODE_OR_MULTIMODEMASTER        ADC_NONMULTIMODE_OR_MULTIMODEMASTER
+#define __HAL_ADC_COMMON_ADC_OTHER                       ADC_COMMON_ADC_OTHER
+#define __HAL_ADC_MULTI_SLAVE                            ADC_MULTI_SLAVE
+
+#define __HAL_ADC_SQR1_L                                 ADC_SQR1_L_SHIFT
+#define __HAL_ADC_JSQR_JL                                ADC_JSQR_JL_SHIFT
+#define __HAL_ADC_JSQR_RK_JL                             ADC_JSQR_RK_JL
+#define __HAL_ADC_CR1_DISCONTINUOUS_NUM                  ADC_CR1_DISCONTINUOUS_NUM
+#define __HAL_ADC_CR1_SCAN                               ADC_CR1_SCAN_SET
+#define __HAL_ADC_CONVCYCLES_MAX_RANGE                   ADC_CONVCYCLES_MAX_RANGE
+#define __HAL_ADC_CLOCK_PRESCALER_RANGE                  ADC_CLOCK_PRESCALER_RANGE
+#define __HAL_ADC_GET_CLOCK_PRESCALER                    ADC_GET_CLOCK_PRESCALER
+
+#define __HAL_ADC_SQR1                                   ADC_SQR1
+#define __HAL_ADC_SMPR1                                  ADC_SMPR1
+#define __HAL_ADC_SMPR2                                  ADC_SMPR2
+#define __HAL_ADC_SQR3_RK                                ADC_SQR3_RK
+#define __HAL_ADC_SQR2_RK                                ADC_SQR2_RK
+#define __HAL_ADC_SQR1_RK                                ADC_SQR1_RK
+#define __HAL_ADC_CR2_CONTINUOUS                         ADC_CR2_CONTINUOUS
+#define __HAL_ADC_CR1_DISCONTINUOUS                      ADC_CR1_DISCONTINUOUS
+#define __HAL_ADC_CR1_SCANCONV                           ADC_CR1_SCANCONV
+#define __HAL_ADC_CR2_EOCSelection                       ADC_CR2_EOCSelection
+#define __HAL_ADC_CR2_DMAContReq                         ADC_CR2_DMAContReq
+#define __HAL_ADC_GET_RESOLUTION                         ADC_GET_RESOLUTION
+#define __HAL_ADC_JSQR                                   ADC_JSQR
+
+#define __HAL_ADC_CHSELR_CHANNEL                         ADC_CHSELR_CHANNEL
+#define __HAL_ADC_CFGR1_REG_DISCCONTINUOUS               ADC_CFGR1_REG_DISCCONTINUOUS
+#define __HAL_ADC_CFGR1_AUTOOFF                          ADC_CFGR1_AUTOOFF
+#define __HAL_ADC_CFGR1_AUTOWAIT                         ADC_CFGR1_AUTOWAIT
+#define __HAL_ADC_CFGR1_CONTINUOUS                       ADC_CFGR1_CONTINUOUS
+#define __HAL_ADC_CFGR1_OVERRUN                          ADC_CFGR1_OVERRUN
+#define __HAL_ADC_CFGR1_SCANDIR                          ADC_CFGR1_SCANDIR
+#define __HAL_ADC_CFGR1_DMACONTREQ                       ADC_CFGR1_DMACONTREQ
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_DAC_Aliased_Macros HAL DAC Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_DHR12R1_ALIGNEMENT                        DAC_DHR12R1_ALIGNMENT
+#define __HAL_DHR12R2_ALIGNEMENT                        DAC_DHR12R2_ALIGNMENT
+#define __HAL_DHR12RD_ALIGNEMENT                        DAC_DHR12RD_ALIGNMENT
+#define IS_DAC_GENERATE_WAVE                            IS_DAC_WAVE
+
+/**
+  * @}
+  */
+   
+/** @defgroup HAL_DBGMCU_Aliased_Macros HAL DBGMCU Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_FREEZE_TIM1_DBGMCU __HAL_DBGMCU_FREEZE_TIM1
+#define __HAL_UNFREEZE_TIM1_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM1
+#define __HAL_FREEZE_TIM2_DBGMCU __HAL_DBGMCU_FREEZE_TIM2
+#define __HAL_UNFREEZE_TIM2_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM2
+#define __HAL_FREEZE_TIM3_DBGMCU __HAL_DBGMCU_FREEZE_TIM3
+#define __HAL_UNFREEZE_TIM3_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM3
+#define __HAL_FREEZE_TIM4_DBGMCU __HAL_DBGMCU_FREEZE_TIM4
+#define __HAL_UNFREEZE_TIM4_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM4
+#define __HAL_FREEZE_TIM5_DBGMCU __HAL_DBGMCU_FREEZE_TIM5
+#define __HAL_UNFREEZE_TIM5_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM5
+#define __HAL_FREEZE_TIM6_DBGMCU __HAL_DBGMCU_FREEZE_TIM6
+#define __HAL_UNFREEZE_TIM6_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM6
+#define __HAL_FREEZE_TIM7_DBGMCU __HAL_DBGMCU_FREEZE_TIM7
+#define __HAL_UNFREEZE_TIM7_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM7
+#define __HAL_FREEZE_TIM8_DBGMCU __HAL_DBGMCU_FREEZE_TIM8
+#define __HAL_UNFREEZE_TIM8_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM8
+
+#define __HAL_FREEZE_TIM9_DBGMCU __HAL_DBGMCU_FREEZE_TIM9
+#define __HAL_UNFREEZE_TIM9_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM9
+#define __HAL_FREEZE_TIM10_DBGMCU __HAL_DBGMCU_FREEZE_TIM10
+#define __HAL_UNFREEZE_TIM10_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM10
+#define __HAL_FREEZE_TIM11_DBGMCU __HAL_DBGMCU_FREEZE_TIM11
+#define __HAL_UNFREEZE_TIM11_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM11
+#define __HAL_FREEZE_TIM12_DBGMCU __HAL_DBGMCU_FREEZE_TIM12
+#define __HAL_UNFREEZE_TIM12_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM12
+#define __HAL_FREEZE_TIM13_DBGMCU __HAL_DBGMCU_FREEZE_TIM13
+#define __HAL_UNFREEZE_TIM13_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM13
+#define __HAL_FREEZE_TIM14_DBGMCU __HAL_DBGMCU_FREEZE_TIM14
+#define __HAL_UNFREEZE_TIM14_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM14
+#define __HAL_FREEZE_CAN2_DBGMCU __HAL_DBGMCU_FREEZE_CAN2
+#define __HAL_UNFREEZE_CAN2_DBGMCU __HAL_DBGMCU_UNFREEZE_CAN2
+
+
+#define __HAL_FREEZE_TIM15_DBGMCU __HAL_DBGMCU_FREEZE_TIM15
+#define __HAL_UNFREEZE_TIM15_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM15
+#define __HAL_FREEZE_TIM16_DBGMCU __HAL_DBGMCU_FREEZE_TIM16
+#define __HAL_UNFREEZE_TIM16_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM16
+#define __HAL_FREEZE_TIM17_DBGMCU __HAL_DBGMCU_FREEZE_TIM17
+#define __HAL_UNFREEZE_TIM17_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM17
+#define __HAL_FREEZE_RTC_DBGMCU __HAL_DBGMCU_FREEZE_RTC
+#define __HAL_UNFREEZE_RTC_DBGMCU __HAL_DBGMCU_UNFREEZE_RTC
+#define __HAL_FREEZE_WWDG_DBGMCU __HAL_DBGMCU_FREEZE_WWDG
+#define __HAL_UNFREEZE_WWDG_DBGMCU __HAL_DBGMCU_UNFREEZE_WWDG
+#define __HAL_FREEZE_IWDG_DBGMCU __HAL_DBGMCU_FREEZE_IWDG
+#define __HAL_UNFREEZE_IWDG_DBGMCU __HAL_DBGMCU_UNFREEZE_IWDG
+#define __HAL_FREEZE_I2C1_TIMEOUT_DBGMCU __HAL_DBGMCU_FREEZE_I2C1_TIMEOUT
+#define __HAL_UNFREEZE_I2C1_TIMEOUT_DBGMCU __HAL_DBGMCU_UNFREEZE_I2C1_TIMEOUT
+#define __HAL_FREEZE_I2C2_TIMEOUT_DBGMCU __HAL_DBGMCU_FREEZE_I2C2_TIMEOUT
+#define __HAL_UNFREEZE_I2C2_TIMEOUT_DBGMCU __HAL_DBGMCU_UNFREEZE_I2C2_TIMEOUT
+#define __HAL_FREEZE_I2C3_TIMEOUT_DBGMCU __HAL_DBGMCU_FREEZE_I2C3_TIMEOUT
+#define __HAL_UNFREEZE_I2C3_TIMEOUT_DBGMCU __HAL_DBGMCU_UNFREEZE_I2C3_TIMEOUT
+#define __HAL_FREEZE_CAN1_DBGMCU __HAL_DBGMCU_FREEZE_CAN1
+#define __HAL_UNFREEZE_CAN1_DBGMCU __HAL_DBGMCU_UNFREEZE_CAN1
+#define __HAL_FREEZE_LPTIM1_DBGMCU __HAL_DBGMCU_FREEZE_LPTIM1
+#define __HAL_UNFREEZE_LPTIM1_DBGMCU __HAL_DBGMCU_UNFREEZE_LPTIM1
+#define __HAL_FREEZE_LPTIM2_DBGMCU __HAL_DBGMCU_FREEZE_LPTIM2
+#define __HAL_UNFREEZE_LPTIM2_DBGMCU __HAL_DBGMCU_UNFREEZE_LPTIM2
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_COMP_Aliased_Macros HAL COMP Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
+                                                          __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE())
+#define __HAL_COMP_EXTI_RISING_IT_DISABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
+                                                          __HAL_COMP_COMP2_EXTI_DISABLE_RISING_EDGE())
+#define __HAL_COMP_EXTI_FALLING_IT_ENABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          __HAL_COMP_COMP2_EXTI_ENABLE_FALLING_EDGE())
+#define __HAL_COMP_EXTI_FALLING_IT_DISABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          __HAL_COMP_COMP2_EXTI_DISABLE_FALLING_EDGE())
+#define __HAL_COMP_EXTI_ENABLE_IT(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_IT() : \
+                                                          __HAL_COMP_COMP2_EXTI_ENABLE_IT())
+#define __HAL_COMP_EXTI_DISABLE_IT(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_IT() : \
+                                                          __HAL_COMP_COMP2_EXTI_DISABLE_IT())
+#define __HAL_COMP_EXTI_GET_FLAG(__FLAG__)   (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_GET_FLAG() : \
+                                                          __HAL_COMP_COMP2_EXTI_GET_FLAG())
+#define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)   (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_CLEAR_FLAG() : \
+                                                          __HAL_COMP_COMP2_EXTI_CLEAR_FLAG())
+#define __HAL_COMP_GET_EXTI_LINE  COMP_GET_EXTI_LINE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_DAC_Aliased_Macros HAL DAC Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define IS_DAC_WAVE(WAVE) (((WAVE) == DAC_WAVE_NONE) || \
+                          ((WAVE) == DAC_WAVE_NOISE)|| \
+                          ((WAVE) == DAC_WAVE_TRIANGLE))
+  
+/**
+  * @}
+  */
+
+/** @defgroup HAL_FLASH_Aliased_Macros HAL FLASH Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define IS_WRPAREA          IS_OB_WRPAREA
+#define IS_TYPEPROGRAM      IS_FLASH_TYPEPROGRAM
+#define IS_TYPEPROGRAMFLASH IS_FLASH_TYPEPROGRAM
+#define IS_TYPEERASE        IS_FLASH_TYPEERASE
+#define IS_NBSECTORS        IS_FLASH_NBSECTORS
+#define IS_OB_WDG_SOURCE    IS_OB_IWDG_SOURCE
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_I2C_Aliased_Macros HAL I2C Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+#define __HAL_I2C_RESET_CR2             I2C_RESET_CR2
+#define __HAL_I2C_GENERATE_START        I2C_GENERATE_START
+#define __HAL_I2C_FREQ_RANGE            I2C_FREQ_RANGE
+#define __HAL_I2C_RISE_TIME             I2C_RISE_TIME
+#define __HAL_I2C_SPEED_STANDARD        I2C_SPEED_STANDARD
+#define __HAL_I2C_SPEED_FAST            I2C_SPEED_FAST
+#define __HAL_I2C_SPEED                 I2C_SPEED
+#define __HAL_I2C_7BIT_ADD_WRITE        I2C_7BIT_ADD_WRITE
+#define __HAL_I2C_7BIT_ADD_READ         I2C_7BIT_ADD_READ
+#define __HAL_I2C_10BIT_ADDRESS         I2C_10BIT_ADDRESS
+#define __HAL_I2C_10BIT_HEADER_WRITE    I2C_10BIT_HEADER_WRITE
+#define __HAL_I2C_10BIT_HEADER_READ     I2C_10BIT_HEADER_READ
+#define __HAL_I2C_MEM_ADD_MSB           I2C_MEM_ADD_MSB
+#define __HAL_I2C_MEM_ADD_LSB           I2C_MEM_ADD_LSB
+#define __HAL_I2C_FREQRANGE             I2C_FREQRANGE
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_I2S_Aliased_Macros HAL I2S Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+#define IS_I2S_INSTANCE                 IS_I2S_ALL_INSTANCE
+#define IS_I2S_INSTANCE_EXT             IS_I2S_ALL_INSTANCE_EXT
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_IRDA_Aliased_Macros HAL IRDA Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+#define __IRDA_DISABLE                  __HAL_IRDA_DISABLE
+#define __IRDA_ENABLE                   __HAL_IRDA_ENABLE
+
+#define __HAL_IRDA_GETCLOCKSOURCE       IRDA_GETCLOCKSOURCE
+#define __HAL_IRDA_MASK_COMPUTATION     IRDA_MASK_COMPUTATION
+#define __IRDA_GETCLOCKSOURCE           IRDA_GETCLOCKSOURCE
+#define __IRDA_MASK_COMPUTATION         IRDA_MASK_COMPUTATION
+
+#define IS_IRDA_ONEBIT_SAMPLE           IS_IRDA_ONE_BIT_SAMPLE                  
+
+
+/**
+  * @}
+  */
+
+
+/** @defgroup HAL_IWDG_Aliased_Macros HAL IWDG Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_IWDG_ENABLE_WRITE_ACCESS  IWDG_ENABLE_WRITE_ACCESS
+#define __HAL_IWDG_DISABLE_WRITE_ACCESS IWDG_DISABLE_WRITE_ACCESS
+/**
+  * @}
+  */
+
+
+/** @defgroup HAL_LPTIM_Aliased_Macros HAL LPTIM Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define __HAL_LPTIM_ENABLE_INTERRUPT    __HAL_LPTIM_ENABLE_IT
+#define __HAL_LPTIM_DISABLE_INTERRUPT   __HAL_LPTIM_DISABLE_IT
+#define __HAL_LPTIM_GET_ITSTATUS        __HAL_LPTIM_GET_IT_SOURCE
+
+/**
+  * @}
+  */
+  
+  
+/** @defgroup HAL_OPAMP_Aliased_Macros HAL OPAMP Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __OPAMP_CSR_OPAXPD                OPAMP_CSR_OPAXPD
+#define __OPAMP_CSR_S3SELX                OPAMP_CSR_S3SELX
+#define __OPAMP_CSR_S4SELX                OPAMP_CSR_S4SELX
+#define __OPAMP_CSR_S5SELX                OPAMP_CSR_S5SELX
+#define __OPAMP_CSR_S6SELX                OPAMP_CSR_S6SELX
+#define __OPAMP_CSR_OPAXCAL_L             OPAMP_CSR_OPAXCAL_L
+#define __OPAMP_CSR_OPAXCAL_H             OPAMP_CSR_OPAXCAL_H
+#define __OPAMP_CSR_OPAXLPM               OPAMP_CSR_OPAXLPM
+#define __OPAMP_CSR_ALL_SWITCHES          OPAMP_CSR_ALL_SWITCHES
+#define __OPAMP_CSR_ANAWSELX              OPAMP_CSR_ANAWSELX
+#define __OPAMP_CSR_OPAXCALOUT            OPAMP_CSR_OPAXCALOUT
+#define __OPAMP_OFFSET_TRIM_BITSPOSITION  OPAMP_OFFSET_TRIM_BITSPOSITION
+#define __OPAMP_OFFSET_TRIM_SET           OPAMP_OFFSET_TRIM_SET
+
+/**
+  * @}
+  */
+
+
+/** @defgroup HAL_PWR_Aliased_Macros HAL PWR Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_PVD_EVENT_DISABLE                                  __HAL_PWR_PVD_EXTI_DISABLE_EVENT
+#define __HAL_PVD_EVENT_ENABLE                                   __HAL_PWR_PVD_EXTI_ENABLE_EVENT
+#define __HAL_PVD_EXTI_FALLINGTRIGGER_DISABLE                    __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE
+#define __HAL_PVD_EXTI_FALLINGTRIGGER_ENABLE                     __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_PVD_EXTI_RISINGTRIGGER_DISABLE                     __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE
+#define __HAL_PVD_EXTI_RISINGTRIGGER_ENABLE                      __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE
+#define __HAL_PVM_EVENT_DISABLE                                  __HAL_PWR_PVM_EVENT_DISABLE
+#define __HAL_PVM_EVENT_ENABLE                                   __HAL_PWR_PVM_EVENT_ENABLE
+#define __HAL_PVM_EXTI_FALLINGTRIGGER_DISABLE                    __HAL_PWR_PVM_EXTI_FALLINGTRIGGER_DISABLE
+#define __HAL_PVM_EXTI_FALLINGTRIGGER_ENABLE                     __HAL_PWR_PVM_EXTI_FALLINGTRIGGER_ENABLE
+#define __HAL_PVM_EXTI_RISINGTRIGGER_DISABLE                     __HAL_PWR_PVM_EXTI_RISINGTRIGGER_DISABLE
+#define __HAL_PVM_EXTI_RISINGTRIGGER_ENABLE                      __HAL_PWR_PVM_EXTI_RISINGTRIGGER_ENABLE
+#define __HAL_PWR_INTERNALWAKEUP_DISABLE                         HAL_PWREx_DisableInternalWakeUpLine
+#define __HAL_PWR_INTERNALWAKEUP_ENABLE                          HAL_PWREx_EnableInternalWakeUpLine
+#define __HAL_PWR_PULL_UP_DOWN_CONFIG_DISABLE                    HAL_PWREx_DisablePullUpPullDownConfig
+#define __HAL_PWR_PULL_UP_DOWN_CONFIG_ENABLE                     HAL_PWREx_EnablePullUpPullDownConfig
+#define __HAL_PWR_PVD_EXTI_CLEAR_EGDE_TRIGGER()                  __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE();__HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE()
+#define __HAL_PWR_PVD_EXTI_EVENT_DISABLE                         __HAL_PWR_PVD_EXTI_DISABLE_EVENT
+#define __HAL_PWR_PVD_EXTI_EVENT_ENABLE                          __HAL_PWR_PVD_EXTI_ENABLE_EVENT
+#define __HAL_PWR_PVD_EXTI_FALLINGTRIGGER_DISABLE                __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE
+#define __HAL_PWR_PVD_EXTI_FALLINGTRIGGER_ENABLE                 __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_PWR_PVD_EXTI_RISINGTRIGGER_DISABLE                 __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE
+#define __HAL_PWR_PVD_EXTI_RISINGTRIGGER_ENABLE                  __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE
+#define __HAL_PWR_PVD_EXTI_SET_FALLING_EGDE_TRIGGER              __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_PWR_PVD_EXTI_SET_RISING_EDGE_TRIGGER               __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE
+#define __HAL_PWR_PVM_DISABLE()                                  HAL_PWREx_DisablePVM1();HAL_PWREx_DisablePVM2();HAL_PWREx_DisablePVM3();HAL_PWREx_DisablePVM4()
+#define __HAL_PWR_PVM_ENABLE()                                   HAL_PWREx_EnablePVM1();HAL_PWREx_EnablePVM2();HAL_PWREx_EnablePVM3();HAL_PWREx_EnablePVM4()
+#define __HAL_PWR_SRAM2CONTENT_PRESERVE_DISABLE                  HAL_PWREx_DisableSRAM2ContentRetention
+#define __HAL_PWR_SRAM2CONTENT_PRESERVE_ENABLE                   HAL_PWREx_EnableSRAM2ContentRetention
+#define __HAL_PWR_VDDIO2_DISABLE                                 HAL_PWREx_DisableVddIO2
+#define __HAL_PWR_VDDIO2_ENABLE                                  HAL_PWREx_EnableVddIO2
+#define __HAL_PWR_VDDIO2_EXTI_CLEAR_EGDE_TRIGGER                 __HAL_PWR_VDDIO2_EXTI_DISABLE_FALLING_EDGE
+#define __HAL_PWR_VDDIO2_EXTI_SET_FALLING_EGDE_TRIGGER           __HAL_PWR_VDDIO2_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_PWR_VDDUSB_DISABLE                                 HAL_PWREx_DisableVddUSB
+#define __HAL_PWR_VDDUSB_ENABLE                                  HAL_PWREx_EnableVddUSB
+
+#if defined (STM32F4)
+#define __HAL_PVD_EXTI_ENABLE_IT(PWR_EXTI_LINE_PVD)         __HAL_PWR_PVD_EXTI_ENABLE_IT()
+#define __HAL_PVD_EXTI_DISABLE_IT(PWR_EXTI_LINE_PVD)        __HAL_PWR_PVD_EXTI_DISABLE_IT()
+#define __HAL_PVD_EXTI_GET_FLAG(PWR_EXTI_LINE_PVD)          __HAL_PWR_PVD_EXTI_GET_FLAG()   
+#define __HAL_PVD_EXTI_CLEAR_FLAG(PWR_EXTI_LINE_PVD)        __HAL_PWR_PVD_EXTI_CLEAR_FLAG()
+#define __HAL_PVD_EXTI_GENERATE_SWIT(PWR_EXTI_LINE_PVD)     __HAL_PWR_PVD_EXTI_GENERATE_SWIT()
+#else
+#define __HAL_PVD_EXTI_CLEAR_FLAG                                __HAL_PWR_PVD_EXTI_CLEAR_FLAG
+#define __HAL_PVD_EXTI_DISABLE_IT                                __HAL_PWR_PVD_EXTI_DISABLE_IT
+#define __HAL_PVD_EXTI_ENABLE_IT                                 __HAL_PWR_PVD_EXTI_ENABLE_IT
+#define __HAL_PVD_EXTI_GENERATE_SWIT                             __HAL_PWR_PVD_EXTI_GENERATE_SWIT
+#define __HAL_PVD_EXTI_GET_FLAG                                  __HAL_PWR_PVD_EXTI_GET_FLAG 
+#endif /* STM32F4 */
+/**   
+  * @}
+  */  
+  
+  
+/** @defgroup HAL_RCC_Aliased HAL RCC Aliased maintained for legacy purpose
+  * @{
+  */
+  
+#define RCC_StopWakeUpClock_MSI     RCC_STOP_WAKEUPCLOCK_MSI
+#define RCC_StopWakeUpClock_HSI     RCC_STOP_WAKEUPCLOCK_HSI
+
+#define HAL_RCC_CCSCallback HAL_RCC_CSSCallback
+#define HAL_RC48_EnableBuffer_Cmd(cmd) (((cmd)==ENABLE) ? HAL_RCCEx_EnableHSI48_VREFINT() : HAL_RCCEx_DisableHSI48_VREFINT())
+
+#define __ADC_CLK_DISABLE __HAL_RCC_ADC_CLK_DISABLE
+#define __ADC_CLK_ENABLE __HAL_RCC_ADC_CLK_ENABLE
+#define __ADC_CLK_SLEEP_DISABLE __HAL_RCC_ADC_CLK_SLEEP_DISABLE
+#define __ADC_CLK_SLEEP_ENABLE __HAL_RCC_ADC_CLK_SLEEP_ENABLE
+#define __ADC_FORCE_RESET __HAL_RCC_ADC_FORCE_RESET
+#define __ADC_RELEASE_RESET __HAL_RCC_ADC_RELEASE_RESET
+#define __ADC1_CLK_DISABLE        __HAL_RCC_ADC1_CLK_DISABLE
+#define __ADC1_CLK_ENABLE         __HAL_RCC_ADC1_CLK_ENABLE
+#define __ADC1_FORCE_RESET        __HAL_RCC_ADC1_FORCE_RESET
+#define __ADC1_RELEASE_RESET      __HAL_RCC_ADC1_RELEASE_RESET
+#define __ADC1_CLK_SLEEP_ENABLE   __HAL_RCC_ADC1_CLK_SLEEP_ENABLE  
+#define __ADC1_CLK_SLEEP_DISABLE  __HAL_RCC_ADC1_CLK_SLEEP_DISABLE  
+#define __ADC2_CLK_DISABLE __HAL_RCC_ADC2_CLK_DISABLE
+#define __ADC2_CLK_ENABLE __HAL_RCC_ADC2_CLK_ENABLE
+#define __ADC2_FORCE_RESET __HAL_RCC_ADC2_FORCE_RESET
+#define __ADC2_RELEASE_RESET __HAL_RCC_ADC2_RELEASE_RESET
+#define __ADC3_CLK_DISABLE __HAL_RCC_ADC3_CLK_DISABLE
+#define __ADC3_CLK_ENABLE __HAL_RCC_ADC3_CLK_ENABLE
+#define __ADC3_FORCE_RESET __HAL_RCC_ADC3_FORCE_RESET
+#define __ADC3_RELEASE_RESET __HAL_RCC_ADC3_RELEASE_RESET
+#define __AES_CLK_DISABLE __HAL_RCC_AES_CLK_DISABLE
+#define __AES_CLK_ENABLE __HAL_RCC_AES_CLK_ENABLE
+#define __AES_CLK_SLEEP_DISABLE __HAL_RCC_AES_CLK_SLEEP_DISABLE
+#define __AES_CLK_SLEEP_ENABLE __HAL_RCC_AES_CLK_SLEEP_ENABLE
+#define __AES_FORCE_RESET __HAL_RCC_AES_FORCE_RESET
+#define __AES_RELEASE_RESET __HAL_RCC_AES_RELEASE_RESET
+#define __CRYP_CLK_SLEEP_ENABLE      __HAL_RCC_CRYP_CLK_SLEEP_ENABLE
+#define __CRYP_CLK_SLEEP_DISABLE  __HAL_RCC_CRYP_CLK_SLEEP_DISABLE
+#define __CRYP_CLK_ENABLE  __HAL_RCC_CRYP_CLK_ENABLE
+#define __CRYP_CLK_DISABLE  __HAL_RCC_CRYP_CLK_DISABLE
+#define __CRYP_FORCE_RESET  __HAL_RCC_CRYP_FORCE_RESET
+#define __CRYP_RELEASE_RESET  __HAL_RCC_CRYP_RELEASE_RESET
+#define __AFIO_CLK_DISABLE __HAL_RCC_AFIO_CLK_DISABLE
+#define __AFIO_CLK_ENABLE __HAL_RCC_AFIO_CLK_ENABLE
+#define __AFIO_FORCE_RESET __HAL_RCC_AFIO_FORCE_RESET
+#define __AFIO_RELEASE_RESET __HAL_RCC_AFIO_RELEASE_RESET
+#define __AHB_FORCE_RESET __HAL_RCC_AHB_FORCE_RESET
+#define __AHB_RELEASE_RESET __HAL_RCC_AHB_RELEASE_RESET
+#define __AHB1_FORCE_RESET __HAL_RCC_AHB1_FORCE_RESET
+#define __AHB1_RELEASE_RESET __HAL_RCC_AHB1_RELEASE_RESET
+#define __AHB2_FORCE_RESET __HAL_RCC_AHB2_FORCE_RESET
+#define __AHB2_RELEASE_RESET __HAL_RCC_AHB2_RELEASE_RESET
+#define __AHB3_FORCE_RESET __HAL_RCC_AHB3_FORCE_RESET
+#define __AHB3_RELEASE_RESET __HAL_RCC_AHB3_RELEASE_RESET
+#define __APB1_FORCE_RESET __HAL_RCC_APB1_FORCE_RESET
+#define __APB1_RELEASE_RESET __HAL_RCC_APB1_RELEASE_RESET
+#define __APB2_FORCE_RESET __HAL_RCC_APB2_FORCE_RESET
+#define __APB2_RELEASE_RESET __HAL_RCC_APB2_RELEASE_RESET
+#define __BKP_CLK_DISABLE __HAL_RCC_BKP_CLK_DISABLE
+#define __BKP_CLK_ENABLE __HAL_RCC_BKP_CLK_ENABLE
+#define __BKP_FORCE_RESET __HAL_RCC_BKP_FORCE_RESET
+#define __BKP_RELEASE_RESET __HAL_RCC_BKP_RELEASE_RESET
+#define __CAN1_CLK_DISABLE __HAL_RCC_CAN1_CLK_DISABLE
+#define __CAN1_CLK_ENABLE __HAL_RCC_CAN1_CLK_ENABLE
+#define __CAN1_CLK_SLEEP_DISABLE __HAL_RCC_CAN1_CLK_SLEEP_DISABLE
+#define __CAN1_CLK_SLEEP_ENABLE __HAL_RCC_CAN1_CLK_SLEEP_ENABLE
+#define __CAN1_FORCE_RESET __HAL_RCC_CAN1_FORCE_RESET
+#define __CAN1_RELEASE_RESET __HAL_RCC_CAN1_RELEASE_RESET
+#define __CAN_CLK_DISABLE         __HAL_RCC_CAN1_CLK_DISABLE
+#define __CAN_CLK_ENABLE          __HAL_RCC_CAN1_CLK_ENABLE
+#define __CAN_FORCE_RESET         __HAL_RCC_CAN1_FORCE_RESET
+#define __CAN_RELEASE_RESET       __HAL_RCC_CAN1_RELEASE_RESET
+#define __CAN2_CLK_DISABLE __HAL_RCC_CAN2_CLK_DISABLE
+#define __CAN2_CLK_ENABLE __HAL_RCC_CAN2_CLK_ENABLE
+#define __CAN2_FORCE_RESET __HAL_RCC_CAN2_FORCE_RESET
+#define __CAN2_RELEASE_RESET __HAL_RCC_CAN2_RELEASE_RESET
+#define __CEC_CLK_DISABLE __HAL_RCC_CEC_CLK_DISABLE
+#define __CEC_CLK_ENABLE __HAL_RCC_CEC_CLK_ENABLE
+#define __COMP_CLK_DISABLE        __HAL_RCC_COMP_CLK_DISABLE
+#define __COMP_CLK_ENABLE         __HAL_RCC_COMP_CLK_ENABLE
+#define __COMP_FORCE_RESET        __HAL_RCC_COMP_FORCE_RESET
+#define __COMP_RELEASE_RESET      __HAL_RCC_COMP_RELEASE_RESET
+#define __COMP_CLK_SLEEP_ENABLE   __HAL_RCC_COMP_CLK_SLEEP_ENABLE
+#define __COMP_CLK_SLEEP_DISABLE  __HAL_RCC_COMP_CLK_SLEEP_DISABLE
+#define __CEC_FORCE_RESET __HAL_RCC_CEC_FORCE_RESET
+#define __CEC_RELEASE_RESET __HAL_RCC_CEC_RELEASE_RESET
+#define __CRC_CLK_DISABLE __HAL_RCC_CRC_CLK_DISABLE
+#define __CRC_CLK_ENABLE __HAL_RCC_CRC_CLK_ENABLE
+#define __CRC_CLK_SLEEP_DISABLE __HAL_RCC_CRC_CLK_SLEEP_DISABLE
+#define __CRC_CLK_SLEEP_ENABLE __HAL_RCC_CRC_CLK_SLEEP_ENABLE
+#define __CRC_FORCE_RESET __HAL_RCC_CRC_FORCE_RESET
+#define __CRC_RELEASE_RESET __HAL_RCC_CRC_RELEASE_RESET
+#define __DAC_CLK_DISABLE __HAL_RCC_DAC_CLK_DISABLE
+#define __DAC_CLK_ENABLE __HAL_RCC_DAC_CLK_ENABLE
+#define __DAC_FORCE_RESET __HAL_RCC_DAC_FORCE_RESET
+#define __DAC_RELEASE_RESET __HAL_RCC_DAC_RELEASE_RESET
+#define __DAC1_CLK_DISABLE __HAL_RCC_DAC1_CLK_DISABLE
+#define __DAC1_CLK_ENABLE __HAL_RCC_DAC1_CLK_ENABLE
+#define __DAC1_CLK_SLEEP_DISABLE __HAL_RCC_DAC1_CLK_SLEEP_DISABLE
+#define __DAC1_CLK_SLEEP_ENABLE __HAL_RCC_DAC1_CLK_SLEEP_ENABLE
+#define __DAC1_FORCE_RESET __HAL_RCC_DAC1_FORCE_RESET
+#define __DAC1_RELEASE_RESET __HAL_RCC_DAC1_RELEASE_RESET
+#define __DBGMCU_CLK_ENABLE     __HAL_RCC_DBGMCU_CLK_ENABLE
+#define __DBGMCU_CLK_DISABLE     __HAL_RCC_DBGMCU_CLK_DISABLE
+#define __DBGMCU_FORCE_RESET    __HAL_RCC_DBGMCU_FORCE_RESET
+#define __DBGMCU_RELEASE_RESET  __HAL_RCC_DBGMCU_RELEASE_RESET
+#define __DFSDM_CLK_DISABLE __HAL_RCC_DFSDM_CLK_DISABLE
+#define __DFSDM_CLK_ENABLE __HAL_RCC_DFSDM_CLK_ENABLE
+#define __DFSDM_CLK_SLEEP_DISABLE __HAL_RCC_DFSDM_CLK_SLEEP_DISABLE
+#define __DFSDM_CLK_SLEEP_ENABLE __HAL_RCC_DFSDM_CLK_SLEEP_ENABLE
+#define __DFSDM_FORCE_RESET __HAL_RCC_DFSDM_FORCE_RESET
+#define __DFSDM_RELEASE_RESET __HAL_RCC_DFSDM_RELEASE_RESET
+#define __DMA1_CLK_DISABLE __HAL_RCC_DMA1_CLK_DISABLE
+#define __DMA1_CLK_ENABLE __HAL_RCC_DMA1_CLK_ENABLE
+#define __DMA1_CLK_SLEEP_DISABLE __HAL_RCC_DMA1_CLK_SLEEP_DISABLE
+#define __DMA1_CLK_SLEEP_ENABLE __HAL_RCC_DMA1_CLK_SLEEP_ENABLE
+#define __DMA1_FORCE_RESET __HAL_RCC_DMA1_FORCE_RESET
+#define __DMA1_RELEASE_RESET __HAL_RCC_DMA1_RELEASE_RESET
+#define __DMA2_CLK_DISABLE __HAL_RCC_DMA2_CLK_DISABLE
+#define __DMA2_CLK_ENABLE __HAL_RCC_DMA2_CLK_ENABLE
+#define __DMA2_CLK_SLEEP_DISABLE __HAL_RCC_DMA2_CLK_SLEEP_DISABLE
+#define __DMA2_CLK_SLEEP_ENABLE __HAL_RCC_DMA2_CLK_SLEEP_ENABLE
+#define __DMA2_FORCE_RESET __HAL_RCC_DMA2_FORCE_RESET
+#define __DMA2_RELEASE_RESET __HAL_RCC_DMA2_RELEASE_RESET
+#define __ETHMAC_CLK_DISABLE __HAL_RCC_ETHMAC_CLK_DISABLE
+#define __ETHMAC_CLK_ENABLE __HAL_RCC_ETHMAC_CLK_ENABLE
+#define __ETHMAC_FORCE_RESET __HAL_RCC_ETHMAC_FORCE_RESET
+#define __ETHMAC_RELEASE_RESET __HAL_RCC_ETHMAC_RELEASE_RESET
+#define __ETHMACRX_CLK_DISABLE __HAL_RCC_ETHMACRX_CLK_DISABLE
+#define __ETHMACRX_CLK_ENABLE __HAL_RCC_ETHMACRX_CLK_ENABLE
+#define __ETHMACTX_CLK_DISABLE __HAL_RCC_ETHMACTX_CLK_DISABLE
+#define __ETHMACTX_CLK_ENABLE __HAL_RCC_ETHMACTX_CLK_ENABLE
+#define __FIREWALL_CLK_DISABLE __HAL_RCC_FIREWALL_CLK_DISABLE
+#define __FIREWALL_CLK_ENABLE __HAL_RCC_FIREWALL_CLK_ENABLE
+#define __FLASH_CLK_DISABLE __HAL_RCC_FLASH_CLK_DISABLE
+#define __FLASH_CLK_ENABLE __HAL_RCC_FLASH_CLK_ENABLE
+#define __FLASH_CLK_SLEEP_DISABLE __HAL_RCC_FLASH_CLK_SLEEP_DISABLE
+#define __FLASH_CLK_SLEEP_ENABLE __HAL_RCC_FLASH_CLK_SLEEP_ENABLE
+#define __FLASH_FORCE_RESET __HAL_RCC_FLASH_FORCE_RESET
+#define __FLASH_RELEASE_RESET __HAL_RCC_FLASH_RELEASE_RESET
+#define __FLITF_CLK_DISABLE       __HAL_RCC_FLITF_CLK_DISABLE
+#define __FLITF_CLK_ENABLE        __HAL_RCC_FLITF_CLK_ENABLE
+#define __FLITF_FORCE_RESET       __HAL_RCC_FLITF_FORCE_RESET
+#define __FLITF_RELEASE_RESET     __HAL_RCC_FLITF_RELEASE_RESET
+#define __FLITF_CLK_SLEEP_ENABLE  __HAL_RCC_FLITF_CLK_SLEEP_ENABLE
+#define __FLITF_CLK_SLEEP_DISABLE __HAL_RCC_FLITF_CLK_SLEEP_DISABLE
+#define __FMC_CLK_DISABLE __HAL_RCC_FMC_CLK_DISABLE
+#define __FMC_CLK_ENABLE __HAL_RCC_FMC_CLK_ENABLE
+#define __FMC_CLK_SLEEP_DISABLE __HAL_RCC_FMC_CLK_SLEEP_DISABLE
+#define __FMC_CLK_SLEEP_ENABLE __HAL_RCC_FMC_CLK_SLEEP_ENABLE
+#define __FMC_FORCE_RESET __HAL_RCC_FMC_FORCE_RESET
+#define __FMC_RELEASE_RESET __HAL_RCC_FMC_RELEASE_RESET
+#define __FSMC_CLK_DISABLE __HAL_RCC_FSMC_CLK_DISABLE
+#define __FSMC_CLK_ENABLE __HAL_RCC_FSMC_CLK_ENABLE
+#define __GPIOA_CLK_DISABLE __HAL_RCC_GPIOA_CLK_DISABLE
+#define __GPIOA_CLK_ENABLE __HAL_RCC_GPIOA_CLK_ENABLE
+#define __GPIOA_CLK_SLEEP_DISABLE __HAL_RCC_GPIOA_CLK_SLEEP_DISABLE
+#define __GPIOA_CLK_SLEEP_ENABLE __HAL_RCC_GPIOA_CLK_SLEEP_ENABLE
+#define __GPIOA_FORCE_RESET __HAL_RCC_GPIOA_FORCE_RESET
+#define __GPIOA_RELEASE_RESET __HAL_RCC_GPIOA_RELEASE_RESET
+#define __GPIOB_CLK_DISABLE __HAL_RCC_GPIOB_CLK_DISABLE
+#define __GPIOB_CLK_ENABLE __HAL_RCC_GPIOB_CLK_ENABLE
+#define __GPIOB_CLK_SLEEP_DISABLE __HAL_RCC_GPIOB_CLK_SLEEP_DISABLE
+#define __GPIOB_CLK_SLEEP_ENABLE __HAL_RCC_GPIOB_CLK_SLEEP_ENABLE
+#define __GPIOB_FORCE_RESET __HAL_RCC_GPIOB_FORCE_RESET
+#define __GPIOB_RELEASE_RESET __HAL_RCC_GPIOB_RELEASE_RESET
+#define __GPIOC_CLK_DISABLE __HAL_RCC_GPIOC_CLK_DISABLE
+#define __GPIOC_CLK_ENABLE __HAL_RCC_GPIOC_CLK_ENABLE
+#define __GPIOC_CLK_SLEEP_DISABLE __HAL_RCC_GPIOC_CLK_SLEEP_DISABLE
+#define __GPIOC_CLK_SLEEP_ENABLE __HAL_RCC_GPIOC_CLK_SLEEP_ENABLE
+#define __GPIOC_FORCE_RESET __HAL_RCC_GPIOC_FORCE_RESET
+#define __GPIOC_RELEASE_RESET __HAL_RCC_GPIOC_RELEASE_RESET
+#define __GPIOD_CLK_DISABLE __HAL_RCC_GPIOD_CLK_DISABLE
+#define __GPIOD_CLK_ENABLE __HAL_RCC_GPIOD_CLK_ENABLE
+#define __GPIOD_CLK_SLEEP_DISABLE __HAL_RCC_GPIOD_CLK_SLEEP_DISABLE
+#define __GPIOD_CLK_SLEEP_ENABLE __HAL_RCC_GPIOD_CLK_SLEEP_ENABLE
+#define __GPIOD_FORCE_RESET __HAL_RCC_GPIOD_FORCE_RESET
+#define __GPIOD_RELEASE_RESET __HAL_RCC_GPIOD_RELEASE_RESET
+#define __GPIOE_CLK_DISABLE __HAL_RCC_GPIOE_CLK_DISABLE
+#define __GPIOE_CLK_ENABLE __HAL_RCC_GPIOE_CLK_ENABLE
+#define __GPIOE_CLK_SLEEP_DISABLE __HAL_RCC_GPIOE_CLK_SLEEP_DISABLE
+#define __GPIOE_CLK_SLEEP_ENABLE __HAL_RCC_GPIOE_CLK_SLEEP_ENABLE
+#define __GPIOE_FORCE_RESET __HAL_RCC_GPIOE_FORCE_RESET
+#define __GPIOE_RELEASE_RESET __HAL_RCC_GPIOE_RELEASE_RESET
+#define __GPIOF_CLK_DISABLE __HAL_RCC_GPIOF_CLK_DISABLE
+#define __GPIOF_CLK_ENABLE __HAL_RCC_GPIOF_CLK_ENABLE
+#define __GPIOF_CLK_SLEEP_DISABLE __HAL_RCC_GPIOF_CLK_SLEEP_DISABLE
+#define __GPIOF_CLK_SLEEP_ENABLE __HAL_RCC_GPIOF_CLK_SLEEP_ENABLE
+#define __GPIOF_FORCE_RESET __HAL_RCC_GPIOF_FORCE_RESET
+#define __GPIOF_RELEASE_RESET __HAL_RCC_GPIOF_RELEASE_RESET
+#define __GPIOG_CLK_DISABLE __HAL_RCC_GPIOG_CLK_DISABLE
+#define __GPIOG_CLK_ENABLE __HAL_RCC_GPIOG_CLK_ENABLE
+#define __GPIOG_CLK_SLEEP_DISABLE __HAL_RCC_GPIOG_CLK_SLEEP_DISABLE
+#define __GPIOG_CLK_SLEEP_ENABLE __HAL_RCC_GPIOG_CLK_SLEEP_ENABLE
+#define __GPIOG_FORCE_RESET __HAL_RCC_GPIOG_FORCE_RESET
+#define __GPIOG_RELEASE_RESET __HAL_RCC_GPIOG_RELEASE_RESET
+#define __GPIOH_CLK_DISABLE __HAL_RCC_GPIOH_CLK_DISABLE
+#define __GPIOH_CLK_ENABLE __HAL_RCC_GPIOH_CLK_ENABLE
+#define __GPIOH_CLK_SLEEP_DISABLE __HAL_RCC_GPIOH_CLK_SLEEP_DISABLE
+#define __GPIOH_CLK_SLEEP_ENABLE __HAL_RCC_GPIOH_CLK_SLEEP_ENABLE
+#define __GPIOH_FORCE_RESET __HAL_RCC_GPIOH_FORCE_RESET
+#define __GPIOH_RELEASE_RESET __HAL_RCC_GPIOH_RELEASE_RESET
+#define __I2C1_CLK_DISABLE __HAL_RCC_I2C1_CLK_DISABLE
+#define __I2C1_CLK_ENABLE __HAL_RCC_I2C1_CLK_ENABLE
+#define __I2C1_CLK_SLEEP_DISABLE __HAL_RCC_I2C1_CLK_SLEEP_DISABLE
+#define __I2C1_CLK_SLEEP_ENABLE __HAL_RCC_I2C1_CLK_SLEEP_ENABLE
+#define __I2C1_FORCE_RESET __HAL_RCC_I2C1_FORCE_RESET
+#define __I2C1_RELEASE_RESET __HAL_RCC_I2C1_RELEASE_RESET
+#define __I2C2_CLK_DISABLE __HAL_RCC_I2C2_CLK_DISABLE
+#define __I2C2_CLK_ENABLE __HAL_RCC_I2C2_CLK_ENABLE
+#define __I2C2_CLK_SLEEP_DISABLE __HAL_RCC_I2C2_CLK_SLEEP_DISABLE
+#define __I2C2_CLK_SLEEP_ENABLE __HAL_RCC_I2C2_CLK_SLEEP_ENABLE
+#define __I2C2_FORCE_RESET __HAL_RCC_I2C2_FORCE_RESET
+#define __I2C2_RELEASE_RESET __HAL_RCC_I2C2_RELEASE_RESET
+#define __I2C3_CLK_DISABLE __HAL_RCC_I2C3_CLK_DISABLE
+#define __I2C3_CLK_ENABLE __HAL_RCC_I2C3_CLK_ENABLE
+#define __I2C3_CLK_SLEEP_DISABLE __HAL_RCC_I2C3_CLK_SLEEP_DISABLE
+#define __I2C3_CLK_SLEEP_ENABLE __HAL_RCC_I2C3_CLK_SLEEP_ENABLE
+#define __I2C3_FORCE_RESET __HAL_RCC_I2C3_FORCE_RESET
+#define __I2C3_RELEASE_RESET __HAL_RCC_I2C3_RELEASE_RESET
+#define __LCD_CLK_DISABLE __HAL_RCC_LCD_CLK_DISABLE
+#define __LCD_CLK_ENABLE __HAL_RCC_LCD_CLK_ENABLE
+#define __LCD_CLK_SLEEP_DISABLE __HAL_RCC_LCD_CLK_SLEEP_DISABLE
+#define __LCD_CLK_SLEEP_ENABLE __HAL_RCC_LCD_CLK_SLEEP_ENABLE
+#define __LCD_FORCE_RESET __HAL_RCC_LCD_FORCE_RESET
+#define __LCD_RELEASE_RESET __HAL_RCC_LCD_RELEASE_RESET
+#define __LPTIM1_CLK_DISABLE __HAL_RCC_LPTIM1_CLK_DISABLE
+#define __LPTIM1_CLK_ENABLE __HAL_RCC_LPTIM1_CLK_ENABLE
+#define __LPTIM1_CLK_SLEEP_DISABLE __HAL_RCC_LPTIM1_CLK_SLEEP_DISABLE
+#define __LPTIM1_CLK_SLEEP_ENABLE __HAL_RCC_LPTIM1_CLK_SLEEP_ENABLE
+#define __LPTIM1_FORCE_RESET __HAL_RCC_LPTIM1_FORCE_RESET
+#define __LPTIM1_RELEASE_RESET __HAL_RCC_LPTIM1_RELEASE_RESET
+#define __LPTIM2_CLK_DISABLE __HAL_RCC_LPTIM2_CLK_DISABLE
+#define __LPTIM2_CLK_ENABLE __HAL_RCC_LPTIM2_CLK_ENABLE
+#define __LPTIM2_CLK_SLEEP_DISABLE __HAL_RCC_LPTIM2_CLK_SLEEP_DISABLE
+#define __LPTIM2_CLK_SLEEP_ENABLE __HAL_RCC_LPTIM2_CLK_SLEEP_ENABLE
+#define __LPTIM2_FORCE_RESET __HAL_RCC_LPTIM2_FORCE_RESET
+#define __LPTIM2_RELEASE_RESET __HAL_RCC_LPTIM2_RELEASE_RESET
+#define __LPUART1_CLK_DISABLE __HAL_RCC_LPUART1_CLK_DISABLE
+#define __LPUART1_CLK_ENABLE __HAL_RCC_LPUART1_CLK_ENABLE
+#define __LPUART1_CLK_SLEEP_DISABLE __HAL_RCC_LPUART1_CLK_SLEEP_DISABLE
+#define __LPUART1_CLK_SLEEP_ENABLE __HAL_RCC_LPUART1_CLK_SLEEP_ENABLE
+#define __LPUART1_FORCE_RESET __HAL_RCC_LPUART1_FORCE_RESET
+#define __LPUART1_RELEASE_RESET __HAL_RCC_LPUART1_RELEASE_RESET
+#define __OPAMP_CLK_DISABLE __HAL_RCC_OPAMP_CLK_DISABLE
+#define __OPAMP_CLK_ENABLE __HAL_RCC_OPAMP_CLK_ENABLE
+#define __OPAMP_CLK_SLEEP_DISABLE __HAL_RCC_OPAMP_CLK_SLEEP_DISABLE
+#define __OPAMP_CLK_SLEEP_ENABLE __HAL_RCC_OPAMP_CLK_SLEEP_ENABLE
+#define __OPAMP_FORCE_RESET __HAL_RCC_OPAMP_FORCE_RESET
+#define __OPAMP_RELEASE_RESET __HAL_RCC_OPAMP_RELEASE_RESET
+#define __OTGFS_CLK_DISABLE __HAL_RCC_OTGFS_CLK_DISABLE
+#define __OTGFS_CLK_ENABLE __HAL_RCC_OTGFS_CLK_ENABLE
+#define __OTGFS_CLK_SLEEP_DISABLE __HAL_RCC_OTGFS_CLK_SLEEP_DISABLE
+#define __OTGFS_CLK_SLEEP_ENABLE __HAL_RCC_OTGFS_CLK_SLEEP_ENABLE
+#define __OTGFS_FORCE_RESET __HAL_RCC_OTGFS_FORCE_RESET
+#define __OTGFS_RELEASE_RESET __HAL_RCC_OTGFS_RELEASE_RESET
+#define __PWR_CLK_DISABLE __HAL_RCC_PWR_CLK_DISABLE
+#define __PWR_CLK_ENABLE __HAL_RCC_PWR_CLK_ENABLE
+#define __PWR_CLK_SLEEP_DISABLE __HAL_RCC_PWR_CLK_SLEEP_DISABLE
+#define __PWR_CLK_SLEEP_ENABLE __HAL_RCC_PWR_CLK_SLEEP_ENABLE
+#define __PWR_FORCE_RESET __HAL_RCC_PWR_FORCE_RESET
+#define __PWR_RELEASE_RESET __HAL_RCC_PWR_RELEASE_RESET
+#define __QSPI_CLK_DISABLE __HAL_RCC_QSPI_CLK_DISABLE
+#define __QSPI_CLK_ENABLE __HAL_RCC_QSPI_CLK_ENABLE
+#define __QSPI_CLK_SLEEP_DISABLE __HAL_RCC_QSPI_CLK_SLEEP_DISABLE
+#define __QSPI_CLK_SLEEP_ENABLE __HAL_RCC_QSPI_CLK_SLEEP_ENABLE
+#define __QSPI_FORCE_RESET __HAL_RCC_QSPI_FORCE_RESET
+#define __QSPI_RELEASE_RESET __HAL_RCC_QSPI_RELEASE_RESET
+#define __RNG_CLK_DISABLE __HAL_RCC_RNG_CLK_DISABLE
+#define __RNG_CLK_ENABLE __HAL_RCC_RNG_CLK_ENABLE
+#define __RNG_CLK_SLEEP_DISABLE __HAL_RCC_RNG_CLK_SLEEP_DISABLE
+#define __RNG_CLK_SLEEP_ENABLE __HAL_RCC_RNG_CLK_SLEEP_ENABLE
+#define __RNG_FORCE_RESET __HAL_RCC_RNG_FORCE_RESET
+#define __RNG_RELEASE_RESET __HAL_RCC_RNG_RELEASE_RESET
+#define __SAI1_CLK_DISABLE __HAL_RCC_SAI1_CLK_DISABLE
+#define __SAI1_CLK_ENABLE __HAL_RCC_SAI1_CLK_ENABLE
+#define __SAI1_CLK_SLEEP_DISABLE __HAL_RCC_SAI1_CLK_SLEEP_DISABLE
+#define __SAI1_CLK_SLEEP_ENABLE __HAL_RCC_SAI1_CLK_SLEEP_ENABLE
+#define __SAI1_FORCE_RESET __HAL_RCC_SAI1_FORCE_RESET
+#define __SAI1_RELEASE_RESET __HAL_RCC_SAI1_RELEASE_RESET
+#define __SAI2_CLK_DISABLE __HAL_RCC_SAI2_CLK_DISABLE
+#define __SAI2_CLK_ENABLE __HAL_RCC_SAI2_CLK_ENABLE
+#define __SAI2_CLK_SLEEP_DISABLE __HAL_RCC_SAI2_CLK_SLEEP_DISABLE
+#define __SAI2_CLK_SLEEP_ENABLE __HAL_RCC_SAI2_CLK_SLEEP_ENABLE
+#define __SAI2_FORCE_RESET __HAL_RCC_SAI2_FORCE_RESET
+#define __SAI2_RELEASE_RESET __HAL_RCC_SAI2_RELEASE_RESET
+#define __SDIO_CLK_DISABLE __HAL_RCC_SDIO_CLK_DISABLE
+#define __SDIO_CLK_ENABLE __HAL_RCC_SDIO_CLK_ENABLE
+#define __SDMMC_CLK_DISABLE __HAL_RCC_SDMMC_CLK_DISABLE
+#define __SDMMC_CLK_ENABLE __HAL_RCC_SDMMC_CLK_ENABLE
+#define __SDMMC_CLK_SLEEP_DISABLE __HAL_RCC_SDMMC_CLK_SLEEP_DISABLE
+#define __SDMMC_CLK_SLEEP_ENABLE __HAL_RCC_SDMMC_CLK_SLEEP_ENABLE
+#define __SDMMC_FORCE_RESET __HAL_RCC_SDMMC_FORCE_RESET
+#define __SDMMC_RELEASE_RESET __HAL_RCC_SDMMC_RELEASE_RESET
+#define __SPI1_CLK_DISABLE __HAL_RCC_SPI1_CLK_DISABLE
+#define __SPI1_CLK_ENABLE __HAL_RCC_SPI1_CLK_ENABLE
+#define __SPI1_CLK_SLEEP_DISABLE __HAL_RCC_SPI1_CLK_SLEEP_DISABLE
+#define __SPI1_CLK_SLEEP_ENABLE __HAL_RCC_SPI1_CLK_SLEEP_ENABLE
+#define __SPI1_FORCE_RESET __HAL_RCC_SPI1_FORCE_RESET
+#define __SPI1_RELEASE_RESET __HAL_RCC_SPI1_RELEASE_RESET
+#define __SPI2_CLK_DISABLE __HAL_RCC_SPI2_CLK_DISABLE
+#define __SPI2_CLK_ENABLE __HAL_RCC_SPI2_CLK_ENABLE
+#define __SPI2_CLK_SLEEP_DISABLE __HAL_RCC_SPI2_CLK_SLEEP_DISABLE
+#define __SPI2_CLK_SLEEP_ENABLE __HAL_RCC_SPI2_CLK_SLEEP_ENABLE
+#define __SPI2_FORCE_RESET __HAL_RCC_SPI2_FORCE_RESET
+#define __SPI2_RELEASE_RESET __HAL_RCC_SPI2_RELEASE_RESET
+#define __SPI3_CLK_DISABLE __HAL_RCC_SPI3_CLK_DISABLE
+#define __SPI3_CLK_ENABLE __HAL_RCC_SPI3_CLK_ENABLE
+#define __SPI3_CLK_SLEEP_DISABLE __HAL_RCC_SPI3_CLK_SLEEP_DISABLE
+#define __SPI3_CLK_SLEEP_ENABLE __HAL_RCC_SPI3_CLK_SLEEP_ENABLE
+#define __SPI3_FORCE_RESET __HAL_RCC_SPI3_FORCE_RESET
+#define __SPI3_RELEASE_RESET __HAL_RCC_SPI3_RELEASE_RESET
+#define __SRAM_CLK_DISABLE __HAL_RCC_SRAM_CLK_DISABLE
+#define __SRAM_CLK_ENABLE __HAL_RCC_SRAM_CLK_ENABLE
+#define __SRAM1_CLK_SLEEP_DISABLE __HAL_RCC_SRAM1_CLK_SLEEP_DISABLE
+#define __SRAM1_CLK_SLEEP_ENABLE __HAL_RCC_SRAM1_CLK_SLEEP_ENABLE
+#define __SRAM2_CLK_SLEEP_DISABLE __HAL_RCC_SRAM2_CLK_SLEEP_DISABLE
+#define __SRAM2_CLK_SLEEP_ENABLE __HAL_RCC_SRAM2_CLK_SLEEP_ENABLE
+#define __SWPMI1_CLK_DISABLE __HAL_RCC_SWPMI1_CLK_DISABLE
+#define __SWPMI1_CLK_ENABLE __HAL_RCC_SWPMI1_CLK_ENABLE
+#define __SWPMI1_CLK_SLEEP_DISABLE __HAL_RCC_SWPMI1_CLK_SLEEP_DISABLE
+#define __SWPMI1_CLK_SLEEP_ENABLE __HAL_RCC_SWPMI1_CLK_SLEEP_ENABLE
+#define __SWPMI1_FORCE_RESET __HAL_RCC_SWPMI1_FORCE_RESET
+#define __SWPMI1_RELEASE_RESET __HAL_RCC_SWPMI1_RELEASE_RESET
+#define __SYSCFG_CLK_DISABLE __HAL_RCC_SYSCFG_CLK_DISABLE
+#define __SYSCFG_CLK_ENABLE __HAL_RCC_SYSCFG_CLK_ENABLE
+#define __SYSCFG_CLK_SLEEP_DISABLE __HAL_RCC_SYSCFG_CLK_SLEEP_DISABLE
+#define __SYSCFG_CLK_SLEEP_ENABLE __HAL_RCC_SYSCFG_CLK_SLEEP_ENABLE
+#define __SYSCFG_FORCE_RESET __HAL_RCC_SYSCFG_FORCE_RESET
+#define __SYSCFG_RELEASE_RESET __HAL_RCC_SYSCFG_RELEASE_RESET
+#define __TIM1_CLK_DISABLE __HAL_RCC_TIM1_CLK_DISABLE
+#define __TIM1_CLK_ENABLE __HAL_RCC_TIM1_CLK_ENABLE
+#define __TIM1_CLK_SLEEP_DISABLE __HAL_RCC_TIM1_CLK_SLEEP_DISABLE
+#define __TIM1_CLK_SLEEP_ENABLE __HAL_RCC_TIM1_CLK_SLEEP_ENABLE
+#define __TIM1_FORCE_RESET __HAL_RCC_TIM1_FORCE_RESET
+#define __TIM1_RELEASE_RESET __HAL_RCC_TIM1_RELEASE_RESET
+#define __TIM10_CLK_DISABLE __HAL_RCC_TIM10_CLK_DISABLE
+#define __TIM10_CLK_ENABLE __HAL_RCC_TIM10_CLK_ENABLE
+#define __TIM10_FORCE_RESET __HAL_RCC_TIM10_FORCE_RESET
+#define __TIM10_RELEASE_RESET __HAL_RCC_TIM10_RELEASE_RESET
+#define __TIM11_CLK_DISABLE __HAL_RCC_TIM11_CLK_DISABLE
+#define __TIM11_CLK_ENABLE __HAL_RCC_TIM11_CLK_ENABLE
+#define __TIM11_FORCE_RESET __HAL_RCC_TIM11_FORCE_RESET
+#define __TIM11_RELEASE_RESET __HAL_RCC_TIM11_RELEASE_RESET
+#define __TIM12_CLK_DISABLE __HAL_RCC_TIM12_CLK_DISABLE
+#define __TIM12_CLK_ENABLE __HAL_RCC_TIM12_CLK_ENABLE
+#define __TIM12_FORCE_RESET __HAL_RCC_TIM12_FORCE_RESET
+#define __TIM12_RELEASE_RESET __HAL_RCC_TIM12_RELEASE_RESET
+#define __TIM13_CLK_DISABLE __HAL_RCC_TIM13_CLK_DISABLE
+#define __TIM13_CLK_ENABLE __HAL_RCC_TIM13_CLK_ENABLE
+#define __TIM13_FORCE_RESET __HAL_RCC_TIM13_FORCE_RESET
+#define __TIM13_RELEASE_RESET __HAL_RCC_TIM13_RELEASE_RESET
+#define __TIM14_CLK_DISABLE __HAL_RCC_TIM14_CLK_DISABLE
+#define __TIM14_CLK_ENABLE __HAL_RCC_TIM14_CLK_ENABLE
+#define __TIM14_FORCE_RESET __HAL_RCC_TIM14_FORCE_RESET
+#define __TIM14_RELEASE_RESET __HAL_RCC_TIM14_RELEASE_RESET
+#define __TIM15_CLK_DISABLE __HAL_RCC_TIM15_CLK_DISABLE
+#define __TIM15_CLK_ENABLE __HAL_RCC_TIM15_CLK_ENABLE
+#define __TIM15_CLK_SLEEP_DISABLE __HAL_RCC_TIM15_CLK_SLEEP_DISABLE
+#define __TIM15_CLK_SLEEP_ENABLE __HAL_RCC_TIM15_CLK_SLEEP_ENABLE
+#define __TIM15_FORCE_RESET __HAL_RCC_TIM15_FORCE_RESET
+#define __TIM15_RELEASE_RESET __HAL_RCC_TIM15_RELEASE_RESET
+#define __TIM16_CLK_DISABLE __HAL_RCC_TIM16_CLK_DISABLE
+#define __TIM16_CLK_ENABLE __HAL_RCC_TIM16_CLK_ENABLE
+#define __TIM16_CLK_SLEEP_DISABLE __HAL_RCC_TIM16_CLK_SLEEP_DISABLE
+#define __TIM16_CLK_SLEEP_ENABLE __HAL_RCC_TIM16_CLK_SLEEP_ENABLE
+#define __TIM16_FORCE_RESET __HAL_RCC_TIM16_FORCE_RESET
+#define __TIM16_RELEASE_RESET __HAL_RCC_TIM16_RELEASE_RESET
+#define __TIM17_CLK_DISABLE __HAL_RCC_TIM17_CLK_DISABLE
+#define __TIM17_CLK_ENABLE __HAL_RCC_TIM17_CLK_ENABLE
+#define __TIM17_CLK_SLEEP_DISABLE __HAL_RCC_TIM17_CLK_SLEEP_DISABLE
+#define __TIM17_CLK_SLEEP_ENABLE __HAL_RCC_TIM17_CLK_SLEEP_ENABLE
+#define __TIM17_FORCE_RESET __HAL_RCC_TIM17_FORCE_RESET
+#define __TIM17_RELEASE_RESET __HAL_RCC_TIM17_RELEASE_RESET
+#define __TIM2_CLK_DISABLE __HAL_RCC_TIM2_CLK_DISABLE
+#define __TIM2_CLK_ENABLE __HAL_RCC_TIM2_CLK_ENABLE
+#define __TIM2_CLK_SLEEP_DISABLE __HAL_RCC_TIM2_CLK_SLEEP_DISABLE
+#define __TIM2_CLK_SLEEP_ENABLE __HAL_RCC_TIM2_CLK_SLEEP_ENABLE
+#define __TIM2_FORCE_RESET __HAL_RCC_TIM2_FORCE_RESET
+#define __TIM2_RELEASE_RESET __HAL_RCC_TIM2_RELEASE_RESET
+#define __TIM3_CLK_DISABLE __HAL_RCC_TIM3_CLK_DISABLE
+#define __TIM3_CLK_ENABLE __HAL_RCC_TIM3_CLK_ENABLE
+#define __TIM3_CLK_SLEEP_DISABLE __HAL_RCC_TIM3_CLK_SLEEP_DISABLE
+#define __TIM3_CLK_SLEEP_ENABLE __HAL_RCC_TIM3_CLK_SLEEP_ENABLE
+#define __TIM3_FORCE_RESET __HAL_RCC_TIM3_FORCE_RESET
+#define __TIM3_RELEASE_RESET __HAL_RCC_TIM3_RELEASE_RESET
+#define __TIM4_CLK_DISABLE __HAL_RCC_TIM4_CLK_DISABLE
+#define __TIM4_CLK_ENABLE __HAL_RCC_TIM4_CLK_ENABLE
+#define __TIM4_CLK_SLEEP_DISABLE __HAL_RCC_TIM4_CLK_SLEEP_DISABLE
+#define __TIM4_CLK_SLEEP_ENABLE __HAL_RCC_TIM4_CLK_SLEEP_ENABLE
+#define __TIM4_FORCE_RESET __HAL_RCC_TIM4_FORCE_RESET
+#define __TIM4_RELEASE_RESET __HAL_RCC_TIM4_RELEASE_RESET
+#define __TIM5_CLK_DISABLE __HAL_RCC_TIM5_CLK_DISABLE
+#define __TIM5_CLK_ENABLE __HAL_RCC_TIM5_CLK_ENABLE
+#define __TIM5_CLK_SLEEP_DISABLE __HAL_RCC_TIM5_CLK_SLEEP_DISABLE
+#define __TIM5_CLK_SLEEP_ENABLE __HAL_RCC_TIM5_CLK_SLEEP_ENABLE
+#define __TIM5_FORCE_RESET __HAL_RCC_TIM5_FORCE_RESET
+#define __TIM5_RELEASE_RESET __HAL_RCC_TIM5_RELEASE_RESET
+#define __TIM6_CLK_DISABLE __HAL_RCC_TIM6_CLK_DISABLE
+#define __TIM6_CLK_ENABLE __HAL_RCC_TIM6_CLK_ENABLE
+#define __TIM6_CLK_SLEEP_DISABLE __HAL_RCC_TIM6_CLK_SLEEP_DISABLE
+#define __TIM6_CLK_SLEEP_ENABLE __HAL_RCC_TIM6_CLK_SLEEP_ENABLE
+#define __TIM6_FORCE_RESET __HAL_RCC_TIM6_FORCE_RESET
+#define __TIM6_RELEASE_RESET __HAL_RCC_TIM6_RELEASE_RESET
+#define __TIM7_CLK_DISABLE __HAL_RCC_TIM7_CLK_DISABLE
+#define __TIM7_CLK_ENABLE __HAL_RCC_TIM7_CLK_ENABLE
+#define __TIM7_CLK_SLEEP_DISABLE __HAL_RCC_TIM7_CLK_SLEEP_DISABLE
+#define __TIM7_CLK_SLEEP_ENABLE __HAL_RCC_TIM7_CLK_SLEEP_ENABLE
+#define __TIM7_FORCE_RESET __HAL_RCC_TIM7_FORCE_RESET
+#define __TIM7_RELEASE_RESET __HAL_RCC_TIM7_RELEASE_RESET
+#define __TIM8_CLK_DISABLE __HAL_RCC_TIM8_CLK_DISABLE
+#define __TIM8_CLK_ENABLE __HAL_RCC_TIM8_CLK_ENABLE
+#define __TIM8_CLK_SLEEP_DISABLE __HAL_RCC_TIM8_CLK_SLEEP_DISABLE
+#define __TIM8_CLK_SLEEP_ENABLE __HAL_RCC_TIM8_CLK_SLEEP_ENABLE
+#define __TIM8_FORCE_RESET __HAL_RCC_TIM8_FORCE_RESET
+#define __TIM8_RELEASE_RESET __HAL_RCC_TIM8_RELEASE_RESET
+#define __TIM9_CLK_DISABLE __HAL_RCC_TIM9_CLK_DISABLE
+#define __TIM9_CLK_ENABLE __HAL_RCC_TIM9_CLK_ENABLE
+#define __TIM9_FORCE_RESET __HAL_RCC_TIM9_FORCE_RESET
+#define __TIM9_RELEASE_RESET __HAL_RCC_TIM9_RELEASE_RESET
+#define __TSC_CLK_DISABLE __HAL_RCC_TSC_CLK_DISABLE
+#define __TSC_CLK_ENABLE __HAL_RCC_TSC_CLK_ENABLE
+#define __TSC_CLK_SLEEP_DISABLE __HAL_RCC_TSC_CLK_SLEEP_DISABLE
+#define __TSC_CLK_SLEEP_ENABLE __HAL_RCC_TSC_CLK_SLEEP_ENABLE
+#define __TSC_FORCE_RESET __HAL_RCC_TSC_FORCE_RESET
+#define __TSC_RELEASE_RESET __HAL_RCC_TSC_RELEASE_RESET
+#define __UART4_CLK_DISABLE __HAL_RCC_UART4_CLK_DISABLE
+#define __UART4_CLK_ENABLE __HAL_RCC_UART4_CLK_ENABLE
+#define __UART4_CLK_SLEEP_DISABLE __HAL_RCC_UART4_CLK_SLEEP_DISABLE
+#define __UART4_CLK_SLEEP_ENABLE __HAL_RCC_UART4_CLK_SLEEP_ENABLE
+#define __UART4_FORCE_RESET __HAL_RCC_UART4_FORCE_RESET
+#define __UART4_RELEASE_RESET __HAL_RCC_UART4_RELEASE_RESET
+#define __UART5_CLK_DISABLE __HAL_RCC_UART5_CLK_DISABLE
+#define __UART5_CLK_ENABLE __HAL_RCC_UART5_CLK_ENABLE
+#define __UART5_CLK_SLEEP_DISABLE __HAL_RCC_UART5_CLK_SLEEP_DISABLE
+#define __UART5_CLK_SLEEP_ENABLE __HAL_RCC_UART5_CLK_SLEEP_ENABLE
+#define __UART5_FORCE_RESET __HAL_RCC_UART5_FORCE_RESET
+#define __UART5_RELEASE_RESET __HAL_RCC_UART5_RELEASE_RESET
+#define __USART1_CLK_DISABLE __HAL_RCC_USART1_CLK_DISABLE
+#define __USART1_CLK_ENABLE __HAL_RCC_USART1_CLK_ENABLE
+#define __USART1_CLK_SLEEP_DISABLE __HAL_RCC_USART1_CLK_SLEEP_DISABLE
+#define __USART1_CLK_SLEEP_ENABLE __HAL_RCC_USART1_CLK_SLEEP_ENABLE
+#define __USART1_FORCE_RESET __HAL_RCC_USART1_FORCE_RESET
+#define __USART1_RELEASE_RESET __HAL_RCC_USART1_RELEASE_RESET
+#define __USART2_CLK_DISABLE __HAL_RCC_USART2_CLK_DISABLE
+#define __USART2_CLK_ENABLE __HAL_RCC_USART2_CLK_ENABLE
+#define __USART2_CLK_SLEEP_DISABLE __HAL_RCC_USART2_CLK_SLEEP_DISABLE
+#define __USART2_CLK_SLEEP_ENABLE __HAL_RCC_USART2_CLK_SLEEP_ENABLE
+#define __USART2_FORCE_RESET __HAL_RCC_USART2_FORCE_RESET
+#define __USART2_RELEASE_RESET __HAL_RCC_USART2_RELEASE_RESET
+#define __USART3_CLK_DISABLE __HAL_RCC_USART3_CLK_DISABLE
+#define __USART3_CLK_ENABLE __HAL_RCC_USART3_CLK_ENABLE
+#define __USART3_CLK_SLEEP_DISABLE __HAL_RCC_USART3_CLK_SLEEP_DISABLE
+#define __USART3_CLK_SLEEP_ENABLE __HAL_RCC_USART3_CLK_SLEEP_ENABLE
+#define __USART3_FORCE_RESET __HAL_RCC_USART3_FORCE_RESET
+#define __USART3_RELEASE_RESET __HAL_RCC_USART3_RELEASE_RESET
+#define __USART4_CLK_DISABLE        __HAL_RCC_USART4_CLK_DISABLE
+#define __USART4_CLK_ENABLE         __HAL_RCC_USART4_CLK_ENABLE
+#define __USART4_CLK_SLEEP_ENABLE   __HAL_RCC_USART4_CLK_SLEEP_ENABLE
+#define __USART4_CLK_SLEEP_DISABLE  __HAL_RCC_USART4_CLK_SLEEP_DISABLE 
+#define __USART4_FORCE_RESET        __HAL_RCC_USART4_FORCE_RESET
+#define __USART4_RELEASE_RESET      __HAL_RCC_USART4_RELEASE_RESET
+#define __USART5_CLK_DISABLE        __HAL_RCC_USART5_CLK_DISABLE
+#define __USART5_CLK_ENABLE         __HAL_RCC_USART5_CLK_ENABLE
+#define __USART5_CLK_SLEEP_ENABLE   __HAL_RCC_USART5_CLK_SLEEP_ENABLE
+#define __USART5_CLK_SLEEP_DISABLE  __HAL_RCC_USART5_CLK_SLEEP_DISABLE 
+#define __USART5_FORCE_RESET        __HAL_RCC_USART5_FORCE_RESET
+#define __USART5_RELEASE_RESET      __HAL_RCC_USART5_RELEASE_RESET
+#define __USART7_CLK_DISABLE        __HAL_RCC_USART7_CLK_DISABLE
+#define __USART7_CLK_ENABLE         __HAL_RCC_USART7_CLK_ENABLE
+#define __USART7_FORCE_RESET        __HAL_RCC_USART7_FORCE_RESET
+#define __USART7_RELEASE_RESET      __HAL_RCC_USART7_RELEASE_RESET
+#define __USART8_CLK_DISABLE        __HAL_RCC_USART8_CLK_DISABLE
+#define __USART8_CLK_ENABLE         __HAL_RCC_USART8_CLK_ENABLE
+#define __USART8_FORCE_RESET        __HAL_RCC_USART8_FORCE_RESET
+#define __USART8_RELEASE_RESET      __HAL_RCC_USART8_RELEASE_RESET
+#define __USB_CLK_DISABLE         __HAL_RCC_USB_CLK_DISABLE
+#define __USB_CLK_ENABLE          __HAL_RCC_USB_CLK_ENABLE
+#define __USB_FORCE_RESET         __HAL_RCC_USB_FORCE_RESET
+#define __USB_CLK_SLEEP_ENABLE    __HAL_RCC_USB_CLK_SLEEP_ENABLE
+#define __USB_CLK_SLEEP_DISABLE   __HAL_RCC_USB_CLK_SLEEP_DISABLE
+#define __USB_OTG_FS_CLK_DISABLE __HAL_RCC_USB_OTG_FS_CLK_DISABLE
+#define __USB_OTG_FS_CLK_ENABLE __HAL_RCC_USB_OTG_FS_CLK_ENABLE
+#define __USB_RELEASE_RESET __HAL_RCC_USB_RELEASE_RESET
+#define __WWDG_CLK_DISABLE __HAL_RCC_WWDG_CLK_DISABLE
+#define __WWDG_CLK_ENABLE __HAL_RCC_WWDG_CLK_ENABLE
+#define __WWDG_CLK_SLEEP_DISABLE __HAL_RCC_WWDG_CLK_SLEEP_DISABLE
+#define __WWDG_CLK_SLEEP_ENABLE __HAL_RCC_WWDG_CLK_SLEEP_ENABLE
+#define __WWDG_FORCE_RESET __HAL_RCC_WWDG_FORCE_RESET
+#define __WWDG_RELEASE_RESET __HAL_RCC_WWDG_RELEASE_RESET
+#define __TIM21_CLK_ENABLE   __HAL_RCC_TIM21_CLK_ENABLE
+#define __TIM21_CLK_DISABLE   __HAL_RCC_TIM21_CLK_DISABLE
+#define __TIM21_FORCE_RESET   __HAL_RCC_TIM21_FORCE_RESET
+#define __TIM21_RELEASE_RESET  __HAL_RCC_TIM21_RELEASE_RESET
+#define __TIM21_CLK_SLEEP_ENABLE   __HAL_RCC_TIM21_CLK_SLEEP_ENABLE
+#define __TIM21_CLK_SLEEP_DISABLE   __HAL_RCC_TIM21_CLK_SLEEP_DISABLE
+#define __TIM22_CLK_ENABLE   __HAL_RCC_TIM22_CLK_ENABLE
+#define __TIM22_CLK_DISABLE   __HAL_RCC_TIM22_CLK_DISABLE
+#define __TIM22_FORCE_RESET   __HAL_RCC_TIM22_FORCE_RESET
+#define __TIM22_RELEASE_RESET  __HAL_RCC_TIM22_RELEASE_RESET
+#define __TIM22_CLK_SLEEP_ENABLE   __HAL_RCC_TIM22_CLK_SLEEP_ENABLE
+#define __TIM22_CLK_SLEEP_DISABLE   __HAL_RCC_TIM22_CLK_SLEEP_DISABLE
+#define __CRS_CLK_DISABLE __HAL_RCC_CRS_CLK_DISABLE
+#define __CRS_CLK_ENABLE __HAL_RCC_CRS_CLK_ENABLE
+#define __CRS_CLK_SLEEP_DISABLE __HAL_RCC_CRS_CLK_SLEEP_DISABLE
+#define __CRS_CLK_SLEEP_ENABLE __HAL_RCC_CRS_CLK_SLEEP_ENABLE
+#define __CRS_FORCE_RESET __HAL_RCC_CRS_FORCE_RESET
+#define __CRS_RELEASE_RESET __HAL_RCC_CRS_RELEASE_RESET
+#define __RCC_BACKUPRESET_FORCE __HAL_RCC_BACKUPRESET_FORCE
+#define __RCC_BACKUPRESET_RELEASE __HAL_RCC_BACKUPRESET_RELEASE
+
+#define __USB_OTG_FS_FORCE_RESET  __HAL_RCC_USB_OTG_FS_FORCE_RESET
+#define __USB_OTG_FS_RELEASE_RESET  __HAL_RCC_USB_OTG_FS_RELEASE_RESET
+#define __USB_OTG_FS_CLK_SLEEP_ENABLE  __HAL_RCC_USB_OTG_FS_CLK_SLEEP_ENABLE
+#define __USB_OTG_FS_CLK_SLEEP_DISABLE  __HAL_RCC_USB_OTG_FS_CLK_SLEEP_DISABLE
+#define __USB_OTG_HS_CLK_DISABLE  __HAL_RCC_USB_OTG_HS_CLK_DISABLE
+#define __USB_OTG_HS_CLK_ENABLE          __HAL_RCC_USB_OTG_HS_CLK_ENABLE
+#define __USB_OTG_HS_ULPI_CLK_ENABLE  __HAL_RCC_USB_OTG_HS_ULPI_CLK_ENABLE
+#define __USB_OTG_HS_ULPI_CLK_DISABLE  __HAL_RCC_USB_OTG_HS_ULPI_CLK_DISABLE  
+#define __TIM9_CLK_SLEEP_ENABLE          __HAL_RCC_TIM9_CLK_SLEEP_ENABLE
+#define __TIM9_CLK_SLEEP_DISABLE  __HAL_RCC_TIM9_CLK_SLEEP_DISABLE  
+#define __TIM10_CLK_SLEEP_ENABLE  __HAL_RCC_TIM10_CLK_SLEEP_ENABLE
+#define __TIM10_CLK_SLEEP_DISABLE  __HAL_RCC_TIM10_CLK_SLEEP_DISABLE  
+#define __TIM11_CLK_SLEEP_ENABLE  __HAL_RCC_TIM11_CLK_SLEEP_ENABLE
+#define __TIM11_CLK_SLEEP_DISABLE  __HAL_RCC_TIM11_CLK_SLEEP_DISABLE  
+#define __ETHMACPTP_CLK_SLEEP_ENABLE  __HAL_RCC_ETHMACPTP_CLK_SLEEP_ENABLE
+#define __ETHMACPTP_CLK_SLEEP_DISABLE  __HAL_RCC_ETHMACPTP_CLK_SLEEP_DISABLE
+#define __ETHMACPTP_CLK_ENABLE          __HAL_RCC_ETHMACPTP_CLK_ENABLE
+#define __ETHMACPTP_CLK_DISABLE          __HAL_RCC_ETHMACPTP_CLK_DISABLE  
+#define __HASH_CLK_ENABLE          __HAL_RCC_HASH_CLK_ENABLE
+#define __HASH_FORCE_RESET          __HAL_RCC_HASH_FORCE_RESET
+#define __HASH_RELEASE_RESET          __HAL_RCC_HASH_RELEASE_RESET
+#define __HASH_CLK_SLEEP_ENABLE          __HAL_RCC_HASH_CLK_SLEEP_ENABLE
+#define __HASH_CLK_SLEEP_DISABLE  __HAL_RCC_HASH_CLK_SLEEP_DISABLE
+#define __HASH_CLK_DISABLE            __HAL_RCC_HASH_CLK_DISABLE  
+#define __SPI5_CLK_ENABLE          __HAL_RCC_SPI5_CLK_ENABLE
+#define __SPI5_CLK_DISABLE              __HAL_RCC_SPI5_CLK_DISABLE
+#define __SPI5_FORCE_RESET          __HAL_RCC_SPI5_FORCE_RESET
+#define __SPI5_RELEASE_RESET          __HAL_RCC_SPI5_RELEASE_RESET
+#define __SPI5_CLK_SLEEP_ENABLE          __HAL_RCC_SPI5_CLK_SLEEP_ENABLE
+#define __SPI5_CLK_SLEEP_DISABLE  __HAL_RCC_SPI5_CLK_SLEEP_DISABLE  
+#define __SPI6_CLK_ENABLE          __HAL_RCC_SPI6_CLK_ENABLE
+#define __SPI6_CLK_DISABLE          __HAL_RCC_SPI6_CLK_DISABLE
+#define __SPI6_FORCE_RESET          __HAL_RCC_SPI6_FORCE_RESET
+#define __SPI6_RELEASE_RESET         __HAL_RCC_SPI6_RELEASE_RESET
+#define __SPI6_CLK_SLEEP_ENABLE          __HAL_RCC_SPI6_CLK_SLEEP_ENABLE
+#define __SPI6_CLK_SLEEP_DISABLE  __HAL_RCC_SPI6_CLK_SLEEP_DISABLE  
+#define __LTDC_CLK_ENABLE          __HAL_RCC_LTDC_CLK_ENABLE
+#define __LTDC_CLK_DISABLE          __HAL_RCC_LTDC_CLK_DISABLE
+#define __LTDC_FORCE_RESET          __HAL_RCC_LTDC_FORCE_RESET
+#define __LTDC_RELEASE_RESET          __HAL_RCC_LTDC_RELEASE_RESET
+#define __LTDC_CLK_SLEEP_ENABLE          __HAL_RCC_LTDC_CLK_SLEEP_ENABLE  
+#define __ETHMAC_CLK_SLEEP_ENABLE  __HAL_RCC_ETHMAC_CLK_SLEEP_ENABLE
+#define __ETHMAC_CLK_SLEEP_DISABLE  __HAL_RCC_ETHMAC_CLK_SLEEP_DISABLE  
+#define __ETHMACTX_CLK_SLEEP_ENABLE  __HAL_RCC_ETHMACTX_CLK_SLEEP_ENABLE
+#define __ETHMACTX_CLK_SLEEP_DISABLE  __HAL_RCC_ETHMACTX_CLK_SLEEP_DISABLE  
+#define __ETHMACRX_CLK_SLEEP_ENABLE  __HAL_RCC_ETHMACRX_CLK_SLEEP_ENABLE
+#define __ETHMACRX_CLK_SLEEP_DISABLE  __HAL_RCC_ETHMACRX_CLK_SLEEP_DISABLE  
+#define __TIM12_CLK_SLEEP_ENABLE  __HAL_RCC_TIM12_CLK_SLEEP_ENABLE
+#define __TIM12_CLK_SLEEP_DISABLE  __HAL_RCC_TIM12_CLK_SLEEP_DISABLE  
+#define __TIM13_CLK_SLEEP_ENABLE  __HAL_RCC_TIM13_CLK_SLEEP_ENABLE
+#define __TIM13_CLK_SLEEP_DISABLE  __HAL_RCC_TIM13_CLK_SLEEP_DISABLE  
+#define __TIM14_CLK_SLEEP_ENABLE  __HAL_RCC_TIM14_CLK_SLEEP_ENABLE
+#define __TIM14_CLK_SLEEP_DISABLE  __HAL_RCC_TIM14_CLK_SLEEP_DISABLE  
+#define __BKPSRAM_CLK_ENABLE          __HAL_RCC_BKPSRAM_CLK_ENABLE
+#define __BKPSRAM_CLK_DISABLE          __HAL_RCC_BKPSRAM_CLK_DISABLE
+#define __BKPSRAM_CLK_SLEEP_ENABLE  __HAL_RCC_BKPSRAM_CLK_SLEEP_ENABLE
+#define __BKPSRAM_CLK_SLEEP_DISABLE  __HAL_RCC_BKPSRAM_CLK_SLEEP_DISABLE  
+#define __CCMDATARAMEN_CLK_ENABLE  __HAL_RCC_CCMDATARAMEN_CLK_ENABLE
+#define __CCMDATARAMEN_CLK_DISABLE  __HAL_RCC_CCMDATARAMEN_CLK_DISABLE  
+#define __USART6_CLK_ENABLE          __HAL_RCC_USART6_CLK_ENABLE
+#define __USART6_CLK_DISABLE          __HAL_RCC_USART6_CLK_DISABLE
+#define __USART6_FORCE_RESET        __HAL_RCC_USART6_FORCE_RESET
+#define __USART6_RELEASE_RESET        __HAL_RCC_USART6_RELEASE_RESET
+#define __USART6_CLK_SLEEP_ENABLE  __HAL_RCC_USART6_CLK_SLEEP_ENABLE
+#define __USART6_CLK_SLEEP_DISABLE  __HAL_RCC_USART6_CLK_SLEEP_DISABLE  
+#define __SPI4_CLK_ENABLE          __HAL_RCC_SPI4_CLK_ENABLE
+#define __SPI4_CLK_DISABLE          __HAL_RCC_SPI4_CLK_DISABLE
+#define __SPI4_FORCE_RESET          __HAL_RCC_SPI4_FORCE_RESET
+#define __SPI4_RELEASE_RESET        __HAL_RCC_SPI4_RELEASE_RESET
+#define __SPI4_CLK_SLEEP_ENABLE   __HAL_RCC_SPI4_CLK_SLEEP_ENABLE
+#define __SPI4_CLK_SLEEP_DISABLE  __HAL_RCC_SPI4_CLK_SLEEP_DISABLE  
+#define __GPIOI_CLK_ENABLE          __HAL_RCC_GPIOI_CLK_ENABLE
+#define __GPIOI_CLK_DISABLE          __HAL_RCC_GPIOI_CLK_DISABLE
+#define __GPIOI_FORCE_RESET          __HAL_RCC_GPIOI_FORCE_RESET
+#define __GPIOI_RELEASE_RESET          __HAL_RCC_GPIOI_RELEASE_RESET
+#define __GPIOI_CLK_SLEEP_ENABLE  __HAL_RCC_GPIOI_CLK_SLEEP_ENABLE
+#define __GPIOI_CLK_SLEEP_DISABLE  __HAL_RCC_GPIOI_CLK_SLEEP_DISABLE  
+#define __GPIOJ_CLK_ENABLE          __HAL_RCC_GPIOJ_CLK_ENABLE
+#define __GPIOJ_CLK_DISABLE          __HAL_RCC_GPIOJ_CLK_DISABLE
+#define __GPIOJ_FORCE_RESET         __HAL_RCC_GPIOJ_FORCE_RESET
+#define __GPIOJ_RELEASE_RESET          __HAL_RCC_GPIOJ_RELEASE_RESET
+#define __GPIOJ_CLK_SLEEP_ENABLE  __HAL_RCC_GPIOJ_CLK_SLEEP_ENABLE
+#define __GPIOJ_CLK_SLEEP_DISABLE  __HAL_RCC_GPIOJ_CLK_SLEEP_DISABLE  
+#define __GPIOK_CLK_ENABLE          __HAL_RCC_GPIOK_CLK_ENABLE
+#define __GPIOK_CLK_DISABLE          __HAL_RCC_GPIOK_CLK_DISABLE
+#define __GPIOK_RELEASE_RESET          __HAL_RCC_GPIOK_RELEASE_RESET
+#define __GPIOK_CLK_SLEEP_ENABLE  __HAL_RCC_GPIOK_CLK_SLEEP_ENABLE
+#define __GPIOK_CLK_SLEEP_DISABLE  __HAL_RCC_GPIOK_CLK_SLEEP_DISABLE  
+#define __ETH_CLK_ENABLE          __HAL_RCC_ETH_CLK_ENABLE
+#define __ETH_CLK_DISABLE          __HAL_RCC_ETH_CLK_DISABLE  
+#define __DCMI_CLK_ENABLE          __HAL_RCC_DCMI_CLK_ENABLE
+#define __DCMI_CLK_DISABLE          __HAL_RCC_DCMI_CLK_DISABLE
+#define __DCMI_FORCE_RESET          __HAL_RCC_DCMI_FORCE_RESET
+#define __DCMI_RELEASE_RESET          __HAL_RCC_DCMI_RELEASE_RESET
+#define __DCMI_CLK_SLEEP_ENABLE   __HAL_RCC_DCMI_CLK_SLEEP_ENABLE
+#define __DCMI_CLK_SLEEP_DISABLE  __HAL_RCC_DCMI_CLK_SLEEP_DISABLE  
+#define __UART7_CLK_ENABLE          __HAL_RCC_UART7_CLK_ENABLE
+#define __UART7_CLK_DISABLE          __HAL_RCC_UART7_CLK_DISABLE
+#define __UART7_RELEASE_RESET       __HAL_RCC_UART7_RELEASE_RESET
+#define __UART7_FORCE_RESET       __HAL_RCC_UART7_FORCE_RESET
+#define __UART7_CLK_SLEEP_ENABLE  __HAL_RCC_UART7_CLK_SLEEP_ENABLE
+#define __UART7_CLK_SLEEP_DISABLE  __HAL_RCC_UART7_CLK_SLEEP_DISABLE  
+#define __UART8_CLK_ENABLE          __HAL_RCC_UART8_CLK_ENABLE
+#define __UART8_CLK_DISABLE          __HAL_RCC_UART8_CLK_DISABLE
+#define __UART8_FORCE_RESET          __HAL_RCC_UART8_FORCE_RESET
+#define __UART8_RELEASE_RESET          __HAL_RCC_UART8_RELEASE_RESET
+#define __UART8_CLK_SLEEP_ENABLE  __HAL_RCC_UART8_CLK_SLEEP_ENABLE
+#define __UART8_CLK_SLEEP_DISABLE  __HAL_RCC_UART8_CLK_SLEEP_DISABLE  
+#define __OTGHS_CLK_SLEEP_ENABLE  __HAL_RCC_USB_OTG_HS_CLK_SLEEP_ENABLE
+#define __OTGHS_CLK_SLEEP_DISABLE  __HAL_RCC_USB_OTG_HS_CLK_SLEEP_DISABLE
+#define __OTGHS_FORCE_RESET          __HAL_RCC_USB_OTG_HS_FORCE_RESET
+#define __OTGHS_RELEASE_RESET          __HAL_RCC_USB_OTG_HS_RELEASE_RESET  
+#define __OTGHSULPI_CLK_SLEEP_ENABLE  __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_ENABLE
+#define __OTGHSULPI_CLK_SLEEP_DISABLE  __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_DISABLE
+#define __HAL_RCC_OTGHS_CLK_SLEEP_ENABLE  __HAL_RCC_USB_OTG_HS_CLK_SLEEP_ENABLE
+#define __HAL_RCC_OTGHS_CLK_SLEEP_DISABLE  __HAL_RCC_USB_OTG_HS_CLK_SLEEP_DISABLE
+#define __HAL_RCC_OTGHS_IS_CLK_SLEEP_ENABLED __HAL_RCC_USB_OTG_HS_IS_CLK_SLEEP_ENABLED
+#define __HAL_RCC_OTGHS_IS_CLK_SLEEP_DISABLED __HAL_RCC_USB_OTG_HS_IS_CLK_SLEEP_DISABLED
+#define __HAL_RCC_OTGHS_FORCE_RESET          __HAL_RCC_USB_OTG_HS_FORCE_RESET
+#define __HAL_RCC_OTGHS_RELEASE_RESET          __HAL_RCC_USB_OTG_HS_RELEASE_RESET  
+#define __HAL_RCC_OTGHSULPI_CLK_SLEEP_ENABLE  __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_ENABLE
+#define __HAL_RCC_OTGHSULPI_CLK_SLEEP_DISABLE  __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_DISABLE 
+#define __HAL_RCC_OTGHSULPI_IS_CLK_SLEEP_ENABLED __HAL_RCC_USB_OTG_HS_ULPI_IS_CLK_SLEEP_ENABLED
+#define __HAL_RCC_OTGHSULPI_IS_CLK_SLEEP_DISABLED __HAL_RCC_USB_OTG_HS_ULPI_IS_CLK_SLEEP_DISABLED   
+#define __CRYP_FORCE_RESET          __HAL_RCC_CRYP_FORCE_RESET  
+#define __SRAM3_CLK_SLEEP_ENABLE  __HAL_RCC_SRAM3_CLK_SLEEP_ENABLE  
+#define __CAN2_CLK_SLEEP_ENABLE          __HAL_RCC_CAN2_CLK_SLEEP_ENABLE
+#define __CAN2_CLK_SLEEP_DISABLE  __HAL_RCC_CAN2_CLK_SLEEP_DISABLE  
+#define __DAC_CLK_SLEEP_ENABLE          __HAL_RCC_DAC_CLK_SLEEP_ENABLE
+#define __DAC_CLK_SLEEP_DISABLE   __HAL_RCC_DAC_CLK_SLEEP_DISABLE  
+#define __ADC2_CLK_SLEEP_ENABLE   __HAL_RCC_ADC2_CLK_SLEEP_ENABLE
+#define __ADC2_CLK_SLEEP_DISABLE  __HAL_RCC_ADC2_CLK_SLEEP_DISABLE  
+#define __ADC3_CLK_SLEEP_ENABLE          __HAL_RCC_ADC3_CLK_SLEEP_ENABLE
+#define __ADC3_CLK_SLEEP_DISABLE  __HAL_RCC_ADC3_CLK_SLEEP_DISABLE  
+#define __FSMC_FORCE_RESET          __HAL_RCC_FSMC_FORCE_RESET
+#define __FSMC_RELEASE_RESET          __HAL_RCC_FSMC_RELEASE_RESET
+#define __FSMC_CLK_SLEEP_ENABLE          __HAL_RCC_FSMC_CLK_SLEEP_ENABLE
+#define __FSMC_CLK_SLEEP_DISABLE  __HAL_RCC_FSMC_CLK_SLEEP_DISABLE  
+#define __SDIO_FORCE_RESET          __HAL_RCC_SDIO_FORCE_RESET
+#define __SDIO_RELEASE_RESET          __HAL_RCC_SDIO_RELEASE_RESET
+#define __SDIO_CLK_SLEEP_DISABLE  __HAL_RCC_SDIO_CLK_SLEEP_DISABLE
+#define __SDIO_CLK_SLEEP_ENABLE          __HAL_RCC_SDIO_CLK_SLEEP_ENABLE  
+#define __DMA2D_CLK_ENABLE          __HAL_RCC_DMA2D_CLK_ENABLE
+#define __DMA2D_CLK_DISABLE          __HAL_RCC_DMA2D_CLK_DISABLE
+#define __DMA2D_FORCE_RESET          __HAL_RCC_DMA2D_FORCE_RESET
+#define __DMA2D_RELEASE_RESET          __HAL_RCC_DMA2D_RELEASE_RESET
+#define __DMA2D_CLK_SLEEP_ENABLE  __HAL_RCC_DMA2D_CLK_SLEEP_ENABLE
+#define __DMA2D_CLK_SLEEP_DISABLE  __HAL_RCC_DMA2D_CLK_SLEEP_DISABLE
+
+/* alias define maintained for legacy */
+#define __HAL_RCC_OTGFS_FORCE_RESET    __HAL_RCC_USB_OTG_FS_FORCE_RESET
+#define __HAL_RCC_OTGFS_RELEASE_RESET  __HAL_RCC_USB_OTG_FS_RELEASE_RESET
+
+#if defined(STM32F4)
+#define __HAL_RCC_SDMMC1_CLK_ENABLE        __HAL_RCC_SDIO_CLK_ENABLE
+#define __HAL_RCC_SDMMC1_FORCE_RESET       __HAL_RCC_SDIO_FORCE_RESET
+#define __HAL_RCC_SDMMC1_RELEASE_RESET     __HAL_RCC_SDIO_RELEASE_RESET
+#define __HAL_RCC_SDMMC1_CLK_SLEEP_ENABLE  __HAL_RCC_SDIO_CLK_SLEEP_ENABLE
+#define __HAL_RCC_SDMMC1_CLK_SLEEP_DISABLE __HAL_RCC_SDIO_CLK_SLEEP_DISABLE
+#define __HAL_RCC_SDMMC1_CLK_ENABLE        __HAL_RCC_SDIO_CLK_ENABLE
+#define __HAL_RCC_SDMMC1_CLK_DISABLE       __HAL_RCC_SDIO_CLK_DISABLE
+#define Sdmmc1ClockSelection               SdioClockSelection
+#define RCC_PERIPHCLK_SDMMC1               RCC_PERIPHCLK_SDIO
+#define RCC_SDMMC1CLKSOURCE_CLK48          RCC_SDIOCLKSOURCE_CK48
+#define RCC_SDMMC1CLKSOURCE_SYSCLK         RCC_SDIOCLKSOURCE_SYSCLK
+#define __HAL_RCC_SDMMC1_CONFIG            __HAL_RCC_SDIO_CONFIG
+#define __HAL_RCC_GET_SDMMC1_SOURCE        __HAL_RCC_GET_SDIO_SOURCE
+#endif
+
+#if defined(STM32F7) || defined(STM32L4)
+#define __HAL_RCC_SDIO_CLK_ENABLE          __HAL_RCC_SDMMC1_CLK_ENABLE
+#define __HAL_RCC_SDIO_FORCE_RESET         __HAL_RCC_SDMMC1_FORCE_RESET
+#define __HAL_RCC_SDIO_RELEASE_RESET       __HAL_RCC_SDMMC1_RELEASE_RESET
+#define __HAL_RCC_SDIO_CLK_SLEEP_ENABLE    __HAL_RCC_SDMMC1_CLK_SLEEP_ENABLE
+#define __HAL_RCC_SDIO_CLK_SLEEP_DISABLE   __HAL_RCC_SDMMC1_CLK_SLEEP_DISABLE
+#define __HAL_RCC_SDIO_CLK_ENABLE          __HAL_RCC_SDMMC1_CLK_ENABLE
+#define __HAL_RCC_SDIO_CLK_DISABLE         __HAL_RCC_SDMMC1_CLK_DISABLE
+#define SdioClockSelection                 Sdmmc1ClockSelection
+#define RCC_PERIPHCLK_SDIO                 RCC_PERIPHCLK_SDMMC1
+#define __HAL_RCC_SDIO_CONFIG              __HAL_RCC_SDMMC1_CONFIG
+#define __HAL_RCC_GET_SDIO_SOURCE          __HAL_RCC_GET_SDMMC1_SOURCE	
+#endif
+
+#if defined(STM32F7)
+#define RCC_SDIOCLKSOURCE_CK48             RCC_SDMMC1CLKSOURCE_CLK48
+#define RCC_SDIOCLKSOURCE_SYSCLK           RCC_SDMMC1CLKSOURCE_SYSCLK
+#endif
+
+#define __HAL_RCC_I2SCLK            __HAL_RCC_I2S_CONFIG
+#define __HAL_RCC_I2SCLK_CONFIG     __HAL_RCC_I2S_CONFIG
+
+#define __RCC_PLLSRC           RCC_GET_PLL_OSCSOURCE
+
+#define IS_RCC_MSIRANGE        IS_RCC_MSI_CLOCK_RANGE
+#define IS_RCC_RTCCLK_SOURCE   IS_RCC_RTCCLKSOURCE
+#define IS_RCC_SYSCLK_DIV      IS_RCC_HCLK
+#define IS_RCC_HCLK_DIV        IS_RCC_PCLK
+
+#define IS_RCC_MCOSOURCE       IS_RCC_MCO1SOURCE
+#define RCC_MCO_NODIV          RCC_MCODIV_1
+#define RCC_RTCCLKSOURCE_NONE  RCC_RTCCLKSOURCE_NO_CLK
+
+#define HSION_BitNumber        RCC_HSION_BIT_NUMBER
+#define CSSON_BitNumber        RCC_CSSON_BIT_NUMBER
+#define PLLON_BitNumber        RCC_PLLON_BIT_NUMBER
+#define PLLI2SON_BitNumber     RCC_PLLI2SON_BIT_NUMBER
+#define I2SSRC_BitNumber       RCC_I2SSRC_BIT_NUMBER
+#define RTCEN_BitNumber        RCC_RTCEN_BIT_NUMBER
+#define BDRST_BitNumber        RCC_BDRST_BIT_NUMBER
+#define LSION_BitNumber        RCC_LSION_BIT_NUMBER
+#define PLLSAION_BitNumber     RCC_PLLSAION_BIT_NUMBER
+#define TIMPRE_BitNumber       RCC_TIMPRE_BIT_NUMBER
+
+#define CR_BYTE2_ADDRESS       RCC_CR_BYTE2_ADDRESS
+#define CIR_BYTE1_ADDRESS      RCC_CIR_BYTE1_ADDRESS
+#define CIR_BYTE2_ADDRESS      RCC_CIR_BYTE2_ADDRESS
+#define BDCR_BYTE0_ADDRESS     RCC_BDCR_BYTE0_ADDRESS
+#define DBP_TIMEOUT_VALUE      RCC_DBP_TIMEOUT_VALUE
+#define LSE_TIMEOUT_VALUE      RCC_LSE_TIMEOUT_VALUE
+
+#define CR_HSION_BB            RCC_CR_HSION_BB
+#define CR_CSSON_BB            RCC_CR_CSSON_BB
+#define CR_PLLON_BB            RCC_CR_PLLON_BB
+#define CR_PLLI2SON_BB         RCC_CR_PLLI2SON_BB
+#define CR_MSION_BB            RCC_CR_MSION_BB
+#define CSR_LSION_BB           RCC_CSR_LSION_BB
+#define CSR_LSEON_BB           RCC_CSR_LSEON_BB
+#define CSR_LSEBYP_BB          RCC_CSR_LSEBYP_BB
+#define CSR_RTCEN_BB           RCC_CSR_RTCEN_BB
+#define CSR_RTCRST_BB          RCC_CSR_RTCRST_BB
+#define CFGR_I2SSRC_BB         RCC_CFGR_I2SSRC_BB
+#define BDCR_RTCEN_BB          RCC_BDCR_RTCEN_BB
+#define BDCR_BDRST_BB          RCC_BDCR_BDRST_BB
+#define CR_PLLSAION_BB         RCC_CR_PLLSAION_BB
+#define DCKCFGR_TIMPRE_BB      RCC_DCKCFGR_TIMPRE_BB
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_RNG_Aliased_Macros HAL RNG Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define  HAL_RNG_ReadyCallback(__HANDLE__)  HAL_RNG_ReadyDataCallback((__HANDLE__), uint32_t random32bit)                                       
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_RTC_Aliased_Macros HAL RTC Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+#define __HAL_RTC_CLEAR_FLAG                      __HAL_RTC_EXTI_CLEAR_FLAG
+#define __HAL_RTC_DISABLE_IT                      __HAL_RTC_EXTI_DISABLE_IT
+#define __HAL_RTC_ENABLE_IT                       __HAL_RTC_EXTI_ENABLE_IT
+
+#if defined (STM32F1)
+#define __HAL_RTC_EXTI_CLEAR_FLAG(RTC_EXTI_LINE_ALARM_EVENT)  __HAL_RTC_ALARM_EXTI_CLEAR_FLAG()
+
+#define __HAL_RTC_EXTI_ENABLE_IT(RTC_EXTI_LINE_ALARM_EVENT)   __HAL_RTC_ALARM_EXTI_ENABLE_IT()
+
+#define __HAL_RTC_EXTI_DISABLE_IT(RTC_EXTI_LINE_ALARM_EVENT)  __HAL_RTC_ALARM_EXTI_DISABLE_IT()
+
+#define __HAL_RTC_EXTI_GET_FLAG(RTC_EXTI_LINE_ALARM_EVENT)    __HAL_RTC_ALARM_EXTI_GET_FLAG()
+
+#define __HAL_RTC_EXTI_GENERATE_SWIT(RTC_EXTI_LINE_ALARM_EVENT)   __HAL_RTC_ALARM_EXTI_GENERATE_SWIT()
+#else
+#define __HAL_RTC_EXTI_CLEAR_FLAG(__EXTI_LINE__)  (((__EXTI_LINE__) == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_CLEAR_FLAG() : \
+                                                   (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_CLEAR_FLAG() : \
+                                                      __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG()))
+#define __HAL_RTC_EXTI_ENABLE_IT(__EXTI_LINE__)   (((__EXTI_LINE__)  == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_ENABLE_IT() : \
+                                                  (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT() : \
+                                                      __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT()))
+#define __HAL_RTC_EXTI_DISABLE_IT(__EXTI_LINE__)  (((__EXTI_LINE__) == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_DISABLE_IT() : \
+                                                  (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_IT() : \
+                                                      __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_IT()))
+#define __HAL_RTC_EXTI_GET_FLAG(__EXTI_LINE__)    (((__EXTI_LINE__) == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_GET_FLAG() : \
+                                                  (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_GET_FLAG() : \
+                                                      __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GET_FLAG()))
+#define __HAL_RTC_EXTI_GENERATE_SWIT(__EXTI_LINE__)   (((__EXTI_LINE__) == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_GENERATE_SWIT() : \
+                                                      (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_GENERATE_SWIT() :  \
+                                                          __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GENERATE_SWIT()))
+#endif   /* STM32F1 */
+
+#define IS_ALARM                                  IS_RTC_ALARM
+#define IS_ALARM_MASK                             IS_RTC_ALARM_MASK
+#define IS_TAMPER                                 IS_RTC_TAMPER
+#define IS_TAMPER_ERASE_MODE                      IS_RTC_TAMPER_ERASE_MODE
+#define IS_TAMPER_FILTER                          IS_RTC_TAMPER_FILTER 
+#define IS_TAMPER_INTERRUPT                       IS_RTC_TAMPER_INTERRUPT
+#define IS_TAMPER_MASKFLAG_STATE                  IS_RTC_TAMPER_MASKFLAG_STATE
+#define IS_TAMPER_PRECHARGE_DURATION              IS_RTC_TAMPER_PRECHARGE_DURATION
+#define IS_TAMPER_PULLUP_STATE                    IS_RTC_TAMPER_PULLUP_STATE
+#define IS_TAMPER_SAMPLING_FREQ                   IS_RTC_TAMPER_SAMPLING_FREQ
+#define IS_TAMPER_TIMESTAMPONTAMPER_DETECTION     IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION
+#define IS_TAMPER_TRIGGER                         IS_RTC_TAMPER_TRIGGER
+#define IS_WAKEUP_CLOCK                           IS_RTC_WAKEUP_CLOCK
+#define IS_WAKEUP_COUNTER                         IS_RTC_WAKEUP_COUNTER
+
+#define __RTC_WRITEPROTECTION_ENABLE  __HAL_RTC_WRITEPROTECTION_ENABLE
+#define __RTC_WRITEPROTECTION_DISABLE  __HAL_RTC_WRITEPROTECTION_DISABLE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SD_Aliased_Macros HAL SD Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define SD_OCR_CID_CSD_OVERWRIETE   SD_OCR_CID_CSD_OVERWRITE
+#define SD_CMD_SD_APP_STAUS         SD_CMD_SD_APP_STATUS
+
+#if defined(STM32F4)
+#define  SD_SDMMC_DISABLED          SD_SDIO_DISABLED
+#define  SD_SDMMC_FUNCTION_BUSY     SD_SDIO_FUNCTION_BUSY     
+#define  SD_SDMMC_FUNCTION_FAILED   SD_SDIO_FUNCTION_FAILED   
+#define  SD_SDMMC_UNKNOWN_FUNCTION  SD_SDIO_UNKNOWN_FUNCTION  
+#define  SD_CMD_SDMMC_SEN_OP_COND   SD_CMD_SDIO_SEN_OP_COND   
+#define  SD_CMD_SDMMC_RW_DIRECT     SD_CMD_SDIO_RW_DIRECT     
+#define  SD_CMD_SDMMC_RW_EXTENDED   SD_CMD_SDIO_RW_EXTENDED   
+#define  __HAL_SD_SDMMC_ENABLE      __HAL_SD_SDIO_ENABLE      
+#define  __HAL_SD_SDMMC_DISABLE     __HAL_SD_SDIO_DISABLE     
+#define  __HAL_SD_SDMMC_DMA_ENABLE  __HAL_SD_SDIO_DMA_ENABLE  
+#define  __HAL_SD_SDMMC_DMA_DISABLE __HAL_SD_SDIO_DMA_DISABL  
+#define  __HAL_SD_SDMMC_ENABLE_IT   __HAL_SD_SDIO_ENABLE_IT   
+#define  __HAL_SD_SDMMC_DISABLE_IT  __HAL_SD_SDIO_DISABLE_IT  
+#define  __HAL_SD_SDMMC_GET_FLAG    __HAL_SD_SDIO_GET_FLAG    
+#define  __HAL_SD_SDMMC_CLEAR_FLAG  __HAL_SD_SDIO_CLEAR_FLAG  
+#define  __HAL_SD_SDMMC_GET_IT      __HAL_SD_SDIO_GET_IT      
+#define  __HAL_SD_SDMMC_CLEAR_IT    __HAL_SD_SDIO_CLEAR_IT    
+#define  SDMMC_STATIC_FLAGS         SDIO_STATIC_FLAGS	       
+#define  SDMMC_CMD0TIMEOUT          SDIO_CMD0TIMEOUT	       
+#define  SD_SDMMC_SEND_IF_COND      SD_SDIO_SEND_IF_COND
+/* alias CMSIS */
+#define  SDMMC1_IRQn                SDIO_IRQn
+#define  SDMMC1_IRQHandler          SDIO_IRQHandler
+#endif
+
+#if defined(STM32F7) || defined(STM32L4)
+#define  SD_SDIO_DISABLED           SD_SDMMC_DISABLED
+#define  SD_SDIO_FUNCTION_BUSY      SD_SDMMC_FUNCTION_BUSY    
+#define  SD_SDIO_FUNCTION_FAILED    SD_SDMMC_FUNCTION_FAILED  
+#define  SD_SDIO_UNKNOWN_FUNCTION   SD_SDMMC_UNKNOWN_FUNCTION
+#define  SD_CMD_SDIO_SEN_OP_COND    SD_CMD_SDMMC_SEN_OP_COND
+#define  SD_CMD_SDIO_RW_DIRECT      SD_CMD_SDMMC_RW_DIRECT
+#define  SD_CMD_SDIO_RW_EXTENDED    SD_CMD_SDMMC_RW_EXTENDED
+#define  __HAL_SD_SDIO_ENABLE       __HAL_SD_SDMMC_ENABLE
+#define  __HAL_SD_SDIO_DISABLE      __HAL_SD_SDMMC_DISABLE
+#define  __HAL_SD_SDIO_DMA_ENABLE   __HAL_SD_SDMMC_DMA_ENABLE
+#define  __HAL_SD_SDIO_DMA_DISABL   __HAL_SD_SDMMC_DMA_DISABLE
+#define  __HAL_SD_SDIO_ENABLE_IT    __HAL_SD_SDMMC_ENABLE_IT
+#define  __HAL_SD_SDIO_DISABLE_IT   __HAL_SD_SDMMC_DISABLE_IT
+#define  __HAL_SD_SDIO_GET_FLAG     __HAL_SD_SDMMC_GET_FLAG
+#define  __HAL_SD_SDIO_CLEAR_FLAG   __HAL_SD_SDMMC_CLEAR_FLAG
+#define  __HAL_SD_SDIO_GET_IT       __HAL_SD_SDMMC_GET_IT
+#define  __HAL_SD_SDIO_CLEAR_IT     __HAL_SD_SDMMC_CLEAR_IT
+#define  SDIO_STATIC_FLAGS	        SDMMC_STATIC_FLAGS
+#define  SDIO_CMD0TIMEOUT	          SDMMC_CMD0TIMEOUT
+#define  SD_SDIO_SEND_IF_COND	      SD_SDMMC_SEND_IF_COND
+/* alias CMSIS for compatibilities */
+#define  SDIO_IRQn                  SDMMC1_IRQn
+#define  SDIO_IRQHandler            SDMMC1_IRQHandler
+#endif
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SMARTCARD_Aliased_Macros HAL SMARTCARD Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define __SMARTCARD_ENABLE_IT           __HAL_SMARTCARD_ENABLE_IT
+#define __SMARTCARD_DISABLE_IT          __HAL_SMARTCARD_DISABLE_IT
+#define __SMARTCARD_ENABLE              __HAL_SMARTCARD_ENABLE
+#define __SMARTCARD_DISABLE             __HAL_SMARTCARD_DISABLE
+#define __SMARTCARD_DMA_REQUEST_ENABLE  __HAL_SMARTCARD_DMA_REQUEST_ENABLE
+#define __SMARTCARD_DMA_REQUEST_DISABLE __HAL_SMARTCARD_DMA_REQUEST_DISABLE
+
+#define __HAL_SMARTCARD_GETCLOCKSOURCE  SMARTCARD_GETCLOCKSOURCE
+#define __SMARTCARD_GETCLOCKSOURCE      SMARTCARD_GETCLOCKSOURCE
+
+#define IS_SMARTCARD_ONEBIT_SAMPLING    IS_SMARTCARD_ONE_BIT_SAMPLE                  
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SMBUS_Aliased_Macros HAL SMBUS Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_SMBUS_RESET_CR1           SMBUS_RESET_CR1
+#define __HAL_SMBUS_RESET_CR2           SMBUS_RESET_CR2
+#define __HAL_SMBUS_GENERATE_START      SMBUS_GENERATE_START
+#define __HAL_SMBUS_GET_ADDR_MATCH      SMBUS_GET_ADDR_MATCH
+#define __HAL_SMBUS_GET_DIR             SMBUS_GET_DIR
+#define __HAL_SMBUS_GET_STOP_MODE       SMBUS_GET_STOP_MODE
+#define __HAL_SMBUS_GET_PEC_MODE        SMBUS_GET_PEC_MODE
+#define __HAL_SMBUS_GET_ALERT_ENABLED   SMBUS_GET_ALERT_ENABLED
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SPI_Aliased_Macros HAL SPI Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define __HAL_SPI_1LINE_TX              SPI_1LINE_TX
+#define __HAL_SPI_1LINE_RX              SPI_1LINE_RX
+#define __HAL_SPI_RESET_CRC             SPI_RESET_CRC
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_UART_Aliased_Macros HAL UART Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define __HAL_UART_GETCLOCKSOURCE       UART_GETCLOCKSOURCE
+#define __HAL_UART_MASK_COMPUTATION     UART_MASK_COMPUTATION
+#define __UART_GETCLOCKSOURCE           UART_GETCLOCKSOURCE
+#define __UART_MASK_COMPUTATION         UART_MASK_COMPUTATION
+
+#define IS_UART_WAKEUPMETHODE           IS_UART_WAKEUPMETHOD
+
+#define IS_UART_ONEBIT_SAMPLE           IS_UART_ONE_BIT_SAMPLE                  
+#define IS_UART_ONEBIT_SAMPLING         IS_UART_ONE_BIT_SAMPLE                  
+
+/**
+  * @}
+  */
+
+
+/** @defgroup HAL_USART_Aliased_Macros HAL USART Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define __USART_ENABLE_IT               __HAL_USART_ENABLE_IT
+#define __USART_DISABLE_IT              __HAL_USART_DISABLE_IT
+#define __USART_ENABLE                  __HAL_USART_ENABLE
+#define __USART_DISABLE                 __HAL_USART_DISABLE
+
+#define __HAL_USART_GETCLOCKSOURCE      USART_GETCLOCKSOURCE
+#define __USART_GETCLOCKSOURCE          USART_GETCLOCKSOURCE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_USB_Aliased_Macros HAL USB Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define USB_EXTI_LINE_WAKEUP                               USB_WAKEUP_EXTI_LINE
+
+#define USB_FS_EXTI_TRIGGER_RISING_EDGE                    USB_OTG_FS_WAKEUP_EXTI_RISING_EDGE
+#define USB_FS_EXTI_TRIGGER_FALLING_EDGE                   USB_OTG_FS_WAKEUP_EXTI_FALLING_EDGE
+#define USB_FS_EXTI_TRIGGER_BOTH_EDGE                      USB_OTG_FS_WAKEUP_EXTI_RISING_FALLING_EDGE
+#define USB_FS_EXTI_LINE_WAKEUP                            USB_OTG_FS_WAKEUP_EXTI_LINE
+
+#define USB_HS_EXTI_TRIGGER_RISING_EDGE                    USB_OTG_HS_WAKEUP_EXTI_RISING_EDGE
+#define USB_HS_EXTI_TRIGGER_FALLING_EDGE                   USB_OTG_HS_WAKEUP_EXTI_FALLING_EDGE
+#define USB_HS_EXTI_TRIGGER_BOTH_EDGE                      USB_OTG_HS_WAKEUP_EXTI_RISING_FALLING_EDGE
+#define USB_HS_EXTI_LINE_WAKEUP                            USB_OTG_HS_WAKEUP_EXTI_LINE
+
+#define __HAL_USB_EXTI_ENABLE_IT                           __HAL_USB_WAKEUP_EXTI_ENABLE_IT
+#define __HAL_USB_EXTI_DISABLE_IT                          __HAL_USB_WAKEUP_EXTI_DISABLE_IT
+#define __HAL_USB_EXTI_GET_FLAG                            __HAL_USB_WAKEUP_EXTI_GET_FLAG
+#define __HAL_USB_EXTI_CLEAR_FLAG                          __HAL_USB_WAKEUP_EXTI_CLEAR_FLAG
+#define __HAL_USB_EXTI_SET_RISING_EDGE_TRIGGER             __HAL_USB_WAKEUP_EXTI_ENABLE_RISING_EDGE
+#define __HAL_USB_EXTI_SET_FALLING_EDGE_TRIGGER            __HAL_USB_WAKEUP_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_USB_EXTI_SET_FALLINGRISING_TRIGGER           __HAL_USB_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE
+
+#define __HAL_USB_FS_EXTI_ENABLE_IT                        __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_IT
+#define __HAL_USB_FS_EXTI_DISABLE_IT                       __HAL_USB_OTG_FS_WAKEUP_EXTI_DISABLE_IT
+#define __HAL_USB_FS_EXTI_GET_FLAG                         __HAL_USB_OTG_FS_WAKEUP_EXTI_GET_FLAG
+#define __HAL_USB_FS_EXTI_CLEAR_FLAG                       __HAL_USB_OTG_FS_WAKEUP_EXTI_CLEAR_FLAG
+#define __HAL_USB_FS_EXTI_SET_RISING_EGDE_TRIGGER          __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_RISING_EDGE
+#define __HAL_USB_FS_EXTI_SET_FALLING_EGDE_TRIGGER         __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_USB_FS_EXTI_SET_FALLINGRISING_TRIGGER        __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE
+#define __HAL_USB_FS_EXTI_GENERATE_SWIT                    __HAL_USB_OTG_FS_WAKEUP_EXTI_GENERATE_SWIT
+
+#define __HAL_USB_HS_EXTI_ENABLE_IT                        __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_IT
+#define __HAL_USB_HS_EXTI_DISABLE_IT                       __HAL_USB_OTG_HS_WAKEUP_EXTI_DISABLE_IT
+#define __HAL_USB_HS_EXTI_GET_FLAG                         __HAL_USB_OTG_HS_WAKEUP_EXTI_GET_FLAG
+#define __HAL_USB_HS_EXTI_CLEAR_FLAG                       __HAL_USB_OTG_HS_WAKEUP_EXTI_CLEAR_FLAG
+#define __HAL_USB_HS_EXTI_SET_RISING_EGDE_TRIGGER          __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_RISING_EDGE
+#define __HAL_USB_HS_EXTI_SET_FALLING_EGDE_TRIGGER         __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_USB_HS_EXTI_SET_FALLINGRISING_TRIGGER        __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE
+#define __HAL_USB_HS_EXTI_GENERATE_SWIT                    __HAL_USB_OTG_HS_WAKEUP_EXTI_GENERATE_SWIT
+
+#define HAL_PCD_ActiveRemoteWakeup                         HAL_PCD_ActivateRemoteWakeup
+#define HAL_PCD_DeActiveRemoteWakeup                       HAL_PCD_DeActivateRemoteWakeup
+
+#define HAL_PCD_SetTxFiFo                                  HAL_PCDEx_SetTxFiFo
+#define HAL_PCD_SetRxFiFo                                  HAL_PCDEx_SetRxFiFo
+/**
+  * @}
+  */
+
+/** @defgroup HAL_TIM_Aliased_Macros HAL TIM Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_TIM_SetICPrescalerValue   TIM_SET_ICPRESCALERVALUE
+#define __HAL_TIM_ResetICPrescalerValue TIM_RESET_ICPRESCALERVALUE
+
+#define TIM_GET_ITSTATUS                __HAL_TIM_GET_IT_SOURCE
+#define TIM_GET_CLEAR_IT                __HAL_TIM_CLEAR_IT
+
+#define __HAL_TIM_GET_ITSTATUS          __HAL_TIM_GET_IT_SOURCE
+
+#define __HAL_TIM_DIRECTION_STATUS      __HAL_TIM_IS_TIM_COUNTING_DOWN
+#define __HAL_TIM_PRESCALER             __HAL_TIM_SET_PRESCALER
+#define __HAL_TIM_SetCounter            __HAL_TIM_SET_COUNTER
+#define __HAL_TIM_GetCounter            __HAL_TIM_GET_COUNTER
+#define __HAL_TIM_SetAutoreload         __HAL_TIM_SET_AUTORELOAD
+#define __HAL_TIM_GetAutoreload         __HAL_TIM_GET_AUTORELOAD
+#define __HAL_TIM_SetClockDivision      __HAL_TIM_SET_CLOCKDIVISION
+#define __HAL_TIM_GetClockDivision      __HAL_TIM_GET_CLOCKDIVISION
+#define __HAL_TIM_SetICPrescaler        __HAL_TIM_SET_ICPRESCALER
+#define __HAL_TIM_GetICPrescaler        __HAL_TIM_GET_ICPRESCALER
+#define __HAL_TIM_SetCompare            __HAL_TIM_SET_COMPARE
+#define __HAL_TIM_GetCompare            __HAL_TIM_GET_COMPARE
+
+#define TIM_TS_ITR0                        ((uint32_t)0x0000)
+#define TIM_TS_ITR1                        ((uint32_t)0x0010)
+#define TIM_TS_ITR2                        ((uint32_t)0x0020)
+#define TIM_TS_ITR3                        ((uint32_t)0x0030)
+#define IS_TIM_INTERNAL_TRIGGER_SELECTION(SELECTION) (((SELECTION) == TIM_TS_ITR0) || \
+                                                      ((SELECTION) == TIM_TS_ITR1) || \
+                                                      ((SELECTION) == TIM_TS_ITR2) || \
+                                                      ((SELECTION) == TIM_TS_ITR3))
+
+#define TIM_CHANNEL_1                      ((uint32_t)0x0000)
+#define TIM_CHANNEL_2                      ((uint32_t)0x0004)
+#define IS_TIM_PWMI_CHANNELS(CHANNEL) (((CHANNEL) == TIM_CHANNEL_1) || \
+                                       ((CHANNEL) == TIM_CHANNEL_2))
+
+#define TIM_OUTPUTNSTATE_DISABLE            ((uint32_t)0x0000)
+#define TIM_OUTPUTNSTATE_ENABLE             (TIM_CCER_CC1NE)
+
+#define IS_TIM_OUTPUTN_STATE(STATE) (((STATE) == TIM_OUTPUTNSTATE_DISABLE) || \
+                                     ((STATE) == TIM_OUTPUTNSTATE_ENABLE))
+
+#define TIM_OUTPUTSTATE_DISABLE            ((uint32_t)0x0000)
+#define TIM_OUTPUTSTATE_ENABLE             (TIM_CCER_CC1E)
+
+#define IS_TIM_OUTPUT_STATE(STATE) (((STATE) == TIM_OUTPUTSTATE_DISABLE) || \
+                                    ((STATE) == TIM_OUTPUTSTATE_ENABLE))  
+/**
+  * @}
+  */
+
+/** @defgroup HAL_ETH_Aliased_Macros HAL ETH Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+#define __HAL_ETH_EXTI_ENABLE_IT                   __HAL_ETH_WAKEUP_EXTI_ENABLE_IT
+#define __HAL_ETH_EXTI_DISABLE_IT                  __HAL_ETH_WAKEUP_EXTI_DISABLE_IT
+#define __HAL_ETH_EXTI_GET_FLAG                    __HAL_ETH_WAKEUP_EXTI_GET_FLAG
+#define __HAL_ETH_EXTI_CLEAR_FLAG                  __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG
+#define __HAL_ETH_EXTI_SET_RISING_EGDE_TRIGGER     __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE_TRIGGER
+#define __HAL_ETH_EXTI_SET_FALLING_EGDE_TRIGGER    __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE_TRIGGER
+#define __HAL_ETH_EXTI_SET_FALLINGRISING_TRIGGER   __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLINGRISING_TRIGGER
+
+#define ETH_PROMISCIOUSMODE_ENABLE   ETH_PROMISCUOUS_MODE_ENABLE 
+#define ETH_PROMISCIOUSMODE_DISABLE  ETH_PROMISCUOUS_MODE_DISABLE
+#define IS_ETH_PROMISCIOUS_MODE      IS_ETH_PROMISCUOUS_MODE
+/**
+  * @}
+  */
+
+/** @defgroup HAL_LTDC_Aliased_Macros HAL LTDC Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_LTDC_LAYER LTDC_LAYER
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SAI_Aliased_Macros HAL SAI Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define SAI_OUTPUTDRIVE_DISABLED          SAI_OUTPUTDRIVE_DISABLE
+#define SAI_OUTPUTDRIVE_ENABLED           SAI_OUTPUTDRIVE_ENABLE
+#define SAI_MASTERDIVIDER_ENABLED         SAI_MASTERDIVIDER_ENABLE
+#define SAI_MASTERDIVIDER_DISABLED        SAI_MASTERDIVIDER_DISABLE
+#define SAI_STREOMODE                     SAI_STEREOMODE
+#define SAI_FIFOStatus_Empty              SAI_FIFOSTATUS_EMPTY              
+#define SAI_FIFOStatus_Less1QuarterFull   SAI_FIFOSTATUS_LESS1QUARTERFULL    
+#define SAI_FIFOStatus_1QuarterFull       SAI_FIFOSTATUS_1QUARTERFULL       
+#define SAI_FIFOStatus_HalfFull           SAI_FIFOSTATUS_HALFFULL           
+#define SAI_FIFOStatus_3QuartersFull      SAI_FIFOSTATUS_3QUARTERFULL       
+#define SAI_FIFOStatus_Full               SAI_FIFOSTATUS_FULL               
+#define IS_SAI_BLOCK_MONO_STREO_MODE     IS_SAI_BLOCK_MONO_STEREO_MODE
+
+/**
+  * @}
+  */
+
+
+/** @defgroup HAL_PPP_Aliased_Macros HAL PPP Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ___STM32_HAL_LEGACY */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/stmhal/hal/f7/inc/stm32f7xx_hal.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal.h
@@ -1,0 +1,209 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   This file contains all the functions prototypes for the HAL
+  *          module driver.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_H
+#define __STM32F7xx_HAL_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_conf.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup HAL
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup HAL_Exported_Macros HAL Exported Macros
+  * @{
+  */
+
+/** @brief  Freeze/Unfreeze Peripherals in Debug mode
+  */
+#define __HAL_DBGMCU_FREEZE_TIM2()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM2_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM3()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM3_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM4()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM4_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM5()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM5_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM6()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM6_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM7()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM7_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM12()          (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM12_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM13()          (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM13_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM14()          (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM14_STOP))
+#define __HAL_DBGMCU_FREEZE_LPTIM1()         (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_LPTIM1_STOP))
+#define __HAL_DBGMCU_FREEZE_RTC()            (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_RTC_STOP))
+#define __HAL_DBGMCU_FREEZE_WWDG()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_WWDG_STOP))
+#define __HAL_DBGMCU_FREEZE_IWDG()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_IWDG_STOP))
+#define __HAL_DBGMCU_FREEZE_I2C1_TIMEOUT()   (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_I2C1_SMBUS_TIMEOUT))
+#define __HAL_DBGMCU_FREEZE_I2C2_TIMEOUT()   (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_I2C2_SMBUS_TIMEOUT))
+#define __HAL_DBGMCU_FREEZE_I2C3_TIMEOUT()   (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_I2C3_SMBUS_TIMEOUT))
+#define __HAL_DBGMCU_FREEZE_I2C4_TIMEOUT()   (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_I2C4_SMBUS_TIMEOUT))
+#define __HAL_DBGMCU_FREEZE_CAN1()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_CAN1_STOP))
+#define __HAL_DBGMCU_FREEZE_CAN2()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_CAN2_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM1()           (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM1_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM8()           (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM8_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM9()           (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM9_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM10()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM10_STOP))
+#define __HAL_DBGMCU_FREEZE_TIM11()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM11_STOP))
+
+#define __HAL_DBGMCU_UNFREEZE_TIM2()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM2_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM3()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM3_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM4()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM4_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM5()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM5_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM6()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM6_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM7()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM7_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM12()          (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM12_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM13()          (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM13_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM14()          (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM14_STOP))
+#define __HAL_DBGMCU_UNFREEZE_LPTIM1()         (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_LPTIM1_STOP))
+#define __HAL_DBGMCU_UNFREEZE_RTC()            (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_RTC_STOP))
+#define __HAL_DBGMCU_UNFREEZE_WWDG()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_WWDG_STOP))
+#define __HAL_DBGMCU_UNFREEZE_IWDG()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_IWDG_STOP))
+#define __HAL_DBGMCU_UNFREEZE_I2C1_TIMEOUT()   (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_I2C1_SMBUS_TIMEOUT))
+#define __HAL_DBGMCU_UNFREEZE_I2C2_TIMEOUT()   (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_I2C2_SMBUS_TIMEOUT))
+#define __HAL_DBGMCU_UNFREEZE_I2C3_TIMEOUT()   (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_I2C3_SMBUS_TIMEOUT))
+#define __HAL_DBGMCU_UNFREEZE_I2C4_TIMEOUT()   (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_I2C4_SMBUS_TIMEOUT))
+#define __HAL_DBGMCU_UNFREEZE_CAN1()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_CAN1_STOP))
+#define __HAL_DBGMCU_UNFREEZE_CAN2()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_CAN2_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM1()           (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM1_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM8()           (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM8_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM9()           (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM9_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM10()          (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM10_STOP))
+#define __HAL_DBGMCU_UNFREEZE_TIM11()          (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM11_STOP))
+
+
+/** @brief  FMC (NOR/RAM) mapped at 0x60000000 and SDRAM mapped at 0xC0000000
+  */
+#define __HAL_SYSCFG_REMAPMEMORY_FMC()          (SYSCFG->MEMRMP &= ~(SYSCFG_MEMRMP_SWP_FMC))
+
+
+/** @brief  FMC/SDRAM  mapped at 0x60000000 (NOR/RAM) mapped at 0xC0000000
+  */
+#define __HAL_SYSCFG_REMAPMEMORY_FMC_SDRAM() do {SYSCFG->MEMRMP &= ~(SYSCFG_MEMRMP_SWP_FMC);\
+                                          SYSCFG->MEMRMP |= (SYSCFG_MEMRMP_SWP_FMC_0);\
+                                         }while(0);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup HAL_Exported_Functions
+  * @{
+  */
+/** @addtogroup HAL_Exported_Functions_Group1
+  * @{
+  */
+/* Initialization and de-initialization functions  ******************************/
+HAL_StatusTypeDef HAL_Init(void);
+HAL_StatusTypeDef HAL_DeInit(void);
+void HAL_MspInit(void);
+void HAL_MspDeInit(void);
+HAL_StatusTypeDef HAL_InitTick (uint32_t TickPriority);
+/**
+  * @}
+  */
+
+/** @addtogroup HAL_Exported_Functions_Group2
+  * @{
+  */
+/* Peripheral Control functions  ************************************************/
+void HAL_IncTick(void);
+void HAL_Delay(__IO uint32_t Delay);
+uint32_t HAL_GetTick(void);
+void HAL_SuspendTick(void);
+void HAL_ResumeTick(void);
+uint32_t HAL_GetHalVersion(void);
+uint32_t HAL_GetREVID(void);
+uint32_t HAL_GetDEVID(void);
+void HAL_DBGMCU_EnableDBGSleepMode(void);
+void HAL_DBGMCU_DisableDBGSleepMode(void);
+void HAL_DBGMCU_EnableDBGStopMode(void);
+void HAL_DBGMCU_DisableDBGStopMode(void);
+void HAL_DBGMCU_EnableDBGStandbyMode(void);
+void HAL_DBGMCU_DisableDBGStandbyMode(void);
+void HAL_EnableCompensationCell(void);
+void HAL_DisableCompensationCell(void);
+void HAL_EnableFMCMemorySwapping(void);
+void HAL_DisableFMCMemorySwapping(void);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup HAL_Private_Variables HAL Private Variables
+  * @{
+  */
+/**
+  * @}
+  */
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup HAL_Private_Constants HAL Private Constants
+  * @{
+  */
+/**
+  * @}
+  */
+/* Private macros ------------------------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_adc.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_adc.h
@@ -1,0 +1,765 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_adc.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of ADC HAL extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_ADC_H
+#define __STM32F7xx_ADC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ADC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup ADC_Exported_Types ADC Exported Types
+  * @{
+  */
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef enum
+{
+  HAL_ADC_STATE_RESET                   = 0x00,    /*!< ADC not yet initialized or disabled */
+  HAL_ADC_STATE_READY                   = 0x01,    /*!< ADC peripheral ready for use */
+  HAL_ADC_STATE_BUSY                    = 0x02,    /*!< An internal process is ongoing */
+  HAL_ADC_STATE_BUSY_REG                = 0x12,    /*!< Regular conversion is ongoing */
+  HAL_ADC_STATE_BUSY_INJ                = 0x22,    /*!< Injected conversion is ongoing */
+  HAL_ADC_STATE_BUSY_INJ_REG            = 0x32,    /*!< Injected and regular conversion are ongoing */
+  HAL_ADC_STATE_TIMEOUT                 = 0x03,    /*!< Timeout state */
+  HAL_ADC_STATE_ERROR                   = 0x04,    /*!< ADC state error */
+  HAL_ADC_STATE_EOC                     = 0x05,    /*!< Conversion is completed */
+  HAL_ADC_STATE_EOC_REG                 = 0x15,    /*!< Regular conversion is completed */
+  HAL_ADC_STATE_EOC_INJ                 = 0x25,    /*!< Injected conversion is completed */
+  HAL_ADC_STATE_EOC_INJ_REG             = 0x35,    /*!< Injected and regular conversion are completed */
+  HAL_ADC_STATE_AWD                     = 0x06    /*!< ADC state analog watchdog */
+
+}HAL_ADC_StateTypeDef;
+
+/**
+  * @brief   ADC Init structure definition
+  */
+typedef struct
+{
+  uint32_t ClockPrescaler;        /*!< Select the frequency of the clock to the ADC. The clock is common for
+                                       all the ADCs.
+                                       This parameter can be a value of @ref ADC_ClockPrescaler */
+  uint32_t Resolution;            /*!< Configures the ADC resolution dual mode.
+                                       This parameter can be a value of @ref ADC_Resolution */
+  uint32_t DataAlign;             /*!< Specifies whether the ADC data  alignment is left or right.
+                                       This parameter can be a value of @ref ADC_data_align */
+  uint32_t ScanConvMode;          /*!< Specifies whether the conversion is performed in Scan (multi channels) or
+                                       Single (one channel) mode.
+                                       This parameter can be set to ENABLE or DISABLE */
+  uint32_t EOCSelection;          /*!< Specifies whether the EOC flag is set
+                                       at the end of single channel conversion or at the end of all conversions.
+                                       This parameter can be a value of @ref ADC_EOCSelection */
+  uint32_t ContinuousConvMode;    /*!< Specifies whether the conversion is performed in Continuous or Single mode.
+                                       This parameter can be set to ENABLE or DISABLE. */
+  uint32_t DMAContinuousRequests; /*!< Specifies whether the DMA requests is performed in Continuous or in Single mode.
+                                       This parameter can be set to ENABLE or DISABLE. */
+  uint32_t NbrOfConversion;       /*!< Specifies the number of ADC conversions that will be done using the sequencer for
+                                       regular channel group.
+                                       This parameter must be a number between Min_Data = 1 and Max_Data = 16. */
+  uint32_t DiscontinuousConvMode; /*!< Specifies whether the conversion is performed in Discontinuous or not
+                                       for regular channels.
+                                       This parameter can be set to ENABLE or DISABLE. */
+  uint32_t NbrOfDiscConversion;   /*!< Specifies the number of ADC discontinuous conversions that will be done
+                                       using the sequencer for regular channel group.
+                                       This parameter must be a number between Min_Data = 1 and Max_Data = 8. */
+  uint32_t ExternalTrigConv;      /*!< Selects the external event used to trigger the conversion start of regular group.
+                                       If set to ADC_SOFTWARE_START, external triggers are disabled.
+                                       This parameter can be a value of @ref ADC_External_trigger_Source_Regular
+                                       Note: This parameter can be modified only if there is no conversion is ongoing. */
+  uint32_t ExternalTrigConvEdge;  /*!< Selects the external trigger edge of regular group.
+                                       If trigger is set to ADC_SOFTWARE_START, this parameter is discarded.
+                                       This parameter can be a value of @ref ADC_External_trigger_edge_Regular
+                                       Note: This parameter can be modified only if there is no conversion is ongoing. */
+}ADC_InitTypeDef;
+
+/**
+  * @brief  ADC handle Structure definition
+  */
+typedef struct
+{
+  ADC_TypeDef                   *Instance;                   /*!< Register base address */
+
+  ADC_InitTypeDef               Init;                        /*!< ADC required parameters */
+
+  __IO uint32_t                 NbrOfCurrentConversionRank;  /*!< ADC number of current conversion rank */
+
+  DMA_HandleTypeDef             *DMA_Handle;                 /*!< Pointer DMA Handler */
+
+  HAL_LockTypeDef               Lock;                        /*!< ADC locking object */
+
+  __IO HAL_ADC_StateTypeDef     State;                       /*!< ADC communication state */
+
+  __IO uint32_t                 ErrorCode;                   /*!< ADC Error code */
+}ADC_HandleTypeDef;
+
+/**
+  * @brief   ADC Configuration regular Channel structure definition
+  */
+typedef struct
+{
+  uint32_t Channel;        /*!< The ADC channel to configure.
+                                This parameter can be a value of @ref ADC_channels */
+  uint32_t Rank;           /*!< The rank in the regular group sequencer.
+                                This parameter must be a number between Min_Data = 1 and Max_Data = 16 */
+  uint32_t SamplingTime;   /*!< The sample time value to be set for the selected channel.
+                                This parameter can be a value of @ref ADC_sampling_times */
+  uint32_t Offset;         /*!< Reserved for future use, can be set to 0 */
+}ADC_ChannelConfTypeDef;
+
+/**
+  * @brief   ADC Configuration multi-mode structure definition
+  */
+typedef struct
+{
+  uint32_t WatchdogMode;      /*!< Configures the ADC analog watchdog mode.
+                                   This parameter can be a value of @ref ADC_analog_watchdog_selection */
+  uint32_t HighThreshold;     /*!< Configures the ADC analog watchdog High threshold value.
+                                   This parameter must be a 12-bit value. */
+  uint32_t LowThreshold;      /*!< Configures the ADC analog watchdog High threshold value.
+                                   This parameter must be a 12-bit value. */
+  uint32_t Channel;           /*!< Configures ADC channel for the analog watchdog.
+                                   This parameter has an effect only if watchdog mode is configured on single channel
+                                   This parameter can be a value of @ref ADC_channels */
+  uint32_t ITMode;            /*!< Specifies whether the analog watchdog is configured
+                                   is interrupt mode or in polling mode.
+                                   This parameter can be set to ENABLE or DISABLE */
+  uint32_t WatchdogNumber;    /*!< Reserved for future use, can be set to 0 */
+}ADC_AnalogWDGConfTypeDef;
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup ADC_Exported_Constants ADC Exported Constants
+  * @{
+  */
+
+
+/** @defgroup ADC_Error_Code ADC Error Code
+  * @{
+  */
+
+#define HAL_ADC_ERROR_NONE        ((uint32_t)0x00)   /*!< No error             */
+#define HAL_ADC_ERROR_OVR         ((uint32_t)0x01)   /*!< OVR error            */
+#define HAL_ADC_ERROR_DMA         ((uint32_t)0x02)   /*!< DMA transfer error   */
+/**
+  * @}
+  */
+
+
+/** @defgroup ADC_ClockPrescaler ADC Clock Prescaler
+  * @{
+  */
+#define ADC_CLOCK_SYNC_PCLK_DIV2    ((uint32_t)0x00000000)
+#define ADC_CLOCK_SYNC_PCLK_DIV4    ((uint32_t)ADC_CCR_ADCPRE_0)
+#define ADC_CLOCK_SYNC_PCLK_DIV6    ((uint32_t)ADC_CCR_ADCPRE_1)
+#define ADC_CLOCK_SYNC_PCLK_DIV8    ((uint32_t)ADC_CCR_ADCPRE)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_delay_between_2_sampling_phases ADC Delay Between 2 Sampling Phases
+  * @{
+  */
+#define ADC_TWOSAMPLINGDELAY_5CYCLES    ((uint32_t)0x00000000)
+#define ADC_TWOSAMPLINGDELAY_6CYCLES    ((uint32_t)ADC_CCR_DELAY_0)
+#define ADC_TWOSAMPLINGDELAY_7CYCLES    ((uint32_t)ADC_CCR_DELAY_1)
+#define ADC_TWOSAMPLINGDELAY_8CYCLES    ((uint32_t)(ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_9CYCLES    ((uint32_t)ADC_CCR_DELAY_2)
+#define ADC_TWOSAMPLINGDELAY_10CYCLES   ((uint32_t)(ADC_CCR_DELAY_2 | ADC_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_11CYCLES   ((uint32_t)(ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1))
+#define ADC_TWOSAMPLINGDELAY_12CYCLES   ((uint32_t)(ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_13CYCLES   ((uint32_t)ADC_CCR_DELAY_3)
+#define ADC_TWOSAMPLINGDELAY_14CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_15CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_1))
+#define ADC_TWOSAMPLINGDELAY_16CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_17CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_2))
+#define ADC_TWOSAMPLINGDELAY_18CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_2 | ADC_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_19CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1))
+#define ADC_TWOSAMPLINGDELAY_20CYCLES   ((uint32_t)ADC_CCR_DELAY)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Resolution ADC Resolution
+  * @{
+  */
+#define ADC_RESOLUTION_12B  ((uint32_t)0x00000000)
+#define ADC_RESOLUTION_10B  ((uint32_t)ADC_CR1_RES_0)
+#define ADC_RESOLUTION_8B   ((uint32_t)ADC_CR1_RES_1)
+#define ADC_RESOLUTION_6B   ((uint32_t)ADC_CR1_RES)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_External_trigger_edge_Regular ADC External Trigger Edge Regular
+  * @{
+  */
+#define ADC_EXTERNALTRIGCONVEDGE_NONE           ((uint32_t)0x00000000)
+#define ADC_EXTERNALTRIGCONVEDGE_RISING         ((uint32_t)ADC_CR2_EXTEN_0)
+#define ADC_EXTERNALTRIGCONVEDGE_FALLING        ((uint32_t)ADC_CR2_EXTEN_1)
+#define ADC_EXTERNALTRIGCONVEDGE_RISINGFALLING  ((uint32_t)ADC_CR2_EXTEN)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_External_trigger_Source_Regular ADC External Trigger Source Regular
+  * @{
+  */
+/* Note: Parameter ADC_SOFTWARE_START is a software parameter used for        */
+/*       compatibility with other STM32 devices.                              */
+#define ADC_EXTERNALTRIGCONV_T1_CC1    ((uint32_t)0x00000000)
+#define ADC_EXTERNALTRIGCONV_T1_CC2    ((uint32_t)ADC_CR2_EXTSEL_0)
+#define ADC_EXTERNALTRIGCONV_T1_CC3    ((uint32_t)ADC_CR2_EXTSEL_1)
+#define ADC_EXTERNALTRIGCONV_T2_CC2    ((uint32_t)(ADC_CR2_EXTSEL_1 | ADC_CR2_EXTSEL_0))
+#define ADC_EXTERNALTRIGCONV_T5_TRGO   ((uint32_t)ADC_CR2_EXTSEL_2)
+#define ADC_EXTERNALTRIGCONV_T4_CC4    ((uint32_t)(ADC_CR2_EXTSEL_2 | ADC_CR2_EXTSEL_0))
+#define ADC_EXTERNALTRIGCONV_T3_CC4    ((uint32_t)(ADC_CR2_EXTSEL_2 | ADC_CR2_EXTSEL_1))
+#define ADC_EXTERNALTRIGCONV_T8_TRGO   ((uint32_t)(ADC_CR2_EXTSEL_2 | ADC_CR2_EXTSEL_1 | ADC_CR2_EXTSEL_0))
+#define ADC_EXTERNALTRIGCONV_T8_TRGO2  ((uint32_t)ADC_CR2_EXTSEL_3)
+#define ADC_EXTERNALTRIGCONV_T1_TRGO   ((uint32_t)(ADC_CR2_EXTSEL_3 | ADC_CR2_EXTSEL_0))
+#define ADC_EXTERNALTRIGCONV_T1_TRGO2  ((uint32_t)(ADC_CR2_EXTSEL_3 | ADC_CR2_EXTSEL_1))
+#define ADC_EXTERNALTRIGCONV_T2_TRGO   ((uint32_t)(ADC_CR2_EXTSEL_3 | ADC_CR2_EXTSEL_1 | ADC_CR2_EXTSEL_0))
+#define ADC_EXTERNALTRIGCONV_T4_TRGO   ((uint32_t)(ADC_CR2_EXTSEL_3 | ADC_CR2_EXTSEL_2))
+#define ADC_EXTERNALTRIGCONV_T6_TRGO   ((uint32_t)(ADC_CR2_EXTSEL_3 | ADC_CR2_EXTSEL_2 | ADC_CR2_EXTSEL_0))
+
+#define ADC_EXTERNALTRIGCONV_EXT_IT11  ((uint32_t)ADC_CR2_EXTSEL)
+#define ADC_SOFTWARE_START             ((uint32_t)ADC_CR2_EXTSEL + 1)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_data_align ADC Data Align
+  * @{
+  */
+#define ADC_DATAALIGN_RIGHT      ((uint32_t)0x00000000)
+#define ADC_DATAALIGN_LEFT       ((uint32_t)ADC_CR2_ALIGN)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_channels ADC Common Channels
+  * @{
+  */
+#define ADC_CHANNEL_0           ((uint32_t)0x00000000)
+#define ADC_CHANNEL_1           ((uint32_t)ADC_CR1_AWDCH_0)
+#define ADC_CHANNEL_2           ((uint32_t)ADC_CR1_AWDCH_1)
+#define ADC_CHANNEL_3           ((uint32_t)(ADC_CR1_AWDCH_1 | ADC_CR1_AWDCH_0))
+#define ADC_CHANNEL_4           ((uint32_t)ADC_CR1_AWDCH_2)
+#define ADC_CHANNEL_5           ((uint32_t)(ADC_CR1_AWDCH_2 | ADC_CR1_AWDCH_0))
+#define ADC_CHANNEL_6           ((uint32_t)(ADC_CR1_AWDCH_2 | ADC_CR1_AWDCH_1))
+#define ADC_CHANNEL_7           ((uint32_t)(ADC_CR1_AWDCH_2 | ADC_CR1_AWDCH_1 | ADC_CR1_AWDCH_0))
+#define ADC_CHANNEL_8           ((uint32_t)ADC_CR1_AWDCH_3)
+#define ADC_CHANNEL_9           ((uint32_t)(ADC_CR1_AWDCH_3 | ADC_CR1_AWDCH_0))
+#define ADC_CHANNEL_10          ((uint32_t)(ADC_CR1_AWDCH_3 | ADC_CR1_AWDCH_1))
+#define ADC_CHANNEL_11          ((uint32_t)(ADC_CR1_AWDCH_3 | ADC_CR1_AWDCH_1 | ADC_CR1_AWDCH_0))
+#define ADC_CHANNEL_12          ((uint32_t)(ADC_CR1_AWDCH_3 | ADC_CR1_AWDCH_2))
+#define ADC_CHANNEL_13          ((uint32_t)(ADC_CR1_AWDCH_3 | ADC_CR1_AWDCH_2 | ADC_CR1_AWDCH_0))
+#define ADC_CHANNEL_14          ((uint32_t)(ADC_CR1_AWDCH_3 | ADC_CR1_AWDCH_2 | ADC_CR1_AWDCH_1))
+#define ADC_CHANNEL_15          ((uint32_t)(ADC_CR1_AWDCH_3 | ADC_CR1_AWDCH_2 | ADC_CR1_AWDCH_1 | ADC_CR1_AWDCH_0))
+#define ADC_CHANNEL_16          ((uint32_t)ADC_CR1_AWDCH_4)
+#define ADC_CHANNEL_17          ((uint32_t)(ADC_CR1_AWDCH_4 | ADC_CR1_AWDCH_0))
+#define ADC_CHANNEL_18          ((uint32_t)(ADC_CR1_AWDCH_4 | ADC_CR1_AWDCH_1))
+
+#define ADC_CHANNEL_VREFINT     ((uint32_t)ADC_CHANNEL_17)
+#define ADC_CHANNEL_VBAT        ((uint32_t)ADC_CHANNEL_18)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_sampling_times ADC Sampling Times
+  * @{
+  */
+#define ADC_SAMPLETIME_3CYCLES    ((uint32_t)0x00000000)
+#define ADC_SAMPLETIME_15CYCLES   ((uint32_t)ADC_SMPR1_SMP10_0)
+#define ADC_SAMPLETIME_28CYCLES   ((uint32_t)ADC_SMPR1_SMP10_1)
+#define ADC_SAMPLETIME_56CYCLES   ((uint32_t)(ADC_SMPR1_SMP10_1 | ADC_SMPR1_SMP10_0))
+#define ADC_SAMPLETIME_84CYCLES   ((uint32_t)ADC_SMPR1_SMP10_2)
+#define ADC_SAMPLETIME_112CYCLES  ((uint32_t)(ADC_SMPR1_SMP10_2 | ADC_SMPR1_SMP10_0))
+#define ADC_SAMPLETIME_144CYCLES  ((uint32_t)(ADC_SMPR1_SMP10_2 | ADC_SMPR1_SMP10_1))
+#define ADC_SAMPLETIME_480CYCLES  ((uint32_t)ADC_SMPR1_SMP10)
+/**
+  * @}
+  */
+
+  /** @defgroup ADC_EOCSelection ADC EOC Selection
+  * @{
+  */
+#define ADC_EOC_SEQ_CONV              ((uint32_t)0x00000000)
+#define ADC_EOC_SINGLE_CONV           ((uint32_t)0x00000001)
+#define ADC_EOC_SINGLE_SEQ_CONV       ((uint32_t)0x00000002)  /*!< reserved for future use */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Event_type ADC Event Type
+  * @{
+  */
+#define ADC_AWD_EVENT             ((uint32_t)ADC_FLAG_AWD)
+#define ADC_OVR_EVENT             ((uint32_t)ADC_FLAG_OVR)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_analog_watchdog_selection ADC Analog Watchdog Selection
+  * @{
+  */
+#define ADC_ANALOGWATCHDOG_SINGLE_REG         ((uint32_t)(ADC_CR1_AWDSGL | ADC_CR1_AWDEN))
+#define ADC_ANALOGWATCHDOG_SINGLE_INJEC       ((uint32_t)(ADC_CR1_AWDSGL | ADC_CR1_JAWDEN))
+#define ADC_ANALOGWATCHDOG_SINGLE_REGINJEC    ((uint32_t)(ADC_CR1_AWDSGL | ADC_CR1_AWDEN | ADC_CR1_JAWDEN))
+#define ADC_ANALOGWATCHDOG_ALL_REG            ((uint32_t)ADC_CR1_AWDEN)
+#define ADC_ANALOGWATCHDOG_ALL_INJEC          ((uint32_t)ADC_CR1_JAWDEN)
+#define ADC_ANALOGWATCHDOG_ALL_REGINJEC       ((uint32_t)(ADC_CR1_AWDEN | ADC_CR1_JAWDEN))
+#define ADC_ANALOGWATCHDOG_NONE               ((uint32_t)0x00000000)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_interrupts_definition ADC Interrupts Definition
+  * @{
+  */
+#define ADC_IT_EOC      ((uint32_t)ADC_CR1_EOCIE)
+#define ADC_IT_AWD      ((uint32_t)ADC_CR1_AWDIE)
+#define ADC_IT_JEOC     ((uint32_t)ADC_CR1_JEOCIE)
+#define ADC_IT_OVR      ((uint32_t)ADC_CR1_OVRIE)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_flags_definition ADC Flags Definition
+  * @{
+  */
+#define ADC_FLAG_AWD    ((uint32_t)ADC_SR_AWD)
+#define ADC_FLAG_EOC    ((uint32_t)ADC_SR_EOC)
+#define ADC_FLAG_JEOC   ((uint32_t)ADC_SR_JEOC)
+#define ADC_FLAG_JSTRT  ((uint32_t)ADC_SR_JSTRT)
+#define ADC_FLAG_STRT   ((uint32_t)ADC_SR_STRT)
+#define ADC_FLAG_OVR    ((uint32_t)ADC_SR_OVR)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_channels_type ADC Channels Type
+  * @{
+  */
+#define ADC_ALL_CHANNELS      ((uint32_t)0x00000001)
+#define ADC_REGULAR_CHANNELS  ((uint32_t)0x00000002) /*!< reserved for future use */
+#define ADC_INJECTED_CHANNELS ((uint32_t)0x00000003) /*!< reserved for future use */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup ADC_Exported_Macros ADC Exported Macros
+  * @{
+  */
+
+/** @brief Reset ADC handle state
+  * @param  __HANDLE__: ADC handle
+  * @retval None
+  */
+#define __HAL_ADC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_ADC_STATE_RESET)
+
+/**
+  * @brief  Enable the ADC peripheral.
+  * @param  __HANDLE__: ADC handle
+  * @retval None
+  */
+#define __HAL_ADC_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR2 |=  ADC_CR2_ADON)
+
+/**
+  * @brief  Disable the ADC peripheral.
+  * @param  __HANDLE__: ADC handle
+  * @retval None
+  */
+#define __HAL_ADC_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR2 &=  ~ADC_CR2_ADON)
+
+/**
+  * @brief  Enable the ADC end of conversion interrupt.
+  * @param  __HANDLE__: specifies the ADC Handle.
+  * @param  __INTERRUPT__: ADC Interrupt.
+  * @retval None
+  */
+#define __HAL_ADC_ENABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR1) |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the ADC end of conversion interrupt.
+  * @param  __HANDLE__: specifies the ADC Handle.
+  * @param  __INTERRUPT__: ADC interrupt.
+  * @retval None
+  */
+#define __HAL_ADC_DISABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR1) &= ~(__INTERRUPT__))
+
+/** @brief  Check if the specified ADC interrupt source is enabled or disabled.
+  * @param  __HANDLE__: specifies the ADC Handle.
+  * @param  __INTERRUPT__: specifies the ADC interrupt source to check.
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_ADC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)  (((__HANDLE__)->Instance->CR1 & (__INTERRUPT__)) == (__INTERRUPT__))
+
+/**
+  * @brief  Clear the ADC's pending flags.
+  * @param  __HANDLE__: specifies the ADC Handle.
+  * @param  __FLAG__: ADC flag.
+  * @retval None
+  */
+#define __HAL_ADC_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) = ~(__FLAG__))
+
+/**
+  * @brief  Get the selected ADC's flag status.
+  * @param  __HANDLE__: specifies the ADC Handle.
+  * @param  __FLAG__: ADC flag.
+  * @retval None
+  */
+#define __HAL_ADC_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->SR) & (__FLAG__)) == (__FLAG__))
+
+/**
+  * @}
+  */
+
+/* Include ADC HAL Extension module */
+#include "stm32f7xx_hal_adc_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup ADC_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup ADC_Exported_Functions_Group1
+  * @{
+  */
+/* Initialization/de-initialization functions ***********************************/
+HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef *hadc);
+void       HAL_ADC_MspInit(ADC_HandleTypeDef* hadc);
+void       HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc);
+/**
+  * @}
+  */
+
+/** @addtogroup ADC_Exported_Functions_Group2
+  * @{
+  */
+/* I/O operation functions ******************************************************/
+HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout);
+
+HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout);
+
+HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc);
+
+void              HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc);
+
+HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length);
+HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc);
+
+uint32_t          HAL_ADC_GetValue(ADC_HandleTypeDef* hadc);
+
+void       HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc);
+void       HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc);
+void       HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef* hadc);
+void       HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc);
+/**
+  * @}
+  */
+
+/** @addtogroup ADC_Exported_Functions_Group3
+  * @{
+  */
+/* Peripheral Control functions *************************************************/
+HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig);
+HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig);
+/**
+  * @}
+  */
+
+/** @addtogroup ADC_Exported_Functions_Group4
+  * @{
+  */
+/* Peripheral State functions ***************************************************/
+HAL_ADC_StateTypeDef HAL_ADC_GetState(ADC_HandleTypeDef* hadc);
+uint32_t             HAL_ADC_GetError(ADC_HandleTypeDef *hadc);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup ADC_Private_Constants ADC Private Constants
+  * @{
+  */
+/* Delay for ADC stabilization time.                                        */
+/* Maximum delay is 1us (refer to device datasheet, parameter tSTAB).       */
+/* Unit: us                                                                 */
+#define ADC_STAB_DELAY_US               ((uint32_t) 3)
+/* Delay for temperature sensor stabilization time.                         */
+/* Maximum delay is 10us (refer to device datasheet, parameter tSTART).     */
+/* Unit: us                                                                 */
+#define ADC_TEMPSENSOR_DELAY_US         ((uint32_t) 10)
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup ADC_Private_Macros ADC Private Macros
+  * @{
+  */
+#define IS_ADC_CLOCKPRESCALER(__ADC_CLOCK__)     (((__ADC_CLOCK__) == ADC_CLOCK_SYNC_PCLK_DIV2) || \
+                                                  ((__ADC_CLOCK__) == ADC_CLOCK_SYNC_PCLK_DIV4) || \
+                                                  ((__ADC_CLOCK__) == ADC_CLOCK_SYNC_PCLK_DIV6) || \
+                                                  ((__ADC_CLOCK__) == ADC_CLOCK_SYNC_PCLK_DIV8))
+#define IS_ADC_SAMPLING_DELAY(__DELAY__) (((__DELAY__) == ADC_TWOSAMPLINGDELAY_5CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_6CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_7CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_8CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_9CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_10CYCLES) || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_11CYCLES) || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_12CYCLES) || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_13CYCLES) || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_14CYCLES) || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_15CYCLES) || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_16CYCLES) || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_17CYCLES) || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_18CYCLES) || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_19CYCLES) || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_20CYCLES))
+#define IS_ADC_RESOLUTION(__RESOLUTION__) (((__RESOLUTION__) == ADC_RESOLUTION_12B) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_10B) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_8B)  || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_6B))
+#define IS_ADC_EXT_TRIG_EDGE(__EDGE__) (((__EDGE__) == ADC_EXTERNALTRIGCONVEDGE_NONE)    || \
+                                        ((__EDGE__) == ADC_EXTERNALTRIGCONVEDGE_RISING)  || \
+                                        ((__EDGE__) == ADC_EXTERNALTRIGCONVEDGE_FALLING) || \
+                                        ((__EDGE__) == ADC_EXTERNALTRIGCONVEDGE_RISINGFALLING))
+#define IS_ADC_EXT_TRIG(__REGTRIG__) (((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T1_CC1)   || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T1_CC2)   || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T1_CC3)   || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T2_CC2)   || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T5_TRGO)  || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T4_CC4)   || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T3_CC4) || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T8_TRGO)  || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T8_TRGO2) || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T1_TRGO)  || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T1_TRGO2) || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T2_TRGO)  || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T4_TRGO)  || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_T6_TRGO)  || \
+                                      ((__REGTRIG__) == ADC_EXTERNALTRIGCONV_EXT_IT11) || \
+																			((__REGTRIG__) == ADC_SOFTWARE_START))
+#define IS_ADC_DATA_ALIGN(__ALIGN__) (((__ALIGN__) == ADC_DATAALIGN_RIGHT) || \
+                                      ((__ALIGN__) == ADC_DATAALIGN_LEFT))
+
+#define IS_ADC_SAMPLE_TIME(__TIME__) (((__TIME__) == ADC_SAMPLETIME_3CYCLES)   || \
+                                      ((__TIME__) == ADC_SAMPLETIME_15CYCLES)  || \
+                                      ((__TIME__) == ADC_SAMPLETIME_28CYCLES)  || \
+                                      ((__TIME__) == ADC_SAMPLETIME_56CYCLES)  || \
+                                      ((__TIME__) == ADC_SAMPLETIME_84CYCLES)  || \
+                                      ((__TIME__) == ADC_SAMPLETIME_112CYCLES) || \
+                                      ((__TIME__) == ADC_SAMPLETIME_144CYCLES) || \
+                                      ((__TIME__) == ADC_SAMPLETIME_480CYCLES))
+#define IS_ADC_EOCSelection(__EOCSelection__) (((__EOCSelection__) == ADC_EOC_SINGLE_CONV)   || \
+                                               ((__EOCSelection__) == ADC_EOC_SEQ_CONV)  || \
+                                               ((__EOCSelection__) == ADC_EOC_SINGLE_SEQ_CONV))
+#define IS_ADC_EVENT_TYPE(__EVENT__) (((__EVENT__) == ADC_AWD_EVENT) || \
+                                      ((__EVENT__) == ADC_OVR_EVENT))
+#define IS_ADC_ANALOG_WATCHDOG(__WATCHDOG__) (((__WATCHDOG__) == ADC_ANALOGWATCHDOG_SINGLE_REG)        || \
+                                              ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_SINGLE_INJEC)      || \
+                                              ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_SINGLE_REGINJEC)   || \
+                                              ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_ALL_REG)           || \
+                                              ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_ALL_INJEC)         || \
+                                              ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_ALL_REGINJEC)      || \
+                                              ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_NONE))
+#define IS_ADC_CHANNELS_TYPE(CHANNEL_TYPE) (((CHANNEL_TYPE) == ADC_ALL_CHANNELS) || \
+                                            ((CHANNEL_TYPE) == ADC_REGULAR_CHANNELS) || \
+                                            ((CHANNEL_TYPE) == ADC_INJECTED_CHANNELS))
+#define IS_ADC_THRESHOLD(__THRESHOLD__) ((__THRESHOLD__) <= ((uint32_t)0xFFF))
+#define IS_ADC_REGULAR_LENGTH(__LENGTH__) (((__LENGTH__) >= ((uint32_t)1)) && ((__LENGTH__) <= ((uint32_t)16)))
+#define IS_ADC_REGULAR_RANK(__RANK__) (((__RANK__) >= ((uint32_t)1)) && ((__RANK__) <= ((uint32_t)16)))
+#define IS_ADC_REGULAR_DISC_NUMBER(__NUMBER__) (((__NUMBER__) >= ((uint32_t)1)) && ((__NUMBER__) <= ((uint32_t)8)))
+#define IS_ADC_RANGE(__RESOLUTION__, __ADC_VALUE__)                                     \
+   ((((__RESOLUTION__) == ADC_RESOLUTION_12B) && ((__ADC_VALUE__) <= ((uint32_t)0x0FFF))) || \
+    (((__RESOLUTION__) == ADC_RESOLUTION_10B) && ((__ADC_VALUE__) <= ((uint32_t)0x03FF))) || \
+    (((__RESOLUTION__) == ADC_RESOLUTION_8B)  && ((__ADC_VALUE__) <= ((uint32_t)0x00FF))) || \
+    (((__RESOLUTION__) == ADC_RESOLUTION_6B)  && ((__ADC_VALUE__) <= ((uint32_t)0x003F))))
+
+/**
+  * @brief  Set ADC Regular channel sequence length.
+  * @param  _NbrOfConversion_: Regular channel sequence length.
+  * @retval None
+  */
+#define ADC_SQR1(_NbrOfConversion_) (((_NbrOfConversion_) - (uint8_t)1) << 20)
+
+/**
+  * @brief  Set the ADC's sample time for channel numbers between 10 and 18.
+  * @param  _SAMPLETIME_: Sample time parameter.
+  * @param  _CHANNELNB_: Channel number.
+  * @retval None
+  */
+#define ADC_SMPR1(_SAMPLETIME_, _CHANNELNB_) ((_SAMPLETIME_) << (3 * (((uint32_t)((uint16_t)(_CHANNELNB_))) - 10)))
+
+/**
+  * @brief  Set the ADC's sample time for channel numbers between 0 and 9.
+  * @param  _SAMPLETIME_: Sample time parameter.
+  * @param  _CHANNELNB_: Channel number.
+  * @retval None
+  */
+#define ADC_SMPR2(_SAMPLETIME_, _CHANNELNB_) ((_SAMPLETIME_) << (3 * ((uint32_t)((uint16_t)(_CHANNELNB_)))))
+
+/**
+  * @brief  Set the selected regular channel rank for rank between 1 and 6.
+  * @param  _CHANNELNB_: Channel number.
+  * @param  _RANKNB_: Rank number.
+  * @retval None
+  */
+#define ADC_SQR3_RK(_CHANNELNB_, _RANKNB_) (((uint32_t)((uint16_t)(_CHANNELNB_))) << (5 * ((_RANKNB_) - 1)))
+
+/**
+  * @brief  Set the selected regular channel rank for rank between 7 and 12.
+  * @param  _CHANNELNB_: Channel number.
+  * @param  _RANKNB_: Rank number.
+  * @retval None
+  */
+#define ADC_SQR2_RK(_CHANNELNB_, _RANKNB_) (((uint32_t)((uint16_t)(_CHANNELNB_))) << (5 * ((_RANKNB_) - 7)))
+
+/**
+  * @brief  Set the selected regular channel rank for rank between 13 and 16.
+  * @param  _CHANNELNB_: Channel number.
+  * @param  _RANKNB_: Rank number.
+  * @retval None
+  */
+#define ADC_SQR1_RK(_CHANNELNB_, _RANKNB_) (((uint32_t)((uint16_t)(_CHANNELNB_))) << (5 * ((_RANKNB_) - 13)))
+
+/**
+  * @brief  Enable ADC continuous conversion mode.
+  * @param  _CONTINUOUS_MODE_: Continuous mode.
+  * @retval None
+  */
+#define ADC_CR2_CONTINUOUS(_CONTINUOUS_MODE_) ((_CONTINUOUS_MODE_) << 1)
+
+/**
+  * @brief  Configures the number of discontinuous conversions for the regular group channels.
+  * @param  _NBR_DISCONTINUOUSCONV_: Number of discontinuous conversions.
+  * @retval None
+  */
+#define ADC_CR1_DISCONTINUOUS(_NBR_DISCONTINUOUSCONV_) (((_NBR_DISCONTINUOUSCONV_) - 1) << POSITION_VAL(ADC_CR1_DISCNUM))
+
+/**
+  * @brief  Enable ADC scan mode.
+  * @param  _SCANCONV_MODE_: Scan conversion mode.
+  * @retval None
+  */
+#define ADC_CR1_SCANCONV(_SCANCONV_MODE_) ((_SCANCONV_MODE_) << 8)
+
+/**
+  * @brief  Enable the ADC end of conversion selection.
+  * @param  _EOCSelection_MODE_: End of conversion selection mode.
+  * @retval None
+  */
+#define ADC_CR2_EOCSelection(_EOCSelection_MODE_) ((_EOCSelection_MODE_) << 10)
+
+/**
+  * @brief  Enable the ADC DMA continuous request.
+  * @param  _DMAContReq_MODE_: DMA continuous request mode.
+  * @retval None
+  */
+#define ADC_CR2_DMAContReq(_DMAContReq_MODE_) ((_DMAContReq_MODE_) << 9)
+
+/**
+  * @brief Return resolution bits in CR1 register.
+  * @param __HANDLE__: ADC handle
+  * @retval None
+  */
+#define ADC_GET_RESOLUTION(__HANDLE__) (((__HANDLE__)->Instance->CR1) & ADC_CR1_RES)
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup ADC_Private_Functions ADC Private Functions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32F7xx_ADC_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_adc_ex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_adc_ex.h
@@ -1,0 +1,329 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_adc.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of ADC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_ADC_EX_H
+#define __STM32F7xx_ADC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ADCEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup ADCEx_Exported_Types ADC Exported Types
+  * @{
+  */
+
+/**
+  * @brief   ADC Configuration injected Channel structure definition
+  */
+typedef struct
+{
+  uint32_t InjectedChannel;                /*!< Configure the ADC injected channel.
+                                                This parameter can be a value of @ref ADC_channels */
+  uint32_t InjectedRank;                   /*!< The rank in the injected group sequencer
+                                                This parameter must be a number between Min_Data = 1 and Max_Data = 4. */
+  uint32_t InjectedSamplingTime;           /*!< The sample time value to be set for the selected channel.
+                                                This parameter can be a value of @ref ADC_sampling_times */
+  uint32_t InjectedOffset;                 /*!< Defines the offset to be subtracted from the raw converted data when convert injected channels.
+                                                This parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFF. */
+  uint32_t InjectedNbrOfConversion;        /*!< Specifies the number of ADC conversions that will be done using the sequencer for
+                                                injected channel group.
+                                                This parameter must be a number between Min_Data = 1 and Max_Data = 4. */
+  uint32_t AutoInjectedConv;               /*!< Enables or disables the selected ADC automatic injected group
+                                                conversion after regular one */
+  uint32_t InjectedDiscontinuousConvMode;  /*!< Specifies whether the conversion is performed in Discontinuous mode or not for injected channels.
+                                                This parameter can be set to ENABLE or DISABLE. */
+  uint32_t ExternalTrigInjecConvEdge;      /*!< Select the external trigger edge and enable the trigger of an injected channels.
+                                                This parameter can be a value of @ref ADCEx_External_trigger_edge_Injected */
+  uint32_t ExternalTrigInjecConv;          /*!< Select the external event used to trigger the start of conversion of a injected channels.
+                                                This parameter can be a value of @ref ADCEx_External_trigger_Source_Injected */
+}ADC_InjectionConfTypeDef;
+
+/**
+  * @brief   ADC Configuration multi-mode structure definition
+  */
+typedef struct
+{
+  uint32_t Mode;              /*!< Configures the ADC to operate in independent or multi mode.
+                                   This parameter can be a value of @ref ADCEx_Common_mode */
+  uint32_t DMAAccessMode;     /*!< Configures the Direct memory access mode for multi ADC mode.
+                                   This parameter can be a value of @ref ADCEx_Direct_memory_access_mode_for_multi_mode */
+  uint32_t TwoSamplingDelay;  /*!< Configures the Delay between 2 sampling phases.
+                                   This parameter can be a value of @ref ADC_delay_between_2_sampling_phases */
+}ADC_MultiModeTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup ADCEx_Exported_Constants ADC Exported Constants
+  * @{
+  */
+
+/** @defgroup ADCEx_Common_mode ADC Common Mode
+  * @{
+  */
+#define ADC_MODE_INDEPENDENT                  ((uint32_t)0x00000000)
+#define ADC_DUALMODE_REGSIMULT_INJECSIMULT    ((uint32_t)ADC_CCR_MULTI_0)
+#define ADC_DUALMODE_REGSIMULT_ALTERTRIG      ((uint32_t)ADC_CCR_MULTI_1)
+#define ADC_DUALMODE_INJECSIMULT              ((uint32_t)(ADC_CCR_MULTI_2 | ADC_CCR_MULTI_0))
+#define ADC_DUALMODE_REGSIMULT                ((uint32_t)(ADC_CCR_MULTI_2 | ADC_CCR_MULTI_1))
+#define ADC_DUALMODE_INTERL                   ((uint32_t)(ADC_CCR_MULTI_2 | ADC_CCR_MULTI_1 | ADC_CCR_MULTI_0))
+#define ADC_DUALMODE_ALTERTRIG                ((uint32_t)(ADC_CCR_MULTI_3 | ADC_CCR_MULTI_0))
+#define ADC_TRIPLEMODE_REGSIMULT_INJECSIMULT  ((uint32_t)(ADC_CCR_MULTI_4 | ADC_CCR_MULTI_0))
+#define ADC_TRIPLEMODE_REGSIMULT_AlterTrig    ((uint32_t)(ADC_CCR_MULTI_4 | ADC_CCR_MULTI_1))
+#define ADC_TRIPLEMODE_INJECSIMULT            ((uint32_t)(ADC_CCR_MULTI_4 | ADC_CCR_MULTI_2 | ADC_CCR_MULTI_0))
+#define ADC_TRIPLEMODE_REGSIMULT              ((uint32_t)(ADC_CCR_MULTI_4 | ADC_CCR_MULTI_2 | ADC_CCR_MULTI_1))
+#define ADC_TRIPLEMODE_INTERL                 ((uint32_t)(ADC_CCR_MULTI_4 | ADC_CCR_MULTI_2 | ADC_CCR_MULTI_1 | ADC_CCR_MULTI_0))
+#define ADC_TRIPLEMODE_ALTERTRIG              ((uint32_t)(ADC_CCR_MULTI_4 | ADC_CCR_MULTI_3 | ADC_CCR_MULTI_0))
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Direct_memory_access_mode_for_multi_mode ADC Direct Memory Access Mode For Multi Mode
+  * @{
+  */
+#define ADC_DMAACCESSMODE_DISABLED  ((uint32_t)0x00000000)     /*!< DMA mode disabled */
+#define ADC_DMAACCESSMODE_1         ((uint32_t)ADC_CCR_DMA_0)  /*!< DMA mode 1 enabled (2 / 3 half-words one by one - 1 then 2 then 3)*/
+#define ADC_DMAACCESSMODE_2         ((uint32_t)ADC_CCR_DMA_1)  /*!< DMA mode 2 enabled (2 / 3 half-words by pairs - 2&1 then 1&3 then 3&2)*/
+#define ADC_DMAACCESSMODE_3         ((uint32_t)ADC_CCR_DMA)    /*!< DMA mode 3 enabled (2 / 3 bytes by pairs - 2&1 then 1&3 then 3&2) */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_External_trigger_edge_Injected ADC External Trigger Edge Injected
+  * @{
+  */
+#define ADC_EXTERNALTRIGINJECCONVEDGE_NONE           ((uint32_t)0x00000000)
+#define ADC_EXTERNALTRIGINJECCONVEDGE_RISING         ((uint32_t)ADC_CR2_JEXTEN_0)
+#define ADC_EXTERNALTRIGINJECCONVEDGE_FALLING        ((uint32_t)ADC_CR2_JEXTEN_1)
+#define ADC_EXTERNALTRIGINJECCONVEDGE_RISINGFALLING  ((uint32_t)ADC_CR2_JEXTEN)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_External_trigger_Source_Injected ADC External Trigger Source Injected
+  * @{
+  */
+#define ADC_EXTERNALTRIGINJECCONV_T1_TRGO         ((uint32_t)0x00000000)
+#define ADC_EXTERNALTRIGINJECCONV_T1_CC4          ((uint32_t)ADC_CR2_JEXTSEL_0)
+#define ADC_EXTERNALTRIGINJECCONV_T2_TRGO         ((uint32_t)ADC_CR2_JEXTSEL_1)
+#define ADC_EXTERNALTRIGINJECCONV_T2_CC1          ((uint32_t)(ADC_CR2_JEXTSEL_1 | ADC_CR2_JEXTSEL_0))
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC4          ((uint32_t)ADC_CR2_JEXTSEL_2)
+#define ADC_EXTERNALTRIGINJECCONV_T4_TRGO         ((uint32_t)(ADC_CR2_JEXTSEL_2 | ADC_CR2_JEXTSEL_0))
+
+#define ADC_EXTERNALTRIGINJECCONV_T8_CC4          ((uint32_t)(ADC_CR2_JEXTSEL_2 | ADC_CR2_JEXTSEL_1 | ADC_CR2_JEXTSEL_0))
+#define ADC_EXTERNALTRIGINJECCONV_T1_TRGO2        ((uint32_t)ADC_CR2_JEXTSEL_3)
+#define ADC_EXTERNALTRIGINJECCONV_T8_TRGO         ((uint32_t)(ADC_CR2_JEXTSEL_3 | ADC_CR2_JEXTSEL_0))
+#define ADC_EXTERNALTRIGINJECCONV_T8_TRGO2        ((uint32_t)(ADC_CR2_JEXTSEL_3 | ADC_CR2_JEXTSEL_1))
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC3          ((uint32_t)(ADC_CR2_JEXTSEL_3 | ADC_CR2_JEXTSEL_1 | ADC_CR2_JEXTSEL_0))
+#define ADC_EXTERNALTRIGINJECCONV_T5_TRGO         ((uint32_t)(ADC_CR2_JEXTSEL_3 | ADC_CR2_JEXTSEL_2))
+#define ADC_EXTERNALTRIGINJECCONV_T3_CC1          ((uint32_t)(ADC_CR2_JEXTSEL_3 | ADC_CR2_JEXTSEL_2 | ADC_CR2_JEXTSEL_0))
+#define ADC_EXTERNALTRIGINJECCONV_T6_TRGO         ((uint32_t)(ADC_CR2_JEXTSEL_3 | ADC_CR2_JEXTSEL_2 | ADC_CR2_JEXTSEL_1))
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_injected_channel_selection ADC Injected Channel Selection
+  * @{
+  */
+#define ADC_INJECTED_RANK_1    ((uint32_t)0x00000001)
+#define ADC_INJECTED_RANK_2    ((uint32_t)0x00000002)
+#define ADC_INJECTED_RANK_3    ((uint32_t)0x00000003)
+#define ADC_INJECTED_RANK_4    ((uint32_t)0x00000004)
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_channels  ADC Specific Channels
+  * @{
+  */
+#define ADC_CHANNEL_TEMPSENSOR  ((uint32_t)ADC_CHANNEL_16)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup ADC_Exported_Macros ADC Exported Macros
+  * @{
+  */
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup ADCEx_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup ADCEx_Exported_Functions_Group1
+  * @{
+  */
+
+/* I/O operation functions ******************************************************/
+HAL_StatusTypeDef HAL_ADCEx_InjectedStart(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef HAL_ADCEx_InjectedStop(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef HAL_ADCEx_InjectedPollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout);
+HAL_StatusTypeDef HAL_ADCEx_InjectedStart_IT(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef HAL_ADCEx_InjectedStop_IT(ADC_HandleTypeDef* hadc);
+uint32_t          HAL_ADCEx_InjectedGetValue(ADC_HandleTypeDef* hadc, uint32_t InjectedRank);
+HAL_StatusTypeDef HAL_ADCEx_MultiModeStart_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length);
+HAL_StatusTypeDef HAL_ADCEx_MultiModeStop_DMA(ADC_HandleTypeDef* hadc);
+uint32_t          HAL_ADCEx_MultiModeGetValue(ADC_HandleTypeDef* hadc);
+void       HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef* hadc);
+
+/* Peripheral Control functions *************************************************/
+HAL_StatusTypeDef HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef* hadc,ADC_InjectionConfTypeDef* sConfigInjected);
+HAL_StatusTypeDef HAL_ADCEx_MultiModeConfigChannel(ADC_HandleTypeDef* hadc, ADC_MultiModeTypeDef* multimode);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup ADCEx_Private_Constants ADC Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup ADCEx_Private_Macros ADC Private Macros
+  * @{
+  */
+#define IS_ADC_CHANNEL(CHANNEL) (((CHANNEL) <= ADC_CHANNEL_18)  || \
+                                 ((CHANNEL) == ADC_CHANNEL_TEMPSENSOR))
+
+#define IS_ADC_MODE(__MODE__) (((__MODE__) == ADC_MODE_INDEPENDENT)                 || \
+                               ((__MODE__) == ADC_DUALMODE_REGSIMULT_INJECSIMULT)   || \
+                               ((__MODE__) == ADC_DUALMODE_REGSIMULT_ALTERTRIG)     || \
+                               ((__MODE__) == ADC_DUALMODE_INJECSIMULT)             || \
+                               ((__MODE__) == ADC_DUALMODE_REGSIMULT)               || \
+                               ((__MODE__) == ADC_DUALMODE_INTERL)                  || \
+                               ((__MODE__) == ADC_DUALMODE_ALTERTRIG)               || \
+                               ((__MODE__) == ADC_TRIPLEMODE_REGSIMULT_INJECSIMULT) || \
+                               ((__MODE__) == ADC_TRIPLEMODE_REGSIMULT_AlterTrig)   || \
+                               ((__MODE__) == ADC_TRIPLEMODE_INJECSIMULT)           || \
+                               ((__MODE__) == ADC_TRIPLEMODE_REGSIMULT)             || \
+                               ((__MODE__) == ADC_TRIPLEMODE_INTERL)                || \
+                               ((__MODE__) == ADC_TRIPLEMODE_ALTERTRIG))
+#define IS_ADC_DMA_ACCESS_MODE(__MODE__) (((__MODE__) == ADC_DMAACCESSMODE_DISABLED) || \
+                                          ((__MODE__) == ADC_DMAACCESSMODE_1)        || \
+                                          ((__MODE__) == ADC_DMAACCESSMODE_2)        || \
+                                          ((__MODE__) == ADC_DMAACCESSMODE_3))
+#define IS_ADC_EXT_INJEC_TRIG_EDGE(__EDGE__) (((__EDGE__) == ADC_EXTERNALTRIGINJECCONVEDGE_NONE)    || \
+                                              ((__EDGE__) == ADC_EXTERNALTRIGINJECCONVEDGE_RISING)  || \
+                                              ((__EDGE__) == ADC_EXTERNALTRIGINJECCONVEDGE_FALLING) || \
+                                              ((__EDGE__) == ADC_EXTERNALTRIGINJECCONVEDGE_RISINGFALLING))
+#define IS_ADC_EXT_INJEC_TRIG(__INJTRIG__) (((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)  || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)   || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)  || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)   || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)   || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)  || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T8_CC4)   || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2) || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO)  || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO2) || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)   || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T5_TRGO)  || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)   || \
+                                            ((__INJTRIG__) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO))
+#define IS_ADC_INJECTED_LENGTH(__LENGTH__) (((__LENGTH__) >= ((uint32_t)1)) && ((__LENGTH__) <= ((uint32_t)4)))
+#define IS_ADC_INJECTED_RANK(__RANK__) (((__RANK__) >= ((uint32_t)1)) && ((__RANK__) <= ((uint32_t)4)))
+
+/**
+  * @brief  Set the selected injected Channel rank.
+  * @param  _CHANNELNB_: Channel number.
+  * @param  _RANKNB_: Rank number.
+  * @param  _JSQR_JL_: Sequence length.
+  * @retval None
+  */
+#define   ADC_JSQR(_CHANNELNB_, _RANKNB_,_JSQR_JL_) (((uint32_t)((uint16_t)(_CHANNELNB_))) << (5 * (uint8_t)(((_RANKNB_) + 3) - (_JSQR_JL_))))
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup ADCEx_Private_Functions ADC Private Functions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32F7xx_ADC_EX_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_can.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_can.h
@@ -1,0 +1,769 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_can.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of CAN HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_CAN_H
+#define __STM32F7xx_HAL_CAN_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup CAN
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup CAN_Exported_Types CAN Exported Types
+  * @{
+  */
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef enum
+{
+  HAL_CAN_STATE_RESET             = 0x00,  /*!< CAN not yet initialized or disabled */
+  HAL_CAN_STATE_READY             = 0x01,  /*!< CAN initialized and ready for use   */
+  HAL_CAN_STATE_BUSY              = 0x02,  /*!< CAN process is ongoing              */
+  HAL_CAN_STATE_BUSY_TX           = 0x12,  /*!< CAN process is ongoing              */
+  HAL_CAN_STATE_BUSY_RX           = 0x22,  /*!< CAN process is ongoing              */
+  HAL_CAN_STATE_BUSY_TX_RX        = 0x32,  /*!< CAN process is ongoing              */
+  HAL_CAN_STATE_TIMEOUT           = 0x03,  /*!< Timeout state                       */
+  HAL_CAN_STATE_ERROR             = 0x04   /*!< CAN error state                     */
+
+}HAL_CAN_StateTypeDef;
+
+/**
+  * @brief  CAN init structure definition
+  */
+typedef struct
+{
+  uint32_t Prescaler;  /*!< Specifies the length of a time quantum.
+                            This parameter must be a number between Min_Data = 1 and Max_Data = 1024 */
+
+  uint32_t Mode;       /*!< Specifies the CAN operating mode.
+                            This parameter can be a value of @ref CAN_operating_mode */
+
+  uint32_t SJW;        /*!< Specifies the maximum number of time quanta
+                            the CAN hardware is allowed to lengthen or
+                            shorten a bit to perform resynchronization.
+                            This parameter can be a value of @ref CAN_synchronisation_jump_width */
+
+  uint32_t BS1;        /*!< Specifies the number of time quanta in Bit Segment 1.
+                            This parameter can be a value of @ref CAN_time_quantum_in_bit_segment_1 */
+
+  uint32_t BS2;        /*!< Specifies the number of time quanta in Bit Segment 2.
+                            This parameter can be a value of @ref CAN_time_quantum_in_bit_segment_2 */
+
+  uint32_t TTCM;       /*!< Enable or disable the time triggered communication mode.
+                            This parameter can be set to ENABLE or DISABLE. */
+
+  uint32_t ABOM;       /*!< Enable or disable the automatic bus-off management.
+                            This parameter can be set to ENABLE or DISABLE */
+
+  uint32_t AWUM;       /*!< Enable or disable the automatic wake-up mode.
+                            This parameter can be set to ENABLE or DISABLE */
+
+  uint32_t NART;       /*!< Enable or disable the non-automatic retransmission mode.
+                            This parameter can be set to ENABLE or DISABLE */
+
+  uint32_t RFLM;       /*!< Enable or disable the receive FIFO Locked mode.
+                            This parameter can be set to ENABLE or DISABLE */
+
+  uint32_t TXFP;       /*!< Enable or disable the transmit FIFO priority.
+                            This parameter can be set to ENABLE or DISABLE */
+}CAN_InitTypeDef;
+
+/**
+  * @brief  CAN filter configuration structure definition
+  */
+typedef struct
+{
+  uint32_t FilterIdHigh;          /*!< Specifies the filter identification number (MSBs for a 32-bit
+                                       configuration, first one for a 16-bit configuration).
+                                       This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t FilterIdLow;           /*!< Specifies the filter identification number (LSBs for a 32-bit
+                                       configuration, second one for a 16-bit configuration).
+                                       This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t FilterMaskIdHigh;      /*!< Specifies the filter mask number or identification number,
+                                       according to the mode (MSBs for a 32-bit configuration,
+                                       first one for a 16-bit configuration).
+                                       This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t FilterMaskIdLow;       /*!< Specifies the filter mask number or identification number,
+                                       according to the mode (LSBs for a 32-bit configuration,
+                                       second one for a 16-bit configuration).
+                                       This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t FilterFIFOAssignment;  /*!< Specifies the FIFO (0 or 1) which will be assigned to the filter.
+                                       This parameter can be a value of @ref CAN_filter_FIFO */
+
+  uint32_t FilterNumber;          /*!< Specifies the filter which will be initialized.
+                                       This parameter must be a number between Min_Data = 0 and Max_Data = 27 */
+
+  uint32_t FilterMode;            /*!< Specifies the filter mode to be initialized.
+                                       This parameter can be a value of @ref CAN_filter_mode */
+
+  uint32_t FilterScale;           /*!< Specifies the filter scale.
+                                       This parameter can be a value of @ref CAN_filter_scale */
+
+  uint32_t FilterActivation;      /*!< Enable or disable the filter.
+                                       This parameter can be set to ENABLE or DISABLE. */
+
+  uint32_t BankNumber;            /*!< Select the start slave bank filter.
+                                       This parameter must be a number between Min_Data = 0 and Max_Data = 28 */
+
+}CAN_FilterConfTypeDef;
+
+/**
+  * @brief  CAN Tx message structure definition
+  */
+typedef struct
+{
+  uint32_t StdId;    /*!< Specifies the standard identifier.
+                          This parameter must be a number between Min_Data = 0 and Max_Data = 0x7FF */
+
+  uint32_t ExtId;    /*!< Specifies the extended identifier.
+                          This parameter must be a number between Min_Data = 0 and Max_Data = 0x1FFFFFFF */
+
+  uint32_t IDE;      /*!< Specifies the type of identifier for the message that will be transmitted.
+                          This parameter can be a value of @ref CAN_Identifier_Type */
+
+  uint32_t RTR;      /*!< Specifies the type of frame for the message that will be transmitted.
+                          This parameter can be a value of @ref CAN_remote_transmission_request */
+
+  uint32_t DLC;      /*!< Specifies the length of the frame that will be transmitted.
+                          This parameter must be a number between Min_Data = 0 and Max_Data = 8 */
+
+  uint8_t Data[8];  /*!< Contains the data to be transmitted.
+                          This parameter must be a number between Min_Data = 0 and Max_Data = 0xFF */
+
+}CanTxMsgTypeDef;
+
+/**
+  * @brief  CAN Rx message structure definition
+  */
+typedef struct
+{
+  uint32_t StdId;       /*!< Specifies the standard identifier.
+                             This parameter must be a number between Min_Data = 0 and Max_Data = 0x7FF */
+
+  uint32_t ExtId;       /*!< Specifies the extended identifier.
+                             This parameter must be a number between Min_Data = 0 and Max_Data = 0x1FFFFFFF */
+
+  uint32_t IDE;         /*!< Specifies the type of identifier for the message that will be received.
+                             This parameter can be a value of @ref CAN_Identifier_Type */
+
+  uint32_t RTR;         /*!< Specifies the type of frame for the received message.
+                             This parameter can be a value of @ref CAN_remote_transmission_request */
+
+  uint32_t DLC;         /*!< Specifies the length of the frame that will be received.
+                             This parameter must be a number between Min_Data = 0 and Max_Data = 8 */
+
+  uint8_t Data[8];      /*!< Contains the data to be received.
+                             This parameter must be a number between Min_Data = 0 and Max_Data = 0xFF */
+
+  uint32_t FMI;         /*!< Specifies the index of the filter the message stored in the mailbox passes through.
+                             This parameter must be a number between Min_Data = 0 and Max_Data = 0xFF */
+
+  uint32_t FIFONumber;  /*!< Specifies the receive FIFO number.
+                             This parameter can be CAN_FIFO0 or CAN_FIFO1 */
+
+}CanRxMsgTypeDef;
+
+/**
+  * @brief  CAN handle Structure definition
+  */
+typedef struct
+{
+  CAN_TypeDef                 *Instance;  /*!< Register base address          */
+
+  CAN_InitTypeDef             Init;       /*!< CAN required parameters        */
+
+  CanTxMsgTypeDef*            pTxMsg;     /*!< Pointer to transmit structure  */
+
+  CanRxMsgTypeDef*            pRxMsg;     /*!< Pointer to reception structure */
+
+  __IO HAL_CAN_StateTypeDef   State;      /*!< CAN communication state        */
+
+  HAL_LockTypeDef             Lock;       /*!< CAN locking object             */
+
+  __IO uint32_t               ErrorCode;  /*!< CAN Error code                 */
+
+}CAN_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup CAN_Exported_Constants CAN Exported Constants
+  * @{
+  */
+
+/** @defgroup HAL_CAN_Error_Code HAL CAN Error Code
+  * @{
+  */
+#define   HAL_CAN_ERROR_NONE      0x00    /*!< No error             */
+#define   HAL_CAN_ERROR_EWG       0x01    /*!< EWG error            */
+#define   HAL_CAN_ERROR_EPV       0x02    /*!< EPV error            */
+#define   HAL_CAN_ERROR_BOF       0x04    /*!< BOF error            */
+#define   HAL_CAN_ERROR_STF       0x08    /*!< Stuff error          */
+#define   HAL_CAN_ERROR_FOR       0x10    /*!< Form error           */
+#define   HAL_CAN_ERROR_ACK       0x20    /*!< Acknowledgment error */
+#define   HAL_CAN_ERROR_BR        0x40    /*!< Bit recessive        */
+#define   HAL_CAN_ERROR_BD        0x80    /*!< LEC dominant         */
+#define   HAL_CAN_ERROR_CRC       0x100   /*!< LEC transfer error   */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_InitStatus CAN InitStatus
+  * @{
+  */
+#define CAN_INITSTATUS_FAILED       ((uint8_t)0x00)  /*!< CAN initialization failed */
+#define CAN_INITSTATUS_SUCCESS      ((uint8_t)0x01)  /*!< CAN initialization OK */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_operating_mode CAN Operating Mode
+  * @{
+  */
+#define CAN_MODE_NORMAL             ((uint32_t)0x00000000)                     /*!< Normal mode   */
+#define CAN_MODE_LOOPBACK           ((uint32_t)CAN_BTR_LBKM)                   /*!< Loopback mode */
+#define CAN_MODE_SILENT             ((uint32_t)CAN_BTR_SILM)                   /*!< Silent mode   */
+#define CAN_MODE_SILENT_LOOPBACK    ((uint32_t)(CAN_BTR_LBKM | CAN_BTR_SILM))  /*!< Loopback combined with silent mode */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_synchronisation_jump_width CAN Synchronisation Jump Width
+  * @{
+  */
+#define CAN_SJW_1TQ                 ((uint32_t)0x00000000)     /*!< 1 time quantum */
+#define CAN_SJW_2TQ                 ((uint32_t)CAN_BTR_SJW_0)  /*!< 2 time quantum */
+#define CAN_SJW_3TQ                 ((uint32_t)CAN_BTR_SJW_1)  /*!< 3 time quantum */
+#define CAN_SJW_4TQ                 ((uint32_t)CAN_BTR_SJW)    /*!< 4 time quantum */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_time_quantum_in_bit_segment_1 CAN Time Quantum in bit segment 1
+  * @{
+  */
+#define CAN_BS1_1TQ                 ((uint32_t)0x00000000)                                       /*!< 1 time quantum  */
+#define CAN_BS1_2TQ                 ((uint32_t)CAN_BTR_TS1_0)                                    /*!< 2 time quantum  */
+#define CAN_BS1_3TQ                 ((uint32_t)CAN_BTR_TS1_1)                                    /*!< 3 time quantum  */
+#define CAN_BS1_4TQ                 ((uint32_t)(CAN_BTR_TS1_1 | CAN_BTR_TS1_0))                  /*!< 4 time quantum  */
+#define CAN_BS1_5TQ                 ((uint32_t)CAN_BTR_TS1_2)                                    /*!< 5 time quantum  */
+#define CAN_BS1_6TQ                 ((uint32_t)(CAN_BTR_TS1_2 | CAN_BTR_TS1_0))                  /*!< 6 time quantum  */
+#define CAN_BS1_7TQ                 ((uint32_t)(CAN_BTR_TS1_2 | CAN_BTR_TS1_1))                  /*!< 7 time quantum  */
+#define CAN_BS1_8TQ                 ((uint32_t)(CAN_BTR_TS1_2 | CAN_BTR_TS1_1 | CAN_BTR_TS1_0))  /*!< 8 time quantum  */
+#define CAN_BS1_9TQ                 ((uint32_t)CAN_BTR_TS1_3)                                    /*!< 9 time quantum  */
+#define CAN_BS1_10TQ                ((uint32_t)(CAN_BTR_TS1_3 | CAN_BTR_TS1_0))                  /*!< 10 time quantum */
+#define CAN_BS1_11TQ                ((uint32_t)(CAN_BTR_TS1_3 | CAN_BTR_TS1_1))                  /*!< 11 time quantum */
+#define CAN_BS1_12TQ                ((uint32_t)(CAN_BTR_TS1_3 | CAN_BTR_TS1_1 | CAN_BTR_TS1_0))  /*!< 12 time quantum */
+#define CAN_BS1_13TQ                ((uint32_t)(CAN_BTR_TS1_3 | CAN_BTR_TS1_2))                  /*!< 13 time quantum */
+#define CAN_BS1_14TQ                ((uint32_t)(CAN_BTR_TS1_3 | CAN_BTR_TS1_2 | CAN_BTR_TS1_0))  /*!< 14 time quantum */
+#define CAN_BS1_15TQ                ((uint32_t)(CAN_BTR_TS1_3 | CAN_BTR_TS1_2 | CAN_BTR_TS1_1))  /*!< 15 time quantum */
+#define CAN_BS1_16TQ                ((uint32_t)CAN_BTR_TS1) /*!< 16 time quantum */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_time_quantum_in_bit_segment_2 CAN Time Quantum in bit segment 2
+  * @{
+  */
+#define CAN_BS2_1TQ                 ((uint32_t)0x00000000)                       /*!< 1 time quantum */
+#define CAN_BS2_2TQ                 ((uint32_t)CAN_BTR_TS2_0)                    /*!< 2 time quantum */
+#define CAN_BS2_3TQ                 ((uint32_t)CAN_BTR_TS2_1)                    /*!< 3 time quantum */
+#define CAN_BS2_4TQ                 ((uint32_t)(CAN_BTR_TS2_1 | CAN_BTR_TS2_0))  /*!< 4 time quantum */
+#define CAN_BS2_5TQ                 ((uint32_t)CAN_BTR_TS2_2)                    /*!< 5 time quantum */
+#define CAN_BS2_6TQ                 ((uint32_t)(CAN_BTR_TS2_2 | CAN_BTR_TS2_0))  /*!< 6 time quantum */
+#define CAN_BS2_7TQ                 ((uint32_t)(CAN_BTR_TS2_2 | CAN_BTR_TS2_1))  /*!< 7 time quantum */
+#define CAN_BS2_8TQ                 ((uint32_t)CAN_BTR_TS2)                      /*!< 8 time quantum */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_filter_mode  CAN Filter Mode
+  * @{
+  */
+#define CAN_FILTERMODE_IDMASK       ((uint8_t)0x00)  /*!< Identifier mask mode */
+#define CAN_FILTERMODE_IDLIST       ((uint8_t)0x01)  /*!< Identifier list mode */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_filter_scale CAN Filter Scale
+  * @{
+  */
+#define CAN_FILTERSCALE_16BIT       ((uint8_t)0x00)  /*!< Two 16-bit filters */
+#define CAN_FILTERSCALE_32BIT       ((uint8_t)0x01)  /*!< One 32-bit filter  */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_filter_FIFO CAN Filter FIFO
+  * @{
+  */
+#define CAN_FILTER_FIFO0             ((uint8_t)0x00)  /*!< Filter FIFO 0 assignment for filter x */
+#define CAN_FILTER_FIFO1             ((uint8_t)0x01)  /*!< Filter FIFO 1 assignment for filter x */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_Identifier_Type CAN Identifier Type
+  * @{
+  */
+#define CAN_ID_STD             ((uint32_t)0x00000000)  /*!< Standard Id */
+#define CAN_ID_EXT             ((uint32_t)0x00000004)  /*!< Extended Id */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_remote_transmission_request CAN Remote Transmission Request
+  * @{
+  */
+#define CAN_RTR_DATA                ((uint32_t)0x00000000)  /*!< Data frame */
+#define CAN_RTR_REMOTE              ((uint32_t)0x00000002)  /*!< Remote frame */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_receive_FIFO_number_constants CAN Receive FIFO Number Constants
+  * @{
+  */
+#define CAN_FIFO0                   ((uint8_t)0x00)  /*!< CAN FIFO 0 used to receive */
+#define CAN_FIFO1                   ((uint8_t)0x01)  /*!< CAN FIFO 1 used to receive */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_flags CAN Flags
+  * @{
+  */
+/* If the flag is 0x3XXXXXXX, it means that it can be used with CAN_GetFlagStatus()
+   and CAN_ClearFlag() functions. */
+/* If the flag is 0x1XXXXXXX, it means that it can only be used with
+   CAN_GetFlagStatus() function.  */
+
+/* Transmit Flags */
+#define CAN_FLAG_RQCP0             ((uint32_t)0x00000500)  /*!< Request MailBox0 flag         */
+#define CAN_FLAG_RQCP1             ((uint32_t)0x00000508)  /*!< Request MailBox1 flag         */
+#define CAN_FLAG_RQCP2             ((uint32_t)0x00000510)  /*!< Request MailBox2 flag         */
+#define CAN_FLAG_TXOK0             ((uint32_t)0x00000501)  /*!< Transmission OK MailBox0 flag */
+#define CAN_FLAG_TXOK1             ((uint32_t)0x00000509)  /*!< Transmission OK MailBox1 flag */
+#define CAN_FLAG_TXOK2             ((uint32_t)0x00000511)  /*!< Transmission OK MailBox2 flag */
+#define CAN_FLAG_TME0              ((uint32_t)0x0000051A)  /*!< Transmit mailbox 0 empty flag */
+#define CAN_FLAG_TME1              ((uint32_t)0x0000051B)  /*!< Transmit mailbox 0 empty flag */
+#define CAN_FLAG_TME2              ((uint32_t)0x0000051C)  /*!< Transmit mailbox 0 empty flag */
+
+/* Receive Flags */
+#define CAN_FLAG_FF0               ((uint32_t)0x00000203)  /*!< FIFO 0 Full flag    */
+#define CAN_FLAG_FOV0              ((uint32_t)0x00000204)  /*!< FIFO 0 Overrun flag */
+
+#define CAN_FLAG_FF1               ((uint32_t)0x00000403)  /*!< FIFO 1 Full flag    */
+#define CAN_FLAG_FOV1              ((uint32_t)0x00000404)  /*!< FIFO 1 Overrun flag */
+
+/* Operating Mode Flags */
+#define CAN_FLAG_WKU               ((uint32_t)0x00000103)  /*!< Wake up flag           */
+#define CAN_FLAG_SLAK              ((uint32_t)0x00000101)  /*!< Sleep acknowledge flag */
+#define CAN_FLAG_SLAKI             ((uint32_t)0x00000104)  /*!< Sleep acknowledge flag */
+/* @note When SLAK interrupt is disabled (SLKIE=0), no polling on SLAKI is possible.
+         In this case the SLAK bit can be polled.*/
+
+/* Error Flags */
+#define CAN_FLAG_EWG               ((uint32_t)0x00000300)  /*!< Error warning flag   */
+#define CAN_FLAG_EPV               ((uint32_t)0x00000301)  /*!< Error passive flag   */
+#define CAN_FLAG_BOF               ((uint32_t)0x00000302)  /*!< Bus-Off flag         */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_Interrupts CAN Interrupts
+  * @{
+  */
+#define CAN_IT_TME                  ((uint32_t)CAN_IER_TMEIE)   /*!< Transmit mailbox empty interrupt */
+
+/* Receive Interrupts */
+#define CAN_IT_FMP0                 ((uint32_t)CAN_IER_FMPIE0)  /*!< FIFO 0 message pending interrupt */
+#define CAN_IT_FF0                  ((uint32_t)CAN_IER_FFIE0)   /*!< FIFO 0 full interrupt            */
+#define CAN_IT_FOV0                 ((uint32_t)CAN_IER_FOVIE0)  /*!< FIFO 0 overrun interrupt         */
+#define CAN_IT_FMP1                 ((uint32_t)CAN_IER_FMPIE1)  /*!< FIFO 1 message pending interrupt */
+#define CAN_IT_FF1                  ((uint32_t)CAN_IER_FFIE1)   /*!< FIFO 1 full interrupt            */
+#define CAN_IT_FOV1                 ((uint32_t)CAN_IER_FOVIE1)  /*!< FIFO 1 overrun interrupt         */
+
+/* Operating Mode Interrupts */
+#define CAN_IT_WKU                  ((uint32_t)CAN_IER_WKUIE)  /*!< Wake-up interrupt           */
+#define CAN_IT_SLK                  ((uint32_t)CAN_IER_SLKIE)  /*!< Sleep acknowledge interrupt */
+
+/* Error Interrupts */
+#define CAN_IT_EWG                  ((uint32_t)CAN_IER_EWGIE) /*!< Error warning interrupt   */
+#define CAN_IT_EPV                  ((uint32_t)CAN_IER_EPVIE) /*!< Error passive interrupt   */
+#define CAN_IT_BOF                  ((uint32_t)CAN_IER_BOFIE) /*!< Bus-off interrupt         */
+#define CAN_IT_LEC                  ((uint32_t)CAN_IER_LECIE) /*!< Last error code interrupt */
+#define CAN_IT_ERR                  ((uint32_t)CAN_IER_ERRIE) /*!< Error Interrupt           */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_Mailboxes_Definition CAN Mailboxes Definition
+  * @{
+  */
+#define CAN_TXMAILBOX_0   ((uint8_t)0x00)
+#define CAN_TXMAILBOX_1   ((uint8_t)0x01)
+#define CAN_TXMAILBOX_2   ((uint8_t)0x02)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup CAN_Exported_Macros CAN Exported Macros
+  * @{
+  */
+
+/** @brief Reset CAN handle state
+  * @param  __HANDLE__: specifies the CAN Handle.
+  * @retval None
+  */
+#define __HAL_CAN_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_CAN_STATE_RESET)
+
+/**
+  * @brief  Enable the specified CAN interrupts.
+  * @param  __HANDLE__: CAN handle
+  * @param  __INTERRUPT__: CAN Interrupt
+  * @retval None
+  */
+#define __HAL_CAN_ENABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->IER) |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the specified CAN interrupts.
+  * @param  __HANDLE__: CAN handle
+  * @param  __INTERRUPT__: CAN Interrupt
+  * @retval None
+  */
+#define __HAL_CAN_DISABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->IER) &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Return the number of pending received messages.
+  * @param  __HANDLE__: CAN handle
+  * @param  __FIFONUMBER__: Receive FIFO number, CAN_FIFO0 or CAN_FIFO1.
+  * @retval The number of pending message.
+  */
+#define __HAL_CAN_MSG_PENDING(__HANDLE__, __FIFONUMBER__) (((__FIFONUMBER__) == CAN_FIFO0)? \
+((uint8_t)((__HANDLE__)->Instance->RF0R&(uint32_t)0x03)) : ((uint8_t)((__HANDLE__)->Instance->RF1R&(uint32_t)0x03)))
+
+/** @brief  Check whether the specified CAN flag is set or not.
+  * @param  __HANDLE__: CAN Handle
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg CAN_TSR_RQCP0: Request MailBox0 Flag
+  *            @arg CAN_TSR_RQCP1: Request MailBox1 Flag
+  *            @arg CAN_TSR_RQCP2: Request MailBox2 Flag
+  *            @arg CAN_FLAG_TXOK0: Transmission OK MailBox0 Flag
+  *            @arg CAN_FLAG_TXOK1: Transmission OK MailBox1 Flag
+  *            @arg CAN_FLAG_TXOK2: Transmission OK MailBox2 Flag
+  *            @arg CAN_FLAG_TME0: Transmit mailbox 0 empty Flag
+  *            @arg CAN_FLAG_TME1: Transmit mailbox 1 empty Flag
+  *            @arg CAN_FLAG_TME2: Transmit mailbox 2 empty Flag
+  *            @arg CAN_FLAG_FMP0: FIFO 0 Message Pending Flag
+  *            @arg CAN_FLAG_FF0: FIFO 0 Full Flag
+  *            @arg CAN_FLAG_FOV0: FIFO 0 Overrun Flag
+  *            @arg CAN_FLAG_FMP1: FIFO 1 Message Pending Flag
+  *            @arg CAN_FLAG_FF1: FIFO 1 Full Flag
+  *            @arg CAN_FLAG_FOV1: FIFO 1 Overrun Flag
+  *            @arg CAN_FLAG_WKU: Wake up Flag
+  *            @arg CAN_FLAG_SLAK: Sleep acknowledge Flag
+  *            @arg CAN_FLAG_SLAKI: Sleep acknowledge Flag
+  *            @arg CAN_FLAG_EWG: Error Warning Flag
+  *            @arg CAN_FLAG_EPV: Error Passive Flag
+  *            @arg CAN_FLAG_BOF: Bus-Off Flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_CAN_GET_FLAG(__HANDLE__, __FLAG__) \
+((((__FLAG__) >> 8) == 5)? ((((__HANDLE__)->Instance->TSR) & (1 << ((__FLAG__) & CAN_FLAG_MASK))) == (1 << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8) == 2)? ((((__HANDLE__)->Instance->RF0R) & (1 << ((__FLAG__) & CAN_FLAG_MASK))) == (1 << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8) == 4)? ((((__HANDLE__)->Instance->RF1R) & (1 << ((__FLAG__) & CAN_FLAG_MASK))) == (1 << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8) == 1)? ((((__HANDLE__)->Instance->MSR) & (1 << ((__FLAG__) & CAN_FLAG_MASK))) == (1 << ((__FLAG__) & CAN_FLAG_MASK))): \
+ ((((__HANDLE__)->Instance->ESR) & (1 << ((__FLAG__) & CAN_FLAG_MASK))) == (1 << ((__FLAG__) & CAN_FLAG_MASK))))
+
+/** @brief  Clear the specified CAN pending flag.
+  * @param  __HANDLE__: CAN Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg CAN_TSR_RQCP0: Request MailBox0 Flag
+  *            @arg CAN_TSR_RQCP1: Request MailBox1 Flag
+  *            @arg CAN_TSR_RQCP2: Request MailBox2 Flag
+  *            @arg CAN_FLAG_TXOK0: Transmission OK MailBox0 Flag
+  *            @arg CAN_FLAG_TXOK1: Transmission OK MailBox1 Flag
+  *            @arg CAN_FLAG_TXOK2: Transmission OK MailBox2 Flag
+  *            @arg CAN_FLAG_TME0: Transmit mailbox 0 empty Flag
+  *            @arg CAN_FLAG_TME1: Transmit mailbox 1 empty Flag
+  *            @arg CAN_FLAG_TME2: Transmit mailbox 2 empty Flag
+  *            @arg CAN_FLAG_FMP0: FIFO 0 Message Pending Flag
+  *            @arg CAN_FLAG_FF0: FIFO 0 Full Flag
+  *            @arg CAN_FLAG_FOV0: FIFO 0 Overrun Flag
+  *            @arg CAN_FLAG_FMP1: FIFO 1 Message Pending Flag
+  *            @arg CAN_FLAG_FF1: FIFO 1 Full Flag
+  *            @arg CAN_FLAG_FOV1: FIFO 1 Overrun Flag
+  *            @arg CAN_FLAG_WKU: Wake up Flag
+  *            @arg CAN_FLAG_SLAK: Sleep acknowledge Flag
+  *            @arg CAN_FLAG_SLAKI: Sleep acknowledge Flag
+  *            @arg CAN_FLAG_EWG: Error Warning Flag
+  *            @arg CAN_FLAG_EPV: Error Passive Flag
+  *            @arg CAN_FLAG_BOF: Bus-Off Flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_CAN_CLEAR_FLAG(__HANDLE__, __FLAG__) \
+((((__FLAG__) >> 8) == 5)? (((__HANDLE__)->Instance->TSR) = ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8) == 2)? (((__HANDLE__)->Instance->RF0R) = ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8) == 4)? (((__HANDLE__)->Instance->RF1R) = ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8) == 1)? (((__HANDLE__)->Instance->MSR) = ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__HANDLE__)->Instance->ESR) = ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))))
+
+/** @brief  Check if the specified CAN interrupt source is enabled or disabled.
+  * @param  __HANDLE__: CAN Handle
+  * @param  __INTERRUPT__: specifies the CAN interrupt source to check.
+  *          This parameter can be one of the following values:
+  *             @arg CAN_IT_TME: Transmit mailbox empty interrupt enable
+  *             @arg CAN_IT_FMP0: FIFO0 message pending interrupt enable
+  *             @arg CAN_IT_FMP1: FIFO1 message pending interrupt enable
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_CAN_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->IER & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/**
+  * @brief  Check the transmission status of a CAN Frame.
+  * @param  __HANDLE__: CAN Handle
+  * @param  __TRANSMITMAILBOX__: the number of the mailbox that is used for transmission.
+  * @retval The new status of transmission  (TRUE or FALSE).
+  */
+#define __HAL_CAN_TRANSMIT_STATUS(__HANDLE__, __TRANSMITMAILBOX__)\
+(((__TRANSMITMAILBOX__) == CAN_TXMAILBOX_0)? ((((__HANDLE__)->Instance->TSR) & (CAN_TSR_RQCP0 | CAN_TSR_TXOK0 | CAN_TSR_TME0)) == (CAN_TSR_RQCP0 | CAN_TSR_TXOK0 | CAN_TSR_TME0)) :\
+ ((__TRANSMITMAILBOX__) == CAN_TXMAILBOX_1)? ((((__HANDLE__)->Instance->TSR) & (CAN_TSR_RQCP1 | CAN_TSR_TXOK1 | CAN_TSR_TME1)) == (CAN_TSR_RQCP1 | CAN_TSR_TXOK1 | CAN_TSR_TME1)) :\
+ ((((__HANDLE__)->Instance->TSR) & (CAN_TSR_RQCP2 | CAN_TSR_TXOK2 | CAN_TSR_TME2)) == (CAN_TSR_RQCP2 | CAN_TSR_TXOK2 | CAN_TSR_TME2)))
+
+/**
+  * @brief  Release the specified receive FIFO.
+  * @param  __HANDLE__: CAN handle
+  * @param  __FIFONUMBER__: Receive FIFO number, CAN_FIFO0 or CAN_FIFO1.
+  * @retval None
+  */
+#define __HAL_CAN_FIFO_RELEASE(__HANDLE__, __FIFONUMBER__) (((__FIFONUMBER__) == CAN_FIFO0)? \
+((__HANDLE__)->Instance->RF0R |= CAN_RF0R_RFOM0) : ((__HANDLE__)->Instance->RF1R |= CAN_RF1R_RFOM1))
+
+/**
+  * @brief  Cancel a transmit request.
+  * @param  __HANDLE__: CAN Handle
+  * @param  __TRANSMITMAILBOX__: the number of the mailbox that is used for transmission.
+  * @retval None
+  */
+#define __HAL_CAN_CANCEL_TRANSMIT(__HANDLE__, __TRANSMITMAILBOX__)\
+(((__TRANSMITMAILBOX__) == CAN_TXMAILBOX_0)? ((__HANDLE__)->Instance->TSR |= CAN_TSR_ABRQ0) :\
+ ((__TRANSMITMAILBOX__) == CAN_TXMAILBOX_1)? ((__HANDLE__)->Instance->TSR |= CAN_TSR_ABRQ1) :\
+ ((__HANDLE__)->Instance->TSR |= CAN_TSR_ABRQ2))
+
+/**
+  * @brief  Enable or disable the DBG Freeze for CAN.
+  * @param  __HANDLE__: CAN Handle
+  * @param  __NEWSTATE__: new state of the CAN peripheral.
+  *          This parameter can be: ENABLE (CAN reception/transmission is frozen
+  *          during debug. Reception FIFOs can still be accessed/controlled normally)
+  *          or DISABLE (CAN is working during debug).
+  * @retval None
+  */
+#define __HAL_CAN_DBG_FREEZE(__HANDLE__, __NEWSTATE__) (((__NEWSTATE__) == ENABLE)? \
+((__HANDLE__)->Instance->MCR |= CAN_MCR_DBF) : ((__HANDLE__)->Instance->MCR &= ~CAN_MCR_DBF))
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup CAN_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup CAN_Exported_Functions_Group1
+  * @{
+  */
+/* Initialization/de-initialization functions ***********************************/
+HAL_StatusTypeDef HAL_CAN_Init(CAN_HandleTypeDef* hcan);
+HAL_StatusTypeDef HAL_CAN_ConfigFilter(CAN_HandleTypeDef* hcan, CAN_FilterConfTypeDef* sFilterConfig);
+HAL_StatusTypeDef HAL_CAN_DeInit(CAN_HandleTypeDef* hcan);
+void HAL_CAN_MspInit(CAN_HandleTypeDef* hcan);
+void HAL_CAN_MspDeInit(CAN_HandleTypeDef* hcan);
+/**
+  * @}
+  */
+
+/** @addtogroup CAN_Exported_Functions_Group2
+  * @{
+  */
+/* I/O operation functions ******************************************************/
+HAL_StatusTypeDef HAL_CAN_Transmit(CAN_HandleTypeDef *hcan, uint32_t Timeout);
+HAL_StatusTypeDef HAL_CAN_Transmit_IT(CAN_HandleTypeDef *hcan);
+HAL_StatusTypeDef HAL_CAN_Receive(CAN_HandleTypeDef *hcan, uint8_t FIFONumber, uint32_t Timeout);
+HAL_StatusTypeDef HAL_CAN_Receive_IT(CAN_HandleTypeDef *hcan, uint8_t FIFONumber);
+HAL_StatusTypeDef HAL_CAN_Sleep(CAN_HandleTypeDef *hcan);
+HAL_StatusTypeDef HAL_CAN_WakeUp(CAN_HandleTypeDef *hcan);
+void HAL_CAN_IRQHandler(CAN_HandleTypeDef* hcan);
+void HAL_CAN_TxCpltCallback(CAN_HandleTypeDef* hcan);
+void HAL_CAN_RxCpltCallback(CAN_HandleTypeDef* hcan);
+void HAL_CAN_ErrorCallback(CAN_HandleTypeDef *hcan);
+/**
+  * @}
+  */
+
+/** @addtogroup CAN_Exported_Functions_Group3
+  * @{
+  */
+/* Peripheral State functions ***************************************************/
+uint32_t HAL_CAN_GetError(CAN_HandleTypeDef *hcan);
+HAL_CAN_StateTypeDef HAL_CAN_GetState(CAN_HandleTypeDef* hcan);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/** @defgroup CAN_Private_Types CAN Private Types
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup CAN_Private_Variables CAN Private Variables
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup CAN_Private_Constants CAN Private Constants
+  * @{
+  */
+#define CAN_TXSTATUS_NOMAILBOX      ((uint8_t)0x04)  /*!< CAN cell did not provide CAN_TxStatus_NoMailBox */
+#define CAN_FLAG_MASK  ((uint32_t)0x000000FF)
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup CAN_Private_Macros CAN Private Macros
+  * @{
+  */
+#define IS_CAN_MODE(MODE) (((MODE) == CAN_MODE_NORMAL) || \
+                           ((MODE) == CAN_MODE_LOOPBACK)|| \
+                           ((MODE) == CAN_MODE_SILENT) || \
+                           ((MODE) == CAN_MODE_SILENT_LOOPBACK))
+#define IS_CAN_SJW(SJW) (((SJW) == CAN_SJW_1TQ) || ((SJW) == CAN_SJW_2TQ)|| \
+                         ((SJW) == CAN_SJW_3TQ) || ((SJW) == CAN_SJW_4TQ))
+#define IS_CAN_BS1(BS1) ((BS1) <= CAN_BS1_16TQ)
+#define IS_CAN_BS2(BS2) ((BS2) <= CAN_BS2_8TQ)
+#define IS_CAN_PRESCALER(PRESCALER) (((PRESCALER) >= 1) && ((PRESCALER) <= 1024))
+#define IS_CAN_FILTER_NUMBER(NUMBER) ((NUMBER) <= 27)
+#define IS_CAN_FILTER_MODE(MODE) (((MODE) == CAN_FILTERMODE_IDMASK) || \
+                                  ((MODE) == CAN_FILTERMODE_IDLIST))
+#define IS_CAN_FILTER_SCALE(SCALE) (((SCALE) == CAN_FILTERSCALE_16BIT) || \
+                                    ((SCALE) == CAN_FILTERSCALE_32BIT))
+#define IS_CAN_FILTER_FIFO(FIFO) (((FIFO) == CAN_FILTER_FIFO0) || \
+                                  ((FIFO) == CAN_FILTER_FIFO1))
+#define IS_CAN_BANKNUMBER(BANKNUMBER) ((BANKNUMBER) <= 28)
+
+#define IS_CAN_TRANSMITMAILBOX(TRANSMITMAILBOX) ((TRANSMITMAILBOX) <= ((uint8_t)0x02))
+#define IS_CAN_STDID(STDID)   ((STDID) <= ((uint32_t)0x7FF))
+#define IS_CAN_EXTID(EXTID)   ((EXTID) <= ((uint32_t)0x1FFFFFFF))
+#define IS_CAN_DLC(DLC)       ((DLC) <= ((uint8_t)0x08))
+
+#define IS_CAN_IDTYPE(IDTYPE)  (((IDTYPE) == CAN_ID_STD) || \
+                                ((IDTYPE) == CAN_ID_EXT))
+#define IS_CAN_RTR(RTR) (((RTR) == CAN_RTR_DATA) || ((RTR) == CAN_RTR_REMOTE))
+#define IS_CAN_FIFO(FIFO) (((FIFO) == CAN_FIFO0) || ((FIFO) == CAN_FIFO1))
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup CAN_Private_Functions CAN Private Functions
+  * @{
+  */
+
+/**
+  * @}
+  */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_CAN_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_cortex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_cortex.h
@@ -1,0 +1,490 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_cortex.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of CORTEX HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_CORTEX_H
+#define __STM32F7xx_HAL_CORTEX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup CORTEX
+  * @{
+  */
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup CORTEX_Exported_Types Cortex Exported Types
+  * @{
+  */
+
+#if (__MPU_PRESENT == 1)
+/** @defgroup CORTEX_MPU_Region_Initialization_Structure_definition MPU Region Initialization Structure Definition
+  * @brief  MPU Region initialization structure
+  * @{
+  */
+typedef struct
+{
+  uint8_t                Enable;                /*!< Specifies the status of the region.
+                                                     This parameter can be a value of @ref CORTEX_MPU_Region_Enable                 */
+  uint8_t                Number;                /*!< Specifies the number of the region to protect.
+                                                     This parameter can be a value of @ref CORTEX_MPU_Region_Number                 */
+  uint32_t               BaseAddress;           /*!< Specifies the base address of the region to protect.                           */
+  uint8_t                Size;                  /*!< Specifies the size of the region to protect.
+                                                     This parameter can be a value of @ref CORTEX_MPU_Region_Size                   */
+  uint8_t                SubRegionDisable;      /*!< Specifies the number of the subregion protection to disable.
+                                                     This parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFF    */
+  uint8_t                TypeExtField;          /*!< Specifies the TEX field level.
+                                                     This parameter can be a value of @ref CORTEX_MPU_TEX_Levels                    */
+  uint8_t                AccessPermission;      /*!< Specifies the region access permission type.
+                                                     This parameter can be a value of @ref CORTEX_MPU_Region_Permission_Attributes  */
+  uint8_t                DisableExec;           /*!< Specifies the instruction access status.
+                                                     This parameter can be a value of @ref CORTEX_MPU_Instruction_Access            */
+  uint8_t                IsShareable;           /*!< Specifies the shareability status of the protected region.
+                                                     This parameter can be a value of @ref CORTEX_MPU_Access_Shareable              */
+  uint8_t                IsCacheable;           /*!< Specifies the cacheable status of the region protected.
+                                                     This parameter can be a value of @ref CORTEX_MPU_Access_Cacheable              */
+  uint8_t                IsBufferable;          /*!< Specifies the bufferable status of the protected region.
+                                                     This parameter can be a value of @ref CORTEX_MPU_Access_Bufferable             */
+}MPU_Region_InitTypeDef;
+/**
+  * @}
+  */
+#endif /* __MPU_PRESENT */
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup CORTEX_Exported_Constants CORTEX Exported Constants
+  * @{
+  */
+
+/** @defgroup CORTEX_Preemption_Priority_Group CORTEX Preemption Priority Group
+  * @{
+  */
+#define NVIC_PRIORITYGROUP_0         ((uint32_t)0x00000007) /*!< 0 bits for pre-emption priority
+                                                                 4 bits for subpriority */
+#define NVIC_PRIORITYGROUP_1         ((uint32_t)0x00000006) /*!< 1 bits for pre-emption priority
+                                                                 3 bits for subpriority */
+#define NVIC_PRIORITYGROUP_2         ((uint32_t)0x00000005) /*!< 2 bits for pre-emption priority
+                                                                 2 bits for subpriority */
+#define NVIC_PRIORITYGROUP_3         ((uint32_t)0x00000004) /*!< 3 bits for pre-emption priority
+                                                                 1 bits for subpriority */
+#define NVIC_PRIORITYGROUP_4         ((uint32_t)0x00000003) /*!< 4 bits for pre-emption priority
+                                                                 0 bits for subpriority */
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_SysTick_clock_source CORTEX _SysTick clock source
+  * @{
+  */
+#define SYSTICK_CLKSOURCE_HCLK_DIV8    ((uint32_t)0x00000000)
+#define SYSTICK_CLKSOURCE_HCLK         ((uint32_t)0x00000004)
+
+/**
+  * @}
+  */
+
+#if (__MPU_PRESENT == 1)
+/** @defgroup CORTEX_MPU_HFNMI_PRIVDEF_Control MPU HFNMI and PRIVILEGED Access control
+  * @{
+  */
+#define  MPU_HFNMI_PRIVDEF_NONE      ((uint32_t)0x00000000)
+#define  MPU_HARDFAULT_NMI           ((uint32_t)0x00000002)
+#define  MPU_PRIVILEGED_DEFAULT      ((uint32_t)0x00000004)
+#define  MPU_HFNMI_PRIVDEF           ((uint32_t)0x00000006)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Region_Enable CORTEX MPU Region Enable
+  * @{
+  */
+#define  MPU_REGION_ENABLE     ((uint8_t)0x01)
+#define  MPU_REGION_DISABLE    ((uint8_t)0x00)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Instruction_Access CORTEX MPU Instruction Access
+  * @{
+  */
+#define  MPU_INSTRUCTION_ACCESS_ENABLE      ((uint8_t)0x00)
+#define  MPU_INSTRUCTION_ACCESS_DISABLE     ((uint8_t)0x01)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Access_Shareable CORTEX MPU Instruction Access Shareable
+  * @{
+  */
+#define  MPU_ACCESS_SHAREABLE        ((uint8_t)0x01)
+#define  MPU_ACCESS_NOT_SHAREABLE    ((uint8_t)0x00)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Access_Cacheable CORTEX MPU Instruction Access Cacheable
+  * @{
+  */
+#define  MPU_ACCESS_CACHEABLE         ((uint8_t)0x01)
+#define  MPU_ACCESS_NOT_CACHEABLE     ((uint8_t)0x00)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Access_Bufferable CORTEX MPU Instruction Access Bufferable
+  * @{
+  */
+#define  MPU_ACCESS_BUFFERABLE         ((uint8_t)0x01)
+#define  MPU_ACCESS_NOT_BUFFERABLE     ((uint8_t)0x00)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_TEX_Levels MPU TEX Levels
+  * @{
+  */
+#define  MPU_TEX_LEVEL0    ((uint8_t)0x00)
+#define  MPU_TEX_LEVEL1    ((uint8_t)0x01)
+#define  MPU_TEX_LEVEL2    ((uint8_t)0x02)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Region_Size CORTEX MPU Region Size
+  * @{
+  */
+#define   MPU_REGION_SIZE_32B      ((uint8_t)0x04)
+#define   MPU_REGION_SIZE_64B      ((uint8_t)0x05)
+#define   MPU_REGION_SIZE_128B     ((uint8_t)0x06)
+#define   MPU_REGION_SIZE_256B     ((uint8_t)0x07)
+#define   MPU_REGION_SIZE_512B     ((uint8_t)0x08)
+#define   MPU_REGION_SIZE_1KB      ((uint8_t)0x09)
+#define   MPU_REGION_SIZE_2KB      ((uint8_t)0x0A)
+#define   MPU_REGION_SIZE_4KB      ((uint8_t)0x0B)
+#define   MPU_REGION_SIZE_8KB      ((uint8_t)0x0C)
+#define   MPU_REGION_SIZE_16KB     ((uint8_t)0x0D)
+#define   MPU_REGION_SIZE_32KB     ((uint8_t)0x0E)
+#define   MPU_REGION_SIZE_64KB     ((uint8_t)0x0F)
+#define   MPU_REGION_SIZE_128KB    ((uint8_t)0x10)
+#define   MPU_REGION_SIZE_256KB    ((uint8_t)0x11)
+#define   MPU_REGION_SIZE_512KB    ((uint8_t)0x12)
+#define   MPU_REGION_SIZE_1MB      ((uint8_t)0x13)
+#define   MPU_REGION_SIZE_2MB      ((uint8_t)0x14)
+#define   MPU_REGION_SIZE_4MB      ((uint8_t)0x15)
+#define   MPU_REGION_SIZE_8MB      ((uint8_t)0x16)
+#define   MPU_REGION_SIZE_16MB     ((uint8_t)0x17)
+#define   MPU_REGION_SIZE_32MB     ((uint8_t)0x18)
+#define   MPU_REGION_SIZE_64MB     ((uint8_t)0x19)
+#define   MPU_REGION_SIZE_128MB    ((uint8_t)0x1A)
+#define   MPU_REGION_SIZE_256MB    ((uint8_t)0x1B)
+#define   MPU_REGION_SIZE_512MB    ((uint8_t)0x1C)
+#define   MPU_REGION_SIZE_1GB      ((uint8_t)0x1D)
+#define   MPU_REGION_SIZE_2GB      ((uint8_t)0x1E)
+#define   MPU_REGION_SIZE_4GB      ((uint8_t)0x1F)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Region_Permission_Attributes CORTEX MPU Region Permission Attributes
+  * @{
+  */
+#define  MPU_REGION_NO_ACCESS      ((uint8_t)0x00)
+#define  MPU_REGION_PRIV_RW        ((uint8_t)0x01)
+#define  MPU_REGION_PRIV_RW_URO    ((uint8_t)0x02)
+#define  MPU_REGION_FULL_ACCESS    ((uint8_t)0x03)
+#define  MPU_REGION_PRIV_RO        ((uint8_t)0x05)
+#define  MPU_REGION_PRIV_RO_URO    ((uint8_t)0x06)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Region_Number CORTEX MPU Region Number
+  * @{
+  */
+#define  MPU_REGION_NUMBER0    ((uint8_t)0x00)
+#define  MPU_REGION_NUMBER1    ((uint8_t)0x01)
+#define  MPU_REGION_NUMBER2    ((uint8_t)0x02)
+#define  MPU_REGION_NUMBER3    ((uint8_t)0x03)
+#define  MPU_REGION_NUMBER4    ((uint8_t)0x04)
+#define  MPU_REGION_NUMBER5    ((uint8_t)0x05)
+#define  MPU_REGION_NUMBER6    ((uint8_t)0x06)
+#define  MPU_REGION_NUMBER7    ((uint8_t)0x07)
+/**
+  * @}
+  */
+#endif /* __MPU_PRESENT */
+
+/**
+  * @}
+  */
+
+
+/* Exported Macros -----------------------------------------------------------*/
+/** @defgroup CORTEX_Exported_Macros CORTEX Exported Macros
+  * @{
+  */
+
+/** @brief Configures the SysTick clock source.
+  * @param __CLKSRC__: specifies the SysTick clock source.
+  *   This parameter can be one of the following values:
+  *     @arg SYSTICK_CLKSOURCE_HCLK_DIV8: AHB clock divided by 8 selected as SysTick clock source.
+  *     @arg SYSTICK_CLKSOURCE_HCLK: AHB clock selected as SysTick clock source.
+  * @retval None
+  */
+#define __HAL_CORTEX_SYSTICKCLK_CONFIG(__CLKSRC__)                             \
+                            do {                                               \
+                                 if ((__CLKSRC__) == SYSTICK_CLKSOURCE_HCLK)   \
+                                  {                                            \
+                                    SysTick->CTRL |= SYSTICK_CLKSOURCE_HCLK;   \
+                                  }                                            \
+                                 else                                          \
+                                    SysTick->CTRL &= ~SYSTICK_CLKSOURCE_HCLK;  \
+                                } while(0)
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup CORTEX_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup CORTEX_Exported_Functions_Group1
+ * @{
+ */
+/* Initialization and de-initialization functions *****************************/
+void HAL_NVIC_SetPriorityGrouping(uint32_t PriorityGroup);
+void HAL_NVIC_SetPriority(IRQn_Type IRQn, uint32_t PreemptPriority, uint32_t SubPriority);
+void HAL_NVIC_EnableIRQ(IRQn_Type IRQn);
+void HAL_NVIC_DisableIRQ(IRQn_Type IRQn);
+void HAL_NVIC_SystemReset(void);
+uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb);
+/**
+  * @}
+  */
+
+/** @addtogroup CORTEX_Exported_Functions_Group2
+ * @{
+ */
+/* Peripheral Control functions ***********************************************/
+#if (__MPU_PRESENT == 1)
+void HAL_MPU_ConfigRegion(MPU_Region_InitTypeDef *MPU_Init);
+#endif /* __MPU_PRESENT */
+uint32_t HAL_NVIC_GetPriorityGrouping(void);
+void HAL_NVIC_GetPriority(IRQn_Type IRQn, uint32_t PriorityGroup, uint32_t* pPreemptPriority, uint32_t* pSubPriority);
+uint32_t HAL_NVIC_GetPendingIRQ(IRQn_Type IRQn);
+void HAL_NVIC_SetPendingIRQ(IRQn_Type IRQn);
+void HAL_NVIC_ClearPendingIRQ(IRQn_Type IRQn);
+uint32_t HAL_NVIC_GetActive(IRQn_Type IRQn);
+void HAL_SYSTICK_CLKSourceConfig(uint32_t CLKSource);
+void HAL_SYSTICK_IRQHandler(void);
+void HAL_SYSTICK_Callback(void);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup CORTEX_Private_Macros CORTEX Private Macros
+  * @{
+  */
+#define IS_NVIC_PRIORITY_GROUP(GROUP) (((GROUP) == NVIC_PRIORITYGROUP_0) || \
+                                       ((GROUP) == NVIC_PRIORITYGROUP_1) || \
+                                       ((GROUP) == NVIC_PRIORITYGROUP_2) || \
+                                       ((GROUP) == NVIC_PRIORITYGROUP_3) || \
+                                       ((GROUP) == NVIC_PRIORITYGROUP_4))
+
+#define IS_NVIC_PREEMPTION_PRIORITY(PRIORITY)  ((PRIORITY) < 0x10)
+
+#define IS_NVIC_SUB_PRIORITY(PRIORITY)         ((PRIORITY) < 0x10)
+
+#define IS_NVIC_DEVICE_IRQ(IRQ)                ((IRQ) >= 0x00)
+
+#define IS_SYSTICK_CLK_SOURCE(SOURCE) (((SOURCE) == SYSTICK_CLKSOURCE_HCLK) || \
+                                       ((SOURCE) == SYSTICK_CLKSOURCE_HCLK_DIV8))
+
+#if (__MPU_PRESENT == 1)
+#define IS_MPU_REGION_ENABLE(STATE) (((STATE) == MPU_REGION_ENABLE) || \
+                                     ((STATE) == MPU_REGION_DISABLE))
+
+#define IS_MPU_INSTRUCTION_ACCESS(STATE) (((STATE) == MPU_INSTRUCTION_ACCESS_ENABLE) || \
+                                          ((STATE) == MPU_INSTRUCTION_ACCESS_DISABLE))
+
+#define IS_MPU_ACCESS_SHAREABLE(STATE)   (((STATE) == MPU_ACCESS_SHAREABLE) || \
+                                          ((STATE) == MPU_ACCESS_NOT_SHAREABLE))
+
+#define IS_MPU_ACCESS_CACHEABLE(STATE)   (((STATE) == MPU_ACCESS_CACHEABLE) || \
+                                          ((STATE) == MPU_ACCESS_NOT_CACHEABLE))
+
+#define IS_MPU_ACCESS_BUFFERABLE(STATE)   (((STATE) == MPU_ACCESS_BUFFERABLE) || \
+                                          ((STATE) == MPU_ACCESS_NOT_BUFFERABLE))
+
+#define IS_MPU_TEX_LEVEL(TYPE) (((TYPE) == MPU_TEX_LEVEL0)  || \
+                                ((TYPE) == MPU_TEX_LEVEL1)  || \
+                                ((TYPE) == MPU_TEX_LEVEL2))
+
+#define IS_MPU_REGION_PERMISSION_ATTRIBUTE(TYPE) (((TYPE) == MPU_REGION_NO_ACCESS)   || \
+                                                  ((TYPE) == MPU_REGION_PRIV_RW)     || \
+                                                  ((TYPE) == MPU_REGION_PRIV_RW_URO) || \
+                                                  ((TYPE) == MPU_REGION_FULL_ACCESS) || \
+                                                  ((TYPE) == MPU_REGION_PRIV_RO)     || \
+                                                  ((TYPE) == MPU_REGION_PRIV_RO_URO))
+
+#define IS_MPU_REGION_NUMBER(NUMBER)    (((NUMBER) == MPU_REGION_NUMBER0) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER1) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER2) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER3) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER4) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER5) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER6) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER7))
+
+#define IS_MPU_REGION_SIZE(SIZE)    (((SIZE) == MPU_REGION_SIZE_32B)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_64B)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_128B)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_256B)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_512B)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_1KB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_2KB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_4KB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_8KB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_16KB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_32KB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_64KB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_128KB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_256KB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_512KB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_1MB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_2MB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_4MB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_8MB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_16MB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_32MB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_64MB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_128MB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_256MB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_512MB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_1GB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_2GB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_4GB))
+
+#define IS_MPU_SUB_REGION_DISABLE(SUBREGION)  ((SUBREGION) < (uint16_t)0x00FF)
+#endif /* __MPU_PRESENT */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup CORTEX_Private_Functions CORTEX Private Functions
+  * @brief    CORTEX private  functions
+  * @{
+  */
+
+#if (__MPU_PRESENT == 1)
+/**
+  * @brief  Disables the MPU
+  * @retval None
+  */
+__STATIC_INLINE void HAL_MPU_Disable(void)
+{
+  /* Disable fault exceptions */
+  SCB->SHCSR &= ~SCB_SHCSR_MEMFAULTENA_Msk;
+
+  /* Disable the MPU */
+  MPU->CTRL  &= ~MPU_CTRL_ENABLE_Msk;
+}
+
+/**
+  * @brief  Enables the MPU
+  * @param  MPU_Control: Specifies the control mode of the MPU during hard fault,
+  *          NMI, FAULTMASK and privileged access to the default memory
+  *          This parameter can be one of the following values:
+  *            @arg MPU_HFNMI_PRIVDEF_NONE
+  *            @arg MPU_HARDFAULT_NMI
+  *            @arg MPU_PRIVILEGED_DEFAULT
+  *            @arg MPU_HFNMI_PRIVDEF
+  * @retval None
+  */
+__STATIC_INLINE void HAL_MPU_Enable(uint32_t MPU_Control)
+{
+  /* Enable the MPU */
+  MPU->CTRL   = MPU_Control | MPU_CTRL_ENABLE_Msk;
+
+  /* Enable fault exceptions */
+  SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
+}
+#endif /* __MPU_PRESENT */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_CORTEX_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_dac.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_dac.h
@@ -1,0 +1,408 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_dac.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of DAC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_DAC_H
+#define __STM32F7xx_HAL_DAC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup DAC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup DAC_Exported_Types DAC Exported Types
+  * @{
+  */
+
+/**
+  * @brief HAL State structures definition
+  */
+typedef enum
+{
+  HAL_DAC_STATE_RESET             = 0x00,  /*!< DAC not yet initialized or disabled  */
+  HAL_DAC_STATE_READY             = 0x01,  /*!< DAC initialized and ready for use    */
+  HAL_DAC_STATE_BUSY              = 0x02,  /*!< DAC internal processing is ongoing   */
+  HAL_DAC_STATE_TIMEOUT           = 0x03,  /*!< DAC timeout state                    */
+  HAL_DAC_STATE_ERROR             = 0x04   /*!< DAC error state                      */
+}HAL_DAC_StateTypeDef;
+
+/**
+  * @brief DAC handle Structure definition
+  */
+typedef struct
+{
+  DAC_TypeDef                 *Instance;     /*!< Register base address             */
+
+  __IO HAL_DAC_StateTypeDef   State;         /*!< DAC communication state           */
+
+  HAL_LockTypeDef             Lock;          /*!< DAC locking object                */
+
+  DMA_HandleTypeDef           *DMA_Handle1;  /*!< Pointer DMA handler for channel 1 */
+
+  DMA_HandleTypeDef           *DMA_Handle2;  /*!< Pointer DMA handler for channel 2 */
+
+  __IO uint32_t               ErrorCode;     /*!< DAC Error code                    */
+
+}DAC_HandleTypeDef;
+
+/**
+  * @brief DAC Configuration regular Channel structure definition
+  */
+typedef struct
+{
+  uint32_t DAC_Trigger;       /*!< Specifies the external trigger for the selected DAC channel.
+                                   This parameter can be a value of @ref DAC_trigger_selection */
+
+  uint32_t DAC_OutputBuffer;  /*!< Specifies whether the DAC channel output buffer is enabled or disabled.
+                                   This parameter can be a value of @ref DAC_output_buffer */
+}DAC_ChannelConfTypeDef;
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup DAC_Exported_Constants DAC Exported Constants
+  * @{
+  */
+
+/** @defgroup DAC_Error_Code DAC Error Code
+  * @{
+  */
+#define  HAL_DAC_ERROR_NONE              0x00    /*!< No error                          */
+#define  HAL_DAC_ERROR_DMAUNDERRUNCH1    0x01    /*!< DAC channel1 DAM underrun error   */
+#define  HAL_DAC_ERROR_DMAUNDERRUNCH2    0x02    /*!< DAC channel2 DAM underrun error   */
+#define  HAL_DAC_ERROR_DMA               0x04    /*!< DMA error                         */
+/**
+  * @}
+  */
+
+/** @defgroup DAC_trigger_selection DAC Trigger Selection
+  * @{
+  */
+
+#define DAC_TRIGGER_NONE                   ((uint32_t)0x00000000) /*!< Conversion is automatic once the DAC1_DHRxxxx register
+                                                                       has been loaded, and not by external trigger */
+#define DAC_TRIGGER_T2_TRGO                ((uint32_t)(DAC_CR_TSEL1_2 | DAC_CR_TEN1)) /*!< TIM2 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T4_TRGO                ((uint32_t)(DAC_CR_TSEL1_2 | DAC_CR_TSEL1_0 | DAC_CR_TEN1)) /*!< TIM4 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T5_TRGO                ((uint32_t)(DAC_CR_TSEL1_1 | DAC_CR_TSEL1_0 | DAC_CR_TEN1)) /*!< TIM5 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T6_TRGO                ((uint32_t)DAC_CR_TEN1) /*!< TIM6 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T7_TRGO                ((uint32_t)(DAC_CR_TSEL1_1 | DAC_CR_TEN1)) /*!< TIM7 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T8_TRGO                ((uint32_t)(DAC_CR_TSEL1_0 | DAC_CR_TEN1)) /*!< TIM8 TRGO selected as external conversion trigger for DAC channel */
+
+#define DAC_TRIGGER_EXT_IT9                ((uint32_t)(DAC_CR_TSEL1_2 | DAC_CR_TSEL1_1 | DAC_CR_TEN1)) /*!< EXTI Line9 event selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_SOFTWARE               ((uint32_t)(DAC_CR_TSEL1 | DAC_CR_TEN1)) /*!< Conversion started by software trigger for DAC channel */
+/**
+  * @}
+  */
+
+/** @defgroup DAC_output_buffer  DAC Output Buffer
+  * @{
+  */
+#define DAC_OUTPUTBUFFER_ENABLE            ((uint32_t)0x00000000)
+#define DAC_OUTPUTBUFFER_DISABLE           ((uint32_t)DAC_CR_BOFF1)
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Channel_selection DAC Channel Selection
+  * @{
+  */
+#define DAC_CHANNEL_1                      ((uint32_t)0x00000000)
+#define DAC_CHANNEL_2                      ((uint32_t)0x00000010)
+/**
+  * @}
+  */
+
+/** @defgroup DAC_data_alignment DAC Data Alignment
+  * @{
+  */
+#define DAC_ALIGN_12B_R                    ((uint32_t)0x00000000)
+#define DAC_ALIGN_12B_L                    ((uint32_t)0x00000004)
+#define DAC_ALIGN_8B_R                     ((uint32_t)0x00000008)
+/**
+  * @}
+  */
+
+/** @defgroup DAC_flags_definition DAC Flags Definition
+  * @{
+  */
+#define DAC_FLAG_DMAUDR1                   ((uint32_t)DAC_SR_DMAUDR1)
+#define DAC_FLAG_DMAUDR2                   ((uint32_t)DAC_SR_DMAUDR2)
+/**
+  * @}
+  */
+
+/** @defgroup DAC_IT_definition DAC IT Definition
+  * @{
+  */
+#define DAC_IT_DMAUDR1                   ((uint32_t)DAC_SR_DMAUDR1)
+#define DAC_IT_DMAUDR2                   ((uint32_t)DAC_SR_DMAUDR2)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup DAC_Exported_Macros DAC Exported Macros
+  * @{
+  */
+
+/** @brief Reset DAC handle state
+  * @param  __HANDLE__: specifies the DAC handle.
+  * @retval None
+  */
+#define __HAL_DAC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_DAC_STATE_RESET)
+
+/** @brief Enable the DAC channel
+  * @param  __HANDLE__: specifies the DAC handle.
+  * @param  __DAC_CHANNEL__: specifies the DAC channel
+  * @retval None
+  */
+#define __HAL_DAC_ENABLE(__HANDLE__, __DAC_CHANNEL__) \
+((__HANDLE__)->Instance->CR |=  (DAC_CR_EN1 << (__DAC_CHANNEL__)))
+
+/** @brief Disable the DAC channel
+  * @param  __HANDLE__: specifies the DAC handle
+  * @param  __DAC_CHANNEL__: specifies the DAC channel.
+  * @retval None
+  */
+#define __HAL_DAC_DISABLE(__HANDLE__, __DAC_CHANNEL__) \
+((__HANDLE__)->Instance->CR &=  ~(DAC_CR_EN1 << (__DAC_CHANNEL__)))
+
+
+/** @brief Enable the DAC interrupt
+  * @param  __HANDLE__: specifies the DAC handle
+  * @param  __INTERRUPT__: specifies the DAC interrupt.
+  * @retval None
+  */
+#define __HAL_DAC_ENABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR) |= (__INTERRUPT__))
+
+/** @brief Disable the DAC interrupt
+  * @param  __HANDLE__: specifies the DAC handle
+  * @param  __INTERRUPT__: specifies the DAC interrupt.
+  * @retval None
+  */
+#define __HAL_DAC_DISABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR) &= ~(__INTERRUPT__))
+
+/** @brief  Checks if the specified DAC interrupt source is enabled or disabled.
+  * @param __HANDLE__: DAC handle
+  * @param __INTERRUPT__: DAC interrupt source to check
+  *          This parameter can be any combination of the following values:
+  *            @arg DAC_IT_DMAUDR1: DAC channel 1 DMA underrun interrupt
+  *            @arg DAC_IT_DMAUDR2: DAC channel 2 DMA underrun interrupt
+  * @retval State of interruption (SET or RESET)
+  */
+#define __HAL_DAC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR & (__INTERRUPT__)) == (__INTERRUPT__))
+
+/** @brief  Get the selected DAC's flag status.
+  * @param  __HANDLE__: specifies the DAC handle.
+  * @param  __FLAG__: specifies the flag to clear.
+  *         This parameter can be any combination of the following values:
+  *            @arg DAC_FLAG_DMAUDR1: DMA underrun 1 flag
+  *            @arg DAC_FLAG_DMAUDR2: DMA underrun 2 flag
+  * @retval None
+  */
+#define __HAL_DAC_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->SR) & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Clear the DAC's flag.
+  * @param  __HANDLE__: specifies the DAC handle.
+  * @param  __FLAG__: specifies the flag to clear.
+  *         This parameter can be any combination of the following values:
+  *            @arg DAC_FLAG_DMAUDR1: DMA underrun 1 flag
+  *            @arg DAC_FLAG_DMAUDR2: DMA underrun 2 flag
+  * @retval None
+  */
+#define __HAL_DAC_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) = (__FLAG__))
+/**
+  * @}
+  */
+
+/* Include DAC HAL Extension module */
+#include "stm32f7xx_hal_dac_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup DAC_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group1
+  * @{
+  */
+/* Initialization/de-initialization functions *********************************/
+HAL_StatusTypeDef HAL_DAC_Init(DAC_HandleTypeDef* hdac);
+HAL_StatusTypeDef HAL_DAC_DeInit(DAC_HandleTypeDef* hdac);
+void HAL_DAC_MspInit(DAC_HandleTypeDef* hdac);
+void HAL_DAC_MspDeInit(DAC_HandleTypeDef* hdac);
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group2
+  * @{
+  */
+/* I/O operation functions ****************************************************/
+HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef* hdac, uint32_t Channel);
+HAL_StatusTypeDef HAL_DAC_Stop(DAC_HandleTypeDef* hdac, uint32_t Channel);
+HAL_StatusTypeDef HAL_DAC_Start_DMA(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t* pData, uint32_t Length, uint32_t Alignment);
+HAL_StatusTypeDef HAL_DAC_Stop_DMA(DAC_HandleTypeDef* hdac, uint32_t Channel);
+uint32_t HAL_DAC_GetValue(DAC_HandleTypeDef* hdac, uint32_t Channel);
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group3
+  * @{
+  */
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef HAL_DAC_ConfigChannel(DAC_HandleTypeDef* hdac, DAC_ChannelConfTypeDef* sConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t Alignment, uint32_t Data);
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group4
+  * @{
+  */
+/* Peripheral State functions *************************************************/
+HAL_DAC_StateTypeDef HAL_DAC_GetState(DAC_HandleTypeDef* hdac);
+void HAL_DAC_IRQHandler(DAC_HandleTypeDef* hdac);
+uint32_t HAL_DAC_GetError(DAC_HandleTypeDef *hdac);
+
+void HAL_DAC_ConvCpltCallbackCh1(DAC_HandleTypeDef* hdac);
+void HAL_DAC_ConvHalfCpltCallbackCh1(DAC_HandleTypeDef* hdac);
+void HAL_DAC_ErrorCallbackCh1(DAC_HandleTypeDef *hdac);
+void HAL_DAC_DMAUnderrunCallbackCh1(DAC_HandleTypeDef *hdac);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup DAC_Private_Constants DAC Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup DAC_Private_Macros DAC Private Macros
+  * @{
+  */
+#define IS_DAC_DATA(DATA) ((DATA) <= 0xFFF0)
+#define IS_DAC_ALIGN(ALIGN) (((ALIGN) == DAC_ALIGN_12B_R) || \
+                             ((ALIGN) == DAC_ALIGN_12B_L) || \
+                             ((ALIGN) == DAC_ALIGN_8B_R))
+#define IS_DAC_CHANNEL(CHANNEL) (((CHANNEL) == DAC_CHANNEL_1) || \
+                                 ((CHANNEL) == DAC_CHANNEL_2))
+#define IS_DAC_OUTPUT_BUFFER_STATE(STATE) (((STATE) == DAC_OUTPUTBUFFER_ENABLE) || \
+                                           ((STATE) == DAC_OUTPUTBUFFER_DISABLE))
+
+#define IS_DAC_TRIGGER(TRIGGER) (((TRIGGER) == DAC_TRIGGER_NONE) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T2_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T8_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T7_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T5_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T6_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T4_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_EXT_IT9) || \
+                                 ((TRIGGER) == DAC_TRIGGER_SOFTWARE))
+
+/** @brief Set DHR12R1 alignment
+  * @param  __ALIGNMENT__: specifies the DAC alignment
+  * @retval None
+  */
+#define DAC_DHR12R1_ALIGNMENT(__ALIGNMENT__) (((uint32_t)0x00000008) + (__ALIGNMENT__))
+
+/** @brief  Set DHR12R2 alignment
+  * @param  __ALIGNMENT__: specifies the DAC alignment
+  * @retval None
+  */
+#define DAC_DHR12R2_ALIGNMENT(__ALIGNMENT__) (((uint32_t)0x00000014) + (__ALIGNMENT__))
+
+/** @brief  Set DHR12RD alignment
+  * @param  __ALIGNMENT__: specifies the DAC alignment
+  * @retval None
+  */
+#define DAC_DHR12RD_ALIGNMENT(__ALIGNMENT__) (((uint32_t)0x00000020) + (__ALIGNMENT__))
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup DAC_Private_Functions DAC Private Functions
+  * @{
+  */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32F7xx_HAL_DAC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_dac_ex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_dac_ex.h
@@ -1,0 +1,191 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_dac.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of DAC HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_DAC_EX_H
+#define __STM32F7xx_HAL_DAC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup DACEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup DACEx_Exported_Constants DAC Exported Constants
+  * @{
+  */
+
+/** @defgroup DACEx_lfsrunmask_triangleamplitude DAC LFS Run Mask Triangle Amplitude
+  * @{
+  */
+#define DAC_LFSRUNMASK_BIT0                ((uint32_t)0x00000000) /*!< Unmask DAC channel LFSR bit0 for noise wave generation */
+#define DAC_LFSRUNMASK_BITS1_0             ((uint32_t)DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[1:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS2_0             ((uint32_t)DAC_CR_MAMP1_1) /*!< Unmask DAC channel LFSR bit[2:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS3_0             ((uint32_t)DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0)/*!< Unmask DAC channel LFSR bit[3:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS4_0             ((uint32_t)DAC_CR_MAMP1_2) /*!< Unmask DAC channel LFSR bit[4:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS5_0             ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[5:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS6_0             ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1) /*!< Unmask DAC channel LFSR bit[6:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS7_0             ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[7:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS8_0             ((uint32_t)DAC_CR_MAMP1_3) /*!< Unmask DAC channel LFSR bit[8:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS9_0             ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[9:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS10_0            ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1) /*!< Unmask DAC channel LFSR bit[10:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS11_0            ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[11:0] for noise wave generation */
+#define DAC_TRIANGLEAMPLITUDE_1            ((uint32_t)0x00000000) /*!< Select max triangle amplitude of 1 */
+#define DAC_TRIANGLEAMPLITUDE_3            ((uint32_t)DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 3 */
+#define DAC_TRIANGLEAMPLITUDE_7            ((uint32_t)DAC_CR_MAMP1_1) /*!< Select max triangle amplitude of 7 */
+#define DAC_TRIANGLEAMPLITUDE_15           ((uint32_t)DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 15 */
+#define DAC_TRIANGLEAMPLITUDE_31           ((uint32_t)DAC_CR_MAMP1_2) /*!< Select max triangle amplitude of 31 */
+#define DAC_TRIANGLEAMPLITUDE_63           ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 63 */
+#define DAC_TRIANGLEAMPLITUDE_127          ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1) /*!< Select max triangle amplitude of 127 */
+#define DAC_TRIANGLEAMPLITUDE_255          ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 255 */
+#define DAC_TRIANGLEAMPLITUDE_511          ((uint32_t)DAC_CR_MAMP1_3) /*!< Select max triangle amplitude of 511 */
+#define DAC_TRIANGLEAMPLITUDE_1023         ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 1023 */
+#define DAC_TRIANGLEAMPLITUDE_2047         ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1) /*!< Select max triangle amplitude of 2047 */
+#define DAC_TRIANGLEAMPLITUDE_4095         ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 4095 */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup DACEx_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup DACEx_Exported_Functions_Group1
+  * @{
+  */
+/* Extension features functions ***********************************************/
+uint32_t HAL_DACEx_DualGetValue(DAC_HandleTypeDef* hdac);
+HAL_StatusTypeDef HAL_DACEx_TriangleWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t Amplitude);
+HAL_StatusTypeDef HAL_DACEx_NoiseWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t Amplitude);
+HAL_StatusTypeDef HAL_DACEx_DualSetValue(DAC_HandleTypeDef* hdac, uint32_t Alignment, uint32_t Data1, uint32_t Data2);
+
+void HAL_DACEx_ConvCpltCallbackCh2(DAC_HandleTypeDef* hdac);
+void HAL_DACEx_ConvHalfCpltCallbackCh2(DAC_HandleTypeDef* hdac);
+void HAL_DACEx_ErrorCallbackCh2(DAC_HandleTypeDef* hdac);
+void HAL_DACEx_DMAUnderrunCallbackCh2(DAC_HandleTypeDef* hdac);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup DACEx_Private_Constants DAC Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup DACEx_Private_Macros DAC Private Macros
+  * @{
+  */
+#define IS_DAC_LFSR_UNMASK_TRIANGLE_AMPLITUDE(VALUE) (((VALUE) == DAC_LFSRUNMASK_BIT0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS1_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS2_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS3_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS4_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS5_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS6_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS7_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS8_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS9_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS10_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS11_0) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_1) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_3) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_7) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_15) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_31) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_63) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_127) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_255) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_511) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_1023) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_2047) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_4095))
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup DACEx_Private_Functions DAC Private Functions
+  * @{
+  */
+void DAC_DMAConvCpltCh2(DMA_HandleTypeDef *hdma);
+void DAC_DMAErrorCh2(DMA_HandleTypeDef *hdma);
+void DAC_DMAHalfConvCpltCh2(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32F7xx_HAL_DAC_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_def.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_def.h
@@ -1,0 +1,213 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_def.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   This file contains HAL common defines, enumeration, macros and
+  *          structures definitions.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_DEF
+#define __STM32F7xx_HAL_DEF
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx.h"
+#include "Legacy/stm32_hal_legacy.h"
+#include <stdio.h>
+/* Exported types ------------------------------------------------------------*/
+
+/**
+  * @brief  HAL Status structures definition
+  */
+typedef enum
+{
+  HAL_OK       = 0x00,
+  HAL_ERROR    = 0x01,
+  HAL_BUSY     = 0x02,
+  HAL_TIMEOUT  = 0x03
+} HAL_StatusTypeDef;
+
+/**
+  * @brief  HAL Lock structures definition
+  */
+typedef enum
+{
+  HAL_UNLOCKED = 0x00,
+  HAL_LOCKED   = 0x01
+} HAL_LockTypeDef;
+
+/* Exported macro ------------------------------------------------------------*/
+#define HAL_MAX_DELAY      0xFFFFFFFF
+
+#define HAL_IS_BIT_SET(REG, BIT)         (((REG) & (BIT)) != RESET)
+#define HAL_IS_BIT_CLR(REG, BIT)         (((REG) & (BIT)) == RESET)
+
+#define __HAL_LINKDMA(__HANDLE__, __PPP_DMA_FIELD__, __DMA_HANDLE__)               \
+                        do{                                                      \
+                              (__HANDLE__)->__PPP_DMA_FIELD__ = &(__DMA_HANDLE__); \
+                              (__DMA_HANDLE__).Parent = (__HANDLE__);             \
+                          } while(0)
+
+#define UNUSED(x) ((void)(x))
+
+/** @brief Reset the Handle's State field.
+  * @param __HANDLE__: specifies the Peripheral Handle.
+  * @note  This macro can be used for the following purpose:
+  *          - When the Handle is declared as local variable; before passing it as parameter
+  *            to HAL_PPP_Init() for the first time, it is mandatory to use this macro
+  *            to set to 0 the Handle's "State" field.
+  *            Otherwise, "State" field may have any random value and the first time the function
+  *            HAL_PPP_Init() is called, the low level hardware initialization will be missed
+  *            (i.e. HAL_PPP_MspInit() will not be executed).
+  *          - When there is a need to reconfigure the low level hardware: instead of calling
+  *            HAL_PPP_DeInit() then HAL_PPP_Init(), user can make a call to this macro then HAL_PPP_Init().
+  *            In this later function, when the Handle's "State" field is set to 0, it will execute the function
+  *            HAL_PPP_MspInit() which will reconfigure the low level hardware.
+  * @retval None
+  */
+#define __HAL_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = 0)
+
+#if (USE_RTOS == 1)
+  /* Reserved for future use */
+  #error “USE_RTOS should be 0 in the current HAL release”
+#else
+  #define __HAL_LOCK(__HANDLE__)                                           \
+                                do{                                        \
+                                    if((__HANDLE__)->Lock == HAL_LOCKED)   \
+                                    {                                      \
+                                       return HAL_BUSY;                    \
+                                    }                                      \
+                                    else                                   \
+                                    {                                      \
+                                       (__HANDLE__)->Lock = HAL_LOCKED;    \
+                                    }                                      \
+                                  }while (0)
+
+  #define __HAL_UNLOCK(__HANDLE__)                                          \
+                                  do{                                       \
+                                      (__HANDLE__)->Lock = HAL_UNLOCKED;    \
+                                    }while (0)
+#endif /* USE_RTOS */
+
+#if  defined ( __GNUC__ )
+  #ifndef __weak
+    #define __weak   __attribute__((weak))
+  #endif /* __weak */
+  #ifndef __packed
+    #define __packed __attribute__((__packed__))
+  #endif /* __packed */
+#endif /* __GNUC__ */
+
+
+/* Macro to get variable aligned on 4-bytes, for __ICCARM__ the directive "#pragma data_alignment=4" must be used instead */
+#if defined   (__GNUC__)        /* GNU Compiler */
+  #ifndef __ALIGN_END
+    #define __ALIGN_END    __attribute__ ((aligned (4)))
+  #endif /* __ALIGN_END */
+  #ifndef __ALIGN_BEGIN
+    #define __ALIGN_BEGIN
+  #endif /* __ALIGN_BEGIN */
+#else
+  #ifndef __ALIGN_END
+    #define __ALIGN_END
+  #endif /* __ALIGN_END */
+  #ifndef __ALIGN_BEGIN
+    #if defined   (__CC_ARM)      /* ARM Compiler */
+      #define __ALIGN_BEGIN    __align(4)
+    #elif defined (__ICCARM__)    /* IAR Compiler */
+      #define __ALIGN_BEGIN
+    #endif /* __CC_ARM */
+  #endif /* __ALIGN_BEGIN */
+#endif /* __GNUC__ */
+
+
+/**
+  * @brief  __RAM_FUNC definition
+  */
+#if defined ( __CC_ARM   )
+/* ARM Compiler
+   ------------
+   RAM functions are defined using the toolchain options.
+   Functions that are executed in RAM should reside in a separate source module.
+   Using the 'Options for File' dialog you can simply change the 'Code / Const'
+   area of a module to a memory space in physical RAM.
+   Available memory areas are declared in the 'Target' tab of the 'Options for Target'
+   dialog.
+*/
+#define __RAM_FUNC HAL_StatusTypeDef
+
+#elif defined ( __ICCARM__ )
+/* ICCARM Compiler
+   ---------------
+   RAM functions are defined using a specific toolchain keyword "__ramfunc".
+*/
+#define __RAM_FUNC __ramfunc HAL_StatusTypeDef
+
+#elif defined   (  __GNUC__  )
+/* GNU Compiler
+   ------------
+  RAM functions are defined using a specific toolchain attribute
+   "__attribute__((section(".RamFunc")))".
+*/
+#define __RAM_FUNC HAL_StatusTypeDef  __attribute__((section(".RamFunc")))
+
+#endif
+
+/**
+  * @brief  __NOINLINE definition
+  */
+#if defined ( __CC_ARM   ) || defined   (  __GNUC__  )
+/* ARM & GNUCompiler
+   ----------------
+*/
+#define __NOINLINE __attribute__ ( (noinline) )
+
+#elif defined ( __ICCARM__ )
+/* ICCARM Compiler
+   ---------------
+*/
+#define __NOINLINE _Pragma("optimize = no_inline")
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ___STM32F7xx_HAL_DEF */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_dma.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_dma.h
@@ -1,0 +1,772 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_dma.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of DMA HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_DMA_H
+#define __STM32F7xx_HAL_DMA_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup DMA
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup DMA_Exported_Types DMA Exported Types
+  * @brief    DMA Exported Types
+  * @{
+  */
+
+/**
+  * @brief  DMA Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t Channel;              /*!< Specifies the channel used for the specified stream.
+                                      This parameter can be a value of @ref DMA_Channel_selection                    */
+
+  uint32_t Direction;            /*!< Specifies if the data will be transferred from memory to peripheral,
+                                      from memory to memory or from peripheral to memory.
+                                      This parameter can be a value of @ref DMA_Data_transfer_direction              */
+
+  uint32_t PeriphInc;            /*!< Specifies whether the Peripheral address register should be incremented or not.
+                                      This parameter can be a value of @ref DMA_Peripheral_incremented_mode          */
+
+  uint32_t MemInc;               /*!< Specifies whether the memory address register should be incremented or not.
+                                      This parameter can be a value of @ref DMA_Memory_incremented_mode              */
+
+  uint32_t PeriphDataAlignment;  /*!< Specifies the Peripheral data width.
+                                      This parameter can be a value of @ref DMA_Peripheral_data_size                 */
+
+  uint32_t MemDataAlignment;     /*!< Specifies the Memory data width.
+                                      This parameter can be a value of @ref DMA_Memory_data_size                     */
+
+  uint32_t Mode;                 /*!< Specifies the operation mode of the DMAy Streamx.
+                                      This parameter can be a value of @ref DMA_mode
+                                      @note The circular buffer mode cannot be used if the memory-to-memory
+                                            data transfer is configured on the selected Stream                        */
+
+  uint32_t Priority;             /*!< Specifies the software priority for the DMAy Streamx.
+                                      This parameter can be a value of @ref DMA_Priority_level                       */
+
+  uint32_t FIFOMode;             /*!< Specifies if the FIFO mode or Direct mode will be used for the specified stream.
+                                      This parameter can be a value of @ref DMA_FIFO_direct_mode
+                                      @note The Direct mode (FIFO mode disabled) cannot be used if the
+                                            memory-to-memory data transfer is configured on the selected stream       */
+
+  uint32_t FIFOThreshold;        /*!< Specifies the FIFO threshold level.
+                                      This parameter can be a value of @ref DMA_FIFO_threshold_level                  */
+
+  uint32_t MemBurst;             /*!< Specifies the Burst transfer configuration for the memory transfers.
+                                      It specifies the amount of data to be transferred in a single non interruptible
+                                      transaction.
+                                      This parameter can be a value of @ref DMA_Memory_burst
+                                      @note The burst mode is possible only if the address Increment mode is enabled. */
+
+  uint32_t PeriphBurst;          /*!< Specifies the Burst transfer configuration for the peripheral transfers.
+                                      It specifies the amount of data to be transferred in a single non interruptible
+                                      transaction.
+                                      This parameter can be a value of @ref DMA_Peripheral_burst
+                                      @note The burst mode is possible only if the address Increment mode is enabled. */
+}DMA_InitTypeDef;
+
+/**
+  * @brief  HAL DMA State structures definition
+  */
+typedef enum
+{
+  HAL_DMA_STATE_RESET             = 0x00,  /*!< DMA not yet initialized or disabled */
+  HAL_DMA_STATE_READY             = 0x01,  /*!< DMA initialized and ready for use   */
+  HAL_DMA_STATE_READY_MEM0        = 0x11,  /*!< DMA Mem0 process success            */
+  HAL_DMA_STATE_READY_MEM1        = 0x21,  /*!< DMA Mem1 process success            */
+  HAL_DMA_STATE_READY_HALF_MEM0   = 0x31,  /*!< DMA Mem0 Half process success       */
+  HAL_DMA_STATE_READY_HALF_MEM1   = 0x41,  /*!< DMA Mem1 Half process success       */
+  HAL_DMA_STATE_BUSY              = 0x02,  /*!< DMA process is ongoing              */
+  HAL_DMA_STATE_BUSY_MEM0         = 0x12,  /*!< DMA Mem0 process is ongoing         */
+  HAL_DMA_STATE_BUSY_MEM1         = 0x22,  /*!< DMA Mem1 process is ongoing         */
+  HAL_DMA_STATE_TIMEOUT           = 0x03,  /*!< DMA timeout state                   */
+  HAL_DMA_STATE_ERROR             = 0x04,  /*!< DMA error state                     */
+}HAL_DMA_StateTypeDef;
+
+/**
+  * @brief  HAL DMA Error Code structure definition
+  */
+typedef enum
+{
+  HAL_DMA_FULL_TRANSFER      = 0x00,    /*!< Full transfer     */
+  HAL_DMA_HALF_TRANSFER      = 0x01,    /*!< Half Transfer     */
+}HAL_DMA_LevelCompleteTypeDef;
+
+/**
+  * @brief  DMA handle Structure definition
+  */
+typedef struct __DMA_HandleTypeDef
+{
+  DMA_Stream_TypeDef         *Instance;                                                    /*!< Register base address                  */
+
+  DMA_InitTypeDef            Init;                                                         /*!< DMA communication parameters           */
+
+  HAL_LockTypeDef            Lock;                                                         /*!< DMA locking object                     */
+
+  __IO HAL_DMA_StateTypeDef  State;                                                        /*!< DMA transfer state                     */
+
+  void                       *Parent;                                                      /*!< Parent object state                    */
+
+  void                       (* XferCpltCallback)( struct __DMA_HandleTypeDef * hdma);     /*!< DMA transfer complete callback         */
+
+  void                       (* XferHalfCpltCallback)( struct __DMA_HandleTypeDef * hdma); /*!< DMA Half transfer complete callback    */
+
+  void                       (* XferM1CpltCallback)( struct __DMA_HandleTypeDef * hdma);   /*!< DMA transfer complete Memory1 callback */
+
+  void                       (* XferErrorCallback)( struct __DMA_HandleTypeDef * hdma);    /*!< DMA transfer error callback            */
+
+ __IO uint32_t              ErrorCode;                                                    /*!< DMA Error code                          */
+}DMA_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup DMA_Exported_Constants DMA Exported Constants
+  * @brief    DMA Exported constants
+  * @{
+  */
+
+/** @defgroup DMA_Error_Code DMA Error Code
+  * @brief    DMA Error Code
+  * @{
+  */
+#define HAL_DMA_ERROR_NONE      ((uint32_t)0x00000000)    /*!< No error             */
+#define HAL_DMA_ERROR_TE        ((uint32_t)0x00000001)    /*!< Transfer error       */
+#define HAL_DMA_ERROR_FE        ((uint32_t)0x00000002)    /*!< FIFO error           */
+#define HAL_DMA_ERROR_DME       ((uint32_t)0x00000004)    /*!< Direct Mode error    */
+#define HAL_DMA_ERROR_TIMEOUT   ((uint32_t)0x00000020)    /*!< Timeout error        */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Channel_selection DMA Channel selection
+  * @brief    DMA channel selection
+  * @{
+  */
+#define DMA_CHANNEL_0        ((uint32_t)0x00000000)  /*!< DMA Channel 0 */
+#define DMA_CHANNEL_1        ((uint32_t)0x02000000)  /*!< DMA Channel 1 */
+#define DMA_CHANNEL_2        ((uint32_t)0x04000000)  /*!< DMA Channel 2 */
+#define DMA_CHANNEL_3        ((uint32_t)0x06000000)  /*!< DMA Channel 3 */
+#define DMA_CHANNEL_4        ((uint32_t)0x08000000)  /*!< DMA Channel 4 */
+#define DMA_CHANNEL_5        ((uint32_t)0x0A000000)  /*!< DMA Channel 5 */
+#define DMA_CHANNEL_6        ((uint32_t)0x0C000000)  /*!< DMA Channel 6 */
+#define DMA_CHANNEL_7        ((uint32_t)0x0E000000)  /*!< DMA Channel 7 */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Data_transfer_direction DMA Data transfer direction
+  * @brief    DMA data transfer direction
+  * @{
+  */
+#define DMA_PERIPH_TO_MEMORY         ((uint32_t)0x00000000)      /*!< Peripheral to memory direction */
+#define DMA_MEMORY_TO_PERIPH         ((uint32_t)DMA_SxCR_DIR_0)  /*!< Memory to peripheral direction */
+#define DMA_MEMORY_TO_MEMORY         ((uint32_t)DMA_SxCR_DIR_1)  /*!< Memory to memory direction     */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Peripheral_incremented_mode DMA Peripheral incremented mode
+  * @brief    DMA peripheral incremented mode
+  * @{
+  */
+#define DMA_PINC_ENABLE        ((uint32_t)DMA_SxCR_PINC)  /*!< Peripheral increment mode enable  */
+#define DMA_PINC_DISABLE       ((uint32_t)0x00000000)     /*!< Peripheral increment mode disable */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Memory_incremented_mode DMA Memory incremented mode
+  * @brief    DMA memory incremented mode
+  * @{
+  */
+#define DMA_MINC_ENABLE         ((uint32_t)DMA_SxCR_MINC)  /*!< Memory increment mode enable  */
+#define DMA_MINC_DISABLE        ((uint32_t)0x00000000)     /*!< Memory increment mode disable */
+/**
+  * @}
+  */
+
+
+/** @defgroup DMA_Peripheral_data_size DMA Peripheral data size
+  * @brief    DMA peripheral data size
+  * @{
+  */
+#define DMA_PDATAALIGN_BYTE          ((uint32_t)0x00000000)        /*!< Peripheral data alignment: Byte     */
+#define DMA_PDATAALIGN_HALFWORD      ((uint32_t)DMA_SxCR_PSIZE_0)  /*!< Peripheral data alignment: HalfWord */
+#define DMA_PDATAALIGN_WORD          ((uint32_t)DMA_SxCR_PSIZE_1)  /*!< Peripheral data alignment: Word     */
+/**
+  * @}
+  */
+
+
+/** @defgroup DMA_Memory_data_size DMA Memory data size
+  * @brief    DMA memory data size
+  * @{
+  */
+#define DMA_MDATAALIGN_BYTE          ((uint32_t)0x00000000)        /*!< Memory data alignment: Byte     */
+#define DMA_MDATAALIGN_HALFWORD      ((uint32_t)DMA_SxCR_MSIZE_0)  /*!< Memory data alignment: HalfWord */
+#define DMA_MDATAALIGN_WORD          ((uint32_t)DMA_SxCR_MSIZE_1)  /*!< Memory data alignment: Word     */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_mode DMA mode
+  * @brief    DMA mode
+  * @{
+  */
+#define DMA_NORMAL         ((uint32_t)0x00000000)       /*!< Normal mode                  */
+#define DMA_CIRCULAR       ((uint32_t)DMA_SxCR_CIRC)    /*!< Circular mode                */
+#define DMA_PFCTRL         ((uint32_t)DMA_SxCR_PFCTRL)  /*!< Peripheral flow control mode */
+/**
+  * @}
+  */
+
+
+/** @defgroup DMA_Priority_level DMA Priority level
+  * @brief    DMA priority levels
+  * @{
+  */
+#define DMA_PRIORITY_LOW             ((uint32_t)0x00000000)     /*!< Priority level: Low       */
+#define DMA_PRIORITY_MEDIUM          ((uint32_t)DMA_SxCR_PL_0)  /*!< Priority level: Medium    */
+#define DMA_PRIORITY_HIGH            ((uint32_t)DMA_SxCR_PL_1)  /*!< Priority level: High      */
+#define DMA_PRIORITY_VERY_HIGH       ((uint32_t)DMA_SxCR_PL)    /*!< Priority level: Very High */
+/**
+  * @}
+  */
+
+
+/** @defgroup DMA_FIFO_direct_mode DMA FIFO direct mode
+  * @brief    DMA FIFO direct mode
+  * @{
+  */
+#define DMA_FIFOMODE_DISABLE        ((uint32_t)0x00000000)       /*!< FIFO mode disable */
+#define DMA_FIFOMODE_ENABLE         ((uint32_t)DMA_SxFCR_DMDIS)  /*!< FIFO mode enable  */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_FIFO_threshold_level DMA FIFO threshold level
+  * @brief    DMA FIFO level
+  * @{
+  */
+#define DMA_FIFO_THRESHOLD_1QUARTERFULL       ((uint32_t)0x00000000)       /*!< FIFO threshold 1 quart full configuration  */
+#define DMA_FIFO_THRESHOLD_HALFFULL           ((uint32_t)DMA_SxFCR_FTH_0)  /*!< FIFO threshold half full configuration     */
+#define DMA_FIFO_THRESHOLD_3QUARTERSFULL      ((uint32_t)DMA_SxFCR_FTH_1)  /*!< FIFO threshold 3 quarts full configuration */
+#define DMA_FIFO_THRESHOLD_FULL               ((uint32_t)DMA_SxFCR_FTH)    /*!< FIFO threshold full configuration          */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Memory_burst DMA Memory burst
+  * @brief    DMA memory burst
+  * @{
+  */
+#define DMA_MBURST_SINGLE       ((uint32_t)0x00000000)
+#define DMA_MBURST_INC4         ((uint32_t)DMA_SxCR_MBURST_0)
+#define DMA_MBURST_INC8         ((uint32_t)DMA_SxCR_MBURST_1)
+#define DMA_MBURST_INC16        ((uint32_t)DMA_SxCR_MBURST)
+/**
+  * @}
+  */
+
+
+/** @defgroup DMA_Peripheral_burst DMA Peripheral burst
+  * @brief    DMA peripheral burst
+  * @{
+  */
+#define DMA_PBURST_SINGLE       ((uint32_t)0x00000000)
+#define DMA_PBURST_INC4         ((uint32_t)DMA_SxCR_PBURST_0)
+#define DMA_PBURST_INC8         ((uint32_t)DMA_SxCR_PBURST_1)
+#define DMA_PBURST_INC16        ((uint32_t)DMA_SxCR_PBURST)
+/**
+  * @}
+  */
+
+/** @defgroup DMA_interrupt_enable_definitions DMA interrupt enable definitions
+  * @brief    DMA interrupts definition
+  * @{
+  */
+#define DMA_IT_TC                         ((uint32_t)DMA_SxCR_TCIE)
+#define DMA_IT_HT                         ((uint32_t)DMA_SxCR_HTIE)
+#define DMA_IT_TE                         ((uint32_t)DMA_SxCR_TEIE)
+#define DMA_IT_DME                        ((uint32_t)DMA_SxCR_DMEIE)
+#define DMA_IT_FE                         ((uint32_t)0x00000080)
+/**
+  * @}
+  */
+
+/** @defgroup DMA_flag_definitions DMA flag definitions
+  * @brief    DMA flag definitions
+  * @{
+  */
+#define DMA_FLAG_FEIF0_4                    ((uint32_t)0x00800001)
+#define DMA_FLAG_DMEIF0_4                   ((uint32_t)0x00800004)
+#define DMA_FLAG_TEIF0_4                    ((uint32_t)0x00000008)
+#define DMA_FLAG_HTIF0_4                    ((uint32_t)0x00000010)
+#define DMA_FLAG_TCIF0_4                    ((uint32_t)0x00000020)
+#define DMA_FLAG_FEIF1_5                    ((uint32_t)0x00000040)
+#define DMA_FLAG_DMEIF1_5                   ((uint32_t)0x00000100)
+#define DMA_FLAG_TEIF1_5                    ((uint32_t)0x00000200)
+#define DMA_FLAG_HTIF1_5                    ((uint32_t)0x00000400)
+#define DMA_FLAG_TCIF1_5                    ((uint32_t)0x00000800)
+#define DMA_FLAG_FEIF2_6                    ((uint32_t)0x00010000)
+#define DMA_FLAG_DMEIF2_6                   ((uint32_t)0x00040000)
+#define DMA_FLAG_TEIF2_6                    ((uint32_t)0x00080000)
+#define DMA_FLAG_HTIF2_6                    ((uint32_t)0x00100000)
+#define DMA_FLAG_TCIF2_6                    ((uint32_t)0x00200000)
+#define DMA_FLAG_FEIF3_7                    ((uint32_t)0x00400000)
+#define DMA_FLAG_DMEIF3_7                   ((uint32_t)0x01000000)
+#define DMA_FLAG_TEIF3_7                    ((uint32_t)0x02000000)
+#define DMA_FLAG_HTIF3_7                    ((uint32_t)0x04000000)
+#define DMA_FLAG_TCIF3_7                    ((uint32_t)0x08000000)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @brief Reset DMA handle state
+  * @param  __HANDLE__: specifies the DMA handle.
+  * @retval None
+  */
+#define __HAL_DMA_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_DMA_STATE_RESET)
+
+/**
+  * @brief  Return the current DMA Stream FIFO filled level.
+  * @param  __HANDLE__: DMA handle
+  * @retval The FIFO filling state.
+  *           - DMA_FIFOStatus_Less1QuarterFull: when FIFO is less than 1 quarter-full
+  *                                              and not empty.
+  *           - DMA_FIFOStatus_1QuarterFull: if more than 1 quarter-full.
+  *           - DMA_FIFOStatus_HalfFull: if more than 1 half-full.
+  *           - DMA_FIFOStatus_3QuartersFull: if more than 3 quarters-full.
+  *           - DMA_FIFOStatus_Empty: when FIFO is empty
+  *           - DMA_FIFOStatus_Full: when FIFO is full
+  */
+#define __HAL_DMA_GET_FS(__HANDLE__)      (((__HANDLE__)->Instance->FCR & (DMA_SxFCR_FS)))
+
+/**
+  * @brief  Enable the specified DMA Stream.
+  * @param  __HANDLE__: DMA handle
+  * @retval None
+  */
+#define __HAL_DMA_ENABLE(__HANDLE__)      ((__HANDLE__)->Instance->CR |=  DMA_SxCR_EN)
+
+/**
+  * @brief  Disable the specified DMA Stream.
+  * @param  __HANDLE__: DMA handle
+  * @retval None
+  */
+#define __HAL_DMA_DISABLE(__HANDLE__)     ((__HANDLE__)->Instance->CR &=  ~DMA_SxCR_EN)
+
+/* Interrupt & Flag management */
+
+/**
+  * @brief  Return the current DMA Stream transfer complete flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified transfer complete flag index.
+  */
+#define __HAL_DMA_GET_TC_FLAG_INDEX(__HANDLE__) \
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream0))? DMA_FLAG_TCIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream0))? DMA_FLAG_TCIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream4))? DMA_FLAG_TCIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream4))? DMA_FLAG_TCIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream1))? DMA_FLAG_TCIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream1))? DMA_FLAG_TCIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream5))? DMA_FLAG_TCIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream5))? DMA_FLAG_TCIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream2))? DMA_FLAG_TCIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream2))? DMA_FLAG_TCIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream6))? DMA_FLAG_TCIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream6))? DMA_FLAG_TCIF2_6 :\
+   DMA_FLAG_TCIF3_7)
+
+/**
+  * @brief  Return the current DMA Stream half transfer complete flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified half transfer complete flag index.
+  */
+#define __HAL_DMA_GET_HT_FLAG_INDEX(__HANDLE__)\
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream0))? DMA_FLAG_HTIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream0))? DMA_FLAG_HTIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream4))? DMA_FLAG_HTIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream4))? DMA_FLAG_HTIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream1))? DMA_FLAG_HTIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream1))? DMA_FLAG_HTIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream5))? DMA_FLAG_HTIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream5))? DMA_FLAG_HTIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream2))? DMA_FLAG_HTIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream2))? DMA_FLAG_HTIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream6))? DMA_FLAG_HTIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream6))? DMA_FLAG_HTIF2_6 :\
+   DMA_FLAG_HTIF3_7)
+
+/**
+  * @brief  Return the current DMA Stream transfer error flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified transfer error flag index.
+  */
+#define __HAL_DMA_GET_TE_FLAG_INDEX(__HANDLE__)\
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream0))? DMA_FLAG_TEIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream0))? DMA_FLAG_TEIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream4))? DMA_FLAG_TEIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream4))? DMA_FLAG_TEIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream1))? DMA_FLAG_TEIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream1))? DMA_FLAG_TEIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream5))? DMA_FLAG_TEIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream5))? DMA_FLAG_TEIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream2))? DMA_FLAG_TEIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream2))? DMA_FLAG_TEIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream6))? DMA_FLAG_TEIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream6))? DMA_FLAG_TEIF2_6 :\
+   DMA_FLAG_TEIF3_7)
+
+/**
+  * @brief  Return the current DMA Stream FIFO error flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified FIFO error flag index.
+  */
+#define __HAL_DMA_GET_FE_FLAG_INDEX(__HANDLE__)\
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream0))? DMA_FLAG_FEIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream0))? DMA_FLAG_FEIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream4))? DMA_FLAG_FEIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream4))? DMA_FLAG_FEIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream1))? DMA_FLAG_FEIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream1))? DMA_FLAG_FEIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream5))? DMA_FLAG_FEIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream5))? DMA_FLAG_FEIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream2))? DMA_FLAG_FEIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream2))? DMA_FLAG_FEIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream6))? DMA_FLAG_FEIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream6))? DMA_FLAG_FEIF2_6 :\
+   DMA_FLAG_FEIF3_7)
+
+/**
+  * @brief  Return the current DMA Stream direct mode error flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified direct mode error flag index.
+  */
+#define __HAL_DMA_GET_DME_FLAG_INDEX(__HANDLE__)\
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream0))? DMA_FLAG_DMEIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream0))? DMA_FLAG_DMEIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream4))? DMA_FLAG_DMEIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream4))? DMA_FLAG_DMEIF0_4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream1))? DMA_FLAG_DMEIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream1))? DMA_FLAG_DMEIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream5))? DMA_FLAG_DMEIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream5))? DMA_FLAG_DMEIF1_5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream2))? DMA_FLAG_DMEIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream2))? DMA_FLAG_DMEIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Stream6))? DMA_FLAG_DMEIF2_6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Stream6))? DMA_FLAG_DMEIF2_6 :\
+   DMA_FLAG_DMEIF3_7)
+
+/**
+  * @brief  Get the DMA Stream pending flags.
+  * @param  __HANDLE__: DMA handle
+  * @param  __FLAG__: Get the specified flag.
+  *          This parameter can be any combination of the following values:
+  *            @arg DMA_FLAG_TCIFx: Transfer complete flag.
+  *            @arg DMA_FLAG_HTIFx: Half transfer complete flag.
+  *            @arg DMA_FLAG_TEIFx: Transfer error flag.
+  *            @arg DMA_FLAG_DMEIFx: Direct mode error flag.
+  *            @arg DMA_FLAG_FEIFx: FIFO error flag.
+  *         Where x can be 0_4, 1_5, 2_6 or 3_7 to select the DMA Stream flag.
+  * @retval The state of FLAG (SET or RESET).
+  */
+#define __HAL_DMA_GET_FLAG(__HANDLE__, __FLAG__)\
+(((uint32_t)((__HANDLE__)->Instance) > (uint32_t)DMA2_Stream3)? (DMA2->HISR & (__FLAG__)) :\
+ ((uint32_t)((__HANDLE__)->Instance) > (uint32_t)DMA1_Stream7)? (DMA2->LISR & (__FLAG__)) :\
+ ((uint32_t)((__HANDLE__)->Instance) > (uint32_t)DMA1_Stream3)? (DMA1->HISR & (__FLAG__)) : (DMA1->LISR & (__FLAG__)))
+
+/**
+  * @brief  Clear the DMA Stream pending flags.
+  * @param  __HANDLE__: DMA handle
+  * @param  __FLAG__: specifies the flag to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg DMA_FLAG_TCIFx: Transfer complete flag.
+  *            @arg DMA_FLAG_HTIFx: Half transfer complete flag.
+  *            @arg DMA_FLAG_TEIFx: Transfer error flag.
+  *            @arg DMA_FLAG_DMEIFx: Direct mode error flag.
+  *            @arg DMA_FLAG_FEIFx: FIFO error flag.
+  *         Where x can be 0_4, 1_5, 2_6 or 3_7 to select the DMA Stream flag.
+  * @retval None
+  */
+#define __HAL_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__) \
+(((uint32_t)((__HANDLE__)->Instance) > (uint32_t)DMA2_Stream3)? (DMA2->HIFCR = (__FLAG__)) :\
+ ((uint32_t)((__HANDLE__)->Instance) > (uint32_t)DMA1_Stream7)? (DMA2->LIFCR = (__FLAG__)) :\
+ ((uint32_t)((__HANDLE__)->Instance) > (uint32_t)DMA1_Stream3)? (DMA1->HIFCR = (__FLAG__)) : (DMA1->LIFCR = (__FLAG__)))
+
+/**
+  * @brief  Enable the specified DMA Stream interrupts.
+  * @param  __HANDLE__: DMA handle
+  * @param  __INTERRUPT__: specifies the DMA interrupt sources to be enabled or disabled.
+  *        This parameter can be any combination of the following values:
+  *           @arg DMA_IT_TC: Transfer complete interrupt mask.
+  *           @arg DMA_IT_HT: Half transfer complete interrupt mask.
+  *           @arg DMA_IT_TE: Transfer error interrupt mask.
+  *           @arg DMA_IT_FE: FIFO error interrupt mask.
+  *           @arg DMA_IT_DME: Direct mode error interrupt.
+  * @retval None
+  */
+#define __HAL_DMA_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (((__INTERRUPT__) != DMA_IT_FE)? \
+((__HANDLE__)->Instance->CR |= (__INTERRUPT__)) : ((__HANDLE__)->Instance->FCR |= (__INTERRUPT__)))
+
+/**
+  * @brief  Disable the specified DMA Stream interrupts.
+  * @param  __HANDLE__: DMA handle
+  * @param  __INTERRUPT__: specifies the DMA interrupt sources to be enabled or disabled.
+  *         This parameter can be any combination of the following values:
+  *            @arg DMA_IT_TC: Transfer complete interrupt mask.
+  *            @arg DMA_IT_HT: Half transfer complete interrupt mask.
+  *            @arg DMA_IT_TE: Transfer error interrupt mask.
+  *            @arg DMA_IT_FE: FIFO error interrupt mask.
+  *            @arg DMA_IT_DME: Direct mode error interrupt.
+  * @retval None
+  */
+#define __HAL_DMA_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((__INTERRUPT__) != DMA_IT_FE)? \
+((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__)) : ((__HANDLE__)->Instance->FCR &= ~(__INTERRUPT__)))
+
+/**
+  * @brief  Check whether the specified DMA Stream interrupt is enabled or not.
+  * @param  __HANDLE__: DMA handle
+  * @param  __INTERRUPT__: specifies the DMA interrupt source to check.
+  *         This parameter can be one of the following values:
+  *            @arg DMA_IT_TC: Transfer complete interrupt mask.
+  *            @arg DMA_IT_HT: Half transfer complete interrupt mask.
+  *            @arg DMA_IT_TE: Transfer error interrupt mask.
+  *            @arg DMA_IT_FE: FIFO error interrupt mask.
+  *            @arg DMA_IT_DME: Direct mode error interrupt.
+  * @retval The state of DMA_IT.
+  */
+#define __HAL_DMA_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)  (((__INTERRUPT__) != DMA_IT_FE)? \
+                                                        ((__HANDLE__)->Instance->CR & (__INTERRUPT__)) : \
+                                                        ((__HANDLE__)->Instance->FCR & (__INTERRUPT__)))
+
+/**
+  * @brief  Writes the number of data units to be transferred on the DMA Stream.
+  * @param  __HANDLE__: DMA handle
+  * @param  __COUNTER__: Number of data units to be transferred (from 0 to 65535)
+  *          Number of data items depends only on the Peripheral data format.
+  *
+  * @note   If Peripheral data format is Bytes: number of data units is equal
+  *         to total number of bytes to be transferred.
+  *
+  * @note   If Peripheral data format is Half-Word: number of data units is
+  *         equal to total number of bytes to be transferred / 2.
+  *
+  * @note   If Peripheral data format is Word: number of data units is equal
+  *         to total  number of bytes to be transferred / 4.
+  *
+  * @retval The number of remaining data units in the current DMAy Streamx transfer.
+  */
+#define __HAL_DMA_SET_COUNTER(__HANDLE__, __COUNTER__) ((__HANDLE__)->Instance->NDTR = (uint16_t)(__COUNTER__))
+
+/**
+  * @brief  Returns the number of remaining data units in the current DMAy Streamx transfer.
+  * @param  __HANDLE__: DMA handle
+  *
+  * @retval The number of remaining data units in the current DMA Stream transfer.
+  */
+#define __HAL_DMA_GET_COUNTER(__HANDLE__) ((__HANDLE__)->Instance->NDTR)
+
+
+/* Include DMA HAL Extension module */
+#include "stm32f7xx_hal_dma_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup DMA_Exported_Functions DMA Exported Functions
+  * @brief    DMA Exported functions
+  * @{
+  */
+
+/** @defgroup DMA_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @brief   Initialization and de-initialization functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma);
+HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Exported_Functions_Group2 I/O operation functions
+  * @brief   I/O operation functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_DMA_Start (DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
+HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
+HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma);
+HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, uint32_t CompleteLevel, uint32_t Timeout);
+void              HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Exported_Functions_Group3 Peripheral State functions
+  * @brief    Peripheral State functions
+  * @{
+  */
+HAL_DMA_StateTypeDef HAL_DMA_GetState(DMA_HandleTypeDef *hdma);
+uint32_t             HAL_DMA_GetError(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+/**
+  * @}
+  */
+/* Private Constants -------------------------------------------------------------*/
+/** @defgroup DMA_Private_Constants DMA Private Constants
+  * @brief    DMA private defines and constants
+  * @{
+  */
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup DMA_Private_Macros DMA Private Macros
+  * @brief    DMA private macros
+  * @{
+  */
+#define IS_DMA_CHANNEL(CHANNEL) (((CHANNEL) == DMA_CHANNEL_0) || \
+                                 ((CHANNEL) == DMA_CHANNEL_1) || \
+                                 ((CHANNEL) == DMA_CHANNEL_2) || \
+                                 ((CHANNEL) == DMA_CHANNEL_3) || \
+                                 ((CHANNEL) == DMA_CHANNEL_4) || \
+                                 ((CHANNEL) == DMA_CHANNEL_5) || \
+                                 ((CHANNEL) == DMA_CHANNEL_6) || \
+                                 ((CHANNEL) == DMA_CHANNEL_7))
+
+#define IS_DMA_DIRECTION(DIRECTION) (((DIRECTION) == DMA_PERIPH_TO_MEMORY ) || \
+                                     ((DIRECTION) == DMA_MEMORY_TO_PERIPH)  || \
+                                     ((DIRECTION) == DMA_MEMORY_TO_MEMORY))
+
+#define IS_DMA_BUFFER_SIZE(SIZE) (((SIZE) >= 0x1) && ((SIZE) < 0x10000))
+
+#define IS_DMA_PERIPHERAL_INC_STATE(STATE) (((STATE) == DMA_PINC_ENABLE) || \
+                                            ((STATE) == DMA_PINC_DISABLE))
+
+#define IS_DMA_MEMORY_INC_STATE(STATE) (((STATE) == DMA_MINC_ENABLE)  || \
+                                        ((STATE) == DMA_MINC_DISABLE))
+
+#define IS_DMA_PERIPHERAL_DATA_SIZE(SIZE) (((SIZE) == DMA_PDATAALIGN_BYTE)     || \
+                                           ((SIZE) == DMA_PDATAALIGN_HALFWORD) || \
+                                           ((SIZE) == DMA_PDATAALIGN_WORD))
+
+#define IS_DMA_MEMORY_DATA_SIZE(SIZE) (((SIZE) == DMA_MDATAALIGN_BYTE)     || \
+                                       ((SIZE) == DMA_MDATAALIGN_HALFWORD) || \
+                                       ((SIZE) == DMA_MDATAALIGN_WORD ))
+
+#define IS_DMA_MODE(MODE) (((MODE) == DMA_NORMAL )  || \
+                           ((MODE) == DMA_CIRCULAR) || \
+                           ((MODE) == DMA_PFCTRL))
+
+#define IS_DMA_PRIORITY(PRIORITY) (((PRIORITY) == DMA_PRIORITY_LOW )   || \
+                                   ((PRIORITY) == DMA_PRIORITY_MEDIUM) || \
+                                   ((PRIORITY) == DMA_PRIORITY_HIGH)   || \
+                                   ((PRIORITY) == DMA_PRIORITY_VERY_HIGH))
+
+#define IS_DMA_FIFO_MODE_STATE(STATE) (((STATE) == DMA_FIFOMODE_DISABLE ) || \
+                                       ((STATE) == DMA_FIFOMODE_ENABLE))
+
+#define IS_DMA_FIFO_THRESHOLD(THRESHOLD) (((THRESHOLD) == DMA_FIFO_THRESHOLD_1QUARTERFULL ) || \
+                                          ((THRESHOLD) == DMA_FIFO_THRESHOLD_HALFFULL)      || \
+                                          ((THRESHOLD) == DMA_FIFO_THRESHOLD_3QUARTERSFULL) || \
+                                          ((THRESHOLD) == DMA_FIFO_THRESHOLD_FULL))
+
+#define IS_DMA_MEMORY_BURST(BURST) (((BURST) == DMA_MBURST_SINGLE) || \
+                                    ((BURST) == DMA_MBURST_INC4)   || \
+                                    ((BURST) == DMA_MBURST_INC8)   || \
+                                    ((BURST) == DMA_MBURST_INC16))
+
+#define IS_DMA_PERIPHERAL_BURST(BURST) (((BURST) == DMA_PBURST_SINGLE) || \
+                                        ((BURST) == DMA_PBURST_INC4)   || \
+                                        ((BURST) == DMA_PBURST_INC8)   || \
+                                        ((BURST) == DMA_PBURST_INC16))
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup DMA_Private_Functions DMA Private Functions
+  * @brief    DMA private  functions
+  * @{
+  */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_DMA_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_dma_ex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_dma_ex.h
@@ -1,0 +1,123 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_dma_ex.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of DMA HAL extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_DMA_EX_H
+#define __STM32F7xx_HAL_DMA_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup DMAEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup DMAEx_Exported_Types DMAEx Exported Types
+  * @brief DMAEx Exported types
+  * @{
+  */
+
+/**
+  * @brief  HAL DMA Memory definition
+  */
+typedef enum
+{
+  MEMORY0      = 0x00,    /*!< Memory 0     */
+  MEMORY1      = 0x01,    /*!< Memory 1     */
+
+}HAL_DMA_MemoryTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup DMAEx_Exported_Functions DMAEx Exported Functions
+  * @brief   DMAEx Exported functions
+  * @{
+  */
+
+/** @defgroup DMAEx_Exported_Functions_Group1 Extended features functions
+  * @brief   Extended features functions
+  * @{
+  */
+
+/* IO operation functions *******************************************************/
+HAL_StatusTypeDef HAL_DMAEx_MultiBufferStart(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t SecondMemAddress, uint32_t DataLength);
+HAL_StatusTypeDef HAL_DMAEx_MultiBufferStart_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t SecondMemAddress, uint32_t DataLength);
+HAL_StatusTypeDef HAL_DMAEx_ChangeMemory(DMA_HandleTypeDef *hdma, uint32_t Address, HAL_DMA_MemoryTypeDef memory);
+
+/**
+  * @}
+  */
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup DMAEx_Private_Functions DMAEx Private Functions
+  * @brief DMAEx Private functions
+  * @{
+  */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_DMA_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_flash.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_flash.h
@@ -1,0 +1,396 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_flash.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of FLASH HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_FLASH_H
+#define __STM32F7xx_HAL_FLASH_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup FLASH
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup FLASH_Exported_Types FLASH Exported Types
+  * @{
+  */
+
+/**
+  * @brief  FLASH Procedure structure definition
+  */
+typedef enum
+{
+  FLASH_PROC_NONE = 0,
+  FLASH_PROC_SECTERASE,
+  FLASH_PROC_MASSERASE,
+  FLASH_PROC_PROGRAM
+} FLASH_ProcedureTypeDef;
+
+
+/**
+  * @brief  FLASH handle Structure definition
+  */
+typedef struct
+{
+  __IO FLASH_ProcedureTypeDef ProcedureOnGoing;   /* Internal variable to indicate which procedure is ongoing or not in IT context */
+
+  __IO uint32_t               NbSectorsToErase;   /* Internal variable to save the remaining sectors to erase in IT context        */
+
+  __IO uint8_t                VoltageForErase;    /* Internal variable to provide voltage range selected by user in IT context    */
+
+  __IO uint32_t               Sector;             /* Internal variable to define the current sector which is erasing               */
+
+  __IO uint32_t               Address;            /* Internal variable to save address selected for program                        */
+
+  HAL_LockTypeDef             Lock;               /* FLASH locking object                                                          */
+
+  __IO uint32_t               ErrorCode;          /* FLASH error code                    */
+
+}FLASH_ProcessTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup FLASH_Exported_Constants FLASH Exported Constants
+  * @{
+  */
+
+/** @defgroup FLASH_Error_Code FLASH Error Code
+  * @brief    FLASH Error Code
+  * @{
+  */
+#define HAL_FLASH_ERROR_NONE         ((uint32_t)0x00000000)    /*!< No error                      */
+#define HAL_FLASH_ERROR_ERS          ((uint32_t)0x00000002)    /*!< Programming Sequence error    */
+#define HAL_FLASH_ERROR_PGP          ((uint32_t)0x00000004)    /*!< Programming Parallelism error */
+#define HAL_FLASH_ERROR_PGA          ((uint32_t)0x00000008)    /*!< Programming Alignment error   */
+#define HAL_FLASH_ERROR_WRP          ((uint32_t)0x00000010)    /*!< Write protection error        */
+#define HAL_FLASH_ERROR_OPERATION    ((uint32_t)0x00000020)    /*!< Operation Error               */
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Type_Program FLASH Type Program
+  * @{
+  */
+#define FLASH_TYPEPROGRAM_BYTE        ((uint32_t)0x00)  /*!< Program byte (8-bit) at a specified address           */
+#define FLASH_TYPEPROGRAM_HALFWORD    ((uint32_t)0x01)  /*!< Program a half-word (16-bit) at a specified address   */
+#define FLASH_TYPEPROGRAM_WORD        ((uint32_t)0x02)  /*!< Program a word (32-bit) at a specified address        */
+#define FLASH_TYPEPROGRAM_DOUBLEWORD  ((uint32_t)0x03)  /*!< Program a double word (64-bit) at a specified address */
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Flag_definition FLASH Flag definition
+  * @brief Flag definition
+  * @{
+  */
+#define FLASH_FLAG_EOP                 FLASH_SR_EOP            /*!< FLASH End of Operation flag               */
+#define FLASH_FLAG_OPERR               FLASH_SR_OPERR          /*!< FLASH operation Error flag                */
+#define FLASH_FLAG_WRPERR              FLASH_SR_WRPERR         /*!< FLASH Write protected error flag          */
+#define FLASH_FLAG_PGAERR              FLASH_SR_PGAERR         /*!< FLASH Programming Alignment error flag    */
+#define FLASH_FLAG_PGPERR              FLASH_SR_PGPERR         /*!< FLASH Programming Parallelism error flag  */
+#define FLASH_FLAG_ERSERR              FLASH_SR_ERSERR         /*!< FLASH Erasing Sequence error flag         */
+#define FLASH_FLAG_BSY                 FLASH_SR_BSY            /*!< FLASH Busy flag                           */
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Interrupt_definition FLASH Interrupt definition
+  * @brief FLASH Interrupt definition
+  * @{
+  */
+#define FLASH_IT_EOP                   FLASH_CR_EOPIE          /*!< End of FLASH Operation Interrupt source */
+#define FLASH_IT_ERR                   ((uint32_t)0x02000000)  /*!< Error Interrupt source                  */
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Program_Parallelism FLASH Program Parallelism
+  * @{
+  */
+#define FLASH_PSIZE_BYTE           ((uint32_t)0x00000000)
+#define FLASH_PSIZE_HALF_WORD      ((uint32_t)FLASH_CR_PSIZE_0)
+#define FLASH_PSIZE_WORD           ((uint32_t)FLASH_CR_PSIZE_1)
+#define FLASH_PSIZE_DOUBLE_WORD    ((uint32_t)FLASH_CR_PSIZE)
+#define CR_PSIZE_MASK              ((uint32_t)0xFFFFFCFF)
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Keys FLASH Keys
+  * @{
+  */
+#define FLASH_KEY1               ((uint32_t)0x45670123)
+#define FLASH_KEY2               ((uint32_t)0xCDEF89AB)
+#define FLASH_OPT_KEY1           ((uint32_t)0x08192A3B)
+#define FLASH_OPT_KEY2           ((uint32_t)0x4C5D6E7F)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup FLASH_Exported_Macros FLASH Exported Macros
+  * @{
+  */
+/**
+  * @brief  Set the FLASH Latency.
+  * @param  __LATENCY__: FLASH Latency
+  *         The value of this parameter depend on device used within the same series
+  * @retval none
+  */
+#define __HAL_FLASH_SET_LATENCY(__LATENCY__) \
+                  MODIFY_REG(FLASH->ACR, FLASH_ACR_LATENCY, (uint32_t)(__LATENCY__))
+
+/**
+  * @brief  Get the FLASH Latency.
+  * @retval FLASH Latency
+  *          The value of this parameter depend on device used within the same series
+  */
+#define __HAL_FLASH_GET_LATENCY()     (READ_BIT((FLASH->ACR), FLASH_ACR_LATENCY))
+
+/**
+  * @brief  Enable the FLASH prefetch buffer.
+  * @retval none
+  */
+#define __HAL_FLASH_PREFETCH_BUFFER_ENABLE()  (FLASH->ACR |= FLASH_ACR_PRFTEN)
+
+/**
+  * @brief  Disable the FLASH prefetch buffer.
+  * @retval none
+  */
+#define __HAL_FLASH_PREFETCH_BUFFER_DISABLE()   (FLASH->ACR &= (~FLASH_ACR_PRFTEN))
+
+/**
+  * @brief  Enable the FLASH Adaptive Real-Time memory accelerator.
+  * @note   The ART accelerator is available only for flash access on ITCM interface.
+  * @retval none
+  */
+#define __HAL_FLASH_ART_ENABLE()  SET_BIT(FLASH->ACR, FLASH_ACR_ARTEN)
+
+/**
+  * @brief  Disable the FLASH Adaptive Real-Time memory accelerator.
+  * @retval none
+  */
+#define __HAL_FLASH_ART_DISABLE()   CLEAR_BIT(FLASH->ACR, FLASH_ACR_ARTEN)
+
+/**
+  * @brief  Resets the FLASH Adaptive Real-Time memory accelerator.
+  * @note   This function must be used only when the Adaptive Real-Time memory accelerator
+  *         is disabled.
+  * @retval None
+  */
+#define __HAL_FLASH_ART_RESET()  (FLASH->ACR |= FLASH_ACR_ARTRST)
+
+/**
+  * @brief  Enable the specified FLASH interrupt.
+  * @param  __INTERRUPT__ : FLASH interrupt
+  *         This parameter can be any combination of the following values:
+  *     @arg FLASH_IT_EOP: End of FLASH Operation Interrupt
+  *     @arg FLASH_IT_ERR: Error Interrupt
+  * @retval none
+  */
+#define __HAL_FLASH_ENABLE_IT(__INTERRUPT__)  (FLASH->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the specified FLASH interrupt.
+  * @param  __INTERRUPT__ : FLASH interrupt
+  *         This parameter can be any combination of the following values:
+  *     @arg FLASH_IT_EOP: End of FLASH Operation Interrupt
+  *     @arg FLASH_IT_ERR: Error Interrupt
+  * @retval none
+  */
+#define __HAL_FLASH_DISABLE_IT(__INTERRUPT__)  (FLASH->CR &= ~(uint32_t)(__INTERRUPT__))
+
+/**
+  * @brief  Get the specified FLASH flag status.
+  * @param  __FLAG__: specifies the FLASH flag to check.
+  *          This parameter can be one of the following values:
+  *            @arg FLASH_FLAG_EOP   : FLASH End of Operation flag
+  *            @arg FLASH_FLAG_OPERR : FLASH operation Error flag
+  *            @arg FLASH_FLAG_WRPERR: FLASH Write protected error flag
+  *            @arg FLASH_FLAG_PGAERR: FLASH Programming Alignment error flag
+  *            @arg FLASH_FLAG_PGPERR: FLASH Programming Parallelism error flag
+  *            @arg FLASH_FLAG_ERSERR : FLASH Erasing Sequence error flag
+  *            @arg FLASH_FLAG_BSY   : FLASH Busy flag
+  * @retval The new state of __FLAG__ (SET or RESET).
+  */
+#define __HAL_FLASH_GET_FLAG(__FLAG__)   ((FLASH->SR & (__FLAG__)))
+
+/**
+  * @brief  Clear the specified FLASH flag.
+  * @param  __FLAG__: specifies the FLASH flags to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg FLASH_FLAG_EOP   : FLASH End of Operation flag
+  *            @arg FLASH_FLAG_OPERR : FLASH operation Error flag
+  *            @arg FLASH_FLAG_WRPERR: FLASH Write protected error flag
+  *            @arg FLASH_FLAG_PGAERR: FLASH Programming Alignment error flag
+  *            @arg FLASH_FLAG_PGPERR: FLASH Programming Parallelism error flag
+  *            @arg FLASH_FLAG_ERSERR : FLASH Erasing Sequence error flag
+  * @retval none
+  */
+#define __HAL_FLASH_CLEAR_FLAG(__FLAG__)   (FLASH->SR = (__FLAG__))
+/**
+  * @}
+  */
+
+/* Include FLASH HAL Extension module */
+#include "stm32f7xx_hal_flash_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup FLASH_Exported_Functions
+  * @{
+  */
+/** @addtogroup FLASH_Exported_Functions_Group1
+  * @{
+  */
+/* Program operation functions  ***********************************************/
+HAL_StatusTypeDef HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint64_t Data);
+HAL_StatusTypeDef HAL_FLASH_Program_IT(uint32_t TypeProgram, uint32_t Address, uint64_t Data);
+/* FLASH IRQ handler method */
+void HAL_FLASH_IRQHandler(void);
+/* Callbacks in non blocking modes */
+void HAL_FLASH_EndOfOperationCallback(uint32_t ReturnValue);
+void HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue);
+/**
+  * @}
+  */
+
+/** @addtogroup FLASH_Exported_Functions_Group2
+  * @{
+  */
+/* Peripheral Control functions  **********************************************/
+HAL_StatusTypeDef HAL_FLASH_Unlock(void);
+HAL_StatusTypeDef HAL_FLASH_Lock(void);
+HAL_StatusTypeDef HAL_FLASH_OB_Unlock(void);
+HAL_StatusTypeDef HAL_FLASH_OB_Lock(void);
+/* Option bytes control */
+HAL_StatusTypeDef HAL_FLASH_OB_Launch(void);
+/**
+  * @}
+  */
+
+/** @addtogroup FLASH_Exported_Functions_Group3
+  * @{
+  */
+/* Peripheral State functions  ************************************************/
+uint32_t HAL_FLASH_GetError(void);
+HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup FLASH_Private_Variables FLASH Private Variables
+  * @{
+  */
+
+/**
+  * @}
+  */
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup FLASH_Private_Constants FLASH Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup FLASH_Private_Macros FLASH Private Macros
+  * @{
+  */
+
+/** @defgroup FLASH_IS_FLASH_Definitions FLASH Private macros to check input parameters
+  * @{
+  */
+#define IS_FLASH_TYPEPROGRAM(VALUE)(((VALUE) == FLASH_TYPEPROGRAM_BYTE) || \
+                                    ((VALUE) == FLASH_TYPEPROGRAM_HALFWORD) || \
+                                    ((VALUE) == FLASH_TYPEPROGRAM_WORD) || \
+                                    ((VALUE) == FLASH_TYPEPROGRAM_DOUBLEWORD))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup FLASH_Private_Functions FLASH Private Functions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_FLASH_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_flash_ex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_flash_ex.h
@@ -1,0 +1,468 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_flash_ex.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of FLASH HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_FLASH_EX_H
+#define __STM32F7xx_HAL_FLASH_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup FLASHEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup FLASHEx_Exported_Types FLASH Exported Types
+  * @{
+  */
+
+/**
+  * @brief  FLASH Erase structure definition
+  */
+typedef struct
+{
+  uint32_t TypeErase;   /*!< Mass erase or sector Erase.
+                             This parameter can be a value of @ref FLASHEx_Type_Erase */
+
+  uint32_t Sector;      /*!< Initial FLASH sector to erase when Mass erase is disabled
+                             This parameter must be a value of @ref FLASHEx_Sectors */
+
+  uint32_t NbSectors;   /*!< Number of sectors to be erased.
+                             This parameter must be a value between 1 and (max number of sectors - value of Initial sector)*/
+
+  uint32_t VoltageRange;/*!< The device voltage range which defines the erase parallelism
+                             This parameter must be a value of @ref FLASHEx_Voltage_Range */
+
+} FLASH_EraseInitTypeDef;
+
+/**
+  * @brief  FLASH Option Bytes Program structure definition
+  */
+typedef struct
+{
+  uint32_t OptionType;   /*!< Option byte to be configured.
+                              This parameter can be a value of @ref FLASHEx_Option_Type */
+
+  uint32_t WRPState;     /*!< Write protection activation or deactivation.
+                              This parameter can be a value of @ref FLASHEx_WRP_State */
+
+  uint32_t WRPSector;         /*!< Specifies the sector(s) to be write protected.
+                              The value of this parameter depend on device used within the same series */
+
+  uint32_t RDPLevel;     /*!< Set the read protection level.
+                              This parameter can be a value of @ref FLASHEx_Option_Bytes_Read_Protection */
+
+  uint32_t BORLevel;     /*!< Set the BOR Level.
+                              This parameter can be a value of @ref FLASHEx_BOR_Reset_Level */
+
+  uint32_t USERConfig;   /*!< Program the FLASH User Option Byte: WWDG_SW / IWDG_SW / RST_STOP / RST_STDBY /
+                              IWDG_FREEZE_STOP / IWDG_FREEZE_SANDBY. */
+
+  uint32_t BootAddr0;    /*!< Boot base address when Boot pin = 0.
+                              This parameter can be a value of @ref FLASHEx_Boot_Address */
+
+  uint32_t BootAddr1;    /*!< Boot base address when Boot pin = 1.
+                              This parameter can be a value of @ref FLASHEx_Boot_Address */
+
+} FLASH_OBProgramInitTypeDef;
+
+/**
+  * @}
+  */
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup FLASHEx_Exported_Constants FLASH Exported Constants
+  * @{
+  */
+
+/** @defgroup FLASHEx_Type_Erase FLASH Type Erase
+  * @{
+  */
+#define FLASH_TYPEERASE_SECTORS         ((uint32_t)0x00)  /*!< Sectors erase only          */
+#define FLASH_TYPEERASE_MASSERASE       ((uint32_t)0x01)  /*!< Flash Mass erase activation */
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Voltage_Range FLASH Voltage Range
+  * @{
+  */
+#define FLASH_VOLTAGE_RANGE_1        ((uint32_t)0x00)  /*!< Device operating range: 1.8V to 2.1V                */
+#define FLASH_VOLTAGE_RANGE_2        ((uint32_t)0x01)  /*!< Device operating range: 2.1V to 2.7V                */
+#define FLASH_VOLTAGE_RANGE_3        ((uint32_t)0x02)  /*!< Device operating range: 2.7V to 3.6V                */
+#define FLASH_VOLTAGE_RANGE_4        ((uint32_t)0x03)  /*!< Device operating range: 2.7V to 3.6V + External Vpp */
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_WRP_State FLASH WRP State
+  * @{
+  */
+#define OB_WRPSTATE_DISABLE       ((uint32_t)0x00)  /*!< Disable the write protection of the desired bank 1 sectors */
+#define OB_WRPSTATE_ENABLE        ((uint32_t)0x01)  /*!< Enable the write protection of the desired bank 1 sectors  */
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Option_Type FLASH Option Type
+  * @{
+  */
+#define OPTIONBYTE_WRP         ((uint32_t)0x01)  /*!< WRP option byte configuration  */
+#define OPTIONBYTE_RDP         ((uint32_t)0x02)  /*!< RDP option byte configuration  */
+#define OPTIONBYTE_USER        ((uint32_t)0x04)  /*!< USER option byte configuration */
+#define OPTIONBYTE_BOR         ((uint32_t)0x08)  /*!< BOR option byte configuration  */
+#define OPTIONBYTE_BOOTADDR_0  ((uint32_t)0x10)  /*!< Boot 0 Address configuration   */
+#define OPTIONBYTE_BOOTADDR_1  ((uint32_t)0x20)  /*!< Boot 1 Address configuration   */
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Option_Bytes_Read_Protection FLASH Option Bytes Read Protection
+  * @{
+  */
+#define OB_RDP_LEVEL_0       ((uint8_t)0xAA)
+#define OB_RDP_LEVEL_1       ((uint8_t)0x55)
+#define OB_RDP_LEVEL_2       ((uint8_t)0xCC)   /*!< Warning: When enabling read protection level 2
+                                                  it s no more possible to go back to level 1 or 0 */
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Option_Bytes_WWatchdog FLASH Option Bytes WWatchdog
+  * @{
+  */
+#define OB_WWDG_SW           ((uint32_t)0x10)  /*!< Software WWDG selected */
+#define OB_WWDG_HW           ((uint32_t)0x00)  /*!< Hardware WWDG selected */
+/**
+  * @}
+  */
+
+
+/** @defgroup FLASHEx_Option_Bytes_IWatchdog FLASH Option Bytes IWatchdog
+  * @{
+  */
+#define OB_IWDG_SW           ((uint32_t)0x20)  /*!< Software IWDG selected */
+#define OB_IWDG_HW           ((uint32_t)0x00)  /*!< Hardware IWDG selected */
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Option_Bytes_nRST_STOP FLASH Option Bytes nRST_STOP
+  * @{
+  */
+#define OB_STOP_NO_RST       ((uint32_t)0x40) /*!< No reset generated when entering in STOP */
+#define OB_STOP_RST          ((uint32_t)0x00) /*!< Reset generated when entering in STOP    */
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Option_Bytes_nRST_STDBY FLASH Option Bytes nRST_STDBY
+  * @{
+  */
+#define OB_STDBY_NO_RST      ((uint32_t)0x80) /*!< No reset generated when entering in STANDBY */
+#define OB_STDBY_RST         ((uint32_t)0x00) /*!< Reset generated when entering in STANDBY    */
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Option_Bytes_IWDG_FREEZE_STOP FLASH IWDG Counter Freeze in STOP
+  * @{
+  */
+#define OB_IWDG_STOP_FREEZE      ((uint32_t)0x00000000) /*!< Freeze IWDG counter in STOP mode */
+#define OB_IWDG_STOP_ACTIVE      ((uint32_t)0x40000000) /*!< IWDG counter active in STOP mode */
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Option_Bytes_IWDG_FREEZE_SANDBY FLASH IWDG Counter Freeze in STANDBY
+  * @{
+  */
+#define OB_IWDG_STDBY_FREEZE      ((uint32_t)0x00000000) /*!< Freeze IWDG counter in STANDBY mode */
+#define OB_IWDG_STDBY_ACTIVE      ((uint32_t)0x40000000) /*!< IWDG counter active in STANDBY mode */
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_BOR_Reset_Level FLASH BOR Reset Level
+  * @{
+  */
+#define OB_BOR_LEVEL3          ((uint32_t)0x00)  /*!< Supply voltage ranges from 2.70 to 3.60 V */
+#define OB_BOR_LEVEL2          ((uint32_t)0x04)  /*!< Supply voltage ranges from 2.40 to 2.70 V */
+#define OB_BOR_LEVEL1          ((uint32_t)0x08)  /*!< Supply voltage ranges from 2.10 to 2.40 V */
+#define OB_BOR_OFF             ((uint32_t)0x0C)  /*!< Supply voltage ranges from 1.62 to 2.10 V */
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Boot_Address FLASH Boot Address
+  * @{
+  */
+#define OB_BOOTADDR_ITCM_RAM         ((uint32_t)0x0000)  /*!< Boot from ITCM RAM (0x00000000)                 */
+#define OB_BOOTADDR_SYSTEM           ((uint32_t)0x0040)  /*!< Boot from System memory bootloader (0x00100000) */
+#define OB_BOOTADDR_ITCM_FLASH       ((uint32_t)0x0080)  /*!< Boot from Flash on ITCM interface (0x00200000)  */
+#define OB_BOOTADDR_AXIM_FLASH       ((uint32_t)0x2000)  /*!< Boot from Flash on AXIM interface (0x08000000)  */
+#define OB_BOOTADDR_DTCM_RAM         ((uint32_t)0x8000)  /*!< Boot from DTCM RAM (0x20000000)                 */
+#define OB_BOOTADDR_SRAM1            ((uint32_t)0x8004)  /*!< Boot from SRAM1 (0x20010000)                    */
+#define OB_BOOTADDR_SRAM2            ((uint32_t)0x8013)  /*!< Boot from SRAM2 (0x2004C000)                    */
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Latency FLASH Latency
+  * @{
+  */
+#define FLASH_LATENCY_0                FLASH_ACR_LATENCY_0WS   /*!< FLASH Zero Latency cycle      */
+#define FLASH_LATENCY_1                FLASH_ACR_LATENCY_1WS   /*!< FLASH One Latency cycle       */
+#define FLASH_LATENCY_2                FLASH_ACR_LATENCY_2WS   /*!< FLASH Two Latency cycles      */
+#define FLASH_LATENCY_3                FLASH_ACR_LATENCY_3WS   /*!< FLASH Three Latency cycles    */
+#define FLASH_LATENCY_4                FLASH_ACR_LATENCY_4WS   /*!< FLASH Four Latency cycles     */
+#define FLASH_LATENCY_5                FLASH_ACR_LATENCY_5WS   /*!< FLASH Five Latency cycles     */
+#define FLASH_LATENCY_6                FLASH_ACR_LATENCY_6WS   /*!< FLASH Six Latency cycles      */
+#define FLASH_LATENCY_7                FLASH_ACR_LATENCY_7WS   /*!< FLASH Seven Latency cycles    */
+#define FLASH_LATENCY_8                FLASH_ACR_LATENCY_8WS   /*!< FLASH Eight Latency cycles    */
+#define FLASH_LATENCY_9                FLASH_ACR_LATENCY_9WS   /*!< FLASH Nine Latency cycles     */
+#define FLASH_LATENCY_10               FLASH_ACR_LATENCY_10WS  /*!< FLASH Ten Latency cycles      */
+#define FLASH_LATENCY_11               FLASH_ACR_LATENCY_11WS  /*!< FLASH Eleven Latency cycles   */
+#define FLASH_LATENCY_12               FLASH_ACR_LATENCY_12WS  /*!< FLASH Twelve Latency cycles   */
+#define FLASH_LATENCY_13               FLASH_ACR_LATENCY_13WS  /*!< FLASH Thirteen Latency cycles */
+#define FLASH_LATENCY_14               FLASH_ACR_LATENCY_14WS  /*!< FLASH Fourteen Latency cycles */
+#define FLASH_LATENCY_15               FLASH_ACR_LATENCY_15WS  /*!< FLASH Fifteen Latency cycles  */
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_MassErase_bit FLASH Mass Erase bit
+  * @{
+  */
+#define FLASH_MER_BIT     (FLASH_CR_MER) /*!< MER bit to clear */
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Sectors FLASH Sectors
+  * @{
+  */
+#define FLASH_SECTOR_0     ((uint32_t)0) /*!< Sector Number 0   */
+#define FLASH_SECTOR_1     ((uint32_t)1) /*!< Sector Number 1   */
+#define FLASH_SECTOR_2     ((uint32_t)2) /*!< Sector Number 2   */
+#define FLASH_SECTOR_3     ((uint32_t)3) /*!< Sector Number 3   */
+#define FLASH_SECTOR_4     ((uint32_t)4) /*!< Sector Number 4   */
+#define FLASH_SECTOR_5     ((uint32_t)5) /*!< Sector Number 5   */
+#define FLASH_SECTOR_6     ((uint32_t)6) /*!< Sector Number 6   */
+#define FLASH_SECTOR_7     ((uint32_t)7) /*!< Sector Number 7   */
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Option_Bytes_Write_Protection FLASH Option Bytes Write Protection
+  * @{
+  */
+#define OB_WRP_SECTOR_0       ((uint32_t)0x00010000) /*!< Write protection of Sector0     */
+#define OB_WRP_SECTOR_1       ((uint32_t)0x00020000) /*!< Write protection of Sector1     */
+#define OB_WRP_SECTOR_2       ((uint32_t)0x00040000) /*!< Write protection of Sector2     */
+#define OB_WRP_SECTOR_3       ((uint32_t)0x00080000) /*!< Write protection of Sector3     */
+#define OB_WRP_SECTOR_4       ((uint32_t)0x00100000) /*!< Write protection of Sector4     */
+#define OB_WRP_SECTOR_5       ((uint32_t)0x00200000) /*!< Write protection of Sector5     */
+#define OB_WRP_SECTOR_6       ((uint32_t)0x00400000) /*!< Write protection of Sector6     */
+#define OB_WRP_SECTOR_7       ((uint32_t)0x00800000) /*!< Write protection of Sector7     */
+#define OB_WRP_SECTOR_All     ((uint32_t)0x00FF0000) /*!< Write protection of all Sectors */
+
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup FLASHEx_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup FLASHEx_Exported_Functions_Group1
+  * @{
+  */
+/* Extension Program operation functions  *************************************/
+HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t *SectorError);
+HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit);
+HAL_StatusTypeDef HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit);
+void              HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup FLASHEx_Private_Constants FLASH Private Constants
+  * @{
+  */
+#define FLASH_SECTOR_TOTAL  8
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup FLASHEx_Private_Macros FLASH Private Macros
+  * @{
+  */
+
+/** @defgroup FLASHEx_IS_FLASH_Definitions FLASH Private macros to check input parameters
+  * @{
+  */
+
+#define IS_FLASH_TYPEERASE(VALUE)(((VALUE) == FLASH_TYPEERASE_SECTORS) || \
+                                  ((VALUE) == FLASH_TYPEERASE_MASSERASE))
+
+#define IS_VOLTAGERANGE(RANGE)(((RANGE) == FLASH_VOLTAGE_RANGE_1) || \
+                               ((RANGE) == FLASH_VOLTAGE_RANGE_2) || \
+                               ((RANGE) == FLASH_VOLTAGE_RANGE_3) || \
+                               ((RANGE) == FLASH_VOLTAGE_RANGE_4))
+
+#define IS_WRPSTATE(VALUE)(((VALUE) == OB_WRPSTATE_DISABLE) || \
+                           ((VALUE) == OB_WRPSTATE_ENABLE))
+
+#define IS_OPTIONBYTE(VALUE)(((VALUE) <= (OPTIONBYTE_WRP | OPTIONBYTE_RDP        | OPTIONBYTE_USER |\
+                                          OPTIONBYTE_BOR | OPTIONBYTE_BOOTADDR_0 | OPTIONBYTE_BOOTADDR_1)))
+
+#define IS_OB_BOOT_ADDRESS(ADDRESS) (((ADDRESS) == OB_BOOTADDR_ITCM_RAM)   || \
+                                     ((ADDRESS) == OB_BOOTADDR_SYSTEM)     || \
+                                     ((ADDRESS) == OB_BOOTADDR_ITCM_FLASH) || \
+                                     ((ADDRESS) == OB_BOOTADDR_AXIM_FLASH) || \
+                                     ((ADDRESS) == OB_BOOTADDR_DTCM_RAM)   || \
+                                     ((ADDRESS) == OB_BOOTADDR_SRAM1)      || \
+                                     ((ADDRESS) == OB_BOOTADDR_SRAM2))
+
+#define IS_OB_RDP_LEVEL(LEVEL) (((LEVEL) == OB_RDP_LEVEL_0)   ||\
+                                ((LEVEL) == OB_RDP_LEVEL_1)   ||\
+                                ((LEVEL) == OB_RDP_LEVEL_2))
+
+#define IS_OB_WWDG_SOURCE(SOURCE) (((SOURCE) == OB_WWDG_SW) || ((SOURCE) == OB_WWDG_HW))
+
+#define IS_OB_IWDG_SOURCE(SOURCE) (((SOURCE) == OB_IWDG_SW) || ((SOURCE) == OB_IWDG_HW))
+
+#define IS_OB_STOP_SOURCE(SOURCE) (((SOURCE) == OB_STOP_NO_RST) || ((SOURCE) == OB_STOP_RST))
+
+#define IS_OB_STDBY_SOURCE(SOURCE) (((SOURCE) == OB_STDBY_NO_RST) || ((SOURCE) == OB_STDBY_RST))
+
+#define IS_OB_IWDG_STOP_FREEZE(FREEZE) (((FREEZE) == OB_IWDG_STOP_FREEZE) || ((FREEZE) == OB_IWDG_STOP_ACTIVE))
+
+#define IS_OB_IWDG_STDBY_FREEZE(FREEZE) (((FREEZE) == OB_IWDG_STDBY_FREEZE) || ((FREEZE) == OB_IWDG_STDBY_ACTIVE))
+
+#define IS_OB_BOR_LEVEL(LEVEL) (((LEVEL) == OB_BOR_LEVEL1) || ((LEVEL) == OB_BOR_LEVEL2) ||\
+                                ((LEVEL) == OB_BOR_LEVEL3) || ((LEVEL) == OB_BOR_OFF))
+
+#define IS_FLASH_LATENCY(LATENCY) (((LATENCY) == FLASH_LATENCY_0)  || \
+                                   ((LATENCY) == FLASH_LATENCY_1)  || \
+                                   ((LATENCY) == FLASH_LATENCY_2)  || \
+                                   ((LATENCY) == FLASH_LATENCY_3)  || \
+                                   ((LATENCY) == FLASH_LATENCY_4)  || \
+                                   ((LATENCY) == FLASH_LATENCY_5)  || \
+                                   ((LATENCY) == FLASH_LATENCY_6)  || \
+                                   ((LATENCY) == FLASH_LATENCY_7)  || \
+                                   ((LATENCY) == FLASH_LATENCY_8)  || \
+                                   ((LATENCY) == FLASH_LATENCY_9)  || \
+                                   ((LATENCY) == FLASH_LATENCY_10) || \
+                                   ((LATENCY) == FLASH_LATENCY_11) || \
+                                   ((LATENCY) == FLASH_LATENCY_12) || \
+                                   ((LATENCY) == FLASH_LATENCY_13) || \
+                                   ((LATENCY) == FLASH_LATENCY_14) || \
+                                   ((LATENCY) == FLASH_LATENCY_15))
+
+#define IS_FLASH_SECTOR(SECTOR) (((SECTOR) == FLASH_SECTOR_0)   || ((SECTOR) == FLASH_SECTOR_1)   ||\
+                                 ((SECTOR) == FLASH_SECTOR_2)   || ((SECTOR) == FLASH_SECTOR_3)   ||\
+                                 ((SECTOR) == FLASH_SECTOR_4)   || ((SECTOR) == FLASH_SECTOR_5)   ||\
+                                 ((SECTOR) == FLASH_SECTOR_6)   || ((SECTOR) == FLASH_SECTOR_7))
+
+
+#define IS_FLASH_ADDRESS(ADDRESS) (((ADDRESS) >= FLASH_BASE) && ((ADDRESS) <= FLASH_END))
+
+#define IS_FLASH_NBSECTORS(NBSECTORS) (((NBSECTORS) != 0) && ((NBSECTORS) <= FLASH_SECTOR_TOTAL))
+
+#define IS_OB_WRP_SECTOR(SECTOR)  ((((SECTOR) & (uint32_t)0xFF00FFFF) == 0x00000000) && ((SECTOR) != 0x00000000))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup FLASHEx_Private_Functions FLASH Private Functions
+  * @{
+  */
+void FLASH_Erase_Sector(uint32_t Sector, uint8_t VoltageRange);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_FLASH_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_gpio.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_gpio.h
@@ -1,0 +1,327 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_gpio.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of GPIO HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_GPIO_H
+#define __STM32F7xx_HAL_GPIO_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup GPIO
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup GPIO_Exported_Types GPIO Exported Types
+  * @{
+  */
+
+/**
+  * @brief GPIO Init structure definition
+  */
+typedef struct
+{
+  uint32_t Pin;       /*!< Specifies the GPIO pins to be configured.
+                           This parameter can be any value of @ref GPIO_pins_define */
+
+  uint32_t Mode;      /*!< Specifies the operating mode for the selected pins.
+                           This parameter can be a value of @ref GPIO_mode_define */
+
+  uint32_t Pull;      /*!< Specifies the Pull-up or Pull-Down activation for the selected pins.
+                           This parameter can be a value of @ref GPIO_pull_define */
+
+  uint32_t Speed;     /*!< Specifies the speed for the selected pins.
+                           This parameter can be a value of @ref GPIO_speed_define */
+
+  uint32_t Alternate;  /*!< Peripheral to be connected to the selected pins.
+                            This parameter can be a value of @ref GPIO_Alternate_function_selection */
+}GPIO_InitTypeDef;
+
+/**
+  * @brief  GPIO Bit SET and Bit RESET enumeration
+  */
+typedef enum
+{
+  GPIO_PIN_RESET = 0,
+  GPIO_PIN_SET
+}GPIO_PinState;
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup GPIO_Exported_Constants GPIO Exported Constants
+  * @{
+  */
+
+/** @defgroup GPIO_pins_define GPIO pins define
+  * @{
+  */
+#define GPIO_PIN_0                 ((uint16_t)0x0001)  /* Pin 0 selected    */
+#define GPIO_PIN_1                 ((uint16_t)0x0002)  /* Pin 1 selected    */
+#define GPIO_PIN_2                 ((uint16_t)0x0004)  /* Pin 2 selected    */
+#define GPIO_PIN_3                 ((uint16_t)0x0008)  /* Pin 3 selected    */
+#define GPIO_PIN_4                 ((uint16_t)0x0010)  /* Pin 4 selected    */
+#define GPIO_PIN_5                 ((uint16_t)0x0020)  /* Pin 5 selected    */
+#define GPIO_PIN_6                 ((uint16_t)0x0040)  /* Pin 6 selected    */
+#define GPIO_PIN_7                 ((uint16_t)0x0080)  /* Pin 7 selected    */
+#define GPIO_PIN_8                 ((uint16_t)0x0100)  /* Pin 8 selected    */
+#define GPIO_PIN_9                 ((uint16_t)0x0200)  /* Pin 9 selected    */
+#define GPIO_PIN_10                ((uint16_t)0x0400)  /* Pin 10 selected   */
+#define GPIO_PIN_11                ((uint16_t)0x0800)  /* Pin 11 selected   */
+#define GPIO_PIN_12                ((uint16_t)0x1000)  /* Pin 12 selected   */
+#define GPIO_PIN_13                ((uint16_t)0x2000)  /* Pin 13 selected   */
+#define GPIO_PIN_14                ((uint16_t)0x4000)  /* Pin 14 selected   */
+#define GPIO_PIN_15                ((uint16_t)0x8000)  /* Pin 15 selected   */
+#define GPIO_PIN_All               ((uint16_t)0xFFFF)  /* All pins selected */
+
+#define GPIO_PIN_MASK              ((uint32_t)0x0000FFFF) /* PIN mask for assert test */
+/**
+  * @}
+  */
+
+/** @defgroup GPIO_mode_define GPIO mode define
+  * @brief GPIO Configuration Mode
+  *        Elements values convention: 0xX0yz00YZ
+  *           - X  : GPIO mode or EXTI Mode
+  *           - y  : External IT or Event trigger detection
+  *           - z  : IO configuration on External IT or Event
+  *           - Y  : Output type (Push Pull or Open Drain)
+  *           - Z  : IO Direction mode (Input, Output, Alternate or Analog)
+  * @{
+  */
+#define  GPIO_MODE_INPUT                        ((uint32_t)0x00000000)   /*!< Input Floating Mode                   */
+#define  GPIO_MODE_OUTPUT_PP                    ((uint32_t)0x00000001)   /*!< Output Push Pull Mode                 */
+#define  GPIO_MODE_OUTPUT_OD                    ((uint32_t)0x00000011)   /*!< Output Open Drain Mode                */
+#define  GPIO_MODE_AF_PP                        ((uint32_t)0x00000002)   /*!< Alternate Function Push Pull Mode     */
+#define  GPIO_MODE_AF_OD                        ((uint32_t)0x00000012)   /*!< Alternate Function Open Drain Mode    */
+
+#define  GPIO_MODE_ANALOG                       ((uint32_t)0x00000003)   /*!< Analog Mode  */
+
+#define  GPIO_MODE_IT_RISING                    ((uint32_t)0x10110000)   /*!< External Interrupt Mode with Rising edge trigger detection          */
+#define  GPIO_MODE_IT_FALLING                   ((uint32_t)0x10210000)   /*!< External Interrupt Mode with Falling edge trigger detection         */
+#define  GPIO_MODE_IT_RISING_FALLING            ((uint32_t)0x10310000)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection  */
+
+#define  GPIO_MODE_EVT_RISING                   ((uint32_t)0x10120000)   /*!< External Event Mode with Rising edge trigger detection               */
+#define  GPIO_MODE_EVT_FALLING                  ((uint32_t)0x10220000)   /*!< External Event Mode with Falling edge trigger detection              */
+#define  GPIO_MODE_EVT_RISING_FALLING           ((uint32_t)0x10320000)   /*!< External Event Mode with Rising/Falling edge trigger detection       */
+/**
+  * @}
+  */
+
+/** @defgroup GPIO_speed_define  GPIO speed define
+  * @brief GPIO Output Maximum frequency
+  * @{
+  */
+#define  GPIO_SPEED_LOW         ((uint32_t)0x00000000)  /*!< Low speed     */
+#define  GPIO_SPEED_MEDIUM      ((uint32_t)0x00000001)  /*!< Medium speed  */
+#define  GPIO_SPEED_FAST        ((uint32_t)0x00000002)  /*!< Fast speed    */
+#define  GPIO_SPEED_HIGH        ((uint32_t)0x00000003)  /*!< High speed    */
+/**
+  * @}
+  */
+
+ /** @defgroup GPIO_pull_define GPIO pull define
+   * @brief GPIO Pull-Up or Pull-Down Activation
+   * @{
+   */
+#define  GPIO_NOPULL        ((uint32_t)0x00000000)   /*!< No Pull-up or Pull-down activation  */
+#define  GPIO_PULLUP        ((uint32_t)0x00000001)   /*!< Pull-up activation                  */
+#define  GPIO_PULLDOWN      ((uint32_t)0x00000002)   /*!< Pull-down activation                */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup GPIO_Exported_Macros GPIO Exported Macros
+  * @{
+  */
+
+/**
+  * @brief  Checks whether the specified EXTI line flag is set or not.
+  * @param  __EXTI_LINE__: specifies the EXTI line flag to check.
+  *         This parameter can be GPIO_PIN_x where x can be(0..15)
+  * @retval The new state of __EXTI_LINE__ (SET or RESET).
+  */
+#define __HAL_GPIO_EXTI_GET_FLAG(__EXTI_LINE__) (EXTI->PR & (__EXTI_LINE__))
+
+/**
+  * @brief  Clears the EXTI's line pending flags.
+  * @param  __EXTI_LINE__: specifies the EXTI lines flags to clear.
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15)
+  * @retval None
+  */
+#define __HAL_GPIO_EXTI_CLEAR_FLAG(__EXTI_LINE__) (EXTI->PR = (__EXTI_LINE__))
+
+/**
+  * @brief  Checks whether the specified EXTI line is asserted or not.
+  * @param  __EXTI_LINE__: specifies the EXTI line to check.
+  *          This parameter can be GPIO_PIN_x where x can be(0..15)
+  * @retval The new state of __EXTI_LINE__ (SET or RESET).
+  */
+#define __HAL_GPIO_EXTI_GET_IT(__EXTI_LINE__) (EXTI->PR & (__EXTI_LINE__))
+
+/**
+  * @brief  Clears the EXTI's line pending bits.
+  * @param  __EXTI_LINE__: specifies the EXTI lines to clear.
+  *          This parameter can be any combination of GPIO_PIN_x where x can be (0..15)
+  * @retval None
+  */
+#define __HAL_GPIO_EXTI_CLEAR_IT(__EXTI_LINE__) (EXTI->PR = (__EXTI_LINE__))
+
+/**
+  * @brief  Generates a Software interrupt on selected EXTI line.
+  * @param  __EXTI_LINE__: specifies the EXTI line to check.
+  *          This parameter can be GPIO_PIN_x where x can be(0..15)
+  * @retval None
+  */
+#define __HAL_GPIO_EXTI_GENERATE_SWIT(__EXTI_LINE__) (EXTI->SWIER |= (__EXTI_LINE__))
+/**
+  * @}
+  */
+
+/* Include GPIO HAL Extension module */
+#include "stm32f7xx_hal_gpio_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup GPIO_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup GPIO_Exported_Functions_Group1
+  * @{
+  */
+/* Initialization and de-initialization functions *****************************/
+void  HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init);
+void  HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin);
+/**
+  * @}
+  */
+
+/** @addtogroup GPIO_Exported_Functions_Group2
+  * @{
+  */
+/* IO operation functions *****************************************************/
+GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+void HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState);
+void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+void HAL_GPIO_EXTI_IRQHandler(uint16_t GPIO_Pin);
+void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup GPIO_Private_Constants GPIO Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup GPIO_Private_Macros GPIO Private Macros
+  * @{
+  */
+#define IS_GPIO_PIN_ACTION(ACTION) (((ACTION) == GPIO_PIN_RESET) || ((ACTION) == GPIO_PIN_SET))
+#define IS_GPIO_PIN(PIN)           (((PIN) & GPIO_PIN_MASK ) != (uint32_t)0x00)
+#define IS_GPIO_MODE(MODE) (((MODE) == GPIO_MODE_INPUT)              ||\
+                            ((MODE) == GPIO_MODE_OUTPUT_PP)          ||\
+                            ((MODE) == GPIO_MODE_OUTPUT_OD)          ||\
+                            ((MODE) == GPIO_MODE_AF_PP)              ||\
+                            ((MODE) == GPIO_MODE_AF_OD)              ||\
+                            ((MODE) == GPIO_MODE_IT_RISING)          ||\
+                            ((MODE) == GPIO_MODE_IT_FALLING)         ||\
+                            ((MODE) == GPIO_MODE_IT_RISING_FALLING)  ||\
+                            ((MODE) == GPIO_MODE_EVT_RISING)         ||\
+                            ((MODE) == GPIO_MODE_EVT_FALLING)        ||\
+                            ((MODE) == GPIO_MODE_EVT_RISING_FALLING) ||\
+                            ((MODE) == GPIO_MODE_ANALOG))
+#define IS_GPIO_SPEED(SPEED) (((SPEED) == GPIO_SPEED_LOW)  || ((SPEED) == GPIO_SPEED_MEDIUM) || \
+                              ((SPEED) == GPIO_SPEED_FAST) || ((SPEED) == GPIO_SPEED_HIGH))
+#define IS_GPIO_PULL(PULL) (((PULL) == GPIO_NOPULL) || ((PULL) == GPIO_PULLUP) || \
+                            ((PULL) == GPIO_PULLDOWN))
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup GPIO_Private_Functions GPIO Private Functions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_GPIO_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_gpio_ex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_gpio_ex.h
@@ -1,0 +1,377 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_gpio_ex.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of GPIO HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_GPIO_EX_H
+#define __STM32F7xx_HAL_GPIO_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup GPIOEx GPIOEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup GPIOEx_Exported_Constants GPIO Exported Constants
+  * @{
+  */
+
+/** @defgroup GPIO_Alternate_function_selection GPIO Alternate Function Selection
+  * @{
+  */
+
+/**
+  * @brief   AF 0 selection
+  */
+#define GPIO_AF0_RTC_50Hz      ((uint8_t)0x00)  /* RTC_50Hz Alternate Function mapping                       */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /* MCO (MCO1 and MCO2) Alternate Function mapping            */
+#define GPIO_AF0_SWJ           ((uint8_t)0x00)  /* SWJ (SWD and JTAG) Alternate Function mapping             */
+#define GPIO_AF0_TRACE         ((uint8_t)0x00)  /* TRACE Alternate Function mapping                          */
+
+/**
+  * @brief   AF 1 selection
+  */
+#define GPIO_AF1_TIM1          ((uint8_t)0x01)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF1_TIM2          ((uint8_t)0x01)  /* TIM2 Alternate Function mapping */
+
+/**
+  * @brief   AF 2 selection
+  */
+#define GPIO_AF2_TIM3          ((uint8_t)0x02)  /* TIM3 Alternate Function mapping */
+#define GPIO_AF2_TIM4          ((uint8_t)0x02)  /* TIM4 Alternate Function mapping */
+#define GPIO_AF2_TIM5          ((uint8_t)0x02)  /* TIM5 Alternate Function mapping */
+
+/**
+  * @brief   AF 3 selection
+  */
+#define GPIO_AF3_TIM8          ((uint8_t)0x03)  /* TIM8 Alternate Function mapping  */
+#define GPIO_AF3_TIM9          ((uint8_t)0x03)  /* TIM9 Alternate Function mapping  */
+#define GPIO_AF3_TIM10         ((uint8_t)0x03)  /* TIM10 Alternate Function mapping */
+#define GPIO_AF3_TIM11         ((uint8_t)0x03)  /* TIM11 Alternate Function mapping */
+#define GPIO_AF3_LPTIM1        ((uint8_t)0x03)  /* LPTIM1 Alternate Function mapping */
+#define GPIO_AF3_CEC           ((uint8_t)0x03)  /* CEC Alternate Function mapping */
+
+
+/**
+  * @brief   AF 4 selection
+  */
+#define GPIO_AF4_I2C1          ((uint8_t)0x04)  /* I2C1 Alternate Function mapping */
+#define GPIO_AF4_I2C2          ((uint8_t)0x04)  /* I2C2 Alternate Function mapping */
+#define GPIO_AF4_I2C3          ((uint8_t)0x04)  /* I2C3 Alternate Function mapping */
+#define GPIO_AF4_I2C4          ((uint8_t)0x04)  /* I2C4 Alternate Function mapping */
+#define GPIO_AF4_CEC           ((uint8_t)0x04)  /* CEC Alternate Function mapping */
+
+/**
+  * @brief   AF 5 selection
+  */
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /* SPI1 Alternate Function mapping        */
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /* SPI2/I2S2 Alternate Function mapping   */
+#define GPIO_AF5_SPI3          ((uint8_t)0x05)  /* SPI3/I2S3 Alternate Function mapping   */
+#define GPIO_AF5_SPI4          ((uint8_t)0x05)  /* SPI4 Alternate Function mapping        */
+#define GPIO_AF5_SPI5          ((uint8_t)0x05)  /* SPI5 Alternate Function mapping        */
+#define GPIO_AF5_SPI6          ((uint8_t)0x05)  /* SPI6 Alternate Function mapping        */
+
+/**
+  * @brief   AF 6 selection
+  */
+#define GPIO_AF6_SPI3          ((uint8_t)0x06)  /* SPI3/I2S3 Alternate Function mapping  */
+#define GPIO_AF6_SAI1          ((uint8_t)0x06)  /* SAI1 Alternate Function mapping       */
+
+/**
+  * @brief   AF 7 selection
+  */
+#define GPIO_AF7_USART1        ((uint8_t)0x07)  /* USART1 Alternate Function mapping     */
+#define GPIO_AF7_USART2        ((uint8_t)0x07)  /* USART2 Alternate Function mapping     */
+#define GPIO_AF7_USART3        ((uint8_t)0x07)  /* USART3 Alternate Function mapping     */
+#define GPIO_AF7_UART5         ((uint8_t)0x07)  /* UART5 Alternate Function mapping      */
+#define GPIO_AF7_SPDIFRX       ((uint8_t)0x07)  /* SPDIF-RX Alternate Function mapping   */
+#define GPIO_AF7_SPI2          ((uint8_t)0x07)  /* SPI2 Alternate Function mapping       */
+#define GPIO_AF7_SPI3          ((uint8_t)0x07)  /* SPI3 Alternate Function mapping       */
+
+/**
+  * @brief   AF 8 selection
+  */
+#define GPIO_AF8_UART4         ((uint8_t)0x08)  /* UART4 Alternate Function mapping  */
+#define GPIO_AF8_UART5         ((uint8_t)0x08)  /* UART5 Alternate Function mapping  */
+#define GPIO_AF8_USART6        ((uint8_t)0x08)  /* USART6 Alternate Function mapping */
+#define GPIO_AF8_UART7         ((uint8_t)0x08)  /* UART7 Alternate Function mapping  */
+#define GPIO_AF8_UART8         ((uint8_t)0x08)  /* UART8 Alternate Function mapping  */
+#define GPIO_AF8_SPDIFRX       ((uint8_t)0x08)  /* SPIDIF-RX Alternate Function mapping  */
+#define GPIO_AF8_SAI2          ((uint8_t)0x08)  /* SAI2 Alternate Function mapping  */
+
+
+/**
+  * @brief   AF 9 selection
+  */
+#define GPIO_AF9_CAN1          ((uint8_t)0x09)  /* CAN1 Alternate Function mapping    */
+#define GPIO_AF9_CAN2          ((uint8_t)0x09)  /* CAN2 Alternate Function mapping    */
+#define GPIO_AF9_TIM12         ((uint8_t)0x09)  /* TIM12 Alternate Function mapping   */
+#define GPIO_AF9_TIM13         ((uint8_t)0x09)  /* TIM13 Alternate Function mapping   */
+#define GPIO_AF9_TIM14         ((uint8_t)0x09)  /* TIM14 Alternate Function mapping   */
+#define GPIO_AF9_QUADSPI       ((uint8_t)0x09)  /* QUADSPI Alternate Function mapping */
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define GPIO_AF9_LTDC          ((uint8_t)0x09)  /* LCD-TFT Alternate Function mapping */
+#endif /* STM32F756xx || STM32F746xx */
+/**
+  * @brief   AF 10 selection
+  */
+#define GPIO_AF10_OTG_FS        ((uint8_t)0xA)  /* OTG_FS Alternate Function mapping */
+#define GPIO_AF10_OTG_HS        ((uint8_t)0xA)  /* OTG_HS Alternate Function mapping */
+#define GPIO_AF10_QUADSPI       ((uint8_t)0xA)  /* QUADSPI Alternate Function mapping */
+#define GPIO_AF10_SAI2          ((uint8_t)0xA)  /* SAI2 Alternate Function mapping */
+
+/**
+  * @brief   AF 11 selection
+  */
+#define GPIO_AF11_ETH           ((uint8_t)0x0B)  /* ETHERNET Alternate Function mapping */
+
+/**
+  * @brief   AF 12 selection
+  */
+#define GPIO_AF12_FMC           ((uint8_t)0xC)  /* FMC Alternate Function mapping                      */
+#define GPIO_AF12_OTG_HS_FS     ((uint8_t)0xC)  /* OTG HS configured in FS, Alternate Function mapping */
+#define GPIO_AF12_SDMMC1        ((uint8_t)0xC)  /* SDMMC1 Alternate Function mapping                     */
+
+/**
+  * @brief   AF 13 selection
+  */
+#define GPIO_AF13_DCMI          ((uint8_t)0x0D)  /* DCMI Alternate Function mapping */
+
+#if defined(STM32F756xx) || defined(STM32F746xx)
+/**
+  * @brief   AF 14 selection
+  */
+#define GPIO_AF14_LTDC          ((uint8_t)0x0E)  /* LCD-TFT Alternate Function mapping */
+#endif /* STM32F756xx || STM32F746xx */
+/**
+  * @brief   AF 15 selection
+  */
+#define GPIO_AF15_EVENTOUT      ((uint8_t)0x0F)  /* EVENTOUT Alternate Function mapping */
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup GPIOEx_Exported_Macros GPIO Exported Macros
+  * @{
+  */
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup GPIOEx_Exported_Functions GPIO Exported Functions
+  * @{
+  */
+/**
+  * @}
+  */
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup GPIOEx_Private_Constants GPIO Private Constants
+  * @{
+  */
+
+/**
+  * @brief   GPIO pin available on the platform
+  */
+/* Defines the available pins per GPIOs */
+#define GPIOA_PIN_AVAILABLE  GPIO_PIN_All
+#define GPIOB_PIN_AVAILABLE  GPIO_PIN_All
+#define GPIOC_PIN_AVAILABLE  GPIO_PIN_All
+#define GPIOD_PIN_AVAILABLE  GPIO_PIN_All
+#define GPIOE_PIN_AVAILABLE  GPIO_PIN_All
+#define GPIOF_PIN_AVAILABLE  GPIO_PIN_All
+#define GPIOG_PIN_AVAILABLE  GPIO_PIN_All
+#define GPIOI_PIN_AVAILABLE  GPIO_PIN_All
+#define GPIOJ_PIN_AVAILABLE  GPIO_PIN_All
+#define GPIOH_PIN_AVAILABLE  GPIO_PIN_All
+#define GPIOK_PIN_AVAILABLE  (GPIO_PIN_0 | GPIO_PIN_1 | GPIO_PIN_3 | GPIO_PIN_4 | \
+                              GPIO_PIN_5 | GPIO_PIN_6 | GPIO_PIN_7)
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup GPIOEx_Private_Macros GPIO Private Macros
+  * @{
+  */
+/** @defgroup GPIOEx_Get_Port_Index GPIO Get Port Index
+  * @{
+  */
+#define GPIO_GET_INDEX(__GPIOx__)   (uint8_t)(((__GPIOx__) == (GPIOA))? 0U :\
+                                              ((__GPIOx__) == (GPIOB))? 1U :\
+                                              ((__GPIOx__) == (GPIOC))? 2U :\
+                                              ((__GPIOx__) == (GPIOD))? 3U :\
+                                              ((__GPIOx__) == (GPIOE))? 4U :\
+                                              ((__GPIOx__) == (GPIOF))? 5U :\
+                                              ((__GPIOx__) == (GPIOG))? 6U :\
+                                              ((__GPIOx__) == (GPIOH))? 7U :\
+                                              ((__GPIOx__) == (GPIOI))? 8U :\
+                                              ((__GPIOx__) == (GPIOJ))? 9U : 10U)
+/**
+  * @}
+  */
+
+#define IS_GPIO_PIN_AVAILABLE(__INSTANCE__,__PIN__)  \
+           ((((__INSTANCE__) == GPIOA) && (((__PIN__) & (GPIOA_PIN_AVAILABLE)) != 0) && (((__PIN__) | (GPIOA_PIN_AVAILABLE)) == (GPIOA_PIN_AVAILABLE))) || \
+            (((__INSTANCE__) == GPIOB) && (((__PIN__) & (GPIOB_PIN_AVAILABLE)) != 0) && (((__PIN__) | (GPIOB_PIN_AVAILABLE)) == (GPIOB_PIN_AVAILABLE))) || \
+            (((__INSTANCE__) == GPIOC) && (((__PIN__) & (GPIOC_PIN_AVAILABLE)) != 0) && (((__PIN__) | (GPIOC_PIN_AVAILABLE)) == (GPIOC_PIN_AVAILABLE))) || \
+            (((__INSTANCE__) == GPIOD) && (((__PIN__) & (GPIOD_PIN_AVAILABLE)) != 0) && (((__PIN__) | (GPIOD_PIN_AVAILABLE)) == (GPIOD_PIN_AVAILABLE))) || \
+            (((__INSTANCE__) == GPIOE) && (((__PIN__) & (GPIOE_PIN_AVAILABLE)) != 0) && (((__PIN__) | (GPIOE_PIN_AVAILABLE)) == (GPIOE_PIN_AVAILABLE))) || \
+            (((__INSTANCE__) == GPIOF) && (((__PIN__) & (GPIOF_PIN_AVAILABLE)) != 0) && (((__PIN__) | (GPIOF_PIN_AVAILABLE)) == (GPIOF_PIN_AVAILABLE))) || \
+			(((__INSTANCE__) == GPIOG) && (((__PIN__) & (GPIOG_PIN_AVAILABLE)) != 0) && (((__PIN__) | (GPIOG_PIN_AVAILABLE)) == (GPIOG_PIN_AVAILABLE))) || \
+			(((__INSTANCE__) == GPIOI) && (((__PIN__) & (GPIOI_PIN_AVAILABLE)) != 0) && (((__PIN__) | (GPIOI_PIN_AVAILABLE)) == (GPIOI_PIN_AVAILABLE))) || \
+			(((__INSTANCE__) == GPIOJ) && (((__PIN__) & (GPIOJ_PIN_AVAILABLE)) != 0) && (((__PIN__) | (GPIOJ_PIN_AVAILABLE)) == (GPIOJ_PIN_AVAILABLE))) || \
+			(((__INSTANCE__) == GPIOK) && (((__PIN__) & (GPIOK_PIN_AVAILABLE)) != 0) && (((__PIN__) | (GPIOK_PIN_AVAILABLE)) == (GPIOK_PIN_AVAILABLE))) || \
+			(((__INSTANCE__) == GPIOH) && (((__PIN__) & (GPIOH_PIN_AVAILABLE)) != 0) && (((__PIN__) | (GPIOH_PIN_AVAILABLE)) == (GPIOH_PIN_AVAILABLE))))
+/** @defgroup GPIOEx_IS_Alternat_function_selection GPIO Check Alternate Function
+  * @{
+  */
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)        || \
+                          ((AF) == GPIO_AF0_SWJ)        || ((AF) == GPIO_AF0_TRACE)      || \
+                          ((AF) == GPIO_AF0_MCO)       || ((AF) == GPIO_AF1_TIM2)       || \
+                          ((AF) == GPIO_AF2_TIM3)       || ((AF) == GPIO_AF2_TIM4)       || \
+                          ((AF) == GPIO_AF2_TIM5)       || ((AF) == GPIO_AF3_TIM8)       || \
+                          ((AF) == GPIO_AF3_TIM9)       || ((AF) == GPIO_AF3_TIM10)      || \
+                          ((AF) == GPIO_AF3_TIM11)      || ((AF) == GPIO_AF3_LPTIM1)     || \
+                          ((AF) == GPIO_AF3_CEC)        || ((AF) == GPIO_AF4_CEC)        || \
+                          ((AF) == GPIO_AF4_I2C1)       || ((AF) == GPIO_AF4_I2C2)       || \
+                          ((AF) == GPIO_AF4_I2C3)       || ((AF) == GPIO_AF4_I2C4)       || \
+                          ((AF) == GPIO_AF5_SPI1)       || ((AF) == GPIO_AF5_SPI2)       || \
+                          ((AF) == GPIO_AF5_SPI3)       || ((AF) == GPIO_AF5_SPI4)       || \
+                          ((AF) == GPIO_AF5_SPI5)       || ((AF) == GPIO_AF5_SPI6)       || \
+                          ((AF) == GPIO_AF6_SPI3)       || ((AF) == GPIO_AF6_SAI1)       || \
+                          ((AF) == GPIO_AF7_SPI3)       || ((AF) == GPIO_AF7_SPI2)        || \
+                          ((AF) == GPIO_AF7_USART1)     || ((AF) == GPIO_AF7_USART2)      || \
+                          ((AF) == GPIO_AF7_USART3)     || ((AF) == GPIO_AF7_UART5)       || \
+                          ((AF) == GPIO_AF7_SPDIFRX)    || ((AF) == GPIO_AF8_SPDIFRX)     || \
+                          ((AF) == GPIO_AF8_SAI2)       || ((AF) == GPIO_AF8_USART6)      || \
+                          ((AF) == GPIO_AF8_UART4)      || ((AF) == GPIO_AF8_UART5)       || \
+                          ((AF) == GPIO_AF8_UART7)      || ((AF) == GPIO_AF8_UART8)       || \
+                          ((AF) == GPIO_AF9_CAN1)       || ((AF) == GPIO_AF9_CAN2)        || \
+                          ((AF) == GPIO_AF9_TIM12)      || ((AF) == GPIO_AF9_TIM12)      || \
+                          ((AF) == GPIO_AF9_TIM14)      || ((AF) == GPIO_AF9_QUADSPI)    || \
+                          ((AF) == GPIO_AF9_LTDC)       || ((AF) == GPIO_AF10_OTG_FS)    || \
+                          ((AF) == GPIO_AF10_OTG_HS)    || ((AF) == GPIO_AF10_SAI2)      || \
+                          ((AF) == GPIO_AF10_QUADSPI)   || ((AF) == GPIO_AF11_ETH)       || \
+                          ((AF) == GPIO_AF12_OTG_HS_FS) || ((AF) == GPIO_AF12_SDMMC1)     || \
+                          ((AF) == GPIO_AF12_FMC)       || ((AF) == GPIO_AF15_EVENTOUT)  || \
+                          ((AF) == GPIO_AF13_DCMI)      || ((AF) == GPIO_AF14_LTDC))
+#elif defined(STM32F745xx)
+#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)        || \
+                          ((AF) == GPIO_AF0_SWJ)        || ((AF) == GPIO_AF0_TRACE)      || \
+                          ((AF) == GPIO_AF0_MCO)       || ((AF) == GPIO_AF1_TIM2)       || \
+                          ((AF) == GPIO_AF2_TIM3)       || ((AF) == GPIO_AF2_TIM4)       || \
+                          ((AF) == GPIO_AF2_TIM5)       || ((AF) == GPIO_AF3_TIM8)       || \
+                          ((AF) == GPIO_AF3_TIM9)       || ((AF) == GPIO_AF3_TIM10)      || \
+                          ((AF) == GPIO_AF3_TIM11)      || ((AF) == GPIO_AF3_LPTIM1)     || \
+                          ((AF) == GPIO_AF3_CEC)        || ((AF) == GPIO_AF4_CEC)        || \
+                          ((AF) == GPIO_AF4_I2C1)       || ((AF) == GPIO_AF4_I2C2)       || \
+                          ((AF) == GPIO_AF4_I2C3)       || ((AF) == GPIO_AF4_I2C4)       || \
+                          ((AF) == GPIO_AF5_SPI1)       || ((AF) == GPIO_AF5_SPI2)       || \
+                          ((AF) == GPIO_AF5_SPI3)       || ((AF) == GPIO_AF5_SPI4)       || \
+                          ((AF) == GPIO_AF5_SPI5)       || ((AF) == GPIO_AF5_SPI6)       || \
+                          ((AF) == GPIO_AF6_SPI3)       || ((AF) == GPIO_AF6_SAI1)       || \
+                          ((AF) == GPIO_AF7_SPI3)       || ((AF) == GPIO_AF7_SPI2)        || \
+                          ((AF) == GPIO_AF7_USART1)     || ((AF) == GPIO_AF7_USART2)      || \
+                          ((AF) == GPIO_AF7_USART3)     || ((AF) == GPIO_AF7_UART5)       || \
+                          ((AF) == GPIO_AF7_SPDIFRX)    || ((AF) == GPIO_AF8_SPDIFRX)     || \
+                          ((AF) == GPIO_AF8_SAI2)       || ((AF) == GPIO_AF8_USART6)      || \
+                          ((AF) == GPIO_AF8_UART4)      || ((AF) == GPIO_AF8_UART5)       || \
+                          ((AF) == GPIO_AF8_UART7)      || ((AF) == GPIO_AF8_UART8)       || \
+                          ((AF) == GPIO_AF9_CAN1)       || ((AF) == GPIO_AF9_CAN2)        || \
+                          ((AF) == GPIO_AF9_TIM12)      || ((AF) == GPIO_AF9_TIM12)      || \
+                          ((AF) == GPIO_AF9_TIM14)      || ((AF) == GPIO_AF9_QUADSPI)    || \
+                          ((AF) == GPIO_AF13_DCMI)      || ((AF) == GPIO_AF10_OTG_FS)    || \
+                          ((AF) == GPIO_AF10_OTG_HS)    || ((AF) == GPIO_AF10_SAI2)      || \
+                          ((AF) == GPIO_AF10_QUADSPI)   || ((AF) == GPIO_AF11_ETH)       || \
+                          ((AF) == GPIO_AF12_OTG_HS_FS) || ((AF) == GPIO_AF12_SDMMC1)     || \
+                          ((AF) == GPIO_AF12_FMC)       || ((AF) == GPIO_AF15_EVENTOUT))
+#endif /* STM32F756xx || STM32F746xx */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup GPIOEx_Private_Functions GPIO Private Functions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_GPIO_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_i2c.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_i2c.h
@@ -1,0 +1,598 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_i2c.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of I2C HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_I2C_H
+#define __STM32F7xx_HAL_I2C_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup I2C
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup I2C_Exported_Types I2C Exported Types
+  * @{
+  */
+
+/** @defgroup I2C_Configuration_Structure_definition I2C Configuration Structure definition
+  * @brief  I2C Configuration Structure definition
+  * @{
+  */
+typedef struct
+{
+  uint32_t Timing;              /*!< Specifies the I2C_TIMINGR_register value.
+                                  This parameter calculated by referring to I2C initialization
+                                         section in Reference manual */
+
+  uint32_t OwnAddress1;         /*!< Specifies the first device own address.
+                                  This parameter can be a 7-bit or 10-bit address. */
+
+  uint32_t AddressingMode;      /*!< Specifies if 7-bit or 10-bit addressing mode is selected.
+                                  This parameter can be a value of @ref I2C_addressing_mode */
+
+  uint32_t DualAddressMode;     /*!< Specifies if dual addressing mode is selected.
+                                  This parameter can be a value of @ref I2C_dual_addressing_mode */
+
+  uint32_t OwnAddress2;         /*!< Specifies the second device own address if dual addressing mode is selected
+                                  This parameter can be a 7-bit address. */
+
+  uint32_t OwnAddress2Masks;    /*!< Specifies the acknoledge mask address second device own address if dual addressing mode is selected
+                                  This parameter can be a value of @ref I2C_own_address2_masks */
+
+  uint32_t GeneralCallMode;     /*!< Specifies if general call mode is selected.
+                                  This parameter can be a value of @ref I2C_general_call_addressing_mode */
+
+  uint32_t NoStretchMode;       /*!< Specifies if nostretch mode is selected.
+                                  This parameter can be a value of @ref I2C_nostretch_mode */
+
+}I2C_InitTypeDef;
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_state_structure_definition HAL state structure definition
+  * @brief  HAL State structure definition
+  * @{
+  */
+
+typedef enum
+{
+  HAL_I2C_STATE_RESET           = 0x00,  /*!< I2C not yet initialized or disabled         */
+  HAL_I2C_STATE_READY           = 0x01,  /*!< I2C initialized and ready for use           */
+  HAL_I2C_STATE_BUSY            = 0x02,  /*!< I2C internal process is ongoing             */
+  HAL_I2C_STATE_MASTER_BUSY_TX  = 0x12,  /*!< Master Data Transmission process is ongoing */
+  HAL_I2C_STATE_MASTER_BUSY_RX  = 0x22,  /*!< Master Data Reception process is ongoing    */
+  HAL_I2C_STATE_SLAVE_BUSY_TX   = 0x32,  /*!< Slave Data Transmission process is ongoing  */
+  HAL_I2C_STATE_SLAVE_BUSY_RX   = 0x42,  /*!< Slave Data Reception process is ongoing     */
+  HAL_I2C_STATE_MEM_BUSY_TX     = 0x52,  /*!< Memory Data Transmission process is ongoing */
+  HAL_I2C_STATE_MEM_BUSY_RX     = 0x62,  /*!< Memory Data Reception process is ongoing    */
+  HAL_I2C_STATE_TIMEOUT         = 0x03,  /*!< Timeout state                               */
+  HAL_I2C_STATE_ERROR           = 0x04   /*!< Reception process is ongoing                */
+}HAL_I2C_StateTypeDef;
+
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Error_Code_definition I2C Error Code definition
+  * @brief  I2C Error Code definition
+  * @{
+  */
+#define HAL_I2C_ERROR_NONE      ((uint32_t)0x00000000)    /*!< No error              */
+#define HAL_I2C_ERROR_BERR      ((uint32_t)0x00000001)    /*!< BERR error            */
+#define HAL_I2C_ERROR_ARLO      ((uint32_t)0x00000002)    /*!< ARLO error            */
+#define HAL_I2C_ERROR_AF        ((uint32_t)0x00000004)    /*!< ACKF error            */
+#define HAL_I2C_ERROR_OVR       ((uint32_t)0x00000008)    /*!< OVR error             */
+#define HAL_I2C_ERROR_DMA       ((uint32_t)0x00000010)    /*!< DMA transfer error    */
+#define HAL_I2C_ERROR_TIMEOUT   ((uint32_t)0x00000020)    /*!< Timeout error         */
+#define HAL_I2C_ERROR_SIZE      ((uint32_t)0x00000040)    /*!< Size Management error */
+/**
+  * @}
+  */
+
+/** @defgroup I2C_handle_Structure_definition I2C handle Structure definition
+  * @brief  I2C handle Structure definition
+  * @{
+  */
+typedef struct
+{
+  I2C_TypeDef                *Instance;  /*!< I2C registers base address     */
+
+  I2C_InitTypeDef            Init;       /*!< I2C communication parameters   */
+
+  uint8_t                    *pBuffPtr;  /*!< Pointer to I2C transfer buffer */
+
+  uint16_t                   XferSize;   /*!< I2C transfer size              */
+
+  __IO uint16_t              XferCount;  /*!< I2C transfer counter           */
+
+  DMA_HandleTypeDef          *hdmatx;    /*!< I2C Tx DMA handle parameters   */
+
+  DMA_HandleTypeDef          *hdmarx;    /*!< I2C Rx DMA handle parameters   */
+
+  HAL_LockTypeDef            Lock;       /*!< I2C locking object             */
+
+  __IO HAL_I2C_StateTypeDef  State;      /*!< I2C communication state        */
+
+  __IO uint32_t              ErrorCode;  /*!< I2C Error code                   */
+
+}I2C_HandleTypeDef;
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup I2C_Exported_Constants I2C Exported Constants
+  * @{
+  */
+
+/** @defgroup I2C_addressing_mode I2C addressing mode
+  * @{
+  */
+#define I2C_ADDRESSINGMODE_7BIT         ((uint32_t)0x00000001)
+#define I2C_ADDRESSINGMODE_10BIT        ((uint32_t)0x00000002)
+/**
+  * @}
+  */
+
+/** @defgroup I2C_dual_addressing_mode I2C dual addressing mode
+  * @{
+  */
+#define I2C_DUALADDRESS_DISABLE         ((uint32_t)0x00000000)
+#define I2C_DUALADDRESS_ENABLE          I2C_OAR2_OA2EN
+/**
+  * @}
+  */
+
+/** @defgroup I2C_own_address2_masks I2C own address2 masks
+  * @{
+  */
+#define I2C_OA2_NOMASK                  ((uint8_t)0x00)
+#define I2C_OA2_MASK01                  ((uint8_t)0x01)
+#define I2C_OA2_MASK02                  ((uint8_t)0x02)
+#define I2C_OA2_MASK03                  ((uint8_t)0x03)
+#define I2C_OA2_MASK04                  ((uint8_t)0x04)
+#define I2C_OA2_MASK05                  ((uint8_t)0x05)
+#define I2C_OA2_MASK06                  ((uint8_t)0x06)
+#define I2C_OA2_MASK07                  ((uint8_t)0x07)
+/**
+  * @}
+  */
+
+/** @defgroup I2C_general_call_addressing_mode I2C general call addressing mode
+  * @{
+  */
+#define I2C_GENERALCALL_DISABLE         ((uint32_t)0x00000000)
+#define I2C_GENERALCALL_ENABLE          I2C_CR1_GCEN
+/**
+  * @}
+  */
+
+/** @defgroup I2C_nostretch_mode I2C nostretch mode
+  * @{
+  */
+#define I2C_NOSTRETCH_DISABLE           ((uint32_t)0x00000000)
+#define I2C_NOSTRETCH_ENABLE            I2C_CR1_NOSTRETCH
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Memory_Address_Size I2C Memory Address Size
+  * @{
+  */
+#define I2C_MEMADD_SIZE_8BIT            ((uint32_t)0x00000001)
+#define I2C_MEMADD_SIZE_16BIT           ((uint32_t)0x00000002)
+/**
+  * @}
+  */
+
+/** @defgroup I2C_ReloadEndMode_definition I2C ReloadEndMode definition
+  * @{
+  */
+#define  I2C_RELOAD_MODE                I2C_CR2_RELOAD
+#define  I2C_AUTOEND_MODE               I2C_CR2_AUTOEND
+#define  I2C_SOFTEND_MODE               ((uint32_t)0x00000000)
+/**
+  * @}
+  */
+
+/** @defgroup I2C_StartStopMode_definition I2C StartStopMode definition
+  * @{
+  */
+#define  I2C_NO_STARTSTOP               ((uint32_t)0x00000000)
+#define  I2C_GENERATE_STOP              I2C_CR2_STOP
+#define  I2C_GENERATE_START_READ        (uint32_t)(I2C_CR2_START | I2C_CR2_RD_WRN)
+#define  I2C_GENERATE_START_WRITE       I2C_CR2_START
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Interrupt_configuration_definition I2C Interrupt configuration definition
+  * @brief I2C Interrupt definition
+  *        Elements values convention: 0xXXXXXXXX
+  *           - XXXXXXXX  : Interrupt control mask
+  * @{
+  */
+#define I2C_IT_ERRI                     I2C_CR1_ERRIE
+#define I2C_IT_TCI                      I2C_CR1_TCIE
+#define I2C_IT_STOPI                    I2C_CR1_STOPIE
+#define I2C_IT_NACKI                    I2C_CR1_NACKIE
+#define I2C_IT_ADDRI                    I2C_CR1_ADDRIE
+#define I2C_IT_RXI                      I2C_CR1_RXIE
+#define I2C_IT_TXI                      I2C_CR1_TXIE
+
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Flag_definition I2C Flag definition
+  * @{
+  */
+#define I2C_FLAG_TXE                    I2C_ISR_TXE
+#define I2C_FLAG_TXIS                   I2C_ISR_TXIS
+#define I2C_FLAG_RXNE                   I2C_ISR_RXNE
+#define I2C_FLAG_ADDR                   I2C_ISR_ADDR
+#define I2C_FLAG_AF                     I2C_ISR_NACKF
+#define I2C_FLAG_STOPF                  I2C_ISR_STOPF
+#define I2C_FLAG_TC                     I2C_ISR_TC
+#define I2C_FLAG_TCR                    I2C_ISR_TCR
+#define I2C_FLAG_BERR                   I2C_ISR_BERR
+#define I2C_FLAG_ARLO                   I2C_ISR_ARLO
+#define I2C_FLAG_OVR                    I2C_ISR_OVR
+#define I2C_FLAG_PECERR                 I2C_ISR_PECERR
+#define I2C_FLAG_TIMEOUT                I2C_ISR_TIMEOUT
+#define I2C_FLAG_ALERT                  I2C_ISR_ALERT
+#define I2C_FLAG_BUSY                   I2C_ISR_BUSY
+#define I2C_FLAG_DIR                    I2C_ISR_DIR
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+
+/** @defgroup I2C_Exported_Macros I2C Exported Macros
+  * @{
+  */
+
+/** @brief Reset I2C handle state
+  * @param  __HANDLE__: specifies the I2C Handle.
+  * @retval None
+  */
+#define __HAL_I2C_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_I2C_STATE_RESET)
+
+/** @brief  Enable the specified I2C interrupts.
+  * @param  __HANDLE__: specifies the I2C Handle.
+  * @param  __INTERRUPT__: specifies the interrupt source to enable.
+  *        This parameter can be one of the following values:
+  *            @arg I2C_IT_ERRI: Errors interrupt enable
+  *            @arg I2C_IT_TCI: Transfer complete interrupt enable
+  *            @arg I2C_IT_STOPI: STOP detection interrupt enable
+  *            @arg I2C_IT_NACKI: NACK received interrupt enable
+  *            @arg I2C_IT_ADDRI: Address match interrupt enable
+  *            @arg I2C_IT_RXI: RX interrupt enable
+  *            @arg I2C_IT_TXI: TX interrupt enable
+  *
+  * @retval None
+  */
+
+#define __HAL_I2C_ENABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CR1 |= (__INTERRUPT__))
+
+/** @brief  Disable the specified I2C interrupts.
+  * @param  __HANDLE__: specifies the I2C Handle.
+  * @param  __INTERRUPT__: specifies the interrupt source to disable.
+  *        This parameter can be one of the following values:
+  *            @arg I2C_IT_ERRI: Errors interrupt enable
+  *            @arg I2C_IT_TCI: Transfer complete interrupt enable
+  *            @arg I2C_IT_STOPI: STOP detection interrupt enable
+  *            @arg I2C_IT_NACKI: NACK received interrupt enable
+  *            @arg I2C_IT_ADDRI: Address match interrupt enable
+  *            @arg I2C_IT_RXI: RX interrupt enable
+  *            @arg I2C_IT_TXI: TX interrupt enable
+  *
+  * @retval None
+  */
+#define __HAL_I2C_DISABLE_IT(__HANDLE__, __INTERRUPT__)  ((__HANDLE__)->Instance->CR1 &= (~(__INTERRUPT__)))
+
+/** @brief  Checks if the specified I2C interrupt source is enabled or disabled.
+  * @param  __HANDLE__: specifies the I2C Handle.
+  * @param  __INTERRUPT__: specifies the I2C interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg I2C_IT_ERRI: Errors interrupt enable
+  *            @arg I2C_IT_TCI: Transfer complete interrupt enable
+  *            @arg I2C_IT_STOPI: STOP detection interrupt enable
+  *            @arg I2C_IT_NACKI: NACK received interrupt enable
+  *            @arg I2C_IT_ADDRI: Address match interrupt enable
+  *            @arg I2C_IT_RXI: RX interrupt enable
+  *            @arg I2C_IT_TXI: TX interrupt enable
+  *
+  * @retval The new state of __INTERRUPT__ (TRUE or FALSE).
+  */
+#define __HAL_I2C_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR1 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/** @brief  Checks whether the specified I2C flag is set or not.
+  * @param  __HANDLE__: specifies the I2C Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg I2C_FLAG_TXE:      Transmit data register empty
+  *            @arg I2C_FLAG_TXIS:     Transmit interrupt status
+  *            @arg I2C_FLAG_RXNE:     Receive data register not empty
+  *            @arg I2C_FLAG_ADDR:     Address matched (slave mode)
+  *            @arg I2C_FLAG_AF:       Acknowledge failure received flag
+  *            @arg I2C_FLAG_STOPF:    STOP detection flag
+  *            @arg I2C_FLAG_TC:       Transfer complete (master mode)
+  *            @arg I2C_FLAG_TCR:      Transfer complete reload
+  *            @arg I2C_FLAG_BERR:     Bus error
+  *            @arg I2C_FLAG_ARLO:     Arbitration lost
+  *            @arg I2C_FLAG_OVR:      Overrun/Underrun
+  *            @arg I2C_FLAG_PECERR:   PEC error in reception
+  *            @arg I2C_FLAG_TIMEOUT:  Timeout or Tlow detection flag
+  *            @arg I2C_FLAG_ALERT:    SMBus alert
+  *            @arg I2C_FLAG_BUSY:     Bus busy
+  *            @arg I2C_FLAG_DIR:      Transfer direction (slave mode)
+  *
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define I2C_FLAG_MASK  ((uint32_t)0x0001FFFF)
+#define __HAL_I2C_GET_FLAG(__HANDLE__, __FLAG__) (((((__HANDLE__)->Instance->ISR) & ((__FLAG__) & I2C_FLAG_MASK)) == ((__FLAG__) & I2C_FLAG_MASK)))
+
+/** @brief  Clears the I2C pending flags which are cleared by writing 1 in a specific bit.
+  * @param  __HANDLE__: specifies the I2C Handle.
+  * @param  __FLAG__: specifies the flag to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg I2C_FLAG_ADDR:    Address matched (slave mode)
+  *            @arg I2C_FLAG_AF:      Acknowledge failure received flag
+  *            @arg I2C_FLAG_STOPF:   STOP detection flag
+  *            @arg I2C_FLAG_BERR:    Bus error
+  *            @arg I2C_FLAG_ARLO:    Arbitration lost
+  *            @arg I2C_FLAG_OVR:     Overrun/Underrun
+  *            @arg I2C_FLAG_PECERR:  PEC error in reception
+  *            @arg I2C_FLAG_TIMEOUT: Timeout or Tlow detection flag
+  *            @arg I2C_FLAG_ALERT:   SMBus alert
+  *
+  * @retval None
+  */
+#define __HAL_I2C_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ICR = ((__FLAG__) & I2C_FLAG_MASK))
+
+/** @brief  Enable the specified I2C peripheral.
+  * @param  __HANDLE__: specifies the I2C Handle.
+  * @retval None
+  */
+#define __HAL_I2C_ENABLE(__HANDLE__)                            (SET_BIT((__HANDLE__)->Instance->CR1,  I2C_CR1_PE))
+
+/** @brief  Disable the specified I2C peripheral.
+  * @param  __HANDLE__: specifies the I2C Handle.
+  * @retval None
+  */
+#define __HAL_I2C_DISABLE(__HANDLE__)                           (CLEAR_BIT((__HANDLE__)->Instance->CR1, I2C_CR1_PE))
+
+/**
+  * @}
+  */
+
+/* Include I2C HAL Extension module */
+#include "stm32f7xx_hal_i2c_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup I2C_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup I2C_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+/* Initialization and de-initialization functions******************************/
+HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef HAL_I2C_DeInit (I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c);
+/**
+  * @}
+  */
+
+/** @addtogroup I2C_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
+/* IO operation functions  ****************************************************/
+ /******* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout);
+
+ /******* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+
+ /******* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+/**
+  * @}
+  */
+
+/** @addtogroup IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
+ * @{
+ */
+/******* I2C IRQHandler and Callbacks used in non blocking modes (Interrupt and DMA) */
+void HAL_I2C_EV_IRQHandler(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_ER_IRQHandler(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_SlaveTxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c);
+/**
+  * @}
+  */
+
+/** @addtogroup I2C_Exported_Functions_Group3 Peripheral State and Errors functions
+  * @{
+  */
+/* Peripheral State and Errors functions  *************************************/
+HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c);
+uint32_t             HAL_I2C_GetError(I2C_HandleTypeDef *hi2c);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup I2C_Private_Constants I2C Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup I2C_Private_Macro I2C Private Macros
+  * @{
+  */
+
+#define IS_I2C_ADDRESSING_MODE(MODE)    (((MODE) == I2C_ADDRESSINGMODE_7BIT) || \
+                                          ((MODE) == I2C_ADDRESSINGMODE_10BIT))
+
+#define IS_I2C_DUAL_ADDRESS(ADDRESS)    (((ADDRESS) == I2C_DUALADDRESS_DISABLE) || \
+                                          ((ADDRESS) == I2C_DUALADDRESS_ENABLE))
+
+#define IS_I2C_OWN_ADDRESS2_MASK(MASK)  (((MASK) == I2C_OA2_NOMASK)  || \
+                                          ((MASK) == I2C_OA2_MASK01) || \
+                                          ((MASK) == I2C_OA2_MASK02) || \
+                                          ((MASK) == I2C_OA2_MASK03) || \
+                                          ((MASK) == I2C_OA2_MASK04) || \
+                                          ((MASK) == I2C_OA2_MASK05) || \
+                                          ((MASK) == I2C_OA2_MASK06) || \
+                                          ((MASK) == I2C_OA2_MASK07))
+
+#define IS_I2C_GENERAL_CALL(CALL)       (((CALL) == I2C_GENERALCALL_DISABLE) || \
+                                          ((CALL) == I2C_GENERALCALL_ENABLE))
+
+#define IS_I2C_NO_STRETCH(STRETCH)      (((STRETCH) == I2C_NOSTRETCH_DISABLE) || \
+                                          ((STRETCH) == I2C_NOSTRETCH_ENABLE))
+
+#define IS_I2C_MEMADD_SIZE(SIZE)        (((SIZE) == I2C_MEMADD_SIZE_8BIT) || \
+                                          ((SIZE) == I2C_MEMADD_SIZE_16BIT))
+
+
+#define IS_TRANSFER_MODE(MODE)          (((MODE) == I2C_RELOAD_MODE)   || \
+                                          ((MODE) == I2C_AUTOEND_MODE) || \
+                                          ((MODE) == I2C_SOFTEND_MODE))
+
+#define IS_TRANSFER_REQUEST(REQUEST)    (((REQUEST) == I2C_GENERATE_STOP)         || \
+                                          ((REQUEST) == I2C_GENERATE_START_READ)  || \
+                                          ((REQUEST) == I2C_GENERATE_START_WRITE) || \
+                                          ((REQUEST) == I2C_NO_STARTSTOP))
+
+
+#define I2C_RESET_CR2(__HANDLE__)       ((__HANDLE__)->Instance->CR2 &= (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_HEAD10R | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_RD_WRN)))
+
+#define IS_I2C_OWN_ADDRESS1(ADDRESS1)   ((ADDRESS1) <= (uint32_t)0x000003FF)
+#define IS_I2C_OWN_ADDRESS2(ADDRESS2)   ((ADDRESS2) <= (uint16_t)0x00FF)
+
+#define I2C_MEM_ADD_MSB(__ADDRESS__)    ((uint8_t)((uint16_t)(((uint16_t)((__ADDRESS__) & (uint16_t)(0xFF00))) >> 8)))
+#define I2C_MEM_ADD_LSB(__ADDRESS__)    ((uint8_t)((uint16_t)((__ADDRESS__) & (uint16_t)(0x00FF))))
+
+#define I2C_GENERATE_START(__ADDMODE__,__ADDRESS__)   (((__ADDMODE__) == I2C_ADDRESSINGMODE_7BIT) ? (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | (I2C_CR2_START) | (I2C_CR2_AUTOEND)) & (~I2C_CR2_RD_WRN)) : \
+                                                          (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | (I2C_CR2_ADD10) | (I2C_CR2_START)) & (~I2C_CR2_RD_WRN)))
+/**
+  * @}
+  */
+
+/* Private Functions ---------------------------------------------------------*/
+/** @defgroup I2C_Private_Functions I2C Private Functions
+  * @{
+  */
+/* Private functions are defined in stm32f7xx_hal_i2c.c file */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32F7xx_HAL_I2C_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_i2c_ex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_i2c_ex.h
@@ -1,0 +1,129 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_i2c_ex.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of I2C HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_I2C_EX_H
+#define __STM32F7xx_HAL_I2C_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup I2CEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup I2CEx_Exported_Constants I2CEx Exported Constants
+  * @{
+  */
+
+/** @defgroup I2CEx_Analog_Filter I2CEx Analog Filter
+  * @{
+  */
+#define I2C_ANALOGFILTER_ENABLE        ((uint32_t)0x00000000)
+#define I2C_ANALOGFILTER_DISABLE       I2C_CR1_ANFOFF
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/* Peripheral Control methods  ************************************************/
+HAL_StatusTypeDef HAL_I2CEx_ConfigAnalogFilter(I2C_HandleTypeDef *hi2c, uint32_t AnalogFilter);
+HAL_StatusTypeDef HAL_I2CEx_ConfigDigitalFilter(I2C_HandleTypeDef *hi2c, uint32_t DigitalFilter);
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup I2C_Private_Constants I2C Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup I2C_Private_Macro I2C Private Macros
+  * @{
+  */
+#define IS_I2C_ANALOG_FILTER(FILTER)    (((FILTER) == I2C_ANALOGFILTER_ENABLE) || \
+                                          ((FILTER) == I2C_ANALOGFILTER_DISABLE))
+
+#define IS_I2C_DIGITAL_FILTER(FILTER)   ((FILTER) <= 0x0000000F)
+/**
+  * @}
+  */
+
+/* Private Functions ---------------------------------------------------------*/
+/** @defgroup I2C_Private_Functions I2C Private Functions
+  * @{
+  */
+/* Private functions are defined in stm32f7xx_hal_i2c_ex.c file */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_I2C_EX_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_i2s.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_i2s.h
@@ -1,0 +1,483 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_i2s.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of I2S HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_I2S_H
+#define __STM32F7xx_HAL_I2S_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup I2S
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup I2S_Exported_Types I2S Exported Types
+  * @{
+  */
+
+/**
+  * @brief I2S Init structure definition
+  */
+typedef struct
+{
+  uint32_t Mode;                /*!< Specifies the I2S operating mode.
+                                     This parameter can be a value of @ref I2S_Mode */
+
+  uint32_t Standard;            /*!< Specifies the standard used for the I2S communication.
+                                     This parameter can be a value of @ref I2S_Standard */
+
+  uint32_t DataFormat;          /*!< Specifies the data format for the I2S communication.
+                                     This parameter can be a value of @ref I2S_Data_Format */
+
+  uint32_t MCLKOutput;          /*!< Specifies whether the I2S MCLK output is enabled or not.
+                                     This parameter can be a value of @ref I2S_MCLK_Output */
+
+  uint32_t AudioFreq;           /*!< Specifies the frequency selected for the I2S communication.
+                                     This parameter can be a value of @ref I2S_Audio_Frequency */
+
+  uint32_t CPOL;                /*!< Specifies the idle state of the I2S clock.
+                                     This parameter can be a value of @ref I2S_Clock_Polarity */
+
+  uint32_t ClockSource;         /*!< Specifies the I2S Clock Source.
+                                     This parameter can be a value of @ref I2S_Clock_Source */
+}I2S_InitTypeDef;
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef enum
+{
+  HAL_I2S_STATE_RESET      = 0x00,  /*!< I2S not yet initialized or disabled                */
+  HAL_I2S_STATE_READY      = 0x01,  /*!< I2S initialized and ready for use                  */
+  HAL_I2S_STATE_BUSY       = 0x02,  /*!< I2S internal process is ongoing                    */
+  HAL_I2S_STATE_BUSY_TX    = 0x03,  /*!< Data Transmission process is ongoing               */
+  HAL_I2S_STATE_BUSY_RX    = 0x04,  /*!< Data Reception process is ongoing                  */
+  HAL_I2S_STATE_BUSY_TX_RX = 0x05,  /*!< Data Transmission and Reception process is ongoing */
+  HAL_I2S_STATE_TIMEOUT    = 0x06,  /*!< I2S timeout state                                  */
+  HAL_I2S_STATE_ERROR      = 0x07   /*!< I2S error state                                    */
+
+}HAL_I2S_StateTypeDef;
+
+/**
+  * @brief I2S handle Structure definition
+  */
+typedef struct
+{
+  SPI_TypeDef                *Instance;    /* I2S registers base address */
+
+  I2S_InitTypeDef            Init;         /* I2S communication parameters */
+
+  uint16_t                   *pTxBuffPtr;  /* Pointer to I2S Tx transfer buffer */
+
+  __IO uint16_t              TxXferSize;   /* I2S Tx transfer size */
+
+  __IO uint16_t              TxXferCount;  /* I2S Tx transfer Counter */
+
+  uint16_t                   *pRxBuffPtr;  /* Pointer to I2S Rx transfer buffer */
+
+  __IO uint16_t              RxXferSize;   /* I2S Rx transfer size */
+
+  __IO uint16_t              RxXferCount;  /* I2S Rx transfer counter
+                                              (This field is initialized at the
+                                               same value as transfer size at the
+                                               beginning of the transfer and
+                                               decremented when a sample is received.
+                                               NbSamplesReceived = RxBufferSize-RxBufferCount) */
+
+  DMA_HandleTypeDef          *hdmatx;      /* I2S Tx DMA handle parameters */
+
+  DMA_HandleTypeDef          *hdmarx;      /* I2S Rx DMA handle parameters */
+
+  __IO HAL_LockTypeDef       Lock;         /* I2S locking object */
+
+  __IO HAL_I2S_StateTypeDef  State;        /* I2S communication state */
+
+  __IO uint32_t  ErrorCode;                /* I2S Error code                 */
+
+}I2S_HandleTypeDef;
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup I2S_Exported_Constants I2S Exported Constants
+  * @{
+  */
+
+/** @defgroup I2S_Error_Defintion I2S_Error_Defintion
+  *@brief     I2S Error Code
+  * @{
+  */
+#define HAL_I2S_ERROR_NONE      ((uint32_t)0x00000000)  /*!< No error           */
+#define HAL_I2S_ERROR_TIMEOUT   ((uint32_t)0x00000001)  /*!< Timeout error      */
+#define HAL_I2S_ERROR_OVR       ((uint32_t)0x00000002)  /*!< OVR error          */
+#define HAL_I2S_ERROR_UDR       ((uint32_t)0x00000004)  /*!< UDR error          */
+#define HAL_I2S_ERROR_DMA       ((uint32_t)0x00000008)  /*!< DMA transfer error */
+#define HAL_I2S_ERROR_UNKNOW    ((uint32_t)0x00000010)  /*!< Unknow Error error */
+
+/**
+  * @}
+  */
+/** @defgroup I2S_Clock_Source I2S Clock Source
+  * @{
+  */
+#define I2S_CLOCK_EXTERNAL                ((uint32_t)0x00000001)
+#define I2S_CLOCK_SYSCLK                  ((uint32_t)0x00000002)
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Mode I2S Mode
+  * @{
+  */
+#define I2S_MODE_SLAVE_TX                ((uint32_t)0x00000000)
+#define I2S_MODE_SLAVE_RX                ((uint32_t)0x00000100)
+#define I2S_MODE_MASTER_TX               ((uint32_t)0x00000200)
+#define I2S_MODE_MASTER_RX               ((uint32_t)0x00000300)
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Standard I2S Standard
+  * @{
+  */
+#define I2S_STANDARD_PHILIPS             ((uint32_t)0x00000000)
+#define I2S_STANDARD_MSB                 ((uint32_t)0x00000010)
+#define I2S_STANDARD_LSB                 ((uint32_t)0x00000020)
+#define I2S_STANDARD_PCM_SHORT           ((uint32_t)0x00000030)
+#define I2S_STANDARD_PCM_LONG            ((uint32_t)0x000000B0)
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Data_Format I2S Data Format
+  * @{
+  */
+#define I2S_DATAFORMAT_16B               ((uint32_t)0x00000000)
+#define I2S_DATAFORMAT_16B_EXTENDED      ((uint32_t)0x00000001)
+#define I2S_DATAFORMAT_24B               ((uint32_t)0x00000003)
+#define I2S_DATAFORMAT_32B               ((uint32_t)0x00000005)
+/**
+  * @}
+  */
+
+/** @defgroup I2S_MCLK_Output I2S Mclk Output
+  * @{
+  */
+#define I2S_MCLKOUTPUT_ENABLE           ((uint32_t)SPI_I2SPR_MCKOE)
+#define I2S_MCLKOUTPUT_DISABLE          ((uint32_t)0x00000000)
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Audio_Frequency I2S Audio Frequency
+  * @{
+  */
+#define I2S_AUDIOFREQ_192K               ((uint32_t)192000)
+#define I2S_AUDIOFREQ_96K                ((uint32_t)96000)
+#define I2S_AUDIOFREQ_48K                ((uint32_t)48000)
+#define I2S_AUDIOFREQ_44K                ((uint32_t)44100)
+#define I2S_AUDIOFREQ_32K                ((uint32_t)32000)
+#define I2S_AUDIOFREQ_22K                ((uint32_t)22050)
+#define I2S_AUDIOFREQ_16K                ((uint32_t)16000)
+#define I2S_AUDIOFREQ_11K                ((uint32_t)11025)
+#define I2S_AUDIOFREQ_8K                 ((uint32_t)8000)
+#define I2S_AUDIOFREQ_DEFAULT            ((uint32_t)2)
+/**
+  * @}
+  */
+
+
+/** @defgroup I2S_Clock_Polarity I2S Clock Polarity
+  * @{
+  */
+#define I2S_CPOL_LOW                    ((uint32_t)0x00000000)
+#define I2S_CPOL_HIGH                   ((uint32_t)SPI_I2SCFGR_CKPOL)
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Interrupts_Definition I2S Interrupts Definition
+  * @{
+  */
+#define I2S_IT_TXE                      SPI_CR2_TXEIE
+#define I2S_IT_RXNE                     SPI_CR2_RXNEIE
+#define I2S_IT_ERR                      SPI_CR2_ERRIE
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Flags_Definition I2S Flags Definition
+  * @{
+  */
+#define I2S_FLAG_TXE                    SPI_SR_TXE
+#define I2S_FLAG_RXNE                   SPI_SR_RXNE
+
+#define I2S_FLAG_UDR                    SPI_SR_UDR
+#define I2S_FLAG_OVR                    SPI_SR_OVR
+#define I2S_FLAG_FRE                    SPI_SR_FRE
+
+#define I2S_FLAG_CHSIDE                 SPI_SR_CHSIDE
+#define I2S_FLAG_BSY                    SPI_SR_BSY
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup I2S_Exported_Macros I2S Exported Macros
+  * @{
+  */
+
+/** @brief  Reset I2S handle state
+  * @param  __HANDLE__: specifies the I2S handle.
+  * @retval None
+  */
+#define __HAL_I2S_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_I2S_STATE_RESET)
+
+/** @brief  Enable or disable the specified SPI peripheral (in I2S mode).
+  * @param  __HANDLE__: specifies the I2S Handle.
+  * @retval None
+  */
+#define __HAL_I2S_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->I2SCFGR |= SPI_I2SCFGR_I2SE)
+#define __HAL_I2S_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->I2SCFGR &= ~SPI_I2SCFGR_I2SE)
+
+/** @brief  Enable or disable the specified I2S interrupts.
+  * @param  __HANDLE__: specifies the I2S Handle.
+  * @param  __INTERRUPT__: specifies the interrupt source to enable or disable.
+  *        This parameter can be one of the following values:
+  *            @arg I2S_IT_TXE: Tx buffer empty interrupt enable
+  *            @arg I2S_IT_RXNE: RX buffer not empty interrupt enable
+  *            @arg I2S_IT_ERR: Error interrupt enable
+  * @retval None
+  */
+#define __HAL_I2S_ENABLE_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->CR2 |= (__INTERRUPT__))
+#define __HAL_I2S_DISABLE_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->CR2 &= ~(__INTERRUPT__))
+
+/** @brief  Checks if the specified I2S interrupt source is enabled or disabled.
+  * @param  __HANDLE__: specifies the I2S Handle.
+  *         This parameter can be I2S where x: 1, 2, or 3 to select the I2S peripheral.
+  * @param  __INTERRUPT__: specifies the I2S interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg I2S_IT_TXE: Tx buffer empty interrupt enable
+  *            @arg I2S_IT_RXNE: RX buffer not empty interrupt enable
+  *            @arg I2S_IT_ERR: Error interrupt enable
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_I2S_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR2 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/** @brief  Checks whether the specified I2S flag is set or not.
+  * @param  __HANDLE__: specifies the I2S Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg I2S_FLAG_RXNE: Receive buffer not empty flag
+  *            @arg I2S_FLAG_TXE: Transmit buffer empty flag
+  *            @arg I2S_FLAG_UDR: Underrun flag
+  *            @arg I2S_FLAG_OVR: Overrun flag
+  *            @arg I2S_FLAG_FRE: Frame error flag
+  *            @arg I2S_FLAG_CHSIDE: Channel Side flag
+  *            @arg I2S_FLAG_BSY: Busy flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_I2S_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->SR) & (__FLAG__)) == (__FLAG__))
+
+/** @brief Clears the I2S OVR pending flag.
+  * @param  __HANDLE__: specifies the I2S Handle.
+  * @retval None
+  */
+#define __HAL_I2S_CLEAR_OVRFLAG(__HANDLE__)     \
+  do{                                           \
+    __IO uint32_t tmpreg;                       \
+    tmpreg = (__HANDLE__)->Instance->DR;        \
+    tmpreg = (__HANDLE__)->Instance->SR;        \
+    UNUSED(tmpreg);                             \
+  } while(0)
+
+/** @brief Clears the I2S UDR pending flag.
+  * @param  __HANDLE__: specifies the I2S Handle.
+  * @retval None
+  */
+#define __HAL_I2S_CLEAR_UDRFLAG(__HANDLE__)     \
+  do{                                             \
+  __IO uint32_t tmpreg;                         \
+  tmpreg = (__HANDLE__)->Instance->SR;          \
+  UNUSED(tmpreg);                               \
+  } while(0)
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup I2S_Exported_Functions  I2S Exported Functions
+  * @{
+  */
+
+/** @addtogroup I2S_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+
+/* Initialization and de-initialization functions *****************************/
+HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s);
+HAL_StatusTypeDef HAL_I2S_DeInit (I2S_HandleTypeDef *hi2s);
+void HAL_I2S_MspInit(I2S_HandleTypeDef *hi2s);
+void HAL_I2S_MspDeInit(I2S_HandleTypeDef *hi2s);
+/**
+  * @}
+  */
+
+/** @addtogroup I2S_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
+/* I/O operation functions  ***************************************************/
+ /* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_I2S_Transmit(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2S_Receive(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout);
+
+ /* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_I2S_Transmit_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2S_Receive_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size);
+void HAL_I2S_IRQHandler(I2S_HandleTypeDef *hi2s);
+
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_I2S_Transmit_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2S_Receive_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size);
+
+HAL_StatusTypeDef HAL_I2S_DMAPause(I2S_HandleTypeDef *hi2s);
+HAL_StatusTypeDef HAL_I2S_DMAResume(I2S_HandleTypeDef *hi2s);
+HAL_StatusTypeDef HAL_I2S_DMAStop(I2S_HandleTypeDef *hi2s);
+
+/* Callbacks used in non blocking modes (Interrupt and DMA) *******************/
+void HAL_I2S_TxHalfCpltCallback(I2S_HandleTypeDef *hi2s);
+void HAL_I2S_TxCpltCallback(I2S_HandleTypeDef *hi2s);
+void HAL_I2S_RxHalfCpltCallback(I2S_HandleTypeDef *hi2s);
+void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s);
+void HAL_I2S_ErrorCallback(I2S_HandleTypeDef *hi2s);
+/**
+  * @}
+  */
+
+/** @addtogroup I2S_Exported_Functions_Group3 Peripheral State and Errors functions
+  * @{
+  */
+/* Peripheral Control and State functions  ************************************/
+HAL_I2S_StateTypeDef HAL_I2S_GetState(I2S_HandleTypeDef *hi2s);
+uint32_t HAL_I2S_GetError(I2S_HandleTypeDef *hi2s);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup I2S_Private_Constants I2S Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup I2S_Private_Macros I2S Private Macros
+  * @{
+  */
+#define IS_I2S_CLOCKSOURCE(CLOCK) (((CLOCK) == I2S_CLOCK_EXTERNAL) || \
+                                   ((CLOCK) == I2S_CLOCK_SYSCLK))
+
+#define IS_I2S_MODE(MODE) (((MODE) == I2S_MODE_SLAVE_TX) || \
+                           ((MODE) == I2S_MODE_SLAVE_RX) || \
+                           ((MODE) == I2S_MODE_MASTER_TX)|| \
+                           ((MODE) == I2S_MODE_MASTER_RX))
+
+#define IS_I2S_STANDARD(STANDARD) (((STANDARD) == I2S_STANDARD_PHILIPS)   || \
+                                   ((STANDARD) == I2S_STANDARD_MSB)       || \
+                                   ((STANDARD) == I2S_STANDARD_LSB)       || \
+                                   ((STANDARD) == I2S_STANDARD_PCM_SHORT) || \
+                                   ((STANDARD) == I2S_STANDARD_PCM_LONG))
+
+#define IS_I2S_DATA_FORMAT(FORMAT) (((FORMAT) == I2S_DATAFORMAT_16B)          || \
+                                    ((FORMAT) == I2S_DATAFORMAT_16B_EXTENDED) || \
+                                    ((FORMAT) == I2S_DATAFORMAT_24B)          || \
+                                    ((FORMAT) == I2S_DATAFORMAT_32B))
+
+#define IS_I2S_MCLK_OUTPUT(OUTPUT) (((OUTPUT) == I2S_MCLKOUTPUT_ENABLE) || \
+                                    ((OUTPUT) == I2S_MCLKOUTPUT_DISABLE))
+
+#define IS_I2S_AUDIO_FREQ(FREQ) ((((FREQ) >= I2S_AUDIOFREQ_8K) && \
+                                 ((FREQ) <= I2S_AUDIOFREQ_192K)) || \
+                                 ((FREQ) == I2S_AUDIOFREQ_DEFAULT))
+
+#define IS_I2S_CPOL(CPOL) (((CPOL) == I2S_CPOL_LOW) || \
+                           ((CPOL) == I2S_CPOL_HIGH))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32F7xx_HAL_I2S_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_pcd.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_pcd.h
@@ -1,0 +1,326 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_pcd.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of PCD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_PCD_H
+#define __STM32F7xx_HAL_PCD_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_ll_usb.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PCD
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup PCD_Exported_Types PCD Exported Types
+  * @{
+  */
+
+/**
+  * @brief  PCD State structure definition
+  */
+typedef enum
+{
+  HAL_PCD_STATE_RESET   = 0x00,
+  HAL_PCD_STATE_READY   = 0x01,
+  HAL_PCD_STATE_ERROR   = 0x02,
+  HAL_PCD_STATE_BUSY    = 0x03,
+  HAL_PCD_STATE_TIMEOUT = 0x04
+} PCD_StateTypeDef;
+
+/* Device LPM suspend state */
+typedef enum
+{
+  LPM_L0 = 0x00, /* on */
+  LPM_L1 = 0x01, /* LPM L1 sleep */
+  LPM_L2 = 0x02, /* suspend */
+  LPM_L3 = 0x03, /* off */
+}PCD_LPM_StateTypeDef;
+
+typedef USB_OTG_GlobalTypeDef  PCD_TypeDef;
+typedef USB_OTG_CfgTypeDef     PCD_InitTypeDef;
+typedef USB_OTG_EPTypeDef      PCD_EPTypeDef ;
+
+/**
+  * @brief  PCD Handle Structure definition
+  */
+typedef struct
+{
+  PCD_TypeDef             *Instance;   /*!< Register base address              */
+  PCD_InitTypeDef         Init;       /*!< PCD required parameters            */
+  PCD_EPTypeDef           IN_ep[15];  /*!< IN endpoint parameters             */
+  PCD_EPTypeDef           OUT_ep[15]; /*!< OUT endpoint parameters            */
+  HAL_LockTypeDef         Lock;       /*!< PCD peripheral status              */
+  __IO PCD_StateTypeDef   State;      /*!< PCD communication state            */
+  uint32_t                Setup[12];  /*!< Setup packet buffer                */
+  PCD_LPM_StateTypeDef    LPM_State;    /*!< LPM State                          */
+  uint32_t                BESL;
+  uint32_t                lpm_active;   /*!< Enable or disable the Link Power Management .
+                                        This parameter can be set to ENABLE or DISABLE */
+  void                    *pData;       /*!< Pointer to upper stack Handler */
+} PCD_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Include PCD HAL Extension module */
+#include "stm32f7xx_hal_pcd_ex.h"
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup PCD_Exported_Constants PCD Exported Constants
+  * @{
+  */
+
+/** @defgroup PCD_Speed PCD Speed
+  * @{
+  */
+#define PCD_SPEED_HIGH               0
+#define PCD_SPEED_HIGH_IN_FULL       1
+#define PCD_SPEED_FULL               2
+/**
+  * @}
+  */
+
+/** @defgroup PCD_PHY_Module PCD PHY Module
+  * @{
+  */
+#define PCD_PHY_ULPI                 1
+#define PCD_PHY_EMBEDDED             2
+/**
+  * @}
+  */
+
+/** @defgroup PCD_Turnaround_Timeout Turnaround Timeout Value
+  * @{
+  */
+#ifndef USBD_HS_TRDT_VALUE
+ #define USBD_HS_TRDT_VALUE           9
+#endif /* USBD_HS_TRDT_VALUE */
+#ifndef USBD_FS_TRDT_VALUE
+ #define USBD_FS_TRDT_VALUE           5
+#endif /* USBD_HS_TRDT_VALUE */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup PCD_Exported_Macros PCD Exported Macros
+ *  @brief macros to handle interrupts and specific clock configurations
+ * @{
+ */
+#define __HAL_PCD_ENABLE(__HANDLE__)                   USB_EnableGlobalInt ((__HANDLE__)->Instance)
+#define __HAL_PCD_DISABLE(__HANDLE__)                  USB_DisableGlobalInt ((__HANDLE__)->Instance)
+
+#define __HAL_PCD_GET_FLAG(__HANDLE__, __INTERRUPT__)      ((USB_ReadInterrupts((__HANDLE__)->Instance) & (__INTERRUPT__)) == (__INTERRUPT__))
+#define __HAL_PCD_CLEAR_FLAG(__HANDLE__, __INTERRUPT__)    (((__HANDLE__)->Instance->GINTSTS) = (__INTERRUPT__))
+#define __HAL_PCD_IS_INVALID_INTERRUPT(__HANDLE__)         (USB_ReadInterrupts((__HANDLE__)->Instance) == 0)
+
+
+#define __HAL_PCD_UNGATE_PHYCLOCK(__HANDLE__)             *(__IO uint32_t *)((uint32_t)((__HANDLE__)->Instance) + USB_OTG_PCGCCTL_BASE) &= \
+                                                       ~(USB_OTG_PCGCCTL_STOPCLK)
+
+#define __HAL_PCD_GATE_PHYCLOCK(__HANDLE__)               *(__IO uint32_t *)((uint32_t)((__HANDLE__)->Instance) + USB_OTG_PCGCCTL_BASE) |= USB_OTG_PCGCCTL_STOPCLK
+
+#define __HAL_PCD_IS_PHY_SUSPENDED(__HANDLE__)            ((*(__IO uint32_t *)((uint32_t)((__HANDLE__)->Instance) + USB_OTG_PCGCCTL_BASE))&0x10)
+
+#define USB_OTG_FS_WAKEUP_EXTI_RISING_EDGE      ((uint32_t)0x08)
+#define USB_OTG_FS_WAKEUP_EXTI_FALLING_EDGE     ((uint32_t)0x0C)
+#define USB_OTG_FS_WAKEUP_EXTI_RISING_FALLING_EDGE        ((uint32_t)0x10)
+
+#define USB_OTG_HS_WAKEUP_EXTI_RISING_EDGE      ((uint32_t)0x08)
+#define USB_OTG_HS_WAKEUP_EXTI_FALLING_EDGE     ((uint32_t)0x0C)
+#define USB_OTG_HS_WAKEUP_EXTI_RISING_FALLING_EDGE        ((uint32_t)0x10)
+
+#define USB_OTG_HS_WAKEUP_EXTI_LINE              ((uint32_t)0x00100000)  /*!< External interrupt line 20 Connected to the USB HS EXTI Line */
+#define USB_OTG_FS_WAKEUP_EXTI_LINE              ((uint32_t)0x00040000)  /*!< External interrupt line 18 Connected to the USB FS EXTI Line */
+
+#define __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_IT()    EXTI->IMR |= (USB_OTG_HS_WAKEUP_EXTI_LINE)
+#define __HAL_USB_OTG_HS_WAKEUP_EXTI_DISABLE_IT()   EXTI->IMR &= ~(USB_OTG_HS_WAKEUP_EXTI_LINE)
+#define __HAL_USB_OTG_HS_WAKEUP_EXTI_GET_FLAG()     EXTI->PR & (USB_OTG_HS_WAKEUP_EXTI_LINE)
+#define __HAL_USB_OTG_HS_WAKEUP_EXTI_CLEAR_FLAG()   EXTI->PR = (USB_OTG_HS_WAKEUP_EXTI_LINE)
+
+#define __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_RISING_EDGE() EXTI->FTSR &= ~(USB_OTG_HS_WAKEUP_EXTI_LINE);\
+                                                          EXTI->RTSR |= USB_OTG_HS_WAKEUP_EXTI_LINE
+
+#define __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_FALLING_EDGE()  EXTI->FTSR |= (USB_OTG_HS_WAKEUP_EXTI_LINE);\
+                                                            EXTI->RTSR &= ~(USB_OTG_HS_WAKEUP_EXTI_LINE)
+
+#define __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE()   EXTI->RTSR &= ~(USB_OTG_HS_WAKEUP_EXTI_LINE);\
+                                                                    EXTI->FTSR &= ~(USB_OTG_HS_WAKEUP_EXTI_LINE;)\
+                                                                    EXTI->RTSR |= USB_OTG_HS_WAKEUP_EXTI_LINE;\
+                                                                    EXTI->FTSR |= USB_OTG_HS_WAKEUP_EXTI_LINE
+
+#define __HAL_USB_OTG_HS_WAKEUP_EXTI_GENERATE_SWIT()   (EXTI->SWIER |= USB_OTG_FS_WAKEUP_EXTI_LINE)
+
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_IT()    EXTI->IMR |= USB_OTG_FS_WAKEUP_EXTI_LINE
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_DISABLE_IT()   EXTI->IMR &= ~(USB_OTG_FS_WAKEUP_EXTI_LINE)
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_GET_FLAG()     EXTI->PR & (USB_OTG_FS_WAKEUP_EXTI_LINE)
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_CLEAR_FLAG()   EXTI->PR = USB_OTG_FS_WAKEUP_EXTI_LINE
+
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_RISING_EDGE() EXTI->FTSR &= ~(USB_OTG_FS_WAKEUP_EXTI_LINE);\
+                                                          EXTI->RTSR |= USB_OTG_FS_WAKEUP_EXTI_LINE
+
+
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_FALLING_EDGE()  EXTI->FTSR |= (USB_OTG_FS_WAKEUP_EXTI_LINE);\
+                                                            EXTI->RTSR &= ~(USB_OTG_FS_WAKEUP_EXTI_LINE)
+
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE()  EXTI->RTSR &= ~(USB_OTG_FS_WAKEUP_EXTI_LINE);\
+                                                                   EXTI->FTSR &= ~(USB_OTG_FS_WAKEUP_EXTI_LINE);\
+                                                                   EXTI->RTSR |= USB_OTG_FS_WAKEUP_EXTI_LINE;\
+                                                                   EXTI->FTSR |= USB_OTG_FS_WAKEUP_EXTI_LINE
+
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_GENERATE_SWIT()  (EXTI->SWIER |= USB_OTG_FS_WAKEUP_EXTI_LINE)
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup PCD_Exported_Functions PCD Exported Functions
+  * @{
+  */
+
+/* Initialization/de-initialization functions  ********************************/
+/** @addtogroup PCD_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_DeInit (PCD_HandleTypeDef *hpcd);
+void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd);
+/**
+  * @}
+  */
+
+/* I/O operation functions  ***************************************************/
+/* Non-Blocking mode: Interrupt */
+/** @addtogroup PCD_Exported_Functions_Group2 IO operation functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_PCD_Start(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd);
+
+void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_ISOOUTIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd);
+/**
+  * @}
+  */
+
+/* Peripheral Control functions  **********************************************/
+/** @addtogroup PCD_Exported_Functions_Group3 Peripheral Control functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_PCD_DevConnect(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_DevDisconnect(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_SetAddress(PCD_HandleTypeDef *hpcd, uint8_t address);
+HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint16_t ep_mps, uint8_t ep_type);
+HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
+HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
+uint16_t          HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_ActivateRemoteWakeup(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_DeActivateRemoteWakeup(PCD_HandleTypeDef *hpcd);
+/**
+  * @}
+  */
+
+/* Peripheral State functions  ************************************************/
+/** @addtogroup PCD_Exported_Functions_Group4 Peripheral State functions
+  * @{
+  */
+PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup PCD_Instance_definition PCD Instance definition
+  * @{
+  */
+#define IS_PCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS) || \
+                                       ((INSTANCE) == USB_OTG_HS))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32F7xx_HAL_PCD_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_pcd_ex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_pcd_ex.h
@@ -1,0 +1,101 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_pcd_ex.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of PCD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_PCD_EX_H
+#define __STM32F7xx_HAL_PCD_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PCDEx
+  * @{
+  */
+/* Exported types ------------------------------------------------------------*/
+typedef enum
+{
+  PCD_LPM_L0_ACTIVE = 0x00, /* on */
+  PCD_LPM_L1_ACTIVE = 0x01, /* LPM L1 sleep */
+}PCD_LPM_MsgTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+/* Exported macros -----------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup PCDEx_Exported_Functions PCDEx Exported Functions
+  * @{
+  */
+/** @addtogroup PCDEx_Exported_Functions_Group1 Peripheral Control functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_PCDEx_SetTxFiFo(PCD_HandleTypeDef *hpcd, uint8_t fifo, uint16_t size);
+HAL_StatusTypeDef HAL_PCDEx_SetRxFiFo(PCD_HandleTypeDef *hpcd, uint16_t size);
+HAL_StatusTypeDef HAL_PCDEx_ActivateLPM(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCDEx_DeActivateLPM(PCD_HandleTypeDef *hpcd);
+void HAL_PCDEx_LPM_Callback(PCD_HandleTypeDef *hpcd, PCD_LPM_MsgTypeDef msg);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32F7xx_HAL_PCD_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_pwr.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_pwr.h
@@ -1,0 +1,424 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_pwr.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of PWR HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_PWR_H
+#define __STM32F7xx_HAL_PWR_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PWR
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup PWR_Exported_Types PWR Exported Types
+  * @{
+  */
+
+/**
+  * @brief  PWR PVD configuration structure definition
+  */
+typedef struct
+{
+  uint32_t PVDLevel;   /*!< PVDLevel: Specifies the PVD detection level.
+                            This parameter can be a value of @ref PWR_PVD_detection_level */
+
+  uint32_t Mode;      /*!< Mode: Specifies the operating mode for the selected pins.
+                           This parameter can be a value of @ref PWR_PVD_Mode */
+}PWR_PVDTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup PWR_Exported_Constants PWR Exported Constants
+  * @{
+  */
+
+/** @defgroup PWR_PVD_detection_level PWR PVD detection level
+  * @{
+  */
+#define PWR_PVDLEVEL_0                  PWR_CR1_PLS_LEV0
+#define PWR_PVDLEVEL_1                  PWR_CR1_PLS_LEV1
+#define PWR_PVDLEVEL_2                  PWR_CR1_PLS_LEV2
+#define PWR_PVDLEVEL_3                  PWR_CR1_PLS_LEV3
+#define PWR_PVDLEVEL_4                  PWR_CR1_PLS_LEV4
+#define PWR_PVDLEVEL_5                  PWR_CR1_PLS_LEV5
+#define PWR_PVDLEVEL_6                  PWR_CR1_PLS_LEV6
+#define PWR_PVDLEVEL_7                  PWR_CR1_PLS_LEV7/* External input analog voltage
+                                                          (Compare internally to VREFINT) */
+
+/**
+  * @}
+  */
+
+/** @defgroup PWR_PVD_Mode PWR PVD Mode
+  * @{
+  */
+#define PWR_PVD_MODE_NORMAL                 ((uint32_t)0x00000000)   /*!< basic mode is used */
+#define PWR_PVD_MODE_IT_RISING              ((uint32_t)0x00010001)   /*!< External Interrupt Mode with Rising edge trigger detection */
+#define PWR_PVD_MODE_IT_FALLING             ((uint32_t)0x00010002)   /*!< External Interrupt Mode with Falling edge trigger detection */
+#define PWR_PVD_MODE_IT_RISING_FALLING      ((uint32_t)0x00010003)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
+#define PWR_PVD_MODE_EVENT_RISING           ((uint32_t)0x00020001)   /*!< Event Mode with Rising edge trigger detection */
+#define PWR_PVD_MODE_EVENT_FALLING          ((uint32_t)0x00020002)   /*!< Event Mode with Falling edge trigger detection */
+#define PWR_PVD_MODE_EVENT_RISING_FALLING   ((uint32_t)0x00020003)   /*!< Event Mode with Rising/Falling edge trigger detection */
+/**
+  * @}
+  */
+
+/** @defgroup PWR_Regulator_state_in_STOP_mode PWR Regulator state in SLEEP/STOP mode
+  * @{
+  */
+#define PWR_MAINREGULATOR_ON                        ((uint32_t)0x00000000)
+#define PWR_LOWPOWERREGULATOR_ON                    PWR_CR1_LPDS
+/**
+  * @}
+  */
+
+/** @defgroup PWR_SLEEP_mode_entry PWR SLEEP mode entry
+  * @{
+  */
+#define PWR_SLEEPENTRY_WFI              ((uint8_t)0x01)
+#define PWR_SLEEPENTRY_WFE              ((uint8_t)0x02)
+/**
+  * @}
+  */
+
+/** @defgroup PWR_STOP_mode_entry PWR STOP mode entry
+  * @{
+  */
+#define PWR_STOPENTRY_WFI               ((uint8_t)0x01)
+#define PWR_STOPENTRY_WFE               ((uint8_t)0x02)
+/**
+  * @}
+  */
+
+/** @defgroup PWR_Regulator_Voltage_Scale PWR Regulator Voltage Scale
+  * @{
+  */
+#define PWR_REGULATOR_VOLTAGE_SCALE1         PWR_CR1_VOS
+#define PWR_REGULATOR_VOLTAGE_SCALE2         PWR_CR1_VOS_1
+#define PWR_REGULATOR_VOLTAGE_SCALE3         PWR_CR1_VOS_0
+/**
+  * @}
+  */
+
+/** @defgroup PWR_Flag PWR Flag
+  * @{
+  */
+#define PWR_FLAG_WU                     PWR_CSR1_WUIF
+#define PWR_FLAG_SB                     PWR_CSR1_SBF
+#define PWR_FLAG_PVDO                   PWR_CSR1_PVDO
+#define PWR_FLAG_BRR                    PWR_CSR1_BRR
+#define PWR_FLAG_VOSRDY                 PWR_CSR1_VOSRDY
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup PWR_Exported_Macro PWR Exported Macro
+  * @{
+  */
+
+/** @brief  macros configure the main internal regulator output voltage.
+  * @param  __REGULATOR__: specifies the regulator output voltage to achieve
+  *         a tradeoff between performance and power consumption when the device does
+  *         not operate at the maximum frequency (refer to the datasheets for more details).
+  *          This parameter can be one of the following values:
+  *            @arg PWR_REGULATOR_VOLTAGE_SCALE1: Regulator voltage output Scale 1 mode
+  *            @arg PWR_REGULATOR_VOLTAGE_SCALE2: Regulator voltage output Scale 2 mode
+  *            @arg PWR_REGULATOR_VOLTAGE_SCALE3: Regulator voltage output Scale 3 mode
+  * @retval None
+  */
+#define __HAL_PWR_VOLTAGESCALING_CONFIG(__REGULATOR__) do {                                                     \
+                                                            __IO uint32_t tmpreg;                               \
+                                                            MODIFY_REG(PWR->CR1, PWR_CR1_VOS, (__REGULATOR__)); \
+                                                            /* Delay after an RCC peripheral clock enabling */  \
+                                                            tmpreg = READ_BIT(PWR->CR1, PWR_CR1_VOS);           \
+                                                            UNUSED(tmpreg);                                     \
+				                                                	} while(0)
+
+/** @brief  Check PWR flag is set or not.
+  * @param  __FLAG__: specifies the flag to check.
+  *           This parameter can be one of the following values:
+  *            @arg PWR_FLAG_WU: Wake Up flag. This flag indicates that a wakeup event
+  *                  was received on the internal wakeup line in standby mode (RTC alarm (Alarm A or Alarm B),
+  *                  RTC Tamper event, RTC TimeStamp event or RTC Wakeup)).
+  *            @arg PWR_FLAG_SB: StandBy flag. This flag indicates that the system was
+  *                  resumed from StandBy mode.
+  *            @arg PWR_FLAG_PVDO: PVD Output. This flag is valid only if PVD is enabled
+  *                  by the HAL_PWR_EnablePVD() function. The PVD is stopped by Standby mode
+  *                  For this reason, this bit is equal to 0 after Standby or reset
+  *                  until the PVDE bit is set.
+  *            @arg PWR_FLAG_BRR: Backup regulator ready flag. This bit is not reset
+  *                  when the device wakes up from Standby mode or by a system reset
+  *                  or power reset.
+  *            @arg PWR_FLAG_VOSRDY: This flag indicates that the Regulator voltage
+  *                 scaling output selection is ready.
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_PWR_GET_FLAG(__FLAG__) ((PWR->CSR1 & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Clear the PWR's pending flags.
+  * @param  __FLAG__: specifies the flag to clear.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_FLAG_SB: StandBy flag
+  */
+#define __HAL_PWR_CLEAR_FLAG(__FLAG__) (PWR->CR1 |=  (__FLAG__) << 2)
+
+/**
+  * @brief Enable the PVD Exti Line 16.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_IT()   (EXTI->IMR |= (PWR_EXTI_LINE_PVD))
+
+/**
+  * @brief Disable the PVD EXTI Line 16.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_IT()  (EXTI->IMR &= ~(PWR_EXTI_LINE_PVD))
+
+/**
+  * @brief Enable event on PVD Exti Line 16.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_EVENT()   (EXTI->EMR |= (PWR_EXTI_LINE_PVD))
+
+/**
+  * @brief Disable event on PVD Exti Line 16.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_EVENT()  (EXTI->EMR &= ~(PWR_EXTI_LINE_PVD))
+
+/**
+  * @brief Enable the PVD Extended Interrupt Rising Trigger.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE()   SET_BIT(EXTI->RTSR, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Disable the PVD Extended Interrupt Rising Trigger.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE()  CLEAR_BIT(EXTI->RTSR, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Enable the PVD Extended Interrupt Falling Trigger.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE()   SET_BIT(EXTI->FTSR, PWR_EXTI_LINE_PVD)
+
+
+/**
+  * @brief Disable the PVD Extended Interrupt Falling Trigger.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE()  CLEAR_BIT(EXTI->FTSR, PWR_EXTI_LINE_PVD)
+
+
+/**
+  * @brief  PVD EXTI line configuration: set rising & falling edge trigger.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_RISING_FALLING_EDGE()   __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE();__HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE();
+
+/**
+  * @brief Disable the PVD Extended Interrupt Rising & Falling Trigger.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_RISING_FALLING_EDGE()  __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE();__HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE();
+
+/**
+  * @brief checks whether the specified PVD Exti interrupt flag is set or not.
+  * @retval EXTI PVD Line Status.
+  */
+#define __HAL_PWR_PVD_EXTI_GET_FLAG()  (EXTI->PR & (PWR_EXTI_LINE_PVD))
+
+/**
+  * @brief Clear the PVD Exti flag.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_CLEAR_FLAG()  (EXTI->PR = (PWR_EXTI_LINE_PVD))
+
+/**
+  * @brief  Generates a Software interrupt on PVD EXTI line.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_GENERATE_SWIT() (EXTI->SWIER |= (PWR_EXTI_LINE_PVD))
+
+/**
+  * @}
+  */
+
+/* Include PWR HAL Extension module */
+#include "stm32f7xx_hal_pwr_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup PWR_Exported_Functions PWR Exported Functions
+  * @{
+  */
+
+/** @addtogroup PWR_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+/* Initialization and de-initialization functions *****************************/
+void HAL_PWR_DeInit(void);
+void HAL_PWR_EnableBkUpAccess(void);
+void HAL_PWR_DisableBkUpAccess(void);
+/**
+  * @}
+  */
+
+/** @addtogroup PWR_Exported_Functions_Group2 Peripheral Control functions
+  * @{
+  */
+/* Peripheral Control functions  **********************************************/
+/* PVD configuration */
+void HAL_PWR_ConfigPVD(PWR_PVDTypeDef *sConfigPVD);
+void HAL_PWR_EnablePVD(void);
+void HAL_PWR_DisablePVD(void);
+
+/* WakeUp pins configuration */
+void HAL_PWR_EnableWakeUpPin(uint32_t WakeUpPinPolarity);
+void HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx);
+
+/* Low Power modes entry */
+void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry);
+void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry);
+void HAL_PWR_EnterSTANDBYMode(void);
+
+/* Power PVD IRQ Handler */
+void HAL_PWR_PVD_IRQHandler(void);
+void HAL_PWR_PVDCallback(void);
+
+/* Cortex System Control functions  *******************************************/
+void HAL_PWR_EnableSleepOnExit(void);
+void HAL_PWR_DisableSleepOnExit(void);
+void HAL_PWR_EnableSEVOnPend(void);
+void HAL_PWR_DisableSEVOnPend(void);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup PWR_Private_Constants PWR Private Constants
+  * @{
+  */
+
+/** @defgroup PWR_PVD_EXTI_Line PWR PVD EXTI Line
+  * @{
+  */
+#define PWR_EXTI_LINE_PVD  ((uint32_t)EXTI_IMR_MR16)  /*!< External interrupt line 16 Connected to the PVD EXTI Line */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup PWR_Private_Macros PWR Private Macros
+  * @{
+  */
+
+/** @defgroup PWR_IS_PWR_Definitions PWR Private macros to check input parameters
+  * @{
+  */
+#define IS_PWR_WAKEUP_POLARITY(POLARITY)       (((POLARITY) == PWR_POLARITY_RISINGEDGE)  || \
+                                                    ((POLARITY) == PWR_POLARITY_FALLINGEDGE))
+#define IS_PWR_PVD_LEVEL(LEVEL) (((LEVEL) == PWR_PVDLEVEL_0) || ((LEVEL) == PWR_PVDLEVEL_1)|| \
+                                 ((LEVEL) == PWR_PVDLEVEL_2) || ((LEVEL) == PWR_PVDLEVEL_3)|| \
+                                 ((LEVEL) == PWR_PVDLEVEL_4) || ((LEVEL) == PWR_PVDLEVEL_5)|| \
+                                 ((LEVEL) == PWR_PVDLEVEL_6) || ((LEVEL) == PWR_PVDLEVEL_7))
+#define IS_PWR_PVD_MODE(MODE) (((MODE) == PWR_PVD_MODE_IT_RISING)|| ((MODE) == PWR_PVD_MODE_IT_FALLING) || \
+                              ((MODE) == PWR_PVD_MODE_IT_RISING_FALLING) || ((MODE) == PWR_PVD_MODE_EVENT_RISING) || \
+                              ((MODE) == PWR_PVD_MODE_EVENT_FALLING) || ((MODE) == PWR_PVD_MODE_EVENT_RISING_FALLING) || \
+                              ((MODE) == PWR_PVD_MODE_NORMAL))
+#define IS_PWR_REGULATOR(REGULATOR) (((REGULATOR) == PWR_MAINREGULATOR_ON) || \
+                                     ((REGULATOR) == PWR_LOWPOWERREGULATOR_ON))
+#define IS_PWR_SLEEP_ENTRY(ENTRY) (((ENTRY) == PWR_SLEEPENTRY_WFI) || ((ENTRY) == PWR_SLEEPENTRY_WFE))
+#define IS_PWR_STOP_ENTRY(ENTRY) (((ENTRY) == PWR_STOPENTRY_WFI) || ((ENTRY) == PWR_STOPENTRY_WFE))
+#define IS_PWR_REGULATOR_VOLTAGE(VOLTAGE) (((VOLTAGE) == PWR_REGULATOR_VOLTAGE_SCALE1) || \
+                                           ((VOLTAGE) == PWR_REGULATOR_VOLTAGE_SCALE2) || \
+                                           ((VOLTAGE) == PWR_REGULATOR_VOLTAGE_SCALE3))
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32F7xx_HAL_PWR_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_pwr_ex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_pwr_ex.h
@@ -1,0 +1,280 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_pwr_ex.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of PWR HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_PWR_EX_H
+#define __STM32F7xx_HAL_PWR_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PWREx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup PWREx_Exported_Constants PWREx Exported Constants
+  * @{
+  */
+/** @defgroup PWREx_WakeUp_Pins PWREx Wake Up Pins
+  * @{
+  */
+#define PWR_WAKEUP_PIN1                PWR_CSR2_EWUP1
+#define PWR_WAKEUP_PIN2                PWR_CSR2_EWUP2
+#define PWR_WAKEUP_PIN3                PWR_CSR2_EWUP3
+#define PWR_WAKEUP_PIN4                PWR_CSR2_EWUP4
+#define PWR_WAKEUP_PIN5                PWR_CSR2_EWUP5
+#define PWR_WAKEUP_PIN6                PWR_CSR2_EWUP6
+#define PWR_WAKEUP_PIN1_HIGH           PWR_CSR2_EWUP1
+#define PWR_WAKEUP_PIN2_HIGH           PWR_CSR2_EWUP2
+#define PWR_WAKEUP_PIN3_HIGH           PWR_CSR2_EWUP3
+#define PWR_WAKEUP_PIN4_HIGH           PWR_CSR2_EWUP4
+#define PWR_WAKEUP_PIN5_HIGH           PWR_CSR2_EWUP5
+#define PWR_WAKEUP_PIN6_HIGH           PWR_CSR2_EWUP6
+#define PWR_WAKEUP_PIN1_LOW            (uint32_t)((PWR_CR2_WUPP1<<6) | PWR_CSR2_EWUP1)
+#define PWR_WAKEUP_PIN2_LOW            (uint32_t)((PWR_CR2_WUPP2<<6) | PWR_CSR2_EWUP2)
+#define PWR_WAKEUP_PIN3_LOW            (uint32_t)((PWR_CR2_WUPP3<<6) | PWR_CSR2_EWUP3)
+#define PWR_WAKEUP_PIN4_LOW            (uint32_t)((PWR_CR2_WUPP4<<6) | PWR_CSR2_EWUP4)
+#define PWR_WAKEUP_PIN5_LOW            (uint32_t)((PWR_CR2_WUPP5<<6) | PWR_CSR2_EWUP5)
+#define PWR_WAKEUP_PIN6_LOW            (uint32_t)((PWR_CR2_WUPP6<<6) | PWR_CSR2_EWUP6)
+
+/**
+  * @}
+  */
+
+/** @defgroup PWREx_Regulator_state_in_UnderDrive_mode PWREx Regulator state in UnderDrive mode
+  * @{
+  */
+#define PWR_MAINREGULATOR_UNDERDRIVE_ON                       PWR_CR1_MRUDS
+#define PWR_LOWPOWERREGULATOR_UNDERDRIVE_ON                   ((uint32_t)(PWR_CR1_LPDS | PWR_CR1_LPUDS))
+/**
+  * @}
+  */
+
+/** @defgroup PWREx_Over_Under_Drive_Flag PWREx Over Under Drive Flag
+  * @{
+  */
+#define PWR_FLAG_ODRDY                  PWR_CSR1_ODRDY
+#define PWR_FLAG_ODSWRDY                PWR_CSR1_ODSWRDY
+#define PWR_FLAG_UDRDY                  PWR_CSR1_UDSWRDY
+/**
+  * @}
+  */
+
+/** @defgroup PWREx_Wakeup_Pins_Flag PWREx Wake Up Pin Flags
+  * @{
+  */
+#define PWR_WAKEUP_PIN_FLAG1            PWR_CSR2_WUPF1
+#define PWR_WAKEUP_PIN_FLAG2            PWR_CSR2_WUPF2
+#define PWR_WAKEUP_PIN_FLAG3            PWR_CSR2_WUPF3
+#define PWR_WAKEUP_PIN_FLAG4            PWR_CSR2_WUPF4
+#define PWR_WAKEUP_PIN_FLAG5            PWR_CSR2_WUPF5
+#define PWR_WAKEUP_PIN_FLAG6            PWR_CSR2_WUPF6
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup PWREx_Exported_Macro PWREx Exported Macro
+  *  @{
+  */
+/** @brief Macros to enable or disable the Over drive mode.
+  */
+#define __HAL_PWR_OVERDRIVE_ENABLE() (PWR->CR1 |= (uint32_t)PWR_CR1_ODEN)
+#define __HAL_PWR_OVERDRIVE_DISABLE() (PWR->CR1 &= (uint32_t)(~PWR_CR1_ODEN))
+
+/** @brief Macros to enable or disable the Over drive switching.
+  */
+#define __HAL_PWR_OVERDRIVESWITCHING_ENABLE() (PWR->CR1 |= (uint32_t)PWR_CR1_ODSWEN)
+#define __HAL_PWR_OVERDRIVESWITCHING_DISABLE() (PWR->CR1 &= (uint32_t)(~PWR_CR1_ODSWEN))
+
+/** @brief Macros to enable or disable the Under drive mode.
+  * @note  This mode is enabled only with STOP low power mode.
+  *        In this mode, the 1.2V domain is preserved in reduced leakage mode. This
+  *        mode is only available when the main regulator or the low power regulator
+  *        is in low voltage mode.
+  * @note  If the Under-drive mode was enabled, it is automatically disabled after
+  *        exiting Stop mode.
+  *        When the voltage regulator operates in Under-drive mode, an additional
+  *        startup delay is induced when waking up from Stop mode.
+  */
+#define __HAL_PWR_UNDERDRIVE_ENABLE() (PWR->CR1 |= (uint32_t)PWR_CR1_UDEN)
+#define __HAL_PWR_UNDERDRIVE_DISABLE() (PWR->CR1 &= (uint32_t)(~PWR_CR1_UDEN))
+
+/** @brief  Check PWR flag is set or not.
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg PWR_FLAG_ODRDY: This flag indicates that the Over-drive mode
+  *                                 is ready
+  *            @arg PWR_FLAG_ODSWRDY: This flag indicates that the Over-drive mode
+  *                                   switching is ready
+  *            @arg PWR_FLAG_UDRDY: This flag indicates that the Under-drive mode
+  *                                 is enabled in Stop mode
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_PWR_GET_ODRUDR_FLAG(__FLAG__) ((PWR->CSR1 & (__FLAG__)) == (__FLAG__))
+
+/** @brief Clear the Under-Drive Ready flag.
+  */
+#define __HAL_PWR_CLEAR_ODRUDR_FLAG() (PWR->CSR1 |= PWR_FLAG_UDRDY)
+
+/** @brief  Check Wake Up flag is set or not.
+  * @param  __WUFLAG__: specifies the Wake Up flag to check.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_WAKEUP_PIN_FLAG1: Wakeup Pin Flag for PA0
+  *            @arg PWR_WAKEUP_PIN_FLAG2: Wakeup Pin Flag for PA2
+  *            @arg PWR_WAKEUP_PIN_FLAG3: Wakeup Pin Flag for PC1
+  *            @arg PWR_WAKEUP_PIN_FLAG4: Wakeup Pin Flag for PC13
+  *            @arg PWR_WAKEUP_PIN_FLAG5: Wakeup Pin Flag for PI8
+  *            @arg PWR_WAKEUP_PIN_FLAG6: Wakeup Pin Flag for PI11
+  */
+#define __HAL_PWR_GET_WAKEUP_FLAG(__WUFLAG__) (PWR->CSR2 & (__WUFLAG__))
+
+/** @brief  Clear the WakeUp pins flags.
+  * @param  __WUFLAG__: specifies the Wake Up pin flag to clear.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_WAKEUP_PIN_FLAG1: Wakeup Pin Flag for PA0
+  *            @arg PWR_WAKEUP_PIN_FLAG2: Wakeup Pin Flag for PA2
+  *            @arg PWR_WAKEUP_PIN_FLAG3: Wakeup Pin Flag for PC1
+  *            @arg PWR_WAKEUP_PIN_FLAG4: Wakeup Pin Flag for PC13
+  *            @arg PWR_WAKEUP_PIN_FLAG5: Wakeup Pin Flag for PI8
+  *            @arg PWR_WAKEUP_PIN_FLAG6: Wakeup Pin Flag for PI11
+  */
+#define __HAL_PWR_CLEAR_WAKEUP_FLAG(__WUFLAG__) (PWR->CR2 |=  (__WUFLAG__))
+/**
+  * @}
+  */
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup PWREx_Exported_Functions PWREx Exported Functions
+  *  @{
+  */
+
+/** @addtogroup PWREx_Exported_Functions_Group1
+  * @{
+  */
+uint32_t HAL_PWREx_GetVoltageRange(void);
+HAL_StatusTypeDef HAL_PWREx_ControlVoltageScaling(uint32_t VoltageScaling);
+
+void HAL_PWREx_EnableFlashPowerDown(void);
+void HAL_PWREx_DisableFlashPowerDown(void);
+HAL_StatusTypeDef HAL_PWREx_EnableBkUpReg(void);
+HAL_StatusTypeDef HAL_PWREx_DisableBkUpReg(void);
+
+void HAL_PWREx_EnableMainRegulatorLowVoltage(void);
+void HAL_PWREx_DisableMainRegulatorLowVoltage(void);
+void HAL_PWREx_EnableLowRegulatorLowVoltage(void);
+void HAL_PWREx_DisableLowRegulatorLowVoltage(void);
+
+HAL_StatusTypeDef HAL_PWREx_EnableOverDrive(void);
+HAL_StatusTypeDef HAL_PWREx_DisableOverDrive(void);
+HAL_StatusTypeDef HAL_PWREx_EnterUnderDriveSTOPMode(uint32_t Regulator, uint8_t STOPEntry);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup PWREx_Private_Macros PWREx Private Macros
+  * @{
+  */
+
+/** @defgroup PWREx_IS_PWR_Definitions PWREx Private macros to check input parameters
+  * @{
+  */
+#define IS_PWR_REGULATOR_UNDERDRIVE(REGULATOR) (((REGULATOR) == PWR_MAINREGULATOR_UNDERDRIVE_ON) || \
+                                                ((REGULATOR) == PWR_LOWPOWERREGULATOR_UNDERDRIVE_ON))
+#define IS_PWR_WAKEUP_PIN(__PIN__)         (((__PIN__) == PWR_WAKEUP_PIN1)       || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN2)       || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN3)       || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN4)       || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN5)       || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN6)  		 || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN1_HIGH)  || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN2_HIGH)  || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN3_HIGH)  || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN4_HIGH)  || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN5_HIGH)  || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN6_HIGH)  || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN1_LOW)   || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN2_LOW)   || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN3_LOW)   || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN4_LOW)   || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN5_LOW)	 || \
+                                            ((__PIN__) == PWR_WAKEUP_PIN6_LOW))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32F7xx_HAL_PWR_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_rcc.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_rcc.h
@@ -1,0 +1,1304 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rcc.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of RCC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_RCC_H
+#define __STM32F7xx_HAL_RCC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RCC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup RCC_Exported_Types RCC Exported Types
+  * @{
+  */
+
+/**
+  * @brief  RCC PLL configuration structure definition
+  */
+typedef struct
+{
+  uint32_t PLLState;   /*!< The new state of the PLL.
+                            This parameter can be a value of @ref RCC_PLL_Config                      */
+
+  uint32_t PLLSource;  /*!< RCC_PLLSource: PLL entry clock source.
+                            This parameter must be a value of @ref RCC_PLL_Clock_Source               */
+
+  uint32_t PLLM;       /*!< PLLM: Division factor for PLL VCO input clock.
+                            This parameter must be a number between Min_Data = 2 and Max_Data = 63    */
+
+  uint32_t PLLN;       /*!< PLLN: Multiplication factor for PLL VCO output clock.
+                            This parameter must be a number between Min_Data = 192 and Max_Data = 432 */
+
+  uint32_t PLLP;       /*!< PLLP: Division factor for main system clock (SYSCLK).
+                            This parameter must be a value of @ref RCC_PLLP_Clock_Divider             */
+
+  uint32_t PLLQ;       /*!< PLLQ: Division factor for OTG FS, SDMMC and RNG clocks.
+                            This parameter must be a number between Min_Data = 2 and Max_Data = 15    */
+
+}RCC_PLLInitTypeDef;
+
+/**
+  * @brief  RCC Internal/External Oscillator (HSE, HSI, LSE and LSI) configuration structure definition
+  */
+typedef struct
+{
+  uint32_t OscillatorType;       /*!< The oscillators to be configured.
+                                      This parameter can be a value of @ref RCC_Oscillator_Type                   */
+
+  uint32_t HSEState;             /*!< The new state of the HSE.
+                                      This parameter can be a value of @ref RCC_HSE_Config                        */
+
+  uint32_t LSEState;             /*!< The new state of the LSE.
+                                      This parameter can be a value of @ref RCC_LSE_Config                        */
+
+  uint32_t HSIState;             /*!< The new state of the HSI.
+                                      This parameter can be a value of @ref RCC_HSI_Config                        */
+
+  uint32_t HSICalibrationValue;   /*!< The calibration trimming value (default is RCC_HSICALIBRATION_DEFAULT).
+                                       This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x1F */
+
+  uint32_t LSIState;             /*!< The new state of the LSI.
+                                      This parameter can be a value of @ref RCC_LSI_Config                        */
+
+  RCC_PLLInitTypeDef PLL;        /*!< PLL structure parameters                                                    */
+
+}RCC_OscInitTypeDef;
+
+/**
+  * @brief  RCC System, AHB and APB busses clock configuration structure definition
+  */
+typedef struct
+{
+  uint32_t ClockType;             /*!< The clock to be configured.
+                                       This parameter can be a value of @ref RCC_System_Clock_Type */
+
+  uint32_t SYSCLKSource;          /*!< The clock source (SYSCLKS) used as system clock.
+                                       This parameter can be a value of @ref RCC_System_Clock_Source    */
+
+  uint32_t AHBCLKDivider;         /*!< The AHB clock (HCLK) divider. This clock is derived from the system clock (SYSCLK).
+                                       This parameter can be a value of @ref RCC_AHB_Clock_Source       */
+
+  uint32_t APB1CLKDivider;        /*!< The APB1 clock (PCLK1) divider. This clock is derived from the AHB clock (HCLK).
+                                       This parameter can be a value of @ref RCC_APB1_APB2_Clock_Source */
+
+  uint32_t APB2CLKDivider;        /*!< The APB2 clock (PCLK2) divider. This clock is derived from the AHB clock (HCLK).
+                                       This parameter can be a value of @ref RCC_APB1_APB2_Clock_Source */
+
+}RCC_ClkInitTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RCC_Exported_Constants RCC Exported Constants
+  * @{
+  */
+
+/** @defgroup RCC_Oscillator_Type Oscillator Type
+  * @{
+  */
+#define RCC_OSCILLATORTYPE_NONE            ((uint32_t)0x00000000)
+#define RCC_OSCILLATORTYPE_HSE             ((uint32_t)0x00000001)
+#define RCC_OSCILLATORTYPE_HSI             ((uint32_t)0x00000002)
+#define RCC_OSCILLATORTYPE_LSE             ((uint32_t)0x00000004)
+#define RCC_OSCILLATORTYPE_LSI             ((uint32_t)0x00000008)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_HSE_Config RCC HSE Config
+  * @{
+  */
+#define RCC_HSE_OFF                      ((uint32_t)0x00000000)
+#define RCC_HSE_ON                       RCC_CR_HSEON
+#define RCC_HSE_BYPASS                   ((uint32_t)(RCC_CR_HSEBYP | RCC_CR_HSEON))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_LSE_Config RCC LSE Config
+  * @{
+  */
+#define RCC_LSE_OFF                    ((uint32_t)0x00000000)
+#define RCC_LSE_ON                     RCC_BDCR_LSEON
+#define RCC_LSE_BYPASS                 ((uint32_t)(RCC_BDCR_LSEBYP | RCC_BDCR_LSEON))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_HSI_Config RCC HSI Config
+  * @{
+  */
+#define RCC_HSI_OFF                    ((uint32_t)0x00000000)
+#define RCC_HSI_ON                     RCC_CR_HSION
+/**
+  * @}
+  */
+
+/** @defgroup RCC_LSI_Config RCC LSI Config
+  * @{
+  */
+#define RCC_LSI_OFF                    ((uint32_t)0x00000000)
+#define RCC_LSI_ON                     RCC_CSR_LSION
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLL_Config RCC PLL Config
+  * @{
+  */
+#define RCC_PLL_NONE                   ((uint32_t)0x00000000)
+#define RCC_PLL_OFF                    ((uint32_t)0x00000001)
+#define RCC_PLL_ON                     ((uint32_t)0x00000002)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLLP_Clock_Divider PLLP Clock Divider
+  * @{
+  */
+#define RCC_PLLP_DIV2                  ((uint32_t)0x00000002)
+#define RCC_PLLP_DIV4                  ((uint32_t)0x00000004)
+#define RCC_PLLP_DIV6                  ((uint32_t)0x00000006)
+#define RCC_PLLP_DIV8                  ((uint32_t)0x00000008)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLL_Clock_Source PLL Clock Source
+  * @{
+  */
+#define RCC_PLLSOURCE_HSI                RCC_PLLCFGR_PLLSRC_HSI
+#define RCC_PLLSOURCE_HSE                RCC_PLLCFGR_PLLSRC_HSE
+/**
+  * @}
+  */
+
+/** @defgroup RCC_System_Clock_Type RCC System Clock Type
+  * @{
+  */
+#define RCC_CLOCKTYPE_SYSCLK             ((uint32_t)0x00000001)
+#define RCC_CLOCKTYPE_HCLK               ((uint32_t)0x00000002)
+#define RCC_CLOCKTYPE_PCLK1              ((uint32_t)0x00000004)
+#define RCC_CLOCKTYPE_PCLK2              ((uint32_t)0x00000008)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_System_Clock_Source RCC System Clock Source
+  * @{
+  */
+#define RCC_SYSCLKSOURCE_HSI             RCC_CFGR_SW_HSI
+#define RCC_SYSCLKSOURCE_HSE             RCC_CFGR_SW_HSE
+#define RCC_SYSCLKSOURCE_PLLCLK          RCC_CFGR_SW_PLL
+/**
+  * @}
+  */
+
+
+/** @defgroup RCC_System_Clock_Source_Status System Clock Source Status
+  * @{
+  */
+#define RCC_SYSCLKSOURCE_STATUS_HSI      RCC_CFGR_SWS_HSI   /*!< HSI used as system clock */
+#define RCC_SYSCLKSOURCE_STATUS_HSE      RCC_CFGR_SWS_HSE   /*!< HSE used as system clock */
+#define RCC_SYSCLKSOURCE_STATUS_PLLCLK   RCC_CFGR_SWS_PLL   /*!< PLL used as system clock */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB_Clock_Source RCC AHB Clock Source
+  * @{
+  */
+#define RCC_SYSCLK_DIV1                  RCC_CFGR_HPRE_DIV1
+#define RCC_SYSCLK_DIV2                  RCC_CFGR_HPRE_DIV2
+#define RCC_SYSCLK_DIV4                  RCC_CFGR_HPRE_DIV4
+#define RCC_SYSCLK_DIV8                  RCC_CFGR_HPRE_DIV8
+#define RCC_SYSCLK_DIV16                 RCC_CFGR_HPRE_DIV16
+#define RCC_SYSCLK_DIV64                 RCC_CFGR_HPRE_DIV64
+#define RCC_SYSCLK_DIV128                RCC_CFGR_HPRE_DIV128
+#define RCC_SYSCLK_DIV256                RCC_CFGR_HPRE_DIV256
+#define RCC_SYSCLK_DIV512                RCC_CFGR_HPRE_DIV512
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB1_APB2_Clock_Source RCC APB1/APB2 Clock Source
+  * @{
+  */
+#define RCC_HCLK_DIV1                    RCC_CFGR_PPRE1_DIV1
+#define RCC_HCLK_DIV2                    RCC_CFGR_PPRE1_DIV2
+#define RCC_HCLK_DIV4                    RCC_CFGR_PPRE1_DIV4
+#define RCC_HCLK_DIV8                    RCC_CFGR_PPRE1_DIV8
+#define RCC_HCLK_DIV16                   RCC_CFGR_PPRE1_DIV16
+/**
+  * @}
+  */
+
+/** @defgroup RCC_RTC_Clock_Source RCC RTC Clock Source
+  * @{
+  */
+#define RCC_RTCCLKSOURCE_LSE             ((uint32_t)0x00000100)
+#define RCC_RTCCLKSOURCE_LSI             ((uint32_t)0x00000200)
+#define RCC_RTCCLKSOURCE_HSE_DIV2        ((uint32_t)0x00020300)
+#define RCC_RTCCLKSOURCE_HSE_DIV3        ((uint32_t)0x00030300)
+#define RCC_RTCCLKSOURCE_HSE_DIV4        ((uint32_t)0x00040300)
+#define RCC_RTCCLKSOURCE_HSE_DIV5        ((uint32_t)0x00050300)
+#define RCC_RTCCLKSOURCE_HSE_DIV6        ((uint32_t)0x00060300)
+#define RCC_RTCCLKSOURCE_HSE_DIV7        ((uint32_t)0x00070300)
+#define RCC_RTCCLKSOURCE_HSE_DIV8        ((uint32_t)0x00080300)
+#define RCC_RTCCLKSOURCE_HSE_DIV9        ((uint32_t)0x00090300)
+#define RCC_RTCCLKSOURCE_HSE_DIV10       ((uint32_t)0x000A0300)
+#define RCC_RTCCLKSOURCE_HSE_DIV11       ((uint32_t)0x000B0300)
+#define RCC_RTCCLKSOURCE_HSE_DIV12       ((uint32_t)0x000C0300)
+#define RCC_RTCCLKSOURCE_HSE_DIV13       ((uint32_t)0x000D0300)
+#define RCC_RTCCLKSOURCE_HSE_DIV14       ((uint32_t)0x000E0300)
+#define RCC_RTCCLKSOURCE_HSE_DIV15       ((uint32_t)0x000F0300)
+#define RCC_RTCCLKSOURCE_HSE_DIV16       ((uint32_t)0x00100300)
+#define RCC_RTCCLKSOURCE_HSE_DIV17       ((uint32_t)0x00110300)
+#define RCC_RTCCLKSOURCE_HSE_DIV18       ((uint32_t)0x00120300)
+#define RCC_RTCCLKSOURCE_HSE_DIV19       ((uint32_t)0x00130300)
+#define RCC_RTCCLKSOURCE_HSE_DIV20       ((uint32_t)0x00140300)
+#define RCC_RTCCLKSOURCE_HSE_DIV21       ((uint32_t)0x00150300)
+#define RCC_RTCCLKSOURCE_HSE_DIV22       ((uint32_t)0x00160300)
+#define RCC_RTCCLKSOURCE_HSE_DIV23       ((uint32_t)0x00170300)
+#define RCC_RTCCLKSOURCE_HSE_DIV24       ((uint32_t)0x00180300)
+#define RCC_RTCCLKSOURCE_HSE_DIV25       ((uint32_t)0x00190300)
+#define RCC_RTCCLKSOURCE_HSE_DIV26       ((uint32_t)0x001A0300)
+#define RCC_RTCCLKSOURCE_HSE_DIV27       ((uint32_t)0x001B0300)
+#define RCC_RTCCLKSOURCE_HSE_DIV28       ((uint32_t)0x001C0300)
+#define RCC_RTCCLKSOURCE_HSE_DIV29       ((uint32_t)0x001D0300)
+#define RCC_RTCCLKSOURCE_HSE_DIV30       ((uint32_t)0x001E0300)
+#define RCC_RTCCLKSOURCE_HSE_DIV31       ((uint32_t)0x001F0300)
+/**
+  * @}
+  */
+
+
+
+/** @defgroup RCC_MCO_Index RCC MCO Index
+  * @{
+  */
+#define RCC_MCO1                         ((uint32_t)0x00000000)
+#define RCC_MCO2                         ((uint32_t)0x00000001)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_MCO1_Clock_Source RCC MCO1 Clock Source
+  * @{
+  */
+#define RCC_MCO1SOURCE_HSI               ((uint32_t)0x00000000)
+#define RCC_MCO1SOURCE_LSE               RCC_CFGR_MCO1_0
+#define RCC_MCO1SOURCE_HSE               RCC_CFGR_MCO1_1
+#define RCC_MCO1SOURCE_PLLCLK            RCC_CFGR_MCO1
+/**
+  * @}
+  */
+
+/** @defgroup RCC_MCO2_Clock_Source RCC MCO2 Clock Source
+  * @{
+  */
+#define RCC_MCO2SOURCE_SYSCLK            ((uint32_t)0x00000000)
+#define RCC_MCO2SOURCE_PLLI2SCLK         RCC_CFGR_MCO2_0
+#define RCC_MCO2SOURCE_HSE               RCC_CFGR_MCO2_1
+#define RCC_MCO2SOURCE_PLLCLK            RCC_CFGR_MCO2
+/**
+  * @}
+  */
+
+/** @defgroup RCC_MCOx_Clock_Prescaler RCC MCO1 Clock Prescaler
+  * @{
+  */
+#define RCC_MCODIV_1                    ((uint32_t)0x00000000)
+#define RCC_MCODIV_2                    RCC_CFGR_MCO1PRE_2
+#define RCC_MCODIV_3                    ((uint32_t)RCC_CFGR_MCO1PRE_0 | RCC_CFGR_MCO1PRE_2)
+#define RCC_MCODIV_4                    ((uint32_t)RCC_CFGR_MCO1PRE_1 | RCC_CFGR_MCO1PRE_2)
+#define RCC_MCODIV_5                    RCC_CFGR_MCO1PRE
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Interrupt RCC Interrupt
+  * @{
+  */
+#define RCC_IT_LSIRDY                    ((uint8_t)0x01)
+#define RCC_IT_LSERDY                    ((uint8_t)0x02)
+#define RCC_IT_HSIRDY                    ((uint8_t)0x04)
+#define RCC_IT_HSERDY                    ((uint8_t)0x08)
+#define RCC_IT_PLLRDY                    ((uint8_t)0x10)
+#define RCC_IT_PLLI2SRDY                 ((uint8_t)0x20)
+#define RCC_IT_PLLSAIRDY                 ((uint8_t)0x40)
+#define RCC_IT_CSS                       ((uint8_t)0x80)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Flag RCC Flags
+  *        Elements values convention: 0XXYYYYYb
+  *           - YYYYY  : Flag position in the register
+  *           - 0XX  : Register index
+  *                 - 01: CR register
+  *                 - 10: BDCR register
+  *                 - 11: CSR register
+  * @{
+  */
+/* Flags in the CR register */
+#define RCC_FLAG_HSIRDY                  ((uint8_t)0x21)
+#define RCC_FLAG_HSERDY                  ((uint8_t)0x31)
+#define RCC_FLAG_PLLRDY                  ((uint8_t)0x39)
+#define RCC_FLAG_PLLI2SRDY               ((uint8_t)0x3B)
+#define RCC_FLAG_PLLSAIRDY               ((uint8_t)0x3C)
+
+/* Flags in the BDCR register */
+#define RCC_FLAG_LSERDY                  ((uint8_t)0x41)
+
+/* Flags in the CSR register */
+#define RCC_FLAG_LSIRDY                  ((uint8_t)0x61)
+#define RCC_FLAG_BORRST                  ((uint8_t)0x79)
+#define RCC_FLAG_PINRST                  ((uint8_t)0x7A)
+#define RCC_FLAG_PORRST                  ((uint8_t)0x7B)
+#define RCC_FLAG_SFTRST                  ((uint8_t)0x7C)
+#define RCC_FLAG_IWDGRST                 ((uint8_t)0x7D)
+#define RCC_FLAG_WWDGRST                 ((uint8_t)0x7E)
+#define RCC_FLAG_LPWRRST                 ((uint8_t)0x7F)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_LSEDrive_Configuration RCC LSE Drive configurations
+  * @{
+  */
+#define RCC_LSEDRIVE_LOW                 ((uint32_t)0x00000000)
+#define RCC_LSEDRIVE_MEDIUMLOW           RCC_BDCR_LSEDRV_1
+#define RCC_LSEDRIVE_MEDIUMHIGH          RCC_BDCR_LSEDRV_0
+#define RCC_LSEDRIVE_HIGH                RCC_BDCR_LSEDRV
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup RCC_Exported_Macros RCC Exported Macros
+  * @{
+  */
+
+/** @defgroup RCC_AHB1_Clock_Enable_Disable AHB1 Peripheral Clock Enable Disable
+  * @brief  Enable or disable the AHB1 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+#define __HAL_RCC_CRC_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_CRCEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_CRCEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_DMA1_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA1EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA1EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_CRC_CLK_DISABLE()          (RCC->AHB1ENR &= ~(RCC_AHB1ENR_CRCEN))
+#define __HAL_RCC_DMA1_CLK_DISABLE()         (RCC->AHB1ENR &= ~(RCC_AHB1ENR_DMA1EN))
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB1_Clock_Enable_Disable APB1 Peripheral Clock Enable Disable
+  * @brief  Enable or disable the Low Speed APB (APB1) peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+#define __HAL_RCC_WWDG_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_WWDGEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_WWDGEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_PWR_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_PWREN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_PWREN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_WWDG_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_WWDGEN))
+#define __HAL_RCC_PWR_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_PWREN))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB2_Clock_Enable_Disable APB2 Peripheral Clock Enable Disable
+  * @brief  Enable or disable the High Speed APB (APB2) peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+#define __HAL_RCC_SYSCFG_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SYSCFGEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SYSCFGEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_SYSCFG_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_SYSCFGEN))
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB1_Peripheral_Clock_Enable_Disable_Status AHB1 Peripheral Clock Enable Disable Status
+  * @brief  Get the enable or disable status of the AHB1 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+#define __HAL_RCC_CRC_IS_CLK_ENABLED()         ((RCC->AHB1ENR & (RCC_AHB1ENR_CRCEN)) != RESET)
+#define __HAL_RCC_DMA1_IS_CLK_ENABLED()        ((RCC->AHB1ENR & (RCC_AHB1ENR_DMA1EN)) != RESET)
+
+#define __HAL_RCC_CRC_IS_CLK_DISABLED()        ((RCC->AHB1ENR & (RCC_AHB1ENR_CRCEN)) == RESET)
+#define __HAL_RCC_DMA1_IS_CLK_DISABLED()       ((RCC->AHB1ENR & (RCC_AHB1ENR_DMA1EN)) == RESET)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB1_Clock_Enable_Disable_Status APB1 Peripheral Clock Enable Disable  Status
+  * @brief  Get the enable or disable status of the APB1 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+#define __HAL_RCC_WWDG_IS_CLK_ENABLED()        ((RCC->APB1ENR & (RCC_APB1ENR_WWDGEN)) != RESET)
+#define __HAL_RCC_PWR_IS_CLK_ENABLED()         ((RCC->APB1ENR & (RCC_APB1ENR_PWREN)) != RESET)
+
+#define __HAL_RCC_WWDG_IS_CLK_DISABLED()       ((RCC->APB1ENR & (RCC_APB1ENR_WWDGEN)) == RESET)
+#define __HAL_RCC_PWR_IS_CLK_DISABLED()        ((RCC->APB1ENR & (RCC_APB1ENR_PWREN)) == RESET)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB2_Clock_Enable_Disable_Status APB2 Peripheral Clock Enable Disable Status
+  * @brief  EGet the enable or disable status of the APB2 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+#define __HAL_RCC_SYSCFG_IS_CLK_ENABLED()      ((RCC->APB2ENR & (RCC_APB2ENR_SYSCFGEN)) != RESET)
+#define __HAL_RCC_SYSCFG_IS_CLK_DISABLED()     ((RCC->APB2ENR & (RCC_APB2ENR_SYSCFGEN)) == RESET)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Peripheral_Clock_Force_Release RCC Peripheral Clock Force Release
+  * @brief  Force or release AHB peripheral reset.
+  * @{
+  */
+#define __HAL_RCC_AHB1_FORCE_RESET()    (RCC->AHB1RSTR = 0xFFFFFFFF)
+#define __HAL_RCC_CRC_FORCE_RESET()     (RCC->AHB1RSTR |= (RCC_AHB1RSTR_CRCRST))
+#define __HAL_RCC_DMA1_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_DMA1RST))
+
+#define __HAL_RCC_AHB1_RELEASE_RESET()  (RCC->AHB1RSTR = 0x00)
+#define __HAL_RCC_CRC_RELEASE_RESET()   (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_CRCRST))
+#define __HAL_RCC_DMA1_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_DMA1RST))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB1_Force_Release_Reset APB1 Force Release Reset
+  * @brief  Force or release APB1 peripheral reset.
+  * @{
+  */
+#define __HAL_RCC_APB1_FORCE_RESET()     (RCC->APB1RSTR = 0xFFFFFFFF)
+#define __HAL_RCC_WWDG_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_WWDGRST))
+#define __HAL_RCC_PWR_FORCE_RESET()      (RCC->APB1RSTR |= (RCC_APB1RSTR_PWRRST))
+
+#define __HAL_RCC_APB1_RELEASE_RESET()   (RCC->APB1RSTR = 0x00)
+#define __HAL_RCC_WWDG_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_WWDGRST))
+#define __HAL_RCC_PWR_RELEASE_RESET()    (RCC->APB1RSTR &= ~(RCC_APB1RSTR_PWRRST))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB2_Force_Release_Reset APB2 Force Release Reset
+  * @brief  Force or release APB2 peripheral reset.
+  * @{
+  */
+#define __HAL_RCC_APB2_FORCE_RESET()     (RCC->APB2RSTR = 0xFFFFFFFF)
+#define __HAL_RCC_SYSCFG_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_SYSCFGRST))
+
+#define __HAL_RCC_APB2_RELEASE_RESET()   (RCC->APB2RSTR = 0x00)
+#define __HAL_RCC_SYSCFG_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SYSCFGRST))
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Peripheral_Clock_Sleep_Enable_Disable RCC Peripheral Clock Sleep Enable Disable
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+#define __HAL_RCC_CRC_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_CRCLPEN))
+#define __HAL_RCC_DMA1_CLK_SLEEP_ENABLE()     (RCC->AHB1LPENR |= (RCC_AHB1LPENR_DMA1LPEN))
+
+#define __HAL_RCC_CRC_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_CRCLPEN))
+#define __HAL_RCC_DMA1_CLK_SLEEP_DISABLE()    (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_DMA1LPEN))
+
+/** @brief  Enable or disable the APB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __HAL_RCC_WWDG_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_WWDGLPEN))
+#define __HAL_RCC_PWR_CLK_SLEEP_ENABLE()     (RCC->APB1LPENR |= (RCC_APB1LPENR_PWRLPEN))
+
+#define __HAL_RCC_WWDG_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_WWDGLPEN))
+#define __HAL_RCC_PWR_CLK_SLEEP_DISABLE()    (RCC->APB1LPENR &= ~(RCC_APB1LPENR_PWRLPEN))
+
+/** @brief  Enable or disable the APB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __HAL_RCC_SYSCFG_CLK_SLEEP_ENABLE()  (RCC->APB2LPENR |= (RCC_APB2LPENR_SYSCFGLPEN))
+#define __HAL_RCC_SYSCFG_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SYSCFGLPEN))
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB1_Clock_Sleep_Enable_Disable_Status AHB1 Peripheral Clock Sleep Enable Disable Status
+  * @brief  Get the enable or disable status of the AHB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+#define __HAL_RCC_CRC_IS_CLK_SLEEP_ENABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_CRCLPEN)) != RESET)
+#define __HAL_RCC_DMA1_IS_CLK_SLEEP_ENABLED()    ((RCC->AHB1LPENR & (RCC_AHB1LPENR_DMA1LPEN)) != RESET)
+
+#define __HAL_RCC_CRC_IS_CLK_SLEEP_DISABLED()    ((RCC->AHB1LPENR & (RCC_AHB1LPENR_CRCLPEN)) == RESET)
+#define __HAL_RCC_DMA1_IS_CLK_SLEEP_DISABLED()   ((RCC->AHB1LPENR & (RCC_AHB1LPENR_DMA1LPEN)) == RESET)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB1_Clock_Sleep_Enable_Disable_Status APB1 Peripheral Clock Sleep Enable Disable Status
+  * @brief  Get the enable or disable status of the APB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+#define __HAL_RCC_WWDG_IS_CLK_SLEEP_ENABLED()      ((RCC->APB1LPENR & (RCC_APB1LPENR_WWDGLPEN)) != RESET)
+#define __HAL_RCC_PWR_IS_CLK_SLEEP_ENABLED()       ((RCC->APB1LPENR & (RCC_APB1LPENR_PWRLPEN)) != RESET)
+
+#define __HAL_RCC_WWDG_IS_CLK_SLEEP_DISABLED()     ((RCC->APB1LPENR & (RCC_APB1LPENR_WWDGLPEN)) == RESET)
+#define __HAL_RCC_PWR_IS_CLK_SLEEP_DISABLED()      ((RCC->APB1LPENR & (RCC_APB1LPENR_PWRLPEN)) == RESET)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB2_Clock_Sleep_Enable_Disable_Status APB2 Peripheral Clock Sleep Enable Disable Status
+  * @brief  Get the enable or disable status of the APB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+#define __HAL_RCC_SYSCFG_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_SYSCFGLPEN)) != RESET)
+#define __HAL_RCC_SYSCFG_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_SYSCFGLPEN)) == RESET)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_HSI_Configuration HSI Configuration
+  * @{
+  */
+
+/** @brief  Macros to enable or disable the Internal High Speed oscillator (HSI).
+  * @note   The HSI is stopped by hardware when entering STOP and STANDBY modes.
+  *         It is used (enabled by hardware) as system clock source after startup
+  *         from Reset, wakeup from STOP and STANDBY mode, or in case of failure
+  *         of the HSE used directly or indirectly as system clock (if the Clock
+  *         Security System CSS is enabled).
+  * @note   HSI can not be stopped if it is used as system clock source. In this case,
+  *         you have to select another source of the system clock then stop the HSI.
+  * @note   After enabling the HSI, the application software should wait on HSIRDY
+  *         flag to be set indicating that HSI clock is stable and can be used as
+  *         system clock source.
+  * @note   When the HSI is stopped, HSIRDY flag goes low after 6 HSI oscillator
+  *         clock cycles.
+  */
+#define __HAL_RCC_HSI_ENABLE() (RCC->CR |= (RCC_CR_HSION))
+#define __HAL_RCC_HSI_DISABLE() (RCC->CR &= ~(RCC_CR_HSION))
+
+/** @brief  Macro to adjust the Internal High Speed oscillator (HSI) calibration value.
+  * @note   The calibration is used to compensate for the variations in voltage
+  *         and temperature that influence the frequency of the internal HSI RC.
+  * @param  __HSICALIBRATIONVALUE__: specifies the calibration trimming value.
+  *         This parameter must be a number between 0 and 0x1F.
+  */
+#define __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(__HSICALIBRATIONVALUE__) (MODIFY_REG(RCC->CR,\
+        RCC_CR_HSITRIM, (uint32_t)(__HSICALIBRATIONVALUE__) << POSITION_VAL(RCC_CR_HSITRIM)))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_LSI_Configuration LSI Configuration
+  * @{
+  */
+
+/** @brief  Macros to enable or disable the Internal Low Speed oscillator (LSI).
+  * @note   After enabling the LSI, the application software should wait on
+  *         LSIRDY flag to be set indicating that LSI clock is stable and can
+  *         be used to clock the IWDG and/or the RTC.
+  * @note   LSI can not be disabled if the IWDG is running.
+  * @note   When the LSI is stopped, LSIRDY flag goes low after 6 LSI oscillator
+  *         clock cycles.
+  */
+#define __HAL_RCC_LSI_ENABLE()  (RCC->CSR |= (RCC_CSR_LSION))
+#define __HAL_RCC_LSI_DISABLE() (RCC->CSR &= ~(RCC_CSR_LSION))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_HSE_Configuration HSE Configuration
+  * @{
+  */
+/**
+  * @brief  Macro to configure the External High Speed oscillator (__HSE__).
+  * @note   After enabling the HSE (RCC_HSE_ON or RCC_HSE_Bypass), the application
+  *         software should wait on HSERDY flag to be set indicating that HSE clock
+  *         is stable and can be used to clock the PLL and/or system clock.
+  * @note   HSE state can not be changed if it is used directly or through the
+  *         PLL as system clock. In this case, you have to select another source
+  *         of the system clock then change the HSE state (ex. disable it).
+  * @note   The HSE is stopped by hardware when entering STOP and STANDBY modes.
+  * @note   This function reset the CSSON bit, so if the clock security system(CSS)
+  *         was previously enabled you have to enable it again after calling this
+  *         function.
+  * @param  __STATE__: specifies the new state of the HSE.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_HSE_OFF: turn OFF the HSE oscillator, HSERDY flag goes low after
+  *                              6 HSE oscillator clock cycles.
+  *            @arg RCC_HSE_ON: turn ON the HSE oscillator.
+  *            @arg RCC_HSE_BYPASS: HSE oscillator bypassed with external clock.
+  */
+#define __HAL_RCC_HSE_CONFIG(__STATE__) \
+                    do {                                     \
+                      CLEAR_BIT(RCC->CR, RCC_CR_HSEON);      \
+                      if((__STATE__) == RCC_HSE_ON)          \
+                      {                                      \
+                        CLEAR_BIT(RCC->CR, RCC_CR_HSEBYP);   \
+                        SET_BIT(RCC->CR, RCC_CR_HSEON);      \
+                      }                                      \
+                      else if((__STATE__) == RCC_HSE_BYPASS) \
+                      {                                      \
+                        SET_BIT(RCC->CR, RCC_CR_HSEBYP);     \
+                        SET_BIT(RCC->CR, RCC_CR_HSEON);      \
+                      }                                      \
+                      else                                   \
+                      {                                      \
+                        CLEAR_BIT(RCC->CR, RCC_CR_HSEBYP);   \
+                        CLEAR_BIT(RCC->CR, RCC_CR_HSEON);    \
+                        }                                    \
+                    } while(0)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_LSE_Configuration LSE Configuration
+  * @{
+  */
+
+/**
+  * @brief  Macro to configure the External Low Speed oscillator (LSE).
+  * @note   Transition LSE Bypass to LSE On and LSE On to LSE Bypass are not supported by this macro.
+  *         User should request a transition to LSE Off first and then LSE On or LSE Bypass.
+  * @note   As the LSE is in the Backup domain and write access is denied to
+  *         this domain after reset, you have to enable write access using
+  *         HAL_PWR_EnableBkUpAccess() function before to configure the LSE
+  *         (to be done once after reset).
+  * @note   After enabling the LSE (RCC_LSE_ON or RCC_LSE_BYPASS), the application
+  *         software should wait on LSERDY flag to be set indicating that LSE clock
+  *         is stable and can be used to clock the RTC.
+  * @param  __STATE__: specifies the new state of the LSE.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_LSE_OFF: turn OFF the LSE oscillator, LSERDY flag goes low after
+  *                              6 LSE oscillator clock cycles.
+  *            @arg RCC_LSE_ON: turn ON the LSE oscillator.
+  *            @arg RCC_LSE_BYPASS: LSE oscillator bypassed with external clock.
+  */
+#define __HAL_RCC_LSE_CONFIG(__STATE__) \
+                    do {                                       \
+                      CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEON);    \
+                      if((__STATE__) == RCC_LSE_ON)            \
+                      {                                        \
+                        CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEBYP); \
+                        SET_BIT(RCC->BDCR, RCC_BDCR_LSEON);    \
+                      }                                        \
+                      else if((__STATE__) == RCC_LSE_BYPASS)   \
+                      {                                        \
+                        SET_BIT(RCC->BDCR, RCC_BDCR_LSEBYP);   \
+                        SET_BIT(RCC->BDCR, RCC_BDCR_LSEON);    \
+                      }                                        \
+                      else                                     \
+                      {                                        \
+                        CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEBYP); \
+                        CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEON);  \
+                      }                                        \
+                    } while(0)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Internal_RTC_Clock_Configuration RTC Clock Configuration
+  * @{
+  */
+
+/** @brief  Macros to enable or disable the RTC clock.
+  * @note   These macros must be used only after the RTC clock source was selected.
+  */
+#define __HAL_RCC_RTC_ENABLE()  (RCC->BDCR |= (RCC_BDCR_RTCEN))
+#define __HAL_RCC_RTC_DISABLE() (RCC->BDCR &= ~(RCC_BDCR_RTCEN))
+
+/** @brief  Macros to configure the RTC clock (RTCCLK).
+  * @note   As the RTC clock configuration bits are in the Backup domain and write
+  *         access is denied to this domain after reset, you have to enable write
+  *         access using the Power Backup Access macro before to configure
+  *         the RTC clock source (to be done once after reset).
+  * @note   Once the RTC clock is configured it can't be changed unless the
+  *         Backup domain is reset using __HAL_RCC_BackupReset_RELEASE() macro, or by
+  *         a Power On Reset (POR).
+  * @param  __RTCCLKSource__: specifies the RTC clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_RTCCLKSOURCE_LSE: LSE selected as RTC clock.
+  *            @arg RCC_RTCCLKSOURCE_LSI: LSI selected as RTC clock.
+  *            @arg RCC_RTCCLKSOURCE_HSE_DIVx: HSE clock divided by x selected
+  *                                            as RTC clock, where x:[2,31]
+  * @note   If the LSE or LSI is used as RTC clock source, the RTC continues to
+  *         work in STOP and STANDBY modes, and can be used as wakeup source.
+  *         However, when the HSE clock is used as RTC clock source, the RTC
+  *         cannot be used in STOP and STANDBY modes.
+  * @note   The maximum input clock frequency for RTC is 1MHz (when using HSE as
+  *         RTC clock source).
+  */
+#define __HAL_RCC_RTC_CLKPRESCALER(__RTCCLKSource__) (((__RTCCLKSource__) & RCC_BDCR_RTCSEL) == RCC_BDCR_RTCSEL) ?    \
+                                                 MODIFY_REG(RCC->CFGR, RCC_CFGR_RTCPRE, ((__RTCCLKSource__) & 0xFFFFCFF)) : CLEAR_BIT(RCC->CFGR, RCC_CFGR_RTCPRE)
+
+#define __HAL_RCC_RTC_CONFIG(__RTCCLKSource__) do { __HAL_RCC_RTC_CLKPRESCALER(__RTCCLKSource__);    \
+                                                    RCC->BDCR |= ((__RTCCLKSource__) & 0x00000FFF);  \
+                                                   } while (0)
+
+/** @brief  Macros to force or release the Backup domain reset.
+  * @note   This function resets the RTC peripheral (including the backup registers)
+  *         and the RTC clock source selection in RCC_CSR register.
+  * @note   The BKPSRAM is not affected by this reset.
+  */
+#define __HAL_RCC_BACKUPRESET_FORCE()   (RCC->BDCR |= (RCC_BDCR_BDRST))
+#define __HAL_RCC_BACKUPRESET_RELEASE() (RCC->BDCR &= ~(RCC_BDCR_BDRST))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLL_Configuration PLL Configuration
+  * @{
+  */
+
+/** @brief  Macros to enable or disable the main PLL.
+  * @note   After enabling the main PLL, the application software should wait on
+  *         PLLRDY flag to be set indicating that PLL clock is stable and can
+  *         be used as system clock source.
+  * @note   The main PLL can not be disabled if it is used as system clock source
+  * @note   The main PLL is disabled by hardware when entering STOP and STANDBY modes.
+  */
+#define __HAL_RCC_PLL_ENABLE() SET_BIT(RCC->CR, RCC_CR_PLLON)
+#define __HAL_RCC_PLL_DISABLE() CLEAR_BIT(RCC->CR, RCC_CR_PLLON)
+
+
+/** @brief  Macro to configure the main PLL clock source, multiplication and division factors.
+  * @note   This function must be used only when the main PLL is disabled.
+  * @param  __RCC_PLLSource__: specifies the PLL entry clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_PLLSOURCE_HSI: HSI oscillator clock selected as PLL clock entry
+  *            @arg RCC_PLLSOURCE_HSE: HSE oscillator clock selected as PLL clock entry
+  * @note   This clock source (RCC_PLLSource) is common for the main PLL and PLLI2S.
+  * @param  __PLLM__: specifies the division factor for PLL VCO input clock
+  *         This parameter must be a number between Min_Data = 2 and Max_Data = 63.
+  * @note   You have to set the PLLM parameter correctly to ensure that the VCO input
+  *         frequency ranges from 1 to 2 MHz. It is recommended to select a frequency
+  *         of 2 MHz to limit PLL jitter.
+  * @param  __PLLN__: specifies the multiplication factor for PLL VCO output clock
+  *         This parameter must be a number between Min_Data = 192 and Max_Data = 432.
+  * @note   You have to set the PLLN parameter correctly to ensure that the VCO
+  *         output frequency is between 192 and 432 MHz.
+  * @param  __PLLP__: specifies the division factor for main system clock (SYSCLK)
+  *         This parameter must be a number in the range {2, 4, 6, or 8}.
+  * @note   You have to set the PLLP parameter correctly to not exceed 216 MHz on
+  *         the System clock frequency.
+  * @param  __PLLQ__: specifies the division factor for OTG FS, SDMMC and RNG clocks
+  *         This parameter must be a number between Min_Data = 2 and Max_Data = 15.
+  * @note   If the USB OTG FS is used in your application, you have to set the
+  *         PLLQ parameter correctly to have 48 MHz clock for the USB. However,
+  *         the SDMMC and RNG need a frequency lower than or equal to 48 MHz to work
+  *         correctly.
+  */
+#define __HAL_RCC_PLL_CONFIG(__RCC_PLLSource__, __PLLM__, __PLLN__, __PLLP__, __PLLQ__)\
+                            (RCC->PLLCFGR = (0x20000000 | (__PLLM__) | ((__PLLN__) << POSITION_VAL(RCC_PLLCFGR_PLLN)) | \
+                            ((((__PLLP__) >> 1) -1) << POSITION_VAL(RCC_PLLCFGR_PLLP)) | (__RCC_PLLSource__) | \
+                            ((__PLLQ__) << POSITION_VAL(RCC_PLLCFGR_PLLQ))))
+
+/** @brief  Macro to configure the PLL clock source.
+  * @note   This function must be used only when the main PLL is disabled.
+  * @param  __PLLSOURCE__: specifies the PLL entry clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_PLLSOURCE_HSI: HSI oscillator clock selected as PLL clock entry
+  *            @arg RCC_PLLSOURCE_HSE: HSE oscillator clock selected as PLL clock entry
+  *
+  */
+#define __HAL_RCC_PLL_PLLSOURCE_CONFIG(__PLLSOURCE__) MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC, (__PLLSOURCE__))
+
+/** @brief  Macro to configure the PLL multiplication factor.
+  * @note   This function must be used only when the main PLL is disabled.
+  * @param  __PLLM__: specifies the division factor for PLL VCO input clock
+  *         This parameter must be a number between Min_Data = 2 and Max_Data = 63.
+  * @note   You have to set the PLLM parameter correctly to ensure that the VCO input
+  *         frequency ranges from 1 to 2 MHz. It is recommended to select a frequency
+  *         of 2 MHz to limit PLL jitter.
+  *
+  */
+#define __HAL_RCC_PLL_PLLM_CONFIG(__PLLM__) MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLM, (__PLLM__))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLL_I2S_Configuration PLL I2S Configuration
+  * @{
+  */
+
+/** @brief  Macro to configure the I2S clock source (I2SCLK).
+  * @note   This function must be called before enabling the I2S APB clock.
+  * @param  __SOURCE__: specifies the I2S clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_I2SCLKSOURCE_PLLI2S: PLLI2S clock used as I2S clock source.
+  *            @arg RCC_I2SCLKSOURCE_EXT: External clock mapped on the I2S_CKIN pin
+  *                                       used as I2S clock source.
+  */
+#define __HAL_RCC_I2S_CONFIG(__SOURCE__) do {RCC->CFGR &= ~(RCC_CFGR_I2SSRC); \
+                                          RCC->CFGR |= (__SOURCE__); \
+                                         }while(0)
+
+/** @brief Macros to enable or disable the PLLI2S.
+  * @note  The PLLI2S is disabled by hardware when entering STOP and STANDBY modes.
+  */
+#define __HAL_RCC_PLLI2S_ENABLE() (RCC->CR |= (RCC_CR_PLLI2SON))
+#define __HAL_RCC_PLLI2S_DISABLE() (RCC->CR &= ~(RCC_CR_PLLI2SON))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Get_Clock_source Get Clock source
+  * @{
+  */
+/**
+  * @brief Macro to configure the system clock source.
+  * @param __RCC_SYSCLKSOURCE__: specifies the system clock source.
+  * This parameter can be one of the following values:
+  *              - RCC_SYSCLKSOURCE_HSI: HSI oscillator is used as system clock source.
+  *              - RCC_SYSCLKSOURCE_HSE: HSE oscillator is used as system clock source.
+  *              - RCC_SYSCLKSOURCE_PLLCLK: PLL output is used as system clock source.
+  */
+#define __HAL_RCC_SYSCLK_CONFIG(__RCC_SYSCLKSOURCE__) MODIFY_REG(RCC->CFGR, RCC_CFGR_SW, (__RCC_SYSCLKSOURCE__))
+
+/** @brief  Macro to get the clock source used as system clock.
+  * @retval The clock source used as system clock. The returned value can be one
+  *         of the following:
+  *              - RCC_SYSCLKSOURCE_STATUS_HSI: HSI used as system clock.
+  *              - RCC_SYSCLKSOURCE_STATUS_HSE: HSE used as system clock.
+  *              - RCC_SYSCLKSOURCE_STATUS_PLLCLK: PLL used as system clock.
+  */
+#define __HAL_RCC_GET_SYSCLK_SOURCE() ((uint32_t)(RCC->CFGR & RCC_CFGR_SWS))
+
+/**
+  * @brief  Macro to configures the External Low Speed oscillator (LSE) drive capability.
+  * @note   As the LSE is in the Backup domain and write access is denied to
+  *         this domain after reset, you have to enable write access using
+  *         HAL_PWR_EnableBkUpAccess() function before to configure the LSE
+  *         (to be done once after reset).
+  * @param  __RCC_LSEDRIVE__: specifies the new state of the LSE drive capability.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_LSEDRIVE_LOW: LSE oscillator low drive capability.
+  *            @arg RCC_LSEDRIVE_MEDIUMLOW: LSE oscillator medium low drive capability.
+  *            @arg RCC_LSEDRIVE_MEDIUMHIGH: LSE oscillator medium high drive capability.
+  *            @arg RCC_LSEDRIVE_HIGH: LSE oscillator high drive capability.
+  * @retval None
+  */
+#define __HAL_RCC_LSEDRIVE_CONFIG(__RCC_LSEDRIVE__) \
+                  (MODIFY_REG(RCC->BDCR, RCC_BDCR_LSEDRV, (uint32_t)(__RCC_LSEDRIVE__) ))
+
+/** @brief  Macro to get the oscillator used as PLL clock source.
+  * @retval The oscillator used as PLL clock source. The returned value can be one
+  *         of the following:
+  *              - RCC_PLLSOURCE_HSI: HSI oscillator is used as PLL clock source.
+  *              - RCC_PLLSOURCE_HSE: HSE oscillator is used as PLL clock source.
+  */
+#define __HAL_RCC_GET_PLL_OSCSOURCE() ((uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Flags_Interrupts_Management Flags Interrupts Management
+  * @brief macros to manage the specified RCC Flags and interrupts.
+  * @{
+  */
+
+/** @brief  Enable RCC interrupt (Perform Byte access to RCC_CIR[14:8] bits to enable
+  *         the selected interrupts).
+  * @param  __INTERRUPT__: specifies the RCC interrupt sources to be enabled.
+  *         This parameter can be any combination of the following values:
+  *            @arg RCC_IT_LSIRDY: LSI ready interrupt.
+  *            @arg RCC_IT_LSERDY: LSE ready interrupt.
+  *            @arg RCC_IT_HSIRDY: HSI ready interrupt.
+  *            @arg RCC_IT_HSERDY: HSE ready interrupt.
+  *            @arg RCC_IT_PLLRDY: Main PLL ready interrupt.
+  *            @arg RCC_IT_PLLI2SRDY: PLLI2S ready interrupt.
+  */
+#define __HAL_RCC_ENABLE_IT(__INTERRUPT__) (*(__IO uint8_t *) RCC_CIR_BYTE1_ADDRESS |= (__INTERRUPT__))
+
+/** @brief Disable RCC interrupt (Perform Byte access to RCC_CIR[14:8] bits to disable
+  *        the selected interrupts).
+  * @param  __INTERRUPT__: specifies the RCC interrupt sources to be disabled.
+  *         This parameter can be any combination of the following values:
+  *            @arg RCC_IT_LSIRDY: LSI ready interrupt.
+  *            @arg RCC_IT_LSERDY: LSE ready interrupt.
+  *            @arg RCC_IT_HSIRDY: HSI ready interrupt.
+  *            @arg RCC_IT_HSERDY: HSE ready interrupt.
+  *            @arg RCC_IT_PLLRDY: Main PLL ready interrupt.
+  *            @arg RCC_IT_PLLI2SRDY: PLLI2S ready interrupt.
+  */
+#define __HAL_RCC_DISABLE_IT(__INTERRUPT__) (*(__IO uint8_t *) RCC_CIR_BYTE1_ADDRESS &= ~(__INTERRUPT__))
+
+/** @brief  Clear the RCC's interrupt pending bits (Perform Byte access to RCC_CIR[23:16]
+  *         bits to clear the selected interrupt pending bits.
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
+  *         This parameter can be any combination of the following values:
+  *            @arg RCC_IT_LSIRDY: LSI ready interrupt.
+  *            @arg RCC_IT_LSERDY: LSE ready interrupt.
+  *            @arg RCC_IT_HSIRDY: HSI ready interrupt.
+  *            @arg RCC_IT_HSERDY: HSE ready interrupt.
+  *            @arg RCC_IT_PLLRDY: Main PLL ready interrupt.
+  *            @arg RCC_IT_PLLI2SRDY: PLLI2S ready interrupt.
+  *            @arg RCC_IT_CSS: Clock Security System interrupt
+  */
+#define __HAL_RCC_CLEAR_IT(__INTERRUPT__) (*(__IO uint8_t *) RCC_CIR_BYTE2_ADDRESS = (__INTERRUPT__))
+
+/** @brief  Check the RCC's interrupt has occurred or not.
+  * @param  __INTERRUPT__: specifies the RCC interrupt source to check.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_IT_LSIRDY: LSI ready interrupt.
+  *            @arg RCC_IT_LSERDY: LSE ready interrupt.
+  *            @arg RCC_IT_HSIRDY: HSI ready interrupt.
+  *            @arg RCC_IT_HSERDY: HSE ready interrupt.
+  *            @arg RCC_IT_PLLRDY: Main PLL ready interrupt.
+  *            @arg RCC_IT_PLLI2SRDY: PLLI2S ready interrupt.
+  *            @arg RCC_IT_CSS: Clock Security System interrupt
+  * @retval The new state of __INTERRUPT__ (TRUE or FALSE).
+  */
+#define __HAL_RCC_GET_IT(__INTERRUPT__) ((RCC->CIR & (__INTERRUPT__)) == (__INTERRUPT__))
+
+/** @brief Set RMVF bit to clear the reset flags: RCC_FLAG_PINRST, RCC_FLAG_PORRST,
+  *        RCC_FLAG_SFTRST, RCC_FLAG_IWDGRST, RCC_FLAG_WWDGRST and RCC_FLAG_LPWRRST.
+  */
+#define __HAL_RCC_CLEAR_RESET_FLAGS() (RCC->CSR |= RCC_CSR_RMVF)
+
+/** @brief  Check RCC flag is set or not.
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_FLAG_HSIRDY: HSI oscillator clock ready.
+  *            @arg RCC_FLAG_HSERDY: HSE oscillator clock ready.
+  *            @arg RCC_FLAG_PLLRDY: Main PLL clock ready.
+  *            @arg RCC_FLAG_PLLI2SRDY: PLLI2S clock ready.
+  *            @arg RCC_FLAG_LSERDY: LSE oscillator clock ready.
+  *            @arg RCC_FLAG_LSIRDY: LSI oscillator clock ready.
+  *            @arg RCC_FLAG_BORRST: POR/PDR or BOR reset.
+  *            @arg RCC_FLAG_PINRST: Pin reset.
+  *            @arg RCC_FLAG_PORRST: POR/PDR reset.
+  *            @arg RCC_FLAG_SFTRST: Software reset.
+  *            @arg RCC_FLAG_IWDGRST: Independent Watchdog reset.
+  *            @arg RCC_FLAG_WWDGRST: Window Watchdog reset.
+  *            @arg RCC_FLAG_LPWRRST: Low Power reset.
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define RCC_FLAG_MASK  ((uint8_t)0x1F)
+#define __HAL_RCC_GET_FLAG(__FLAG__) (((((((__FLAG__) >> 5) == 1)? RCC->CR :((((__FLAG__) >> 5) == 2) ? RCC->BDCR :((((__FLAG__) >> 5) == 3)? RCC->CSR :RCC->CIR))) & ((uint32_t)1 << ((__FLAG__) & RCC_FLAG_MASK)))!= 0)? 1 : 0)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Include RCC HAL Extension module */
+#include "stm32f7xx_hal_rcc_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+ /** @addtogroup RCC_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup RCC_Exported_Functions_Group1
+  * @{
+  */
+/* Initialization and de-initialization functions  ******************************/
+void HAL_RCC_DeInit(void);
+HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef *RCC_OscInitStruct);
+HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef *RCC_ClkInitStruct, uint32_t FLatency);
+/**
+  * @}
+  */
+
+/** @addtogroup RCC_Exported_Functions_Group2
+  * @{
+  */
+/* Peripheral Control functions  ************************************************/
+void     HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_MCODiv);
+void     HAL_RCC_EnableCSS(void);
+void     HAL_RCC_DisableCSS(void);
+uint32_t HAL_RCC_GetSysClockFreq(void);
+uint32_t HAL_RCC_GetHCLKFreq(void);
+uint32_t HAL_RCC_GetPCLK1Freq(void);
+uint32_t HAL_RCC_GetPCLK2Freq(void);
+void     HAL_RCC_GetOscConfig(RCC_OscInitTypeDef *RCC_OscInitStruct);
+void     HAL_RCC_GetClockConfig(RCC_ClkInitTypeDef *RCC_ClkInitStruct, uint32_t *pFLatency);
+
+/* CSS NMI IRQ handler */
+void HAL_RCC_NMI_IRQHandler(void);
+
+/* User Callbacks in non blocking mode (IT mode) */
+void HAL_RCC_CSSCallback(void);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup RCC_Private_Constants RCC Private Constants
+  * @{
+  */
+#define HSE_TIMEOUT_VALUE          HSE_STARTUP_TIMEOUT
+#define HSI_TIMEOUT_VALUE          ((uint32_t)100)  /* 100 ms */
+#define LSI_TIMEOUT_VALUE          ((uint32_t)100)  /* 100 ms */
+#define PLL_TIMEOUT_VALUE          ((uint32_t)100)  /* 100 ms */
+#define CLOCKSWITCH_TIMEOUT_VALUE  ((uint32_t)5000) /* 5 s    */
+
+/** @defgroup RCC_BitAddress_Alias RCC BitAddress Alias
+  * @brief RCC registers bit address alias
+  * @{
+  */
+/* CIR register byte 2 (Bits[15:8]) base address */
+#define RCC_CIR_BYTE1_ADDRESS         ((uint32_t)(RCC_BASE + 0x0C + 0x01))
+
+/* CIR register byte 3 (Bits[23:16]) base address */
+#define RCC_CIR_BYTE2_ADDRESS         ((uint32_t)(RCC_BASE + 0x0C + 0x02))
+
+#define RCC_DBP_TIMEOUT_VALUE      ((uint32_t)100)
+#define RCC_LSE_TIMEOUT_VALUE      ((uint32_t)5000)
+/**
+  * @}
+  */
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @addtogroup RCC_Private_Macros RCC Private Macros
+  * @{
+  */
+
+/** @defgroup RCC_IS_RCC_Definitions RCC Private macros to check input parameters
+  * @{
+  */
+#define IS_RCC_OSCILLATORTYPE(OSCILLATOR) ((OSCILLATOR) <= 15)
+
+#define IS_RCC_HSE(HSE) (((HSE) == RCC_HSE_OFF) || ((HSE) == RCC_HSE_ON) || \
+                         ((HSE) == RCC_HSE_BYPASS))
+
+#define IS_RCC_LSE(LSE) (((LSE) == RCC_LSE_OFF) || ((LSE) == RCC_LSE_ON) || \
+                         ((LSE) == RCC_LSE_BYPASS))
+
+#define IS_RCC_HSI(HSI) (((HSI) == RCC_HSI_OFF) || ((HSI) == RCC_HSI_ON))
+
+#define IS_RCC_LSI(LSI) (((LSI) == RCC_LSI_OFF) || ((LSI) == RCC_LSI_ON))
+
+#define IS_RCC_PLL(PLL) (((PLL) == RCC_PLL_NONE) ||((PLL) == RCC_PLL_OFF) || ((PLL) == RCC_PLL_ON))
+
+#define IS_RCC_PLLSOURCE(SOURCE) (((SOURCE) == RCC_PLLSOURCE_HSI) || \
+                                  ((SOURCE) == RCC_PLLSOURCE_HSE))
+
+#define IS_RCC_SYSCLKSOURCE(SOURCE) (((SOURCE) == RCC_SYSCLKSOURCE_HSI) || \
+                                     ((SOURCE) == RCC_SYSCLKSOURCE_HSE) || \
+                                     ((SOURCE) == RCC_SYSCLKSOURCE_PLLCLK))
+#define IS_RCC_PLLM_VALUE(VALUE) ((2 <= (VALUE)) && ((VALUE) <= 63))
+
+#define IS_RCC_PLLN_VALUE(VALUE) ((192 <= (VALUE)) && ((VALUE) <= 432))
+
+#define IS_RCC_PLLP_VALUE(VALUE) (((VALUE) == RCC_PLLP_DIV2) || ((VALUE) == RCC_PLLP_DIV4) || \
+                                  ((VALUE) == RCC_PLLP_DIV6) || ((VALUE) == RCC_PLLP_DIV8))
+#define IS_RCC_PLLQ_VALUE(VALUE) ((2 <= (VALUE)) && ((VALUE) <= 15))
+
+#define IS_RCC_HCLK(HCLK) (((HCLK) == RCC_SYSCLK_DIV1)   || ((HCLK) == RCC_SYSCLK_DIV2)   || \
+                           ((HCLK) == RCC_SYSCLK_DIV4)   || ((HCLK) == RCC_SYSCLK_DIV8)   || \
+                           ((HCLK) == RCC_SYSCLK_DIV16)  || ((HCLK) == RCC_SYSCLK_DIV64)  || \
+                           ((HCLK) == RCC_SYSCLK_DIV128) || ((HCLK) == RCC_SYSCLK_DIV256) || \
+                           ((HCLK) == RCC_SYSCLK_DIV512))
+
+#define IS_RCC_CLOCKTYPE(CLK) ((1 <= (CLK)) && ((CLK) <= 15))
+
+#define IS_RCC_PCLK(PCLK) (((PCLK) == RCC_HCLK_DIV1) || ((PCLK) == RCC_HCLK_DIV2) || \
+                           ((PCLK) == RCC_HCLK_DIV4) || ((PCLK) == RCC_HCLK_DIV8) || \
+                           ((PCLK) == RCC_HCLK_DIV16))
+
+#define IS_RCC_MCO(MCOX) (((MCOX) == RCC_MCO1) || ((MCOX) == RCC_MCO2))
+
+
+#define IS_RCC_MCO1SOURCE(SOURCE) (((SOURCE) == RCC_MCO1SOURCE_HSI) || ((SOURCE) == RCC_MCO1SOURCE_LSE) || \
+                                   ((SOURCE) == RCC_MCO1SOURCE_HSE) || ((SOURCE) == RCC_MCO1SOURCE_PLLCLK))
+
+#define IS_RCC_MCO2SOURCE(SOURCE) (((SOURCE) == RCC_MCO2SOURCE_SYSCLK) || ((SOURCE) == RCC_MCO2SOURCE_PLLI2SCLK)|| \
+                                   ((SOURCE) == RCC_MCO2SOURCE_HSE)    || ((SOURCE) == RCC_MCO2SOURCE_PLLCLK))
+
+#define IS_RCC_MCODIV(DIV) (((DIV) == RCC_MCODIV_1)  || ((DIV) == RCC_MCODIV_2) || \
+                             ((DIV) == RCC_MCODIV_3) || ((DIV) == RCC_MCODIV_4) || \
+                             ((DIV) == RCC_MCODIV_5))
+#define IS_RCC_CALIBRATION_VALUE(VALUE) ((VALUE) <= 0x1F)
+
+#define IS_RCC_RTCCLKSOURCE(SOURCE) (((SOURCE) == RCC_RTCCLKSOURCE_LSE) || ((SOURCE) == RCC_RTCCLKSOURCE_LSI) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV2) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV3) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV4) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV5) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV6) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV7) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV8) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV9) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV10) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV11) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV12) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV13) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV14) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV15) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV16) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV17) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV18) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV19) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV20) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV21) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV22) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV23) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV24) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV25) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV26) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV27) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV28) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV29) || \
+                                     ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV30) || ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV31))
+
+
+#define IS_RCC_LSE_DRIVE(DRIVE) (((DRIVE) == RCC_LSEDRIVE_LOW)        || \
+                                     ((DRIVE) == RCC_LSEDRIVE_MEDIUMLOW)  || \
+                                     ((DRIVE) == RCC_LSEDRIVE_MEDIUMHIGH) || \
+                                     ((DRIVE) == RCC_LSEDRIVE_HIGH))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_RCC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_rcc_ex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_rcc_ex.h
@@ -1,0 +1,2698 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rcc_ex.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of RCC HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_RCC_EX_H
+#define __STM32F7xx_HAL_RCC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RCCEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup RCCEx_Exported_Types RCCEx Exported Types
+  * @{
+  */
+
+/**
+  * @brief  PLLI2S Clock structure definition
+  */
+typedef struct
+{
+  uint32_t PLLI2SN;    /*!< Specifies the multiplication factor for PLLI2S VCO output clock.
+                            This parameter must be a number between Min_Data = 49 and Max_Data = 432.
+                            This parameter will be used only when PLLI2S is selected as Clock Source I2S or SAI */
+
+  uint32_t PLLI2SR;    /*!< Specifies the division factor for I2S clock.
+                            This parameter must be a number between Min_Data = 2 and Max_Data = 7.
+                            This parameter will be used only when PLLI2S is selected as Clock Source I2S or SAI */
+
+  uint32_t PLLI2SQ;    /*!< Specifies the division factor for SAI1 clock.
+                            This parameter must be a number between Min_Data = 2 and Max_Data = 15.
+                            This parameter will be used only when PLLI2S is selected as Clock Source SAI */
+
+  uint32_t PLLI2SP;    /*!< Specifies the division factor for SPDIF-RX clock.
+                            This parameter must be a number between 0 and 3 for respective values 2, 4, 6 and 8.
+                            This parameter will be used only when PLLI2S is selected as Clock Source SPDDIF-RX */
+}RCC_PLLI2SInitTypeDef;
+
+/**
+  * @brief  PLLSAI Clock structure definition
+  */
+typedef struct
+{
+  uint32_t PLLSAIN;    /*!< Specifies the multiplication factor for PLLI2S VCO output clock.
+                            This parameter must be a number between Min_Data = 49 and Max_Data = 432.
+                            This parameter will be used only when PLLSAI is selected as Clock Source SAI or LTDC */
+
+  uint32_t PLLSAIQ;    /*!< Specifies the division factor for SAI1 clock.
+                            This parameter must be a number between Min_Data = 2 and Max_Data = 15.
+                            This parameter will be used only when PLLSAI is selected as Clock Source SAI or LTDC */
+
+  uint32_t PLLSAIR;    /*!< specifies the division factor for LTDC clock
+                            This parameter must be a number between Min_Data = 2 and Max_Data = 7.
+                            This parameter will be used only when PLLSAI is selected as Clock Source LTDC */
+
+  uint32_t PLLSAIP;    /*!< Specifies the division factor for 48MHz clock.
+                            This parameter can be a value of @ref RCCEx_PLLSAIP_Clock_Divider
+                            This parameter will be used only when PLLSAI is disabled */
+}RCC_PLLSAIInitTypeDef;
+
+/**
+  * @brief  RCC extended clocks structure definition
+  */
+typedef struct
+{
+  uint32_t PeriphClockSelection; /*!< The Extended Clock to be configured.
+                                      This parameter can be a value of @ref RCCEx_Periph_Clock_Selection */
+
+  RCC_PLLI2SInitTypeDef PLLI2S;  /*!< PLL I2S structure parameters.
+                                      This parameter will be used only when PLLI2S is selected as Clock Source I2S or SAI */
+
+  RCC_PLLSAIInitTypeDef PLLSAI;  /*!< PLL SAI structure parameters.
+                                      This parameter will be used only when PLLI2S is selected as Clock Source SAI or LTDC */
+
+  uint32_t PLLI2SDivQ;           /*!< Specifies the PLLI2S division factor for SAI1 clock.
+                                      This parameter must be a number between Min_Data = 1 and Max_Data = 32
+                                      This parameter will be used only when PLLI2S is selected as Clock Source SAI */
+
+  uint32_t PLLSAIDivQ;           /*!< Specifies the PLLI2S division factor for SAI1 clock.
+                                      This parameter must be a number between Min_Data = 1 and Max_Data = 32
+                                      This parameter will be used only when PLLSAI is selected as Clock Source SAI */
+
+  uint32_t PLLSAIDivR;           /*!< Specifies the PLLSAI division factor for LTDC clock.
+                                      This parameter must be one value of @ref RCCEx_PLLSAI_DIVR */
+
+  uint32_t RTCClockSelection;      /*!< Specifies RTC Clock source Selection.
+                                        This parameter can be a value of @ref RCC_RTC_Clock_Source */
+
+  uint32_t I2sClockSelection;      /*!< Specifies I2S Clock source Selection.
+                                        This parameter can be a value of @ref RCCEx_I2S_Clock_Source */
+
+  uint32_t TIMPresSelection;      /*!< Specifies TIM Clock Prescalers Selection.
+                                       This parameter can be a value of @ref RCCEx_TIM_Prescaler_Selection */
+
+  uint32_t Sai1ClockSelection;     /*!< Specifies SAI1 Clock Prescalers Selection
+                                        This parameter can be a value of @ref RCCEx_SAI1_Clock_Source */
+
+  uint32_t Sai2ClockSelection;     /*!< Specifies SAI2 Clock Prescalers Selection
+                                        This parameter can be a value of @ref RCCEx_SAI2_Clock_Source */
+
+  uint32_t Usart1ClockSelection; /*!< USART1 clock source
+                                      This parameter can be a value of @ref RCCEx_USART1_Clock_Source */
+
+  uint32_t Usart2ClockSelection; /*!< USART2 clock source
+                                      This parameter can be a value of @ref RCCEx_USART2_Clock_Source */
+
+  uint32_t Usart3ClockSelection; /*!< USART3 clock source
+                                      This parameter can be a value of @ref RCCEx_USART3_Clock_Source */
+
+  uint32_t Uart4ClockSelection;  /*!< UART4 clock source
+                                      This parameter can be a value of @ref RCCEx_UART4_Clock_Source */
+
+  uint32_t Uart5ClockSelection;  /*!< UART5 clock source
+                                      This parameter can be a value of @ref RCCEx_UART5_Clock_Source */
+
+  uint32_t Usart6ClockSelection;  /*!< USART6 clock source
+                                      This parameter can be a value of @ref RCCEx_USART6_Clock_Source */
+
+  uint32_t Uart7ClockSelection;  /*!< UART7 clock source
+                                      This parameter can be a value of @ref RCCEx_UART7_Clock_Source */
+
+  uint32_t Uart8ClockSelection;  /*!< UART8 clock source
+                                      This parameter can be a value of @ref RCCEx_UART8_Clock_Source */
+
+  uint32_t I2c1ClockSelection;   /*!< I2C1 clock source
+                                      This parameter can be a value of @ref RCCEx_I2C1_Clock_Source */
+
+  uint32_t I2c2ClockSelection;   /*!< I2C2 clock source
+                                      This parameter can be a value of @ref RCCEx_I2C2_Clock_Source */
+
+  uint32_t I2c3ClockSelection;   /*!< I2C3 clock source
+                                      This parameter can be a value of @ref RCCEx_I2C3_Clock_Source */
+
+  uint32_t I2c4ClockSelection;   /*!< I2C4 clock source
+                                      This parameter can be a value of @ref RCCEx_I2C4_Clock_Source */
+
+  uint32_t Lptim1ClockSelection;   /*!< Specifies LPTIM1 clock source
+                                        This parameter can be a value of @ref RCCEx_LPTIM1_Clock_Source */
+
+  uint32_t CecClockSelection;      /*!< CEC clock source
+                                        This parameter can be a value of @ref RCCEx_CEC_Clock_Source */
+
+  uint32_t Clk48ClockSelection;    /*!< Specifies 48Mhz clock source used by USB OTG FS, RNG and SDMMC
+                                        This parameter can be a value of @ref RCCEx_CLK48_Clock_Source */
+
+  uint32_t Sdmmc1ClockSelection;     /*!< SDMMC1 clock source
+                                        This parameter can be a value of @ref RCCEx_SDMMC1_Clock_Source */
+
+}RCC_PeriphCLKInitTypeDef;
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RCCEx_Exported_Constants RCCEx Exported Constants
+  * @{
+  */
+
+/** @defgroup RCCEx_Periph_Clock_Selection RCC Periph Clock Selection
+  * @{
+  */
+#define RCC_PERIPHCLK_I2S             ((uint32_t)0x00000001)
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define RCC_PERIPHCLK_LTDC            ((uint32_t)0x00000008)
+#endif /* STM32F756xx || STM32F746xx */
+#define RCC_PERIPHCLK_TIM             ((uint32_t)0x00000010)
+#define RCC_PERIPHCLK_RTC             ((uint32_t)0x00000020)
+#define RCC_PERIPHCLK_USART1          ((uint32_t)0x00000040)
+#define RCC_PERIPHCLK_USART2          ((uint32_t)0x00000080)
+#define RCC_PERIPHCLK_USART3          ((uint32_t)0x00000100)
+#define RCC_PERIPHCLK_UART4           ((uint32_t)0x00000200)
+#define RCC_PERIPHCLK_UART5           ((uint32_t)0x00000400)
+#define RCC_PERIPHCLK_USART6          ((uint32_t)0x00000800)
+#define RCC_PERIPHCLK_UART7           ((uint32_t)0x00001000)
+#define RCC_PERIPHCLK_UART8           ((uint32_t)0x00002000)
+#define RCC_PERIPHCLK_I2C1            ((uint32_t)0x00004000)
+#define RCC_PERIPHCLK_I2C2            ((uint32_t)0x00008000)
+#define RCC_PERIPHCLK_I2C3            ((uint32_t)0x00010000)
+#define RCC_PERIPHCLK_I2C4            ((uint32_t)0x00020000)
+#define RCC_PERIPHCLK_LPTIM1          ((uint32_t)0x00040000)
+#define RCC_PERIPHCLK_SAI1            ((uint32_t)0x00080000)
+#define RCC_PERIPHCLK_SAI2            ((uint32_t)0x00100000)
+#define RCC_PERIPHCLK_CLK48           ((uint32_t)0x00200000)
+#define RCC_PERIPHCLK_CEC             ((uint32_t)0x00400000)
+#define RCC_PERIPHCLK_SDMMC1          ((uint32_t)0x00800000)
+#define RCC_PERIPHCLK_SPDIFRX         ((uint32_t)0x01000000)
+#define RCC_PERIPHCLK_PLLI2S          ((uint32_t)0x02000000)
+
+
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_PLLSAIP_Clock_Divider RCCEx PLLSAIP Clock Divider
+  * @{
+  */
+#define RCC_PLLSAIP_DIV2                  ((uint32_t)0x00000000)
+#define RCC_PLLSAIP_DIV4                  ((uint32_t)0x00000001)
+#define RCC_PLLSAIP_DIV6                  ((uint32_t)0x00000002)
+#define RCC_PLLSAIP_DIV8                  ((uint32_t)0x00000003)
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_PLLSAI_DIVR RCCEx PLLSAI DIVR
+  * @{
+  */
+#define RCC_PLLSAIDIVR_2                ((uint32_t)0x00000000)
+#define RCC_PLLSAIDIVR_4                RCC_DCKCFGR1_PLLSAIDIVR_0
+#define RCC_PLLSAIDIVR_8                RCC_DCKCFGR1_PLLSAIDIVR_1
+#define RCC_PLLSAIDIVR_16               RCC_DCKCFGR1_PLLSAIDIVR
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2S_Clock_Source RCCEx I2S Clock Source
+  * @{
+  */
+#define RCC_I2SCLKSOURCE_PLLI2S             ((uint32_t)0x00000000)
+#define RCC_I2SCLKSOURCE_EXT                RCC_CFGR_I2SSRC
+
+/**
+  * @}
+  */
+
+
+/** @defgroup RCCEx_SAI1_Clock_Source RCCEx SAI1 Clock Source
+  * @{
+  */
+#define RCC_SAI1CLKSOURCE_PLLSAI             ((uint32_t)0x00000000)
+#define RCC_SAI1CLKSOURCE_PLLI2S             RCC_DCKCFGR1_SAI1SEL_0
+#define RCC_SAI1CLKSOURCE_PIN                RCC_DCKCFGR1_SAI1SEL_1
+
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_SAI2_Clock_Source RCCEx SAI2 Clock Source
+  * @{
+  */
+#define RCC_SAI2CLKSOURCE_PLLSAI             ((uint32_t)0x00000000)
+#define RCC_SAI2CLKSOURCE_PLLI2S             RCC_DCKCFGR1_SAI2SEL_0
+#define RCC_SAI2CLKSOURCE_PIN                RCC_DCKCFGR1_SAI2SEL_1
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_SDMMC1_Clock_Source RCCEx SDMMC1 Clock Source
+  * @{
+  */
+#define RCC_SDMMC1CLKSOURCE_CLK48              ((uint32_t)0x00000000)
+#define RCC_SDMMC1CLKSOURCE_SYSCLK             RCC_DCKCFGR2_SDMMC1SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CEC_Clock_Source RCCEx CEC Clock Source
+  * @{
+  */
+#define RCC_CECCLKSOURCE_LSE             ((uint32_t)0x00000000)
+#define RCC_CECCLKSOURCE_HSI             RCC_DCKCFGR2_CECSEL /* CEC clock is HSI/488*/
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_USART1_Clock_Source RCCEx USART1 Clock Source
+  * @{
+  */
+#define RCC_USART1CLKSOURCE_PCLK2      ((uint32_t)0x00000000)
+#define RCC_USART1CLKSOURCE_SYSCLK     RCC_DCKCFGR2_USART1SEL_0
+#define RCC_USART1CLKSOURCE_HSI        RCC_DCKCFGR2_USART1SEL_1
+#define RCC_USART1CLKSOURCE_LSE        RCC_DCKCFGR2_USART1SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_USART2_Clock_Source RCCEx USART2 Clock Source
+  * @{
+  */
+#define RCC_USART2CLKSOURCE_PCLK1       ((uint32_t)0x00000000)
+#define RCC_USART2CLKSOURCE_SYSCLK     RCC_DCKCFGR2_USART2SEL_0
+#define RCC_USART2CLKSOURCE_HSI        RCC_DCKCFGR2_USART2SEL_1
+#define RCC_USART2CLKSOURCE_LSE        RCC_DCKCFGR2_USART2SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_USART3_Clock_Source RCCEx USART3 Clock Source
+  * @{
+  */
+#define RCC_USART3CLKSOURCE_PCLK1       ((uint32_t)0x00000000)
+#define RCC_USART3CLKSOURCE_SYSCLK     RCC_DCKCFGR2_USART3SEL_0
+#define RCC_USART3CLKSOURCE_HSI        RCC_DCKCFGR2_USART3SEL_1
+#define RCC_USART3CLKSOURCE_LSE        RCC_DCKCFGR2_USART3SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_UART4_Clock_Source RCCEx UART4 Clock Source
+  * @{
+  */
+#define RCC_UART4CLKSOURCE_PCLK1        ((uint32_t)0x00000000)
+#define RCC_UART4CLKSOURCE_SYSCLK       RCC_DCKCFGR2_UART4SEL_0
+#define RCC_UART4CLKSOURCE_HSI          RCC_DCKCFGR2_UART4SEL_1
+#define RCC_UART4CLKSOURCE_LSE          RCC_DCKCFGR2_UART4SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_UART5_Clock_Source RCCEx UART5 Clock Source
+  * @{
+  */
+#define RCC_UART5CLKSOURCE_PCLK1        ((uint32_t)0x00000000)
+#define RCC_UART5CLKSOURCE_SYSCLK       RCC_DCKCFGR2_UART5SEL_0
+#define RCC_UART5CLKSOURCE_HSI          RCC_DCKCFGR2_UART5SEL_1
+#define RCC_UART5CLKSOURCE_LSE          RCC_DCKCFGR2_UART5SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_USART6_Clock_Source RCCEx USART6 Clock Source
+  * @{
+  */
+#define RCC_USART6CLKSOURCE_PCLK2       ((uint32_t)0x00000000)
+#define RCC_USART6CLKSOURCE_SYSCLK      RCC_DCKCFGR2_USART6SEL_0
+#define RCC_USART6CLKSOURCE_HSI         RCC_DCKCFGR2_USART6SEL_1
+#define RCC_USART6CLKSOURCE_LSE         RCC_DCKCFGR2_USART6SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_UART7_Clock_Source RCCEx UART7 Clock Source
+  * @{
+  */
+#define RCC_UART7CLKSOURCE_PCLK1       ((uint32_t)0x00000000)
+#define RCC_UART7CLKSOURCE_SYSCLK      RCC_DCKCFGR2_UART7SEL_0
+#define RCC_UART7CLKSOURCE_HSI         RCC_DCKCFGR2_UART7SEL_1
+#define RCC_UART7CLKSOURCE_LSE         RCC_DCKCFGR2_UART7SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_UART8_Clock_Source RCCEx UART8 Clock Source
+  * @{
+  */
+#define RCC_UART8CLKSOURCE_PCLK1        ((uint32_t)0x00000000)
+#define RCC_UART8CLKSOURCE_SYSCLK      RCC_DCKCFGR2_UART8SEL_0
+#define RCC_UART8CLKSOURCE_HSI         RCC_DCKCFGR2_UART8SEL_1
+#define RCC_UART8CLKSOURCE_LSE         RCC_DCKCFGR2_UART8SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2C1_Clock_Source RCCEx I2C1 Clock Source
+  * @{
+  */
+#define RCC_I2C1CLKSOURCE_PCLK1        ((uint32_t)0x00000000)
+#define RCC_I2C1CLKSOURCE_SYSCLK       RCC_DCKCFGR2_I2C1SEL_0
+#define RCC_I2C1CLKSOURCE_HSI          RCC_DCKCFGR2_I2C1SEL_1
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2C2_Clock_Source RCCEx I2C2 Clock Source
+  * @{
+  */
+#define RCC_I2C2CLKSOURCE_PCLK1        ((uint32_t)0x00000000)
+#define RCC_I2C2CLKSOURCE_SYSCLK       RCC_DCKCFGR2_I2C2SEL_0
+#define RCC_I2C2CLKSOURCE_HSI          RCC_DCKCFGR2_I2C2SEL_1
+
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2C3_Clock_Source RCCEx I2C3 Clock Source
+  * @{
+  */
+#define RCC_I2C3CLKSOURCE_PCLK1        ((uint32_t)0x00000000)
+#define RCC_I2C3CLKSOURCE_SYSCLK       RCC_DCKCFGR2_I2C3SEL_0
+#define RCC_I2C3CLKSOURCE_HSI          RCC_DCKCFGR2_I2C3SEL_1
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2C4_Clock_Source RCCEx I2C4 Clock Source
+  * @{
+  */
+#define RCC_I2C4CLKSOURCE_PCLK1        ((uint32_t)0x00000000)
+#define RCC_I2C4CLKSOURCE_SYSCLK       RCC_DCKCFGR2_I2C4SEL_0
+#define RCC_I2C4CLKSOURCE_HSI          RCC_DCKCFGR2_I2C4SEL_1
+/**
+  * @}
+  */
+
+
+/** @defgroup RCCEx_LPTIM1_Clock_Source RCCEx LPTIM1 Clock Source
+  * @{
+  */
+#define RCC_LPTIM1CLKSOURCE_PCLK       ((uint32_t)0x00000000)
+#define RCC_LPTIM1CLKSOURCE_LSI        RCC_DCKCFGR2_LPTIM1SEL_0
+#define RCC_LPTIM1CLKSOURCE_HSI        RCC_DCKCFGR2_LPTIM1SEL_1
+#define RCC_LPTIM1CLKSOURCE_LSE        RCC_DCKCFGR2_LPTIM1SEL
+
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CLK48_Clock_Source RCCEx CLK48 Clock Source
+  * @{
+  */
+#define RCC_CLK48SOURCE_PLL         ((uint32_t)0x00000000)
+#define RCC_CLK48SOURCE_PLLSAIP     RCC_DCKCFGR2_CK48MSEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIM_Prescaler_Selection RCCEx TIM Prescaler Selection
+  * @{
+  */
+#define RCC_TIMPRES_DESACTIVATED        ((uint32_t)0x00000000)
+#define RCC_TIMPRES_ACTIVATED           RCC_DCKCFGR1_TIMPRE
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup RCCEx_Exported_Macros RCCEx Exported Macros
+  * @{
+  */
+/** @defgroup RCCEx_Peripheral_Clock_Enable_Disable RCCEx_Peripheral_Clock_Enable_Disable
+  * @brief  Enables or disables the AHB/APB peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+
+/** @brief  Enables or disables the AHB1 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  */
+#define __HAL_RCC_BKPSRAM_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_BKPSRAMEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_BKPSRAMEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_DTCMRAMEN_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DTCMRAMEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DTCMRAMEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_DMA2_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA2EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA2EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_DMA2D_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA2DEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA2DEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_USB_OTG_HS_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_OTGHSEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_OTGHSEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_USB_OTG_HS_ULPI_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_OTGHSULPIEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_OTGHSULPIEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_GPIOA_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOAEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOAEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_GPIOB_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOBEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOBEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_GPIOC_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOCEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOCEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_GPIOD_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIODEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIODEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_GPIOE_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOEEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOEEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_GPIOF_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOFEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOFEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_GPIOG_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOGEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOGEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_GPIOH_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOHEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOHEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_GPIOI_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOIEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOIEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_GPIOJ_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOJEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOJEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_GPIOK_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOKEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_GPIOKEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_BKPSRAM_CLK_DISABLE()         (RCC->AHB1ENR &= ~(RCC_AHB1ENR_BKPSRAMEN))
+#define __HAL_RCC_DTCMRAMEN_CLK_DISABLE()       (RCC->AHB1ENR &= ~(RCC_AHB1ENR_DTCMRAMEN))
+#define __HAL_RCC_DMA2_CLK_DISABLE()            (RCC->AHB1ENR &= ~(RCC_AHB1ENR_DMA2EN))
+#define __HAL_RCC_DMA2D_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_DMA2DEN))
+#define __HAL_RCC_USB_OTG_HS_CLK_DISABLE()      (RCC->AHB1ENR &= ~(RCC_AHB1ENR_OTGHSEN))
+#define __HAL_RCC_USB_OTG_HS_ULPI_CLK_DISABLE() (RCC->AHB1ENR &= ~(RCC_AHB1ENR_OTGHSULPIEN))
+#define __HAL_RCC_GPIOA_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOAEN))
+#define __HAL_RCC_GPIOB_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOBEN))
+#define __HAL_RCC_GPIOC_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOCEN))
+#define __HAL_RCC_GPIOD_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIODEN))
+#define __HAL_RCC_GPIOE_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOEEN))
+#define __HAL_RCC_GPIOF_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOFEN))
+#define __HAL_RCC_GPIOG_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOGEN))
+#define __HAL_RCC_GPIOH_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOHEN))
+#define __HAL_RCC_GPIOI_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOIEN))
+#define __HAL_RCC_GPIOJ_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOJEN))
+#define __HAL_RCC_GPIOK_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOKEN))
+/**
+  * @brief  Enable ETHERNET clock.
+  */
+#define __HAL_RCC_ETHMAC_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHMACEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHMACEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_ETHMACTX_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHMACTXEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHMACTXEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_ETHMACRX_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHMACRXEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHMACRXEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_ETHMACPTP_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHMACPTPEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_ETHMACPTPEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_ETH_CLK_ENABLE()       do {                            \
+                                     __HAL_RCC_ETHMAC_CLK_ENABLE();      \
+                                     __HAL_RCC_ETHMACTX_CLK_ENABLE();    \
+                                     __HAL_RCC_ETHMACRX_CLK_ENABLE();    \
+                                    } while(0)
+/**
+  * @brief  Disable ETHERNET clock.
+  */
+#define __HAL_RCC_ETHMAC_CLK_DISABLE()    (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACEN))
+#define __HAL_RCC_ETHMACTX_CLK_DISABLE()  (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACTXEN))
+#define __HAL_RCC_ETHMACRX_CLK_DISABLE()  (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACRXEN))
+#define __HAL_RCC_ETHMACPTP_CLK_DISABLE() (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACPTPEN))
+#define __HAL_RCC_ETH_CLK_DISABLE()       do {                             \
+                                      __HAL_RCC_ETHMACTX_CLK_DISABLE();    \
+                                      __HAL_RCC_ETHMACRX_CLK_DISABLE();    \
+                                      __HAL_RCC_ETHMAC_CLK_DISABLE();      \
+                                     } while(0)
+
+/** @brief  Enable or disable the AHB2 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  */
+#define __HAL_RCC_DCMI_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_DCMIEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_DCMIEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_RNG_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_RNGEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_RNGEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_USB_OTG_FS_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_OTGFSEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_OTGFSEN);\
+                                        UNUSED(tmpreg); \
+										__HAL_RCC_SYSCFG_CLK_ENABLE();\
+                                      } while(0)
+
+#define __HAL_RCC_DCMI_CLK_DISABLE()  (RCC->AHB2ENR &= ~(RCC_AHB2ENR_DCMIEN))
+#define __HAL_RCC_RNG_CLK_DISABLE()   (RCC->AHB2ENR &= ~(RCC_AHB2ENR_RNGEN))
+
+#define __HAL_RCC_USB_OTG_FS_CLK_DISABLE() do { (RCC->AHB2ENR &= ~(RCC_AHB2ENR_OTGFSEN));\
+                                         __HAL_RCC_SYSCFG_CLK_DISABLE();\
+                                    }while(0)
+#if defined(STM32F756xx)
+#define __HAL_RCC_CRYP_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_CRYPEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_CRYPEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_HASH_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_HASHEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_HASHEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_CRYP_CLK_DISABLE()  (RCC->AHB2ENR &= ~(RCC_AHB2ENR_CRYPEN))
+#define __HAL_RCC_HASH_CLK_DISABLE()  (RCC->AHB2ENR &= ~(RCC_AHB2ENR_HASHEN))
+#endif /* STM32F756x */
+/** @brief  Enables or disables the AHB3 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  */
+#define __HAL_RCC_FMC_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB3ENR, RCC_AHB3ENR_FMCEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB3ENR, RCC_AHB3ENR_FMCEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_QSPI_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->AHB3ENR, RCC_AHB3ENR_QSPIEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->AHB3ENR, RCC_AHB3ENR_QSPIEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_FMC_CLK_DISABLE()   (RCC->AHB3ENR &= ~(RCC_AHB3ENR_FMCEN))
+#define __HAL_RCC_QSPI_CLK_DISABLE()  (RCC->AHB3ENR &= ~(RCC_AHB3ENR_QSPIEN))
+
+/** @brief  Enable or disable the Low Speed APB (APB1) peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  */
+#define __HAL_RCC_TIM2_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM2EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM2EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM3_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM3EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM3EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM4_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM4EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM4EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM5_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM5EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM5EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM6_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM6EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM6EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM7_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM7EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM7EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM12_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM12EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM12EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM13_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM13EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM13EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM14_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM14EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM14EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_LPTIM1_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_LPTIM1EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_LPTIM1EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_SPI2_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_SPI2EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_SPI2EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_SPI3_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_SPI3EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_SPI3EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_SPDIFRX_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_SPDIFRXEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_SPDIFRXEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_USART2_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_USART2EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_USART2EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_USART3_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_USART3EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_USART3EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_UART4_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_UART4EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_UART4EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_UART5_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_UART5EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_UART5EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_I2C1_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C1EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C1EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_I2C2_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C2EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C2EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_I2C3_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C3EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C3EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_I2C4_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C4EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C4EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_CAN1_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_CAN1EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_CAN1EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_CAN2_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_CAN2EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_CAN2EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_CEC_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_CECEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_CECEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_DAC_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_DACEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_DACEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_UART7_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_UART7EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_UART7EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_UART8_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB1ENR, RCC_APB1ENR_UART8EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_UART8EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM2_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM2EN))
+#define __HAL_RCC_TIM3_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM3EN))
+#define __HAL_RCC_TIM4_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM4EN))
+#define __HAL_RCC_TIM5_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM5EN))
+#define __HAL_RCC_TIM6_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM6EN))
+#define __HAL_RCC_TIM7_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM7EN))
+#define __HAL_RCC_TIM12_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM12EN))
+#define __HAL_RCC_TIM13_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM13EN))
+#define __HAL_RCC_TIM14_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM14EN))
+#define __HAL_RCC_LPTIM1_CLK_DISABLE() (RCC->APB1ENR &= ~(RCC_APB1ENR_LPTIM1EN))
+#define __HAL_RCC_SPI2_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_SPI2EN))
+#define __HAL_RCC_SPI3_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_SPI3EN))
+#define __HAL_RCC_SPDIFRX_CLK_DISABLE()(RCC->APB1ENR &= ~(RCC_APB1ENR_SPDIFRXEN))
+#define __HAL_RCC_USART2_CLK_DISABLE() (RCC->APB1ENR &= ~(RCC_APB1ENR_USART2EN))
+#define __HAL_RCC_USART3_CLK_DISABLE() (RCC->APB1ENR &= ~(RCC_APB1ENR_USART3EN))
+#define __HAL_RCC_UART4_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_UART4EN))
+#define __HAL_RCC_UART5_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_UART5EN))
+#define __HAL_RCC_I2C1_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define __HAL_RCC_I2C2_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C2EN))
+#define __HAL_RCC_I2C3_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C3EN))
+#define __HAL_RCC_I2C4_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C4EN))
+#define __HAL_RCC_CAN1_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_CAN1EN))
+#define __HAL_RCC_CAN2_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_CAN2EN))
+#define __HAL_RCC_CEC_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_CECEN))
+#define __HAL_RCC_DAC_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_DACEN))
+#define __HAL_RCC_UART7_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_UART7EN))
+#define __HAL_RCC_UART8_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_UART8EN))
+
+/** @brief  Enable or disable the High Speed APB (APB2) peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  */
+#define __HAL_RCC_TIM1_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM1EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM1EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM8_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM8EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM8EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_USART1_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_USART6_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_USART6EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USART6EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_ADC1_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_ADC1EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_ADC1EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_ADC2_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_ADC2EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_ADC2EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_ADC3_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_ADC3EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_ADC3EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_SDMMC1_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SDMMC1EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SDMMC1EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_SPI1_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_SPI4_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI4EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI4EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM9_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM9EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM9EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM10_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM10EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM10EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_TIM11_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM11EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM11EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_SPI5_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI5EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI5EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_SPI6_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI6EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI6EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_SAI1_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI1EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI1EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#define __HAL_RCC_SAI2_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI2EN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI2EN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define __HAL_RCC_LTDC_CLK_ENABLE()   do { \
+                                        __IO uint32_t tmpreg; \
+                                        SET_BIT(RCC->APB2ENR, RCC_APB2ENR_LTDCEN);\
+                                        /* Delay after an RCC peripheral clock enabling */ \
+                                        tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_LTDCEN);\
+                                        UNUSED(tmpreg); \
+                                      } while(0)
+#endif /* STM32F756xx || STM32F746xx */
+
+#define __HAL_RCC_TIM1_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM1EN))
+#define __HAL_RCC_TIM8_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM8EN))
+#define __HAL_RCC_USART1_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_USART1EN))
+#define __HAL_RCC_USART6_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_USART6EN))
+#define __HAL_RCC_ADC1_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_ADC1EN))
+#define __HAL_RCC_ADC2_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_ADC2EN))
+#define __HAL_RCC_ADC3_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_ADC3EN))
+#define __HAL_RCC_SDMMC1_CLK_DISABLE()  (RCC->APB2ENR &= ~(RCC_APB2ENR_SDMMC1EN))
+#define __HAL_RCC_SPI1_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI1EN))
+#define __HAL_RCC_SPI4_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI4EN))
+#define __HAL_RCC_TIM9_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM9EN))
+#define __HAL_RCC_TIM10_CLK_DISABLE()  (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM10EN))
+#define __HAL_RCC_TIM11_CLK_DISABLE()  (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM11EN))
+#define __HAL_RCC_SPI5_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI5EN))
+#define __HAL_RCC_SPI6_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI6EN))
+#define __HAL_RCC_SAI1_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_SAI1EN))
+#define __HAL_RCC_SAI2_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_SAI2EN))
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define __HAL_RCC_LTDC_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_LTDCEN))
+#endif /* STM32F756xx || STM32F746xx */
+/**
+  * @}
+  */
+
+
+/** @defgroup RCCEx_Peripheral_Clock_Enable_Disable_Status Peripheral Clock Enable Disable Status
+  * @brief  Get the enable or disable status of the AHB/APB peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+
+/** @brief  Get the enable or disable status of the AHB1 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  */
+#define __HAL_RCC_BKPSRAM_IS_CLK_ENABLED()          ((RCC->AHB1ENR & (RCC_AHB1ENR_BKPSRAMEN)) != RESET)
+#define __HAL_RCC_DTCMRAMEN_IS_CLK_ENABLED()        ((RCC->AHB1ENR & (RCC_AHB1ENR_DTCMRAMEN)) != RESET)
+#define __HAL_RCC_DMA2_IS_CLK_ENABLED()             ((RCC->AHB1ENR & (RCC_AHB1ENR_DMA2EN)) != RESET)
+#define __HAL_RCC_DMA2D_IS_CLK_ENABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_DMA2DEN)) != RESET)
+#define __HAL_RCC_USB_OTG_HS_IS_CLK_ENABLED()       ((RCC->AHB1ENR & (RCC_AHB1ENR_OTGHSEN)) != RESET)
+#define __HAL_RCC_USB_OTG_HS_ULPI_IS_CLK_ENABLED()  ((RCC->AHB1ENR & (RCC_AHB1ENR_OTGHSULPIEN)) != RESET)
+#define __HAL_RCC_GPIOA_IS_CLK_ENABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOAEN)) != RESET)
+#define __HAL_RCC_GPIOB_IS_CLK_ENABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOBEN)) != RESET)
+#define __HAL_RCC_GPIOC_IS_CLK_ENABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOCEN)) != RESET)
+#define __HAL_RCC_GPIOD_IS_CLK_ENABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIODEN)) != RESET)
+#define __HAL_RCC_GPIOE_IS_CLK_ENABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOEEN)) != RESET)
+#define __HAL_RCC_GPIOF_IS_CLK_ENABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOFEN)) != RESET)
+#define __HAL_RCC_GPIOG_IS_CLK_ENABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOGEN)) != RESET)
+#define __HAL_RCC_GPIOH_IS_CLK_ENABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOHEN)) != RESET)
+#define __HAL_RCC_GPIOI_IS_CLK_ENABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOIEN)) != RESET)
+#define __HAL_RCC_GPIOJ_IS_CLK_ENABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOJEN)) != RESET)
+#define __HAL_RCC_GPIOK_IS_CLK_ENABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOKEN)) != RESET)
+
+#define __HAL_RCC_BKPSRAM_IS_CLK_DISABLED()         ((RCC->AHB1ENR & (RCC_AHB1ENR_BKPSRAMEN)) == RESET)
+#define __HAL_RCC_DTCMRAMEN_IS_CLK_DISABLED()       ((RCC->AHB1ENR & (RCC_AHB1ENR_DTCMRAMEN)) == RESET)
+#define __HAL_RCC_DMA2_IS_CLK_DISABLED()            ((RCC->AHB1ENR & (RCC_AHB1ENR_DMA2EN)) == RESET)
+#define __HAL_RCC_DMA2D_IS_CLK_DISABLED()           ((RCC->AHB1ENR & (RCC_AHB1ENR_DMA2DEN)) == RESET)
+#define __HAL_RCC_USB_OTG_HS_IS_CLK_DISABLED()      ((RCC->AHB1ENR & (RCC_AHB1ENR_OTGHSEN)) == RESET)
+#define __HAL_RCC_USB_OTG_HS_ULPI_IS_CLK_DISABLED() ((RCC->AHB1ENR & (RCC_AHB1ENR_OTGHSULPIEN)) == RESET)
+#define __HAL_RCC_GPIOA_IS_CLK_DISABLED()           ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOAEN)) == RESET)
+#define __HAL_RCC_GPIOB_IS_CLK_DISABLED()           ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOBEN)) == RESET)
+#define __HAL_RCC_GPIOC_IS_CLK_DISABLED()           ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOCEN)) == RESET)
+#define __HAL_RCC_GPIOD_IS_CLK_DISABLED()           ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIODEN)) == RESET)
+#define __HAL_RCC_GPIOE_IS_CLK_DISABLED()           ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOEEN)) == RESET)
+#define __HAL_RCC_GPIOF_IS_CLK_DISABLED()           ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOFEN)) == RESET)
+#define __HAL_RCC_GPIOG_IS_CLK_DISABLED()           ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOGEN)) == RESET)
+#define __HAL_RCC_GPIOH_IS_CLK_DISABLED()           ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOHEN)) == RESET)
+#define __HAL_RCC_GPIOI_IS_CLK_DISABLED()           ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOIEN)) == RESET)
+#define __HAL_RCC_GPIOJ_IS_CLK_DISABLED()           ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOJEN)) == RESET)
+#define __HAL_RCC_GPIOK_IS_CLK_DISABLED()           ((RCC->AHB1ENR & (RCC_AHB1ENR_GPIOKEN)) == RESET)
+/**
+  * @brief  Enable ETHERNET clock.
+  */
+#define __HAL_RCC_ETHMAC_IS_CLK_ENABLED()     ((RCC->AHB1ENR & (RCC_AHB1ENR_ETHMACEN)) != RESET)
+#define __HAL_RCC_ETHMACTX_IS_CLK_ENABLED()   ((RCC->AHB1ENR & (RCC_AHB1ENR_ETHMACTXEN)) != RESET)
+#define __HAL_RCC_ETHMACRX_IS_CLK_ENABLED()   ((RCC->AHB1ENR & (RCC_AHB1ENR_ETHMACRXEN)) != RESET)
+#define __HAL_RCC_ETHMACPTP_IS_CLK_ENABLED()  ((RCC->AHB1ENR & (RCC_AHB1ENR_ETHMACPTPEN)) != RESET)
+#define __HAL_RCC_ETH_IS_CLK_ENABLED()        (__HAL_RCC_ETHMAC_IS_CLK_ENABLED()   && \
+                                               __HAL_RCC_ETHMACTX_IS_CLK_ENABLED() && \
+											   __HAL_RCC_ETHMACRX_IS_CLK_ENABLED())
+
+/**
+  * @brief  Disable ETHERNET clock.
+  */
+#define __HAL_RCC_ETHMAC_IS_CLK_DISABLED()    ((RCC->AHB1ENR & (RCC_AHB1ENR_ETHMACEN)) == RESET)
+#define __HAL_RCC_ETHMACTX_IS_CLK_DISABLED()  ((RCC->AHB1ENR & (RCC_AHB1ENR_ETHMACTXEN)) == RESET)
+#define __HAL_RCC_ETHMACRX_IS_CLK_DISABLED()  ((RCC->AHB1ENR & (RCC_AHB1ENR_ETHMACRXEN)) == RESET)
+#define __HAL_RCC_ETHMACPTP_IS_CLK_DISABLED() ((RCC->AHB1ENR & (RCC_AHB1ENR_ETHMACPTPEN)) == RESET)
+#define __HAL_RCC_ETH_IS_CLK_DISABLED()        (__HAL_RCC_ETHMAC_IS_CLK_DISABLED()   && \
+                                                __HAL_RCC_ETHMACTX_IS_CLK_DISABLED() && \
+											    __HAL_RCC_ETHMACRX_IS_CLK_DISABLED())
+
+/** @brief  Get the enable or disable status of the AHB2 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  */
+#define __HAL_RCC_DCMI_IS_CLK_ENABLED()        ((RCC->AHB2ENR & (RCC_AHB2ENR_DCMIEN)) != RESET)
+#define __HAL_RCC_RNG_IS_CLK_ENABLED()         ((RCC->AHB2ENR & (RCC_AHB2ENR_RNGEN)) != RESET)
+#define __HAL_RCC_USB_OTG_FS_IS_CLK_ENABLED()  ((RCC->AHB2ENR & (RCC_AHB2ENR_OTGFSEN)) != RESET)
+
+
+#define __HAL_RCC_DCMI_IS_CLK_DISABLED()       ((RCC->AHB2ENR & (RCC_AHB2ENR_DCMIEN)) == RESET)
+#define __HAL_RCC_RNG_IS_CLK_DISABLED()        ((RCC->AHB2ENR & (RCC_AHB2ENR_RNGEN)) == RESET)
+#define __HAL_RCC_USB_IS_OTG_FS_CLK_DISABLED() ((RCC->AHB2ENR & (RCC_AHB2ENR_OTGFSEN)) == RESET)
+
+#if defined(STM32F756xx)
+#define __HAL_RCC_CRYP_IS_CLK_ENABLED()   ((RCC->AHB2ENR & (RCC_AHB2ENR_CRYPEN)) != RESET)
+#define __HAL_RCC_HASH_IS_CLK_ENABLED()   ((RCC->AHB2ENR & (RCC_AHB2ENR_HASHEN)) != RESET)
+#define __HAL_RCC_CRYP_IS_CLK_DISABLED()  ((RCC->AHB2ENR & (RCC_AHB2ENR_CRYPEN)) == RESET)
+#define __HAL_RCC_HASH_IS_CLK_DISABLED()  ((RCC->AHB2ENR & (RCC_AHB2ENR_HASHEN)) == RESET)
+#endif /* STM32F756x */
+
+/** @brief  Get the enable or disable status of the AHB3 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  */
+#define __HAL_RCC_FMC_IS_CLK_ENABLED()   ((RCC->AHB3ENR & (RCC_AHB3ENR_FMCEN)) != RESET)
+#define __HAL_RCC_QSPI_IS_CLK_ENABLED()  ((RCC->AHB3ENR & (RCC_AHB3ENR_QSPIEN)) != RESET)
+
+#define __HAL_RCC_FMC_IS_CLK_DISABLED()   ((RCC->AHB3ENR & (RCC_AHB3ENR_FMCEN)) == RESET)
+#define __HAL_RCC_QSPI_IS_CLK_DISABLED()  ((RCC->AHB3ENR & (RCC_AHB3ENR_QSPIEN)) == RESET)
+
+/** @brief  Get the enable or disable status of the APB1 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  */
+#define __HAL_RCC_TIM2_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_TIM2EN)) != RESET)
+#define __HAL_RCC_TIM3_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_TIM3EN)) != RESET)
+#define __HAL_RCC_TIM4_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_TIM4EN)) != RESET)
+#define __HAL_RCC_TIM5_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_TIM5EN)) != RESET)
+#define __HAL_RCC_TIM6_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_TIM6EN)) != RESET)
+#define __HAL_RCC_TIM7_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_TIM7EN)) != RESET)
+#define __HAL_RCC_TIM12_IS_CLK_ENABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_TIM12EN)) != RESET)
+#define __HAL_RCC_TIM13_IS_CLK_ENABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_TIM13EN)) != RESET)
+#define __HAL_RCC_TIM14_IS_CLK_ENABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_TIM14EN)) != RESET)
+#define __HAL_RCC_LPTIM1_IS_CLK_ENABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_LPTIM1EN)) != RESET)
+#define __HAL_RCC_SPI2_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_SPI2EN)) != RESET)
+#define __HAL_RCC_SPI3_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_SPI3EN)) != RESET)
+#define __HAL_RCC_SPDIFRX_IS_CLK_ENABLED() ((RCC->APB1ENR & (RCC_APB1ENR_SPDIFRXEN)) != RESET)
+#define __HAL_RCC_USART2_IS_CLK_ENABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_USART2EN)) != RESET)
+#define __HAL_RCC_USART3_IS_CLK_ENABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_USART3EN)) != RESET)
+#define __HAL_RCC_UART4_IS_CLK_ENABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_UART4EN)) != RESET)
+#define __HAL_RCC_UART5_IS_CLK_ENABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_UART5EN)) != RESET)
+#define __HAL_RCC_I2C1_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_I2C1EN)) != RESET)
+#define __HAL_RCC_I2C2_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_I2C2EN)) != RESET)
+#define __HAL_RCC_I2C3_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_I2C3EN)) != RESET)
+#define __HAL_RCC_I2C4_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_I2C4EN)) != RESET)
+#define __HAL_RCC_CAN1_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_CAN1EN)) != RESET)
+#define __HAL_RCC_CAN2_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_CAN2EN)) != RESET)
+#define __HAL_RCC_CEC_IS_CLK_ENABLED()     ((RCC->APB1ENR & (RCC_APB1ENR_CECEN)) != RESET)
+#define __HAL_RCC_DAC_IS_CLK_ENABLED()     ((RCC->APB1ENR & (RCC_APB1ENR_DACEN)) != RESET)
+#define __HAL_RCC_UART7_IS_CLK_ENABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_UART7EN)) != RESET)
+#define __HAL_RCC_UART8_IS_CLK_ENABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_UART8EN)) != RESET)
+
+#define __HAL_RCC_TIM2_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_TIM2EN)) == RESET)
+#define __HAL_RCC_TIM3_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_TIM3EN)) == RESET)
+#define __HAL_RCC_TIM4_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_TIM4EN)) == RESET)
+#define __HAL_RCC_TIM5_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_TIM5EN)) == RESET)
+#define __HAL_RCC_TIM6_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_TIM6EN)) == RESET)
+#define __HAL_RCC_TIM7_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_TIM7EN)) == RESET)
+#define __HAL_RCC_TIM12_IS_CLK_DISABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_TIM12EN)) == RESET)
+#define __HAL_RCC_TIM13_IS_CLK_DISABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_TIM13EN)) == RESET)
+#define __HAL_RCC_TIM14_IS_CLK_DISABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_TIM14EN)) == RESET)
+#define __HAL_RCC_LPTIM1_IS_CLK_DISABLED() ((RCC->APB1ENR & (RCC_APB1ENR_LPTIM1EN)) == RESET)
+#define __HAL_RCC_SPI2_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_SPI2EN)) == RESET)
+#define __HAL_RCC_SPI3_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_SPI3EN)) == RESET)
+#define __HAL_RCC_SPDIFRX_IS_CLK_DISABLED()((RCC->APB1ENR & (RCC_APB1ENR_SPDIFRXEN)) == RESET)
+#define __HAL_RCC_USART2_IS_CLK_DISABLED() ((RCC->APB1ENR & (RCC_APB1ENR_USART2EN)) == RESET)
+#define __HAL_RCC_USART3_IS_CLK_DISABLED() ((RCC->APB1ENR & (RCC_APB1ENR_USART3EN)) == RESET)
+#define __HAL_RCC_UART4_IS_CLK_DISABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_UART4EN)) == RESET)
+#define __HAL_RCC_UART5_IS_CLK_DISABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_UART5EN)) == RESET)
+#define __HAL_RCC_I2C1_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_I2C1EN)) == RESET)
+#define __HAL_RCC_I2C2_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_I2C2EN)) == RESET)
+#define __HAL_RCC_I2C3_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_I2C3EN)) == RESET)
+#define __HAL_RCC_I2C4_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_I2C4EN)) == RESET)
+#define __HAL_RCC_CAN1_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_CAN1EN)) == RESET)
+#define __HAL_RCC_CAN2_IS_CLK_DISABLED()   ((RCC->APB1ENR & (RCC_APB1ENR_CAN2EN)) == RESET)
+#define __HAL_RCC_CEC_IS_CLK_DISABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_CECEN)) == RESET)
+#define __HAL_RCC_DAC_IS_CLK_DISABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_DACEN)) == RESET)
+#define __HAL_RCC_UART7_IS_CLK_DISABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_UART7EN)) == RESET)
+#define __HAL_RCC_UART8_IS_CLK_DISABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_UART8EN)) == RESET)
+
+/** @brief  Get the enable or disable status of the APB2 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  */
+#define __HAL_RCC_TIM1_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_TIM1EN)) != RESET)
+#define __HAL_RCC_TIM8_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_TIM8EN)) != RESET)
+#define __HAL_RCC_USART1_IS_CLK_ENABLED()  ((RCC->APB2ENR & (RCC_APB2ENR_USART1EN)) != RESET)
+#define __HAL_RCC_USART6_IS_CLK_ENABLED()  ((RCC->APB2ENR & (RCC_APB2ENR_USART6EN)) != RESET)
+#define __HAL_RCC_ADC1_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_ADC1EN)) != RESET)
+#define __HAL_RCC_ADC2_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_ADC2EN)) != RESET)
+#define __HAL_RCC_ADC3_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_ADC3EN)) != RESET)
+#define __HAL_RCC_SDMMC1_IS_CLK_ENABLED()  ((RCC->APB2ENR & (RCC_APB2ENR_SDMMC1EN)) != RESET)
+#define __HAL_RCC_SPI1_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_SPI1EN)) != RESET)
+#define __HAL_RCC_SPI4_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_SPI4EN)) != RESET)
+#define __HAL_RCC_TIM9_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_TIM9EN)) != RESET)
+#define __HAL_RCC_TIM10_IS_CLK_ENABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_TIM10EN)) != RESET)
+#define __HAL_RCC_TIM11_IS_CLK_ENABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_TIM11EN)) != RESET)
+#define __HAL_RCC_SPI5_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_SPI5EN)) != RESET)
+#define __HAL_RCC_SPI6_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_SPI6EN)) != RESET)
+#define __HAL_RCC_SAI1_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_SAI1EN)) != RESET)
+#define __HAL_RCC_SAI2_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_SAI2EN)) != RESET)
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define __HAL_RCC_LTDC_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_LTDCEN)) != RESET)
+#endif /* STM32F756xx || STM32F746xx */
+#define __HAL_RCC_TIM1_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_TIM1EN)) == RESET)
+#define __HAL_RCC_TIM8_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_TIM8EN)) == RESET)
+#define __HAL_RCC_USART1_IS_CLK_DISABLED() ((RCC->APB2ENR & (RCC_APB2ENR_USART1EN)) == RESET)
+#define __HAL_RCC_USART6_IS_CLK_DISABLED() ((RCC->APB2ENR & (RCC_APB2ENR_USART6EN)) == RESET)
+#define __HAL_RCC_ADC1_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_ADC1EN)) == RESET)
+#define __HAL_RCC_ADC2_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_ADC2EN)) == RESET)
+#define __HAL_RCC_ADC3_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_ADC3EN)) == RESET)
+#define __HAL_RCC_SDMMC1_IS_CLK_DISABLED() ((RCC->APB2ENR & (RCC_APB2ENR_SDMMC1EN)) == RESET)
+#define __HAL_RCC_SPI1_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_SPI1EN)) == RESET)
+#define __HAL_RCC_SPI4_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_SPI4EN)) == RESET)
+#define __HAL_RCC_TIM9_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_TIM9EN)) == RESET)
+#define __HAL_RCC_TIM10_IS_CLK_DISABLED()  ((RCC->APB2ENR & (RCC_APB2ENR_TIM10EN)) == RESET)
+#define __HAL_RCC_TIM11_IS_CLK_DISABLED()  ((RCC->APB2ENR & (RCC_APB2ENR_TIM11EN)) == RESET)
+#define __HAL_RCC_SPI5_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_SPI5EN)) == RESET)
+#define __HAL_RCC_SPI6_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_SPI6EN)) == RESET)
+#define __HAL_RCC_SAI1_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_SAI1EN)) == RESET)
+#define __HAL_RCC_SAI2_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_SAI2EN)) == RESET)
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define __HAL_RCC_LTDC_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_LTDCEN)) == RESET)
+#endif /* STM32F756xx || STM32F746xx */
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_Force_Release_Peripheral_Reset RCCEx Force Release Peripheral Reset
+  * @brief  Forces or releases AHB/APB peripheral reset.
+  * @{
+  */
+
+/** @brief  Force or release AHB1 peripheral reset.
+  */
+#define __HAL_RCC_DMA2_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_DMA2RST))
+#define __HAL_RCC_DMA2D_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_DMA2DRST))
+#define __HAL_RCC_ETHMAC_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_ETHMACRST))
+#define __HAL_RCC_USB_OTG_HS_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_OTGHRST))
+#define __HAL_RCC_GPIOA_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOARST))
+#define __HAL_RCC_GPIOB_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOBRST))
+#define __HAL_RCC_GPIOC_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOCRST))
+#define __HAL_RCC_GPIOD_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIODRST))
+#define __HAL_RCC_GPIOE_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOERST))
+#define __HAL_RCC_GPIOF_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOFRST))
+#define __HAL_RCC_GPIOG_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOGRST))
+#define __HAL_RCC_GPIOH_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOHRST))
+#define __HAL_RCC_GPIOI_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOIRST))
+#define __HAL_RCC_GPIOJ_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOJRST))
+#define __HAL_RCC_GPIOK_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOKRST))
+
+#define __HAL_RCC_DMA2_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_DMA2RST))
+#define __HAL_RCC_DMA2D_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_DMA2DRST))
+#define __HAL_RCC_ETHMAC_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_ETHMACRST))
+#define __HAL_RCC_USB_OTG_HS_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_OTGHRST))
+#define __HAL_RCC_GPIOA_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOARST))
+#define __HAL_RCC_GPIOB_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOBRST))
+#define __HAL_RCC_GPIOC_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOCRST))
+#define __HAL_RCC_GPIOD_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIODRST))
+#define __HAL_RCC_GPIOE_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOERST))
+#define __HAL_RCC_GPIOF_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOFRST))
+#define __HAL_RCC_GPIOG_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOGRST))
+#define __HAL_RCC_GPIOH_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOHRST))
+#define __HAL_RCC_GPIOI_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOIRST))
+#define __HAL_RCC_GPIOJ_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOJRST))
+#define __HAL_RCC_GPIOK_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOKRST))
+
+/** @brief  Force or release AHB2 peripheral reset.
+  */
+#define __HAL_RCC_AHB2_FORCE_RESET()    (RCC->AHB2RSTR = 0xFFFFFFFF)
+#define __HAL_RCC_DCMI_FORCE_RESET()   (RCC->AHB2RSTR |= (RCC_AHB2RSTR_DCMIRST))
+
+#define __HAL_RCC_RNG_FORCE_RESET()    (RCC->AHB2RSTR |= (RCC_AHB2RSTR_RNGRST))
+#define __HAL_RCC_USB_OTG_FS_FORCE_RESET()   (RCC->AHB2RSTR |= (RCC_AHB2RSTR_OTGFSRST))
+
+#define __HAL_RCC_AHB2_RELEASE_RESET()  (RCC->AHB2RSTR = 0x00)
+#define __HAL_RCC_DCMI_RELEASE_RESET() (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_DCMIRST))
+#define __HAL_RCC_RNG_RELEASE_RESET()  (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_RNGRST))
+#define __HAL_RCC_USB_OTG_FS_RELEASE_RESET() (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_OTGFSRST))
+
+#if defined(STM32F756xx)
+#define __HAL_RCC_CRYP_FORCE_RESET()   (RCC->AHB2RSTR |= (RCC_AHB2RSTR_CRYPRST))
+#define __HAL_RCC_HASH_FORCE_RESET()   (RCC->AHB2RSTR |= (RCC_AHB2RSTR_HASHRST))
+#define __HAL_RCC_CRYP_RELEASE_RESET() (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_CRYPRST))
+#define __HAL_RCC_HASH_RELEASE_RESET() (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_HASHRST))
+#endif /* STM32F756xx */
+
+/** @brief  Force or release AHB3 peripheral reset
+  */
+#define __HAL_RCC_AHB3_FORCE_RESET()   (RCC->AHB3RSTR = 0xFFFFFFFF)
+#define __HAL_RCC_FMC_FORCE_RESET()    (RCC->AHB3RSTR |= (RCC_AHB3RSTR_FMCRST))
+#define __HAL_RCC_QSPI_FORCE_RESET()   (RCC->AHB3RSTR |= (RCC_AHB3RSTR_QSPIRST))
+
+#define __HAL_RCC_AHB3_RELEASE_RESET() (RCC->AHB3RSTR = 0x00)
+#define __HAL_RCC_FMC_RELEASE_RESET()  (RCC->AHB3RSTR &= ~(RCC_AHB3RSTR_FMCRST))
+#define __HAL_RCC_QSPI_RELEASE_RESET() (RCC->AHB3RSTR &= ~(RCC_AHB3RSTR_QSPIRST))
+
+/** @brief  Force or release APB1 peripheral reset.
+  */
+#define __HAL_RCC_TIM2_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM2RST))
+#define __HAL_RCC_TIM3_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM3RST))
+#define __HAL_RCC_TIM4_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM4RST))
+#define __HAL_RCC_TIM5_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM5RST))
+#define __HAL_RCC_TIM6_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM6RST))
+#define __HAL_RCC_TIM7_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM7RST))
+#define __HAL_RCC_TIM12_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM12RST))
+#define __HAL_RCC_TIM13_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM13RST))
+#define __HAL_RCC_TIM14_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM14RST))
+#define __HAL_RCC_LPTIM1_FORCE_RESET()   (RCC->APB1RSTR |= (RCC_APB1RSTR_LPTIM1RST))
+#define __HAL_RCC_SPI2_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_SPI2RST))
+#define __HAL_RCC_SPI3_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_SPI3RST))
+#define __HAL_RCC_SPDIFRX_FORCE_RESET()  (RCC->APB1RSTR |= (RCC_APB1RSTR_SPDIFRXRST))
+#define __HAL_RCC_USART2_FORCE_RESET()   (RCC->APB1RSTR |= (RCC_APB1RSTR_USART2RST))
+#define __HAL_RCC_USART3_FORCE_RESET()   (RCC->APB1RSTR |= (RCC_APB1RSTR_USART3RST))
+#define __HAL_RCC_UART4_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_UART4RST))
+#define __HAL_RCC_UART5_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_UART5RST))
+#define __HAL_RCC_I2C1_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_I2C1RST))
+#define __HAL_RCC_I2C2_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_I2C2RST))
+#define __HAL_RCC_I2C3_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_I2C3RST))
+#define __HAL_RCC_I2C4_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_I2C4RST))
+#define __HAL_RCC_CAN1_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_CAN1RST))
+#define __HAL_RCC_CAN2_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_CAN2RST))
+#define __HAL_RCC_CEC_FORCE_RESET()      (RCC->APB1RSTR |= (RCC_APB1RSTR_CECRST))
+#define __HAL_RCC_DAC_FORCE_RESET()      (RCC->APB1RSTR |= (RCC_APB1RSTR_DACRST))
+#define __HAL_RCC_UART7_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_UART7RST))
+#define __HAL_RCC_UART8_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_UART8RST))
+
+#define __HAL_RCC_TIM2_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM2RST))
+#define __HAL_RCC_TIM3_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM3RST))
+#define __HAL_RCC_TIM4_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM4RST))
+#define __HAL_RCC_TIM5_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM5RST))
+#define __HAL_RCC_TIM6_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM6RST))
+#define __HAL_RCC_TIM7_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM7RST))
+#define __HAL_RCC_TIM12_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM12RST))
+#define __HAL_RCC_TIM13_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM13RST))
+#define __HAL_RCC_TIM14_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM14RST))
+#define __HAL_RCC_LPTIM1_RELEASE_RESET() (RCC->APB1RSTR &= ~(RCC_APB1RSTR_LPTIM1RST))
+#define __HAL_RCC_SPI2_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_SPI2RST))
+#define __HAL_RCC_SPI3_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_SPI3RST))
+#define __HAL_RCC_SPDIFRX_RELEASE_RESET()(RCC->APB1RSTR &= ~(RCC_APB1RSTR_SPDIFRXRST))
+#define __HAL_RCC_USART2_RELEASE_RESET() (RCC->APB1RSTR &= ~(RCC_APB1RSTR_USART2RST))
+#define __HAL_RCC_USART3_RELEASE_RESET() (RCC->APB1RSTR &= ~(RCC_APB1RSTR_USART3RST))
+#define __HAL_RCC_UART4_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART4RST))
+#define __HAL_RCC_UART5_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART5RST))
+#define __HAL_RCC_I2C1_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_I2C1RST))
+#define __HAL_RCC_I2C2_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_I2C2RST))
+#define __HAL_RCC_I2C3_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_I2C3RST))
+#define __HAL_RCC_I2C4_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_I2C4RST))
+#define __HAL_RCC_CAN1_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_CAN1RST))
+#define __HAL_RCC_CAN2_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_CAN2RST))
+#define __HAL_RCC_CEC_RELEASE_RESET()    (RCC->APB1RSTR &= ~(RCC_APB1RSTR_CECRST))
+#define __HAL_RCC_DAC_RELEASE_RESET()    (RCC->APB1RSTR &= ~(RCC_APB1RSTR_DACRST))
+#define __HAL_RCC_UART7_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART7RST))
+#define __HAL_RCC_UART8_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART8RST))
+
+/** @brief  Force or release APB2 peripheral reset.
+  */
+#define __HAL_RCC_TIM1_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM1RST))
+#define __HAL_RCC_TIM8_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM8RST))
+#define __HAL_RCC_USART1_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_USART1RST))
+#define __HAL_RCC_USART6_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_USART6RST))
+#define __HAL_RCC_ADC_FORCE_RESET()      (RCC->APB2RSTR |= (RCC_APB2RSTR_ADCRST))
+#define __HAL_RCC_SDMMC1_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_SDMMC1RST))
+#define __HAL_RCC_SPI1_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI1RST))
+#define __HAL_RCC_SPI4_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI4RST))
+#define __HAL_RCC_TIM9_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM9RST))
+#define __HAL_RCC_TIM10_FORCE_RESET()    (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM10RST))
+#define __HAL_RCC_TIM11_FORCE_RESET()    (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM11RST))
+#define __HAL_RCC_SPI5_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI5RST))
+#define __HAL_RCC_SPI6_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI6RST))
+#define __HAL_RCC_SAI1_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SAI1RST))
+#define __HAL_RCC_SAI2_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SAI2RST))
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define __HAL_RCC_LTDC_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_LTDCRST))
+#endif /* STM32F756xx || STM32F746xx */
+
+#define __HAL_RCC_TIM1_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM1RST))
+#define __HAL_RCC_TIM8_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM8RST))
+#define __HAL_RCC_USART1_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_USART1RST))
+#define __HAL_RCC_USART6_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_USART6RST))
+#define __HAL_RCC_ADC_RELEASE_RESET()    (RCC->APB2RSTR &= ~(RCC_APB2RSTR_ADCRST))
+#define __HAL_RCC_SDMMC1_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SDMMC1RST))
+#define __HAL_RCC_SPI1_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI1RST))
+#define __HAL_RCC_SPI4_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI4RST))
+#define __HAL_RCC_TIM9_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM9RST))
+#define __HAL_RCC_TIM10_RELEASE_RESET()  (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM10RST))
+#define __HAL_RCC_TIM11_RELEASE_RESET()  (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM11RST))
+#define __HAL_RCC_SPI5_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI5RST))
+#define __HAL_RCC_SPI6_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI6RST))
+#define __HAL_RCC_SAI1_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SAI1RST))
+#define __HAL_RCC_SAI2_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SAI2RST))
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define __HAL_RCC_LTDC_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_LTDCRST))
+#endif /* STM32F756xx || STM32F746xx */
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_Peripheral_Clock_Sleep_Enable_Disable RCCEx Peripheral Clock Sleep Enable Disable
+  * @brief  Enables or disables the AHB/APB peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+
+/** @brief  Enable or disable the AHB1 peripheral clock during Low Power (Sleep) mode.
+  */
+#define __HAL_RCC_FLITF_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_FLITFLPEN))
+#define __HAL_RCC_AXI_CLK_SLEEP_ENABLE()        (RCC->AHB1LPENR |= (RCC_AHB1LPENR_AXILPEN))
+#define __HAL_RCC_SRAM1_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_SRAM1LPEN))
+#define __HAL_RCC_SRAM2_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_SRAM2LPEN))
+#define __HAL_RCC_BKPSRAM_CLK_SLEEP_ENABLE()    (RCC->AHB1LPENR |= (RCC_AHB1LPENR_BKPSRAMLPEN))
+#define __HAL_RCC_DTCM_CLK_SLEEP_ENABLE()       (RCC->AHB1LPENR |= (RCC_AHB1LPENR_DTCMLPEN))
+#define __HAL_RCC_DMA2_CLK_SLEEP_ENABLE()       (RCC->AHB1LPENR |= (RCC_AHB1LPENR_DMA2LPEN))
+#define __HAL_RCC_DMA2D_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_DMA2DLPEN))
+#define __HAL_RCC_ETHMAC_CLK_SLEEP_ENABLE()     (RCC->AHB1LPENR |= (RCC_AHB1LPENR_ETHMACLPEN))
+#define __HAL_RCC_ETHMACTX_CLK_SLEEP_ENABLE()   (RCC->AHB1LPENR |= (RCC_AHB1LPENR_ETHMACTXLPEN))
+#define __HAL_RCC_ETHMACRX_CLK_SLEEP_ENABLE()   (RCC->AHB1LPENR |= (RCC_AHB1LPENR_ETHMACRXLPEN))
+#define __HAL_RCC_ETHMACPTP_CLK_SLEEP_ENABLE()  (RCC->AHB1LPENR |= (RCC_AHB1LPENR_ETHMACPTPLPEN))
+#define __HAL_RCC_USB_OTG_HS_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_OTGHSLPEN))
+#define __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_ENABLE() (RCC->AHB1LPENR |= (RCC_AHB1LPENR_OTGHSULPILPEN))
+#define __HAL_RCC_GPIOA_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOALPEN))
+#define __HAL_RCC_GPIOB_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOBLPEN))
+#define __HAL_RCC_GPIOC_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOCLPEN))
+#define __HAL_RCC_GPIOD_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIODLPEN))
+#define __HAL_RCC_GPIOE_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOELPEN))
+#define __HAL_RCC_GPIOF_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOFLPEN))
+#define __HAL_RCC_GPIOG_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOGLPEN))
+#define __HAL_RCC_GPIOH_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOHLPEN))
+#define __HAL_RCC_GPIOI_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOILPEN))
+#define __HAL_RCC_GPIOJ_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOJLPEN))
+#define __HAL_RCC_GPIOK_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOKLPEN))
+
+#define __HAL_RCC_FLITF_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_FLITFLPEN))
+#define __HAL_RCC_AXI_CLK_SLEEP_DISABLE()       (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_AXILPEN))
+#define __HAL_RCC_SRAM1_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_SRAM1LPEN))
+#define __HAL_RCC_SRAM2_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_SRAM2LPEN))
+#define __HAL_RCC_BKPSRAM_CLK_SLEEP_DISABLE()   (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_BKPSRAMLPEN))
+#define __HAL_RCC_DTCM_CLK_SLEEP_DISABLE()      (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_DTCMLPEN))
+#define __HAL_RCC_DMA2_CLK_SLEEP_DISABLE()      (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_DMA2LPEN))
+#define __HAL_RCC_DMA2D_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_DMA2DLPEN))
+#define __HAL_RCC_ETHMAC_CLK_SLEEP_DISABLE()    (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_ETHMACLPEN))
+#define __HAL_RCC_ETHMACTX_CLK_SLEEP_DISABLE()  (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_ETHMACTXLPEN))
+#define __HAL_RCC_ETHMACRX_CLK_SLEEP_DISABLE()  (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_ETHMACRXLPEN))
+#define __HAL_RCC_ETHMACPTP_CLK_SLEEP_DISABLE() (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_ETHMACPTPLPEN))
+#define __HAL_RCC_USB_OTG_HS_CLK_SLEEP_DISABLE()      (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_OTGHSLPEN))
+#define __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_DISABLE() (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_OTGHSULPILPEN))
+#define __HAL_RCC_GPIOA_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOALPEN))
+#define __HAL_RCC_GPIOB_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOBLPEN))
+#define __HAL_RCC_GPIOC_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOCLPEN))
+#define __HAL_RCC_GPIOD_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIODLPEN))
+#define __HAL_RCC_GPIOE_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOELPEN))
+#define __HAL_RCC_GPIOF_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOFLPEN))
+#define __HAL_RCC_GPIOG_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOGLPEN))
+#define __HAL_RCC_GPIOH_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOHLPEN))
+#define __HAL_RCC_GPIOI_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOILPEN))
+#define __HAL_RCC_GPIOJ_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOJLPEN))
+#define __HAL_RCC_GPIOK_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOKLPEN))
+
+/** @brief  Enable or disable the AHB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __HAL_RCC_DCMI_CLK_SLEEP_ENABLE()        (RCC->AHB2LPENR |= (RCC_AHB2LPENR_DCMILPEN))
+#define __HAL_RCC_DCMI_CLK_SLEEP_DISABLE()       (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_DCMILPEN))
+
+#define __HAL_RCC_RNG_CLK_SLEEP_ENABLE()         (RCC->AHB2LPENR |= (RCC_AHB2LPENR_RNGLPEN))
+#define __HAL_RCC_RNG_CLK_SLEEP_DISABLE()        (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_RNGLPEN))
+
+#define __HAL_RCC_USB_OTG_FS_CLK_SLEEP_ENABLE()  (RCC->AHB2LPENR |= (RCC_AHB2LPENR_OTGFSLPEN))
+#define __HAL_RCC_USB_OTG_FS_CLK_SLEEP_DISABLE() (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_OTGFSLPEN))
+
+#if defined(STM32F756xx)
+#define __HAL_RCC_CRYP_CLK_SLEEP_ENABLE()        (RCC->AHB2LPENR |= (RCC_AHB2LPENR_CRYPLPEN))
+#define __HAL_RCC_HASH_CLK_SLEEP_ENABLE()        (RCC->AHB2LPENR |= (RCC_AHB2LPENR_HASHLPEN))
+
+#define __HAL_RCC_CRYP_CLK_SLEEP_DISABLE()       (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_CRYPLPEN))
+#define __HAL_RCC_HASH_CLK_SLEEP_DISABLE()       (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_HASHLPEN))
+#endif /* STM32F756xx */
+
+/** @brief  Enable or disable the AHB3 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __HAL_RCC_FMC_CLK_SLEEP_ENABLE()  (RCC->AHB3LPENR |= (RCC_AHB3LPENR_FMCLPEN))
+#define __HAL_RCC_FMC_CLK_SLEEP_DISABLE() (RCC->AHB3LPENR &= ~(RCC_AHB3LPENR_FMCLPEN))
+
+#define __HAL_RCC_QSPI_CLK_SLEEP_ENABLE()  (RCC->AHB3LPENR |= (RCC_AHB3LPENR_QSPILPEN))
+#define __HAL_RCC_QSPI_CLK_SLEEP_DISABLE() (RCC->AHB3LPENR &= ~(RCC_AHB3LPENR_QSPILPEN))
+
+/** @brief  Enable or disable the APB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __HAL_RCC_TIM2_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM2LPEN))
+#define __HAL_RCC_TIM3_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM3LPEN))
+#define __HAL_RCC_TIM4_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM4LPEN))
+#define __HAL_RCC_TIM5_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM5LPEN))
+#define __HAL_RCC_TIM6_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM6LPEN))
+#define __HAL_RCC_TIM7_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM7LPEN))
+#define __HAL_RCC_TIM12_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM12LPEN))
+#define __HAL_RCC_TIM13_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM13LPEN))
+#define __HAL_RCC_TIM14_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM14LPEN))
+#define __HAL_RCC_LPTIM1_CLK_SLEEP_ENABLE()  (RCC->APB1LPENR |= (RCC_APB1LPENR_LPTIM1LPEN))
+#define __HAL_RCC_SPI2_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_SPI2LPEN))
+#define __HAL_RCC_SPI3_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_SPI3LPEN))
+#define __HAL_RCC_SPDIFRX_CLK_SLEEP_ENABLE() (RCC->APB1LPENR |= (RCC_APB1LPENR_SPDIFRXLPEN))
+#define __HAL_RCC_USART2_CLK_SLEEP_ENABLE()  (RCC->APB1LPENR |= (RCC_APB1LPENR_USART2LPEN))
+#define __HAL_RCC_USART3_CLK_SLEEP_ENABLE()  (RCC->APB1LPENR |= (RCC_APB1LPENR_USART3LPEN))
+#define __HAL_RCC_UART4_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_UART4LPEN))
+#define __HAL_RCC_UART5_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_UART5LPEN))
+#define __HAL_RCC_I2C1_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_I2C1LPEN))
+#define __HAL_RCC_I2C2_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_I2C2LPEN))
+#define __HAL_RCC_I2C3_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_I2C3LPEN))
+#define __HAL_RCC_I2C4_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_I2C4LPEN))
+#define __HAL_RCC_CAN1_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_CAN1LPEN))
+#define __HAL_RCC_CAN2_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_CAN2LPEN))
+#define __HAL_RCC_CEC_CLK_SLEEP_ENABLE()     (RCC->APB1LPENR |= (RCC_APB1LPENR_CECLPEN))
+#define __HAL_RCC_DAC_CLK_SLEEP_ENABLE()     (RCC->APB1LPENR |= (RCC_APB1LPENR_DACLPEN))
+#define __HAL_RCC_UART7_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_UART7LPEN))
+#define __HAL_RCC_UART8_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_UART8LPEN))
+
+#define __HAL_RCC_TIM2_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM2LPEN))
+#define __HAL_RCC_TIM3_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM3LPEN))
+#define __HAL_RCC_TIM4_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM4LPEN))
+#define __HAL_RCC_TIM5_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM5LPEN))
+#define __HAL_RCC_TIM6_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM6LPEN))
+#define __HAL_RCC_TIM7_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM7LPEN))
+#define __HAL_RCC_TIM12_CLK_SLEEP_DISABLE()  (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM12LPEN))
+#define __HAL_RCC_TIM13_CLK_SLEEP_DISABLE()  (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM13LPEN))
+#define __HAL_RCC_TIM14_CLK_SLEEP_DISABLE()  (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM14LPEN))
+#define __HAL_RCC_LPTIM1_CLK_SLEEP_DISABLE() (RCC->APB1LPENR &= ~(RCC_APB1LPENR_LPTIM1LPEN))
+#define __HAL_RCC_SPI2_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_SPI2LPEN))
+#define __HAL_RCC_SPI3_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_SPI3LPEN))
+#define __HAL_RCC_SPDIFRX_CLK_SLEEP_DISABLE()(RCC->APB1LPENR &= ~(RCC_APB1LPENR_SPDIFRXLPEN))
+#define __HAL_RCC_USART2_CLK_SLEEP_DISABLE() (RCC->APB1LPENR &= ~(RCC_APB1LPENR_USART2LPEN))
+#define __HAL_RCC_USART3_CLK_SLEEP_DISABLE() (RCC->APB1LPENR &= ~(RCC_APB1LPENR_USART3LPEN))
+#define __HAL_RCC_UART4_CLK_SLEEP_DISABLE()  (RCC->APB1LPENR &= ~(RCC_APB1LPENR_UART4LPEN))
+#define __HAL_RCC_UART5_CLK_SLEEP_DISABLE()  (RCC->APB1LPENR &= ~(RCC_APB1LPENR_UART5LPEN))
+#define __HAL_RCC_I2C1_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_I2C1LPEN))
+#define __HAL_RCC_I2C2_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_I2C2LPEN))
+#define __HAL_RCC_I2C3_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_I2C3LPEN))
+#define __HAL_RCC_I2C4_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_I2C4LPEN))
+#define __HAL_RCC_CAN1_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_CAN1LPEN))
+#define __HAL_RCC_CAN2_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_CAN2LPEN))
+#define __HAL_RCC_CEC_CLK_SLEEP_DISABLE()    (RCC->APB1LPENR &= ~(RCC_APB1LPENR_CECLPEN))
+#define __HAL_RCC_DAC_CLK_SLEEP_DISABLE()    (RCC->APB1LPENR &= ~(RCC_APB1LPENR_DACLPEN))
+#define __HAL_RCC_UART7_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_UART7LPEN))
+#define __HAL_RCC_UART8_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_UART8LPEN))
+
+/** @brief  Enable or disable the APB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __HAL_RCC_TIM1_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_TIM1LPEN))
+#define __HAL_RCC_TIM8_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_TIM8LPEN))
+#define __HAL_RCC_USART1_CLK_SLEEP_ENABLE()  (RCC->APB2LPENR |= (RCC_APB2LPENR_USART1LPEN))
+#define __HAL_RCC_USART6_CLK_SLEEP_ENABLE()  (RCC->APB2LPENR |= (RCC_APB2LPENR_USART6LPEN))
+#define __HAL_RCC_ADC1_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_ADC1LPEN))
+#define __HAL_RCC_ADC2_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_ADC2LPEN))
+#define __HAL_RCC_ADC3_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_ADC3LPEN))
+#define __HAL_RCC_SDMMC1_CLK_SLEEP_ENABLE()  (RCC->APB2LPENR |= (RCC_APB2LPENR_SDMMC1LPEN))
+#define __HAL_RCC_SPI1_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_SPI1LPEN))
+#define __HAL_RCC_SPI4_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_SPI4LPEN))
+#define __HAL_RCC_TIM9_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_TIM9LPEN))
+#define __HAL_RCC_TIM10_CLK_SLEEP_ENABLE()   (RCC->APB2LPENR |= (RCC_APB2LPENR_TIM10LPEN))
+#define __HAL_RCC_TIM11_CLK_SLEEP_ENABLE()   (RCC->APB2LPENR |= (RCC_APB2LPENR_TIM11LPEN))
+#define __HAL_RCC_SPI5_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_SPI5LPEN))
+#define __HAL_RCC_SPI6_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_SPI6LPEN))
+#define __HAL_RCC_SAI1_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_SAI1LPEN))
+#define __HAL_RCC_SAI2_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_SAI2LPEN))
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define __HAL_RCC_LTDC_CLK_SLEEP_ENABLE()    (RCC->APB2LPENR |= (RCC_APB2LPENR_LTDCLPEN))
+#endif /* STM32F756xx || STM32F746xx */
+
+#define __HAL_RCC_TIM1_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_TIM1LPEN))
+#define __HAL_RCC_TIM8_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_TIM8LPEN))
+#define __HAL_RCC_USART1_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_USART1LPEN))
+#define __HAL_RCC_USART6_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_USART6LPEN))
+#define __HAL_RCC_ADC1_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_ADC1LPEN))
+#define __HAL_RCC_ADC2_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_ADC2LPEN))
+#define __HAL_RCC_ADC3_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_ADC3LPEN))
+#define __HAL_RCC_SDMMC1_CLK_SLEEP_DISABLE()  (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SDMMC1LPEN))
+#define __HAL_RCC_SPI1_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SPI1LPEN))
+#define __HAL_RCC_SPI4_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SPI4LPEN))
+#define __HAL_RCC_TIM9_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_TIM9LPEN))
+#define __HAL_RCC_TIM10_CLK_SLEEP_DISABLE()  (RCC->APB2LPENR &= ~(RCC_APB2LPENR_TIM10LPEN))
+#define __HAL_RCC_TIM11_CLK_SLEEP_DISABLE()  (RCC->APB2LPENR &= ~(RCC_APB2LPENR_TIM11LPEN))
+#define __HAL_RCC_SPI5_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SPI5LPEN))
+#define __HAL_RCC_SPI6_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SPI6LPEN))
+#define __HAL_RCC_SAI1_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SAI1LPEN))
+#define __HAL_RCC_SAI2_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SAI2LPEN))
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define __HAL_RCC_LTDC_CLK_SLEEP_DISABLE()   (RCC->APB2LPENR &= ~(RCC_APB2LPENR_LTDCLPEN))
+#endif /* STM32F756xx || STM32F746xx */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Clock_Sleep_Enable_Disable_Status AHB/APB Peripheral Clock Sleep Enable Disable Status
+  * @brief  Get the enable or disable status of the AHB/APB peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+
+/** @brief  Get the enable or disable status of the AHB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __HAL_RCC_FLITF_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_FLITFLPEN)) != RESET)
+#define __HAL_RCC_AXI_IS_CLK_SLEEP_ENABLED()        ((RCC->AHB1LPENR & (RCC_AHB1LPENR_AXILPEN)) != RESET)
+#define __HAL_RCC_SRAM1_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_SRAM1LPEN)) != RESET)
+#define __HAL_RCC_SRAM2_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_SRAM2LPEN)) != RESET)
+#define __HAL_RCC_BKPSRAM_IS_CLK_SLEEP_ENABLED()    ((RCC->AHB1LPENR & (RCC_AHB1LPENR_BKPSRAMLPEN)) != RESET)
+#define __HAL_RCC_DTCM_IS_CLK_SLEEP_ENABLED()       ((RCC->AHB1LPENR & (RCC_AHB1LPENR_DTCMLPEN)) != RESET)
+#define __HAL_RCC_DMA2_IS_CLK_SLEEP_ENABLED()       ((RCC->AHB1LPENR & (RCC_AHB1LPENR_DMA2LPEN)) != RESET)
+#define __HAL_RCC_DMA2D_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_DMA2DLPEN)) != RESET)
+#define __HAL_RCC_ETHMAC_IS_CLK_SLEEP_ENABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_ETHMACLPEN)) != RESET)
+#define __HAL_RCC_ETHMACTX_IS_CLK_SLEEP_ENABLED()   ((RCC->AHB1LPENR & (RCC_AHB1LPENR_ETHMACTXLPEN)) != RESET)
+#define __HAL_RCC_ETHMACRX_IS_CLK_SLEEP_ENABLED()   ((RCC->AHB1LPENR & (RCC_AHB1LPENR_ETHMACRXLPEN)) != RESET)
+#define __HAL_RCC_ETHMACPTP_IS_CLK_SLEEP_ENABLED()  ((RCC->AHB1LPENR & (RCC_AHB1LPENR_ETHMACPTPLPEN)) != RESET)
+#define __HAL_RCC_USB_OTG_HS_IS_CLK_SLEEP_ENABLED() ((RCC->AHB1LPENR & (RCC_AHB1LPENR_OTGHSLPEN)) != RESET)
+#define __HAL_RCC_USB_OTG_HS_ULPI_IS_CLK_SLEEP_ENABLED() ((RCC->AHB1LPENR & (RCC_AHB1LPENR_OTGHSULPILPEN)) != RESET)
+#define __HAL_RCC_GPIOA_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOALPEN)) != RESET)
+#define __HAL_RCC_GPIOB_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOBLPEN)) != RESET)
+#define __HAL_RCC_GPIOC_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOCLPEN)) != RESET)
+#define __HAL_RCC_GPIOD_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIODLPEN)) != RESET)
+#define __HAL_RCC_GPIOE_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOELPEN)) != RESET)
+#define __HAL_RCC_GPIOF_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOFLPEN)) != RESET)
+#define __HAL_RCC_GPIOG_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOGLPEN)) != RESET)
+#define __HAL_RCC_GPIOH_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOHLPEN)) != RESET)
+#define __HAL_RCC_GPIOI_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOILPEN)) != RESET)
+#define __HAL_RCC_GPIOJ_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOJLPEN)) != RESET)
+#define __HAL_RCC_GPIOK_IS_CLK_SLEEP_ENABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOKLPEN)) != RESET)
+
+#define __HAL_RCC_FLITF_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_FLITFLPEN)) == RESET)
+#define __HAL_RCC_AXI_IS_CLK_SLEEP_DISABLED()       ((RCC->AHB1LPENR & (RCC_AHB1LPENR_AXILPEN)) == RESET)
+#define __HAL_RCC_SRAM1_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_SRAM1LPEN)) == RESET)
+#define __HAL_RCC_SRAM2_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_SRAM2LPEN)) == RESET)
+#define __HAL_RCC_BKPSRAM_IS_CLK_SLEEP_DISABLED()   ((RCC->AHB1LPENR & (RCC_AHB1LPENR_BKPSRAMLPEN)) == RESET)
+#define __HAL_RCC_DTCM_IS_CLK_SLEEP_DISABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_DTCMLPEN)) == RESET)
+#define __HAL_RCC_DMA2_IS_CLK_SLEEP_DISABLED()      ((RCC->AHB1LPENR & (RCC_AHB1LPENR_DMA2LPEN)) == RESET)
+#define __HAL_RCC_DMA2D_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_DMA2DLPEN)) == RESET)
+#define __HAL_RCC_ETHMAC_IS_CLK_SLEEP_DISABLED()    ((RCC->AHB1LPENR & (RCC_AHB1LPENR_ETHMACLPEN)) == RESET)
+#define __HAL_RCC_ETHMACTX_IS_CLK_SLEEP_DISABLED()  ((RCC->AHB1LPENR & (RCC_AHB1LPENR_ETHMACTXLPEN)) == RESET)
+#define __HAL_RCC_ETHMACRX_IS_CLK_SLEEP_DISABLED()  ((RCC->AHB1LPENR & (RCC_AHB1LPENR_ETHMACRXLPEN)) == RESET)
+#define __HAL_RCC_ETHMACPTP_IS_CLK_SLEEP_DISABLED() ((RCC->AHB1LPENR & (RCC_AHB1LPENR_ETHMACPTPLPEN)) == RESET)
+#define __HAL_RCC_USB_OTG_HS_IS_CLK_SLEEP_DISABLED() ((RCC->AHB1LPENR & (RCC_AHB1LPENR_OTGHSLPEN)) == RESET)
+#define __HAL_RCC_USB_OTG_HS_ULPI_IS_CLK_SLEEP_DISABLED() ((RCC->AHB1LPENR & (RCC_AHB1LPENR_OTGHSULPILPEN)) == RESET)
+#define __HAL_RCC_GPIOA_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOALPEN)) == RESET)
+#define __HAL_RCC_GPIOB_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOBLPEN)) == RESET)
+#define __HAL_RCC_GPIOC_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOCLPEN)) == RESET)
+#define __HAL_RCC_GPIOD_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIODLPEN)) == RESET)
+#define __HAL_RCC_GPIOE_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOELPEN)) == RESET)
+#define __HAL_RCC_GPIOF_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOFLPEN)) == RESET)
+#define __HAL_RCC_GPIOG_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOGLPEN)) == RESET)
+#define __HAL_RCC_GPIOH_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOHLPEN)) == RESET)
+#define __HAL_RCC_GPIOI_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOILPEN)) == RESET)
+#define __HAL_RCC_GPIOJ_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOJLPEN)) == RESET)
+#define __HAL_RCC_GPIOK_IS_CLK_SLEEP_DISABLED()     ((RCC->AHB1LPENR & (RCC_AHB1LPENR_GPIOKLPEN)) == RESET)
+
+/** @brief  Get the enable or disable status of the AHB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __HAL_RCC_DCMI_IS_CLK_SLEEP_ENABLED()        ((RCC->AHB2LPENR & (RCC_AHB2LPENR_DCMILPEN)) != RESET)
+#define __HAL_RCC_DCMI_IS_CLK_SLEEP_DISABLED()       ((RCC->AHB2LPENR & (RCC_AHB2LPENR_DCMILPEN)) == RESET)
+
+#define __HAL_RCC_RNG_IS_CLK_SLEEP_ENABLED()         ((RCC->AHB2LPENR & (RCC_AHB2LPENR_RNGLPEN)) != RESET)
+#define __HAL_RCC_RNG_IS_CLK_SLEEP_DISABLED()        ((RCC->AHB2LPENR & (RCC_AHB2LPENR_RNGLPEN)) == RESET)
+
+#define __HAL_RCC_USB_OTG_FS_IS_CLK_SLEEP_ENABLED()  ((RCC->AHB2LPENR & (RCC_AHB2LPENR_OTGFSLPEN)) != RESET)
+#define __HAL_RCC_USB_OTG_FS_IS_CLK_SLEEP_DISABLED() ((RCC->AHB2LPENR & (RCC_AHB2LPENR_OTGFSLPEN)) == RESET)
+
+#if defined(STM32F756xx)
+#define __HAL_RCC_CRYP_IS_CLK_SLEEP_ENABLED()        ((RCC->AHB2LPENR & (RCC_AHB2LPENR_CRYPLPEN)) != RESET)
+#define __HAL_RCC_HASH_IS_CLK_SLEEP_ENABLED()        ((RCC->AHB2LPENR & (RCC_AHB2LPENR_HASHLPEN)) != RESET)
+
+#define __HAL_RCC_CRYP_IS_CLK_SLEEP_DISABLED()       ((RCC->AHB2LPENR & (RCC_AHB2LPENR_CRYPLPEN)) == RESET)
+#define __HAL_RCC_HASH_IS_CLK_SLEEP_DISABLED()       ((RCC->AHB2LPENR & (RCC_AHB2LPENR_HASHLPEN)) == RESET)
+#endif /* STM32F756xx */
+
+/** @brief  Get the enable or disable status of the AHB3 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __HAL_RCC_FMC_IS_CLK_SLEEP_ENABLED()  ((RCC->AHB3LPENR & (RCC_AHB3LPENR_FMCLPEN)) != RESET)
+#define __HAL_RCC_FMC_IS_CLK_SLEEP_DISABLED() ((RCC->AHB3LPENR & (RCC_AHB3LPENR_FMCLPEN)) == RESET)
+
+#define __HAL_RCC_QSPI_IS_CLK_SLEEP_ENABLED()  ((RCC->AHB3LPENR & (RCC_AHB3LPENR_QSPILPEN)) != RESET)
+#define __HAL_RCC_QSPI_IS_CLK_SLEEP_DISABLED() ((RCC->AHB3LPENR & (RCC_AHB3LPENR_QSPILPEN)) == RESET)
+
+/** @brief  Get the enable or disable status of the APB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __HAL_RCC_TIM2_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM2LPEN)) != RESET)
+#define __HAL_RCC_TIM3_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM3LPEN)) != RESET)
+#define __HAL_RCC_TIM4_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM4LPEN)) != RESET)
+#define __HAL_RCC_TIM5_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM5LPEN)) != RESET)
+#define __HAL_RCC_TIM6_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM6LPEN)) != RESET)
+#define __HAL_RCC_TIM7_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM7LPEN)) != RESET)
+#define __HAL_RCC_TIM12_IS_CLK_SLEEP_ENABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM12LPEN)) != RESET)
+#define __HAL_RCC_TIM13_IS_CLK_SLEEP_ENABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM13LPEN)) != RESET)
+#define __HAL_RCC_TIM14_IS_CLK_SLEEP_ENABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM14LPEN)) != RESET)
+#define __HAL_RCC_LPTIM1_IS_CLK_SLEEP_ENABLED()  ((RCC->APB1LPENR & (RCC_APB1LPENR_LPTIM1LPEN)) != RESET)
+#define __HAL_RCC_SPI2_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_SPI2LPEN)) != RESET)
+#define __HAL_RCC_SPI3_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_SPI3LPEN)) != RESET)
+#define __HAL_RCC_SPDIFRX_IS_CLK_SLEEP_ENABLED() ((RCC->APB1LPENR & (RCC_APB1LPENR_SPDIFRXLPEN)) != RESET)
+#define __HAL_RCC_USART2_IS_CLK_SLEEP_ENABLED()  ((RCC->APB1LPENR & (RCC_APB1LPENR_USART2LPEN)) != RESET)
+#define __HAL_RCC_USART3_IS_CLK_SLEEP_ENABLED()  ((RCC->APB1LPENR & (RCC_APB1LPENR_USART3LPEN)) != RESET)
+#define __HAL_RCC_UART4_IS_CLK_SLEEP_ENABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_UART4LPEN)) != RESET)
+#define __HAL_RCC_UART5_IS_CLK_SLEEP_ENABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_UART5LPEN)) != RESET)
+#define __HAL_RCC_I2C1_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_I2C1LPEN)) != RESET)
+#define __HAL_RCC_I2C2_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_I2C2LPEN)) != RESET)
+#define __HAL_RCC_I2C3_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_I2C3LPEN)) != RESET)
+#define __HAL_RCC_I2C4_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_I2C4LPEN)) != RESET)
+#define __HAL_RCC_CAN1_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_CAN1LPEN)) != RESET)
+#define __HAL_RCC_CAN2_IS_CLK_SLEEP_ENABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_CAN2LPEN)) != RESET)
+#define __HAL_RCC_CEC_IS_CLK_SLEEP_ENABLED()     ((RCC->APB1LPENR & (RCC_APB1LPENR_CECLPEN)) != RESET)
+#define __HAL_RCC_DAC_IS_CLK_SLEEP_ENABLED()     ((RCC->APB1LPENR & (RCC_APB1LPENR_DACLPEN)) != RESET)
+#define __HAL_RCC_UART7_IS_CLK_SLEEP_ENABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_UART7LPEN)) != RESET)
+#define __HAL_RCC_UART8_IS_CLK_SLEEP_ENABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_UART8LPEN)) != RESET)
+
+#define __HAL_RCC_TIM2_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM2LPEN)) == RESET)
+#define __HAL_RCC_TIM3_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM3LPEN)) == RESET)
+#define __HAL_RCC_TIM4_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM4LPEN)) == RESET)
+#define __HAL_RCC_TIM5_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM5LPEN)) == RESET)
+#define __HAL_RCC_TIM6_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM6LPEN)) == RESET)
+#define __HAL_RCC_TIM7_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM7LPEN)) == RESET)
+#define __HAL_RCC_TIM12_IS_CLK_SLEEP_DISABLED()  ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM12LPEN)) == RESET)
+#define __HAL_RCC_TIM13_IS_CLK_SLEEP_DISABLED()  ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM13LPEN)) == RESET)
+#define __HAL_RCC_TIM14_IS_CLK_SLEEP_DISABLED()  ((RCC->APB1LPENR & (RCC_APB1LPENR_TIM14LPEN)) == RESET)
+#define __HAL_RCC_LPTIM1_IS_CLK_SLEEP_DISABLED() ((RCC->APB1LPENR & (RCC_APB1LPENR_LPTIM1LPEN)) == RESET)
+#define __HAL_RCC_SPI2_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_SPI2LPEN)) == RESET)
+#define __HAL_RCC_SPI3_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_SPI3LPEN)) == RESET)
+#define __HAL_RCC_SPDIFRX_IS_CLK_SLEEP_DISABLED()((RCC->APB1LPENR & (RCC_APB1LPENR_SPDIFRXLPEN)) == RESET)
+#define __HAL_RCC_USART2_IS_CLK_SLEEP_DISABLED() ((RCC->APB1LPENR & (RCC_APB1LPENR_USART2LPEN)) == RESET)
+#define __HAL_RCC_USART3_IS_CLK_SLEEP_DISABLED() ((RCC->APB1LPENR & (RCC_APB1LPENR_USART3LPEN)) == RESET)
+#define __HAL_RCC_UART4_IS_CLK_SLEEP_DISABLED()  ((RCC->APB1LPENR & (RCC_APB1LPENR_UART4LPEN)) == RESET)
+#define __HAL_RCC_UART5_IS_CLK_SLEEP_DISABLED()  ((RCC->APB1LPENR & (RCC_APB1LPENR_UART5LPEN)) == RESET)
+#define __HAL_RCC_I2C1_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_I2C1LPEN)) == RESET)
+#define __HAL_RCC_I2C2_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_I2C2LPEN)) == RESET)
+#define __HAL_RCC_I2C3_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_I2C3LPEN)) == RESET)
+#define __HAL_RCC_I2C4_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_I2C4LPEN)) == RESET)
+#define __HAL_RCC_CAN1_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_CAN1LPEN)) == RESET)
+#define __HAL_RCC_CAN2_IS_CLK_SLEEP_DISABLED()   ((RCC->APB1LPENR & (RCC_APB1LPENR_CAN2LPEN)) == RESET)
+#define __HAL_RCC_CEC_IS_CLK_SLEEP_DISABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_CECLPEN)) == RESET)
+#define __HAL_RCC_DAC_IS_CLK_SLEEP_DISABLED()    ((RCC->APB1LPENR & (RCC_APB1LPENR_DACLPEN)) == RESET)
+#define __HAL_RCC_UART7_IS_CLK_SLEEP_DISABLED()  ((RCC->APB1LPENR & (RCC_APB1LPENR_UART7LPEN)) == RESET)
+#define __HAL_RCC_UART8_IS_CLK_SLEEP_DISABLED()  ((RCC->APB1LPENR & (RCC_APB1LPENR_UART8LPEN)) == RESET)
+
+/** @brief  Get the enable or disable status of the APB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __HAL_RCC_TIM1_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_TIM1LPEN)) != RESET)
+#define __HAL_RCC_TIM8_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_TIM8LPEN)) != RESET)
+#define __HAL_RCC_USART1_IS_CLK_SLEEP_ENABLED()  ((RCC->APB2LPENR & (RCC_APB2LPENR_USART1LPEN)) != RESET)
+#define __HAL_RCC_USART6_IS_CLK_SLEEP_ENABLED()  ((RCC->APB2LPENR & (RCC_APB2LPENR_USART6LPEN)) != RESET)
+#define __HAL_RCC_ADC1_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_ADC1LPEN)) != RESET)
+#define __HAL_RCC_ADC2_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_ADC2LPEN)) != RESET)
+#define __HAL_RCC_ADC3_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_ADC3LPEN)) != RESET)
+#define __HAL_RCC_SDMMC1_IS_CLK_SLEEP_ENABLED()  ((RCC->APB2LPENR & (RCC_APB2LPENR_SDMMC1LPEN)) != RESET)
+#define __HAL_RCC_SPI1_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_SPI1LPEN)) != RESET)
+#define __HAL_RCC_SPI4_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_SPI4LPEN)) != RESET)
+#define __HAL_RCC_TIM9_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_TIM9LPEN)) != RESET)
+#define __HAL_RCC_TIM10_IS_CLK_SLEEP_ENABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_TIM10LPEN)) != RESET)
+#define __HAL_RCC_TIM11_IS_CLK_SLEEP_ENABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_TIM11LPEN)) != RESET)
+#define __HAL_RCC_SPI5_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_SPI5LPEN)) != RESET)
+#define __HAL_RCC_SPI6_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_SPI6LPEN)) != RESET)
+#define __HAL_RCC_SAI1_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_SAI1LPEN)) != RESET)
+#define __HAL_RCC_SAI2_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_SAI2LPEN)) != RESET)
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define __HAL_RCC_LTDC_IS_CLK_SLEEP_ENABLED()    ((RCC->APB2LPENR & (RCC_APB2LPENR_LTDCLPEN)) != RESET)
+#endif /* STM32F756xx || STM32F746xx */
+
+#define __HAL_RCC_TIM1_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_TIM1LPEN)) == RESET)
+#define __HAL_RCC_TIM8_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_TIM8LPEN)) == RESET)
+#define __HAL_RCC_USART1_IS_CLK_SLEEP_DISABLED() ((RCC->APB2LPENR & (RCC_APB2LPENR_USART1LPEN)) == RESET)
+#define __HAL_RCC_USART6_IS_CLK_SLEEP_DISABLED() ((RCC->APB2LPENR & (RCC_APB2LPENR_USART6LPEN)) == RESET)
+#define __HAL_RCC_ADC1_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_ADC1LPEN)) == RESET)
+#define __HAL_RCC_ADC2_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_ADC2LPEN)) == RESET)
+#define __HAL_RCC_ADC3_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_ADC3LPEN)) == RESET)
+#define __HAL_RCC_SDMMC1_IS_CLK_SLEEP_DISABLED() ((RCC->APB2LPENR & (RCC_APB2LPENR_SDMMC1LPEN)) == RESET)
+#define __HAL_RCC_SPI1_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_SPI1LPEN)) == RESET)
+#define __HAL_RCC_SPI4_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_SPI4LPEN)) == RESET)
+#define __HAL_RCC_TIM9_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_TIM9LPEN)) == RESET)
+#define __HAL_RCC_TIM10_IS_CLK_SLEEP_DISABLED()  ((RCC->APB2LPENR & (RCC_APB2LPENR_TIM10LPEN)) == RESET)
+#define __HAL_RCC_TIM11_IS_CLK_SLEEP_DISABLED()  ((RCC->APB2LPENR & (RCC_APB2LPENR_TIM11LPEN)) == RESET)
+#define __HAL_RCC_SPI5_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_SPI5LPEN)) == RESET)
+#define __HAL_RCC_SPI6_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_SPI6LPEN)) == RESET)
+#define __HAL_RCC_SAI1_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_SAI1LPEN)) == RESET)
+#define __HAL_RCC_SAI2_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_SAI2LPEN)) == RESET)
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define __HAL_RCC_LTDC_IS_CLK_SLEEP_DISABLED()   ((RCC->APB2LPENR & (RCC_APB2LPENR_LTDCLPEN)) == RESET)
+#endif /* STM32F756xx || STM32F746xx */
+/**
+  * @}
+  */
+
+/*---------------------------------------------------------------------------------------------*/
+
+/** @brief  Macro to configure the Timers clocks prescalers
+  * @param  __PRESC__ : specifies the Timers clocks prescalers selection
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIMPRES_DESACTIVATED: The Timers kernels clocks prescaler is
+  *                 equal to HPRE if PPREx is corresponding to division by 1 or 2,
+  *                 else it is equal to [(HPRE * PPREx) / 2] if PPREx is corresponding to
+  *                 division by 4 or more.
+  *            @arg RCC_TIMPRES_ACTIVATED: The Timers kernels clocks prescaler is
+  *                 equal to HPRE if PPREx is corresponding to division by 1, 2 or 4,
+  *                 else it is equal to [(HPRE * PPREx) / 4] if PPREx is corresponding
+  *                 to division by 8 or more.
+  */
+#define __HAL_RCC_TIMCLKPRESCALER(__PRESC__) do {RCC->DCKCFGR1 &= ~(RCC_DCKCFGR1_TIMPRE);\
+                                             RCC->DCKCFGR1 |= (__PRESC__);\
+                                             }while(0)
+
+/** @brief Macros to Enable or Disable the PLLISAI.
+  * @note  The PLLSAI is disabled by hardware when entering STOP and STANDBY modes.
+  */
+#define __HAL_RCC_PLLSAI_ENABLE() (RCC->CR |= (RCC_CR_PLLSAION))
+#define __HAL_RCC_PLLSAI_DISABLE() (RCC->CR &= ~(RCC_CR_PLLSAION))
+
+/** @brief  Macro to configure the PLLSAI clock multiplication and division factors.
+  * @note   This function must be used only when the PLLSAI is disabled.
+  * @note   PLLSAI clock source is common with the main PLL (configured in
+  *         RCC_PLLConfig function )
+  * @param  __PLLSAIN__: specifies the multiplication factor for PLLSAI VCO output clock.
+  *         This parameter must be a number between Min_Data = 49 and Max_Data = 432.
+  * @note   You have to set the PLLSAIN parameter correctly to ensure that the VCO
+  *         output frequency is between Min_Data = 49 and Max_Data = 432 MHz.
+  * @param  __PLLSAIQ__: specifies the division factor for SAI clock
+  *         This parameter must be a number between Min_Data = 2 and Max_Data = 15.
+  * @param  __PLLSAIR__: specifies the division factor for LTDC clock
+  *         This parameter must be a number between Min_Data = 2 and Max_Data = 7.
+  * @param  __PLLSAIP__: specifies the division factor for USB, RNG, SDMMC clocks
+  *         This parameter can be a value of @ref RCCEx_PLLSAIP_Clock_Divider .
+  */
+#define __HAL_RCC_PLLSAI_CONFIG(__PLLSAIN__, __PLLSAIP__, __PLLSAIQ__, __PLLSAIR__) (RCC->PLLSAICFGR = ((__PLLSAIN__) << 6) | ((__PLLSAIP__) << 16) | ((__PLLSAIQ__) << 24) | ((__PLLSAIR__) << 28))
+
+/** @brief  Macro used by the SAI HAL driver to configure the PLLI2S clock multiplication and division factors.
+  * @note   This macro must be used only when the PLLI2S is disabled.
+  * @note   PLLI2S clock source is common with the main PLL (configured in
+  *         HAL_RCC_ClockConfig() API)
+  * @param  __PLLI2SN__: specifies the multiplication factor for PLLI2S VCO output clock.
+  *         This parameter must be a number between Min_Data = 192 and Max_Data = 432.
+  * @note   You have to set the PLLI2SN parameter correctly to ensure that the VCO
+  *         output frequency is between Min_Data = 192 and Max_Data = 432 MHz.
+  * @param  __PLLI2SQ__: specifies the division factor for SAI clock.
+  *         This parameter must be a number between Min_Data = 2 and Max_Data = 15.
+  * @param  __PLLI2SR__: specifies the division factor for I2S clock
+  *         This parameter must be a number between Min_Data = 2 and Max_Data = 7.
+  * @note   You have to set the PLLI2SR parameter correctly to not exceed 192 MHz
+  *         on the I2S clock frequency.
+  * @param  __PLLI2SP__: specifies the division factor for SPDDIF-RX clock.
+  *         This parameter can be a number between 0 and 3 for respective values 2, 4, 6 and 8
+  */
+#define __HAL_RCC_PLLI2S_CONFIG(__PLLI2SN__, __PLLI2SP__, __PLLI2SQ__, __PLLI2SR__) (RCC->PLLI2SCFGR = ((__PLLI2SN__) << 6) | ((__PLLI2SP__) << 16)  | ((__PLLI2SQ__) << 24) | ((__PLLI2SR__) << 28))
+
+/** @brief  Macro to configure the SAI clock Divider coming from PLLI2S.
+  * @note   This function must be called before enabling the PLLI2S.
+  * @param  __PLLI2SDivQ__: specifies the PLLI2S division factor for SAI1 clock .
+  *          This parameter must be a number between 1 and 32.
+  *          SAI1 clock frequency = f(PLLI2SQ) / __PLLI2SDivQ__
+  */
+#define __HAL_RCC_PLLI2S_PLLSAICLKDIVQ_CONFIG(__PLLI2SDivQ__) (MODIFY_REG(RCC->DCKCFGR1, RCC_DCKCFGR1_PLLI2SDIVQ, (__PLLI2SDivQ__)-1))
+
+/** @brief  Macro to configure the SAI clock Divider coming from PLLSAI.
+  * @note   This function must be called before enabling the PLLSAI.
+  * @param  __PLLSAIDivQ__: specifies the PLLSAI division factor for SAI1 clock .
+  *         This parameter must be a number between Min_Data = 1 and Max_Data = 32.
+  *         SAI1 clock frequency = f(PLLSAIQ) / __PLLSAIDivQ__
+  */
+#define __HAL_RCC_PLLSAI_PLLSAICLKDIVQ_CONFIG(__PLLSAIDivQ__) (MODIFY_REG(RCC->DCKCFGR1, RCC_DCKCFGR1_PLLSAIDIVQ, ((__PLLSAIDivQ__)-1)<<8))
+
+/** @brief  Macro to configure the LTDC clock Divider coming from PLLSAI.
+  *
+  * @note   This function must be called before enabling the PLLSAI.
+  * @param  __PLLSAIDivR__: specifies the PLLSAI division factor for LTDC clock .
+  *          This parameter must be a number between Min_Data = 2 and Max_Data = 16.
+  *          LTDC clock frequency = f(PLLSAIR) / __PLLSAIDivR__
+  */
+#define __HAL_RCC_PLLSAI_PLLSAICLKDIVR_CONFIG(__PLLSAIDivR__)\
+                            MODIFY_REG(RCC->DCKCFGR1, RCC_DCKCFGR1_PLLSAIDIVR, (uint32_t)(__PLLSAIDivR__))
+
+/** @brief  Macro to configure SAI1 clock source selection.
+  * @note   This function must be called before enabling PLLSAI, PLLI2S and
+  *         the SAI clock.
+  * @param  __SOURCE__: specifies the SAI1 clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_SAI1CLKSOURCE_PLLI2S: PLLI2S_Q clock divided by PLLI2SDIVQ used
+  *                                           as SAI1 clock.
+  *            @arg RCC_SAI1CLKSOURCE_PLLSAI: PLLISAI_Q clock divided by PLLSAIDIVQ used
+  *                                           as SAI1 clock.
+  *            @arg RCC_SAI1CLKSOURCE_PIN: External clock mapped on the I2S_CKIN pin
+  *                                        used as SAI1 clock.
+  */
+#define __HAL_RCC_SAI1_CONFIG(__SOURCE__)\
+                             MODIFY_REG(RCC->DCKCFGR1, RCC_DCKCFGR1_SAI1SEL, (uint32_t)(__SOURCE__))
+
+/** @brief  Macro to get the SAI1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_SAI1CLKSOURCE_PLLI2S: PLLI2S_Q clock divided by PLLI2SDIVQ used
+  *                                           as SAI1 clock.
+  *            @arg RCC_SAI1CLKSOURCE_PLLSAI: PLLISAI_Q clock divided by PLLSAIDIVQ used
+  *                                           as SAI1 clock.
+  *            @arg RCC_SAI1CLKSOURCE_PIN: External clock mapped on the I2S_CKIN pin
+  *                                        used as SAI1 clock.
+  */
+#define __HAL_RCC_GET_SAI1_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR1, RCC_DCKCFGR1_SAI1SEL)))
+
+
+/** @brief  Macro to configure SAI2 clock source selection.
+  * @note   This function must be called before enabling PLLSAI, PLLI2S and
+  *         the SAI clock.
+  * @param  __SOURCE__: specifies the SAI2 clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_SAI2CLKSOURCE_PLLI2S: PLLI2S_Q clock divided by PLLI2SDIVQ used
+  *                                           as SAI2 clock.
+  *            @arg RCC_SAI2CLKSOURCE_PLLSAI: PLLISAI_Q clock divided by PLLSAIDIVQ used
+  *                                           as SAI2 clock.
+  *            @arg RCC_SAI2CLKSOURCE_PIN: External clock mapped on the I2S_CKIN pin
+  *                                        used as SAI2 clock.
+  */
+#define __HAL_RCC_SAI2_CONFIG(__SOURCE__)\
+                            MODIFY_REG(RCC->DCKCFGR1, RCC_DCKCFGR1_SAI2SEL, (uint32_t)(__SOURCE__))
+
+
+/** @brief  Macro to get the SAI2 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_SAI2CLKSOURCE_PLLI2S: PLLI2S_Q clock divided by PLLI2SDIVQ used
+  *                                           as SAI2 clock.
+  *            @arg RCC_SAI2CLKSOURCE_PLLSAI: PLLISAI_Q clock divided by PLLSAIDIVQ used
+  *                                           as SAI2 clock.
+  *            @arg RCC_SAI2CLKSOURCE_PIN: External clock mapped on the I2S_CKIN pin
+  *                                        used as SAI2 clock.
+  */
+#define __HAL_RCC_GET_SAI2_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR1, RCC_DCKCFGR1_SAI2SEL)))
+
+
+/** @brief Enable PLLSAI_RDY interrupt.
+  */
+#define __HAL_RCC_PLLSAI_ENABLE_IT() (RCC->CIR |= (RCC_CIR_PLLSAIRDYIE))
+
+/** @brief Disable PLLSAI_RDY interrupt.
+  */
+#define __HAL_RCC_PLLSAI_DISABLE_IT() (RCC->CIR &= ~(RCC_CIR_PLLSAIRDYIE))
+
+/** @brief Clear the PLLSAI RDY interrupt pending bits.
+  */
+#define __HAL_RCC_PLLSAI_CLEAR_IT() (RCC->CIR |= (RCC_CIR_PLLSAIRDYF))
+
+/** @brief Check the PLLSAI RDY interrupt has occurred or not.
+  * @retval The new state (TRUE or FALSE).
+  */
+#define __HAL_RCC_PLLSAI_GET_IT() ((RCC->CIR & (RCC_CIR_PLLSAIRDYIE)) == (RCC_CIR_PLLSAIRDYIE))
+
+/** @brief  Check PLLSAI RDY flag is set or not.
+  * @retval The new state (TRUE or FALSE).
+  */
+#define __HAL_RCC_PLLSAI_GET_FLAG() ((RCC->CR & (RCC_CR_PLLSAIRDY)) == (RCC_CR_PLLSAIRDY))
+
+/** @brief  Macro to Get I2S clock source selection.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_I2SCLKSOURCE_PLLI2S: PLLI2S VCO output clock divided by PLLI2SR used as I2S clock.
+  *            @arg RCC_I2SCLKSOURCE_EXT: External clock mapped on the I2S_CKIN pin used as I2S clock source
+  */
+#define __HAL_RCC_GET_I2SCLKSOURCE() (READ_BIT(RCC->CFGR, RCC_CFGR_I2SSRC))
+
+/** @brief  Macro to configure the I2C1 clock (I2C1CLK).
+  *
+  * @param  __I2C1_CLKSOURCE__: specifies the I2C1 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_I2C1CLKSOURCE_PCLK1: PCLK1 selected as I2C1 clock
+  *            @arg RCC_I2C1CLKSOURCE_HSI: HSI selected as I2C1 clock
+  *            @arg RCC_I2C1CLKSOURCE_SYSCLK: System Clock selected as I2C1 clock
+  */
+#define __HAL_RCC_I2C1_CONFIG(__I2C1_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_I2C1SEL, (uint32_t)(__I2C1_CLKSOURCE__))
+
+/** @brief  Macro to get the I2C1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_I2C1CLKSOURCE_PCLK1: PCLK1 selected as I2C1 clock
+  *            @arg RCC_I2C1CLKSOURCE_HSI: HSI selected as I2C1 clock
+  *            @arg RCC_I2C1CLKSOURCE_SYSCLK: System Clock selected as I2C1 clock
+  */
+#define __HAL_RCC_GET_I2C1_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_I2C1SEL)))
+
+/** @brief  Macro to configure the I2C2 clock (I2C2CLK).
+  *
+  * @param  __I2C2_CLKSOURCE__: specifies the I2C2 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_I2C2CLKSOURCE_PCLK1: PCLK1 selected as I2C2 clock
+  *            @arg RCC_I2C2CLKSOURCE_HSI: HSI selected as I2C2 clock
+  *            @arg RCC_I2C2CLKSOURCE_SYSCLK: System Clock selected as I2C2 clock
+  */
+#define __HAL_RCC_I2C2_CONFIG(__I2C2_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_I2C2SEL, (uint32_t)(__I2C2_CLKSOURCE__))
+
+/** @brief  Macro to get the I2C2 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_I2C2CLKSOURCE_PCLK1: PCLK1 selected as I2C2 clock
+  *            @arg RCC_I2C2CLKSOURCE_HSI: HSI selected as I2C2 clock
+  *            @arg RCC_I2C2CLKSOURCE_SYSCLK: System Clock selected as I2C2 clock
+  */
+#define __HAL_RCC_GET_I2C2_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_I2C2SEL)))
+
+/** @brief  Macro to configure the I2C3 clock (I2C3CLK).
+  *
+  * @param  __I2C3_CLKSOURCE__: specifies the I2C3 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_I2C3CLKSOURCE_PCLK1: PCLK1 selected as I2C3 clock
+  *            @arg RCC_I2C3CLKSOURCE_HSI: HSI selected as I2C3 clock
+  *            @arg RCC_I2C3CLKSOURCE_SYSCLK: System Clock selected as I2C3 clock
+  */
+#define __HAL_RCC_I2C3_CONFIG(__I2C3_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_I2C3SEL, (uint32_t)(__I2C3_CLKSOURCE__))
+
+/** @brief  macro to get the I2C3 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_I2C3CLKSOURCE_PCLK1: PCLK1 selected as I2C3 clock
+  *            @arg RCC_I2C3CLKSOURCE_HSI: HSI selected as I2C3 clock
+  *            @arg RCC_I2C3CLKSOURCE_SYSCLK: System Clock selected as I2C3 clock
+  */
+#define __HAL_RCC_GET_I2C3_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_I2C3SEL)))
+
+/** @brief  Macro to configure the I2C4 clock (I2C4CLK).
+  *
+  * @param  __I2C4_CLKSOURCE__: specifies the I2C4 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_I2C4CLKSOURCE_PCLK1: PCLK1 selected as I2C4 clock
+  *            @arg RCC_I2C4CLKSOURCE_HSI: HSI selected as I2C4 clock
+  *            @arg RCC_I2C4CLKSOURCE_SYSCLK: System Clock selected as I2C4 clock
+  */
+#define __HAL_RCC_I2C4_CONFIG(__I2C4_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_I2C4SEL, (uint32_t)(__I2C4_CLKSOURCE__))
+
+/** @brief  macro to get the I2C4 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_I2C4CLKSOURCE_PCLK1: PCLK1 selected as I2C4 clock
+  *            @arg RCC_I2C4CLKSOURCE_HSI: HSI selected as I2C4 clock
+  *            @arg RCC_I2C4CLKSOURCE_SYSCLK: System Clock selected as I2C4 clock
+  */
+#define __HAL_RCC_GET_I2C4_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_I2C4SEL)))
+
+/** @brief  Macro to configure the USART1 clock (USART1CLK).
+  *
+  * @param  __USART1_CLKSOURCE__: specifies the USART1 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_USART1CLKSOURCE_PCLK2: PCLK2 selected as USART1 clock
+  *            @arg RCC_USART1CLKSOURCE_HSI: HSI selected as USART1 clock
+  *            @arg RCC_USART1CLKSOURCE_SYSCLK: System Clock selected as USART1 clock
+  *            @arg RCC_USART1CLKSOURCE_LSE: LSE selected as USART1 clock
+  */
+#define __HAL_RCC_USART1_CONFIG(__USART1_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_USART1SEL, (uint32_t)(__USART1_CLKSOURCE__))
+
+/** @brief  macro to get the USART1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_USART1CLKSOURCE_PCLK2: PCLK2 selected as USART1 clock
+  *            @arg RCC_USART1CLKSOURCE_HSI: HSI selected as USART1 clock
+  *            @arg RCC_USART1CLKSOURCE_SYSCLK: System Clock selected as USART1 clock
+  *            @arg RCC_USART1CLKSOURCE_LSE: LSE selected as USART1 clock
+  */
+#define __HAL_RCC_GET_USART1_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_USART1SEL)))
+
+/** @brief  Macro to configure the USART2 clock (USART2CLK).
+  *
+  * @param  __USART2_CLKSOURCE__: specifies the USART2 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_USART2CLKSOURCE_PCLK1: PCLK1 selected as USART2 clock
+  *            @arg RCC_USART2CLKSOURCE_HSI: HSI selected as USART2 clock
+  *            @arg RCC_USART2CLKSOURCE_SYSCLK: System Clock selected as USART2 clock
+  *            @arg RCC_USART2CLKSOURCE_LSE: LSE selected as USART2 clock
+  */
+#define __HAL_RCC_USART2_CONFIG(__USART2_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_USART2SEL, (uint32_t)(__USART2_CLKSOURCE__))
+
+/** @brief  macro to get the USART2 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_USART2CLKSOURCE_PCLK1: PCLK1 selected as USART2 clock
+  *            @arg RCC_USART2CLKSOURCE_HSI: HSI selected as USART2 clock
+  *            @arg RCC_USART2CLKSOURCE_SYSCLK: System Clock selected as USART2 clock
+  *            @arg RCC_USART2CLKSOURCE_LSE: LSE selected as USART2 clock
+  */
+#define __HAL_RCC_GET_USART2_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_USART2SEL)))
+
+/** @brief  Macro to configure the USART3 clock (USART3CLK).
+  *
+  * @param  __USART3_CLKSOURCE__: specifies the USART3 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_USART3CLKSOURCE_PCLK1: PCLK1 selected as USART3 clock
+  *            @arg RCC_USART3CLKSOURCE_HSI: HSI selected as USART3 clock
+  *            @arg RCC_USART3CLKSOURCE_SYSCLK: System Clock selected as USART3 clock
+  *            @arg RCC_USART3CLKSOURCE_LSE: LSE selected as USART3 clock
+  */
+#define __HAL_RCC_USART3_CONFIG(__USART3_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_USART3SEL, (uint32_t)(__USART3_CLKSOURCE__))
+
+/** @brief  macro to get the USART3 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_USART3CLKSOURCE_PCLK1: PCLK1 selected as USART3 clock
+  *            @arg RCC_USART3CLKSOURCE_HSI: HSI selected as USART3 clock
+  *            @arg RCC_USART3CLKSOURCE_SYSCLK: System Clock selected as USART3 clock
+  *            @arg RCC_USART3CLKSOURCE_LSE: LSE selected as USART3 clock
+  */
+#define __HAL_RCC_GET_USART3_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_USART3SEL)))
+
+ /** @brief  Macro to configure the UART4 clock (UART4CLK).
+  *
+  * @param  __UART4_CLKSOURCE__: specifies the UART4 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_UART4CLKSOURCE_PCLK1: PCLK1 selected as UART4 clock
+  *            @arg RCC_UART4CLKSOURCE_HSI: HSI selected as UART4 clock
+  *            @arg RCC_UART4CLKSOURCE_SYSCLK: System Clock selected as UART4 clock
+  *            @arg RCC_UART4CLKSOURCE_LSE: LSE selected as UART4 clock
+  */
+#define __HAL_RCC_UART4_CONFIG(__UART4_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_UART4SEL, (uint32_t)(__UART4_CLKSOURCE__))
+
+/** @brief  macro to get the UART4 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_UART4CLKSOURCE_PCLK1: PCLK1 selected as UART4 clock
+  *            @arg RCC_UART4CLKSOURCE_HSI: HSI selected as UART4 clock
+  *            @arg RCC_UART4CLKSOURCE_SYSCLK: System Clock selected as UART4 clock
+  *            @arg RCC_UART4CLKSOURCE_LSE: LSE selected as UART4 clock
+  */
+#define __HAL_RCC_GET_UART4_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_UART4SEL)))
+
+ /** @brief  Macro to configure the UART5 clock (UART5CLK).
+  *
+  * @param  __UART5_CLKSOURCE__: specifies the UART5 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_UART5CLKSOURCE_PCLK1: PCLK1 selected as UART5 clock
+  *            @arg RCC_UART5CLKSOURCE_HSI: HSI selected as UART5 clock
+  *            @arg RCC_UART5CLKSOURCE_SYSCLK: System Clock selected as UART5 clock
+  *            @arg RCC_UART5CLKSOURCE_LSE: LSE selected as UART5 clock
+  */
+#define __HAL_RCC_UART5_CONFIG(__UART5_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_UART5SEL, (uint32_t)(__UART5_CLKSOURCE__))
+
+/** @brief  macro to get the UART5 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_UART5CLKSOURCE_PCLK1: PCLK1 selected as UART5 clock
+  *            @arg RCC_UART5CLKSOURCE_HSI: HSI selected as UART5 clock
+  *            @arg RCC_UART5CLKSOURCE_SYSCLK: System Clock selected as UART5 clock
+  *            @arg RCC_UART5CLKSOURCE_LSE: LSE selected as UART5 clock
+  */
+#define __HAL_RCC_GET_UART5_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_UART5SEL)))
+
+ /** @brief  Macro to configure the USART6 clock (USART6CLK).
+  *
+  * @param  __USART6_CLKSOURCE__: specifies the USART6 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_USART6CLKSOURCE_PCLK1: PCLK1 selected as USART6 clock
+  *            @arg RCC_USART6CLKSOURCE_HSI: HSI selected as USART6 clock
+  *            @arg RCC_USART6CLKSOURCE_SYSCLK: System Clock selected as USART6 clock
+  *            @arg RCC_USART6CLKSOURCE_LSE: LSE selected as USART6 clock
+  */
+#define __HAL_RCC_USART6_CONFIG(__USART6_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_USART6SEL, (uint32_t)(__USART6_CLKSOURCE__))
+
+/** @brief  macro to get the USART6 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_USART6CLKSOURCE_PCLK1: PCLK1 selected as USART6 clock
+  *            @arg RCC_USART6CLKSOURCE_HSI: HSI selected as USART6 clock
+  *            @arg RCC_USART6CLKSOURCE_SYSCLK: System Clock selected as USART6 clock
+  *            @arg RCC_USART6CLKSOURCE_LSE: LSE selected as USART6 clock
+  */
+#define __HAL_RCC_GET_USART6_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_USART6SEL)))
+
+ /** @brief  Macro to configure the UART7 clock (UART7CLK).
+  *
+  * @param  __UART7_CLKSOURCE__: specifies the UART7 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_UART7CLKSOURCE_PCLK1: PCLK1 selected as UART7 clock
+  *            @arg RCC_UART7CLKSOURCE_HSI: HSI selected as UART7 clock
+  *            @arg RCC_UART7CLKSOURCE_SYSCLK: System Clock selected as UART7 clock
+  *            @arg RCC_UART7CLKSOURCE_LSE: LSE selected as UART7 clock
+  */
+#define __HAL_RCC_UART7_CONFIG(__UART7_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_UART7SEL, (uint32_t)(__UART7_CLKSOURCE__))
+
+/** @brief  macro to get the UART7 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_UART7CLKSOURCE_PCLK1: PCLK1 selected as UART7 clock
+  *            @arg RCC_UART7CLKSOURCE_HSI: HSI selected as UART7 clock
+  *            @arg RCC_UART7CLKSOURCE_SYSCLK: System Clock selected as UART7 clock
+  *            @arg RCC_UART7CLKSOURCE_LSE: LSE selected as UART7 clock
+  */
+#define __HAL_RCC_GET_UART7_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_UART7SEL)))
+
+/** @brief  Macro to configure the UART8 clock (UART8CLK).
+  *
+  * @param  __UART8_CLKSOURCE__: specifies the UART8 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_UART8CLKSOURCE_PCLK1: PCLK1 selected as UART8 clock
+  *            @arg RCC_UART8CLKSOURCE_HSI: HSI selected as UART8 clock
+  *            @arg RCC_UART8CLKSOURCE_SYSCLK: System Clock selected as UART8 clock
+  *            @arg RCC_UART8CLKSOURCE_LSE: LSE selected as UART8 clock
+  */
+#define __HAL_RCC_UART8_CONFIG(__UART8_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_UART8SEL, (uint32_t)(__UART8_CLKSOURCE__))
+
+/** @brief  macro to get the UART8 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_UART8CLKSOURCE_PCLK1: PCLK1 selected as UART8 clock
+  *            @arg RCC_UART8CLKSOURCE_HSI: HSI selected as UART8 clock
+  *            @arg RCC_UART8CLKSOURCE_SYSCLK: System Clock selected as UART8 clock
+  *            @arg RCC_UART8CLKSOURCE_LSE: LSE selected as UART8 clock
+  */
+#define __HAL_RCC_GET_UART8_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_UART8SEL)))
+
+/** @brief  Macro to configure the LPTIM1 clock (LPTIM1CLK).
+  *
+  * @param  __LPTIM1_CLKSOURCE__: specifies the LPTIM1 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_LPTIM1CLKSOURCE_PCLK: PCLK selected as LPTIM1 clock
+  *            @arg RCC_LPTIM1CLKSOURCE_HSI: HSI selected as LPTIM1 clock
+  *            @arg RCC_LPTIM1CLKSOURCE_LSI: LSI selected as LPTIM1 clock
+  *            @arg RCC_LPTIM1CLKSOURCE_LSE: LSE selected as LPTIM1 clock
+  */
+#define __HAL_RCC_LPTIM1_CONFIG(__LPTIM1_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_LPTIM1SEL, (uint32_t)(__LPTIM1_CLKSOURCE__))
+
+/** @brief  macro to get the LPTIM1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_LPTIM1CLKSOURCE_PCLK: PCLK selected as LPTIM1 clock
+  *            @arg RCC_LPTIM1CLKSOURCE_HSI: HSI selected as LPTIM1 clock
+  *            @arg RCC_LPTIM1CLKSOURCE_LSI: LSI selected as LPTIM1 clock
+  *            @arg RCC_LPTIM1CLKSOURCE_LSE: LSE selected as LPTIM1 clock
+  */
+#define __HAL_RCC_GET_LPTIM1_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_LPTIM1SEL)))
+
+/** @brief  Macro to configure the CEC clock (CECCLK).
+  *
+  * @param  __CEC_CLKSOURCE__: specifies the CEC clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_CECCLKSOURCE_LSE: LSE selected as CEC clock
+  *            @arg RCC_CECCLKSOURCE_HSI: HSI selected as CEC clock
+  */
+#define __HAL_RCC_CEC_CONFIG(__CEC_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_CECSEL, (uint32_t)(__CEC_CLKSOURCE__))
+
+/** @brief  macro to get the CEC clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_CECCLKSOURCE_LSE: LSE selected as CEC clock
+  *            @arg RCC_CECCLKSOURCE_HSI: HSI selected as CEC clock
+  */
+#define __HAL_RCC_GET_CEC_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_CECSEL)))
+
+/** @brief  Macro to configure the CLK48 source (CLK48CLK).
+  *
+  * @param  __CLK48_SOURCE__: specifies the CLK48 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_CLK48SOURCE_PLL: PLL selected as CLK48 source
+  *            @arg RCC_CLK48SOURCE_PLSAI1: PLLSAI1 selected as CLK48 source
+  */
+#define __HAL_RCC_CLK48_CONFIG(__CLK48_SOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_CK48MSEL, (uint32_t)(__CLK48_SOURCE__))
+
+/** @brief  macro to get the CLK48 source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_CLK48SOURCE_PLL: PLL used as CLK48 source
+  *            @arg RCC_CLK48SOURCE_PLSAI1: PLLSAI1 used as CLK48 source
+  */
+#define __HAL_RCC_GET_CLK48_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_CK48MSEL)))
+
+/** @brief  Macro to configure the SDMMC1 clock (SDMMC1CLK).
+  *
+  * @param  __SDMMC1_CLKSOURCE__: specifies the SDMMC1 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_SDMMC1CLKSOURCE_CLK48: CLK48 selected as SDMMC clock
+  *            @arg RCC_SDMMC1CLKSOURCE_SYSCLK: SYSCLK selected as SDMMC clock
+  */
+#define __HAL_RCC_SDMMC1_CONFIG(__SDMMC1_CLKSOURCE__) \
+                  MODIFY_REG(RCC->DCKCFGR2, RCC_DCKCFGR2_SDMMC1SEL, (uint32_t)(__SDMMC1_CLKSOURCE__))
+
+/** @brief  macro to get the SDMMC1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_SDMMC1CLKSOURCE_CLK48: CLK48 selected as SDMMC1 clock
+  *            @arg RCC_SDMMC1CLKSOURCE_SYSCLK: SYSCLK selected as SDMMC1 clock
+  */
+#define __HAL_RCC_GET_SDMMC1_SOURCE() ((uint32_t)(READ_BIT(RCC->DCKCFGR2, RCC_DCKCFGR2_SDMMC1SEL)))
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup RCCEx_Exported_Functions_Group1
+  * @{
+  */
+HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit);
+void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit);
+uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk);
+
+/**
+  * @}
+  */
+/* Private macros ------------------------------------------------------------*/
+/** @addtogroup RCCEx_Private_Macros RCCEx Private Macros
+  * @{
+  */
+/** @defgroup RCCEx_IS_RCC_Definitions RCC Private macros to check input parameters
+  * @{
+  */
+#if defined(STM32F756xx) || defined(STM32F746xx)
+#define IS_RCC_PERIPHCLOCK(SELECTION)  \
+               ((((SELECTION) & RCC_PERIPHCLK_I2S)         == RCC_PERIPHCLK_I2S)      || \
+                (((SELECTION) & RCC_PERIPHCLK_LTDC)        == RCC_PERIPHCLK_LTDC)    || \
+                (((SELECTION) & RCC_PERIPHCLK_TIM)         == RCC_PERIPHCLK_TIM)     || \
+                (((SELECTION) & RCC_PERIPHCLK_USART1)      == RCC_PERIPHCLK_USART1)  || \
+                (((SELECTION) & RCC_PERIPHCLK_USART2)      == RCC_PERIPHCLK_USART2)  || \
+                (((SELECTION) & RCC_PERIPHCLK_USART3)      == RCC_PERIPHCLK_USART3)  || \
+                (((SELECTION) & RCC_PERIPHCLK_UART4)       == RCC_PERIPHCLK_UART4)   || \
+                (((SELECTION) & RCC_PERIPHCLK_UART5)       == RCC_PERIPHCLK_UART5)   || \
+                (((SELECTION) & RCC_PERIPHCLK_USART6)      == RCC_PERIPHCLK_USART6)  || \
+                (((SELECTION) & RCC_PERIPHCLK_UART7)       == RCC_PERIPHCLK_UART7)   || \
+                (((SELECTION) & RCC_PERIPHCLK_UART8)       == RCC_PERIPHCLK_UART8)   || \
+                (((SELECTION) & RCC_PERIPHCLK_I2C1)        == RCC_PERIPHCLK_I2C1)    || \
+                (((SELECTION) & RCC_PERIPHCLK_I2C2)        == RCC_PERIPHCLK_I2C2)    || \
+                (((SELECTION) & RCC_PERIPHCLK_I2C3)        == RCC_PERIPHCLK_I2C3)    || \
+                (((SELECTION) & RCC_PERIPHCLK_I2C4)        == RCC_PERIPHCLK_I2C4)    || \
+                (((SELECTION) & RCC_PERIPHCLK_LPTIM1)      == RCC_PERIPHCLK_LPTIM1)  || \
+                (((SELECTION) & RCC_PERIPHCLK_SAI1)        == RCC_PERIPHCLK_SAI1)    || \
+                (((SELECTION) & RCC_PERIPHCLK_SAI2)        == RCC_PERIPHCLK_SAI2)    || \
+                (((SELECTION) & RCC_PERIPHCLK_CLK48)       == RCC_PERIPHCLK_CLK48)   || \
+                (((SELECTION) & RCC_PERIPHCLK_CEC)         == RCC_PERIPHCLK_CEC)     || \
+                (((SELECTION) & RCC_PERIPHCLK_SDMMC1)      == RCC_PERIPHCLK_SDMMC1)    || \
+                (((SELECTION) & RCC_PERIPHCLK_SPDIFRX)     == RCC_PERIPHCLK_SPDIFRX)    || \
+                (((SELECTION) & RCC_PERIPHCLK_RTC)         == RCC_PERIPHCLK_RTC))
+#elif defined(STM32F745xx)
+#define IS_RCC_PERIPHCLOCK(SELECTION)  \
+               ((((SELECTION) & RCC_PERIPHCLK_I2S)         == RCC_PERIPHCLK_I2S)      || \
+                (((SELECTION) & RCC_PERIPHCLK_TIM)         == RCC_PERIPHCLK_TIM)     || \
+                (((SELECTION) & RCC_PERIPHCLK_USART1)      == RCC_PERIPHCLK_USART1)  || \
+                (((SELECTION) & RCC_PERIPHCLK_USART2)      == RCC_PERIPHCLK_USART2)  || \
+                (((SELECTION) & RCC_PERIPHCLK_USART3)      == RCC_PERIPHCLK_USART3)  || \
+                (((SELECTION) & RCC_PERIPHCLK_UART4)       == RCC_PERIPHCLK_UART4)   || \
+                (((SELECTION) & RCC_PERIPHCLK_UART5)       == RCC_PERIPHCLK_UART5)   || \
+                (((SELECTION) & RCC_PERIPHCLK_USART6)      == RCC_PERIPHCLK_USART6)  || \
+                (((SELECTION) & RCC_PERIPHCLK_UART7)       == RCC_PERIPHCLK_UART7)   || \
+                (((SELECTION) & RCC_PERIPHCLK_UART8)       == RCC_PERIPHCLK_UART8)   || \
+                (((SELECTION) & RCC_PERIPHCLK_I2C1)        == RCC_PERIPHCLK_I2C1)    || \
+                (((SELECTION) & RCC_PERIPHCLK_I2C2)        == RCC_PERIPHCLK_I2C2)    || \
+                (((SELECTION) & RCC_PERIPHCLK_I2C3)        == RCC_PERIPHCLK_I2C3)    || \
+                (((SELECTION) & RCC_PERIPHCLK_I2C4)        == RCC_PERIPHCLK_I2C4)    || \
+                (((SELECTION) & RCC_PERIPHCLK_LPTIM1)      == RCC_PERIPHCLK_LPTIM1)  || \
+                (((SELECTION) & RCC_PERIPHCLK_SAI1)        == RCC_PERIPHCLK_SAI1)    || \
+                (((SELECTION) & RCC_PERIPHCLK_SAI2)        == RCC_PERIPHCLK_SAI2)    || \
+                (((SELECTION) & RCC_PERIPHCLK_CLK48)       == RCC_PERIPHCLK_CLK48)   || \
+                (((SELECTION) & RCC_PERIPHCLK_CEC)         == RCC_PERIPHCLK_CEC)     || \
+                (((SELECTION) & RCC_PERIPHCLK_SDMMC1)      == RCC_PERIPHCLK_SDMMC1)    || \
+                (((SELECTION) & RCC_PERIPHCLK_SPDIFRX)     == RCC_PERIPHCLK_SPDIFRX)    || \
+                (((SELECTION) & RCC_PERIPHCLK_RTC)         == RCC_PERIPHCLK_RTC))
+#endif /* STM32F756xx || STM32F746xx */
+#define IS_RCC_PLLI2SN_VALUE(VALUE) ((49 <= (VALUE)) && ((VALUE) <= 432))
+#define IS_RCC_PLLI2SP_VALUE(VALUE) ((2 <= (VALUE)) && ((VALUE) <= 8))
+#define IS_RCC_PLLI2SQ_VALUE(VALUE) ((2 <= (VALUE)) && ((VALUE) <= 15))
+#define IS_RCC_PLLI2SR_VALUE(VALUE) ((2 <= (VALUE)) && ((VALUE) <= 7))
+
+#define IS_RCC_PLLSAIN_VALUE(VALUE) ((49 <= (VALUE)) && ((VALUE) <= 432))
+#define IS_RCC_PLLSAIP_VALUE(VALUE) ((2 <= (VALUE)) && ((VALUE) <= 8))
+#define IS_RCC_PLLSAIQ_VALUE(VALUE) ((2 <= (VALUE)) && ((VALUE) <= 15))
+#define IS_RCC_PLLSAIR_VALUE(VALUE) ((2 <= (VALUE)) && ((VALUE) <= 7))
+
+#define IS_RCC_PLLSAI_DIVQ_VALUE(VALUE) ((1 <= (VALUE)) && ((VALUE) <= 32))
+
+#define IS_RCC_PLLI2S_DIVQ_VALUE(VALUE) ((1 <= (VALUE)) && ((VALUE) <= 32))
+
+#define IS_RCC_PLLSAI_DIVR_VALUE(VALUE) (((VALUE) == RCC_PLLSAIDIVR_2) ||\
+                                         ((VALUE) == RCC_PLLSAIDIVR_4)  ||\
+                                         ((VALUE) == RCC_PLLSAIDIVR_8)  ||\
+                                         ((VALUE) == RCC_PLLSAIDIVR_16))
+#define IS_RCC_I2SCLKSOURCE(SOURCE)  (((SOURCE) == RCC_I2SCLKSOURCE_PLLI2S) || \
+                                          ((SOURCE) == RCC_I2SCLKSOURCE_EXT))
+#define IS_RCC_SAI1CLKSOURCE(SOURCE)  (((SOURCE) == RCC_SAI1CLKSOURCE_PLLSAI) || \
+                                      ((SOURCE) == RCC_SAI1CLKSOURCE_PLLI2S) || \
+                                      ((SOURCE) == RCC_SAI1CLKSOURCE_PIN))
+#define IS_RCC_SAI2CLKSOURCE(SOURCE)  (((SOURCE) == RCC_SAI2CLKSOURCE_PLLSAI) || \
+                                      ((SOURCE) == RCC_SAI2CLKSOURCE_PLLI2S) || \
+                                      ((SOURCE) == RCC_SAI2CLKSOURCE_PIN))
+
+#define IS_RCC_SDMMC1CLKSOURCE(SOURCE)  (((SOURCE) == RCC_SDMMC1CLKSOURCE_SYSCLK) || \
+                                      ((SOURCE) == RCC_SDMMC1CLKSOURCE_CLK48))
+
+#define IS_RCC_CECCLKSOURCE(SOURCE)  (((SOURCE) == RCC_CECCLKSOURCE_HSI) || \
+                                      ((SOURCE) == RCC_CECCLKSOURCE_LSE))
+#define IS_RCC_USART1CLKSOURCE(SOURCE)  \
+               (((SOURCE) == RCC_USART1CLKSOURCE_PCLK2)  || \
+                ((SOURCE) == RCC_USART1CLKSOURCE_SYSCLK) || \
+                ((SOURCE) == RCC_USART1CLKSOURCE_LSE)    || \
+                ((SOURCE) == RCC_USART1CLKSOURCE_HSI))
+
+#define IS_RCC_USART2CLKSOURCE(SOURCE)  \
+               (((SOURCE) == RCC_USART2CLKSOURCE_PCLK1)  || \
+                ((SOURCE) == RCC_USART2CLKSOURCE_SYSCLK) || \
+                ((SOURCE) == RCC_USART2CLKSOURCE_LSE)    || \
+                ((SOURCE) == RCC_USART2CLKSOURCE_HSI))
+#define IS_RCC_USART3CLKSOURCE(SOURCE)  \
+               (((SOURCE) == RCC_USART3CLKSOURCE_PCLK1)  || \
+                ((SOURCE) == RCC_USART3CLKSOURCE_SYSCLK) || \
+                ((SOURCE) == RCC_USART3CLKSOURCE_LSE)    || \
+                ((SOURCE) == RCC_USART3CLKSOURCE_HSI))
+
+#define IS_RCC_UART4CLKSOURCE(SOURCE)  \
+               (((SOURCE) == RCC_UART4CLKSOURCE_PCLK1)  || \
+                ((SOURCE) == RCC_UART4CLKSOURCE_SYSCLK) || \
+                ((SOURCE) == RCC_UART4CLKSOURCE_LSE)    || \
+                ((SOURCE) == RCC_UART4CLKSOURCE_HSI))
+
+#define IS_RCC_UART5CLKSOURCE(SOURCE)  \
+               (((SOURCE) == RCC_UART5CLKSOURCE_PCLK1)  || \
+                ((SOURCE) == RCC_UART5CLKSOURCE_SYSCLK) || \
+                ((SOURCE) == RCC_UART5CLKSOURCE_LSE)    || \
+                ((SOURCE) == RCC_UART5CLKSOURCE_HSI))
+
+#define IS_RCC_USART6CLKSOURCE(SOURCE)  \
+               (((SOURCE) == RCC_USART6CLKSOURCE_PCLK2)  || \
+                ((SOURCE) == RCC_USART6CLKSOURCE_SYSCLK) || \
+                ((SOURCE) == RCC_USART6CLKSOURCE_LSE)    || \
+                ((SOURCE) == RCC_USART6CLKSOURCE_HSI))
+
+#define IS_RCC_UART7CLKSOURCE(SOURCE)  \
+               (((SOURCE) == RCC_UART7CLKSOURCE_PCLK1)  || \
+                ((SOURCE) == RCC_UART7CLKSOURCE_SYSCLK) || \
+                ((SOURCE) == RCC_UART7CLKSOURCE_LSE)    || \
+                ((SOURCE) == RCC_UART7CLKSOURCE_HSI))
+
+#define IS_RCC_UART8CLKSOURCE(SOURCE)  \
+               (((SOURCE) == RCC_UART8CLKSOURCE_PCLK1)  || \
+                ((SOURCE) == RCC_UART8CLKSOURCE_SYSCLK) || \
+                ((SOURCE) == RCC_UART8CLKSOURCE_LSE)    || \
+                ((SOURCE) == RCC_UART8CLKSOURCE_HSI))
+#define IS_RCC_I2C1CLKSOURCE(SOURCE)   \
+               (((SOURCE) == RCC_I2C1CLKSOURCE_PCLK1) || \
+                ((SOURCE) == RCC_I2C1CLKSOURCE_SYSCLK)|| \
+                ((SOURCE) == RCC_I2C1CLKSOURCE_HSI))
+#define IS_RCC_I2C2CLKSOURCE(SOURCE)   \
+               (((SOURCE) == RCC_I2C2CLKSOURCE_PCLK1) || \
+                ((SOURCE) == RCC_I2C2CLKSOURCE_SYSCLK)|| \
+                ((SOURCE) == RCC_I2C2CLKSOURCE_HSI))
+
+#define IS_RCC_I2C3CLKSOURCE(SOURCE)   \
+               (((SOURCE) == RCC_I2C3CLKSOURCE_PCLK1) || \
+                ((SOURCE) == RCC_I2C3CLKSOURCE_SYSCLK)|| \
+                ((SOURCE) == RCC_I2C3CLKSOURCE_HSI))
+#define IS_RCC_I2C4CLKSOURCE(SOURCE)   \
+               (((SOURCE) == RCC_I2C4CLKSOURCE_PCLK1) || \
+                ((SOURCE) == RCC_I2C4CLKSOURCE_SYSCLK)|| \
+                ((SOURCE) == RCC_I2C4CLKSOURCE_HSI))
+#define IS_RCC_LPTIM1CLK(SOURCE)  \
+               (((SOURCE) == RCC_LPTIM1CLKSOURCE_PCLK) || \
+                ((SOURCE) == RCC_LPTIM1CLKSOURCE_LSI)  || \
+                ((SOURCE) == RCC_LPTIM1CLKSOURCE_HSI)  || \
+                ((SOURCE) == RCC_LPTIM1CLKSOURCE_LSE))
+#define IS_RCC_CLK48SOURCE(SOURCE)  \
+               (((SOURCE) == RCC_CLK48SOURCE_PLLSAIP) || \
+                ((SOURCE) == RCC_CLK48SOURCE_PLL))
+#define IS_RCC_TIMPRES(VALUE)  \
+               (((VALUE) == RCC_TIMPRES_DESACTIVATED) || \
+                ((VALUE) == RCC_TIMPRES_ACTIVATED))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_RCC_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_rng.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_rng.h
@@ -1,0 +1,358 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rng.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of RNG HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_RNG_H
+#define __STM32F7xx_HAL_RNG_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RNG RNG
+  * @brief RNG HAL module driver
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup RNG_Exported_Types RNG Exported Types
+  * @{
+  */
+
+/** @defgroup RNG_Exported_Types_Group1 RNG State Structure definition
+  * @{
+  */
+typedef enum
+{
+  HAL_RNG_STATE_RESET     = 0x00,  /*!< RNG not yet initialized or disabled */
+  HAL_RNG_STATE_READY     = 0x01,  /*!< RNG initialized and ready for use   */
+  HAL_RNG_STATE_BUSY      = 0x02,  /*!< RNG internal process is ongoing     */
+  HAL_RNG_STATE_TIMEOUT   = 0x03,  /*!< RNG timeout state                   */
+  HAL_RNG_STATE_ERROR     = 0x04   /*!< RNG error state                     */
+
+}HAL_RNG_StateTypeDef;
+
+/**
+  * @}
+  */
+
+/** @defgroup RNG_Exported_Types_Group2 RNG Handle Structure definition
+  * @{
+  */
+typedef struct
+{
+  RNG_TypeDef                 *Instance;    /*!< Register base address   */
+
+  uint32_t                    RandomNumber; /*!< Last Generated random number */
+
+  HAL_LockTypeDef             Lock;         /*!< RNG locking object      */
+
+  __IO HAL_RNG_StateTypeDef   State;        /*!< RNG communication state */
+
+}RNG_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup RNG_Exported_Constants RNG Exported Constants
+  * @{
+  */
+
+/** @defgroup RNG_Exported_Constants_Group1 RNG Interrupt definition
+  * @{
+  */
+#define RNG_IT_DRDY  RNG_SR_DRDY  /*!< Data Ready interrupt  */
+#define RNG_IT_CEI   RNG_SR_CEIS  /*!< Clock error interrupt */
+#define RNG_IT_SEI   RNG_SR_SEIS  /*!< Seed error interrupt  */
+/**
+  * @}
+  */
+
+/** @defgroup RNG_Exported_Constants_Group2 RNG Flag definition
+  * @{
+  */
+#define RNG_FLAG_DRDY   RNG_SR_DRDY  /*!< Data ready                 */
+#define RNG_FLAG_CECS   RNG_SR_CECS  /*!< Clock error current status */
+#define RNG_FLAG_SECS   RNG_SR_SECS  /*!< Seed error current status  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+
+/** @defgroup RNG_Exported_Macros RNG Exported Macros
+  * @{
+  */
+
+/** @brief Reset RNG handle state
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_RNG_STATE_RESET)
+
+/**
+  * @brief  Enables the RNG peripheral.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR |=  RNG_CR_RNGEN)
+
+/**
+  * @brief  Disables the RNG peripheral.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR &= ~RNG_CR_RNGEN)
+
+/**
+  * @brief  Check the selected RNG flag status.
+  * @param  __HANDLE__: RNG Handle
+  * @param  __FLAG__: RNG flag
+  *          This parameter can be one of the following values:
+  *            @arg RNG_FLAG_DRDY: Data ready
+  *            @arg RNG_FLAG_CECS: Clock error current status
+  *            @arg RNG_FLAG_SECS: Seed error current status
+  * @retval The new state of __FLAG__ (SET or RESET).
+  */
+#define __HAL_RNG_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR & (__FLAG__)) == (__FLAG__))
+
+/**
+  * @brief  Clears the selected RNG flag status.
+  * @param  __HANDLE__: RNG handle
+  * @param  __FLAG__: RNG flag to clear
+  * @note   WARNING: This is a dummy macro for HAL code alignment,
+  *         flags RNG_FLAG_DRDY, RNG_FLAG_CECS and RNG_FLAG_SECS are read-only.
+  * @retval None
+  */
+#define __HAL_RNG_CLEAR_FLAG(__HANDLE__, __FLAG__)                      /* dummy  macro */
+
+
+
+/**
+  * @brief  Enables the RNG interrupts.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_ENABLE_IT(__HANDLE__) ((__HANDLE__)->Instance->CR |=  RNG_CR_IE)
+
+/**
+  * @brief  Disables the RNG interrupts.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_DISABLE_IT(__HANDLE__) ((__HANDLE__)->Instance->CR &= ~RNG_CR_IE)
+
+/**
+  * @brief  Checks whether the specified RNG interrupt has occurred or not.
+  * @param  __HANDLE__: RNG Handle
+  * @param  __INTERRUPT__: specifies the RNG interrupt status flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg RNG_IT_DRDY: Data ready interrupt
+  *            @arg RNG_IT_CEI: Clock error interrupt
+  *            @arg RNG_IT_SEI: Seed error interrupt
+  * @retval The new state of __INTERRUPT__ (SET or RESET).
+  */
+#define __HAL_RNG_GET_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->SR & (__INTERRUPT__)) == (__INTERRUPT__))
+
+/**
+  * @brief  Clear the RNG interrupt status flags.
+  * @param  __HANDLE__: RNG Handle
+  * @param  __INTERRUPT__: specifies the RNG interrupt status flag to clear.
+  *          This parameter can be one of the following values:
+  *            @arg RNG_IT_CEI: Clock error interrupt
+  *            @arg RNG_IT_SEI: Seed error interrupt
+  * @note   RNG_IT_DRDY flag is read-only, reading RNG_DR register automatically clears RNG_IT_DRDY.
+  * @retval None
+  */
+#define __HAL_RNG_CLEAR_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->SR) = ~(__INTERRUPT__))
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup RNG_Exported_Functions RNG Exported Functions
+  * @{
+  */
+
+/** @defgroup RNG_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_RNG_Init(RNG_HandleTypeDef *hrng);
+HAL_StatusTypeDef HAL_RNG_DeInit (RNG_HandleTypeDef *hrng);
+void HAL_RNG_MspInit(RNG_HandleTypeDef *hrng);
+void HAL_RNG_MspDeInit(RNG_HandleTypeDef *hrng);
+
+/**
+  * @}
+  */
+
+/** @defgroup RNG_Exported_Functions_Group2 Peripheral Control functions
+  * @{
+  */
+uint32_t HAL_RNG_GetRandomNumber(RNG_HandleTypeDef *hrng);    /* Obsolete, use HAL_RNG_GenerateRandomNumber() instead    */
+uint32_t HAL_RNG_GetRandomNumber_IT(RNG_HandleTypeDef *hrng); /* Obsolete, use HAL_RNG_GenerateRandomNumber_IT() instead */
+
+HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber(RNG_HandleTypeDef *hrng, uint32_t *random32bit);
+HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber_IT(RNG_HandleTypeDef *hrng);
+uint32_t HAL_RNG_ReadLastRandomNumber(RNG_HandleTypeDef *hrng);
+
+void HAL_RNG_IRQHandler(RNG_HandleTypeDef *hrng);
+void HAL_RNG_ErrorCallback(RNG_HandleTypeDef *hrng);
+void HAL_RNG_ReadyDataCallback(RNG_HandleTypeDef* hrng, uint32_t random32bit);
+
+/**
+  * @}
+  */
+
+/** @defgroup RNG_Exported_Functions_Group3 Peripheral State functions
+  * @{
+  */
+HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/** @defgroup RNG_Private_Types RNG Private Types
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private defines -----------------------------------------------------------*/
+/** @defgroup RNG_Private_Defines RNG Private Defines
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup RNG_Private_Variables RNG Private Variables
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup RNG_Private_Constants RNG Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup RNG_Private_Macros RNG Private Macros
+  * @{
+  */
+#define IS_RNG_IT(IT) (((IT) == RNG_IT_CEI) || \
+                       ((IT) == RNG_IT_SEI))
+
+#define IS_RNG_FLAG(FLAG) (((FLAG) == RNG_FLAG_DRDY) || \
+                           ((FLAG) == RNG_FLAG_CECS) || \
+                           ((FLAG) == RNG_FLAG_SECS))
+
+/**
+  * @}
+  */
+
+/* Private functions prototypes ----------------------------------------------*/
+/** @defgroup RNG_Private_Functions_Prototypes RNG Private Functions Prototypes
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup RNG_Private_Functions RNG Private Functions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_RNG_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_rtc.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_rtc.h
@@ -1,0 +1,806 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rtc.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of RTC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_RTC_H
+#define __STM32F7xx_HAL_RTC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RTC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup RTC_Exported_Types RTC Exported Types
+  * @{
+  */
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef enum
+{
+  HAL_RTC_STATE_RESET             = 0x00,  /*!< RTC not yet initialized or disabled */
+  HAL_RTC_STATE_READY             = 0x01,  /*!< RTC initialized and ready for use   */
+  HAL_RTC_STATE_BUSY              = 0x02,  /*!< RTC process is ongoing              */
+  HAL_RTC_STATE_TIMEOUT           = 0x03,  /*!< RTC timeout state                   */
+  HAL_RTC_STATE_ERROR             = 0x04   /*!< RTC error state                     */
+
+}HAL_RTCStateTypeDef;
+
+/**
+  * @brief  RTC Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t HourFormat;      /*!< Specifies the RTC Hour Format.
+                                 This parameter can be a value of @ref RTC_Hour_Formats */
+
+  uint32_t AsynchPrediv;    /*!< Specifies the RTC Asynchronous Predivider value.
+                                 This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7F */
+
+  uint32_t SynchPrediv;     /*!< Specifies the RTC Synchronous Predivider value.
+                                 This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7FFF */
+
+  uint32_t OutPut;          /*!< Specifies which signal will be routed to the RTC output.
+                                 This parameter can be a value of @ref RTCEx_Output_selection_Definitions */
+
+  uint32_t OutPutPolarity;  /*!< Specifies the polarity of the output signal.
+                                 This parameter can be a value of @ref RTC_Output_Polarity_Definitions */
+
+  uint32_t OutPutType;      /*!< Specifies the RTC Output Pin mode.
+                                 This parameter can be a value of @ref RTC_Output_Type_ALARM_OUT */
+}RTC_InitTypeDef;
+
+/**
+  * @brief  RTC Time structure definition
+  */
+typedef struct
+{
+  uint8_t Hours;            /*!< Specifies the RTC Time Hour.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 12 if the RTC_HourFormat_12 is selected.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 23 if the RTC_HourFormat_24 is selected  */
+
+  uint8_t Minutes;          /*!< Specifies the RTC Time Minutes.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 59 */
+
+  uint8_t Seconds;          /*!< Specifies the RTC Time Seconds.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 59 */
+
+  uint32_t SubSeconds;      /*!< Specifies the RTC Time SubSeconds.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 59 */
+
+  uint8_t TimeFormat;       /*!< Specifies the RTC AM/PM Time.
+                                 This parameter can be a value of @ref RTC_AM_PM_Definitions */
+
+  uint32_t DayLightSaving;  /*!< Specifies RTC_DayLightSaveOperation: the value of hour adjustment.
+                                 This parameter can be a value of @ref RTC_DayLightSaving_Definitions */
+
+  uint32_t StoreOperation;  /*!< Specifies RTC_StoreOperation value to be written in the BCK bit
+                                 in CR register to store the operation.
+                                 This parameter can be a value of @ref RTC_StoreOperation_Definitions */
+}RTC_TimeTypeDef;
+
+/**
+  * @brief  RTC Date structure definition
+  */
+typedef struct
+{
+  uint8_t WeekDay;  /*!< Specifies the RTC Date WeekDay.
+                         This parameter can be a value of @ref RTC_WeekDay_Definitions */
+
+  uint8_t Month;    /*!< Specifies the RTC Date Month (in BCD format).
+                         This parameter can be a value of @ref RTC_Month_Date_Definitions */
+
+  uint8_t Date;     /*!< Specifies the RTC Date.
+                         This parameter must be a number between Min_Data = 1 and Max_Data = 31 */
+
+  uint8_t Year;     /*!< Specifies the RTC Date Year.
+                         This parameter must be a number between Min_Data = 0 and Max_Data = 99 */
+
+}RTC_DateTypeDef;
+
+/**
+  * @brief  RTC Alarm structure definition
+  */
+typedef struct
+{
+  RTC_TimeTypeDef AlarmTime;     /*!< Specifies the RTC Alarm Time members */
+
+  uint32_t AlarmMask;            /*!< Specifies the RTC Alarm Masks.
+                                      This parameter can be a value of @ref RTC_AlarmMask_Definitions */
+
+  uint32_t AlarmSubSecondMask;   /*!< Specifies the RTC Alarm SubSeconds Masks.
+                                      This parameter can be a value of @ref RTC_Alarm_Sub_Seconds_Masks_Definitions */
+
+  uint32_t AlarmDateWeekDaySel;  /*!< Specifies the RTC Alarm is on Date or WeekDay.
+                                     This parameter can be a value of @ref RTC_AlarmDateWeekDay_Definitions */
+
+  uint8_t AlarmDateWeekDay;      /*!< Specifies the RTC Alarm Date/WeekDay.
+                                      If the Alarm Date is selected, this parameter must be set to a value in the 1-31 range.
+                                      If the Alarm WeekDay is selected, this parameter can be a value of @ref RTC_WeekDay_Definitions */
+
+  uint32_t Alarm;                /*!< Specifies the alarm .
+                                      This parameter can be a value of @ref RTC_Alarms_Definitions */
+}RTC_AlarmTypeDef;
+
+/**
+  * @brief  RTC Handle Structure definition
+  */
+typedef struct
+{
+  RTC_TypeDef                 *Instance;  /*!< Register base address    */
+
+  RTC_InitTypeDef             Init;       /*!< RTC required parameters  */
+
+  HAL_LockTypeDef             Lock;       /*!< RTC locking object       */
+
+  __IO HAL_RTCStateTypeDef    State;      /*!< Time communication state */
+
+}RTC_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RTC_Exported_Constants RTC Exported Constants
+  * @{
+  */
+
+/** @defgroup RTC_Hour_Formats RTC Hour Formats
+  * @{
+  */
+#define RTC_HOURFORMAT_24              ((uint32_t)0x00000000)
+#define RTC_HOURFORMAT_12              ((uint32_t)0x00000040)
+/**
+  * @}
+  */
+
+
+/** @defgroup RTC_Output_Polarity_Definitions RTC Output Polarity Definitions
+  * @{
+  */
+#define RTC_OUTPUT_POLARITY_HIGH       ((uint32_t)0x00000000)
+#define RTC_OUTPUT_POLARITY_LOW        ((uint32_t)0x00100000)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_Type_ALARM_OUT RTC Output Type ALARM OUT
+  * @{
+  */
+#define RTC_OUTPUT_TYPE_OPENDRAIN      ((uint32_t)0x00000000)
+#define RTC_OUTPUT_TYPE_PUSHPULL       ((uint32_t)RTC_OR_ALARMTYPE)  /* 0x00000008 */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_AM_PM_Definitions RTC AM PM Definitions
+  * @{
+  */
+#define RTC_HOURFORMAT12_AM            ((uint8_t)0x00)
+#define RTC_HOURFORMAT12_PM            ((uint8_t)0x40)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_DayLightSaving_Definitions RTC DayLight Saving Definitions
+  * @{
+  */
+#define RTC_DAYLIGHTSAVING_SUB1H       ((uint32_t)0x00020000)
+#define RTC_DAYLIGHTSAVING_ADD1H       ((uint32_t)0x00010000)
+#define RTC_DAYLIGHTSAVING_NONE        ((uint32_t)0x00000000)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_StoreOperation_Definitions RTC Store Operation Definitions
+  * @{
+  */
+#define RTC_STOREOPERATION_RESET        ((uint32_t)0x00000000)
+#define RTC_STOREOPERATION_SET          ((uint32_t)0x00040000)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Input_parameter_format_definitions RTC Input Parameter Format Definitions
+  * @{
+  */
+#define RTC_FORMAT_BIN                      ((uint32_t)0x000000000)
+#define RTC_FORMAT_BCD                      ((uint32_t)0x000000001)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Month_Date_Definitions RTC Month Date Definitions
+  * @{
+  */
+/* Coded in BCD format */
+#define RTC_MONTH_JANUARY              ((uint8_t)0x01)
+#define RTC_MONTH_FEBRUARY             ((uint8_t)0x02)
+#define RTC_MONTH_MARCH                ((uint8_t)0x03)
+#define RTC_MONTH_APRIL                ((uint8_t)0x04)
+#define RTC_MONTH_MAY                  ((uint8_t)0x05)
+#define RTC_MONTH_JUNE                 ((uint8_t)0x06)
+#define RTC_MONTH_JULY                 ((uint8_t)0x07)
+#define RTC_MONTH_AUGUST               ((uint8_t)0x08)
+#define RTC_MONTH_SEPTEMBER            ((uint8_t)0x09)
+#define RTC_MONTH_OCTOBER              ((uint8_t)0x10)
+#define RTC_MONTH_NOVEMBER             ((uint8_t)0x11)
+#define RTC_MONTH_DECEMBER             ((uint8_t)0x12)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_WeekDay_Definitions RTC WeekDay Definitions
+  * @{
+  */
+#define RTC_WEEKDAY_MONDAY             ((uint8_t)0x01)
+#define RTC_WEEKDAY_TUESDAY            ((uint8_t)0x02)
+#define RTC_WEEKDAY_WEDNESDAY          ((uint8_t)0x03)
+#define RTC_WEEKDAY_THURSDAY           ((uint8_t)0x04)
+#define RTC_WEEKDAY_FRIDAY             ((uint8_t)0x05)
+#define RTC_WEEKDAY_SATURDAY           ((uint8_t)0x06)
+#define RTC_WEEKDAY_SUNDAY             ((uint8_t)0x07)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_AlarmDateWeekDay_Definitions RTC Alarm Date WeekDay Definitions
+  * @{
+  */
+#define RTC_ALARMDATEWEEKDAYSEL_DATE      ((uint32_t)0x00000000)
+#define RTC_ALARMDATEWEEKDAYSEL_WEEKDAY   ((uint32_t)0x40000000)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_AlarmMask_Definitions RTC Alarm Mask Definitions
+  * @{
+  */
+#define RTC_ALARMMASK_NONE                ((uint32_t)0x00000000)
+#define RTC_ALARMMASK_DATEWEEKDAY         RTC_ALRMAR_MSK4
+#define RTC_ALARMMASK_HOURS               RTC_ALRMAR_MSK3
+#define RTC_ALARMMASK_MINUTES             RTC_ALRMAR_MSK2
+#define RTC_ALARMMASK_SECONDS             RTC_ALRMAR_MSK1
+#define RTC_ALARMMASK_ALL                 ((uint32_t)0x80808080)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Alarms_Definitions RTC Alarms Definitions
+  * @{
+  */
+#define RTC_ALARM_A                       RTC_CR_ALRAE
+#define RTC_ALARM_B                       RTC_CR_ALRBE
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Alarm_Sub_Seconds_Masks_Definitions RTC Alarm Sub Seconds Masks Definitions
+  * @{
+  */
+#define RTC_ALARMSUBSECONDMASK_ALL         ((uint32_t)0x00000000)  /*!< All Alarm SS fields are masked.
+                                                                        There is no comparison on sub seconds
+                                                                        for Alarm */
+#define RTC_ALARMSUBSECONDMASK_SS14_1      ((uint32_t)0x01000000)  /*!< SS[14:1] are don't care in Alarm
+                                                                        comparison. Only SS[0] is compared.    */
+#define RTC_ALARMSUBSECONDMASK_SS14_2      ((uint32_t)0x02000000)  /*!< SS[14:2] are don't care in Alarm
+                                                                        comparison. Only SS[1:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_3      ((uint32_t)0x03000000)  /*!< SS[14:3] are don't care in Alarm
+                                                                        comparison. Only SS[2:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_4      ((uint32_t)0x04000000)  /*!< SS[14:4] are don't care in Alarm
+                                                                        comparison. Only SS[3:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_5      ((uint32_t)0x05000000)  /*!< SS[14:5] are don't care in Alarm
+                                                                        comparison. Only SS[4:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_6      ((uint32_t)0x06000000)  /*!< SS[14:6] are don't care in Alarm
+                                                                        comparison. Only SS[5:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_7      ((uint32_t)0x07000000)  /*!< SS[14:7] are don't care in Alarm
+                                                                        comparison. Only SS[6:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_8      ((uint32_t)0x08000000)  /*!< SS[14:8] are don't care in Alarm
+                                                                        comparison. Only SS[7:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_9      ((uint32_t)0x09000000)  /*!< SS[14:9] are don't care in Alarm
+                                                                        comparison. Only SS[8:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_10     ((uint32_t)0x0A000000)  /*!< SS[14:10] are don't care in Alarm
+                                                                        comparison. Only SS[9:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_11     ((uint32_t)0x0B000000)  /*!< SS[14:11] are don't care in Alarm
+                                                                        comparison. Only SS[10:0] are compared */
+#define RTC_ALARMSUBSECONDMASK_SS14_12     ((uint32_t)0x0C000000)  /*!< SS[14:12] are don't care in Alarm
+                                                                        comparison.Only SS[11:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_13     ((uint32_t)0x0D000000)  /*!< SS[14:13] are don't care in Alarm
+                                                                        comparison. Only SS[12:0] are compared */
+#define RTC_ALARMSUBSECONDMASK_SS14        ((uint32_t)0x0E000000)  /*!< SS[14] is don't care in Alarm
+                                                                        comparison.Only SS[13:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_NONE        ((uint32_t)0x0F000000)  /*!< SS[14:0] are compared and must match
+                                                                        to activate alarm. */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Interrupts_Definitions RTC Interrupts Definitions
+  * @{
+  */
+#define RTC_IT_TS                         ((uint32_t)RTC_CR_TSIE)
+#define RTC_IT_WUT                        ((uint32_t)RTC_CR_WUTIE)
+#define RTC_IT_ALRA                       ((uint32_t)RTC_CR_ALRAIE)
+#define RTC_IT_ALRB                       ((uint32_t)RTC_CR_ALRBIE)
+#define RTC_IT_TAMP                       ((uint32_t)RTC_TAMPCR_TAMPIE) /* Used only to Enable the Tamper Interrupt */
+#define RTC_IT_TAMP1                      ((uint32_t)RTC_TAMPCR_TAMP1IE)
+#define RTC_IT_TAMP2                      ((uint32_t)RTC_TAMPCR_TAMP2IE)
+#define RTC_IT_TAMP3                      ((uint32_t)RTC_TAMPCR_TAMP3IE)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Flags_Definitions RTC Flags Definitions
+  * @{
+  */
+#define RTC_FLAG_RECALPF                  ((uint32_t)RTC_ISR_RECALPF)
+#define RTC_FLAG_TAMP3F                   ((uint32_t)RTC_ISR_TAMP3F)
+#define RTC_FLAG_TAMP2F                   ((uint32_t)RTC_ISR_TAMP2F)
+#define RTC_FLAG_TAMP1F                   ((uint32_t)RTC_ISR_TAMP1F)
+#define RTC_FLAG_TSOVF                    ((uint32_t)RTC_ISR_TSOVF)
+#define RTC_FLAG_TSF                      ((uint32_t)RTC_ISR_TSF)
+#define RTC_FLAG_ITSF                     ((uint32_t)RTC_ISR_ITSF)
+#define RTC_FLAG_WUTF                     ((uint32_t)RTC_ISR_WUTF)
+#define RTC_FLAG_ALRBF                    ((uint32_t)RTC_ISR_ALRBF)
+#define RTC_FLAG_ALRAF                    ((uint32_t)RTC_ISR_ALRAF)
+#define RTC_FLAG_INITF                    ((uint32_t)RTC_ISR_INITF)
+#define RTC_FLAG_RSF                      ((uint32_t)RTC_ISR_RSF)
+#define RTC_FLAG_INITS                    ((uint32_t)RTC_ISR_INITS)
+#define RTC_FLAG_SHPF                     ((uint32_t)RTC_ISR_SHPF)
+#define RTC_FLAG_WUTWF                    ((uint32_t)RTC_ISR_WUTWF)
+#define RTC_FLAG_ALRBWF                   ((uint32_t)RTC_ISR_ALRBWF)
+#define RTC_FLAG_ALRAWF                   ((uint32_t)RTC_ISR_ALRAWF)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup RTC_Exported_Macros RTC Exported Macros
+  * @{
+  */
+
+/** @brief Reset RTC handle state
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_RTC_STATE_RESET)
+
+/**
+  * @brief  Disable the write protection for RTC registers.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WRITEPROTECTION_DISABLE(__HANDLE__)             \
+                        do{                                       \
+                            (__HANDLE__)->Instance->WPR = 0xCA;   \
+                            (__HANDLE__)->Instance->WPR = 0x53;   \
+                          } while(0)
+
+/**
+  * @brief  Enable the write protection for RTC registers.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WRITEPROTECTION_ENABLE(__HANDLE__)              \
+                        do{                                       \
+                            (__HANDLE__)->Instance->WPR = 0xFF;   \
+                          } while(0)
+
+/**
+  * @brief  Enable the RTC ALARMA peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMA_ENABLE(__HANDLE__)                           ((__HANDLE__)->Instance->CR |= (RTC_CR_ALRAE))
+
+/**
+  * @brief  Disable the RTC ALARMA peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMA_DISABLE(__HANDLE__)                          ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ALRAE))
+
+/**
+  * @brief  Enable the RTC ALARMB peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMB_ENABLE(__HANDLE__)                           ((__HANDLE__)->Instance->CR |= (RTC_CR_ALRBE))
+
+/**
+  * @brief  Disable the RTC ALARMB peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMB_DISABLE(__HANDLE__)                          ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ALRBE))
+
+/**
+  * @brief  Enable the RTC Alarm interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Alarm interrupt sources to be enabled or disabled.
+  *          This parameter can be any combination of the following values:
+  *             @arg RTC_IT_ALRA: Alarm A interrupt
+  *             @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_ENABLE_IT(__HANDLE__, __INTERRUPT__)          ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC Alarm interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Alarm interrupt sources to be enabled or disabled.
+  *         This parameter can be any combination of the following values:
+  *            @arg RTC_IT_ALRA: Alarm A interrupt
+  *            @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_DISABLE_IT(__HANDLE__, __INTERRUPT__)         ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC Alarm interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Alarm interrupt to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_ALRA: Alarm A interrupt
+  *            @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_GET_IT(__HANDLE__, __INTERRUPT__)                  ((((((__HANDLE__)->Instance->ISR)& ((__INTERRUPT__)>> 4)) & 0x0000FFFF) != RESET)? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC Alarm's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Alarm Flag to check.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_ALRAF
+  *            @arg RTC_FLAG_ALRBF
+  *            @arg RTC_FLAG_ALRAWF
+  *            @arg RTC_FLAG_ALRBWF
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_GET_FLAG(__HANDLE__, __FLAG__)                (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET)? SET : RESET)
+
+/**
+  * @brief  Clear the RTC Alarm's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Alarm Flag sources to be enabled or disabled.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_ALRAF
+  *             @arg RTC_FLAG_ALRBF
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_CLEAR_FLAG(__HANDLE__, __FLAG__)                  ((__HANDLE__)->Instance->ISR) = (~(((__FLAG__) | RTC_ISR_INIT)& 0x0000FFFF)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Check whether the specified RTC Alarm interrupt has been enabled or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Alarm interrupt sources to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_ALRA: Alarm A interrupt
+  *            @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)     (((((__HANDLE__)->Instance->CR) & (__INTERRUPT__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Enable interrupt on the RTC Alarm associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_IT()            (EXTI->IMR |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Disable interrupt on the RTC Alarm associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_IT()           (EXTI->IMR &= ~(RTC_EXTI_LINE_ALARM_EVENT))
+
+/**
+  * @brief  Enable event on the RTC Alarm associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_EVENT()         (EXTI->EMR |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Disable event on the RTC Alarm associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_EVENT()         (EXTI->EMR &= ~(RTC_EXTI_LINE_ALARM_EVENT))
+
+/**
+  * @brief  Enable falling edge trigger on the RTC Alarm associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Disable falling edge trigger on the RTC Alarm associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR &= ~(RTC_EXTI_LINE_ALARM_EVENT))
+
+/**
+  * @brief  Enable rising edge trigger on the RTC Alarm associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Disable rising edge trigger on the RTC Alarm associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR &= ~(RTC_EXTI_LINE_ALARM_EVENT))
+
+/**
+  * @brief  Enable rising & falling edge trigger on the RTC Alarm associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_RISING_FALLING_EDGE() __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE();__HAL_RTC_ALARM_EXTI_ENABLE_FALLING_EDGE();
+
+/**
+  * @brief  Disable rising & falling edge trigger on the RTC Alarm associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_RISING_FALLING_EDGE() __HAL_RTC_ALARM_EXTI_DISABLE_RISING_EDGE();__HAL_RTC_ALARM_EXTI_DISABLE_FALLING_EDGE();
+
+/**
+  * @brief Check whether the RTC Alarm associated Exti line interrupt flag is set or not.
+  * @retval Line Status.
+  */
+#define __HAL_RTC_ALARM_EXTI_GET_FLAG()              (EXTI->PR & RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief Clear the RTC Alarm associated Exti line flag.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_CLEAR_FLAG()            (EXTI->PR = RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief Generate a Software interrupt on RTC Alarm associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_GENERATE_SWIT()         (EXTI->SWIER |= RTC_EXTI_LINE_ALARM_EVENT)
+/**
+  * @}
+  */
+
+/* Include RTC HAL Extension module */
+#include "stm32f7xx_hal_rtc_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup RTC_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group1
+  * @{
+  */
+/* Initialization and de-initialization functions  ****************************/
+HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc);
+void       HAL_RTC_MspInit(RTC_HandleTypeDef *hrtc);
+void       HAL_RTC_MspDeInit(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group2
+  * @{
+  */
+/* RTC Time and Date functions ************************************************/
+HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format);
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group3
+  * @{
+  */
+/* RTC Alarm functions ********************************************************/
+HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alarm);
+HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Alarm, uint32_t Format);
+void                HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef   HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+void         HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group4
+  * @{
+  */
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef   HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc);
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group5
+  * @{
+  */
+/* Peripheral State functions *************************************************/
+HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup RTC_Private_Constants RTC Private Constants
+  * @{
+  */
+/* Masks Definition */
+#define RTC_TR_RESERVED_MASK    ((uint32_t)0x007F7F7F)
+#define RTC_DR_RESERVED_MASK    ((uint32_t)0x00FFFF3F)
+#define RTC_INIT_MASK           ((uint32_t)0xFFFFFFFF)
+#define RTC_RSF_MASK            ((uint32_t)0xFFFFFF5F)
+
+#define RTC_TIMEOUT_VALUE       1000
+
+#define RTC_EXTI_LINE_ALARM_EVENT             ((uint32_t)EXTI_IMR_MR17)  /*!< External interrupt line 17 Connected to the RTC Alarm event */
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup RTC_Private_Macros RTC Private Macros
+  * @{
+  */
+
+/** @defgroup RTC_IS_RTC_Definitions RTC Private macros to check input parameters
+  * @{
+  */
+#define IS_RTC_HOUR_FORMAT(__FORMAT__) (((__FORMAT__) == RTC_HOURFORMAT_12) || \
+                                        ((__FORMAT__) == RTC_HOURFORMAT_24))
+#define IS_RTC_OUTPUT_POL(__POL__)     (((__POL__) == RTC_OUTPUT_POLARITY_HIGH) || \
+                                        ((__POL__) == RTC_OUTPUT_POLARITY_LOW))
+#define IS_RTC_OUTPUT_TYPE(__TYPE__)   (((__TYPE__) == RTC_OUTPUT_TYPE_OPENDRAIN) || \
+                                        ((__TYPE__) == RTC_OUTPUT_TYPE_PUSHPULL))
+#define IS_RTC_ASYNCH_PREDIV(__PREDIV__)   ((__PREDIV__) <= (uint32_t)0x7F)
+#define IS_RTC_SYNCH_PREDIV(__PREDIV__)    ((__PREDIV__) <= (uint32_t)0x7FFF)
+#define IS_RTC_HOUR12(__HOUR__)            (((__HOUR__) > (uint32_t)0) && ((__HOUR__) <= (uint32_t)12))
+#define IS_RTC_HOUR24(__HOUR__)            ((__HOUR__) <= (uint32_t)23)
+#define IS_RTC_MINUTES(__MINUTES__)        ((__MINUTES__) <= (uint32_t)59)
+#define IS_RTC_SECONDS(__SECONDS__)        ((__SECONDS__) <= (uint32_t)59)
+#define IS_RTC_HOURFORMAT12(__PM__)  (((__PM__) == RTC_HOURFORMAT12_AM) || ((__PM__) == RTC_HOURFORMAT12_PM))
+#define IS_RTC_DAYLIGHT_SAVING(__SAVE__) (((__SAVE__) == RTC_DAYLIGHTSAVING_SUB1H) || \
+                                          ((__SAVE__) == RTC_DAYLIGHTSAVING_ADD1H) || \
+                                          ((__SAVE__) == RTC_DAYLIGHTSAVING_NONE))
+#define IS_RTC_STORE_OPERATION(__OPERATION__) (((__OPERATION__) == RTC_STOREOPERATION_RESET) || \
+                                               ((__OPERATION__) == RTC_STOREOPERATION_SET))
+#define IS_RTC_FORMAT(__FORMAT__) (((__FORMAT__) == RTC_FORMAT_BIN) || ((__FORMAT__) == RTC_FORMAT_BCD))
+#define IS_RTC_YEAR(__YEAR__)              ((__YEAR__) <= (uint32_t)99)
+#define IS_RTC_MONTH(__MONTH__)            (((__MONTH__) >= (uint32_t)1) && ((__MONTH__) <= (uint32_t)12))
+#define IS_RTC_DATE(__DATE__)              (((__DATE__) >= (uint32_t)1) && ((__DATE__) <= (uint32_t)31))
+#define IS_RTC_WEEKDAY(__WEEKDAY__) (((__WEEKDAY__) == RTC_WEEKDAY_MONDAY)    || \
+                                     ((__WEEKDAY__) == RTC_WEEKDAY_TUESDAY)   || \
+                                     ((__WEEKDAY__) == RTC_WEEKDAY_WEDNESDAY) || \
+                                     ((__WEEKDAY__) == RTC_WEEKDAY_THURSDAY)  || \
+                                     ((__WEEKDAY__) == RTC_WEEKDAY_FRIDAY)    || \
+                                     ((__WEEKDAY__) == RTC_WEEKDAY_SATURDAY)  || \
+                                     ((__WEEKDAY__) == RTC_WEEKDAY_SUNDAY))
+
+#define IS_RTC_ALARM_DATE_WEEKDAY_DATE(__DATE__) (((__DATE__) >(uint32_t) 0) && ((__DATE__) <= (uint32_t)31))
+#define IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(__WEEKDAY__) (((__WEEKDAY__) == RTC_WEEKDAY_MONDAY)    || \
+                                                        ((__WEEKDAY__) == RTC_WEEKDAY_TUESDAY)   || \
+                                                        ((__WEEKDAY__) == RTC_WEEKDAY_WEDNESDAY) || \
+                                                        ((__WEEKDAY__) == RTC_WEEKDAY_THURSDAY)  || \
+                                                        ((__WEEKDAY__) == RTC_WEEKDAY_FRIDAY)    || \
+                                                        ((__WEEKDAY__) == RTC_WEEKDAY_SATURDAY)  || \
+                                                        ((__WEEKDAY__) == RTC_WEEKDAY_SUNDAY))
+#define IS_RTC_ALARM_DATE_WEEKDAY_SEL(__SEL__) (((__SEL__) == RTC_ALARMDATEWEEKDAYSEL_DATE) || \
+                                                ((__SEL__) == RTC_ALARMDATEWEEKDAYSEL_WEEKDAY))
+#define IS_RTC_ALARM_MASK(__MASK__)  (((__MASK__) & 0x7F7F7F7F) == (uint32_t)RESET)
+#define IS_RTC_ALARM(__ALARM__)      (((__ALARM__) == RTC_ALARM_A) || ((__ALARM__) == RTC_ALARM_B))
+#define IS_RTC_ALARM_SUB_SECOND_VALUE(__VALUE__) ((__VALUE__) <= (uint32_t)0x00007FFF)
+#define IS_RTC_ALARM_SUB_SECOND_MASK(__MASK__)   (((__MASK__) == RTC_ALARMSUBSECONDMASK_ALL) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_1) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_2) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_3) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_4) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_5) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_6) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_7) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_8) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_9) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_10) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_11) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_12) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14_13) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_SS14) || \
+                                                  ((__MASK__) == RTC_ALARMSUBSECONDMASK_NONE))
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup RTC_Private_Functions RTC Private Functions
+  * @{
+  */
+HAL_StatusTypeDef  RTC_EnterInitMode(RTC_HandleTypeDef* hrtc);
+uint8_t            RTC_ByteToBcd2(uint8_t Value);
+uint8_t            RTC_Bcd2ToByte(uint8_t Value);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_RTC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_rtc_ex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_rtc_ex.h
@@ -1,0 +1,1035 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rtc_ex.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of RTC HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_RTC_EX_H
+#define __STM32F7xx_HAL_RTC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RTCEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup RTCEx_Exported_Types RTCEx Exported Types
+  * @{
+  */
+
+/**
+  * @brief  RTC Tamper structure definition
+  */
+typedef struct
+{
+  uint32_t Tamper;                      /*!< Specifies the Tamper Pin.
+                                             This parameter can be a value of @ref  RTCEx_Tamper_Pins_Definitions */
+
+  uint32_t Interrupt;                   /*!< Specifies the Tamper Interrupt.
+                                             This parameter can be a value of @ref  RTCEx_Tamper_Interrupt_Definitions */
+
+  uint32_t Trigger;                     /*!< Specifies the Tamper Trigger.
+                                             This parameter can be a value of @ref  RTCEx_Tamper_Trigger_Definitions */
+
+  uint32_t NoErase;                     /*!< Specifies the Tamper no erase mode.
+                                             This parameter can be a value of @ref  RTCEx_Tamper_EraseBackUp_Definitions */
+
+  uint32_t MaskFlag;                     /*!< Specifies the Tamper Flag masking.
+                                             This parameter can be a value of @ref RTCEx_Tamper_MaskFlag_Definitions   */
+
+  uint32_t Filter;                      /*!< Specifies the RTC Filter Tamper.
+                                             This parameter can be a value of @ref RTCEx_Tamper_Filter_Definitions */
+
+  uint32_t SamplingFrequency;           /*!< Specifies the sampling frequency.
+                                             This parameter can be a value of @ref RTCEx_Tamper_Sampling_Frequencies_Definitions */
+
+  uint32_t PrechargeDuration;           /*!< Specifies the Precharge Duration .
+                                             This parameter can be a value of @ref RTCEx_Tamper_Pin_Precharge_Duration_Definitions */
+
+  uint32_t TamperPullUp;                /*!< Specifies the Tamper PullUp .
+                                             This parameter can be a value of @ref RTCEx_Tamper_Pull_UP_Definitions */
+
+  uint32_t TimeStampOnTamperDetection;  /*!< Specifies the TimeStampOnTamperDetection.
+                                             This parameter can be a value of @ref RTCEx_Tamper_TimeStampOnTamperDetection_Definitions */
+}RTC_TamperTypeDef;
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RTCEx_Exported_Constants RTCEx Exported Constants
+  * @{
+  */
+
+/** @defgroup RTCEx_Output_selection_Definitions RTCEx Output selection Definitions
+  * @{
+  */
+#define RTC_OUTPUT_DISABLE             ((uint32_t)0x00000000)
+#define RTC_OUTPUT_ALARMA              ((uint32_t)0x00200000)
+#define RTC_OUTPUT_ALARMB              ((uint32_t)0x00400000)
+#define RTC_OUTPUT_WAKEUP              ((uint32_t)0x00600000)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Backup_Registers_Definitions RTC Backup Registers Definitions
+  * @{
+  */
+#define RTC_BKP_DR0                       ((uint32_t)0x00000000)
+#define RTC_BKP_DR1                       ((uint32_t)0x00000001)
+#define RTC_BKP_DR2                       ((uint32_t)0x00000002)
+#define RTC_BKP_DR3                       ((uint32_t)0x00000003)
+#define RTC_BKP_DR4                       ((uint32_t)0x00000004)
+#define RTC_BKP_DR5                       ((uint32_t)0x00000005)
+#define RTC_BKP_DR6                       ((uint32_t)0x00000006)
+#define RTC_BKP_DR7                       ((uint32_t)0x00000007)
+#define RTC_BKP_DR8                       ((uint32_t)0x00000008)
+#define RTC_BKP_DR9                       ((uint32_t)0x00000009)
+#define RTC_BKP_DR10                      ((uint32_t)0x0000000A)
+#define RTC_BKP_DR11                      ((uint32_t)0x0000000B)
+#define RTC_BKP_DR12                      ((uint32_t)0x0000000C)
+#define RTC_BKP_DR13                      ((uint32_t)0x0000000D)
+#define RTC_BKP_DR14                      ((uint32_t)0x0000000E)
+#define RTC_BKP_DR15                      ((uint32_t)0x0000000F)
+#define RTC_BKP_DR16                      ((uint32_t)0x00000010)
+#define RTC_BKP_DR17                      ((uint32_t)0x00000011)
+#define RTC_BKP_DR18                      ((uint32_t)0x00000012)
+#define RTC_BKP_DR19                      ((uint32_t)0x00000013)
+#define RTC_BKP_DR20                      ((uint32_t)0x00000014)
+#define RTC_BKP_DR21                      ((uint32_t)0x00000015)
+#define RTC_BKP_DR22                      ((uint32_t)0x00000016)
+#define RTC_BKP_DR23                      ((uint32_t)0x00000017)
+#define RTC_BKP_DR24                      ((uint32_t)0x00000018)
+#define RTC_BKP_DR25                      ((uint32_t)0x00000019)
+#define RTC_BKP_DR26                      ((uint32_t)0x0000001A)
+#define RTC_BKP_DR27                      ((uint32_t)0x0000001B)
+#define RTC_BKP_DR28                      ((uint32_t)0x0000001C)
+#define RTC_BKP_DR29                      ((uint32_t)0x0000001D)
+#define RTC_BKP_DR30                      ((uint32_t)0x0000001E)
+#define RTC_BKP_DR31                      ((uint32_t)0x0000001F)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Time_Stamp_Edges_definitions RTCEx Time Stamp Edges definitions
+  * @{
+  */
+#define RTC_TIMESTAMPEDGE_RISING          ((uint32_t)0x00000000)
+#define RTC_TIMESTAMPEDGE_FALLING         ((uint32_t)0x00000008)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Pins_Definitions RTCEx Tamper Pins Definitions
+  * @{
+  */
+#define RTC_TAMPER_1                    RTC_TAMPCR_TAMP1E
+#define RTC_TAMPER_2                    RTC_TAMPCR_TAMP2E
+#define RTC_TAMPER_3                    RTC_TAMPCR_TAMP3E
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Interrupt_Definitions RTCEx Tamper Interrupt Definitions
+  * @{
+  */
+#define RTC_TAMPER1_INTERRUPT                RTC_TAMPCR_TAMP1IE
+#define RTC_TAMPER2_INTERRUPT                RTC_TAMPCR_TAMP2IE
+#define RTC_TAMPER3_INTERRUPT                RTC_TAMPCR_TAMP3IE
+#define RTC_ALL_TAMPER_INTERRUPT             RTC_TAMPCR_TAMPIE
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_TimeStamp_Pin_Selection RTCEx TimeStamp Pin Selection
+  * @{
+  */
+#define RTC_TIMESTAMPPIN_DEFAULT            ((uint32_t)0x00000000)
+#define RTC_TIMESTAMPPIN_POS1               ((uint32_t)0x00000002)
+#define RTC_TIMESTAMPPIN_POS2               ((uint32_t)0x00000004)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Trigger_Definitions RTCEx Tamper Trigger Definitions
+  * @{
+  */
+#define RTC_TAMPERTRIGGER_RISINGEDGE       ((uint32_t)0x00000000)
+#define RTC_TAMPERTRIGGER_FALLINGEDGE      ((uint32_t)0x00000002)
+#define RTC_TAMPERTRIGGER_LOWLEVEL         RTC_TAMPERTRIGGER_RISINGEDGE
+#define RTC_TAMPERTRIGGER_HIGHLEVEL        RTC_TAMPERTRIGGER_FALLINGEDGE
+/**
+  * @}
+  */
+
+  /** @defgroup RTCEx_Tamper_EraseBackUp_Definitions RTCEx Tamper EraseBackUp Definitions
+* @{
+*/
+#define RTC_TAMPER_ERASE_BACKUP_ENABLE               ((uint32_t)0x00000000)
+#define RTC_TAMPER_ERASE_BACKUP_DISABLE              ((uint32_t)0x00020000)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_MaskFlag_Definitions RTCEx Tamper MaskFlag Definitions
+  * @{
+  */
+#define RTC_TAMPERMASK_FLAG_DISABLE                ((uint32_t)0x00000000)
+#define RTC_TAMPERMASK_FLAG_ENABLE                 ((uint32_t)0x00040000)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Filter_Definitions RTCEx Tamper Filter Definitions
+  * @{
+  */
+#define RTC_TAMPERFILTER_DISABLE   ((uint32_t)0x00000000)  /*!< Tamper filter is disabled */
+
+#define RTC_TAMPERFILTER_2SAMPLE   ((uint32_t)0x00000800)  /*!< Tamper is activated after 2
+                                                                consecutive samples at the active level */
+#define RTC_TAMPERFILTER_4SAMPLE   ((uint32_t)0x00001000)  /*!< Tamper is activated after 4
+                                                                consecutive samples at the active level */
+#define RTC_TAMPERFILTER_8SAMPLE   ((uint32_t)0x00001800)  /*!< Tamper is activated after 8
+                                                                consecutive samples at the active leve. */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Sampling_Frequencies_Definitions RTCEx Tamper Sampling Frequencies Definitions
+  * @{
+  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV32768  ((uint32_t)0x00000000)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 32768 */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV16384  ((uint32_t)0x00000100)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 16384 */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV8192   ((uint32_t)0x00000200)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 8192  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV4096   ((uint32_t)0x00000300)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 4096  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV2048   ((uint32_t)0x00000400)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 2048  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV1024   ((uint32_t)0x00000500)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 1024  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV512    ((uint32_t)0x00000600)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 512   */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV256    ((uint32_t)0x00000700)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 256   */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Pin_Precharge_Duration_Definitions RTCEx Tamper Pin Precharge Duration Definitions
+  * @{
+  */
+#define RTC_TAMPERPRECHARGEDURATION_1RTCCLK ((uint32_t)0x00000000)  /*!< Tamper pins are pre-charged before
+                                                                         sampling during 1 RTCCLK cycle */
+#define RTC_TAMPERPRECHARGEDURATION_2RTCCLK ((uint32_t)0x00002000)  /*!< Tamper pins are pre-charged before
+                                                                         sampling during 2 RTCCLK cycles */
+#define RTC_TAMPERPRECHARGEDURATION_4RTCCLK ((uint32_t)0x00004000)  /*!< Tamper pins are pre-charged before
+                                                                         sampling during 4 RTCCLK cycles */
+#define RTC_TAMPERPRECHARGEDURATION_8RTCCLK ((uint32_t)0x00006000)  /*!< Tamper pins are pre-charged before
+                                                                         sampling during 8 RTCCLK cycles */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_TimeStampOnTamperDetection_Definitions RTCEx Tamper TimeStampOnTamperDetection Definitions
+  * @{
+  */
+#define RTC_TIMESTAMPONTAMPERDETECTION_ENABLE  ((uint32_t)RTC_TAMPCR_TAMPTS)  /*!< TimeStamp on Tamper Detection event saved        */
+#define RTC_TIMESTAMPONTAMPERDETECTION_DISABLE ((uint32_t)0x00000000)        /*!< TimeStamp on Tamper Detection event is not saved */
+/**
+  * @}
+  */
+
+/** @defgroup  RTCEx_Tamper_Pull_UP_Definitions RTCEx Tamper Pull UP Definitions
+  * @{
+  */
+#define RTC_TAMPER_PULLUP_ENABLE  ((uint32_t)0x00000000)            /*!< TimeStamp on Tamper Detection event saved        */
+#define RTC_TAMPER_PULLUP_DISABLE ((uint32_t)RTC_TAMPCR_TAMPPUDIS)   /*!< TimeStamp on Tamper Detection event is not saved */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Wakeup_Timer_Definitions RTCEx Wakeup Timer Definitions
+  * @{
+  */
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV16        ((uint32_t)0x00000000)
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV8         ((uint32_t)0x00000001)
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV4         ((uint32_t)0x00000002)
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV2         ((uint32_t)0x00000003)
+#define RTC_WAKEUPCLOCK_CK_SPRE_16BITS      ((uint32_t)0x00000004)
+#define RTC_WAKEUPCLOCK_CK_SPRE_17BITS      ((uint32_t)0x00000006)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Smooth_calib_period_Definitions RTCEx Smooth calib period Definitions
+  * @{
+  */
+#define RTC_SMOOTHCALIB_PERIOD_32SEC   ((uint32_t)0x00000000)  /*!< If RTCCLK = 32768 Hz, Smooth calibration
+                                                                    period is 32s,  else 2exp20 RTCCLK seconds */
+#define RTC_SMOOTHCALIB_PERIOD_16SEC   ((uint32_t)0x00002000)  /*!< If RTCCLK = 32768 Hz, Smooth calibration
+                                                                    period is 16s, else 2exp19 RTCCLK seconds */
+#define RTC_SMOOTHCALIB_PERIOD_8SEC    ((uint32_t)0x00004000)  /*!< If RTCCLK = 32768 Hz, Smooth calibration
+                                                                    period is 8s, else 2exp18 RTCCLK seconds */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Smooth_calib_Plus_pulses_Definitions RTCEx Smooth calib Plus pulses Definitions
+  * @{
+  */
+#define RTC_SMOOTHCALIB_PLUSPULSES_SET    ((uint32_t)0x00008000)  /*!< The number of RTCCLK pulses added
+                                                                       during a X -second window = Y - CALM[8:0]
+                                                                       with Y = 512, 256, 128 when X = 32, 16, 8 */
+#define RTC_SMOOTHCALIB_PLUSPULSES_RESET  ((uint32_t)0x00000000)  /*!< The number of RTCCLK pulses subbstited
+                                                                       during a 32-second window = CALM[8:0] */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Add_1_Second_Parameter_Definitions RTCEx Add 1 Second Parameter Definitions
+  * @{
+  */
+#define RTC_SHIFTADD1S_RESET      ((uint32_t)0x00000000)
+#define RTC_SHIFTADD1S_SET        ((uint32_t)0x80000000)
+/**
+  * @}
+  */
+
+ /** @defgroup RTCEx_Calib_Output_selection_Definitions RTCEx Calib Output selection Definitions
+  * @{
+  */
+#define RTC_CALIBOUTPUT_512HZ            ((uint32_t)0x00000000)
+#define RTC_CALIBOUTPUT_1HZ              ((uint32_t)0x00080000)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup RTCEx_Exported_Macros RTCEx Exported Macros
+  * @{
+  */
+
+/**
+  * @brief  Enable the RTC WakeUp Timer peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_ENABLE(__HANDLE__)                     ((__HANDLE__)->Instance->CR |= (RTC_CR_WUTE))
+
+/**
+  * @brief  Disable the RTC WakeUp Timer peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_DISABLE(__HANDLE__)                    ((__HANDLE__)->Instance->CR &= ~(RTC_CR_WUTE))
+
+/**
+  * @brief  Enable the RTC WakeUpTimer interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC WakeUpTimer interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT: WakeUpTimer interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_ENABLE_IT(__HANDLE__, __INTERRUPT__)    ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC WakeUpTimer interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC WakeUpTimer interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT: WakeUpTimer interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_DISABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC WakeUpTimer interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC WakeUpTimer interrupt sources to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT:  WakeUpTimer interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_GET_IT(__HANDLE__, __INTERRUPT__)       (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 4)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Check whether the specified RTC Wake Up timer interrupt has been enabled or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Wake Up timer interrupt sources to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT:  WakeUpTimer interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)   (((((__HANDLE__)->Instance->CR) & (__INTERRUPT__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC WakeUpTimer's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC WakeUpTimer Flag is pending or not.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_WUTF
+  *             @arg RTC_FLAG_WUTWF
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_GET_FLAG(__HANDLE__, __FLAG__)   (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Clear the RTC Wake Up timer's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC WakeUpTimer Flag to clear.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_WUTF
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Enable the RTC Tamper1 input detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER1_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->TAMPCR |= (RTC_TAMPCR_TAMP1E))
+
+/**
+  * @brief  Disable the RTC Tamper1 input detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER1_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->TAMPCR &= ~(RTC_TAMPCR_TAMP1E))
+
+/**
+  * @brief  Enable the RTC Tamper2 input detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER2_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->TAMPCR |= (RTC_TAMPCR_TAMP2E))
+
+/**
+  * @brief  Disable the RTC Tamper2 input detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER2_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->TAMPCR &= ~(RTC_TAMPCR_TAMP2E))
+
+/**
+  * @brief  Enable the RTC Tamper3 input detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER3_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->TAMPCR |= (RTC_TAMPCR_TAMP3E))
+
+/**
+  * @brief  Disable the RTC Tamper3 input detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER3_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->TAMPCR &= ~(RTC_TAMPCR_TAMP3E))
+
+/**
+  * @brief  Check whether the specified RTC Tamper interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Tamper interrupt to check.
+  *         This parameter can be:
+  *            @arg  RTC_IT_TAMP: All tampers interrupts
+  *            @arg  RTC_IT_TAMP1: Tamper1 interrupt
+  *            @arg  RTC_IT_TAMP2: Tamper2 interrupt
+  *            @arg  RTC_IT_TAMP3: Tamper3 interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_GET_IT(__HANDLE__, __INTERRUPT__)           (((__INTERRUPT__) == RTC_IT_TAMP1) ? (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 3)) != RESET) ? SET : RESET) : \
+                                                                      ((__INTERRUPT__) == RTC_IT_TAMP2) ? (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 5)) != RESET) ? SET : RESET) : \
+                                                                                                          (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 7)) != RESET) ? SET : RESET))
+
+/**
+  * @brief  Check whether the specified RTC Tamper interrupt has been enabled or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Tamper interrupt source to check.
+  *         This parameter can be:
+  *            @arg  RTC_IT_TAMP: All tampers interrupts
+  *            @arg  RTC_IT_TAMP1: Tamper1 interrupt
+  *            @arg  RTC_IT_TAMP2: Tamper2 interrupt
+  *            @arg  RTC_IT_TAMP3: Tamper3 interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)    (((((__HANDLE__)->Instance->TAMPCR) & (__INTERRUPT__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC Tamper's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Tamper Flag is pending or not.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_TAMP1F: Tamper1 flag
+  *             @arg RTC_FLAG_TAMP2F: Tamper2 flag
+  *             @arg RTC_FLAG_TAMP3F: Tamper3 flag
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_GET_FLAG(__HANDLE__, __FLAG__)        (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Clear the RTC Tamper's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Tamper Flag sources to clear.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_TAMP1F: Tamper1 flag
+  *             @arg RTC_FLAG_TAMP2F: Tamper2 flag
+  *             @arg RTC_FLAG_TAMP3F: Tamper3 flag
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_CLEAR_FLAG(__HANDLE__, __FLAG__)      ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Enable the RTC TimeStamp peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_ENABLE(__HANDLE__)                       ((__HANDLE__)->Instance->CR |= (RTC_CR_TSE))
+
+/**
+  * @brief  Disable the RTC TimeStamp peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_DISABLE(__HANDLE__)                      ((__HANDLE__)->Instance->CR &= ~(RTC_CR_TSE))
+
+/**
+  * @brief  Enable the RTC TimeStamp interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC TimeStamp interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_ENABLE_IT(__HANDLE__, __INTERRUPT__)     ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC TimeStamp interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC TimeStamp interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_DISABLE_IT(__HANDLE__, __INTERRUPT__)    ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC TimeStamp interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC TimeStamp interrupt sources to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_GET_IT(__HANDLE__, __INTERRUPT__)        (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 4)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Check whether the specified RTC Time Stamp interrupt has been enabled or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Time Stamp interrupt source to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)     (((((__HANDLE__)->Instance->CR) & (__INTERRUPT__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC TimeStamp's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC TimeStamp Flag is pending or not.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_TSF
+  *            @arg RTC_FLAG_TSOVF
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)     (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Clear the RTC Time Stamp's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Alarm Flag sources to clear.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_TSF
+  *             @arg RTC_FLAG_TSOVF
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)   ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Enable the RTC internal TimeStamp peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_ENABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR |= (RTC_CR_ITSE))
+
+/**
+  * @brief  Disable the RTC internal TimeStamp peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_DISABLE(__HANDLE__)               ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ITSE))
+
+/**
+  * @brief  Get the selected RTC Internal Time Stamp's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Internal Time Stamp Flag is pending or not.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_ITSF
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)    (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Clear the RTC Internal Time Stamp's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Internal Time Stamp Flag source to clear.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_ITSF
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)  ((__HANDLE__)->Instance->ISR) = (~(((__FLAG__) | RTC_ISR_INIT)& 0x0003FFFF)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Enable the RTC calibration output.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CALIBRATION_OUTPUT_ENABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR |= (RTC_CR_COE))
+
+/**
+  * @brief  Disable the calibration output.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CALIBRATION_OUTPUT_DISABLE(__HANDLE__)               ((__HANDLE__)->Instance->CR &= ~(RTC_CR_COE))
+
+/**
+  * @brief  Enable the clock reference detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CLOCKREF_DETECTION_ENABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR |= (RTC_CR_REFCKON))
+
+/**
+  * @brief  Disable the clock reference detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CLOCKREF_DETECTION_DISABLE(__HANDLE__)               ((__HANDLE__)->Instance->CR &= ~(RTC_CR_REFCKON))
+
+/**
+  * @brief  Get the selected RTC shift operation's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC shift operation Flag is pending or not.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_SHPF
+  * @retval None
+  */
+#define __HAL_RTC_SHIFT_GET_FLAG(__HANDLE__, __FLAG__)         (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Enable interrupt on the RTC WakeUp Timer associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT()       (EXTI->IMR |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Disable interrupt on the RTC WakeUp Timer associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_IT()      (EXTI->IMR &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
+
+/**
+  * @brief  Enable event on the RTC WakeUp Timer associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_EVENT()    (EXTI->EMR |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Disable event on the RTC WakeUp Timer associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_EVENT()   (EXTI->EMR &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
+
+/**
+  * @brief  Enable falling edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Disable falling edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
+
+/**
+  * @brief  Enable rising edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Disable rising edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
+
+/**
+  * @brief  Enable rising & falling edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_FALLING_EDGE() __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE();__HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_FALLING_EDGE();
+
+/**
+  * @brief  Disable rising & falling edge trigger on the RTC WakeUp Timer associated Exti line.
+  * This parameter can be:
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_FALLING_EDGE() __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_EDGE();__HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_FALLING_EDGE();
+
+/**
+  * @brief Check whether the RTC WakeUp Timer associated Exti line interrupt flag is set or not.
+  * @retval Line Status.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_GET_FLAG()              (EXTI->PR & RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief Clear the RTC WakeUp Timer associated Exti line flag.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_CLEAR_FLAG()            (EXTI->PR = RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief Generate a Software interrupt on the RTC WakeUp Timer associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_GENERATE_SWIT()         (EXTI->SWIER |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Enable interrupt on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT()        (EXTI->IMR |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Disable interrupt on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_IT()       (EXTI->IMR &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
+
+/**
+  * @brief  Enable event on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_EVENT()    (EXTI->EMR |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Disable event on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_EVENT()   (EXTI->EMR &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
+
+/**
+  * @brief  Enable falling edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Disable falling edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
+
+/**
+  * @brief  Enable rising edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Disable rising edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
+
+/**
+  * @brief  Enable rising & falling edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_FALLING_EDGE() __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE();__HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_FALLING_EDGE();
+
+/**
+  * @brief  Disable rising & falling edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * This parameter can be:
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_FALLING_EDGE() __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_EDGE();__HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_FALLING_EDGE();
+
+/**
+  * @brief Check whether the RTC Tamper and Timestamp associated Exti line interrupt flag is set or not.
+  * @retval Line Status.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GET_FLAG()         (EXTI->PR & RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief Clear the RTC Tamper and Timestamp associated Exti line flag.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG()       (EXTI->PR = RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief Generate a Software interrupt on the RTC Tamper and Timestamp associated Exti line
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GENERATE_SWIT()    (EXTI->SWIER |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup RTCEx_Exported_Functions RTCEx Exported Functions
+  * @{
+  */
+
+/** @addtogroup RTCEx_Exported_Functions_Group1
+  * @{
+  */
+
+/* RTC TimeStamp and Tamper functions *****************************************/
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin);
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_SetInternalTimeStamp(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateInternalTimeStamp(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_GetTimeStamp(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTimeStamp, RTC_DateTypeDef *sTimeStampDate, uint32_t Format);
+
+HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper);
+HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t Tamper);
+void              HAL_RTCEx_TamperTimeStampIRQHandler(RTC_HandleTypeDef *hrtc);
+
+void              HAL_RTCEx_Tamper1EventCallback(RTC_HandleTypeDef *hrtc);
+void              HAL_RTCEx_Tamper2EventCallback(RTC_HandleTypeDef *hrtc);
+void              HAL_RTCEx_Tamper3EventCallback(RTC_HandleTypeDef *hrtc);
+void              HAL_RTCEx_TimeStampEventCallback(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_PollForTimeStampEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper1Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper2Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/** @addtogroup RTCEx_Exported_Functions_Group2
+  * @{
+  */
+/* RTC Wake-up functions ******************************************************/
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock);
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock);
+uint32_t          HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc);
+uint32_t          HAL_RTCEx_GetWakeUpTimer(RTC_HandleTypeDef *hrtc);
+void              HAL_RTCEx_WakeUpTimerIRQHandler(RTC_HandleTypeDef *hrtc);
+void              HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/** @addtogroup RTCEx_Exported_Functions_Group3
+  * @{
+  */
+/* Extension Control functions ************************************************/
+void              HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data);
+uint32_t          HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister);
+
+HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef *hrtc, uint32_t SmoothCalibPeriod, uint32_t SmoothCalibPlusPulses, uint32_t SmouthCalibMinusPulsesValue);
+HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef *hrtc, uint32_t ShiftAdd1S, uint32_t ShiftSubFS);
+HAL_StatusTypeDef HAL_RTCEx_SetCalibrationOutPut(RTC_HandleTypeDef *hrtc, uint32_t CalibOutput);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateCalibrationOutPut(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_SetRefClock(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateRefClock(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
+
+/** @addtogroup RTCEx_Exported_Functions_Group4
+  * @{
+  */
+/* Extension RTC features functions *******************************************/
+void              HAL_RTCEx_AlarmBEventCallback(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup RTCEx_Private_Constants RTCEx Private Constants
+  * @{
+  */
+#define RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT  ((uint32_t)EXTI_IMR_MR21)  /*!< External interrupt line 21 Connected to the RTC Tamper and Time Stamp events */
+#define RTC_EXTI_LINE_WAKEUPTIMER_EVENT       ((uint32_t)EXTI_IMR_MR22)  /*!< External interrupt line 22 Connected to the RTC Wake-up event */
+/**
+  * @}
+  */
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup RTCEx_Private_Constants RTCEx Private Constants
+  * @{
+  */
+/* Masks Definition */
+#define RTC_TAMPCR_TAMPXE     ((uint32_t) (RTC_TAMPCR_TAMP3E | RTC_TAMPCR_TAMP2E | RTC_TAMPCR_TAMP1E))
+#define RTC_TAMPCR_TAMPXIE    ((uint32_t) (RTC_TAMPER1_INTERRUPT | RTC_TAMPER2_INTERRUPT | RTC_TAMPER3_INTERRUPT))
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup RTCEx_Private_Macros RTCEx Private Macros
+  * @{
+  */
+
+/** @defgroup RTCEx_IS_RTC_Definitions Private macros to check input parameters
+  * @{
+  */
+#define IS_RTC_OUTPUT(__OUTPUT__)      (((__OUTPUT__) == RTC_OUTPUT_DISABLE) || \
+                                        ((__OUTPUT__) == RTC_OUTPUT_ALARMA)  || \
+                                        ((__OUTPUT__) == RTC_OUTPUT_ALARMB)  || \
+                                        ((__OUTPUT__) == RTC_OUTPUT_WAKEUP))
+#define IS_RTC_BKP(__BKP__)               ((__BKP__) < (uint32_t) RTC_BKP_NUMBER)
+#define IS_TIMESTAMP_EDGE(__EDGE__) (((__EDGE__) == RTC_TIMESTAMPEDGE_RISING) || \
+                                     ((__EDGE__) == RTC_TIMESTAMPEDGE_FALLING))
+#define IS_RTC_TAMPER(__TAMPER__)   ((((__TAMPER__) & ((uint32_t)(0xFFFFFFFF ^ RTC_TAMPCR_TAMPXE))) == 0x00) && ((__TAMPER__) != (uint32_t)RESET))
+
+#define IS_RTC_TAMPER_INTERRUPT(__INTERRUPT__)  ((((__INTERRUPT__) & (uint32_t)(0xFFFFFFFF ^ RTC_TAMPCR_TAMPXIE)) == 0x00) && ((__INTERRUPT__) != (uint32_t)RESET))
+
+#define IS_RTC_TIMESTAMP_PIN(__PIN__) (((__PIN__) == RTC_TIMESTAMPPIN_DEFAULT) || \
+                                       ((__PIN__) == RTC_TIMESTAMPPIN_POS1)  || \
+                                       ((__PIN__) == RTC_TIMESTAMPPIN_POS2))
+#define IS_RTC_TAMPER_TRIGGER(__TRIGGER__) (((__TRIGGER__) == RTC_TAMPERTRIGGER_RISINGEDGE) || \
+                                        ((__TRIGGER__) == RTC_TAMPERTRIGGER_FALLINGEDGE) || \
+                                        ((__TRIGGER__) == RTC_TAMPERTRIGGER_LOWLEVEL) || \
+                                        ((__TRIGGER__) == RTC_TAMPERTRIGGER_HIGHLEVEL))
+#define IS_RTC_TAMPER_ERASE_MODE(__MODE__)             (((__MODE__) == RTC_TAMPER_ERASE_BACKUP_ENABLE) || \
+                                                        ((__MODE__) == RTC_TAMPER_ERASE_BACKUP_DISABLE))
+#define IS_RTC_TAMPER_MASKFLAG_STATE(__STATE__)     (((__STATE__) == RTC_TAMPERMASK_FLAG_ENABLE) || \
+                                                     ((__STATE__) == RTC_TAMPERMASK_FLAG_DISABLE))
+#define IS_RTC_TAMPER_FILTER(__FILTER__)  (((__FILTER__) == RTC_TAMPERFILTER_DISABLE) || \
+                                       ((__FILTER__) == RTC_TAMPERFILTER_2SAMPLE) || \
+                                       ((__FILTER__) == RTC_TAMPERFILTER_4SAMPLE) || \
+                                       ((__FILTER__) == RTC_TAMPERFILTER_8SAMPLE))
+#define IS_RTC_TAMPER_SAMPLING_FREQ(__FREQ__) (((__FREQ__) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV32768)|| \
+                                           ((__FREQ__) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV16384)|| \
+                                           ((__FREQ__) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV8192) || \
+                                           ((__FREQ__) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV4096) || \
+                                           ((__FREQ__) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV2048) || \
+                                           ((__FREQ__) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV1024) || \
+                                           ((__FREQ__) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV512)  || \
+                                           ((__FREQ__) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV256))
+#define IS_RTC_TAMPER_PRECHARGE_DURATION(__DURATION__) (((__DURATION__) == RTC_TAMPERPRECHARGEDURATION_1RTCCLK) || \
+                                                    ((__DURATION__) == RTC_TAMPERPRECHARGEDURATION_2RTCCLK) || \
+                                                    ((__DURATION__) == RTC_TAMPERPRECHARGEDURATION_4RTCCLK) || \
+                                                    ((__DURATION__) == RTC_TAMPERPRECHARGEDURATION_8RTCCLK))
+#define IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION(__DETECTION__) (((__DETECTION__) == RTC_TIMESTAMPONTAMPERDETECTION_ENABLE) || \
+                                                              ((__DETECTION__) == RTC_TIMESTAMPONTAMPERDETECTION_DISABLE))
+#define IS_RTC_TAMPER_PULLUP_STATE(__STATE__) (((__STATE__) == RTC_TAMPER_PULLUP_ENABLE) || \
+                                       ((__STATE__) == RTC_TAMPER_PULLUP_DISABLE))
+#define IS_RTC_WAKEUP_CLOCK(__CLOCK__) (((__CLOCK__) == RTC_WAKEUPCLOCK_RTCCLK_DIV16)       || \
+                                    ((__CLOCK__) == RTC_WAKEUPCLOCK_RTCCLK_DIV8)    || \
+                                    ((__CLOCK__) == RTC_WAKEUPCLOCK_RTCCLK_DIV4)    || \
+                                    ((__CLOCK__) == RTC_WAKEUPCLOCK_RTCCLK_DIV2)    || \
+                                    ((__CLOCK__) == RTC_WAKEUPCLOCK_CK_SPRE_16BITS) || \
+                                    ((__CLOCK__) == RTC_WAKEUPCLOCK_CK_SPRE_17BITS))
+
+#define IS_RTC_WAKEUP_COUNTER(__COUNTER__)  ((__COUNTER__) <= 0xFFFF)
+#define IS_RTC_SMOOTH_CALIB_PERIOD(__PERIOD__) (((__PERIOD__) == RTC_SMOOTHCALIB_PERIOD_32SEC) || \
+                                                ((__PERIOD__) == RTC_SMOOTHCALIB_PERIOD_16SEC) || \
+                                                ((__PERIOD__) == RTC_SMOOTHCALIB_PERIOD_8SEC))
+#define IS_RTC_SMOOTH_CALIB_PLUS(__PLUS__) (((__PLUS__) == RTC_SMOOTHCALIB_PLUSPULSES_SET) || \
+                                            ((__PLUS__) == RTC_SMOOTHCALIB_PLUSPULSES_RESET))
+#define  IS_RTC_SMOOTH_CALIB_MINUS(__VALUE__) ((__VALUE__) <= 0x000001FF)
+#define IS_RTC_SHIFT_ADD1S(__SEL__) (((__SEL__) == RTC_SHIFTADD1S_RESET) || \
+                                     ((__SEL__) == RTC_SHIFTADD1S_SET))
+#define IS_RTC_SHIFT_SUBFS(__FS__) ((__FS__) <= 0x00007FFF)
+#define IS_RTC_CALIB_OUTPUT(__OUTPUT__)  (((__OUTPUT__) == RTC_CALIBOUTPUT_512HZ) || \
+                                          ((__OUTPUT__) == RTC_CALIBOUTPUT_1HZ))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_RTC_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_sd.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_sd.h
@@ -1,0 +1,774 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_sd.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of SD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_SD_H
+#define __STM32F7xx_HAL_SD_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_ll_sdmmc.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SD SD
+  * @brief SD HAL module driver
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup SD_Exported_Types SD Exported Types
+  * @{
+  */
+
+/** @defgroup SD_Exported_Types_Group1 SD Handle Structure definition
+  * @{
+  */
+#define SD_InitTypeDef      SDMMC_InitTypeDef
+#define SD_TypeDef          SDMMC_TypeDef
+
+typedef struct
+{
+  SD_TypeDef                   *Instance;        /*!< SDMMC register base address                     */
+
+  SD_InitTypeDef               Init;             /*!< SD required parameters                         */
+
+  HAL_LockTypeDef              Lock;             /*!< SD locking object                              */
+
+  uint32_t                     CardType;         /*!< SD card type                                   */
+
+  uint32_t                     RCA;              /*!< SD relative card address                       */
+
+  uint32_t                     CSD[4];           /*!< SD card specific data table                    */
+
+  uint32_t                     CID[4];           /*!< SD card identification number table            */
+
+  __IO uint32_t                SdTransferCplt;   /*!< SD transfer complete flag in non blocking mode */
+
+  __IO uint32_t                SdTransferErr;    /*!< SD transfer error flag in non blocking mode    */
+
+  __IO uint32_t                DmaTransferCplt;  /*!< SD DMA transfer complete flag                  */
+
+  __IO uint32_t                SdOperation;      /*!< SD transfer operation (read/write)             */
+
+  DMA_HandleTypeDef            *hdmarx;          /*!< SD Rx DMA handle parameters                    */
+
+  DMA_HandleTypeDef            *hdmatx;          /*!< SD Tx DMA handle parameters                    */
+
+}SD_HandleTypeDef;
+/**
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group2 Card Specific Data: CSD Register
+  * @{
+  */
+typedef struct
+{
+  __IO uint8_t  CSDStruct;            /*!< CSD structure                         */
+  __IO uint8_t  SysSpecVersion;       /*!< System specification version          */
+  __IO uint8_t  Reserved1;            /*!< Reserved                              */
+  __IO uint8_t  TAAC;                 /*!< Data read access time 1               */
+  __IO uint8_t  NSAC;                 /*!< Data read access time 2 in CLK cycles */
+  __IO uint8_t  MaxBusClkFrec;        /*!< Max. bus clock frequency              */
+  __IO uint16_t CardComdClasses;      /*!< Card command classes                  */
+  __IO uint8_t  RdBlockLen;           /*!< Max. read data block length           */
+  __IO uint8_t  PartBlockRead;        /*!< Partial blocks for read allowed       */
+  __IO uint8_t  WrBlockMisalign;      /*!< Write block misalignment              */
+  __IO uint8_t  RdBlockMisalign;      /*!< Read block misalignment               */
+  __IO uint8_t  DSRImpl;              /*!< DSR implemented                       */
+  __IO uint8_t  Reserved2;            /*!< Reserved                              */
+  __IO uint32_t DeviceSize;           /*!< Device Size                           */
+  __IO uint8_t  MaxRdCurrentVDDMin;   /*!< Max. read current @ VDD min           */
+  __IO uint8_t  MaxRdCurrentVDDMax;   /*!< Max. read current @ VDD max           */
+  __IO uint8_t  MaxWrCurrentVDDMin;   /*!< Max. write current @ VDD min          */
+  __IO uint8_t  MaxWrCurrentVDDMax;   /*!< Max. write current @ VDD max          */
+  __IO uint8_t  DeviceSizeMul;        /*!< Device size multiplier                */
+  __IO uint8_t  EraseGrSize;          /*!< Erase group size                      */
+  __IO uint8_t  EraseGrMul;           /*!< Erase group size multiplier           */
+  __IO uint8_t  WrProtectGrSize;      /*!< Write protect group size              */
+  __IO uint8_t  WrProtectGrEnable;    /*!< Write protect group enable            */
+  __IO uint8_t  ManDeflECC;           /*!< Manufacturer default ECC              */
+  __IO uint8_t  WrSpeedFact;          /*!< Write speed factor                    */
+  __IO uint8_t  MaxWrBlockLen;        /*!< Max. write data block length          */
+  __IO uint8_t  WriteBlockPaPartial;  /*!< Partial blocks for write allowed      */
+  __IO uint8_t  Reserved3;            /*!< Reserved                              */
+  __IO uint8_t  ContentProtectAppli;  /*!< Content protection application        */
+  __IO uint8_t  FileFormatGrouop;     /*!< File format group                     */
+  __IO uint8_t  CopyFlag;             /*!< Copy flag (OTP)                       */
+  __IO uint8_t  PermWrProtect;        /*!< Permanent write protection            */
+  __IO uint8_t  TempWrProtect;        /*!< Temporary write protection            */
+  __IO uint8_t  FileFormat;           /*!< File format                           */
+  __IO uint8_t  ECC;                  /*!< ECC code                              */
+  __IO uint8_t  CSD_CRC;              /*!< CSD CRC                               */
+  __IO uint8_t  Reserved4;            /*!< Always 1                              */
+
+}HAL_SD_CSDTypedef;
+/**
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group3 Card Identification Data: CID Register
+  * @{
+  */
+typedef struct
+{
+  __IO uint8_t  ManufacturerID;  /*!< Manufacturer ID       */
+  __IO uint16_t OEM_AppliID;     /*!< OEM/Application ID    */
+  __IO uint32_t ProdName1;       /*!< Product Name part1    */
+  __IO uint8_t  ProdName2;       /*!< Product Name part2    */
+  __IO uint8_t  ProdRev;         /*!< Product Revision      */
+  __IO uint32_t ProdSN;          /*!< Product Serial Number */
+  __IO uint8_t  Reserved1;       /*!< Reserved1             */
+  __IO uint16_t ManufactDate;    /*!< Manufacturing Date    */
+  __IO uint8_t  CID_CRC;         /*!< CID CRC               */
+  __IO uint8_t  Reserved2;       /*!< Always 1              */
+
+}HAL_SD_CIDTypedef;
+/**
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group4 SD Card Status returned by ACMD13
+  * @{
+  */
+typedef struct
+{
+  __IO uint8_t  DAT_BUS_WIDTH;           /*!< Shows the currently defined data bus width                 */
+  __IO uint8_t  SECURED_MODE;            /*!< Card is in secured mode of operation                       */
+  __IO uint16_t SD_CARD_TYPE;            /*!< Carries information about card type                        */
+  __IO uint32_t SIZE_OF_PROTECTED_AREA;  /*!< Carries information about the capacity of protected area   */
+  __IO uint8_t  SPEED_CLASS;             /*!< Carries information about the speed class of the card      */
+  __IO uint8_t  PERFORMANCE_MOVE;        /*!< Carries information about the card's performance move      */
+  __IO uint8_t  AU_SIZE;                 /*!< Carries information about the card's allocation unit size  */
+  __IO uint16_t ERASE_SIZE;              /*!< Determines the number of AUs to be erased in one operation */
+  __IO uint8_t  ERASE_TIMEOUT;           /*!< Determines the timeout for any number of AU erase          */
+  __IO uint8_t  ERASE_OFFSET;            /*!< Carries information about the erase offset                 */
+
+}HAL_SD_CardStatusTypedef;
+/**
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group5 SD Card information structure
+  * @{
+  */
+typedef struct
+{
+  HAL_SD_CSDTypedef   SD_csd;         /*!< SD card specific data register         */
+  HAL_SD_CIDTypedef   SD_cid;         /*!< SD card identification number register */
+  uint64_t            CardCapacity;   /*!< Card capacity                          */
+  uint32_t            CardBlockSize;  /*!< Card block size                        */
+  uint16_t            RCA;            /*!< SD relative card address               */
+  uint8_t             CardType;       /*!< SD card type                           */
+
+}HAL_SD_CardInfoTypedef;
+/**
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group6 SD Error status enumeration Structure definition
+  * @{
+  */
+typedef enum
+{
+/**
+  * @brief  SD specific error defines
+  */
+  SD_CMD_CRC_FAIL                    = (1),   /*!< Command response received (but CRC check failed)              */
+  SD_DATA_CRC_FAIL                   = (2),   /*!< Data block sent/received (CRC check failed)                   */
+  SD_CMD_RSP_TIMEOUT                 = (3),   /*!< Command response timeout                                      */
+  SD_DATA_TIMEOUT                    = (4),   /*!< Data timeout                                                  */
+  SD_TX_UNDERRUN                     = (5),   /*!< Transmit FIFO underrun                                        */
+  SD_RX_OVERRUN                      = (6),   /*!< Receive FIFO overrun                                          */
+  SD_START_BIT_ERR                   = (7),   /*!< Start bit not detected on all data signals in wide bus mode   */
+  SD_CMD_OUT_OF_RANGE                = (8),   /*!< Command's argument was out of range.                          */
+  SD_ADDR_MISALIGNED                 = (9),   /*!< Misaligned address                                            */
+  SD_BLOCK_LEN_ERR                   = (10),  /*!< Transferred block length is not allowed for the card or the number of transferred bytes does not match the block length */
+  SD_ERASE_SEQ_ERR                   = (11),  /*!< An error in the sequence of erase command occurs.            */
+  SD_BAD_ERASE_PARAM                 = (12),  /*!< An invalid selection for erase groups                        */
+  SD_WRITE_PROT_VIOLATION            = (13),  /*!< Attempt to program a write protect block                     */
+  SD_LOCK_UNLOCK_FAILED              = (14),  /*!< Sequence or password error has been detected in unlock command or if there was an attempt to access a locked card */
+  SD_COM_CRC_FAILED                  = (15),  /*!< CRC check of the previous command failed                     */
+  SD_ILLEGAL_CMD                     = (16),  /*!< Command is not legal for the card state                      */
+  SD_CARD_ECC_FAILED                 = (17),  /*!< Card internal ECC was applied but failed to correct the data */
+  SD_CC_ERROR                        = (18),  /*!< Internal card controller error                               */
+  SD_GENERAL_UNKNOWN_ERROR           = (19),  /*!< General or unknown error                                     */
+  SD_STREAM_READ_UNDERRUN            = (20),  /*!< The card could not sustain data transfer in stream read operation. */
+  SD_STREAM_WRITE_OVERRUN            = (21),  /*!< The card could not sustain data programming in stream mode   */
+  SD_CID_CSD_OVERWRITE               = (22),  /*!< CID/CSD overwrite error                                      */
+  SD_WP_ERASE_SKIP                   = (23),  /*!< Only partial address space was erased                        */
+  SD_CARD_ECC_DISABLED               = (24),  /*!< Command has been executed without using internal ECC         */
+  SD_ERASE_RESET                     = (25),  /*!< Erase sequence was cleared before executing because an out of erase sequence command was received */
+  SD_AKE_SEQ_ERROR                   = (26),  /*!< Error in sequence of authentication.                         */
+  SD_INVALID_VOLTRANGE               = (27),
+  SD_ADDR_OUT_OF_RANGE               = (28),
+  SD_SWITCH_ERROR                    = (29),
+  SD_SDMMC_DISABLED                  = (30),
+  SD_SDMMC_FUNCTION_BUSY             = (31),
+  SD_SDMMC_FUNCTION_FAILED           = (32),
+  SD_SDMMC_UNKNOWN_FUNCTION          = (33),
+
+/**
+  * @brief  Standard error defines
+  */
+  SD_INTERNAL_ERROR                  = (34),
+  SD_NOT_CONFIGURED                  = (35),
+  SD_REQUEST_PENDING                 = (36),
+  SD_REQUEST_NOT_APPLICABLE          = (37),
+  SD_INVALID_PARAMETER               = (38),
+  SD_UNSUPPORTED_FEATURE             = (39),
+  SD_UNSUPPORTED_HW                  = (40),
+  SD_ERROR                           = (41),
+  SD_OK                              = (0)
+
+}HAL_SD_ErrorTypedef;
+/**
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group7 SD Transfer state enumeration structure
+  * @{
+  */
+typedef enum
+{
+  SD_TRANSFER_OK    = 0,  /*!< Transfer success      */
+  SD_TRANSFER_BUSY  = 1,  /*!< Transfer is occurring */
+  SD_TRANSFER_ERROR = 2   /*!< Transfer failed       */
+
+}HAL_SD_TransferStateTypedef;
+/**
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group8 SD Card State enumeration structure
+  * @{
+  */
+typedef enum
+{
+  SD_CARD_READY                  = ((uint32_t)0x00000001),  /*!< Card state is ready                     */
+  SD_CARD_IDENTIFICATION         = ((uint32_t)0x00000002),  /*!< Card is in identification state         */
+  SD_CARD_STANDBY                = ((uint32_t)0x00000003),  /*!< Card is in standby state                */
+  SD_CARD_TRANSFER               = ((uint32_t)0x00000004),  /*!< Card is in transfer state               */
+  SD_CARD_SENDING                = ((uint32_t)0x00000005),  /*!< Card is sending an operation            */
+  SD_CARD_RECEIVING              = ((uint32_t)0x00000006),  /*!< Card is receiving operation information */
+  SD_CARD_PROGRAMMING            = ((uint32_t)0x00000007),  /*!< Card is in programming state            */
+  SD_CARD_DISCONNECTED           = ((uint32_t)0x00000008),  /*!< Card is disconnected                    */
+  SD_CARD_ERROR                  = ((uint32_t)0x000000FF)   /*!< Card is in error state                  */
+
+}HAL_SD_CardStateTypedef;
+/**
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group9 SD Operation enumeration structure
+  * @{
+  */
+typedef enum
+{
+  SD_READ_SINGLE_BLOCK    = 0,  /*!< Read single block operation      */
+  SD_READ_MULTIPLE_BLOCK  = 1,  /*!< Read multiple blocks operation   */
+  SD_WRITE_SINGLE_BLOCK   = 2,  /*!< Write single block operation     */
+  SD_WRITE_MULTIPLE_BLOCK = 3   /*!< Write multiple blocks operation  */
+
+}HAL_SD_OperationTypedef;
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup SD_Exported_Constants SD Exported Constants
+  * @{
+  */
+
+/**
+  * @brief SD Commands Index
+  */
+#define SD_CMD_GO_IDLE_STATE                       ((uint8_t)0)   /*!< Resets the SD memory card.                                                               */
+#define SD_CMD_SEND_OP_COND                        ((uint8_t)1)   /*!< Sends host capacity support information and activates the card's initialization process. */
+#define SD_CMD_ALL_SEND_CID                        ((uint8_t)2)   /*!< Asks any card connected to the host to send the CID numbers on the CMD line.             */
+#define SD_CMD_SET_REL_ADDR                        ((uint8_t)3)   /*!< Asks the card to publish a new relative address (RCA).                                   */
+#define SD_CMD_SET_DSR                             ((uint8_t)4)   /*!< Programs the DSR of all cards.                                                           */
+#define SD_CMD_SDMMC_SEN_OP_COND                   ((uint8_t)5)   /*!< Sends host capacity support information (HCS) and asks the accessed card to send its
+                                                                       operating condition register (OCR) content in the response on the CMD line.              */
+#define SD_CMD_HS_SWITCH                           ((uint8_t)6)   /*!< Checks switchable function (mode 0) and switch card function (mode 1).                   */
+#define SD_CMD_SEL_DESEL_CARD                      ((uint8_t)7)   /*!< Selects the card by its own relative address and gets deselected by any other address    */
+#define SD_CMD_HS_SEND_EXT_CSD                     ((uint8_t)8)   /*!< Sends SD Memory Card interface condition, which includes host supply voltage information
+                                                                       and asks the card whether card supports voltage.                                         */
+#define SD_CMD_SEND_CSD                            ((uint8_t)9)   /*!< Addressed card sends its card specific data (CSD) on the CMD line.                       */
+#define SD_CMD_SEND_CID                            ((uint8_t)10)  /*!< Addressed card sends its card identification (CID) on the CMD line.                      */
+#define SD_CMD_READ_DAT_UNTIL_STOP                 ((uint8_t)11)  /*!< SD card doesn't support it.                                                              */
+#define SD_CMD_STOP_TRANSMISSION                   ((uint8_t)12)  /*!< Forces the card to stop transmission.                                                    */
+#define SD_CMD_SEND_STATUS                         ((uint8_t)13)  /*!< Addressed card sends its status register.                                                */
+#define SD_CMD_HS_BUSTEST_READ                     ((uint8_t)14)
+#define SD_CMD_GO_INACTIVE_STATE                   ((uint8_t)15)  /*!< Sends an addressed card into the inactive state.                                         */
+#define SD_CMD_SET_BLOCKLEN                        ((uint8_t)16)  /*!< Sets the block length (in bytes for SDSC) for all following block commands
+                                                                       (read, write, lock). Default block length is fixed to 512 Bytes. Not effective
+                                                                       for SDHS and SDXC.                                                                       */
+#define SD_CMD_READ_SINGLE_BLOCK                   ((uint8_t)17)  /*!< Reads single block of size selected by SET_BLOCKLEN in case of SDSC, and a block of
+                                                                       fixed 512 bytes in case of SDHC and SDXC.                                                */
+#define SD_CMD_READ_MULT_BLOCK                     ((uint8_t)18)  /*!< Continuously transfers data blocks from card to host until interrupted by
+                                                                       STOP_TRANSMISSION command.                                                               */
+#define SD_CMD_HS_BUSTEST_WRITE                    ((uint8_t)19)  /*!< 64 bytes tuning pattern is sent for SDR50 and SDR104.                                    */
+#define SD_CMD_WRITE_DAT_UNTIL_STOP                ((uint8_t)20)  /*!< Speed class control command.                                                             */
+#define SD_CMD_SET_BLOCK_COUNT                     ((uint8_t)23)  /*!< Specify block count for CMD18 and CMD25.                                                 */
+#define SD_CMD_WRITE_SINGLE_BLOCK                  ((uint8_t)24)  /*!< Writes single block of size selected by SET_BLOCKLEN in case of SDSC, and a block of
+                                                                       fixed 512 bytes in case of SDHC and SDXC.                                                */
+#define SD_CMD_WRITE_MULT_BLOCK                    ((uint8_t)25)  /*!< Continuously writes blocks of data until a STOP_TRANSMISSION follows.                    */
+#define SD_CMD_PROG_CID                            ((uint8_t)26)  /*!< Reserved for manufacturers.                                                              */
+#define SD_CMD_PROG_CSD                            ((uint8_t)27)  /*!< Programming of the programmable bits of the CSD.                                         */
+#define SD_CMD_SET_WRITE_PROT                      ((uint8_t)28)  /*!< Sets the write protection bit of the addressed group.                                    */
+#define SD_CMD_CLR_WRITE_PROT                      ((uint8_t)29)  /*!< Clears the write protection bit of the addressed group.                                  */
+#define SD_CMD_SEND_WRITE_PROT                     ((uint8_t)30)  /*!< Asks the card to send the status of the write protection bits.                           */
+#define SD_CMD_SD_ERASE_GRP_START                  ((uint8_t)32)  /*!< Sets the address of the first write block to be erased. (For SD card only).              */
+#define SD_CMD_SD_ERASE_GRP_END                    ((uint8_t)33)  /*!< Sets the address of the last write block of the continuous range to be erased.           */
+#define SD_CMD_ERASE_GRP_START                     ((uint8_t)35)  /*!< Sets the address of the first write block to be erased. Reserved for each command
+                                                                       system set by switch function command (CMD6).                                            */
+#define SD_CMD_ERASE_GRP_END                       ((uint8_t)36)  /*!< Sets the address of the last write block of the continuous range to be erased.
+                                                                       Reserved for each command system set by switch function command (CMD6).                  */
+#define SD_CMD_ERASE                               ((uint8_t)38)  /*!< Reserved for SD security applications.                                                   */
+#define SD_CMD_FAST_IO                             ((uint8_t)39)  /*!< SD card doesn't support it (Reserved).                                                   */
+#define SD_CMD_GO_IRQ_STATE                        ((uint8_t)40)  /*!< SD card doesn't support it (Reserved).                                                   */
+#define SD_CMD_LOCK_UNLOCK                         ((uint8_t)42)  /*!< Sets/resets the password or lock/unlock the card. The size of the data block is set by
+                                                                       the SET_BLOCK_LEN command.                                                               */
+#define SD_CMD_APP_CMD                             ((uint8_t)55)  /*!< Indicates to the card that the next command is an application specific command rather
+                                                                       than a standard command.                                                                 */
+#define SD_CMD_GEN_CMD                             ((uint8_t)56)  /*!< Used either to transfer a data block to the card or to get a data block from the card
+                                                                       for general purpose/application specific commands.                                       */
+#define SD_CMD_NO_CMD                              ((uint8_t)64)
+
+/**
+  * @brief Following commands are SD Card Specific commands.
+  *        SDMMC_APP_CMD should be sent before sending these commands.
+  */
+#define SD_CMD_APP_SD_SET_BUSWIDTH                 ((uint8_t)6)   /*!< (ACMD6) Defines the data bus width to be used for data transfer. The allowed data bus
+                                                                       widths are given in SCR register.                                                          */
+#define SD_CMD_SD_APP_STATUS                       ((uint8_t)13)  /*!< (ACMD13) Sends the SD status.                                                              */
+#define SD_CMD_SD_APP_SEND_NUM_WRITE_BLOCKS        ((uint8_t)22)  /*!< (ACMD22) Sends the number of the written (without errors) write blocks. Responds with
+                                                                       32bit+CRC data block.                                                                      */
+#define SD_CMD_SD_APP_OP_COND                      ((uint8_t)41)  /*!< (ACMD41) Sends host capacity support information (HCS) and asks the accessed card to
+                                                                       send its operating condition register (OCR) content in the response on the CMD line.       */
+#define SD_CMD_SD_APP_SET_CLR_CARD_DETECT          ((uint8_t)42)  /*!< (ACMD42) Connects/Disconnects the 50 KOhm pull-up resistor on CD/DAT3 (pin 1) of the card. */
+#define SD_CMD_SD_APP_SEND_SCR                     ((uint8_t)51)  /*!< Reads the SD Configuration Register (SCR).                                                 */
+#define SD_CMD_SDMMC_RW_DIRECT                     ((uint8_t)52)  /*!< For SD I/O card only, reserved for security specification.                                 */
+#define SD_CMD_SDMMC_RW_EXTENDED                   ((uint8_t)53)  /*!< For SD I/O card only, reserved for security specification.                                 */
+
+/**
+  * @brief Following commands are SD Card Specific security commands.
+  *        SD_CMD_APP_CMD should be sent before sending these commands.
+  */
+#define SD_CMD_SD_APP_GET_MKB                      ((uint8_t)43)  /*!< For SD card only */
+#define SD_CMD_SD_APP_GET_MID                      ((uint8_t)44)  /*!< For SD card only */
+#define SD_CMD_SD_APP_SET_CER_RN1                  ((uint8_t)45)  /*!< For SD card only */
+#define SD_CMD_SD_APP_GET_CER_RN2                  ((uint8_t)46)  /*!< For SD card only */
+#define SD_CMD_SD_APP_SET_CER_RES2                 ((uint8_t)47)  /*!< For SD card only */
+#define SD_CMD_SD_APP_GET_CER_RES1                 ((uint8_t)48)  /*!< For SD card only */
+#define SD_CMD_SD_APP_SECURE_READ_MULTIPLE_BLOCK   ((uint8_t)18)  /*!< For SD card only */
+#define SD_CMD_SD_APP_SECURE_WRITE_MULTIPLE_BLOCK  ((uint8_t)25)  /*!< For SD card only */
+#define SD_CMD_SD_APP_SECURE_ERASE                 ((uint8_t)38)  /*!< For SD card only */
+#define SD_CMD_SD_APP_CHANGE_SECURE_AREA           ((uint8_t)49)  /*!< For SD card only */
+#define SD_CMD_SD_APP_SECURE_WRITE_MKB             ((uint8_t)48)  /*!< For SD card only */
+
+/**
+  * @brief Supported SD Memory Cards
+  */
+#define STD_CAPACITY_SD_CARD_V1_1             ((uint32_t)0x00000000)
+#define STD_CAPACITY_SD_CARD_V2_0             ((uint32_t)0x00000001)
+#define HIGH_CAPACITY_SD_CARD                 ((uint32_t)0x00000002)
+#define MULTIMEDIA_CARD                       ((uint32_t)0x00000003)
+#define SECURE_DIGITAL_IO_CARD                ((uint32_t)0x00000004)
+#define HIGH_SPEED_MULTIMEDIA_CARD            ((uint32_t)0x00000005)
+#define SECURE_DIGITAL_IO_COMBO_CARD          ((uint32_t)0x00000006)
+#define HIGH_CAPACITY_MMC_CARD                ((uint32_t)0x00000007)
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup SD_Exported_macros SD Exported Macros
+ *  @brief macros to handle interrupts and specific clock configurations
+ * @{
+ */
+
+/**
+  * @brief  Enable the SD device.
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_ENABLE(__HANDLE__) __SDMMC_ENABLE((__HANDLE__)->Instance)
+
+/**
+  * @brief  Disable the SD device.
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_DISABLE(__HANDLE__) __SDMMC_DISABLE((__HANDLE__)->Instance)
+
+/**
+  * @brief  Enable the SDMMC DMA transfer.
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_DMA_ENABLE(__HANDLE__) __SDMMC_DMA_ENABLE((__HANDLE__)->Instance)
+
+/**
+  * @brief  Disable the SDMMC DMA transfer.
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_DMA_DISABLE(__HANDLE__)  __SDMMC_DMA_DISABLE((__HANDLE__)->Instance)
+
+/**
+  * @brief  Enable the SD device interrupt.
+  * @param  __HANDLE__: SD Handle
+  * @param  __INTERRUPT__: specifies the SDMMC interrupt sources to be enabled.
+  *         This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDACT:   Command transfer in progress interrupt
+  *            @arg SDMMC_IT_TXACT:    Data transmit in progress interrupt
+  *            @arg SDMMC_IT_RXACT:    Data receive in progress interrupt
+  *            @arg SDMMC_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+  *            @arg SDMMC_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+  *            @arg SDMMC_IT_TXFIFOF:  Transmit FIFO full interrupt
+  *            @arg SDMMC_IT_RXFIFOF:  Receive FIFO full interrupt
+  *            @arg SDMMC_IT_TXFIFOE:  Transmit FIFO empty interrupt
+  *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
+  *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
+  *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_ENABLE_IT(__HANDLE__, __INTERRUPT__) __SDMMC_ENABLE_IT((__HANDLE__)->Instance, (__INTERRUPT__))
+
+/**
+  * @brief  Disable the SD device interrupt.
+  * @param  __HANDLE__: SD Handle
+  * @param  __INTERRUPT__: specifies the SDMMC interrupt sources to be disabled.
+  *          This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDACT:   Command transfer in progress interrupt
+  *            @arg SDMMC_IT_TXACT:    Data transmit in progress interrupt
+  *            @arg SDMMC_IT_RXACT:    Data receive in progress interrupt
+  *            @arg SDMMC_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+  *            @arg SDMMC_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+  *            @arg SDMMC_IT_TXFIFOF:  Transmit FIFO full interrupt
+  *            @arg SDMMC_IT_RXFIFOF:  Receive FIFO full interrupt
+  *            @arg SDMMC_IT_TXFIFOE:  Transmit FIFO empty interrupt
+  *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
+  *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
+  *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_DISABLE_IT(__HANDLE__, __INTERRUPT__) __SDMMC_DISABLE_IT((__HANDLE__)->Instance, (__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified SD flag is set or not.
+  * @param  __HANDLE__: SD Handle
+  * @param  __FLAG__: specifies the flag to check.
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_FLAG_CCRCFAIL: Command response received (CRC check failed)
+  *            @arg SDMMC_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
+  *            @arg SDMMC_FLAG_CTIMEOUT: Command response timeout
+  *            @arg SDMMC_FLAG_DTIMEOUT: Data timeout
+  *            @arg SDMMC_FLAG_TXUNDERR: Transmit FIFO underrun error
+  *            @arg SDMMC_FLAG_RXOVERR:  Received FIFO overrun error
+  *            @arg SDMMC_FLAG_CMDREND:  Command response received (CRC check passed)
+  *            @arg SDMMC_FLAG_CMDSENT:  Command sent (no response required)
+  *            @arg SDMMC_FLAG_DATAEND:  Data end (data counter, SDIDCOUNT, is zero)
+  *            @arg SDMMC_FLAG_DBCKEND:  Data block sent/received (CRC check passed)
+  *            @arg SDMMC_FLAG_CMDACT:   Command transfer in progress
+  *            @arg SDMMC_FLAG_TXACT:    Data transmit in progress
+  *            @arg SDMMC_FLAG_RXACT:    Data receive in progress
+  *            @arg SDMMC_FLAG_TXFIFOHE: Transmit FIFO Half Empty
+  *            @arg SDMMC_FLAG_RXFIFOHF: Receive FIFO Half Full
+  *            @arg SDMMC_FLAG_TXFIFOF:  Transmit FIFO full
+  *            @arg SDMMC_FLAG_RXFIFOF:  Receive FIFO full
+  *            @arg SDMMC_FLAG_TXFIFOE:  Transmit FIFO empty
+  *            @arg SDMMC_FLAG_RXFIFOE:  Receive FIFO empty
+  *            @arg SDMMC_FLAG_TXDAVL:   Data available in transmit FIFO
+  *            @arg SDMMC_FLAG_RXDAVL:   Data available in receive FIFO
+  *            @arg SDMMC_FLAG_SDIOIT:   SD I/O interrupt received
+  * @retval The new state of SD FLAG (SET or RESET).
+  */
+#define __HAL_SD_SDMMC_GET_FLAG(__HANDLE__, __FLAG__) __SDMMC_GET_FLAG((__HANDLE__)->Instance, (__FLAG__))
+
+/**
+  * @brief  Clear the SD's pending flags.
+  * @param  __HANDLE__: SD Handle
+  * @param  __FLAG__: specifies the flag to clear.
+  *          This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_FLAG_CCRCFAIL: Command response received (CRC check failed)
+  *            @arg SDMMC_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
+  *            @arg SDMMC_FLAG_CTIMEOUT: Command response timeout
+  *            @arg SDMMC_FLAG_DTIMEOUT: Data timeout
+  *            @arg SDMMC_FLAG_TXUNDERR: Transmit FIFO underrun error
+  *            @arg SDMMC_FLAG_RXOVERR:  Received FIFO overrun error
+  *            @arg SDMMC_FLAG_CMDREND:  Command response received (CRC check passed)
+  *            @arg SDMMC_FLAG_CMDSENT:  Command sent (no response required)
+  *            @arg SDMMC_FLAG_DATAEND:  Data end (data counter, SDIDCOUNT, is zero)
+  *            @arg SDMMC_FLAG_DBCKEND:  Data block sent/received (CRC check passed)
+  *            @arg SDMMC_FLAG_SDIOIT:   SD I/O interrupt received
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_CLEAR_FLAG(__HANDLE__, __FLAG__) __SDMMC_CLEAR_FLAG((__HANDLE__)->Instance, (__FLAG__))
+
+/**
+  * @brief  Check whether the specified SD interrupt has occurred or not.
+  * @param  __HANDLE__: SD Handle
+  * @param  __INTERRUPT__: specifies the SDMMC interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDACT:   Command transfer in progress interrupt
+  *            @arg SDMMC_IT_TXACT:    Data transmit in progress interrupt
+  *            @arg SDMMC_IT_RXACT:    Data receive in progress interrupt
+  *            @arg SDMMC_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+  *            @arg SDMMC_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+  *            @arg SDMMC_IT_TXFIFOF:  Transmit FIFO full interrupt
+  *            @arg SDMMC_IT_RXFIFOF:  Receive FIFO full interrupt
+  *            @arg SDMMC_IT_TXFIFOE:  Transmit FIFO empty interrupt
+  *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
+  *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
+  *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval The new state of SD IT (SET or RESET).
+  */
+#define __HAL_SD_SDMMC_GET_IT(__HANDLE__, __INTERRUPT__) __SDMMC_GET_IT((__HANDLE__)->Instance, (__INTERRUPT__))
+
+/**
+  * @brief  Clear the SD's interrupt pending bits.
+  * @param  __HANDLE__: SD Handle
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
+  *          This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDMMC_DCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_CLEAR_IT(__HANDLE__, __INTERRUPT__) __SDMMC_CLEAR_IT((__HANDLE__)->Instance, (__INTERRUPT__))
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup SD_Exported_Functions SD Exported Functions
+  * @{
+  */
+
+/** @defgroup SD_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+HAL_SD_ErrorTypedef HAL_SD_Init(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTypedef *SDCardInfo);
+HAL_StatusTypeDef   HAL_SD_DeInit (SD_HandleTypeDef *hsd);
+void HAL_SD_MspInit(SD_HandleTypeDef *hsd);
+void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd);
+/**
+  * @}
+  */
+
+/** @defgroup SD_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
+/* Blocking mode: Polling */
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
+HAL_SD_ErrorTypedef HAL_SD_Erase(SD_HandleTypeDef *hsd, uint64_t startaddr, uint64_t endaddr);
+
+/* Non-Blocking mode: Interrupt */
+void HAL_SD_IRQHandler(SD_HandleTypeDef *hsd);
+
+/* Callback in non blocking modes (DMA) */
+void HAL_SD_DMA_RxCpltCallback(DMA_HandleTypeDef *hdma);
+void HAL_SD_DMA_RxErrorCallback(DMA_HandleTypeDef *hdma);
+void HAL_SD_DMA_TxCpltCallback(DMA_HandleTypeDef *hdma);
+void HAL_SD_DMA_TxErrorCallback(DMA_HandleTypeDef *hdma);
+void HAL_SD_XferCpltCallback(SD_HandleTypeDef *hsd);
+void HAL_SD_XferErrorCallback(SD_HandleTypeDef *hsd);
+
+/* Non-Blocking mode: DMA */
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
+HAL_SD_ErrorTypedef HAL_SD_CheckWriteOperation(SD_HandleTypeDef *hsd, uint32_t Timeout);
+HAL_SD_ErrorTypedef HAL_SD_CheckReadOperation(SD_HandleTypeDef *hsd, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/** @defgroup SD_Exported_Functions_Group3 Peripheral Control functions
+  * @{
+  */
+HAL_SD_ErrorTypedef HAL_SD_Get_CardInfo(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTypedef *pCardInfo);
+HAL_SD_ErrorTypedef HAL_SD_WideBusOperation_Config(SD_HandleTypeDef *hsd, uint32_t WideMode);
+HAL_SD_ErrorTypedef HAL_SD_StopTransfer(SD_HandleTypeDef *hsd);
+HAL_SD_ErrorTypedef HAL_SD_HighSpeed (SD_HandleTypeDef *hsd);
+/**
+  * @}
+  */
+
+/* Peripheral State functions  ************************************************/
+/** @defgroup SD_Exported_Functions_Group4 Peripheral State functions
+  * @{
+  */
+HAL_SD_ErrorTypedef HAL_SD_SendSDStatus(SD_HandleTypeDef *hsd, uint32_t *pSDstatus);
+HAL_SD_ErrorTypedef HAL_SD_GetCardStatus(SD_HandleTypeDef *hsd, HAL_SD_CardStatusTypedef *pCardStatus);
+HAL_SD_TransferStateTypedef HAL_SD_GetStatus(SD_HandleTypeDef *hsd);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/** @defgroup SD_Private_Types SD Private Types
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private defines -----------------------------------------------------------*/
+/** @defgroup SD_Private_Defines SD Private Defines
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup SD_Private_Variables SD Private Variables
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup SD_Private_Constants SD Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup SD_Private_Macros SD Private Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions prototypes ----------------------------------------------*/
+/** @defgroup SD_Private_Functions_Prototypes SD Private Functions Prototypes
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup SD_Private_Functions SD Private Functions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32F7xx_HAL_SD_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_spi.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_spi.h
@@ -1,0 +1,696 @@
+ /**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_spi.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of SPI HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_SPI_H
+#define __STM32F7xx_HAL_SPI_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup SPI
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup SPI_Exported_Types SPI Exported Types
+  * @{
+  */
+
+/**
+  * @brief  SPI Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t Mode;                /*!< Specifies the SPI operating mode.
+                                     This parameter can be a value of @ref SPI_Mode */
+
+  uint32_t Direction;           /*!< Specifies the SPI bidirectional mode state.
+                                     This parameter can be a value of @ref SPI_Direction */
+
+  uint32_t DataSize;            /*!< Specifies the SPI data size.
+                                     This parameter can be a value of @ref SPI_Data_Size */
+
+  uint32_t CLKPolarity;         /*!< Specifies the serial clock steady state.
+                                     This parameter can be a value of @ref SPI_Clock_Polarity */
+
+  uint32_t CLKPhase;            /*!< Specifies the clock active edge for the bit capture.
+                                     This parameter can be a value of @ref SPI_Clock_Phase */
+
+  uint32_t NSS;                 /*!< Specifies whether the NSS signal is managed by
+                                     hardware (NSS pin) or by software using the SSI bit.
+                                     This parameter can be a value of @ref SPI_Slave_Select_management */
+
+  uint32_t BaudRatePrescaler;   /*!< Specifies the Baud Rate prescaler value which will be
+                                     used to configure the transmit and receive SCK clock.
+                                     This parameter can be a value of @ref SPI_BaudRate_Prescaler
+                                     @note The communication clock is derived from the master
+                                     clock. The slave clock does not need to be set. */
+
+  uint32_t FirstBit;            /*!< Specifies whether data transfers start from MSB or LSB bit.
+                                     This parameter can be a value of @ref SPI_MSB_LSB_transmission */
+
+  uint32_t TIMode;              /*!< Specifies if the TI mode is enabled or not .
+                                     This parameter can be a value of @ref SPI_TI_mode */
+
+  uint32_t CRCCalculation;      /*!< Specifies if the CRC calculation is enabled or not.
+                                     This parameter can be a value of @ref SPI_CRC_Calculation */
+
+  uint32_t CRCPolynomial;       /*!< Specifies the polynomial used for the CRC calculation.
+                                     This parameter must be a number between Min_Data = 0 and Max_Data = 65535 */
+
+  uint32_t CRCLength;           /*!< Specifies the CRC Length used for the CRC calculation.
+                                     CRC Length is only used with Data8 and Data16, not other data size
+                                     This parameter can be a value of @ref SPI_CRC_length */
+
+  uint32_t NSSPMode;            /*!< Specifies whether the NSSP signal is enabled or not .
+                                     This parameter can be a value of @ref SPI_NSSP_Mode
+                                     This mode is activated by the NSSP bit in the SPIx_CR2 register and
+                                     it takes effect only if the SPI interface is configured as Motorola SPI
+                                     master (FRF=0) with capture on the first edge (SPIx_CR1 CPHA = 0,
+                                     CPOL setting is ignored).. */
+} SPI_InitTypeDef;
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef enum
+{
+  HAL_SPI_STATE_RESET      = 0x00,    /*!< Peripheral not Initialized                         */
+  HAL_SPI_STATE_READY      = 0x01,    /*!< Peripheral Initialized and ready for use           */
+  HAL_SPI_STATE_BUSY       = 0x02,    /*!< an internal process is ongoing                     */
+  HAL_SPI_STATE_BUSY_TX    = 0x03,    /*!< Data Transmission process is ongoing               */
+  HAL_SPI_STATE_BUSY_RX    = 0x04,    /*!< Data Reception process is ongoing                  */
+  HAL_SPI_STATE_BUSY_TX_RX = 0x05,    /*!< Data Transmission and Reception process is ongoing*/
+  HAL_SPI_STATE_ERROR      = 0x06     /*!< SPI error state                                   */
+}HAL_SPI_StateTypeDef;
+
+/**
+  * @brief  SPI handle Structure definition
+  */
+typedef struct __SPI_HandleTypeDef
+{
+  SPI_TypeDef             *Instance;      /* SPI registers base address     */
+
+  SPI_InitTypeDef         Init;           /* SPI communication parameters   */
+
+  uint8_t                 *pTxBuffPtr;    /* Pointer to SPI Tx transfer Buffer */
+
+  uint16_t                TxXferSize;     /* SPI Tx Transfer size */
+
+  uint16_t                TxXferCount;    /* SPI Tx Transfer Counter */
+
+  uint8_t                 *pRxBuffPtr;    /* Pointer to SPI Rx transfer Buffer */
+
+  uint16_t                RxXferSize;     /* SPI Rx Transfer size */
+
+  uint16_t                RxXferCount;    /* SPI Rx Transfer Counter */
+
+  uint32_t                CRCSize;        /* SPI CRC size used for the transfer */
+
+  void (*RxISR)(struct __SPI_HandleTypeDef *hspi); /* function pointer on Rx IRQ handler   */
+
+  void (*TxISR)(struct __SPI_HandleTypeDef *hspi); /* function pointer on Tx IRQ handler   */
+
+  DMA_HandleTypeDef       *hdmatx;        /* SPI Tx DMA Handle parameters   */
+
+  DMA_HandleTypeDef       *hdmarx;        /* SPI Rx DMA Handle parameters   */
+
+  HAL_LockTypeDef         Lock;           /* Locking object                 */
+
+  HAL_SPI_StateTypeDef    State;          /* SPI communication state        */
+
+  uint32_t                ErrorCode;      /* SPI Error code                 */
+
+}SPI_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup SPI_Exported_Constants SPI Exported Constants
+  * @{
+  */
+
+/** @defgroup SPI_Error_Code SPI Error Code
+  * @{
+  */
+#define HAL_SPI_ERROR_NONE   (uint32_t)0x00000000  /*!< No error                          */
+#define HAL_SPI_ERROR_MODF   (uint32_t)0x00000001  /*!< MODF error                        */
+#define HAL_SPI_ERROR_CRC    (uint32_t)0x00000002  /*!< CRC error                         */
+#define HAL_SPI_ERROR_OVR    (uint32_t)0x00000004  /*!< OVR error                         */
+#define HAL_SPI_ERROR_FRE    (uint32_t)0x00000008  /*!< FRE error                         */
+#define HAL_SPI_ERROR_DMA    (uint32_t)0x00000010  /*!< DMA transfer error                */
+#define HAL_SPI_ERROR_FLAG   (uint32_t)0x00000020  /*!< Error on BSY/TXE/FTLVL/FRLVL Flag */
+#define HAL_SPI_ERROR_UNKNOW (uint32_t)0x00000040  /*!< Unknow Error error                */
+/**
+  * @}
+  */
+
+
+/** @defgroup SPI_Mode SPI Mode
+  * @{
+  */
+#define SPI_MODE_SLAVE                  ((uint32_t)0x00000000)
+#define SPI_MODE_MASTER                 (SPI_CR1_MSTR | SPI_CR1_SSI)
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Direction SPI Direction Mode
+  * @{
+  */
+#define SPI_DIRECTION_2LINES            ((uint32_t)0x00000000)
+#define SPI_DIRECTION_2LINES_RXONLY     SPI_CR1_RXONLY
+#define SPI_DIRECTION_1LINE             SPI_CR1_BIDIMODE
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Data_Size SPI Data Size
+  * @{
+  */
+#define SPI_DATASIZE_4BIT               ((uint32_t)0x0300)
+#define SPI_DATASIZE_5BIT               ((uint32_t)0x0400)
+#define SPI_DATASIZE_6BIT               ((uint32_t)0x0500)
+#define SPI_DATASIZE_7BIT               ((uint32_t)0x0600)
+#define SPI_DATASIZE_8BIT               ((uint32_t)0x0700)
+#define SPI_DATASIZE_9BIT               ((uint32_t)0x0800)
+#define SPI_DATASIZE_10BIT              ((uint32_t)0x0900)
+#define SPI_DATASIZE_11BIT              ((uint32_t)0x0A00)
+#define SPI_DATASIZE_12BIT              ((uint32_t)0x0B00)
+#define SPI_DATASIZE_13BIT              ((uint32_t)0x0C00)
+#define SPI_DATASIZE_14BIT              ((uint32_t)0x0D00)
+#define SPI_DATASIZE_15BIT              ((uint32_t)0x0E00)
+#define SPI_DATASIZE_16BIT              ((uint32_t)0x0F00)
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Clock_Polarity SPI Clock Polarity
+  * @{
+  */
+#define SPI_POLARITY_LOW                ((uint32_t)0x00000000)
+#define SPI_POLARITY_HIGH               SPI_CR1_CPOL
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Clock_Phase SPI Clock Phase
+  * @{
+  */
+#define SPI_PHASE_1EDGE                 ((uint32_t)0x00000000)
+#define SPI_PHASE_2EDGE                 SPI_CR1_CPHA
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Slave_Select_management SPI Slave Select management
+  * @{
+  */
+#define SPI_NSS_SOFT                    SPI_CR1_SSM
+#define SPI_NSS_HARD_INPUT              ((uint32_t)0x00000000)
+#define SPI_NSS_HARD_OUTPUT             ((uint32_t)0x00040000)
+/**
+  * @}
+  */
+
+/** @defgroup SPI_NSSP_Mode SPI NSS Pulse Mode
+  * @{
+  */
+#define SPI_NSS_PULSE_ENABLE            SPI_CR2_NSSP
+#define SPI_NSS_PULSE_DISABLE           ((uint32_t)0x00000000)
+/**
+  * @}
+  */
+
+/** @defgroup SPI_BaudRate_Prescaler SPI BaudRate Prescaler
+  * @{
+  */
+#define SPI_BAUDRATEPRESCALER_2         ((uint32_t)0x00000000)
+#define SPI_BAUDRATEPRESCALER_4         ((uint32_t)0x00000008)
+#define SPI_BAUDRATEPRESCALER_8         ((uint32_t)0x00000010)
+#define SPI_BAUDRATEPRESCALER_16        ((uint32_t)0x00000018)
+#define SPI_BAUDRATEPRESCALER_32        ((uint32_t)0x00000020)
+#define SPI_BAUDRATEPRESCALER_64        ((uint32_t)0x00000028)
+#define SPI_BAUDRATEPRESCALER_128       ((uint32_t)0x00000030)
+#define SPI_BAUDRATEPRESCALER_256       ((uint32_t)0x00000038)
+/**
+  * @}
+  */
+
+/** @defgroup SPI_MSB_LSB_transmission SPI MSB LSB transmission
+  * @{
+  */
+#define SPI_FIRSTBIT_MSB                ((uint32_t)0x00000000)
+#define SPI_FIRSTBIT_LSB                SPI_CR1_LSBFIRST
+/**
+  * @}
+  */
+
+/** @defgroup SPI_TI_mode SPI TI mode
+  * @{
+  */
+#define SPI_TIMODE_DISABLE              ((uint32_t)0x00000000)
+#define SPI_TIMODE_ENABLE               SPI_CR2_FRF
+/**
+  * @}
+  */
+
+/** @defgroup SPI_CRC_Calculation SPI CRC Calculation
+  * @{
+  */
+#define SPI_CRCCALCULATION_DISABLE      ((uint32_t)0x00000000)
+#define SPI_CRCCALCULATION_ENABLE       SPI_CR1_CRCEN
+/**
+  * @}
+  */
+
+/** @defgroup SPI_CRC_length SPI CRC Length
+  * @{
+  * This parameter can be one of the following values:
+  *     SPI_CRC_LENGTH_DATASIZE: aligned with the data size
+  *     SPI_CRC_LENGTH_8BIT    : CRC 8bit
+  *     SPI_CRC_LENGTH_16BIT   : CRC 16bit
+  */
+#define SPI_CRC_LENGTH_DATASIZE         ((uint32_t)0x00000000)
+#define SPI_CRC_LENGTH_8BIT             ((uint32_t)0x00000001)
+#define SPI_CRC_LENGTH_16BIT            ((uint32_t)0x00000002)
+/**
+  * @}
+  */
+
+/** @defgroup SPI_FIFO_reception_threshold SPI FIFO Reception Threshold
+  * @{
+  * This parameter can be one of the following values:
+  *     SPI_RXFIFO_THRESHOLD or SPI_RXFIFO_THRESHOLD_QF :
+  *          RXNE event is generated if the FIFO
+  *          level is greater or equal to 1/2(16-bits).
+  *     SPI_RXFIFO_THRESHOLD_HF: RXNE event is generated if the FIFO
+  *          level is greater or equal to 1/4(8 bits). */
+#define SPI_RXFIFO_THRESHOLD            SPI_CR2_FRXTH
+#define SPI_RXFIFO_THRESHOLD_QF         SPI_CR2_FRXTH
+#define SPI_RXFIFO_THRESHOLD_HF         ((uint32_t)0x00000000)
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Interrupt_configuration_definition SPI Interrupt configuration definition
+  * @brief SPI Interrupt definition
+  *        Elements values convention: 0xXXXXXXXX
+  *           - XXXXXXXX  : Interrupt control mask
+  * @{
+  */
+#define SPI_IT_TXE                      SPI_CR2_TXEIE
+#define SPI_IT_RXNE                     SPI_CR2_RXNEIE
+#define SPI_IT_ERR                      SPI_CR2_ERRIE
+/**
+  * @}
+  */
+
+
+/** @defgroup SPI_Flag_definition SPI Flag definition
+  * @brief Flag definition
+  *        Elements values convention: 0xXXXXYYYY
+  *           - XXXX  : Flag register Index
+  *           - YYYY  : Flag mask
+  * @{
+  */
+#define SPI_FLAG_RXNE                   SPI_SR_RXNE   /* SPI status flag: Rx buffer not empty flag */
+#define SPI_FLAG_TXE                    SPI_SR_TXE    /* SPI status flag: Tx buffer empty flag */
+#define SPI_FLAG_BSY                    SPI_SR_BSY    /* SPI status flag: Busy flag */
+#define SPI_FLAG_CRCERR                 SPI_SR_CRCERR /* SPI Error flag: CRC error flag */
+#define SPI_FLAG_MODF                   SPI_SR_MODF   /* SPI Error flag: Mode fault flag */
+#define SPI_FLAG_OVR                    SPI_SR_OVR    /* SPI Error flag: Overrun flag */
+#define SPI_FLAG_FRE                    SPI_SR_FRE    /* SPI Error flag: TI mode frame format error flag */
+#define SPI_FLAG_FTLVL                  SPI_SR_FTLVL  /* SPI fifo transmission level */
+#define SPI_FLAG_FRLVL                  SPI_SR_FRLVL  /* SPI fifo reception level */
+/**
+  * @}
+  */
+
+/** @defgroup SPI_transmission_fifo_status_level SPI Transmission FIFO Status Level
+  * @{
+  */
+#define SPI_FTLVL_EMPTY           ((uint32_t)0x0000)
+#define SPI_FTLVL_QUARTER_FULL    ((uint32_t)0x0800)
+#define SPI_FTLVL_HALF_FULL       ((uint32_t)0x1000)
+#define SPI_FTLVL_FULL            ((uint32_t)0x1800)
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_reception_fifo_status_level SPI Reception FIFO Status Level
+  * @{
+  */
+#define SPI_FRLVL_EMPTY           ((uint32_t)0x0000)
+#define SPI_FRLVL_QUARTER_FULL    ((uint32_t)0x0200)
+#define SPI_FRLVL_HALF_FULL       ((uint32_t)0x0400)
+#define SPI_FRLVL_FULL            ((uint32_t)0x0600)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros ------------------------------------------------------------*/
+/** @defgroup SPI_Exported_Macros SPI Exported Macros
+  * @{
+  */
+
+/** @brief  Reset SPI handle state
+  * @param  __HANDLE__: SPI handle.
+  * @retval None
+  */
+#define __HAL_SPI_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_SPI_STATE_RESET)
+
+/** @brief  Enables or disables the specified SPI interrupts.
+  * @param  __HANDLE__ : specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @param  __INTERRUPT__ : specifies the interrupt source to enable or disable.
+  *        This parameter can be one of the following values:
+  *            @arg SPI_IT_TXE: Tx buffer empty interrupt enable
+  *            @arg SPI_IT_RXNE: RX buffer not empty interrupt enable
+  *            @arg SPI_IT_ERR: Error interrupt enable
+  * @retval None
+  */
+#define __HAL_SPI_ENABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CR2 |= (__INTERRUPT__))
+#define __HAL_SPI_DISABLE_IT(__HANDLE__, __INTERRUPT__)  ((__HANDLE__)->Instance->CR2 &= (~(__INTERRUPT__)))
+
+/** @brief  Checks if the specified SPI interrupt source is enabled or disabled.
+  * @param  __HANDLE__ : specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @param  __INTERRUPT__ : specifies the SPI interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg SPI_IT_TXE: Tx buffer empty interrupt enable
+  *            @arg SPI_IT_RXNE: RX buffer not empty interrupt enable
+  *            @arg SPI_IT_ERR: Error interrupt enable
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_SPI_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR2 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/** @brief  Checks whether the specified SPI flag is set or not.
+  * @param  __HANDLE__ : specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @param  __FLAG__ : specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg SPI_FLAG_RXNE: Receive buffer not empty flag
+  *            @arg SPI_FLAG_TXE: Transmit buffer empty flag
+  *            @arg SPI_FLAG_CRCERR: CRC error flag
+  *            @arg SPI_FLAG_MODF: Mode fault flag
+  *            @arg SPI_FLAG_OVR: Overrun flag
+  *            @arg SPI_FLAG_BSY: Busy flag
+  *            @arg SPI_FLAG_FRE: Frame format error flag
+  *            @arg SPI_FLAG_FTLVL: SPI fifo transmission level
+  *            @arg SPI_FLAG_FRLVL: SPI fifo reception level
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_SPI_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->SR) & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Clears the SPI CRCERR pending flag.
+  * @param  __HANDLE__ : specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define __HAL_SPI_CLEAR_CRCERRFLAG(__HANDLE__) ((__HANDLE__)->Instance->SR = (uint16_t)(~SPI_FLAG_CRCERR))
+
+/** @brief  Clears the SPI MODF pending flag.
+  * @param  __HANDLE__ : specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  *
+  * @retval None
+  */
+#define __HAL_SPI_CLEAR_MODFFLAG(__HANDLE__)        \
+   do{                                              \
+     __IO uint32_t tmpreg;                          \
+     tmpreg = (__HANDLE__)->Instance->SR;           \
+     (__HANDLE__)->Instance->CR1 &= (~SPI_CR1_SPE); \
+     UNUSED(tmpreg);                                \
+   } while(0)
+
+/** @brief  Clears the SPI OVR pending flag.
+  * @param  __HANDLE__ : specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  *
+  * @retval None
+  */
+#define __HAL_SPI_CLEAR_OVRFLAG(__HANDLE__)         \
+   do{                                              \
+     __IO uint32_t tmpreg;                          \
+     tmpreg = (__HANDLE__)->Instance->DR;           \
+     tmpreg = (__HANDLE__)->Instance->SR;           \
+     UNUSED(tmpreg);                                \
+   } while(0)
+
+/** @brief  Clears the SPI FRE pending flag.
+  * @param  __HANDLE__ : specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  *
+  * @retval None
+  */
+#define __HAL_SPI_CLEAR_FREFLAG(__HANDLE__)         \
+   do{                                              \
+     __IO uint32_t tmpreg;                          \
+     tmpreg = (__HANDLE__)->Instance->SR;           \
+     UNUSED(tmpreg);                                \
+   } while(0)
+
+/** @brief  Enables the SPI.
+  * @param  __HANDLE__ : specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define __HAL_SPI_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR1 |=  SPI_CR1_SPE)
+
+/** @brief  Disables the SPI.
+  * @param  __HANDLE__ : specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define __HAL_SPI_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR1 &= (~SPI_CR1_SPE))
+
+/**
+  * @}
+  */
+
+/* Private macros --------------------------------------------------------*/
+/** @defgroup SPI_Private_Macros   SPI Private Macros
+  * @{
+  */
+
+/** @brief  Sets the SPI transmit-only mode.
+  * @param  __HANDLE__ : specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define SPI_1LINE_TX(__HANDLE__) ((__HANDLE__)->Instance->CR1 |= SPI_CR1_BIDIOE)
+
+/** @brief  Sets the SPI receive-only mode.
+  * @param  __HANDLE__ : specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define SPI_1LINE_RX(__HANDLE__) ((__HANDLE__)->Instance->CR1 &= (~SPI_CR1_BIDIOE))
+
+/** @brief  Resets the CRC calculation of the SPI.
+  * @param  __HANDLE__ : specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define SPI_RESET_CRC(__HANDLE__) do{(__HANDLE__)->Instance->CR1 &= (uint16_t)(~SPI_CR1_CRCEN);\
+                                     (__HANDLE__)->Instance->CR1 |= SPI_CR1_CRCEN;}while(0)
+
+#define IS_SPI_MODE(MODE) (((MODE) == SPI_MODE_SLAVE) || \
+                           ((MODE) == SPI_MODE_MASTER))
+
+#define IS_SPI_DIRECTION(MODE)   (((MODE) == SPI_DIRECTION_2LINES) || \
+                                  ((MODE) == SPI_DIRECTION_2LINES_RXONLY) ||\
+                                  ((MODE) == SPI_DIRECTION_1LINE))
+
+#define IS_SPI_DIRECTION_2LINES(MODE) ((MODE) == SPI_DIRECTION_2LINES)
+
+#define IS_SPI_DIRECTION_2LINES_OR_1LINE(MODE) (((MODE) == SPI_DIRECTION_2LINES)|| \
+                                                 ((MODE) == SPI_DIRECTION_1LINE))
+
+#define IS_SPI_DATASIZE(DATASIZE) (((DATASIZE) == SPI_DATASIZE_16BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_15BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_14BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_13BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_12BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_11BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_10BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_9BIT)  || \
+                                   ((DATASIZE) == SPI_DATASIZE_8BIT)  || \
+                                   ((DATASIZE) == SPI_DATASIZE_7BIT)  || \
+                                   ((DATASIZE) == SPI_DATASIZE_6BIT)  || \
+                                   ((DATASIZE) == SPI_DATASIZE_5BIT)  || \
+                                   ((DATASIZE) == SPI_DATASIZE_4BIT))
+
+#define IS_SPI_CPOL(CPOL) (((CPOL) == SPI_POLARITY_LOW) || \
+                           ((CPOL) == SPI_POLARITY_HIGH))
+
+#define IS_SPI_CPHA(CPHA) (((CPHA) == SPI_PHASE_1EDGE) || \
+                           ((CPHA) == SPI_PHASE_2EDGE))
+
+#define IS_SPI_NSS(NSS) (((NSS) == SPI_NSS_SOFT) || \
+                         ((NSS) == SPI_NSS_HARD_INPUT) || \
+                         ((NSS) == SPI_NSS_HARD_OUTPUT))
+
+#define IS_SPI_NSSP(NSSP) (((NSSP) == SPI_NSS_PULSE_ENABLE) || \
+                           ((NSSP) == SPI_NSS_PULSE_DISABLE))
+
+#define IS_SPI_BAUDRATE_PRESCALER(PRESCALER) (((PRESCALER) == SPI_BAUDRATEPRESCALER_2) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_4) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_8) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_16) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_32) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_64) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_128) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_256))
+
+#define IS_SPI_FIRST_BIT(BIT) (((BIT) == SPI_FIRSTBIT_MSB) || \
+                               ((BIT) == SPI_FIRSTBIT_LSB))
+
+#define IS_SPI_TIMODE(MODE) (((MODE) == SPI_TIMODE_DISABLE) || \
+                             ((MODE) == SPI_TIMODE_ENABLE))
+
+#define IS_SPI_CRC_CALCULATION(CALCULATION) (((CALCULATION) == SPI_CRCCALCULATION_DISABLE) || \
+                                             ((CALCULATION) == SPI_CRCCALCULATION_ENABLE))
+
+#define IS_SPI_CRC_LENGTH(LENGTH) (((LENGTH) == SPI_CRC_LENGTH_DATASIZE) ||\
+                                   ((LENGTH) == SPI_CRC_LENGTH_8BIT)  ||   \
+                                   ((LENGTH) == SPI_CRC_LENGTH_16BIT))
+
+#define IS_SPI_CRC_POLYNOMIAL(POLYNOMIAL) (((POLYNOMIAL) >= 0x1) && ((POLYNOMIAL) <= 0xFFFF))
+
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup SPI_Exported_Functions SPI Exported Functions
+  * @{
+  */
+
+/** @addtogroup SPI_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+
+/* Initialization and de-initialization functions  ****************************/
+HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPI_DeInit (SPI_HandleTypeDef *hspi);
+void HAL_SPI_MspInit(SPI_HandleTypeDef *hspi);
+void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi);
+/**
+  * @}
+  */
+
+/** @addtogroup SPI_Exported_Functions_Group2 IO operation functions
+  * @{
+  */
+
+/* IO operation functions *****************************************************/
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_DMAPause(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPI_DMAResume(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPI_DMAStop(SPI_HandleTypeDef *hspi);
+
+void HAL_SPI_IRQHandler(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxHalfCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_RxHalfCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxRxHalfCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi);
+/**
+  * @}
+  */
+
+/** @addtogroup SPI_Exported_Functions_Group3 Peripheral State and Errors functions
+  * @{
+  */
+
+/* Peripheral State and Error functions ***************************************/
+HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi);
+uint32_t             HAL_SPI_GetError(SPI_HandleTypeDef *hspi);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_SPI_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_tim.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_tim.h
@@ -1,0 +1,1546 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_tim.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of TIM HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_TIM_H
+#define __STM32F7xx_HAL_TIM_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup TIM
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup TIM_Exported_Types TIM Exported Types
+  * @{
+  */
+
+/**
+  * @brief  TIM Time base Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t Prescaler;         /*!< Specifies the prescaler value used to divide the TIM clock.
+                                   This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t CounterMode;       /*!< Specifies the counter mode.
+                                   This parameter can be a value of @ref TIM_Counter_Mode */
+
+  uint32_t Period;            /*!< Specifies the period value to be loaded into the active
+                                   Auto-Reload Register at the next update event.
+                                   This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF.  */
+
+  uint32_t ClockDivision;     /*!< Specifies the clock division.
+                                   This parameter can be a value of @ref TIM_ClockDivision */
+
+  uint32_t RepetitionCounter;  /*!< Specifies the repetition counter value. Each time the RCR downcounter
+                                    reaches zero, an update event is generated and counting restarts
+                                    from the RCR value (N).
+                                    This means in PWM mode that (N+1) corresponds to:
+                                        - the number of PWM periods in edge-aligned mode
+                                        - the number of half PWM period in center-aligned mode
+                                     This parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFF.
+                                     @note This parameter is valid only for TIM1 and TIM8. */
+} TIM_Base_InitTypeDef;
+
+/**
+  * @brief  TIM Output Compare Configuration Structure definition
+  */
+
+typedef struct
+{
+  uint32_t OCMode;        /*!< Specifies the TIM mode.
+                               This parameter can be a value of @ref TIMEx_Output_Compare_and_PWM_modes */
+
+  uint32_t Pulse;         /*!< Specifies the pulse value to be loaded into the Capture Compare Register.
+                               This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t OCPolarity;    /*!< Specifies the output polarity.
+                               This parameter can be a value of @ref TIM_Output_Compare_Polarity */
+
+  uint32_t OCNPolarity;   /*!< Specifies the complementary output polarity.
+                               This parameter can be a value of @ref TIM_Output_Compare_N_Polarity
+                               @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint32_t OCFastMode;   /*!< Specifies the Fast mode state.
+                               This parameter can be a value of @ref TIM_Output_Fast_State
+                               @note This parameter is valid only in PWM1 and PWM2 mode. */
+
+
+  uint32_t OCIdleState;   /*!< Specifies the TIM Output Compare pin state during Idle state.
+                               This parameter can be a value of @ref TIM_Output_Compare_Idle_State
+                               @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint32_t OCNIdleState;  /*!< Specifies the TIM Output Compare pin state during Idle state.
+                               This parameter can be a value of @ref TIM_Output_Compare_N_Idle_State
+                               @note This parameter is valid only for TIM1 and TIM8. */
+} TIM_OC_InitTypeDef;
+
+/**
+  * @brief  TIM One Pulse Mode Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t OCMode;        /*!< Specifies the TIM mode.
+                               This parameter can be a value of @ref TIMEx_Output_Compare_and_PWM_modes */
+
+  uint32_t Pulse;         /*!< Specifies the pulse value to be loaded into the Capture Compare Register.
+                               This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t OCPolarity;    /*!< Specifies the output polarity.
+                               This parameter can be a value of @ref TIM_Output_Compare_Polarity */
+
+  uint32_t OCNPolarity;   /*!< Specifies the complementary output polarity.
+                               This parameter can be a value of @ref TIM_Output_Compare_N_Polarity
+                               @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint32_t OCIdleState;   /*!< Specifies the TIM Output Compare pin state during Idle state.
+                               This parameter can be a value of @ref TIM_Output_Compare_Idle_State
+                               @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint32_t OCNIdleState;  /*!< Specifies the TIM Output Compare pin state during Idle state.
+                               This parameter can be a value of @ref TIM_Output_Compare_N_Idle_State
+                               @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint32_t ICPolarity;    /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t ICSelection;   /*!< Specifies the input.
+                              This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint32_t ICFilter;      /*!< Specifies the input capture filter.
+                              This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+} TIM_OnePulse_InitTypeDef;
+
+
+/**
+  * @brief  TIM Input Capture Configuration Structure definition
+  */
+
+typedef struct
+{
+  uint32_t  ICPolarity;   /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t ICSelection;  /*!< Specifies the input.
+                              This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint32_t ICPrescaler;  /*!< Specifies the Input Capture Prescaler.
+                              This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+  uint32_t ICFilter;     /*!< Specifies the input capture filter.
+                              This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+} TIM_IC_InitTypeDef;
+
+/**
+  * @brief  TIM Encoder Configuration Structure definition
+  */
+
+typedef struct
+{
+  uint32_t EncoderMode;   /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Encoder_Mode */
+
+  uint32_t IC1Polarity;   /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t IC1Selection;  /*!< Specifies the input.
+                               This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint32_t IC1Prescaler;  /*!< Specifies the Input Capture Prescaler.
+                               This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+  uint32_t IC1Filter;     /*!< Specifies the input capture filter.
+                               This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+
+  uint32_t IC2Polarity;   /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t IC2Selection;  /*!< Specifies the input.
+                              This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint32_t IC2Prescaler;  /*!< Specifies the Input Capture Prescaler.
+                               This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+  uint32_t IC2Filter;     /*!< Specifies the input capture filter.
+                               This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+} TIM_Encoder_InitTypeDef;
+
+/**
+  * @brief  Clock Configuration Handle Structure definition
+  */
+typedef struct
+{
+  uint32_t ClockSource;     /*!< TIM clock sources.
+                                 This parameter can be a value of @ref TIM_Clock_Source */
+  uint32_t ClockPolarity;   /*!< TIM clock polarity.
+                                 This parameter can be a value of @ref TIM_Clock_Polarity */
+  uint32_t ClockPrescaler;  /*!< TIM clock prescaler.
+                                 This parameter can be a value of @ref TIM_Clock_Prescaler */
+  uint32_t ClockFilter;    /*!< TIM clock filter.
+                                This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+}TIM_ClockConfigTypeDef;
+
+/**
+  * @brief  Clear Input Configuration Handle Structure definition
+  */
+typedef struct
+{
+  uint32_t ClearInputState;      /*!< TIM clear Input state.
+                                      This parameter can be ENABLE or DISABLE */
+  uint32_t ClearInputSource;     /*!< TIM clear Input sources.
+                                      This parameter can be a value of @ref TIMEx_ClearInput_Source */
+  uint32_t ClearInputPolarity;   /*!< TIM Clear Input polarity.
+                                      This parameter can be a value of @ref TIM_ClearInput_Polarity */
+  uint32_t ClearInputPrescaler;  /*!< TIM Clear Input prescaler.
+                                      This parameter can be a value of @ref TIM_ClearInput_Prescaler */
+  uint32_t ClearInputFilter;    /*!< TIM Clear Input filter.
+                                     This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+}TIM_ClearInputConfigTypeDef;
+
+/**
+  * @brief  TIM Slave configuration Structure definition
+  */
+typedef struct {
+  uint32_t  SlaveMode;         /*!< Slave mode selection
+                                  This parameter can be a value of @ref TIMEx_Slave_Mode */
+  uint32_t  InputTrigger;      /*!< Input Trigger source
+                                  This parameter can be a value of @ref TIM_Trigger_Selection */
+  uint32_t  TriggerPolarity;   /*!< Input Trigger polarity
+                                  This parameter can be a value of @ref TIM_Trigger_Polarity */
+  uint32_t  TriggerPrescaler;  /*!< Input trigger prescaler
+                                  This parameter can be a value of @ref TIM_Trigger_Prescaler */
+  uint32_t  TriggerFilter;     /*!< Input trigger filter
+                                  This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+
+}TIM_SlaveConfigTypeDef;
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef enum
+{
+  HAL_TIM_STATE_RESET             = 0x00,    /*!< Peripheral not yet initialized or disabled  */
+  HAL_TIM_STATE_READY             = 0x01,    /*!< Peripheral Initialized and ready for use    */
+  HAL_TIM_STATE_BUSY              = 0x02,    /*!< An internal process is ongoing              */
+  HAL_TIM_STATE_TIMEOUT           = 0x03,    /*!< Timeout state                               */
+  HAL_TIM_STATE_ERROR             = 0x04     /*!< Reception process is ongoing                */
+}HAL_TIM_StateTypeDef;
+
+/**
+  * @brief  HAL Active channel structures definition
+  */
+typedef enum
+{
+  HAL_TIM_ACTIVE_CHANNEL_1        = 0x01,    /*!< The active channel is 1     */
+  HAL_TIM_ACTIVE_CHANNEL_2        = 0x02,    /*!< The active channel is 2     */
+  HAL_TIM_ACTIVE_CHANNEL_3        = 0x04,    /*!< The active channel is 3     */
+  HAL_TIM_ACTIVE_CHANNEL_4        = 0x08,    /*!< The active channel is 4     */
+  HAL_TIM_ACTIVE_CHANNEL_CLEARED  = 0x00     /*!< All active channels cleared */
+}HAL_TIM_ActiveChannel;
+
+/**
+  * @brief  TIM Time Base Handle Structure definition
+  */
+typedef struct
+{
+  TIM_TypeDef                 *Instance;     /*!< Register base address             */
+  TIM_Base_InitTypeDef        Init;          /*!< TIM Time Base required parameters */
+  HAL_TIM_ActiveChannel       Channel;       /*!< Active channel                    */
+  DMA_HandleTypeDef           *hdma[7];      /*!< DMA Handlers array
+                                             This array is accessed by a @ref DMA_Handle_index */
+  HAL_LockTypeDef             Lock;          /*!< Locking object                    */
+  __IO HAL_TIM_StateTypeDef   State;         /*!< TIM operation state               */
+}TIM_HandleTypeDef;
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup TIM_Exported_Constants  TIM Exported Constants
+  * @{
+  */
+
+/** @defgroup TIM_Input_Channel_Polarity TIM Input Channel Polarity
+  * @{
+  */
+#define  TIM_INPUTCHANNELPOLARITY_RISING      ((uint32_t)0x00000000)            /*!< Polarity for TIx source */
+#define  TIM_INPUTCHANNELPOLARITY_FALLING     (TIM_CCER_CC1P)                   /*!< Polarity for TIx source */
+#define  TIM_INPUTCHANNELPOLARITY_BOTHEDGE    (TIM_CCER_CC1P | TIM_CCER_CC1NP)  /*!< Polarity for TIx source */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ETR_Polarity  TIM ETR Polarity
+  * @{
+  */
+#define TIM_ETRPOLARITY_INVERTED              (TIM_SMCR_ETP)                    /*!< Polarity for ETR source */
+#define TIM_ETRPOLARITY_NONINVERTED           ((uint32_t)0x0000)                /*!< Polarity for ETR source */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ETR_Prescaler  TIM ETR Prescaler
+  * @{
+  */
+#define TIM_ETRPRESCALER_DIV1                 ((uint32_t)0x0000)                /*!< No prescaler is used */
+#define TIM_ETRPRESCALER_DIV2                 (TIM_SMCR_ETPS_0)                 /*!< ETR input source is divided by 2 */
+#define TIM_ETRPRESCALER_DIV4                 (TIM_SMCR_ETPS_1)                 /*!< ETR input source is divided by 4 */
+#define TIM_ETRPRESCALER_DIV8                 (TIM_SMCR_ETPS)                   /*!< ETR input source is divided by 8 */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Counter_Mode  TIM Counter Mode
+  * @{
+  */
+#define TIM_COUNTERMODE_UP                 ((uint32_t)0x0000)
+#define TIM_COUNTERMODE_DOWN               TIM_CR1_DIR
+#define TIM_COUNTERMODE_CENTERALIGNED1     TIM_CR1_CMS_0
+#define TIM_COUNTERMODE_CENTERALIGNED2     TIM_CR1_CMS_1
+#define TIM_COUNTERMODE_CENTERALIGNED3     TIM_CR1_CMS
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ClockDivision TIM Clock Division
+  * @{
+  */
+#define TIM_CLOCKDIVISION_DIV1                       ((uint32_t)0x0000)
+#define TIM_CLOCKDIVISION_DIV2                       (TIM_CR1_CKD_0)
+#define TIM_CLOCKDIVISION_DIV4                       (TIM_CR1_CKD_1)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_State TIM Output Compare State
+  * @{
+  */
+#define TIM_OUTPUTSTATE_DISABLE            ((uint32_t)0x0000)
+#define TIM_OUTPUTSTATE_ENABLE             (TIM_CCER_CC1E)
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Fast_State  TIM Output Fast State
+  * @{
+  */
+#define TIM_OCFAST_DISABLE                ((uint32_t)0x0000)
+#define TIM_OCFAST_ENABLE                 (TIM_CCMR1_OC1FE)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_N_State TIM Complementary Output Compare State
+  * @{
+  */
+#define TIM_OUTPUTNSTATE_DISABLE            ((uint32_t)0x0000)
+#define TIM_OUTPUTNSTATE_ENABLE             (TIM_CCER_CC1NE)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_Polarity TIM Output Compare Polarity
+  * @{
+  */
+#define TIM_OCPOLARITY_HIGH                ((uint32_t)0x0000)
+#define TIM_OCPOLARITY_LOW                 (TIM_CCER_CC1P)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_N_Polarity TIM Complementary Output Compare Polarity
+  * @{
+  */
+#define TIM_OCNPOLARITY_HIGH               ((uint32_t)0x0000)
+#define TIM_OCNPOLARITY_LOW                (TIM_CCER_CC1NP)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_Idle_State  TIM Output Compare Idle State
+  * @{
+  */
+#define TIM_OCIDLESTATE_SET                (TIM_CR2_OIS1)
+#define TIM_OCIDLESTATE_RESET              ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_N_Idle_State  TIM Output Compare N Idle State
+  * @{
+  */
+#define TIM_OCNIDLESTATE_SET               (TIM_CR2_OIS1N)
+#define TIM_OCNIDLESTATE_RESET             ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Input_Capture_Polarity  TIM Input Capture Polarity
+  * @{
+  */
+#define  TIM_ICPOLARITY_RISING             TIM_INPUTCHANNELPOLARITY_RISING
+#define  TIM_ICPOLARITY_FALLING            TIM_INPUTCHANNELPOLARITY_FALLING
+#define  TIM_ICPOLARITY_BOTHEDGE           TIM_INPUTCHANNELPOLARITY_BOTHEDGE
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Input_Capture_Selection  TIM Input Capture Selection
+  * @{
+  */
+#define TIM_ICSELECTION_DIRECTTI           (TIM_CCMR1_CC1S_0)   /*!< TIM Input 1, 2, 3 or 4 is selected to be
+                                                                     connected to IC1, IC2, IC3 or IC4, respectively */
+#define TIM_ICSELECTION_INDIRECTTI         (TIM_CCMR1_CC1S_1)   /*!< TIM Input 1, 2, 3 or 4 is selected to be
+                                                                     connected to IC2, IC1, IC4 or IC3, respectively */
+#define TIM_ICSELECTION_TRC                (TIM_CCMR1_CC1S)     /*!< TIM Input 1, 2, 3 or 4 is selected to be connected to TRC */
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Input_Capture_Prescaler  TIM Input Capture Prescaler
+  * @{
+  */
+#define TIM_ICPSC_DIV1                     ((uint32_t)0x0000)       /*!< Capture performed each time an edge is detected on the capture input */
+#define TIM_ICPSC_DIV2                     (TIM_CCMR1_IC1PSC_0)     /*!< Capture performed once every 2 events */
+#define TIM_ICPSC_DIV4                     (TIM_CCMR1_IC1PSC_1)     /*!< Capture performed once every 4 events */
+#define TIM_ICPSC_DIV8                     (TIM_CCMR1_IC1PSC)       /*!< Capture performed once every 8 events */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_One_Pulse_Mode TIM One Pulse Mode
+  * @{
+  */
+#define TIM_OPMODE_SINGLE                  (TIM_CR1_OPM)
+#define TIM_OPMODE_REPETITIVE              ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Encoder_Mode TIM Encoder Mode
+  * @{
+  */
+#define TIM_ENCODERMODE_TI1                (TIM_SMCR_SMS_0)
+#define TIM_ENCODERMODE_TI2                (TIM_SMCR_SMS_1)
+#define TIM_ENCODERMODE_TI12               (TIM_SMCR_SMS_1 | TIM_SMCR_SMS_0)
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Interrupt_definition  TIM Interrupt definition
+  * @{
+  */
+#define TIM_IT_UPDATE           (TIM_DIER_UIE)
+#define TIM_IT_CC1              (TIM_DIER_CC1IE)
+#define TIM_IT_CC2              (TIM_DIER_CC2IE)
+#define TIM_IT_CC3              (TIM_DIER_CC3IE)
+#define TIM_IT_CC4              (TIM_DIER_CC4IE)
+#define TIM_IT_COM              (TIM_DIER_COMIE)
+#define TIM_IT_TRIGGER          (TIM_DIER_TIE)
+#define TIM_IT_BREAK            (TIM_DIER_BIE)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Commutation_Source  TIM Commutation Source
+  * @{
+  */
+#define TIM_COMMUTATION_TRGI              (TIM_CR2_CCUS)
+#define TIM_COMMUTATION_SOFTWARE          ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_DMA_sources  TIM DMA sources
+  * @{
+  */
+#define TIM_DMA_UPDATE                     (TIM_DIER_UDE)
+#define TIM_DMA_CC1                        (TIM_DIER_CC1DE)
+#define TIM_DMA_CC2                        (TIM_DIER_CC2DE)
+#define TIM_DMA_CC3                        (TIM_DIER_CC3DE)
+#define TIM_DMA_CC4                        (TIM_DIER_CC4DE)
+#define TIM_DMA_COM                        (TIM_DIER_COMDE)
+#define TIM_DMA_TRIGGER                    (TIM_DIER_TDE)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Event_Source  TIM Event Source
+  * @{
+  */
+#define TIM_EVENTSOURCE_UPDATE              TIM_EGR_UG
+#define TIM_EVENTSOURCE_CC1                 TIM_EGR_CC1G
+#define TIM_EVENTSOURCE_CC2                 TIM_EGR_CC2G
+#define TIM_EVENTSOURCE_CC3                 TIM_EGR_CC3G
+#define TIM_EVENTSOURCE_CC4                 TIM_EGR_CC4G
+#define TIM_EVENTSOURCE_COM                 TIM_EGR_COMG
+#define TIM_EVENTSOURCE_TRIGGER             TIM_EGR_TG
+#define TIM_EVENTSOURCE_BREAK               TIM_EGR_BG
+#define TIM_EVENTSOURCE_BREAK2              TIM_EGR_B2G
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Flag_definition  TIM Flag definition
+  * @{
+  */
+#define TIM_FLAG_UPDATE                    (TIM_SR_UIF)
+#define TIM_FLAG_CC1                       (TIM_SR_CC1IF)
+#define TIM_FLAG_CC2                       (TIM_SR_CC2IF)
+#define TIM_FLAG_CC3                       (TIM_SR_CC3IF)
+#define TIM_FLAG_CC4                       (TIM_SR_CC4IF)
+#define TIM_FLAG_COM                       (TIM_SR_COMIF)
+#define TIM_FLAG_TRIGGER                   (TIM_SR_TIF)
+#define TIM_FLAG_BREAK                     (TIM_SR_BIF)
+#define TIM_FLAG_BREAK2                    (TIM_SR_B2IF)
+#define TIM_FLAG_CC1OF                     (TIM_SR_CC1OF)
+#define TIM_FLAG_CC2OF                     (TIM_SR_CC2OF)
+#define TIM_FLAG_CC3OF                     (TIM_SR_CC3OF)
+#define TIM_FLAG_CC4OF                     (TIM_SR_CC4OF)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Clock_Source  TIM Clock Source
+  * @{
+  */
+#define	TIM_CLOCKSOURCE_ETRMODE2    (TIM_SMCR_ETPS_1)
+#define	TIM_CLOCKSOURCE_INTERNAL    (TIM_SMCR_ETPS_0)
+#define	TIM_CLOCKSOURCE_ITR0        ((uint32_t)0x0000)
+#define	TIM_CLOCKSOURCE_ITR1        (TIM_SMCR_TS_0)
+#define	TIM_CLOCKSOURCE_ITR2        (TIM_SMCR_TS_1)
+#define	TIM_CLOCKSOURCE_ITR3        (TIM_SMCR_TS_0 | TIM_SMCR_TS_1)
+#define	TIM_CLOCKSOURCE_TI1ED       (TIM_SMCR_TS_2)
+#define	TIM_CLOCKSOURCE_TI1         (TIM_SMCR_TS_0 | TIM_SMCR_TS_2)
+#define	TIM_CLOCKSOURCE_TI2         (TIM_SMCR_TS_1 | TIM_SMCR_TS_2)
+#define	TIM_CLOCKSOURCE_ETRMODE1    (TIM_SMCR_TS)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Clock_Polarity  TIM Clock Polarity
+  * @{
+  */
+#define TIM_CLOCKPOLARITY_INVERTED           TIM_ETRPOLARITY_INVERTED          /*!< Polarity for ETRx clock sources */
+#define TIM_CLOCKPOLARITY_NONINVERTED        TIM_ETRPOLARITY_NONINVERTED       /*!< Polarity for ETRx clock sources */
+#define TIM_CLOCKPOLARITY_RISING             TIM_INPUTCHANNELPOLARITY_RISING   /*!< Polarity for TIx clock sources */
+#define TIM_CLOCKPOLARITY_FALLING            TIM_INPUTCHANNELPOLARITY_FALLING   /*!< Polarity for TIx clock sources */
+#define TIM_CLOCKPOLARITY_BOTHEDGE           TIM_INPUTCHANNELPOLARITY_BOTHEDGE  /*!< Polarity for TIx clock sources */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Clock_Prescaler  TIM Clock Prescaler
+  * @{
+  */
+#define TIM_CLOCKPRESCALER_DIV1              TIM_ETRPRESCALER_DIV1     /*!< No prescaler is used */
+#define TIM_CLOCKPRESCALER_DIV2              TIM_ETRPRESCALER_DIV2     /*!< Prescaler for External ETR Clock: Capture performed once every 2 events. */
+#define TIM_CLOCKPRESCALER_DIV4              TIM_ETRPRESCALER_DIV4     /*!< Prescaler for External ETR Clock: Capture performed once every 4 events. */
+#define TIM_CLOCKPRESCALER_DIV8              TIM_ETRPRESCALER_DIV8     /*!< Prescaler for External ETR Clock: Capture performed once every 8 events. */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ClearInput_Polarity  TIM Clear Input Polarity
+  * @{
+  */
+#define TIM_CLEARINPUTPOLARITY_INVERTED           TIM_ETRPOLARITY_INVERTED                    /*!< Polarity for ETRx pin */
+#define TIM_CLEARINPUTPOLARITY_NONINVERTED        TIM_ETRPOLARITY_NONINVERTED                 /*!< Polarity for ETRx pin */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ClearInput_Prescaler TIM Clear Input Prescaler
+  * @{
+  */
+#define TIM_CLEARINPUTPRESCALER_DIV1                    TIM_ETRPRESCALER_DIV1      /*!< No prescaler is used */
+#define TIM_CLEARINPUTPRESCALER_DIV2                    TIM_ETRPRESCALER_DIV2      /*!< Prescaler for External ETR pin: Capture performed once every 2 events. */
+#define TIM_CLEARINPUTPRESCALER_DIV4                    TIM_ETRPRESCALER_DIV4      /*!< Prescaler for External ETR pin: Capture performed once every 4 events. */
+#define TIM_CLEARINPUTPRESCALER_DIV8                    TIM_ETRPRESCALER_DIV8        /*!< Prescaler for External ETR pin: Capture performed once every 8 events. */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_OSSR_Off_State_Selection_for_Run_mode_state TIM OSSR OffState Selection for Run mode state
+  * @{
+  */
+#define TIM_OSSR_ENABLE 	      (TIM_BDTR_OSSR)
+#define TIM_OSSR_DISABLE          ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_OSSI_Off_State_Selection_for_Idle_mode_state TIM OSSI OffState Selection for Idle mode state
+  * @{
+  */
+#define TIM_OSSI_ENABLE	 	    (TIM_BDTR_OSSI)
+#define TIM_OSSI_DISABLE            ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Lock_level  TIM Lock level
+  * @{
+  */
+#define TIM_LOCKLEVEL_OFF	   ((uint32_t)0x0000)
+#define TIM_LOCKLEVEL_1            (TIM_BDTR_LOCK_0)
+#define TIM_LOCKLEVEL_2            (TIM_BDTR_LOCK_1)
+#define TIM_LOCKLEVEL_3            (TIM_BDTR_LOCK)
+/**
+  * @}
+  */
+/** @defgroup TIM_Break_Input_enable_disable  TIM Break Input State
+  * @{
+  */
+#define TIM_BREAK_ENABLE          (TIM_BDTR_BKE)
+#define TIM_BREAK_DISABLE         ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Break_Polarity  TIM Break Polarity
+  * @{
+  */
+#define TIM_BREAKPOLARITY_LOW        ((uint32_t)0x0000)
+#define TIM_BREAKPOLARITY_HIGH       (TIM_BDTR_BKP)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_AOE_Bit_Set_Reset  TIM AOE Bit State
+  * @{
+  */
+#define TIM_AUTOMATICOUTPUT_ENABLE           (TIM_BDTR_AOE)
+#define	TIM_AUTOMATICOUTPUT_DISABLE          ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Master_Mode_Selection TIM Master Mode Selection
+  * @{
+  */
+#define	TIM_TRGO_RESET            ((uint32_t)0x0000)
+#define	TIM_TRGO_ENABLE           (TIM_CR2_MMS_0)
+#define	TIM_TRGO_UPDATE           (TIM_CR2_MMS_1)
+#define	TIM_TRGO_OC1              ((TIM_CR2_MMS_1 | TIM_CR2_MMS_0))
+#define	TIM_TRGO_OC1REF           (TIM_CR2_MMS_2)
+#define	TIM_TRGO_OC2REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_0))
+#define	TIM_TRGO_OC3REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_1))
+#define	TIM_TRGO_OC4REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_1 | TIM_CR2_MMS_0))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Master_Slave_Mode  TIM Master Slave Mode
+  * @{
+  */
+#define TIM_MASTERSLAVEMODE_ENABLE          ((uint32_t)0x0080)
+#define TIM_MASTERSLAVEMODE_DISABLE         ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Trigger_Selection  TIM Trigger Selection
+  * @{
+  */
+#define TIM_TS_ITR0                        ((uint32_t)0x0000)
+#define TIM_TS_ITR1                        ((uint32_t)0x0010)
+#define TIM_TS_ITR2                        ((uint32_t)0x0020)
+#define TIM_TS_ITR3                        ((uint32_t)0x0030)
+#define TIM_TS_TI1F_ED                     ((uint32_t)0x0040)
+#define TIM_TS_TI1FP1                      ((uint32_t)0x0050)
+#define TIM_TS_TI2FP2                      ((uint32_t)0x0060)
+#define TIM_TS_ETRF                        ((uint32_t)0x0070)
+#define TIM_TS_NONE                        ((uint32_t)0xFFFF)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Trigger_Polarity TIM Trigger Polarity
+  * @{
+  */
+#define TIM_TRIGGERPOLARITY_INVERTED           TIM_ETRPOLARITY_INVERTED      /*!< Polarity for ETRx trigger sources */
+#define TIM_TRIGGERPOLARITY_NONINVERTED        TIM_ETRPOLARITY_NONINVERTED   /*!< Polarity for ETRx trigger sources */
+#define TIM_TRIGGERPOLARITY_RISING             TIM_INPUTCHANNELPOLARITY_RISING        /*!< Polarity for TIxFPx or TI1_ED trigger sources */
+#define TIM_TRIGGERPOLARITY_FALLING            TIM_INPUTCHANNELPOLARITY_FALLING       /*!< Polarity for TIxFPx or TI1_ED trigger sources */
+#define TIM_TRIGGERPOLARITY_BOTHEDGE           TIM_INPUTCHANNELPOLARITY_BOTHEDGE      /*!< Polarity for TIxFPx or TI1_ED trigger sources */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Trigger_Prescaler TIM Trigger Prescaler
+  * @{
+  */
+#define TIM_TRIGGERPRESCALER_DIV1             TIM_ETRPRESCALER_DIV1     /*!< No prescaler is used */
+#define TIM_TRIGGERPRESCALER_DIV2             TIM_ETRPRESCALER_DIV2     /*!< Prescaler for External ETR Trigger: Capture performed once every 2 events. */
+#define TIM_TRIGGERPRESCALER_DIV4             TIM_ETRPRESCALER_DIV4     /*!< Prescaler for External ETR Trigger: Capture performed once every 4 events. */
+#define TIM_TRIGGERPRESCALER_DIV8             TIM_ETRPRESCALER_DIV8     /*!< Prescaler for External ETR Trigger: Capture performed once every 8 events. */
+/**
+  * @}
+  */
+
+
+/** @defgroup TIM_TI1_Selection TIM TI1 Selection
+  * @{
+  */
+#define TIM_TI1SELECTION_CH1                ((uint32_t)0x0000)
+#define TIM_TI1SELECTION_XORCOMBINATION     (TIM_CR2_TI1S)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_DMA_Base_address  TIM DMA Base address
+  * @{
+  */
+#define TIM_DMABASE_CR1                    (0x00000000)
+#define TIM_DMABASE_CR2                    (0x00000001)
+#define TIM_DMABASE_SMCR                   (0x00000002)
+#define TIM_DMABASE_DIER                   (0x00000003)
+#define TIM_DMABASE_SR                     (0x00000004)
+#define TIM_DMABASE_EGR                    (0x00000005)
+#define TIM_DMABASE_CCMR1                  (0x00000006)
+#define TIM_DMABASE_CCMR2                  (0x00000007)
+#define TIM_DMABASE_CCER                   (0x00000008)
+#define TIM_DMABASE_CNT                    (0x00000009)
+#define TIM_DMABASE_PSC                    (0x0000000A)
+#define TIM_DMABASE_ARR                    (0x0000000B)
+#define TIM_DMABASE_RCR                    (0x0000000C)
+#define TIM_DMABASE_CCR1                   (0x0000000D)
+#define TIM_DMABASE_CCR2                   (0x0000000E)
+#define TIM_DMABASE_CCR3                   (0x0000000F)
+#define TIM_DMABASE_CCR4                   (0x00000010)
+#define TIM_DMABASE_BDTR                   (0x00000011)
+#define TIM_DMABASE_DCR                    (0x00000012)
+#define TIM_DMABASE_OR                     (0x00000013)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_DMA_Burst_Length  TIM DMA Burst Length
+  * @{
+  */
+#define TIM_DMABURSTLENGTH_1TRANSFER           (0x00000000)
+#define TIM_DMABURSTLENGTH_2TRANSFERS          (0x00000100)
+#define TIM_DMABURSTLENGTH_3TRANSFERS          (0x00000200)
+#define TIM_DMABURSTLENGTH_4TRANSFERS          (0x00000300)
+#define TIM_DMABURSTLENGTH_5TRANSFERS          (0x00000400)
+#define TIM_DMABURSTLENGTH_6TRANSFERS          (0x00000500)
+#define TIM_DMABURSTLENGTH_7TRANSFERS          (0x00000600)
+#define TIM_DMABURSTLENGTH_8TRANSFERS          (0x00000700)
+#define TIM_DMABURSTLENGTH_9TRANSFERS          (0x00000800)
+#define TIM_DMABURSTLENGTH_10TRANSFERS         (0x00000900)
+#define TIM_DMABURSTLENGTH_11TRANSFERS         (0x00000A00)
+#define TIM_DMABURSTLENGTH_12TRANSFERS         (0x00000B00)
+#define TIM_DMABURSTLENGTH_13TRANSFERS         (0x00000C00)
+#define TIM_DMABURSTLENGTH_14TRANSFERS         (0x00000D00)
+#define TIM_DMABURSTLENGTH_15TRANSFERS         (0x00000E00)
+#define TIM_DMABURSTLENGTH_16TRANSFERS         (0x00000F00)
+#define TIM_DMABURSTLENGTH_17TRANSFERS         (0x00001000)
+#define TIM_DMABURSTLENGTH_18TRANSFERS         (0x00001100)
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Handle_index  DMA Handle index
+  * @{
+  */
+#define TIM_DMA_ID_UPDATE                ((uint16_t) 0x0)       /*!< Index of the DMA handle used for Update DMA requests */
+#define TIM_DMA_ID_CC1                   ((uint16_t) 0x1)       /*!< Index of the DMA handle used for Capture/Compare 1 DMA requests */
+#define TIM_DMA_ID_CC2                   ((uint16_t) 0x2)       /*!< Index of the DMA handle used for Capture/Compare 2 DMA requests */
+#define TIM_DMA_ID_CC3                   ((uint16_t) 0x3)       /*!< Index of the DMA handle used for Capture/Compare 3 DMA requests */
+#define TIM_DMA_ID_CC4                   ((uint16_t) 0x4)       /*!< Index of the DMA handle used for Capture/Compare 4 DMA requests */
+#define TIM_DMA_ID_COMMUTATION           ((uint16_t) 0x5)       /*!< Index of the DMA handle used for Commutation DMA requests */
+#define TIM_DMA_ID_TRIGGER               ((uint16_t) 0x6)       /*!< Index of the DMA handle used for Trigger DMA requests */
+/**
+  * @}
+  */
+
+/** @defgroup Channel_CC_State  Channel CC State
+  * @{
+  */
+#define TIM_CCx_ENABLE                   ((uint32_t)0x0001)
+#define TIM_CCx_DISABLE                  ((uint32_t)0x0000)
+#define TIM_CCxN_ENABLE                  ((uint32_t)0x0004)
+#define TIM_CCxN_DISABLE                 ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup TIM_Exported_Macros TIM Exported Macros
+  * @{
+  */
+/** @brief Reset TIM handle state
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+  */
+#define __HAL_TIM_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_TIM_STATE_RESET)
+
+/**
+  * @brief  Enable the TIM peripheral.
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+ */
+#define __HAL_TIM_ENABLE(__HANDLE__)                 ((__HANDLE__)->Instance->CR1|=(TIM_CR1_CEN))
+
+/**
+  * @brief  Enable the TIM update source request.
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+ */
+#define __HAL_TIM_URS_ENABLE(__HANDLE__)             ((__HANDLE__)->Instance->CR1|=(TIM_CR1_URS))
+
+/**
+  * @brief  Enable the TIM main Output.
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+  */
+#define __HAL_TIM_MOE_ENABLE(__HANDLE__)             ((__HANDLE__)->Instance->BDTR|=(TIM_BDTR_MOE))
+
+
+/* The counter of a timer instance is disabled only if all the CCx and CCxN
+   channels have been disabled */
+#define TIM_CCER_CCxE_MASK ((uint32_t)(TIM_CCER_CC1E | TIM_CCER_CC2E | TIM_CCER_CC3E | TIM_CCER_CC4E))
+#define TIM_CCER_CCxNE_MASK ((uint32_t)(TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE))
+
+/**
+  * @brief  Disable the TIM peripheral.
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+  */
+#define __HAL_TIM_DISABLE(__HANDLE__) \
+                        do { \
+                          if (((__HANDLE__)->Instance->CCER & TIM_CCER_CCxE_MASK) == 0) \
+                          { \
+                            if(((__HANDLE__)->Instance->CCER & TIM_CCER_CCxNE_MASK) == 0) \
+                            { \
+                              (__HANDLE__)->Instance->CR1 &= ~(TIM_CR1_CEN); \
+                            } \
+                          } \
+                        } while(0)
+
+/**
+  * @brief  Disable the TIM update source request.
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+ */
+#define __HAL_TIM_URS_DISABLE(__HANDLE__)            ((__HANDLE__)->Instance->CR1&=~(TIM_CR1_URS))
+
+
+/* The Main Output of a timer instance is disabled only if all the CCx and CCxN
+   channels have been disabled */
+/**
+  * @brief  Disable the TIM main Output.
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+  */
+#define __HAL_TIM_MOE_DISABLE(__HANDLE__) \
+                        do { \
+                          if (((__HANDLE__)->Instance->CCER & TIM_CCER_CCxE_MASK) == 0) \
+                          { \
+                            if(((__HANDLE__)->Instance->CCER & TIM_CCER_CCxNE_MASK) == 0) \
+                            { \
+                              (__HANDLE__)->Instance->BDTR &= ~(TIM_BDTR_MOE); \
+                            } \
+                          } \
+                        } while(0)
+
+#define __HAL_TIM_ENABLE_IT(__HANDLE__, __INTERRUPT__)    ((__HANDLE__)->Instance->DIER |= (__INTERRUPT__))
+#define __HAL_TIM_ENABLE_DMA(__HANDLE__, __DMA__)         ((__HANDLE__)->Instance->DIER |= (__DMA__))
+#define __HAL_TIM_DISABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->DIER &= ~(__INTERRUPT__))
+#define __HAL_TIM_DISABLE_DMA(__HANDLE__, __DMA__)        ((__HANDLE__)->Instance->DIER &= ~(__DMA__))
+#define __HAL_TIM_GET_FLAG(__HANDLE__, __FLAG__)          (((__HANDLE__)->Instance->SR &(__FLAG__)) == (__FLAG__))
+#define __HAL_TIM_CLEAR_FLAG(__HANDLE__, __FLAG__)        ((__HANDLE__)->Instance->SR = ~(__FLAG__))
+
+#define __HAL_TIM_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->DIER & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+#define __HAL_TIM_CLEAR_IT(__HANDLE__, __INTERRUPT__)     ((__HANDLE__)->Instance->SR = ~(__INTERRUPT__))
+
+#define __HAL_TIM_IS_TIM_COUNTING_DOWN(__HANDLE__)            (((__HANDLE__)->Instance->CR1 &(TIM_CR1_DIR)) == (TIM_CR1_DIR))
+#define __HAL_TIM_SET_PRESCALER (__HANDLE__, __PRESC__)       ((__HANDLE__)->Instance->PSC = (__PRESC__))
+
+#define TIM_SET_ICPRESCALERVALUE(__HANDLE__, __CHANNEL__, __ICPSC__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCMR1 |= (__ICPSC__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCMR1 |= ((__ICPSC__) << 8)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCMR2 |= (__ICPSC__)) :\
+ ((__HANDLE__)->Instance->CCMR2 |= ((__ICPSC__) << 8)))
+
+#define TIM_RESET_ICPRESCALERVALUE(__HANDLE__, __CHANNEL__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCMR1 &= (uint16_t)~TIM_CCMR1_IC1PSC) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCMR1 &= (uint16_t)~TIM_CCMR1_IC2PSC) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCMR2 &= (uint16_t)~TIM_CCMR2_IC3PSC) :\
+ ((__HANDLE__)->Instance->CCMR2 &= (uint16_t)~TIM_CCMR2_IC4PSC))
+
+#define TIM_SET_CAPTUREPOLARITY(__HANDLE__, __CHANNEL__, __POLARITY__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCER |= (__POLARITY__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCER |= ((__POLARITY__) << 4)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCER |= ((__POLARITY__) << 8)) :\
+ ((__HANDLE__)->Instance->CCER |= (((__POLARITY__) << 12) & TIM_CCER_CC4P)))
+
+#define TIM_RESET_CAPTUREPOLARITY(__HANDLE__, __CHANNEL__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCER &= (uint16_t)~(TIM_CCER_CC1P | TIM_CCER_CC1NP)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCER &= (uint16_t)~(TIM_CCER_CC2P | TIM_CCER_CC2NP)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCER &= (uint16_t)~(TIM_CCER_CC3P | TIM_CCER_CC3NP)) :\
+ ((__HANDLE__)->Instance->CCER &= (uint16_t)~TIM_CCER_CC4P))
+
+/**
+  * @brief  Sets the TIM Counter Register value on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __COUNTER__: specifies the Counter register new value.
+  * @retval None
+  */
+#define __HAL_TIM_SET_COUNTER(__HANDLE__, __COUNTER__) ((__HANDLE__)->Instance->CNT = (__COUNTER__))
+
+/**
+  * @brief  Gets the TIM Counter Register value on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @retval None
+  */
+#define __HAL_TIM_GET_COUNTER(__HANDLE__) ((__HANDLE__)->Instance->CNT)
+
+/**
+  * @brief  Sets the TIM Autoreload Register value on runtime without calling
+  *         another time any Init function.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __AUTORELOAD__: specifies the Counter register new value.
+  * @retval None
+  */
+#define __HAL_TIM_SET_AUTORELOAD(__HANDLE__, __AUTORELOAD__)                  \
+                        do{                                                  \
+                            (__HANDLE__)->Instance->ARR = (__AUTORELOAD__);  \
+                            (__HANDLE__)->Init.Period = (__AUTORELOAD__);    \
+                          } while(0)
+/**
+  * @brief  Gets the TIM Autoreload Register value on runtime
+  * @param  __HANDLE__: TIM handle.
+  * @retval None
+  */
+#define __HAL_TIM_GET_AUTORELOAD(__HANDLE__) ((__HANDLE__)->Instance->ARR)
+
+/**
+  * @brief  Sets the TIM Clock Division value on runtime without calling
+  *         another time any Init function.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CKD__: specifies the clock division value.
+  *          This parameter can be one of the following value:
+  *            @arg TIM_CLOCKDIVISION_DIV1
+  *            @arg TIM_CLOCKDIVISION_DIV2
+  *            @arg TIM_CLOCKDIVISION_DIV4
+  * @retval None
+  */
+#define __HAL_TIM_SET_CLOCKDIVISION(__HANDLE__, __CKD__) \
+                        do{                                                             \
+                              (__HANDLE__)->Instance->CR1 &= (uint16_t)(~TIM_CR1_CKD);  \
+                              (__HANDLE__)->Instance->CR1 |= (__CKD__);                 \
+                              (__HANDLE__)->Init.ClockDivision = (__CKD__);             \
+                          } while(0)
+/**
+  * @brief  Gets the TIM Clock Division value on runtime
+  * @param  __HANDLE__: TIM handle.
+  * @retval None
+  */
+#define __HAL_TIM_GET_CLOCKDIVISION(__HANDLE__) ((__HANDLE__)->Instance->CR1 & TIM_CR1_CKD)
+
+/**
+  * @brief  Sets the TIM Input Capture prescaler on runtime without calling
+  *         another time HAL_TIM_IC_ConfigChannel() function.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__ : TIM Channels to be configured.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  __ICPSC__: specifies the Input Capture4 prescaler new value.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPSC_DIV1: no prescaler
+  *            @arg TIM_ICPSC_DIV2: capture is done once every 2 events
+  *            @arg TIM_ICPSC_DIV4: capture is done once every 4 events
+  *            @arg TIM_ICPSC_DIV8: capture is done once every 8 events
+  * @retval None
+  */
+#define __HAL_TIM_SET_ICPRESCALER(__HANDLE__, __CHANNEL__, __ICPSC__) \
+                        do{                                                    \
+                              TIM_RESET_ICPRESCALERVALUE((__HANDLE__), (__CHANNEL__));  \
+                              TIM_SET_ICPRESCALERVALUE((__HANDLE__), (__CHANNEL__), (__ICPSC__)); \
+                          } while(0)
+
+/**
+  * @brief  Gets the TIM Input Capture prescaler on runtime
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__ : TIM Channels to be configured.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: get input capture 1 prescaler value
+  *            @arg TIM_CHANNEL_2: get input capture 2 prescaler value
+  *            @arg TIM_CHANNEL_3: get input capture 3 prescaler value
+  *            @arg TIM_CHANNEL_4: get input capture 4 prescaler value
+  * @retval None
+  */
+#define __HAL_TIM_GET_ICPRESCALER(__HANDLE__, __CHANNEL__)  \
+  (((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCMR1 & TIM_CCMR1_IC1PSC) :\
+   ((__CHANNEL__) == TIM_CHANNEL_2) ? (((__HANDLE__)->Instance->CCMR1 & TIM_CCMR1_IC2PSC) >> 8) :\
+   ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCMR2 & TIM_CCMR2_IC3PSC) :\
+   (((__HANDLE__)->Instance->CCMR2 & TIM_CCMR2_IC4PSC)) >> 8)
+
+/**
+  * @brief  Sets the TIM Capture x input polarity on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__: TIM Channels to be configured.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  __POLARITY__: Polarity for TIx source
+  *            @arg TIM_INPUTCHANNELPOLARITY_RISING: Rising Edge
+  *            @arg TIM_INPUTCHANNELPOLARITY_FALLING: Falling Edge
+  *            @arg TIM_INPUTCHANNELPOLARITY_BOTHEDGE: Rising and Falling Edge
+  * @note  The polarity TIM_INPUTCHANNELPOLARITY_BOTHEDGE is not authorized  for TIM Channel 4.
+  * @retval None
+  */
+#define __HAL_TIM_SET_CAPTUREPOLARITY(__HANDLE__, __CHANNEL__, __POLARITY__)                          \
+                       do{                                                                            \
+                           TIM_RESET_CAPTUREPOLARITY((__HANDLE__), (__CHANNEL__));               \
+                           TIM_SET_CAPTUREPOLARITY((__HANDLE__), (__CHANNEL__), (__POLARITY__)); \
+                         }while(0)
+
+/**
+  * @}
+  */
+
+/* Include TIM HAL Extension module */
+#include "stm32f7xx_hal_tim_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup TIM_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group1
+  * @{
+  */
+
+/* Time Base functions ********************************************************/
+HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_Base_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_Base_Start(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_Base_Stop(TIM_HandleTypeDef *htim);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_Base_Start_IT(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_Base_Stop_IT(TIM_HandleTypeDef *htim);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_Base_Stop_DMA(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group2
+  * @{
+  */
+/* Timer Output Compare functions **********************************************/
+HAL_StatusTypeDef HAL_TIM_OC_Init(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_OC_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_OC_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_OC_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_OC_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_OC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group3
+  * @{
+  */
+/* Timer PWM functions *********************************************************/
+HAL_StatusTypeDef HAL_TIM_PWM_Init(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_PWM_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_PWM_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_PWM_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group4
+  * @{
+  */
+/* Timer Input Capture functions ***********************************************/
+HAL_StatusTypeDef HAL_TIM_IC_Init(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_IC_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_IC_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_IC_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_IC_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_IC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_IC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group5
+  * @{
+  */
+/* Timer One Pulse functions ***************************************************/
+HAL_StatusTypeDef HAL_TIM_OnePulse_Init(TIM_HandleTypeDef *htim, uint32_t OnePulseMode);
+HAL_StatusTypeDef HAL_TIM_OnePulse_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_OnePulse_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_OnePulse_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+HAL_StatusTypeDef HAL_TIM_OnePulse_Stop(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group6
+  * @{
+  */
+/* Timer Encoder functions *****************************************************/
+HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_InitTypeDef* sConfig);
+HAL_StatusTypeDef HAL_TIM_Encoder_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim);
+ /* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData1, uint32_t *pData2, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group7
+  * @{
+  */
+/* Interrupt Handler functions  **********************************************/
+void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim);
+
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group8
+  * @{
+  */
+/* Control functions  *********************************************************/
+HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitTypeDef* sConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OnePulse_InitTypeDef* sConfig, uint32_t OutputChannel,  uint32_t InputChannel);
+HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim, TIM_ClearInputConfigTypeDef * sClearInputConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_ConfigClockSource(TIM_HandleTypeDef *htim, TIM_ClockConfigTypeDef * sClockSourceConfig);
+HAL_StatusTypeDef HAL_TIM_ConfigTI1Input(TIM_HandleTypeDef *htim, uint32_t TI1_Selection);
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchronization(TIM_HandleTypeDef *htim, TIM_SlaveConfigTypeDef * sSlaveConfig);
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchronization_IT(TIM_HandleTypeDef *htim, TIM_SlaveConfigTypeDef * sSlaveConfig);
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc, \
+                                              uint32_t  *BurstBuffer, uint32_t  BurstLength);
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc);
+HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc, \
+                                              uint32_t  *BurstBuffer, uint32_t  BurstLength);
+HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc);
+HAL_StatusTypeDef HAL_TIM_GenerateEvent(TIM_HandleTypeDef *htim, uint32_t EventSource);
+uint32_t HAL_TIM_ReadCapturedValue(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group9
+  * @{
+  */
+/* Callback in non blocking modes (Interrupt and DMA) *************************/
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_TriggerCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_ErrorCallback(TIM_HandleTypeDef *htim);
+
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group10
+  * @{
+  */
+/* Peripheral State functions  **************************************************/
+HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_OC_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(TIM_HandleTypeDef *htim);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup TIM_Private_Macros TIM Private Macros
+  * @{
+  */
+
+/** @defgroup TIM_IS_TIM_Definitions TIM Private macros to check input parameters
+  * @{
+  */
+#define IS_TIM_COUNTER_MODE(__MODE__) (((__MODE__) == TIM_COUNTERMODE_UP)              || \
+                                       ((__MODE__) == TIM_COUNTERMODE_DOWN)            || \
+                                       ((__MODE__) == TIM_COUNTERMODE_CENTERALIGNED1)  || \
+                                       ((__MODE__) == TIM_COUNTERMODE_CENTERALIGNED2)  || \
+                                       ((__MODE__) == TIM_COUNTERMODE_CENTERALIGNED3))
+
+#define IS_TIM_CLOCKDIVISION_DIV(__DIV__) (((__DIV__) == TIM_CLOCKDIVISION_DIV1) || \
+                                           ((__DIV__) == TIM_CLOCKDIVISION_DIV2) || \
+                                           ((__DIV__) == TIM_CLOCKDIVISION_DIV4))
+
+#define IS_TIM_FAST_STATE(__STATE__) (((__STATE__) == TIM_OCFAST_DISABLE) || \
+                                      ((__STATE__) == TIM_OCFAST_ENABLE))
+
+#define IS_TIM_OUTPUT_STATE(STATE) (((STATE) == TIM_OUTPUTSTATE_DISABLE) || \
+                                    ((STATE) == TIM_OUTPUTSTATE_ENABLE))
+
+#define IS_TIM_OUTPUTN_STATE(STATE) (((STATE) == TIM_OUTPUTNSTATE_DISABLE) || \
+                                     ((STATE) == TIM_OUTPUTNSTATE_ENABLE))
+
+#define IS_TIM_OC_POLARITY(__POLARITY__) (((__POLARITY__) == TIM_OCPOLARITY_HIGH) || \
+                                          ((__POLARITY__) == TIM_OCPOLARITY_LOW))
+
+#define IS_TIM_OCN_POLARITY(__POLARITY__) (((__POLARITY__) == TIM_OCNPOLARITY_HIGH) || \
+                                           ((__POLARITY__) == TIM_OCNPOLARITY_LOW))
+
+#define IS_TIM_OCIDLE_STATE(__STATE__) (((__STATE__) == TIM_OCIDLESTATE_SET) || \
+                                        ((__STATE__) == TIM_OCIDLESTATE_RESET))
+
+#define IS_TIM_OCNIDLE_STATE(__STATE__) (((__STATE__) == TIM_OCNIDLESTATE_SET) || \
+                                         ((__STATE__) == TIM_OCNIDLESTATE_RESET))
+
+#define IS_TIM_IC_POLARITY(__POLARITY__) (((__POLARITY__) == TIM_ICPOLARITY_RISING)   || \
+                                          ((__POLARITY__) == TIM_ICPOLARITY_FALLING)  || \
+                                          ((__POLARITY__) == TIM_ICPOLARITY_BOTHEDGE))
+
+#define IS_TIM_IC_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_ICSELECTION_DIRECTTI) || \
+                                            ((__SELECTION__) == TIM_ICSELECTION_INDIRECTTI) || \
+                                            ((__SELECTION__) == TIM_ICSELECTION_TRC))
+
+#define IS_TIM_IC_PRESCALER(__PRESCALER__) (((__PRESCALER__) == TIM_ICPSC_DIV1) || \
+                                            ((__PRESCALER__) == TIM_ICPSC_DIV2) || \
+                                            ((__PRESCALER__) == TIM_ICPSC_DIV4) || \
+                                            ((__PRESCALER__) == TIM_ICPSC_DIV8))
+
+#define IS_TIM_OPM_MODE(__MODE__) (((__MODE__) == TIM_OPMODE_SINGLE) || \
+                                   ((__MODE__) == TIM_OPMODE_REPETITIVE))
+
+#define IS_TIM_ENCODER_MODE(__MODE__) (((__MODE__) == TIM_ENCODERMODE_TI1) || \
+                                       ((__MODE__) == TIM_ENCODERMODE_TI2) || \
+                                       ((__MODE__) == TIM_ENCODERMODE_TI12))
+
+#define IS_TIM_IT(__IT__) ((((__IT__) & 0xFFFFFF00) == 0x00000000) && ((__IT__) != 0x00000000))
+
+
+#define IS_TIM_GET_IT(__IT__) (((__IT__) == TIM_IT_UPDATE)  || \
+                               ((__IT__) == TIM_IT_CC1)     || \
+                               ((__IT__) == TIM_IT_CC2)     || \
+                               ((__IT__) == TIM_IT_CC3)     || \
+                               ((__IT__) == TIM_IT_CC4)     || \
+                               ((__IT__) == TIM_IT_COM)     || \
+                               ((__IT__) == TIM_IT_TRIGGER) || \
+                               ((__IT__) == TIM_IT_BREAK))
+
+#define IS_TIM_DMA_SOURCE(__SOURCE__) ((((__SOURCE__) & 0xFFFF80FF) == 0x00000000) && ((__SOURCE__) != 0x00000000))
+
+#define IS_TIM_EVENT_SOURCE(__SOURCE__) ((((__SOURCE__) & 0xFFFFFE00) == 0x00000000) && ((__SOURCE__) != 0x00000000))
+
+#define IS_TIM_FLAG(__FLAG__) (((__FLAG__) == TIM_FLAG_UPDATE) || \
+                               ((__FLAG__) == TIM_FLAG_CC1)     || \
+                               ((__FLAG__) == TIM_FLAG_CC2)     || \
+                               ((__FLAG__) == TIM_FLAG_CC3)     || \
+                               ((__FLAG__) == TIM_FLAG_CC4)     || \
+                               ((__FLAG__) == TIM_FLAG_COM)     || \
+                               ((__FLAG__) == TIM_FLAG_TRIGGER) || \
+                               ((__FLAG__) == TIM_FLAG_BREAK)   || \
+                               ((__FLAG__) == TIM_FLAG_BREAK2)  || \
+                               ((__FLAG__) == TIM_FLAG_CC1OF)   || \
+                               ((__FLAG__) == TIM_FLAG_CC2OF)   || \
+                               ((__FLAG__) == TIM_FLAG_CC3OF)   || \
+                               ((__FLAG__) == TIM_FLAG_CC4OF))
+
+#define IS_TIM_CLOCKSOURCE(__CLOCK__) (((__CLOCK__) == TIM_CLOCKSOURCE_INTERNAL) || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ETRMODE2) || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR0)     || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR1)     || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR2)     || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR3)     || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_TI1ED)    || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_TI1)      || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_TI2)      || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ETRMODE1))
+
+#define IS_TIM_CLOCKPOLARITY(__POLARITY__) (((__POLARITY__) == TIM_CLOCKPOLARITY_INVERTED)    || \
+                                        ((__POLARITY__) == TIM_CLOCKPOLARITY_NONINVERTED) || \
+                                        ((__POLARITY__) == TIM_CLOCKPOLARITY_RISING)      || \
+                                        ((__POLARITY__) == TIM_CLOCKPOLARITY_FALLING)     || \
+                                        ((__POLARITY__) == TIM_CLOCKPOLARITY_BOTHEDGE))
+
+#define IS_TIM_CLOCKPRESCALER(__PRESCALER__) (((__PRESCALER__) == TIM_CLOCKPRESCALER_DIV1) || \
+                                              ((__PRESCALER__) == TIM_CLOCKPRESCALER_DIV2) || \
+                                              ((__PRESCALER__) == TIM_CLOCKPRESCALER_DIV4) || \
+                                              ((__PRESCALER__) == TIM_CLOCKPRESCALER_DIV8))
+
+#define IS_TIM_CLOCKFILTER(__ICFILTER__)      ((__ICFILTER__) <= 0xF)
+
+#define IS_TIM_CLEARINPUT_POLARITY(__POLARITY__)   (((__POLARITY__) == TIM_CLEARINPUTPOLARITY_INVERTED) || \
+                                                    ((__POLARITY__) == TIM_CLEARINPUTPOLARITY_NONINVERTED))
+
+#define IS_TIM_CLEARINPUT_PRESCALER(__PRESCALER__)   (((__PRESCALER__) == TIM_CLEARINPUTPRESCALER_DIV1) || \
+                                                 ((__PRESCALER__) == TIM_CLEARINPUTPRESCALER_DIV2) || \
+                                                 ((__PRESCALER__) == TIM_CLEARINPUTPRESCALER_DIV4) || \
+                                                 ((__PRESCALER__) == TIM_CLEARINPUTPRESCALER_DIV8))
+
+#define IS_TIM_CLEARINPUT_FILTER(__ICFILTER__) ((__ICFILTER__) <= 0xF)
+
+#define IS_TIM_OSSR_STATE(__STATE__) (((__STATE__) == TIM_OSSR_ENABLE) || \
+                                      ((__STATE__) == TIM_OSSR_DISABLE))
+
+#define IS_TIM_OSSI_STATE(__STATE__) (((__STATE__) == TIM_OSSI_ENABLE) || \
+                                      ((__STATE__) == TIM_OSSI_DISABLE))
+
+#define IS_TIM_LOCK_LEVEL(__LEVEL__) (((__LEVEL__) == TIM_LOCKLEVEL_OFF) || \
+                                      ((__LEVEL__) == TIM_LOCKLEVEL_1) || \
+                                      ((__LEVEL__) == TIM_LOCKLEVEL_2) || \
+                                      ((__LEVEL__) == TIM_LOCKLEVEL_3))
+
+#define IS_TIM_BREAK_STATE(__STATE__) (((__STATE__) == TIM_BREAK_ENABLE) || \
+                                       ((__STATE__) == TIM_BREAK_DISABLE))
+
+#define IS_TIM_BREAK_POLARITY(__POLARITY__) (((__POLARITY__) == TIM_BREAKPOLARITY_LOW) || \
+                                             ((__POLARITY__) == TIM_BREAKPOLARITY_HIGH))
+
+#define IS_TIM_AUTOMATIC_OUTPUT_STATE(__STATE__) (((__STATE__) == TIM_AUTOMATICOUTPUT_ENABLE) || \
+                                                  ((__STATE__) == TIM_AUTOMATICOUTPUT_DISABLE))
+
+#define IS_TIM_TRGO_SOURCE(__SOURCE__) (((__SOURCE__) == TIM_TRGO_RESET) || \
+                                        ((__SOURCE__) == TIM_TRGO_ENABLE) || \
+                                        ((__SOURCE__) == TIM_TRGO_UPDATE) || \
+                                        ((__SOURCE__) == TIM_TRGO_OC1) || \
+                                        ((__SOURCE__) == TIM_TRGO_OC1REF) || \
+                                        ((__SOURCE__) == TIM_TRGO_OC2REF) || \
+                                        ((__SOURCE__) == TIM_TRGO_OC3REF) || \
+                                        ((__SOURCE__) == TIM_TRGO_OC4REF))
+
+#define IS_TIM_MSM_STATE(__STATE__) (((__STATE__) == TIM_MASTERSLAVEMODE_ENABLE) || \
+                                     ((__STATE__) == TIM_MASTERSLAVEMODE_DISABLE))
+
+#define IS_TIM_TRIGGER_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_TS_ITR0) || \
+                                                 ((__SELECTION__) == TIM_TS_ITR1) || \
+                                                 ((__SELECTION__) == TIM_TS_ITR2) || \
+                                                 ((__SELECTION__) == TIM_TS_ITR3) || \
+                                                 ((__SELECTION__) == TIM_TS_TI1F_ED) || \
+                                                 ((__SELECTION__) == TIM_TS_TI1FP1) || \
+                                                 ((__SELECTION__) == TIM_TS_TI2FP2) || \
+                                                 ((__SELECTION__) == TIM_TS_ETRF))
+
+#define IS_TIM_INTERNAL_TRIGGER_SELECTION(SELECTION) (((SELECTION) == TIM_TS_ITR0) || \
+                                                      ((SELECTION) == TIM_TS_ITR1) || \
+                                                      ((SELECTION) == TIM_TS_ITR2) || \
+                                                      ((SELECTION) == TIM_TS_ITR3))
+
+#define IS_TIM_INTERNAL_TRIGGEREVENT_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_TS_ITR0) || \
+                                                               ((__SELECTION__) == TIM_TS_ITR1) || \
+                                                               ((__SELECTION__) == TIM_TS_ITR2) || \
+                                                               ((__SELECTION__) == TIM_TS_ITR3) || \
+                                                               ((__SELECTION__) == TIM_TS_NONE))
+
+#define IS_TIM_TRIGGERPOLARITY(__POLARITY__)     (((__POLARITY__) == TIM_TRIGGERPOLARITY_INVERTED   ) || \
+                                                  ((__POLARITY__) == TIM_TRIGGERPOLARITY_NONINVERTED) || \
+                                                  ((__POLARITY__) == TIM_TRIGGERPOLARITY_RISING     ) || \
+                                                  ((__POLARITY__) == TIM_TRIGGERPOLARITY_FALLING    ) || \
+                                                  ((__POLARITY__) == TIM_TRIGGERPOLARITY_BOTHEDGE   ))
+
+#define IS_TIM_TRIGGERPRESCALER(__PRESCALER__)  (((__PRESCALER__) == TIM_TRIGGERPRESCALER_DIV1) || \
+                                                 ((__PRESCALER__) == TIM_TRIGGERPRESCALER_DIV2) || \
+                                                 ((__PRESCALER__) == TIM_TRIGGERPRESCALER_DIV4) || \
+                                                 ((__PRESCALER__) == TIM_TRIGGERPRESCALER_DIV8))
+
+#define IS_TIM_TRIGGERFILTER(__ICFILTER__)     ((__ICFILTER__) <= 0xF)
+
+#define IS_TIM_TI1SELECTION(__TI1SELECTION__)   (((__TI1SELECTION__) == TIM_TI1SELECTION_CH1) || \
+                                                 ((__TI1SELECTION__) == TIM_TI1SELECTION_XORCOMBINATION))
+
+#define IS_TIM_DMA_BASE(__BASE__) (((__BASE__) == TIM_DMABASE_CR1) || \
+                                   ((__BASE__) == TIM_DMABASE_CR2) || \
+                                   ((__BASE__) == TIM_DMABASE_SMCR) || \
+                                   ((__BASE__) == TIM_DMABASE_DIER) || \
+                                   ((__BASE__) == TIM_DMABASE_SR) || \
+                                   ((__BASE__) == TIM_DMABASE_EGR) || \
+                                   ((__BASE__) == TIM_DMABASE_CCMR1) || \
+                                   ((__BASE__) == TIM_DMABASE_CCMR2) || \
+                                   ((__BASE__) == TIM_DMABASE_CCER) || \
+                                   ((__BASE__) == TIM_DMABASE_CNT) || \
+                                   ((__BASE__) == TIM_DMABASE_PSC) || \
+                                   ((__BASE__) == TIM_DMABASE_ARR) || \
+                                   ((__BASE__) == TIM_DMABASE_RCR) || \
+                                   ((__BASE__) == TIM_DMABASE_CCR1) || \
+                                   ((__BASE__) == TIM_DMABASE_CCR2) || \
+                                   ((__BASE__) == TIM_DMABASE_CCR3) || \
+                                   ((__BASE__) == TIM_DMABASE_CCR4) || \
+                                   ((__BASE__) == TIM_DMABASE_BDTR) || \
+                                   ((__BASE__) == TIM_DMABASE_DCR) || \
+                                   ((__BASE__) == TIM_DMABASE_OR))
+
+#define IS_TIM_DMA_LENGTH(__LENGTH__) (((__LENGTH__) == TIM_DMABURSTLENGTH_1TRANSFER) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_2TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_3TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_4TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_5TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_6TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_7TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_8TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_9TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_10TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_11TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_12TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_13TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_14TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_15TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_16TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_17TRANSFERS) || \
+                                       ((__LENGTH__) == TIM_DMABURSTLENGTH_18TRANSFERS))
+
+#define IS_TIM_IC_FILTER(ICFILTER) ((ICFILTER) <= 0xF)
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup TIM_Private_Functions TIM Private Functions
+  * @{
+  */
+void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure);
+void TIM_TI1_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection, uint32_t TIM_ICFilter);
+void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+void TIM_ETR_SetConfig(TIM_TypeDef* TIMx, uint32_t TIM_ExtTRGPrescaler, uint32_t TIM_ExtTRGPolarity, uint32_t ExtTRGFilter);
+
+void HAL_TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma);
+void HAL_TIM_DMAError(DMA_HandleTypeDef *hdma);
+void HAL_TIM_DMACaptureCplt(DMA_HandleTypeDef *hdma);
+void TIM_CCxChannelCmd(TIM_TypeDef* TIMx, uint32_t Channel, uint32_t ChannelState);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_TIM_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_tim_ex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_tim_ex.h
@@ -1,0 +1,552 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_tim_ex.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of TIM HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_TIM_EX_H
+#define __STM32F7xx_HAL_TIM_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup TIMEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup TIMEx_Exported_Types TIM Exported Types
+  * @{
+  */
+
+/**
+  * @brief  TIM Hall sensor Configuration Structure definition
+  */
+
+typedef struct
+{
+
+  uint32_t IC1Polarity;            /*!< Specifies the active edge of the input signal.
+                                        This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t IC1Prescaler;        /*!< Specifies the Input Capture Prescaler.
+                                     This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+  uint32_t IC1Filter;           /*!< Specifies the input capture filter.
+                                     This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+  uint32_t Commutation_Delay;  /*!< Specifies the pulse value to be loaded into the Capture Compare Register.
+                                    This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+} TIM_HallSensor_InitTypeDef;
+
+/**
+  * @brief  TIM Master configuration Structure definition
+  */
+typedef struct {
+  uint32_t  MasterOutputTrigger;   /*!< Trigger output (TRGO) selection.
+                                      This parameter can be a value of @ref TIM_Master_Mode_Selection */
+  uint32_t  MasterOutputTrigger2;  /*!< Trigger output2 (TRGO2) selection
+                                      This parameter can be a value of @ref TIMEx_Master_Mode_Selection_2 */
+  uint32_t  MasterSlaveMode;       /*!< Master/slave mode selection.
+                                      This parameter can be a value of @ref TIM_Master_Slave_Mode */
+}TIM_MasterConfigTypeDef;
+
+/**
+  * @brief  TIM Break input(s) and Dead time configuration Structure definition
+  * @note   2 break inputs can be configured (BKIN and BKIN2) with configurable
+  *        filter and polarity.
+  */
+typedef struct
+{
+  uint32_t OffStateRunMode;	        /*!< TIM off state in run mode.
+                                       This parameter can be a value of @ref TIM_OSSR_Off_State_Selection_for_Run_mode_state */
+  uint32_t OffStateIDLEMode;	    /*!< TIM off state in IDLE mode.
+                                       This parameter can be a value of @ref TIM_OSSI_Off_State_Selection_for_Idle_mode_state */
+  uint32_t LockLevel;	 	        /*!< TIM Lock level.
+                                       This parameter can be a value of @ref TIM_Lock_level */
+  uint32_t DeadTime;	 	        /*!< TIM dead Time.
+                                       This parameter can be a number between Min_Data = 0x00 and Max_Data = 0xFF */
+  uint32_t BreakState;	 	        /*!< TIM Break State.
+                                       This parameter can be a value of @ref TIM_Break_Input_enable_disable */
+  uint32_t BreakPolarity;           /*!< TIM Break input polarity.
+                                       This parameter can be a value of @ref TIM_Break_Polarity */
+  uint32_t BreakFilter;             /*!< Specifies the break input filter.
+                                       This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+  uint32_t Break2State;	 	        /*!< TIM Break2 State
+                                       This parameter can be a value of @ref TIMEx_Break2_Input_enable_disable */
+  uint32_t Break2Polarity;          /*!< TIM Break2 input polarity
+                                       This parameter can be a value of @ref TIMEx_Break2_Polarity */
+  uint32_t Break2Filter;            /*!< TIM break2 input filter.
+                                       This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+  uint32_t AutomaticOutput;         /*!< TIM Automatic Output Enable state
+                                       This parameter can be a value of @ref TIM_AOE_Bit_Set_Reset */
+} TIM_BreakDeadTimeConfigTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup TIMEx_Exported_Constants  TIMEx Exported Constants
+  * @{
+  */
+
+/** @defgroup TIMEx_Channel TIMEx Channel
+  * @{
+  */
+
+#define TIM_CHANNEL_1                      ((uint32_t)0x0000)
+#define TIM_CHANNEL_2                      ((uint32_t)0x0004)
+#define TIM_CHANNEL_3                      ((uint32_t)0x0008)
+#define TIM_CHANNEL_4                      ((uint32_t)0x000C)
+#define TIM_CHANNEL_5                      ((uint32_t)0x0010)
+#define TIM_CHANNEL_6                      ((uint32_t)0x0014)
+#define TIM_CHANNEL_ALL                    ((uint32_t)0x003C)
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Output_Compare_and_PWM_modes TIMEx Output Compare and PWM Modes
+  * @{
+  */
+#define TIM_OCMODE_TIMING                   ((uint32_t)0x0000)
+#define TIM_OCMODE_ACTIVE                   ((uint32_t)TIM_CCMR1_OC1M_0)
+#define TIM_OCMODE_INACTIVE                 ((uint32_t)TIM_CCMR1_OC1M_1)
+#define TIM_OCMODE_TOGGLE                   ((uint32_t)TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0)
+#define TIM_OCMODE_PWM1                     ((uint32_t)TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1)
+#define TIM_OCMODE_PWM2                     ((uint32_t)TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0)
+#define TIM_OCMODE_FORCED_ACTIVE            ((uint32_t)TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_0)
+#define TIM_OCMODE_FORCED_INACTIVE          ((uint32_t)TIM_CCMR1_OC1M_2)
+
+#define TIM_OCMODE_RETRIGERRABLE_OPM1      ((uint32_t)TIM_CCMR1_OC1M_3)
+#define TIM_OCMODE_RETRIGERRABLE_OPM2      ((uint32_t)TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0)
+#define TIM_OCMODE_COMBINED_PWM1           ((uint32_t)TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_2)
+#define TIM_OCMODE_COMBINED_PWM2           ((uint32_t)TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_2)
+#define TIM_OCMODE_ASSYMETRIC_PWM1         ((uint32_t)TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2)
+#define TIM_OCMODE_ASSYMETRIC_PWM2         ((uint32_t)TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M)
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Remap  TIMEx Remap
+  * @{
+  */
+#define TIM_TIM2_TIM8_TRGO                     (0x00000000)
+#define TIM_TIM2_ETH_PTP                       (0x00000400)
+#define TIM_TIM2_USBFS_SOF                     (0x00000800)
+#define TIM_TIM2_USBHS_SOF                     (0x00000C00)
+#define TIM_TIM5_GPIO                          (0x00000000)
+#define TIM_TIM5_LSI                           (0x00000040)
+#define TIM_TIM5_LSE                           (0x00000080)
+#define TIM_TIM5_RTC                           (0x000000C0)
+#define TIM_TIM11_GPIO                         (0x00000000)
+#define TIM_TIM11_SPDIFRX                      (0x00000001)
+#define TIM_TIM11_HSE                          (0x00000002)
+#define TIM_TIM11_MCO1                         (0x00000003)
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_ClearInput_Source TIMEx Clear Input Source
+  * @{
+  */
+#define TIM_CLEARINPUTSOURCE_ETR            ((uint32_t)0x0001)
+#define TIM_CLEARINPUTSOURCE_OCREFCLR       ((uint32_t)0x0002)
+#define TIM_CLEARINPUTSOURCE_NONE           ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Break2_Input_enable_disable  TIMEx Break input 2 Enable
+  * @{
+  */
+#define TIM_BREAK2_DISABLE         ((uint32_t)0x00000000)
+#define TIM_BREAK2_ENABLE          ((uint32_t)TIM_BDTR_BK2E)
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Break2_Polarity TIMEx Break2 Polarity
+  * @{
+  */
+#define TIM_BREAK2POLARITY_LOW        ((uint32_t)0x00000000)
+#define TIM_BREAK2POLARITY_HIGH       (TIM_BDTR_BK2P)
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Group_Channel5 TIMEx Group Channel 5 and Channel 1, 2 or 3
+  * @{
+  */
+#define TIM_GROUPCH5_NONE       (uint32_t)0x00000000  /* !< No effect of OC5REF on OC1REFC, OC2REFC and OC3REFC */
+#define TIM_GROUPCH5_OC1REFC    (TIM_CCR5_GC5C1)      /* !< OC1REFC is the logical AND of OC1REFC and OC5REF */
+#define TIM_GROUPCH5_OC2REFC    (TIM_CCR5_GC5C2)      /* !< OC2REFC is the logical AND of OC2REFC and OC5REF */
+#define TIM_GROUPCH5_OC3REFC    (TIM_CCR5_GC5C3)       /* !< OC3REFC is the logical AND of OC3REFC and OC5REF */
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Master_Mode_Selection_2 TIMEx Master Mode Selection 2 (TRGO2)
+  * @{
+  */
+#define	TIM_TRGO2_RESET                          ((uint32_t)0x00000000)
+#define	TIM_TRGO2_ENABLE                         ((uint32_t)(TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_UPDATE                         ((uint32_t)(TIM_CR2_MMS2_1))
+#define	TIM_TRGO2_OC1                            ((uint32_t)(TIM_CR2_MMS2_1 | TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_OC1REF                         ((uint32_t)(TIM_CR2_MMS2_2))
+#define	TIM_TRGO2_OC2REF                         ((uint32_t)(TIM_CR2_MMS2_2 | TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_OC3REF                         ((uint32_t)(TIM_CR2_MMS2_2 | TIM_CR2_MMS2_1))
+#define	TIM_TRGO2_OC4REF                         ((uint32_t)(TIM_CR2_MMS2_2 | TIM_CR2_MMS2_1 | TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_OC5REF                         ((uint32_t)(TIM_CR2_MMS2_3))
+#define	TIM_TRGO2_OC6REF                         ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_OC4REF_RISINGFALLING           ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_1))
+#define	TIM_TRGO2_OC6REF_RISINGFALLING           ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_1 | TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_OC4REF_RISING_OC6REF_RISING    ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_2))
+#define	TIM_TRGO2_OC4REF_RISING_OC6REF_FALLING   ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_2 | TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_OC5REF_RISING_OC6REF_RISING    ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_2 |TIM_CR2_MMS2_1))
+#define	TIM_TRGO2_OC5REF_RISING_OC6REF_FALLING   ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_2 | TIM_CR2_MMS2_1 | TIM_CR2_MMS2_0))
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Slave_Mode TIMEx Slave mode
+  * @{
+  */
+#define TIM_SLAVEMODE_DISABLE                ((uint32_t)0x0000)
+#define TIM_SLAVEMODE_RESET                  ((uint32_t)(TIM_SMCR_SMS_2))
+#define TIM_SLAVEMODE_GATED                  ((uint32_t)(TIM_SMCR_SMS_2 | TIM_SMCR_SMS_0))
+#define TIM_SLAVEMODE_TRIGGER                ((uint32_t)(TIM_SMCR_SMS_2 | TIM_SMCR_SMS_1))
+#define TIM_SLAVEMODE_EXTERNAL1              ((uint32_t)(TIM_SMCR_SMS_2 | TIM_SMCR_SMS_1 | TIM_SMCR_SMS_0))
+#define TIM_SLAVEMODE_COMBINED_RESETTRIGGER  ((uint32_t)(TIM_SMCR_SMS_3))
+/**
+  * @}
+  */
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup TIMEx_Exported_Macros TIMEx Exported Macros
+  * @{
+  */
+
+/**
+  * @brief  Sets the TIM Capture Compare Register value on runtime without
+  *         calling another time ConfigChannel function.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__ : TIM Channels to be configured.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  * @param  __COMPARE__: specifies the Capture Compare register new value.
+  * @retval None
+  */
+#define __HAL_TIM_SET_COMPARE(__HANDLE__, __CHANNEL__, __COMPARE__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCR1 = (__COMPARE__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCR2 = (__COMPARE__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCR3 = (__COMPARE__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_4) ? ((__HANDLE__)->Instance->CCR4 = (__COMPARE__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_5) ? ((__HANDLE__)->Instance->CCR5 = (__COMPARE__)) :\
+ ((__HANDLE__)->Instance->CCR6 |= (__COMPARE__)))
+
+/**
+  * @brief  Gets the TIM Capture Compare Register value on runtime
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__ : TIM Channel associated with the capture compare register
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: get capture/compare 1 register value
+  *            @arg TIM_CHANNEL_2: get capture/compare 2 register value
+  *            @arg TIM_CHANNEL_3: get capture/compare 3 register value
+  *            @arg TIM_CHANNEL_4: get capture/compare 4 register value
+  *            @arg TIM_CHANNEL_5: get capture/compare 5 register value
+  *            @arg TIM_CHANNEL_6: get capture/compare 6 register value
+  * @retval None
+  */
+#define __HAL_TIM_GET_COMPARE(__HANDLE__, __CHANNEL__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCR1) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCR2) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCR3) :\
+ ((__CHANNEL__) == TIM_CHANNEL_4) ? ((__HANDLE__)->Instance->CCR4) :\
+ ((__CHANNEL__) == TIM_CHANNEL_5) ? ((__HANDLE__)->Instance->CCR5) :\
+ ((__HANDLE__)->Instance->CCR6))
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup TIMEx_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group1
+  * @{
+  */
+/*  Timer Hall Sensor functions  **********************************************/
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef* htim, TIM_HallSensor_InitTypeDef* sConfig);
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_DeInit(TIM_HandleTypeDef* htim);
+
+void HAL_TIMEx_HallSensor_MspInit(TIM_HandleTypeDef* htim);
+void HAL_TIMEx_HallSensor_MspDeInit(TIM_HandleTypeDef* htim);
+
+ /* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start(TIM_HandleTypeDef* htim);
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop(TIM_HandleTypeDef* htim);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_IT(TIM_HandleTypeDef* htim);
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_IT(TIM_HandleTypeDef* htim);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_DMA(TIM_HandleTypeDef* htim, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_DMA(TIM_HandleTypeDef* htim);
+/**
+  * @}
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group2
+  * @{
+  */
+/*  Timer Complementary Output Compare functions  *****************************/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start(TIM_HandleTypeDef* htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIMEx_OCN_Stop(TIM_HandleTypeDef* htim, uint32_t Channel);
+
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start_IT(TIM_HandleTypeDef* htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef* htim, uint32_t Channel);
+
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef* htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef* htim, uint32_t Channel);
+/**
+  * @}
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group3
+  * @{
+  */
+/*  Timer Complementary PWM functions  ****************************************/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start(TIM_HandleTypeDef* htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop(TIM_HandleTypeDef* htim, uint32_t Channel);
+
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_IT(TIM_HandleTypeDef* htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT(TIM_HandleTypeDef* htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef* htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef* htim, uint32_t Channel);
+/**
+  * @}
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group4
+  * @{
+  */
+/*  Timer Complementary One Pulse functions  **********************************/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start(TIM_HandleTypeDef* htim, uint32_t OutputChannel);
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop(TIM_HandleTypeDef* htim, uint32_t OutputChannel);
+
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start_IT(TIM_HandleTypeDef* htim, uint32_t OutputChannel);
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop_IT(TIM_HandleTypeDef* htim, uint32_t OutputChannel);
+/**
+  * @}
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group5
+  * @{
+  */
+/* Extension Control functions  ************************************************/
+HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent(TIM_HandleTypeDef* htim, uint32_t  InputTrigger, uint32_t  CommutationSource);
+HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent_IT(TIM_HandleTypeDef* htim, uint32_t  InputTrigger, uint32_t  CommutationSource);
+HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent_DMA(TIM_HandleTypeDef* htim, uint32_t  InputTrigger, uint32_t  CommutationSource);
+HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef* htim, TIM_MasterConfigTypeDef * sMasterConfig);
+HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef* htim, TIM_BreakDeadTimeConfigTypeDef *sBreakDeadTimeConfig);
+HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef* htim, uint32_t Remap);
+HAL_StatusTypeDef HAL_TIMEx_GroupChannel5(TIM_HandleTypeDef *htim, uint32_t OCRef);
+/**
+  * @}
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group6
+  * @{
+  */
+/* Extension Callback *********************************************************/
+void HAL_TIMEx_CommutationCallback(TIM_HandleTypeDef* htim);
+void HAL_TIMEx_BreakCallback(TIM_HandleTypeDef* htim);
+void HAL_TIMEx_DMACommutationCplt(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group7
+  * @{
+  */
+/* Extension Peripheral State functions  **************************************/
+HAL_TIM_StateTypeDef HAL_TIMEx_HallSensor_GetState(TIM_HandleTypeDef* htim);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup TIMEx_Private_Macros TIMEx Private Macros
+  * @{
+  */
+#define IS_TIM_CHANNELS(CHANNEL) (((CHANNEL) == TIM_CHANNEL_1) || \
+                                  ((CHANNEL) == TIM_CHANNEL_2) || \
+                                  ((CHANNEL) == TIM_CHANNEL_3) || \
+                                  ((CHANNEL) == TIM_CHANNEL_4) || \
+                                  ((CHANNEL) == TIM_CHANNEL_5) || \
+                                  ((CHANNEL) == TIM_CHANNEL_6) || \
+                                  ((CHANNEL) == TIM_CHANNEL_ALL))
+
+#define IS_TIM_PWMI_CHANNELS(CHANNEL) (((CHANNEL) == TIM_CHANNEL_1) || \
+                                       ((CHANNEL) == TIM_CHANNEL_2))
+
+#define IS_TIM_OPM_CHANNELS(CHANNEL) (((CHANNEL) == TIM_CHANNEL_1) || \
+                                      ((CHANNEL) == TIM_CHANNEL_2))
+
+#define IS_TIM_COMPLEMENTARY_CHANNELS(CHANNEL) (((CHANNEL) == TIM_CHANNEL_1) || \
+                                                ((CHANNEL) == TIM_CHANNEL_2) || \
+                                                ((CHANNEL) == TIM_CHANNEL_3))
+#define IS_TIM_PWM_MODE(MODE) (((MODE) == TIM_OCMODE_PWM1)               || \
+	                       ((MODE) == TIM_OCMODE_PWM2)               || \
+                               ((MODE) == TIM_OCMODE_COMBINED_PWM1)      || \
+                               ((MODE) == TIM_OCMODE_COMBINED_PWM2)      || \
+                               ((MODE) == TIM_OCMODE_ASSYMETRIC_PWM1)    || \
+                               ((MODE) == TIM_OCMODE_ASSYMETRIC_PWM2))
+
+#define IS_TIM_OC_MODE(MODE) (((MODE) == TIM_OCMODE_TIMING)             || \
+                             ((MODE) == TIM_OCMODE_ACTIVE)             || \
+                             ((MODE) == TIM_OCMODE_INACTIVE)           || \
+                             ((MODE) == TIM_OCMODE_TOGGLE)             || \
+                             ((MODE) == TIM_OCMODE_FORCED_ACTIVE)      || \
+                             ((MODE) == TIM_OCMODE_FORCED_INACTIVE)    || \
+                             ((MODE) == TIM_OCMODE_RETRIGERRABLE_OPM1) || \
+                             ((MODE) == TIM_OCMODE_RETRIGERRABLE_OPM2))
+#define IS_TIM_REMAP(__TIM_REMAP__)	 (((__TIM_REMAP__) == TIM_TIM2_TIM8_TRGO)||\
+                                      ((__TIM_REMAP__) == TIM_TIM2_ETH_PTP)||\
+                                      ((__TIM_REMAP__) == TIM_TIM2_USBFS_SOF)||\
+                                      ((__TIM_REMAP__) == TIM_TIM2_USBHS_SOF)||\
+                                      ((__TIM_REMAP__) == TIM_TIM5_GPIO)||\
+                                      ((__TIM_REMAP__) == TIM_TIM5_LSI)||\
+                                      ((__TIM_REMAP__) == TIM_TIM5_LSE)||\
+                                      ((__TIM_REMAP__) == TIM_TIM5_RTC)||\
+                                      ((__TIM_REMAP__) == TIM_TIM11_GPIO)||\
+                                      ((__TIM_REMAP__) == TIM_TIM11_SPDIFRX)||\
+                                      ((__TIM_REMAP__) == TIM_TIM11_HSE)||\
+                                      ((__TIM_REMAP__) == TIM_TIM11_MCO1))
+#define IS_TIM_DEADTIME(__DEADTIME__)      ((__DEADTIME__) <= 0xFF)
+#define IS_TIM_BREAK_FILTER(__FILTER__) ((__FILTER__) <= 0xF)
+#define IS_TIM_CLEARINPUT_SOURCE(MODE) (((MODE) == TIM_CLEARINPUTSOURCE_ETR)      || \
+                                        ((MODE) == TIM_CLEARINPUTSOURCE_OCREFCLR)  || \
+                                        ((MODE) == TIM_CLEARINPUTSOURCE_NONE))
+#define IS_TIM_BREAK2_STATE(STATE) (((STATE) == TIM_BREAK2_ENABLE) || \
+                                    ((STATE) == TIM_BREAK2_DISABLE))
+#define IS_TIM_BREAK2_POLARITY(__POLARITY__) (((__POLARITY__) == TIM_BREAK2POLARITY_LOW) || \
+                                              ((__POLARITY__) == TIM_BREAK2POLARITY_HIGH))
+#define IS_TIM_GROUPCH5(OCREF) ((((OCREF) & 0x1FFFFFFF) == 0x00000000))
+#define IS_TIM_TRGO2_SOURCE(SOURCE) (((SOURCE) == TIM_TRGO2_RESET)                        || \
+                                     ((SOURCE) == TIM_TRGO2_ENABLE)                       || \
+                                     ((SOURCE) == TIM_TRGO2_UPDATE)                       || \
+                                     ((SOURCE) == TIM_TRGO2_OC1)                          || \
+                                     ((SOURCE) == TIM_TRGO2_OC1REF)                       || \
+                                     ((SOURCE) == TIM_TRGO2_OC2REF)                       || \
+                                     ((SOURCE) == TIM_TRGO2_OC3REF)                       || \
+                                     ((SOURCE) == TIM_TRGO2_OC3REF)                       || \
+                                     ((SOURCE) == TIM_TRGO2_OC4REF)                       || \
+                                     ((SOURCE) == TIM_TRGO2_OC5REF)                       || \
+                                     ((SOURCE) == TIM_TRGO2_OC6REF)                       || \
+                                     ((SOURCE) == TIM_TRGO2_OC4REF_RISINGFALLING)         || \
+                                     ((SOURCE) == TIM_TRGO2_OC6REF_RISINGFALLING)         || \
+                                     ((SOURCE) == TIM_TRGO2_OC4REF_RISING_OC6REF_RISING)  || \
+                                     ((SOURCE) == TIM_TRGO2_OC4REF_RISING_OC6REF_FALLING) || \
+                                     ((SOURCE) == TIM_TRGO2_OC5REF_RISING_OC6REF_RISING)  || \
+                                     ((SOURCE) == TIM_TRGO2_OC5REF_RISING_OC6REF_FALLING))
+#define IS_TIM_SLAVE_MODE(MODE) (((MODE) == TIM_SLAVEMODE_DISABLE)   || \
+                                 ((MODE) == TIM_SLAVEMODE_RESET)     || \
+                                 ((MODE) == TIM_SLAVEMODE_GATED)     || \
+                                 ((MODE) == TIM_SLAVEMODE_TRIGGER)   || \
+                                 ((MODE) == TIM_SLAVEMODE_EXTERNAL1) || \
+                                 ((MODE) == TIM_SLAVEMODE_COMBINED_RESETTRIGGER))
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup TIMEx_Private_Functions TIMEx Private Functions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_TIM_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_uart.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_uart.h
@@ -1,0 +1,1165 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_uart.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of UART HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_UART_H
+#define __STM32F7xx_HAL_UART_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup UART
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup UART_Exported_Types UART Exported Types
+  * @{
+  */
+
+/**
+  * @brief UART Init Structure definition
+  */
+typedef struct
+{
+  uint32_t BaudRate;                  /*!< This member configures the UART communication baud rate.
+                                           The baud rate register is computed using the following formula:
+                                           - If oversampling is 16 or in LIN mode,
+                                              Baud Rate Register = ((PCLKx) / ((huart->Init.BaudRate)))
+                                           - If oversampling is 8,
+                                              Baud Rate Register[15:4] = ((2 * PCLKx) / ((huart->Init.BaudRate)))[15:4]
+                                              Baud Rate Register[3] =  0
+                                              Baud Rate Register[2:0] =  (((2 * PCLKx) / ((huart->Init.BaudRate)))[3:0]) >> 1      */
+
+  uint32_t WordLength;                /*!< Specifies the number of data bits transmitted or received in a frame.
+                                           This parameter can be a value of @ref UARTEx_Word_Length */
+
+  uint32_t StopBits;                  /*!< Specifies the number of stop bits transmitted.
+                                           This parameter can be a value of @ref UART_Stop_Bits */
+
+  uint32_t Parity;                    /*!< Specifies the parity mode.
+                                           This parameter can be a value of @ref UART_Parity
+                                           @note When parity is enabled, the computed parity is inserted
+                                                 at the MSB position of the transmitted data (9th bit when
+                                                 the word length is set to 9 data bits; 8th bit when the
+                                                 word length is set to 8 data bits). */
+
+  uint32_t Mode;                      /*!< Specifies whether the Receive or Transmit mode is enabled or disabled.
+                                           This parameter can be a value of @ref UART_Mode */
+
+  uint32_t HwFlowCtl;                 /*!< Specifies whether the hardware flow control mode is enabled
+                                           or disabled.
+                                           This parameter can be a value of @ref UART_Hardware_Flow_Control */
+
+  uint32_t OverSampling;              /*!< Specifies whether the Over sampling 8 is enabled or disabled, to achieve higher speed (up to fPCLK/8).
+                                           This parameter can be a value of @ref UART_Over_Sampling */
+
+  uint32_t OneBitSampling;            /*!< Specifies whether a single sample or three samples' majority vote is selected.
+                                           Selecting the single sample method increases the receiver tolerance to clock
+                                           deviations. This parameter can be a value of @ref UART_OneBit_Sampling */
+}UART_InitTypeDef;
+
+/**
+  * @brief  UART Advanced Features initalization structure definition
+  */
+typedef struct
+{
+  uint32_t AdvFeatureInit;        /*!< Specifies which advanced UART features is initialized. Several
+                                       Advanced Features may be initialized at the same time .
+                                       This parameter can be a value of @ref UART_Advanced_Features_Initialization_Type */
+
+  uint32_t TxPinLevelInvert;      /*!< Specifies whether the TX pin active level is inverted.
+                                       This parameter can be a value of @ref UART_Tx_Inv  */
+
+  uint32_t RxPinLevelInvert;      /*!< Specifies whether the RX pin active level is inverted.
+                                       This parameter can be a value of @ref UART_Rx_Inv  */
+
+  uint32_t DataInvert;            /*!< Specifies whether data are inverted (positive/direct logic
+                                       vs negative/inverted logic).
+                                       This parameter can be a value of @ref UART_Data_Inv */
+
+  uint32_t Swap;                  /*!< Specifies whether TX and RX pins are swapped.
+                                       This parameter can be a value of @ref UART_Rx_Tx_Swap */
+
+  uint32_t OverrunDisable;        /*!< Specifies whether the reception overrun detection is disabled.
+                                       This parameter can be a value of @ref UART_Overrun_Disable */
+
+  uint32_t DMADisableonRxError;   /*!< Specifies whether the DMA is disabled in case of reception error.
+                                       This parameter can be a value of @ref UART_DMA_Disable_on_Rx_Error */
+
+  uint32_t AutoBaudRateEnable;    /*!< Specifies whether auto Baud rate detection is enabled.
+                                       This parameter can be a value of @ref UART_AutoBaudRate_Enable */
+
+  uint32_t AutoBaudRateMode;      /*!< If auto Baud rate detection is enabled, specifies how the rate
+                                       detection is carried out.
+                                       This parameter can be a value of @ref UART_AutoBaud_Rate_Mode */
+
+  uint32_t MSBFirst;              /*!< Specifies whether MSB is sent first on UART line.
+                                       This parameter can be a value of @ref UART_MSB_First */
+} UART_AdvFeatureInitTypeDef;
+
+
+
+/**
+  * @brief HAL UART State structures definition
+  */
+typedef enum
+{
+  HAL_UART_STATE_RESET             = 0x00,    /*!< Peripheral is not initialized                      */
+  HAL_UART_STATE_READY             = 0x01,    /*!< Peripheral Initialized and ready for use           */
+  HAL_UART_STATE_BUSY              = 0x02,    /*!< an internal process is ongoing                     */
+  HAL_UART_STATE_BUSY_TX           = 0x12,    /*!< Data Transmission process is ongoing               */
+  HAL_UART_STATE_BUSY_RX           = 0x22,    /*!< Data Reception process is ongoing                  */
+  HAL_UART_STATE_BUSY_TX_RX        = 0x32,    /*!< Data Transmission and Reception process is ongoing */
+  HAL_UART_STATE_TIMEOUT           = 0x03,    /*!< Timeout state                                      */
+  HAL_UART_STATE_ERROR             = 0x04     /*!< Error                                              */
+}HAL_UART_StateTypeDef;
+
+/**
+  * @brief UART clock sources definition
+  */
+typedef enum
+{
+  UART_CLOCKSOURCE_PCLK1      = 0x00,    /*!< PCLK1 clock source  */
+  UART_CLOCKSOURCE_PCLK2      = 0x01,    /*!< PCLK2 clock source  */
+  UART_CLOCKSOURCE_HSI        = 0x02,    /*!< HSI clock source    */
+  UART_CLOCKSOURCE_SYSCLK     = 0x04,    /*!< SYSCLK clock source */
+  UART_CLOCKSOURCE_LSE        = 0x08,    /*!< LSE clock source       */
+  UART_CLOCKSOURCE_UNDEFINED  = 0x10     /*!< Undefined clock source */
+}UART_ClockSourceTypeDef;
+
+/**
+  * @brief  UART handle Structure definition
+  */
+typedef struct
+{
+  USART_TypeDef            *Instance;        /*!< UART registers base address        */
+
+  UART_InitTypeDef         Init;             /*!< UART communication parameters      */
+
+  UART_AdvFeatureInitTypeDef AdvancedInit;   /*!< UART Advanced Features initialization parameters */
+
+  uint8_t                  *pTxBuffPtr;      /*!< Pointer to UART Tx transfer Buffer */
+
+  uint16_t                 TxXferSize;       /*!< UART Tx Transfer size              */
+
+  uint16_t                 TxXferCount;      /*!< UART Tx Transfer Counter           */
+
+  uint8_t                  *pRxBuffPtr;      /*!< Pointer to UART Rx transfer Buffer */
+
+  uint16_t                 RxXferSize;       /*!< UART Rx Transfer size              */
+
+  uint16_t                 RxXferCount;      /*!< UART Rx Transfer Counter           */
+
+  uint16_t                 Mask;             /*!< UART Rx RDR register mask          */
+
+  DMA_HandleTypeDef        *hdmatx;          /*!< UART Tx DMA Handle parameters      */
+
+  DMA_HandleTypeDef        *hdmarx;          /*!< UART Rx DMA Handle parameters      */
+
+  HAL_LockTypeDef           Lock;            /*!< Locking object                     */
+
+  __IO HAL_UART_StateTypeDef    State;       /*!< UART communication state           */
+
+  __IO uint32_t             ErrorCode;   /*!< UART Error code                    */
+
+}UART_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup UART_Exported_Constants UART Exported Constants
+  * @{
+  */
+/** @defgroup UART_Error_Definition   UART Error Definition
+  * @{
+  */
+#define  HAL_UART_ERROR_NONE       ((uint32_t)0x00000000)    /*!< No error            */
+#define  HAL_UART_ERROR_PE         ((uint32_t)0x00000001)    /*!< Parity error        */
+#define  HAL_UART_ERROR_NE         ((uint32_t)0x00000002)    /*!< Noise error         */
+#define  HAL_UART_ERROR_FE         ((uint32_t)0x00000004)    /*!< frame error         */
+#define  HAL_UART_ERROR_ORE        ((uint32_t)0x00000008)    /*!< Overrun error       */
+#define  HAL_UART_ERROR_DMA        ((uint32_t)0x00000010)    /*!< DMA transfer error  */
+/**
+  * @}
+  */
+/** @defgroup UART_Stop_Bits   UART Number of Stop Bits
+  * @{
+  */
+#define UART_STOPBITS_1                     ((uint32_t)0x0000)
+#define UART_STOPBITS_2                     ((uint32_t)USART_CR2_STOP_1)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Parity  UART Parity
+  * @{
+  */
+#define UART_PARITY_NONE                    ((uint32_t)0x00000000)
+#define UART_PARITY_EVEN                    ((uint32_t)USART_CR1_PCE)
+#define UART_PARITY_ODD                     ((uint32_t)(USART_CR1_PCE | USART_CR1_PS))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Hardware_Flow_Control UART Hardware Flow Control
+  * @{
+  */
+#define UART_HWCONTROL_NONE                  ((uint32_t)0x00000000)
+#define UART_HWCONTROL_RTS                   ((uint32_t)USART_CR3_RTSE)
+#define UART_HWCONTROL_CTS                   ((uint32_t)USART_CR3_CTSE)
+#define UART_HWCONTROL_RTS_CTS               ((uint32_t)(USART_CR3_RTSE | USART_CR3_CTSE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Mode UART Transfer Mode
+  * @{
+  */
+#define UART_MODE_RX                        ((uint32_t)USART_CR1_RE)
+#define UART_MODE_TX                        ((uint32_t)USART_CR1_TE)
+#define UART_MODE_TX_RX                     ((uint32_t)(USART_CR1_TE |USART_CR1_RE))
+/**
+  * @}
+  */
+
+ /** @defgroup UART_State  UART State
+  * @{
+  */
+#define UART_STATE_DISABLE                  ((uint32_t)0x00000000)
+#define UART_STATE_ENABLE                   ((uint32_t)USART_CR1_UE)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Over_Sampling UART Over Sampling
+  * @{
+  */
+#define UART_OVERSAMPLING_16                ((uint32_t)0x00000000)
+#define UART_OVERSAMPLING_8                 ((uint32_t)USART_CR1_OVER8)
+/**
+  * @}
+  */
+
+/** @defgroup UART_OneBit_Sampling UART One Bit Sampling Method
+  * @{
+  */
+#define UART_ONE_BIT_SAMPLE_DISABLE         ((uint32_t)0x00000000)
+#define UART_ONE_BIT_SAMPLE_ENABLE          ((uint32_t)USART_CR3_ONEBIT)
+/**
+  * @}
+  */
+
+/** @defgroup UART_AutoBaud_Rate_Mode    UART Advanced Feature AutoBaud Rate Mode
+  * @{
+  */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ONSTARTBIT    ((uint32_t)0x0000)
+#define UART_ADVFEATURE_AUTOBAUDRATE_ONFALLINGEDGE ((uint32_t)USART_CR2_ABRMODE_0)
+#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X7FFRAME   ((uint32_t)USART_CR2_ABRMODE_1)
+#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X55FRAME   ((uint32_t)USART_CR2_ABRMODE)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Receiver_TimeOut UART Receiver TimeOut
+  * @{
+  */
+#define UART_RECEIVER_TIMEOUT_DISABLE       ((uint32_t)0x00000000)
+#define UART_RECEIVER_TIMEOUT_ENABLE        ((uint32_t)USART_CR2_RTOEN)
+/**
+  * @}
+  */
+
+/** @defgroup UART_LIN    UART Local Interconnection Network mode
+  * @{
+  */
+#define UART_LIN_DISABLE                    ((uint32_t)0x00000000)
+#define UART_LIN_ENABLE                     ((uint32_t)USART_CR2_LINEN)
+/**
+  * @}
+  */
+
+/** @defgroup UART_LIN_Break_Detection  UART LIN Break Detection
+  * @{
+  */
+#define UART_LINBREAKDETECTLENGTH_10B       ((uint32_t)0x00000000)
+#define UART_LINBREAKDETECTLENGTH_11B       ((uint32_t)USART_CR2_LBDL)
+/**
+  * @}
+  */
+
+/** @defgroup UART_DMA_Tx    UART DMA Tx
+  * @{
+  */
+#define UART_DMA_TX_DISABLE                 ((uint32_t)0x00000000)
+#define UART_DMA_TX_ENABLE                  ((uint32_t)USART_CR3_DMAT)
+/**
+  * @}
+  */
+
+/** @defgroup UART_DMA_Rx   UART DMA Rx
+  * @{
+  */
+#define UART_DMA_RX_DISABLE                 ((uint32_t)0x0000)
+#define UART_DMA_RX_ENABLE                  ((uint32_t)USART_CR3_DMAR)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Half_Duplex_Selection  UART Half Duplex Selection
+  * @{
+  */
+#define UART_HALF_DUPLEX_DISABLE            ((uint32_t)0x0000)
+#define UART_HALF_DUPLEX_ENABLE             ((uint32_t)USART_CR3_HDSEL)
+/**
+  * @}
+  */
+
+/** @defgroup UART_WakeUp_Methods   UART WakeUp Methods
+  * @{
+  */
+#define UART_WAKEUPMETHOD_IDLELINE          ((uint32_t)0x00000000)
+#define UART_WAKEUPMETHOD_ADDRESSMARK       ((uint32_t)USART_CR1_WAKE)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Request_Parameters UART Request Parameters
+  * @{
+  */
+#define UART_AUTOBAUD_REQUEST               ((uint32_t)USART_RQR_ABRRQ)        /*!< Auto-Baud Rate Request */
+#define UART_SENDBREAK_REQUEST              ((uint32_t)USART_RQR_SBKRQ)        /*!< Send Break Request */
+#define UART_MUTE_MODE_REQUEST              ((uint32_t)USART_RQR_MMRQ)         /*!< Mute Mode Request */
+#define UART_RXDATA_FLUSH_REQUEST           ((uint32_t)USART_RQR_RXFRQ)        /*!< Receive Data flush Request */
+#define UART_TXDATA_FLUSH_REQUEST           ((uint32_t)USART_RQR_TXFRQ)        /*!< Transmit data flush Request */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Advanced_Features_Initialization_Type  UART Advanced Feature Initialization Type
+  * @{
+  */
+#define UART_ADVFEATURE_NO_INIT                 ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_TXINVERT_INIT           ((uint32_t)0x00000001)
+#define UART_ADVFEATURE_RXINVERT_INIT           ((uint32_t)0x00000002)
+#define UART_ADVFEATURE_DATAINVERT_INIT         ((uint32_t)0x00000004)
+#define UART_ADVFEATURE_SWAP_INIT               ((uint32_t)0x00000008)
+#define UART_ADVFEATURE_RXOVERRUNDISABLE_INIT   ((uint32_t)0x00000010)
+#define UART_ADVFEATURE_DMADISABLEONERROR_INIT  ((uint32_t)0x00000020)
+#define UART_ADVFEATURE_AUTOBAUDRATE_INIT       ((uint32_t)0x00000040)
+#define UART_ADVFEATURE_MSBFIRST_INIT           ((uint32_t)0x00000080)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Tx_Inv UART Advanced Feature TX Pin Active Level Inversion
+  * @{
+  */
+#define UART_ADVFEATURE_TXINV_DISABLE       ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_TXINV_ENABLE        ((uint32_t)USART_CR2_TXINV)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Rx_Inv UART Advanced Feature RX Pin Active Level Inversion
+  * @{
+  */
+#define UART_ADVFEATURE_RXINV_DISABLE       ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_RXINV_ENABLE        ((uint32_t)USART_CR2_RXINV)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Data_Inv  UART Advanced Feature Binary Data Inversion
+  * @{
+  */
+#define UART_ADVFEATURE_DATAINV_DISABLE     ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_DATAINV_ENABLE      ((uint32_t)USART_CR2_DATAINV)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Rx_Tx_Swap UART Advanced Feature RX TX Pins Swap
+  * @{
+  */
+#define UART_ADVFEATURE_SWAP_DISABLE        ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_SWAP_ENABLE         ((uint32_t)USART_CR2_SWAP)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Overrun_Disable  UART Advanced Feature Overrun Disable
+  * @{
+  */
+#define UART_ADVFEATURE_OVERRUN_ENABLE      ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_OVERRUN_DISABLE     ((uint32_t)USART_CR3_OVRDIS)
+/**
+  * @}
+  */
+
+/** @defgroup UART_AutoBaudRate_Enable  UART Advanced Feature Auto BaudRate Enable
+  * @{
+  */
+#define UART_ADVFEATURE_AUTOBAUDRATE_DISABLE   ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_AUTOBAUDRATE_ENABLE    ((uint32_t)USART_CR2_ABREN)
+/**
+  * @}
+  */
+
+/** @defgroup UART_DMA_Disable_on_Rx_Error   UART Advanced Feature DMA Disable On Rx Error
+  * @{
+  */
+#define UART_ADVFEATURE_DMA_ENABLEONRXERROR    ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_DMA_DISABLEONRXERROR   ((uint32_t)USART_CR3_DDRE)
+/**
+  * @}
+  */
+
+/** @defgroup UART_MSB_First   UART Advanced Feature MSB First
+  * @{
+  */
+#define UART_ADVFEATURE_MSBFIRST_DISABLE    ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_MSBFIRST_ENABLE     ((uint32_t)USART_CR2_MSBFIRST)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Mute_Mode   UART Advanced Feature Mute Mode Enable
+  * @{
+  */
+#define UART_ADVFEATURE_MUTEMODE_DISABLE    ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_MUTEMODE_ENABLE     ((uint32_t)USART_CR1_MME)
+/**
+  * @}
+  */
+
+/** @defgroup UART_CR2_ADDRESS_LSB_POS    UART Address-matching LSB Position In CR2 Register
+  * @{
+  */
+#define UART_CR2_ADDRESS_LSB_POS            ((uint32_t) 24)
+/**
+  * @}
+  */
+
+/** @defgroup UART_DriverEnable_Polarity      UART DriverEnable Polarity
+  * @{
+  */
+#define UART_DE_POLARITY_HIGH               ((uint32_t)0x00000000)
+#define UART_DE_POLARITY_LOW                ((uint32_t)USART_CR3_DEP)
+/**
+  * @}
+  */
+
+/** @defgroup UART_CR1_DEAT_ADDRESS_LSB_POS    UART Driver Enable Assertion Time LSB Position In CR1 Register
+  * @{
+  */
+#define UART_CR1_DEAT_ADDRESS_LSB_POS       ((uint32_t) 21)
+/**
+  * @}
+  */
+
+/** @defgroup UART_CR1_DEDT_ADDRESS_LSB_POS    UART Driver Enable DeAssertion Time LSB Position In CR1 Register
+  * @{
+  */
+#define UART_CR1_DEDT_ADDRESS_LSB_POS       ((uint32_t) 16)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Interruption_Mask    UART Interruptions Flag Mask
+  * @{
+  */
+#define UART_IT_MASK                        ((uint32_t)0x001F)
+/**
+  * @}
+  */
+
+/** @defgroup UART_TimeOut_Value    UART polling-based communications time-out value
+  * @{
+  */
+#define HAL_UART_TIMEOUT_VALUE              0x1FFFFFF
+/**
+  * @}
+  */
+
+/** @defgroup UART_Flags     UART Status Flags
+  *        Elements values convention: 0xXXXX
+  *           - 0xXXXX  : Flag mask in the ISR register
+  * @{
+  */
+#define UART_FLAG_TEACK                     ((uint32_t)0x00200000)
+#define UART_FLAG_SBKF                      ((uint32_t)0x00040000)
+#define UART_FLAG_CMF                       ((uint32_t)0x00020000)
+#define UART_FLAG_BUSY                      ((uint32_t)0x00010000)
+#define UART_FLAG_ABRF                      ((uint32_t)0x00008000)
+#define UART_FLAG_ABRE                      ((uint32_t)0x00004000)
+#define UART_FLAG_EOBF                      ((uint32_t)0x00001000)
+#define UART_FLAG_RTOF                      ((uint32_t)0x00000800)
+#define UART_FLAG_CTS                       ((uint32_t)0x00000400)
+#define UART_FLAG_CTSIF                     ((uint32_t)0x00000200)
+#define UART_FLAG_LBDF                      ((uint32_t)0x00000100)
+#define UART_FLAG_TXE                       ((uint32_t)0x00000080)
+#define UART_FLAG_TC                        ((uint32_t)0x00000040)
+#define UART_FLAG_RXNE                      ((uint32_t)0x00000020)
+#define UART_FLAG_IDLE                      ((uint32_t)0x00000010)
+#define UART_FLAG_ORE                       ((uint32_t)0x00000008)
+#define UART_FLAG_NE                        ((uint32_t)0x00000004)
+#define UART_FLAG_FE                        ((uint32_t)0x00000002)
+#define UART_FLAG_PE                        ((uint32_t)0x00000001)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Interrupt_definition   UART Interrupts Definition
+  *        Elements values convention: 0000ZZZZ0XXYYYYYb
+  *           - YYYYY  : Interrupt source position in the XX register (5bits)
+  *           - XX  : Interrupt source register (2bits)
+  *                 - 01: CR1 register
+  *                 - 10: CR2 register
+  *                 - 11: CR3 register
+  *           - ZZZZ  : Flag position in the ISR register(4bits)
+  * @{
+  */
+#define UART_IT_PE                          ((uint32_t)0x0028)
+#define UART_IT_TXE                         ((uint32_t)0x0727)
+#define UART_IT_TC                          ((uint32_t)0x0626)
+#define UART_IT_RXNE                        ((uint32_t)0x0525)
+#define UART_IT_IDLE                        ((uint32_t)0x0424)
+#define UART_IT_LBD                         ((uint32_t)0x0846)
+#define UART_IT_CTS                         ((uint32_t)0x096A)
+#define UART_IT_CM                          ((uint32_t)0x112E)
+
+/**       Elements values convention: 000000000XXYYYYYb
+  *           - YYYYY  : Interrupt source position in the XX register (5bits)
+  *           - XX  : Interrupt source register (2bits)
+  *                 - 01: CR1 register
+  *                 - 10: CR2 register
+  *                 - 11: CR3 register
+  */
+#define UART_IT_ERR                         ((uint32_t)0x0060)
+
+/**       Elements values convention: 0000ZZZZ00000000b
+  *           - ZZZZ  : Flag position in the ISR register(4bits)
+  */
+#define UART_IT_ORE                         ((uint32_t)0x0300)
+#define UART_IT_NE                          ((uint32_t)0x0200)
+#define UART_IT_FE                          ((uint32_t)0x0100)
+/**
+  * @}
+  */
+
+/** @defgroup UART_IT_CLEAR_Flags  UART Interruption Clear Flags
+  * @{
+  */
+#define UART_CLEAR_PEF                       USART_ICR_PECF            /*!< Parity Error Clear Flag */
+#define UART_CLEAR_FEF                       USART_ICR_FECF            /*!< Framing Error Clear Flag */
+#define UART_CLEAR_NEF                       USART_ICR_NCF             /*!< Noise detected Clear Flag */
+#define UART_CLEAR_OREF                      USART_ICR_ORECF           /*!< OverRun Error Clear Flag */
+#define UART_CLEAR_IDLEF                     USART_ICR_IDLECF          /*!< IDLE line detected Clear Flag */
+#define UART_CLEAR_TCF                       USART_ICR_TCCF            /*!< Transmission Complete Clear Flag */
+#define UART_CLEAR_LBDF                      USART_ICR_LBDCF           /*!< LIN Break Detection Clear Flag */
+#define UART_CLEAR_CTSF                      USART_ICR_CTSCF           /*!< CTS Interrupt Clear Flag */
+#define UART_CLEAR_RTOF                      USART_ICR_RTOCF           /*!< Receiver Time Out Clear Flag */
+#define UART_CLEAR_EOBF                      USART_ICR_EOBCF           /*!< End Of Block Clear Flag */
+#define UART_CLEAR_CMF                       USART_ICR_CMCF            /*!< Character Match Clear Flag */
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup UART_Exported_Macros UART Exported Macros
+  * @{
+  */
+
+/** @brief Reset UART handle state
+  * @param  __HANDLE__: UART handle.
+  * @retval None
+  */
+#define __HAL_UART_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_UART_STATE_RESET)
+
+/** @brief  Flush the UART Data registers
+  * @param  __HANDLE__: specifies the UART Handle.
+  */
+#define __HAL_UART_FLUSH_DRREGISTER(__HANDLE__)  \
+  do{                \
+      SET_BIT((__HANDLE__)->Instance->RQR, UART_RXDATA_FLUSH_REQUEST); \
+      SET_BIT((__HANDLE__)->Instance->RQR, UART_TXDATA_FLUSH_REQUEST); \
+    }  while(0)
+
+/** @brief  Clears the specified UART ISR flag, in setting the proper ICR register flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __FLAG__: specifies the interrupt clear register flag that needs to be set
+  *                       to clear the corresponding interrupt
+  *          This parameter can be one of the following values:
+  *            @arg UART_CLEAR_PEF: Parity Error Clear Flag
+  *            @arg UART_CLEAR_FEF: Framing Error Clear Flag
+  *            @arg UART_CLEAR_NEF: Noise detected Clear Flag
+  *            @arg UART_CLEAR_OREF: OverRun Error Clear Flag
+  *            @arg UART_CLEAR_IDLEF: IDLE line detected Clear Flag
+  *            @arg UART_CLEAR_TCF: Transmission Complete Clear Flag
+  *            @arg UART_CLEAR_LBDF: LIN Break Detection Clear Flag
+  *            @arg UART_CLEAR_CTSF: CTS Interrupt Clear Flag
+  *            @arg UART_CLEAR_RTOF: Receiver Time Out Clear Flag
+  *            @arg UART_CLEAR_EOBF: End Of Block Clear Flag
+  *            @arg UART_CLEAR_CMF: Character Match Clear Flag
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_IT(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ICR = ~(__FLAG__))
+
+/** @brief  Clear the UART PE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_PEFLAG(__HANDLE__)   __HAL_UART_CLEAR_IT((__HANDLE__),UART_CLEAR_PEF)
+
+/** @brief  Clear the UART FE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_FEFLAG(__HANDLE__)   __HAL_UART_CLEAR_IT((__HANDLE__),UART_CLEAR_FEF)
+
+/** @brief  Clear the UART NE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_NEFLAG(__HANDLE__)  __HAL_UART_CLEAR_IT((__HANDLE__),UART_CLEAR_NEF)
+
+/** @brief  Clear the UART ORE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_OREFLAG(__HANDLE__)   __HAL_UART_CLEAR_IT((__HANDLE__),UART_CLEAR_OREF)
+
+/** @brief  Clear the UART IDLE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_IDLEFLAG(__HANDLE__)   __HAL_UART_CLEAR_IT((__HANDLE__),UART_CLEAR_IDLEF)
+
+/** @brief  Checks whether the specified UART flag is set or not.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg UART_FLAG_REACK: Receive enable acknowledge flag
+  *            @arg UART_FLAG_TEACK: Transmit enable acknowledge flag
+  *            @arg UART_FLAG_WUF:   Wake up from stop mode flag
+  *            @arg UART_FLAG_RWU:   Receiver wake up flag (is the UART in mute mode)
+  *            @arg UART_FLAG_SBKF:  Send Break flag
+  *            @arg UART_FLAG_CMF:   Character match flag
+  *            @arg UART_FLAG_BUSY:  Busy flag
+  *            @arg UART_FLAG_ABRF:  Auto Baud rate detection flag
+  *            @arg UART_FLAG_ABRE:  Auto Baud rate detection error flag
+  *            @arg UART_FLAG_EOBF:  End of block flag
+  *            @arg UART_FLAG_RTOF:  Receiver timeout flag
+  *            @arg UART_FLAG_CTS:   CTS Change flag (not available for UART4 and UART5)
+  *            @arg UART_FLAG_LBD:   LIN Break detection flag
+  *            @arg UART_FLAG_TXE:   Transmit data register empty flag
+  *            @arg UART_FLAG_TC:    Transmission Complete flag
+  *            @arg UART_FLAG_RXNE:  Receive data register not empty flag
+  *            @arg UART_FLAG_IDLE:  Idle Line detection flag
+  *            @arg UART_FLAG_ORE:   OverRun Error flag
+  *            @arg UART_FLAG_NE:    Noise Error flag
+  *            @arg UART_FLAG_FE:    Framing Error flag
+  *            @arg UART_FLAG_PE:    Parity Error flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_UART_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->ISR & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Enables the specified UART interrupt.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __INTERRUPT__: specifies the UART interrupt source to enable.
+  *          This parameter can be one of the following values:
+  *            @arg UART_IT_WUF:  Wakeup from stop mode interrupt
+  *            @arg UART_IT_CM:   Character match interrupt
+  *            @arg UART_IT_CTS:  CTS change interrupt
+  *            @arg UART_IT_LBD:  LIN Break detection interrupt
+  *            @arg UART_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg UART_IT_TC:   Transmission complete interrupt
+  *            @arg UART_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg UART_IT_IDLE: Idle line detection interrupt
+  *            @arg UART_IT_PE:   Parity Error interrupt
+  *            @arg UART_IT_ERR:  Error interrupt(Frame error, noise error, overrun error)
+  * @retval None
+  */
+#define __HAL_UART_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (((((uint8_t)(__INTERRUPT__)) >> 5U) == 1)? ((__HANDLE__)->Instance->CR1 |= (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 2)? ((__HANDLE__)->Instance->CR2 |= (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((__HANDLE__)->Instance->CR3 |= (1U << ((__INTERRUPT__) & UART_IT_MASK))))
+
+
+/** @brief  Disables the specified UART interrupt.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __INTERRUPT__: specifies the UART interrupt source to disable.
+  *          This parameter can be one of the following values:
+  *            @arg UART_IT_CM:   Character match interrupt
+  *            @arg UART_IT_CTS:  CTS change interrupt
+  *            @arg UART_IT_LBD:  LIN Break detection interrupt
+  *            @arg UART_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg UART_IT_TC:   Transmission complete interrupt
+  *            @arg UART_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg UART_IT_IDLE: Idle line detection interrupt
+  *            @arg UART_IT_PE:   Parity Error interrupt
+  *            @arg UART_IT_ERR:  Error interrupt(Frame error, noise error, overrun error)
+  * @retval None
+  */
+#define __HAL_UART_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((((uint8_t)(__INTERRUPT__)) >> 5U) == 1)? ((__HANDLE__)->Instance->CR1 &= ~ (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 2)? ((__HANDLE__)->Instance->CR2 &= ~ (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((__HANDLE__)->Instance->CR3 &= ~ (1U << ((__INTERRUPT__) & UART_IT_MASK))))
+
+/** @brief  Checks whether the specified UART interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __IT__: specifies the UART interrupt to check.
+  *          This parameter can be one of the following values:
+  *            @arg UART_IT_CM:   Character match interrupt
+  *            @arg UART_IT_CTS:  CTS change interrupt (not available for UART4 and UART5)
+  *            @arg UART_IT_LBD:  LIN Break detection interrupt
+  *            @arg UART_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg UART_IT_TC:   Transmission complete interrupt
+  *            @arg UART_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg UART_IT_IDLE: Idle line detection interrupt
+  *            @arg UART_IT_ORE:  OverRun Error interrupt
+  *            @arg UART_IT_NE:   Noise Error interrupt
+  *            @arg UART_IT_FE:   Framing Error interrupt
+  *            @arg UART_IT_PE:   Parity Error interrupt
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_UART_GET_IT(__HANDLE__, __IT__) ((__HANDLE__)->Instance->ISR & ((uint32_t)1 << ((__IT__)>> 0x08)))
+
+/** @brief  Checks whether the specified UART interrupt source is enabled.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __IT__: specifies the UART interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg UART_IT_CTS: CTS change interrupt (not available for UART4 and UART5)
+  *            @arg UART_IT_LBD: LIN Break detection interrupt
+  *            @arg UART_IT_TXE: Transmit Data Register empty interrupt
+  *            @arg UART_IT_TC:  Transmission complete interrupt
+  *            @arg UART_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg UART_IT_IDLE: Idle line detection interrupt
+  *            @arg UART_IT_ORE: OverRun Error interrupt
+  *            @arg UART_IT_NE: Noise Error interrupt
+  *            @arg UART_IT_FE: Framing Error interrupt
+  *            @arg UART_IT_PE: Parity Error interrupt
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_UART_GET_IT_SOURCE(__HANDLE__, __IT__) ((((((uint8_t)(__IT__)) >> 5U) == 1)? (__HANDLE__)->Instance->CR1:(((((uint8_t)(__IT__)) >> 5U) == 2)? \
+                                                       (__HANDLE__)->Instance->CR2 : (__HANDLE__)->Instance->CR3)) & ((uint32_t)1 << (((uint16_t)(__IT__)) & UART_IT_MASK)))
+
+/** @brief  Set a specific UART request flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __REQ__: specifies the request flag to set
+  *          This parameter can be one of the following values:
+  *            @arg UART_AUTOBAUD_REQUEST: Auto-Baud Rate Request
+  *            @arg UART_SENDBREAK_REQUEST: Send Break Request
+  *            @arg UART_MUTE_MODE_REQUEST: Mute Mode Request
+  *            @arg UART_RXDATA_FLUSH_REQUEST: Receive Data flush Request
+  *            @arg UART_TXDATA_FLUSH_REQUEST: Transmit data flush Request
+  * @retval None
+  */
+#define __HAL_UART_SEND_REQ(__HANDLE__, __REQ__) ((__HANDLE__)->Instance->RQR |= (uint32_t)(__REQ__))
+
+/** @brief  Enables the UART one bit sample method
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_ONE_BIT_SAMPLE_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR3|= USART_CR3_ONEBIT)
+
+/** @brief  Disables the UART one bit sample method
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_ONE_BIT_SAMPLE_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_ONEBIT))
+
+/** @brief  Enable UART
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_ENABLE(__HANDLE__)                   ((__HANDLE__)->Instance->CR1 |=  USART_CR1_UE)
+
+/** @brief  Disable UART
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_DISABLE(__HANDLE__)                  ((__HANDLE__)->Instance->CR1 &=  ~USART_CR1_UE)
+
+/** @brief  Enable CTS flow control
+  *         This macro allows to enable CTS hardware flow control for a given UART instance,
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying CTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e __HAL_UART_ENABLE(__HANDLE__)).
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_CTS_ENABLE(__HANDLE__)        \
+  do{                                                      \
+    SET_BIT((__HANDLE__)->Instance->CR3, USART_CR3_CTSE);  \
+    (__HANDLE__)->Init.HwFlowCtl |= USART_CR3_CTSE;        \
+  } while(0)
+
+/** @brief  Disable CTS flow control
+  *         This macro allows to disable CTS hardware flow control for a given UART instance,
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying CTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e __HAL_UART_ENABLE(__HANDLE__)).
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_CTS_DISABLE(__HANDLE__)        \
+  do{                                                       \
+    CLEAR_BIT((__HANDLE__)->Instance->CR3, USART_CR3_CTSE); \
+    (__HANDLE__)->Init.HwFlowCtl &= ~(USART_CR3_CTSE);      \
+  } while(0)
+
+/** @brief  Enable RTS flow control
+  *         This macro allows to enable RTS hardware flow control for a given UART instance,
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying RTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e __HAL_UART_ENABLE(__HANDLE__)).
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_RTS_ENABLE(__HANDLE__)       \
+  do{                                                     \
+    SET_BIT((__HANDLE__)->Instance->CR3, USART_CR3_RTSE); \
+    (__HANDLE__)->Init.HwFlowCtl |= USART_CR3_RTSE;       \
+  } while(0)
+
+/** @brief  Disable RTS flow control
+  *         This macro allows to disable RTS hardware flow control for a given UART instance,
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying RTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e __HAL_UART_ENABLE(__HANDLE__)).
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_RTS_DISABLE(__HANDLE__)       \
+  do{                                                      \
+    CLEAR_BIT((__HANDLE__)->Instance->CR3, USART_CR3_RTSE);\
+    (__HANDLE__)->Init.HwFlowCtl &= ~(USART_CR3_RTSE);     \
+  } while(0)
+
+/**
+  * @}
+  */
+
+/* Private macros --------------------------------------------------------*/
+/** @defgroup UART_Private_Macros   UART Private Macros
+  * @{
+  */
+/** @brief  BRR division operation to set BRR register with LPUART
+  * @param  _PCLK_: LPUART clock
+  * @param  _BAUD_: Baud rate set by the user
+  * @retval Division result
+  */
+#define UART_DIV_LPUART(_PCLK_, _BAUD_)                (((_PCLK_)*256)/((_BAUD_)))
+
+/** @brief  BRR division operation to set BRR register in 8-bit oversampling mode
+  * @param  _PCLK_: UART clock
+  * @param  _BAUD_: Baud rate set by the user
+  * @retval Division result
+  */
+#define UART_DIV_SAMPLING8(_PCLK_, _BAUD_)             (((_PCLK_)*2)/((_BAUD_)))
+
+/** @brief  BRR division operation to set BRR register in 16-bit oversampling mode
+  * @param  _PCLK_: UART clock
+  * @param  _BAUD_: Baud rate set by the user
+  * @retval Division result
+  */
+#define UART_DIV_SAMPLING16(_PCLK_, _BAUD_)             (((_PCLK_))/((_BAUD_)))
+
+/** @brief  Check UART Baud rate
+  * @param  BAUDRATE: Baudrate specified by the user
+  *         The maximum Baud Rate is derived from the maximum clock on F7 (i.e. 216 MHz)
+  *         divided by the smallest oversampling used on the USART (i.e. 8)
+  * @retval Test result (TRUE or FALSE).
+  */
+#define IS_UART_BAUDRATE(BAUDRATE) ((BAUDRATE) < 9000001)
+
+/** @brief  Check UART assertion time
+  * @param  TIME: 5-bit value assertion time
+  * @retval Test result (TRUE or FALSE).
+  */
+#define IS_UART_ASSERTIONTIME(TIME)    ((TIME) <= 0x1F)
+
+/** @brief  Check UART deassertion time
+  * @param  TIME: 5-bit value deassertion time
+  * @retval Test result (TRUE or FALSE).
+  */
+#define IS_UART_DEASSERTIONTIME(TIME) ((TIME) <= 0x1F)
+
+#define IS_UART_STOPBITS(STOPBITS) (((STOPBITS) == UART_STOPBITS_1) || \
+                                    ((STOPBITS) == UART_STOPBITS_2))
+
+#define IS_UART_PARITY(PARITY) (((PARITY) == UART_PARITY_NONE) || \
+                                ((PARITY) == UART_PARITY_EVEN) || \
+                                ((PARITY) == UART_PARITY_ODD))
+
+#define IS_UART_HARDWARE_FLOW_CONTROL(CONTROL)\
+                              (((CONTROL) == UART_HWCONTROL_NONE) || \
+                               ((CONTROL) == UART_HWCONTROL_RTS) || \
+                               ((CONTROL) == UART_HWCONTROL_CTS) || \
+                               ((CONTROL) == UART_HWCONTROL_RTS_CTS))
+
+#define IS_UART_MODE(MODE) ((((MODE) & (~((uint32_t)(UART_MODE_TX_RX)))) == (uint32_t)0x00) && ((MODE) != (uint32_t)0x00))
+
+#define IS_UART_STATE(STATE) (((STATE) == UART_STATE_DISABLE) || \
+                              ((STATE) == UART_STATE_ENABLE))
+
+#define IS_UART_OVERSAMPLING(SAMPLING) (((SAMPLING) == UART_OVERSAMPLING_16) || \
+                                        ((SAMPLING) == UART_OVERSAMPLING_8))
+
+#define IS_UART_ONE_BIT_SAMPLE(ONEBIT) (((ONEBIT) == UART_ONE_BIT_SAMPLE_DISABLE) || \
+                                        ((ONEBIT) == UART_ONE_BIT_SAMPLE_ENABLE))
+
+#define IS_UART_ADVFEATURE_AUTOBAUDRATEMODE(MODE)  (((MODE) == UART_ADVFEATURE_AUTOBAUDRATE_ONSTARTBIT) || \
+                                                    ((MODE) == UART_ADVFEATURE_AUTOBAUDRATE_ONFALLINGEDGE) || \
+                                                    ((MODE) == UART_ADVFEATURE_AUTOBAUDRATE_ON0X7FFRAME) || \
+                                                    ((MODE) == UART_ADVFEATURE_AUTOBAUDRATE_ON0X55FRAME))
+
+#define IS_UART_RECEIVER_TIMEOUT(TIMEOUT) (((TIMEOUT) == UART_RECEIVER_TIMEOUT_DISABLE) || \
+                                           ((TIMEOUT) == UART_RECEIVER_TIMEOUT_ENABLE))
+
+#define IS_UART_LIN(LIN)            (((LIN) == UART_LIN_DISABLE) || \
+                                     ((LIN) == UART_LIN_ENABLE))
+
+#define IS_UART_WAKEUPMETHOD(WAKEUP) (((WAKEUP) == UART_WAKEUPMETHOD_IDLELINE) || \
+                                      ((WAKEUP) == UART_WAKEUPMETHOD_ADDRESSMARK))
+
+#define IS_UART_LIN_BREAK_DETECT_LENGTH(LENGTH) (((LENGTH) == UART_LINBREAKDETECTLENGTH_10B) || \
+                                                 ((LENGTH) == UART_LINBREAKDETECTLENGTH_11B))
+
+#define IS_UART_DMA_TX(DMATX)         (((DMATX) == UART_DMA_TX_DISABLE) || \
+                                       ((DMATX) == UART_DMA_TX_ENABLE))
+
+#define IS_UART_DMA_RX(DMARX)         (((DMARX) == UART_DMA_RX_DISABLE) || \
+                                       ((DMARX) == UART_DMA_RX_ENABLE))
+
+#define IS_UART_HALF_DUPLEX(HDSEL)         (((HDSEL) == UART_HALF_DUPLEX_DISABLE) || \
+                                            ((HDSEL) == UART_HALF_DUPLEX_ENABLE))
+
+#define IS_UART_REQUEST_PARAMETER(PARAM) (((PARAM) == UART_AUTOBAUD_REQUEST) || \
+                                          ((PARAM) == UART_SENDBREAK_REQUEST) || \
+                                          ((PARAM) == UART_MUTE_MODE_REQUEST) || \
+                                          ((PARAM) == UART_RXDATA_FLUSH_REQUEST) || \
+                                          ((PARAM) == UART_TXDATA_FLUSH_REQUEST))
+
+#define IS_UART_ADVFEATURE_INIT(INIT)           ((INIT) <= (UART_ADVFEATURE_NO_INIT | \
+                                                            UART_ADVFEATURE_TXINVERT_INIT | \
+                                                            UART_ADVFEATURE_RXINVERT_INIT | \
+                                                            UART_ADVFEATURE_DATAINVERT_INIT | \
+                                                            UART_ADVFEATURE_SWAP_INIT | \
+                                                            UART_ADVFEATURE_RXOVERRUNDISABLE_INIT | \
+                                                            UART_ADVFEATURE_DMADISABLEONERROR_INIT   | \
+                                                            UART_ADVFEATURE_AUTOBAUDRATE_INIT | \
+                                                            UART_ADVFEATURE_MSBFIRST_INIT))
+
+#define IS_UART_ADVFEATURE_TXINV(TXINV) (((TXINV) == UART_ADVFEATURE_TXINV_DISABLE) || \
+                                         ((TXINV) == UART_ADVFEATURE_TXINV_ENABLE))
+
+#define IS_UART_ADVFEATURE_RXINV(RXINV) (((RXINV) == UART_ADVFEATURE_RXINV_DISABLE) || \
+                                         ((RXINV) == UART_ADVFEATURE_RXINV_ENABLE))
+
+#define IS_UART_ADVFEATURE_DATAINV(DATAINV) (((DATAINV) == UART_ADVFEATURE_DATAINV_DISABLE) || \
+                                             ((DATAINV) == UART_ADVFEATURE_DATAINV_ENABLE))
+
+#define IS_UART_ADVFEATURE_SWAP(SWAP) (((SWAP) == UART_ADVFEATURE_SWAP_DISABLE) || \
+                                       ((SWAP) == UART_ADVFEATURE_SWAP_ENABLE))
+
+#define IS_UART_OVERRUN(OVERRUN)         (((OVERRUN) == UART_ADVFEATURE_OVERRUN_ENABLE) || \
+                                          ((OVERRUN) == UART_ADVFEATURE_OVERRUN_DISABLE))
+
+#define IS_UART_ADVFEATURE_AUTOBAUDRATE(AUTOBAUDRATE)  (((AUTOBAUDRATE) == UART_ADVFEATURE_AUTOBAUDRATE_DISABLE) || \
+                                                        ((AUTOBAUDRATE) == UART_ADVFEATURE_AUTOBAUDRATE_ENABLE))
+
+#define IS_UART_ADVFEATURE_DMAONRXERROR(DMA)      (((DMA) == UART_ADVFEATURE_DMA_ENABLEONRXERROR) || \
+                                                   ((DMA) == UART_ADVFEATURE_DMA_DISABLEONRXERROR))
+
+#define IS_UART_ADVFEATURE_MSBFIRST(MSBFIRST) (((MSBFIRST) == UART_ADVFEATURE_MSBFIRST_DISABLE) || \
+                                               ((MSBFIRST) == UART_ADVFEATURE_MSBFIRST_ENABLE))
+
+#define IS_UART_MUTE_MODE(MUTE)           (((MUTE) == UART_ADVFEATURE_MUTEMODE_DISABLE) || \
+                                           ((MUTE) == UART_ADVFEATURE_MUTEMODE_ENABLE))
+
+#define IS_UART_DE_POLARITY(POLARITY)    (((POLARITY) == UART_DE_POLARITY_HIGH) || \
+                                          ((POLARITY) == UART_DE_POLARITY_LOW))
+
+/**
+  * @}
+  */
+/* Include UART HAL Extension module */
+#include "stm32f7xx_hal_uart_ex.h"
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup UART_Exported_Functions UART Exported Functions
+  * @{
+  */
+
+/** @addtogroup UART_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+
+/* Initialization and de-initialization functions  ****************************/
+HAL_StatusTypeDef HAL_UART_Init(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_HalfDuplex_Init(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_LIN_Init(UART_HandleTypeDef *huart, uint32_t BreakDetectLength);
+HAL_StatusTypeDef HAL_MultiProcessor_Init(UART_HandleTypeDef *huart, uint8_t Address, uint32_t WakeUpMethod);
+HAL_StatusTypeDef HAL_UART_DeInit (UART_HandleTypeDef *huart);
+void HAL_UART_MspInit(UART_HandleTypeDef *huart);
+void HAL_UART_MspDeInit(UART_HandleTypeDef *huart);
+
+/**
+  * @}
+  */
+
+/** @addtogroup UART_Exported_Functions_Group2 IO operation functions
+  * @{
+  */
+
+/* IO operation functions *****************************************************/
+HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_DMAPause(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_UART_DMAResume(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_UART_DMAStop(UART_HandleTypeDef *huart);
+void HAL_UART_IRQHandler(UART_HandleTypeDef *huart);
+void HAL_UART_TxHalfCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart);
+
+/**
+  * @}
+  */
+
+/** @addtogroup UART_Exported_Functions_Group3 Peripheral Control functions
+  * @{
+  */
+
+/* Peripheral Control functions  ************************************************/
+HAL_StatusTypeDef HAL_LIN_SendBreak(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_MultiProcessor_EnableMuteMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_MultiProcessor_DisableMuteMode(UART_HandleTypeDef *huart);
+void HAL_MultiProcessor_EnterMuteMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_HalfDuplex_EnableTransmitter(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_HalfDuplex_EnableReceiver(UART_HandleTypeDef *huart);
+
+/**
+  * @}
+  */
+
+/** @addtogroup UART_Exported_Functions_Group4 Peripheral State and Error functions
+  * @{
+  */
+
+/* Peripheral State and Errors functions  **************************************************/
+HAL_UART_StateTypeDef HAL_UART_GetState(UART_HandleTypeDef *huart);
+uint32_t HAL_UART_GetError(UART_HandleTypeDef *huart);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions -----------------------------------------------------------*/
+/** @addtogroup UART_Private_Functions UART Private Functions
+  * @{
+  */
+
+HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+void UART_AdvFeatureConfig(UART_HandleTypeDef *huart);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_UART_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_hal_uart_ex.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_uart_ex.h
@@ -1,0 +1,335 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_uart_ex.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of UART HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_UART_EX_H
+#define __STM32F7xx_HAL_UART_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup UARTEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup UARTEx_Exported_Constants UARTEx Exported Constants
+  * @{
+  */
+  
+/** @defgroup UARTEx_Word_Length UARTEx Word Length
+  * @{
+  */
+#define UART_WORDLENGTH_7B                  ((uint32_t)USART_CR1_M_1)
+#define UART_WORDLENGTH_8B                  ((uint32_t)0x0000)
+#define UART_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M_0)
+#define IS_UART_WORD_LENGTH(__LENGTH__) (((__LENGTH__) == UART_WORDLENGTH_7B) || \
+                                         ((__LENGTH__) == UART_WORDLENGTH_8B) || \
+                                         ((__LENGTH__) == UART_WORDLENGTH_9B))
+#define IS_LIN_WORD_LENGTH(LENGTH) (((LENGTH) == UART_WORDLENGTH_8B))																				 
+/**
+  * @}
+  */
+
+  
+/** @defgroup UARTEx_WakeUp_Address_Length UARTEx WakeUp Address Length
+  * @{
+  */
+#define UART_ADDRESS_DETECT_4B                ((uint32_t)0x00000000)
+#define UART_ADDRESS_DETECT_7B                ((uint32_t)USART_CR2_ADDM7)
+#define IS_UART_ADDRESSLENGTH_DETECT(__ADDRESS__) (((__ADDRESS__) == UART_ADDRESS_DETECT_4B) || \
+                                                   ((__ADDRESS__) == UART_ADDRESS_DETECT_7B))
+/**
+  * @}
+  */  
+
+  
+/**
+  * @}
+  */  
+  
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup UARTEx_Exported_Macros UARTEx Exported Macros
+  * @{
+  */
+           
+/** @brief  Reports the UART clock source.
+  * @param  __HANDLE__: specifies the UART Handle
+  * @param  __CLOCKSOURCE__: output variable   
+  * @retval UART clocking source, written in __CLOCKSOURCE__.
+  */
+#define UART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__) \
+  do {                                                        \
+    if((__HANDLE__)->Instance == USART1)                      \
+    {                                                         \
+       switch(__HAL_RCC_GET_USART1_SOURCE())                  \
+       {                                                      \
+        case RCC_USART1CLKSOURCE_PCLK2:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK2;         \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART2)                 \
+    {                                                         \
+       switch(__HAL_RCC_GET_USART2_SOURCE())                  \
+       {                                                      \
+        case RCC_USART2CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART3)                 \
+    {                                                         \
+       switch(__HAL_RCC_GET_USART3_SOURCE())                  \
+       {                                                      \
+        case RCC_USART3CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if((__HANDLE__)->Instance == UART4)                  \
+    {                                                         \
+       switch(__HAL_RCC_GET_UART4_SOURCE())                   \
+       {                                                      \
+        case RCC_UART4CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_UART4CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_UART4CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_UART4CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if ((__HANDLE__)->Instance == UART5)                 \
+    {                                                         \
+       switch(__HAL_RCC_GET_UART5_SOURCE())                   \
+       {                                                      \
+        case RCC_UART5CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_UART5CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_UART5CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_UART5CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART6)                 \
+    {                                                         \
+       switch(__HAL_RCC_GET_USART6_SOURCE())                  \
+       {                                                      \
+        case RCC_USART6CLKSOURCE_PCLK2:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK2;         \
+          break;                                              \
+        case RCC_USART6CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART6CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART6CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if ((__HANDLE__)->Instance == UART7)                 \
+    {                                                         \
+       switch(__HAL_RCC_GET_UART7_SOURCE())                   \
+       {                                                      \
+        case RCC_UART7CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_UART7CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_UART7CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_UART7CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    } 																												\
+    else if ((__HANDLE__)->Instance == UART8)                 \
+    {                                                         \
+       switch(__HAL_RCC_GET_UART8_SOURCE())                   \
+       {                                                      \
+        case RCC_UART8CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_UART8CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_UART8CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_UART8CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    } 																												\
+  } while(0)
+
+/** @brief  Reports the UART mask to apply to retrieve the received data
+  *         according to the word length and to the parity bits activation.
+  *         If PCE = 1, the parity bit is not included in the data extracted
+  *         by the reception API().
+  *         This masking operation is not carried out in the case of
+  *         DMA transfers.        
+  * @param  __HANDLE__: specifies the UART Handle
+  * @retval mask to apply to UART RDR register value.
+  */
+#define UART_MASK_COMPUTATION(__HANDLE__)                       \
+  do {                                                                \
+  if ((__HANDLE__)->Init.WordLength == UART_WORDLENGTH_9B)            \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == UART_PARITY_NONE)               \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x01FF ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x00FF ;                                 \
+     }                                                                \
+  }                                                                   \
+  else if ((__HANDLE__)->Init.WordLength == UART_WORDLENGTH_8B)       \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == UART_PARITY_NONE)               \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x00FF ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x007F ;                                 \
+     }                                                                \
+  }                                                                   \
+  else if ((__HANDLE__)->Init.WordLength == UART_WORDLENGTH_7B)       \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == UART_PARITY_NONE)               \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x007F ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x003F ;                                 \
+     }                                                                \
+  }                                                                   \
+} while(0)
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_UART_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_ll_sdmmc.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_ll_sdmmc.h
@@ -1,0 +1,804 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_ll_sdmmc.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of SDMMC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_LL_SDMMC_H
+#define __STM32F7xx_LL_SDMMC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_Driver
+  * @{
+  */
+
+/** @addtogroup SDMMC_LL
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup SDMMC_LL_Exported_Types SDMMC_LL Exported Types
+  * @{
+  */
+
+/**
+  * @brief  SDMMC Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t ClockEdge;            /*!< Specifies the clock transition on which the bit capture is made.
+                                      This parameter can be a value of @ref SDMMC_LL_Clock_Edge                 */
+
+  uint32_t ClockBypass;          /*!< Specifies whether the SDMMC Clock divider bypass is
+                                      enabled or disabled.
+                                      This parameter can be a value of @ref SDMMC_LL_Clock_Bypass               */
+
+  uint32_t ClockPowerSave;       /*!< Specifies whether SDMMC Clock output is enabled or
+                                      disabled when the bus is idle.
+                                      This parameter can be a value of @ref SDMMC_LL_Clock_Power_Save           */
+
+  uint32_t BusWide;              /*!< Specifies the SDMMC bus width.
+                                      This parameter can be a value of @ref SDMMC_LL_Bus_Wide                   */
+
+  uint32_t HardwareFlowControl;  /*!< Specifies whether the SDMMC hardware flow control is enabled or disabled.
+                                      This parameter can be a value of @ref SDMMC_LL_Hardware_Flow_Control      */
+
+  uint32_t ClockDiv;             /*!< Specifies the clock frequency of the SDMMC controller.
+                                      This parameter can be a value between Min_Data = 0 and Max_Data = 255 */
+
+}SDMMC_InitTypeDef;
+
+
+/**
+  * @brief  SDMMC Command Control structure
+  */
+typedef struct
+{
+  uint32_t Argument;            /*!< Specifies the SDMMC command argument which is sent
+                                     to a card as part of a command message. If a command
+                                     contains an argument, it must be loaded into this register
+                                     before writing the command to the command register.              */
+
+  uint32_t CmdIndex;            /*!< Specifies the SDMMC command index. It must be Min_Data = 0 and
+                                     Max_Data = 64                                                    */
+
+  uint32_t Response;            /*!< Specifies the SDMMC response type.
+                                     This parameter can be a value of @ref SDMMC_LL_Response_Type         */
+
+  uint32_t WaitForInterrupt;    /*!< Specifies whether SDMMC wait for interrupt request is
+                                     enabled or disabled.
+                                     This parameter can be a value of @ref SDMMC_LL_Wait_Interrupt_State  */
+
+  uint32_t CPSM;                /*!< Specifies whether SDMMC Command path state machine (CPSM)
+                                     is enabled or disabled.
+                                     This parameter can be a value of @ref SDMMC_LL_CPSM_State            */
+}SDMMC_CmdInitTypeDef;
+
+
+/**
+  * @brief  SDMMC Data Control structure
+  */
+typedef struct
+{
+  uint32_t DataTimeOut;         /*!< Specifies the data timeout period in card bus clock periods.  */
+
+  uint32_t DataLength;          /*!< Specifies the number of data bytes to be transferred.         */
+
+  uint32_t DataBlockSize;       /*!< Specifies the data block size for block transfer.
+                                     This parameter can be a value of @ref SDMMC_LL_Data_Block_Size    */
+
+  uint32_t TransferDir;         /*!< Specifies the data transfer direction, whether the transfer
+                                     is a read or write.
+                                     This parameter can be a value of @ref SDMMC_LL_Transfer_Direction */
+
+  uint32_t TransferMode;        /*!< Specifies whether data transfer is in stream or block mode.
+                                     This parameter can be a value of @ref SDMMC_LL_Transfer_Type      */
+
+  uint32_t DPSM;                /*!< Specifies whether SDMMC Data path state machine (DPSM)
+                                     is enabled or disabled.
+                                     This parameter can be a value of @ref SDMMC_LL_DPSM_State         */
+}SDMMC_DataInitTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup SDMMC_LL_Exported_Constants SDMMC_LL Exported Constants
+  * @{
+  */
+
+/** @defgroup SDMMC_LL_Clock_Edge Clock Edge
+  * @{
+  */
+#define SDMMC_CLOCK_EDGE_RISING               ((uint32_t)0x00000000)
+#define SDMMC_CLOCK_EDGE_FALLING              SDMMC_CLKCR_NEGEDGE
+
+#define IS_SDMMC_CLOCK_EDGE(EDGE) (((EDGE) == SDMMC_CLOCK_EDGE_RISING) || \
+                                  ((EDGE) == SDMMC_CLOCK_EDGE_FALLING))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Clock_Bypass Clock Bypass
+  * @{
+  */
+#define SDMMC_CLOCK_BYPASS_DISABLE             ((uint32_t)0x00000000)
+#define SDMMC_CLOCK_BYPASS_ENABLE              SDMMC_CLKCR_BYPASS
+
+#define IS_SDMMC_CLOCK_BYPASS(BYPASS) (((BYPASS) == SDMMC_CLOCK_BYPASS_DISABLE) || \
+                                      ((BYPASS) == SDMMC_CLOCK_BYPASS_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Clock_Power_Save Clock Power Saving
+  * @{
+  */
+#define SDMMC_CLOCK_POWER_SAVE_DISABLE         ((uint32_t)0x00000000)
+#define SDMMC_CLOCK_POWER_SAVE_ENABLE          SDMMC_CLKCR_PWRSAV
+
+#define IS_SDMMC_CLOCK_POWER_SAVE(SAVE) (((SAVE) == SDMMC_CLOCK_POWER_SAVE_DISABLE) || \
+                                        ((SAVE) == SDMMC_CLOCK_POWER_SAVE_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Bus_Wide Bus Width
+  * @{
+  */
+#define SDMMC_BUS_WIDE_1B                      ((uint32_t)0x00000000)
+#define SDMMC_BUS_WIDE_4B                      SDMMC_CLKCR_WIDBUS_0
+#define SDMMC_BUS_WIDE_8B                      SDMMC_CLKCR_WIDBUS_1
+
+#define IS_SDMMC_BUS_WIDE(WIDE) (((WIDE) == SDMMC_BUS_WIDE_1B) || \
+                                ((WIDE) == SDMMC_BUS_WIDE_4B) || \
+                                ((WIDE) == SDMMC_BUS_WIDE_8B))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Hardware_Flow_Control Hardware Flow Control
+  * @{
+  */
+#define SDMMC_HARDWARE_FLOW_CONTROL_DISABLE    ((uint32_t)0x00000000)
+#define SDMMC_HARDWARE_FLOW_CONTROL_ENABLE     SDMMC_CLKCR_HWFC_EN
+
+#define IS_SDMMC_HARDWARE_FLOW_CONTROL(CONTROL) (((CONTROL) == SDMMC_HARDWARE_FLOW_CONTROL_DISABLE) || \
+                                                ((CONTROL) == SDMMC_HARDWARE_FLOW_CONTROL_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Clock_Division Clock Division
+  * @{
+  */
+#define IS_SDMMC_CLKDIV(DIV)   ((DIV) <= 0xFF)
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Command_Index Command Index
+  * @{
+  */
+#define IS_SDMMC_CMD_INDEX(INDEX)            ((INDEX) < 0x40)
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Response_Type Response Type
+  * @{
+  */
+#define SDMMC_RESPONSE_NO                    ((uint32_t)0x00000000)
+#define SDMMC_RESPONSE_SHORT                 SDMMC_CMD_WAITRESP_0
+#define SDMMC_RESPONSE_LONG                  SDMMC_CMD_WAITRESP
+
+#define IS_SDMMC_RESPONSE(RESPONSE) (((RESPONSE) == SDMMC_RESPONSE_NO)    || \
+                                    ((RESPONSE) == SDMMC_RESPONSE_SHORT) || \
+                                    ((RESPONSE) == SDMMC_RESPONSE_LONG))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Wait_Interrupt_State Wait Interrupt
+  * @{
+  */
+#define SDMMC_WAIT_NO                        ((uint32_t)0x00000000)
+#define SDMMC_WAIT_IT                        SDMMC_CMD_WAITINT
+#define SDMMC_WAIT_PEND                      SDMMC_CMD_WAITPEND
+
+#define IS_SDMMC_WAIT(WAIT) (((WAIT) == SDMMC_WAIT_NO) || \
+                            ((WAIT) == SDMMC_WAIT_IT) || \
+                            ((WAIT) == SDMMC_WAIT_PEND))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_CPSM_State CPSM State
+  * @{
+  */
+#define SDMMC_CPSM_DISABLE                   ((uint32_t)0x00000000)
+#define SDMMC_CPSM_ENABLE                    SDMMC_CMD_CPSMEN
+
+#define IS_SDMMC_CPSM(CPSM) (((CPSM) == SDMMC_CPSM_DISABLE) || \
+                            ((CPSM) == SDMMC_CPSM_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Response_Registers Response Register
+  * @{
+  */
+#define SDMMC_RESP1                          ((uint32_t)0x00000000)
+#define SDMMC_RESP2                          ((uint32_t)0x00000004)
+#define SDMMC_RESP3                          ((uint32_t)0x00000008)
+#define SDMMC_RESP4                          ((uint32_t)0x0000000C)
+
+#define IS_SDMMC_RESP(RESP) (((RESP) == SDMMC_RESP1) || \
+                            ((RESP) == SDMMC_RESP2) || \
+                            ((RESP) == SDMMC_RESP3) || \
+                            ((RESP) == SDMMC_RESP4))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Data_Length Data Lenght
+  * @{
+  */
+#define IS_SDMMC_DATA_LENGTH(LENGTH) ((LENGTH) <= 0x01FFFFFF)
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Data_Block_Size  Data Block Size
+  * @{
+  */
+#define SDMMC_DATABLOCK_SIZE_1B               ((uint32_t)0x00000000)
+#define SDMMC_DATABLOCK_SIZE_2B               SDMMC_DCTRL_DBLOCKSIZE_0
+#define SDMMC_DATABLOCK_SIZE_4B               SDMMC_DCTRL_DBLOCKSIZE_1
+#define SDMMC_DATABLOCK_SIZE_8B               (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_1)
+#define SDMMC_DATABLOCK_SIZE_16B              SDMMC_DCTRL_DBLOCKSIZE_2
+#define SDMMC_DATABLOCK_SIZE_32B              (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_2)
+#define SDMMC_DATABLOCK_SIZE_64B              (SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_2)
+#define SDMMC_DATABLOCK_SIZE_128B             (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_2)
+#define SDMMC_DATABLOCK_SIZE_256B             SDMMC_DCTRL_DBLOCKSIZE_3
+#define SDMMC_DATABLOCK_SIZE_512B             (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_3)
+#define SDMMC_DATABLOCK_SIZE_1024B            (SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_3)
+#define SDMMC_DATABLOCK_SIZE_2048B            (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_3)
+#define SDMMC_DATABLOCK_SIZE_4096B            (SDMMC_DCTRL_DBLOCKSIZE_2|SDMMC_DCTRL_DBLOCKSIZE_3)
+#define SDMMC_DATABLOCK_SIZE_8192B            (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_2|SDMMC_DCTRL_DBLOCKSIZE_3)
+#define SDMMC_DATABLOCK_SIZE_16384B           (SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_2|SDMMC_DCTRL_DBLOCKSIZE_3)
+
+#define IS_SDMMC_BLOCK_SIZE(SIZE) (((SIZE) == SDMMC_DATABLOCK_SIZE_1B)    || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_2B)    || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_4B)    || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_8B)    || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_16B)   || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_32B)   || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_64B)   || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_128B)  || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_256B)  || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_512B)  || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_1024B) || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_2048B) || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_4096B) || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_8192B) || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_16384B))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Transfer_Direction Transfer Direction
+  * @{
+  */
+#define SDMMC_TRANSFER_DIR_TO_CARD            ((uint32_t)0x00000000)
+#define SDMMC_TRANSFER_DIR_TO_SDMMC            SDMMC_DCTRL_DTDIR
+
+#define IS_SDMMC_TRANSFER_DIR(DIR) (((DIR) == SDMMC_TRANSFER_DIR_TO_CARD) || \
+                                   ((DIR) == SDMMC_TRANSFER_DIR_TO_SDMMC))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Transfer_Type Transfer Type
+  * @{
+  */
+#define SDMMC_TRANSFER_MODE_BLOCK             ((uint32_t)0x00000000)
+#define SDMMC_TRANSFER_MODE_STREAM            SDMMC_DCTRL_DTMODE
+
+#define IS_SDMMC_TRANSFER_MODE(MODE) (((MODE) == SDMMC_TRANSFER_MODE_BLOCK) || \
+                                     ((MODE) == SDMMC_TRANSFER_MODE_STREAM))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_DPSM_State DPSM State
+  * @{
+  */
+#define SDMMC_DPSM_DISABLE                    ((uint32_t)0x00000000)
+#define SDMMC_DPSM_ENABLE                     SDMMC_DCTRL_DTEN
+
+#define IS_SDMMC_DPSM(DPSM) (((DPSM) == SDMMC_DPSM_DISABLE) ||\
+                            ((DPSM) == SDMMC_DPSM_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Read_Wait_Mode Read Wait Mode
+  * @{
+  */
+#define SDMMC_READ_WAIT_MODE_DATA2                ((uint32_t)0x00000000)
+#define SDMMC_READ_WAIT_MODE_CLK                  (SDMMC_DCTRL_RWMOD)
+
+#define IS_SDMMC_READWAIT_MODE(MODE) (((MODE) == SDMMC_READ_WAIT_MODE_CLK) || \
+                                     ((MODE) == SDMMC_READ_WAIT_MODE_DATA2))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Interrupt_sources Interrupt Sources
+  * @{
+  */
+#define SDMMC_IT_CCRCFAIL                    SDMMC_STA_CCRCFAIL
+#define SDMMC_IT_DCRCFAIL                    SDMMC_STA_DCRCFAIL
+#define SDMMC_IT_CTIMEOUT                    SDMMC_STA_CTIMEOUT
+#define SDMMC_IT_DTIMEOUT                    SDMMC_STA_DTIMEOUT
+#define SDMMC_IT_TXUNDERR                    SDMMC_STA_TXUNDERR
+#define SDMMC_IT_RXOVERR                     SDMMC_STA_RXOVERR
+#define SDMMC_IT_CMDREND                     SDMMC_STA_CMDREND
+#define SDMMC_IT_CMDSENT                     SDMMC_STA_CMDSENT
+#define SDMMC_IT_DATAEND                     SDMMC_STA_DATAEND
+#define SDMMC_IT_DBCKEND                     SDMMC_STA_DBCKEND
+#define SDMMC_IT_CMDACT                      SDMMC_STA_CMDACT
+#define SDMMC_IT_TXACT                       SDMMC_STA_TXACT
+#define SDMMC_IT_RXACT                       SDMMC_STA_RXACT
+#define SDMMC_IT_TXFIFOHE                    SDMMC_STA_TXFIFOHE
+#define SDMMC_IT_RXFIFOHF                    SDMMC_STA_RXFIFOHF
+#define SDMMC_IT_TXFIFOF                     SDMMC_STA_TXFIFOF
+#define SDMMC_IT_RXFIFOF                     SDMMC_STA_RXFIFOF
+#define SDMMC_IT_TXFIFOE                     SDMMC_STA_TXFIFOE
+#define SDMMC_IT_RXFIFOE                     SDMMC_STA_RXFIFOE
+#define SDMMC_IT_TXDAVL                      SDMMC_STA_TXDAVL
+#define SDMMC_IT_RXDAVL                      SDMMC_STA_RXDAVL
+#define SDMMC_IT_SDIOIT                      SDMMC_STA_SDIOIT
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Flags Flags
+  * @{
+  */
+#define SDMMC_FLAG_CCRCFAIL                  SDMMC_STA_CCRCFAIL
+#define SDMMC_FLAG_DCRCFAIL                  SDMMC_STA_DCRCFAIL
+#define SDMMC_FLAG_CTIMEOUT                  SDMMC_STA_CTIMEOUT
+#define SDMMC_FLAG_DTIMEOUT                  SDMMC_STA_DTIMEOUT
+#define SDMMC_FLAG_TXUNDERR                  SDMMC_STA_TXUNDERR
+#define SDMMC_FLAG_RXOVERR                   SDMMC_STA_RXOVERR
+#define SDMMC_FLAG_CMDREND                   SDMMC_STA_CMDREND
+#define SDMMC_FLAG_CMDSENT                   SDMMC_STA_CMDSENT
+#define SDMMC_FLAG_DATAEND                   SDMMC_STA_DATAEND
+#define SDMMC_FLAG_DBCKEND                   SDMMC_STA_DBCKEND
+#define SDMMC_FLAG_CMDACT                    SDMMC_STA_CMDACT
+#define SDMMC_FLAG_TXACT                     SDMMC_STA_TXACT
+#define SDMMC_FLAG_RXACT                     SDMMC_STA_RXACT
+#define SDMMC_FLAG_TXFIFOHE                  SDMMC_STA_TXFIFOHE
+#define SDMMC_FLAG_RXFIFOHF                  SDMMC_STA_RXFIFOHF
+#define SDMMC_FLAG_TXFIFOF                   SDMMC_STA_TXFIFOF
+#define SDMMC_FLAG_RXFIFOF                   SDMMC_STA_RXFIFOF
+#define SDMMC_FLAG_TXFIFOE                   SDMMC_STA_TXFIFOE
+#define SDMMC_FLAG_RXFIFOE                   SDMMC_STA_RXFIFOE
+#define SDMMC_FLAG_TXDAVL                    SDMMC_STA_TXDAVL
+#define SDMMC_FLAG_RXDAVL                    SDMMC_STA_RXDAVL
+#define SDMMC_FLAG_SDIOIT                    SDMMC_STA_SDIOIT
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup SDMMC_LL_Exported_macros SDMMC_LL Exported Macros
+  * @{
+  */
+
+/** @defgroup SDMMC_LL_Register Bits And Addresses Definitions
+  * @brief SDMMC_LL registers bit address in the alias region
+  * @{
+  */
+/* ---------------------- SDMMC registers bit mask --------------------------- */
+/* --- CLKCR Register ---*/
+/* CLKCR register clear mask */
+#define CLKCR_CLEAR_MASK         ((uint32_t)(SDMMC_CLKCR_CLKDIV  | SDMMC_CLKCR_PWRSAV |\
+                                             SDMMC_CLKCR_BYPASS  | SDMMC_CLKCR_WIDBUS |\
+                                             SDMMC_CLKCR_NEGEDGE | SDMMC_CLKCR_HWFC_EN))
+
+/* --- DCTRL Register ---*/
+/* SDMMC DCTRL Clear Mask */
+#define DCTRL_CLEAR_MASK         ((uint32_t)(SDMMC_DCTRL_DTEN    | SDMMC_DCTRL_DTDIR |\
+                                             SDMMC_DCTRL_DTMODE  | SDMMC_DCTRL_DBLOCKSIZE))
+
+/* --- CMD Register ---*/
+/* CMD Register clear mask */
+#define CMD_CLEAR_MASK           ((uint32_t)(SDMMC_CMD_CMDINDEX | SDMMC_CMD_WAITRESP |\
+                                             SDMMC_CMD_WAITINT  | SDMMC_CMD_WAITPEND |\
+                                             SDMMC_CMD_CPSMEN   | SDMMC_CMD_SDIOSUSPEND))
+
+/* SDMMC Initialization Frequency (400KHz max) */
+#define SDMMC_INIT_CLK_DIV ((uint8_t)0x76)
+
+/* SDMMC Data Transfer Frequency (25MHz max) */
+#define SDMMC_TRANSFER_CLK_DIV ((uint8_t)0x0)
+
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Interrupt_Clock Interrupt And Clock Configuration
+ *  @brief macros to handle interrupts and specific clock configurations
+ * @{
+ */
+
+/**
+  * @brief  Enable the SDMMC device.
+  * @param  __INSTANCE__: SDMMC Instance
+  * @retval None
+  */
+#define __SDMMC_ENABLE(__INSTANCE__)  ((__INSTANCE__)->CLKCR |= SDMMC_CLKCR_CLKEN)
+
+/**
+  * @brief  Disable the SDMMC device.
+  * @param  __INSTANCE__: SDMMC Instance
+  * @retval None
+  */
+#define __SDMMC_DISABLE(__INSTANCE__)  ((__INSTANCE__)->CLKCR &= ~SDMMC_CLKCR_CLKEN)
+
+/**
+  * @brief  Enable the SDMMC DMA transfer.
+  * @param  __INSTANCE__: SDMMC Instance
+  * @retval None
+  */
+#define __SDMMC_DMA_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_DMAEN)
+/**
+  * @brief  Disable the SDMMC DMA transfer.
+  * @param  __INSTANCE__: SDMMC Instance
+  * @retval None
+  */
+#define __SDMMC_DMA_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_DMAEN)
+
+/**
+  * @brief  Enable the SDMMC device interrupt.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INTERRUPT__ : specifies the SDMMC interrupt sources to be enabled.
+  *         This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDACT:   Command transfer in progress interrupt
+  *            @arg SDMMC_IT_TXACT:    Data transmit in progress interrupt
+  *            @arg SDMMC_IT_RXACT:    Data receive in progress interrupt
+  *            @arg SDMMC_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+  *            @arg SDMMC_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+  *            @arg SDMMC_IT_TXFIFOF:  Transmit FIFO full interrupt
+  *            @arg SDMMC_IT_RXFIFOF:  Receive FIFO full interrupt
+  *            @arg SDMMC_IT_TXFIFOE:  Transmit FIFO empty interrupt
+  *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
+  *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
+  *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval None
+  */
+#define __SDMMC_ENABLE_IT(__INSTANCE__, __INTERRUPT__)  ((__INSTANCE__)->MASK |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the SDMMC device interrupt.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INTERRUPT__ : specifies the SDMMC interrupt sources to be disabled.
+  *          This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDACT:   Command transfer in progress interrupt
+  *            @arg SDMMC_IT_TXACT:    Data transmit in progress interrupt
+  *            @arg SDMMC_IT_RXACT:    Data receive in progress interrupt
+  *            @arg SDMMC_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+  *            @arg SDMMC_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+  *            @arg SDMMC_IT_TXFIFOF:  Transmit FIFO full interrupt
+  *            @arg SDMMC_IT_RXFIFOF:  Receive FIFO full interrupt
+  *            @arg SDMMC_IT_TXFIFOE:  Transmit FIFO empty interrupt
+  *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
+  *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
+  *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval None
+  */
+#define __SDMMC_DISABLE_IT(__INSTANCE__, __INTERRUPT__)  ((__INSTANCE__)->MASK &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Checks whether the specified SDMMC flag is set or not.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __FLAG__: specifies the flag to check.
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_FLAG_CCRCFAIL: Command response received (CRC check failed)
+  *            @arg SDMMC_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
+  *            @arg SDMMC_FLAG_CTIMEOUT: Command response timeout
+  *            @arg SDMMC_FLAG_DTIMEOUT: Data timeout
+  *            @arg SDMMC_FLAG_TXUNDERR: Transmit FIFO underrun error
+  *            @arg SDMMC_FLAG_RXOVERR:  Received FIFO overrun error
+  *            @arg SDMMC_FLAG_CMDREND:  Command response received (CRC check passed)
+  *            @arg SDMMC_FLAG_CMDSENT:  Command sent (no response required)
+  *            @arg SDMMC_FLAG_DATAEND:  Data end (data counter, SDIDCOUNT, is zero)
+  *            @arg SDMMC_FLAG_DBCKEND:  Data block sent/received (CRC check passed)
+  *            @arg SDMMC_FLAG_CMDACT:   Command transfer in progress
+  *            @arg SDMMC_FLAG_TXACT:    Data transmit in progress
+  *            @arg SDMMC_FLAG_RXACT:    Data receive in progress
+  *            @arg SDMMC_FLAG_TXFIFOHE: Transmit FIFO Half Empty
+  *            @arg SDMMC_FLAG_RXFIFOHF: Receive FIFO Half Full
+  *            @arg SDMMC_FLAG_TXFIFOF:  Transmit FIFO full
+  *            @arg SDMMC_FLAG_RXFIFOF:  Receive FIFO full
+  *            @arg SDMMC_FLAG_TXFIFOE:  Transmit FIFO empty
+  *            @arg SDMMC_FLAG_RXFIFOE:  Receive FIFO empty
+  *            @arg SDMMC_FLAG_TXDAVL:   Data available in transmit FIFO
+  *            @arg SDMMC_FLAG_RXDAVL:   Data available in receive FIFO
+  *            @arg SDMMC_FLAG_SDMMCIT:   SD I/O interrupt received
+  * @retval The new state of SDMMC_FLAG (SET or RESET).
+  */
+#define __SDMMC_GET_FLAG(__INSTANCE__, __FLAG__)  (((__INSTANCE__)->STA &(__FLAG__)) != RESET)
+
+
+/**
+  * @brief  Clears the SDMMC pending flags.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __FLAG__: specifies the flag to clear.
+  *          This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_FLAG_CCRCFAIL: Command response received (CRC check failed)
+  *            @arg SDMMC_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
+  *            @arg SDMMC_FLAG_CTIMEOUT: Command response timeout
+  *            @arg SDMMC_FLAG_DTIMEOUT: Data timeout
+  *            @arg SDMMC_FLAG_TXUNDERR: Transmit FIFO underrun error
+  *            @arg SDMMC_FLAG_RXOVERR:  Received FIFO overrun error
+  *            @arg SDMMC_FLAG_CMDREND:  Command response received (CRC check passed)
+  *            @arg SDMMC_FLAG_CMDSENT:  Command sent (no response required)
+  *            @arg SDMMC_FLAG_DATAEND:  Data end (data counter, SDIDCOUNT, is zero)
+  *            @arg SDMMC_FLAG_DBCKEND:  Data block sent/received (CRC check passed)
+  *            @arg SDMMC_FLAG_SDMMCIT:   SD I/O interrupt received
+  * @retval None
+  */
+#define __SDMMC_CLEAR_FLAG(__INSTANCE__, __FLAG__)  ((__INSTANCE__)->ICR = (__FLAG__))
+
+/**
+  * @brief  Checks whether the specified SDMMC interrupt has occurred or not.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INTERRUPT__: specifies the SDMMC interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDACT:   Command transfer in progress interrupt
+  *            @arg SDMMC_IT_TXACT:    Data transmit in progress interrupt
+  *            @arg SDMMC_IT_RXACT:    Data receive in progress interrupt
+  *            @arg SDMMC_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+  *            @arg SDMMC_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+  *            @arg SDMMC_IT_TXFIFOF:  Transmit FIFO full interrupt
+  *            @arg SDMMC_IT_RXFIFOF:  Receive FIFO full interrupt
+  *            @arg SDMMC_IT_TXFIFOE:  Transmit FIFO empty interrupt
+  *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
+  *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
+  *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval The new state of SDMMC_IT (SET or RESET).
+  */
+#define __SDMMC_GET_IT  (__INSTANCE__, __INTERRUPT__)  (((__INSTANCE__)->STA &(__INTERRUPT__)) == (__INTERRUPT__))
+
+/**
+  * @brief  Clears the SDMMC's interrupt pending bits.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
+  *          This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDMMC_DCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval None
+  */
+#define __SDMMC_CLEAR_IT(__INSTANCE__, __INTERRUPT__)  ((__INSTANCE__)->ICR = (__INTERRUPT__))
+
+/**
+  * @brief  Enable Start the SD I/O Read Wait operation.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @retval None
+  */
+#define __SDMMC_START_READWAIT_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_RWSTART)
+
+/**
+  * @brief  Disable Start the SD I/O Read Wait operations.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @retval None
+  */
+#define __SDMMC_START_READWAIT_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_RWSTART)
+
+/**
+  * @brief  Enable Start the SD I/O Read Wait operation.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @retval None
+  */
+#define __SDMMC_STOP_READWAIT_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_RWSTOP)
+
+/**
+  * @brief  Disable Stop the SD I/O Read Wait operations.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @retval None
+  */
+#define __SDMMC_STOP_READWAIT_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_RWSTOP)
+
+/**
+  * @brief  Enable the SD I/O Mode Operation.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @retval None
+  */
+#define __SDMMC_OPERATION_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_SDIOEN)
+
+/**
+  * @brief  Disable the SD I/O Mode Operation.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @retval None
+  */
+#define __SDMMC_OPERATION_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_SDIOEN)
+
+/**
+  * @brief  Enable the SD I/O Suspend command sending.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @retval None
+  */
+#define __SDMMC_SUSPEND_CMD_ENABLE(__INSTANCE__)  ((__INSTANCE__)->CMD |= SDMMC_CMD_SDIOSUSPEND)
+
+/**
+  * @brief  Disable the SD I/O Suspend command sending.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @retval None
+  */
+#define __SDMMC_SUSPEND_CMD_DISABLE(__INSTANCE__)  ((__INSTANCE__)->CMD &= ~SDMMC_CMD_SDIOSUSPEND)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup SDMMC_LL_Exported_Functions
+  * @{
+  */
+
+/* Initialization/de-initialization functions  **********************************/
+/** @addtogroup HAL_SDMMC_LL_Group1
+  * @{
+  */
+HAL_StatusTypeDef SDMMC_Init(SDMMC_TypeDef *SDMMCx, SDMMC_InitTypeDef Init);
+/**
+  * @}
+  */
+
+/* I/O operation functions  *****************************************************/
+/** @addtogroup HAL_SDMMC_LL_Group2
+  * @{
+  */
+/* Blocking mode: Polling */
+uint32_t          SDMMC_ReadFIFO(SDMMC_TypeDef *SDMMCx);
+HAL_StatusTypeDef SDMMC_WriteFIFO(SDMMC_TypeDef *SDMMCx, uint32_t *pWriteData);
+/**
+  * @}
+  */
+
+/* Peripheral Control functions  ************************************************/
+/** @addtogroup HAL_SDMMC_LL_Group3
+  * @{
+  */
+HAL_StatusTypeDef SDMMC_PowerState_ON(SDMMC_TypeDef *SDMMCx);
+HAL_StatusTypeDef SDMMC_PowerState_OFF(SDMMC_TypeDef *SDMMCx);
+uint32_t          SDMMC_GetPowerState(SDMMC_TypeDef *SDMMCx);
+
+/* Command path state machine (CPSM) management functions */
+HAL_StatusTypeDef SDMMC_SendCommand(SDMMC_TypeDef *SDMMCx, SDMMC_CmdInitTypeDef *Command);
+uint8_t           SDMMC_GetCommandResponse(SDMMC_TypeDef *SDMMCx);
+uint32_t          SDMMC_GetResponse(SDMMC_TypeDef *SDMMCx, uint32_t Response);
+
+/* Data path state machine (DPSM) management functions */
+HAL_StatusTypeDef SDMMC_DataConfig(SDMMC_TypeDef *SDMMCx, SDMMC_DataInitTypeDef* Data);
+uint32_t          SDMMC_GetDataCounter(SDMMC_TypeDef *SDMMCx);
+uint32_t          SDMMC_GetFIFOCount(SDMMC_TypeDef *SDMMCx);
+
+/* SDMMC Cards mode management functions */
+HAL_StatusTypeDef SDMMC_SetSDMMCReadWaitMode(SDMMC_TypeDef *SDMMCx, uint32_t SDMMC_ReadWaitMode);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_LL_SDMMC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/inc/stm32f7xx_ll_usb.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_ll_usb.h
@@ -1,0 +1,463 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_ll_usb.h
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Header file of USB Core HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_LL_USB_H
+#define __STM32F7xx_LL_USB_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL
+  * @{
+  */
+
+/** @addtogroup USB_Core
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/**
+  * @brief  USB Mode definition
+  */
+typedef enum
+{
+   USB_OTG_DEVICE_MODE  = 0,
+   USB_OTG_HOST_MODE    = 1,
+   USB_OTG_DRD_MODE     = 2
+
+}USB_OTG_ModeTypeDef;
+
+/**
+  * @brief  URB States definition
+  */
+typedef enum {
+  URB_IDLE = 0,
+  URB_DONE,
+  URB_NOTREADY,
+  URB_NYET,
+  URB_ERROR,
+  URB_STALL
+
+}USB_OTG_URBStateTypeDef;
+
+/**
+  * @brief  Host channel States  definition
+  */
+typedef enum {
+  HC_IDLE = 0,
+  HC_XFRC,
+  HC_HALTED,
+  HC_NAK,
+  HC_NYET,
+  HC_STALL,
+  HC_XACTERR,
+  HC_BBLERR,
+  HC_DATATGLERR
+
+}USB_OTG_HCStateTypeDef;
+
+/**
+  * @brief  PCD Initialization Structure definition
+  */
+typedef struct
+{
+  uint32_t dev_endpoints;        /*!< Device Endpoints number.
+                                      This parameter depends on the used USB core.
+                                      This parameter must be a number between Min_Data = 1 and Max_Data = 15 */
+
+  uint32_t Host_channels;        /*!< Host Channels number.
+                                      This parameter Depends on the used USB core.
+                                      This parameter must be a number between Min_Data = 1 and Max_Data = 15 */
+
+  uint32_t speed;                /*!< USB Core speed.
+                                      This parameter can be any value of @ref USB_Core_Speed_                */
+
+  uint32_t dma_enable;           /*!< Enable or disable of the USB embedded DMA.                             */
+
+  uint32_t ep0_mps;              /*!< Set the Endpoint 0 Max Packet size.
+                                      This parameter can be any value of @ref USB_EP0_MPS_                   */
+
+  uint32_t phy_itface;           /*!< Select the used PHY interface.
+                                      This parameter can be any value of @ref USB_Core_PHY_                  */
+
+  uint32_t Sof_enable;           /*!< Enable or disable the output of the SOF signal.                        */
+
+  uint32_t low_power_enable;     /*!< Enable or disable the low power mode.                                  */
+
+  uint32_t lpm_enable;           /*!< Enable or disable Link Power Management.                               */
+
+  uint32_t vbus_sensing_enable;  /*!< Enable or disable the VBUS Sensing feature.                            */
+
+  uint32_t use_dedicated_ep1;    /*!< Enable or disable the use of the dedicated EP1 interrupt.              */
+
+  uint32_t use_external_vbus;    /*!< Enable or disable the use of the external VBUS.                        */
+
+}USB_OTG_CfgTypeDef;
+
+typedef struct
+{
+  uint8_t   num;            /*!< Endpoint number
+                                This parameter must be a number between Min_Data = 1 and Max_Data = 15    */
+
+  uint8_t   is_in;          /*!< Endpoint direction
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1     */
+
+  uint8_t   is_stall;       /*!< Endpoint stall condition
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1     */
+
+  uint8_t   type;           /*!< Endpoint type
+                                 This parameter can be any value of @ref USB_EP_Type_                     */
+
+  uint8_t   data_pid_start; /*!< Initial data PID
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1     */
+
+  uint8_t   even_odd_frame; /*!< IFrame parity
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 1    */
+
+  uint16_t  tx_fifo_num;    /*!< Transmission FIFO number
+                                 This parameter must be a number between Min_Data = 1 and Max_Data = 15   */
+
+  uint32_t  maxpacket;      /*!< Endpoint Max packet size
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 64KB */
+
+  uint8_t   *xfer_buff;     /*!< Pointer to transfer buffer                                               */
+
+  uint32_t  dma_addr;       /*!< 32 bits aligned transfer buffer address                                  */
+
+  uint32_t  xfer_len;       /*!< Current transfer length                                                  */
+
+  uint32_t  xfer_count;     /*!< Partial transfer length in case of multi packet transfer                 */
+
+}USB_OTG_EPTypeDef;
+
+typedef struct
+{
+  uint8_t   dev_addr ;     /*!< USB device address.
+                                This parameter must be a number between Min_Data = 1 and Max_Data = 255    */
+
+  uint8_t   ch_num;        /*!< Host channel number.
+                                This parameter must be a number between Min_Data = 1 and Max_Data = 15     */
+
+  uint8_t   ep_num;        /*!< Endpoint number.
+                                This parameter must be a number between Min_Data = 1 and Max_Data = 15     */
+
+  uint8_t   ep_is_in;      /*!< Endpoint direction
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1      */
+
+  uint8_t   speed;         /*!< USB Host speed.
+                                This parameter can be any value of @ref USB_Core_Speed_                    */
+
+  uint8_t   do_ping;       /*!< Enable or disable the use of the PING protocol for HS mode.                */
+
+  uint8_t   process_ping;  /*!< Execute the PING protocol for HS mode.                                     */
+
+  uint8_t   ep_type;       /*!< Endpoint Type.
+                                This parameter can be any value of @ref USB_EP_Type_                       */
+
+  uint16_t  max_packet;    /*!< Endpoint Max packet size.
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 64KB   */
+
+  uint8_t   data_pid;      /*!< Initial data PID.
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1      */
+
+  uint8_t   *xfer_buff;    /*!< Pointer to transfer buffer.                                                */
+
+  uint32_t  xfer_len;      /*!< Current transfer length.                                                   */
+
+  uint32_t  xfer_count;    /*!< Partial transfer length in case of multi packet transfer.                  */
+
+  uint8_t   toggle_in;     /*!< IN transfer current toggle flag.
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1      */
+
+  uint8_t   toggle_out;    /*!< OUT transfer current toggle flag
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1      */
+
+  uint32_t  dma_addr;      /*!< 32 bits aligned transfer buffer address.                                   */
+
+  uint32_t  ErrCnt;        /*!< Host channel error count.*/
+
+  USB_OTG_URBStateTypeDef  urb_state;  /*!< URB state.
+                                           This parameter can be any value of @ref USB_OTG_URBStateTypeDef */
+
+  USB_OTG_HCStateTypeDef   state;     /*!< Host Channel state.
+                                           This parameter can be any value of @ref USB_OTG_HCStateTypeDef  */
+
+}USB_OTG_HCTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup PCD_Exported_Constants PCD Exported Constants
+  * @{
+  */
+
+/** @defgroup USB_Core_Mode_ USB Core Mode
+  * @{
+  */
+#define USB_OTG_MODE_DEVICE                    0
+#define USB_OTG_MODE_HOST                      1
+#define USB_OTG_MODE_DRD                       2
+/**
+  * @}
+  */
+
+/** @defgroup USB_Core_Speed_   USB Core Speed
+  * @{
+  */
+#define USB_OTG_SPEED_HIGH                     0
+#define USB_OTG_SPEED_HIGH_IN_FULL             1
+#define USB_OTG_SPEED_LOW                      2
+#define USB_OTG_SPEED_FULL                     3
+/**
+  * @}
+  */
+
+/** @defgroup USB_Core_PHY_   USB Core PHY
+  * @{
+  */
+#define USB_OTG_ULPI_PHY                       1
+#define USB_OTG_EMBEDDED_PHY                   2
+/**
+  * @}
+  */
+
+/** @defgroup USB_Core_MPS_   USB Core MPS
+  * @{
+  */
+#define USB_OTG_HS_MAX_PACKET_SIZE           512
+#define USB_OTG_FS_MAX_PACKET_SIZE           64
+#define USB_OTG_MAX_EP0_SIZE                 64
+/**
+  * @}
+  */
+
+/** @defgroup USB_Core_Phy_Frequency_   USB Core Phy Frequency
+  * @{
+  */
+#define DSTS_ENUMSPD_HS_PHY_30MHZ_OR_60MHZ     (0 << 1)
+#define DSTS_ENUMSPD_FS_PHY_30MHZ_OR_60MHZ     (1 << 1)
+#define DSTS_ENUMSPD_LS_PHY_6MHZ               (2 << 1)
+#define DSTS_ENUMSPD_FS_PHY_48MHZ              (3 << 1)
+/**
+  * @}
+  */
+
+/** @defgroup USB_CORE_Frame_Interval_   USB CORE Frame Interval
+  * @{
+  */
+#define DCFG_FRAME_INTERVAL_80                 0
+#define DCFG_FRAME_INTERVAL_85                 1
+#define DCFG_FRAME_INTERVAL_90                 2
+#define DCFG_FRAME_INTERVAL_95                 3
+/**
+  * @}
+  */
+
+/** @defgroup USB_EP0_MPS_  USB EP0 MPS
+  * @{
+  */
+#define DEP0CTL_MPS_64                         0
+#define DEP0CTL_MPS_32                         1
+#define DEP0CTL_MPS_16                         2
+#define DEP0CTL_MPS_8                          3
+/**
+  * @}
+  */
+
+/** @defgroup USB_EP_Speed_  USB EP Speed
+  * @{
+  */
+#define EP_SPEED_LOW                           0
+#define EP_SPEED_FULL                          1
+#define EP_SPEED_HIGH                          2
+/**
+  * @}
+  */
+
+/** @defgroup USB_EP_Type_  USB EP Type
+  * @{
+  */
+#define EP_TYPE_CTRL                           0
+#define EP_TYPE_ISOC                           1
+#define EP_TYPE_BULK                           2
+#define EP_TYPE_INTR                           3
+#define EP_TYPE_MSK                            3
+/**
+  * @}
+  */
+
+/** @defgroup USB_STS_Defines_   USB STS Defines
+  * @{
+  */
+#define STS_GOUT_NAK                           1
+#define STS_DATA_UPDT                          2
+#define STS_XFER_COMP                          3
+#define STS_SETUP_COMP                         4
+#define STS_SETUP_UPDT                         6
+/**
+  * @}
+  */
+
+/** @defgroup HCFG_SPEED_Defines_   HCFG SPEED Defines
+  * @{
+  */
+#define HCFG_30_60_MHZ                         0
+#define HCFG_48_MHZ                            1
+#define HCFG_6_MHZ                             2
+/**
+  * @}
+  */
+
+/** @defgroup HPRT0_PRTSPD_SPEED_Defines_  HPRT0 PRTSPD SPEED Defines
+  * @{
+  */
+#define HPRT0_PRTSPD_HIGH_SPEED                0
+#define HPRT0_PRTSPD_FULL_SPEED                1
+#define HPRT0_PRTSPD_LOW_SPEED                 2
+/**
+  * @}
+  */
+
+#define HCCHAR_CTRL                            0
+#define HCCHAR_ISOC                            1
+#define HCCHAR_BULK                            2
+#define HCCHAR_INTR                            3
+
+#define HC_PID_DATA0                           0
+#define HC_PID_DATA2                           1
+#define HC_PID_DATA1                           2
+#define HC_PID_SETUP                           3
+
+#define GRXSTS_PKTSTS_IN                       2
+#define GRXSTS_PKTSTS_IN_XFER_COMP             3
+#define GRXSTS_PKTSTS_DATA_TOGGLE_ERR          5
+#define GRXSTS_PKTSTS_CH_HALTED                7
+
+#define USBx_PCGCCTL    *(__IO uint32_t *)((uint32_t)USBx + USB_OTG_PCGCCTL_BASE)
+#define USBx_HPRT0      *(__IO uint32_t *)((uint32_t)USBx + USB_OTG_HOST_PORT_BASE)
+
+#define USBx_DEVICE     ((USB_OTG_DeviceTypeDef *)((uint32_t )USBx + USB_OTG_DEVICE_BASE))
+#define USBx_INEP(i)    ((USB_OTG_INEndpointTypeDef *)((uint32_t)USBx + USB_OTG_IN_ENDPOINT_BASE + (i)*USB_OTG_EP_REG_SIZE))
+#define USBx_OUTEP(i)   ((USB_OTG_OUTEndpointTypeDef *)((uint32_t)USBx + USB_OTG_OUT_ENDPOINT_BASE + (i)*USB_OTG_EP_REG_SIZE))
+#define USBx_DFIFO(i)   *(__IO uint32_t *)((uint32_t)USBx + USB_OTG_FIFO_BASE + (i) * USB_OTG_FIFO_SIZE)
+
+#define USBx_HOST       ((USB_OTG_HostTypeDef *)((uint32_t )USBx + USB_OTG_HOST_BASE))
+#define USBx_HC(i)      ((USB_OTG_HostChannelTypeDef *)((uint32_t)USBx + USB_OTG_HOST_CHANNEL_BASE + (i)*USB_OTG_HOST_CHANNEL_SIZE))
+/**
+  * @}
+  */
+/* Exported macro ------------------------------------------------------------*/
+#define USB_MASK_INTERRUPT(__INSTANCE__, __INTERRUPT__)     ((__INSTANCE__)->GINTMSK &= ~(__INTERRUPT__))
+#define USB_UNMASK_INTERRUPT(__INSTANCE__, __INTERRUPT__)   ((__INSTANCE__)->GINTMSK |= (__INTERRUPT__))
+
+#define CLEAR_IN_EP_INTR(__EPNUM__, __INTERRUPT__)          (USBx_INEP(__EPNUM__)->DIEPINT = (__INTERRUPT__))
+#define CLEAR_OUT_EP_INTR(__EPNUM__, __INTERRUPT__)         (USBx_OUTEP(__EPNUM__)->DOEPINT = (__INTERRUPT__))
+
+/* Exported functions --------------------------------------------------------*/
+HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef Init);
+HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef Init);
+HAL_StatusTypeDef USB_EnableGlobalInt(USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_DisableGlobalInt(USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_SetCurrentMode(USB_OTG_GlobalTypeDef *USBx , USB_OTG_ModeTypeDef mode);
+HAL_StatusTypeDef USB_SetDevSpeed(USB_OTG_GlobalTypeDef *USBx , uint8_t speed);
+HAL_StatusTypeDef USB_FlushRxFifo (USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_FlushTxFifo (USB_OTG_GlobalTypeDef *USBx, uint32_t num );
+HAL_StatusTypeDef USB_ActivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep);
+HAL_StatusTypeDef USB_DeactivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep);
+HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep);
+HAL_StatusTypeDef USB_DeactivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep);
+HAL_StatusTypeDef USB_EPStartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma);
+HAL_StatusTypeDef USB_EP0StartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma);
+HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uint8_t ch_ep_num, uint16_t len, uint8_t dma);
+void *            USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len);
+HAL_StatusTypeDef USB_EPSetStall(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep);
+HAL_StatusTypeDef USB_EPClearStall(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep);
+HAL_StatusTypeDef USB_SetDevAddress (USB_OTG_GlobalTypeDef *USBx, uint8_t address);
+HAL_StatusTypeDef USB_DevConnect (USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_DevDisconnect (USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_StopDevice(USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_ActivateSetup (USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_EP0_OutStart(USB_OTG_GlobalTypeDef *USBx, uint8_t dma, uint8_t *psetup);
+uint8_t           USB_GetDevSpeed(USB_OTG_GlobalTypeDef *USBx);
+uint32_t          USB_GetMode(USB_OTG_GlobalTypeDef *USBx);
+uint32_t          USB_ReadInterrupts (USB_OTG_GlobalTypeDef *USBx);
+uint32_t          USB_ReadDevAllOutEpInterrupt (USB_OTG_GlobalTypeDef *USBx);
+uint32_t          USB_ReadDevOutEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum);
+uint32_t          USB_ReadDevAllInEpInterrupt (USB_OTG_GlobalTypeDef *USBx);
+uint32_t          USB_ReadDevInEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum);
+void              USB_ClearInterrupts (USB_OTG_GlobalTypeDef *USBx, uint32_t interrupt);
+
+HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_InitFSLSPClkSel(USB_OTG_GlobalTypeDef *USBx , uint8_t freq);
+HAL_StatusTypeDef USB_ResetPort(USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_DriveVbus (USB_OTG_GlobalTypeDef *USBx, uint8_t state);
+uint32_t          USB_GetHostSpeed (USB_OTG_GlobalTypeDef *USBx);
+uint32_t          USB_GetCurrentFrame (USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_HC_Init(USB_OTG_GlobalTypeDef *USBx,
+                                  uint8_t ch_num,
+                                  uint8_t epnum,
+                                  uint8_t dev_address,
+                                  uint8_t speed,
+                                  uint8_t ep_type,
+                                  uint16_t mps);
+HAL_StatusTypeDef USB_HC_StartXfer(USB_OTG_GlobalTypeDef *USBx, USB_OTG_HCTypeDef *hc, uint8_t dma);
+uint32_t          USB_HC_ReadInterrupt (USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_HC_Halt(USB_OTG_GlobalTypeDef *USBx , uint8_t hc_num);
+HAL_StatusTypeDef USB_DoPing(USB_OTG_GlobalTypeDef *USBx , uint8_t ch_num);
+HAL_StatusTypeDef USB_StopHost(USB_OTG_GlobalTypeDef *USBx);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32F7xx_LL_USB_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal.c
@@ -1,0 +1,504 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   HAL module driver.
+  *          This is the common part of the HAL initialization
+  *
+  @verbatim
+  ==============================================================================
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+    The common HAL driver contains a set of generic and common APIs that can be
+    used by the PPP peripheral drivers and the user to start using the HAL.
+    [..]
+    The HAL contains two APIs' categories:
+         (+) Common HAL APIs
+         (+) Services HAL APIs
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup HAL HAL
+  * @brief HAL module driver.
+  * @{
+  */
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @addtogroup HAL_Private_Constants
+  * @{
+  */
+/**
+ * @brief STM32F7xx HAL Driver version number V1.0.1
+   */
+#define __STM32F7xx_HAL_VERSION_MAIN   (0x01) /*!< [31:24] main version */
+#define __STM32F7xx_HAL_VERSION_SUB1   (0x00) /*!< [23:16] sub1 version */
+#define __STM32F7xx_HAL_VERSION_SUB2   (0x01) /*!< [15:8]  sub2 version */
+#define __STM32F7xx_HAL_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
+#define __STM32F7xx_HAL_VERSION         ((__STM32F7xx_HAL_VERSION_MAIN << 24)\
+                                        |(__STM32F7xx_HAL_VERSION_SUB1 << 16)\
+                                        |(__STM32F7xx_HAL_VERSION_SUB2 << 8 )\
+                                        |(__STM32F7xx_HAL_VERSION_RC))
+
+#define IDCODE_DEVID_MASK    ((uint32_t)0x00000FFF)
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/** @addtogroup HAL_Private_Variables
+  * @{
+  */
+static __IO uint32_t uwTick;
+/**
+  * @}
+  */
+
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup HAL_Exported_Functions HAL Exported Functions
+  * @{
+  */
+
+/** @defgroup HAL_Exported_Functions_Group1 Initialization and de-initialization Functions
+ *  @brief    Initialization and de-initialization functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initializes the Flash interface the NVIC allocation and initial clock
+          configuration. It initializes the systick also when timeout is needed
+          and the backup domain when enabled.
+      (+) de-Initializes common part of the HAL
+      (+) Configure The time base source to have 1ms time base with a dedicated
+          Tick interrupt priority.
+        (++) Systick timer is used by default as source of time base, but user
+             can eventually implement his proper time base source (a general purpose
+             timer for example or other time source), keeping in mind that Time base
+             duration should be kept 1ms since PPP_TIMEOUT_VALUEs are defined and
+             handled in milliseconds basis.
+        (++) Time base configuration function (HAL_InitTick ()) is called automatically
+             at the beginning of the program after reset by HAL_Init() or at any time
+             when clock is configured, by HAL_RCC_ClockConfig().
+        (++) Source of time base is configured  to generate interrupts at regular
+             time intervals. Care must be taken if HAL_Delay() is called from a
+             peripheral ISR process, the Tick interrupt line must have higher priority
+            (numerically lower) than the peripheral interrupt. Otherwise the caller
+            ISR process will be blocked.
+       (++) functions affecting time base configurations are declared as __weak
+             to make  override possible  in case of other  implementations in user file.
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  This function is used to initialize the HAL Library; it must be the first
+  *         instruction to be executed in the main program (before to call any other
+  *         HAL function), it performs the following:
+  *           Configure the Flash prefetch, and instruction cache through ART accelerator.
+  *           Configures the SysTick to generate an interrupt each 1 millisecond,
+  *           which is clocked by the HSI (at this stage, the clock is not yet
+  *           configured and thus the system is running from the internal HSI at 16 MHz).
+  *           Set NVIC Group Priority to 4.
+  *           Calls the HAL_MspInit() callback function defined in user file
+  *           "stm32f7xx_hal_msp.c" to do the global low level hardware initialization
+  *
+  * @note   SysTick is used as time base for the HAL_Delay() function, the application
+  *         need to ensure that the SysTick time base is always set to 1 millisecond
+  *         to have correct HAL operation.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_Init(void)
+{
+  /* Configure Flash prefetch and Instruction cache through ART accelerator */
+#if (ART_ACCLERATOR_ENABLE != 0)
+   __HAL_FLASH_ART_ENABLE();
+#endif /* ART_ACCLERATOR_ENABLE */
+
+  /* Set Interrupt Group Priority */
+  HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
+
+  /* Use systick as time base source and configure 1ms tick (default clock after Reset is HSI) */
+  HAL_InitTick(TICK_INT_PRIORITY);
+
+  /* Init the low level hardware */
+  HAL_MspInit();
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function de-Initializes common part of the HAL and stops the systick.
+  *         This function is optional.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DeInit(void)
+{
+  /* Reset of all peripherals */
+  __HAL_RCC_APB1_FORCE_RESET();
+  __HAL_RCC_APB1_RELEASE_RESET();
+
+  __HAL_RCC_APB2_FORCE_RESET();
+  __HAL_RCC_APB2_RELEASE_RESET();
+
+  __HAL_RCC_AHB1_FORCE_RESET();
+  __HAL_RCC_AHB1_RELEASE_RESET();
+
+  __HAL_RCC_AHB2_FORCE_RESET();
+  __HAL_RCC_AHB2_RELEASE_RESET();
+
+  __HAL_RCC_AHB3_FORCE_RESET();
+  __HAL_RCC_AHB3_RELEASE_RESET();
+
+  /* De-Init the low level hardware */
+  HAL_MspDeInit();
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the MSP.
+  * @retval None
+  */
+__weak void HAL_MspInit(void)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the MSP.
+  * @retval None
+  */
+__weak void HAL_MspDeInit(void)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief This function configures the source of the time base.
+  *        The time source is configured  to have 1ms time base with a dedicated
+  *        Tick interrupt priority.
+  * @note This function is called  automatically at the beginning of program after
+  *       reset by HAL_Init() or at any time when clock is reconfigured  by HAL_RCC_ClockConfig().
+  * @note In the default implementation, SysTick timer is the source of time base.
+  *       It is used to generate interrupts at regular time intervals.
+  *       Care must be taken if HAL_Delay() is called from a peripheral ISR process,
+  *       The the SysTick interrupt must have higher priority (numerically lower)
+  *       than the peripheral interrupt. Otherwise the caller ISR process will be blocked.
+  *       The function is declared as __weak  to be overwritten  in case of other
+  *       implementation  in user file.
+  * @param TickPriority: Tick interrupt priority.
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
+{
+  /*Configure the SysTick to have interrupt in 1ms time basis*/
+  HAL_SYSTICK_Config(HAL_RCC_GetHCLKFreq()/1000);
+
+  /*Configure the SysTick IRQ priority */
+  HAL_NVIC_SetPriority(SysTick_IRQn, TickPriority ,0);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_Exported_Functions_Group2 HAL Control functions
+ *  @brief    HAL Control functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### HAL Control functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Provide a tick value in millisecond
+      (+) Provide a blocking delay in millisecond
+      (+) Suspend the time base source interrupt
+      (+) Resume the time base source interrupt
+      (+) Get the HAL API driver version
+      (+) Get the device identifier
+      (+) Get the device revision identifier
+      (+) Enable/Disable Debug module during SLEEP mode
+      (+) Enable/Disable Debug module during STOP mode
+      (+) Enable/Disable Debug module during STANDBY mode
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief This function is called to increment  a global variable "uwTick"
+  *        used as application time base.
+  * @note In the default implementation, this variable is incremented each 1ms
+  *       in Systick ISR.
+ * @note This function is declared as __weak to be overwritten in case of other
+  *      implementations in user file.
+  * @retval None
+  */
+__weak void HAL_IncTick(void)
+{
+  uwTick++;
+}
+
+/**
+  * @brief Provides a tick value in millisecond.
+  * @note This function is declared as __weak to be overwritten in case of other
+  *       implementations in user file.
+  * @retval tick value
+  */
+__weak uint32_t HAL_GetTick(void)
+{
+  return uwTick;
+}
+
+/**
+  * @brief This function provides accurate delay (in milliseconds) based
+  *        on variable incremented.
+  * @note In the default implementation , SysTick timer is the source of time base.
+  *       It is used to generate interrupts at regular time intervals where uwTick
+  *       is incremented.
+  * @note ThiS function is declared as __weak to be overwritten in case of other
+  *       implementations in user file.
+  * @param Delay: specifies the delay time length, in milliseconds.
+  * @retval None
+  */
+__weak void HAL_Delay(__IO uint32_t Delay)
+{
+  uint32_t tickstart = 0;
+  tickstart = HAL_GetTick();
+  while((HAL_GetTick() - tickstart) < Delay)
+  {
+  }
+}
+
+/**
+  * @brief Suspend Tick increment.
+  * @note In the default implementation , SysTick timer is the source of time base. It is
+  *       used to generate interrupts at regular time intervals. Once HAL_SuspendTick()
+  *       is called, the the SysTick interrupt will be disabled and so Tick increment
+  *       is suspended.
+  * @note This function is declared as __weak to be overwritten in case of other
+  *       implementations in user file.
+  * @retval None
+  */
+__weak void HAL_SuspendTick(void)
+{
+  /* Disable SysTick Interrupt */
+  SysTick->CTRL &= ~SysTick_CTRL_TICKINT_Msk;
+}
+
+/**
+  * @brief Resume Tick increment.
+  * @note In the default implementation , SysTick timer is the source of time base. It is
+  *       used to generate interrupts at regular time intervals. Once HAL_ResumeTick()
+  *       is called, the the SysTick interrupt will be enabled and so Tick increment
+  *       is resumed.
+  * @note This function is declared as __weak to be overwritten in case of other
+  *       implementations in user file.
+  * @retval None
+  */
+__weak void HAL_ResumeTick(void)
+{
+  /* Enable SysTick Interrupt */
+  SysTick->CTRL  |= SysTick_CTRL_TICKINT_Msk;
+}
+
+/**
+  * @brief  Returns the HAL revision
+  * @retval version : 0xXYZR (8bits for each decimal, R for RC)
+  */
+uint32_t HAL_GetHalVersion(void)
+{
+ return __STM32F7xx_HAL_VERSION;
+}
+
+/**
+  * @brief  Returns the device revision identifier.
+  * @retval Device revision identifier
+  */
+uint32_t HAL_GetREVID(void)
+{
+   return((DBGMCU->IDCODE) >> 16);
+}
+
+/**
+  * @brief  Returns the device identifier.
+  * @retval Device identifier
+  */
+uint32_t HAL_GetDEVID(void)
+{
+   return((DBGMCU->IDCODE) & IDCODE_DEVID_MASK);
+}
+
+/**
+  * @brief  Enable the Debug Module during SLEEP mode
+  * @retval None
+  */
+void HAL_DBGMCU_EnableDBGSleepMode(void)
+{
+  SET_BIT(DBGMCU->CR, DBGMCU_CR_DBG_SLEEP);
+}
+
+/**
+  * @brief  Disable the Debug Module during SLEEP mode
+  * @retval None
+  */
+void HAL_DBGMCU_DisableDBGSleepMode(void)
+{
+  CLEAR_BIT(DBGMCU->CR, DBGMCU_CR_DBG_SLEEP);
+}
+
+/**
+  * @brief  Enable the Debug Module during STOP mode
+  * @retval None
+  */
+void HAL_DBGMCU_EnableDBGStopMode(void)
+{
+  SET_BIT(DBGMCU->CR, DBGMCU_CR_DBG_STOP);
+}
+
+/**
+  * @brief  Disable the Debug Module during STOP mode
+  * @retval None
+  */
+void HAL_DBGMCU_DisableDBGStopMode(void)
+{
+  CLEAR_BIT(DBGMCU->CR, DBGMCU_CR_DBG_STOP);
+}
+
+/**
+  * @brief  Enable the Debug Module during STANDBY mode
+  * @retval None
+  */
+void HAL_DBGMCU_EnableDBGStandbyMode(void)
+{
+  SET_BIT(DBGMCU->CR, DBGMCU_CR_DBG_STANDBY);
+}
+
+/**
+  * @brief  Disable the Debug Module during STANDBY mode
+  * @retval None
+  */
+void HAL_DBGMCU_DisableDBGStandbyMode(void)
+{
+  CLEAR_BIT(DBGMCU->CR, DBGMCU_CR_DBG_STANDBY);
+}
+
+/**
+  * @brief  Enables the I/O Compensation Cell.
+  * @note   The I/O compensation cell can be used only when the device supply
+  *         voltage ranges from 2.4 to 3.6 V.
+  * @retval None
+  */
+void HAL_EnableCompensationCell(void)
+{
+  SYSCFG->CMPCR |= SYSCFG_CMPCR_CMP_PD;
+}
+
+/**
+  * @brief  Power-down the I/O Compensation Cell.
+  * @note   The I/O compensation cell can be used only when the device supply
+  *         voltage ranges from 2.4 to 3.6 V.
+  * @retval None
+  */
+void HAL_DisableCompensationCell(void)
+{
+  SYSCFG->CMPCR &= (uint32_t)~((uint32_t)SYSCFG_CMPCR_CMP_PD);
+}
+
+/**
+  * @brief  Enables the FMC Memory Mapping Swapping.
+  *
+  * @note   SDRAM is accessible at 0x60000000
+  *         and NOR/RAM is accessible at 0xC0000000
+  *
+  * @retval None
+  */
+void HAL_EnableFMCMemorySwapping(void)
+{
+  SYSCFG->MEMRMP |= SYSCFG_MEMRMP_SWP_FMC_0;
+}
+
+/**
+  * @brief  Disables the FMC Memory Mapping Swapping
+  *
+  * @note   SDRAM is accessible at 0xC0000000 (default mapping)
+  *         and NOR/RAM is accessible at 0x60000000 (default mapping)
+  *
+  * @retval None
+  */
+void HAL_DisableFMCMemorySwapping(void)
+{
+
+  SYSCFG->MEMRMP &= (uint32_t)~((uint32_t)SYSCFG_MEMRMP_SWP_FMC);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_adc.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_adc.c
@@ -1,0 +1,1408 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_adc.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   This file provides firmware functions to manage the following
+  *          functionalities of the Analog to Digital Convertor (ADC) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + State and errors functions
+  *
+  @verbatim
+  ==============================================================================
+                    ##### ADC Peripheral features #####
+  ==============================================================================
+  [..]
+  (#) 12-bit, 10-bit, 8-bit or 6-bit configurable resolution.
+  (#) Interrupt generation at the end of conversion, end of injected conversion,
+      and in case of analog watchdog or overrun events
+  (#) Single and continuous conversion modes.
+  (#) Scan mode for automatic conversion of channel 0 to channel x.
+  (#) Data alignment with in-built data coherency.
+  (#) Channel-wise programmable sampling time.
+  (#) External trigger option with configurable polarity for both regular and
+      injected conversion.
+  (#) Dual/Triple mode (on devices with 2 ADCs or more).
+  (#) Configurable DMA data storage in Dual/Triple ADC mode.
+  (#) Configurable delay between conversions in Dual/Triple interleaved mode.
+  (#) ADC conversion type (refer to the datasheets).
+  (#) ADC supply requirements: 2.4 V to 3.6 V at full speed and down to 1.8 V at
+      slower speed.
+  (#) ADC input range: VREF(minus) = VIN = VREF(plus).
+  (#) DMA request generation during regular channel conversion.
+
+
+                     ##### How to use this driver #####
+  ==============================================================================
+  [..]
+  (#)Initialize the ADC low level resources by implementing the HAL_ADC_MspInit():
+       (##) Enable the ADC interface clock using __HAL_RCC_ADC_CLK_ENABLE()
+       (##) ADC pins configuration
+             (+++) Enable the clock for the ADC GPIOs using the following function:
+                   __HAL_RCC_GPIOx_CLK_ENABLE()
+             (+++) Configure these ADC pins in analog mode using HAL_GPIO_Init()
+       (##) In case of using interrupts (e.g. HAL_ADC_Start_IT())
+             (+++) Configure the ADC interrupt priority using HAL_NVIC_SetPriority()
+             (+++) Enable the ADC IRQ handler using HAL_NVIC_EnableIRQ()
+             (+++) In ADC IRQ handler, call HAL_ADC_IRQHandler()
+       (##) In case of using DMA to control data transfer (e.g. HAL_ADC_Start_DMA())
+             (+++) Enable the DMAx interface clock using __HAL_RCC_DMAx_CLK_ENABLE()
+             (+++) Configure and enable two DMA streams stream for managing data
+                 transfer from peripheral to memory (output stream)
+             (+++) Associate the initialized DMA handle to the CRYP DMA handle
+                 using  __HAL_LINKDMA()
+             (+++) Configure the priority and enable the NVIC for the transfer complete
+                 interrupt on the two DMA Streams. The output stream should have higher
+                 priority than the input stream.
+
+    *** Configuration of ADC, groups regular/injected, channels parameters ***
+  ==============================================================================
+  [..]
+  (#) Configure the ADC parameters (resolution, data alignment, ...)
+      and regular group parameters (conversion trigger, sequencer, ...)
+      using function HAL_ADC_Init().
+
+  (#) Configure the channels for regular group parameters (channel number,
+      channel rank into sequencer, ..., into regular group)
+      using function HAL_ADC_ConfigChannel().
+
+  (#) Optionally, configure the injected group parameters (conversion trigger,
+      sequencer, ..., of injected group)
+      and the channels for injected group parameters (channel number,
+      channel rank into sequencer, ..., into injected group)
+      using function HAL_ADCEx_InjectedConfigChannel().
+
+  (#) Optionally, configure the analog watchdog parameters (channels
+      monitored, thresholds, ...) using function HAL_ADC_AnalogWDGConfig().
+
+  (#) Optionally, for devices with several ADC instances: configure the
+      multimode parameters using function HAL_ADCEx_MultiModeConfigChannel().
+
+                       *** Execution of ADC conversions ***
+  ==============================================================================
+  [..]
+  (#) ADC driver can be used among three modes: polling, interruption,
+      transfer by DMA.
+
+     *** Polling mode IO operation ***
+     =================================
+     [..]
+       (+) Start the ADC peripheral using HAL_ADC_Start()
+       (+) Wait for end of conversion using HAL_ADC_PollForConversion(), at this stage
+           user can specify the value of timeout according to his end application
+       (+) To read the ADC converted values, use the HAL_ADC_GetValue() function.
+       (+) Stop the ADC peripheral using HAL_ADC_Stop()
+
+     *** Interrupt mode IO operation ***
+     ===================================
+     [..]
+       (+) Start the ADC peripheral using HAL_ADC_Start_IT()
+       (+) Use HAL_ADC_IRQHandler() called under ADC_IRQHandler() Interrupt subroutine
+       (+) At ADC end of conversion HAL_ADC_ConvCpltCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_ADC_ConvCpltCallback
+       (+) In case of ADC Error, HAL_ADC_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_ADC_ErrorCallback
+       (+) Stop the ADC peripheral using HAL_ADC_Stop_IT()
+
+     *** DMA mode IO operation ***
+     ==============================
+     [..]
+       (+) Start the ADC peripheral using HAL_ADC_Start_DMA(), at this stage the user specify the length
+           of data to be transferred at each end of conversion
+       (+) At The end of data transfer by HAL_ADC_ConvCpltCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_ADC_ConvCpltCallback
+       (+) In case of transfer Error, HAL_ADC_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_ADC_ErrorCallback
+       (+) Stop the ADC peripheral using HAL_ADC_Stop_DMA()
+
+     *** ADC HAL driver macros list ***
+     =============================================
+     [..]
+       Below the list of most used macros in ADC HAL driver.
+
+      (+) __HAL_ADC_ENABLE : Enable the ADC peripheral
+      (+) __HAL_ADC_DISABLE : Disable the ADC peripheral
+      (+) __HAL_ADC_ENABLE_IT: Enable the ADC end of conversion interrupt
+      (+) __HAL_ADC_DISABLE_IT: Disable the ADC end of conversion interrupt
+      (+) __HAL_ADC_GET_IT_SOURCE: Check if the specified ADC interrupt source is enabled or disabled
+      (+) __HAL_ADC_CLEAR_FLAG: Clear the ADC's pending flags
+      (+) __HAL_ADC_GET_FLAG: Get the selected ADC's flag status
+      (+) ADC_GET_RESOLUTION: Return resolution bits in CR1 register
+
+     [..]
+       (@) You can refer to the ADC HAL driver header file for more useful macros
+
+                      *** Deinitialization of ADC ***
+  ==============================================================================
+  [..]
+  (#) Disable the ADC interface
+     (++) ADC clock can be hard reset and disabled at RCC top level.
+     (++) Hard reset of ADC peripherals
+          using macro __HAL_RCC_ADC_FORCE_RESET(), __HAL_RCC_ADC_RELEASE_RESET().
+     (++) ADC clock disable using the equivalent macro/functions as configuration step.
+               (+++) Example:
+                   Into HAL_ADC_MspDeInit() (recommended code location) or with
+                   other device clock parameters configuration:
+               (+++) HAL_RCC_GetOscConfig(&RCC_OscInitStructure);
+               (+++) RCC_OscInitStructure.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+               (+++) RCC_OscInitStructure.HSIState = RCC_HSI_OFF; (if not used for system clock)
+               (+++) HAL_RCC_OscConfig(&RCC_OscInitStructure);
+
+  (#) ADC pins configuration
+     (++) Disable the clock for the ADC GPIOs using macro __HAL_RCC_GPIOx_CLK_DISABLE()
+
+  (#) Optionally, in case of usage of ADC with interruptions:
+     (++) Disable the NVIC for ADC using function HAL_NVIC_DisableIRQ(ADCx_IRQn)
+
+  (#) Optionally, in case of usage of DMA:
+        (++) Deinitialize the DMA using function HAL_DMA_DeInit().
+        (++) Disable the NVIC for DMA using function HAL_NVIC_DisableIRQ(DMAx_Channelx_IRQn)
+
+    @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup ADC ADC
+  * @brief ADC driver modules
+  * @{
+  */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/** @addtogroup ADC_Private_Functions
+  * @{
+  */
+/* Private function prototypes -----------------------------------------------*/
+static void ADC_Init(ADC_HandleTypeDef* hadc);
+static void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma);
+static void ADC_DMAError(DMA_HandleTypeDef *hdma);
+static void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup ADC_Exported_Functions ADC Exported Functions
+  * @{
+  */
+
+/** @defgroup ADC_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the ADC.
+      (+) De-initialize the ADC.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the ADCx peripheral according to the specified parameters
+  *         in the ADC_InitStruct and initializes the ADC MSP.
+  *
+  * @note   This function is used to configure the global features of the ADC (
+  *         ClockPrescaler, Resolution, Data Alignment and number of conversion), however,
+  *         the rest of the configuration parameters are specific to the regular
+  *         channels group (scan mode activation, continuous mode activation,
+  *         External trigger source and edge, DMA continuous request after the
+  *         last transfer and End of conversion selection).
+  *
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
+{
+  /* Check ADC handle */
+  if(hadc == NULL)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_CLOCKPRESCALER(hadc->Init.ClockPrescaler));
+  assert_param(IS_ADC_RESOLUTION(hadc->Init.Resolution));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ScanConvMode));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EXT_TRIG(hadc->Init.ExternalTrigConv));
+  assert_param(IS_ADC_DATA_ALIGN(hadc->Init.DataAlign));
+  assert_param(IS_ADC_REGULAR_LENGTH(hadc->Init.NbrOfConversion));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DMAContinuousRequests));
+  assert_param(IS_ADC_EOCSelection(hadc->Init.EOCSelection));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DiscontinuousConvMode));
+
+  if(hadc->Init.ExternalTrigConv != ADC_SOFTWARE_START)
+  {
+    assert_param(IS_ADC_EXT_TRIG_EDGE(hadc->Init.ExternalTrigConvEdge));
+  }
+
+  if(hadc->State == HAL_ADC_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hadc->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware */
+    HAL_ADC_MspInit(hadc);
+  }
+
+  /* Initialize the ADC state */
+  hadc->State = HAL_ADC_STATE_BUSY;
+
+  /* Set ADC parameters */
+  ADC_Init(hadc);
+
+  /* Set ADC error code to none */
+  hadc->ErrorCode = HAL_ADC_ERROR_NONE;
+
+  /* Initialize the ADC state */
+  hadc->State = HAL_ADC_STATE_READY;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deinitializes the ADCx peripheral registers to their default reset values.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
+{
+  /* Check ADC handle */
+  if(hadc == NULL)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_BUSY;
+
+  /* DeInit the low level hardware */
+  HAL_ADC_MspDeInit(hadc);
+
+  /* Set ADC error code to none */
+  hadc->ErrorCode = HAL_ADC_ERROR_NONE;
+
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_RESET;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the ADC MSP.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+__weak void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the ADC MSP.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+__weak void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group2 IO operation functions
+ *  @brief    IO operation functions
+ *
+@verbatim
+ ===============================================================================
+             ##### IO operation functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Start conversion of regular channel.
+      (+) Stop conversion of regular channel.
+      (+) Start conversion of regular channel and enable interrupt.
+      (+) Stop conversion of regular channel and disable interrupt.
+      (+) Start conversion of regular channel and enable DMA transfer.
+      (+) Stop conversion of regular channel and disable DMA transfer.
+      (+) Handle ADC interrupt request.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enables ADC and starts conversion of the regular channels.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef* hadc)
+{
+  __IO uint32_t counter = 0;
+
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EXT_TRIG_EDGE(hadc->Init.ExternalTrigConvEdge));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Check if an injected conversion is ongoing */
+  if(hadc->State == HAL_ADC_STATE_BUSY_INJ)
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_BUSY_INJ_REG;
+  }
+  else
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_BUSY_REG;
+  }
+
+  /* Check if ADC peripheral is disabled in order to enable it and wait during
+  Tstab time the ADC's stabilization */
+  if((hadc->Instance->CR2 & ADC_CR2_ADON) != ADC_CR2_ADON)
+  {
+    /* Enable the Peripheral */
+    __HAL_ADC_ENABLE(hadc);
+
+    /* Delay for ADC stabilization time */
+    /* Compute number of CPU cycles to wait for */
+    counter = (ADC_STAB_DELAY_US * (SystemCoreClock / 1000000));
+    while(counter != 0)
+    {
+      counter--;
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Check if Multimode enabled */
+  if(HAL_IS_BIT_CLR(ADC->CCR, ADC_CCR_MULTI))
+  {
+    /* if no external trigger present enable software conversion of regular channels */
+    if((hadc->Instance->CR2 & ADC_CR2_EXTEN) == RESET)
+    {
+      /* Enable the selected ADC software conversion for regular group */
+      hadc->Instance->CR2 |= (uint32_t)ADC_CR2_SWSTART;
+    }
+  }
+  else
+  {
+    /* if instance of handle correspond to ADC1 and  no external trigger present enable software conversion of regular channels */
+    if((hadc->Instance == ADC1) && ((hadc->Instance->CR2 & ADC_CR2_EXTEN) == RESET))
+    {
+      /* Enable the selected ADC software conversion for regular group */
+        hadc->Instance->CR2 |= (uint32_t)ADC_CR2_SWSTART;
+    }
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables ADC and stop conversion of regular channels.
+  *
+  * @note   Caution: This function will stop also injected channels.
+  *
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  *
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc)
+{
+  /* Disable the Peripheral */
+  __HAL_ADC_DISABLE(hadc);
+
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Poll for regular conversion complete
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  Timeout: Timeout value in millisecond.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  /* Verification that ADC configuration is compliant with polling for      */
+  /* each conversion:                                                       */
+  /* Particular case is ADC configured in DMA mode and ADC sequencer with   */
+  /* several ranks and polling for end of each conversion.                  */
+  /* For code simplicity sake, this particular case is generalized to       */
+  /* ADC configured in DMA mode and polling for end of each conversion.     */
+  if (HAL_IS_BIT_SET(hadc->Instance->CR2, ADC_CR2_EOCS) &&
+      HAL_IS_BIT_SET(hadc->Instance->CR2, ADC_CR2_DMA)    )
+  {
+    /* Update ADC state machine to error */
+    hadc->State = HAL_ADC_STATE_ERROR;
+
+    /* Process unlocked */
+    __HAL_UNLOCK(hadc);
+
+    return HAL_ERROR;
+  }
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Check End of conversion flag */
+  while(!(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOC)))
+  {
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hadc->State= HAL_ADC_STATE_TIMEOUT;
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Check if an injected conversion is ready */
+  if(hadc->State == HAL_ADC_STATE_EOC_INJ)
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_EOC_INJ_REG;
+  }
+  else
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_EOC_REG;
+  }
+
+  /* Return ADC state */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Poll for conversion event
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  EventType: the ADC event type.
+  *          This parameter can be one of the following values:
+  *            @arg ADC_AWD_EVENT: ADC Analog watch Dog event.
+  *            @arg ADC_OVR_EVENT: ADC Overrun event.
+  * @param  Timeout: Timeout value in millisecond.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_EVENT_TYPE(EventType));
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Check selected event flag */
+  while(!(__HAL_ADC_GET_FLAG(hadc,EventType)))
+  {
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hadc->State= HAL_ADC_STATE_TIMEOUT;
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Check analog watchdog flag */
+  if(EventType == ADC_AWD_EVENT)
+  {
+     /* Change ADC state */
+     hadc->State = HAL_ADC_STATE_AWD;
+
+     /* Clear the ADCx's analog watchdog flag */
+     __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD);
+  }
+  else
+  {
+     /* Change ADC state */
+     hadc->State = HAL_ADC_STATE_ERROR;
+
+     /* Clear the ADCx's Overrun flag */
+     __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);
+  }
+
+  /* Return ADC state */
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Enables the interrupt and starts ADC conversion of regular channels.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc)
+{
+  __IO uint32_t counter = 0;
+
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EXT_TRIG_EDGE(hadc->Init.ExternalTrigConvEdge));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Check if an injected conversion is ongoing */
+  if(hadc->State == HAL_ADC_STATE_BUSY_INJ)
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_BUSY_INJ_REG;
+  }
+  else
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_BUSY_REG;
+  }
+
+  /* Set ADC error code to none */
+  hadc->ErrorCode = HAL_ADC_ERROR_NONE;
+
+  /* Check if ADC peripheral is disabled in order to enable it and wait during
+     Tstab time the ADC's stabilization */
+  if((hadc->Instance->CR2 & ADC_CR2_ADON) != ADC_CR2_ADON)
+  {
+    /* Enable the Peripheral */
+    __HAL_ADC_ENABLE(hadc);
+
+    /* Delay for ADC stabilization time */
+    /* Compute number of CPU cycles to wait for */
+    counter = (ADC_STAB_DELAY_US * (SystemCoreClock / 1000000));
+    while(counter != 0)
+    {
+      counter--;
+    }
+  }
+
+  /* Enable the ADC overrun interrupt */
+  __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
+
+  /* Enable the ADC end of conversion interrupt for regular group */
+  __HAL_ADC_ENABLE_IT(hadc, ADC_IT_EOC);
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Check if Multimode enabled */
+  if(HAL_IS_BIT_CLR(ADC->CCR, ADC_CCR_MULTI))
+  {
+    /* if no external trigger present enable software conversion of regular channels */
+    if((hadc->Instance->CR2 & ADC_CR2_EXTEN) == RESET)
+    {
+      /* Enable the selected ADC software conversion for regular group */
+      hadc->Instance->CR2 |= (uint32_t)ADC_CR2_SWSTART;
+    }
+  }
+  else
+  {
+    /* if instance of handle correspond to ADC1 and  no external trigger present enable software conversion of regular channels */
+    if((hadc->Instance == (ADC_TypeDef*)0x40012000) && ((hadc->Instance->CR2 & ADC_CR2_EXTEN) == RESET))
+    {
+      /* Enable the selected ADC software conversion for regular group */
+        hadc->Instance->CR2 |= (uint32_t)ADC_CR2_SWSTART;
+    }
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables the interrupt and stop ADC conversion of regular channels.
+  *
+  * @note   Caution: This function will stop also injected channels.
+  *
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc)
+{
+  /* Disable the ADC end of conversion interrupt for regular group */
+  __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC);
+
+  /* Disable the ADC end of conversion interrupt for injected group */
+  __HAL_ADC_DISABLE_IT(hadc, ADC_CR1_JEOCIE);
+
+  /* Enable the Peripheral */
+  __HAL_ADC_DISABLE(hadc);
+
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles ADC interrupt request
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
+{
+  uint32_t tmp1 = 0, tmp2 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_REGULAR_LENGTH(hadc->Init.NbrOfConversion));
+  assert_param(IS_ADC_EOCSelection(hadc->Init.EOCSelection));
+
+  tmp1 = __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOC);
+  tmp2 = __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_EOC);
+  /* Check End of conversion flag for regular channels */
+  if(tmp1 && tmp2)
+  {
+    /* Check if an injected conversion is ready */
+    if(hadc->State == HAL_ADC_STATE_EOC_INJ)
+    {
+      /* Change ADC state */
+      hadc->State = HAL_ADC_STATE_EOC_INJ_REG;
+    }
+    else
+    {
+      /* Change ADC state */
+      hadc->State = HAL_ADC_STATE_EOC_REG;
+    }
+
+    if((hadc->Init.ContinuousConvMode == DISABLE) && ((hadc->Instance->CR2 & ADC_CR2_EXTEN) == RESET))
+    {
+      if(hadc->Init.EOCSelection == ADC_EOC_SEQ_CONV)
+      {
+        /* DISABLE the ADC end of conversion interrupt for regular group */
+        __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC);
+
+        /* DISABLE the ADC overrun interrupt */
+        __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+      }
+      else
+      {
+        if (hadc->NbrOfCurrentConversionRank == 0)
+        {
+          hadc->NbrOfCurrentConversionRank = hadc->Init.NbrOfConversion;
+        }
+
+        /* Decrement the number of conversion when an interrupt occurs */
+        hadc->NbrOfCurrentConversionRank--;
+
+        /* Check if all conversions are finished */
+        if(hadc->NbrOfCurrentConversionRank == 0)
+        {
+          /* DISABLE the ADC end of conversion interrupt for regular group */
+          __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC);
+
+          /* DISABLE the ADC overrun interrupt */
+          __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+        }
+      }
+    }
+
+    /* Conversion complete callback */
+    HAL_ADC_ConvCpltCallback(hadc);
+
+   /* Clear the ADCx flag for regular end of conversion */
+    __HAL_ADC_CLEAR_FLAG(hadc,ADC_FLAG_EOC);
+  }
+
+  tmp1 = __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOC);
+  tmp2 = __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_JEOC);
+  /* Check End of conversion flag for injected channels */
+  if(tmp1 && tmp2)
+  {
+    /* Check if a regular conversion is ready */
+    if(hadc->State == HAL_ADC_STATE_EOC_REG)
+    {
+      /* Change ADC state */
+      hadc->State = HAL_ADC_STATE_EOC_INJ_REG;
+    }
+    else
+    {
+      /* Change ADC state */
+      hadc->State = HAL_ADC_STATE_EOC_INJ;
+    }
+
+    tmp1 = HAL_IS_BIT_CLR(hadc->Instance->CR1, ADC_CR1_JAUTO);
+    tmp2 = HAL_IS_BIT_CLR(hadc->Instance->CR2, ADC_CR2_JEXTEN);
+    if(((hadc->Init.ContinuousConvMode == DISABLE) || tmp1) && tmp2)
+    {
+      /* DISABLE the ADC end of conversion interrupt for injected group */
+      __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC);
+    }
+
+    /* Conversion complete callback */
+    HAL_ADCEx_InjectedConvCpltCallback(hadc);
+
+   /* Clear the ADCx flag for injected end of conversion */
+    __HAL_ADC_CLEAR_FLAG(hadc,ADC_FLAG_JEOC);
+  }
+
+  tmp1 = __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_AWD);
+  tmp2 = __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_AWD);
+  /* Check Analog watchdog flag */
+  if(tmp1 && tmp2)
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_AWD;
+
+    /* Clear the ADCx's Analog watchdog flag */
+    __HAL_ADC_CLEAR_FLAG(hadc,ADC_FLAG_AWD);
+
+    /* Level out of window callback */
+    HAL_ADC_LevelOutOfWindowCallback(hadc);
+  }
+
+  tmp1 = __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_OVR);
+  tmp2 = __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_OVR);
+  /* Check Overrun flag */
+  if(tmp1 && tmp2)
+  {
+    /* Change ADC state to overrun state */
+    hadc->State = HAL_ADC_STATE_ERROR;
+
+    /* Set ADC error code to overrun */
+    hadc->ErrorCode |= HAL_ADC_ERROR_OVR;
+
+    /* Clear the Overrun flag */
+    __HAL_ADC_CLEAR_FLAG(hadc,ADC_FLAG_OVR);
+
+    /* Error callback */
+    HAL_ADC_ErrorCallback(hadc);
+  }
+}
+
+/**
+  * @brief  Enables ADC DMA request after last transfer (Single-ADC mode) and enables ADC peripheral
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  pData: The destination Buffer address.
+  * @param  Length: The length of data to be transferred from ADC peripheral to memory.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length)
+{
+  __IO uint32_t counter = 0;
+
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EXT_TRIG_EDGE(hadc->Init.ExternalTrigConvEdge));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Enable ADC overrun interrupt */
+  __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
+
+  /* Enable ADC DMA mode */
+  hadc->Instance->CR2 |= ADC_CR2_DMA;
+
+  /* Set the DMA transfer complete callback */
+  hadc->DMA_Handle->XferCpltCallback = ADC_DMAConvCplt;
+
+  /* Set the DMA half transfer complete callback */
+  hadc->DMA_Handle->XferHalfCpltCallback = ADC_DMAHalfConvCplt;
+
+  /* Set the DMA error callback */
+  hadc->DMA_Handle->XferErrorCallback = ADC_DMAError ;
+
+  /* Enable the DMA Stream */
+  HAL_DMA_Start_IT(hadc->DMA_Handle, (uint32_t)&hadc->Instance->DR, (uint32_t)pData, Length);
+
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_BUSY_REG;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Check if ADC peripheral is disabled in order to enable it and wait during
+     Tstab time the ADC's stabilization */
+  if((hadc->Instance->CR2 & ADC_CR2_ADON) != ADC_CR2_ADON)
+  {
+    /* Enable the Peripheral */
+    __HAL_ADC_ENABLE(hadc);
+
+    /* Delay for ADC stabilization time */
+    /* Compute number of CPU cycles to wait for */
+    counter = (ADC_STAB_DELAY_US * (SystemCoreClock / 1000000));
+    while(counter != 0)
+    {
+      counter--;
+    }
+  }
+
+  /* if no external trigger present enable software conversion of regular channels */
+  if((hadc->Instance->CR2 & ADC_CR2_EXTEN) == RESET)
+  {
+    /* Enable the selected ADC software conversion for regular group */
+    hadc->Instance->CR2 |= ADC_CR2_SWSTART;
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables ADC DMA (Single-ADC mode) and disables ADC peripheral
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
+{
+  /* Disable the Peripheral */
+  __HAL_ADC_DISABLE(hadc);
+
+  /* Disable ADC overrun interrupt */
+  __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+
+  /* Disable the selected ADC DMA mode */
+  hadc->Instance->CR2 &= ~ADC_CR2_DMA;
+
+  /* Disable the ADC DMA Stream */
+  HAL_DMA_Abort(hadc->DMA_Handle);
+
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Gets the converted value from data register of regular channel.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval Converted value
+  */
+uint32_t HAL_ADC_GetValue(ADC_HandleTypeDef* hadc)
+{
+  /* Return the selected ADC converted value */
+  return hadc->Instance->DR;
+}
+
+/**
+  * @brief  Regular conversion complete callback in non blocking mode
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+__weak void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_ConvCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Regular conversion half DMA transfer callback in non blocking mode
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+__weak void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_ConvHalfCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Analog watchdog callback in non blocking mode
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+__weak void HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef* hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_LevelOoutOfWindowCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error ADC callback.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+__weak void HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group3 Peripheral Control functions
+ *  @brief   	Peripheral Control functions
+ *
+@verbatim
+ ===============================================================================
+             ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Configure regular channels.
+      (+) Configure injected channels.
+      (+) Configure multimode.
+      (+) Configure the analog watch dog.
+
+@endverbatim
+  * @{
+  */
+
+  /**
+  * @brief  Configures for the selected ADC regular channel its corresponding
+  *         rank in the sequencer and its sample time.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  sConfig: ADC configuration structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig)
+{
+  __IO uint32_t counter = 0;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_CHANNEL(sConfig->Channel));
+  assert_param(IS_ADC_REGULAR_RANK(sConfig->Rank));
+  assert_param(IS_ADC_SAMPLE_TIME(sConfig->SamplingTime));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* if ADC_Channel_10 ... ADC_Channel_18 is selected */
+  if (sConfig->Channel > ADC_CHANNEL_9)
+  {
+    /* Clear the old sample time */
+    hadc->Instance->SMPR1 &= ~ADC_SMPR1(ADC_SMPR1_SMP10, sConfig->Channel);
+
+    /* Set the new sample time */
+    hadc->Instance->SMPR1 |= ADC_SMPR1(sConfig->SamplingTime, sConfig->Channel);
+  }
+  else /* ADC_Channel include in ADC_Channel_[0..9] */
+  {
+    /* Clear the old sample time */
+    hadc->Instance->SMPR2 &= ~ADC_SMPR2(ADC_SMPR2_SMP0, sConfig->Channel);
+
+    /* Set the new sample time */
+    hadc->Instance->SMPR2 |= ADC_SMPR2(sConfig->SamplingTime, sConfig->Channel);
+  }
+
+  /* For Rank 1 to 6 */
+  if (sConfig->Rank < 7)
+  {
+    /* Clear the old SQx bits for the selected rank */
+    hadc->Instance->SQR3 &= ~ADC_SQR3_RK(ADC_SQR3_SQ1, sConfig->Rank);
+
+    /* Set the SQx bits for the selected rank */
+    hadc->Instance->SQR3 |= ADC_SQR3_RK(sConfig->Channel, sConfig->Rank);
+  }
+  /* For Rank 7 to 12 */
+  else if (sConfig->Rank < 13)
+  {
+    /* Clear the old SQx bits for the selected rank */
+    hadc->Instance->SQR2 &= ~ADC_SQR2_RK(ADC_SQR2_SQ7, sConfig->Rank);
+
+    /* Set the SQx bits for the selected rank */
+    hadc->Instance->SQR2 |= ADC_SQR2_RK(sConfig->Channel, sConfig->Rank);
+  }
+  /* For Rank 13 to 16 */
+  else
+  {
+    /* Clear the old SQx bits for the selected rank */
+    hadc->Instance->SQR1 &= ~ADC_SQR1_RK(ADC_SQR1_SQ13, sConfig->Rank);
+
+    /* Set the SQx bits for the selected rank */
+    hadc->Instance->SQR1 |= ADC_SQR1_RK(sConfig->Channel, sConfig->Rank);
+  }
+
+  /* if ADC1 Channel_18 is selected enable VBAT Channel */
+  if ((hadc->Instance == ADC1) && (sConfig->Channel == ADC_CHANNEL_VBAT))
+  {
+    /* Enable the VBAT channel*/
+    ADC->CCR |= ADC_CCR_VBATE;
+  }
+
+  /* if ADC1 Channel_16 or Channel_17 is selected enable TSVREFE Channel(Temperature sensor and VREFINT) */
+  if ((hadc->Instance == ADC1) && ((sConfig->Channel == ADC_CHANNEL_TEMPSENSOR) || (sConfig->Channel == ADC_CHANNEL_VREFINT)))
+  {
+    /* Enable the TSVREFE channel*/
+    ADC->CCR |= ADC_CCR_TSVREFE;
+
+    if((sConfig->Channel == ADC_CHANNEL_TEMPSENSOR))
+    {
+      /* Delay for temperature sensor stabilization time */
+      /* Compute number of CPU cycles to wait for */
+      counter = (ADC_TEMPSENSOR_DELAY_US * (SystemCoreClock / 1000000));
+      while(counter != 0)
+      {
+        counter--;
+      }
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the analog watchdog.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  AnalogWDGConfig : pointer to an ADC_AnalogWDGConfTypeDef structure
+  *         that contains the configuration information of ADC analog watchdog.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig)
+{
+#ifdef USE_FULL_ASSERT
+  uint32_t tmp = 0;
+#endif /* USE_FULL_ASSERT  */
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ANALOG_WATCHDOG(AnalogWDGConfig->WatchdogMode));
+  assert_param(IS_ADC_CHANNEL(AnalogWDGConfig->Channel));
+  assert_param(IS_FUNCTIONAL_STATE(AnalogWDGConfig->ITMode));
+
+#ifdef USE_FULL_ASSERT
+  tmp = ADC_GET_RESOLUTION(hadc);
+  assert_param(IS_ADC_RANGE(tmp, AnalogWDGConfig->HighThreshold));
+  assert_param(IS_ADC_RANGE(tmp, AnalogWDGConfig->LowThreshold));
+#endif /* USE_FULL_ASSERT  */
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  if(AnalogWDGConfig->ITMode == ENABLE)
+  {
+    /* Enable the ADC Analog watchdog interrupt */
+    __HAL_ADC_ENABLE_IT(hadc, ADC_IT_AWD);
+  }
+  else
+  {
+    /* Disable the ADC Analog watchdog interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_AWD);
+  }
+
+  /* Clear AWDEN, JAWDEN and AWDSGL bits */
+  hadc->Instance->CR1 &=  ~(ADC_CR1_AWDSGL | ADC_CR1_JAWDEN | ADC_CR1_AWDEN);
+
+  /* Set the analog watchdog enable mode */
+  hadc->Instance->CR1 |= AnalogWDGConfig->WatchdogMode;
+
+  /* Set the high threshold */
+  hadc->Instance->HTR = AnalogWDGConfig->HighThreshold;
+
+  /* Set the low threshold */
+  hadc->Instance->LTR = AnalogWDGConfig->LowThreshold;
+
+  /* Clear the Analog watchdog channel select bits */
+  hadc->Instance->CR1 &= ~ADC_CR1_AWDCH;
+
+  /* Set the Analog watchdog channel */
+  hadc->Instance->CR1 |= (uint32_t)((uint16_t)(AnalogWDGConfig->Channel));
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group4 ADC Peripheral State functions
+ *  @brief   ADC Peripheral State functions
+ *
+@verbatim
+ ===============================================================================
+            ##### Peripheral State and errors functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) Check the ADC state
+      (+) Check the ADC Error
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  return the ADC state
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL state
+  */
+HAL_ADC_StateTypeDef HAL_ADC_GetState(ADC_HandleTypeDef* hadc)
+{
+  /* Return ADC state */
+  return hadc->State;
+}
+
+/**
+  * @brief  Return the ADC error code
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval ADC Error Code
+  */
+uint32_t HAL_ADC_GetError(ADC_HandleTypeDef *hadc)
+{
+  return hadc->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup ADC_Private_Functions ADC Private Functions
+  * @{
+  */
+
+/**
+  * @brief  Initializes the ADCx peripheral according to the specified parameters
+  *         in the ADC_InitStruct without initializing the ADC MSP.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+static void ADC_Init(ADC_HandleTypeDef* hadc)
+{
+  /* Set ADC parameters */
+  /* Set the ADC clock prescaler */
+  ADC->CCR &= ~(ADC_CCR_ADCPRE);
+  ADC->CCR |=  hadc->Init.ClockPrescaler;
+
+  /* Set ADC scan mode */
+  hadc->Instance->CR1 &= ~(ADC_CR1_SCAN);
+  hadc->Instance->CR1 |=  ADC_CR1_SCANCONV(hadc->Init.ScanConvMode);
+
+  /* Set ADC resolution */
+  hadc->Instance->CR1 &= ~(ADC_CR1_RES);
+  hadc->Instance->CR1 |=  hadc->Init.Resolution;
+
+  /* Set ADC data alignment */
+  hadc->Instance->CR2 &= ~(ADC_CR2_ALIGN);
+  hadc->Instance->CR2 |= hadc->Init.DataAlign;
+
+  /* Enable external trigger if trigger selection is different of software  */
+  /* start.                                                                 */
+  /* Note: This configuration keeps the hardware feature of parameter       */
+  /*       ExternalTrigConvEdge "trigger edge none" equivalent to           */
+  /*       software start.                                                  */
+  if(hadc->Init.ExternalTrigConv != ADC_SOFTWARE_START)
+  {
+    /* Select external trigger to start conversion */
+    hadc->Instance->CR2 &= ~(ADC_CR2_EXTSEL);
+    hadc->Instance->CR2 |= hadc->Init.ExternalTrigConv;
+
+    /* Select external trigger polarity */
+    hadc->Instance->CR2 &= ~(ADC_CR2_EXTEN);
+    hadc->Instance->CR2 |= hadc->Init.ExternalTrigConvEdge;
+  }
+  else
+  {
+    /* Reset the external trigger */
+    hadc->Instance->CR2 &= ~(ADC_CR2_EXTSEL);
+    hadc->Instance->CR2 &= ~(ADC_CR2_EXTEN);
+  }
+
+  /* Enable or disable ADC continuous conversion mode */
+  hadc->Instance->CR2 &= ~(ADC_CR2_CONT);
+  hadc->Instance->CR2 |= ADC_CR2_CONTINUOUS(hadc->Init.ContinuousConvMode);
+
+  if(hadc->Init.DiscontinuousConvMode != DISABLE)
+  {
+    assert_param(IS_ADC_REGULAR_DISC_NUMBER(hadc->Init.NbrOfDiscConversion));
+
+    /* Enable the selected ADC regular discontinuous mode */
+    hadc->Instance->CR1 |= (uint32_t)ADC_CR1_DISCEN;
+
+    /* Set the number of channels to be converted in discontinuous mode */
+    hadc->Instance->CR1 &= ~(ADC_CR1_DISCNUM);
+    hadc->Instance->CR1 |=  ADC_CR1_DISCONTINUOUS(hadc->Init.NbrOfDiscConversion);
+  }
+  else
+  {
+    /* Disable the selected ADC regular discontinuous mode */
+    hadc->Instance->CR1 &= ~(ADC_CR1_DISCEN);
+  }
+
+  /* Set ADC number of conversion */
+  hadc->Instance->SQR1 &= ~(ADC_SQR1_L);
+  hadc->Instance->SQR1 |=  ADC_SQR1(hadc->Init.NbrOfConversion);
+
+  /* Enable or disable ADC DMA continuous request */
+  hadc->Instance->CR2 &= ~(ADC_CR2_DDS);
+  hadc->Instance->CR2 |= ADC_CR2_DMAContReq(hadc->Init.DMAContinuousRequests);
+
+  /* Enable or disable ADC end of conversion selection */
+  hadc->Instance->CR2 &= ~(ADC_CR2_EOCS);
+  hadc->Instance->CR2 |= ADC_CR2_EOCSelection(hadc->Init.EOCSelection);
+}
+
+/**
+  * @brief  DMA transfer complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma)
+{
+  ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Check if an injected conversion is ready */
+  if(hadc->State == HAL_ADC_STATE_EOC_INJ)
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_EOC_INJ_REG;
+  }
+  else
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_EOC_REG;
+  }
+
+  HAL_ADC_ConvCpltCallback(hadc);
+}
+
+/**
+  * @brief  DMA half transfer complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma)
+{
+  ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  /* Conversion complete callback */
+  HAL_ADC_ConvHalfCpltCallback(hadc);
+}
+
+/**
+  * @brief  DMA error callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void ADC_DMAError(DMA_HandleTypeDef *hdma)
+{
+  ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  hadc->State= HAL_ADC_STATE_ERROR;
+  /* Set ADC error code to DMA error */
+  hadc->ErrorCode |= HAL_ADC_ERROR_DMA;
+  HAL_ADC_ErrorCallback(hadc);
+}
+
+
+/**
+  * @}
+  */
+
+#endif /* HAL_ADC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_adc_ex.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_adc_ex.c
@@ -1,0 +1,854 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_adc_ex.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   This file provides firmware functions to manage the following
+  *          functionalities of the ADC extension peripheral:
+  *           + Extended features functions
+  *
+  @verbatim
+  ==============================================================================
+                    ##### How to use this driver #####
+  ==============================================================================
+    [..]
+    (#)Initialize the ADC low level resources by implementing the HAL_ADC_MspInit():
+       (##) Enable the ADC interface clock using __HAL_RCC_ADC_CLK_ENABLE()
+       (##) ADC pins configuration
+             (+++) Enable the clock for the ADC GPIOs using the following function:
+                   __HAL_RCC_GPIOx_CLK_ENABLE()
+             (+++) Configure these ADC pins in analog mode using HAL_GPIO_Init()
+       (##) In case of using interrupts (e.g. HAL_ADC_Start_IT())
+             (+++) Configure the ADC interrupt priority using HAL_NVIC_SetPriority()
+             (+++) Enable the ADC IRQ handler using HAL_NVIC_EnableIRQ()
+             (+++) In ADC IRQ handler, call HAL_ADC_IRQHandler()
+      (##) In case of using DMA to control data transfer (e.g. HAL_ADC_Start_DMA())
+             (+++) Enable the DMAx interface clock using __HAL_RCC_DMAx_CLK_ENABLE()
+             (+++) Configure and enable two DMA streams stream for managing data
+                 transfer from peripheral to memory (output stream)
+             (+++) Associate the initialized DMA handle to the ADC DMA handle
+                 using  __HAL_LINKDMA()
+             (+++) Configure the priority and enable the NVIC for the transfer complete
+                 interrupt on the two DMA Streams. The output stream should have higher
+                 priority than the input stream.
+     (#) Configure the ADC Prescaler, conversion resolution and data alignment
+         using the HAL_ADC_Init() function.
+
+     (#) Configure the ADC Injected channels group features, use HAL_ADC_Init()
+         and HAL_ADC_ConfigChannel() functions.
+
+     (#) Three operation modes are available within this driver :
+
+     *** Polling mode IO operation ***
+     =================================
+     [..]
+       (+) Start the ADC peripheral using HAL_ADCEx_InjectedStart()
+       (+) Wait for end of conversion using HAL_ADC_PollForConversion(), at this stage
+           user can specify the value of timeout according to his end application
+       (+) To read the ADC converted values, use the HAL_ADCEx_InjectedGetValue() function.
+       (+) Stop the ADC peripheral using HAL_ADCEx_InjectedStop()
+
+     *** Interrupt mode IO operation ***
+     ===================================
+     [..]
+       (+) Start the ADC peripheral using HAL_ADCEx_InjectedStart_IT()
+       (+) Use HAL_ADC_IRQHandler() called under ADC_IRQHandler() Interrupt subroutine
+       (+) At ADC end of conversion HAL_ADCEx_InjectedConvCpltCallback() function is executed and user can
+            add his own code by customization of function pointer HAL_ADCEx_InjectedConvCpltCallback
+       (+) In case of ADC Error, HAL_ADCEx_InjectedErrorCallback() function is executed and user can
+            add his own code by customization of function pointer HAL_ADCEx_InjectedErrorCallback
+       (+) Stop the ADC peripheral using HAL_ADCEx_InjectedStop_IT()
+
+
+     *** DMA mode IO operation ***
+     ==============================
+     [..]
+       (+) Start the ADC peripheral using HAL_ADCEx_InjectedStart_DMA(), at this stage the user specify the length
+           of data to be transferred at each end of conversion
+       (+) At The end of data transfer ba HAL_ADCEx_InjectedConvCpltCallback() function is executed and user can
+            add his own code by customization of function pointer HAL_ADCEx_InjectedConvCpltCallback
+       (+) In case of transfer Error, HAL_ADCEx_InjectedErrorCallback() function is executed and user can
+            add his own code by customization of function pointer HAL_ADCEx_InjectedErrorCallback
+        (+) Stop the ADC peripheral using HAL_ADCEx_InjectedStop_DMA()
+
+     *** Multi mode ADCs Regular channels configuration ***
+     ======================================================
+     [..]
+       (+) Select the Multi mode ADC regular channels features (dual or triple mode)
+          and configure the DMA mode using HAL_ADCEx_MultiModeConfigChannel() functions.
+       (+) Start the ADC peripheral using HAL_ADCEx_MultiModeStart_DMA(), at this stage the user specify the length
+           of data to be transferred at each end of conversion
+       (+) Read the ADCs converted values using the HAL_ADCEx_MultiModeGetValue() function.
+
+
+    @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup ADCEx ADCEx
+  * @brief ADC Extended driver modules
+  * @{
+  */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @addtogroup ADCEx_Private_Functions
+  * @{
+  */
+static void ADC_MultiModeDMAConvCplt(DMA_HandleTypeDef *hdma);
+static void ADC_MultiModeDMAError(DMA_HandleTypeDef *hdma);
+static void ADC_MultiModeDMAHalfConvCplt(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+
+/* Exported functions ---------------------------------------------------------*/
+/** @defgroup ADCEx_Exported_Functions ADC Exported Functions
+  * @{
+  */
+
+/** @defgroup ADCEx_Exported_Functions_Group1  Extended features functions
+ *  @brief    Extended features functions
+ *
+@verbatim
+ ===============================================================================
+                 ##### Extended features functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Start conversion of injected channel.
+      (+) Stop conversion of injected channel.
+      (+) Start multimode and enable DMA transfer.
+      (+) Stop multimode and disable DMA transfer.
+      (+) Get result of injected channel conversion.
+      (+) Get result of multimode conversion.
+      (+) Configure injected channels.
+      (+) Configure multimode.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enables the selected ADC software start conversion of the injected channels.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStart(ADC_HandleTypeDef* hadc)
+{
+  __IO uint32_t counter = 0;
+  uint32_t tmp1 = 0, tmp2 = 0;
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Check if a regular conversion is ongoing */
+  if(hadc->State == HAL_ADC_STATE_BUSY_REG)
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_BUSY_INJ_REG;
+  }
+  else
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_BUSY_INJ;
+  }
+
+  /* Check if ADC peripheral is disabled in order to enable it and wait during
+     Tstab time the ADC's stabilization */
+  if((hadc->Instance->CR2 & ADC_CR2_ADON) != ADC_CR2_ADON)
+  {
+    /* Enable the Peripheral */
+    __HAL_ADC_ENABLE(hadc);
+
+    /* Delay for temperature sensor stabilization time */
+    /* Compute number of CPU cycles to wait for */
+    counter = (ADC_STAB_DELAY_US * (SystemCoreClock / 1000000));
+    while(counter != 0)
+    {
+      counter--;
+    }
+  }
+
+  /* Check if Multimode enabled */
+  if(HAL_IS_BIT_CLR(ADC->CCR, ADC_CCR_MULTI))
+  {
+    tmp1 = HAL_IS_BIT_CLR(hadc->Instance->CR2, ADC_CR2_JEXTEN);
+    tmp2 = HAL_IS_BIT_CLR(hadc->Instance->CR1, ADC_CR1_JAUTO);
+    if(tmp1 && tmp2)
+    {
+      /* Enable the selected ADC software conversion for injected group */
+      hadc->Instance->CR2 |= ADC_CR2_JSWSTART;
+    }
+  }
+  else
+  {
+    tmp1 = HAL_IS_BIT_CLR(hadc->Instance->CR2, ADC_CR2_JEXTEN);
+    tmp2 = HAL_IS_BIT_CLR(hadc->Instance->CR1, ADC_CR1_JAUTO);
+    if((hadc->Instance == ADC1) && tmp1 && tmp2)
+    {
+      /* Enable the selected ADC software conversion for injected group */
+      hadc->Instance->CR2 |= ADC_CR2_JSWSTART;
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables the interrupt and starts ADC conversion of injected channels.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  *
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStart_IT(ADC_HandleTypeDef* hadc)
+{
+  __IO uint32_t counter = 0;
+  uint32_t tmp1 = 0, tmp2 =0;
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Check if a regular conversion is ongoing */
+  if(hadc->State == HAL_ADC_STATE_BUSY_REG)
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_BUSY_INJ_REG;
+  }
+  else
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_BUSY_INJ;
+  }
+
+  /* Set ADC error code to none */
+  hadc->ErrorCode = HAL_ADC_ERROR_NONE;
+
+  /* Check if ADC peripheral is disabled in order to enable it and wait during
+     Tstab time the ADC's stabilization */
+  if((hadc->Instance->CR2 & ADC_CR2_ADON) != ADC_CR2_ADON)
+  {
+    /* Enable the Peripheral */
+    __HAL_ADC_ENABLE(hadc);
+
+    /* Delay for temperature sensor stabilization time */
+    /* Compute number of CPU cycles to wait for */
+    counter = (ADC_STAB_DELAY_US * (SystemCoreClock / 1000000));
+    while(counter != 0)
+    {
+      counter--;
+    }
+  }
+
+  /* Enable the ADC end of conversion interrupt for injected group */
+  __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOC);
+
+  /* Enable the ADC overrun interrupt */
+  __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
+
+  /* Check if Multimode enabled */
+  if(HAL_IS_BIT_CLR(ADC->CCR, ADC_CCR_MULTI))
+  {
+    tmp1 = HAL_IS_BIT_CLR(hadc->Instance->CR2, ADC_CR2_JEXTEN);
+    tmp2 = HAL_IS_BIT_CLR(hadc->Instance->CR1, ADC_CR1_JAUTO);
+    if(tmp1 && tmp2)
+    {
+      /* Enable the selected ADC software conversion for injected group */
+      hadc->Instance->CR2 |= ADC_CR2_JSWSTART;
+    }
+  }
+  else
+  {
+    tmp1 = HAL_IS_BIT_CLR(hadc->Instance->CR2, ADC_CR2_JEXTEN);
+    tmp2 = HAL_IS_BIT_CLR(hadc->Instance->CR1, ADC_CR1_JAUTO);
+    if((hadc->Instance == ADC1) && tmp1 && tmp2)
+    {
+      /* Enable the selected ADC software conversion for injected group */
+      hadc->Instance->CR2 |= ADC_CR2_JSWSTART;
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables ADC and stop conversion of injected channels.
+  *
+  * @note   Caution: This function will stop also regular channels.
+  *
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStop(ADC_HandleTypeDef* hadc)
+{
+  /* Disable the Peripheral */
+  __HAL_ADC_DISABLE(hadc);
+
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Poll for injected conversion complete
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  Timeout: Timeout value in millisecond.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedPollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Check End of conversion flag */
+  while(!(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOC)))
+  {
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hadc->State= HAL_ADC_STATE_TIMEOUT;
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Check if a regular conversion is ready */
+  if(hadc->State == HAL_ADC_STATE_EOC_REG)
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_EOC_INJ_REG;
+  }
+  else
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_EOC_INJ;
+  }
+
+  /* Return ADC state */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables the interrupt and stop ADC conversion of injected channels.
+  *
+  * @note   Caution: This function will stop also regular channels.
+  *
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStop_IT(ADC_HandleTypeDef* hadc)
+{
+  /* Disable the ADC end of conversion interrupt for regular group */
+  __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC);
+
+  /* Disable the ADC end of conversion interrupt for injected group */
+  __HAL_ADC_DISABLE_IT(hadc, ADC_CR1_JEOCIE);
+
+  /* Enable the Peripheral */
+  __HAL_ADC_DISABLE(hadc);
+
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Gets the converted value from data register of injected channel.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  InjectedRank: the ADC injected rank.
+  *          This parameter can be one of the following values:
+  *            @arg ADC_INJECTED_RANK_1: Injected Channel1 selected
+  *            @arg ADC_INJECTED_RANK_2: Injected Channel2 selected
+  *            @arg ADC_INJECTED_RANK_3: Injected Channel3 selected
+  *            @arg ADC_INJECTED_RANK_4: Injected Channel4 selected
+  * @retval None
+  */
+uint32_t HAL_ADCEx_InjectedGetValue(ADC_HandleTypeDef* hadc, uint32_t InjectedRank)
+{
+  __IO uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_INJECTED_RANK(InjectedRank));
+
+   /* Clear the ADCx's flag for injected end of conversion */
+   __HAL_ADC_CLEAR_FLAG(hadc,ADC_FLAG_JEOC);
+
+  /* Return the selected ADC converted value */
+  switch(InjectedRank)
+  {
+    case ADC_INJECTED_RANK_4:
+    {
+      tmp =  hadc->Instance->JDR4;
+    }
+    break;
+    case ADC_INJECTED_RANK_3:
+    {
+      tmp =  hadc->Instance->JDR3;
+    }
+    break;
+    case ADC_INJECTED_RANK_2:
+    {
+      tmp =  hadc->Instance->JDR2;
+    }
+    break;
+    case ADC_INJECTED_RANK_1:
+    {
+      tmp =  hadc->Instance->JDR1;
+    }
+    break;
+    default:
+    break;
+  }
+  return tmp;
+}
+
+/**
+  * @brief  Enables ADC DMA request after last transfer (Multi-ADC mode) and enables ADC peripheral
+  *
+  * @note   Caution: This function must be used only with the ADC master.
+  *
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  pData:   Pointer to buffer in which transferred from ADC peripheral to memory will be stored.
+  * @param  Length:  The length of data to be transferred from ADC peripheral to memory.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_MultiModeStart_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length)
+{
+  __IO uint32_t counter = 0;
+
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EXT_TRIG_EDGE(hadc->Init.ExternalTrigConvEdge));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DMAContinuousRequests));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Enable ADC overrun interrupt */
+  __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
+
+  if (hadc->Init.DMAContinuousRequests != DISABLE)
+  {
+    /* Enable the selected ADC DMA request after last transfer */
+    ADC->CCR |= ADC_CCR_DDS;
+  }
+  else
+  {
+    /* Disable the selected ADC EOC rising on each regular channel conversion */
+    ADC->CCR &= ~ADC_CCR_DDS;
+  }
+
+  /* Set the DMA transfer complete callback */
+  hadc->DMA_Handle->XferCpltCallback = ADC_MultiModeDMAConvCplt;
+
+  /* Set the DMA half transfer complete callback */
+  hadc->DMA_Handle->XferHalfCpltCallback = ADC_MultiModeDMAHalfConvCplt;
+
+  /* Set the DMA error callback */
+  hadc->DMA_Handle->XferErrorCallback = ADC_MultiModeDMAError ;
+
+  /* Enable the DMA Stream */
+  HAL_DMA_Start_IT(hadc->DMA_Handle, (uint32_t)&ADC->CDR, (uint32_t)pData, Length);
+
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_BUSY_REG;
+
+  /* Check if ADC peripheral is disabled in order to enable it and wait during
+     Tstab time the ADC's stabilization */
+  if((hadc->Instance->CR2 & ADC_CR2_ADON) != ADC_CR2_ADON)
+  {
+    /* Enable the Peripheral */
+    __HAL_ADC_ENABLE(hadc);
+
+    /* Delay for temperature sensor stabilization time */
+    /* Compute number of CPU cycles to wait for */
+    counter = (ADC_STAB_DELAY_US * (SystemCoreClock / 1000000));
+    while(counter != 0)
+    {
+      counter--;
+    }
+  }
+
+  /* if no external trigger present enable software conversion of regular channels */
+  if((hadc->Instance->CR2 & ADC_CR2_EXTEN) == RESET)
+  {
+    /* Enable the selected ADC software conversion for regular group */
+    hadc->Instance->CR2 |= (uint32_t)ADC_CR2_SWSTART;
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables ADC DMA (multi-ADC mode) and disables ADC peripheral
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_MultiModeStop_DMA(ADC_HandleTypeDef* hadc)
+{
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Enable the Peripheral */
+  __HAL_ADC_DISABLE(hadc);
+
+  /* Disable ADC overrun interrupt */
+  __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+
+  /* Disable the selected ADC DMA request after last transfer */
+  ADC->CCR &= ~ADC_CCR_DDS;
+
+  /* Disable the ADC DMA Stream */
+  HAL_DMA_Abort(hadc->DMA_Handle);
+
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Returns the last ADC1, ADC2 and ADC3 regular conversions results
+  *         data in the selected multi mode.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval The converted data value.
+  */
+uint32_t HAL_ADCEx_MultiModeGetValue(ADC_HandleTypeDef* hadc)
+{
+  /* Return the multi mode conversion value */
+  return ADC->CDR;
+}
+
+/**
+  * @brief  Injected conversion complete callback in non blocking mode
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+__weak void HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef* hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_InjectedConvCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Configures for the selected ADC injected channel its corresponding
+  *         rank in the sequencer and its sample time.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  sConfigInjected: ADC configuration structure for injected channel.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef* hadc, ADC_InjectionConfTypeDef* sConfigInjected)
+{
+
+#ifdef USE_FULL_ASSERT
+  uint32_t tmp = 0;
+#endif /* USE_FULL_ASSERT  */
+
+  /* Check the parameters */
+  assert_param(IS_ADC_CHANNEL(sConfigInjected->InjectedChannel));
+  assert_param(IS_ADC_INJECTED_RANK(sConfigInjected->InjectedRank));
+  assert_param(IS_ADC_SAMPLE_TIME(sConfigInjected->InjectedSamplingTime));
+  assert_param(IS_ADC_EXT_INJEC_TRIG(sConfigInjected->ExternalTrigInjecConv));
+  assert_param(IS_ADC_EXT_INJEC_TRIG_EDGE(sConfigInjected->ExternalTrigInjecConvEdge));
+  assert_param(IS_ADC_INJECTED_LENGTH(sConfigInjected->InjectedNbrOfConversion));
+  assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->AutoInjectedConv));
+  assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->InjectedDiscontinuousConvMode));
+
+#ifdef USE_FULL_ASSERT
+  tmp = ADC_GET_RESOLUTION(hadc);
+  assert_param(IS_ADC_RANGE(tmp, sConfigInjected->InjectedOffset));
+#endif /* USE_FULL_ASSERT  */
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* if ADC_Channel_10 ... ADC_Channel_18 is selected */
+  if (sConfigInjected->InjectedChannel > ADC_CHANNEL_9)
+  {
+    /* Clear the old sample time */
+    hadc->Instance->SMPR1 &= ~ADC_SMPR1(ADC_SMPR1_SMP10, sConfigInjected->InjectedChannel);
+
+    /* Set the new sample time */
+    hadc->Instance->SMPR1 |= ADC_SMPR1(sConfigInjected->InjectedSamplingTime, sConfigInjected->InjectedChannel);
+  }
+  else /* ADC_Channel include in ADC_Channel_[0..9] */
+  {
+    /* Clear the old sample time */
+    hadc->Instance->SMPR2 &= ~ADC_SMPR2(ADC_SMPR2_SMP0, sConfigInjected->InjectedChannel);
+
+    /* Set the new sample time */
+    hadc->Instance->SMPR2 |= ADC_SMPR2(sConfigInjected->InjectedSamplingTime, sConfigInjected->InjectedChannel);
+  }
+
+  /*---------------------------- ADCx JSQR Configuration -----------------*/
+  hadc->Instance->JSQR &= ~(ADC_JSQR_JL);
+  hadc->Instance->JSQR |=  ADC_SQR1(sConfigInjected->InjectedNbrOfConversion);
+
+  /* Rank configuration */
+
+  /* Clear the old SQx bits for the selected rank */
+  hadc->Instance->JSQR &= ~ADC_JSQR(ADC_JSQR_JSQ1, sConfigInjected->InjectedRank,sConfigInjected->InjectedNbrOfConversion);
+
+  /* Set the SQx bits for the selected rank */
+  hadc->Instance->JSQR |= ADC_JSQR(sConfigInjected->InjectedChannel, sConfigInjected->InjectedRank,sConfigInjected->InjectedNbrOfConversion);
+
+  /* Select external trigger to start conversion */
+  hadc->Instance->CR2 &= ~(ADC_CR2_JEXTSEL);
+  hadc->Instance->CR2 |=  sConfigInjected->ExternalTrigInjecConv;
+
+  /* Select external trigger polarity */
+  hadc->Instance->CR2 &= ~(ADC_CR2_JEXTEN);
+  hadc->Instance->CR2 |= sConfigInjected->ExternalTrigInjecConvEdge;
+
+  if (sConfigInjected->AutoInjectedConv != DISABLE)
+  {
+    /* Enable the selected ADC automatic injected group conversion */
+    hadc->Instance->CR1 |= ADC_CR1_JAUTO;
+  }
+  else
+  {
+    /* Disable the selected ADC automatic injected group conversion */
+    hadc->Instance->CR1 &= ~(ADC_CR1_JAUTO);
+  }
+
+  if (sConfigInjected->InjectedDiscontinuousConvMode != DISABLE)
+  {
+    /* Enable the selected ADC injected discontinuous mode */
+    hadc->Instance->CR1 |= ADC_CR1_JDISCEN;
+  }
+  else
+  {
+    /* Disable the selected ADC injected discontinuous mode */
+    hadc->Instance->CR1 &= ~(ADC_CR1_JDISCEN);
+  }
+
+  switch(sConfigInjected->InjectedRank)
+  {
+    case 1:
+      /* Set injected channel 1 offset */
+      hadc->Instance->JOFR1 &= ~(ADC_JOFR1_JOFFSET1);
+      hadc->Instance->JOFR1 |= sConfigInjected->InjectedOffset;
+      break;
+    case 2:
+      /* Set injected channel 2 offset */
+      hadc->Instance->JOFR2 &= ~(ADC_JOFR2_JOFFSET2);
+      hadc->Instance->JOFR2 |= sConfigInjected->InjectedOffset;
+      break;
+    case 3:
+      /* Set injected channel 3 offset */
+      hadc->Instance->JOFR3 &= ~(ADC_JOFR3_JOFFSET3);
+      hadc->Instance->JOFR3 |= sConfigInjected->InjectedOffset;
+      break;
+    default:
+      /* Set injected channel 4 offset */
+      hadc->Instance->JOFR4 &= ~(ADC_JOFR4_JOFFSET4);
+      hadc->Instance->JOFR4 |= sConfigInjected->InjectedOffset;
+      break;
+  }
+
+  /* if ADC1 Channel_18 is selected enable VBAT Channel */
+  if ((hadc->Instance == ADC1) && (sConfigInjected->InjectedChannel == ADC_CHANNEL_VBAT))
+  {
+    /* Enable the VBAT channel*/
+    ADC->CCR |= ADC_CCR_VBATE;
+  }
+
+  /* if ADC1 Channel_16 or Channel_17 is selected enable TSVREFE Channel(Temperature sensor and VREFINT) */
+  if ((hadc->Instance == ADC1) && ((sConfigInjected->InjectedChannel == ADC_CHANNEL_TEMPSENSOR) || (sConfigInjected->InjectedChannel == ADC_CHANNEL_VREFINT)))
+  {
+    /* Enable the TSVREFE channel*/
+    ADC->CCR |= ADC_CCR_TSVREFE;
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the ADC multi-mode
+  * @param  hadc      : pointer to a ADC_HandleTypeDef structure that contains
+  *                     the configuration information for the specified ADC.
+  * @param  multimode : pointer to an ADC_MultiModeTypeDef structure that contains
+  *                     the configuration information for  multimode.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_MultiModeConfigChannel(ADC_HandleTypeDef* hadc, ADC_MultiModeTypeDef* multimode)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_MODE(multimode->Mode));
+  assert_param(IS_ADC_DMA_ACCESS_MODE(multimode->DMAAccessMode));
+  assert_param(IS_ADC_SAMPLING_DELAY(multimode->TwoSamplingDelay));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Set ADC mode */
+  ADC->CCR &= ~(ADC_CCR_MULTI);
+  ADC->CCR |= multimode->Mode;
+
+  /* Set the ADC DMA access mode */
+  ADC->CCR &= ~(ADC_CCR_DMA);
+  ADC->CCR |= multimode->DMAAccessMode;
+
+  /* Set delay between two sampling phases */
+  ADC->CCR &= ~(ADC_CCR_DELAY);
+  ADC->CCR |= multimode->TwoSamplingDelay;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+  /**
+  * @brief  DMA transfer complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void ADC_MultiModeDMAConvCplt(DMA_HandleTypeDef *hdma)
+{
+    ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Check if an injected conversion is ready */
+  if(hadc->State == HAL_ADC_STATE_EOC_INJ)
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_EOC_INJ_REG;
+  }
+  else
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_EOC_REG;
+  }
+
+    HAL_ADC_ConvCpltCallback(hadc);
+}
+
+/**
+  * @brief  DMA half transfer complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void ADC_MultiModeDMAHalfConvCplt(DMA_HandleTypeDef *hdma)
+{
+    ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+    /* Conversion complete callback */
+    HAL_ADC_ConvHalfCpltCallback(hadc);
+}
+
+/**
+  * @brief  DMA error callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void ADC_MultiModeDMAError(DMA_HandleTypeDef *hdma)
+{
+    ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+    hadc->State= HAL_ADC_STATE_ERROR;
+    /* Set ADC error code to DMA error */
+    hadc->ErrorCode |= HAL_ADC_ERROR_DMA;
+    HAL_ADC_ErrorCallback(hadc);
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_ADC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_can.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_can.c
@@ -1,0 +1,1435 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_can.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   CAN HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Controller Area Network (CAN) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State and Error functions
+  *
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      (#) Enable the CAN controller interface clock using
+          __HAL_RCC_CAN1_CLK_ENABLE() for CAN1 and __HAL_RCC_CAN2_CLK_ENABLE() for CAN2
+      -@- In case you are using CAN2 only, you have to enable the CAN1 clock.
+
+      (#) CAN pins configuration
+        (++) Enable the clock for the CAN GPIOs using the following function:
+             __HAL_RCC_GPIOx_CLK_ENABLE()
+        (++) Connect and configure the involved CAN pins to AF9 using the
+              following function HAL_GPIO_Init()
+
+      (#) Initialize and configure the CAN using HAL_CAN_Init() function.
+
+      (#) Transmit the desired CAN frame using HAL_CAN_Transmit() function.
+
+      (#) Receive a CAN frame using HAL_CAN_Receive() function.
+
+     *** Polling mode IO operation ***
+     =================================
+     [..]
+       (+) Start the CAN peripheral transmission and wait the end of this operation
+           using HAL_CAN_Transmit(), at this stage user can specify the value of timeout
+           according to his end application
+       (+) Start the CAN peripheral reception and wait the end of this operation
+           using HAL_CAN_Receive(), at this stage user can specify the value of timeout
+           according to his end application
+
+     *** Interrupt mode IO operation ***
+     ===================================
+     [..]
+       (+) Start the CAN peripheral transmission using HAL_CAN_Transmit_IT()
+       (+) Start the CAN peripheral reception using HAL_CAN_Receive_IT()
+       (+) Use HAL_CAN_IRQHandler() called under the used CAN Interrupt subroutine
+       (+) At CAN end of transmission HAL_CAN_TxCpltCallback() function is executed and user can
+            add his own code by customization of function pointer HAL_CAN_TxCpltCallback
+       (+) In case of CAN Error, HAL_CAN_ErrorCallback() function is executed and user can
+            add his own code by customization of function pointer HAL_CAN_ErrorCallback
+
+     *** CAN HAL driver macros list ***
+     =============================================
+     [..]
+       Below the list of most used macros in CAN HAL driver.
+
+      (+) __HAL_CAN_ENABLE_IT: Enable the specified CAN interrupts
+      (+) __HAL_CAN_DISABLE_IT: Disable the specified CAN interrupts
+      (+) __HAL_CAN_GET_IT_SOURCE: Check if the specified CAN interrupt source is enabled or disabled
+      (+) __HAL_CAN_CLEAR_FLAG: Clear the CAN's pending flags
+      (+) __HAL_CAN_GET_FLAG: Get the selected CAN's flag status
+
+     [..]
+      (@) You can refer to the CAN HAL driver header file for more useful macros
+
+  @endverbatim
+
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup CAN CAN
+  * @brief CAN driver modules
+  * @{
+  */
+
+#ifdef HAL_CAN_MODULE_ENABLED
+
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @addtogroup CAN_Private_Constants
+  * @{
+  */
+#define CAN_TIMEOUT_VALUE  10
+/**
+  * @}
+  */
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @addtogroup CAN_Private_Functions
+  * @{
+  */
+static HAL_StatusTypeDef CAN_Receive_IT(CAN_HandleTypeDef* hcan, uint8_t FIFONumber);
+static HAL_StatusTypeDef CAN_Transmit_IT(CAN_HandleTypeDef* hcan);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup CAN_Exported_Functions CAN Exported Functions
+  * @{
+  */
+
+/** @defgroup CAN_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+  ==============================================================================
+              ##### Initialization and de-initialization functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the CAN.
+      (+) De-initialize the CAN.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the CAN peripheral according to the specified
+  *         parameters in the CAN_InitStruct.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CAN_Init(CAN_HandleTypeDef* hcan)
+{
+  uint32_t InitStatus = 3;
+  uint32_t tickstart = 0;
+
+  /* Check CAN handle */
+  if(hcan == NULL)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_CAN_ALL_INSTANCE(hcan->Instance));
+  assert_param(IS_FUNCTIONAL_STATE(hcan->Init.TTCM));
+  assert_param(IS_FUNCTIONAL_STATE(hcan->Init.ABOM));
+  assert_param(IS_FUNCTIONAL_STATE(hcan->Init.AWUM));
+  assert_param(IS_FUNCTIONAL_STATE(hcan->Init.NART));
+  assert_param(IS_FUNCTIONAL_STATE(hcan->Init.RFLM));
+  assert_param(IS_FUNCTIONAL_STATE(hcan->Init.TXFP));
+  assert_param(IS_CAN_MODE(hcan->Init.Mode));
+  assert_param(IS_CAN_SJW(hcan->Init.SJW));
+  assert_param(IS_CAN_BS1(hcan->Init.BS1));
+  assert_param(IS_CAN_BS2(hcan->Init.BS2));
+  assert_param(IS_CAN_PRESCALER(hcan->Init.Prescaler));
+
+
+  if(hcan->State == HAL_CAN_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hcan->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware */
+    HAL_CAN_MspInit(hcan);
+  }
+
+  /* Initialize the CAN state*/
+  hcan->State = HAL_CAN_STATE_BUSY;
+
+  /* Exit from sleep mode */
+  hcan->Instance->MCR &= (~(uint32_t)CAN_MCR_SLEEP);
+
+  /* Request initialisation */
+  hcan->Instance->MCR |= CAN_MCR_INRQ ;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait the acknowledge */
+  while((hcan->Instance->MSR & CAN_MSR_INAK) != CAN_MSR_INAK)
+  {
+    if((HAL_GetTick() - tickstart ) > CAN_TIMEOUT_VALUE)
+    {
+      hcan->State= HAL_CAN_STATE_TIMEOUT;
+      /* Process unlocked */
+      __HAL_UNLOCK(hcan);
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Check acknowledge */
+  if ((hcan->Instance->MSR & CAN_MSR_INAK) != CAN_MSR_INAK)
+  {
+    InitStatus = CAN_INITSTATUS_FAILED;
+  }
+  else
+  {
+    /* Set the time triggered communication mode */
+    if (hcan->Init.TTCM == ENABLE)
+    {
+      hcan->Instance->MCR |= CAN_MCR_TTCM;
+    }
+    else
+    {
+      hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_TTCM;
+    }
+
+    /* Set the automatic bus-off management */
+    if (hcan->Init.ABOM == ENABLE)
+    {
+      hcan->Instance->MCR |= CAN_MCR_ABOM;
+    }
+    else
+    {
+      hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_ABOM;
+    }
+
+    /* Set the automatic wake-up mode */
+    if (hcan->Init.AWUM == ENABLE)
+    {
+      hcan->Instance->MCR |= CAN_MCR_AWUM;
+    }
+    else
+    {
+      hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_AWUM;
+    }
+
+    /* Set the no automatic retransmission */
+    if (hcan->Init.NART == ENABLE)
+    {
+      hcan->Instance->MCR |= CAN_MCR_NART;
+    }
+    else
+    {
+      hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_NART;
+    }
+
+    /* Set the receive FIFO locked mode */
+    if (hcan->Init.RFLM == ENABLE)
+    {
+      hcan->Instance->MCR |= CAN_MCR_RFLM;
+    }
+    else
+    {
+      hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_RFLM;
+    }
+
+    /* Set the transmit FIFO priority */
+    if (hcan->Init.TXFP == ENABLE)
+    {
+      hcan->Instance->MCR |= CAN_MCR_TXFP;
+    }
+    else
+    {
+      hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_TXFP;
+    }
+
+    /* Set the bit timing register */
+    hcan->Instance->BTR = (uint32_t)((uint32_t)hcan->Init.Mode) | \
+                ((uint32_t)hcan->Init.SJW) | \
+                ((uint32_t)hcan->Init.BS1) | \
+                ((uint32_t)hcan->Init.BS2) | \
+               ((uint32_t)hcan->Init.Prescaler - 1);
+
+    /* Request leave initialisation */
+    hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_INRQ;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+   /* Wait the acknowledge */
+   while((hcan->Instance->MSR & CAN_MSR_INAK) == CAN_MSR_INAK)
+   {
+    if((HAL_GetTick() - tickstart ) > CAN_TIMEOUT_VALUE)
+     {
+       hcan->State= HAL_CAN_STATE_TIMEOUT;
+       /* Process unlocked */
+       __HAL_UNLOCK(hcan);
+       return HAL_TIMEOUT;
+     }
+   }
+
+    /* Check acknowledged */
+    if ((hcan->Instance->MSR & CAN_MSR_INAK) == CAN_MSR_INAK)
+    {
+      InitStatus = CAN_INITSTATUS_FAILED;
+    }
+    else
+    {
+      InitStatus = CAN_INITSTATUS_SUCCESS;
+    }
+  }
+
+  if(InitStatus == CAN_INITSTATUS_SUCCESS)
+  {
+    /* Set CAN error code to none */
+    hcan->ErrorCode = HAL_CAN_ERROR_NONE;
+
+    /* Initialize the CAN state */
+    hcan->State = HAL_CAN_STATE_READY;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Initialize the CAN state */
+    hcan->State = HAL_CAN_STATE_ERROR;
+
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Configures the CAN reception filter according to the specified
+  *         parameters in the CAN_FilterInitStruct.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @param  sFilterConfig: pointer to a CAN_FilterConfTypeDef structure that
+  *         contains the filter configuration information.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_CAN_ConfigFilter(CAN_HandleTypeDef* hcan, CAN_FilterConfTypeDef* sFilterConfig)
+{
+  uint32_t filternbrbitpos = 0;
+
+  /* Check the parameters */
+  assert_param(IS_CAN_FILTER_NUMBER(sFilterConfig->FilterNumber));
+  assert_param(IS_CAN_FILTER_MODE(sFilterConfig->FilterMode));
+  assert_param(IS_CAN_FILTER_SCALE(sFilterConfig->FilterScale));
+  assert_param(IS_CAN_FILTER_FIFO(sFilterConfig->FilterFIFOAssignment));
+  assert_param(IS_FUNCTIONAL_STATE(sFilterConfig->FilterActivation));
+  assert_param(IS_CAN_BANKNUMBER(sFilterConfig->BankNumber));
+
+  filternbrbitpos = ((uint32_t)1) << sFilterConfig->FilterNumber;
+
+  /* Initialisation mode for the filter */
+  CAN1->FMR |= (uint32_t)CAN_FMR_FINIT;
+
+  /* Select the start slave bank */
+  CAN1->FMR &= ~((uint32_t)CAN_FMR_CAN2SB);
+  CAN1->FMR |= (uint32_t)(sFilterConfig->BankNumber << 8);
+
+  /* Filter Deactivation */
+  CAN1->FA1R &= ~(uint32_t)filternbrbitpos;
+
+  /* Filter Scale */
+  if (sFilterConfig->FilterScale == CAN_FILTERSCALE_16BIT)
+  {
+    /* 16-bit scale for the filter */
+    CAN1->FS1R &= ~(uint32_t)filternbrbitpos;
+
+    /* First 16-bit identifier and First 16-bit mask */
+    /* Or First 16-bit identifier and Second 16-bit identifier */
+    CAN1->sFilterRegister[sFilterConfig->FilterNumber].FR1 =
+       ((0x0000FFFF & (uint32_t)sFilterConfig->FilterMaskIdLow) << 16) |
+        (0x0000FFFF & (uint32_t)sFilterConfig->FilterIdLow);
+
+    /* Second 16-bit identifier and Second 16-bit mask */
+    /* Or Third 16-bit identifier and Fourth 16-bit identifier */
+    CAN1->sFilterRegister[sFilterConfig->FilterNumber].FR2 =
+       ((0x0000FFFF & (uint32_t)sFilterConfig->FilterMaskIdHigh) << 16) |
+        (0x0000FFFF & (uint32_t)sFilterConfig->FilterIdHigh);
+  }
+
+  if (sFilterConfig->FilterScale == CAN_FILTERSCALE_32BIT)
+  {
+    /* 32-bit scale for the filter */
+    CAN1->FS1R |= filternbrbitpos;
+    /* 32-bit identifier or First 32-bit identifier */
+    CAN1->sFilterRegister[sFilterConfig->FilterNumber].FR1 =
+       ((0x0000FFFF & (uint32_t)sFilterConfig->FilterIdHigh) << 16) |
+        (0x0000FFFF & (uint32_t)sFilterConfig->FilterIdLow);
+    /* 32-bit mask or Second 32-bit identifier */
+    CAN1->sFilterRegister[sFilterConfig->FilterNumber].FR2 =
+       ((0x0000FFFF & (uint32_t)sFilterConfig->FilterMaskIdHigh) << 16) |
+        (0x0000FFFF & (uint32_t)sFilterConfig->FilterMaskIdLow);
+  }
+
+  /* Filter Mode */
+  if (sFilterConfig->FilterMode == CAN_FILTERMODE_IDMASK)
+  {
+    /*Id/Mask mode for the filter*/
+    CAN1->FM1R &= ~(uint32_t)filternbrbitpos;
+  }
+  else /* CAN_FilterInitStruct->CAN_FilterMode == CAN_FilterMode_IdList */
+  {
+    /*Identifier list mode for the filter*/
+    CAN1->FM1R |= (uint32_t)filternbrbitpos;
+  }
+
+  /* Filter FIFO assignment */
+  if (sFilterConfig->FilterFIFOAssignment == CAN_FILTER_FIFO0)
+  {
+    /* FIFO 0 assignation for the filter */
+    CAN1->FFA1R &= ~(uint32_t)filternbrbitpos;
+  }
+
+  if (sFilterConfig->FilterFIFOAssignment == CAN_FILTER_FIFO1)
+  {
+    /* FIFO 1 assignation for the filter */
+    CAN1->FFA1R |= (uint32_t)filternbrbitpos;
+  }
+
+  /* Filter activation */
+  if (sFilterConfig->FilterActivation == ENABLE)
+  {
+    CAN1->FA1R |= filternbrbitpos;
+  }
+
+  /* Leave the initialisation mode for the filter */
+  CAN1->FMR &= ~((uint32_t)CAN_FMR_FINIT);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deinitializes the CANx peripheral registers to their default reset values.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CAN_DeInit(CAN_HandleTypeDef* hcan)
+{
+  /* Check CAN handle */
+  if(hcan == NULL)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_CAN_ALL_INSTANCE(hcan->Instance));
+
+  /* Change CAN state */
+  hcan->State = HAL_CAN_STATE_BUSY;
+
+  /* DeInit the low level hardware */
+  HAL_CAN_MspDeInit(hcan);
+
+  /* Change CAN state */
+  hcan->State = HAL_CAN_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hcan);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CAN MSP.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval None
+  */
+__weak void HAL_CAN_MspInit(CAN_HandleTypeDef* hcan)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_CAN_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the CAN MSP.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval None
+  */
+__weak void HAL_CAN_MspDeInit(CAN_HandleTypeDef* hcan)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_CAN_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup CAN_Exported_Functions_Group2 IO operation functions
+ *  @brief    IO operation functions
+ *
+@verbatim
+  ==============================================================================
+                      ##### IO operation functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Transmit a CAN frame message.
+      (+) Receive a CAN frame message.
+      (+) Enter CAN peripheral in sleep mode.
+      (+) Wake up the CAN peripheral from sleep mode.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initiates and transmits a CAN frame message.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @param  Timeout: Specify Timeout value
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CAN_Transmit(CAN_HandleTypeDef* hcan, uint32_t Timeout)
+{
+  uint32_t  transmitmailbox = 5;
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_CAN_IDTYPE(hcan->pTxMsg->IDE));
+  assert_param(IS_CAN_RTR(hcan->pTxMsg->RTR));
+  assert_param(IS_CAN_DLC(hcan->pTxMsg->DLC));
+
+  /* Process locked */
+  __HAL_LOCK(hcan);
+
+  if(hcan->State == HAL_CAN_STATE_BUSY_RX)
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_TX_RX;
+  }
+  else
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_TX;
+  }
+
+  /* Select one empty transmit mailbox */
+  if ((hcan->Instance->TSR&CAN_TSR_TME0) == CAN_TSR_TME0)
+  {
+    transmitmailbox = 0;
+  }
+  else if ((hcan->Instance->TSR&CAN_TSR_TME1) == CAN_TSR_TME1)
+  {
+    transmitmailbox = 1;
+  }
+  else if ((hcan->Instance->TSR&CAN_TSR_TME2) == CAN_TSR_TME2)
+  {
+    transmitmailbox = 2;
+  }
+  else
+  {
+    transmitmailbox = CAN_TXSTATUS_NOMAILBOX;
+  }
+
+  if (transmitmailbox != CAN_TXSTATUS_NOMAILBOX)
+  {
+    /* Set up the Id */
+    hcan->Instance->sTxMailBox[transmitmailbox].TIR &= CAN_TI0R_TXRQ;
+    if (hcan->pTxMsg->IDE == CAN_ID_STD)
+    {
+      assert_param(IS_CAN_STDID(hcan->pTxMsg->StdId));
+      hcan->Instance->sTxMailBox[transmitmailbox].TIR |= ((hcan->pTxMsg->StdId << 21) | \
+                                                  hcan->pTxMsg->RTR);
+    }
+    else
+    {
+      assert_param(IS_CAN_EXTID(hcan->pTxMsg->ExtId));
+      hcan->Instance->sTxMailBox[transmitmailbox].TIR |= ((hcan->pTxMsg->ExtId << 3) | \
+                                                  hcan->pTxMsg->IDE | \
+                                                  hcan->pTxMsg->RTR);
+    }
+
+    /* Set up the DLC */
+    hcan->pTxMsg->DLC &= (uint8_t)0x0000000F;
+    hcan->Instance->sTxMailBox[transmitmailbox].TDTR &= (uint32_t)0xFFFFFFF0;
+    hcan->Instance->sTxMailBox[transmitmailbox].TDTR |= hcan->pTxMsg->DLC;
+
+    /* Set up the data field */
+    hcan->Instance->sTxMailBox[transmitmailbox].TDLR = (((uint32_t)hcan->pTxMsg->Data[3] << 24) |
+                                             ((uint32_t)hcan->pTxMsg->Data[2] << 16) |
+                                             ((uint32_t)hcan->pTxMsg->Data[1] << 8) |
+                                             ((uint32_t)hcan->pTxMsg->Data[0]));
+    hcan->Instance->sTxMailBox[transmitmailbox].TDHR = (((uint32_t)hcan->pTxMsg->Data[7] << 24) |
+                                             ((uint32_t)hcan->pTxMsg->Data[6] << 16) |
+                                             ((uint32_t)hcan->pTxMsg->Data[5] << 8) |
+                                             ((uint32_t)hcan->pTxMsg->Data[4]));
+    /* Request transmission */
+    hcan->Instance->sTxMailBox[transmitmailbox].TIR |= CAN_TI0R_TXRQ;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+    /* Check End of transmission flag */
+    while(!(__HAL_CAN_TRANSMIT_STATUS(hcan, transmitmailbox)))
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+       if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+       {
+         hcan->State = HAL_CAN_STATE_TIMEOUT;
+         /* Process unlocked */
+         __HAL_UNLOCK(hcan);
+         return HAL_TIMEOUT;
+        }
+      }
+    }
+    if(hcan->State == HAL_CAN_STATE_BUSY_TX_RX)
+    {
+      /* Change CAN state */
+      hcan->State = HAL_CAN_STATE_BUSY_RX;
+
+      /* Process unlocked */
+      __HAL_UNLOCK(hcan);
+    }
+    else
+    {
+      /* Change CAN state */
+      hcan->State = HAL_CAN_STATE_READY;
+
+      /* Process unlocked */
+      __HAL_UNLOCK(hcan);
+    }
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_ERROR;
+
+    /* Process unlocked */
+    __HAL_UNLOCK(hcan);
+
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Initiates and transmits a CAN frame message.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CAN_Transmit_IT(CAN_HandleTypeDef* hcan)
+{
+  uint32_t  transmitmailbox = 5;
+  uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_CAN_IDTYPE(hcan->pTxMsg->IDE));
+  assert_param(IS_CAN_RTR(hcan->pTxMsg->RTR));
+  assert_param(IS_CAN_DLC(hcan->pTxMsg->DLC));
+
+  tmp = hcan->State;
+  if((tmp == HAL_CAN_STATE_READY) || (tmp == HAL_CAN_STATE_BUSY_RX))
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcan);
+
+    /* Select one empty transmit mailbox */
+    if((hcan->Instance->TSR&CAN_TSR_TME0) == CAN_TSR_TME0)
+    {
+      transmitmailbox = 0;
+    }
+    else if((hcan->Instance->TSR&CAN_TSR_TME1) == CAN_TSR_TME1)
+    {
+      transmitmailbox = 1;
+    }
+    else if((hcan->Instance->TSR&CAN_TSR_TME2) == CAN_TSR_TME2)
+    {
+      transmitmailbox = 2;
+    }
+    else
+    {
+      transmitmailbox = CAN_TXSTATUS_NOMAILBOX;
+    }
+
+    if(transmitmailbox != CAN_TXSTATUS_NOMAILBOX)
+    {
+      /* Set up the Id */
+      hcan->Instance->sTxMailBox[transmitmailbox].TIR &= CAN_TI0R_TXRQ;
+      if(hcan->pTxMsg->IDE == CAN_ID_STD)
+      {
+        assert_param(IS_CAN_STDID(hcan->pTxMsg->StdId));
+        hcan->Instance->sTxMailBox[transmitmailbox].TIR |= ((hcan->pTxMsg->StdId << 21) | \
+                                                  hcan->pTxMsg->RTR);
+      }
+      else
+      {
+        assert_param(IS_CAN_EXTID(hcan->pTxMsg->ExtId));
+        hcan->Instance->sTxMailBox[transmitmailbox].TIR |= ((hcan->pTxMsg->ExtId << 3) | \
+                                                  hcan->pTxMsg->IDE | \
+                                                  hcan->pTxMsg->RTR);
+      }
+
+      /* Set up the DLC */
+      hcan->pTxMsg->DLC &= (uint8_t)0x0000000F;
+      hcan->Instance->sTxMailBox[transmitmailbox].TDTR &= (uint32_t)0xFFFFFFF0;
+      hcan->Instance->sTxMailBox[transmitmailbox].TDTR |= hcan->pTxMsg->DLC;
+
+      /* Set up the data field */
+      hcan->Instance->sTxMailBox[transmitmailbox].TDLR = (((uint32_t)hcan->pTxMsg->Data[3] << 24) |
+                                             ((uint32_t)hcan->pTxMsg->Data[2] << 16) |
+                                             ((uint32_t)hcan->pTxMsg->Data[1] << 8) |
+                                             ((uint32_t)hcan->pTxMsg->Data[0]));
+      hcan->Instance->sTxMailBox[transmitmailbox].TDHR = (((uint32_t)hcan->pTxMsg->Data[7] << 24) |
+                                             ((uint32_t)hcan->pTxMsg->Data[6] << 16) |
+                                             ((uint32_t)hcan->pTxMsg->Data[5] << 8) |
+                                             ((uint32_t)hcan->pTxMsg->Data[4]));
+
+      if(hcan->State == HAL_CAN_STATE_BUSY_RX)
+      {
+        /* Change CAN state */
+        hcan->State = HAL_CAN_STATE_BUSY_TX_RX;
+      }
+      else
+      {
+        /* Change CAN state */
+        hcan->State = HAL_CAN_STATE_BUSY_TX;
+      }
+
+      /* Set CAN error code to none */
+      hcan->ErrorCode = HAL_CAN_ERROR_NONE;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hcan);
+
+      /* Enable Error warning Interrupt */
+      __HAL_CAN_ENABLE_IT(hcan, CAN_IT_EWG);
+
+      /* Enable Error passive Interrupt */
+      __HAL_CAN_ENABLE_IT(hcan, CAN_IT_EPV);
+
+      /* Enable Bus-off Interrupt */
+      __HAL_CAN_ENABLE_IT(hcan, CAN_IT_BOF);
+
+      /* Enable Last error code Interrupt */
+      __HAL_CAN_ENABLE_IT(hcan, CAN_IT_LEC);
+
+      /* Enable Error Interrupt */
+      __HAL_CAN_ENABLE_IT(hcan, CAN_IT_ERR);
+
+      /* Enable Transmit mailbox empty Interrupt */
+      __HAL_CAN_ENABLE_IT(hcan, CAN_IT_TME);
+
+      /* Request transmission */
+      hcan->Instance->sTxMailBox[transmitmailbox].TIR |= CAN_TI0R_TXRQ;
+    }
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Receives a correct CAN frame.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @param  FIFONumber: FIFO Number value
+  * @param  Timeout: Specify Timeout value
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CAN_Receive(CAN_HandleTypeDef* hcan, uint8_t FIFONumber, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_CAN_FIFO(FIFONumber));
+
+  /* Process locked */
+  __HAL_LOCK(hcan);
+
+  if(hcan->State == HAL_CAN_STATE_BUSY_TX)
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_TX_RX;
+  }
+  else
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_RX;
+  }
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Check pending message */
+  while(__HAL_CAN_MSG_PENDING(hcan, FIFONumber) == 0)
+  {
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hcan->State = HAL_CAN_STATE_TIMEOUT;
+        /* Process unlocked */
+        __HAL_UNLOCK(hcan);
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Get the Id */
+  hcan->pRxMsg->IDE = (uint8_t)0x04 & hcan->Instance->sFIFOMailBox[FIFONumber].RIR;
+  if (hcan->pRxMsg->IDE == CAN_ID_STD)
+  {
+    hcan->pRxMsg->StdId = (uint32_t)0x000007FF & (hcan->Instance->sFIFOMailBox[FIFONumber].RIR >> 21);
+  }
+  else
+  {
+    hcan->pRxMsg->ExtId = (uint32_t)0x1FFFFFFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RIR >> 3);
+  }
+
+  hcan->pRxMsg->RTR = (uint8_t)0x02 & hcan->Instance->sFIFOMailBox[FIFONumber].RIR;
+  /* Get the DLC */
+  hcan->pRxMsg->DLC = (uint8_t)0x0F & hcan->Instance->sFIFOMailBox[FIFONumber].RDTR;
+  /* Get the FMI */
+  hcan->pRxMsg->FMI = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDTR >> 8);
+  /* Get the data field */
+  hcan->pRxMsg->Data[0] = (uint8_t)0xFF & hcan->Instance->sFIFOMailBox[FIFONumber].RDLR;
+  hcan->pRxMsg->Data[1] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDLR >> 8);
+  hcan->pRxMsg->Data[2] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDLR >> 16);
+  hcan->pRxMsg->Data[3] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDLR >> 24);
+  hcan->pRxMsg->Data[4] = (uint8_t)0xFF & hcan->Instance->sFIFOMailBox[FIFONumber].RDHR;
+  hcan->pRxMsg->Data[5] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDHR >> 8);
+  hcan->pRxMsg->Data[6] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDHR >> 16);
+  hcan->pRxMsg->Data[7] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDHR >> 24);
+
+  /* Release the FIFO */
+  if(FIFONumber == CAN_FIFO0)
+  {
+    /* Release FIFO0 */
+    __HAL_CAN_FIFO_RELEASE(hcan, CAN_FIFO0);
+  }
+  else /* FIFONumber == CAN_FIFO1 */
+  {
+    /* Release FIFO1 */
+    __HAL_CAN_FIFO_RELEASE(hcan, CAN_FIFO1);
+  }
+
+  if(hcan->State == HAL_CAN_STATE_BUSY_TX_RX)
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_TX;
+
+    /* Process unlocked */
+    __HAL_UNLOCK(hcan);
+  }
+  else
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_READY;
+
+    /* Process unlocked */
+    __HAL_UNLOCK(hcan);
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Receives a correct CAN frame.
+  * @param  hcan:       Pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @param  FIFONumber: Specify the FIFO number
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CAN_Receive_IT(CAN_HandleTypeDef* hcan, uint8_t FIFONumber)
+{
+  uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_CAN_FIFO(FIFONumber));
+
+  tmp = hcan->State;
+  if((tmp == HAL_CAN_STATE_READY) || (tmp == HAL_CAN_STATE_BUSY_TX))
+  {
+    /* Process locked */
+    __HAL_LOCK(hcan);
+
+    if(hcan->State == HAL_CAN_STATE_BUSY_TX)
+    {
+      /* Change CAN state */
+      hcan->State = HAL_CAN_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      /* Change CAN state */
+      hcan->State = HAL_CAN_STATE_BUSY_RX;
+    }
+
+    /* Set CAN error code to none */
+    hcan->ErrorCode = HAL_CAN_ERROR_NONE;
+
+    /* Enable Error warning Interrupt */
+    __HAL_CAN_ENABLE_IT(hcan, CAN_IT_EWG);
+
+    /* Enable Error passive Interrupt */
+    __HAL_CAN_ENABLE_IT(hcan, CAN_IT_EPV);
+
+    /* Enable Bus-off Interrupt */
+    __HAL_CAN_ENABLE_IT(hcan, CAN_IT_BOF);
+
+    /* Enable Last error code Interrupt */
+    __HAL_CAN_ENABLE_IT(hcan, CAN_IT_LEC);
+
+    /* Enable Error Interrupt */
+    __HAL_CAN_ENABLE_IT(hcan, CAN_IT_ERR);
+
+    /* Process unlocked */
+    __HAL_UNLOCK(hcan);
+
+    if(FIFONumber == CAN_FIFO0)
+    {
+      /* Enable FIFO 0 message pending Interrupt */
+      __HAL_CAN_ENABLE_IT(hcan, CAN_IT_FMP0);
+    }
+    else
+    {
+      /* Enable FIFO 1 message pending Interrupt */
+      __HAL_CAN_ENABLE_IT(hcan, CAN_IT_FMP1);
+    }
+
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enters the Sleep (low power) mode.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_CAN_Sleep(CAN_HandleTypeDef* hcan)
+{
+  uint32_t tickstart = 0;
+
+  /* Process locked */
+  __HAL_LOCK(hcan);
+
+  /* Change CAN state */
+  hcan->State = HAL_CAN_STATE_BUSY;
+
+  /* Request Sleep mode */
+   hcan->Instance->MCR = (((hcan->Instance->MCR) & (uint32_t)(~(uint32_t)CAN_MCR_INRQ)) | CAN_MCR_SLEEP);
+
+  /* Sleep mode status */
+  if ((hcan->Instance->MSR & (CAN_MSR_SLAK|CAN_MSR_INAK)) != CAN_MSR_SLAK)
+  {
+    /* Process unlocked */
+    __HAL_UNLOCK(hcan);
+
+    /* Return function status */
+    return HAL_ERROR;
+  }
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait the acknowledge */
+  while((hcan->Instance->MSR & (CAN_MSR_SLAK|CAN_MSR_INAK)) != CAN_MSR_SLAK)
+  {
+    if((HAL_GetTick()  - tickstart) > CAN_TIMEOUT_VALUE)
+    {
+      hcan->State = HAL_CAN_STATE_TIMEOUT;
+      /* Process unlocked */
+      __HAL_UNLOCK(hcan);
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Change CAN state */
+  hcan->State = HAL_CAN_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hcan);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Wakes up the CAN peripheral from sleep mode, after that the CAN peripheral
+  *         is in the normal mode.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_CAN_WakeUp(CAN_HandleTypeDef* hcan)
+{
+  uint32_t tickstart = 0;
+
+  /* Process locked */
+  __HAL_LOCK(hcan);
+
+  /* Change CAN state */
+  hcan->State = HAL_CAN_STATE_BUSY;
+
+  /* Wake up request */
+  hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_SLEEP;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Sleep mode status */
+  while((hcan->Instance->MSR & CAN_MSR_SLAK) == CAN_MSR_SLAK)
+  {
+    if((HAL_GetTick()  - tickstart) > CAN_TIMEOUT_VALUE)
+    {
+      hcan->State= HAL_CAN_STATE_TIMEOUT;
+      /* Process unlocked */
+      __HAL_UNLOCK(hcan);
+      return HAL_TIMEOUT;
+    }
+  }
+  if((hcan->Instance->MSR & CAN_MSR_SLAK) == CAN_MSR_SLAK)
+  {
+    /* Process unlocked */
+    __HAL_UNLOCK(hcan);
+
+    /* Return function status */
+    return HAL_ERROR;
+  }
+
+  /* Change CAN state */
+  hcan->State = HAL_CAN_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hcan);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles CAN interrupt request
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval None
+  */
+void HAL_CAN_IRQHandler(CAN_HandleTypeDef* hcan)
+{
+  uint32_t tmp1 = 0, tmp2 = 0, tmp3 = 0;
+
+  /* Check End of transmission flag */
+  if(__HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_TME))
+  {
+    tmp1 = __HAL_CAN_TRANSMIT_STATUS(hcan, CAN_TXMAILBOX_0);
+    tmp2 = __HAL_CAN_TRANSMIT_STATUS(hcan, CAN_TXMAILBOX_1);
+    tmp3 = __HAL_CAN_TRANSMIT_STATUS(hcan, CAN_TXMAILBOX_2);
+    if(tmp1 || tmp2 || tmp3)
+    {
+      /* Call transmit function */
+      CAN_Transmit_IT(hcan);
+    }
+  }
+
+  tmp1 = __HAL_CAN_MSG_PENDING(hcan, CAN_FIFO0);
+  tmp2 = __HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_FMP0);
+  /* Check End of reception flag for FIFO0 */
+  if((tmp1 != 0) && tmp2)
+  {
+    /* Call receive function */
+    CAN_Receive_IT(hcan, CAN_FIFO0);
+  }
+
+  tmp1 = __HAL_CAN_MSG_PENDING(hcan, CAN_FIFO1);
+  tmp2 = __HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_FMP1);
+  /* Check End of reception flag for FIFO1 */
+  if((tmp1 != 0) && tmp2)
+  {
+    /* Call receive function */
+    CAN_Receive_IT(hcan, CAN_FIFO1);
+  }
+
+  tmp1 = __HAL_CAN_GET_FLAG(hcan, CAN_FLAG_EWG);
+  tmp2 = __HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_EWG);
+  tmp3 = __HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_ERR);
+  /* Check Error Warning Flag */
+  if(tmp1 && tmp2 && tmp3)
+  {
+    /* Set CAN error code to EWG error */
+    hcan->ErrorCode |= HAL_CAN_ERROR_EWG;
+    /* Clear Error Warning Flag */
+    __HAL_CAN_CLEAR_FLAG(hcan, CAN_FLAG_EWG);
+  }
+
+  tmp1 = __HAL_CAN_GET_FLAG(hcan, CAN_FLAG_EPV);
+  tmp2 = __HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_EPV);
+  tmp3 = __HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_ERR);
+  /* Check Error Passive Flag */
+  if(tmp1 && tmp2 && tmp3)
+  {
+    /* Set CAN error code to EPV error */
+    hcan->ErrorCode |= HAL_CAN_ERROR_EPV;
+    /* Clear Error Passive Flag */
+    __HAL_CAN_CLEAR_FLAG(hcan, CAN_FLAG_EPV);
+  }
+
+  tmp1 = __HAL_CAN_GET_FLAG(hcan, CAN_FLAG_BOF);
+  tmp2 = __HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_BOF);
+  tmp3 = __HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_ERR);
+  /* Check Bus-Off Flag */
+  if(tmp1 && tmp2 && tmp3)
+  {
+    /* Set CAN error code to BOF error */
+    hcan->ErrorCode |= HAL_CAN_ERROR_BOF;
+    /* Clear Bus-Off Flag */
+    __HAL_CAN_CLEAR_FLAG(hcan, CAN_FLAG_BOF);
+  }
+
+  tmp1 = HAL_IS_BIT_CLR(hcan->Instance->ESR, CAN_ESR_LEC);
+  tmp2 = __HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_LEC);
+  tmp3 = __HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_ERR);
+  /* Check Last error code Flag */
+  if((!tmp1) && tmp2 && tmp3)
+  {
+    tmp1 = (hcan->Instance->ESR) & CAN_ESR_LEC;
+    switch(tmp1)
+    {
+      case(CAN_ESR_LEC_0):
+          /* Set CAN error code to STF error */
+          hcan->ErrorCode |= HAL_CAN_ERROR_STF;
+          break;
+      case(CAN_ESR_LEC_1):
+          /* Set CAN error code to FOR error */
+          hcan->ErrorCode |= HAL_CAN_ERROR_FOR;
+          break;
+      case(CAN_ESR_LEC_1 | CAN_ESR_LEC_0):
+          /* Set CAN error code to ACK error */
+          hcan->ErrorCode |= HAL_CAN_ERROR_ACK;
+          break;
+      case(CAN_ESR_LEC_2):
+          /* Set CAN error code to BR error */
+          hcan->ErrorCode |= HAL_CAN_ERROR_BR;
+          break;
+      case(CAN_ESR_LEC_2 | CAN_ESR_LEC_0):
+          /* Set CAN error code to BD error */
+          hcan->ErrorCode |= HAL_CAN_ERROR_BD;
+          break;
+      case(CAN_ESR_LEC_2 | CAN_ESR_LEC_1):
+          /* Set CAN error code to CRC error */
+          hcan->ErrorCode |= HAL_CAN_ERROR_CRC;
+          break;
+      default:
+          break;
+    }
+
+    /* Clear Last error code Flag */
+    hcan->Instance->ESR &= ~(CAN_ESR_LEC);
+  }
+
+  /* Call the Error call Back in case of Errors */
+  if(hcan->ErrorCode != HAL_CAN_ERROR_NONE)
+  {
+    /* Set the CAN state ready to be able to start again the process */
+    hcan->State = HAL_CAN_STATE_READY;
+    /* Call Error callback function */
+    HAL_CAN_ErrorCallback(hcan);
+  }
+}
+
+/**
+  * @brief  Transmission  complete callback in non blocking mode
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval None
+  */
+__weak void HAL_CAN_TxCpltCallback(CAN_HandleTypeDef* hcan)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_CAN_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Transmission  complete callback in non blocking mode
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval None
+  */
+__weak void HAL_CAN_RxCpltCallback(CAN_HandleTypeDef* hcan)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_CAN_RxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error CAN callback.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval None
+  */
+__weak void HAL_CAN_ErrorCallback(CAN_HandleTypeDef *hcan)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_CAN_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup CAN_Exported_Functions_Group3 Peripheral State and Error functions
+ *  @brief   CAN Peripheral State functions
+ *
+@verbatim
+  ==============================================================================
+            ##### Peripheral State and Error functions #####
+  ==============================================================================
+    [..]
+    This subsection provides functions allowing to :
+      (+) Check the CAN state.
+      (+) Check CAN Errors detected during interrupt process
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  return the CAN state
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval HAL state
+  */
+HAL_CAN_StateTypeDef HAL_CAN_GetState(CAN_HandleTypeDef* hcan)
+{
+  /* Return CAN state */
+  return hcan->State;
+}
+
+/**
+  * @brief  Return the CAN error code
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval CAN Error Code
+  */
+uint32_t HAL_CAN_GetError(CAN_HandleTypeDef *hcan)
+{
+  return hcan->ErrorCode;
+}
+
+/**
+  * @}
+  */
+/**
+  * @brief  Initiates and transmits a CAN frame message.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef CAN_Transmit_IT(CAN_HandleTypeDef* hcan)
+{
+  /* Disable Transmit mailbox empty Interrupt */
+  __HAL_CAN_DISABLE_IT(hcan, CAN_IT_TME);
+
+  if(hcan->State == HAL_CAN_STATE_BUSY_TX)
+  {
+    /* Disable Error warning Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_EWG);
+
+    /* Disable Error passive Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_EPV);
+
+    /* Disable Bus-off Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_BOF);
+
+    /* Disable Last error code Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_LEC);
+
+    /* Disable Error Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_ERR);
+  }
+
+  if(hcan->State == HAL_CAN_STATE_BUSY_TX_RX)
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_RX;
+  }
+  else
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_READY;
+  }
+
+  /* Transmission complete callback */
+  HAL_CAN_TxCpltCallback(hcan);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Receives a correct CAN frame.
+  * @param  hcan:       Pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @param  FIFONumber: Specify the FIFO number
+  * @retval HAL status
+  * @retval None
+  */
+static HAL_StatusTypeDef CAN_Receive_IT(CAN_HandleTypeDef* hcan, uint8_t FIFONumber)
+{
+  /* Get the Id */
+  hcan->pRxMsg->IDE = (uint8_t)0x04 & hcan->Instance->sFIFOMailBox[FIFONumber].RIR;
+  if (hcan->pRxMsg->IDE == CAN_ID_STD)
+  {
+    hcan->pRxMsg->StdId = (uint32_t)0x000007FF & (hcan->Instance->sFIFOMailBox[FIFONumber].RIR >> 21);
+  }
+  else
+  {
+    hcan->pRxMsg->ExtId = (uint32_t)0x1FFFFFFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RIR >> 3);
+  }
+
+  hcan->pRxMsg->RTR = (uint8_t)0x02 & hcan->Instance->sFIFOMailBox[FIFONumber].RIR;
+  /* Get the DLC */
+  hcan->pRxMsg->DLC = (uint8_t)0x0F & hcan->Instance->sFIFOMailBox[FIFONumber].RDTR;
+  /* Get the FMI */
+  hcan->pRxMsg->FMI = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDTR >> 8);
+  /* Get the data field */
+  hcan->pRxMsg->Data[0] = (uint8_t)0xFF & hcan->Instance->sFIFOMailBox[FIFONumber].RDLR;
+  hcan->pRxMsg->Data[1] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDLR >> 8);
+  hcan->pRxMsg->Data[2] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDLR >> 16);
+  hcan->pRxMsg->Data[3] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDLR >> 24);
+  hcan->pRxMsg->Data[4] = (uint8_t)0xFF & hcan->Instance->sFIFOMailBox[FIFONumber].RDHR;
+  hcan->pRxMsg->Data[5] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDHR >> 8);
+  hcan->pRxMsg->Data[6] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDHR >> 16);
+  hcan->pRxMsg->Data[7] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDHR >> 24);
+  /* Release the FIFO */
+  /* Release FIFO0 */
+  if (FIFONumber == CAN_FIFO0)
+  {
+    __HAL_CAN_FIFO_RELEASE(hcan, CAN_FIFO0);
+
+    /* Disable FIFO 0 message pending Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_FMP0);
+  }
+  /* Release FIFO1 */
+  else /* FIFONumber == CAN_FIFO1 */
+  {
+    __HAL_CAN_FIFO_RELEASE(hcan, CAN_FIFO1);
+
+    /* Disable FIFO 1 message pending Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_FMP1);
+  }
+
+  if(hcan->State == HAL_CAN_STATE_BUSY_RX)
+  {
+    /* Disable Error warning Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_EWG);
+
+    /* Disable Error passive Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_EPV);
+
+    /* Disable Bus-off Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_BOF);
+
+    /* Disable Last error code Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_LEC);
+
+    /* Disable Error Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_ERR);
+  }
+
+  if(hcan->State == HAL_CAN_STATE_BUSY_TX_RX)
+  {
+    /* Disable CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_TX;
+  }
+  else
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_READY;
+  }
+
+  /* Receive complete callback */
+  HAL_CAN_RxCpltCallback(hcan);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+ * @}
+ */
+
+#endif /* HAL_CAN_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_cortex.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_cortex.c
@@ -1,0 +1,483 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_cortex.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   CORTEX HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the CORTEX:
+  *           + Initialization and de-initialization functions
+  *           + Peripheral Control functions
+  *
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+
+    [..]
+    *** How to configure Interrupts using CORTEX HAL driver ***
+    ===========================================================
+    [..]
+    This section provides functions allowing to configure the NVIC interrupts (IRQ).
+    The Cortex-M4 exceptions are managed by CMSIS functions.
+
+    (#) Configure the NVIC Priority Grouping using HAL_NVIC_SetPriorityGrouping()
+        function according to the following table.
+    (#) Configure the priority of the selected IRQ Channels using HAL_NVIC_SetPriority().
+    (#) Enable the selected IRQ Channels using HAL_NVIC_EnableIRQ().
+    (#) please refer to programming manual for details in how to configure priority.
+
+     -@- When the NVIC_PRIORITYGROUP_0 is selected, IRQ preemption is no more possible.
+         The pending IRQ priority will be managed only by the sub priority.
+
+     -@- IRQ priority order (sorted by highest to lowest priority):
+        (+@) Lowest preemption priority
+        (+@) Lowest sub priority
+        (+@) Lowest hardware priority (IRQ number)
+
+    [..]
+    *** How to configure Systick using CORTEX HAL driver ***
+    ========================================================
+    [..]
+    Setup SysTick Timer for time base.
+
+   (+) The HAL_SYSTICK_Config() function calls the SysTick_Config() function which
+       is a CMSIS function that:
+        (++) Configures the SysTick Reload register with value passed as function parameter.
+        (++) Configures the SysTick IRQ priority to the lowest value (0x0F).
+        (++) Resets the SysTick Counter register.
+        (++) Configures the SysTick Counter clock source to be Core Clock Source (HCLK).
+        (++) Enables the SysTick Interrupt.
+        (++) Starts the SysTick Counter.
+
+   (+) You can change the SysTick Clock source to be HCLK_Div8 by calling the macro
+       __HAL_CORTEX_SYSTICKCLK_CONFIG(SYSTICK_CLKSOURCE_HCLK_DIV8) just after the
+       HAL_SYSTICK_Config() function call. The __HAL_CORTEX_SYSTICKCLK_CONFIG() macro is defined
+       inside the stm32f7xx_hal_cortex.h file.
+
+   (+) You can change the SysTick IRQ priority by calling the
+       HAL_NVIC_SetPriority(SysTick_IRQn,...) function just after the HAL_SYSTICK_Config() function
+       call. The HAL_NVIC_SetPriority() call the NVIC_SetPriority() function which is a CMSIS function.
+
+   (+) To adjust the SysTick time base, use the following formula:
+
+       Reload Value = SysTick Counter Clock (Hz) x  Desired Time base (s)
+       (++) Reload Value is the parameter to be passed for HAL_SYSTICK_Config() function
+       (++) Reload Value should not exceed 0xFFFFFF
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup CORTEX CORTEX
+  * @brief CORTEX HAL module driver
+  * @{
+  */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup CORTEX_Exported_Functions CORTEX Exported Functions
+  * @{
+  */
+
+
+/** @defgroup CORTEX_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+  ==============================================================================
+              ##### Initialization and de-initialization functions #####
+  ==============================================================================
+    [..]
+      This section provides the CORTEX HAL driver functions allowing to configure Interrupts
+      Systick functionalities
+
+@endverbatim
+  * @{
+  */
+
+
+/**
+  * @brief  Sets the priority grouping field (preemption priority and subpriority)
+  *         using the required unlock sequence.
+  * @param  PriorityGroup: The priority grouping bits length.
+  *         This parameter can be one of the following values:
+  *         @arg NVIC_PRIORITYGROUP_0: 0 bits for preemption priority
+  *                                    4 bits for subpriority
+  *         @arg NVIC_PRIORITYGROUP_1: 1 bits for preemption priority
+  *                                    3 bits for subpriority
+  *         @arg NVIC_PRIORITYGROUP_2: 2 bits for preemption priority
+  *                                    2 bits for subpriority
+  *         @arg NVIC_PRIORITYGROUP_3: 3 bits for preemption priority
+  *                                    1 bits for subpriority
+  *         @arg NVIC_PRIORITYGROUP_4: 4 bits for preemption priority
+  *                                    0 bits for subpriority
+  * @note   When the NVIC_PriorityGroup_0 is selected, IRQ preemption is no more possible.
+  *         The pending IRQ priority will be managed only by the subpriority.
+  * @retval None
+  */
+void HAL_NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_PRIORITY_GROUP(PriorityGroup));
+
+  /* Set the PRIGROUP[10:8] bits according to the PriorityGroup parameter value */
+  NVIC_SetPriorityGrouping(PriorityGroup);
+}
+
+/**
+  * @brief  Sets the priority of an interrupt.
+  * @param  IRQn: External interrupt number.
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32f7xxxx.h))
+  * @param  PreemptPriority: The preemption priority for the IRQn channel.
+  *         This parameter can be a value between 0 and 15
+  *         A lower priority value indicates a higher priority
+  * @param  SubPriority: the subpriority level for the IRQ channel.
+  *         This parameter can be a value between 0 and 15
+  *         A lower priority value indicates a higher priority.
+  * @retval None
+  */
+void HAL_NVIC_SetPriority(IRQn_Type IRQn, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t prioritygroup = 0x00;
+
+  /* Check the parameters */
+  assert_param(IS_NVIC_SUB_PRIORITY(SubPriority));
+  assert_param(IS_NVIC_PREEMPTION_PRIORITY(PreemptPriority));
+
+  prioritygroup = NVIC_GetPriorityGrouping();
+
+  NVIC_SetPriority(IRQn, NVIC_EncodePriority(prioritygroup, PreemptPriority, SubPriority));
+}
+
+/**
+  * @brief  Enables a device specific interrupt in the NVIC interrupt controller.
+  * @note   To configure interrupts priority correctly, the NVIC_PriorityGroupConfig()
+  *         function should be called before.
+  * @param  IRQn External interrupt number.
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32f7xxxx.h))
+  * @retval None
+  */
+void HAL_NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_DEVICE_IRQ(IRQn));
+
+  /* Enable interrupt */
+  NVIC_EnableIRQ(IRQn);
+}
+
+/**
+  * @brief  Disables a device specific interrupt in the NVIC interrupt controller.
+  * @param  IRQn External interrupt number.
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32f7xxxx.h))
+  * @retval None
+  */
+void HAL_NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_DEVICE_IRQ(IRQn));
+
+  /* Disable interrupt */
+  NVIC_DisableIRQ(IRQn);
+}
+
+/**
+  * @brief  Initiates a system reset request to reset the MCU.
+  * @retval None
+  */
+void HAL_NVIC_SystemReset(void)
+{
+  /* System Reset */
+  NVIC_SystemReset();
+}
+
+/**
+  * @brief  Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+  *         Counter is in free running mode to generate periodic interrupts.
+  * @param  TicksNumb: Specifies the ticks Number of ticks between two interrupts.
+  * @retval status:  - 0  Function succeeded.
+  *                  - 1  Function failed.
+  */
+uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb)
+{
+   return SysTick_Config(TicksNumb);
+}
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_Exported_Functions_Group2 Peripheral Control functions
+ *  @brief   Cortex control functions
+ *
+@verbatim
+  ==============================================================================
+                      ##### Peripheral Control functions #####
+  ==============================================================================
+    [..]
+      This subsection provides a set of functions allowing to control the CORTEX
+      (NVIC, SYSTICK, MPU) functionalities.
+
+
+@endverbatim
+  * @{
+  */
+
+#if (__MPU_PRESENT == 1)
+/**
+  * @brief  Initializes and configures the Region and the memory to be protected.
+  * @param  MPU_Init: Pointer to a MPU_Region_InitTypeDef structure that contains
+  *                the initialization and configuration information.
+  * @retval None
+  */
+void HAL_MPU_ConfigRegion(MPU_Region_InitTypeDef *MPU_Init)
+{
+  /* Check the parameters */
+  assert_param(IS_MPU_REGION_NUMBER(MPU_Init->Number));
+  assert_param(IS_MPU_REGION_ENABLE(MPU_Init->Enable));
+
+  /* Set the Region number */
+  MPU->RNR = MPU_Init->Number;
+
+  if ((MPU_Init->Enable) != RESET)
+  {
+    /* Check the parameters */
+    assert_param(IS_MPU_INSTRUCTION_ACCESS(MPU_Init->DisableExec));
+    assert_param(IS_MPU_REGION_PERMISSION_ATTRIBUTE(MPU_Init->AccessPermission));
+    assert_param(IS_MPU_TEX_LEVEL(MPU_Init->TypeExtField));
+    assert_param(IS_MPU_ACCESS_SHAREABLE(MPU_Init->IsShareable));
+    assert_param(IS_MPU_ACCESS_CACHEABLE(MPU_Init->IsCacheable));
+    assert_param(IS_MPU_ACCESS_BUFFERABLE(MPU_Init->IsBufferable));
+    assert_param(IS_MPU_SUB_REGION_DISABLE(MPU_Init->SubRegionDisable));
+    assert_param(IS_MPU_REGION_SIZE(MPU_Init->Size));
+
+    MPU->RBAR = MPU_Init->BaseAddress;
+    MPU->RASR = ((uint32_t)MPU_Init->DisableExec             << MPU_RASR_XN_Pos)   |
+                ((uint32_t)MPU_Init->AccessPermission        << MPU_RASR_AP_Pos)   |
+                ((uint32_t)MPU_Init->TypeExtField            << MPU_RASR_TEX_Pos)  |
+                ((uint32_t)MPU_Init->IsShareable             << MPU_RASR_S_Pos)    |
+                ((uint32_t)MPU_Init->IsCacheable             << MPU_RASR_C_Pos)    |
+                ((uint32_t)MPU_Init->IsBufferable            << MPU_RASR_B_Pos)    |
+                ((uint32_t)MPU_Init->SubRegionDisable        << MPU_RASR_SRD_Pos)  |
+                ((uint32_t)MPU_Init->Size                    << MPU_RASR_SIZE_Pos) |
+                ((uint32_t)MPU_Init->Enable                  << MPU_RASR_ENABLE_Pos);
+  }
+  else
+  {
+    MPU->RBAR = 0x00;
+    MPU->RASR = 0x00;
+  }
+}
+#endif /* __MPU_PRESENT */
+
+/**
+  * @brief  Gets the priority grouping field from the NVIC Interrupt Controller.
+  * @retval Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field)
+  */
+uint32_t HAL_NVIC_GetPriorityGrouping(void)
+{
+  /* Get the PRIGROUP[10:8] field value */
+  return NVIC_GetPriorityGrouping();
+}
+
+/**
+  * @brief  Gets the priority of an interrupt.
+  * @param  IRQn: External interrupt number.
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32f7xxxx.h))
+  * @param   PriorityGroup: the priority grouping bits length.
+  *         This parameter can be one of the following values:
+  *           @arg NVIC_PRIORITYGROUP_0: 0 bits for preemption priority
+  *                                      4 bits for subpriority
+  *           @arg NVIC_PRIORITYGROUP_1: 1 bits for preemption priority
+  *                                      3 bits for subpriority
+  *           @arg NVIC_PRIORITYGROUP_2: 2 bits for preemption priority
+  *                                      2 bits for subpriority
+  *           @arg NVIC_PRIORITYGROUP_3: 3 bits for preemption priority
+  *                                      1 bits for subpriority
+  *           @arg NVIC_PRIORITYGROUP_4: 4 bits for preemption priority
+  *                                      0 bits for subpriority
+  * @param  pPreemptPriority: Pointer on the Preemptive priority value (starting from 0).
+  * @param  pSubPriority: Pointer on the Subpriority value (starting from 0).
+  * @retval None
+  */
+void HAL_NVIC_GetPriority(IRQn_Type IRQn, uint32_t PriorityGroup, uint32_t *pPreemptPriority, uint32_t *pSubPriority)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_PRIORITY_GROUP(PriorityGroup));
+ /* Get priority for Cortex-M system or device specific interrupts */
+  NVIC_DecodePriority(NVIC_GetPriority(IRQn), PriorityGroup, pPreemptPriority, pSubPriority);
+}
+
+/**
+  * @brief  Sets Pending bit of an external interrupt.
+  * @param  IRQn External interrupt number
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32f7xxxx.h))
+  * @retval None
+  */
+void HAL_NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_DEVICE_IRQ(IRQn));
+
+  /* Set interrupt pending */
+  NVIC_SetPendingIRQ(IRQn);
+}
+
+/**
+  * @brief  Gets Pending Interrupt (reads the pending register in the NVIC
+  *         and returns the pending bit for the specified interrupt).
+  * @param  IRQn External interrupt number.
+  *          This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32f7xxxx.h))
+  * @retval status: - 0  Interrupt status is not pending.
+  *                 - 1  Interrupt status is pending.
+  */
+uint32_t HAL_NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_DEVICE_IRQ(IRQn));
+
+  /* Return 1 if pending else 0 */
+  return NVIC_GetPendingIRQ(IRQn);
+}
+
+/**
+  * @brief  Clears the pending bit of an external interrupt.
+  * @param  IRQn External interrupt number.
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32f7xxxx.h))
+  * @retval None
+  */
+void HAL_NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_DEVICE_IRQ(IRQn));
+
+  /* Clear pending interrupt */
+  NVIC_ClearPendingIRQ(IRQn);
+}
+
+/**
+  * @brief Gets active interrupt ( reads the active register in NVIC and returns the active bit).
+  * @param IRQn External interrupt number
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32f7xxxx.h))
+  * @retval status: - 0  Interrupt status is not pending.
+  *                 - 1  Interrupt status is pending.
+  */
+uint32_t HAL_NVIC_GetActive(IRQn_Type IRQn)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_DEVICE_IRQ(IRQn));
+
+  /* Return 1 if active else 0 */
+  return NVIC_GetActive(IRQn);
+}
+
+/**
+  * @brief  Configures the SysTick clock source.
+  * @param  CLKSource: specifies the SysTick clock source.
+  *          This parameter can be one of the following values:
+  *             @arg SYSTICK_CLKSOURCE_HCLK_DIV8: AHB clock divided by 8 selected as SysTick clock source.
+  *             @arg SYSTICK_CLKSOURCE_HCLK: AHB clock selected as SysTick clock source.
+  * @retval None
+  */
+void HAL_SYSTICK_CLKSourceConfig(uint32_t CLKSource)
+{
+  /* Check the parameters */
+  assert_param(IS_SYSTICK_CLK_SOURCE(CLKSource));
+  if (CLKSource == SYSTICK_CLKSOURCE_HCLK)
+  {
+    SysTick->CTRL |= SYSTICK_CLKSOURCE_HCLK;
+  }
+  else
+  {
+    SysTick->CTRL &= ~SYSTICK_CLKSOURCE_HCLK;
+  }
+}
+
+/**
+  * @brief  This function handles SYSTICK interrupt request.
+  * @retval None
+  */
+void HAL_SYSTICK_IRQHandler(void)
+{
+  HAL_SYSTICK_Callback();
+}
+
+/**
+  * @brief  SYSTICK callback.
+  * @retval None
+  */
+__weak void HAL_SYSTICK_Callback(void)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SYSTICK_Callback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_dac.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_dac.c
@@ -1,0 +1,949 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_dac.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   DAC HAL module driver.
+  *         This file provides firmware functions to manage the following
+  *         functionalities of the Digital to Analog Converter (DAC) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State and Errors functions
+  *
+  *
+  @verbatim
+  ==============================================================================
+                      ##### DAC Peripheral features #####
+  ==============================================================================
+    [..]
+      *** DAC Channels ***
+      ====================
+    [..]
+    The device integrates two 12-bit Digital Analog Converters that can
+    be used independently or simultaneously (dual mode):
+      (#) DAC channel1 with DAC_OUT1 (PA4) as output
+      (#) DAC channel2 with DAC_OUT2 (PA5) as output
+
+      *** DAC Triggers ***
+      ====================
+    [..]
+    Digital to Analog conversion can be non-triggered using DAC_TRIGGER_NONE
+    and DAC_OUT1/DAC_OUT2 is available once writing to DHRx register.
+    [..]
+    Digital to Analog conversion can be triggered by:
+      (#) External event: EXTI Line 9 (any GPIOx_Pin9) using DAC_TRIGGER_EXT_IT9.
+          The used pin (GPIOx_Pin9) must be configured in input mode.
+
+      (#) Timers TRGO: TIM2, TIM4, TIM5, TIM6, TIM7 and TIM8
+          (DAC_TRIGGER_T2_TRGO, DAC_TRIGGER_T4_TRGO...)
+
+      (#) Software using DAC_TRIGGER_SOFTWARE
+
+      *** DAC Buffer mode feature ***
+      ===============================
+      [..]
+      Each DAC channel integrates an output buffer that can be used to
+      reduce the output impedance, and to drive external loads directly
+      without having to add an external operational amplifier.
+      To enable, the output buffer use
+      sConfig.DAC_OutputBuffer = DAC_OUTPUTBUFFER_ENABLE;
+      [..]
+      (@) Refer to the device datasheet for more details about output
+          impedance value with and without output buffer.
+
+       *** DAC wave generation feature ***
+       ===================================
+       [..]
+       Both DAC channels can be used to generate
+         (#) Noise wave using HAL_DACEx_NoiseWaveGenerate()
+         (#) Triangle wave using HAL_DACEx_TriangleWaveGenerate()
+
+       *** DAC data format ***
+       =======================
+       [..]
+       The DAC data format can be:
+         (#) 8-bit right alignment using DAC_ALIGN_8B_R
+         (#) 12-bit left alignment using DAC_ALIGN_12B_L
+         (#) 12-bit right alignment using DAC_ALIGN_12B_R
+
+       *** DAC data value to voltage correspondence ***
+       ================================================
+       [..]
+       The analog output voltage on each DAC channel pin is determined
+       by the following equation:
+       DAC_OUTx = VREF+ * DOR / 4095
+       with  DOR is the Data Output Register
+          VEF+ is the input voltage reference (refer to the device datasheet)
+        e.g. To set DAC_OUT1 to 0.7V, use
+          Assuming that VREF+ = 3.3V, DAC_OUT1 = (3.3 * 868) / 4095 = 0.7V
+
+       *** DMA requests  ***
+       =====================
+       [..]
+       A DMA1 request can be generated when an external trigger (but not
+       a software trigger) occurs if DMA1 requests are enabled using
+       HAL_DAC_Start_DMA()
+       [..]
+       DMA1 requests are mapped as following:
+         (#) DAC channel1 : mapped on DMA1 Stream5 channel7 which must be
+             already configured
+         (#) DAC channel2 : mapped on DMA1 Stream6 channel7 which must be
+             already configured
+
+    -@- For Dual mode and specific signal (Triangle and noise) generation please
+        refer to Extension Features Driver description
+
+
+                      ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      (+) DAC APB clock must be enabled to get write access to DAC
+          registers using HAL_DAC_Init()
+      (+) Configure DAC_OUTx (DAC_OUT1: PA4, DAC_OUT2: PA5) in analog mode.
+      (+) Configure the DAC channel using HAL_DAC_ConfigChannel() function.
+      (+) Enable the DAC channel using HAL_DAC_Start() or HAL_DAC_Start_DMA functions
+
+     *** Polling mode IO operation ***
+     =================================
+     [..]
+       (+) Start the DAC peripheral using HAL_DAC_Start()
+       (+) To read the DAC last data output value, use the HAL_DAC_GetValue() function.
+       (+) Stop the DAC peripheral using HAL_DAC_Stop()
+
+
+     *** DMA mode IO operation ***
+     ==============================
+     [..]
+       (+) Start the DAC peripheral using HAL_DAC_Start_DMA(), at this stage the user specify the length
+           of data to be transferred at each end of conversion
+       (+) At The end of data transfer HAL_DAC_ConvCpltCallbackCh1()or HAL_DAC_ConvCpltCallbackCh2()
+           function is executed and user can add his own code by customization of function pointer
+           HAL_DAC_ConvCpltCallbackCh1 or HAL_DAC_ConvCpltCallbackCh2
+       (+) In case of transfer Error, HAL_DAC_ErrorCallbackCh1() function is executed and user can
+            add his own code by customization of function pointer HAL_DAC_ErrorCallbackCh1
+       (+) Stop the DAC peripheral using HAL_DAC_Stop_DMA()
+
+
+     *** DAC HAL driver macros list ***
+     =============================================
+     [..]
+       Below the list of most used macros in DAC HAL driver.
+
+      (+) __HAL_DAC_ENABLE : Enable the DAC peripheral
+      (+) __HAL_DAC_DISABLE : Disable the DAC peripheral
+      (+) __HAL_DAC_CLEAR_FLAG: Clear the DAC's pending flags
+      (+) __HAL_DAC_GET_FLAG: Get the selected DAC's flag status
+
+     [..]
+      (@) You can refer to the DAC HAL driver header file for more useful macros
+
+ @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup DAC DAC
+  * @brief DAC driver modules
+  * @{
+  */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/** @addtogroup DAC_Private_Functions
+  * @{
+  */
+/* Private function prototypes -----------------------------------------------*/
+static void DAC_DMAConvCpltCh1(DMA_HandleTypeDef *hdma);
+static void DAC_DMAErrorCh1(DMA_HandleTypeDef *hdma);
+static void DAC_DMAHalfConvCpltCh1(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup DAC_Exported_Functions DAC Exported Functions
+  * @{
+  */
+
+/** @defgroup DAC_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+  ==============================================================================
+              ##### Initialization and de-initialization functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the DAC.
+      (+) De-initialize the DAC.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the DAC peripheral according to the specified parameters
+  *         in the DAC_InitStruct.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Init(DAC_HandleTypeDef* hdac)
+{
+  /* Check DAC handle */
+  if(hdac == NULL)
+  {
+     return HAL_ERROR;
+  }
+  /* Check the parameters */
+  assert_param(IS_DAC_ALL_INSTANCE(hdac->Instance));
+
+  if(hdac->State == HAL_DAC_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hdac->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware */
+    HAL_DAC_MspInit(hdac);
+  }
+
+  /* Initialize the DAC state*/
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Set DAC error code to none */
+  hdac->ErrorCode = HAL_DAC_ERROR_NONE;
+
+  /* Initialize the DAC state*/
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deinitializes the DAC peripheral registers to their default reset values.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_DeInit(DAC_HandleTypeDef* hdac)
+{
+  /* Check DAC handle */
+  if(hdac == NULL)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_DAC_ALL_INSTANCE(hdac->Instance));
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* DeInit the low level hardware */
+  HAL_DAC_MspDeInit(hdac);
+
+  /* Set DAC error code to none */
+  hdac->ErrorCode = HAL_DAC_ERROR_NONE;
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the DAC MSP.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_MspInit(DAC_HandleTypeDef* hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the DAC MSP.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_MspDeInit(DAC_HandleTypeDef* hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Exported_Functions_Group2 IO operation functions
+ *  @brief    IO operation functions
+ *
+@verbatim
+  ==============================================================================
+             ##### IO operation functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Start conversion.
+      (+) Stop conversion.
+      (+) Start conversion and enable DMA transfer.
+      (+) Stop conversion and disable DMA transfer.
+      (+) Get result of conversion.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enables DAC and starts conversion of channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef* hdac, uint32_t Channel)
+{
+  uint32_t tmp1 = 0, tmp2 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Enable the Peripheral */
+  __HAL_DAC_ENABLE(hdac, Channel);
+
+  if(Channel == DAC_CHANNEL_1)
+  {
+    tmp1 = hdac->Instance->CR & DAC_CR_TEN1;
+    tmp2 = hdac->Instance->CR & DAC_CR_TSEL1;
+    /* Check if software trigger enabled */
+    if((tmp1 ==  DAC_CR_TEN1) && (tmp2 ==  DAC_CR_TSEL1))
+    {
+      /* Enable the selected DAC software conversion */
+      hdac->Instance->SWTRIGR |= (uint32_t)DAC_SWTRIGR_SWTRIG1;
+    }
+  }
+  else
+  {
+    tmp1 = hdac->Instance->CR & DAC_CR_TEN2;
+    tmp2 = hdac->Instance->CR & DAC_CR_TSEL2;
+    /* Check if software trigger enabled */
+    if((tmp1 == DAC_CR_TEN2) && (tmp2 == DAC_CR_TSEL2))
+    {
+      /* Enable the selected DAC software conversion*/
+      hdac->Instance->SWTRIGR |= (uint32_t)DAC_SWTRIGR_SWTRIG2;
+    }
+  }
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables DAC and stop conversion of channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Stop(DAC_HandleTypeDef* hdac, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+
+  /* Disable the Peripheral */
+  __HAL_DAC_DISABLE(hdac, Channel);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables DAC and starts conversion of channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @param  pData: The destination peripheral Buffer address.
+  * @param  Length: The length of data to be transferred from memory to DAC peripheral
+  * @param  Alignment: Specifies the data alignment for DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_ALIGN_8B_R: 8bit right data alignment selected
+  *            @arg DAC_ALIGN_12B_L: 12bit left data alignment selected
+  *            @arg DAC_ALIGN_12B_R: 12bit right data alignment selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Start_DMA(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t* pData, uint32_t Length, uint32_t Alignment)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_ALIGN(Alignment));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  if(Channel == DAC_CHANNEL_1)
+  {
+    /* Set the DMA transfer complete callback for channel1 */
+    hdac->DMA_Handle1->XferCpltCallback = DAC_DMAConvCpltCh1;
+
+    /* Set the DMA half transfer complete callback for channel1 */
+    hdac->DMA_Handle1->XferHalfCpltCallback = DAC_DMAHalfConvCpltCh1;
+
+    /* Set the DMA error callback for channel1 */
+    hdac->DMA_Handle1->XferErrorCallback = DAC_DMAErrorCh1;
+
+    /* Enable the selected DAC channel1 DMA request */
+    hdac->Instance->CR |= DAC_CR_DMAEN1;
+
+    /* Case of use of channel 1 */
+    switch(Alignment)
+    {
+      case DAC_ALIGN_12B_R:
+        /* Get DHR12R1 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR12R1;
+        break;
+      case DAC_ALIGN_12B_L:
+        /* Get DHR12L1 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR12L1;
+        break;
+      case DAC_ALIGN_8B_R:
+        /* Get DHR8R1 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR8R1;
+        break;
+      default:
+        break;
+    }
+  }
+  else
+  {
+    /* Set the DMA transfer complete callback for channel2 */
+    hdac->DMA_Handle2->XferCpltCallback = DAC_DMAConvCpltCh2;
+
+    /* Set the DMA half transfer complete callback for channel2 */
+    hdac->DMA_Handle2->XferHalfCpltCallback = DAC_DMAHalfConvCpltCh2;
+
+    /* Set the DMA error callback for channel2 */
+    hdac->DMA_Handle2->XferErrorCallback = DAC_DMAErrorCh2;
+
+    /* Enable the selected DAC channel2 DMA request */
+    hdac->Instance->CR |= DAC_CR_DMAEN2;
+
+    /* Case of use of channel 2 */
+    switch(Alignment)
+    {
+      case DAC_ALIGN_12B_R:
+        /* Get DHR12R2 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR12R2;
+        break;
+      case DAC_ALIGN_12B_L:
+        /* Get DHR12L2 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR12L2;
+        break;
+      case DAC_ALIGN_8B_R:
+        /* Get DHR8R2 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR8R2;
+        break;
+      default:
+        break;
+    }
+  }
+
+  /* Enable the DMA Stream */
+  if(Channel == DAC_CHANNEL_1)
+  {
+    /* Enable the DAC DMA underrun interrupt */
+    __HAL_DAC_ENABLE_IT(hdac, DAC_IT_DMAUDR1);
+
+    /* Enable the DMA Stream */
+    HAL_DMA_Start_IT(hdac->DMA_Handle1, (uint32_t)pData, tmpreg, Length);
+  }
+  else
+  {
+    /* Enable the DAC DMA underrun interrupt */
+    __HAL_DAC_ENABLE_IT(hdac, DAC_IT_DMAUDR2);
+
+    /* Enable the DMA Stream */
+    HAL_DMA_Start_IT(hdac->DMA_Handle2, (uint32_t)pData, tmpreg, Length);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_DAC_ENABLE(hdac, Channel);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables DAC and stop conversion of channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Stop_DMA(DAC_HandleTypeDef* hdac, uint32_t Channel)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+
+  /* Disable the selected DAC channel DMA request */
+   hdac->Instance->CR &= ~(DAC_CR_DMAEN1 << Channel);
+
+  /* Disable the Peripheral */
+  __HAL_DAC_DISABLE(hdac, Channel);
+
+  /* Disable the DMA Channel */
+  /* Channel1 is used */
+  if(Channel == DAC_CHANNEL_1)
+  {
+    status = HAL_DMA_Abort(hdac->DMA_Handle1);
+  }
+  else /* Channel2 is used for */
+  {
+    status = HAL_DMA_Abort(hdac->DMA_Handle2);
+  }
+
+  /* Check if DMA Channel effectively disabled */
+  if(status != HAL_OK)
+  {
+    /* Update DAC state machine to error */
+    hdac->State = HAL_DAC_STATE_ERROR;
+  }
+  else
+  {
+    /* Change DAC state */
+    hdac->State = HAL_DAC_STATE_READY;
+  }
+
+  /* Return function status */
+  return status;
+}
+
+/**
+  * @brief  Returns the last data output value of the selected DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval The selected DAC channel data output value.
+  */
+uint32_t HAL_DAC_GetValue(DAC_HandleTypeDef* hdac, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+
+  /* Returns the DAC channel data output register value */
+  if(Channel == DAC_CHANNEL_1)
+  {
+    return hdac->Instance->DOR1;
+  }
+  else
+  {
+    return hdac->Instance->DOR2;
+  }
+}
+
+/**
+  * @brief  Handles DAC interrupt request
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+void HAL_DAC_IRQHandler(DAC_HandleTypeDef* hdac)
+{
+  /* Check underrun channel 1 flag */
+  if(__HAL_DAC_GET_FLAG(hdac, DAC_FLAG_DMAUDR1))
+  {
+    /* Change DAC state to error state */
+    hdac->State = HAL_DAC_STATE_ERROR;
+
+    /* Set DAC error code to channel1 DMA underrun error */
+    hdac->ErrorCode |= HAL_DAC_ERROR_DMAUNDERRUNCH1;
+
+    /* Clear the underrun flag */
+    __HAL_DAC_CLEAR_FLAG(hdac,DAC_FLAG_DMAUDR1);
+
+    /* Disable the selected DAC channel1 DMA request */
+    hdac->Instance->CR &= ~DAC_CR_DMAEN1;
+
+    /* Error callback */
+    HAL_DAC_DMAUnderrunCallbackCh1(hdac);
+  }
+  /* Check underrun channel 2 flag */
+  if(__HAL_DAC_GET_FLAG(hdac, DAC_FLAG_DMAUDR2))
+  {
+    /* Change DAC state to error state */
+    hdac->State = HAL_DAC_STATE_ERROR;
+
+    /* Set DAC error code to channel2 DMA underrun error */
+    hdac->ErrorCode |= HAL_DAC_ERROR_DMAUNDERRUNCH2;
+
+    /* Clear the underrun flag */
+    __HAL_DAC_CLEAR_FLAG(hdac,DAC_FLAG_DMAUDR2);
+
+    /* Disable the selected DAC channel1 DMA request */
+    hdac->Instance->CR &= ~DAC_CR_DMAEN2;
+
+    /* Error callback */
+    HAL_DACEx_DMAUnderrunCallbackCh2(hdac);
+  }
+}
+
+/**
+  * @brief  Conversion complete callback in non blocking mode for Channel1
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_ConvCpltCallbackCh1(DAC_HandleTypeDef* hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_ConvCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Conversion half DMA transfer callback in non blocking mode for Channel1
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_ConvHalfCpltCallbackCh1(DAC_HandleTypeDef* hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_ConvHalfCpltCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error DAC callback for Channel1.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_ErrorCallbackCh1(DAC_HandleTypeDef *hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_ErrorCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DMA underrun DAC callback for channel1.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_DMAUnderrunCallbackCh1(DAC_HandleTypeDef *hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_DMAUnderrunCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Exported_Functions_Group3 Peripheral Control functions
+ *  @brief   	Peripheral Control functions
+ *
+@verbatim
+  ==============================================================================
+             ##### Peripheral Control functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Configure channels.
+      (+) Set the specified data holding register value for DAC channel.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configures the selected DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  sConfig: DAC configuration structure.
+  * @param  Channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_ConfigChannel(DAC_HandleTypeDef* hdac, DAC_ChannelConfTypeDef* sConfig, uint32_t Channel)
+{
+  uint32_t tmpreg1 = 0, tmpreg2 = 0;
+
+  /* Check the DAC parameters */
+  assert_param(IS_DAC_TRIGGER(sConfig->DAC_Trigger));
+  assert_param(IS_DAC_OUTPUT_BUFFER_STATE(sConfig->DAC_OutputBuffer));
+  assert_param(IS_DAC_CHANNEL(Channel));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Get the DAC CR value */
+  tmpreg1 = hdac->Instance->CR;
+  /* Clear BOFFx, TENx, TSELx, WAVEx and MAMPx bits */
+  tmpreg1 &= ~(((uint32_t)(DAC_CR_MAMP1 | DAC_CR_WAVE1 | DAC_CR_TSEL1 | DAC_CR_TEN1 | DAC_CR_BOFF1)) << Channel);
+  /* Configure for the selected DAC channel: buffer output, trigger */
+  /* Set TSELx and TENx bits according to DAC_Trigger value */
+  /* Set BOFFx bit according to DAC_OutputBuffer value */
+  tmpreg2 = (sConfig->DAC_Trigger | sConfig->DAC_OutputBuffer);
+  /* Calculate CR register value depending on DAC_Channel */
+  tmpreg1 |= tmpreg2 << Channel;
+  /* Write to DAC CR */
+  hdac->Instance->CR = tmpreg1;
+  /* Disable wave generation */
+  hdac->Instance->CR &= ~(DAC_CR_WAVE1 << Channel);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the specified data holding register value for DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @param  Alignment: Specifies the data alignment.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_ALIGN_8B_R: 8bit right data alignment selected
+  *            @arg DAC_ALIGN_12B_L: 12bit left data alignment selected
+  *            @arg DAC_ALIGN_12B_R: 12bit right data alignment selected
+  * @param  Data: Data to be loaded in the selected data holding register.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t Alignment, uint32_t Data)
+{
+  __IO uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_ALIGN(Alignment));
+  assert_param(IS_DAC_DATA(Data));
+
+  tmp = (uint32_t)hdac->Instance;
+  if(Channel == DAC_CHANNEL_1)
+  {
+    tmp += DAC_DHR12R1_ALIGNMENT(Alignment);
+  }
+  else
+  {
+    tmp += DAC_DHR12R2_ALIGNMENT(Alignment);
+  }
+
+  /* Set the DAC channel1 selected data holding register */
+  *(__IO uint32_t *) tmp = Data;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Exported_Functions_Group4 Peripheral State and Errors functions
+ *  @brief   Peripheral State and Errors functions
+ *
+@verbatim
+  ==============================================================================
+            ##### Peripheral State and Errors functions #####
+  ==============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) Check the DAC state.
+      (+) Check the DAC Errors.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  return the DAC state
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL state
+  */
+HAL_DAC_StateTypeDef HAL_DAC_GetState(DAC_HandleTypeDef* hdac)
+{
+  /* Return DAC state */
+  return hdac->State;
+}
+
+
+/**
+  * @brief  Return the DAC error code
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval DAC Error Code
+  */
+uint32_t HAL_DAC_GetError(DAC_HandleTypeDef *hdac)
+{
+  return hdac->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  DMA conversion complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void DAC_DMAConvCpltCh1(DMA_HandleTypeDef *hdma)
+{
+  DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_DAC_ConvCpltCallbackCh1(hdac);
+
+  hdac->State= HAL_DAC_STATE_READY;
+}
+
+/**
+  * @brief  DMA half transfer complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void DAC_DMAHalfConvCpltCh1(DMA_HandleTypeDef *hdma)
+{
+    DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+    /* Conversion complete callback */
+    HAL_DAC_ConvHalfCpltCallbackCh1(hdac);
+}
+
+/**
+  * @brief  DMA error callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void DAC_DMAErrorCh1(DMA_HandleTypeDef *hdma)
+{
+  DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Set DAC error code to DMA error */
+  hdac->ErrorCode |= HAL_DAC_ERROR_DMA;
+
+  HAL_DAC_ErrorCallbackCh1(hdac);
+
+  hdac->State= HAL_DAC_STATE_READY;
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_dac_ex.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_dac_ex.c
@@ -1,0 +1,376 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_dac_ex.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Extended DAC HAL module driver.
+  *         This file provides firmware functions to manage the following
+  *         functionalities of DAC extension peripheral:
+  *           + Extended features functions
+  *
+  *
+  @verbatim
+  ==============================================================================
+                      ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      (+) When Dual mode is enabled (i.e DAC Channel1 and Channel2 are used simultaneously) :
+          Use HAL_DACEx_DualGetValue() to get digital data to be converted and use
+          HAL_DACEx_DualSetValue() to set digital value to converted simultaneously in Channel 1 and Channel 2.
+      (+) Use HAL_DACEx_TriangleWaveGenerate() to generate Triangle signal.
+      (+) Use HAL_DACEx_NoiseWaveGenerate() to generate Noise signal.
+
+ @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup DACEx DACEx
+  * @brief DAC driver modules
+  * @{
+  */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup DACEx_Exported_Functions DAC Exported Functions
+  * @{
+  */
+
+/** @defgroup DACEx_Exported_Functions_Group1 Extended features functions
+ *  @brief    Extended features functions
+ *
+@verbatim
+  ==============================================================================
+                 ##### Extended features functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Start conversion.
+      (+) Stop conversion.
+      (+) Start conversion and enable DMA transfer.
+      (+) Stop conversion and disable DMA transfer.
+      (+) Get result of conversion.
+      (+) Get result of dual mode conversion.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the last data output value of the selected DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval The selected DAC channel data output value.
+  */
+uint32_t HAL_DACEx_DualGetValue(DAC_HandleTypeDef* hdac)
+{
+  uint32_t tmp = 0;
+
+  tmp |= hdac->Instance->DOR1;
+
+  tmp |= hdac->Instance->DOR2 << 16;
+
+  /* Returns the DAC channel data output register value */
+  return tmp;
+}
+
+/**
+  * @brief  Enables or disables the selected DAC channel wave generation.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @param  Amplitude: Select max triangle amplitude.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_TRIANGLEAMPLITUDE_1: Select max triangle amplitude of 1
+  *            @arg DAC_TRIANGLEAMPLITUDE_3: Select max triangle amplitude of 3
+  *            @arg DAC_TRIANGLEAMPLITUDE_7: Select max triangle amplitude of 7
+  *            @arg DAC_TRIANGLEAMPLITUDE_15: Select max triangle amplitude of 15
+  *            @arg DAC_TRIANGLEAMPLITUDE_31: Select max triangle amplitude of 31
+  *            @arg DAC_TRIANGLEAMPLITUDE_63: Select max triangle amplitude of 63
+  *            @arg DAC_TRIANGLEAMPLITUDE_127: Select max triangle amplitude of 127
+  *            @arg DAC_TRIANGLEAMPLITUDE_255: Select max triangle amplitude of 255
+  *            @arg DAC_TRIANGLEAMPLITUDE_511: Select max triangle amplitude of 511
+  *            @arg DAC_TRIANGLEAMPLITUDE_1023: Select max triangle amplitude of 1023
+  *            @arg DAC_TRIANGLEAMPLITUDE_2047: Select max triangle amplitude of 2047
+  *            @arg DAC_TRIANGLEAMPLITUDE_4095: Select max triangle amplitude of 4095
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_TriangleWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t Amplitude)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_LFSR_UNMASK_TRIANGLE_AMPLITUDE(Amplitude));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Enable the selected wave generation for the selected DAC channel */
+  MODIFY_REG(hdac->Instance->CR, (DAC_CR_WAVE1 | DAC_CR_MAMP1) << Channel, (DAC_CR_WAVE1_1 | Amplitude) << Channel);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables or disables the selected DAC channel wave generation.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @param  Amplitude: Unmask DAC channel LFSR for noise wave generation.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_LFSRUNMASK_BIT0: Unmask DAC channel LFSR bit0 for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS1_0: Unmask DAC channel LFSR bit[1:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS2_0: Unmask DAC channel LFSR bit[2:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS3_0: Unmask DAC channel LFSR bit[3:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS4_0: Unmask DAC channel LFSR bit[4:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS5_0: Unmask DAC channel LFSR bit[5:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS6_0: Unmask DAC channel LFSR bit[6:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS7_0: Unmask DAC channel LFSR bit[7:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS8_0: Unmask DAC channel LFSR bit[8:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS9_0: Unmask DAC channel LFSR bit[9:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS10_0: Unmask DAC channel LFSR bit[10:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS11_0: Unmask DAC channel LFSR bit[11:0] for noise wave generation
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_NoiseWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t Amplitude)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_LFSR_UNMASK_TRIANGLE_AMPLITUDE(Amplitude));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Enable the selected wave generation for the selected DAC channel */
+  MODIFY_REG(hdac->Instance->CR, (DAC_CR_WAVE1 | DAC_CR_MAMP1) << Channel, (DAC_CR_WAVE1_0 | Amplitude) << Channel);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the specified data holding register value for dual DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *               the configuration information for the specified DAC.
+  * @param  Alignment: Specifies the data alignment for dual channel DAC.
+  *          This parameter can be one of the following values:
+  *            DAC_ALIGN_8B_R: 8bit right data alignment selected
+  *            DAC_ALIGN_12B_L: 12bit left data alignment selected
+  *            DAC_ALIGN_12B_R: 12bit right data alignment selected
+  * @param  Data1: Data for DAC Channel2 to be loaded in the selected data holding register.
+  * @param  Data2: Data for DAC Channel1 to be loaded in the selected data  holding register.
+  * @note   In dual mode, a unique register access is required to write in both
+  *          DAC channels at the same time.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_DualSetValue(DAC_HandleTypeDef* hdac, uint32_t Alignment, uint32_t Data1, uint32_t Data2)
+{
+  uint32_t data = 0, tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_DAC_ALIGN(Alignment));
+  assert_param(IS_DAC_DATA(Data1));
+  assert_param(IS_DAC_DATA(Data2));
+
+  /* Calculate and set dual DAC data holding register value */
+  if (Alignment == DAC_ALIGN_8B_R)
+  {
+    data = ((uint32_t)Data2 << 8) | Data1;
+  }
+  else
+  {
+    data = ((uint32_t)Data2 << 16) | Data1;
+  }
+
+  tmp = (uint32_t)hdac->Instance;
+  tmp += DAC_DHR12RD_ALIGNMENT(Alignment);
+
+  /* Set the dual DAC selected data holding register */
+  *(__IO uint32_t *)tmp = data;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  Conversion complete callback in non blocking mode for Channel2
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DACEx_ConvCpltCallbackCh2(DAC_HandleTypeDef* hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_ConvCpltCallbackCh2 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Conversion half DMA transfer callback in non blocking mode for Channel2
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DACEx_ConvHalfCpltCallbackCh2(DAC_HandleTypeDef* hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DACEx_ConvHalfCpltCallbackCh2 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error DAC callback for Channel2.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DACEx_ErrorCallbackCh2(DAC_HandleTypeDef *hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DACEx_ErrorCallbackCh2 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DMA underrun DAC callback for channel2.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DACEx_DMAUnderrunCallbackCh2(DAC_HandleTypeDef *hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DACEx_DMAUnderrunCallbackCh2 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DMA conversion complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void DAC_DMAConvCpltCh2(DMA_HandleTypeDef *hdma)
+{
+  DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_DACEx_ConvCpltCallbackCh2(hdac);
+
+  hdac->State= HAL_DAC_STATE_READY;
+}
+
+/**
+  * @brief  DMA half transfer complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void DAC_DMAHalfConvCpltCh2(DMA_HandleTypeDef *hdma)
+{
+    DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+    /* Conversion complete callback */
+    HAL_DACEx_ConvHalfCpltCallbackCh2(hdac);
+}
+
+/**
+  * @brief  DMA error callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void DAC_DMAErrorCh2(DMA_HandleTypeDef *hdma)
+{
+  DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Set DAC error code to DMA error */
+  hdac->ErrorCode |= HAL_DAC_ERROR_DMA;
+
+  HAL_DACEx_ErrorCallbackCh2(hdac);
+
+  hdac->State= HAL_DAC_STATE_READY;
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_dma.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_dma.c
@@ -1,0 +1,921 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_dma.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   DMA HAL module driver.
+  *
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Direct Memory Access (DMA) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral State and errors functions
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+  [..]
+   (#) Enable and configure the peripheral to be connected to the DMA Stream
+       (except for internal SRAM/FLASH memories: no initialization is
+       necessary) please refer to Reference manual for connection between peripherals
+       and DMA requests .
+
+   (#) For a given Stream, program the required configuration through the following parameters:
+       Transfer Direction, Source and Destination data formats,
+       Circular, Normal or peripheral flow control mode, Stream Priority level,
+       Source and Destination Increment mode, FIFO mode and its Threshold (if needed),
+       Burst mode for Source and/or Destination (if needed) using HAL_DMA_Init() function.
+
+     *** Polling mode IO operation ***
+     =================================
+    [..]
+          (+) Use HAL_DMA_Start() to start DMA transfer after the configuration of Source
+              address and destination address and the Length of data to be transferred
+          (+) Use HAL_DMA_PollForTransfer() to poll for the end of current transfer, in this
+              case a fixed Timeout can be configured by User depending from his application.
+
+     *** Interrupt mode IO operation ***
+     ===================================
+    [..]
+          (+) Configure the DMA interrupt priority using HAL_NVIC_SetPriority()
+          (+) Enable the DMA IRQ handler using HAL_NVIC_EnableIRQ()
+          (+) Use HAL_DMA_Start_IT() to start DMA transfer after the configuration of
+              Source address and destination address and the Length of data to be transferred. In this
+              case the DMA interrupt is configured
+          (+) Use HAL_DMA_IRQHandler() called under DMA_IRQHandler() Interrupt subroutine
+          (+) At the end of data transfer HAL_DMA_IRQHandler() function is executed and user can
+              add his own function by customization of function pointer XferCpltCallback and
+              XferErrorCallback (i.e a member of DMA handle structure).
+    [..]
+     (#) Use HAL_DMA_GetState() function to return the DMA state and HAL_DMA_GetError() in case of error
+         detection.
+
+     (#) Use HAL_DMA_Abort() function to abort the current transfer
+
+     -@-   In Memory-to-Memory transfer mode, Circular mode is not allowed.
+
+     -@-   The FIFO is used mainly to reduce bus usage and to allow data packing/unpacking: it is
+           possible to set different Data Sizes for the Peripheral and the Memory (ie. you can set
+           Half-Word data size for the peripheral to access its data register and set Word data size
+           for the Memory to gain in access time. Each two half words will be packed and written in
+           a single access to a Word in the Memory).
+
+     -@-   When FIFO is disabled, it is not allowed to configure different Data Sizes for Source
+           and Destination. In this case the Peripheral Data Size will be applied to both Source
+           and Destination.
+
+     *** DMA HAL driver macros list ***
+     =============================================
+     [..]
+       Below the list of most used macros in DMA HAL driver.
+
+      (+) __HAL_DMA_ENABLE: Enable the specified DMA Stream.
+      (+) __HAL_DMA_DISABLE: Disable the specified DMA Stream.
+      (+) __HAL_DMA_GET_FS: Return the current DMA Stream FIFO filled level.
+      (+) __HAL_DMA_GET_FLAG: Get the DMA Stream pending flags.
+      (+) __HAL_DMA_CLEAR_FLAG: Clear the DMA Stream pending flags.
+      (+) __HAL_DMA_ENABLE_IT: Enable the specified DMA Stream interrupts.
+      (+) __HAL_DMA_DISABLE_IT: Disable the specified DMA Stream interrupts.
+      (+) __HAL_DMA_GET_IT_SOURCE: Check whether the specified DMA Stream interrupt has occurred or not.
+
+     [..]
+      (@) You can refer to the DMA HAL driver header file for more useful macros
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup DMA DMA
+  * @brief DMA HAL module driver
+  * @{
+  */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @addtogroup DMA_Private_Constants
+ * @{
+ */
+ #define HAL_TIMEOUT_DMA_ABORT    ((uint32_t)1000)  /* 1s */
+/**
+  * @}
+  */
+/* Private macros ------------------------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/** @addtogroup DMA_Private_Functions
+  * @{
+  */
+static void DMA_SetConfig(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
+/**
+  * @brief  Sets the DMA Transfer parameter.
+  * @param  hdma:       pointer to a DMA_HandleTypeDef structure that contains
+  *                     the configuration information for the specified DMA Stream.
+  * @param  SrcAddress: The source memory Buffer address
+  * @param  DstAddress: The destination memory Buffer address
+  * @param  DataLength: The length of data to be transferred from source to destination
+  * @retval HAL status
+  */
+static void DMA_SetConfig(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength)
+{
+  /* Clear DBM bit */
+  hdma->Instance->CR &= (uint32_t)(~DMA_SxCR_DBM);
+
+  /* Configure DMA Stream data length */
+  hdma->Instance->NDTR = DataLength;
+
+  /* Peripheral to Memory */
+  if((hdma->Init.Direction) == DMA_MEMORY_TO_PERIPH)
+  {
+    /* Configure DMA Stream destination address */
+    hdma->Instance->PAR = DstAddress;
+
+    /* Configure DMA Stream source address */
+    hdma->Instance->M0AR = SrcAddress;
+  }
+  /* Memory to Peripheral */
+  else
+  {
+    /* Configure DMA Stream source address */
+    hdma->Instance->PAR = SrcAddress;
+
+    /* Configure DMA Stream destination address */
+    hdma->Instance->M0AR = DstAddress;
+  }
+}
+
+/**
+  * @}
+  */
+
+/* Exported functions ---------------------------------------------------------*/
+/** @addtogroup DMA_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup DMA_Exported_Functions_Group1
+  *
+@verbatim
+ ===============================================================================
+             ##### Initialization and de-initialization functions  #####
+ ===============================================================================
+    [..]
+    This section provides functions allowing to initialize the DMA Stream source
+    and destination addresses, incrementation and data sizes, transfer direction,
+    circular/normal mode selection, memory-to-memory mode selection and Stream priority value.
+    [..]
+    The HAL_DMA_Init() function follows the DMA configuration procedures as described in
+    reference manual.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the DMA according to the specified
+  *         parameters in the DMA_InitTypeDef and create the associated handle.
+  * @param  hdma: Pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Stream.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
+{
+  uint32_t tmp = 0;
+
+  /* Check the DMA peripheral state */
+  if(hdma == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_DMA_STREAM_ALL_INSTANCE(hdma->Instance));
+  assert_param(IS_DMA_CHANNEL(hdma->Init.Channel));
+  assert_param(IS_DMA_DIRECTION(hdma->Init.Direction));
+  assert_param(IS_DMA_PERIPHERAL_INC_STATE(hdma->Init.PeriphInc));
+  assert_param(IS_DMA_MEMORY_INC_STATE(hdma->Init.MemInc));
+  assert_param(IS_DMA_PERIPHERAL_DATA_SIZE(hdma->Init.PeriphDataAlignment));
+  assert_param(IS_DMA_MEMORY_DATA_SIZE(hdma->Init.MemDataAlignment));
+  assert_param(IS_DMA_MODE(hdma->Init.Mode));
+  assert_param(IS_DMA_PRIORITY(hdma->Init.Priority));
+  assert_param(IS_DMA_FIFO_MODE_STATE(hdma->Init.FIFOMode));
+  /* Check the memory burst, peripheral burst and FIFO threshold parameters only
+     when FIFO mode is enabled */
+  if(hdma->Init.FIFOMode != DMA_FIFOMODE_DISABLE)
+  {
+    assert_param(IS_DMA_FIFO_THRESHOLD(hdma->Init.FIFOThreshold));
+    assert_param(IS_DMA_MEMORY_BURST(hdma->Init.MemBurst));
+    assert_param(IS_DMA_PERIPHERAL_BURST(hdma->Init.PeriphBurst));
+  }
+
+  /* Change DMA peripheral state */
+  hdma->State = HAL_DMA_STATE_BUSY;
+
+  /* Get the CR register value */
+  tmp = hdma->Instance->CR;
+
+  /* Clear CHSEL, MBURST, PBURST, PL, MSIZE, PSIZE, MINC, PINC, CIRC, DIR, CT and DBM bits */
+  tmp &= ((uint32_t)~(DMA_SxCR_CHSEL | DMA_SxCR_MBURST | DMA_SxCR_PBURST | \
+                      DMA_SxCR_PL    | DMA_SxCR_MSIZE  | DMA_SxCR_PSIZE  | \
+                      DMA_SxCR_MINC  | DMA_SxCR_PINC   | DMA_SxCR_CIRC   | \
+                      DMA_SxCR_DIR   | DMA_SxCR_CT     | DMA_SxCR_DBM));
+
+  /* Prepare the DMA Stream configuration */
+  tmp |=  hdma->Init.Channel             | hdma->Init.Direction        |
+          hdma->Init.PeriphInc           | hdma->Init.MemInc           |
+          hdma->Init.PeriphDataAlignment | hdma->Init.MemDataAlignment |
+          hdma->Init.Mode                | hdma->Init.Priority;
+
+  /* the Memory burst and peripheral burst are not used when the FIFO is disabled */
+  if(hdma->Init.FIFOMode == DMA_FIFOMODE_ENABLE)
+  {
+    /* Get memory burst and peripheral burst */
+    tmp |=  hdma->Init.MemBurst | hdma->Init.PeriphBurst;
+  }
+
+  /* Write to DMA Stream CR register */
+  hdma->Instance->CR = tmp;
+
+  /* Get the FCR register value */
+  tmp = hdma->Instance->FCR;
+
+  /* Clear Direct mode and FIFO threshold bits */
+  tmp &= (uint32_t)~(DMA_SxFCR_DMDIS | DMA_SxFCR_FTH);
+
+  /* Prepare the DMA Stream FIFO configuration */
+  tmp |= hdma->Init.FIFOMode;
+
+  /* the FIFO threshold is not used when the FIFO mode is disabled */
+  if(hdma->Init.FIFOMode == DMA_FIFOMODE_ENABLE)
+  {
+    /* Get the FIFO threshold */
+    tmp |= hdma->Init.FIFOThreshold;
+  }
+
+  /* Write to DMA Stream FCR */
+  hdma->Instance->FCR = tmp;
+
+  /* Initialize the error code */
+  hdma->ErrorCode = HAL_DMA_ERROR_NONE;
+
+  /* Initialize the DMA state */
+  hdma->State = HAL_DMA_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the DMA peripheral
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Stream.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma)
+{
+  /* Check the DMA peripheral state */
+  if(hdma == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the DMA peripheral state */
+  if(hdma->State == HAL_DMA_STATE_BUSY)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Disable the selected DMA Streamx */
+  __HAL_DMA_DISABLE(hdma);
+
+  /* Reset DMA Streamx control register */
+  hdma->Instance->CR   = 0;
+
+  /* Reset DMA Streamx number of data to transfer register */
+  hdma->Instance->NDTR = 0;
+
+  /* Reset DMA Streamx peripheral address register */
+  hdma->Instance->PAR  = 0;
+
+  /* Reset DMA Streamx memory 0 address register */
+  hdma->Instance->M0AR = 0;
+
+  /* Reset DMA Streamx memory 1 address register */
+  hdma->Instance->M1AR = 0;
+
+  /* Reset DMA Streamx FIFO control register */
+  hdma->Instance->FCR  = (uint32_t)0x00000021;
+
+  /* Clear all flags */
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_DME_FLAG_INDEX(hdma));
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma));
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_FE_FLAG_INDEX(hdma));
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+
+  /* Initialize the error code */
+  hdma->ErrorCode = HAL_DMA_ERROR_NONE;
+
+  /* Initialize the DMA state */
+  hdma->State = HAL_DMA_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hdma);
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @addtogroup DMA_Exported_Functions_Group2
+  *
+@verbatim
+ ===============================================================================
+                      #####  IO operation functions  #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Configure the source, destination address and data length and Start DMA transfer
+      (+) Configure the source, destination address and data length and
+          Start DMA transfer with interrupt
+      (+) Abort DMA transfer
+      (+) Poll for transfer complete
+      (+) Handle DMA interrupt request
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Starts the DMA Transfer.
+  * @param  hdma      : pointer to a DMA_HandleTypeDef structure that contains
+  *                     the configuration information for the specified DMA Stream.
+  * @param  SrcAddress: The source memory Buffer address
+  * @param  DstAddress: The destination memory Buffer address
+  * @param  DataLength: The length of data to be transferred from source to destination
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_Start(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength)
+{
+  /* Process locked */
+  __HAL_LOCK(hdma);
+
+  /* Change DMA peripheral state */
+  hdma->State = HAL_DMA_STATE_BUSY;
+
+   /* Check the parameters */
+  assert_param(IS_DMA_BUFFER_SIZE(DataLength));
+
+  /* Disable the peripheral */
+  __HAL_DMA_DISABLE(hdma);
+
+  /* Configure the source, destination address and the data length */
+  DMA_SetConfig(hdma, SrcAddress, DstAddress, DataLength);
+
+  /* Enable the Peripheral */
+  __HAL_DMA_ENABLE(hdma);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Start the DMA Transfer with interrupt enabled.
+  * @param  hdma:       pointer to a DMA_HandleTypeDef structure that contains
+  *                     the configuration information for the specified DMA Stream.
+  * @param  SrcAddress: The source memory Buffer address
+  * @param  DstAddress: The destination memory Buffer address
+  * @param  DataLength: The length of data to be transferred from source to destination
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength)
+{
+  /* Process locked */
+  __HAL_LOCK(hdma);
+
+  /* Change DMA peripheral state */
+  hdma->State = HAL_DMA_STATE_BUSY;
+
+   /* Check the parameters */
+  assert_param(IS_DMA_BUFFER_SIZE(DataLength));
+
+  /* Disable the peripheral */
+  __HAL_DMA_DISABLE(hdma);
+
+  /* Configure the source, destination address and the data length */
+  DMA_SetConfig(hdma, SrcAddress, DstAddress, DataLength);
+
+  /* Enable the transfer complete interrupt */
+  __HAL_DMA_ENABLE_IT(hdma, DMA_IT_TC);
+
+  /* Enable the Half transfer complete interrupt */
+  __HAL_DMA_ENABLE_IT(hdma, DMA_IT_HT);
+
+  /* Enable the transfer Error interrupt */
+  __HAL_DMA_ENABLE_IT(hdma, DMA_IT_TE);
+
+  /* Enable the FIFO Error interrupt */
+  __HAL_DMA_ENABLE_IT(hdma, DMA_IT_FE);
+
+  /* Enable the direct mode Error interrupt */
+  __HAL_DMA_ENABLE_IT(hdma, DMA_IT_DME);
+
+   /* Enable the Peripheral */
+  __HAL_DMA_ENABLE(hdma);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Aborts the DMA Transfer.
+  * @param  hdma  : pointer to a DMA_HandleTypeDef structure that contains
+  *                 the configuration information for the specified DMA Stream.
+  *
+  * @note  After disabling a DMA Stream, a check for wait until the DMA Stream is
+  *        effectively disabled is added. If a Stream is disabled
+  *        while a data transfer is ongoing, the current data will be transferred
+  *        and the Stream will be effectively disabled only after the transfer of
+  *        this single data is finished.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
+{
+  uint32_t tickstart = 0;
+
+  /* Disable the stream */
+  __HAL_DMA_DISABLE(hdma);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Check if the DMA Stream is effectively disabled */
+  while((hdma->Instance->CR & DMA_SxCR_EN) != 0)
+  {
+    /* Check for the Timeout */
+    if((HAL_GetTick() - tickstart ) > HAL_TIMEOUT_DMA_ABORT)
+    {
+      /* Update error code */
+      hdma->ErrorCode |= HAL_DMA_ERROR_TIMEOUT;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_TIMEOUT;
+
+      return HAL_TIMEOUT;
+    }
+  }
+  /* Process Unlocked */
+  __HAL_UNLOCK(hdma);
+
+  /* Change the DMA state*/
+  hdma->State = HAL_DMA_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Polling for transfer complete.
+  * @param  hdma:          pointer to a DMA_HandleTypeDef structure that contains
+  *                        the configuration information for the specified DMA Stream.
+  * @param  CompleteLevel: Specifies the DMA level complete.
+  * @param  Timeout:       Timeout duration.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, uint32_t CompleteLevel, uint32_t Timeout)
+{
+  uint32_t temp, tmp, tmp1, tmp2;
+  uint32_t tickstart = 0;
+
+  /* Get the level transfer complete flag */
+  if(CompleteLevel == HAL_DMA_FULL_TRANSFER)
+  {
+    /* Transfer Complete flag */
+    temp = __HAL_DMA_GET_TC_FLAG_INDEX(hdma);
+  }
+  else
+  {
+    /* Half Transfer Complete flag */
+    temp = __HAL_DMA_GET_HT_FLAG_INDEX(hdma);
+  }
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while(__HAL_DMA_GET_FLAG(hdma, temp) == RESET)
+  {
+    tmp  = __HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma));
+    tmp1 = __HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_FE_FLAG_INDEX(hdma));
+    tmp2 = __HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_DME_FLAG_INDEX(hdma));
+    if((tmp != RESET) || (tmp1 != RESET) || (tmp2 != RESET))
+    {
+      if(tmp != RESET)
+      {
+        /* Update error code */
+        hdma->ErrorCode |= HAL_DMA_ERROR_TE;
+
+        /* Clear the transfer error flag */
+        __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma));
+      }
+      if(tmp1 != RESET)
+      {
+        /* Update error code */
+        hdma->ErrorCode |= HAL_DMA_ERROR_FE;
+
+        /* Clear the FIFO error flag */
+        __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_FE_FLAG_INDEX(hdma));
+      }
+      if(tmp2 != RESET)
+      {
+        /* Update error code */
+        hdma->ErrorCode |= HAL_DMA_ERROR_DME;
+
+        /* Clear the Direct Mode error flag */
+        __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_DME_FLAG_INDEX(hdma));
+      }
+      /* Change the DMA state */
+      hdma->State= HAL_DMA_STATE_ERROR;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+
+      return HAL_ERROR;
+    }
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        /* Update error code */
+        hdma->ErrorCode |= HAL_DMA_ERROR_TIMEOUT;
+
+        /* Change the DMA state */
+        hdma->State = HAL_DMA_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hdma);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  if(CompleteLevel == HAL_DMA_FULL_TRANSFER)
+  {
+    /* Multi_Buffering mode enabled */
+    if(((hdma->Instance->CR) & (uint32_t)(DMA_SxCR_DBM)) != 0)
+    {
+      /* Clear the half transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+      /* Clear the transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
+
+      /* Current memory buffer used is Memory 0 */
+      if((hdma->Instance->CR & DMA_SxCR_CT) == 0)
+      {
+        /* Change DMA peripheral state */
+        hdma->State = HAL_DMA_STATE_READY_MEM0;
+      }
+      /* Current memory buffer used is Memory 1 */
+      else if((hdma->Instance->CR & DMA_SxCR_CT) != 0)
+      {
+        /* Change DMA peripheral state */
+        hdma->State = HAL_DMA_STATE_READY_MEM1;
+      }
+    }
+    else
+    {
+      /* Clear the half transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+      /* Clear the transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
+
+      /* The selected Streamx EN bit is cleared (DMA is disabled and all transfers
+         are complete) */
+      hdma->State = HAL_DMA_STATE_READY_MEM0;
+    }
+    /* Process Unlocked */
+    __HAL_UNLOCK(hdma);
+  }
+  else
+  {
+    /* Multi_Buffering mode enabled */
+    if(((hdma->Instance->CR) & (uint32_t)(DMA_SxCR_DBM)) != 0)
+    {
+      /* Clear the half transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+
+      /* Current memory buffer used is Memory 0 */
+      if((hdma->Instance->CR & DMA_SxCR_CT) == 0)
+      {
+        /* Change DMA peripheral state */
+        hdma->State = HAL_DMA_STATE_READY_HALF_MEM0;
+      }
+      /* Current memory buffer used is Memory 1 */
+      else if((hdma->Instance->CR & DMA_SxCR_CT) != 0)
+      {
+        /* Change DMA peripheral state */
+        hdma->State = HAL_DMA_STATE_READY_HALF_MEM1;
+      }
+    }
+    else
+    {
+      /* Clear the half transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+
+      /* Change DMA peripheral state */
+      hdma->State = HAL_DMA_STATE_READY_HALF_MEM0;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles DMA interrupt request.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Stream.
+  * @retval None
+  */
+void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
+{
+  /* Transfer Error Interrupt management ***************************************/
+  if(__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma)) != RESET)
+  {
+    if(__HAL_DMA_GET_IT_SOURCE(hdma, DMA_IT_TE) != RESET)
+    {
+      /* Disable the transfer error interrupt */
+      __HAL_DMA_DISABLE_IT(hdma, DMA_IT_TE);
+
+      /* Clear the transfer error flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma));
+
+      /* Update error code */
+      hdma->ErrorCode |= HAL_DMA_ERROR_TE;
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_ERROR;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+
+      if(hdma->XferErrorCallback != NULL)
+      {
+        /* Transfer error callback */
+        hdma->XferErrorCallback(hdma);
+      }
+    }
+  }
+  /* FIFO Error Interrupt management ******************************************/
+  if(__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_FE_FLAG_INDEX(hdma)) != RESET)
+  {
+    if(__HAL_DMA_GET_IT_SOURCE(hdma, DMA_IT_FE) != RESET)
+    {
+      /* Disable the FIFO Error interrupt */
+      __HAL_DMA_DISABLE_IT(hdma, DMA_IT_FE);
+
+      /* Clear the FIFO error flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_FE_FLAG_INDEX(hdma));
+
+      /* Update error code */
+      hdma->ErrorCode |= HAL_DMA_ERROR_FE;
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_ERROR;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+
+      if(hdma->XferErrorCallback != NULL)
+      {
+        /* Transfer error callback */
+        hdma->XferErrorCallback(hdma);
+      }
+    }
+  }
+  /* Direct Mode Error Interrupt management ***********************************/
+  if(__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_DME_FLAG_INDEX(hdma)) != RESET)
+  {
+    if(__HAL_DMA_GET_IT_SOURCE(hdma, DMA_IT_DME) != RESET)
+    {
+      /* Disable the direct mode Error interrupt */
+      __HAL_DMA_DISABLE_IT(hdma, DMA_IT_DME);
+
+      /* Clear the direct mode error flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_DME_FLAG_INDEX(hdma));
+
+      /* Update error code */
+      hdma->ErrorCode |= HAL_DMA_ERROR_DME;
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_ERROR;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+
+      if(hdma->XferErrorCallback != NULL)
+      {
+        /* Transfer error callback */
+        hdma->XferErrorCallback(hdma);
+      }
+    }
+  }
+  /* Half Transfer Complete Interrupt management ******************************/
+  if(__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma)) != RESET)
+  {
+    if(__HAL_DMA_GET_IT_SOURCE(hdma, DMA_IT_HT) != RESET)
+    {
+      /* Multi_Buffering mode enabled */
+      if(((hdma->Instance->CR) & (uint32_t)(DMA_SxCR_DBM)) != 0)
+      {
+        /* Clear the half transfer complete flag */
+        __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+
+        /* Current memory buffer used is Memory 0 */
+        if((hdma->Instance->CR & DMA_SxCR_CT) == 0)
+        {
+          /* Change DMA peripheral state */
+          hdma->State = HAL_DMA_STATE_READY_HALF_MEM0;
+        }
+        /* Current memory buffer used is Memory 1 */
+        else if((hdma->Instance->CR & DMA_SxCR_CT) != 0)
+        {
+          /* Change DMA peripheral state */
+          hdma->State = HAL_DMA_STATE_READY_HALF_MEM1;
+        }
+      }
+      else
+      {
+        /* Disable the half transfer interrupt if the DMA mode is not CIRCULAR */
+        if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
+        {
+          /* Disable the half transfer interrupt */
+          __HAL_DMA_DISABLE_IT(hdma, DMA_IT_HT);
+        }
+        /* Clear the half transfer complete flag */
+        __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+
+        /* Change DMA peripheral state */
+        hdma->State = HAL_DMA_STATE_READY_HALF_MEM0;
+      }
+
+      if(hdma->XferHalfCpltCallback != NULL)
+      {
+        /* Half transfer callback */
+        hdma->XferHalfCpltCallback(hdma);
+      }
+    }
+  }
+  /* Transfer Complete Interrupt management ***********************************/
+  if(__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma)) != RESET)
+  {
+    if(__HAL_DMA_GET_IT_SOURCE(hdma, DMA_IT_TC) != RESET)
+    {
+      if(((hdma->Instance->CR) & (uint32_t)(DMA_SxCR_DBM)) != 0)
+      {
+        /* Clear the transfer complete flag */
+        __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
+
+        /* Current memory buffer used is Memory 1 */
+        if((hdma->Instance->CR & DMA_SxCR_CT) == 0)
+        {
+          if(hdma->XferM1CpltCallback != NULL)
+          {
+            /* Transfer complete Callback for memory1 */
+            hdma->XferM1CpltCallback(hdma);
+          }
+        }
+        /* Current memory buffer used is Memory 0 */
+        else if((hdma->Instance->CR & DMA_SxCR_CT) != 0)
+        {
+          if(hdma->XferCpltCallback != NULL)
+          {
+            /* Transfer complete Callback for memory0 */
+            hdma->XferCpltCallback(hdma);
+          }
+        }
+      }
+      /* Disable the transfer complete interrupt if the DMA mode is not CIRCULAR */
+      else
+      {
+        if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
+        {
+          /* Disable the transfer complete interrupt */
+          __HAL_DMA_DISABLE_IT(hdma, DMA_IT_TC);
+        }
+        /* Clear the transfer complete flag */
+        __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
+
+        /* Update error code */
+        hdma->ErrorCode |= HAL_DMA_ERROR_NONE;
+
+        /* Change the DMA state */
+        hdma->State = HAL_DMA_STATE_READY_MEM0;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hdma);
+
+        if(hdma->XferCpltCallback != NULL)
+        {
+          /* Transfer complete callback */
+          hdma->XferCpltCallback(hdma);
+        }
+      }
+    }
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @addtogroup DMA_Exported_Functions_Group3
+  *
+@verbatim
+ ===============================================================================
+                    ##### State and Errors functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) Check the DMA state
+      (+) Get error code
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the DMA state.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Stream.
+  * @retval HAL state
+  */
+HAL_DMA_StateTypeDef HAL_DMA_GetState(DMA_HandleTypeDef *hdma)
+{
+  return hdma->State;
+}
+
+/**
+  * @brief  Return the DMA error code
+  * @param  hdma : pointer to a DMA_HandleTypeDef structure that contains
+  *              the configuration information for the specified DMA Stream.
+  * @retval DMA Error Code
+  */
+uint32_t HAL_DMA_GetError(DMA_HandleTypeDef *hdma)
+{
+  return hdma->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_DMA_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_flash.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_flash.c
@@ -1,0 +1,817 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_flash.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   FLASH HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the internal FLASH memory:
+  *           + Program operations functions
+  *           + Memory Control functions
+  *           + Peripheral Errors functions
+  *
+  @verbatim
+  ==============================================================================
+                        ##### FLASH peripheral features #####
+  ==============================================================================
+
+  [..] The Flash memory interface manages CPU AHB I-Code and D-Code accesses
+       to the Flash memory. It implements the erase and program Flash memory operations
+       and the read and write protection mechanisms.
+
+  [..] The Flash memory interface accelerates code execution with a system of instruction
+       prefetch and cache lines.
+
+  [..] The FLASH main features are:
+      (+) Flash memory read operations
+      (+) Flash memory program/erase operations
+      (+) Read / write protections
+      (+) Prefetch on I-Code
+      (+) 64 cache lines of 128 bits on I-Code
+      (+) 8 cache lines of 128 bits on D-Code
+
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      This driver provides functions and macros to configure and program the FLASH
+      memory of all STM32F7xx devices.
+
+      (#) FLASH Memory IO Programming functions:
+           (++) Lock and Unlock the FLASH interface using HAL_FLASH_Unlock() and
+                HAL_FLASH_Lock() functions
+           (++) Program functions: byte, half word, word and double word
+           (++) There Two modes of programming :
+            (+++) Polling mode using HAL_FLASH_Program() function
+            (+++) Interrupt mode using HAL_FLASH_Program_IT() function
+
+      (#) Interrupts and flags management functions :
+           (++) Handle FLASH interrupts by calling HAL_FLASH_IRQHandler()
+           (++) Wait for last FLASH operation according to its status
+           (++) Get error flag status by calling HAL_SetErrorCode()
+    [..]
+      In addition to these functions, this driver includes a set of macros allowing
+      to handle the following operations:
+       (+) Set the latency
+       (+) Enable/Disable the prefetch buffer
+       (+) Enable/Disable the Instruction cache and the Data cache
+       (+) Reset the Instruction cache and the Data cache
+       (+) Enable/Disable the FLASH interrupts
+       (+) Monitor the FLASH flags status
+    [..]
+	(@) For any Flash memory program operation (erase or program), the CPU clock frequency
+        (HCLK) must be at least 1MHz.
+	(@) The contents of the Flash memory are not guaranteed if a device reset occurs during
+	    a Flash memory operation.
+    (@) Any attempt to read the Flash memory while it is being written or erased, causes the
+	    bus to stall. Read operations are processed correctly once the program operation has
+		completed. This means that code or data fetches cannot be performed while a write/erase
+		operation is ongoing.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup FLASH FLASH
+  * @brief FLASH HAL module driver
+  * @{
+  */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @addtogroup FLASH_Private_Constants
+  * @{
+  */
+#define SECTOR_MASK               ((uint32_t)0xFFFFFF07)
+#define FLASH_TIMEOUT_VALUE       ((uint32_t)50000)/* 50 s */
+/**
+  * @}
+  */
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/** @addtogroup FLASH_Private_Variables
+  * @{
+  */
+/* Variable used for Erase sectors under interruption */
+FLASH_ProcessTypeDef pFlash;
+/**
+  * @}
+  */
+
+/* Private function prototypes -----------------------------------------------*/
+/** @addtogroup FLASH_Private_Functions
+  * @{
+  */
+/* Program operations */
+static void   FLASH_Program_DoubleWord(uint32_t Address, uint64_t Data);
+static void   FLASH_Program_Word(uint32_t Address, uint32_t Data);
+static void   FLASH_Program_HalfWord(uint32_t Address, uint16_t Data);
+static void   FLASH_Program_Byte(uint32_t Address, uint8_t Data);
+static void   FLASH_SetErrorCode(void);
+
+HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup FLASH_Exported_Functions FLASH Exported Functions
+  * @{
+  */
+
+/** @defgroup FLASH_Exported_Functions_Group1 Programming operation functions
+ *  @brief   Programming operation functions
+ *
+@verbatim
+ ===============================================================================
+                  ##### Programming operation functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to manage the FLASH
+    program operations.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Program byte, halfword, word or double word at a specified address
+  * @param  TypeProgram:  Indicate the way to program at a specified address.
+  *                           This parameter can be a value of @ref FLASH_Type_Program
+  * @param  Address:  specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed
+  *
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint64_t Data)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_FLASH_TYPEPROGRAM(TypeProgram));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+  if(status == HAL_OK)
+  {
+    switch(TypeProgram)
+    {
+      case FLASH_TYPEPROGRAM_BYTE :
+      {
+        /*Program byte (8-bit) at a specified address.*/
+        FLASH_Program_Byte(Address, (uint8_t) Data);
+        break;
+      }
+
+      case FLASH_TYPEPROGRAM_HALFWORD :
+      {
+        /*Program halfword (16-bit) at a specified address.*/
+        FLASH_Program_HalfWord(Address, (uint16_t) Data);
+        break;
+      }
+
+      case FLASH_TYPEPROGRAM_WORD :
+      {
+        /*Program word (32-bit) at a specified address.*/
+        FLASH_Program_Word(Address, (uint32_t) Data);
+        break;
+      }
+
+      case FLASH_TYPEPROGRAM_DOUBLEWORD :
+      {
+        /*Program double word (64-bit) at a specified address.*/
+        FLASH_Program_DoubleWord(Address, Data);
+        break;
+      }
+      default :
+        break;
+    }
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+    /* If the program operation is completed, disable the PG Bit */
+    FLASH->CR &= (~FLASH_CR_PG);
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(&pFlash);
+
+  return status;
+}
+
+/**
+  * @brief   Program byte, halfword, word or double word at a specified address  with interrupt enabled.
+  * @param  TypeProgram:  Indicate the way to program at a specified address.
+  *                           This parameter can be a value of @ref FLASH_Type_Program
+  * @param  Address:  specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed
+  *
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Program_IT(uint32_t TypeProgram, uint32_t Address, uint64_t Data)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_FLASH_TYPEPROGRAM(TypeProgram));
+
+  /* Enable End of FLASH Operation interrupt */
+  __HAL_FLASH_ENABLE_IT(FLASH_IT_EOP);
+
+  /* Enable Error source interrupt */
+  __HAL_FLASH_ENABLE_IT(FLASH_IT_ERR);
+
+  /* Clear pending flags (if any) */
+  __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP    | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR |\
+                         FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR| FLASH_FLAG_ERSERR);
+
+  pFlash.ProcedureOnGoing = FLASH_PROC_PROGRAM;
+  pFlash.Address = Address;
+
+  switch(TypeProgram)
+  {
+    case FLASH_TYPEPROGRAM_BYTE :
+    {
+      /*Program byte (8-bit) at a specified address.*/
+      FLASH_Program_Byte(Address, (uint8_t) Data);
+      break;
+    }
+
+    case FLASH_TYPEPROGRAM_HALFWORD :
+    {
+      /*Program halfword (16-bit) at a specified address.*/
+      FLASH_Program_HalfWord(Address, (uint16_t) Data);
+      break;
+    }
+
+    case FLASH_TYPEPROGRAM_WORD :
+    {
+      /*Program word (32-bit) at a specified address.*/
+      FLASH_Program_Word(Address, (uint32_t) Data);
+      break;
+    }
+
+    case FLASH_TYPEPROGRAM_DOUBLEWORD :
+    {
+      /*Program double word (64-bit) at a specified address.*/
+      FLASH_Program_DoubleWord(Address, Data);
+      break;
+    }
+    default :
+      break;
+  }
+  return status;
+}
+
+/**
+  * @brief This function handles FLASH interrupt request.
+  * @retval None
+  */
+void HAL_FLASH_IRQHandler(void)
+{
+  uint32_t temp = 0;
+
+  /* If the program operation is completed, disable the PG Bit */
+  FLASH->CR &= (~FLASH_CR_PG);
+
+  /* If the erase operation is completed, disable the SER Bit */
+  FLASH->CR &= (~FLASH_CR_SER);
+  FLASH->CR &= SECTOR_MASK;
+
+  /* if the erase operation is completed, disable the MER Bit */
+  FLASH->CR &= (~FLASH_MER_BIT);
+
+  /* Check FLASH End of Operation flag  */
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_EOP) != RESET)
+  {
+    switch (pFlash.ProcedureOnGoing)
+    {
+      case FLASH_PROC_SECTERASE :
+      {
+        /* Nb of sector to erased can be decreased */
+        pFlash.NbSectorsToErase--;
+
+        /* Check if there are still sectors to erase */
+        if(pFlash.NbSectorsToErase != 0)
+        {
+          temp = pFlash.Sector;
+          /* Indicate user which sector has been erased */
+          HAL_FLASH_EndOfOperationCallback(temp);
+
+          /* Clear pending flags (if any) */
+          __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP);
+
+          /* Increment sector number */
+          temp = ++pFlash.Sector;
+          FLASH_Erase_Sector(temp, pFlash.VoltageForErase);
+        }
+        else
+        {
+          /* No more sectors to Erase, user callback can be called.*/
+          /* Reset Sector and stop Erase sectors procedure */
+          pFlash.Sector = temp = 0xFFFFFFFF;
+          /* FLASH EOP interrupt user callback */
+          HAL_FLASH_EndOfOperationCallback(temp);
+          /* Sector Erase procedure is completed */
+          pFlash.ProcedureOnGoing = FLASH_PROC_NONE;
+          /* Clear FLASH End of Operation pending bit */
+          __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP);
+        }
+        break;
+      }
+
+      case FLASH_PROC_MASSERASE :
+      {
+        /* MassErase ended. Return the selected bank : in this product we don't have Banks */
+        /* FLASH EOP interrupt user callback */
+        HAL_FLASH_EndOfOperationCallback(0);
+        /* MAss Erase procedure is completed */
+        pFlash.ProcedureOnGoing = FLASH_PROC_NONE;
+        /* Clear FLASH End of Operation pending bit */
+        __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP);
+        break;
+      }
+
+      case FLASH_PROC_PROGRAM :
+      {
+        /*Program ended. Return the selected address*/
+        /* FLASH EOP interrupt user callback */
+        HAL_FLASH_EndOfOperationCallback(pFlash.Address);
+        /* Programming procedure is completed */
+        pFlash.ProcedureOnGoing = FLASH_PROC_NONE;
+        /* Clear FLASH End of Operation pending bit */
+        __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP);
+        break;
+      }
+      default :
+        break;
+    }
+  }
+
+  /* Check FLASH operation error flags */
+  if(__HAL_FLASH_GET_FLAG((FLASH_FLAG_OPERR  | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_ERSERR )) != RESET)
+  {
+    switch (pFlash.ProcedureOnGoing)
+    {
+      case FLASH_PROC_SECTERASE :
+      {
+        /* return the faulty sector */
+        temp = pFlash.Sector;
+        pFlash.Sector = 0xFFFFFFFF;
+        break;
+      }
+      case FLASH_PROC_MASSERASE :
+      {
+        /* No return in case of Mass Erase */
+        temp = 0;
+        break;
+      }
+      case FLASH_PROC_PROGRAM :
+      {
+        /*return the faulty address*/
+        temp = pFlash.Address;
+        break;
+      }
+			default :
+				break;
+    }
+    /*Save the Error code*/
+    FLASH_SetErrorCode();
+
+    /* FLASH error interrupt user callback */
+    HAL_FLASH_OperationErrorCallback(temp);
+    /* Clear FLASH error pending bits */
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_OPERR  | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_ERSERR );
+
+    /*Stop the procedure ongoing */
+    pFlash.ProcedureOnGoing = FLASH_PROC_NONE;
+  }
+
+  if(pFlash.ProcedureOnGoing == FLASH_PROC_NONE)
+  {
+    /* Disable End of FLASH Operation interrupt */
+    __HAL_FLASH_DISABLE_IT(FLASH_IT_EOP);
+
+    /* Disable Error source interrupt */
+    __HAL_FLASH_DISABLE_IT(FLASH_IT_ERR);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(&pFlash);
+  }
+
+}
+
+/**
+  * @brief  FLASH end of operation interrupt callback
+  * @param  ReturnValue: The value saved in this parameter depends on the ongoing procedure
+  *                 - Sectors Erase: Sector which has been erased (if 0xFFFFFFFF, it means that
+  *                                  all the selected sectors have been erased)
+  *                 - Program      : Address which was selected for data program
+  *                 - Mass Erase   : No return value expected
+  * @retval None
+  */
+__weak void HAL_FLASH_EndOfOperationCallback(uint32_t ReturnValue)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FLASH_EndOfOperationCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  FLASH operation error interrupt callback
+  * @param  ReturnValue: The value saved in this parameter depends on the ongoing procedure
+  *                 - Sectors Erase: Sector which has been erased (if 0xFFFFFFFF, it means that
+  *                                  all the selected sectors have been erased)
+  *                 - Program      : Address which was selected for data program
+  *                 - Mass Erase   : No return value expected
+  * @retval None
+  */
+__weak void HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FLASH_OperationErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Exported_Functions_Group2 Peripheral Control functions
+ *  @brief   management functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the FLASH
+    memory operations.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Unlock the FLASH control register access
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Unlock(void)
+{
+  if((FLASH->CR & FLASH_CR_LOCK) != RESET)
+  {
+    /* Authorize the FLASH Registers access */
+    FLASH->KEYR = FLASH_KEY1;
+    FLASH->KEYR = FLASH_KEY2;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Locks the FLASH control register access
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Lock(void)
+{
+  /* Set the LOCK Bit to lock the FLASH Registers access */
+  FLASH->CR |= FLASH_CR_LOCK;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Unlock the FLASH Option Control Registers access.
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_OB_Unlock(void)
+{
+  if((FLASH->OPTCR & FLASH_OPTCR_OPTLOCK) != RESET)
+  {
+    /* Authorizes the Option Byte register programming */
+    FLASH->OPTKEYR = FLASH_OPT_KEY1;
+    FLASH->OPTKEYR = FLASH_OPT_KEY2;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Lock the FLASH Option Control Registers access.
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_OB_Lock(void)
+{
+  /* Set the OPTLOCK Bit to lock the FLASH Option Byte Registers access */
+  FLASH->OPTCR |= FLASH_OPTCR_OPTLOCK;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Launch the option byte loading.
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_OB_Launch(void)
+{
+  /* Set the OPTSTRT bit in OPTCR register */
+  FLASH->OPTCR |= FLASH_OPTCR_OPTSTRT;
+
+  /* Wait for last operation to be completed */
+  return(FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE));
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Exported_Functions_Group3 Peripheral State and Errors functions
+ *  @brief   Peripheral Errors functions
+ *
+@verbatim
+ ===============================================================================
+                ##### Peripheral Errors functions #####
+ ===============================================================================
+    [..]
+    This subsection permits to get in run-time Errors of the FLASH peripheral.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Get the specific FLASH error flag.
+  * @retval FLASH_ErrorCode: The returned value can be:
+  *            @arg FLASH_ERROR_ERS: FLASH Erasing Sequence error flag
+  *            @arg FLASH_ERROR_PGP: FLASH Programming Parallelism error flag
+  *            @arg FLASH_ERROR_PGA: FLASH Programming Alignment error flag
+  *            @arg FLASH_ERROR_WRP: FLASH Write protected error flag
+  *            @arg FLASH_ERROR_OPERATION: FLASH operation Error flag
+  */
+uint32_t HAL_FLASH_GetError(void)
+{
+   return pFlash.ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  Wait for a FLASH operation to complete.
+  * @param  Timeout: maximum flash operationtimeout
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  /* Clear Error Code */
+  pFlash.ErrorCode = HAL_FLASH_ERROR_NONE;
+
+  /* Wait for the FLASH operation to complete by polling on BUSY flag to be reset.
+     Even if the FLASH operation fails, the BUSY flag will be reset and an error
+     flag will be set */
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while(__HAL_FLASH_GET_FLAG(FLASH_FLAG_BSY) != RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  if(__HAL_FLASH_GET_FLAG((FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | \
+                           FLASH_FLAG_PGPERR | FLASH_FLAG_ERSERR )) != RESET)
+  {
+    /*Save the error code*/
+    FLASH_SetErrorCode();
+    return HAL_ERROR;
+  }
+
+  /* If there is an error flag set */
+  return HAL_OK;
+
+}
+
+/**
+  * @brief  Program a double word (64-bit) at a specified address.
+  * @note   This function must be used when the device voltage range is from
+  *         2.7V to 3.6V and an External Vpp is present.
+  *
+  * @note   If an erase and a program operations are requested simultaneously,
+  *         the erase operation is performed before the program one.
+  *
+  * @param  Address: specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed.
+  * @retval None
+  */
+static void FLASH_Program_DoubleWord(uint32_t Address, uint64_t Data)
+{
+  /* Check the parameters */
+  assert_param(IS_FLASH_ADDRESS(Address));
+
+  /* If the previous operation is completed, proceed to program the new data */
+  FLASH->CR &= CR_PSIZE_MASK;
+  FLASH->CR |= FLASH_PSIZE_DOUBLE_WORD;
+  FLASH->CR |= FLASH_CR_PG;
+
+  *(__IO uint64_t*)Address = Data;
+
+  /* Data synchronous Barrier (DSB) Just after the write operation
+     This will force the CPU to respect the sequence of instruction (no optimization).*/
+  __DSB();
+}
+
+
+/**
+  * @brief  Program word (32-bit) at a specified address.
+  * @note   This function must be used when the device voltage range is from
+  *         2.7V to 3.6V.
+  *
+  * @note   If an erase and a program operations are requested simultaneously,
+  *         the erase operation is performed before the program one.
+  *
+  * @param  Address: specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed.
+  * @retval None
+  */
+static void FLASH_Program_Word(uint32_t Address, uint32_t Data)
+{
+  /* Check the parameters */
+  assert_param(IS_FLASH_ADDRESS(Address));
+
+  /* If the previous operation is completed, proceed to program the new data */
+  FLASH->CR &= CR_PSIZE_MASK;
+  FLASH->CR |= FLASH_PSIZE_WORD;
+  FLASH->CR |= FLASH_CR_PG;
+
+  *(__IO uint32_t*)Address = Data;
+
+  /* Data synchronous Barrier (DSB) Just after the write operation
+     This will force the CPU to respect the sequence of instruction (no optimization).*/
+  __DSB();
+}
+
+/**
+  * @brief  Program a half-word (16-bit) at a specified address.
+  * @note   This function must be used when the device voltage range is from
+  *         2.7V to 3.6V.
+  *
+  * @note   If an erase and a program operations are requested simultaneously,
+  *         the erase operation is performed before the program one.
+  *
+  * @param  Address: specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed.
+  * @retval None
+  */
+static void FLASH_Program_HalfWord(uint32_t Address, uint16_t Data)
+{
+  /* Check the parameters */
+  assert_param(IS_FLASH_ADDRESS(Address));
+
+  /* If the previous operation is completed, proceed to program the new data */
+  FLASH->CR &= CR_PSIZE_MASK;
+  FLASH->CR |= FLASH_PSIZE_HALF_WORD;
+  FLASH->CR |= FLASH_CR_PG;
+
+  *(__IO uint16_t*)Address = Data;
+
+  /* Data synchronous Barrier (DSB) Just after the write operation
+     This will force the CPU to respect the sequence of instruction (no optimization).*/
+  __DSB();
+
+}
+
+/**
+  * @brief  Program byte (8-bit) at a specified address.
+  * @note   This function must be used when the device voltage range is from
+  *         2.7V to 3.6V.
+  *
+  * @note   If an erase and a program operations are requested simultaneously,
+  *         the erase operation is performed before the program one.
+  *
+  * @param  Address: specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed.
+  * @retval None
+  */
+static void FLASH_Program_Byte(uint32_t Address, uint8_t Data)
+{
+  /* Check the parameters */
+  assert_param(IS_FLASH_ADDRESS(Address));
+
+  /* If the previous operation is completed, proceed to program the new data */
+  FLASH->CR &= CR_PSIZE_MASK;
+  FLASH->CR |= FLASH_PSIZE_BYTE;
+  FLASH->CR |= FLASH_CR_PG;
+
+  *(__IO uint8_t*)Address = Data;
+
+  /* Data synchronous Barrier (DSB) Just after the write operation
+     This will force the CPU to respect the sequence of instruction (no optimization).*/
+  __DSB();
+}
+
+/**
+  * @brief  Set the specific FLASH error flag.
+  * @retval None
+  */
+static void FLASH_SetErrorCode(void)
+{
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_WRPERR) != RESET)
+  {
+   pFlash.ErrorCode |= HAL_FLASH_ERROR_WRP;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGAERR) != RESET)
+  {
+   pFlash.ErrorCode |= HAL_FLASH_ERROR_PGA;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGPERR) != RESET)
+  {
+    pFlash.ErrorCode |= HAL_FLASH_ERROR_PGP;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_ERSERR) != RESET)
+  {
+    pFlash.ErrorCode |= HAL_FLASH_ERROR_ERS;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_OPERR) != RESET)
+  {
+    pFlash.ErrorCode |= HAL_FLASH_ERROR_OPERATION;
+  }
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_flash_ex.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_flash_ex.c
@@ -1,0 +1,817 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_flash_ex.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Extended FLASH HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the FLASH extension peripheral:
+  *           + Extended programming operations functions
+  *
+  @verbatim
+  ==============================================================================
+                   ##### Flash Extension features #####
+  ==============================================================================
+
+  [..] Comparing to other previous devices, the FLASH interface for STM32F727xx/437xx and
+       devices contains the following additional features
+
+       (+) Capacity up to 2 Mbyte with dual bank architecture supporting read-while-write
+           capability (RWW)
+       (+) Dual bank memory organization
+       (+) PCROP protection for all banks
+
+                      ##### How to use this driver #####
+  ==============================================================================
+  [..] This driver provides functions to configure and program the FLASH memory
+       of all STM32F7xx devices. It includes
+      (#) FLASH Memory Erase functions:
+           (++) Lock and Unlock the FLASH interface using HAL_FLASH_Unlock() and
+                HAL_FLASH_Lock() functions
+           (++) Erase function: Erase sector, erase all sectors
+           (++) There are two modes of erase :
+             (+++) Polling Mode using HAL_FLASHEx_Erase()
+             (+++) Interrupt Mode using HAL_FLASHEx_Erase_IT()
+
+      (#) Option Bytes Programming functions: Use HAL_FLASHEx_OBProgram() to :
+           (++) Set/Reset the write protection
+           (++) Set the Read protection Level
+           (++) Set the BOR level
+           (++) Program the user Option Bytes
+      (#) Advanced Option Bytes Programming functions: Use HAL_FLASHEx_AdvOBProgram() to :
+       (++) Extended space (bank 2) erase function
+       (++) Full FLASH space (2 Mo) erase (bank 1 and bank 2)
+       (++) Dual Boot activation
+       (++) Write protection configuration for bank 2
+       (++) PCROP protection configuration and control for both banks
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup FLASHEx FLASHEx
+  * @brief FLASH HAL Extension module driver
+  * @{
+  */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @addtogroup FLASHEx_Private_Constants
+  * @{
+  */
+#define SECTOR_MASK               ((uint32_t)0xFFFFFF07)
+#define FLASH_TIMEOUT_VALUE       ((uint32_t)50000)/* 50 s */
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/** @addtogroup FLASHEx_Private_Variables
+  * @{
+  */
+extern FLASH_ProcessTypeDef pFlash;
+/**
+  * @}
+  */
+
+/* Private function prototypes -----------------------------------------------*/
+/** @addtogroup FLASHEx_Private_Functions
+  * @{
+  */
+/* Option bytes control */
+static void               FLASH_MassErase(uint8_t VoltageRange);
+static HAL_StatusTypeDef  FLASH_OB_EnableWRP(uint32_t WRPSector);
+static HAL_StatusTypeDef  FLASH_OB_DisableWRP(uint32_t WRPSector);
+static HAL_StatusTypeDef  FLASH_OB_RDP_LevelConfig(uint32_t Level);
+static HAL_StatusTypeDef  FLASH_OB_UserConfig(uint32_t Wwdg, uint32_t Iwdg, uint32_t Stop, uint32_t Stdby, uint32_t Iwdgstop, uint32_t Iwdgstdby);
+static HAL_StatusTypeDef  FLASH_OB_BOR_LevelConfig(uint8_t Level);
+static HAL_StatusTypeDef  FLASH_OB_BootAddressConfig(uint32_t BootOption, uint32_t Address);
+static uint32_t           FLASH_OB_GetUser(void);
+static uint32_t           FLASH_OB_GetWRP(void);
+static uint8_t            FLASH_OB_GetRDP(void);
+static uint32_t           FLASH_OB_GetBOR(void);
+static uint32_t           FLASH_OB_GetBootAddress(uint32_t BootOption);
+
+extern HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup FLASHEx_Exported_Functions FLASHEx Exported Functions
+  * @{
+  */
+
+/** @defgroup FLASHEx_Exported_Functions_Group1 Extended IO operation functions
+ *  @brief   Extended IO operation functions
+ *
+@verbatim
+ ===============================================================================
+                ##### Extended programming operation functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to manage the Extension FLASH
+    programming operations Operations.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Perform a mass erase or erase the specified FLASH memory sectors
+  * @param[in]  pEraseInit: pointer to an FLASH_EraseInitTypeDef structure that
+  *         contains the configuration information for the erasing.
+  *
+  * @param[out]  SectorError: pointer to variable  that
+  *         contains the configuration information on faulty sector in case of error
+  *         (0xFFFFFFFF means that all the sectors have been correctly erased)
+  *
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t *SectorError)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  uint32_t index = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_FLASH_TYPEERASE(pEraseInit->TypeErase));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+  if(status == HAL_OK)
+  {
+    /*Initialization of SectorError variable*/
+    *SectorError = 0xFFFFFFFF;
+
+    if(pEraseInit->TypeErase == FLASH_TYPEERASE_MASSERASE)
+    {
+      /*Mass erase to be done*/
+      FLASH_MassErase((uint8_t) pEraseInit->VoltageRange);
+
+      /* Wait for last operation to be completed */
+      status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+      /* if the erase operation is completed, disable the MER Bit */
+      FLASH->CR &= (~FLASH_MER_BIT);
+    }
+    else
+    {
+      /* Check the parameters */
+      assert_param(IS_FLASH_NBSECTORS(pEraseInit->NbSectors + pEraseInit->Sector));
+
+      /* Erase by sector by sector to be done*/
+      for(index = pEraseInit->Sector; index < (pEraseInit->NbSectors + pEraseInit->Sector); index++)
+      {
+        FLASH_Erase_Sector(index, (uint8_t) pEraseInit->VoltageRange);
+
+        /* Wait for last operation to be completed */
+        status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+        /* If the erase operation is completed, disable the SER Bit */
+        FLASH->CR &= (~FLASH_CR_SER);
+        FLASH->CR &= SECTOR_MASK;
+
+        if(status != HAL_OK)
+        {
+          /* In case of error, stop erase procedure and return the faulty sector*/
+          *SectorError = index;
+          break;
+        }
+      }
+    }
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(&pFlash);
+
+  return status;
+}
+
+/**
+  * @brief  Perform a mass erase or erase the specified FLASH memory sectors  with interrupt enabled
+  * @param  pEraseInit: pointer to an FLASH_EraseInitTypeDef structure that
+  *         contains the configuration information for the erasing.
+  *
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_FLASH_TYPEERASE(pEraseInit->TypeErase));
+
+  /* Enable End of FLASH Operation interrupt */
+  __HAL_FLASH_ENABLE_IT(FLASH_IT_EOP);
+
+  /* Enable Error source interrupt */
+  __HAL_FLASH_ENABLE_IT(FLASH_IT_ERR);
+
+  /* Clear pending flags (if any) */
+  __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP    | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR |\
+                         FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR| FLASH_FLAG_ERSERR);
+
+  if(pEraseInit->TypeErase == FLASH_TYPEERASE_MASSERASE)
+  {
+    /*Mass erase to be done*/
+    pFlash.ProcedureOnGoing = FLASH_PROC_MASSERASE;
+    FLASH_MassErase((uint8_t) pEraseInit->VoltageRange);
+  }
+  else
+  {
+    /* Erase by sector to be done*/
+
+    /* Check the parameters */
+    assert_param(IS_FLASH_NBSECTORS(pEraseInit->NbSectors + pEraseInit->Sector));
+
+    pFlash.ProcedureOnGoing = FLASH_PROC_SECTERASE;
+    pFlash.NbSectorsToErase = pEraseInit->NbSectors;
+    pFlash.Sector = pEraseInit->Sector;
+    pFlash.VoltageForErase = (uint8_t)pEraseInit->VoltageRange;
+
+    /*Erase 1st sector and wait for IT*/
+    FLASH_Erase_Sector(pEraseInit->Sector, pEraseInit->VoltageRange);
+  }
+
+  return status;
+}
+
+/**
+  * @brief   Program option bytes
+  * @param  pOBInit: pointer to an FLASH_OBInitStruct structure that
+  *         contains the configuration information for the programming.
+  *
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_OPTIONBYTE(pOBInit->OptionType));
+
+  /* Write protection configuration */
+  if((pOBInit->OptionType & OPTIONBYTE_WRP) == OPTIONBYTE_WRP)
+  {
+    assert_param(IS_WRPSTATE(pOBInit->WRPState));
+    if(pOBInit->WRPState == OB_WRPSTATE_ENABLE)
+    {
+      /*Enable of Write protection on the selected Sector*/
+      status = FLASH_OB_EnableWRP(pOBInit->WRPSector);
+    }
+    else
+    {
+      /*Disable of Write protection on the selected Sector*/
+      status = FLASH_OB_DisableWRP(pOBInit->WRPSector);
+    }
+  }
+
+  /* Read protection configuration */
+  if((pOBInit->OptionType & OPTIONBYTE_RDP) == OPTIONBYTE_RDP)
+  {
+    status = FLASH_OB_RDP_LevelConfig(pOBInit->RDPLevel);
+  }
+
+  /* USER  configuration */
+  if((pOBInit->OptionType & OPTIONBYTE_USER) == OPTIONBYTE_USER)
+  {
+    status = FLASH_OB_UserConfig(pOBInit->USERConfig & OB_WWDG_SW,
+                                 pOBInit->USERConfig & OB_IWDG_SW,
+                                 pOBInit->USERConfig & OB_STOP_NO_RST,
+                                 pOBInit->USERConfig & OB_STDBY_NO_RST,
+                                 pOBInit->USERConfig & OB_IWDG_STOP_ACTIVE,
+                                 pOBInit->USERConfig & OB_IWDG_STDBY_ACTIVE);
+  }
+
+  /* BOR Level  configuration */
+  if((pOBInit->OptionType & OPTIONBYTE_BOR) == OPTIONBYTE_BOR)
+  {
+    status = FLASH_OB_BOR_LevelConfig(pOBInit->BORLevel);
+  }
+
+  /* Boot 0 Address configuration */
+  if((pOBInit->OptionType & OPTIONBYTE_BOOTADDR_0) == OPTIONBYTE_BOOTADDR_0)
+  {
+    status = FLASH_OB_BootAddressConfig(OPTIONBYTE_BOOTADDR_0, pOBInit->BootAddr0);
+  }
+
+  /* Boot 1 Address configuration */
+  if((pOBInit->OptionType & OPTIONBYTE_BOOTADDR_1) == OPTIONBYTE_BOOTADDR_1)
+  {
+    status = FLASH_OB_BootAddressConfig(OPTIONBYTE_BOOTADDR_1, pOBInit->BootAddr1);
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(&pFlash);
+
+  return status;
+}
+
+/**
+  * @brief   Get the Option byte configuration
+  * @param  pOBInit: pointer to an FLASH_OBInitStruct structure that
+  *         contains the configuration information for the programming.
+  *
+  * @retval None
+  */
+void HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit)
+{
+  pOBInit->OptionType = OPTIONBYTE_WRP | OPTIONBYTE_RDP | OPTIONBYTE_USER |\
+	                      OPTIONBYTE_BOR | OPTIONBYTE_BOOTADDR_0 | OPTIONBYTE_BOOTADDR_1;
+
+  /*Get WRP*/
+  pOBInit->WRPSector = FLASH_OB_GetWRP();
+
+  /*Get RDP Level*/
+  pOBInit->RDPLevel = FLASH_OB_GetRDP();
+
+  /*Get USER*/
+  pOBInit->USERConfig = FLASH_OB_GetUser();
+
+  /*Get BOR Level*/
+  pOBInit->BORLevel = FLASH_OB_GetBOR();
+
+	/*Get Boot Address when Boot pin = 0 */
+  pOBInit->BootAddr0 = FLASH_OB_GetBootAddress(OPTIONBYTE_BOOTADDR_0);
+
+  /*Get Boot Address when Boot pin = 1 */
+  pOBInit->BootAddr1 = FLASH_OB_GetBootAddress(OPTIONBYTE_BOOTADDR_1);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  Full erase of FLASH memory sectors
+  * @param  VoltageRange: The device voltage range which defines the erase parallelism.
+  *          This parameter can be one of the following values:
+  *            @arg VOLTAGE_RANGE_1: when the device voltage range is 1.8V to 2.1V,
+  *                                  the operation will be done by byte (8-bit)
+  *            @arg VOLTAGE_RANGE_2: when the device voltage range is 2.1V to 2.7V,
+  *                                  the operation will be done by half word (16-bit)
+  *            @arg VOLTAGE_RANGE_3: when the device voltage range is 2.7V to 3.6V,
+  *                                  the operation will be done by word (32-bit)
+  *            @arg VOLTAGE_RANGE_4: when the device voltage range is 2.7V to 3.6V + External Vpp,
+  *                                  the operation will be done by double word (64-bit)
+  *
+  * @retval HAL Status
+  */
+static void FLASH_MassErase(uint8_t VoltageRange)
+{
+  uint32_t tmp_psize = 0;
+
+  /* Check the parameters */
+  assert_param(IS_VOLTAGERANGE(VoltageRange));
+
+  /* if the previous operation is completed, proceed to erase all sectors */
+  FLASH->CR &= CR_PSIZE_MASK;
+  FLASH->CR |= tmp_psize;
+  FLASH->CR |= FLASH_CR_MER;
+  FLASH->CR |= FLASH_CR_STRT;
+  /* Data synchronous Barrier (DSB) Just after the write operation
+     This will force the CPU to respect the sequence of instruction (no optimization).*/
+  __DSB();
+}
+
+/**
+  * @brief  Erase the specified FLASH memory sector
+  * @param  Sector: FLASH sector to erase
+  *         The value of this parameter depend on device used within the same series
+  * @param  VoltageRange: The device voltage range which defines the erase parallelism.
+  *          This parameter can be one of the following values:
+  *            @arg FLASH_VOLTAGE_RANGE_1: when the device voltage range is 1.8V to 2.1V,
+  *                                  the operation will be done by byte (8-bit)
+  *            @arg FLASH_VOLTAGE_RANGE_2: when the device voltage range is 2.1V to 2.7V,
+  *                                  the operation will be done by half word (16-bit)
+  *            @arg FLASH_VOLTAGE_RANGE_3: when the device voltage range is 2.7V to 3.6V,
+  *                                  the operation will be done by word (32-bit)
+  *            @arg FLASH_VOLTAGE_RANGE_4: when the device voltage range is 2.7V to 3.6V + External Vpp,
+  *                                  the operation will be done by double word (64-bit)
+  *
+  * @retval None
+  */
+void FLASH_Erase_Sector(uint32_t Sector, uint8_t VoltageRange)
+{
+  uint32_t tmp_psize = 0;
+
+  /* Check the parameters */
+  assert_param(IS_FLASH_SECTOR(Sector));
+  assert_param(IS_VOLTAGERANGE(VoltageRange));
+
+  if(VoltageRange == FLASH_VOLTAGE_RANGE_1)
+  {
+     tmp_psize = FLASH_PSIZE_BYTE;
+  }
+  else if(VoltageRange == FLASH_VOLTAGE_RANGE_2)
+  {
+    tmp_psize = FLASH_PSIZE_HALF_WORD;
+  }
+  else if(VoltageRange == FLASH_VOLTAGE_RANGE_3)
+  {
+    tmp_psize = FLASH_PSIZE_WORD;
+  }
+  else
+  {
+    tmp_psize = FLASH_PSIZE_DOUBLE_WORD;
+  }
+
+  /* If the previous operation is completed, proceed to erase the sector */
+  FLASH->CR &= CR_PSIZE_MASK;
+  FLASH->CR |= tmp_psize;
+  FLASH->CR &= SECTOR_MASK;
+  FLASH->CR |= FLASH_CR_SER | (Sector << POSITION_VAL(FLASH_CR_SNB));
+  FLASH->CR |= FLASH_CR_STRT;
+
+  /* Data synchronous Barrier (DSB) Just after the write operation
+     This will force the CPU to respect the sequence of instruction (no optimization).*/
+  __DSB();
+}
+
+/**
+  * @brief  Enable the write protection of the desired bank1 or bank 2 sectors
+  *
+  * @note   When the memory read protection level is selected (RDP level = 1),
+  *         it is not possible to program or erase the flash sector i if CortexM4
+  *         debug features are connected or boot code is executed in RAM, even if nWRPi = 1
+  * @note   Active value of nWRPi bits is inverted when PCROP mode is active (SPRMOD =1).
+  *
+  * @param  WRPSector: specifies the sector(s) to be write protected.
+  *          This parameter can be one of the following values:
+  *            @arg WRPSector: A value between OB_WRP_SECTOR_0 and OB_WRP_SECTOR_7
+  *            @arg OB_WRP_SECTOR_All
+  *
+  * @retval HAL FLASH State
+  */
+static HAL_StatusTypeDef FLASH_OB_EnableWRP(uint32_t WRPSector)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_OB_WRP_SECTOR(WRPSector));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+  if(status == HAL_OK)
+  {
+    /*Write protection enabled on sectors */
+    FLASH->OPTCR &= (~WRPSector);
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Disable the write protection of the desired bank1 or bank 2 sectors
+  *
+  * @note   When the memory read protection level is selected (RDP level = 1),
+  *         it is not possible to program or erase the flash sector i if CortexM4
+  *         debug features are connected or boot code is executed in RAM, even if nWRPi = 1
+  *
+  * @param  WRPSector: specifies the sector(s) to be write protected.
+  *          This parameter can be one of the following values:
+  *            @arg WRPSector: A value between OB_WRP_SECTOR_0 and OB_WRP_SECTOR_7
+  *            @arg OB_WRP_Sector_All
+  *
+  *
+  * @retval HAL Status
+  */
+static HAL_StatusTypeDef FLASH_OB_DisableWRP(uint32_t WRPSector)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_OB_WRP_SECTOR(WRPSector));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+  if(status == HAL_OK)
+  {
+    /* Write protection disabled on sectors */
+    FLASH->OPTCR |= (WRPSector);
+  }
+
+  return status;
+}
+
+
+
+
+/**
+  * @brief  Set the read protection level.
+  * @param  Level: specifies the read protection level.
+  *          This parameter can be one of the following values:
+  *            @arg OB_RDP_LEVEL_0: No protection
+  *            @arg OB_RDP_LEVEL_1: Read protection of the memory
+  *            @arg OB_RDP_LEVEL_2: Full chip protection
+  *
+  * @note WARNING: When enabling OB_RDP level 2 it's no more possible to go back to level 1 or 0
+  *
+  * @retval HAL Status
+  */
+static HAL_StatusTypeDef FLASH_OB_RDP_LevelConfig(uint32_t Level)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_OB_RDP_LEVEL(Level));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+  if(status == HAL_OK)
+  {
+    MODIFY_REG(FLASH->OPTCR, FLASH_OPTCR_RDP, Level);
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Program the FLASH User Option Byte: IWDG_SW / RST_STOP / RST_STDBY.
+  * @param  Wwdg: Selects the IWDG mode
+  *          This parameter can be one of the following values:
+  *            @arg OB_WWDG_SW: Software WWDG selected
+  *            @arg OB_WWDG_HW: Hardware WWDG selected
+  * @param  Iwdg: Selects the WWDG mode
+  *          This parameter can be one of the following values:
+  *            @arg OB_IWDG_SW: Software IWDG selected
+  *            @arg OB_IWDG_HW: Hardware IWDG selected
+  * @param  Stop: Reset event when entering STOP mode.
+  *          This parameter  can be one of the following values:
+  *            @arg OB_STOP_NO_RST: No reset generated when entering in STOP
+  *            @arg OB_STOP_RST: Reset generated when entering in STOP
+  * @param  Stdby: Reset event when entering Standby mode.
+  *          This parameter  can be one of the following values:
+  *            @arg OB_STDBY_NO_RST: No reset generated when entering in STANDBY
+  *            @arg OB_STDBY_RST: Reset generated when entering in STANDBY
+  * @param  Iwdgstop: Independent watchdog counter freeze in Stop mode.
+  *          This parameter  can be one of the following values:
+  *            @arg OB_IWDG_STOP_FREEZE: Freeze IWDG counter in STOP
+  *            @arg OB_IWDG_STOP_ACTIVE: IWDG counter active in STOP
+  * @param  Iwdgstdby: Independent watchdog counter freeze in standby mode.
+  *          This parameter  can be one of the following values:
+  *            @arg OB_IWDG_STDBY_FREEZE: Freeze IWDG counter in STANDBY
+  *            @arg OB_IWDG_STDBY_ACTIVE: IWDG counter active in STANDBY
+  * @retval HAL Status
+  */
+static HAL_StatusTypeDef FLASH_OB_UserConfig(uint32_t Wwdg, uint32_t Iwdg, uint32_t Stop, uint32_t Stdby, uint32_t Iwdgstop, uint32_t Iwdgstdby )
+{
+  uint32_t useroptionmask = 0x00;
+  uint32_t useroptionvalue = 0x00;
+
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_OB_WWDG_SOURCE(Wwdg));
+  assert_param(IS_OB_IWDG_SOURCE(Iwdg));
+  assert_param(IS_OB_STOP_SOURCE(Stop));
+  assert_param(IS_OB_STDBY_SOURCE(Stdby));
+  assert_param(IS_OB_IWDG_STOP_FREEZE(Iwdgstop));
+  assert_param(IS_OB_IWDG_STDBY_FREEZE(Iwdgstdby));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+  if(status == HAL_OK)
+  {
+    useroptionmask = (FLASH_OPTCR_WWDG_SW | FLASH_OPTCR_IWDG_SW | FLASH_OPTCR_nRST_STOP | \
+                      FLASH_OPTCR_nRST_STDBY | FLASH_OPTCR_IWDG_STOP | FLASH_OPTCR_IWDG_STDBY);
+
+    useroptionvalue = (Iwdg | Wwdg | Stop | Stdby | Iwdgstop | Iwdgstdby);
+
+    /* Update User Option Byte */
+    MODIFY_REG(FLASH->OPTCR, useroptionmask, useroptionvalue);
+  }
+
+  return status;
+
+}
+
+/**
+  * @brief  Set the BOR Level.
+  * @param  Level: specifies the Option Bytes BOR Reset Level.
+  *          This parameter can be one of the following values:
+  *            @arg OB_BOR_LEVEL3: Supply voltage ranges from 2.7 to 3.6 V
+  *            @arg OB_BOR_LEVEL2: Supply voltage ranges from 2.4 to 2.7 V
+  *            @arg OB_BOR_LEVEL1: Supply voltage ranges from 2.1 to 2.4 V
+  *            @arg OB_BOR_OFF: Supply voltage ranges from 1.62 to 2.1 V
+  * @retval HAL Status
+  */
+static HAL_StatusTypeDef FLASH_OB_BOR_LevelConfig(uint8_t Level)
+{
+  /* Check the parameters */
+  assert_param(IS_OB_BOR_LEVEL(Level));
+
+  /* Set the BOR Level */
+  MODIFY_REG(FLASH->OPTCR, FLASH_OPTCR_BOR_LEV, Level);
+
+  return HAL_OK;
+
+}
+
+/**
+  * @brief  Configure Boot base address.
+  *
+  * @param   BootOption : specifies Boot base address depending from Boot pin = 0 or pin = 1
+  *          This parameter can be one of the following values:
+  *            @arg OPTIONBYTE_BOOTADDR_0 : Boot address based when Boot pin = 0
+  *            @arg OPTIONBYTE_BOOTADDR_1 : Boot address based when Boot pin = 1
+  * @param   Address: specifies Boot base address
+  *          This parameter can be one of the following values:
+  *            @arg OB_BOOTADDR_ITCM_RAM : Boot from ITCM RAM (0x00000000)
+  *            @arg OB_BOOTADDR_SYSTEM : Boot from System memory bootloader (0x00100000)
+  *            @arg OB_BOOTADDR_ITCM_FLASH : Boot from Flash on ITCM interface (0x00200000)
+  *            @arg OB_BOOTADDR_AXIM_FLASH : Boot from Flash on AXIM interface (0x08000000)
+  *            @arg OB_BOOTADDR_DTCM_RAM : Boot from DTCM RAM (0x20000000)
+  *            @arg OB_BOOTADDR_SRAM1 : Boot from SRAM1 (0x20010000)
+  *            @arg OB_BOOTADDR_SRAM2 : Boot from SRAM2 (0x2004C000)
+  *
+  * @retval HAL Status
+  */
+static HAL_StatusTypeDef FLASH_OB_BootAddressConfig(uint32_t BootOption, uint32_t Address)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_OB_BOOT_ADDRESS(Address));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+  if(status == HAL_OK)
+  {
+    if(BootOption == OPTIONBYTE_BOOTADDR_0)
+    {
+      MODIFY_REG(FLASH->OPTCR1, FLASH_OPTCR1_BOOT_ADD0, Address);
+	  }
+		else
+		{
+			MODIFY_REG(FLASH->OPTCR1, FLASH_OPTCR1_BOOT_ADD1, (Address << 16));
+		}
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Return the FLASH User Option Byte value.
+  * @retval uint32_t FLASH User Option Bytes values: IWDG_SW(Bit0), RST_STOP(Bit1)
+  *         and RST_STDBY(Bit2).
+  */
+static uint32_t FLASH_OB_GetUser(void)
+{
+  /* Return the User Option Byte */
+  return ((uint32_t)(FLASH->OPTCR & 0xC00000F0));
+}
+
+/**
+  * @brief  Return the FLASH Write Protection Option Bytes value.
+  * @retval uint32_t FLASH Write Protection Option Bytes value
+  */
+static uint32_t FLASH_OB_GetWRP(void)
+{
+  /* Return the FLASH write protection Register value */
+  return ((uint32_t)(FLASH->OPTCR & 0x00FF0000));
+}
+
+/**
+  * @brief  Returns the FLASH Read Protection level.
+  * @retval FlagStatus FLASH ReadOut Protection Status:
+  *         This parameter can be one of the following values:
+  *            @arg OB_RDP_LEVEL_0: No protection
+  *            @arg OB_RDP_LEVEL_1: Read protection of the memory
+  *            @arg OB_RDP_LEVEL_2: Full chip protection
+  */
+static uint8_t FLASH_OB_GetRDP(void)
+{
+  uint8_t readstatus = OB_RDP_LEVEL_0;
+
+  if (((FLASH->OPTCR & FLASH_OPTCR_RDP) >> 8) == OB_RDP_LEVEL_0)
+  {
+    readstatus = OB_RDP_LEVEL_0;
+  }
+  else if (((FLASH->OPTCR & FLASH_OPTCR_RDP) >> 8) == OB_RDP_LEVEL_2)
+  {
+    readstatus = OB_RDP_LEVEL_2;
+  }
+  else
+  {
+    readstatus = OB_RDP_LEVEL_1;
+  }
+
+  return readstatus;
+}
+
+/**
+  * @brief  Returns the FLASH BOR level.
+  * @retval uint32_t The FLASH BOR level:
+  *           - OB_BOR_LEVEL3: Supply voltage ranges from 2.7 to 3.6 V
+  *           - OB_BOR_LEVEL2: Supply voltage ranges from 2.4 to 2.7 V
+  *           - OB_BOR_LEVEL1: Supply voltage ranges from 2.1 to 2.4 V
+  *           - OB_BOR_OFF   : Supply voltage ranges from 1.62 to 2.1 V
+  */
+static uint32_t FLASH_OB_GetBOR(void)
+{
+  /* Return the FLASH BOR level */
+  return ((uint32_t)(FLASH->OPTCR & 0x0C));
+}
+
+/**
+  * @brief  Configure Boot base address.
+  *
+  * @param   BootOption : specifies Boot base address depending from Boot pin = 0 or pin = 1
+  *          This parameter can be one of the following values:
+  *            @arg OPTIONBYTE_BOOTADDR_0 : Boot address based when Boot pin = 0
+  *            @arg OPTIONBYTE_BOOTADDR_1 : Boot address based when Boot pin = 1
+  *
+  * @retval uint32_t Boot Base Address:
+  *            - OB_BOOTADDR_ITCM_RAM : Boot from ITCM RAM (0x00000000)
+  *            - OB_BOOTADDR_SYSTEM : Boot from System memory bootloader (0x00100000)
+  *            - OB_BOOTADDR_ITCM_FLASH : Boot from Flash on ITCM interface (0x00200000)
+  *            - OB_BOOTADDR_AXIM_FLASH : Boot from Flash on AXIM interface (0x08000000)
+  *            - OB_BOOTADDR_DTCM_RAM : Boot from DTCM RAM (0x20000000)
+  *            - OB_BOOTADDR_SRAM1 : Boot from SRAM1 (0x20010000)
+  *            - OB_BOOTADDR_SRAM2 : Boot from SRAM2 (0x2004C000)
+  */
+static uint32_t FLASH_OB_GetBootAddress(uint32_t BootOption)
+{
+  uint32_t Address = 0;
+
+	/* Return the Boot base Address */
+  if(BootOption == OPTIONBYTE_BOOTADDR_0)
+  {
+    Address = FLASH->OPTCR1 & FLASH_OPTCR1_BOOT_ADD0;
+	}
+  else
+	{
+		Address = ((FLASH->OPTCR1 & FLASH_OPTCR1_BOOT_ADD1) >> 16);
+	}
+
+  return Address;
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_gpio.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_gpio.c
@@ -1,0 +1,540 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_gpio.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   GPIO HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the General Purpose Input/Output (GPIO) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *
+  @verbatim
+  ==============================================================================
+                    ##### GPIO Peripheral features #####
+  ==============================================================================
+  [..]
+  Subject to the specific hardware characteristics of each I/O port listed in the datasheet, each
+  port bit of the General Purpose IO (GPIO) Ports, can be individually configured by software
+  in several modes:
+  (+) Input mode
+  (+) Analog mode
+  (+) Output mode
+  (+) Alternate function mode
+  (+) External interrupt/event lines
+
+  [..]
+  During and just after reset, the alternate functions and external interrupt
+  lines are not active and the I/O ports are configured in input floating mode.
+
+  [..]
+  All GPIO pins have weak internal pull-up and pull-down resistors, which can be
+  activated or not.
+
+  [..]
+  In Output or Alternate mode, each IO can be configured on open-drain or push-pull
+  type and the IO speed can be selected depending on the VDD value.
+
+  [..]
+  All ports have external interrupt/event capability. To use external interrupt
+  lines, the port must be configured in input mode. All available GPIO pins are
+  connected to the 16 external interrupt/event lines from EXTI0 to EXTI15.
+
+  [..]
+  The external interrupt/event controller consists of up to 23 edge detectors
+  (16 lines are connected to GPIO) for generating event/interrupt requests (each
+  input line can be independently configured to select the type (interrupt or event)
+  and the corresponding trigger event (rising or falling or both). Each line can
+  also be masked independently.
+
+                     ##### How to use this driver #####
+  ==============================================================================
+  [..]
+    (#) Enable the GPIO AHB clock using the following function: __HAL_RCC_GPIOx_CLK_ENABLE().
+
+    (#) Configure the GPIO pin(s) using HAL_GPIO_Init().
+        (++) Configure the IO mode using "Mode" member from GPIO_InitTypeDef structure
+        (++) Activate Pull-up, Pull-down resistor using "Pull" member from GPIO_InitTypeDef
+             structure.
+        (++) In case of Output or alternate function mode selection: the speed is
+             configured through "Speed" member from GPIO_InitTypeDef structure.
+        (++) In alternate mode is selection, the alternate function connected to the IO
+             is configured through "Alternate" member from GPIO_InitTypeDef structure.
+        (++) Analog mode is required when a pin is to be used as ADC channel
+             or DAC output.
+        (++) In case of external interrupt/event selection the "Mode" member from
+             GPIO_InitTypeDef structure select the type (interrupt or event) and
+             the corresponding trigger event (rising or falling or both).
+
+    (#) In case of external interrupt/event mode selection, configure NVIC IRQ priority
+        mapped to the EXTI line using HAL_NVIC_SetPriority() and enable it using
+        HAL_NVIC_EnableIRQ().
+
+    (#) To get the level of a pin configured in input mode use HAL_GPIO_ReadPin().
+
+    (#) To set/reset the level of a pin configured in output mode use
+        HAL_GPIO_WritePin()/HAL_GPIO_TogglePin().
+
+    (#) To lock pin configuration until next reset use HAL_GPIO_LockPin().
+
+
+    (#) During and just after reset, the alternate functions are not
+        active and the GPIO pins are configured in input floating mode (except JTAG
+        pins).
+
+    (#) The LSE oscillator pins OSC32_IN and OSC32_OUT can be used as general purpose
+        (PC14 and PC15, respectively) when the LSE oscillator is off. The LSE has
+        priority over the GPIO function.
+
+    (#) The HSE oscillator pins OSC_IN/OSC_OUT can be used as
+        general purpose PH0 and PH1, respectively, when the HSE oscillator is off.
+        The HSE has priority over the GPIO function.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup GPIO GPIO
+  * @brief GPIO HAL module driver
+  * @{
+  */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @addtogroup GPIO_Private_Constants GPIO Private Constants
+  * @{
+  */
+#define GPIO_MODE             ((uint32_t)0x00000003)
+#define EXTI_MODE             ((uint32_t)0x10000000)
+#define GPIO_MODE_IT          ((uint32_t)0x00010000)
+#define GPIO_MODE_EVT         ((uint32_t)0x00020000)
+#define RISING_EDGE           ((uint32_t)0x00100000)
+#define FALLING_EDGE          ((uint32_t)0x00200000)
+#define GPIO_OUTPUT_TYPE      ((uint32_t)0x00000010)
+
+#define GPIO_NUMBER           ((uint32_t)16)
+/**
+  * @}
+  */
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup GPIO_Exported_Functions GPIO Exported Functions
+  * @{
+  */
+
+/** @defgroup GPIO_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+  [..]
+    This section provides functions allowing to initialize and de-initialize the GPIOs
+    to be ready for use.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the GPIOx peripheral according to the specified parameters in the GPIO_Init.
+  * @param  GPIOx: where x can be (A..K) to select the GPIO peripheral.
+  * @param  GPIO_Init: pointer to a GPIO_InitTypeDef structure that contains
+  *         the configuration information for the specified GPIO peripheral.
+  * @retval None
+  */
+void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
+{
+  uint32_t position = 0x00;
+  uint32_t ioposition = 0x00;
+  uint32_t iocurrent = 0x00;
+  uint32_t temp = 0x00;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_INSTANCE(GPIOx));
+  assert_param(IS_GPIO_PIN(GPIO_Init->Pin));
+  assert_param(IS_GPIO_MODE(GPIO_Init->Mode));
+  assert_param(IS_GPIO_PULL(GPIO_Init->Pull));
+
+  /* Configure the port pins */
+  for(position = 0; position < GPIO_NUMBER; position++)
+  {
+    /* Get the IO position */
+    ioposition = ((uint32_t)0x01) << position;
+    /* Get the current IO position */
+    iocurrent = (uint32_t)(GPIO_Init->Pin) & ioposition;
+
+    if(iocurrent == ioposition)
+    {
+      /*--------------------- GPIO Mode Configuration ------------------------*/
+      /* In case of Alternate function mode selection */
+      if((GPIO_Init->Mode == GPIO_MODE_AF_PP) || (GPIO_Init->Mode == GPIO_MODE_AF_OD))
+      {
+        /* Check the Alternate function parameter */
+        assert_param(IS_GPIO_AF(GPIO_Init->Alternate));
+
+        /* Configure Alternate function mapped with the current IO */
+        temp = GPIOx->AFR[position >> 3];
+        temp &= ~((uint32_t)0xF << ((uint32_t)(position & (uint32_t)0x07) * 4)) ;
+        temp |= ((uint32_t)(GPIO_Init->Alternate) << (((uint32_t)position & (uint32_t)0x07) * 4));
+        GPIOx->AFR[position >> 3] = temp;
+      }
+
+      /* Configure IO Direction mode (Input, Output, Alternate or Analog) */
+      temp = GPIOx->MODER;
+      temp &= ~(GPIO_MODER_MODER0 << (position * 2));
+      temp |= ((GPIO_Init->Mode & GPIO_MODE) << (position * 2));
+      GPIOx->MODER = temp;
+
+      /* In case of Output or Alternate function mode selection */
+      if((GPIO_Init->Mode == GPIO_MODE_OUTPUT_PP) || (GPIO_Init->Mode == GPIO_MODE_AF_PP) ||
+         (GPIO_Init->Mode == GPIO_MODE_OUTPUT_OD) || (GPIO_Init->Mode == GPIO_MODE_AF_OD))
+      {
+        /* Check the Speed parameter */
+        assert_param(IS_GPIO_SPEED(GPIO_Init->Speed));
+        /* Configure the IO Speed */
+        temp = GPIOx->OSPEEDR;
+        temp &= ~(GPIO_OSPEEDER_OSPEEDR0 << (position * 2));
+        temp |= (GPIO_Init->Speed << (position * 2));
+        GPIOx->OSPEEDR = temp;
+
+        /* Configure the IO Output Type */
+        temp = GPIOx->OTYPER;
+        temp &= ~(GPIO_OTYPER_OT_0 << position) ;
+        temp |= (((GPIO_Init->Mode & GPIO_OUTPUT_TYPE) >> 4) << position);
+        GPIOx->OTYPER = temp;
+      }
+
+      /* Activate the Pull-up or Pull down resistor for the current IO */
+      temp = GPIOx->PUPDR;
+      temp &= ~(GPIO_PUPDR_PUPDR0 << (position * 2));
+      temp |= ((GPIO_Init->Pull) << (position * 2));
+      GPIOx->PUPDR = temp;
+
+      /*--------------------- EXTI Mode Configuration ------------------------*/
+      /* Configure the External Interrupt or event for the current IO */
+      if((GPIO_Init->Mode & EXTI_MODE) == EXTI_MODE)
+      {
+        /* Enable SYSCFG Clock */
+        __HAL_RCC_SYSCFG_CLK_ENABLE();
+
+        temp = SYSCFG->EXTICR[position >> 2];
+        temp &= ~(((uint32_t)0x0F) << (4 * (position & 0x03)));
+        temp |= ((uint32_t)(GPIO_GET_INDEX(GPIOx)) << (4 * (position & 0x03)));
+        SYSCFG->EXTICR[position >> 2] = temp;
+
+        /* Clear EXTI line configuration */
+        temp = EXTI->IMR;
+        temp &= ~((uint32_t)iocurrent);
+        if((GPIO_Init->Mode & GPIO_MODE_IT) == GPIO_MODE_IT)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->IMR = temp;
+
+        temp = EXTI->EMR;
+        temp &= ~((uint32_t)iocurrent);
+        if((GPIO_Init->Mode & GPIO_MODE_EVT) == GPIO_MODE_EVT)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->EMR = temp;
+
+        /* Clear Rising Falling edge configuration */
+        temp = EXTI->RTSR;
+        temp &= ~((uint32_t)iocurrent);
+        if((GPIO_Init->Mode & RISING_EDGE) == RISING_EDGE)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->RTSR = temp;
+
+        temp = EXTI->FTSR;
+        temp &= ~((uint32_t)iocurrent);
+        if((GPIO_Init->Mode & FALLING_EDGE) == FALLING_EDGE)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->FTSR = temp;
+      }
+    }
+  }
+}
+
+/**
+  * @brief  De-initializes the GPIOx peripheral registers to their default reset values.
+  * @param  GPIOx: where x can be (A..K) to select the GPIO peripheral.
+  * @param  GPIO_Pin: specifies the port bit to be written.
+  *          This parameter can be one of GPIO_PIN_x where x can be (0..15).
+  * @retval None
+  */
+void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
+{
+  uint32_t position;
+  uint32_t ioposition = 0x00;
+  uint32_t iocurrent = 0x00;
+  uint32_t tmp = 0x00;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_INSTANCE(GPIOx));
+
+  /* Configure the port pins */
+  for(position = 0; position < GPIO_NUMBER; position++)
+  {
+    /* Get the IO position */
+    ioposition = ((uint32_t)0x01) << position;
+    /* Get the current IO position */
+    iocurrent = (GPIO_Pin) & ioposition;
+
+    if(iocurrent == ioposition)
+    {
+      /*------------------------- GPIO Mode Configuration --------------------*/
+      /* Configure IO Direction in Input Floating Mode */
+      GPIOx->MODER &= ~(GPIO_MODER_MODER0 << (position * 2));
+
+      /* Configure the default Alternate Function in current IO */
+      GPIOx->AFR[position >> 3] &= ~((uint32_t)0xF << ((uint32_t)(position & (uint32_t)0x07) * 4)) ;
+
+      /* Configure the default value for IO Speed */
+      GPIOx->OSPEEDR &= ~(GPIO_OSPEEDER_OSPEEDR0 << (position * 2));
+
+      /* Configure the default value IO Output Type */
+      GPIOx->OTYPER  &= ~(GPIO_OTYPER_OT_0 << position) ;
+
+      /* Deactivate the Pull-up and Pull-down resistor for the current IO */
+      GPIOx->PUPDR &= ~(GPIO_PUPDR_PUPDR0 << (position * 2));
+
+      /*------------------------- EXTI Mode Configuration --------------------*/
+      tmp = SYSCFG->EXTICR[position >> 2];
+      tmp &= (((uint32_t)0x0F) << (4 * (position & 0x03)));
+      if(tmp == ((uint32_t)(GPIO_GET_INDEX(GPIOx)) << (4 * (position & 0x03))))
+      {
+        /* Configure the External Interrupt or event for the current IO */
+        tmp = ((uint32_t)0x0F) << (4 * (position & 0x03));
+        SYSCFG->EXTICR[position >> 2] &= ~tmp;
+
+        /* Clear EXTI line configuration */
+        EXTI->IMR &= ~((uint32_t)iocurrent);
+        EXTI->EMR &= ~((uint32_t)iocurrent);
+
+        /* Clear Rising Falling edge configuration */
+        EXTI->RTSR &= ~((uint32_t)iocurrent);
+        EXTI->FTSR &= ~((uint32_t)iocurrent);
+	  }
+    }
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup GPIO_Exported_Functions_Group2 IO operation functions
+ *  @brief   GPIO Read and Write
+ *
+@verbatim
+ ===============================================================================
+                       ##### IO operation functions #####
+ ===============================================================================
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Reads the specified input port pin.
+  * @param  GPIOx: where x can be (A..K) to select the GPIO peripheral.
+  * @param  GPIO_Pin: specifies the port bit to read.
+  *         This parameter can be GPIO_PIN_x where x can be (0..15).
+  * @retval The input port pin value.
+  */
+GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  GPIO_PinState bitstatus;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+
+  if((GPIOx->IDR & GPIO_Pin) != (uint32_t)GPIO_PIN_RESET)
+  {
+    bitstatus = GPIO_PIN_SET;
+  }
+  else
+  {
+    bitstatus = GPIO_PIN_RESET;
+  }
+  return bitstatus;
+}
+
+/**
+  * @brief  Sets or clears the selected data port bit.
+  *
+  * @note   This function uses GPIOx_BSRR register to allow atomic read/modify
+  *         accesses. In this way, there is no risk of an IRQ occurring between
+  *         the read and the modify access.
+  *
+  * @param  GPIOx: where x can be (A..K) to select the GPIO peripheral.
+  * @param  GPIO_Pin: specifies the port bit to be written.
+  *          This parameter can be one of GPIO_PIN_x where x can be (0..15).
+  * @param  PinState: specifies the value to be written to the selected bit.
+  *          This parameter can be one of the GPIO_PinState enum values:
+  *            @arg GPIO_PIN_RESET: to clear the port pin
+  *            @arg GPIO_PIN_SET: to set the port pin
+  * @retval None
+  */
+void HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+  assert_param(IS_GPIO_PIN_ACTION(PinState));
+
+  if(PinState != GPIO_PIN_RESET)
+  {
+    GPIOx->BSRR = GPIO_Pin;
+  }
+  else
+  {
+    GPIOx->BSRR = (uint32_t)GPIO_Pin << 16;
+  }
+}
+
+/**
+  * @brief  Toggles the specified GPIO pins.
+  * @param  GPIOx: Where x can be (A..I) to select the GPIO peripheral.
+  * @param  GPIO_Pin: Specifies the pins to be toggled.
+  * @retval None
+  */
+void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+
+  GPIOx->ODR ^= GPIO_Pin;
+}
+
+/**
+  * @brief  Locks GPIO Pins configuration registers.
+  * @note   The locked registers are GPIOx_MODER, GPIOx_OTYPER, GPIOx_OSPEEDR,
+  *         GPIOx_PUPDR, GPIOx_AFRL and GPIOx_AFRH.
+  * @note   The configuration of the locked GPIO pins can no longer be modified
+  *         until the next reset.
+  * @param  GPIOx: where x can be (A..F) to select the GPIO peripheral for STM32F7 family
+  * @param  GPIO_Pin: specifies the port bit to be locked.
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15).
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  __IO uint32_t tmp = GPIO_LCKR_LCKK;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+
+  /* Apply lock key write sequence */
+  tmp |= GPIO_Pin;
+  /* Set LCKx bit(s): LCKK='1' + LCK[15-0] */
+  GPIOx->LCKR = tmp;
+  /* Reset LCKx bit(s): LCKK='0' + LCK[15-0] */
+  GPIOx->LCKR = GPIO_Pin;
+  /* Set LCKx bit(s): LCKK='1' + LCK[15-0] */
+  GPIOx->LCKR = tmp;
+  /* Read LCKK bit*/
+  tmp = GPIOx->LCKR;
+
+ if((GPIOx->LCKR & GPIO_LCKR_LCKK) != RESET)
+  {
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  This function handles EXTI interrupt request.
+  * @param  GPIO_Pin: Specifies the pins connected EXTI line
+  * @retval None
+  */
+void HAL_GPIO_EXTI_IRQHandler(uint16_t GPIO_Pin)
+{
+  /* EXTI line interrupt detected */
+  if(__HAL_GPIO_EXTI_GET_IT(GPIO_Pin) != RESET)
+  {
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_Pin);
+    HAL_GPIO_EXTI_Callback(GPIO_Pin);
+  }
+}
+
+/**
+  * @brief  EXTI line detection callbacks.
+  * @param  GPIO_Pin: Specifies the pins connected EXTI line
+  * @retval None
+  */
+__weak void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_GPIO_EXTI_Callback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+#endif /* HAL_GPIO_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_i2c.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_i2c.c
@@ -1,0 +1,4110 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_i2c.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   I2C HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Inter Integrated Circuit (I2C) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral State and Errors functions
+  *
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]
+    The I2C HAL driver can be used as follows:
+
+    (#) Declare a I2C_HandleTypeDef handle structure, for example:
+        I2C_HandleTypeDef  hi2c;
+
+    (#)Initialize the I2C low level resources by implement the HAL_I2C_MspInit ()API:
+        (##) Enable the I2Cx interface clock
+        (##) I2C pins configuration
+            (+++) Enable the clock for the I2C GPIOs
+            (+++) Configure I2C pins as alternate function open-drain
+        (##) NVIC configuration if you need to use interrupt process
+            (+++) Configure the I2Cx interrupt priority
+            (+++) Enable the NVIC I2C IRQ Channel
+        (##) DMA Configuration if you need to use DMA process
+            (+++) Declare a DMA_HandleTypeDef handle structure for the transmit or receive stream
+            (+++) Enable the DMAx interface clock using
+            (+++) Configure the DMA handle parameters
+            (+++) Configure the DMA Tx or Rx Stream
+            (+++) Associate the initialized DMA handle to the hi2c DMA Tx or Rx handle
+            (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx or Rx Stream
+
+    (#) Configure the Communication Clock Timing, Own Address1, Master Addressing Mode, Dual Addressing mode,
+        Own Address2, Own Address2 Mask, General call and Nostretch mode in the hi2c Init structure.
+
+    (#) Initialize the I2C registers by calling the HAL_I2C_Init(), configures also the low level Hardware
+        (GPIO, CLOCK, NVIC...etc) by calling the customed HAL_I2C_MspInit(&hi2c) API.
+
+    (#) To check if target device is ready for communication, use the function HAL_I2C_IsDeviceReady()
+
+    (#) For I2C IO and IO MEM operations, three operation modes are available within this driver :
+
+    *** Polling mode IO operation ***
+    =================================
+    [..]
+      (+) Transmit in master mode an amount of data in blocking mode using HAL_I2C_Master_Transmit()
+      (+) Receive in master mode an amount of data in blocking mode using HAL_I2C_Master_Receive()
+      (+) Transmit in slave mode an amount of data in blocking mode using HAL_I2C_Slave_Transmit()
+      (+) Receive in slave mode an amount of data in blocking mode using HAL_I2C_Slave_Receive()
+
+    *** Polling mode IO MEM operation ***
+    =====================================
+    [..]
+      (+) Write an amount of data in blocking mode to a specific memory address using HAL_I2C_Mem_Write()
+      (+) Read an amount of data in blocking mode from a specific memory address using HAL_I2C_Mem_Read()
+
+
+    *** Interrupt mode IO operation ***
+    ===================================
+    [..]
+      (+) Transmit in master mode an amount of data in non blocking mode using HAL_I2C_Master_Transmit_IT()
+      (+) At transmission end of transfer HAL_I2C_MasterTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterTxCpltCallback
+      (+) Receive in master mode an amount of data in non blocking mode using HAL_I2C_Master_Receive_IT()
+      (+) At reception end of transfer HAL_I2C_MasterRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterRxCpltCallback
+      (+) Transmit in slave mode an amount of data in non blocking mode using HAL_I2C_Slave_Transmit_IT()
+      (+) At transmission end of transfer HAL_I2C_SlaveTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveTxCpltCallback
+      (+) Receive in slave mode an amount of data in non blocking mode using HAL_I2C_Slave_Receive_IT()
+      (+) At reception end of transfer HAL_I2C_SlaveRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ErrorCallback
+
+    *** Interrupt mode IO MEM operation ***
+    =======================================
+    [..]
+      (+) Write an amount of data in no-blocking mode with Interrupt to a specific memory address using
+          HAL_I2C_Mem_Write_IT()
+      (+) At MEM end of write transfer HAL_I2C_MemTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MemTxCpltCallback
+      (+) Read an amount of data in no-blocking mode with Interrupt from a specific memory address using
+          HAL_I2C_Mem_Read_IT()
+      (+) At MEM end of read transfer HAL_I2C_MemRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MemRxCpltCallback
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ErrorCallback
+
+    *** DMA mode IO operation ***
+    ==============================
+    [..]
+      (+) Transmit in master mode an amount of data in non blocking mode (DMA) using
+          HAL_I2C_Master_Transmit_DMA()
+      (+) At transmission end of transfer HAL_I2C_MasterTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterTxCpltCallback
+      (+) Receive in master mode an amount of data in non blocking mode (DMA) using
+          HAL_I2C_Master_Receive_DMA()
+      (+) At reception end of transfer HAL_I2C_MasterRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterRxCpltCallback
+      (+) Transmit in slave mode an amount of data in non blocking mode (DMA) using
+          HAL_I2C_Slave_Transmit_DMA()
+      (+) At transmission end of transfer HAL_I2C_SlaveTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveTxCpltCallback
+      (+) Receive in slave mode an amount of data in non blocking mode (DMA) using
+          HAL_I2C_Slave_Receive_DMA()
+      (+) At reception end of transfer HAL_I2C_SlaveRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ErrorCallback
+
+    *** DMA mode IO MEM operation ***
+    =================================
+    [..]
+      (+) Write an amount of data in no-blocking mode with DMA to a specific memory address using
+          HAL_I2C_Mem_Write_DMA()
+      (+) At MEM end of write transfer HAL_I2C_MemTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MemTxCpltCallback
+      (+) Read an amount of data in no-blocking mode with DMA from a specific memory address using
+          HAL_I2C_Mem_Read_DMA()
+      (+) At MEM end of read transfer HAL_I2C_MemRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MemRxCpltCallback
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ErrorCallback
+
+
+     *** I2C HAL driver macros list ***
+     ==================================
+     [..]
+       Below the list of most used macros in I2C HAL driver.
+
+      (+) __HAL_I2C_ENABLE: Enable the I2C peripheral
+      (+) __HAL_I2C_DISABLE: Disable the I2C peripheral
+      (+) __HAL_I2C_GET_FLAG : Checks whether the specified I2C flag is set or not
+      (+) __HAL_I2C_CLEAR_FLAG : Clear the specified I2C pending flag
+      (+) __HAL_I2C_ENABLE_IT: Enable the specified I2C interrupt
+      (+) __HAL_I2C_DISABLE_IT: Disable the specified I2C interrupt
+
+     [..]
+       (@) You can refer to the I2C HAL driver header file for more useful macros
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup I2C I2C
+  * @brief I2C HAL module driver
+  * @{
+  */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @addtogroup I2C_Private_Constants I2C Private Constants
+  * @{
+  */
+#define TIMING_CLEAR_MASK   ((uint32_t)0xF0FFFFFF)  /*<! I2C TIMING clear register Mask */
+#define I2C_TIMEOUT_ADDR    ((uint32_t)10000)  /* 10 s  */
+#define I2C_TIMEOUT_BUSY    ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_DIR     ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_RXNE    ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_STOPF   ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_TC      ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_TCR     ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_TXIS    ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_FLAG    ((uint32_t)25)     /* 25 ms */
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @addtogroup I2C_Private_Functions I2C Private Functions
+  * @{
+  */
+static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMASlaveReceiveCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMAMemTransmitCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMAMemReceiveCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMAError(DMA_HandleTypeDef *hdma);
+
+static HAL_StatusTypeDef I2C_RequestMemoryWrite(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout);
+static HAL_StatusTypeDef I2C_RequestMemoryRead(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout);
+static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout);
+static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout);
+static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout);
+static HAL_StatusTypeDef I2C_IsAcknowledgeFailed(I2C_HandleTypeDef *hi2c, uint32_t Timeout);
+
+static HAL_StatusTypeDef I2C_MasterTransmit_ISR(I2C_HandleTypeDef *hi2c);
+static HAL_StatusTypeDef I2C_MasterReceive_ISR(I2C_HandleTypeDef *hi2c);
+
+static HAL_StatusTypeDef I2C_SlaveTransmit_ISR(I2C_HandleTypeDef *hi2c);
+static HAL_StatusTypeDef I2C_SlaveReceive_ISR(I2C_HandleTypeDef *hi2c);
+
+static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup I2C_Exported_Functions I2C Exported Functions
+  * @{
+  */
+
+/** @defgroup I2C_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This subsection provides a set of functions allowing to initialize and
+          de-initialize the I2Cx peripheral:
+
+      (+) User must Implement HAL_I2C_MspInit() function in which he configures
+          all related peripherals resources (CLOCK, GPIO, DMA, IT and NVIC ).
+
+      (+) Call the function HAL_I2C_Init() to configure the selected device with
+          the selected configuration:
+        (++) Clock Timing
+        (++) Own Address 1
+        (++) Addressing mode (Master, Slave)
+        (++) Dual Addressing mode
+        (++) Own Address 2
+        (++) Own Address 2 Mask
+        (++) General call mode
+        (++) Nostretch mode
+
+      (+) Call the function HAL_I2C_DeInit() to restore the default configuration
+          of the selected I2Cx peripheral.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the I2C according to the specified parameters
+  *         in the I2C_InitTypeDef and create the associated handle.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c)
+{
+  /* Check the I2C handle allocation */
+  if(hi2c == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  assert_param(IS_I2C_OWN_ADDRESS1(hi2c->Init.OwnAddress1));
+  assert_param(IS_I2C_ADDRESSING_MODE(hi2c->Init.AddressingMode));
+  assert_param(IS_I2C_DUAL_ADDRESS(hi2c->Init.DualAddressMode));
+  assert_param(IS_I2C_OWN_ADDRESS2(hi2c->Init.OwnAddress2));
+  assert_param(IS_I2C_OWN_ADDRESS2_MASK(hi2c->Init.OwnAddress2Masks));
+  assert_param(IS_I2C_GENERAL_CALL(hi2c->Init.GeneralCallMode));
+  assert_param(IS_I2C_NO_STRETCH(hi2c->Init.NoStretchMode));
+
+  if(hi2c->State == HAL_I2C_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hi2c->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX...etc */
+    HAL_I2C_MspInit(hi2c);
+  }
+
+  hi2c->State = HAL_I2C_STATE_BUSY;
+
+  /* Disable the selected I2C peripheral */
+  __HAL_I2C_DISABLE(hi2c);
+
+  /*---------------------------- I2Cx TIMINGR Configuration ------------------*/
+  /* Configure I2Cx: Frequency range */
+  hi2c->Instance->TIMINGR = hi2c->Init.Timing & TIMING_CLEAR_MASK;
+
+  /*---------------------------- I2Cx OAR1 Configuration ---------------------*/
+  /* Configure I2Cx: Own Address1 and ack own address1 mode */
+  hi2c->Instance->OAR1 &= ~I2C_OAR1_OA1EN;
+  if(hi2c->Init.OwnAddress1 != 0)
+  {
+    if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_7BIT)
+    {
+      hi2c->Instance->OAR1 = (I2C_OAR1_OA1EN | hi2c->Init.OwnAddress1);
+    }
+    else /* I2C_ADDRESSINGMODE_10BIT */
+    {
+      hi2c->Instance->OAR1 = (I2C_OAR1_OA1EN | I2C_OAR1_OA1MODE | hi2c->Init.OwnAddress1);
+    }
+  }
+
+  /*---------------------------- I2Cx CR2 Configuration ----------------------*/
+  /* Configure I2Cx: Addressing Master mode */
+  if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
+  {
+    hi2c->Instance->CR2 = (I2C_CR2_ADD10);
+  }
+  /* Enable the AUTOEND by default, and enable NACK (should be disable only during Slave process */
+  hi2c->Instance->CR2 |= (I2C_CR2_AUTOEND | I2C_CR2_NACK);
+
+  /*---------------------------- I2Cx OAR2 Configuration ---------------------*/
+  /* Configure I2Cx: Dual mode and Own Address2 */
+  hi2c->Instance->OAR2 = (hi2c->Init.DualAddressMode | hi2c->Init.OwnAddress2 | (hi2c->Init.OwnAddress2Masks << 8));
+
+  /*---------------------------- I2Cx CR1 Configuration ----------------------*/
+  /* Configure I2Cx: Generalcall and NoStretch mode */
+  hi2c->Instance->CR1 = (hi2c->Init.GeneralCallMode | hi2c->Init.NoStretchMode);
+
+  /* Enable the selected I2C peripheral */
+  __HAL_I2C_ENABLE(hi2c);
+
+  hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+  hi2c->State = HAL_I2C_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the I2C peripheral.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_DeInit(I2C_HandleTypeDef *hi2c)
+{
+  /* Check the I2C handle allocation */
+  if(hi2c == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+
+  hi2c->State = HAL_I2C_STATE_BUSY;
+
+  /* Disable the I2C Peripheral Clock */
+  __HAL_I2C_DISABLE(hi2c);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_I2C_MspDeInit(hi2c);
+
+  hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+  hi2c->State = HAL_I2C_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief I2C MSP Init.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+ __weak void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief I2C MSP DeInit
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+ __weak void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Exported_Functions_Group2 Input and Output operation functions
+ *  @brief   Data transfers functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to manage the I2C data
+    transfers.
+
+    (#) There are two modes of transfer:
+       (++) Blocking mode : The communication is performed in the polling mode.
+            The status of all data processing is returned by the same function
+            after finishing transfer.
+       (++) No-Blocking mode : The communication is performed using Interrupts
+            or DMA. These functions return the status of the transfer startup.
+            The end of the data processing will be indicated through the
+            dedicated I2C IRQ when using Interrupt mode or the DMA IRQ when
+            using DMA mode.
+
+    (#) Blocking mode functions are :
+        (++) HAL_I2C_Master_Transmit()
+        (++) HAL_I2C_Master_Receive()
+        (++) HAL_I2C_Slave_Transmit()
+        (++) HAL_I2C_Slave_Receive()
+        (++) HAL_I2C_Mem_Write()
+        (++) HAL_I2C_Mem_Read()
+        (++) HAL_I2C_IsDeviceReady()
+
+    (#) No-Blocking mode functions with Interrupt are :
+        (++) HAL_I2C_Master_Transmit_IT()
+        (++) HAL_I2C_Master_Receive_IT()
+        (++) HAL_I2C_Slave_Transmit_IT()
+        (++) HAL_I2C_Slave_Receive_IT()
+        (++) HAL_I2C_Mem_Write_IT()
+        (++) HAL_I2C_Mem_Read_IT()
+
+    (#) No-Blocking mode functions with DMA are :
+        (++) HAL_I2C_Master_Transmit_DMA()
+        (++) HAL_I2C_Master_Receive_DMA()
+        (++) HAL_I2C_Slave_Transmit_DMA()
+        (++) HAL_I2C_Slave_Receive_DMA()
+        (++) HAL_I2C_Mem_Write_DMA()
+        (++) HAL_I2C_Mem_Read_DMA()
+
+    (#) A set of Transfer Complete Callbacks are provided in non Blocking mode:
+        (++) HAL_I2C_MemTxCpltCallback()
+        (++) HAL_I2C_MemRxCpltCallback()
+        (++) HAL_I2C_MasterTxCpltCallback()
+        (++) HAL_I2C_MasterRxCpltCallback()
+        (++) HAL_I2C_SlaveTxCpltCallback()
+        (++) HAL_I2C_SlaveRxCpltCallback()
+        (++) HAL_I2C_ErrorCallback()
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Transmits in master mode an amount of data in blocking mode.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t sizetmp = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_MASTER_BUSY_TX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    /* Size > 255, need to set RELOAD bit */
+    if(Size > 255)
+    {
+      I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+      sizetmp = 255;
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_GENERATE_START_WRITE);
+      sizetmp = Size;
+    }
+
+    do
+    {
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          return HAL_ERROR;
+        }
+        else
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = (*pData++);
+      sizetmp--;
+      Size--;
+
+      if((sizetmp == 0)&&(Size!=0))
+      {
+        /* Wait until TXE flag is set */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        if(Size > 255)
+        {
+          I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          sizetmp = 255;
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          sizetmp = Size;
+        }
+      }
+
+    }while(Size > 0);
+
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is set */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receives in master mode an amount of data in blocking mode.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t sizetmp = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_MASTER_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    /* Size > 255, need to set RELOAD bit */
+    if(Size > 255)
+    {
+      I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+      sizetmp = 255;
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+      sizetmp = Size;
+    }
+
+    do
+    {
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+      {
+        return HAL_TIMEOUT;
+      }
+
+      /* Write data to RXDR */
+      (*pData++) =hi2c->Instance->RXDR;
+      sizetmp--;
+      Size--;
+
+      if((sizetmp == 0)&&(Size!=0))
+      {
+        /* Wait until TCR flag is set */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        if(Size > 255)
+        {
+          I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          sizetmp = 255;
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          sizetmp = Size;
+        }
+      }
+
+    }while(Size > 0);
+
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is set */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmits in slave mode an amount of data in blocking mode.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_SLAVE_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Wait until ADDR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+
+    /* If 10bit addressing mode is selected */
+    if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
+    {
+      /* Wait until ADDR flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout) != HAL_OK)
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+        return HAL_TIMEOUT;
+      }
+
+      /* Clear ADDR flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+    }
+
+    /* Wait until DIR flag is set Transmitter mode */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_DIR, RESET, Timeout) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    do
+    {
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          return HAL_ERROR;
+        }
+        else
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+
+      /* Read data from TXDR */
+      hi2c->Instance->TXDR = (*pData++);
+      Size--;
+    }while(Size > 0);
+
+    /* Wait until STOP flag is set */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+	/* Normal use case for Transmitter mode */
+	/* A NACK is generated to confirm the end of transfer */
+	hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_STOPF);
+
+    /* Wait until BUSY flag is reset */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, Timeout) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Disable Address Acknowledge */
+    hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive in slave mode an amount of data in blocking mode
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_SLAVE_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Wait until ADDR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+
+    /* Wait until DIR flag is reset Receiver mode */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_DIR, SET, Timeout) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    while(Size > 0)
+    {
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnRXNEFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_TIMEOUT)
+        {
+          return HAL_TIMEOUT;
+        }
+        else
+        {
+          return HAL_ERROR;
+        }
+      }
+
+      /* Read data from RXDR */
+      (*pData++) = hi2c->Instance->RXDR;
+      Size--;
+    }
+
+    /* Wait until STOP flag is set */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_STOPF);
+
+    /* Wait until BUSY flag is reset */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, Timeout) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+
+    /* Disable Address Acknowledge */
+    hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit in master mode an amount of data in no-blocking mode with Interrupt
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_MASTER_BUSY_TX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_WRITE);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    __HAL_I2C_ENABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_TXI );
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive in master mode an amount of data in no-blocking mode with Interrupt
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_MASTER_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+    /* Enable ERR, TC, STOP, NACK, RXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    __HAL_I2C_ENABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_RXI );
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit in slave mode an amount of data in no-blocking mode with Interrupt
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_SLAVE_BUSY_TX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferSize = Size;
+    hi2c->XferCount = Size;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    __HAL_I2C_ENABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_TXI );
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive in slave mode an amount of data in no-blocking mode with Interrupt
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_SLAVE_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferSize = Size;
+    hi2c->XferCount = Size;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+    /* Enable ERR, TC, STOP, NACK, RXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    __HAL_I2C_ENABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit in master mode an amount of data in no-blocking mode with DMA
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_MASTER_BUSY_TX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmatx->XferCpltCallback = I2C_DMAMasterTransmitCplt;
+
+    /* Set the DMA error callback */
+    hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_WRITE);
+    }
+
+    /* Wait until TXIS flag is set */
+    if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, I2C_TIMEOUT_TXIS) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive in master mode an amount of data in no-blocking mode with DMA
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_MASTER_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmarx->XferCpltCallback = I2C_DMAMasterReceiveCplt;
+
+    /* Set the DMA error callback */
+    hi2c->hdmarx->XferErrorCallback = I2C_DMAError;
+
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, hi2c->XferSize);
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+    }
+
+    /* Wait until RXNE flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, I2C_TIMEOUT_RXNE) != HAL_OK)
+    {
+      return HAL_TIMEOUT;
+    }
+
+
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit in slave mode an amount of data in no-blocking mode with DMA
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_SLAVE_BUSY_TX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    hi2c->XferSize = Size;
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmatx->XferCpltCallback = I2C_DMASlaveTransmitCplt;
+
+    /* Set the DMA error callback */
+    hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Wait until ADDR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, I2C_TIMEOUT_ADDR) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+
+    /* If 10bits addressing mode is selected */
+    if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
+    {
+      /* Wait until ADDR flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, I2C_TIMEOUT_ADDR) != HAL_OK)
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+        return HAL_TIMEOUT;
+      }
+
+      /* Clear ADDR flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+    }
+
+    /* Wait until DIR flag is set Transmitter mode */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_DIR, RESET, I2C_TIMEOUT_BUSY) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive in slave mode an amount of data in no-blocking mode with DMA
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_SLAVE_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferSize = Size;
+    hi2c->XferCount = Size;
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmarx->XferCpltCallback = I2C_DMASlaveReceiveCplt;
+
+    /* Set the DMA error callback */
+    hi2c->hdmarx->XferErrorCallback = I2C_DMAError;
+
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, Size);
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Wait until ADDR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, I2C_TIMEOUT_ADDR) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+
+    /* Wait until DIR flag is set Receiver mode */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_DIR, SET, I2C_TIMEOUT_DIR) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+/**
+  * @brief  Write an amount of data in blocking mode to a specific memory address
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t Sizetmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_MEM_BUSY_TX;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryWrite(hi2c, DevAddress, MemAddress, MemAddSize, Timeout) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set NBYTES to write and reload if size > 255 */
+    /* Size > 255, need to set RELOAD bit */
+    if(Size > 255)
+    {
+      I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      Sizetmp = 255;
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      Sizetmp = Size;
+    }
+
+    do
+    {
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          return HAL_ERROR;
+        }
+        else
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+
+      /* Write data to DR */
+      hi2c->Instance->TXDR = (*pData++);
+      Sizetmp--;
+      Size--;
+
+      if((Sizetmp == 0)&&(Size!=0))
+      {
+        /* Wait until TCR flag is set */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+
+        if(Size > 255)
+        {
+          I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          Sizetmp = 255;
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          Sizetmp = Size;
+        }
+      }
+
+    }while(Size > 0);
+
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Read an amount of data in blocking mode from a specific memory address
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t Sizetmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_MEM_BUSY_RX;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryRead(hi2c, DevAddress, MemAddress, MemAddSize, Timeout) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    /* Size > 255, need to set RELOAD bit */
+    if(Size > 255)
+    {
+      I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+      Sizetmp = 255;
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+      Sizetmp = Size;
+    }
+
+    do
+    {
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+      {
+        return HAL_TIMEOUT;
+      }
+
+      /* Read data from RXDR */
+      (*pData++) = hi2c->Instance->RXDR;
+
+      /* Decrement the Size counter */
+      Sizetmp--;
+      Size--;
+
+      if((Sizetmp == 0)&&(Size!=0))
+      {
+        /* Wait until TCR flag is set */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        if(Size > 255)
+        {
+          I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          Sizetmp = 255;
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          Sizetmp = Size;
+        }
+      }
+
+    }while(Size > 0);
+
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+/**
+  * @brief  Write an amount of data in no-blocking mode with Interrupt to a specific memory address
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_MEM_BUSY_TX;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryWrite(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set NBYTES to write and reload if size > 255 */
+    /* Size > 255, need to set RELOAD bit */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    __HAL_I2C_ENABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_TXI );
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Read an amount of data in no-blocking mode with Interrupt from a specific memory address
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_MEM_BUSY_RX;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryRead(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    /* Size > 255, need to set RELOAD bit */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+    /* Enable ERR, TC, STOP, NACK, RXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    __HAL_I2C_ENABLE_IT(hi2c, I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_RXI );
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+/**
+  * @brief  Write an amount of data in no-blocking mode with DMA to a specific memory address
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_MEM_BUSY_TX;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmatx->XferCpltCallback = I2C_DMAMemTransmitCplt;
+
+    /* Set the DMA error callback */
+    hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryWrite(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+    }
+
+    /* Wait until TXIS flag is set */
+    if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, I2C_TIMEOUT_TXIS) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Reads an amount of data in no-blocking mode with DMA from a specific memory address.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be read
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_MEM_BUSY_RX;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmarx->XferCpltCallback = I2C_DMAMemReceiveCplt;
+
+    /* Set the DMA error callback */
+    hi2c->hdmarx->XferErrorCallback = I2C_DMAError;
+
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, hi2c->XferSize);
+
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryRead(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+    }
+
+    /* Wait until RXNE flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, I2C_TIMEOUT_RXNE) != HAL_OK)
+    {
+      return HAL_TIMEOUT;
+    }
+
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Checks if target device is ready for communication.
+  * @note   This function is used with Memory devices
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  Trials: Number of trials
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  __IO uint32_t I2C_Trials = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    do
+    {
+      /* Generate Start */
+      hi2c->Instance->CR2 = I2C_GENERATE_START(hi2c->Init.AddressingMode,DevAddress);
+
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is set or a NACK flag is set*/
+      tickstart = HAL_GetTick();
+      while((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET) && (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == RESET) && (hi2c->State != HAL_I2C_STATE_TIMEOUT))
+      {
+      	if(Timeout != HAL_MAX_DELAY)
+      	{
+          if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+          {
+            /* Device is ready */
+            hi2c->State = HAL_I2C_STATE_READY;
+            /* Process Unlocked */
+            __HAL_UNLOCK(hi2c);
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+
+      /* Check if the NACKF flag has not been set */
+      if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == RESET)
+      {
+        /* Wait until STOPF flag is reset */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+        /* Device is ready */
+        hi2c->State = HAL_I2C_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        return HAL_OK;
+      }
+      else
+      {
+        /* Wait until STOPF flag is reset */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+        /* Clear STOP Flag, auto generated with autoend*/
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+      }
+
+      /* Check if the maximum allowed number of trials has been reached */
+      if (I2C_Trials++ == Trials)
+      {
+        /* Generate Stop */
+        hi2c->Instance->CR2 |= I2C_CR2_STOP;
+
+        /* Wait until STOPF flag is reset */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+      }
+    }while(I2C_Trials < Trials);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_TIMEOUT;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+/**
+  * @}
+  */
+
+/** @defgroup IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
+ * @{
+ */
+
+/**
+  * @brief  This function handles I2C event interrupt request.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+void HAL_I2C_EV_IRQHandler(I2C_HandleTypeDef *hi2c)
+{
+  /* I2C in mode Transmitter ---------------------------------------------------*/
+  if (((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR) == SET)) && (__HAL_I2C_GET_IT_SOURCE(hi2c, (I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_TXI | I2C_IT_ADDRI)) == SET))
+  {
+    /* Slave mode selected */
+    if (hi2c->State == HAL_I2C_STATE_SLAVE_BUSY_TX)
+    {
+      I2C_SlaveTransmit_ISR(hi2c);
+    }
+  }
+
+  if (((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)) && (__HAL_I2C_GET_IT_SOURCE(hi2c, (I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_TXI)) == SET))
+  {
+    /* Master mode selected */
+    if ((hi2c->State == HAL_I2C_STATE_MASTER_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_MEM_BUSY_TX))
+    {
+      I2C_MasterTransmit_ISR(hi2c);
+    }
+  }
+
+  /* I2C in mode Receiver ----------------------------------------------------*/
+  if (((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR) == SET)) && (__HAL_I2C_GET_IT_SOURCE(hi2c, (I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_RXI | I2C_IT_ADDRI)) == SET))
+  {
+    /* Slave mode selected */
+    if (hi2c->State == HAL_I2C_STATE_SLAVE_BUSY_RX)
+    {
+      I2C_SlaveReceive_ISR(hi2c);
+    }
+  }
+  if (((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)) && (__HAL_I2C_GET_IT_SOURCE(hi2c, (I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_RXI)) == SET))
+  {
+    /* Master mode selected */
+    if ((hi2c->State == HAL_I2C_STATE_MASTER_BUSY_RX) || (hi2c->State == HAL_I2C_STATE_MEM_BUSY_RX))
+    {
+      I2C_MasterReceive_ISR(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  This function handles I2C error interrupt request.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+void HAL_I2C_ER_IRQHandler(I2C_HandleTypeDef *hi2c)
+{
+  /* I2C Bus error interrupt occurred ------------------------------------*/
+  if((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BERR) == SET) && (__HAL_I2C_GET_IT_SOURCE(hi2c, I2C_IT_ERRI) == SET))
+  {
+    hi2c->ErrorCode |= HAL_I2C_ERROR_BERR;
+
+    /* Clear BERR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_BERR);
+  }
+
+  /* I2C Over-Run/Under-Run interrupt occurred ----------------------------------------*/
+  if((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_OVR) == SET) && (__HAL_I2C_GET_IT_SOURCE(hi2c, I2C_IT_ERRI) == SET))
+  {
+    hi2c->ErrorCode |= HAL_I2C_ERROR_OVR;
+
+    /* Clear OVR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_OVR);
+  }
+
+  /* I2C Arbitration Loss error interrupt occurred -------------------------------------*/
+  if((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ARLO) == SET) && (__HAL_I2C_GET_IT_SOURCE(hi2c, I2C_IT_ERRI) == SET))
+  {
+    hi2c->ErrorCode |= HAL_I2C_ERROR_ARLO;
+
+    /* Clear ARLO flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_ARLO);
+  }
+
+  /* Call the Error Callback in case of Error detected */
+  if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+  {
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+}
+
+/**
+  * @brief  Master Tx Transfer completed callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+ __weak void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Master Rx Transfer completed callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/** @brief  Slave Tx Transfer completed callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+ __weak void HAL_I2C_SlaveTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Slave Rx Transfer completed callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Memory Tx Transfer completed callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+ __weak void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Memory Rx Transfer completed callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  I2C error callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+ __weak void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Exported_Functions_Group3 Peripheral State and Errors functions
+ *  @brief   Peripheral State and Errors functions
+ *
+@verbatim
+ ===============================================================================
+            ##### Peripheral State and Errors functions #####
+ ===============================================================================
+    [..]
+    This subsection permit to get in run-time the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the I2C state.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL state
+  */
+HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c)
+{
+  return hi2c->State;
+}
+
+/**
+  * @brief  Return the I2C error code
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *              the configuration information for the specified I2C.
+* @retval I2C Error Code
+*/
+uint32_t HAL_I2C_GetError(I2C_HandleTypeDef *hi2c)
+{
+  return hi2c->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup I2C_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Handle Interrupt Flags Master Transmit Mode
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_MasterTransmit_ISR(I2C_HandleTypeDef *hi2c)
+{
+  uint16_t DevAddress;
+
+  /* Process Locked */
+  __HAL_LOCK(hi2c);
+
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == SET)
+  {
+    /* Write data to TXDR */
+    hi2c->Instance->TXDR = (*hi2c->pBuffPtr++);
+    hi2c->XferSize--;
+    hi2c->XferCount--;
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) == SET)
+  {
+    if((hi2c->XferSize == 0)&&(hi2c->XferCount!=0))
+    {
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+
+      if(hi2c->XferCount > 255)
+      {
+        I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferCount, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+        hi2c->XferSize = hi2c->XferCount;
+      }
+    }
+    else
+    {
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      /* Wrong size Status regarding TCR flag event */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_SIZE;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET)
+  {
+    if(hi2c->XferCount == 0)
+    {
+      /* Generate Stop */
+      hi2c->Instance->CR2 |= I2C_CR2_STOP;
+    }
+    else
+    {
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      /* Wrong size Status regarding TCR flag event */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_SIZE;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+  {
+    /* Disable ERR, TC, STOP, NACK, TXI interrupt */
+    __HAL_I2C_DISABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_TXI );
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    if(hi2c->State == HAL_I2C_STATE_MEM_BUSY_TX)
+    {
+      HAL_I2C_MemTxCpltCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MasterTxCpltCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
+  {
+    /* Clear NACK Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handle Interrupt Flags Master Receive Mode
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_MasterReceive_ISR(I2C_HandleTypeDef *hi2c)
+{
+  uint16_t DevAddress;
+
+  /* Process Locked */
+  __HAL_LOCK(hi2c);
+
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET)
+  {
+    /* Read data from RXDR */
+    (*hi2c->pBuffPtr++) = hi2c->Instance->RXDR;
+    hi2c->XferSize--;
+    hi2c->XferCount--;
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) == SET)
+  {
+    if((hi2c->XferSize == 0)&&(hi2c->XferCount!=0))
+    {
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+
+      if(hi2c->XferCount > 255)
+      {
+        I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferCount, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+        hi2c->XferSize = hi2c->XferCount;
+      }
+    }
+    else
+    {
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      /* Wrong size Status regarding TCR flag event */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_SIZE;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET)
+  {
+    if(hi2c->XferCount == 0)
+    {
+      /* Generate Stop */
+      hi2c->Instance->CR2 |= I2C_CR2_STOP;
+    }
+    else
+    {
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      /* Wrong size Status regarding TCR flag event */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_SIZE;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+  {
+    /* Disable ERR, TC, STOP, NACK, TXI interrupt */
+    __HAL_I2C_DISABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_RXI );
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    if(hi2c->State == HAL_I2C_STATE_MEM_BUSY_RX)
+    {
+      HAL_I2C_MemRxCpltCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MasterRxCpltCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
+  {
+    /* Clear NACK Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK;
+
+}
+
+/**
+  * @brief  Handle Interrupt Flags Slave Transmit Mode
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_SlaveTransmit_ISR(I2C_HandleTypeDef *hi2c)
+{
+  /* Process locked */
+  __HAL_LOCK(hi2c);
+
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) != RESET)
+  {
+    /* Check that I2C transfer finished */
+    /* if yes, normal usecase, a NACK is sent by the MASTER when Transfer is finished */
+    /* Mean XferCount == 0*/
+    /* So clear Flag NACKF only */
+    if(hi2c->XferCount == 0)
+    {
+      /* Clear NACK Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+    }
+    else
+    {
+      /* if no, error usecase, a Non-Acknowledge of last Data is generated by the MASTER*/
+      /* Clear NACK Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+      /* Set ErrorCode corresponding to a Non-Acknowledge */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      /* Call the Error callback to prevent upper layer */
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR) == SET)
+  {
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_ADDR);
+  }
+  /* Check first if STOPF is set          */
+  /* to prevent a Write Data in TX buffer */
+  /* which is stuck in TXDR until next    */
+  /* communication with Master            */
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+  {
+    /* Disable ERRI, TCI, STOPI, NACKI, ADDRI, RXI, TXI interrupt */
+    __HAL_I2C_DISABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI );
+
+    /* Disable Address Acknowledge */
+    hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    HAL_I2C_SlaveTxCpltCallback(hi2c);
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == SET)
+  {
+    /* Write data to TXDR only if XferCount not reach "0" */
+    /* A TXIS flag can be set, during STOP treatment      */
+    if(hi2c->XferCount > 0)
+    {
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = (*hi2c->pBuffPtr++);
+      hi2c->XferCount--;
+    }
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handle Interrupt Flags Slave Receive Mode
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_SlaveReceive_ISR(I2C_HandleTypeDef *hi2c)
+{
+  /* Process Locked */
+  __HAL_LOCK(hi2c);
+
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) != RESET)
+  {
+    /* Clear NACK Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR) == SET)
+  {
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_ADDR);
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET)
+  {
+    /* Read data from RXDR */
+    (*hi2c->pBuffPtr++) = hi2c->Instance->RXDR;
+    hi2c->XferSize--;
+    hi2c->XferCount--;
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+  {
+    /* Disable ERRI, TCI, STOPI, NACKI, ADDRI, RXI, TXI interrupt */
+    __HAL_I2C_DISABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_RXI );
+
+    /* Disable Address Acknowledge */
+    hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    HAL_I2C_SlaveRxCpltCallback(hi2c);
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Master sends target device address followed by internal memory address for write request.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_RequestMemoryWrite(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout)
+{
+  I2C_TransferConfig(hi2c,DevAddress,MemAddSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+
+  /* Wait until TXIS flag is set */
+  if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+  {
+    if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* If Memory address size is 8Bit */
+  if(MemAddSize == I2C_MEMADD_SIZE_8BIT)
+  {
+    /* Send Memory Address */
+    hi2c->Instance->TXDR = I2C_MEM_ADD_LSB(MemAddress);
+  }
+  /* If Memory address size is 16Bit */
+  else
+  {
+    /* Send MSB of Memory Address */
+    hi2c->Instance->TXDR = I2C_MEM_ADD_MSB(MemAddress);
+
+    /* Wait until TXIS flag is set */
+    if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Send LSB of Memory Address */
+    hi2c->Instance->TXDR = I2C_MEM_ADD_LSB(MemAddress);
+  }
+
+  /* Wait until TCR flag is set */
+  if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+
+return HAL_OK;
+}
+
+/**
+  * @brief  Master sends target device address followed by internal memory address for read request.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_RequestMemoryRead(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout)
+{
+  I2C_TransferConfig(hi2c,DevAddress,MemAddSize, I2C_SOFTEND_MODE, I2C_GENERATE_START_WRITE);
+
+  /* Wait until TXIS flag is set */
+  if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+  {
+    if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* If Memory address size is 8Bit */
+  if(MemAddSize == I2C_MEMADD_SIZE_8BIT)
+  {
+    /* Send Memory Address */
+    hi2c->Instance->TXDR = I2C_MEM_ADD_LSB(MemAddress);
+  }
+  /* If Memory address size is 16Bit */
+  else
+  {
+    /* Send MSB of Memory Address */
+    hi2c->Instance->TXDR = I2C_MEM_ADD_MSB(MemAddress);
+
+    /* Wait until TXIS flag is set */
+    if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Send LSB of Memory Address */
+    hi2c->Instance->TXDR = I2C_MEM_ADD_LSB(MemAddress);
+  }
+
+  /* Wait until TC flag is set */
+  if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TC, RESET, Timeout) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DMA I2C master transmit process complete callback.
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  uint16_t DevAddress;
+  I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  /* Check if last DMA request was done with RELOAD */
+  /* Set NBYTES to write and reload if size > 255 */
+  if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+  {
+    /* Wait until TCR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, I2C_TIMEOUT_TCR) != HAL_OK)
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is reset */
+      if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+        else
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        }
+      }
+
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c);
+
+      hi2c->XferCount = 0;
+
+      hi2c->State = HAL_I2C_STATE_READY;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      hi2c->pBuffPtr += hi2c->XferSize;
+      hi2c->XferCount -= hi2c->XferSize;
+      if(hi2c->XferCount > 255)
+      {
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+      }
+
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)hi2c->pBuffPtr, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if size > 255 */
+      if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }
+
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, I2C_TIMEOUT_TXIS) != HAL_OK)
+      {
+        /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+        /* Wait until STOPF flag is reset */
+        if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+        {
+          if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+          }
+          else
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          }
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+        /* Clear Configuration Register 2 */
+        I2C_RESET_CR2(hi2c);
+
+        hi2c->XferCount = 0;
+
+        hi2c->State = HAL_I2C_STATE_READY;
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+      }
+    }
+  }
+  else
+  {
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+      else
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN;
+
+    hi2c->XferCount = 0;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+   /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MasterTxCpltCallback(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  DMA I2C slave transmit process complete callback.
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  /* Wait until STOP flag is set */
+  if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+  {
+    if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    {
+      /* Normal Use case, a AF is generated by master */
+      /* to inform slave the end of transfer */
+      hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+    }
+    else
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+  }
+
+  /* Clear STOP flag */
+  __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_STOPF);
+
+  /* Wait until BUSY flag is reset */
+  if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, I2C_TIMEOUT_BUSY) != HAL_OK)
+  {
+    hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+  }
+
+  /* Disable DMA Request */
+  hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN;
+
+  hi2c->XferCount = 0;
+
+  hi2c->State = HAL_I2C_STATE_READY;
+
+  /* Check if Errors has been detected during transfer */
+  if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+  {
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+  else
+  {
+    HAL_I2C_SlaveTxCpltCallback(hi2c);
+  }
+}
+
+/**
+  * @brief DMA I2C master receive process complete callback
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  uint16_t DevAddress;
+
+  /* Check if last DMA request was done with RELOAD */
+  /* Set NBYTES to write and reload if size > 255 */
+  if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+  {
+    /* Wait until TCR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, I2C_TIMEOUT_TCR) != HAL_OK)
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is reset */
+      if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+        else
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        }
+      }
+
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c);
+
+      hi2c->XferCount = 0;
+
+      hi2c->State = HAL_I2C_STATE_READY;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      hi2c->pBuffPtr += hi2c->XferSize;
+      hi2c->XferCount -= hi2c->XferSize;
+      if(hi2c->XferCount > 255)
+      {
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+      }
+
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)hi2c->pBuffPtr, hi2c->XferSize);
+
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if size > 255 */
+      if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }
+
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, I2C_TIMEOUT_RXNE) != HAL_OK)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+
+      /* Check if Errors has been detected during transfer */
+      if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+      {
+        /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+        /* Wait until STOPF flag is reset */
+        if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+        {
+          if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+          }
+          else
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          }
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+        /* Clear Configuration Register 2 */
+        I2C_RESET_CR2(hi2c);
+
+        hi2c->XferCount = 0;
+
+        hi2c->State = HAL_I2C_STATE_READY;
+
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+      }
+    }
+  }
+  else
+  {
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+      else
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN;
+
+    hi2c->XferCount = 0;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MasterRxCpltCallback(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  DMA I2C slave receive process complete callback.
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void I2C_DMASlaveReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  /* Wait until STOPF flag is reset */
+  if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+  {
+    if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+    }
+    else
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+  }
+
+  /* Clear STOPF flag */
+  __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+  /* Wait until BUSY flag is reset */
+  if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, I2C_TIMEOUT_BUSY) != HAL_OK)
+  {
+    hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+  }
+
+  /* Disable DMA Request */
+  hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN;
+
+  /* Disable Address Acknowledge */
+  hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+  hi2c->XferCount = 0;
+
+  hi2c->State = HAL_I2C_STATE_READY;
+
+  /* Check if Errors has been detected during transfer */
+  if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+  {
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+  else
+  {
+    HAL_I2C_SlaveRxCpltCallback(hi2c);
+  }
+}
+
+/**
+  * @brief DMA I2C Memory Write process complete callback
+  * @param hdma : DMA handle
+  * @retval None
+  */
+static void I2C_DMAMemTransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  uint16_t DevAddress;
+  I2C_HandleTypeDef* hi2c = ( I2C_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Check if last DMA request was done with RELOAD */
+  /* Set NBYTES to write and reload if size > 255 */
+  if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+  {
+    /* Wait until TCR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, I2C_TIMEOUT_TCR) != HAL_OK)
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is reset */
+      if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+        else
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        }
+      }
+
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c);
+
+      hi2c->XferCount = 0;
+
+      hi2c->State = HAL_I2C_STATE_READY;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      hi2c->pBuffPtr += hi2c->XferSize;
+      hi2c->XferCount -= hi2c->XferSize;
+      if(hi2c->XferCount > 255)
+      {
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+      }
+
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)hi2c->pBuffPtr, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if size > 255 */
+      if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }
+
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, I2C_TIMEOUT_TXIS) != HAL_OK)
+      {
+        /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+        /* Wait until STOPF flag is reset */
+        if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+        {
+          if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+          }
+          else
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          }
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+        /* Clear Configuration Register 2 */
+        I2C_RESET_CR2(hi2c);
+
+        hi2c->XferCount = 0;
+
+        hi2c->State = HAL_I2C_STATE_READY;
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+      }
+    }
+  }
+  else
+  {
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+      else
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN;
+
+    hi2c->XferCount = 0;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MemTxCpltCallback(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  DMA I2C Memory Read process complete callback
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void I2C_DMAMemReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  I2C_HandleTypeDef* hi2c = ( I2C_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  uint16_t DevAddress;
+
+  /* Check if last DMA request was done with RELOAD */
+  /* Set NBYTES to write and reload if size > 255 */
+  if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+  {
+    /* Wait until TCR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, I2C_TIMEOUT_TCR) != HAL_OK)
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is reset */
+      if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+        else
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        }
+      }
+
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c);
+
+      hi2c->XferCount = 0;
+
+      hi2c->State = HAL_I2C_STATE_READY;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      hi2c->pBuffPtr += hi2c->XferSize;
+      hi2c->XferCount -= hi2c->XferSize;
+      if(hi2c->XferCount > 255)
+      {
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+      }
+
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)hi2c->pBuffPtr, hi2c->XferSize);
+
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if size > 255 */
+      if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }
+
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, I2C_TIMEOUT_RXNE) != HAL_OK)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+
+      /* Check if Errors has been detected during transfer */
+      if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+      {
+        /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+        /* Wait until STOPF flag is reset */
+        if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+        {
+          if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+          }
+          else
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          }
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+        /* Clear Configuration Register 2 */
+        I2C_RESET_CR2(hi2c);
+
+        hi2c->XferCount = 0;
+
+        hi2c->State = HAL_I2C_STATE_READY;
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+      }
+    }
+  }
+  else
+  {
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+      else
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN;
+
+    hi2c->XferCount = 0;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MemRxCpltCallback(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  DMA I2C communication error callback.
+  * @param hdma : DMA handle
+  * @retval None
+  */
+static void I2C_DMAError(DMA_HandleTypeDef *hdma)
+{
+  I2C_HandleTypeDef* hi2c = ( I2C_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Disable Acknowledge */
+  hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+  hi2c->XferCount = 0;
+
+  hi2c->State = HAL_I2C_STATE_READY;
+
+  hi2c->ErrorCode |= HAL_I2C_ERROR_DMA;
+
+  HAL_I2C_ErrorCallback(hi2c);
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Flag: specifies the I2C flag to check.
+  * @param  Status: The new Flag status (SET or RESET).
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Flag, FlagStatus Status, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {
+    while(__HAL_I2C_GET_FLAG(hi2c, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          hi2c->State= HAL_I2C_STATE_READY;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_I2C_GET_FLAG(hi2c, Flag) != RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          hi2c->State= HAL_I2C_STATE_READY;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout for specific usage of TXIS flag.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+
+  while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == RESET)
+  {
+    /* Check if a NACK is detected */
+    if(I2C_IsAcknowledgeFailed(hi2c, Timeout) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        hi2c->State= HAL_I2C_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout for specific usage of STOP flag.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout)
+{
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+
+  while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET)
+  {
+    /* Check if a NACK is detected */
+    if(I2C_IsAcknowledgeFailed(hi2c, Timeout) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+
+    /* Check for the Timeout */
+    if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      hi2c->State= HAL_I2C_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout for specific usage of RXNE flag.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout)
+{
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+
+  while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == RESET)
+  {
+    /* Check if a STOPF is detected */
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+    {
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c);
+
+      hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+      hi2c->State= HAL_I2C_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      return HAL_ERROR;
+    }
+
+    /* Check for the Timeout */
+    if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      hi2c->State= HAL_I2C_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles Acknowledge failed detection during an I2C Communication.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_IsAcknowledgeFailed(I2C_HandleTypeDef *hi2c, uint32_t Timeout)
+{
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
+  {
+    /* Generate stop if necessary only in case of I2C peripheral in MASTER mode */
+    if((hi2c->State == HAL_I2C_STATE_MASTER_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_MEM_BUSY_TX)
+       || (hi2c->State == HAL_I2C_STATE_MEM_BUSY_RX))
+    {
+      /* No need to generate the STOP condition if AUTOEND mode is enabled */
+      /* Generate the STOP condition only in case of SOFTEND mode is enabled */
+      if((hi2c->Instance->CR2 & I2C_AUTOEND_MODE) != I2C_AUTOEND_MODE)
+      {
+        /* Generate Stop */
+        hi2c->Instance->CR2 |= I2C_CR2_STOP;
+      }
+    }
+
+    /* Wait until STOP Flag is reset */
+    /* AutoEnd should be initiate after AF */
+    while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          hi2c->State= HAL_I2C_STATE_READY;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+
+    /* Clear NACKF Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    hi2c->ErrorCode = HAL_I2C_ERROR_AF;
+    hi2c->State= HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_ERROR;
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles I2Cx communication when starting transfer or during transfer (TC or TCR flag are set).
+  * @param  hi2c: I2C handle.
+  * @param  DevAddress: specifies the slave address to be programmed.
+  * @param  Size: specifies the number of bytes to be programmed.
+  *   This parameter must be a value between 0 and 255.
+  * @param  Mode: new state of the I2C START condition generation.
+  *   This parameter can be one of the following values:
+  *     @arg I2C_RELOAD_MODE: Enable Reload mode .
+  *     @arg I2C_AUTOEND_MODE: Enable Automatic end mode.
+  *     @arg I2C_SOFTEND_MODE: Enable Software end mode.
+  * @param  Request: new state of the I2C START condition generation.
+  *   This parameter can be one of the following values:
+  *     @arg I2C_NO_STARTSTOP: Don't Generate stop and start condition.
+  *     @arg I2C_GENERATE_STOP: Generate stop condition (Size should be set to 0).
+  *     @arg I2C_GENERATE_START_READ: Generate Restart for read request.
+  *     @arg I2C_GENERATE_START_WRITE: Generate Restart for write request.
+  * @retval None
+  */
+static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  assert_param(IS_TRANSFER_MODE(Mode));
+  assert_param(IS_TRANSFER_REQUEST(Request));
+
+  /* Get the CR2 register value */
+  tmpreg = hi2c->Instance->CR2;
+
+  /* clear tmpreg specific bits */
+  tmpreg &= (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_AUTOEND | I2C_CR2_RD_WRN | I2C_CR2_START | I2C_CR2_STOP));
+
+  /* update tmpreg */
+  tmpreg |= (uint32_t)(((uint32_t)DevAddress & I2C_CR2_SADD) | (((uint32_t)Size << 16 ) & I2C_CR2_NBYTES) | \
+            (uint32_t)Mode | (uint32_t)Request);
+
+  /* update CR2 register */
+  hi2c->Instance->CR2 = tmpreg;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_I2C_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_i2s.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_i2s.c
@@ -1,0 +1,1535 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_i2s.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   I2S HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Integrated Interchip Sound (I2S) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral State and Errors functions
+  @verbatim
+ ===============================================================================
+                  ##### How to use this driver #####
+ ===============================================================================
+ [..]
+    The I2S HAL driver can be used as follows:
+
+    (#) Declare a I2S_HandleTypeDef handle structure.
+    (#) Initialize the I2S low level resources by implement the HAL_I2S_MspInit() API:
+        (##) Enable the SPIx interface clock.
+        (##) I2S pins configuration:
+            (+++) Enable the clock for the I2S GPIOs.
+            (+++) Configure these I2S pins as alternate function pull-up.
+        (##) NVIC configuration if you need to use interrupt process (HAL_I2S_Transmit_IT()
+             and HAL_I2S_Receive_IT() APIs).
+            (+++) Configure the I2Sx interrupt priority.
+            (+++) Enable the NVIC I2S IRQ handle.
+        (##) DMA Configuration if you need to use DMA process (HAL_I2S_Transmit_DMA()
+             and HAL_I2S_Receive_DMA() APIs:
+            (+++) Declare a DMA handle structure for the Tx/Rx channel.
+            (+++) Enable the DMAx interface clock.
+            (+++) Configure the declared DMA handle structure with the required Tx/Rx parameters.
+            (+++) Configure the DMA Tx/Rx Channel.
+            (+++) Associate the initialized DMA handle to the I2S DMA Tx/Rx handle.
+            (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the
+                DMA Tx/Rx Channel.
+
+   (#) Program the Mode, Standard, Data Format, MCLK Output, Audio frequency and Polarity
+       using HAL_I2S_Init() function.
+
+   -@- The specific I2S interrupts (Transmission complete interrupt,
+       RXNE interrupt and Error Interrupts) will be managed using the macros
+       __HAL_I2S_ENABLE_IT() and __HAL_I2S_DISABLE_IT() inside the transmit and receive process.
+   -@- Make sure that either:
+       (+@) I2S clock is configured based on SYSCLK or
+       (+@) External clock source is configured after setting correctly
+            the define constant EXTERNAL_CLOCK_VALUE in the stm32f3xx_hal_conf.h file.
+
+   (#) Three mode of operations are available within this driver :
+
+   *** Polling mode IO operation ***
+   =================================
+   [..]
+     (+) Send an amount of data in blocking mode using HAL_I2S_Transmit()
+     (+) Receive an amount of data in blocking mode using HAL_I2S_Receive()
+
+   *** Interrupt mode IO operation ***
+   ===================================
+   [..]
+     (+) Send an amount of data in non blocking mode using HAL_I2S_Transmit_IT()
+     (+) At transmission end of half transfer HAL_I2S_TxHalfCpltCallback is executed and user can
+         add his own code by customization of function pointer HAL_I2S_TxHalfCpltCallback
+     (+) At transmission end of transfer HAL_I2S_TxCpltCallback is executed and user can
+         add his own code by customization of function pointer HAL_I2S_TxCpltCallback
+     (+) Receive an amount of data in non blocking mode using HAL_I2S_Receive_IT()
+     (+) At reception end of half transfer HAL_I2S_RxHalfCpltCallback is executed and user can
+         add his own code by customization of function pointer HAL_I2S_RxHalfCpltCallback
+     (+) At reception end of transfer HAL_I2S_RxCpltCallback is executed and user can
+         add his own code by customization of function pointer HAL_I2S_RxCpltCallback
+     (+) In case of transfer Error, HAL_I2S_ErrorCallback() function is executed and user can
+         add his own code by customization of function pointer HAL_I2S_ErrorCallback
+
+   *** DMA mode IO operation ***
+   ==============================
+   [..]
+     (+) Send an amount of data in non blocking mode (DMA) using HAL_I2S_Transmit_DMA()
+     (+) At transmission end of half transfer HAL_I2S_TxHalfCpltCallback is executed and user can
+         add his own code by customization of function pointer HAL_I2S_TxHalfCpltCallback
+     (+) At transmission end of transfer HAL_I2S_TxCpltCallback is executed and user can
+         add his own code by customization of function pointer HAL_I2S_TxCpltCallback
+     (+) Receive an amount of data in non blocking mode (DMA) using HAL_I2S_Receive_DMA()
+     (+) At reception end of half transfer HAL_I2S_RxHalfCpltCallback is executed and user can
+         add his own code by customization of function pointer HAL_I2S_RxHalfCpltCallback
+     (+) At reception end of transfer HAL_I2S_RxCpltCallback is executed and user can
+         add his own code by customization of function pointer HAL_I2S_RxCpltCallback
+     (+) In case of transfer Error, HAL_I2S_ErrorCallback() function is executed and user can
+         add his own code by customization of function pointer HAL_I2S_ErrorCallback
+     (+) Pause the DMA Transfer using HAL_I2S_DMAPause()
+     (+) Resume the DMA Transfer using HAL_I2S_DMAResume()
+     (+) Stop the DMA Transfer using HAL_I2S_DMAStop()
+
+   *** I2S HAL driver macros list ***
+   =============================================
+   [..]
+     Below the list of most used macros in I2S HAL driver.
+
+      (+) __HAL_I2S_ENABLE: Enable the specified SPI peripheral (in I2S mode)
+      (+) __HAL_I2S_DISABLE: Disable the specified SPI peripheral (in I2S mode)
+      (+) __HAL_I2S_ENABLE_IT : Enable the specified I2S interrupts
+      (+) __HAL_I2S_DISABLE_IT : Disable the specified I2S interrupts
+      (+) __HAL_I2S_GET_FLAG: Check whether the specified I2S flag is set or not
+
+    [..]
+      (@) You can refer to the I2S HAL driver header file for more useful macros
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup I2S I2S
+  * @brief I2S HAL module driver
+  * @{
+  */
+
+#ifdef HAL_I2S_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @defgroup I2S_Private_Functions I2S Private Functions
+  * @{
+  */
+static void I2S_DMATxCplt(DMA_HandleTypeDef *hdma);
+static void I2S_DMATxHalfCplt(DMA_HandleTypeDef *hdma);
+static void I2S_DMARxCplt(DMA_HandleTypeDef *hdma);
+static void I2S_DMARxHalfCplt(DMA_HandleTypeDef *hdma);
+static void I2S_DMAError(DMA_HandleTypeDef *hdma);
+static void I2S_Transmit_IT(I2S_HandleTypeDef *hi2s);
+static void I2S_Receive_IT(I2S_HandleTypeDef *hi2s);
+static uint32_t I2S_GetClockFreq(I2S_HandleTypeDef *hi2s);
+static HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, uint32_t Flag, uint32_t State, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/* Exported functions ---------------------------------------------------------*/
+
+/** @defgroup I2S_Exported_Functions I2S Exported Functions
+  * @{
+  */
+
+/** @defgroup  I2S_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and Configuration functions
+  *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This subsection provides a set of functions allowing to initialize and
+          de-initialize the I2Sx peripheral in simplex mode:
+
+      (+) User must Implement HAL_I2S_MspInit() function in which he configures
+          all related peripherals resources (CLOCK, GPIO, DMA, IT and NVIC ).
+
+      (+) Call the function HAL_I2S_Init() to configure the selected device with
+          the selected configuration:
+        (++) Mode
+        (++) Standard
+        (++) Data Format
+        (++) MCLK Output
+        (++) Audio frequency
+        (++) Polarity
+        (++) Full duplex mode
+
+      (+) Call the function HAL_I2S_DeInit() to restore the default configuration
+          of the selected I2Sx peripheral.
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Initializes the I2S according to the specified parameters
+  *         in the I2S_InitTypeDef and create the associated handle.
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
+{
+  uint16_t tmpreg = 0, i2sdiv = 2, i2sodd = 0, packetlength = 1;
+  uint32_t tmp = 0, i2sclk = 0;
+
+  /* Check the I2S handle allocation */
+  if(hi2s == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_I2S_ALL_INSTANCE(hi2s->Instance));
+  assert_param(IS_I2S_MODE(hi2s->Init.Mode));
+  assert_param(IS_I2S_STANDARD(hi2s->Init.Standard));
+  assert_param(IS_I2S_DATA_FORMAT(hi2s->Init.DataFormat));
+  assert_param(IS_I2S_MCLK_OUTPUT(hi2s->Init.MCLKOutput));
+  assert_param(IS_I2S_AUDIO_FREQ(hi2s->Init.AudioFreq));
+  assert_param(IS_I2S_CPOL(hi2s->Init.CPOL));
+  assert_param(IS_I2S_CLOCKSOURCE(hi2s->Init.ClockSource));
+
+  if(hi2s->State == HAL_I2S_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hi2s->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX...etc */
+    HAL_I2S_MspInit(hi2s);
+  }
+
+  hi2s->State = HAL_I2S_STATE_BUSY;
+
+  /*----------------------- SPIx I2SCFGR & I2SPR Configuration -----------------*/
+  /* Clear I2SMOD, I2SE, I2SCFG, PCMSYNC, I2SSTD, CKPOL, DATLEN and CHLEN bits */
+  hi2s->Instance->I2SCFGR &= ~(SPI_I2SCFGR_CHLEN | SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CKPOL | \
+                               SPI_I2SCFGR_I2SSTD | SPI_I2SCFGR_PCMSYNC | SPI_I2SCFGR_I2SCFG | \
+                               SPI_I2SCFGR_I2SE | SPI_I2SCFGR_I2SMOD);
+  hi2s->Instance->I2SPR = 0x0002;
+
+  /* Get the I2SCFGR register value */
+  tmpreg = hi2s->Instance->I2SCFGR;
+
+  /* If the default value has to be written, reinitialize i2sdiv and i2sodd*/
+  if(hi2s->Init.AudioFreq == I2S_AUDIOFREQ_DEFAULT)
+  {
+    i2sodd = (uint16_t)0;
+    i2sdiv = (uint16_t)2;
+  }
+  /* If the requested audio frequency is not the default, compute the prescaler */
+  else
+  {
+    /* Check the frame length (For the Prescaler computing) *******************/
+    if(hi2s->Init.DataFormat == I2S_DATAFORMAT_16B)
+    {
+      /* Packet length is 16 bits */
+      packetlength = 1;
+    }
+    else
+    {
+      /* Packet length is 32 bits */
+      packetlength = 2;
+    }
+
+    /* Get I2S source Clock frequency  ****************************************/
+
+    /* If an external I2S clock has to be used, the specific define should be set
+    in the project configuration or in the stm32f3xx_conf.h file */
+    if(hi2s->Init.ClockSource == I2S_CLOCK_EXTERNAL)
+    {
+      /* Set the I2S clock to the external clock  value */
+      i2sclk = EXTERNAL_CLOCK_VALUE;
+    }
+    else
+    {
+      /* Get the I2S source clock value */
+			i2sclk = I2S_GetClockFreq(hi2s);
+    }
+
+    /* Compute the Real divider depending on the MCLK output state, with a floating point */
+    if(hi2s->Init.MCLKOutput == I2S_MCLKOUTPUT_ENABLE)
+    {
+      /* MCLK output is enabled */
+      tmp = (uint16_t)(((((i2sclk / 256) * 10) / hi2s->Init.AudioFreq)) + 5);
+    }
+    else
+    {
+      /* MCLK output is disabled */
+      tmp = (uint16_t)(((((i2sclk / (32 * packetlength)) *10 ) / hi2s->Init.AudioFreq)) + 5);
+    }
+
+    /* Remove the flatting point */
+    tmp = tmp / 10;
+
+    /* Check the parity of the divider */
+    i2sodd = (uint16_t)(tmp & (uint16_t)0x0001);
+
+    /* Compute the i2sdiv prescaler */
+    i2sdiv = (uint16_t)((tmp - i2sodd) / 2);
+
+    /* Get the Mask for the Odd bit (SPI_I2SPR[8]) register */
+    i2sodd = (uint16_t) (i2sodd << 8);
+  }
+
+  /* Test if the divider is 1 or 0 or greater than 0xFF */
+  if((i2sdiv < 2) || (i2sdiv > 0xFF))
+  {
+    /* Set the default values */
+    i2sdiv = 2;
+    i2sodd = 0;
+  }
+
+  /* Write to SPIx I2SPR register the computed value */
+  hi2s->Instance->I2SPR = (uint16_t)((uint16_t)i2sdiv | (uint16_t)(i2sodd | (uint16_t)hi2s->Init.MCLKOutput));
+
+  /* Configure the I2S with the I2S_InitStruct values */
+  tmpreg |= (uint16_t)((uint16_t)SPI_I2SCFGR_I2SMOD | (uint16_t)(hi2s->Init.Mode | \
+                       (uint16_t)(hi2s->Init.Standard | (uint16_t)(hi2s->Init.DataFormat | \
+                       (uint16_t)hi2s->Init.CPOL))));
+
+  /* Write to SPIx I2SCFGR */
+  hi2s->Instance->I2SCFGR = tmpreg;
+
+  hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+  hi2s->State= HAL_I2S_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief DeInitializes the I2S peripheral
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_DeInit(I2S_HandleTypeDef *hi2s)
+{
+  /* Check the I2S handle allocation */
+  if(hi2s == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_I2S_ALL_INSTANCE(hi2s->Instance));
+
+  hi2s->State = HAL_I2S_STATE_BUSY;
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC... */
+  HAL_I2S_MspDeInit(hi2s);
+
+  hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+  hi2s->State = HAL_I2S_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hi2s);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief I2S MSP Init
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+ __weak void HAL_I2S_MspInit(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief I2S MSP DeInit
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+ __weak void HAL_I2S_MspDeInit(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Exported_Functions_Group2 Input and Output operation functions
+  *  @brief Data transfers functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to manage the I2S data
+    transfers.
+
+    (#) There are two modes of transfer:
+       (++) Blocking mode : The communication is performed in the polling mode.
+            The status of all data processing is returned by the same function
+            after finishing transfer.
+       (++) No-Blocking mode : The communication is performed using Interrupts
+            or DMA. These functions return the status of the transfer startup.
+            The end of the data processing will be indicated through the
+            dedicated I2S IRQ when using Interrupt mode or the DMA IRQ when
+            using DMA mode.
+
+    (#) Blocking mode functions are :
+        (++) HAL_I2S_Transmit()
+        (++) HAL_I2S_Receive()
+
+    (#) No-Blocking mode functions with Interrupt are :
+        (++) HAL_I2S_Transmit_IT()
+        (++) HAL_I2S_Receive_IT()
+
+    (#) No-Blocking mode functions with DMA are :
+        (++) HAL_I2S_Transmit_DMA()
+        (++) HAL_I2S_Receive_DMA()
+
+    (#) A set of Transfer Complete Callbacks are provided in non Blocking mode:
+        (++) HAL_I2S_TxCpltCallback()
+        (++) HAL_I2S_RxCpltCallback()
+        (++) HAL_I2S_ErrorCallback()
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Transmit an amount of data in blocking mode
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param pData: a 16-bit pointer to data buffer.
+  * @param Size: number of data sample to be sent:
+  * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
+  *       configuration phase, the Size parameter means the number of 16-bit data length
+  *       in the transaction and when a 24-bit data frame or a 32-bit data frame is selected
+  *       the Size parameter means the number of 16-bit data length.
+  * @param  Timeout: Timeout duration
+  * @note The I2S is kept enabled at the end of transaction to avoid the clock de-synchronization
+  *       between Master and Slave(example: audio streaming).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Transmit(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  if((pData == NULL ) || (Size == 0))
+  {
+    return  HAL_ERROR;
+  }
+
+  if(hi2s->State == HAL_I2S_STATE_READY)
+  {
+    if(((hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN)) == I2S_DATAFORMAT_24B)||\
+       ((hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN)) == I2S_DATAFORMAT_32B))
+    {
+      hi2s->TxXferSize = (Size << 1);
+      hi2s->TxXferCount = (Size << 1);
+    }
+    else
+    {
+      hi2s->TxXferSize = Size;
+      hi2s->TxXferCount = Size;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2s);
+
+    hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+    hi2s->State = HAL_I2S_STATE_BUSY_TX;
+
+    /* Check if the I2S is already enabled */
+    if((hi2s->Instance->I2SCFGR &SPI_I2SCFGR_I2SE) != SPI_I2SCFGR_I2SE)
+    {
+      /* Enable I2S peripheral */
+      __HAL_I2S_ENABLE(hi2s);
+    }
+
+    while(hi2s->TxXferCount > 0)
+    {
+      hi2s->Instance->DR = (*pData++);
+      hi2s->TxXferCount--;
+      /* Wait until TXE flag is set */
+      if (I2S_WaitFlagStateUntilTimeout(hi2s, I2S_FLAG_TXE, SET, Timeout) != HAL_OK)
+      {
+        /* Set the error code and execute error callback*/
+        hi2s->ErrorCode |= HAL_I2S_ERROR_TIMEOUT;
+        HAL_I2S_ErrorCallback(hi2s);
+        return HAL_TIMEOUT;
+      }
+
+      /* Check if an underrun occurs */
+      if(__HAL_I2S_GET_FLAG(hi2s, I2S_FLAG_UDR) == SET)
+      {
+        /* Set the I2S State ready */
+        hi2s->State = HAL_I2S_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2s);
+
+        /* Set the error code and execute error callback*/
+        hi2s->ErrorCode |= HAL_I2S_ERROR_UDR;
+        HAL_I2S_ErrorCallback(hi2s);
+
+        return HAL_ERROR;
+      }
+    }
+
+    /* Check if Slave mode is selected */
+    if(((hi2s->Instance->I2SCFGR & SPI_I2SCFGR_I2SCFG) == I2S_MODE_SLAVE_TX) || ((hi2s->Instance->I2SCFGR & SPI_I2SCFGR_I2SCFG) == I2S_MODE_SLAVE_RX))
+    {
+      /* Wait until Busy flag is reset */
+      if (I2S_WaitFlagStateUntilTimeout(hi2s, I2S_FLAG_BSY, RESET, Timeout) != HAL_OK)
+      {
+        /* Set the error code and execute error callback*/
+        hi2s->ErrorCode |= HAL_I2S_ERROR_TIMEOUT;
+        HAL_I2S_ErrorCallback(hi2s);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hi2s->State = HAL_I2S_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2s);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in blocking mode
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param pData: a 16-bit pointer to data buffer.
+  * @param Size: number of data sample to be sent:
+  * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
+  *       configuration phase, the Size parameter means the number of 16-bit data length
+  *       in the transaction and when a 24-bit data frame or a 32-bit data frame is selected
+  *       the Size parameter means the number of 16-bit data length.
+  * @param Timeout: Timeout duration
+  * @note The I2S is kept enabled at the end of transaction to avoid the clock de-synchronization
+  *       between Master and Slave(example: audio streaming).
+  * @note In I2S Master Receiver mode, just after enabling the peripheral the clock will be generate
+  *       in continuous way and as the I2S is not disabled at the end of the I2S transaction.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Receive(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  if((pData == NULL ) || (Size == 0))
+  {
+    return  HAL_ERROR;
+  }
+
+  if(hi2s->State == HAL_I2S_STATE_READY)
+  {
+    if(((hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN)) == I2S_DATAFORMAT_24B)||\
+       ((hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN)) == I2S_DATAFORMAT_32B))
+    {
+      hi2s->RxXferSize = (Size << 1);
+      hi2s->RxXferCount = (Size << 1);
+    }
+    else
+    {
+      hi2s->RxXferSize = Size;
+      hi2s->RxXferCount = Size;
+    }
+    /* Process Locked */
+    __HAL_LOCK(hi2s);
+
+    hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+    hi2s->State = HAL_I2S_STATE_BUSY_RX;
+
+    /* Check if the I2S is already enabled */
+    if((hi2s->Instance->I2SCFGR & SPI_I2SCFGR_I2SE) != SPI_I2SCFGR_I2SE)
+    {
+      /* Enable I2S peripheral */
+      __HAL_I2S_ENABLE(hi2s);
+    }
+
+    /* Check if Master Receiver mode is selected */
+    if((hi2s->Instance->I2SCFGR & SPI_I2SCFGR_I2SCFG) == I2S_MODE_MASTER_RX)
+    {
+      /* Clear the Overrun Flag by a read operation on the SPI_DR register followed by a read
+      access to the SPI_SR register. */
+      __HAL_I2S_CLEAR_OVRFLAG(hi2s);
+    }
+
+    /* Receive data */
+    while(hi2s->RxXferCount > 0)
+    {
+      /* Wait until RXNE flag is set */
+      if (I2S_WaitFlagStateUntilTimeout(hi2s, I2S_FLAG_RXNE, SET, Timeout) != HAL_OK)
+      {
+        /* Set the error code and execute error callback*/
+        hi2s->ErrorCode |= HAL_I2S_ERROR_TIMEOUT;
+        HAL_I2S_ErrorCallback(hi2s);
+        return HAL_TIMEOUT;
+      }
+
+      /* Check if an overrun occurs */
+      if(__HAL_I2S_GET_FLAG(hi2s, I2S_FLAG_OVR) == SET)
+      {
+        /* Set the I2S State ready */
+        hi2s->State = HAL_I2S_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2s);
+
+        /* Set the error code and execute error callback*/
+        hi2s->ErrorCode |= HAL_I2S_ERROR_OVR;
+        HAL_I2S_ErrorCallback(hi2s);
+
+        return HAL_ERROR;
+      }
+
+      (*pData++) = hi2s->Instance->DR;
+      hi2s->RxXferCount--;
+    }
+
+    hi2s->State = HAL_I2S_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2s);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Transmit an amount of data in non-blocking mode with Interrupt
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param pData: a 16-bit pointer to data buffer.
+  * @param Size: number of data sample to be sent:
+  * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
+  *       configuration phase, the Size parameter means the number of 16-bit data length
+  *       in the transaction and when a 24-bit data frame or a 32-bit data frame is selected
+  *       the Size parameter means the number of 16-bit data length.
+  * @note The I2S is kept enabled at the end of transaction to avoid the clock de-synchronization
+  *       between Master and Slave(example: audio streaming).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Transmit_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size)
+{
+  if(hi2s->State == HAL_I2S_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    hi2s->pTxBuffPtr = pData;
+    if(((hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN)) == I2S_DATAFORMAT_24B)||\
+      ((hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN)) == I2S_DATAFORMAT_32B))
+    {
+      hi2s->TxXferSize = (Size << 1);
+      hi2s->TxXferCount = (Size << 1);
+    }
+    else
+    {
+      hi2s->TxXferSize = Size;
+      hi2s->TxXferCount = Size;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2s);
+
+    hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+    hi2s->State = HAL_I2S_STATE_BUSY_TX;
+
+    /* Enable TXE and ERR interrupt */
+    __HAL_I2S_ENABLE_IT(hi2s, (I2S_IT_TXE | I2S_IT_ERR));
+
+    /* Check if the I2S is already enabled */
+    if((hi2s->Instance->I2SCFGR &SPI_I2SCFGR_I2SE) != SPI_I2SCFGR_I2SE)
+    {
+      /* Enable I2S peripheral */
+      __HAL_I2S_ENABLE(hi2s);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2s);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in non-blocking mode with Interrupt
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param pData: a 16-bit pointer to the Receive data buffer.
+  * @param Size: number of data sample to be sent:
+  * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
+  *       configuration phase, the Size parameter means the number of 16-bit data length
+  *       in the transaction and when a 24-bit data frame or a 32-bit data frame is selected
+  *       the Size parameter means the number of 16-bit data length.
+  * @note The I2S is kept enabled at the end of transaction to avoid the clock de-synchronization
+  *       between Master and Slave(example: audio streaming).
+  * @note It is recommended to use DMA for the I2S receiver to avoid de-synchronisation
+  * between Master and Slave otherwise the I2S interrupt should be optimized.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Receive_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size)
+{
+  if(hi2s->State == HAL_I2S_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    hi2s->pRxBuffPtr = pData;
+    if(((hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN)) == I2S_DATAFORMAT_24B)||\
+      ((hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN)) == I2S_DATAFORMAT_32B))
+    {
+      hi2s->RxXferSize = (Size << 1);
+      hi2s->RxXferCount = (Size << 1);
+    }
+    else
+    {
+      hi2s->RxXferSize = Size;
+      hi2s->RxXferCount = Size;
+    }
+    /* Process Locked */
+    __HAL_LOCK(hi2s);
+
+    hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+    hi2s->State = HAL_I2S_STATE_BUSY_RX;
+
+    /* Enable TXE and ERR interrupt */
+    __HAL_I2S_ENABLE_IT(hi2s, (I2S_IT_RXNE | I2S_IT_ERR));
+
+    /* Check if the I2S is already enabled */
+    if((hi2s->Instance->I2SCFGR &SPI_I2SCFGR_I2SE) != SPI_I2SCFGR_I2SE)
+    {
+      /* Enable I2S peripheral */
+      __HAL_I2S_ENABLE(hi2s);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2s);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Transmit an amount of data in non-blocking mode with DMA
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param pData: a 16-bit pointer to the Transmit data buffer.
+  * @param Size: number of data sample to be sent:
+  * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
+  *       configuration phase, the Size parameter means the number of 16-bit data length
+  *       in the transaction and when a 24-bit data frame or a 32-bit data frame is selected
+  *       the Size parameter means the number of 16-bit data length.
+  * @note The I2S is kept enabled at the end of transaction to avoid the clock de-synchronization
+  *       between Master and Slave(example: audio streaming).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Transmit_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+
+  if((pData == NULL) || (Size == 0))
+  {
+    return  HAL_ERROR;
+  }
+
+  if(hi2s->State == HAL_I2S_STATE_READY)
+  {
+    hi2s->pTxBuffPtr = pData;
+    if(((hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN)) == I2S_DATAFORMAT_24B)||\
+      ((hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN)) == I2S_DATAFORMAT_32B))
+    {
+      hi2s->TxXferSize = (Size << 1);
+      hi2s->TxXferCount = (Size << 1);
+    }
+    else
+    {
+      hi2s->TxXferSize = Size;
+      hi2s->TxXferCount = Size;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2s);
+
+    hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+    hi2s->State = HAL_I2S_STATE_BUSY_TX;
+
+    /* Set the I2S Tx DMA Half transfer complete callback */
+    hi2s->hdmatx->XferHalfCpltCallback = I2S_DMATxHalfCplt;
+
+    /* Set the I2S TxDMA transfer complete callback */
+    hi2s->hdmatx->XferCpltCallback = I2S_DMATxCplt;
+
+    /* Set the DMA error callback */
+    hi2s->hdmatx->XferErrorCallback = I2S_DMAError;
+
+    /* Enable the Tx DMA Channel */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(hi2s->hdmatx, *(uint32_t*)tmp, (uint32_t)&hi2s->Instance->DR, hi2s->TxXferSize);
+
+    /* Check if the I2S is already enabled */
+    if((hi2s->Instance->I2SCFGR &SPI_I2SCFGR_I2SE) != SPI_I2SCFGR_I2SE)
+    {
+      /* Enable I2S peripheral */
+      __HAL_I2S_ENABLE(hi2s);
+    }
+
+    /* Enable Tx DMA Request */
+    hi2s->Instance->CR2 |= SPI_CR2_TXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2s);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in non-blocking mode with DMA
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param pData: a 16-bit pointer to the Receive data buffer.
+  * @param Size: number of data sample to be sent:
+  * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
+  *       configuration phase, the Size parameter means the number of 16-bit data length
+  *       in the transaction and when a 24-bit data frame or a 32-bit data frame is selected
+  *       the Size parameter means the number of 16-bit data length.
+  * @note The I2S is kept enabled at the end of transaction to avoid the clock de-synchronization
+  *       between Master and Slave(example: audio streaming).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Receive_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+
+  if((pData == NULL) || (Size == 0))
+  {
+    return  HAL_ERROR;
+  }
+
+  if(hi2s->State == HAL_I2S_STATE_READY)
+  {
+    hi2s->pRxBuffPtr = pData;
+    if(((hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN)) == I2S_DATAFORMAT_24B)||\
+      ((hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN)) == I2S_DATAFORMAT_32B))
+    {
+      hi2s->RxXferSize = (Size << 1);
+      hi2s->RxXferCount = (Size << 1);
+    }
+    else
+    {
+      hi2s->RxXferSize = Size;
+      hi2s->RxXferCount = Size;
+    }
+    /* Process Locked */
+    __HAL_LOCK(hi2s);
+
+    hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+    hi2s->State = HAL_I2S_STATE_BUSY_RX;
+
+    /* Set the I2S Rx DMA Half transfer complete callback */
+    hi2s->hdmarx->XferHalfCpltCallback = I2S_DMARxHalfCplt;
+
+    /* Set the I2S Rx DMA transfer complete callback */
+    hi2s->hdmarx->XferCpltCallback = I2S_DMARxCplt;
+
+    /* Set the DMA error callback */
+    hi2s->hdmarx->XferErrorCallback = I2S_DMAError;
+
+    /* Check if Master Receiver mode is selected */
+    if((hi2s->Instance->I2SCFGR & SPI_I2SCFGR_I2SCFG) == I2S_MODE_MASTER_RX)
+    {
+      /* Clear the Overrun Flag by a read operation to the SPI_DR register followed by a read
+      access to the SPI_SR register. */
+      __HAL_I2S_CLEAR_OVRFLAG(hi2s);
+    }
+
+    /* Enable the Rx DMA Channel */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(hi2s->hdmarx, (uint32_t)&hi2s->Instance->DR, *(uint32_t*)tmp, hi2s->RxXferSize);
+
+    /* Check if the I2S is already enabled */
+    if((hi2s->Instance->I2SCFGR &SPI_I2SCFGR_I2SE) != SPI_I2SCFGR_I2SE)
+    {
+      /* Enable I2S peripheral */
+      __HAL_I2S_ENABLE(hi2s);
+    }
+
+    /* Enable Rx DMA Request */
+    hi2s->Instance->CR2 |= SPI_CR2_RXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2s);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Pauses the audio stream playing from the Media.
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_DMAPause(I2S_HandleTypeDef *hi2s)
+{
+  /* Process Locked */
+  __HAL_LOCK(hi2s);
+
+  if(hi2s->State == HAL_I2S_STATE_BUSY_TX)
+  {
+    /* Disable the I2S DMA Tx request */
+    hi2s->Instance->CR2 &= (uint32_t)(~SPI_CR2_TXDMAEN);
+  }
+  else if(hi2s->State == HAL_I2S_STATE_BUSY_RX)
+  {
+    /* Disable the I2S DMA Rx request */
+    hi2s->Instance->CR2 &= (uint32_t)(~SPI_CR2_RXDMAEN);
+  }
+  else if(hi2s->State == HAL_I2S_STATE_BUSY_TX_RX)
+  {
+    if((hi2s->Init.Mode == I2S_MODE_SLAVE_TX)||(hi2s->Init.Mode == I2S_MODE_MASTER_TX))
+    {
+      /* Disable the I2S DMA Tx request */
+      hi2s->Instance->CR2 &= (uint32_t)(~SPI_CR2_TXDMAEN);
+    }
+    else
+    {
+      /* Disable the I2S DMA Rx request */
+      hi2s->Instance->CR2 &= (uint32_t)(~SPI_CR2_RXDMAEN);
+    }
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2s);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Resumes the audio stream playing from the Media.
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_DMAResume(I2S_HandleTypeDef *hi2s)
+{
+  /* Process Locked */
+  __HAL_LOCK(hi2s);
+
+  if(hi2s->State == HAL_I2S_STATE_BUSY_TX)
+  {
+    /* Enable the I2S DMA Tx request */
+    SET_BIT(hi2s->Instance->CR2, SPI_CR2_TXDMAEN);
+  }
+  else if(hi2s->State == HAL_I2S_STATE_BUSY_RX)
+  {
+    /* Enable the I2S DMA Rx request */
+    SET_BIT(hi2s->Instance->CR2, SPI_CR2_RXDMAEN);
+  }
+
+  /* If the I2S peripheral is still not enabled, enable it */
+  if(HAL_IS_BIT_CLR(hi2s->Instance->I2SCFGR, SPI_I2SCFGR_I2SE))
+  {
+    /* Enable I2S peripheral */
+    __HAL_I2S_ENABLE(hi2s);
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2s);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Stops the audio stream playing from the Media.
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_DMAStop(I2S_HandleTypeDef *hi2s)
+{
+  /* Process Locked */
+  __HAL_LOCK(hi2s);
+
+  /* Disable the I2S Tx/Rx DMA requests */
+  CLEAR_BIT(hi2s->Instance->CR2, SPI_CR2_TXDMAEN);
+  CLEAR_BIT(hi2s->Instance->CR2, SPI_CR2_RXDMAEN);
+
+  /* Abort the I2S DMA Channel tx */
+  if(hi2s->hdmatx != NULL)
+  {
+    /* Disable the I2S DMA channel */
+    __HAL_DMA_DISABLE(hi2s->hdmatx);
+    HAL_DMA_Abort(hi2s->hdmatx);
+  }
+  /* Abort the I2S DMA Channel rx */
+  if(hi2s->hdmarx != NULL)
+  {
+    /* Disable the I2S DMA channel */
+    __HAL_DMA_DISABLE(hi2s->hdmarx);
+    HAL_DMA_Abort(hi2s->hdmarx);
+  }
+
+  /* Disable I2S peripheral */
+  __HAL_I2S_DISABLE(hi2s);
+
+  hi2s->State = HAL_I2S_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2s);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles I2S interrupt request.
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL status
+  */
+void HAL_I2S_IRQHandler(I2S_HandleTypeDef *hi2s)
+{
+  __IO uint32_t i2ssr = hi2s->Instance->SR;
+
+  if(hi2s->State == HAL_I2S_STATE_BUSY_RX)
+  {
+    /* I2S in mode Receiver ----------------------------------------------------*/
+    if(((i2ssr & I2S_FLAG_RXNE) == I2S_FLAG_RXNE) && (__HAL_I2S_GET_IT_SOURCE(hi2s, I2S_IT_RXNE) != RESET))
+    {
+      I2S_Receive_IT(hi2s);
+    }
+
+    /* I2S Overrun error interrupt occurred -------------------------------------*/
+    if(((i2ssr & I2S_FLAG_OVR) == I2S_FLAG_OVR) && (__HAL_I2S_GET_IT_SOURCE(hi2s, I2S_IT_ERR) != RESET))
+    {
+      /* Disable RXNE and ERR interrupt */
+      __HAL_I2S_DISABLE_IT(hi2s, (I2S_IT_RXNE | I2S_IT_ERR));
+
+      /* Set the I2S State ready */
+      hi2s->State = HAL_I2S_STATE_READY;
+
+      /* Set the error code and execute error callback*/
+      hi2s->ErrorCode |= HAL_I2S_ERROR_OVR;
+      HAL_I2S_ErrorCallback(hi2s);
+    }
+  }
+  else if(hi2s->State == HAL_I2S_STATE_BUSY_TX)
+  {
+    /* I2S in mode Transmitter ---------------------------------------------------*/
+    if(((i2ssr & I2S_FLAG_TXE) == I2S_FLAG_TXE) && (__HAL_I2S_GET_IT_SOURCE(hi2s, I2S_IT_TXE) != RESET))
+    {
+      I2S_Transmit_IT(hi2s);
+    }
+
+    /* I2S Underrun error interrupt occurred ------------------------------------*/
+    if(((i2ssr & I2S_FLAG_UDR) == I2S_FLAG_UDR) && (__HAL_I2S_GET_IT_SOURCE(hi2s, I2S_IT_ERR) != RESET))
+    {
+      /* Disable TXE and ERR interrupt */
+      __HAL_I2S_DISABLE_IT(hi2s, (I2S_IT_TXE | I2S_IT_ERR));
+
+      /* Set the I2S State ready */
+      hi2s->State = HAL_I2S_STATE_READY;
+
+      /* Set the error code and execute error callback*/
+      hi2s->ErrorCode |= HAL_I2S_ERROR_UDR;
+      HAL_I2S_ErrorCallback(hi2s);
+    }
+  }
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup I2S_Private_Functions I2S Private Functions
+  * @{
+  */
+/**
+  * @brief This function handles I2S Communication Timeout.
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param Flag: Flag checked
+  * @param State: Value of the flag expected
+  * @param Timeout: Duration of the timeout
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, uint32_t Flag,
+                                                       uint32_t State, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait until flag is set */
+  if(State == RESET)
+  {
+    while(__HAL_I2S_GET_FLAG(hi2s, Flag) == RESET)
+    {
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Set the I2S State ready */
+          hi2s->State= HAL_I2S_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2s);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_I2S_GET_FLAG(hi2s, Flag) != RESET)
+    {
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Set the I2S State ready */
+          hi2s->State= HAL_I2S_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2s);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;
+}
+/**
+  * @}
+  */
+
+/** @addtogroup I2S_Exported_Functions I2S Exported Functions
+  * @{
+  */
+
+/** @addtogroup  I2S_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
+/**
+  * @brief Tx Transfer Half completed callbacks
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+ __weak void HAL_I2S_TxHalfCpltCallback(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_TxHalfCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief Tx Transfer completed callbacks
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+ __weak void HAL_I2S_TxCpltCallback(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief Rx Transfer half completed callbacks
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+__weak void HAL_I2S_RxHalfCpltCallback(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_RxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief Rx Transfer completed callbacks
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+__weak void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_RxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief I2S error callbacks
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+ __weak void HAL_I2S_ErrorCallback(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Exported_Functions_Group3 Peripheral State and Errors functions
+  *  @brief   Peripheral State functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral State and Errors functions #####
+ ===============================================================================
+    [..]
+    This subsection permits to get in run-time the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the I2S state
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL state
+  */
+HAL_I2S_StateTypeDef HAL_I2S_GetState(I2S_HandleTypeDef *hi2s)
+{
+  return hi2s->State;
+}
+
+/**
+  * @brief  Return the I2S error code
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval I2S Error Code
+  */
+uint32_t HAL_I2S_GetError(I2S_HandleTypeDef *hi2s)
+{
+  return hi2s->ErrorCode;
+}
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+  /**
+  * @brief  Get I2S Input Clock based on I2S source clock selection
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *               the configuration information for I2S module.
+  * @retval I2S Clock Input
+  */
+static uint32_t I2S_GetClockFreq(I2S_HandleTypeDef *hi2s)
+{
+  uint32_t tmpreg = 0;
+  /* This variable used to store the VCO Input (value in Hz) */
+  uint32_t vcoinput = 0;
+  /* This variable used to store the I2S_CK_x (value in Hz) */
+  uint32_t i2sclocksource = 0;
+
+  /* Configure I2S Clock based on I2S source clock selection */
+
+  /* I2S_CLK_x : I2S Block Clock configuration for different clock sources selected */
+  switch(hi2s->Init.ClockSource)
+  {
+    case I2S_CLOCK_SYSCLK :
+    {
+      /* Configure the PLLI2S division factor */
+      /* PLLI2S_VCO Input  = PLL_SOURCE/PLLI2SM */
+      if((RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) == RCC_PLLSOURCE_HSI)
+      {
+        /* In Case the PLL Source is HSI (Internal Clock) */
+        vcoinput = (HSI_VALUE / (uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLM));
+      }
+      else
+      {
+        /* In Case the PLL Source is HSE (External Clock) */
+        vcoinput = ((HSE_VALUE / (uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLM)));
+      }
+
+      /* PLLI2S_VCO Output = PLLI2S_VCO Input * PLLI2SN */
+      /* I2S_CLK(first level) = PLLI2S_VCO Output/PLLI2SR */
+      tmpreg = (RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SR) >> 28;
+      i2sclocksource = (vcoinput * ((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SN) >> 6))/(tmpreg);
+
+      break;
+    }
+    case I2S_CLOCK_EXTERNAL :
+    {
+      i2sclocksource = EXTERNAL_CLOCK_VALUE;
+      break;
+    }
+    default :
+    {
+      break;
+    }
+  }
+
+  /* the return result is the value of I2S clock */
+  return i2sclocksource;
+}
+
+/** @addtogroup I2S_Private_Functions I2S Private Functions
+  * @{
+  */
+/**
+  * @brief DMA I2S transmit process complete callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void I2S_DMATxCplt(DMA_HandleTypeDef *hdma)
+{
+  I2S_HandleTypeDef* hi2s = (I2S_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
+  {
+    hi2s->TxXferCount = 0;
+
+    /* Disable Tx DMA Request */
+    hi2s->Instance->CR2 &= (uint32_t)(~SPI_CR2_TXDMAEN);
+
+    if(hi2s->State == HAL_I2S_STATE_BUSY_TX_RX)
+    {
+      if(hi2s->RxXferCount == 0)
+      {
+        hi2s->State = HAL_I2S_STATE_READY;
+      }
+    }
+    else
+    {
+      hi2s->State = HAL_I2S_STATE_READY;
+    }
+  }
+  HAL_I2S_TxCpltCallback(hi2s);
+}
+
+/**
+  * @brief DMA I2S transmit process half complete callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void I2S_DMATxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  I2S_HandleTypeDef* hi2s = (I2S_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_I2S_TxHalfCpltCallback(hi2s);
+}
+
+/**
+  * @brief DMA I2S receive process complete callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void I2S_DMARxCplt(DMA_HandleTypeDef *hdma)
+{
+  I2S_HandleTypeDef* hi2s = (I2S_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
+  {
+    /* Disable Rx DMA Request */
+    hi2s->Instance->CR2 &= (uint32_t)(~SPI_CR2_RXDMAEN);
+
+    hi2s->RxXferCount = 0;
+    if(hi2s->State == HAL_I2S_STATE_BUSY_TX_RX)
+    {
+      if(hi2s->TxXferCount == 0)
+      {
+        hi2s->State = HAL_I2S_STATE_READY;
+      }
+    }
+    else
+    {
+      hi2s->State = HAL_I2S_STATE_READY;
+    }
+  }
+  HAL_I2S_RxCpltCallback(hi2s);
+}
+
+/**
+  * @brief DMA I2S receive process half complete callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void I2S_DMARxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  I2S_HandleTypeDef* hi2s = (I2S_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_I2S_RxHalfCpltCallback(hi2s);
+}
+
+/**
+  * @brief DMA I2S communication error callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void I2S_DMAError(DMA_HandleTypeDef *hdma)
+{
+  I2S_HandleTypeDef* hi2s = ( I2S_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Disable Rx and Tx DMA Request */
+  hi2s->Instance->CR2 &= (uint32_t)(~(SPI_CR2_RXDMAEN | SPI_CR2_TXDMAEN));
+  hi2s->TxXferCount = 0;
+  hi2s->RxXferCount = 0;
+
+  hi2s->State= HAL_I2S_STATE_READY;
+
+  /* Set the error code and execute error callback*/
+  hi2s->ErrorCode |= HAL_I2S_ERROR_DMA;
+  HAL_I2S_ErrorCallback(hi2s);
+}
+
+/**
+  * @brief Transmit an amount of data in non-blocking mode with Interrupt
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+static void I2S_Transmit_IT(I2S_HandleTypeDef *hi2s)
+{
+  /* Transmit data */
+  hi2s->Instance->DR = (*hi2s->pTxBuffPtr++);
+  hi2s->TxXferCount--;
+
+  if(hi2s->TxXferCount == 0)
+  {
+    /* Disable TXE and ERR interrupt */
+    __HAL_I2S_DISABLE_IT(hi2s, (I2S_IT_TXE | I2S_IT_ERR));
+
+    hi2s->State = HAL_I2S_STATE_READY;
+    HAL_I2S_TxCpltCallback(hi2s);
+  }
+}
+
+/**
+  * @brief Receive an amount of data in non-blocking mode with Interrupt
+  * @param hi2s: I2S handle
+  * @retval None
+  */
+static void I2S_Receive_IT(I2S_HandleTypeDef *hi2s)
+{
+  /* Receive data */
+  (*hi2s->pRxBuffPtr++) = hi2s->Instance->DR;
+  hi2s->RxXferCount--;
+
+  if(hi2s->RxXferCount == 0)
+  {
+    /* Disable RXNE and ERR interrupt */
+    __HAL_I2S_DISABLE_IT(hi2s, (I2S_IT_RXNE | I2S_IT_ERR));
+
+    hi2s->State = HAL_I2S_STATE_READY;
+    HAL_I2S_RxCpltCallback(hi2s);
+  }
+}
+/**
+  * @}
+  */
+
+#endif /* HAL_I2S_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_pcd.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_pcd.c
@@ -1,0 +1,1202 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_pcd.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   PCD HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the USB Peripheral Controller:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *
+  @verbatim
+  ==============================================================================
+                    ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      The PCD HAL driver can be used as follows:
+
+     (#) Declare a PCD_HandleTypeDef handle structure, for example:
+         PCD_HandleTypeDef  hpcd;
+
+     (#) Fill parameters of Init structure in HCD handle
+
+     (#) Call HAL_PCD_Init() API to initialize the HCD peripheral (Core, Device core, ...)
+
+     (#) Initialize the PCD low level resources through the HAL_PCD_MspInit() API:
+         (##) Enable the PCD/USB Low Level interface clock using
+              (+++) __OTGFS-OTG_CLK_ENABLE()/__OTGHS-OTG_CLK_ENABLE();
+              (+++) __OTGHSULPI_CLK_ENABLE(); (For High Speed Mode)
+
+         (##) Initialize the related GPIO clocks
+         (##) Configure PCD pin-out
+         (##) Configure PCD NVIC interrupt
+
+     (#)Associate the Upper USB device stack to the HAL PCD Driver:
+         (##) hpcd.pData = pdev;
+
+     (#)Enable HCD transmission and reception:
+         (##) HAL_PCD_Start();
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PCD PCD
+  * @brief PCD HAL module driver
+  * @{
+  */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup PCD_Private_Macros PCD Private Macros
+  * @{
+  */
+#define PCD_MIN(a, b)  (((a) < (b)) ? (a) : (b))
+#define PCD_MAX(a, b)  (((a) > (b)) ? (a) : (b))
+/**
+  * @}
+  */
+
+/* Private functions prototypes ----------------------------------------------*/
+/** @defgroup PCD_Private_Functions PCD Private Functions
+  * @{
+  */
+static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t epnum);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup PCD_Exported_Functions PCD Exported Functions
+  * @{
+  */
+
+/** @defgroup PCD_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+ ===============================================================================
+            ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the PCD according to the specified
+  *         parameters in the PCD_InitTypeDef and create the associated handle.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
+{
+  uint32_t i = 0;
+
+  /* Check the PCD handle allocation */
+  if(hpcd == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_PCD_ALL_INSTANCE(hpcd->Instance));
+
+  hpcd->State = HAL_PCD_STATE_BUSY;
+
+  /* Init the low level hardware : GPIO, CLOCK, NVIC... */
+  HAL_PCD_MspInit(hpcd);
+
+  /* Disable the Interrupts */
+ __HAL_PCD_DISABLE(hpcd);
+
+ /*Init the Core (common init.) */
+ USB_CoreInit(hpcd->Instance, hpcd->Init);
+
+ /* Force Device Mode*/
+ USB_SetCurrentMode(hpcd->Instance , USB_OTG_DEVICE_MODE);
+
+ /* Init endpoints structures */
+ for (i = 0; i < 15 ; i++)
+ {
+   /* Init ep structure */
+   hpcd->IN_ep[i].is_in = 1;
+   hpcd->IN_ep[i].num = i;
+   hpcd->IN_ep[i].tx_fifo_num = i;
+   /* Control until ep is activated */
+   hpcd->IN_ep[i].type = EP_TYPE_CTRL;
+   hpcd->IN_ep[i].maxpacket =  0;
+   hpcd->IN_ep[i].xfer_buff = 0;
+   hpcd->IN_ep[i].xfer_len = 0;
+ }
+
+ for (i = 0; i < 15 ; i++)
+ {
+   hpcd->OUT_ep[i].is_in = 0;
+   hpcd->OUT_ep[i].num = i;
+   hpcd->IN_ep[i].tx_fifo_num = i;
+   /* Control until ep is activated */
+   hpcd->OUT_ep[i].type = EP_TYPE_CTRL;
+   hpcd->OUT_ep[i].maxpacket = 0;
+   hpcd->OUT_ep[i].xfer_buff = 0;
+   hpcd->OUT_ep[i].xfer_len = 0;
+
+   hpcd->Instance->DIEPTXF[i] = 0;
+ }
+
+ /* Init Device */
+ USB_DevInit(hpcd->Instance, hpcd->Init);
+
+ hpcd->State= HAL_PCD_STATE_READY;
+
+ /* Activate LPM */
+ if (hpcd->Init.lpm_enable == 1)
+ {
+   HAL_PCDEx_ActivateLPM(hpcd);
+ }
+
+ USB_DevDisconnect (hpcd->Instance);
+ return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the PCD peripheral
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DeInit(PCD_HandleTypeDef *hpcd)
+{
+  /* Check the PCD handle allocation */
+  if(hpcd == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  hpcd->State = HAL_PCD_STATE_BUSY;
+
+  /* Stop Device */
+  HAL_PCD_Stop(hpcd);
+
+  /* DeInit the low level hardware */
+  HAL_PCD_MspDeInit(hpcd);
+
+  hpcd->State = HAL_PCD_STATE_RESET;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the PCD MSP.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes PCD MSP.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup PCD_Exported_Functions_Group2 IO operation functions
+ *  @brief   Data transfers functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to manage the PCD data
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Start The USB OTG Device.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_Start(PCD_HandleTypeDef *hpcd)
+{
+  __HAL_LOCK(hpcd);
+  USB_DevConnect (hpcd->Instance);
+  __HAL_PCD_ENABLE(hpcd);
+  __HAL_UNLOCK(hpcd);
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop The USB OTG Device.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd)
+{
+  __HAL_LOCK(hpcd);
+  __HAL_PCD_DISABLE(hpcd);
+  USB_StopDevice(hpcd->Instance);
+  USB_DevDisconnect (hpcd->Instance);
+  __HAL_UNLOCK(hpcd);
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles PCD interrupt request.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+  uint32_t i = 0, ep_intr = 0, epint = 0, epnum = 0;
+  uint32_t fifoemptymsk = 0, temp = 0;
+  USB_OTG_EPTypeDef *ep;
+
+  /* ensure that we are in device mode */
+  if (USB_GetMode(hpcd->Instance) == USB_OTG_MODE_DEVICE)
+  {
+    /* avoid spurious interrupt */
+    if(__HAL_PCD_IS_INVALID_INTERRUPT(hpcd))
+    {
+      return;
+    }
+
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_MMIS))
+    {
+     /* incorrect mode, acknowledge the interrupt */
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_MMIS);
+    }
+
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_OEPINT))
+    {
+      epnum = 0;
+
+      /* Read in the device interrupt bits */
+      ep_intr = USB_ReadDevAllOutEpInterrupt(hpcd->Instance);
+
+      while ( ep_intr )
+      {
+        if (ep_intr & 0x1)
+        {
+          epint = USB_ReadDevOutEPInterrupt(hpcd->Instance, epnum);
+
+          if(( epint & USB_OTG_DOEPINT_XFRC) == USB_OTG_DOEPINT_XFRC)
+          {
+            CLEAR_OUT_EP_INTR(epnum, USB_OTG_DOEPINT_XFRC);
+
+            if(hpcd->Init.dma_enable == 1)
+            {
+              hpcd->OUT_ep[epnum].xfer_count = hpcd->OUT_ep[epnum].maxpacket- (USBx_OUTEP(epnum)->DOEPTSIZ & USB_OTG_DOEPTSIZ_XFRSIZ);
+              hpcd->OUT_ep[epnum].xfer_buff += hpcd->OUT_ep[epnum].maxpacket;
+            }
+
+            HAL_PCD_DataOutStageCallback(hpcd, epnum);
+            if(hpcd->Init.dma_enable == 1)
+            {
+              if((epnum == 0) && (hpcd->OUT_ep[epnum].xfer_len == 0))
+              {
+                 /* this is ZLP, so prepare EP0 for next setup */
+                USB_EP0_OutStart(hpcd->Instance, 1, (uint8_t *)hpcd->Setup);
+              }
+            }
+          }
+
+          if(( epint & USB_OTG_DOEPINT_STUP) == USB_OTG_DOEPINT_STUP)
+          {
+            /* Inform the upper layer that a setup packet is available */
+            HAL_PCD_SetupStageCallback(hpcd);
+            CLEAR_OUT_EP_INTR(epnum, USB_OTG_DOEPINT_STUP);
+          }
+
+          if(( epint & USB_OTG_DOEPINT_OTEPDIS) == USB_OTG_DOEPINT_OTEPDIS)
+          {
+            CLEAR_OUT_EP_INTR(epnum, USB_OTG_DOEPINT_OTEPDIS);
+          }
+        }
+        epnum++;
+        ep_intr >>= 1;
+      }
+    }
+
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_IEPINT))
+    {
+      /* Read in the device interrupt bits */
+      ep_intr = USB_ReadDevAllInEpInterrupt(hpcd->Instance);
+
+      epnum = 0;
+
+      while ( ep_intr )
+      {
+        if (ep_intr & 0x1) /* In ITR */
+        {
+          epint = USB_ReadDevInEPInterrupt(hpcd->Instance, epnum);
+
+           if(( epint & USB_OTG_DIEPINT_XFRC) == USB_OTG_DIEPINT_XFRC)
+          {
+            fifoemptymsk = 0x1 << epnum;
+            USBx_DEVICE->DIEPEMPMSK &= ~fifoemptymsk;
+
+            CLEAR_IN_EP_INTR(epnum, USB_OTG_DIEPINT_XFRC);
+
+            if (hpcd->Init.dma_enable == 1)
+            {
+              hpcd->IN_ep[epnum].xfer_buff += hpcd->IN_ep[epnum].maxpacket;
+            }
+
+            HAL_PCD_DataInStageCallback(hpcd, epnum);
+
+            if (hpcd->Init.dma_enable == 1)
+            {
+              /* this is ZLP, so prepare EP0 for next setup */
+              if((epnum == 0) && (hpcd->IN_ep[epnum].xfer_len == 0))
+              {
+                /* prepare to rx more setup packets */
+                USB_EP0_OutStart(hpcd->Instance, 1, (uint8_t *)hpcd->Setup);
+              }
+            }
+          }
+           if(( epint & USB_OTG_DIEPINT_TOC) == USB_OTG_DIEPINT_TOC)
+          {
+            CLEAR_IN_EP_INTR(epnum, USB_OTG_DIEPINT_TOC);
+          }
+          if(( epint & USB_OTG_DIEPINT_ITTXFE) == USB_OTG_DIEPINT_ITTXFE)
+          {
+            CLEAR_IN_EP_INTR(epnum, USB_OTG_DIEPINT_ITTXFE);
+          }
+          if(( epint & USB_OTG_DIEPINT_INEPNE) == USB_OTG_DIEPINT_INEPNE)
+          {
+            CLEAR_IN_EP_INTR(epnum, USB_OTG_DIEPINT_INEPNE);
+          }
+          if(( epint & USB_OTG_DIEPINT_EPDISD) == USB_OTG_DIEPINT_EPDISD)
+          {
+            CLEAR_IN_EP_INTR(epnum, USB_OTG_DIEPINT_EPDISD);
+          }
+          if(( epint & USB_OTG_DIEPINT_TXFE) == USB_OTG_DIEPINT_TXFE)
+          {
+            PCD_WriteEmptyTxFifo(hpcd , epnum);
+          }
+        }
+        epnum++;
+        ep_intr >>= 1;
+      }
+    }
+
+    /* Handle Resume Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_WKUINT))
+    {
+      /* Clear the Remote Wake-up Signaling */
+      USBx_DEVICE->DCTL &= ~USB_OTG_DCTL_RWUSIG;
+
+      if(hpcd->LPM_State == LPM_L1)
+      {
+        hpcd->LPM_State = LPM_L0;
+        HAL_PCDEx_LPM_Callback(hpcd, PCD_LPM_L0_ACTIVE);
+      }
+      else
+      {
+        HAL_PCD_ResumeCallback(hpcd);
+      }
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_WKUINT);
+    }
+
+    /* Handle Suspend Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_USBSUSP))
+    {
+
+      if((USBx_DEVICE->DSTS & USB_OTG_DSTS_SUSPSTS) == USB_OTG_DSTS_SUSPSTS)
+      {
+
+        HAL_PCD_SuspendCallback(hpcd);
+      }
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_USBSUSP);
+    }
+
+    /* Handle LPM Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_LPMINT))
+    {
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_LPMINT);
+      if( hpcd->LPM_State == LPM_L0)
+      {
+        hpcd->LPM_State = LPM_L1;
+        hpcd->BESL = (hpcd->Instance->GLPMCFG & USB_OTG_GLPMCFG_BESL) >>2 ;
+        HAL_PCDEx_LPM_Callback(hpcd, PCD_LPM_L1_ACTIVE);
+      }
+      else
+      {
+        HAL_PCD_SuspendCallback(hpcd);
+      }
+    }
+
+    /* Handle Reset Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_USBRST))
+    {
+      USBx_DEVICE->DCTL &= ~USB_OTG_DCTL_RWUSIG;
+      USB_FlushTxFifo(hpcd->Instance ,  0 );
+
+      for (i = 0; i < hpcd->Init.dev_endpoints ; i++)
+      {
+        USBx_INEP(i)->DIEPINT = 0xFF;
+        USBx_OUTEP(i)->DOEPINT = 0xFF;
+      }
+      USBx_DEVICE->DAINT = 0xFFFFFFFF;
+      USBx_DEVICE->DAINTMSK |= 0x10001;
+
+      if(hpcd->Init.use_dedicated_ep1)
+      {
+        USBx_DEVICE->DOUTEP1MSK |= (USB_OTG_DOEPMSK_STUPM | USB_OTG_DOEPMSK_XFRCM | USB_OTG_DOEPMSK_EPDM);
+        USBx_DEVICE->DINEP1MSK |= (USB_OTG_DIEPMSK_TOM | USB_OTG_DIEPMSK_XFRCM | USB_OTG_DIEPMSK_EPDM);
+      }
+      else
+      {
+        USBx_DEVICE->DOEPMSK |= (USB_OTG_DOEPMSK_STUPM | USB_OTG_DOEPMSK_XFRCM | USB_OTG_DOEPMSK_EPDM);
+        USBx_DEVICE->DIEPMSK |= (USB_OTG_DIEPMSK_TOM | USB_OTG_DIEPMSK_XFRCM | USB_OTG_DIEPMSK_EPDM);
+      }
+
+      /* Set Default Address to 0 */
+      USBx_DEVICE->DCFG &= ~USB_OTG_DCFG_DAD;
+
+      /* setup EP0 to receive SETUP packets */
+      USB_EP0_OutStart(hpcd->Instance, hpcd->Init.dma_enable, (uint8_t *)hpcd->Setup);
+
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_USBRST);
+    }
+
+    /* Handle Enumeration done Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_ENUMDNE))
+    {
+      USB_ActivateSetup(hpcd->Instance);
+      hpcd->Instance->GUSBCFG &= ~USB_OTG_GUSBCFG_TRDT;
+
+      if ( USB_GetDevSpeed(hpcd->Instance) == USB_OTG_SPEED_HIGH)
+      {
+        hpcd->Init.speed            = USB_OTG_SPEED_HIGH;
+        hpcd->Init.ep0_mps          = USB_OTG_HS_MAX_PACKET_SIZE ;
+        hpcd->Instance->GUSBCFG |= (uint32_t)((USBD_HS_TRDT_VALUE << 10) & USB_OTG_GUSBCFG_TRDT);
+      }
+      else
+      {
+        hpcd->Init.speed            = USB_OTG_SPEED_FULL;
+        hpcd->Init.ep0_mps          = USB_OTG_FS_MAX_PACKET_SIZE ;
+        hpcd->Instance->GUSBCFG |= (uint32_t)((USBD_FS_TRDT_VALUE << 10) & USB_OTG_GUSBCFG_TRDT);
+      }
+
+      HAL_PCD_ResetCallback(hpcd);
+
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_ENUMDNE);
+    }
+
+    /* Handle RxQLevel Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_RXFLVL))
+    {
+      USB_MASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
+      temp = USBx->GRXSTSP;
+      ep = &hpcd->OUT_ep[temp & USB_OTG_GRXSTSP_EPNUM];
+
+      if(((temp & USB_OTG_GRXSTSP_PKTSTS) >> 17) ==  STS_DATA_UPDT)
+      {
+        if((temp & USB_OTG_GRXSTSP_BCNT) != 0)
+        {
+          USB_ReadPacket(USBx, ep->xfer_buff, (temp & USB_OTG_GRXSTSP_BCNT) >> 4);
+          ep->xfer_buff += (temp & USB_OTG_GRXSTSP_BCNT) >> 4;
+          ep->xfer_count += (temp & USB_OTG_GRXSTSP_BCNT) >> 4;
+        }
+      }
+      else if (((temp & USB_OTG_GRXSTSP_PKTSTS) >> 17) ==  STS_SETUP_UPDT)
+      {
+        USB_ReadPacket(USBx, (uint8_t *)hpcd->Setup, 8);
+        ep->xfer_count += (temp & USB_OTG_GRXSTSP_BCNT) >> 4;
+      }
+      USB_UNMASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
+    }
+
+    /* Handle SOF Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_SOF))
+    {
+      HAL_PCD_SOFCallback(hpcd);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_SOF);
+    }
+
+    /* Handle Incomplete ISO IN Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_IISOIXFR))
+    {
+      HAL_PCD_ISOINIncompleteCallback(hpcd, epnum);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_IISOIXFR);
+    }
+
+    /* Handle Incomplete ISO OUT Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_PXFR_INCOMPISOOUT))
+    {
+      HAL_PCD_ISOOUTIncompleteCallback(hpcd, epnum);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_PXFR_INCOMPISOOUT);
+    }
+
+    /* Handle Connection event Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_SRQINT))
+    {
+      HAL_PCD_ConnectCallback(hpcd);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_SRQINT);
+    }
+
+    /* Handle Disconnection event Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_OTGINT))
+    {
+      temp = hpcd->Instance->GOTGINT;
+
+      if((temp & USB_OTG_GOTGINT_SEDET) == USB_OTG_GOTGINT_SEDET)
+      {
+        HAL_PCD_DisconnectCallback(hpcd);
+      }
+      hpcd->Instance->GOTGINT |= temp;
+    }
+  }
+}
+
+/**
+  * @brief  Data out stage callbacks
+  * @param  hpcd: PCD handle
+  * @param  epnum: endpoint number
+  * @retval None
+  */
+ __weak void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Data IN stage callbacks
+  * @param  hpcd: PCD handle
+  * @param  epnum: endpoint number
+  * @retval None
+  */
+ __weak void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataInStageCallback could be implemented in the user file
+   */
+}
+/**
+  * @brief  Setup stage callback
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_SetupStageCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  USB Start Of Frame callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_SOFCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  USB Reset callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_ResetCallback could be implemented in the user file
+   */
+}
+
+
+/**
+  * @brief  Suspend event callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_SuspendCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Resume event callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_ResumeCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Incomplete ISO OUT callbacks
+  * @param  hpcd: PCD handle
+  * @param  epnum: endpoint number
+  * @retval None
+  */
+ __weak void HAL_PCD_ISOOUTIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_ISOOUTIncompleteCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Incomplete ISO IN  callbacks
+  * @param  hpcd: PCD handle
+  * @param  epnum: endpoint number
+  * @retval None
+  */
+ __weak void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_ISOINIncompleteCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Connection event callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_ConnectCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Disconnection event callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DisconnectCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup PCD_Exported_Functions_Group3 Peripheral Control functions
+ *  @brief   management functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the PCD data
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Connect the USB device
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DevConnect(PCD_HandleTypeDef *hpcd)
+{
+  __HAL_LOCK(hpcd);
+  USB_DevConnect(hpcd->Instance);
+  __HAL_UNLOCK(hpcd);
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disconnect the USB device
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DevDisconnect(PCD_HandleTypeDef *hpcd)
+{
+  __HAL_LOCK(hpcd);
+  USB_DevDisconnect(hpcd->Instance);
+  __HAL_UNLOCK(hpcd);
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the USB Device address
+  * @param  hpcd: PCD handle
+  * @param  address: new device address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_SetAddress(PCD_HandleTypeDef *hpcd, uint8_t address)
+{
+  __HAL_LOCK(hpcd);
+  USB_SetDevAddress(hpcd->Instance, address);
+  __HAL_UNLOCK(hpcd);
+  return HAL_OK;
+}
+/**
+  * @brief  Open and configure an endpoint
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @param  ep_mps: endpoint max packet size
+  * @param  ep_type: endpoint type
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint16_t ep_mps, uint8_t ep_type)
+{
+  HAL_StatusTypeDef  ret = HAL_OK;
+  USB_OTG_EPTypeDef *ep;
+
+  if ((ep_addr & 0x80) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr & 0x7F];
+  }
+  ep->num   = ep_addr & 0x7F;
+
+  ep->is_in = (0x80 & ep_addr) != 0;
+  ep->maxpacket = ep_mps;
+  ep->type = ep_type;
+  if (ep->is_in)
+  {
+    /* Assign a Tx FIFO */
+    ep->tx_fifo_num = ep->num;
+  }
+  /* Set initial data PID. */
+  if (ep_type == EP_TYPE_BULK )
+  {
+    ep->data_pid_start = 0;
+  }
+
+  __HAL_LOCK(hpcd);
+  USB_ActivateEndpoint(hpcd->Instance , ep);
+  __HAL_UNLOCK(hpcd);
+  return ret;
+}
+
+
+/**
+  * @brief  Deactivate an endpoint
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  USB_OTG_EPTypeDef *ep;
+
+  if ((ep_addr & 0x80) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr & 0x7F];
+  }
+  ep->num   = ep_addr & 0x7F;
+
+  ep->is_in = (0x80 & ep_addr) != 0;
+
+  __HAL_LOCK(hpcd);
+  USB_DeactivateEndpoint(hpcd->Instance , ep);
+  __HAL_UNLOCK(hpcd);
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Receive an amount of data
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @param  pBuf: pointer to the reception buffer
+  * @param  len: amount of data to be received
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len)
+{
+  USB_OTG_EPTypeDef *ep;
+
+  ep = &hpcd->OUT_ep[ep_addr & 0x7F];
+
+  /*setup and start the Xfer */
+  ep->xfer_buff = pBuf;
+  ep->xfer_len = len;
+  ep->xfer_count = 0;
+  ep->is_in = 0;
+  ep->num = ep_addr & 0x7F;
+
+  if (hpcd->Init.dma_enable == 1)
+  {
+    ep->dma_addr = (uint32_t)pBuf;
+  }
+
+  __HAL_LOCK(hpcd);
+
+  if ((ep_addr & 0x7F) == 0 )
+  {
+    USB_EP0StartXfer(hpcd->Instance , ep, hpcd->Init.dma_enable);
+  }
+  else
+  {
+    USB_EPStartXfer(hpcd->Instance , ep, hpcd->Init.dma_enable);
+  }
+  __HAL_UNLOCK(hpcd);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get Received Data Size
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval Data Size
+  */
+uint16_t HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  return hpcd->OUT_ep[ep_addr & 0x7F].xfer_count;
+}
+/**
+  * @brief  Send an amount of data
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @param  pBuf: pointer to the transmission buffer
+  * @param  len: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len)
+{
+  USB_OTG_EPTypeDef *ep;
+
+  ep = &hpcd->IN_ep[ep_addr & 0x7F];
+
+  /*setup and start the Xfer */
+  ep->xfer_buff = pBuf;
+  ep->xfer_len = len;
+  ep->xfer_count = 0;
+  ep->is_in = 1;
+  ep->num = ep_addr & 0x7F;
+
+  if (hpcd->Init.dma_enable == 1)
+  {
+    ep->dma_addr = (uint32_t)pBuf;
+  }
+
+  __HAL_LOCK(hpcd);
+
+  if ((ep_addr & 0x7F) == 0 )
+  {
+    USB_EP0StartXfer(hpcd->Instance , ep, hpcd->Init.dma_enable);
+  }
+  else
+  {
+    USB_EPStartXfer(hpcd->Instance , ep, hpcd->Init.dma_enable);
+  }
+
+  __HAL_UNLOCK(hpcd);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set a STALL condition over an endpoint
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  USB_OTG_EPTypeDef *ep;
+
+  if ((0x80 & ep_addr) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr];
+  }
+
+  ep->is_stall = 1;
+  ep->num   = ep_addr & 0x7F;
+  ep->is_in = ((ep_addr & 0x80) == 0x80);
+
+
+  __HAL_LOCK(hpcd);
+  USB_EPSetStall(hpcd->Instance , ep);
+  if((ep_addr & 0x7F) == 0)
+  {
+    USB_EP0_OutStart(hpcd->Instance, hpcd->Init.dma_enable, (uint8_t *)hpcd->Setup);
+  }
+  __HAL_UNLOCK(hpcd);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Clear a STALL condition over in an endpoint
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  USB_OTG_EPTypeDef *ep;
+
+  if ((0x80 & ep_addr) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr];
+  }
+
+  ep->is_stall = 0;
+  ep->num   = ep_addr & 0x7F;
+  ep->is_in = ((ep_addr & 0x80) == 0x80);
+
+  __HAL_LOCK(hpcd);
+  USB_EPClearStall(hpcd->Instance , ep);
+  __HAL_UNLOCK(hpcd);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Flush an endpoint
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  __HAL_LOCK(hpcd);
+
+  if ((ep_addr & 0x80) == 0x80)
+  {
+    USB_FlushTxFifo(hpcd->Instance, ep_addr & 0x7F);
+  }
+  else
+  {
+    USB_FlushRxFifo(hpcd->Instance);
+  }
+
+  __HAL_UNLOCK(hpcd);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  HAL_PCD_ActivateRemoteWakeup : Active remote wake-up signalling
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_ActivateRemoteWakeup(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+
+  if((USBx_DEVICE->DSTS & USB_OTG_DSTS_SUSPSTS) == USB_OTG_DSTS_SUSPSTS)
+  {
+    /* Activate Remote wake-up signaling */
+    USBx_DEVICE->DCTL |= USB_OTG_DCTL_RWUSIG;
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  HAL_PCD_DeActivateRemoteWakeup : de-active remote wake-up signalling
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DeActivateRemoteWakeup(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+
+  /* De-activate Remote wake-up signaling */
+   USBx_DEVICE->DCTL &= ~(USB_OTG_DCTL_RWUSIG);
+  return HAL_OK;
+}
+/**
+  * @}
+  */
+
+/** @defgroup PCD_Exported_Functions_Group4 Peripheral State functions
+ *  @brief   Peripheral State functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================
+    [..]
+    This subsection permits to get in run-time the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the PCD state
+  * @param  hpcd: PCD handle
+  * @retval HAL state
+  */
+PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd)
+{
+  return hpcd->State;
+}
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @addtogroup PCD_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  DCD_WriteEmptyTxFifo
+  *         check FIFO for the next packet to be loaded
+  * @param  hpcd: PCD handle
+  * @param  epnum : endpoint number
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t epnum)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+  USB_OTG_EPTypeDef *ep;
+  int32_t len = 0;
+  uint32_t len32b;
+  uint32_t fifoemptymsk = 0;
+
+  ep = &hpcd->IN_ep[epnum];
+  len = ep->xfer_len - ep->xfer_count;
+
+  if (len > ep->maxpacket)
+  {
+    len = ep->maxpacket;
+  }
+
+
+  len32b = (len + 3) / 4;
+
+  while  ( (USBx_INEP(epnum)->DTXFSTS & USB_OTG_DTXFSTS_INEPTFSAV) > len32b &&
+          ep->xfer_count < ep->xfer_len &&
+            ep->xfer_len != 0)
+  {
+    /* Write the FIFO */
+    len = ep->xfer_len - ep->xfer_count;
+
+    if (len > ep->maxpacket)
+    {
+      len = ep->maxpacket;
+    }
+    len32b = (len + 3) / 4;
+
+    USB_WritePacket(USBx, ep->xfer_buff, epnum, len, hpcd->Init.dma_enable);
+
+    ep->xfer_buff  += len;
+    ep->xfer_count += len;
+  }
+
+  if(len <= 0)
+  {
+    fifoemptymsk = 0x1 << epnum;
+    USBx_DEVICE->DIEPEMPMSK &= ~fifoemptymsk;
+
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_PCD_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_pcd_ex.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_pcd_ex.c
@@ -1,0 +1,197 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_pcd_ex.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   PCD HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the USB Peripheral Controller:
+  *           + Extended features functions
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PCDEx PCDEx
+  * @brief PCD Extended HAL module driver
+  * @{
+  */
+#ifdef HAL_PCD_MODULE_ENABLED
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup PCDEx_Exported_Functions PCDEx Exported Functions
+  * @{
+  */
+
+/** @defgroup PCDEx_Exported_Functions_Group1 Peripheral Control functions
+  * @brief    PCDEx control functions
+ *
+@verbatim
+ ===============================================================================
+                 ##### Extended features functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Update FIFO configuration
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Set Tx FIFO
+  * @param  hpcd: PCD handle
+  * @param  fifo: The number of Tx fifo
+  * @param  size: Fifo size
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_SetTxFiFo(PCD_HandleTypeDef *hpcd, uint8_t fifo, uint16_t size)
+{
+  uint8_t i = 0;
+  uint32_t Tx_Offset = 0;
+
+  /*  TXn min size = 16 words. (n  : Transmit FIFO index)
+      When a TxFIFO is not used, the Configuration should be as follows:
+          case 1 :  n > m    and Txn is not used    (n,m  : Transmit FIFO indexes)
+         --> Txm can use the space allocated for Txn.
+         case2  :  n < m    and Txn is not used    (n,m  : Transmit FIFO indexes)
+         --> Txn should be configured with the minimum space of 16 words
+     The FIFO is used optimally when used TxFIFOs are allocated in the top
+         of the FIFO.Ex: use EP1 and EP2 as IN instead of EP1 and EP3 as IN ones.
+     When DMA is used 3n * FIFO locations should be reserved for internal DMA registers */
+
+  Tx_Offset = hpcd->Instance->GRXFSIZ;
+
+  if(fifo == 0)
+  {
+    hpcd->Instance->DIEPTXF0_HNPTXFSIZ = (size << 16) | Tx_Offset;
+  }
+  else
+  {
+    Tx_Offset += (hpcd->Instance->DIEPTXF0_HNPTXFSIZ) >> 16;
+    for (i = 0; i < (fifo - 1); i++)
+    {
+      Tx_Offset += (hpcd->Instance->DIEPTXF[i] >> 16);
+    }
+
+    /* Multiply Tx_Size by 2 to get higher performance */
+    hpcd->Instance->DIEPTXF[fifo - 1] = (size << 16) | Tx_Offset;
+
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set Rx FIFO
+  * @param  hpcd: PCD handle
+  * @param  size: Size of Rx fifo
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_SetRxFiFo(PCD_HandleTypeDef *hpcd, uint16_t size)
+{
+  hpcd->Instance->GRXFSIZ = size;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  HAL_PCDEx_ActivateLPM : active LPM Feature
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_ActivateLPM(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+
+  hpcd->lpm_active = ENABLE;
+  hpcd->LPM_State = LPM_L0;
+  USBx->GINTMSK |= USB_OTG_GINTMSK_LPMINTM;
+  USBx->GLPMCFG |= (USB_OTG_GLPMCFG_LPMEN | USB_OTG_GLPMCFG_LPMACK | USB_OTG_GLPMCFG_ENBESL);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  HAL_PCDEx_DeActivateLPM : de-active LPM feature
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_DeActivateLPM(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+
+  hpcd->lpm_active = DISABLE;
+  USBx->GINTMSK &= ~USB_OTG_GINTMSK_LPMINTM;
+  USBx->GLPMCFG &= ~(USB_OTG_GLPMCFG_LPMEN | USB_OTG_GLPMCFG_LPMACK | USB_OTG_GLPMCFG_ENBESL);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  HAL_PCDEx_LPM_Callback : Send LPM message to user layer
+  * @param  hpcd: PCD handle
+  * @param  msg: LPM message
+  * @retval HAL status
+  */
+__weak void HAL_PCDEx_LPM_Callback(PCD_HandleTypeDef *hpcd, PCD_LPM_MsgTypeDef msg)
+{
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_PCD_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_pwr.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_pwr.c
@@ -1,0 +1,609 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_pwr.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   PWR HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Power Controller (PWR) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + Peripheral Control functions
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PWR PWR
+  * @brief PWR HAL module driver
+  * @{
+  */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @addtogroup PWR_Private_Constants
+  * @{
+  */
+
+/** @defgroup PWR_PVD_Mode_Mask PWR PVD Mode Mask
+  * @{
+  */
+#define PVD_MODE_IT               ((uint32_t)0x00010000)
+#define PVD_MODE_EVT              ((uint32_t)0x00020000)
+#define PVD_RISING_EDGE           ((uint32_t)0x00000001)
+#define PVD_FALLING_EDGE          ((uint32_t)0x00000002)
+/**
+  * @}
+  */
+
+/** @defgroup PWR_ENABLE_WUP_Mask PWR Enable WUP Mask
+  * @{
+  */
+#define  PWR_EWUP_MASK                          ((uint32_t)0x00003F00)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup PWR_Exported_Functions PWR Exported Functions
+  * @{
+  */
+
+/** @defgroup PWR_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and de-initialization functions
+  *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]
+      After reset, the backup domain (RTC registers, RTC backup data
+      registers and backup SRAM) is protected against possible unwanted
+      write accesses.
+      To enable access to the RTC Domain and RTC registers, proceed as follows:
+        (+) Enable the Power Controller (PWR) APB1 interface clock using the
+            __HAL_RCC_PWR_CLK_ENABLE() macro.
+        (+) Enable access to RTC domain using the HAL_PWR_EnableBkUpAccess() function.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Deinitializes the HAL PWR peripheral registers to their default reset values.
+  * @retval None
+  */
+void HAL_PWR_DeInit(void)
+{
+  __HAL_RCC_PWR_FORCE_RESET();
+  __HAL_RCC_PWR_RELEASE_RESET();
+}
+
+/**
+  * @brief Enables access to the backup domain (RTC registers, RTC
+  *         backup data registers and backup SRAM).
+  * @note If the HSE divided by 2, 3, ..31 is used as the RTC clock, the
+  *         Backup Domain Access should be kept enabled.
+  * @retval None
+  */
+void HAL_PWR_EnableBkUpAccess(void)
+{
+  /* Enable access to RTC and backup registers */
+  SET_BIT(PWR->CR1, PWR_CR1_DBP);
+}
+
+/**
+  * @brief Disables access to the backup domain (RTC registers, RTC
+  *         backup data registers and backup SRAM).
+  * @note If the HSE divided by 2, 3, ..31 is used as the RTC clock, the
+  *         Backup Domain Access should be kept enabled.
+  * @retval None
+  */
+void HAL_PWR_DisableBkUpAccess(void)
+{
+  /* Disable access to RTC and backup registers */
+	CLEAR_BIT(PWR->CR1, PWR_CR1_DBP);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup PWR_Exported_Functions_Group2 Peripheral Control functions
+  *  @brief Low Power modes configuration functions
+  *
+@verbatim
+
+ ===============================================================================
+                 ##### Peripheral Control functions #####
+ ===============================================================================
+
+    *** PVD configuration ***
+    =========================
+    [..]
+      (+) The PVD is used to monitor the VDD power supply by comparing it to a
+          threshold selected by the PVD Level (PLS[2:0] bits in the PWR_CR).
+      (+) A PVDO flag is available to indicate if VDD/VDDA is higher or lower
+          than the PVD threshold. This event is internally connected to the EXTI
+          line16 and can generate an interrupt if enabled. This is done through
+          __HAL_PWR_PVD_EXTI_ENABLE_IT() macro.
+      (+) The PVD is stopped in Standby mode.
+
+    *** Wake-up pin configuration ***
+    ================================
+    [..]
+      (+) Wake-up pin is used to wake up the system from Standby mode. This pin is
+          forced in input pull-down configuration and is active on rising edges.
+      (+) There are to 6 Wake-up pin in the STM32F7 devices family
+
+    *** Low Power modes configuration ***
+    =====================================
+    [..]
+      The devices feature 3 low-power modes:
+      (+) Sleep mode: Cortex-M7 core stopped, peripherals kept running.
+      (+) Stop mode: all clocks are stopped, regulator running, regulator
+          in low power mode
+      (+) Standby mode: 1.2V domain powered off.
+
+   *** Sleep mode ***
+   ==================
+    [..]
+      (+) Entry:
+        The Sleep mode is entered by using the HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI)
+              functions with
+          (++) PWR_SLEEPENTRY_WFI: enter SLEEP mode with WFI instruction
+          (++) PWR_SLEEPENTRY_WFE: enter SLEEP mode with WFE instruction
+
+      -@@- The Regulator parameter is not used for the STM32F7 family
+              and is kept as parameter just to maintain compatibility with the
+              lower power families (STM32L).
+      (+) Exit:
+        Any peripheral interrupt acknowledged by the nested vectored interrupt
+              controller (NVIC) can wake up the device from Sleep mode.
+
+   *** Stop mode ***
+   =================
+    [..]
+      In Stop mode, all clocks in the 1.2V domain are stopped, the PLL, the HSI,
+      and the HSE RC oscillators are disabled. Internal SRAM and register contents
+      are preserved.
+      The voltage regulator can be configured either in normal or low-power mode.
+      To minimize the consumption In Stop mode, FLASH can be powered off before
+      entering the Stop mode using the HAL_PWREx_EnableFlashPowerDown() function.
+      It can be switched on again by software after exiting the Stop mode using
+      the HAL_PWREx_DisableFlashPowerDown() function.
+
+      (+) Entry:
+         The Stop mode is entered using the HAL_PWR_EnterSTOPMode(PWR_MAINREGULATOR_ON)
+             function with:
+          (++) Main regulator ON.
+          (++) Low Power regulator ON.
+      (+) Exit:
+        Any EXTI Line (Internal or External) configured in Interrupt/Event mode.
+
+   *** Standby mode ***
+   ====================
+    [..]
+    (+)
+      The Standby mode allows to achieve the lowest power consumption. It is based
+      on the Cortex-M7 deep sleep mode, with the voltage regulator disabled.
+      The 1.2V domain is consequently powered off. The PLL, the HSI oscillator and
+      the HSE oscillator are also switched off. SRAM and register contents are lost
+      except for the RTC registers, RTC backup registers, backup SRAM and Standby
+      circuitry.
+
+      The voltage regulator is OFF.
+
+      (++) Entry:
+        (+++) The Standby mode is entered using the HAL_PWR_EnterSTANDBYMode() function.
+      (++) Exit:
+        (+++) WKUP pin rising or falling edge, RTC alarm (Alarm A and Alarm B), RTC
+             wakeup, tamper event, time stamp event, external reset in NRST pin, IWDG reset.
+
+   *** Auto-wakeup (AWU) from low-power mode ***
+   =============================================
+    [..]
+
+     (+) The MCU can be woken up from low-power mode by an RTC Alarm event, an RTC
+      Wakeup event, a tamper event or a time-stamp event, without depending on
+      an external interrupt (Auto-wakeup mode).
+
+      (+) RTC auto-wakeup (AWU) from the Stop and Standby modes
+
+        (++) To wake up from the Stop mode with an RTC alarm event, it is necessary to
+              configure the RTC to generate the RTC alarm using the HAL_RTC_SetAlarm_IT() function.
+
+        (++) To wake up from the Stop mode with an RTC Tamper or time stamp event, it
+             is necessary to configure the RTC to detect the tamper or time stamp event using the
+                HAL_RTCEx_SetTimeStamp_IT() or HAL_RTCEx_SetTamper_IT() functions.
+
+        (++) To wake up from the Stop mode with an RTC WakeUp event, it is necessary to
+              configure the RTC to generate the RTC WakeUp event using the HAL_RTCEx_SetWakeUpTimer_IT() function.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Configures the voltage threshold detected by the Power Voltage Detector(PVD).
+  * @param sConfigPVD: pointer to an PWR_PVDTypeDef structure that contains the configuration
+  *        information for the PVD.
+  * @note Refer to the electrical characteristics of your device datasheet for
+  *         more details about the voltage threshold corresponding to each
+  *         detection level.
+  * @retval None
+  */
+void HAL_PWR_ConfigPVD(PWR_PVDTypeDef *sConfigPVD)
+{
+  /* Check the parameters */
+  assert_param(IS_PWR_PVD_LEVEL(sConfigPVD->PVDLevel));
+  assert_param(IS_PWR_PVD_MODE(sConfigPVD->Mode));
+
+  /* Set PLS[7:5] bits according to PVDLevel value */
+  MODIFY_REG(PWR->CR1, PWR_CR1_PLS, sConfigPVD->PVDLevel);
+
+  /* Clear any previous config. Keep it clear if no event or IT mode is selected */
+  __HAL_PWR_PVD_EXTI_DISABLE_EVENT();
+  __HAL_PWR_PVD_EXTI_DISABLE_IT();
+  __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE();
+  __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE();
+
+  /* Configure interrupt mode */
+  if((sConfigPVD->Mode & PVD_MODE_IT) == PVD_MODE_IT)
+  {
+    __HAL_PWR_PVD_EXTI_ENABLE_IT();
+  }
+
+  /* Configure event mode */
+  if((sConfigPVD->Mode & PVD_MODE_EVT) == PVD_MODE_EVT)
+  {
+    __HAL_PWR_PVD_EXTI_ENABLE_EVENT();
+  }
+
+  /* Configure the edge */
+  if((sConfigPVD->Mode & PVD_RISING_EDGE) == PVD_RISING_EDGE)
+  {
+    __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE();
+  }
+
+  if((sConfigPVD->Mode & PVD_FALLING_EDGE) == PVD_FALLING_EDGE)
+  {
+    __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE();
+  }
+}
+
+/**
+  * @brief Enables the Power Voltage Detector(PVD).
+  * @retval None
+  */
+void HAL_PWR_EnablePVD(void)
+{
+  /* Enable the power voltage detector */
+	SET_BIT(PWR->CR1, PWR_CR1_PVDE);
+}
+
+/**
+  * @brief Disables the Power Voltage Detector(PVD).
+  * @retval None
+  */
+void HAL_PWR_DisablePVD(void)
+{
+  /* Disable the power voltage detector */
+	CLEAR_BIT(PWR->CR1, PWR_CR1_PVDE);
+}
+
+/**
+  * @brief Enable the WakeUp PINx functionality.
+  * @param WakeUpPinPolarity: Specifies which Wake-Up pin to enable.
+  *         This parameter can be one of the following legacy values, which sets the default polarity:
+  *         detection on high level (rising edge):
+  *           @arg PWR_WAKEUP_PIN1, PWR_WAKEUP_PIN2, PWR_WAKEUP_PIN3, PWR_WAKEUP_PIN4, PWR_WAKEUP_PIN5, PWR_WAKEUP_PIN6
+  *         or one of the following value where the user can explicitly states the enabled pin and
+  *         the chosen polarity
+  *           @arg PWR_WAKEUP_PIN1_HIGH or PWR_WAKEUP_PIN1_LOW
+  *           @arg PWR_WAKEUP_PIN2_HIGH or PWR_WAKEUP_PIN2_LOW
+  *           @arg PWR_WAKEUP_PIN3_HIGH or PWR_WAKEUP_PIN3_LOW
+  *           @arg PWR_WAKEUP_PIN4_HIGH or PWR_WAKEUP_PIN4_LOW
+  *           @arg PWR_WAKEUP_PIN5_HIGH or PWR_WAKEUP_PIN5_LOW
+  *           @arg PWR_WAKEUP_PIN6_HIGH or PWR_WAKEUP_PIN6_LOW
+  * @note  PWR_WAKEUP_PINx and PWR_WAKEUP_PINx_HIGH are equivalent.
+  * @retval None
+  */
+void HAL_PWR_EnableWakeUpPin(uint32_t WakeUpPinPolarity)
+{
+  assert_param(IS_PWR_WAKEUP_PIN(WakeUpPinPolarity));
+
+  /* Enable wake-up pin */
+  SET_BIT(PWR->CSR2, (PWR_EWUP_MASK & WakeUpPinPolarity));
+
+  /* Specifies the Wake-Up pin polarity for the event detection
+    (rising or falling edge) */
+  MODIFY_REG(PWR->CR2, (PWR_EWUP_MASK & WakeUpPinPolarity), (WakeUpPinPolarity >> 0x06));
+}
+
+/**
+  * @brief Disables the WakeUp PINx functionality.
+  * @param WakeUpPinx: Specifies the Power Wake-Up pin to disable.
+  *         This parameter can be one of the following values:
+  *           @arg PWR_WAKEUP_PIN1
+  *           @arg PWR_WAKEUP_PIN2
+  *           @arg PWR_WAKEUP_PIN3
+  *           @arg PWR_WAKEUP_PIN4
+  *           @arg PWR_WAKEUP_PIN5
+  *           @arg PWR_WAKEUP_PIN6
+  * @retval None
+  */
+void HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx)
+{
+  assert_param(IS_PWR_WAKEUP_PIN(WakeUpPinx));
+
+  CLEAR_BIT(PWR->CSR2, WakeUpPinx);
+}
+
+/**
+  * @brief Enters Sleep mode.
+  *
+  * @note In Sleep mode, all I/O pins keep the same state as in Run mode.
+  *
+  * @note In Sleep mode, the systick is stopped to avoid exit from this mode with
+  *       systick interrupt when used as time base for Timeout
+  *
+  * @param Regulator: Specifies the regulator state in SLEEP mode.
+  *            This parameter can be one of the following values:
+  *            @arg PWR_MAINREGULATOR_ON: SLEEP mode with regulator ON
+  *            @arg PWR_LOWPOWERREGULATOR_ON: SLEEP mode with low power regulator ON
+  * @note This parameter is not used for the STM32F7 family and is kept as parameter
+  *       just to maintain compatibility with the lower power families.
+  * @param SLEEPEntry: Specifies if SLEEP mode in entered with WFI or WFE instruction.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_SLEEPENTRY_WFI: enter SLEEP mode with WFI instruction
+  *            @arg PWR_SLEEPENTRY_WFE: enter SLEEP mode with WFE instruction
+  * @retval None
+  */
+void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry)
+{
+  /* Check the parameters */
+  assert_param(IS_PWR_REGULATOR(Regulator));
+  assert_param(IS_PWR_SLEEP_ENTRY(SLEEPEntry));
+
+  /* Clear SLEEPDEEP bit of Cortex System Control Register */
+  CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
+
+  /* Select SLEEP mode entry -------------------------------------------------*/
+  if(SLEEPEntry == PWR_SLEEPENTRY_WFI)
+  {
+    /* Request Wait For Interrupt */
+    __WFI();
+  }
+  else
+  {
+    /* Request Wait For Event */
+    __SEV();
+    __WFE();
+    __WFE();
+  }
+}
+
+/**
+  * @brief Enters Stop mode.
+  * @note In Stop mode, all I/O pins keep the same state as in Run mode.
+  * @note When exiting Stop mode by issuing an interrupt or a wakeup event,
+  *         the HSI RC oscillator is selected as system clock.
+  * @note When the voltage regulator operates in low power mode, an additional
+  *         startup delay is incurred when waking up from Stop mode.
+  *         By keeping the internal regulator ON during Stop mode, the consumption
+  *         is higher although the startup time is reduced.
+  * @param Regulator: Specifies the regulator state in Stop mode.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_MAINREGULATOR_ON: Stop mode with regulator ON
+  *            @arg PWR_LOWPOWERREGULATOR_ON: Stop mode with low power regulator ON
+  * @param STOPEntry: Specifies if Stop mode in entered with WFI or WFE instruction.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_STOPENTRY_WFI: Enter Stop mode with WFI instruction
+  *            @arg PWR_STOPENTRY_WFE: Enter Stop mode with WFE instruction
+  * @retval None
+  */
+void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_PWR_REGULATOR(Regulator));
+  assert_param(IS_PWR_STOP_ENTRY(STOPEntry));
+
+  /* Select the regulator state in Stop mode ---------------------------------*/
+  tmpreg = PWR->CR1;
+  /* Clear PDDS and LPDS bits */
+  tmpreg &= (uint32_t)~(PWR_CR1_PDDS | PWR_CR1_LPDS);
+
+  /* Set LPDS, MRLVDS and LPLVDS bits according to Regulator value */
+  tmpreg |= Regulator;
+
+  /* Store the new value */
+  PWR->CR1 = tmpreg;
+
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+  SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+  /* Select Stop mode entry --------------------------------------------------*/
+  if(STOPEntry == PWR_STOPENTRY_WFI)
+  {
+    /* Request Wait For Interrupt */
+    __WFI();
+  }
+  else
+  {
+    /* Request Wait For Event */
+    __SEV();
+    __WFE();
+    __WFE();
+  }
+  /* Reset SLEEPDEEP bit of Cortex System Control Register */
+  SCB->SCR &= (uint32_t)~((uint32_t)SCB_SCR_SLEEPDEEP_Msk);
+}
+
+/**
+  * @brief Enters Standby mode.
+  * @note In Standby mode, all I/O pins are high impedance except for:
+  *          - Reset pad (still available)
+  *          - RTC_AF1 pin (PC13) if configured for tamper, time-stamp, RTC
+  *            Alarm out, or RTC clock calibration out.
+  *          - RTC_AF2 pin (PI8) if configured for tamper or time-stamp.
+  *          - WKUP pins if enabled.
+  * @retval None
+  */
+void HAL_PWR_EnterSTANDBYMode(void)
+{
+  /* Select Standby mode */
+  PWR->CR1 |= PWR_CR1_PDDS;
+
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+  SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+  /* This option is used to ensure that store operations are completed */
+#if defined ( __CC_ARM)
+  __force_stores();
+#endif
+  /* Request Wait For Interrupt */
+  __WFI();
+}
+
+/**
+  * @brief This function handles the PWR PVD interrupt request.
+  * @note This API should be called under the PVD_IRQHandler().
+  * @retval None
+  */
+void HAL_PWR_PVD_IRQHandler(void)
+{
+  /* Check PWR Exti flag */
+  if(__HAL_PWR_PVD_EXTI_GET_FLAG() != RESET)
+  {
+    /* PWR PVD interrupt user callback */
+    HAL_PWR_PVDCallback();
+
+    /* Clear PWR Exti pending bit */
+    __HAL_PWR_PVD_EXTI_CLEAR_FLAG();
+  }
+}
+
+/**
+  * @brief  PWR PVD interrupt callback
+  * @retval None
+  */
+__weak void HAL_PWR_PVDCallback(void)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PWR_PVDCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief Indicates Sleep-On-Exit when returning from Handler mode to Thread mode.
+  * @note Set SLEEPONEXIT bit of SCR register. When this bit is set, the processor
+  *       re-enters SLEEP mode when an interruption handling is over.
+  *       Setting this bit is useful when the processor is expected to run only on
+  *       interruptions handling.
+  * @retval None
+  */
+void HAL_PWR_EnableSleepOnExit(void)
+{
+  /* Set SLEEPONEXIT bit of Cortex System Control Register */
+  SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPONEXIT_Msk));
+}
+
+/**
+  * @brief Disables Sleep-On-Exit feature when returning from Handler mode to Thread mode.
+  * @note Clears SLEEPONEXIT bit of SCR register. When this bit is set, the processor
+  *       re-enters SLEEP mode when an interruption handling is over.
+  * @retval None
+  */
+void HAL_PWR_DisableSleepOnExit(void)
+{
+  /* Clear SLEEPONEXIT bit of Cortex System Control Register */
+  CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPONEXIT_Msk));
+}
+
+/**
+  * @brief Enables CORTEX M4 SEVONPEND bit.
+  * @note Sets SEVONPEND bit of SCR register. When this bit is set, this causes
+  *       WFE to wake up when an interrupt moves from inactive to pended.
+  * @retval None
+  */
+void HAL_PWR_EnableSEVOnPend(void)
+{
+  /* Set SEVONPEND bit of Cortex System Control Register */
+  SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SEVONPEND_Msk));
+}
+
+/**
+  * @brief Disables CORTEX M4 SEVONPEND bit.
+  * @note Clears SEVONPEND bit of SCR register. When this bit is set, this causes
+  *       WFE to wake up when an interrupt moves from inactive to pended.
+  * @retval None
+  */
+void HAL_PWR_DisableSEVOnPend(void)
+{
+  /* Clear SEVONPEND bit of Cortex System Control Register */
+  CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SEVONPEND_Msk));
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_PWR_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_pwr_ex.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_pwr_ex.c
@@ -1,0 +1,564 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_pwr_ex.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Extended PWR HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of PWR extension peripheral:
+  *           + Peripheral Extended features functions
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PWREx PWREx
+  * @brief PWR HAL module driver
+  * @{
+  */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @addtogroup PWREx_Private_Constants
+  * @{
+  */
+#define PWR_OVERDRIVE_TIMEOUT_VALUE  1000
+#define PWR_UDERDRIVE_TIMEOUT_VALUE  1000
+#define PWR_BKPREG_TIMEOUT_VALUE     1000
+#define PWR_VOSRDY_TIMEOUT_VALUE     1000
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup PWREx_Exported_Functions PWREx Exported Functions
+  *  @{
+  */
+
+/** @defgroup PWREx_Exported_Functions_Group1 Peripheral Extended features functions
+  *  @brief Peripheral Extended features functions
+  *
+@verbatim
+
+ ===============================================================================
+                 ##### Peripheral extended features functions #####
+ ===============================================================================
+
+    *** Main and Backup Regulators configuration ***
+    ================================================
+    [..]
+      (+) The backup domain includes 4 Kbytes of backup SRAM accessible only from
+          the CPU, and address in 32-bit, 16-bit or 8-bit mode. Its content is
+          retained even in Standby or VBAT mode when the low power backup regulator
+          is enabled. It can be considered as an internal EEPROM when VBAT is
+          always present. You can use the HAL_PWREx_EnableBkUpReg() function to
+          enable the low power backup regulator.
+
+      (+) When the backup domain is supplied by VDD (analog switch connected to VDD)
+          the backup SRAM is powered from VDD which replaces the VBAT power supply to
+          save battery life.
+
+      (+) The backup SRAM is not mass erased by a tamper event. It is read
+          protected to prevent confidential data, such as cryptographic private
+          key, from being accessed. The backup SRAM can be erased only through
+          the Flash interface when a protection level change from level 1 to
+          level 0 is requested.
+      -@- Refer to the description of Read protection (RDP) in the Flash
+          programming manual.
+
+      (+) The main internal regulator can be configured to have a tradeoff between
+          performance and power consumption when the device does not operate at
+          the maximum frequency. This is done through __HAL_PWR_MAINREGULATORMODE_CONFIG()
+          macro which configure VOS bit in PWR_CR register
+
+        Refer to the product datasheets for more details.
+
+    *** FLASH Power Down configuration ****
+    =======================================
+    [..]
+      (+) By setting the FPDS bit in the PWR_CR register by using the
+          HAL_PWREx_EnableFlashPowerDown() function, the Flash memory also enters power
+          down mode when the device enters Stop mode. When the Flash memory
+          is in power down mode, an additional startup delay is incurred when
+          waking up from Stop mode.
+
+    *** Over-Drive and Under-Drive configuration ****
+    =================================================
+    [..]
+       (+) In Run mode: the main regulator has 2 operating modes available:
+        (++) Normal mode: The CPU and core logic operate at maximum frequency at a given
+             voltage scaling (scale 1, scale 2 or scale 3)
+        (++) Over-drive mode: This mode allows the CPU and the core logic to operate at a
+            higher frequency than the normal mode for a given voltage scaling (scale 1,
+            scale 2 or scale 3). This mode is enabled through HAL_PWREx_EnableOverDrive() function and
+            disabled by HAL_PWREx_DisableOverDrive() function, to enter or exit from Over-drive mode please follow
+            the sequence described in Reference manual.
+
+       (+) In Stop mode: the main regulator or low power regulator supplies a low power
+           voltage to the 1.2V domain, thus preserving the content of registers
+           and internal SRAM. 2 operating modes are available:
+         (++) Normal mode: the 1.2V domain is preserved in nominal leakage mode. This mode is only
+              available when the main regulator or the low power regulator is used in Scale 3 or
+              low voltage mode.
+         (++) Under-drive mode: the 1.2V domain is preserved in reduced leakage mode. This mode is only
+              available when the main regulator or the low power regulator is in low voltage mode.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Enables the Backup Regulator.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PWREx_EnableBkUpReg(void)
+{
+  uint32_t tickstart = 0;
+
+  /* Enable Backup regulator */
+  PWR->CSR1 |= PWR_CSR1_BRE;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait till Backup regulator ready flag is set */
+  while(__HAL_PWR_GET_FLAG(PWR_FLAG_BRR) == RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > PWR_BKPREG_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief Disables the Backup Regulator.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PWREx_DisableBkUpReg(void)
+{
+  uint32_t tickstart = 0;
+
+  /* Disable Backup regulator */
+  PWR->CSR1 &= (uint32_t)~((uint32_t)PWR_CSR1_BRE);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait till Backup regulator ready flag is set */
+  while(__HAL_PWR_GET_FLAG(PWR_FLAG_BRR) != RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > PWR_BKPREG_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief Enables the Flash Power Down in Stop mode.
+  * @retval None
+  */
+void HAL_PWREx_EnableFlashPowerDown(void)
+{
+  /* Enable the Flash Power Down */
+  PWR->CR1 |= PWR_CR1_FPDS;
+}
+
+/**
+  * @brief Disables the Flash Power Down in Stop mode.
+  * @retval None
+  */
+void HAL_PWREx_DisableFlashPowerDown(void)
+{
+  /* Disable the Flash Power Down */
+  PWR->CR1 &= (uint32_t)~((uint32_t)PWR_CR1_FPDS);
+}
+
+/**
+  * @brief Enables Main Regulator low voltage mode.
+  * @retval None
+  */
+void HAL_PWREx_EnableMainRegulatorLowVoltage(void)
+{
+  /* Enable Main regulator low voltage */
+  PWR->CR1 |= PWR_CR1_MRUDS;
+}
+
+/**
+  * @brief Disables Main Regulator low voltage mode.
+  * @retval None
+  */
+void HAL_PWREx_DisableMainRegulatorLowVoltage(void)
+{
+  /* Disable Main regulator low voltage */
+  PWR->CR1 &= (uint32_t)~((uint32_t)PWR_CR1_MRUDS);
+}
+
+/**
+  * @brief Enables Low Power Regulator low voltage mode.
+  * @retval None
+  */
+void HAL_PWREx_EnableLowRegulatorLowVoltage(void)
+{
+  /* Enable low power regulator */
+  PWR->CR1 |= PWR_CR1_LPUDS;
+}
+
+/**
+  * @brief Disables Low Power Regulator low voltage mode.
+  * @retval None
+  */
+void HAL_PWREx_DisableLowRegulatorLowVoltage(void)
+{
+  /* Disable low power regulator */
+  PWR->CR1 &= (uint32_t)~((uint32_t)PWR_CR1_LPUDS);
+}
+
+/**
+  * @brief  Activates the Over-Drive mode.
+  * @note   This mode allows the CPU and the core logic to operate at a higher frequency
+  *         than the normal mode for a given voltage scaling (scale 1, scale 2 or scale 3).
+  * @note   It is recommended to enter or exit Over-drive mode when the application is not running
+  *         critical tasks and when the system clock source is either HSI or HSE.
+  *         During the Over-drive switch activation, no peripheral clocks should be enabled.
+  *         The peripheral clocks must be enabled once the Over-drive mode is activated.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PWREx_EnableOverDrive(void)
+{
+  uint32_t tickstart = 0;
+
+  __HAL_RCC_PWR_CLK_ENABLE();
+
+  /* Enable the Over-drive to extend the clock frequency to 216 MHz */
+  __HAL_PWR_OVERDRIVE_ENABLE();
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while(!__HAL_PWR_GET_FLAG(PWR_FLAG_ODRDY))
+  {
+    if((HAL_GetTick() - tickstart ) > PWR_OVERDRIVE_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Enable the Over-drive switch */
+  __HAL_PWR_OVERDRIVESWITCHING_ENABLE();
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while(!__HAL_PWR_GET_FLAG(PWR_FLAG_ODSWRDY))
+  {
+    if((HAL_GetTick() - tickstart ) > PWR_OVERDRIVE_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates the Over-Drive mode.
+  * @note   This mode allows the CPU and the core logic to operate at a higher frequency
+  *         than the normal mode for a given voltage scaling (scale 1, scale 2 or scale 3).
+  * @note   It is recommended to enter or exit Over-drive mode when the application is not running
+  *         critical tasks and when the system clock source is either HSI or HSE.
+  *         During the Over-drive switch activation, no peripheral clocks should be enabled.
+  *         The peripheral clocks must be enabled once the Over-drive mode is activated.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PWREx_DisableOverDrive(void)
+{
+  uint32_t tickstart = 0;
+
+  __HAL_RCC_PWR_CLK_ENABLE();
+
+  /* Disable the Over-drive switch */
+  __HAL_PWR_OVERDRIVESWITCHING_DISABLE();
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while(__HAL_PWR_GET_FLAG(PWR_FLAG_ODSWRDY))
+  {
+    if((HAL_GetTick() - tickstart ) > PWR_OVERDRIVE_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Disable the Over-drive */
+  __HAL_PWR_OVERDRIVE_DISABLE();
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while(__HAL_PWR_GET_FLAG(PWR_FLAG_ODRDY))
+  {
+    if((HAL_GetTick() - tickstart ) > PWR_OVERDRIVE_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enters in Under-Drive STOP mode.
+  *
+  * @note    This mode can be selected only when the Under-Drive is already active
+  *
+  * @note    This mode is enabled only with STOP low power mode.
+  *          In this mode, the 1.2V domain is preserved in reduced leakage mode. This
+  *          mode is only available when the main regulator or the low power regulator
+  *          is in low voltage mode
+  *
+  * @note   If the Under-drive mode was enabled, it is automatically disabled after
+  *         exiting Stop mode.
+  *         When the voltage regulator operates in Under-drive mode, an additional
+  *         startup delay is induced when waking up from Stop mode.
+  *
+  * @note   In Stop mode, all I/O pins keep the same state as in Run mode.
+  *
+  * @note   When exiting Stop mode by issuing an interrupt or a wakeup event,
+  *         the HSI RC oscillator is selected as system clock.
+  *
+  * @note   When the voltage regulator operates in low power mode, an additional
+  *         startup delay is incurred when waking up from Stop mode.
+  *         By keeping the internal regulator ON during Stop mode, the consumption
+  *         is higher although the startup time is reduced.
+  *
+  * @param  Regulator: specifies the regulator state in STOP mode.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_MAINREGULATOR_UNDERDRIVE_ON:  Main Regulator in under-drive mode
+  *                 and Flash memory in power-down when the device is in Stop under-drive mode
+  *            @arg PWR_LOWPOWERREGULATOR_UNDERDRIVE_ON:  Low Power Regulator in under-drive mode
+  *                and Flash memory in power-down when the device is in Stop under-drive mode
+  * @param  STOPEntry: specifies if STOP mode in entered with WFI or WFE instruction.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_SLEEPENTRY_WFI: enter STOP mode with WFI instruction
+  *            @arg PWR_SLEEPENTRY_WFE: enter STOP mode with WFE instruction
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_PWREx_EnterUnderDriveSTOPMode(uint32_t Regulator, uint8_t STOPEntry)
+{
+  uint32_t tempreg = 0;
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_PWR_REGULATOR_UNDERDRIVE(Regulator));
+  assert_param(IS_PWR_STOP_ENTRY(STOPEntry));
+
+  /* Enable Power ctrl clock */
+  __HAL_RCC_PWR_CLK_ENABLE();
+  /* Enable the Under-drive Mode ---------------------------------------------*/
+  /* Clear Under-drive flag */
+  __HAL_PWR_CLEAR_ODRUDR_FLAG();
+
+  /* Enable the Under-drive */
+  __HAL_PWR_UNDERDRIVE_ENABLE();
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait for UnderDrive mode is ready */
+  while(__HAL_PWR_GET_FLAG(PWR_FLAG_UDRDY))
+  {
+    if((HAL_GetTick() - tickstart ) > PWR_UDERDRIVE_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Select the regulator state in STOP mode ---------------------------------*/
+  tempreg = PWR->CR1;
+  /* Clear PDDS, LPDS, MRLUDS and LPLUDS bits */
+  tempreg &= (uint32_t)~(PWR_CR1_PDDS | PWR_CR1_LPDS | PWR_CR1_LPUDS | PWR_CR1_MRUDS);
+
+  /* Set LPDS, MRLUDS and LPLUDS bits according to PWR_Regulator value */
+  tempreg |= Regulator;
+
+  /* Store the new value */
+  PWR->CR1 = tempreg;
+
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+  SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+  /* Select STOP mode entry --------------------------------------------------*/
+  if(STOPEntry == PWR_SLEEPENTRY_WFI)
+  {
+    /* Request Wait For Interrupt */
+    __WFI();
+  }
+  else
+  {
+    /* Request Wait For Event */
+    __WFE();
+  }
+  /* Reset SLEEPDEEP bit of Cortex System Control Register */
+  SCB->SCR &= (uint32_t)~((uint32_t)SCB_SCR_SLEEPDEEP_Msk);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Returns Voltage Scaling Range.
+  * @retval VOS bit field (PWR_REGULATOR_VOLTAGE_SCALE1, PWR_REGULATOR_VOLTAGE_SCALE2 or
+  *            PWR_REGULATOR_VOLTAGE_SCALE3)PWR_REGULATOR_VOLTAGE_SCALE1
+  */
+uint32_t HAL_PWREx_GetVoltageRange(void)
+{
+  return  (PWR->CR1 & PWR_CR1_VOS);
+}
+
+/**
+  * @brief Configures the main internal regulator output voltage.
+  * @param  VoltageScaling: specifies the regulator output voltage to achieve
+  *         a tradeoff between performance and power consumption.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_REGULATOR_VOLTAGE_SCALE1: Regulator voltage output range 1 mode,
+  *                                                typical output voltage at 1.4 V,
+  *                                                system frequency up to 216 MHz.
+  *            @arg PWR_REGULATOR_VOLTAGE_SCALE2: Regulator voltage output range 2 mode,
+  *                                                typical output voltage at 1.2 V,
+  *                                                system frequency up to 180 MHz.
+  *            @arg PWR_REGULATOR_VOLTAGE_SCALE3: Regulator voltage output range 2 mode,
+  *                                                typical output voltage at 1.00 V,
+  *                                                system frequency up to 151 MHz.
+  * @note To update the system clock frequency(SYSCLK):
+  *        - Set the HSI or HSE as system clock frequency using the HAL_RCC_ClockConfig().
+  *        - Call the HAL_RCC_OscConfig() to configure the PLL.
+  *        - Call HAL_PWREx_ConfigVoltageScaling() API to adjust the voltage scale.
+  *        - Set the new system clock frequency using the HAL_RCC_ClockConfig().
+  * @note The scale can be modified only when the HSI or HSE clock source is selected
+  *        as system clock source, otherwise the API returns HAL_ERROR.
+  * @note When the PLL is OFF, the voltage scale 3 is automatically selected and the VOS bits
+  *       value in the PWR_CR1 register are not taken in account.
+  * @note This API forces the PLL state ON to allow the possibility to configure the voltage scale 1 or 2.
+  * @note The new voltage scale is active only when the PLL is ON.
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_PWREx_ControlVoltageScaling(uint32_t VoltageScaling)
+{
+  uint32_t tickstart = 0;
+
+  assert_param(IS_PWR_REGULATOR_VOLTAGE(VoltageScaling));
+
+  /* Enable Power ctrl clock */
+  __HAL_RCC_PWR_CLK_ENABLE();
+
+  /* Check if the PLL is used as system clock or not */
+  if(__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_PLL)
+  {
+    /* Disable the main PLL */
+    __HAL_RCC_PLL_DISABLE();
+
+    /* Get Start Tick */
+    tickstart = HAL_GetTick();
+    /* Wait till PLL is disabled */
+    while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) != RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set Range */
+    __HAL_PWR_VOLTAGESCALING_CONFIG(VoltageScaling);
+
+    /* Enable the main PLL */
+    __HAL_RCC_PLL_ENABLE();
+
+    /* Get Start Tick */
+    tickstart = HAL_GetTick();
+    /* Wait till PLL is ready */
+    while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Get Start Tick */
+    tickstart = HAL_GetTick();
+    while((__HAL_PWR_GET_FLAG(PWR_FLAG_VOSRDY) == RESET))
+    {
+      if((HAL_GetTick() - tickstart ) > PWR_VOSRDY_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_PWR_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_rcc.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_rcc.c
@@ -1,0 +1,1197 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rcc.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   RCC HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Reset and Clock Control (RCC) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + Peripheral Control functions
+  *
+  @verbatim
+  ==============================================================================
+                      ##### RCC specific features #####
+  ==============================================================================
+    [..]
+      After reset the device is running from Internal High Speed oscillator
+      (HSI 16MHz) with Flash 0 wait state, Flash prefetch buffer, D-Cache
+      and I-Cache are disabled, and all peripherals are off except internal
+      SRAM, Flash and JTAG.
+      (+) There is no prescaler on High speed (AHB) and Low speed (APB) busses;
+          all peripherals mapped on these busses are running at HSI speed.
+      (+) The clock for all peripherals is switched off, except the SRAM and FLASH.
+      (+) All GPIOs are in input floating state, except the JTAG pins which
+          are assigned to be used for debug purpose.
+
+    [..]
+      Once the device started from reset, the user application has to:
+      (+) Configure the clock source to be used to drive the System clock
+          (if the application needs higher frequency/performance)
+      (+) Configure the System clock frequency and Flash settings
+      (+) Configure the AHB and APB busses prescalers
+      (+) Enable the clock for the peripheral(s) to be used
+      (+) Configure the clock source(s) for peripherals which clocks are not
+          derived from the System clock (I2S, RTC, ADC, USB OTG FS/SDIO/RNG)
+
+                      ##### RCC Limitations #####
+  ==============================================================================
+    [..]
+      A delay between an RCC peripheral clock enable and the effective peripheral
+      enabling should be taken into account in order to manage the peripheral read/write
+      from/to registers.
+      (+) This delay depends on the peripheral mapping.
+      (+) If peripheral is mapped on AHB: the delay is 2 AHB clock cycle
+          after the clock enable bit is set on the hardware register
+      (+) If peripheral is mapped on APB: the delay is 2 APB clock cycle
+          after the clock enable bit is set on the hardware register
+
+    [..]
+      Implemented Workaround:
+      (+) For AHB & APB peripherals, a dummy read to the peripheral register has been
+          inserted in each __HAL_RCC_PPP_CLK_ENABLE() macro.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RCC RCC
+  * @brief RCC HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/** @defgroup RCC_Private_Macros RCC Private Macros
+  * @{
+  */
+
+#define MCO1_CLK_ENABLE()   __HAL_RCC_GPIOA_CLK_ENABLE()
+#define MCO1_GPIO_PORT        GPIOA
+#define MCO1_PIN              GPIO_PIN_8
+
+#define MCO2_CLK_ENABLE()   __HAL_RCC_GPIOC_CLK_ENABLE()
+#define MCO2_GPIO_PORT         GPIOC
+#define MCO2_PIN               GPIO_PIN_9
+
+/**
+  * @}
+  */
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup RCC_Private_Variables RCC Private Variables
+  * @{
+  */
+const uint8_t APBAHBPrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
+
+/**
+  * @}
+  */
+
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
+
+/** @defgroup RCC_Exported_Functions RCC Exported Functions
+  * @{
+  */
+
+/** @defgroup RCC_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and Configuration functions
+  *
+  @verbatim
+  ===============================================================================
+##### Initialization and de-initialization functions #####
+  ===============================================================================
+    [..]
+      This section provides functions allowing to configure the internal/external oscillators
+      (HSE, HSI, LSE, LSI, PLL, CSS and MCO) and the System buses clocks (SYSCLK, AHB, APB1
+      and APB2).
+
+    [..] Internal/external clock and PLL configuration
+      (#) HSI (high-speed internal), 16 MHz factory-trimmed RC used directly or through
+          the PLL as System clock source.
+
+      (#) LSI (low-speed internal), 32 KHz low consumption RC used as IWDG and/or RTC
+          clock source.
+
+      (#) HSE (high-speed external), 4 to 26 MHz crystal oscillator used directly or
+          through the PLL as System clock source. Can be used also as RTC clock source.
+
+      (#) LSE (low-speed external), 32 KHz oscillator used as RTC clock source.
+
+      (#) PLL (clocked by HSI or HSE), featuring two different output clocks:
+        (++) The first output is used to generate the high speed system clock (up to 216 MHz)
+        (++) The second output is used to generate the clock for the USB OTG FS (48 MHz),
+             the random analog generator (<=48 MHz) and the SDIO (<= 48 MHz).
+
+      (#) CSS (Clock security system), once enable using the function HAL_RCC_EnableCSS()
+          and if a HSE clock failure occurs(HSE used directly or through PLL as System
+          clock source), the System clock is automatically switched to HSI and an interrupt
+          is generated if enabled. The interrupt is linked to the Cortex-M7 NMI
+          (Non-Maskable Interrupt) exception vector.
+
+      (#) MCO1 (microcontroller clock output), used to output HSI, LSE, HSE or PLL
+          clock (through a configurable prescaler) on PA8 pin.
+
+      (#) MCO2 (microcontroller clock output), used to output HSE, PLL, SYSCLK or PLLI2S
+          clock (through a configurable prescaler) on PC9 pin.
+
+    [..] System, AHB and APB busses clocks configuration
+      (#) Several clock sources can be used to drive the System clock (SYSCLK): HSI,
+          HSE and PLL.
+          The AHB clock (HCLK) is derived from System clock through configurable
+          prescaler and used to clock the CPU, memory and peripherals mapped
+          on AHB bus (DMA, GPIO...). APB1 (PCLK1) and APB2 (PCLK2) clocks are derived
+          from AHB clock through configurable prescalers and used to clock
+          the peripherals mapped on these busses. You can use
+          "HAL_RCC_GetSysClockFreq()" function to retrieve the frequencies of these clocks.
+
+      -@- All the peripheral clocks are derived from the System clock (SYSCLK) except:
+          (+@) I2S: the I2S clock can be derived either from a specific PLL (PLLI2S) or
+              from an external clock mapped on the I2S_CKIN pin.
+              You have to use __HAL_RCC_PLLI2S_CONFIG() macro to configure this clock.
+          (+@)  SAI: the SAI clock can be derived either from a specific PLL (PLLI2S) or (PLLSAI) or
+              from an external clock mapped on the I2S_CKIN pin.
+               You have to use __HAL_RCC_PLLI2S_CONFIG() macro to configure this clock.
+          (+@) RTC: the RTC clock can be derived either from the LSI, LSE or HSE clock
+              divided by 2 to 31. You have to use __HAL_RCC_RTC_CONFIG() and __HAL_RCC_RTC_ENABLE()
+              macros to configure this clock.
+          (+@) USB OTG FS, SDIO and RTC: USB OTG FS require a frequency equal to 48 MHz
+              to work correctly, while the SDIO require a frequency equal or lower than
+              to 48. This clock is derived of the main PLL through PLLQ divider.
+          (+@) IWDG clock which is always the LSI clock.
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Resets the RCC clock configuration to the default reset state.
+  * @note   The default reset state of the clock configuration is given below:
+  *            - HSI ON and used as system clock source
+  *            - HSE, PLL and PLLI2S OFF
+  *            - AHB, APB1 and APB2 prescaler set to 1.
+  *            - CSS, MCO1 and MCO2 OFF
+  *            - All interrupts disabled
+  * @note   This function doesn't modify the configuration of the
+  *            - Peripheral clocks
+  *            - LSI, LSE and RTC clocks
+  * @retval None
+  */
+void HAL_RCC_DeInit(void)
+{
+  /* Set HSION bit */
+  SET_BIT(RCC->CR, RCC_CR_HSION | RCC_CR_HSITRIM_4);
+
+  /* Reset CFGR register */
+  CLEAR_REG(RCC->CFGR);
+
+  /* Reset HSEON, CSSON, PLLON, PLLI2S */
+  CLEAR_BIT(RCC->CR, RCC_CR_HSEON | RCC_CR_CSSON | RCC_CR_PLLON| RCC_CR_PLLI2SON);
+
+  /* Reset PLLCFGR register */
+  CLEAR_REG(RCC->PLLCFGR);
+  SET_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLM_4 | RCC_PLLCFGR_PLLN_6 | RCC_PLLCFGR_PLLN_7 | RCC_PLLCFGR_PLLQ_2);
+
+  /* Reset PLLI2SCFGR register */
+  CLEAR_REG(RCC->PLLI2SCFGR);
+  SET_BIT(RCC->PLLI2SCFGR,  RCC_PLLI2SCFGR_PLLI2SN_6 | RCC_PLLI2SCFGR_PLLI2SN_7 | RCC_PLLI2SCFGR_PLLI2SR_1);
+
+  /* Reset HSEBYP bit */
+  CLEAR_BIT(RCC->CR, RCC_CR_HSEBYP);
+
+  /* Disable all interrupts */
+  CLEAR_REG(RCC->CIR);
+}
+
+/**
+  * @brief  Initializes the RCC Oscillators according to the specified parameters in the
+  *         RCC_OscInitTypeDef.
+  * @param  RCC_OscInitStruct: pointer to an RCC_OscInitTypeDef structure that
+  *         contains the configuration information for the RCC Oscillators.
+  * @note   The PLL is not disabled when used as system clock.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RCC_OSCILLATORTYPE(RCC_OscInitStruct->OscillatorType));
+
+  /*------------------------------- HSE Configuration ------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_HSE) == RCC_OSCILLATORTYPE_HSE)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_HSE(RCC_OscInitStruct->HSEState));
+    /* When the HSE is used as system clock or clock source for PLL, It can not be disabled */
+    if((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_HSE)
+       || ((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_PLLCLK) && ((RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) == RCC_PLLCFGR_PLLSRC_HSE)))
+    {
+	  if((__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != RESET) && (RCC_OscInitStruct->HSEState == RCC_HSE_OFF))
+      {
+        return HAL_ERROR;
+      }
+    }
+    else
+    {
+      /* Reset HSEON and HSEBYP bits before configuring the HSE --------------*/
+      __HAL_RCC_HSE_CONFIG(RCC_HSE_OFF);
+
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait till HSE is disabled */
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+
+      /* Set the new HSE configuration ---------------------------------------*/
+      __HAL_RCC_HSE_CONFIG(RCC_OscInitStruct->HSEState);
+
+      /* Check the HSE State */
+      if(RCC_OscInitStruct->HSEState != RCC_HSE_OFF)
+      {
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till HSE is ready */
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+      else
+      {
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till HSE is bypassed or disabled */
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != RESET)
+        {
+           if((HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }
+  }
+  /*----------------------------- HSI Configuration --------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_HSI) == RCC_OSCILLATORTYPE_HSI)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_HSI(RCC_OscInitStruct->HSIState));
+    assert_param(IS_RCC_CALIBRATION_VALUE(RCC_OscInitStruct->HSICalibrationValue));
+
+    /* Check if HSI is used as system clock or as PLL source when PLL is selected as system clock */
+    if((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_HSI)
+       || ((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_PLLCLK) && ((RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) == RCC_PLLCFGR_PLLSRC_HSI)))
+    {
+      /* When HSI is used as system clock it will not disabled */
+      if((__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) != RESET) && (RCC_OscInitStruct->HSIState != RCC_HSI_ON))
+      {
+        return HAL_ERROR;
+      }
+      /* Otherwise, just the calibration is allowed */
+      else
+      {
+        /* Adjusts the Internal High Speed oscillator (HSI) calibration value.*/
+        __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->HSICalibrationValue);
+      }
+    }
+    else
+    {
+      /* Check the HSI State */
+      if((RCC_OscInitStruct->HSIState)!= RCC_HSI_OFF)
+      {
+        /* Enable the Internal High Speed oscillator (HSI). */
+        __HAL_RCC_HSI_ENABLE();
+
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till HSI is ready */
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > HSI_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+
+        /* Adjusts the Internal High Speed oscillator (HSI) calibration value.*/
+        __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->HSICalibrationValue);
+      }
+      else
+      {
+        /* Disable the Internal High Speed oscillator (HSI). */
+        __HAL_RCC_HSI_DISABLE();
+
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till HSI is ready */
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > HSI_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }
+  }
+  /*------------------------------ LSI Configuration -------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_LSI) == RCC_OSCILLATORTYPE_LSI)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_LSI(RCC_OscInitStruct->LSIState));
+
+    /* Check the LSI State */
+    if((RCC_OscInitStruct->LSIState)!= RCC_LSI_OFF)
+    {
+      /* Enable the Internal Low Speed oscillator (LSI). */
+      __HAL_RCC_LSI_ENABLE();
+
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait till LSI is ready */
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY) == RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > LSI_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    else
+    {
+      /* Disable the Internal Low Speed oscillator (LSI). */
+      __HAL_RCC_LSI_DISABLE();
+
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait till LSI is ready */
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY) != RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > LSI_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  /*------------------------------ LSE Configuration -------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_LSE) == RCC_OSCILLATORTYPE_LSE)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_LSE(RCC_OscInitStruct->LSEState));
+
+    /* Enable Power Clock*/
+    __HAL_RCC_PWR_CLK_ENABLE();
+
+    /* Enable write access to Backup domain */
+    PWR->CR1 |= PWR_CR1_DBP;
+
+    /* Wait for Backup domain Write protection disable */
+    tickstart = HAL_GetTick();
+
+    while((PWR->CR1 & PWR_CR1_DBP) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RCC_DBP_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Reset LSEON and LSEBYP bits before configuring the LSE ----------------*/
+    __HAL_RCC_LSE_CONFIG(RCC_LSE_OFF);
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    /* Wait till LSE is ready */
+    while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) != RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RCC_LSE_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set the new LSE configuration -----------------------------------------*/
+    __HAL_RCC_LSE_CONFIG(RCC_OscInitStruct->LSEState);
+    /* Check the LSE State */
+    if((RCC_OscInitStruct->LSEState) != RCC_LSE_OFF)
+    {
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait till LSE is ready */
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) == RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > RCC_LSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    else
+    {
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait till LSE is ready */
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) != RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > RCC_LSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  /*-------------------------------- PLL Configuration -----------------------*/
+  /* Check the parameters */
+  assert_param(IS_RCC_PLL(RCC_OscInitStruct->PLL.PLLState));
+  if ((RCC_OscInitStruct->PLL.PLLState) != RCC_PLL_NONE)
+  {
+    /* Check if the PLL is used as system clock or not */
+    if(__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_SYSCLKSOURCE_STATUS_PLLCLK)
+    {
+      if((RCC_OscInitStruct->PLL.PLLState) == RCC_PLL_ON)
+      {
+        /* Check the parameters */
+        assert_param(IS_RCC_PLLSOURCE(RCC_OscInitStruct->PLL.PLLSource));
+        assert_param(IS_RCC_PLLM_VALUE(RCC_OscInitStruct->PLL.PLLM));
+        assert_param(IS_RCC_PLLN_VALUE(RCC_OscInitStruct->PLL.PLLN));
+        assert_param(IS_RCC_PLLP_VALUE(RCC_OscInitStruct->PLL.PLLP));
+        assert_param(IS_RCC_PLLQ_VALUE(RCC_OscInitStruct->PLL.PLLQ));
+
+        /* Disable the main PLL. */
+        __HAL_RCC_PLL_DISABLE();
+
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till PLL is ready */
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+
+        /* Configure the main PLL clock source, multiplication and division factors. */
+        __HAL_RCC_PLL_CONFIG(RCC_OscInitStruct->PLL.PLLSource,
+                             RCC_OscInitStruct->PLL.PLLM,
+                             RCC_OscInitStruct->PLL.PLLN,
+                             RCC_OscInitStruct->PLL.PLLP,
+                             RCC_OscInitStruct->PLL.PLLQ);
+        /* Enable the main PLL. */
+        __HAL_RCC_PLL_ENABLE();
+
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till PLL is ready */
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+      else
+      {
+        /* Disable the main PLL. */
+        __HAL_RCC_PLL_DISABLE();
+
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till PLL is ready */
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }
+    else
+    {
+      return HAL_ERROR;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CPU, AHB and APB busses clocks according to the specified
+  *         parameters in the RCC_ClkInitStruct.
+  * @param  RCC_ClkInitStruct: pointer to an RCC_OscInitTypeDef structure that
+  *         contains the configuration information for the RCC peripheral.
+  * @param  FLatency: FLASH Latency, this parameter depend on device selected
+  *
+  * @note   The SystemCoreClock CMSIS variable is used to store System Clock Frequency
+  *         and updated by HAL_RCC_GetHCLKFreq() function called within this function
+  *
+  * @note   The HSI is used (enabled by hardware) as system clock source after
+  *         startup from Reset, wake-up from STOP and STANDBY mode, or in case
+  *         of failure of the HSE used directly or indirectly as system clock
+  *         (if the Clock Security System CSS is enabled).
+  *
+  * @note   A switch from one clock source to another occurs only if the target
+  *         clock source is ready (clock stable after startup delay or PLL locked).
+  *         If a clock source which is not yet ready is selected, the switch will
+  *         occur when the clock source will be ready.
+  *         You can use HAL_RCC_GetClockConfig() function to know which clock is
+  *         currently used as system clock source.
+  * @note   Depending on the device voltage range, the software has to set correctly
+  *         HPRE[3:0] bits to ensure that HCLK not exceed the maximum allowed frequency
+  *         (for more details refer to section above "Initialization/de-initialization functions")
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, uint32_t FLatency)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RCC_CLOCKTYPE(RCC_ClkInitStruct->ClockType));
+  assert_param(IS_FLASH_LATENCY(FLatency));
+
+  /* To correctly read data from FLASH memory, the number of wait states (LATENCY)
+     must be correctly programmed according to the frequency of the CPU clock
+     (HCLK) and the supply voltage of the device. */
+
+  /* Increasing the CPU frequency */
+  if(FLatency > (FLASH->ACR & FLASH_ACR_LATENCY))
+  {
+    /* Program the new number of wait states to the LATENCY bits in the FLASH_ACR register */
+    __HAL_FLASH_SET_LATENCY(FLatency);
+
+    /* Check that the new number of wait states is taken into account to access the Flash
+    memory by reading the FLASH_ACR register */
+    if((FLASH->ACR & FLASH_ACR_LATENCY) != FLatency)
+    {
+      return HAL_ERROR;
+    }
+
+    /*-------------------------- HCLK Configuration --------------------------*/
+    if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_HCLK) == RCC_CLOCKTYPE_HCLK)
+    {
+      assert_param(IS_RCC_HCLK(RCC_ClkInitStruct->AHBCLKDivider));
+      MODIFY_REG(RCC->CFGR, RCC_CFGR_HPRE, RCC_ClkInitStruct->AHBCLKDivider);
+    }
+
+    /*------------------------- SYSCLK Configuration ---------------------------*/
+    if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_SYSCLK) == RCC_CLOCKTYPE_SYSCLK)
+    {
+      assert_param(IS_RCC_SYSCLKSOURCE(RCC_ClkInitStruct->SYSCLKSource));
+
+      /* HSE is selected as System Clock Source */
+      if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_HSE)
+      {
+        /* Check the HSE ready flag */
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+      /* PLL is selected as System Clock Source */
+      else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_PLLCLK)
+      {
+        /* Check the PLL ready flag */
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+      /* HSI is selected as System Clock Source */
+      else
+      {
+        /* Check the HSI ready flag */
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+
+      __HAL_RCC_SYSCLK_CONFIG(RCC_ClkInitStruct->SYSCLKSource);
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_HSE)
+      {
+        while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_SYSCLKSOURCE_STATUS_HSE)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+      else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_PLLCLK)
+      {
+        while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_SYSCLKSOURCE_STATUS_PLLCLK)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+      else
+      {
+        while(__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_SYSCLKSOURCE_STATUS_HSI)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }
+  }
+  /* Decreasing the CPU frequency */
+  else
+  {
+    /*-------------------------- HCLK Configuration --------------------------*/
+    if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_HCLK) == RCC_CLOCKTYPE_HCLK)
+    {
+      assert_param(IS_RCC_HCLK(RCC_ClkInitStruct->AHBCLKDivider));
+      MODIFY_REG(RCC->CFGR, RCC_CFGR_HPRE, RCC_ClkInitStruct->AHBCLKDivider);
+    }
+
+    /*------------------------- SYSCLK Configuration -------------------------*/
+    if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_SYSCLK) == RCC_CLOCKTYPE_SYSCLK)
+    {
+      assert_param(IS_RCC_SYSCLKSOURCE(RCC_ClkInitStruct->SYSCLKSource));
+
+      /* HSE is selected as System Clock Source */
+      if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_HSE)
+      {
+        /* Check the HSE ready flag */
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+      /* PLL is selected as System Clock Source */
+      else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_PLLCLK)
+      {
+        /* Check the PLL ready flag */
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+      /* HSI is selected as System Clock Source */
+      else
+      {
+        /* Check the HSI ready flag */
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+      __HAL_RCC_SYSCLK_CONFIG(RCC_ClkInitStruct->SYSCLKSource);
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_HSE)
+      {
+        while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_SYSCLKSOURCE_STATUS_HSE)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+      else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_PLLCLK)
+      {
+        while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_SYSCLKSOURCE_STATUS_PLLCLK)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+      else
+      {
+        while(__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_SYSCLKSOURCE_STATUS_HSI)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }
+
+    /* Program the new number of wait states to the LATENCY bits in the FLASH_ACR register */
+    __HAL_FLASH_SET_LATENCY(FLatency);
+
+    /* Check that the new number of wait states is taken into account to access the Flash
+    memory by reading the FLASH_ACR register */
+    if((FLASH->ACR & FLASH_ACR_LATENCY) != FLatency)
+    {
+      return HAL_ERROR;
+    }
+ }
+
+  /*-------------------------- PCLK1 Configuration ---------------------------*/
+  if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_PCLK1) == RCC_CLOCKTYPE_PCLK1)
+  {
+    assert_param(IS_RCC_PCLK(RCC_ClkInitStruct->APB1CLKDivider));
+    MODIFY_REG(RCC->CFGR, RCC_CFGR_PPRE1, RCC_ClkInitStruct->APB1CLKDivider);
+  }
+
+  /*-------------------------- PCLK2 Configuration ---------------------------*/
+  if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_PCLK2) == RCC_CLOCKTYPE_PCLK2)
+  {
+    assert_param(IS_RCC_PCLK(RCC_ClkInitStruct->APB2CLKDivider));
+    MODIFY_REG(RCC->CFGR, RCC_CFGR_PPRE2, ((RCC_ClkInitStruct->APB2CLKDivider) << 3));
+  }
+
+  /* Configure the source of time base considering new system clocks settings*/
+  HAL_InitTick (TICK_INT_PRIORITY);
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Exported_Functions_Group2 Peripheral Control functions
+  *  @brief   RCC clocks control functions
+  *
+  @verbatim
+  ===============================================================================
+                  ##### Peripheral Control functions #####
+  ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the RCC Clocks
+    frequencies.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Selects the clock source to output on MCO1 pin(PA8) or on MCO2 pin(PC9).
+  * @note   PA8/PC9 should be configured in alternate function mode.
+  * @param  RCC_MCOx: specifies the output direction for the clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_MCO1: Clock source to output on MCO1 pin(PA8).
+  *            @arg RCC_MCO2: Clock source to output on MCO2 pin(PC9).
+  * @param  RCC_MCOSource: specifies the clock source to output.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_MCO1SOURCE_HSI: HSI clock selected as MCO1 source
+  *            @arg RCC_MCO1SOURCE_LSE: LSE clock selected as MCO1 source
+  *            @arg RCC_MCO1SOURCE_HSE: HSE clock selected as MCO1 source
+  *            @arg RCC_MCO1SOURCE_PLLCLK: main PLL clock selected as MCO1 source
+  *            @arg RCC_MCO2SOURCE_SYSCLK: System clock (SYSCLK) selected as MCO2 source
+  *            @arg RCC_MCO2SOURCE_PLLI2SCLK: PLLI2S clock selected as MCO2 source
+  *            @arg RCC_MCO2SOURCE_HSE: HSE clock selected as MCO2 source
+  *            @arg RCC_MCO2SOURCE_PLLCLK: main PLL clock selected as MCO2 source
+  * @param  RCC_MCODiv: specifies the MCOx prescaler.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_MCODIV_1: no division applied to MCOx clock
+  *            @arg RCC_MCODIV_2: division by 2 applied to MCOx clock
+  *            @arg RCC_MCODIV_3: division by 3 applied to MCOx clock
+  *            @arg RCC_MCODIV_4: division by 4 applied to MCOx clock
+  *            @arg RCC_MCODIV_5: division by 5 applied to MCOx clock
+  * @retval None
+  */
+void HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_MCODiv)
+{
+  GPIO_InitTypeDef GPIO_InitStruct;
+  /* Check the parameters */
+  assert_param(IS_RCC_MCO(RCC_MCOx));
+  assert_param(IS_RCC_MCODIV(RCC_MCODiv));
+  /* RCC_MCO1 */
+  if(RCC_MCOx == RCC_MCO1)
+  {
+    assert_param(IS_RCC_MCO1SOURCE(RCC_MCOSource));
+
+    /* MCO1 Clock Enable */
+    MCO1_CLK_ENABLE();
+
+    /* Configure the MCO1 pin in alternate function mode */
+    GPIO_InitStruct.Pin = MCO1_PIN;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Alternate = GPIO_AF0_MCO;
+    HAL_GPIO_Init(MCO1_GPIO_PORT, &GPIO_InitStruct);
+
+    /* Mask MCO1 and MCO1PRE[2:0] bits then Select MCO1 clock source and prescaler */
+    MODIFY_REG(RCC->CFGR, (RCC_CFGR_MCO1 | RCC_CFGR_MCO1PRE), (RCC_MCOSource | RCC_MCODiv));
+  }
+  else
+  {
+    assert_param(IS_RCC_MCO2SOURCE(RCC_MCOSource));
+
+    /* MCO2 Clock Enable */
+    MCO2_CLK_ENABLE();
+
+    /* Configure the MCO2 pin in alternate function mode */
+    GPIO_InitStruct.Pin = MCO2_PIN;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Alternate = GPIO_AF0_MCO;
+    HAL_GPIO_Init(MCO2_GPIO_PORT, &GPIO_InitStruct);
+
+    /* Mask MCO2 and MCO2PRE[2:0] bits then Select MCO2 clock source and prescaler */
+    MODIFY_REG(RCC->CFGR, (RCC_CFGR_MCO2 | RCC_CFGR_MCO2PRE), (RCC_MCOSource | (RCC_MCODiv << 3)));
+  }
+}
+
+/**
+  * @brief  Enables the Clock Security System.
+  * @note   If a failure is detected on the HSE oscillator clock, this oscillator
+  *         is automatically disabled and an interrupt is generated to inform the
+  *         software about the failure (Clock Security System Interrupt, CSSI),
+  *         allowing the MCU to perform rescue operations. The CSSI is linked to
+  *         the Cortex-M7 NMI (Non-Maskable Interrupt) exception vector.
+  * @retval None
+  */
+void HAL_RCC_EnableCSS(void)
+{
+  SET_BIT(RCC->CR, RCC_CR_CSSON);
+}
+
+/**
+  * @brief  Disables the Clock Security System.
+  * @retval None
+  */
+void HAL_RCC_DisableCSS(void)
+{
+  CLEAR_BIT(RCC->CR, RCC_CR_CSSON);
+}
+
+/**
+  * @brief  Returns the SYSCLK frequency
+  *
+  * @note   The system frequency computed by this function is not the real
+  *         frequency in the chip. It is calculated based on the predefined
+  *         constant and the selected clock source:
+  * @note     If SYSCLK source is HSI, function returns values based on HSI_VALUE(*)
+  * @note     If SYSCLK source is HSE, function returns values based on HSE_VALUE(**)
+  * @note     If SYSCLK source is PLL, function returns values based on HSE_VALUE(**)
+  *           or HSI_VALUE(*) multiplied/divided by the PLL factors.
+  * @note     (*) HSI_VALUE is a constant defined in stm32f7xx_hal_conf.h file (default value
+  *               16 MHz) but the real value may vary depending on the variations
+  *               in voltage and temperature.
+  * @note     (**) HSE_VALUE is a constant defined in stm32f7xx_hal_conf.h file (default value
+  *                25 MHz), user has to ensure that HSE_VALUE is same as the real
+  *                frequency of the crystal used. Otherwise, this function may
+  *                have wrong result.
+  *
+  * @note   The result of this function could be not correct when using fractional
+  *         value for HSE crystal.
+  *
+  * @note   This function can be used by the user application to compute the
+  *         baudrate for the communication peripherals or configure other parameters.
+  *
+  * @note   Each time SYSCLK changes, this function must be called to update the
+  *         right SYSCLK value. Otherwise, any configuration based on this function will be incorrect.
+  *
+  *
+  * @retval SYSCLK frequency
+  */
+uint32_t HAL_RCC_GetSysClockFreq(void)
+{
+  uint32_t pllm = 0, pllvco = 0, pllp = 0;
+  uint32_t sysclockfreq = 0;
+
+  /* Get SYSCLK source -------------------------------------------------------*/
+  switch (RCC->CFGR & RCC_CFGR_SWS)
+  {
+    case RCC_SYSCLKSOURCE_STATUS_HSI:  /* HSI used as system clock source */
+    {
+      sysclockfreq = HSI_VALUE;
+       break;
+    }
+    case RCC_SYSCLKSOURCE_STATUS_HSE:  /* HSE used as system clock  source */
+    {
+      sysclockfreq = HSE_VALUE;
+      break;
+    }
+    case RCC_SYSCLKSOURCE_STATUS_PLLCLK:  /* PLL used as system clock  source */
+    {
+      /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM) * PLLN
+      SYSCLK = PLL_VCO / PLLP */
+      pllm = RCC->PLLCFGR & RCC_PLLCFGR_PLLM;
+      if (__HAL_RCC_GET_PLL_OSCSOURCE() != RCC_PLLCFGR_PLLSRC_HSI)
+      {
+        /* HSE used as PLL clock source */
+        pllvco = ((HSE_VALUE / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> POSITION_VAL(RCC_PLLCFGR_PLLN)));
+      }
+      else
+      {
+        /* HSI used as PLL clock source */
+        pllvco = ((HSI_VALUE / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> POSITION_VAL(RCC_PLLCFGR_PLLN)));
+      }
+      pllp = ((((RCC->PLLCFGR & RCC_PLLCFGR_PLLP) >> POSITION_VAL(RCC_PLLCFGR_PLLP)) + 1 ) *2);
+
+      sysclockfreq = pllvco/pllp;
+      break;
+    }
+    default:
+    {
+      sysclockfreq = HSI_VALUE;
+      break;
+    }
+  }
+  return sysclockfreq;
+}
+
+/**
+  * @brief  Returns the HCLK frequency
+  * @note   Each time HCLK changes, this function must be called to update the
+  *         right HCLK value. Otherwise, any configuration based on this function will be incorrect.
+  *
+  * @note   The SystemCoreClock CMSIS variable is used to store System Clock Frequency
+  *         and updated within this function
+  * @retval HCLK frequency
+  */
+uint32_t HAL_RCC_GetHCLKFreq(void)
+{
+  SystemCoreClock = HAL_RCC_GetSysClockFreq() >> APBAHBPrescTable[(RCC->CFGR & RCC_CFGR_HPRE)>> POSITION_VAL(RCC_CFGR_HPRE)];
+  return SystemCoreClock;
+}
+
+/**
+  * @brief  Returns the PCLK1 frequency
+  * @note   Each time PCLK1 changes, this function must be called to update the
+  *         right PCLK1 value. Otherwise, any configuration based on this function will be incorrect.
+  * @retval PCLK1 frequency
+  */
+uint32_t HAL_RCC_GetPCLK1Freq(void)
+{
+  /* Get HCLK source and Compute PCLK1 frequency ---------------------------*/
+  return (HAL_RCC_GetHCLKFreq() >> APBAHBPrescTable[(RCC->CFGR & RCC_CFGR_PPRE1)>> POSITION_VAL(RCC_CFGR_PPRE1)]);
+}
+
+/**
+  * @brief  Returns the PCLK2 frequency
+  * @note   Each time PCLK2 changes, this function must be called to update the
+  *         right PCLK2 value. Otherwise, any configuration based on this function will be incorrect.
+  * @retval PCLK2 frequency
+  */
+uint32_t HAL_RCC_GetPCLK2Freq(void)
+{
+  /* Get HCLK source and Compute PCLK2 frequency ---------------------------*/
+  return (HAL_RCC_GetHCLKFreq()>> APBAHBPrescTable[(RCC->CFGR & RCC_CFGR_PPRE2)>> POSITION_VAL(RCC_CFGR_PPRE2)]);
+}
+
+/**
+  * @brief  Configures the RCC_OscInitStruct according to the internal
+  * RCC configuration registers.
+  * @param  RCC_OscInitStruct: pointer to an RCC_OscInitTypeDef structure that
+  * will be configured.
+  * @retval None
+  */
+void HAL_RCC_GetOscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
+{
+  /* Set all possible values for the Oscillator type parameter ---------------*/
+  RCC_OscInitStruct->OscillatorType = RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_LSI;
+
+  /* Get the HSE configuration -----------------------------------------------*/
+  if((RCC->CR &RCC_CR_HSEBYP) == RCC_CR_HSEBYP)
+  {
+    RCC_OscInitStruct->HSEState = RCC_HSE_BYPASS;
+  }
+  else if((RCC->CR &RCC_CR_HSEON) == RCC_CR_HSEON)
+  {
+    RCC_OscInitStruct->HSEState = RCC_HSE_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->HSEState = RCC_HSE_OFF;
+  }
+
+  /* Get the HSI configuration -----------------------------------------------*/
+  if((RCC->CR &RCC_CR_HSION) == RCC_CR_HSION)
+  {
+    RCC_OscInitStruct->HSIState = RCC_HSI_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->HSIState = RCC_HSI_OFF;
+  }
+
+  RCC_OscInitStruct->HSICalibrationValue = (uint32_t)((RCC->CR &RCC_CR_HSITRIM) >> POSITION_VAL(RCC_CR_HSITRIM));
+
+  /* Get the LSE configuration -----------------------------------------------*/
+  if((RCC->BDCR &RCC_BDCR_LSEBYP) == RCC_BDCR_LSEBYP)
+  {
+    RCC_OscInitStruct->LSEState = RCC_LSE_BYPASS;
+  }
+  else if((RCC->BDCR &RCC_BDCR_LSEON) == RCC_BDCR_LSEON)
+  {
+    RCC_OscInitStruct->LSEState = RCC_LSE_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->LSEState = RCC_LSE_OFF;
+  }
+
+  /* Get the LSI configuration -----------------------------------------------*/
+  if((RCC->CSR &RCC_CSR_LSION) == RCC_CSR_LSION)
+  {
+    RCC_OscInitStruct->LSIState = RCC_LSI_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->LSIState = RCC_LSI_OFF;
+  }
+
+  /* Get the PLL configuration -----------------------------------------------*/
+  if((RCC->CR &RCC_CR_PLLON) == RCC_CR_PLLON)
+  {
+    RCC_OscInitStruct->PLL.PLLState = RCC_PLL_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->PLL.PLLState = RCC_PLL_OFF;
+  }
+  RCC_OscInitStruct->PLL.PLLSource = (uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC);
+  RCC_OscInitStruct->PLL.PLLM = (uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLM);
+  RCC_OscInitStruct->PLL.PLLN = (uint32_t)((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> POSITION_VAL(RCC_PLLCFGR_PLLN));
+  RCC_OscInitStruct->PLL.PLLP = (uint32_t)((((RCC->PLLCFGR & RCC_PLLCFGR_PLLP) + RCC_PLLCFGR_PLLP_0) << 1) >> POSITION_VAL(RCC_PLLCFGR_PLLP));
+  RCC_OscInitStruct->PLL.PLLQ = (uint32_t)((RCC->PLLCFGR & RCC_PLLCFGR_PLLQ) >> POSITION_VAL(RCC_PLLCFGR_PLLQ));
+}
+
+/**
+  * @brief  Configures the RCC_ClkInitStruct according to the internal
+  * RCC configuration registers.
+  * @param  RCC_ClkInitStruct: pointer to an RCC_ClkInitTypeDef structure that
+  * will be configured.
+  * @param  pFLatency: Pointer on the Flash Latency.
+  * @retval None
+  */
+void HAL_RCC_GetClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, uint32_t *pFLatency)
+{
+  /* Set all possible values for the Clock type parameter --------------------*/
+  RCC_ClkInitStruct->ClockType = RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+
+  /* Get the SYSCLK configuration --------------------------------------------*/
+  RCC_ClkInitStruct->SYSCLKSource = (uint32_t)(RCC->CFGR & RCC_CFGR_SW);
+
+  /* Get the HCLK configuration ----------------------------------------------*/
+  RCC_ClkInitStruct->AHBCLKDivider = (uint32_t)(RCC->CFGR & RCC_CFGR_HPRE);
+
+  /* Get the APB1 configuration ----------------------------------------------*/
+  RCC_ClkInitStruct->APB1CLKDivider = (uint32_t)(RCC->CFGR & RCC_CFGR_PPRE1);
+
+  /* Get the APB2 configuration ----------------------------------------------*/
+  RCC_ClkInitStruct->APB2CLKDivider = (uint32_t)((RCC->CFGR & RCC_CFGR_PPRE2) >> 3);
+
+  /* Get the Flash Wait State (Latency) configuration ------------------------*/
+  *pFLatency = (uint32_t)(FLASH->ACR & FLASH_ACR_LATENCY);
+}
+
+/**
+  * @brief This function handles the RCC CSS interrupt request.
+  * @note This API should be called under the NMI_Handler().
+  * @retval None
+  */
+void HAL_RCC_NMI_IRQHandler(void)
+{
+  /* Check RCC CSSF flag  */
+  if(__HAL_RCC_GET_IT(RCC_IT_CSS))
+  {
+    /* RCC Clock Security System interrupt user callback */
+    HAL_RCC_CSSCallback();
+
+    /* Clear RCC CSS pending bit */
+    __HAL_RCC_CLEAR_IT(RCC_IT_CSS);
+  }
+}
+
+/**
+  * @brief  RCC Clock Security System interrupt callback
+  * @retval None
+  */
+__weak void HAL_RCC_CSSCallback(void)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RCC_CSSCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RCC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_rcc_ex.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_rcc_ex.c
@@ -1,0 +1,861 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rcc_ex.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   Extension RCC HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities RCC extension peripheral:
+  *           + Extended Peripheral Control functions
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RCCEx RCCEx
+  * @brief RCCEx HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @defgroup RCCEx_Private_Defines RCCEx Private Defines
+  * @{
+  */
+
+#define PLLI2S_TIMEOUT_VALUE    100 /* Timeout value fixed to 100 ms  */
+#define PLLSAI_TIMEOUT_VALUE    100 /* Timeout value fixed to 100 ms  */
+
+/**
+  * @}
+  */
+/* Private macro -------------------------------------------------------------*/
+/** @defgroup RCCEx_Private_Macros RCCEx Private Macros
+ * @{
+ */
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_Private_Macros RCCEx Private Macros
+ * @{
+ */
+
+/**
+  * @}
+  */
+
+
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup RCCEx_Exported_Functions RCCEx Exported Functions
+  * @{
+  */
+
+/** @defgroup RCCEx_Exported_Functions_Group1 Extended Peripheral Control functions
+ *  @brief  Extended Peripheral Control functions
+ *
+@verbatim
+ ===============================================================================
+                ##### Extended Peripheral Control functions  #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the RCC Clocks
+    frequencies.
+    [..]
+    (@) Important note: Care must be taken when HAL_RCCEx_PeriphCLKConfig() is used to
+        select the RTC clock source; in this case the Backup domain will be reset in
+        order to modify the RTC Clock source, as consequence RTC registers (including
+        the backup registers) and RCC_BDCR register will be set to their reset values.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the RCC extended peripherals clocks according to the specified
+  *         parameters in the RCC_PeriphCLKInitTypeDef.
+  * @param  PeriphClkInit: pointer to an RCC_PeriphCLKInitTypeDef structure that
+  *         contains the configuration information for the Extended Peripherals
+  *         clocks(I2S, SAI, LTDC RTC, TIM, UARTs, USARTs, LTPIM, SDMMC...).
+  *
+  * @note   Care must be taken when HAL_RCCEx_PeriphCLKConfig() is used to select
+  *         the RTC clock source; in this case the Backup domain will be reset in
+  *         order to modify the RTC Clock source, as consequence RTC registers (including
+  *         the backup registers) and RCC_BDCR register are set to their reset values.
+  *
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
+{
+  uint32_t tickstart = 0;
+  uint32_t tmpreg0 = 0;
+  uint32_t tmpreg1 = 0;
+  uint32_t plli2sused = 0;
+  uint32_t pllsaiused = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RCC_PERIPHCLOCK(PeriphClkInit->PeriphClockSelection));
+
+  /*----------------------------------- I2S configuration ----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2S) == (RCC_PERIPHCLK_I2S))
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_I2SCLKSOURCE(PeriphClkInit->I2sClockSelection));
+
+    /* Configure I2S Clock source */
+    __HAL_RCC_I2S_CONFIG(PeriphClkInit->I2sClockSelection);
+
+    /* Enable the PLLI2S when it's used as clock source for I2S */
+    if(PeriphClkInit->I2sClockSelection == RCC_I2SCLKSOURCE_PLLI2S)
+    {
+      plli2sused = 1;
+    }
+  }
+
+  /*------------------------------------ SAI1 configuration --------------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SAI1) == (RCC_PERIPHCLK_SAI1))
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_SAI1CLKSOURCE(PeriphClkInit->Sai1ClockSelection));
+
+    /* Configure SAI1 Clock source */
+    __HAL_RCC_SAI1_CONFIG(PeriphClkInit->Sai1ClockSelection);
+    /* Enable the PLLI2S when it's used as clock source for SAI */
+    if(PeriphClkInit->Sai1ClockSelection == RCC_SAI1CLKSOURCE_PLLI2S)
+    {
+      plli2sused = 1;
+    }
+    /* Enable the PLLSAI when it's used as clock source for SAI */
+    if(PeriphClkInit->Sai1ClockSelection == RCC_SAI1CLKSOURCE_PLLSAI)
+    {
+      pllsaiused = 1;
+    }
+  }
+
+  /*------------------------------------ SAI2 configuration --------------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SAI2) == (RCC_PERIPHCLK_SAI2))
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_SAI2CLKSOURCE(PeriphClkInit->Sai2ClockSelection));
+
+    /* Configure SAI2 Clock source */
+    __HAL_RCC_SAI2_CONFIG(PeriphClkInit->Sai2ClockSelection);
+
+    /* Enable the PLLI2S when it's used as clock source for SAI */
+    if(PeriphClkInit->Sai2ClockSelection == RCC_SAI2CLKSOURCE_PLLI2S)
+    {
+      plli2sused = 1;
+    }
+    /* Enable the PLLSAI when it's used as clock source for SAI */
+    if(PeriphClkInit->Sai2ClockSelection == RCC_SAI2CLKSOURCE_PLLSAI)
+    {
+      pllsaiused = 1;
+    }
+  }
+
+  /*-------------------------------------- SPDIF-RX Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SPDIFRX) == RCC_PERIPHCLK_SPDIFRX)
+  {
+      plli2sused = 1;
+  }
+
+  /*------------------------------------ RTC configuration --------------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_RTC) == (RCC_PERIPHCLK_RTC))
+  {
+    /* Reset the Backup domain only if the RTC Clock source selection is modified */
+    if((RCC->BDCR & RCC_BDCR_RTCSEL) != (PeriphClkInit->RTCClockSelection & RCC_BDCR_RTCSEL))
+    {
+      /* Enable Power Clock*/
+      __HAL_RCC_PWR_CLK_ENABLE();
+
+      /* Enable write access to Backup domain */
+      PWR->CR1 |= PWR_CR1_DBP;
+
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait for Backup domain Write protection disable */
+      while((PWR->CR1 & PWR_CR1_DBP) == RESET)
+      {
+        if((HAL_GetTick() - tickstart) > RCC_DBP_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+
+      /* Store the content of BDCR register before the reset of Backup Domain */
+      tmpreg0 = (RCC->BDCR & ~(RCC_BDCR_RTCSEL));
+
+      /* RTC Clock selection can be changed only if the Backup Domain is reset */
+      __HAL_RCC_BACKUPRESET_FORCE();
+      __HAL_RCC_BACKUPRESET_RELEASE();
+
+      /* Restore the Content of BDCR register */
+      RCC->BDCR = tmpreg0;
+
+      /* If LSE is selected as RTC clock source, wait for LSE reactivation */
+      if (HAL_IS_BIT_SET(tmpreg0, RCC_BDCR_LSERDY))
+      {
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till LSE is ready */
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > RCC_LSE_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+      __HAL_RCC_RTC_CONFIG(PeriphClkInit->RTCClockSelection);
+    }
+  }
+
+  /*------------------------------------ TIM configuration --------------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_TIM) == (RCC_PERIPHCLK_TIM))
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_TIMPRES(PeriphClkInit->TIMPresSelection));
+
+    /* Configure Timer Prescaler */
+    __HAL_RCC_TIMCLKPRESCALER(PeriphClkInit->TIMPresSelection);
+  }
+
+  /*-------------------------------------- I2C1 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2C1) == RCC_PERIPHCLK_I2C1)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_I2C1CLKSOURCE(PeriphClkInit->I2c1ClockSelection));
+
+    /* Configure the I2C1 clock source */
+    __HAL_RCC_I2C1_CONFIG(PeriphClkInit->I2c1ClockSelection);
+  }
+
+  /*-------------------------------------- I2C2 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2C2) == RCC_PERIPHCLK_I2C2)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_I2C2CLKSOURCE(PeriphClkInit->I2c2ClockSelection));
+
+    /* Configure the I2C2 clock source */
+    __HAL_RCC_I2C2_CONFIG(PeriphClkInit->I2c2ClockSelection);
+  }
+
+  /*-------------------------------------- I2C3 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2C3) == RCC_PERIPHCLK_I2C3)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_I2C3CLKSOURCE(PeriphClkInit->I2c3ClockSelection));
+
+    /* Configure the I2C3 clock source */
+    __HAL_RCC_I2C3_CONFIG(PeriphClkInit->I2c3ClockSelection);
+  }
+
+  /*-------------------------------------- I2C4 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2C4) == RCC_PERIPHCLK_I2C4)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_I2C4CLKSOURCE(PeriphClkInit->I2c4ClockSelection));
+
+    /* Configure the I2C4 clock source */
+    __HAL_RCC_I2C4_CONFIG(PeriphClkInit->I2c4ClockSelection);
+  }
+
+  /*-------------------------------------- USART1 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USART1) == RCC_PERIPHCLK_USART1)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_USART1CLKSOURCE(PeriphClkInit->Usart1ClockSelection));
+
+    /* Configure the USART1 clock source */
+    __HAL_RCC_USART1_CONFIG(PeriphClkInit->Usart1ClockSelection);
+  }
+
+  /*-------------------------------------- USART2 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USART2) == RCC_PERIPHCLK_USART2)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_USART2CLKSOURCE(PeriphClkInit->Usart2ClockSelection));
+
+    /* Configure the USART2 clock source */
+    __HAL_RCC_USART2_CONFIG(PeriphClkInit->Usart2ClockSelection);
+  }
+
+  /*-------------------------------------- USART3 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USART3) == RCC_PERIPHCLK_USART3)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_USART3CLKSOURCE(PeriphClkInit->Usart3ClockSelection));
+
+    /* Configure the USART3 clock source */
+    __HAL_RCC_USART3_CONFIG(PeriphClkInit->Usart3ClockSelection);
+  }
+
+  /*-------------------------------------- UART4 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_UART4) == RCC_PERIPHCLK_UART4)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_UART4CLKSOURCE(PeriphClkInit->Uart4ClockSelection));
+
+    /* Configure the UART4 clock source */
+    __HAL_RCC_UART4_CONFIG(PeriphClkInit->Uart4ClockSelection);
+  }
+
+  /*-------------------------------------- UART5 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_UART5) == RCC_PERIPHCLK_UART5)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_UART5CLKSOURCE(PeriphClkInit->Uart5ClockSelection));
+
+    /* Configure the UART5 clock source */
+    __HAL_RCC_UART5_CONFIG(PeriphClkInit->Uart5ClockSelection);
+  }
+
+  /*-------------------------------------- USART6 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USART6) == RCC_PERIPHCLK_USART6)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_USART6CLKSOURCE(PeriphClkInit->Usart6ClockSelection));
+
+    /* Configure the USART6 clock source */
+    __HAL_RCC_USART6_CONFIG(PeriphClkInit->Usart6ClockSelection);
+  }
+
+  /*-------------------------------------- UART7 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_UART7) == RCC_PERIPHCLK_UART7)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_UART7CLKSOURCE(PeriphClkInit->Uart7ClockSelection));
+
+    /* Configure the UART7 clock source */
+    __HAL_RCC_UART7_CONFIG(PeriphClkInit->Uart7ClockSelection);
+  }
+
+  /*-------------------------------------- UART8 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_UART8) == RCC_PERIPHCLK_UART8)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_UART8CLKSOURCE(PeriphClkInit->Uart8ClockSelection));
+
+    /* Configure the UART8 clock source */
+    __HAL_RCC_UART8_CONFIG(PeriphClkInit->Uart8ClockSelection);
+  }
+
+  /*--------------------------------------- CEC Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_CEC) == RCC_PERIPHCLK_CEC)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_CECCLKSOURCE(PeriphClkInit->CecClockSelection));
+
+    /* Configure the CEC clock source */
+    __HAL_RCC_CEC_CONFIG(PeriphClkInit->CecClockSelection);
+  }
+
+  /*-------------------------------------- CK48 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_CLK48) == RCC_PERIPHCLK_CLK48)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_CLK48SOURCE(PeriphClkInit->Clk48ClockSelection));
+
+    /* Configure the CLK48 source */
+    __HAL_RCC_CLK48_CONFIG(PeriphClkInit->Clk48ClockSelection);
+
+    /* Enable the PLLSAI when it's used as clock source for CK48 */
+    if(PeriphClkInit->Clk48ClockSelection == RCC_CLK48SOURCE_PLLSAIP)
+    {
+      pllsaiused = 1;
+    }
+  }
+
+  /*-------------------------------------- LTDC Configuration -----------------------------------*/
+#if defined(STM32F756xx) || defined(STM32F746xx)
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LTDC) == RCC_PERIPHCLK_LTDC)
+  {
+    pllsaiused = 1;
+  }
+#endif /* STM32F756xx || STM32F746xx */
+  /*-------------------------------------- LPTIM1 Configuration -----------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LPTIM1) == RCC_PERIPHCLK_LPTIM1)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_LPTIM1CLK(PeriphClkInit->Lptim1ClockSelection));
+
+    /* Configure the LTPIM1 clock source */
+    __HAL_RCC_LPTIM1_CONFIG(PeriphClkInit->Lptim1ClockSelection);
+   }
+
+  /*------------------------------------- SDMMC Configuration ------------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SDMMC1) == RCC_PERIPHCLK_SDMMC1)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_SDMMC1CLKSOURCE(PeriphClkInit->Sdmmc1ClockSelection));
+
+    /* Configure the SDMMC1 clock source */
+    __HAL_RCC_SDMMC1_CONFIG(PeriphClkInit->Sdmmc1ClockSelection);
+  }
+
+  /*-------------------------------------- PLLI2S Configuration ---------------------------------*/
+  /* PLLI2S is configured when a peripheral will use it as source clock : SAI1, SAI2, I2S or SPDIF-RX */
+  if((plli2sused == 1) || (PeriphClkInit->PeriphClockSelection == RCC_PERIPHCLK_PLLI2S))
+  {
+    /* Disable the PLLI2S */
+    __HAL_RCC_PLLI2S_DISABLE();
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    /* Wait till PLLI2S is disabled */
+    while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLI2SRDY)  != RESET)
+    {
+      if((HAL_GetTick() - tickstart) > PLLI2S_TIMEOUT_VALUE)
+      {
+        /* return in case of Timeout detected */
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* check for common PLLI2S Parameters */
+    assert_param(IS_RCC_PLLI2SN_VALUE(PeriphClkInit->PLLI2S.PLLI2SN));
+
+    /*----------------- In Case of PLLI2S is selected as source clock for I2S -------------------*/
+    if(((((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2S) == RCC_PERIPHCLK_I2S) && (PeriphClkInit->I2sClockSelection == RCC_I2SCLKSOURCE_PLLI2S)))
+    {
+      /* check for Parameters */
+      assert_param(IS_RCC_PLLI2SR_VALUE(PeriphClkInit->PLLI2S.PLLI2SR));
+
+      /* Read PLLI2SP and PLLI2SQ value from PLLI2SCFGR register (this value is not needed for I2S configuration) */
+      tmpreg0 = ((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SP) >> POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SP));
+      tmpreg1 = ((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SQ) >> POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SQ));
+      /* Configure the PLLI2S division factors */
+      /* PLLI2S_VCO = f(VCO clock) = f(PLLI2S clock input) x (PLLI2SN/PLLM) */
+      /* I2SCLK = f(PLLI2S clock output) = f(VCO clock) / PLLI2SR */
+      __HAL_RCC_PLLI2S_CONFIG(PeriphClkInit->PLLI2S.PLLI2SN , tmpreg0, tmpreg1, PeriphClkInit->PLLI2S.PLLI2SR);
+    }
+
+    /*----------------- In Case of PLLI2S is selected as source clock for SAI -------------------*/
+    if(((((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SAI1) == RCC_PERIPHCLK_SAI1) && (PeriphClkInit->Sai1ClockSelection == RCC_SAI1CLKSOURCE_PLLI2S)) ||
+       ((((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SAI2) == RCC_PERIPHCLK_SAI2) && (PeriphClkInit->Sai2ClockSelection == RCC_SAI2CLKSOURCE_PLLI2S)))
+    {
+      /* Check for PLLI2S Parameters */
+      assert_param(IS_RCC_PLLI2SQ_VALUE(PeriphClkInit->PLLI2S.PLLI2SQ));
+      /* Check for PLLI2S/DIVQ parameters */
+      assert_param(IS_RCC_PLLI2S_DIVQ_VALUE(PeriphClkInit->PLLI2SDivQ));
+
+      /* Read PLLI2SP and PLLI2SR values from PLLI2SCFGR register (this value is not needed for SAI configuration) */
+      tmpreg0 = ((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SP) >> POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SP));
+      tmpreg1 = ((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SR) >> POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SR));
+      /* Configure the PLLI2S division factors */
+      /* PLLI2S_VCO Input  = PLL_SOURCE/PLLM */
+      /* PLLI2S_VCO Output = PLLI2S_VCO Input * PLLI2SN */
+      /* SAI_CLK(first level) = PLLI2S_VCO Output/PLLI2SQ */
+      __HAL_RCC_PLLI2S_CONFIG(PeriphClkInit->PLLI2S.PLLI2SN, tmpreg0, PeriphClkInit->PLLI2S.PLLI2SQ, tmpreg1);
+
+      /* SAI_CLK_x = SAI_CLK(first level)/PLLI2SDIVQ */
+      __HAL_RCC_PLLI2S_PLLSAICLKDIVQ_CONFIG(PeriphClkInit->PLLI2SDivQ);
+    }
+
+    /*----------------- In Case of PLLI2S is selected as source clock for SPDIF-RX -------------------*/
+    if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SPDIFRX) == RCC_PERIPHCLK_SPDIFRX)
+    {
+      /* check for Parameters */
+      assert_param(IS_RCC_PLLI2SP_VALUE(PeriphClkInit->PLLI2S.PLLI2SP));
+
+     /* Read PLLI2SR value from PLLI2SCFGR register (this value is not needed for SPDIF-RX configuration) */
+      tmpreg0 = ((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SQ) >> POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SQ));
+      tmpreg1 = ((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SR) >> POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SR));
+      /* Configure the PLLI2S division factors */
+      /* PLLI2S_VCO = f(VCO clock) = f(PLLI2S clock input) x (PLLI2SN/PLLM) */
+      /* SPDIFCLK = f(PLLI2S clock output) = f(VCO clock) / PLLI2SP */
+      __HAL_RCC_PLLI2S_CONFIG(PeriphClkInit->PLLI2S.PLLI2SN , PeriphClkInit->PLLI2S.PLLI2SP, tmpreg0, tmpreg1);
+    }
+
+    /*----------------- In Case of PLLI2S is just selected  -----------------*/
+    if((PeriphClkInit->PeriphClockSelection & RCC_PERIPHCLK_PLLI2S) == RCC_PERIPHCLK_PLLI2S)
+    {
+      /* Check for Parameters */
+      assert_param(IS_RCC_PLLI2SN_VALUE(PeriphClkInit->PLLI2S.PLLI2SN));
+      assert_param(IS_RCC_PLLI2SP_VALUE(PeriphClkInit->PLLI2S.PLLI2SP));
+      assert_param(IS_RCC_PLLI2SR_VALUE(PeriphClkInit->PLLI2S.PLLI2SR));
+      assert_param(IS_RCC_PLLI2SQ_VALUE(PeriphClkInit->PLLI2S.PLLI2SQ));
+
+      /* Configure the PLLI2S division factors */
+      /* PLLI2S_VCO = f(VCO clock) = f(PLLI2S clock input) x (PLLI2SN/PLLI2SM) */
+      /* SPDIFRXCLK = f(PLLI2S clock output) = f(VCO clock) / PLLI2SP */
+      __HAL_RCC_PLLI2S_CONFIG(PeriphClkInit->PLLI2S.PLLI2SN , PeriphClkInit->PLLI2S.PLLI2SP, PeriphClkInit->PLLI2S.PLLI2SQ, PeriphClkInit->PLLI2S.PLLI2SR);
+    }
+
+    /* Enable the PLLI2S */
+    __HAL_RCC_PLLI2S_ENABLE();
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    /* Wait till PLLI2S is ready */
+    while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLI2SRDY)  == RESET)
+    {
+      if((HAL_GetTick() - tickstart) > PLLI2S_TIMEOUT_VALUE)
+      {
+        /* return in case of Timeout detected */
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /*-------------------------------------- PLLSAI Configuration ---------------------------------*/
+  /* PLLSAI is configured when a peripheral will use it as source clock : SAI1, SAI2, LTDC or CK48 */
+  if(pllsaiused == 1)
+  {
+    /* Disable PLLSAI Clock */
+    __HAL_RCC_PLLSAI_DISABLE();
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    /* Wait till PLLSAI is disabled */
+    while(__HAL_RCC_PLLSAI_GET_FLAG() != RESET)
+    {
+      if((HAL_GetTick() - tickstart) > PLLSAI_TIMEOUT_VALUE)
+      {
+        /* return in case of Timeout detected */
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Check the PLLSAI division factors */
+    assert_param(IS_RCC_PLLSAIN_VALUE(PeriphClkInit->PLLSAI.PLLSAIN));
+
+    /*----------------- In Case of PLLSAI is selected as source clock for SAI -------------------*/
+    if(((((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SAI1) == RCC_PERIPHCLK_SAI1) && (PeriphClkInit->Sai1ClockSelection == RCC_SAI1CLKSOURCE_PLLSAI)) ||
+       ((((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SAI2) == RCC_PERIPHCLK_SAI2) && (PeriphClkInit->Sai2ClockSelection == RCC_SAI2CLKSOURCE_PLLSAI)))
+    {
+      /* check for PLLSAIQ Parameter */
+      assert_param(IS_RCC_PLLSAIQ_VALUE(PeriphClkInit->PLLSAI.PLLSAIQ));
+      /* check for PLLSAI/DIVQ Parameter */
+      assert_param(IS_RCC_PLLSAI_DIVQ_VALUE(PeriphClkInit->PLLSAIDivQ));
+
+      /* Read PLLSAIP value from PLLSAICFGR register (this value is not needed for SAI configuration) */
+      tmpreg0 = ((RCC->PLLSAICFGR & RCC_PLLSAICFGR_PLLSAIP) >> POSITION_VAL(RCC_PLLSAICFGR_PLLSAIP));
+      tmpreg1 = ((RCC->PLLSAICFGR & RCC_PLLI2SCFGR_PLLI2SR) >> POSITION_VAL(RCC_PLLSAICFGR_PLLSAIR));
+      /* PLLSAI_VCO Input  = PLL_SOURCE/PLLM */
+      /* PLLSAI_VCO Output = PLLSAI_VCO Input * PLLSAIN */
+      /* SAI_CLK(first level) = PLLSAI_VCO Output/PLLSAIQ */
+      __HAL_RCC_PLLSAI_CONFIG(PeriphClkInit->PLLSAI.PLLSAIN , tmpreg0, PeriphClkInit->PLLSAI.PLLSAIQ, tmpreg1);
+
+      /* SAI_CLK_x = SAI_CLK(first level)/PLLSAIDIVQ */
+      __HAL_RCC_PLLSAI_PLLSAICLKDIVQ_CONFIG(PeriphClkInit->PLLSAIDivQ);
+    }
+
+    /*----------------- In Case of PLLSAI is selected as source clock for CLK48 -------------------*/
+    /* In Case of PLLI2S is selected as source clock for CK48 */
+    if((((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_CLK48) == RCC_PERIPHCLK_CLK48) && (PeriphClkInit->Clk48ClockSelection == RCC_CLK48SOURCE_PLLSAIP))
+    {
+      /* check for Parameters */
+      assert_param(IS_RCC_PLLSAIP_VALUE(PeriphClkInit->PLLSAI.PLLSAIP));
+      /* Read PLLSAIQ and PLLSAIR value from PLLSAICFGR register (this value is not needed for CK48 configuration) */
+      tmpreg0 = ((RCC->PLLSAICFGR & RCC_PLLSAICFGR_PLLSAIQ) >> POSITION_VAL(RCC_PLLSAICFGR_PLLSAIQ));
+      tmpreg1 = ((RCC->PLLSAICFGR & RCC_PLLSAICFGR_PLLSAIR) >> POSITION_VAL(RCC_PLLSAICFGR_PLLSAIR));
+
+      /* Configure the PLLSAI division factors */
+      /* PLLSAI_VCO = f(VCO clock) = f(PLLSAI clock input) x (PLLI2SN/PLLM) */
+      /* 48CLK = f(PLLSAI clock output) = f(VCO clock) / PLLSAIP */
+      __HAL_RCC_PLLSAI_CONFIG(PeriphClkInit->PLLSAI.PLLSAIN , PeriphClkInit->PLLSAI.PLLSAIP, tmpreg0, tmpreg1);
+    }
+
+#if defined(STM32F756xx) || defined(STM32F746xx)
+    /*---------------------------- LTDC configuration -------------------------------*/
+    if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LTDC) == (RCC_PERIPHCLK_LTDC))
+    {
+      assert_param(IS_RCC_PLLSAIR_VALUE(PeriphClkInit->PLLSAI.PLLSAIR));
+      assert_param(IS_RCC_PLLSAI_DIVR_VALUE(PeriphClkInit->PLLSAIDivR));
+
+      /* Read PLLSAIP and PLLSAIQ value from PLLSAICFGR register (these value are not needed for LTDC configuration) */
+      tmpreg0 = ((RCC->PLLSAICFGR & RCC_PLLSAICFGR_PLLSAIQ) >> POSITION_VAL(RCC_PLLSAICFGR_PLLSAIQ));
+      tmpreg1 = ((RCC->PLLSAICFGR & RCC_PLLSAICFGR_PLLSAIP) >> POSITION_VAL(RCC_PLLSAICFGR_PLLSAIP));
+
+      /* PLLSAI_VCO Input  = PLL_SOURCE/PLLM */
+      /* PLLSAI_VCO Output = PLLSAI_VCO Input * PLLSAIN */
+      /* LTDC_CLK(first level) = PLLSAI_VCO Output/PLLSAIR */
+      __HAL_RCC_PLLSAI_CONFIG(PeriphClkInit->PLLSAI.PLLSAIN , tmpreg1, tmpreg0, PeriphClkInit->PLLSAI.PLLSAIR);
+
+      /* LTDC_CLK = LTDC_CLK(first level)/PLLSAIDIVR */
+      __HAL_RCC_PLLSAI_PLLSAICLKDIVR_CONFIG(PeriphClkInit->PLLSAIDivR);
+    }
+#endif /* STM32F756xx || STM32F746xx */
+
+    /* Enable PLLSAI Clock */
+    __HAL_RCC_PLLSAI_ENABLE();
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    /* Wait till PLLSAI is ready */
+    while(__HAL_RCC_PLLSAI_GET_FLAG() == RESET)
+    {
+      if((HAL_GetTick() - tickstart) > PLLSAI_TIMEOUT_VALUE)
+      {
+        /* return in case of Timeout detected */
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get the RCC_PeriphCLKInitTypeDef according to the internal
+  *         RCC configuration registers.
+  * @param  PeriphClkInit: pointer to the configured RCC_PeriphCLKInitTypeDef structure
+  * @retval None
+  */
+void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
+{
+  uint32_t tempreg = 0;
+
+  /* Set all possible values for the extended clock type parameter------------*/
+  PeriphClkInit->PeriphClockSelection = RCC_PERIPHCLK_I2S      | RCC_PERIPHCLK_LPTIM1 |\
+                                        RCC_PERIPHCLK_SAI1     | RCC_PERIPHCLK_SAI2     |\
+                                        RCC_PERIPHCLK_TIM      | RCC_PERIPHCLK_RTC      |\
+                                        RCC_PERIPHCLK_CEC      | RCC_PERIPHCLK_I2C4     |\
+                                        RCC_PERIPHCLK_I2C1     | RCC_PERIPHCLK_I2C2     |\
+                                        RCC_PERIPHCLK_I2C3     | RCC_PERIPHCLK_USART1   |\
+                                        RCC_PERIPHCLK_USART2   | RCC_PERIPHCLK_USART3   |\
+                                        RCC_PERIPHCLK_UART4    | RCC_PERIPHCLK_UART5    |\
+                                        RCC_PERIPHCLK_USART6   | RCC_PERIPHCLK_UART7    |\
+                                        RCC_PERIPHCLK_UART8    | RCC_PERIPHCLK_SDMMC1    |\
+                                        RCC_PERIPHCLK_CLK48;
+
+  /* Get the PLLI2S Clock configuration -----------------------------------------------*/
+  PeriphClkInit->PLLI2S.PLLI2SN = (uint32_t)((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SN) >> POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SN));
+  PeriphClkInit->PLLI2S.PLLI2SP = (uint32_t)((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SP) >> POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SP));
+  PeriphClkInit->PLLI2S.PLLI2SQ = (uint32_t)((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SQ) >> POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SQ));
+  PeriphClkInit->PLLI2S.PLLI2SR = (uint32_t)((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SR) >> POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SR));
+
+  /* Get the PLLSAI Clock configuration -----------------------------------------------*/
+  PeriphClkInit->PLLSAI.PLLSAIN = (uint32_t)((RCC->PLLSAICFGR & RCC_PLLSAICFGR_PLLSAIN) >> POSITION_VAL(RCC_PLLSAICFGR_PLLSAIN));
+  PeriphClkInit->PLLSAI.PLLSAIP = (uint32_t)((RCC->PLLSAICFGR & RCC_PLLSAICFGR_PLLSAIP) >> POSITION_VAL(RCC_PLLSAICFGR_PLLSAIP));
+  PeriphClkInit->PLLSAI.PLLSAIQ = (uint32_t)((RCC->PLLSAICFGR & RCC_PLLSAICFGR_PLLSAIQ) >> POSITION_VAL(RCC_PLLSAICFGR_PLLSAIQ));
+  PeriphClkInit->PLLSAI.PLLSAIR = (uint32_t)((RCC->PLLSAICFGR & RCC_PLLSAICFGR_PLLSAIR) >> POSITION_VAL(RCC_PLLSAICFGR_PLLSAIR));
+
+  /* Get the PLLSAI/PLLI2S division factors -------------------------------------------*/
+  PeriphClkInit->PLLI2SDivQ = (uint32_t)((RCC->DCKCFGR1 & RCC_DCKCFGR1_PLLI2SDIVQ) >> POSITION_VAL(RCC_DCKCFGR1_PLLI2SDIVQ));
+  PeriphClkInit->PLLSAIDivQ = (uint32_t)((RCC->DCKCFGR1 & RCC_DCKCFGR1_PLLSAIDIVQ) >> POSITION_VAL(RCC_DCKCFGR1_PLLSAIDIVQ));
+  PeriphClkInit->PLLSAIDivR = (uint32_t)((RCC->DCKCFGR1 & RCC_DCKCFGR1_PLLSAIDIVR) >> POSITION_VAL(RCC_DCKCFGR1_PLLSAIDIVR));
+
+  /* Get the SAI1 clock configuration ----------------------------------------------*/
+  PeriphClkInit->Sai1ClockSelection = __HAL_RCC_GET_SAI1_SOURCE();
+
+  /* Get the SAI2 clock configuration ----------------------------------------------*/
+  PeriphClkInit->Sai2ClockSelection = __HAL_RCC_GET_SAI2_SOURCE();
+
+  /* Get the I2S clock configuration ------------------------------------------*/
+  PeriphClkInit->I2sClockSelection = __HAL_RCC_GET_I2SCLKSOURCE();
+
+  /* Get the I2C1 clock configuration ------------------------------------------*/
+  PeriphClkInit->I2c1ClockSelection = __HAL_RCC_GET_I2C1_SOURCE();
+
+  /* Get the I2C2 clock configuration ------------------------------------------*/
+  PeriphClkInit->I2c2ClockSelection = __HAL_RCC_GET_I2C2_SOURCE();
+
+  /* Get the I2C3 clock configuration ------------------------------------------*/
+  PeriphClkInit->I2c3ClockSelection = __HAL_RCC_GET_I2C3_SOURCE();
+
+  /* Get the I2C4 clock configuration ------------------------------------------*/
+  PeriphClkInit->I2c4ClockSelection = __HAL_RCC_GET_I2C4_SOURCE();
+
+  /* Get the USART1 clock configuration ------------------------------------------*/
+  PeriphClkInit->Usart1ClockSelection = __HAL_RCC_GET_USART1_SOURCE();
+
+  /* Get the USART2 clock configuration ------------------------------------------*/
+  PeriphClkInit->Usart2ClockSelection = __HAL_RCC_GET_USART2_SOURCE();
+
+  /* Get the USART3 clock configuration ------------------------------------------*/
+  PeriphClkInit->Usart3ClockSelection = __HAL_RCC_GET_USART3_SOURCE();
+
+  /* Get the UART4 clock configuration ------------------------------------------*/
+  PeriphClkInit->Uart4ClockSelection = __HAL_RCC_GET_UART4_SOURCE();
+
+  /* Get the UART5 clock configuration ------------------------------------------*/
+  PeriphClkInit->Uart5ClockSelection = __HAL_RCC_GET_UART5_SOURCE();
+
+  /* Get the USART6 clock configuration ------------------------------------------*/
+  PeriphClkInit->Usart6ClockSelection = __HAL_RCC_GET_USART6_SOURCE();
+
+  /* Get the UART7 clock configuration ------------------------------------------*/
+  PeriphClkInit->Uart7ClockSelection = __HAL_RCC_GET_UART7_SOURCE();
+
+  /* Get the UART8 clock configuration ------------------------------------------*/
+  PeriphClkInit->Uart8ClockSelection = __HAL_RCC_GET_UART8_SOURCE();
+
+  /* Get the LPTIM1 clock configuration ------------------------------------------*/
+  PeriphClkInit->Lptim1ClockSelection = __HAL_RCC_GET_LPTIM1_SOURCE();
+
+  /* Get the CEC clock configuration -----------------------------------------------*/
+  PeriphClkInit->CecClockSelection = __HAL_RCC_GET_CEC_SOURCE();
+
+  /* Get the CK48 clock configuration -----------------------------------------------*/
+  PeriphClkInit->Clk48ClockSelection = __HAL_RCC_GET_CLK48_SOURCE();
+
+  /* Get the SDMMC clock configuration -----------------------------------------------*/
+  PeriphClkInit->Sdmmc1ClockSelection = __HAL_RCC_GET_SDMMC1_SOURCE();
+
+  /* Get the RTC Clock configuration -----------------------------------------------*/
+  tempreg = (RCC->CFGR & RCC_CFGR_RTCPRE);
+  PeriphClkInit->RTCClockSelection = (uint32_t)((tempreg) | (RCC->BDCR & RCC_BDCR_RTCSEL));
+
+  /* Get the TIM Prescaler configuration --------------------------------------------*/
+  if ((RCC->DCKCFGR1 & RCC_DCKCFGR1_TIMPRE) == RESET)
+  {
+    PeriphClkInit->TIMPresSelection = RCC_TIMPRES_DESACTIVATED;
+  }
+  else
+  {
+    PeriphClkInit->TIMPresSelection = RCC_TIMPRES_ACTIVATED;
+  }
+}
+
+/**
+  * @brief  Return the peripheral clock frequency for a given peripheral(SAI..)
+  * @note   Return 0 if peripheral clock identifier not managed by this API
+  * @param  PeriphClk: Peripheral clock identifier
+  *         This parameter can be one of the following values:
+  *            @arg RCC_PERIPHCLK_SAI1: SAI1 peripheral clock
+  *            @arg RCC_PERIPHCLK_SAI2: SAI2 peripheral clock
+  * @retval Frequency in KHz
+  */
+uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
+{
+  uint32_t tmpreg = 0;
+  /* This variable used to store the SAI clock frequency (value in Hz) */
+  uint32_t frequency = 0;
+  /* This variable used to store the VCO Input (value in Hz) */
+  uint32_t vcoinput = 0;
+  /* This variable used to store the SAI clock source */
+  uint32_t saiclocksource = 0;
+  if ((PeriphClk == RCC_PERIPHCLK_SAI1) || (PeriphClk == RCC_PERIPHCLK_SAI2))
+  {
+    saiclocksource = RCC->DCKCFGR1;
+    saiclocksource &= (RCC_DCKCFGR1_SAI1SEL | RCC_DCKCFGR1_SAI2SEL);
+    switch (saiclocksource)
+    {
+    case 0: /* PLLSAI is the clock source for SAI*/
+      {
+        /* Configure the PLLSAI division factor */
+        /* PLLSAI_VCO Input  = PLL_SOURCE/PLLM */
+        if((RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) == RCC_PLLSOURCE_HSI)
+        {
+          /* In Case the PLL Source is HSI (Internal Clock) */
+          vcoinput = (HSI_VALUE / (uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLM));
+        }
+        else
+        {
+          /* In Case the PLL Source is HSE (External Clock) */
+          vcoinput = ((HSE_VALUE / (uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLM)));
+        }
+        /* PLLSAI_VCO Output = PLLSAI_VCO Input * PLLSAIN */
+        /* SAI_CLK(first level) = PLLSAI_VCO Output/PLLSAIQ */
+        tmpreg = (RCC->PLLSAICFGR & RCC_PLLSAICFGR_PLLSAIQ) >> 24;
+        frequency = (vcoinput * ((RCC->PLLSAICFGR & RCC_PLLSAICFGR_PLLSAIN) >> 6))/(tmpreg);
+
+        /* SAI_CLK_x = SAI_CLK(first level)/PLLSAIDIVQ */
+        tmpreg = (((RCC->DCKCFGR1 & RCC_DCKCFGR1_PLLSAIDIVQ) >> 8) + 1);
+        frequency = frequency/(tmpreg);
+        break;
+      }
+    case RCC_DCKCFGR1_SAI1SEL_0: /* PLLI2S is the clock source for SAI*/
+    case RCC_DCKCFGR1_SAI2SEL_0: /* PLLI2S is the clock source for SAI*/
+      {
+        /* Configure the PLLI2S division factor */
+        /* PLLI2S_VCO Input  = PLL_SOURCE/PLLM */
+        if((RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) == RCC_PLLSOURCE_HSI)
+        {
+          /* In Case the PLL Source is HSI (Internal Clock) */
+          vcoinput = (HSI_VALUE / (uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLM));
+        }
+        else
+        {
+          /* In Case the PLL Source is HSE (External Clock) */
+          vcoinput = ((HSE_VALUE / (uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLM)));
+        }
+
+        /* PLLI2S_VCO Output = PLLI2S_VCO Input * PLLI2SN */
+        /* SAI_CLK(first level) = PLLI2S_VCO Output/PLLI2SQ */
+        tmpreg = (RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SQ) >> 24;
+        frequency = (vcoinput * ((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SN) >> 6))/(tmpreg);
+
+        /* SAI_CLK_x = SAI_CLK(first level)/PLLI2SDIVQ */
+        tmpreg = ((RCC->DCKCFGR1 & RCC_DCKCFGR1_PLLI2SDIVQ) + 1);
+        frequency = frequency/(tmpreg);
+        break;
+      }
+    case RCC_DCKCFGR1_SAI1SEL_1: /* External clock is the clock source for SAI*/
+    case RCC_DCKCFGR1_SAI2SEL_1: /* External clock is the clock source for SAI*/
+      {
+        frequency = EXTERNAL_CLOCK_VALUE;
+        break;
+      }
+    default :
+      {
+        break;
+      }
+    }
+  }
+  return frequency;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RCC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_rng.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_rng.c
@@ -1,0 +1,510 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rng.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   RNG HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Random Number Generator (RNG) peripheral:
+  *           + Initialization/de-initialization functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *
+  @verbatim
+  ==============================================================================
+                     ##### How to use this driver #####
+  ==============================================================================
+  [..]
+      The RNG HAL driver can be used as follows:
+
+      (#) Enable the RNG controller clock using __HAL_RCC_RNG_CLK_ENABLE() macro
+          in HAL_RNG_MspInit().
+      (#) Activate the RNG peripheral using HAL_RNG_Init() function.
+      (#) Wait until the 32 bit Random Number Generator contains a valid
+          random data using (polling/interrupt) mode.
+      (#) Get the 32 bit random number using HAL_RNG_GenerateRandomNumber() function.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RNG
+  * @{
+  */
+
+#ifdef HAL_RNG_MODULE_ENABLED
+
+/* Private types -------------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @addtogroup RNG_Private_Constants
+  * @{
+  */
+#define RNG_TIMEOUT_VALUE     2
+/**
+  * @}
+  */
+/* Private macros ------------------------------------------------------------*/
+/* Private functions prototypes ----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup RNG_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup RNG_Exported_Functions_Group1
+ *  @brief   Initialization and de-initialization functions
+ *
+@verbatim
+ ===============================================================================
+          ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize the RNG according to the specified parameters
+          in the RNG_InitTypeDef and create the associated handle
+      (+) DeInitialize the RNG peripheral
+      (+) Initialize the RNG MSP
+      (+) DeInitialize RNG MSP
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the RNG peripheral and creates the associated handle.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RNG_Init(RNG_HandleTypeDef *hrng)
+{
+  /* Check the RNG handle allocation */
+  if(hrng == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  __HAL_LOCK(hrng);
+
+  if(hrng->State == HAL_RNG_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hrng->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware */
+    HAL_RNG_MspInit(hrng);
+  }
+
+  /* Change RNG peripheral state */
+  hrng->State = HAL_RNG_STATE_BUSY;
+
+  /* Enable the RNG Peripheral */
+  __HAL_RNG_ENABLE(hrng);
+
+  /* Initialize the RNG state */
+  hrng->State = HAL_RNG_STATE_READY;
+
+  __HAL_UNLOCK(hrng);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the RNG peripheral.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RNG_DeInit(RNG_HandleTypeDef *hrng)
+{
+  /* Check the RNG handle allocation */
+  if(hrng == NULL)
+  {
+    return HAL_ERROR;
+  }
+  /* Disable the RNG Peripheral */
+  CLEAR_BIT(hrng->Instance->CR, RNG_CR_IE | RNG_CR_RNGEN);
+
+  /* Clear RNG interrupt status flags */
+  CLEAR_BIT(hrng->Instance->SR, RNG_SR_CEIS | RNG_SR_SEIS);
+
+  /* DeInit the low level hardware */
+  HAL_RNG_MspDeInit(hrng);
+
+  /* Update the RNG state */
+  hrng->State = HAL_RNG_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hrng);
+
+  /* Return the function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the RNG MSP.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+  */
+__weak void HAL_RNG_MspInit(RNG_HandleTypeDef *hrng)
+{
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_RNG_MspInit must be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  DeInitializes the RNG MSP.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+  */
+__weak void HAL_RNG_MspDeInit(RNG_HandleTypeDef *hrng)
+{
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_RNG_MspDeInit must be implemented in the user file.
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @addtogroup RNG_Exported_Functions_Group2
+ *  @brief   Peripheral Control functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Get the 32 bit Random number
+      (+) Get the 32 bit Random number with interrupt enabled
+      (+) Handle RNG interrupt request
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Generates a 32-bit random number.
+  * @note   Each time the random number data is read the RNG_FLAG_DRDY flag
+  *         is automatically cleared.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @param  random32bit: pointer to generated random number variable if successful.
+  * @retval HAL status
+  */
+
+HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber(RNG_HandleTypeDef *hrng, uint32_t *random32bit)
+{
+  uint32_t tickstart = 0;
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process Locked */
+  __HAL_LOCK(hrng);
+
+  /* Check RNG peripheral state */
+  if(hrng->State == HAL_RNG_STATE_READY)
+  {
+    /* Change RNG peripheral state */
+    hrng->State = HAL_RNG_STATE_BUSY;
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Check if data register contains valid random data */
+    while(__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_DRDY) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RNG_TIMEOUT_VALUE)
+      {
+        hrng->State = HAL_RNG_STATE_ERROR;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrng);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Get a 32bit Random number */
+    hrng->RandomNumber = hrng->Instance->DR;
+    *random32bit = hrng->RandomNumber;
+
+    hrng->State = HAL_RNG_STATE_READY;
+  }
+  else
+  {
+    status = HAL_ERROR;
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrng);
+
+  return status;
+}
+
+/**
+  * @brief  Generates a 32-bit random number in interrupt mode.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber_IT(RNG_HandleTypeDef *hrng)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process Locked */
+  __HAL_LOCK(hrng);
+
+  /* Check RNG peripheral state */
+  if(hrng->State == HAL_RNG_STATE_READY)
+  {
+    /* Change RNG peripheral state */
+    hrng->State = HAL_RNG_STATE_BUSY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrng);
+
+    /* Enable the RNG Interrupts: Data Ready, Clock error, Seed error */
+    __HAL_RNG_ENABLE_IT(hrng);
+  }
+  else
+  {
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrng);
+
+    status = HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Handles RNG interrupt request.
+  * @note   In the case of a clock error, the RNG is no more able to generate
+  *         random numbers because the PLL48CLK clock is not correct. User has
+  *         to check that the clock controller is correctly configured to provide
+  *         the RNG clock and clear the CEIS bit using __HAL_RNG_CLEAR_IT().
+  *         The clock error has no impact on the previously generated
+  *         random numbers, and the RNG_DR register contents can be used.
+  * @note   In the case of a seed error, the generation of random numbers is
+  *         interrupted as long as the SECS bit is '1'. If a number is
+  *         available in the RNG_DR register, it must not be used because it may
+  *         not have enough entropy. In this case, it is recommended to clear the
+  *         SEIS bit using __HAL_RNG_CLEAR_IT(), then disable and enable
+  *         the RNG peripheral to reinitialize and restart the RNG.
+  * @note   User-written HAL_RNG_ErrorCallback() API is called once whether SEIS
+  *         or CEIS are set.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+
+  */
+void HAL_RNG_IRQHandler(RNG_HandleTypeDef *hrng)
+{
+  /* RNG clock error interrupt occurred */
+  if((__HAL_RNG_GET_IT(hrng, RNG_IT_CEI) != RESET) ||  (__HAL_RNG_GET_IT(hrng, RNG_IT_SEI) != RESET))
+  {
+    /* Change RNG peripheral state */
+    hrng->State = HAL_RNG_STATE_ERROR;
+
+    HAL_RNG_ErrorCallback(hrng);
+
+    /* Clear the clock error flag */
+    __HAL_RNG_CLEAR_IT(hrng, RNG_IT_CEI|RNG_IT_SEI);
+
+  }
+
+  /* Check RNG data ready interrupt occurred */
+  if(__HAL_RNG_GET_IT(hrng, RNG_IT_DRDY) != RESET)
+  {
+    /* Generate random number once, so disable the IT */
+    __HAL_RNG_DISABLE_IT(hrng);
+
+    /* Get the 32bit Random number (DRDY flag automatically cleared) */
+    hrng->RandomNumber = hrng->Instance->DR;
+
+    if(hrng->State != HAL_RNG_STATE_ERROR)
+    {
+      /* Change RNG peripheral state */
+      hrng->State = HAL_RNG_STATE_READY;
+
+      /* Data Ready callback */
+      HAL_RNG_ReadyDataCallback(hrng, hrng->RandomNumber);
+    }
+  }
+}
+
+/**
+  * @brief  Returns generated random number in polling mode (Obsolete)
+  *         Use HAL_RNG_GenerateRandomNumber() API instead.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval Random value
+  */
+uint32_t HAL_RNG_GetRandomNumber(RNG_HandleTypeDef *hrng)
+{
+  if(HAL_RNG_GenerateRandomNumber(hrng, &(hrng->RandomNumber)) == HAL_OK)
+  {
+    return hrng->RandomNumber;
+  }
+  else
+  {
+    return 0;
+  }
+}
+
+/**
+  * @brief  Returns a 32-bit random number with interrupt enabled (Obsolete),
+  *         Use HAL_RNG_GenerateRandomNumber_IT() API instead.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval 32-bit random number
+  */
+uint32_t HAL_RNG_GetRandomNumber_IT(RNG_HandleTypeDef *hrng)
+{
+  uint32_t random32bit = 0;
+
+  /* Process locked */
+  __HAL_LOCK(hrng);
+
+  /* Change RNG peripheral state */
+  hrng->State = HAL_RNG_STATE_BUSY;
+
+  /* Get a 32bit Random number */
+  random32bit = hrng->Instance->DR;
+
+  /* Enable the RNG Interrupts: Data Ready, Clock error, Seed error */
+  __HAL_RNG_ENABLE_IT(hrng);
+
+  /* Return the 32 bit random number */
+  return random32bit;
+}
+
+/**
+  * @brief  Read latest generated random number.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval random value
+  */
+uint32_t HAL_RNG_ReadLastRandomNumber(RNG_HandleTypeDef *hrng)
+{
+  return(hrng->RandomNumber);
+}
+
+/**
+  * @brief  Data Ready callback in non-blocking mode.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @param  random32bit: generated random number.
+  * @retval None
+  */
+__weak void HAL_RNG_ReadyDataCallback(RNG_HandleTypeDef *hrng, uint32_t random32bit)
+{
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_RNG_ReadyDataCallback must be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  RNG error callbacks.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+  */
+__weak void HAL_RNG_ErrorCallback(RNG_HandleTypeDef *hrng)
+{
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_RNG_ErrorCallback must be implemented in the user file.
+   */
+}
+/**
+  * @}
+  */
+
+
+/** @addtogroup RNG_Exported_Functions_Group3
+ *  @brief   Peripheral State functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================
+    [..]
+    This subsection permits to get in run-time the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the RNG state.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval HAL state
+  */
+HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng)
+{
+  return hrng->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RNG_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_rtc.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_rtc.c
@@ -1,0 +1,1555 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rtc.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   RTC HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Real Time Clock (RTC) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + RTC Time and Date functions
+  *           + RTC Alarm functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *
+  @verbatim
+  ==============================================================================
+              ##### Backup Domain Operating Condition #####
+  ==============================================================================
+  [..] The real-time clock (RTC), the RTC backup registers, and the backup
+       SRAM (BKP SRAM) can be powered from the VBAT voltage when the main
+       VDD supply is powered off.
+       To retain the content of the RTC backup registers, backup SRAM, and supply
+       the RTC when VDD is turned off, VBAT pin can be connected to an optional
+       standby voltage supplied by a battery or by another source.
+
+  [..] To allow the RTC operating even when the main digital supply (VDD) is turned
+       off, the VBAT pin powers the following blocks:
+    (#) The RTC
+    (#) The LSE oscillator
+    (#) The backup SRAM when the low power backup regulator is enabled
+    (#) PC13 to PC15 I/Os, plus PI8 I/O (when available)
+
+  [..] When the backup domain is supplied by VDD (analog switch connected to VDD),
+       the following pins are available:
+    (#) PC14 and PC15 can be used as either GPIO or LSE pins
+    (#) PC13 can be used as a GPIO or as the RTC_AF1 pin
+    (#) PI8 can be used as a GPIO or as the RTC_AF2 pin
+
+  [..] When the backup domain is supplied by VBAT (analog switch connected to VBAT
+       because VDD is not present), the following pins are available:
+    (#) PC14 and PC15 can be used as LSE pins only
+    (#) PC13 can be used as the RTC_AF1 pin
+    (#) PI8 can be used as the RTC_AF2 pin
+    (#) PC1 can be used as the RTC_AF3 pin
+
+                   ##### Backup Domain Reset #####
+  ==================================================================
+  [..] The backup domain reset sets all RTC registers and the RCC_BDCR register
+       to their reset values. The BKPSRAM is not affected by this reset. The only
+       way to reset the BKPSRAM is through the Flash interface by requesting
+       a protection level change from 1 to 0.
+  [..] A backup domain reset is generated when one of the following events occurs:
+    (#) Software reset, triggered by setting the BDRST bit in the
+        RCC Backup domain control register (RCC_BDCR).
+    (#) VDD or VBAT power on, if both supplies have previously been powered off.
+
+                   ##### Backup Domain Access #####
+  ==================================================================
+  [..] After reset, the backup domain (RTC registers, RTC backup data
+       registers and backup SRAM) is protected against possible unwanted write
+       accesses.
+  [..] To enable access to the RTC Domain and RTC registers, proceed as follows:
+    (+) Enable the Power Controller (PWR) APB1 interface clock using the
+        __HAL_RCC_PWR_CLK_ENABLE() function.
+    (+) Enable access to RTC domain using the HAL_PWR_EnableBkUpAccess() function.
+    (+) Select the RTC clock source using the __HAL_RCC_RTC_CONFIG() function.
+    (+) Enable RTC Clock using the __HAL_RCC_RTC_ENABLE() function.
+
+
+                  ##### How to use this driver #####
+  ==================================================================
+  [..]
+    (+) Enable the RTC domain access (see description in the section above).
+    (+) Configure the RTC Prescaler (Asynchronous and Synchronous) and RTC hour
+        format using the HAL_RTC_Init() function.
+
+  *** Time and Date configuration ***
+  ===================================
+  [..]
+    (+) To configure the RTC Calendar (Time and Date) use the HAL_RTC_SetTime()
+        and HAL_RTC_SetDate() functions.
+    (+) To read the RTC Calendar, use the HAL_RTC_GetTime() and HAL_RTC_GetDate() functions.
+
+  *** Alarm configuration ***
+  ===========================
+  [..]
+    (+) To configure the RTC Alarm use the HAL_RTC_SetAlarm() function.
+        You can also configure the RTC Alarm with interrupt mode using the HAL_RTC_SetAlarm_IT() function.
+    (+) To read the RTC Alarm, use the HAL_RTC_GetAlarm() function.
+
+                  ##### RTC and low power modes #####
+  ==================================================================
+  [..] The MCU can be woken up from a low power mode by an RTC alternate
+       function.
+  [..] The RTC alternate functions are the RTC alarms (Alarm A and Alarm B),
+       RTC wakeup, RTC tamper event detection and RTC time stamp event detection.
+       These RTC alternate functions can wake up the system from the Stop and
+       Standby low power modes.
+  [..] The system can also wake up from low power modes without depending
+       on an external interrupt (Auto-wakeup mode), by using the RTC alarm
+       or the RTC wakeup events.
+  [..] The RTC provides a programmable time base for waking up from the
+       Stop or Standby mode at regular intervals.
+       Wakeup from STOP and STANDBY modes is possible only when the RTC clock source
+       is LSE or LSI.
+
+   @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RTC RTC
+  * @brief RTC HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup RTC_Exported_Functions RTC Exported Functions
+  * @{
+  */
+
+/** @defgroup RTC_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+   [..] This section provides functions allowing to initialize and configure the
+         RTC Prescaler (Synchronous and Asynchronous), RTC Hour format, disable
+         RTC registers Write protection, enter and exit the RTC initialization mode,
+         RTC registers synchronization check and reference clock detection enable.
+         (#) The RTC Prescaler is programmed to generate the RTC 1Hz time base.
+             It is split into 2 programmable prescalers to minimize power consumption.
+             (++) A 7-bit asynchronous prescaler and a 13-bit synchronous prescaler.
+             (++) When both prescalers are used, it is recommended to configure the
+                 asynchronous prescaler to a high value to minimize power consumption.
+         (#) All RTC registers are Write protected. Writing to the RTC registers
+             is enabled by writing a key into the Write Protection register, RTC_WPR.
+         (#) To configure the RTC Calendar, user application should enter
+             initialization mode. In this mode, the calendar counter is stopped
+             and its value can be updated. When the initialization sequence is
+             complete, the calendar restarts counting after 4 RTCCLK cycles.
+         (#) To read the calendar through the shadow registers after Calendar
+             initialization, calendar update or after wakeup from low power modes
+             the software must first clear the RSF flag. The software must then
+             wait until it is set again before reading the calendar, which means
+             that the calendar registers have been correctly copied into the
+             RTC_TR and RTC_DR shadow registers.The HAL_RTC_WaitForSynchro() function
+             implements the above software sequence (RSF clear and RSF check).
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the RTC peripheral
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
+{
+  /* Check the RTC peripheral state */
+  if(hrtc == NULL)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_RTC_ALL_INSTANCE(hrtc->Instance));
+  assert_param(IS_RTC_HOUR_FORMAT(hrtc->Init.HourFormat));
+  assert_param(IS_RTC_ASYNCH_PREDIV(hrtc->Init.AsynchPrediv));
+  assert_param(IS_RTC_SYNCH_PREDIV(hrtc->Init.SynchPrediv));
+  assert_param (IS_RTC_OUTPUT(hrtc->Init.OutPut));
+  assert_param (IS_RTC_OUTPUT_POL(hrtc->Init.OutPutPolarity));
+  assert_param(IS_RTC_OUTPUT_TYPE(hrtc->Init.OutPutType));
+
+  if(hrtc->State == HAL_RTC_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hrtc->Lock = HAL_UNLOCKED;
+    /* Initialize RTC MSP */
+    HAL_RTC_MspInit(hrtc);
+  }
+
+  /* Set RTC state */
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state */
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Clear RTC_CR FMT, OSEL and POL Bits */
+    hrtc->Instance->CR &= ((uint32_t)~(RTC_CR_FMT | RTC_CR_OSEL | RTC_CR_POL));
+    /* Set RTC_CR register */
+    hrtc->Instance->CR |= (uint32_t)(hrtc->Init.HourFormat | hrtc->Init.OutPut | hrtc->Init.OutPutPolarity);
+
+    /* Configure the RTC PRER */
+    hrtc->Instance->PRER = (uint32_t)(hrtc->Init.SynchPrediv);
+    hrtc->Instance->PRER |= (uint32_t)(hrtc->Init.AsynchPrediv << 16);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+
+    hrtc->Instance->OR &= (uint32_t)~RTC_OR_ALARMTYPE;
+    hrtc->Instance->OR |= (uint32_t)(hrtc->Init.OutPutType);
+
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state */
+    hrtc->State = HAL_RTC_STATE_READY;
+
+    return HAL_OK;
+  }
+}
+
+/**
+  * @brief  DeInitializes the RTC peripheral
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @note   This function doesn't reset the RTC Backup Data registers.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_ALL_INSTANCE(hrtc->Instance));
+
+  /* Set RTC state */
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state */
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Reset TR, DR and CR registers */
+    hrtc->Instance->TR = (uint32_t)0x00000000;
+    hrtc->Instance->DR = (uint32_t)0x00002101;
+    /* Reset All CR bits except CR[2:0] */
+    hrtc->Instance->CR &= (uint32_t)0x00000007;
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till WUTWF flag is set and if Time out is reached exit */
+    while(((hrtc->Instance->ISR) & RTC_ISR_WUTWF) == (uint32_t)RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        /* Set RTC state */
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Reset all RTC CR register bits */
+    hrtc->Instance->CR &= (uint32_t)0x00000000;
+    hrtc->Instance->WUTR = (uint32_t)0x0000FFFF;
+    hrtc->Instance->PRER = (uint32_t)0x007F00FF;
+    hrtc->Instance->ALRMAR = (uint32_t)0x00000000;
+    hrtc->Instance->ALRMBR = (uint32_t)0x00000000;
+    hrtc->Instance->SHIFTR = (uint32_t)0x00000000;
+    hrtc->Instance->CALR = (uint32_t)0x00000000;
+    hrtc->Instance->ALRMASSR = (uint32_t)0x00000000;
+    hrtc->Instance->ALRMBSSR = (uint32_t)0x00000000;
+
+    /* Reset ISR register and exit initialization mode */
+    hrtc->Instance->ISR = (uint32_t)0x00000000;
+
+    /* Reset Tamper and alternate functions configuration register */
+    hrtc->Instance->TAMPCR = 0x00000000;
+
+    /* Reset Option register */
+    hrtc->Instance->OR = 0x00000000;
+
+    /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == RESET)
+    {
+      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_ERROR;
+
+        return HAL_ERROR;
+      }
+    }
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* De-Initialize RTC MSP */
+  HAL_RTC_MspDeInit(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the RTC MSP.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTC_MspInit(RTC_HandleTypeDef* hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the RTC MSP.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Group2 RTC Time and Date functions
+ *  @brief   RTC Time and Date functions
+ *
+@verbatim
+ ===============================================================================
+                 ##### RTC Time and Date functions #####
+ ===============================================================================
+
+ [..] This section provides functions allowing to configure Time and Date features
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Sets RTC current time.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTime: Pointer to Time structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg FORMAT_BIN: Binary data format
+  *            @arg FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format)
+{
+  uint32_t tmpreg = 0;
+
+ /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_DAYLIGHT_SAVING(sTime->DayLightSaving));
+  assert_param(IS_RTC_STORE_OPERATION(sTime->StoreOperation));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if(Format == RTC_FORMAT_BIN)
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      assert_param(IS_RTC_HOUR12(sTime->Hours));
+      assert_param(IS_RTC_HOURFORMAT12(sTime->TimeFormat));
+    }
+    else
+    {
+      sTime->TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(sTime->Hours));
+    }
+    assert_param(IS_RTC_MINUTES(sTime->Minutes));
+    assert_param(IS_RTC_SECONDS(sTime->Seconds));
+
+    tmpreg = (uint32_t)(((uint32_t)RTC_ByteToBcd2(sTime->Hours) << 16) | \
+                        ((uint32_t)RTC_ByteToBcd2(sTime->Minutes) << 8) | \
+                        ((uint32_t)RTC_ByteToBcd2(sTime->Seconds)) | \
+                        (((uint32_t)sTime->TimeFormat) << 16));
+  }
+  else
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      tmpreg = RTC_Bcd2ToByte(sTime->Hours);
+      assert_param(IS_RTC_HOUR12(tmpreg));
+      assert_param(IS_RTC_HOURFORMAT12(sTime->TimeFormat));
+    }
+    else
+    {
+      sTime->TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(RTC_Bcd2ToByte(sTime->Hours)));
+    }
+    assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sTime->Minutes)));
+    assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sTime->Seconds)));
+    tmpreg = (((uint32_t)(sTime->Hours) << 16) | \
+              ((uint32_t)(sTime->Minutes) << 8) | \
+              ((uint32_t)sTime->Seconds) | \
+              ((uint32_t)(sTime->TimeFormat) << 16));
+  }
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state */
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Set the RTC_TR register */
+    hrtc->Instance->TR = (uint32_t)(tmpreg & RTC_TR_RESERVED_MASK);
+
+    /* Clear the bits to be configured */
+    hrtc->Instance->CR &= (uint32_t)~RTC_CR_BCK;
+
+    /* Configure the RTC_CR register */
+    hrtc->Instance->CR |= (uint32_t)(sTime->DayLightSaving | sTime->StoreOperation);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+
+    /* If  CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == RESET)
+    {
+      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_ERROR;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_ERROR;
+      }
+    }
+
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+   hrtc->State = HAL_RTC_STATE_READY;
+
+   __HAL_UNLOCK(hrtc);
+
+   return HAL_OK;
+  }
+}
+
+/**
+  * @brief  Gets RTC current time.
+  * @param  hrtc: RTC handle
+  * @param  sTime: Pointer to Time structure with Hours, Minutes and Seconds fields returned
+  *                with input format (BIN or BCD), also SubSeconds field returning the
+  *                RTC_SSR register content and SecondFraction field the Synchronous pre-scaler
+  *                factor to be used for second fraction ratio computation.
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_FORMAT_BIN: Binary data format
+  *            @arg RTC_FORMAT_BCD: BCD data format
+  * @note  You can use SubSeconds and SecondFraction (sTime structure fields returned) to convert SubSeconds
+  *        value in second fraction ratio with time unit following generic formula:
+  *        Second fraction ratio * time_unit= [(SecondFraction-SubSeconds)/(SecondFraction+1)] * time_unit
+  *        This conversion can be performed only if no shift operation is pending (ie. SHFP=0) when PREDIV_S >= SS
+  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the values
+  *        in the higher-order calendar shadow registers to ensure consistency between the time and date values.
+  *        Reading RTC current time locks the values in calendar shadow registers until Current date is read
+  *        to ensure consistency between the time and date values.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Get subseconds values from the correspondent registers*/
+  sTime->SubSeconds = (uint32_t)(hrtc->Instance->SSR);
+
+  /* Get the TR register */
+  tmpreg = (uint32_t)(hrtc->Instance->TR & RTC_TR_RESERVED_MASK);
+
+  /* Fill the structure fields with the read parameters */
+  sTime->Hours = (uint8_t)((tmpreg & (RTC_TR_HT | RTC_TR_HU)) >> 16);
+  sTime->Minutes = (uint8_t)((tmpreg & (RTC_TR_MNT | RTC_TR_MNU)) >>8);
+  sTime->Seconds = (uint8_t)(tmpreg & (RTC_TR_ST | RTC_TR_SU));
+  sTime->TimeFormat = (uint8_t)((tmpreg & (RTC_TR_PM)) >> 16);
+
+  /* Check the input parameters format */
+  if(Format == RTC_FORMAT_BIN)
+  {
+    /* Convert the time structure parameters to Binary format */
+    sTime->Hours = (uint8_t)RTC_Bcd2ToByte(sTime->Hours);
+    sTime->Minutes = (uint8_t)RTC_Bcd2ToByte(sTime->Minutes);
+    sTime->Seconds = (uint8_t)RTC_Bcd2ToByte(sTime->Seconds);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets RTC current date.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sDate: Pointer to date structure
+  * @param  Format: specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_FORMAT_BIN: Binary data format
+  *            @arg RTC_FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format)
+{
+  uint32_t datetmpreg = 0;
+
+ /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+ /* Process Locked */
+ __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if((Format == RTC_FORMAT_BIN) && ((sDate->Month & 0x10) == 0x10))
+  {
+    sDate->Month = (uint8_t)((sDate->Month & (uint8_t)~(0x10)) + (uint8_t)0x0A);
+  }
+
+  assert_param(IS_RTC_WEEKDAY(sDate->WeekDay));
+
+  if(Format == RTC_FORMAT_BIN)
+  {
+    assert_param(IS_RTC_YEAR(sDate->Year));
+    assert_param(IS_RTC_MONTH(sDate->Month));
+    assert_param(IS_RTC_DATE(sDate->Date));
+
+   datetmpreg = (((uint32_t)RTC_ByteToBcd2(sDate->Year) << 16) | \
+                 ((uint32_t)RTC_ByteToBcd2(sDate->Month) << 8) | \
+                 ((uint32_t)RTC_ByteToBcd2(sDate->Date)) | \
+                 ((uint32_t)sDate->WeekDay << 13));
+  }
+  else
+  {
+    assert_param(IS_RTC_YEAR(RTC_Bcd2ToByte(sDate->Year)));
+    datetmpreg = RTC_Bcd2ToByte(sDate->Month);
+    assert_param(IS_RTC_MONTH(datetmpreg));
+    datetmpreg = RTC_Bcd2ToByte(sDate->Date);
+    assert_param(IS_RTC_DATE(datetmpreg));
+
+    datetmpreg = ((((uint32_t)sDate->Year) << 16) | \
+                  (((uint32_t)sDate->Month) << 8) | \
+                  ((uint32_t)sDate->Date) | \
+                  (((uint32_t)sDate->WeekDay) << 13));
+  }
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state*/
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Set the RTC_DR register */
+    hrtc->Instance->DR = (uint32_t)(datetmpreg & RTC_DR_RESERVED_MASK);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+
+    /* If  CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == RESET)
+    {
+      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_ERROR;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_ERROR;
+      }
+    }
+
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    hrtc->State = HAL_RTC_STATE_READY ;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_OK;
+  }
+}
+
+/**
+  * @brief  Gets RTC current date.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sDate: Pointer to Date structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_FORMAT_BIN:  Binary data format
+  *            @arg RTC_FORMAT_BCD:  BCD data format
+  * @note You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the values
+  * in the higher-order calendar shadow registers to ensure consistency between the time and date values.
+  * Reading RTC current time locks the values in calendar shadow registers until Current date is read.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format)
+{
+  uint32_t datetmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Get the DR register */
+  datetmpreg = (uint32_t)(hrtc->Instance->DR & RTC_DR_RESERVED_MASK);
+
+  /* Fill the structure fields with the read parameters */
+  sDate->Year = (uint8_t)((datetmpreg & (RTC_DR_YT | RTC_DR_YU)) >> 16);
+  sDate->Month = (uint8_t)((datetmpreg & (RTC_DR_MT | RTC_DR_MU)) >> 8);
+  sDate->Date = (uint8_t)(datetmpreg & (RTC_DR_DT | RTC_DR_DU));
+  sDate->WeekDay = (uint8_t)((datetmpreg & (RTC_DR_WDU)) >> 13);
+
+  /* Check the input parameters format */
+  if(Format == RTC_FORMAT_BIN)
+  {
+    /* Convert the date structure parameters to Binary format */
+    sDate->Year = (uint8_t)RTC_Bcd2ToByte(sDate->Year);
+    sDate->Month = (uint8_t)RTC_Bcd2ToByte(sDate->Month);
+    sDate->Date = (uint8_t)RTC_Bcd2ToByte(sDate->Date);
+  }
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Group3 RTC Alarm functions
+ *  @brief   RTC Alarm functions
+ *
+@verbatim
+ ===============================================================================
+                 ##### RTC Alarm functions #####
+ ===============================================================================
+
+ [..] This section provides functions allowing to configure Alarm feature
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Sets the specified RTC Alarm.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sAlarm: Pointer to Alarm structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg FORMAT_BIN: Binary data format
+  *             @arg FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
+{
+  uint32_t tickstart = 0;
+  uint32_t tmpreg = 0, subsecondtmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_ALARM(sAlarm->Alarm));
+  assert_param(IS_RTC_ALARM_MASK(sAlarm->AlarmMask));
+  assert_param(IS_RTC_ALARM_DATE_WEEKDAY_SEL(sAlarm->AlarmDateWeekDaySel));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_VALUE(sAlarm->AlarmTime.SubSeconds));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_MASK(sAlarm->AlarmSubSecondMask));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if(Format == RTC_FORMAT_BIN)
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      assert_param(IS_RTC_HOUR12(sAlarm->AlarmTime.Hours));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(sAlarm->AlarmTime.Hours));
+    }
+    assert_param(IS_RTC_MINUTES(sAlarm->AlarmTime.Minutes));
+    assert_param(IS_RTC_SECONDS(sAlarm->AlarmTime.Seconds));
+
+    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(sAlarm->AlarmDateWeekDay));
+    }
+    else
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(sAlarm->AlarmDateWeekDay));
+    }
+
+    tmpreg = (((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Hours) << 16) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Minutes) << 8) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Seconds)) | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmDateWeekDay) << 24) | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+              ((uint32_t)sAlarm->AlarmMask));
+  }
+  else
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
+      assert_param(IS_RTC_HOUR12(tmpreg));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours)));
+    }
+
+    assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes)));
+    assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds)));
+
+    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(tmpreg));
+    }
+    else
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(tmpreg));
+    }
+
+    tmpreg = (((uint32_t)(sAlarm->AlarmTime.Hours) << 16) | \
+              ((uint32_t)(sAlarm->AlarmTime.Minutes) << 8) | \
+              ((uint32_t) sAlarm->AlarmTime.Seconds) | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16) | \
+              ((uint32_t)(sAlarm->AlarmDateWeekDay) << 24) | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+              ((uint32_t)sAlarm->AlarmMask));
+  }
+
+  /* Configure the Alarm A or Alarm B Sub Second registers */
+  subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | (uint32_t)(sAlarm->AlarmSubSecondMask));
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Alarm register */
+  if(sAlarm->Alarm == RTC_ALARM_A)
+  {
+    /* Disable the Alarm A interrupt */
+    __HAL_RTC_ALARMA_DISABLE(hrtc);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRA);
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRAWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMAR = (uint32_t)tmpreg;
+    /* Configure the Alarm A Sub Second register */
+    hrtc->Instance->ALRMASSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMA_ENABLE(hrtc);
+  }
+  else
+  {
+    /* Disable the Alarm B interrupt */
+    __HAL_RTC_ALARMB_DISABLE(hrtc);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRB);
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRBWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMBR = (uint32_t)tmpreg;
+    /* Configure the Alarm B Sub Second register */
+    hrtc->Instance->ALRMBSSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMB_ENABLE(hrtc);
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets the specified RTC Alarm with Interrupt
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sAlarm: Pointer to Alarm structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg FORMAT_BIN: Binary data format
+  *             @arg FORMAT_BCD: BCD data format
+  * @note   The Alarm register can only be written when the corresponding Alarm
+  *         is disabled (Use the HAL_RTC_DeactivateAlarm()).
+  * @note   The HAL_RTC_SetTime() must be called before enabling the Alarm feature.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
+{
+  uint32_t tickstart = 0;
+  uint32_t tmpreg = 0, subsecondtmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_ALARM(sAlarm->Alarm));
+  assert_param(IS_RTC_ALARM_MASK(sAlarm->AlarmMask));
+  assert_param(IS_RTC_ALARM_DATE_WEEKDAY_SEL(sAlarm->AlarmDateWeekDaySel));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_VALUE(sAlarm->AlarmTime.SubSeconds));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_MASK(sAlarm->AlarmSubSecondMask));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if(Format == RTC_FORMAT_BIN)
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      assert_param(IS_RTC_HOUR12(sAlarm->AlarmTime.Hours));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(sAlarm->AlarmTime.Hours));
+    }
+    assert_param(IS_RTC_MINUTES(sAlarm->AlarmTime.Minutes));
+    assert_param(IS_RTC_SECONDS(sAlarm->AlarmTime.Seconds));
+
+    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(sAlarm->AlarmDateWeekDay));
+    }
+    else
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(sAlarm->AlarmDateWeekDay));
+    }
+    tmpreg = (((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Hours) << 16) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Minutes) << 8) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Seconds)) | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmDateWeekDay) << 24) | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+              ((uint32_t)sAlarm->AlarmMask));
+  }
+  else
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
+      assert_param(IS_RTC_HOUR12(tmpreg));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours)));
+    }
+
+    assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes)));
+    assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds)));
+
+    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(tmpreg));
+    }
+    else
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(tmpreg));
+    }
+    tmpreg = (((uint32_t)(sAlarm->AlarmTime.Hours) << 16) | \
+              ((uint32_t)(sAlarm->AlarmTime.Minutes) << 8) | \
+              ((uint32_t) sAlarm->AlarmTime.Seconds) | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16) | \
+              ((uint32_t)(sAlarm->AlarmDateWeekDay) << 24) | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+              ((uint32_t)sAlarm->AlarmMask));
+  }
+  /* Configure the Alarm A or Alarm B Sub Second registers */
+  subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | (uint32_t)(sAlarm->AlarmSubSecondMask));
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Alarm register */
+  if(sAlarm->Alarm == RTC_ALARM_A)
+  {
+    /* Disable the Alarm A interrupt */
+    __HAL_RTC_ALARMA_DISABLE(hrtc);
+
+    /* Clear flag alarm A */
+    __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRAWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMAR = (uint32_t)tmpreg;
+    /* Configure the Alarm A Sub Second register */
+    hrtc->Instance->ALRMASSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMA_ENABLE(hrtc);
+    /* Configure the Alarm interrupt */
+    __HAL_RTC_ALARM_ENABLE_IT(hrtc,RTC_IT_ALRA);
+  }
+  else
+  {
+    /* Disable the Alarm B interrupt */
+    __HAL_RTC_ALARMB_DISABLE(hrtc);
+
+    /* Clear flag alarm B */
+    __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRBWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMBR = (uint32_t)tmpreg;
+    /* Configure the Alarm B Sub Second register */
+    hrtc->Instance->ALRMBSSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMB_ENABLE(hrtc);
+    /* Configure the Alarm interrupt */
+    __HAL_RTC_ALARM_ENABLE_IT(hrtc, RTC_IT_ALRB);
+  }
+
+  /* RTC Alarm Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_ALARM_EXTI_ENABLE_IT();
+
+  EXTI->RTSR |= RTC_EXTI_LINE_ALARM_EVENT;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactive the specified RTC Alarm
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Alarm: Specifies the Alarm.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_ALARM_A:  AlarmA
+  *            @arg RTC_ALARM_B:  AlarmB
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alarm)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_ALARM(Alarm));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  if(Alarm == RTC_ALARM_A)
+  {
+    /* AlarmA */
+    __HAL_RTC_ALARMA_DISABLE(hrtc);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRA);
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRxWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  else
+  {
+    /* AlarmB */
+    __HAL_RTC_ALARMB_DISABLE(hrtc);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc,RTC_IT_ALRB);
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRxWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Gets the RTC Alarm value and masks.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sAlarm: Pointer to Date structure
+  * @param  Alarm: Specifies the Alarm.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_ALARM_A: AlarmA
+  *             @arg RTC_ALARM_B: AlarmB
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_FORMAT_BIN: Binary data format
+  *             @arg RTC_FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Alarm, uint32_t Format)
+{
+  uint32_t tmpreg = 0, subsecondtmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_ALARM(Alarm));
+
+  if(Alarm == RTC_ALARM_A)
+  {
+    /* AlarmA */
+    sAlarm->Alarm = RTC_ALARM_A;
+
+    tmpreg = (uint32_t)(hrtc->Instance->ALRMAR);
+    subsecondtmpreg = (uint32_t)((hrtc->Instance->ALRMASSR ) & RTC_ALRMASSR_SS);
+  }
+  else
+  {
+    sAlarm->Alarm = RTC_ALARM_B;
+
+    tmpreg = (uint32_t)(hrtc->Instance->ALRMBR);
+    subsecondtmpreg = (uint32_t)((hrtc->Instance->ALRMBSSR) & RTC_ALRMBSSR_SS);
+  }
+
+  /* Fill the structure with the read parameters */
+  sAlarm->AlarmTime.Hours = (uint32_t)((tmpreg & (RTC_ALRMAR_HT | RTC_ALRMAR_HU)) >> 16);
+  sAlarm->AlarmTime.Minutes = (uint32_t)((tmpreg & (RTC_ALRMAR_MNT | RTC_ALRMAR_MNU)) >> 8);
+  sAlarm->AlarmTime.Seconds = (uint32_t)(tmpreg & (RTC_ALRMAR_ST | RTC_ALRMAR_SU));
+  sAlarm->AlarmTime.TimeFormat = (uint32_t)((tmpreg & RTC_ALRMAR_PM) >> 16);
+  sAlarm->AlarmTime.SubSeconds = (uint32_t) subsecondtmpreg;
+  sAlarm->AlarmDateWeekDay = (uint32_t)((tmpreg & (RTC_ALRMAR_DT | RTC_ALRMAR_DU)) >> 24);
+  sAlarm->AlarmDateWeekDaySel = (uint32_t)(tmpreg & RTC_ALRMAR_WDSEL);
+  sAlarm->AlarmMask = (uint32_t)(tmpreg & RTC_ALARMMASK_ALL);
+
+  if(Format == RTC_FORMAT_BIN)
+  {
+    sAlarm->AlarmTime.Hours = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
+    sAlarm->AlarmTime.Minutes = RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes);
+    sAlarm->AlarmTime.Seconds = RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds);
+    sAlarm->AlarmDateWeekDay = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles Alarm interrupt request.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef* hrtc)
+{
+  if(__HAL_RTC_ALARM_GET_IT(hrtc, RTC_IT_ALRA))
+  {
+    /* Get the status of the Interrupt */
+    if((uint32_t)(hrtc->Instance->CR & RTC_IT_ALRA) != (uint32_t)RESET)
+    {
+      /* AlarmA callback */
+      HAL_RTC_AlarmAEventCallback(hrtc);
+
+      /* Clear the Alarm interrupt pending bit */
+      __HAL_RTC_ALARM_CLEAR_FLAG(hrtc,RTC_FLAG_ALRAF);
+    }
+  }
+
+  if(__HAL_RTC_ALARM_GET_IT(hrtc, RTC_IT_ALRB))
+  {
+    /* Get the status of the Interrupt */
+    if((uint32_t)(hrtc->Instance->CR & RTC_IT_ALRB) != (uint32_t)RESET)
+    {
+      /* AlarmB callback */
+      HAL_RTCEx_AlarmBEventCallback(hrtc);
+
+      /* Clear the Alarm interrupt pending bit */
+      __HAL_RTC_ALARM_CLEAR_FLAG(hrtc,RTC_FLAG_ALRBF);
+    }
+  }
+
+  /* Clear the EXTI's line Flag for RTC Alarm */
+  __HAL_RTC_ALARM_EXTI_CLEAR_FLAG();
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+}
+
+/**
+  * @brief  Alarm A callback.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_AlarmAEventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  This function handles AlarmA Polling request.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+  while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAF) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Alarm interrupt pending bit */
+  __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Group4 Peripheral Control functions
+ *  @brief   Peripheral Control functions
+ *
+@verbatim
+ ===============================================================================
+                     ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) Wait for RTC Time and Date Synchronization
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Waits until the RTC Time and Date registers (RTC_TR and RTC_DR) are
+  *         synchronized with RTC APB clock.
+  * @note   The RTC Resynchronization mode is write protected, use the
+  *         __HAL_RTC_WRITEPROTECTION_DISABLE() before calling this function.
+  * @note   To read the calendar through the shadow registers after Calendar
+  *         initialization, calendar update or after wakeup from low power modes
+  *         the software must first clear the RSF flag.
+  *         The software must then wait until it is set again before reading
+  *         the calendar, which means that the calendar registers have been
+  *         correctly copied into the RTC_TR and RTC_DR shadow registers.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc)
+{
+  uint32_t tickstart = 0;
+
+  /* Clear RSF flag */
+  hrtc->Instance->ISR &= (uint32_t)RTC_RSF_MASK;
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+  /* Wait the registers to be synchronised */
+  while((hrtc->Instance->ISR & RTC_ISR_RSF) == (uint32_t)RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Group5 Peripheral State functions
+ *  @brief   Peripheral State functions
+ *
+@verbatim
+ ===============================================================================
+                     ##### Peripheral State functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) Get RTC state
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Returns the RTC state.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL state
+  */
+HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef* hrtc)
+{
+  return hrtc->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  Enters the RTC Initialization mode.
+  * @note   The RTC Initialization mode is write protected, use the
+  *         __HAL_RTC_WRITEPROTECTION_DISABLE() before calling this function.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef RTC_EnterInitMode(RTC_HandleTypeDef* hrtc)
+{
+  uint32_t tickstart = 0;
+
+  /* Check if the Initialization mode is set */
+  if((hrtc->Instance->ISR & RTC_ISR_INITF) == (uint32_t)RESET)
+  {
+    /* Set the Initialization mode */
+    hrtc->Instance->ISR = (uint32_t)RTC_INIT_MASK;
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC is in INIT state and if Time out is reached exit */
+    while((hrtc->Instance->ISR & RTC_ISR_INITF) == (uint32_t)RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Converts a 2 digit decimal to BCD format.
+  * @param  Value: Byte to be converted
+  * @retval Converted byte
+  */
+uint8_t RTC_ByteToBcd2(uint8_t Value)
+{
+  uint32_t bcdhigh = 0;
+
+  while(Value >= 10)
+  {
+    bcdhigh++;
+    Value -= 10;
+  }
+
+  return  ((uint8_t)(bcdhigh << 4) | Value);
+}
+
+/**
+  * @brief  Converts from 2 digit BCD to Binary.
+  * @param  Value: BCD value to be converted
+  * @retval Converted word
+  */
+uint8_t RTC_Bcd2ToByte(uint8_t Value)
+{
+  uint32_t tmp = 0;
+  tmp = ((uint8_t)(Value & (uint8_t)0xF0) >> (uint8_t)0x4) * 10;
+  return (tmp + (Value & (uint8_t)0x0F));
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RTC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_rtc_ex.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_rtc_ex.c
@@ -1,0 +1,1813 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rtc_ex.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   RTC HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Real Time Clock (RTC) Extension peripheral:
+  *           + RTC Time Stamp functions
+  *           + RTC Tamper functions
+  *           + RTC Wake-up functions
+  *           + Extension Control functions
+  *           + Extension RTC features functions
+  *
+  @verbatim
+  ==============================================================================
+                  ##### How to use this driver #####
+  ==============================================================================
+  [..]
+    (+) Enable the RTC domain access.
+    (+) Configure the RTC Prescaler (Asynchronous and Synchronous) and RTC hour
+        format using the HAL_RTC_Init() function.
+
+  *** RTC Wakeup configuration ***
+  ================================
+  [..]
+    (+) To configure the RTC Wakeup Clock source and Counter use the HAL_RTC_SetWakeUpTimer()
+        function. You can also configure the RTC Wakeup timer in interrupt mode
+        using the HAL_RTC_SetWakeUpTimer_IT() function.
+    (+) To read the RTC WakeUp Counter register, use the HAL_RTC_GetWakeUpTimer()
+        function.
+
+  *** TimeStamp configuration ***
+  ===============================
+  [..]
+    (+) Enables the RTC TimeStamp using the HAL_RTC_SetTimeStamp() function.
+        You can also configure the RTC TimeStamp with interrupt mode using the
+        HAL_RTC_SetTimeStamp_IT() function.
+    (+) To read the RTC TimeStamp Time and Date register, use the HAL_RTC_GetTimeStamp()
+        function.
+
+  *** Internal TimeStamp configuration ***
+  ===============================
+  [..]
+    (+) Enables the RTC internal TimeStamp using the HAL_RTC_SetInternalTimeStamp() function.
+    (+) To read the RTC TimeStamp Time and Date register, use the HAL_RTC_GetTimeStamp()
+        function.
+
+  *** Tamper configuration ***
+  ============================
+  [..]
+    (+) Enable the RTC Tamper and Configure the Tamper filter count, trigger Edge
+        or Level according to the Tamper filter (if equal to 0 Edge else Level)
+        value, sampling frequency, NoErase, MaskFlag,  precharge or discharge and
+        Pull-UP using the HAL_RTC_SetTamper() function. You can configure RTC Tamper
+        with interrupt mode using HAL_RTC_SetTamper_IT() function.
+    (+) The default configuration of the Tamper erases the backup registers. To avoid
+        erase, enable the NoErase field on the RTC_TAMPCR register.
+
+  *** Backup Data Registers configuration ***
+  ===========================================
+  [..]
+    (+) To write to the RTC Backup Data registers, use the HAL_RTC_BKUPWrite()
+        function.
+    (+) To read the RTC Backup Data registers, use the HAL_RTC_BKUPRead()
+        function.
+
+   @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RTCEx RTCEx
+  * @brief RTC Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup RTCEx_Exported_Functions RTCEx Exported Functions
+  * @{
+  */
+
+
+/** @defgroup RTCEx_Group1 RTC TimeStamp and Tamper functions
+ *  @brief   RTC TimeStamp and Tamper functions
+ *
+@verbatim
+ ===============================================================================
+                 ##### RTC TimeStamp and Tamper functions #####
+ ===============================================================================
+
+ [..] This section provides functions allowing to configure TimeStamp feature
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Sets TimeStamp.
+  * @note   This API must be called before enabling the TimeStamp feature.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  TimeStampEdge: Specifies the pin edge on which the TimeStamp is
+  *         activated.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPEDGE_RISING: the Time stamp event occurs on the
+  *                                        rising edge of the related pin.
+  *             @arg RTC_TIMESTAMPEDGE_FALLING: the Time stamp event occurs on the
+  *                                         falling edge of the related pin.
+  * @param  RTC_TimeStampPin: specifies the RTC TimeStamp Pin.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPPIN_PC13: PC13 is selected as RTC TimeStamp Pin.
+  *             @arg RTC_TIMESTAMPPIN_PI8: PI8 is selected as RTC TimeStamp Pin.
+  *             @arg RTC_TIMESTAMPPIN_PC1: PC1 is selected as RTC TimeStamp Pin.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIMESTAMP_EDGE(TimeStampEdge));
+  assert_param(IS_RTC_TIMESTAMP_PIN(RTC_TimeStampPin));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Get the RTC_CR register and clear the bits to be configured */
+  tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
+
+  tmpreg|= TimeStampEdge;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  hrtc->Instance->OR &= (uint32_t)~RTC_OR_TSINSEL;
+  hrtc->Instance->OR |= (uint32_t)(RTC_TimeStampPin);
+
+  /* Configure the Time Stamp TSEDGE and Enable bits */
+  hrtc->Instance->CR = (uint32_t)tmpreg;
+
+  __HAL_RTC_TIMESTAMP_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets TimeStamp with Interrupt.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @note   This API must be called before enabling the TimeStamp feature.
+  * @param  TimeStampEdge: Specifies the pin edge on which the TimeStamp is
+  *         activated.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPEDGE_RISING: the Time stamp event occurs on the
+  *                                        rising edge of the related pin.
+  *             @arg RTC_TIMESTAMPEDGE_FALLING: the Time stamp event occurs on the
+  *                                         falling edge of the related pin.
+  * @param  RTC_TimeStampPin: Specifies the RTC TimeStamp Pin.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPPIN_PC13: PC13 is selected as RTC TimeStamp Pin.
+  *             @arg RTC_TIMESTAMPPIN_PI8: PI8 is selected as RTC TimeStamp Pin.
+  *             @arg RTC_TIMESTAMPPIN_PC1: PC1 is selected as RTC TimeStamp Pin.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIMESTAMP_EDGE(TimeStampEdge));
+  assert_param(IS_RTC_TIMESTAMP_PIN(RTC_TimeStampPin));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Get the RTC_CR register and clear the bits to be configured */
+  tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
+
+  tmpreg |= TimeStampEdge;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Time Stamp TSEDGE and Enable bits */
+  hrtc->Instance->CR = (uint32_t)tmpreg;
+
+  hrtc->Instance->OR &= (uint32_t)~RTC_OR_TSINSEL;
+  hrtc->Instance->OR |= (uint32_t)(RTC_TimeStampPin);
+
+  __HAL_RTC_TIMESTAMP_ENABLE(hrtc);
+
+  /* Enable IT timestamp */
+  __HAL_RTC_TIMESTAMP_ENABLE_IT(hrtc,RTC_IT_TS);
+
+  /* RTC timestamp Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT();
+
+  EXTI->RTSR |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates TimeStamp.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tmpreg = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* In case of interrupt mode is used, the interrupt source must disabled */
+  __HAL_RTC_TIMESTAMP_DISABLE_IT(hrtc, RTC_IT_TS);
+
+  /* Get the RTC_CR register and clear the bits to be configured */
+  tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
+
+  /* Configure the Time Stamp TSEDGE and Enable bits */
+  hrtc->Instance->CR = (uint32_t)tmpreg;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets Internal TimeStamp.
+  * @note   This API must be called before enabling the internal TimeStamp feature.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetInternalTimeStamp(RTC_HandleTypeDef *hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the internal Time Stamp Enable bits */
+  __HAL_RTC_INTERNAL_TIMESTAMP_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates internal TimeStamp.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateInternalTimeStamp(RTC_HandleTypeDef *hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the internal Time Stamp Enable bits */
+  __HAL_RTC_INTERNAL_TIMESTAMP_DISABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Gets the RTC TimeStamp value.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTimeStamp: Pointer to Time structure
+  * @param  sTimeStampDate: Pointer to Date structure
+  * @param  Format: specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             FORMAT_BIN: Binary data format
+  *             FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_GetTimeStamp(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef* sTimeStamp, RTC_DateTypeDef* sTimeStampDate, uint32_t Format)
+{
+  uint32_t tmptime = 0, tmpdate = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Get the TimeStamp time and date registers values */
+  tmptime = (uint32_t)(hrtc->Instance->TSTR & RTC_TR_RESERVED_MASK);
+  tmpdate = (uint32_t)(hrtc->Instance->TSDR & RTC_DR_RESERVED_MASK);
+
+  /* Fill the Time structure fields with the read parameters */
+  sTimeStamp->Hours = (uint8_t)((tmptime & (RTC_TR_HT | RTC_TR_HU)) >> 16);
+  sTimeStamp->Minutes = (uint8_t)((tmptime & (RTC_TR_MNT | RTC_TR_MNU)) >> 8);
+  sTimeStamp->Seconds = (uint8_t)(tmptime & (RTC_TR_ST | RTC_TR_SU));
+  sTimeStamp->TimeFormat = (uint8_t)((tmptime & (RTC_TR_PM)) >> 16);
+  sTimeStamp->SubSeconds = (uint32_t) hrtc->Instance->TSSSR;
+
+  /* Fill the Date structure fields with the read parameters */
+  sTimeStampDate->Year = 0;
+  sTimeStampDate->Month = (uint8_t)((tmpdate & (RTC_DR_MT | RTC_DR_MU)) >> 8);
+  sTimeStampDate->Date = (uint8_t)(tmpdate & (RTC_DR_DT | RTC_DR_DU));
+  sTimeStampDate->WeekDay = (uint8_t)((tmpdate & (RTC_DR_WDU)) >> 13);
+
+  /* Check the input parameters format */
+  if(Format == RTC_FORMAT_BIN)
+  {
+    /* Convert the TimeStamp structure parameters to Binary format */
+    sTimeStamp->Hours = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Hours);
+    sTimeStamp->Minutes = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Minutes);
+    sTimeStamp->Seconds = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Seconds);
+
+    /* Convert the DateTimeStamp structure parameters to Binary format */
+    sTimeStampDate->Month = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->Month);
+    sTimeStampDate->Date = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->Date);
+    sTimeStampDate->WeekDay = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->WeekDay);
+  }
+
+  /* Clear the TIMESTAMP Flag */
+  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets Tamper
+  * @note   By calling this API we disable the tamper interrupt for all tampers.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTamper: Pointer to Tamper Structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_TAMPER(sTamper->Tamper));
+  assert_param(IS_RTC_TAMPER_TRIGGER(sTamper->Trigger));
+  assert_param(IS_RTC_TAMPER_ERASE_MODE(sTamper->NoErase));
+  assert_param(IS_RTC_TAMPER_MASKFLAG_STATE(sTamper->MaskFlag));
+  assert_param(IS_RTC_TAMPER_FILTER(sTamper->Filter));
+  assert_param(IS_RTC_TAMPER_SAMPLING_FREQ(sTamper->SamplingFrequency));
+  assert_param(IS_RTC_TAMPER_PRECHARGE_DURATION(sTamper->PrechargeDuration));
+  assert_param(IS_RTC_TAMPER_PULLUP_STATE(sTamper->TamperPullUp));
+  assert_param(IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION(sTamper->TimeStampOnTamperDetection));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if(sTamper->Trigger != RTC_TAMPERTRIGGER_RISINGEDGE)
+  {
+    sTamper->Trigger = (uint32_t)(sTamper->Tamper << 1);
+  }
+
+  if(sTamper->NoErase != RTC_TAMPER_ERASE_BACKUP_ENABLE)
+  {
+    sTamper->NoErase = 0;
+    if((sTamper->Tamper & RTC_TAMPER_1) != 0)
+    {
+      sTamper->NoErase |= RTC_TAMPCR_TAMP1NOERASE;
+    }
+    if((sTamper->Tamper & RTC_TAMPER_2) != 0)
+    {
+      sTamper->NoErase |= RTC_TAMPCR_TAMP2NOERASE;
+    }
+    if((sTamper->Tamper & RTC_TAMPER_3) != 0)
+    {
+      sTamper->NoErase |= RTC_TAMPCR_TAMP3NOERASE;
+    }
+  }
+
+  if(sTamper->MaskFlag != RTC_TAMPERMASK_FLAG_DISABLE)
+  {
+    sTamper->MaskFlag = 0;
+    if((sTamper->Tamper & RTC_TAMPER_1) != 0)
+    {
+      sTamper->MaskFlag |= RTC_TAMPCR_TAMP1MF;
+    }
+    if((sTamper->Tamper & RTC_TAMPER_2) != 0)
+    {
+      sTamper->MaskFlag |= RTC_TAMPCR_TAMP2MF;
+    }
+    if((sTamper->Tamper & RTC_TAMPER_3) != 0)
+    {
+      sTamper->MaskFlag |= RTC_TAMPCR_TAMP3MF;
+    }
+  }
+
+  tmpreg = ((uint32_t)sTamper->Tamper | (uint32_t)sTamper->Trigger  | (uint32_t)sTamper->NoErase |\
+            (uint32_t)sTamper->MaskFlag | (uint32_t)sTamper->Filter | (uint32_t)sTamper->SamplingFrequency |\
+            (uint32_t)sTamper->PrechargeDuration | (uint32_t)sTamper->TamperPullUp | sTamper->TimeStampOnTamperDetection);
+
+  hrtc->Instance->TAMPCR &= (uint32_t)~((uint32_t)sTamper->Tamper | (uint32_t)(sTamper->Tamper << 1) | (uint32_t)RTC_TAMPCR_TAMPTS |\
+                                       (uint32_t)RTC_TAMPCR_TAMPFREQ | (uint32_t)RTC_TAMPCR_TAMPFLT | (uint32_t)RTC_TAMPCR_TAMPPRCH |\
+                                       (uint32_t)RTC_TAMPCR_TAMPPUDIS | (uint32_t)RTC_TAMPCR_TAMPIE | (uint32_t)RTC_TAMPCR_TAMP1IE |\
+                                       (uint32_t)RTC_TAMPCR_TAMP2IE | (uint32_t)RTC_TAMPCR_TAMP3IE | (uint32_t)RTC_TAMPCR_TAMP1NOERASE |\
+                                       (uint32_t)RTC_TAMPCR_TAMP2NOERASE | (uint32_t)RTC_TAMPCR_TAMP3NOERASE | (uint32_t)RTC_TAMPCR_TAMP1MF |\
+                                       (uint32_t)RTC_TAMPCR_TAMP2MF | (uint32_t)RTC_TAMPCR_TAMP3MF);
+
+  hrtc->Instance->TAMPCR |= tmpreg;
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets Tamper with interrupt.
+  * @note   By calling this API we force the tamper interrupt for all tampers.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTamper: Pointer to RTC Tamper.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_TAMPER(sTamper->Tamper));
+  assert_param(IS_RTC_TAMPER_INTERRUPT(sTamper->Interrupt));
+  assert_param(IS_RTC_TAMPER_TRIGGER(sTamper->Trigger));
+  assert_param(IS_RTC_TAMPER_ERASE_MODE(sTamper->NoErase));
+  assert_param(IS_RTC_TAMPER_MASKFLAG_STATE(sTamper->MaskFlag));
+  assert_param(IS_RTC_TAMPER_FILTER(sTamper->Filter));
+  assert_param(IS_RTC_TAMPER_SAMPLING_FREQ(sTamper->SamplingFrequency));
+  assert_param(IS_RTC_TAMPER_PRECHARGE_DURATION(sTamper->PrechargeDuration));
+  assert_param(IS_RTC_TAMPER_PULLUP_STATE(sTamper->TamperPullUp));
+  assert_param(IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION(sTamper->TimeStampOnTamperDetection));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Configure the tamper trigger */
+  if(sTamper->Trigger != RTC_TAMPERTRIGGER_RISINGEDGE)
+  {
+    sTamper->Trigger = (uint32_t)(sTamper->Tamper << 1);
+  }
+
+  if(sTamper->NoErase != RTC_TAMPER_ERASE_BACKUP_ENABLE)
+  {
+    sTamper->NoErase = 0;
+    if((sTamper->Tamper & RTC_TAMPER_1) != 0)
+    {
+      sTamper->NoErase |= RTC_TAMPCR_TAMP1NOERASE;
+    }
+    if((sTamper->Tamper & RTC_TAMPER_2) != 0)
+    {
+      sTamper->NoErase |= RTC_TAMPCR_TAMP2NOERASE;
+    }
+    if((sTamper->Tamper & RTC_TAMPER_3) != 0)
+    {
+      sTamper->NoErase |= RTC_TAMPCR_TAMP3NOERASE;
+    }
+  }
+
+  if(sTamper->MaskFlag != RTC_TAMPERMASK_FLAG_DISABLE)
+  {
+    sTamper->MaskFlag = 0;
+    if((sTamper->Tamper & RTC_TAMPER_1) != 0)
+    {
+      sTamper->MaskFlag |= RTC_TAMPCR_TAMP1MF;
+    }
+    if((sTamper->Tamper & RTC_TAMPER_2) != 0)
+    {
+      sTamper->MaskFlag |= RTC_TAMPCR_TAMP2MF;
+    }
+    if((sTamper->Tamper & RTC_TAMPER_3) != 0)
+    {
+      sTamper->MaskFlag |= RTC_TAMPCR_TAMP3MF;
+    }
+  }
+
+  tmpreg = ((uint32_t)sTamper->Tamper | (uint32_t)sTamper->Interrupt | (uint32_t)sTamper->Trigger  | (uint32_t)sTamper->NoErase |\
+            (uint32_t)sTamper->MaskFlag | (uint32_t)sTamper->Filter | (uint32_t)sTamper->SamplingFrequency |\
+            (uint32_t)sTamper->PrechargeDuration | (uint32_t)sTamper->TamperPullUp | sTamper->TimeStampOnTamperDetection);
+
+  hrtc->Instance->TAMPCR &= (uint32_t)~((uint32_t)sTamper->Tamper | (uint32_t)(sTamper->Tamper << 1) | (uint32_t)RTC_TAMPCR_TAMPTS |\
+                                       (uint32_t)RTC_TAMPCR_TAMPFREQ | (uint32_t)RTC_TAMPCR_TAMPFLT | (uint32_t)RTC_TAMPCR_TAMPPRCH |\
+                                       (uint32_t)RTC_TAMPCR_TAMPPUDIS | (uint32_t)RTC_TAMPCR_TAMPIE | (uint32_t)RTC_TAMPCR_TAMP1IE |\
+                                       (uint32_t)RTC_TAMPCR_TAMP2IE | (uint32_t)RTC_TAMPCR_TAMP3IE | (uint32_t)RTC_TAMPCR_TAMP1NOERASE |\
+                                       (uint32_t)RTC_TAMPCR_TAMP2NOERASE | (uint32_t)RTC_TAMPCR_TAMP3NOERASE | (uint32_t)RTC_TAMPCR_TAMP1MF |\
+                                       (uint32_t)RTC_TAMPCR_TAMP2MF | (uint32_t)RTC_TAMPCR_TAMP3MF);
+
+  hrtc->Instance->TAMPCR |= tmpreg;
+
+  /* RTC Tamper Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT();
+
+  EXTI->RTSR |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT;
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates Tamper.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Tamper: Selected tamper pin.
+  *          This parameter can be RTC_Tamper_1 and/or RTC_TAMPER_2.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t Tamper)
+{
+  assert_param(IS_RTC_TAMPER(Tamper));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+/* Disable the selected Tamper pin */
+  hrtc->Instance->TAMPCR &= (uint32_t)~Tamper;
+
+  if ((Tamper & RTC_TAMPER_1) != 0)
+  {
+    /* Disable the Tamper1 interrupt */
+    hrtc->Instance->TAMPCR &= (uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP1);
+  }
+  if ((Tamper & RTC_TAMPER_2) != 0)
+  {
+    /* Disable the Tamper2 interrupt */
+    hrtc->Instance->TAMPCR &= (uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP2);
+  }
+  if ((Tamper & RTC_TAMPER_3) != 0)
+  {
+    /* Disable the Tamper2 interrupt */
+    hrtc->Instance->TAMPCR &= (uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP3);
+  }
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles TimeStamp interrupt request.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTCEx_TamperTimeStampIRQHandler(RTC_HandleTypeDef *hrtc)
+{
+  if(__HAL_RTC_TIMESTAMP_GET_IT(hrtc, RTC_IT_TS))
+  {
+    /* Get the status of the Interrupt */
+    if((uint32_t)(hrtc->Instance->CR & RTC_IT_TS) != (uint32_t)RESET)
+    {
+       /* TIMESTAMP callback */
+        HAL_RTCEx_TimeStampEventCallback(hrtc);
+
+      /* Clear the TIMESTAMP interrupt pending bit */
+      __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc,RTC_FLAG_TSF);
+    }
+  }
+
+  /* Get the status of the Interrupt */
+  if(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP1F)== SET)
+  {
+    /* Get the TAMPER Interrupt enable bit and pending bit */
+    if((((hrtc->Instance->TAMPCR & RTC_TAMPCR_TAMPIE)) != (uint32_t)RESET) || \
+       (((hrtc->Instance->TAMPCR & RTC_TAMPCR_TAMP1IE)) != (uint32_t)RESET))
+    {
+      /* Tamper callback */
+      HAL_RTCEx_Tamper1EventCallback(hrtc);
+
+      /* Clear the Tamper interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc,RTC_FLAG_TAMP1F);
+    }
+  }
+
+  /* Get the status of the Interrupt */
+  if(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP2F)== SET)
+  {
+    /* Get the TAMPER Interrupt enable bit and pending bit */
+    if((((hrtc->Instance->TAMPCR & RTC_TAMPCR_TAMPIE)) != (uint32_t)RESET) || \
+       (((hrtc->Instance->TAMPCR & RTC_TAMPCR_TAMP2IE)) != (uint32_t)RESET))
+    {
+      /* Tamper callback */
+      HAL_RTCEx_Tamper2EventCallback(hrtc);
+
+      /* Clear the Tamper interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP2F);
+    }
+  }
+
+  /* Get the status of the Interrupt */
+  if(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP3F)== SET)
+  {
+    /* Get the TAMPER Interrupt enable bit and pending bit */
+    if((((hrtc->Instance->TAMPCR & RTC_TAMPCR_TAMPIE)) != (uint32_t)RESET) || \
+       (((hrtc->Instance->TAMPCR & RTC_TAMPCR_TAMP3IE)) != (uint32_t)RESET))
+    {
+      /* Tamper callback */
+      HAL_RTCEx_Tamper3EventCallback(hrtc);
+
+      /* Clear the Tamper interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP3F);
+    }
+  }
+
+  /* Clear the EXTI's Flag for RTC TimeStamp and Tamper */
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG();
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+}
+
+/**
+  * @brief  TimeStamp callback.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTCEx_TimeStampEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_TimeStampEventCallback could be implemented in the user file
+  */
+}
+
+/**
+  * @brief  Tamper 1 callback.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTCEx_Tamper1EventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_Tamper1EventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Tamper 2 callback.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTCEx_Tamper2EventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_Tamper2EventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Tamper 3 callback.
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+__weak void HAL_RTCEx_Tamper3EventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTCEx_Tamper3EventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  This function handles TimeStamp polling request.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTimeStampEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while(__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSF) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  if(__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSOVF) != RESET)
+  {
+    /* Clear the TIMESTAMP OverRun Flag */
+    __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSOVF);
+
+    /* Change TIMESTAMP state */
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    return HAL_ERROR;
+   }
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles Tamper1 Polling.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper1Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Get the status of the Interrupt */
+  while(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP1F)== RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Tamper Flag */
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc,RTC_FLAG_TAMP1F);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles Tamper2 Polling.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper2Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Get the status of the Interrupt */
+  while(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP2F) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Tamper Flag */
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc,RTC_FLAG_TAMP2F);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles Tamper3 Polling.
+  * @param  hrtc: RTC handle
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+
+  /* Get the status of the Interrupt */
+  while(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP3F) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Tamper Flag */
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc,RTC_FLAG_TAMP3F);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Group2 RTC Wake-up functions
+ *  @brief   RTC Wake-up functions
+ *
+@verbatim
+ ===============================================================================
+                        ##### RTC Wake-up functions #####
+ ===============================================================================
+
+ [..] This section provides functions allowing to configure Wake-up feature
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Sets wake up timer.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  WakeUpCounter: Wake up counter
+  * @param  WakeUpClock: Wake up clock
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_WAKEUP_CLOCK(WakeUpClock));
+  assert_param(IS_RTC_WAKEUP_COUNTER(WakeUpCounter));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /*Check RTC WUTWF flag is reset only when wake up timer enabled*/
+  if((hrtc->Instance->CR & RTC_CR_WUTE) != RESET)
+  {
+    /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Wakeup Timer clock source bits in CR register */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
+
+  /* Configure the clock source */
+  hrtc->Instance->CR |= (uint32_t)WakeUpClock;
+
+  /* Configure the Wakeup Timer counter */
+  hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
+
+   /* Enable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets wake up timer with interrupt
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  WakeUpCounter: Wake up counter
+  * @param  WakeUpClock: Wake up clock
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_WAKEUP_CLOCK(WakeUpClock));
+  assert_param(IS_RTC_WAKEUP_COUNTER(WakeUpCounter));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+    /*Check RTC WUTWF flag is reset only when wake up timer enabled*/
+  if((hrtc->Instance->CR & RTC_CR_WUTE) != RESET)
+  {
+    /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Configure the Wakeup Timer counter */
+  hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
+
+  /* Clear the Wakeup Timer clock source bits in CR register */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
+
+  /* Configure the clock source */
+  hrtc->Instance->CR |= (uint32_t)WakeUpClock;
+
+  /* RTC WakeUpTimer Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT();
+
+  EXTI->RTSR |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT;
+
+  /* Configure the Interrupt in the RTC_CR register */
+  __HAL_RTC_WAKEUPTIMER_ENABLE_IT(hrtc,RTC_IT_WUT);
+
+  /* Enable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates wake up timer counter.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+uint32_t HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tickstart = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Disable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  /* In case of interrupt mode is used, the interrupt source must disabled */
+  __HAL_RTC_WAKEUPTIMER_DISABLE_IT(hrtc,RTC_IT_WUT);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
+  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Gets wake up timer counter.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval Counter value
+  */
+uint32_t HAL_RTCEx_GetWakeUpTimer(RTC_HandleTypeDef *hrtc)
+{
+  /* Get the counter value */
+  return ((uint32_t)(hrtc->Instance->WUTR & RTC_WUTR_WUT));
+}
+
+/**
+  * @brief  This function handles Wake Up Timer interrupt request.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTCEx_WakeUpTimerIRQHandler(RTC_HandleTypeDef *hrtc)
+{
+  if(__HAL_RTC_WAKEUPTIMER_GET_IT(hrtc, RTC_IT_WUT))
+  {
+    /* Get the status of the Interrupt */
+    if((uint32_t)(hrtc->Instance->CR & RTC_IT_WUT) != (uint32_t)RESET)
+    {
+      /* WAKEUPTIMER callback */
+      HAL_RTCEx_WakeUpTimerEventCallback(hrtc);
+
+      /* Clear the WAKEUPTIMER interrupt pending bit */
+      __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+    }
+  }
+
+  /* Clear the EXTI's line Flag for RTC WakeUpTimer */
+  __HAL_RTC_WAKEUPTIMER_EXTI_CLEAR_FLAG();
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+}
+
+/**
+  * @brief  Wake Up Timer callback.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_WakeUpTimerEventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  This function handles Wake Up Timer Polling.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTF) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the WAKEUPTIMER Flag */
+  __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+
+/** @defgroup RTCEx_Group3 Extension Peripheral Control functions
+ *  @brief   Extension Peripheral Control functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Extension Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) Write a data in a specified RTC Backup data register
+      (+) Read a data in a specified RTC Backup data register
+      (+) Set the Coarse calibration parameters.
+      (+) Deactivate the Coarse calibration parameters
+      (+) Set the Smooth calibration parameters.
+      (+) Configure the Synchronization Shift Control Settings.
+      (+) Configure the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+      (+) Deactivate the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+      (+) Enable the RTC reference clock detection.
+      (+) Disable the RTC reference clock detection.
+      (+) Enable the Bypass Shadow feature.
+      (+) Disable the Bypass Shadow feature.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Writes a data in a specified RTC Backup data register.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  BackupRegister: RTC Backup data Register number.
+  *          This parameter can be: RTC_BKP_DRx where x can be from 0 to 19 to
+  *                                 specify the register.
+  * @param  Data: Data to be written in the specified RTC Backup data register.
+  * @retval None
+  */
+void HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data)
+{
+  uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_BKP(BackupRegister));
+
+  tmp = (uint32_t)&(hrtc->Instance->BKP0R);
+  tmp += (BackupRegister * 4);
+
+  /* Write the specified register */
+  *(__IO uint32_t *)tmp = (uint32_t)Data;
+}
+
+/**
+  * @brief  Reads data from the specified RTC Backup data Register.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  BackupRegister: RTC Backup data Register number.
+  *          This parameter can be: RTC_BKP_DRx where x can be from 0 to 19 to
+  *                                 specify the register.
+  * @retval Read value
+  */
+uint32_t HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister)
+{
+  uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_BKP(BackupRegister));
+
+  tmp = (uint32_t)&(hrtc->Instance->BKP0R);
+  tmp += (BackupRegister * 4);
+
+  /* Read the specified register */
+  return (*(__IO uint32_t *)tmp);
+}
+
+/**
+  * @brief  Sets the Smooth calibration parameters.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  SmoothCalibPeriod: Select the Smooth Calibration Period.
+  *          This parameter can be can be one of the following values :
+  *             @arg RTC_SMOOTHCALIB_PERIOD_32SEC: The smooth calibration period is 32s.
+  *             @arg RTC_SMOOTHCALIB_PERIOD_16SEC: The smooth calibration period is 16s.
+  *             @arg RTC_SMOOTHCALIB_PERIOD_8SEC: The smooth calibration period is 8s.
+  * @param  SmoothCalibPlusPulses: Select to Set or reset the CALP bit.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_SMOOTHCALIB_PLUSPULSES_SET: Add one RTCCLK pulses every 2*11 pulses.
+  *             @arg RTC_SMOOTHCALIB_PLUSPULSES_RESET: No RTCCLK pulses are added.
+  * @param  SmouthCalibMinusPulsesValue: Select the value of CALM[8:0] bits.
+  *          This parameter can be one any value from 0 to 0x000001FF.
+  * @note   To deactivate the smooth calibration, the field SmoothCalibPlusPulses
+  *         must be equal to SMOOTHCALIB_PLUSPULSES_RESET and the field
+  *         SmouthCalibMinusPulsesValue must be equal to 0.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef* hrtc, uint32_t SmoothCalibPeriod, uint32_t SmoothCalibPlusPulses, uint32_t SmouthCalibMinusPulsesValue)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_SMOOTH_CALIB_PERIOD(SmoothCalibPeriod));
+  assert_param(IS_RTC_SMOOTH_CALIB_PLUS(SmoothCalibPlusPulses));
+  assert_param(IS_RTC_SMOOTH_CALIB_MINUS(SmouthCalibMinusPulsesValue));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* check if a calibration is pending*/
+  if((hrtc->Instance->ISR & RTC_ISR_RECALPF) != RESET)
+  {
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+    /* check if a calibration is pending*/
+    while((hrtc->Instance->ISR & RTC_ISR_RECALPF) != RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        /* Change RTC state */
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Configure the Smooth calibration settings */
+  hrtc->Instance->CALR = (uint32_t)((uint32_t)SmoothCalibPeriod | (uint32_t)SmoothCalibPlusPulses | (uint32_t)SmouthCalibMinusPulsesValue);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the Synchronization Shift Control Settings.
+  * @note   When REFCKON is set, firmware must not write to Shift control register.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  ShiftAdd1S: Select to add or not 1 second to the time calendar.
+  *          This parameter can be one of the following values :
+  *             @arg RTC_SHIFTADD1S_SET: Add one second to the clock calendar.
+  *             @arg RTC_SHIFTADD1S_RESET: No effect.
+  * @param  ShiftSubFS: Select the number of Second Fractions to substitute.
+  *          This parameter can be one any value from 0 to 0x7FFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef* hrtc, uint32_t ShiftAdd1S, uint32_t ShiftSubFS)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_SHIFT_ADD1S(ShiftAdd1S));
+  assert_param(IS_RTC_SHIFT_SUBFS(ShiftSubFS));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+    /* Wait until the shift is completed*/
+    while((hrtc->Instance->ISR & RTC_ISR_SHPF) != RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Check if the reference clock detection is disabled */
+    if((hrtc->Instance->CR & RTC_CR_REFCKON) == RESET)
+    {
+      /* Configure the Shift settings */
+      hrtc->Instance->SHIFTR = (uint32_t)(uint32_t)(ShiftSubFS) | (uint32_t)(ShiftAdd1S);
+
+      /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+      if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == RESET)
+      {
+        if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+        {
+          /* Enable the write protection for RTC registers */
+          __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+          hrtc->State = HAL_RTC_STATE_ERROR;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hrtc);
+
+          return HAL_ERROR;
+        }
+      }
+    }
+    else
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      /* Change RTC state */
+      hrtc->State = HAL_RTC_STATE_ERROR;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_ERROR;
+    }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  CalibOutput: Select the Calibration output Selection .
+  *          This parameter can be one of the following values:
+  *             @arg RTC_CALIBOUTPUT_512HZ: A signal has a regular waveform at 512Hz.
+  *             @arg RTC_CALIBOUTPUT_1HZ: A signal has a regular waveform at 1Hz.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetCalibrationOutPut(RTC_HandleTypeDef* hrtc, uint32_t CalibOutput)
+{
+  /* Check the parameters */
+  assert_param(IS_RTC_CALIB_OUTPUT(CalibOutput));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Clear flags before config */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_COSEL;
+
+  /* Configure the RTC_CR register */
+  hrtc->Instance->CR |= (uint32_t)CalibOutput;
+
+  __HAL_RTC_CALIBRATION_OUTPUT_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateCalibrationOutPut(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  __HAL_RTC_CALIBRATION_OUTPUT_DISABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables the RTC reference clock detection.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetRefClock(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state*/
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    __HAL_RTC_CLOCKREF_DETECTION_ENABLE(hrtc);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+   /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disable the RTC reference clock detection.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateRefClock(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state*/
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    __HAL_RTC_CLOCKREF_DETECTION_DISABLE(hrtc);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables the Bypass Shadow feature.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @note   When the Bypass Shadow is enabled the calendar value are taken
+  *         directly from the Calendar counter.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set the BYPSHAD bit */
+  hrtc->Instance->CR |= (uint8_t)RTC_CR_BYPSHAD;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables the Bypass Shadow feature.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @note   When the Bypass Shadow is enabled the calendar value are taken
+  *         directly from the Calendar counter.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Reset the BYPSHAD bit */
+  hrtc->Instance->CR &= (uint8_t)~RTC_CR_BYPSHAD;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+  /** @defgroup RTCEx_Group4 Extended features functions
+ *  @brief    Extended features functions
+ *
+@verbatim
+ ===============================================================================
+                 ##### Extended features functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) RTC Alram B callback
+      (+) RTC Poll for Alarm B request
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Alarm B callback.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTCEx_AlarmBEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_AlarmBEventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  This function handles AlarmB Polling request.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBF) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Alarm Flag */
+  __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RTC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_sd.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_sd.c
@@ -1,0 +1,3381 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_sd.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   SD card HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Secure Digital (SD) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+  [..]
+    This driver implements a high level communication layer for read and write from/to
+    this memory. The needed STM32 hardware resources (SDMMC and GPIO) are performed by
+    the user in HAL_SD_MspInit() function (MSP layer).
+    Basically, the MSP layer configuration should be the same as we provide in the
+    examples.
+    You can easily tailor this configuration according to hardware resources.
+
+  [..]
+    This driver is a generic layered driver for SDMMC memories which uses the HAL
+    SDMMC driver functions to interface with SD and uSD cards devices.
+    It is used as follows:
+
+    (#)Initialize the SDMMC low level resources by implement the HAL_SD_MspInit() API:
+        (##) Enable the SDMMC interface clock using __HAL_RCC_SDMMC_CLK_ENABLE();
+        (##) SDMMC pins configuration for SD card
+            (+++) Enable the clock for the SDMMC GPIOs using the functions __HAL_RCC_GPIOx_CLK_ENABLE();
+            (+++) Configure these SDMMC pins as alternate function pull-up using HAL_GPIO_Init()
+                  and according to your pin assignment;
+        (##) DMA Configuration if you need to use DMA process (HAL_SD_ReadBlocks_DMA()
+             and HAL_SD_WriteBlocks_DMA() APIs).
+            (+++) Enable the DMAx interface clock using __HAL_RCC_DMAx_CLK_ENABLE();
+            (+++) Configure the DMA using the function HAL_DMA_Init() with predeclared and filled.
+        (##) NVIC configuration if you need to use interrupt process when using DMA transfer.
+            (+++) Configure the SDMMC and DMA interrupt priorities using functions
+                  HAL_NVIC_SetPriority(); DMA priority is superior to SDMMC's priority
+            (+++) Enable the NVIC DMA and SDMMC IRQs using function HAL_NVIC_EnableIRQ()
+            (+++) SDMMC interrupts are managed using the macros __HAL_SD_SDMMC_ENABLE_IT()
+                  and __HAL_SD_SDMMC_DISABLE_IT() inside the communication process.
+            (+++) SDMMC interrupts pending bits are managed using the macros __HAL_SD_SDMMC_GET_IT()
+                  and __HAL_SD_SDMMC_CLEAR_IT()
+    (#) At this stage, you can perform SD read/write/erase operations after SD card initialization
+
+
+  *** SD Card Initialization and configuration ***
+  ================================================
+  [..]
+    To initialize the SD Card, use the HAL_SD_Init() function.  It Initializes
+    the SD Card and put it into StandBy State (Ready for data transfer).
+    This function provide the following operations:
+
+    (#) Apply the SD Card initialization process at 400KHz and check the SD Card
+        type (Standard Capacity or High Capacity). You can change or adapt this
+        frequency by adjusting the "ClockDiv" field.
+        The SD Card frequency (SDMMC_CK) is computed as follows:
+
+           SDMMC_CK = SDMMCCLK / (ClockDiv + 2)
+
+        In initialization mode and according to the SD Card standard,
+        make sure that the SDMMC_CK frequency doesn't exceed 400KHz.
+
+    (#) Get the SD CID and CSD data. All these information are managed by the SDCardInfo
+        structure. This structure provide also ready computed SD Card capacity
+        and Block size.
+
+        -@- These information are stored in SD handle structure in case of future use.
+
+    (#) Configure the SD Card Data transfer frequency. By Default, the card transfer
+        frequency is set to 24MHz. You can change or adapt this frequency by adjusting
+        the "ClockDiv" field.
+        In transfer mode and according to the SD Card standard, make sure that the
+        SDMMC_CK frequency doesn't exceed 25MHz and 50MHz in High-speed mode switch.
+        To be able to use a frequency higher than 24MHz, you should use the SDMMC
+        peripheral in bypass mode. Refer to the corresponding reference manual
+        for more details.
+
+    (#) Select the corresponding SD Card according to the address read with the step 2.
+
+    (#) Configure the SD Card in wide bus mode: 4-bits data.
+
+  *** SD Card Read operation ***
+  ==============================
+  [..]
+    (+) You can read from SD card in polling mode by using function HAL_SD_ReadBlocks().
+        This function support only 512-bytes block length (the block size should be
+        chosen as 512 bytes).
+        You can choose either one block read operation or multiple block read operation
+        by adjusting the "NumberOfBlocks" parameter.
+
+    (+) You can read from SD card in DMA mode by using function HAL_SD_ReadBlocks_DMA().
+        This function support only 512-bytes block length (the block size should be
+        chosen as 512 bytes).
+        You can choose either one block read operation or multiple block read operation
+        by adjusting the "NumberOfBlocks" parameter.
+        After this, you have to call the function HAL_SD_CheckReadOperation(), to insure
+        that the read transfer is done correctly in both DMA and SD sides.
+
+  *** SD Card Write operation ***
+  ===============================
+  [..]
+    (+) You can write to SD card in polling mode by using function HAL_SD_WriteBlocks().
+        This function support only 512-bytes block length (the block size should be
+        chosen as 512 bytes).
+        You can choose either one block read operation or multiple block read operation
+        by adjusting the "NumberOfBlocks" parameter.
+
+    (+) You can write to SD card in DMA mode by using function HAL_SD_WriteBlocks_DMA().
+        This function support only 512-bytes block length (the block size should be
+        chosen as 512 byte).
+        You can choose either one block read operation or multiple block read operation
+        by adjusting the "NumberOfBlocks" parameter.
+        After this, you have to call the function HAL_SD_CheckWriteOperation(), to insure
+        that the write transfer is done correctly in both DMA and SD sides.
+
+  *** SD card status ***
+  ======================
+  [..]
+    (+) At any time, you can check the SD Card status and get the SD card state
+        by using the HAL_SD_GetStatus() function. This function checks first if the
+        SD card is still connected and then get the internal SD Card transfer state.
+    (+) You can also get the SD card SD Status register by using the HAL_SD_SendSDStatus()
+        function.
+
+  *** SD HAL driver macros list ***
+  ==================================
+  [..]
+    Below the list of most used macros in SD HAL driver.
+
+    (+) __HAL_SD_SDMMC_ENABLE : Enable the SD device
+    (+) __HAL_SD_SDMMC_DISABLE : Disable the SD device
+    (+) __HAL_SD_SDMMC_DMA_ENABLE: Enable the SDMMC DMA transfer
+    (+) __HAL_SD_SDMMC_DMA_DISABLE: Disable the SDMMC DMA transfer
+    (+) __HAL_SD_SDMMC_ENABLE_IT: Enable the SD device interrupt
+    (+) __HAL_SD_SDMMC_DISABLE_IT: Disable the SD device interrupt
+    (+) __HAL_SD_SDMMC_GET_FLAG:Check whether the specified SD flag is set or not
+    (+) __HAL_SD_SDMMC_CLEAR_FLAG: Clear the SD's pending flags
+
+    (@) You can refer to the SD HAL driver header file for more useful macros
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup SD
+  * @{
+  */
+
+#ifdef HAL_SD_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @addtogroup SD_Private_Defines
+  * @{
+  */
+/**
+  * @brief  SDMMC Data block size
+  */
+#define DATA_BLOCK_SIZE                  ((uint32_t)(9 << 4))
+/**
+  * @brief  SDMMC Static flags, Timeout, FIFO Address
+  */
+#define SDMMC_STATIC_FLAGS               ((uint32_t)(SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_CTIMEOUT |\
+                                                    SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_TXUNDERR | SDMMC_FLAG_RXOVERR  |\
+                                                    SDMMC_FLAG_CMDREND  | SDMMC_FLAG_CMDSENT  | SDMMC_FLAG_DATAEND  |\
+                                                    SDMMC_FLAG_DBCKEND))
+
+#define SDMMC_CMD0TIMEOUT                ((uint32_t)0x00010000)
+
+/**
+  * @brief  Mask for errors Card Status R1 (OCR Register)
+  */
+#define SD_OCR_ADDR_OUT_OF_RANGE        ((uint32_t)0x80000000)
+#define SD_OCR_ADDR_MISALIGNED          ((uint32_t)0x40000000)
+#define SD_OCR_BLOCK_LEN_ERR            ((uint32_t)0x20000000)
+#define SD_OCR_ERASE_SEQ_ERR            ((uint32_t)0x10000000)
+#define SD_OCR_BAD_ERASE_PARAM          ((uint32_t)0x08000000)
+#define SD_OCR_WRITE_PROT_VIOLATION     ((uint32_t)0x04000000)
+#define SD_OCR_LOCK_UNLOCK_FAILED       ((uint32_t)0x01000000)
+#define SD_OCR_COM_CRC_FAILED           ((uint32_t)0x00800000)
+#define SD_OCR_ILLEGAL_CMD              ((uint32_t)0x00400000)
+#define SD_OCR_CARD_ECC_FAILED          ((uint32_t)0x00200000)
+#define SD_OCR_CC_ERROR                 ((uint32_t)0x00100000)
+#define SD_OCR_GENERAL_UNKNOWN_ERROR    ((uint32_t)0x00080000)
+#define SD_OCR_STREAM_READ_UNDERRUN     ((uint32_t)0x00040000)
+#define SD_OCR_STREAM_WRITE_OVERRUN     ((uint32_t)0x00020000)
+#define SD_OCR_CID_CSD_OVERWRITE        ((uint32_t)0x00010000)
+#define SD_OCR_WP_ERASE_SKIP            ((uint32_t)0x00008000)
+#define SD_OCR_CARD_ECC_DISABLED        ((uint32_t)0x00004000)
+#define SD_OCR_ERASE_RESET              ((uint32_t)0x00002000)
+#define SD_OCR_AKE_SEQ_ERROR            ((uint32_t)0x00000008)
+#define SD_OCR_ERRORBITS                ((uint32_t)0xFDFFE008)
+
+/**
+  * @brief  Masks for R6 Response
+  */
+#define SD_R6_GENERAL_UNKNOWN_ERROR     ((uint32_t)0x00002000)
+#define SD_R6_ILLEGAL_CMD               ((uint32_t)0x00004000)
+#define SD_R6_COM_CRC_FAILED            ((uint32_t)0x00008000)
+
+#define SD_VOLTAGE_WINDOW_SD            ((uint32_t)0x80100000)
+#define SD_HIGH_CAPACITY                ((uint32_t)0x40000000)
+#define SD_STD_CAPACITY                 ((uint32_t)0x00000000)
+#define SD_CHECK_PATTERN                ((uint32_t)0x000001AA)
+
+#define SD_MAX_VOLT_TRIAL               ((uint32_t)0x0000FFFF)
+#define SD_ALLZERO                      ((uint32_t)0x00000000)
+
+#define SD_WIDE_BUS_SUPPORT             ((uint32_t)0x00040000)
+#define SD_SINGLE_BUS_SUPPORT           ((uint32_t)0x00010000)
+#define SD_CARD_LOCKED                  ((uint32_t)0x02000000)
+
+#define SD_DATATIMEOUT                  ((uint32_t)0xFFFFFFFF)
+#define SD_0TO7BITS                     ((uint32_t)0x000000FF)
+#define SD_8TO15BITS                    ((uint32_t)0x0000FF00)
+#define SD_16TO23BITS                   ((uint32_t)0x00FF0000)
+#define SD_24TO31BITS                   ((uint32_t)0xFF000000)
+#define SD_MAX_DATA_LENGTH              ((uint32_t)0x01FFFFFF)
+
+#define SD_HALFFIFO                     ((uint32_t)0x00000008)
+#define SD_HALFFIFOBYTES                ((uint32_t)0x00000020)
+
+/**
+  * @brief  Command Class Supported
+  */
+#define SD_CCCC_LOCK_UNLOCK             ((uint32_t)0x00000080)
+#define SD_CCCC_WRITE_PROT              ((uint32_t)0x00000040)
+#define SD_CCCC_ERASE                   ((uint32_t)0x00000020)
+
+/**
+  * @brief  Following commands are SD Card Specific commands.
+  *         SDMMC_APP_CMD should be sent before sending these commands.
+  */
+#define SD_SDMMC_SEND_IF_COND            ((uint32_t)SD_CMD_HS_SEND_EXT_CSD)
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup SD_Private_Functions SD Private Functions
+  * @{
+  */
+static HAL_SD_ErrorTypedef SD_Initialize_Cards(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_Select_Deselect(SD_HandleTypeDef *hsd, uint64_t addr);
+static HAL_SD_ErrorTypedef SD_PowerON(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_PowerOFF(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_SendStatus(SD_HandleTypeDef *hsd, uint32_t *pCardStatus);
+static HAL_SD_CardStateTypedef SD_GetState(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_IsCardProgramming(SD_HandleTypeDef *hsd, uint8_t *pStatus);
+static HAL_SD_ErrorTypedef SD_CmdError(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_CmdResp1Error(SD_HandleTypeDef *hsd, uint8_t SD_CMD);
+static HAL_SD_ErrorTypedef SD_CmdResp7Error(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_CmdResp3Error(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_CmdResp2Error(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_CmdResp6Error(SD_HandleTypeDef *hsd, uint8_t SD_CMD, uint16_t *pRCA);
+static HAL_SD_ErrorTypedef SD_WideBus_Enable(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_WideBus_Disable(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_FindSCR(SD_HandleTypeDef *hsd, uint32_t *pSCR);
+static void SD_DMA_RxCplt(DMA_HandleTypeDef *hdma);
+static void SD_DMA_RxError(DMA_HandleTypeDef *hdma);
+static void SD_DMA_TxCplt(DMA_HandleTypeDef *hdma);
+static void SD_DMA_TxError(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup SD_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup SD_Exported_Functions_Group1
+ *  @brief   Initialization and de-initialization functions
+ *
+@verbatim
+  ==============================================================================
+          ##### Initialization and de-initialization functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to initialize/de-initialize the SD
+    card device to be ready for use.
+
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the SD card according to the specified parameters in the
+            SD_HandleTypeDef and create the associated handle.
+  * @param  hsd: SD handle
+  * @param  SDCardInfo: HAL_SD_CardInfoTypedef structure for SD card information
+  * @retval HAL SD error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_Init(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTypedef *SDCardInfo)
+{
+  __IO HAL_SD_ErrorTypedef errorstate = SD_OK;
+  SD_InitTypeDef tmpinit;
+
+  /* Allocate lock resource and initialize it */
+  hsd->Lock = HAL_UNLOCKED;
+
+  /* Initialize the low level hardware (MSP) */
+  HAL_SD_MspInit(hsd);
+
+  /* Default SDMMC peripheral configuration for SD card initialization */
+  tmpinit.ClockEdge           = SDMMC_CLOCK_EDGE_RISING;
+  tmpinit.ClockBypass         = SDMMC_CLOCK_BYPASS_DISABLE;
+  tmpinit.ClockPowerSave      = SDMMC_CLOCK_POWER_SAVE_DISABLE;
+  tmpinit.BusWide             = SDMMC_BUS_WIDE_1B;
+  tmpinit.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_DISABLE;
+  tmpinit.ClockDiv            = SDMMC_INIT_CLK_DIV;
+
+  /* Initialize SDMMC peripheral interface with default configuration */
+  SDMMC_Init(hsd->Instance, tmpinit);
+
+  /* Identify card operating voltage */
+  errorstate = SD_PowerON(hsd);
+
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Initialize the present SDMMC card(s) and put them in idle state */
+  errorstate = SD_Initialize_Cards(hsd);
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Read CSD/CID MSD registers */
+  errorstate = HAL_SD_Get_CardInfo(hsd, SDCardInfo);
+
+  if (errorstate == SD_OK)
+  {
+    /* Select the Card */
+    errorstate = SD_Select_Deselect(hsd, (uint32_t)(((uint32_t)SDCardInfo->RCA) << 16));
+  }
+
+  /* Configure SDMMC peripheral interface */
+  SDMMC_Init(hsd->Instance, hsd->Init);
+
+  return errorstate;
+}
+
+/**
+  * @brief  De-Initializes the SD card.
+  * @param  hsd: SD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SD_DeInit(SD_HandleTypeDef *hsd)
+{
+
+  /* Set SD power state to off */
+  SD_PowerOFF(hsd);
+
+  /* De-Initialize the MSP layer */
+  HAL_SD_MspDeInit(hsd);
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Initializes the SD MSP.
+  * @param  hsd: SD handle
+  * @retval None
+  */
+__weak void HAL_SD_MspInit(SD_HandleTypeDef *hsd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SD_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  De-Initialize SD MSP.
+  * @param  hsd: SD handle
+  * @retval None
+  */
+__weak void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SD_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @addtogroup SD_Exported_Functions_Group2
+ *  @brief   Data transfer functions
+ *
+@verbatim
+  ==============================================================================
+                        ##### IO operation functions #####
+  ==============================================================================
+  [..]
+    This subsection provides a set of functions allowing to manage the data
+    transfer from/to SD card.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Reads block(s) from a specified address in a card. The Data transfer
+  *         is managed by polling mode.
+  * @param  hsd: SD handle
+  * @param  pReadBuffer: pointer to the buffer that will contain the received data
+  * @param  ReadAddr: Address from where data is to be read
+  * @param  BlockSize: SD card Data block size
+  *   @note BlockSize must be 512 bytes.
+  * @param  NumberOfBlocks: Number of SD blocks to read
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
+{
+  SDMMC_CmdInitTypeDef  sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t count = 0, *tempbuff = (uint32_t *)pReadBuffer;
+
+  /* Initialize data control register */
+  hsd->Instance->DCTRL = 0;
+
+  if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
+  {
+    BlockSize = 512;
+    ReadAddr /= 512;
+  }
+
+  /* Set Block Size for Card */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t) BlockSize;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Configure the SD DPSM (Data Path State Machine) */
+  sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdmmc_datainitstructure.DataLength    = NumberOfBlocks * BlockSize;
+  sdmmc_datainitstructure.DataBlockSize = DATA_BLOCK_SIZE;
+  sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+  sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+  SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+
+  if(NumberOfBlocks > 1)
+  {
+    /* Send CMD18 READ_MULT_BLOCK with argument data address */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_READ_MULT_BLOCK;
+  }
+  else
+  {
+    /* Send CMD17 READ_SINGLE_BLOCK */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_READ_SINGLE_BLOCK;
+  }
+
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)ReadAddr;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Read block(s) in polling mode */
+  if(NumberOfBlocks > 1)
+  {
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_READ_MULT_BLOCK);
+
+    if (errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+
+    /* Poll on SDMMC flags */
+    while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
+    {
+      if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXFIFOHF))
+      {
+        /* Read data from SDMMC Rx FIFO */
+        for (count = 0; count < 8; count++)
+        {
+          *(tempbuff + count) = SDMMC_ReadFIFO(hsd->Instance);
+        }
+
+        tempbuff += 8;
+      }
+    }
+  }
+  else
+  {
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_READ_SINGLE_BLOCK);
+
+    if (errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+
+    /* In case of single block transfer, no need of stop transfer at all */
+    while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DBCKEND))
+    {
+      if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXFIFOHF))
+      {
+        /* Read data from SDMMC Rx FIFO */
+        for (count = 0; count < 8; count++)
+        {
+          *(tempbuff + count) = SDMMC_ReadFIFO(hsd->Instance);
+        }
+
+        tempbuff += 8;
+      }
+    }
+  }
+
+  /* Send stop transmission command in case of multiblock read */
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DATAEND) && (NumberOfBlocks > 1))
+  {
+    if ((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1) ||\
+      (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0) ||\
+        (hsd->CardType == HIGH_CAPACITY_SD_CARD))
+    {
+      /* Send stop transmission command */
+      errorstate = HAL_SD_StopTransfer(hsd);
+    }
+  }
+
+  /* Get error state */
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DTIMEOUT))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DTIMEOUT);
+
+    errorstate = SD_DATA_TIMEOUT;
+
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DCRCFAIL))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DCRCFAIL);
+
+    errorstate = SD_DATA_CRC_FAIL;
+
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_RXOVERR);
+
+    errorstate = SD_RX_OVERRUN;
+
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }
+
+  count = SD_DATATIMEOUT;
+
+  /* Empty FIFO if there is still any data */
+  while ((__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXDAVL)) && (count > 0))
+  {
+    *tempbuff = SDMMC_ReadFIFO(hsd->Instance);
+    tempbuff++;
+    count--;
+  }
+
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+  return errorstate;
+}
+
+/**
+  * @brief  Allows to write block(s) to a specified address in a card. The Data
+  *         transfer is managed by polling mode.
+  * @param  hsd: SD handle
+  * @param  pWriteBuffer: pointer to the buffer that will contain the data to transmit
+  * @param  WriteAddr: Address from where data is to be written
+  * @param  BlockSize: SD card Data block size
+  * @note   BlockSize must be 512 bytes.
+  * @param  NumberOfBlocks: Number of SD blocks to write
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t totalnumberofbytes = 0, bytestransferred = 0, count = 0, restwords = 0;
+  uint32_t *tempbuff = (uint32_t *)pWriteBuffer;
+  uint8_t cardstate  = 0;
+
+  /* Initialize data control register */
+  hsd->Instance->DCTRL = 0;
+
+  if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
+  {
+    BlockSize = 512;
+    WriteAddr /= 512;
+  }
+
+  /* Set Block Size for Card */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)BlockSize;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  if(NumberOfBlocks > 1)
+  {
+    /* Send CMD25 WRITE_MULT_BLOCK with argument data address */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_WRITE_MULT_BLOCK;
+  }
+  else
+  {
+    /* Send CMD24 WRITE_SINGLE_BLOCK */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_WRITE_SINGLE_BLOCK;
+  }
+
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)WriteAddr;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  if(NumberOfBlocks > 1)
+  {
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_WRITE_MULT_BLOCK);
+  }
+  else
+  {
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_WRITE_SINGLE_BLOCK);
+  }
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Set total number of bytes to write */
+  totalnumberofbytes = NumberOfBlocks * BlockSize;
+
+  /* Configure the SD DPSM (Data Path State Machine) */
+  sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdmmc_datainitstructure.DataLength    = NumberOfBlocks * BlockSize;
+  sdmmc_datainitstructure.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
+  sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_CARD;
+  sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+  SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+
+  /* Write block(s) in polling mode */
+  if(NumberOfBlocks > 1)
+  {
+    while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_TXUNDERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
+    {
+      if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_TXFIFOHE))
+      {
+        if ((totalnumberofbytes - bytestransferred) < 32)
+        {
+          restwords = ((totalnumberofbytes - bytestransferred) % 4 == 0) ? ((totalnumberofbytes - bytestransferred) / 4) : (( totalnumberofbytes -  bytestransferred) / 4 + 1);
+
+          /* Write data to SDMMC Tx FIFO */
+          for (count = 0; count < restwords; count++)
+          {
+            SDMMC_WriteFIFO(hsd->Instance, tempbuff);
+            tempbuff++;
+            bytestransferred += 4;
+          }
+        }
+        else
+        {
+          /* Write data to SDMMC Tx FIFO */
+          for (count = 0; count < 8; count++)
+          {
+            SDMMC_WriteFIFO(hsd->Instance, (tempbuff + count));
+          }
+
+          tempbuff += 8;
+          bytestransferred += 32;
+        }
+      }
+    }
+  }
+  else
+  {
+    /* In case of single data block transfer no need of stop command at all */
+    while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_TXUNDERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DBCKEND))
+    {
+      if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_TXFIFOHE))
+      {
+        if ((totalnumberofbytes - bytestransferred) < 32)
+        {
+          restwords = ((totalnumberofbytes - bytestransferred) % 4 == 0) ? ((totalnumberofbytes - bytestransferred) / 4) : (( totalnumberofbytes -  bytestransferred) / 4 + 1);
+
+          /* Write data to SDMMC Tx FIFO */
+          for (count = 0; count < restwords; count++)
+          {
+            SDMMC_WriteFIFO(hsd->Instance, tempbuff);
+            tempbuff++;
+            bytestransferred += 4;
+          }
+        }
+        else
+        {
+          /* Write data to SDMMC Tx FIFO */
+          for (count = 0; count < 8; count++)
+          {
+            SDMMC_WriteFIFO(hsd->Instance, (tempbuff + count));
+          }
+
+          tempbuff += 8;
+          bytestransferred += 32;
+        }
+      }
+    }
+  }
+
+  /* Send stop transmission command in case of multiblock write */
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DATAEND) && (NumberOfBlocks > 1))
+  {
+    if ((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1) || (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0) ||\
+      (hsd->CardType == HIGH_CAPACITY_SD_CARD))
+    {
+      /* Send stop transmission command */
+      errorstate = HAL_SD_StopTransfer(hsd);
+    }
+  }
+
+  /* Get error state */
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DTIMEOUT))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DTIMEOUT);
+
+    errorstate = SD_DATA_TIMEOUT;
+
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DCRCFAIL))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DCRCFAIL);
+
+    errorstate = SD_DATA_CRC_FAIL;
+
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_TXUNDERR))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_TXUNDERR);
+
+    errorstate = SD_TX_UNDERRUN;
+
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }
+
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+  /* Wait till the card is in programming state */
+  errorstate = SD_IsCardProgramming(hsd, &cardstate);
+
+  while ((errorstate == SD_OK) && ((cardstate == SD_CARD_PROGRAMMING) || (cardstate == SD_CARD_RECEIVING)))
+  {
+    errorstate = SD_IsCardProgramming(hsd, &cardstate);
+  }
+
+  return errorstate;
+}
+
+/**
+  * @brief  Reads block(s) from a specified address in a card. The Data transfer
+  *         is managed by DMA mode.
+  * @note   This API should be followed by the function HAL_SD_CheckReadOperation()
+  *         to check the completion of the read process
+  * @param  hsd: SD handle
+  * @param  pReadBuffer: Pointer to the buffer that will contain the received data
+  * @param  ReadAddr: Address from where data is to be read
+  * @param  BlockSize: SD card Data block size
+  * @note   BlockSize must be 512 bytes.
+  * @param  NumberOfBlocks: Number of blocks to read.
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+
+  /* Initialize data control register */
+  hsd->Instance->DCTRL = 0;
+
+  /* Initialize handle flags */
+  hsd->SdTransferCplt  = 0;
+  hsd->DmaTransferCplt = 0;
+  hsd->SdTransferErr   = SD_OK;
+
+  /* Initialize SD Read operation */
+  if(NumberOfBlocks > 1)
+  {
+    hsd->SdOperation = SD_READ_MULTIPLE_BLOCK;
+  }
+  else
+  {
+    hsd->SdOperation = SD_READ_SINGLE_BLOCK;
+  }
+
+  /* Enable transfer interrupts */
+  __HAL_SD_SDMMC_ENABLE_IT(hsd, (SDMMC_IT_DCRCFAIL |\
+                                 SDMMC_IT_DTIMEOUT |\
+                                 SDMMC_IT_DATAEND  |\
+                                 SDMMC_IT_RXOVERR));
+
+  /* Enable SDMMC DMA transfer */
+  __HAL_SD_SDMMC_DMA_ENABLE(hsd);
+
+  /* Configure DMA user callbacks */
+  hsd->hdmarx->XferCpltCallback  = SD_DMA_RxCplt;
+  hsd->hdmarx->XferErrorCallback = SD_DMA_RxError;
+
+  /* Enable the DMA Channel */
+  HAL_DMA_Start_IT(hsd->hdmarx, (uint32_t)&hsd->Instance->FIFO, (uint32_t)pReadBuffer, (uint32_t)(BlockSize * NumberOfBlocks)/4);
+
+  if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
+  {
+    BlockSize = 512;
+    ReadAddr /= 512;
+  }
+
+  /* Set Block Size for Card */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)BlockSize;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Configure the SD DPSM (Data Path State Machine) */
+  sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdmmc_datainitstructure.DataLength    = BlockSize * NumberOfBlocks;
+  sdmmc_datainitstructure.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
+  sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+  sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+  SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+
+  /* Check number of blocks command */
+  if(NumberOfBlocks > 1)
+  {
+    /* Send CMD18 READ_MULT_BLOCK with argument data address */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_READ_MULT_BLOCK;
+  }
+  else
+  {
+    /* Send CMD17 READ_SINGLE_BLOCK */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_READ_SINGLE_BLOCK;
+  }
+
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)ReadAddr;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  if(NumberOfBlocks > 1)
+  {
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_READ_MULT_BLOCK);
+  }
+  else
+  {
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_READ_SINGLE_BLOCK);
+  }
+
+  /* Update the SD transfer error in SD handle */
+  hsd->SdTransferErr = errorstate;
+
+  return errorstate;
+}
+
+
+/**
+  * @brief  Writes block(s) to a specified address in a card. The Data transfer
+  *         is managed by DMA mode.
+  * @note   This API should be followed by the function HAL_SD_CheckWriteOperation()
+  *         to check the completion of the write process (by SD current status polling).
+  * @param  hsd: SD handle
+  * @param  pWriteBuffer: pointer to the buffer that will contain the data to transmit
+  * @param  WriteAddr: Address from where data is to be read
+  * @param  BlockSize: the SD card Data block size
+  * @note   BlockSize must be 512 bytes.
+  * @param  NumberOfBlocks: Number of blocks to write
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+
+  /* Initialize data control register */
+  hsd->Instance->DCTRL = 0;
+
+  /* Initialize handle flags */
+  hsd->SdTransferCplt  = 0;
+  hsd->DmaTransferCplt = 0;
+  hsd->SdTransferErr   = SD_OK;
+
+  /* Initialize SD Write operation */
+  if(NumberOfBlocks > 1)
+  {
+    hsd->SdOperation = SD_WRITE_MULTIPLE_BLOCK;
+  }
+  else
+  {
+    hsd->SdOperation = SD_WRITE_SINGLE_BLOCK;
+  }
+
+  /* Enable transfer interrupts */
+  __HAL_SD_SDMMC_ENABLE_IT(hsd, (SDMMC_IT_DCRCFAIL |\
+                                 SDMMC_IT_DTIMEOUT |\
+                                 SDMMC_IT_DATAEND  |\
+                                 SDMMC_IT_TXUNDERR));
+
+  /* Configure DMA user callbacks */
+  hsd->hdmatx->XferCpltCallback  = SD_DMA_TxCplt;
+  hsd->hdmatx->XferErrorCallback = SD_DMA_TxError;
+
+  /* Enable the DMA Channel */
+  HAL_DMA_Start_IT(hsd->hdmatx, (uint32_t)pWriteBuffer, (uint32_t)&hsd->Instance->FIFO, (uint32_t)(BlockSize * NumberOfBlocks)/4);
+
+  /* Enable SDMMC DMA transfer */
+  __HAL_SD_SDMMC_DMA_ENABLE(hsd);
+
+  if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
+  {
+    BlockSize = 512;
+    WriteAddr /= 512;
+  }
+
+  /* Set Block Size for Card */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)BlockSize;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Check number of blocks command */
+  if(NumberOfBlocks <= 1)
+  {
+    /* Send CMD24 WRITE_SINGLE_BLOCK */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_WRITE_SINGLE_BLOCK;
+  }
+  else
+  {
+    /* Send CMD25 WRITE_MULT_BLOCK with argument data address */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_WRITE_MULT_BLOCK;
+  }
+
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)WriteAddr;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  if(NumberOfBlocks > 1)
+  {
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_WRITE_MULT_BLOCK);
+  }
+  else
+  {
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_WRITE_SINGLE_BLOCK);
+  }
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Configure the SD DPSM (Data Path State Machine) */
+  sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdmmc_datainitstructure.DataLength    = BlockSize * NumberOfBlocks;
+  sdmmc_datainitstructure.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
+  sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_CARD;
+  sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+  SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+
+  hsd->SdTransferErr = errorstate;
+
+  return errorstate;
+}
+
+/**
+  * @brief  This function waits until the SD DMA data read transfer is finished.
+  *         This API should be called after HAL_SD_ReadBlocks_DMA() function
+  *         to insure that all data sent by the card is already transferred by the
+  *         DMA controller.
+  * @param  hsd: SD handle
+  * @param  Timeout: Timeout duration
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_CheckReadOperation(SD_HandleTypeDef *hsd, uint32_t Timeout)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t timeout = Timeout;
+  uint32_t tmp1, tmp2;
+  HAL_SD_ErrorTypedef tmp3;
+
+  /* Wait for DMA/SD transfer end or SD error variables to be in SD handle */
+  tmp1 = hsd->DmaTransferCplt;
+  tmp2 = hsd->SdTransferCplt;
+  tmp3 = (HAL_SD_ErrorTypedef)hsd->SdTransferErr;
+
+  while (((tmp1 & tmp2) == 0) && (tmp3 == SD_OK) && (timeout > 0))
+  {
+    tmp1 = hsd->DmaTransferCplt;
+    tmp2 = hsd->SdTransferCplt;
+    tmp3 = (HAL_SD_ErrorTypedef)hsd->SdTransferErr;
+    timeout--;
+  }
+
+  timeout = Timeout;
+
+  /* Wait until the Rx transfer is no longer active */
+  while((__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXACT)) && (timeout > 0))
+  {
+    timeout--;
+  }
+
+  /* Send stop command in multiblock read */
+  if (hsd->SdOperation == SD_READ_MULTIPLE_BLOCK)
+  {
+    errorstate = HAL_SD_StopTransfer(hsd);
+  }
+
+  if ((timeout == 0) && (errorstate == SD_OK))
+  {
+    errorstate = SD_DATA_TIMEOUT;
+  }
+
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+  /* Return error state */
+  if (hsd->SdTransferErr != SD_OK)
+  {
+    return (HAL_SD_ErrorTypedef)(hsd->SdTransferErr);
+  }
+
+  return errorstate;
+}
+
+/**
+  * @brief  This function waits until the SD DMA data write transfer is finished.
+  *         This API should be called after HAL_SD_WriteBlocks_DMA() function
+  *         to insure that all data sent by the card is already transferred by the
+  *         DMA controller.
+  * @param  hsd: SD handle
+  * @param  Timeout: Timeout duration
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_CheckWriteOperation(SD_HandleTypeDef *hsd, uint32_t Timeout)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t timeout = Timeout;
+  uint32_t tmp1, tmp2;
+  HAL_SD_ErrorTypedef tmp3;
+
+  /* Wait for DMA/SD transfer end or SD error variables to be in SD handle */
+  tmp1 = hsd->DmaTransferCplt;
+  tmp2 = hsd->SdTransferCplt;
+  tmp3 = (HAL_SD_ErrorTypedef)hsd->SdTransferErr;
+
+  while (((tmp1 & tmp2) == 0) && (tmp3 == SD_OK) && (timeout > 0))
+  {
+    tmp1 = hsd->DmaTransferCplt;
+    tmp2 = hsd->SdTransferCplt;
+    tmp3 = (HAL_SD_ErrorTypedef)hsd->SdTransferErr;
+    timeout--;
+  }
+
+  timeout = Timeout;
+
+  /* Wait until the Tx transfer is no longer active */
+  while((__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_TXACT))  && (timeout > 0))
+  {
+    timeout--;
+  }
+
+  /* Send stop command in multiblock write */
+  if (hsd->SdOperation == SD_WRITE_MULTIPLE_BLOCK)
+  {
+    errorstate = HAL_SD_StopTransfer(hsd);
+  }
+
+  if ((timeout == 0) && (errorstate == SD_OK))
+  {
+    errorstate = SD_DATA_TIMEOUT;
+  }
+
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+  /* Return error state */
+  if (hsd->SdTransferErr != SD_OK)
+  {
+    return (HAL_SD_ErrorTypedef)(hsd->SdTransferErr);
+  }
+
+  /* Wait until write is complete */
+  while(HAL_SD_GetStatus(hsd) != SD_TRANSFER_OK)
+  {
+  }
+
+  return errorstate;
+}
+
+/**
+  * @brief  Erases the specified memory area of the given SD card.
+  * @param  hsd: SD handle
+  * @param  startaddr: Start byte address
+  * @param  endaddr: End byte address
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_Erase(SD_HandleTypeDef *hsd, uint64_t startaddr, uint64_t endaddr)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+
+  uint32_t delay         = 0;
+  __IO uint32_t maxdelay = 0;
+  uint8_t cardstate      = 0;
+
+  /* Check if the card command class supports erase command */
+  if (((hsd->CSD[1] >> 20) & SD_CCCC_ERASE) == 0)
+  {
+    errorstate = SD_REQUEST_NOT_APPLICABLE;
+
+    return errorstate;
+  }
+
+  /* Get max delay value */
+  maxdelay = 120000 / (((hsd->Instance->CLKCR) & 0xFF) + 2);
+
+  if((SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1) & SD_CARD_LOCKED) == SD_CARD_LOCKED)
+  {
+    errorstate = SD_LOCK_UNLOCK_FAILED;
+
+    return errorstate;
+  }
+
+  /* Get start and end block for high capacity cards */
+  if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
+  {
+    startaddr /= 512;
+    endaddr   /= 512;
+  }
+
+  /* According to sd-card spec 1.0 ERASE_GROUP_START (CMD32) and erase_group_end(CMD33) */
+  if ((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1) || (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0) ||\
+    (hsd->CardType == HIGH_CAPACITY_SD_CARD))
+  {
+    /* Send CMD32 SD_ERASE_GRP_START with argument as addr  */
+    sdmmc_cmdinitstructure.Argument         =(uint32_t)startaddr;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SD_ERASE_GRP_START;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+    sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+    sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_SD_ERASE_GRP_START);
+
+    if (errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+
+    /* Send CMD33 SD_ERASE_GRP_END with argument as addr  */
+    sdmmc_cmdinitstructure.Argument         = (uint32_t)endaddr;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SD_ERASE_GRP_END;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_SD_ERASE_GRP_END);
+
+    if (errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+  }
+
+  /* Send CMD38 ERASE */
+  sdmmc_cmdinitstructure.Argument         = 0;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_ERASE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_ERASE);
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  for (; delay < maxdelay; delay++)
+  {
+  }
+
+  /* Wait until the card is in programming state */
+  errorstate = SD_IsCardProgramming(hsd, &cardstate);
+
+  delay = SD_DATATIMEOUT;
+
+  while ((delay > 0) && (errorstate == SD_OK) && ((cardstate == SD_CARD_PROGRAMMING) || (cardstate == SD_CARD_RECEIVING)))
+  {
+    errorstate = SD_IsCardProgramming(hsd, &cardstate);
+    delay--;
+  }
+
+  return errorstate;
+}
+
+/**
+  * @brief  This function handles SD card interrupt request.
+  * @param  hsd: SD handle
+  * @retval None
+  */
+void HAL_SD_IRQHandler(SD_HandleTypeDef *hsd)
+{
+  /* Check for SDMMC interrupt flags */
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_IT_DATAEND))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_IT_DATAEND);
+
+    /* SD transfer is complete */
+    hsd->SdTransferCplt = 1;
+
+    /* No transfer error */
+    hsd->SdTransferErr  = SD_OK;
+
+    HAL_SD_XferCpltCallback(hsd);
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_IT_DCRCFAIL))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DCRCFAIL);
+
+    hsd->SdTransferErr = SD_DATA_CRC_FAIL;
+
+    HAL_SD_XferErrorCallback(hsd);
+
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_IT_DTIMEOUT))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DTIMEOUT);
+
+    hsd->SdTransferErr = SD_DATA_TIMEOUT;
+
+    HAL_SD_XferErrorCallback(hsd);
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_IT_RXOVERR))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_RXOVERR);
+
+    hsd->SdTransferErr = SD_RX_OVERRUN;
+
+    HAL_SD_XferErrorCallback(hsd);
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_IT_TXUNDERR))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_TXUNDERR);
+
+    hsd->SdTransferErr = SD_TX_UNDERRUN;
+
+    HAL_SD_XferErrorCallback(hsd);
+  }
+  else
+  {
+    /* No error flag set */
+  }
+
+  /* Disable all SDMMC peripheral interrupt sources */
+  __HAL_SD_SDMMC_DISABLE_IT(hsd, SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT | SDMMC_IT_DATAEND  |\
+                                 SDMMC_IT_TXFIFOHE | SDMMC_IT_RXFIFOHF | SDMMC_IT_TXUNDERR |\
+                                 SDMMC_IT_RXOVERR);
+}
+
+
+/**
+  * @brief  SD end of transfer callback.
+  * @param  hsd: SD handle
+  * @retval None
+  */
+__weak void HAL_SD_XferCpltCallback(SD_HandleTypeDef *hsd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SD_XferCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  SD Transfer Error callback.
+  * @param  hsd: SD handle
+  * @retval None
+  */
+__weak void HAL_SD_XferErrorCallback(SD_HandleTypeDef *hsd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SD_XferErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  SD Transfer complete Rx callback in non blocking mode.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+__weak void HAL_SD_DMA_RxCpltCallback(DMA_HandleTypeDef *hdma)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SD_DMA_RxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  SD DMA transfer complete Rx error callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+__weak void HAL_SD_DMA_RxErrorCallback(DMA_HandleTypeDef *hdma)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SD_DMA_RxErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  SD Transfer complete Tx callback in non blocking mode.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+__weak void HAL_SD_DMA_TxCpltCallback(DMA_HandleTypeDef *hdma)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SD_DMA_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  SD DMA transfer complete error Tx callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+__weak void HAL_SD_DMA_TxErrorCallback(DMA_HandleTypeDef *hdma)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SD_DMA_TxErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @addtogroup SD_Exported_Functions_Group3
+ *  @brief   management functions
+ *
+@verbatim
+  ==============================================================================
+                      ##### Peripheral Control functions #####
+  ==============================================================================
+  [..]
+    This subsection provides a set of functions allowing to control the SD card
+    operations.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns information about specific card.
+  * @param  hsd: SD handle
+  * @param  pCardInfo: Pointer to a HAL_SD_CardInfoTypedef structure that
+  *         contains all SD cardinformation
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_Get_CardInfo(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTypedef *pCardInfo)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t tmp = 0;
+
+  pCardInfo->CardType = (uint8_t)(hsd->CardType);
+  pCardInfo->RCA      = (uint16_t)(hsd->RCA);
+
+  /* Byte 0 */
+  tmp = (hsd->CSD[0] & 0xFF000000) >> 24;
+  pCardInfo->SD_csd.CSDStruct      = (uint8_t)((tmp & 0xC0) >> 6);
+  pCardInfo->SD_csd.SysSpecVersion = (uint8_t)((tmp & 0x3C) >> 2);
+  pCardInfo->SD_csd.Reserved1      = tmp & 0x03;
+
+  /* Byte 1 */
+  tmp = (hsd->CSD[0] & 0x00FF0000) >> 16;
+  pCardInfo->SD_csd.TAAC = (uint8_t)tmp;
+
+  /* Byte 2 */
+  tmp = (hsd->CSD[0] & 0x0000FF00) >> 8;
+  pCardInfo->SD_csd.NSAC = (uint8_t)tmp;
+
+  /* Byte 3 */
+  tmp = hsd->CSD[0] & 0x000000FF;
+  pCardInfo->SD_csd.MaxBusClkFrec = (uint8_t)tmp;
+
+  /* Byte 4 */
+  tmp = (hsd->CSD[1] & 0xFF000000) >> 24;
+  pCardInfo->SD_csd.CardComdClasses = (uint16_t)(tmp << 4);
+
+  /* Byte 5 */
+  tmp = (hsd->CSD[1] & 0x00FF0000) >> 16;
+  pCardInfo->SD_csd.CardComdClasses |= (uint16_t)((tmp & 0xF0) >> 4);
+  pCardInfo->SD_csd.RdBlockLen       = (uint8_t)(tmp & 0x0F);
+
+  /* Byte 6 */
+  tmp = (hsd->CSD[1] & 0x0000FF00) >> 8;
+  pCardInfo->SD_csd.PartBlockRead   = (uint8_t)((tmp & 0x80) >> 7);
+  pCardInfo->SD_csd.WrBlockMisalign = (uint8_t)((tmp & 0x40) >> 6);
+  pCardInfo->SD_csd.RdBlockMisalign = (uint8_t)((tmp & 0x20) >> 5);
+  pCardInfo->SD_csd.DSRImpl         = (uint8_t)((tmp & 0x10) >> 4);
+  pCardInfo->SD_csd.Reserved2       = 0; /*!< Reserved */
+
+  if ((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1) || (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0))
+  {
+    pCardInfo->SD_csd.DeviceSize = (tmp & 0x03) << 10;
+
+    /* Byte 7 */
+    tmp = (uint8_t)(hsd->CSD[1] & 0x000000FF);
+    pCardInfo->SD_csd.DeviceSize |= (tmp) << 2;
+
+    /* Byte 8 */
+    tmp = (uint8_t)((hsd->CSD[2] & 0xFF000000) >> 24);
+    pCardInfo->SD_csd.DeviceSize |= (tmp & 0xC0) >> 6;
+
+    pCardInfo->SD_csd.MaxRdCurrentVDDMin = (tmp & 0x38) >> 3;
+    pCardInfo->SD_csd.MaxRdCurrentVDDMax = (tmp & 0x07);
+
+    /* Byte 9 */
+    tmp = (uint8_t)((hsd->CSD[2] & 0x00FF0000) >> 16);
+    pCardInfo->SD_csd.MaxWrCurrentVDDMin = (tmp & 0xE0) >> 5;
+    pCardInfo->SD_csd.MaxWrCurrentVDDMax = (tmp & 0x1C) >> 2;
+    pCardInfo->SD_csd.DeviceSizeMul      = (tmp & 0x03) << 1;
+    /* Byte 10 */
+    tmp = (uint8_t)((hsd->CSD[2] & 0x0000FF00) >> 8);
+    pCardInfo->SD_csd.DeviceSizeMul |= (tmp & 0x80) >> 7;
+
+    pCardInfo->CardCapacity  = (pCardInfo->SD_csd.DeviceSize + 1) ;
+    pCardInfo->CardCapacity *= (1 << (pCardInfo->SD_csd.DeviceSizeMul + 2));
+    pCardInfo->CardBlockSize = 1 << (pCardInfo->SD_csd.RdBlockLen);
+    pCardInfo->CardCapacity *= pCardInfo->CardBlockSize;
+  }
+  else if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
+  {
+    /* Byte 7 */
+    tmp = (uint8_t)(hsd->CSD[1] & 0x000000FF);
+    pCardInfo->SD_csd.DeviceSize = (tmp & 0x3F) << 16;
+
+    /* Byte 8 */
+    tmp = (uint8_t)((hsd->CSD[2] & 0xFF000000) >> 24);
+
+    pCardInfo->SD_csd.DeviceSize |= (tmp << 8);
+
+    /* Byte 9 */
+    tmp = (uint8_t)((hsd->CSD[2] & 0x00FF0000) >> 16);
+
+    pCardInfo->SD_csd.DeviceSize |= (tmp);
+
+    /* Byte 10 */
+    tmp = (uint8_t)((hsd->CSD[2] & 0x0000FF00) >> 8);
+
+    pCardInfo->CardCapacity  = ((pCardInfo->SD_csd.DeviceSize + 1)) * 512 * 1024;
+    pCardInfo->CardBlockSize = 512;
+  }
+  else
+  {
+    /* Not supported card type */
+    errorstate = SD_ERROR;
+  }
+
+  pCardInfo->SD_csd.EraseGrSize = (tmp & 0x40) >> 6;
+  pCardInfo->SD_csd.EraseGrMul  = (tmp & 0x3F) << 1;
+
+  /* Byte 11 */
+  tmp = (uint8_t)(hsd->CSD[2] & 0x000000FF);
+  pCardInfo->SD_csd.EraseGrMul     |= (tmp & 0x80) >> 7;
+  pCardInfo->SD_csd.WrProtectGrSize = (tmp & 0x7F);
+
+  /* Byte 12 */
+  tmp = (uint8_t)((hsd->CSD[3] & 0xFF000000) >> 24);
+  pCardInfo->SD_csd.WrProtectGrEnable = (tmp & 0x80) >> 7;
+  pCardInfo->SD_csd.ManDeflECC        = (tmp & 0x60) >> 5;
+  pCardInfo->SD_csd.WrSpeedFact       = (tmp & 0x1C) >> 2;
+  pCardInfo->SD_csd.MaxWrBlockLen     = (tmp & 0x03) << 2;
+
+  /* Byte 13 */
+  tmp = (uint8_t)((hsd->CSD[3] & 0x00FF0000) >> 16);
+  pCardInfo->SD_csd.MaxWrBlockLen      |= (tmp & 0xC0) >> 6;
+  pCardInfo->SD_csd.WriteBlockPaPartial = (tmp & 0x20) >> 5;
+  pCardInfo->SD_csd.Reserved3           = 0;
+  pCardInfo->SD_csd.ContentProtectAppli = (tmp & 0x01);
+
+  /* Byte 14 */
+  tmp = (uint8_t)((hsd->CSD[3] & 0x0000FF00) >> 8);
+  pCardInfo->SD_csd.FileFormatGrouop = (tmp & 0x80) >> 7;
+  pCardInfo->SD_csd.CopyFlag         = (tmp & 0x40) >> 6;
+  pCardInfo->SD_csd.PermWrProtect    = (tmp & 0x20) >> 5;
+  pCardInfo->SD_csd.TempWrProtect    = (tmp & 0x10) >> 4;
+  pCardInfo->SD_csd.FileFormat       = (tmp & 0x0C) >> 2;
+  pCardInfo->SD_csd.ECC              = (tmp & 0x03);
+
+  /* Byte 15 */
+  tmp = (uint8_t)(hsd->CSD[3] & 0x000000FF);
+  pCardInfo->SD_csd.CSD_CRC   = (tmp & 0xFE) >> 1;
+  pCardInfo->SD_csd.Reserved4 = 1;
+
+  /* Byte 0 */
+  tmp = (uint8_t)((hsd->CID[0] & 0xFF000000) >> 24);
+  pCardInfo->SD_cid.ManufacturerID = tmp;
+
+  /* Byte 1 */
+  tmp = (uint8_t)((hsd->CID[0] & 0x00FF0000) >> 16);
+  pCardInfo->SD_cid.OEM_AppliID = tmp << 8;
+
+  /* Byte 2 */
+  tmp = (uint8_t)((hsd->CID[0] & 0x000000FF00) >> 8);
+  pCardInfo->SD_cid.OEM_AppliID |= tmp;
+
+  /* Byte 3 */
+  tmp = (uint8_t)(hsd->CID[0] & 0x000000FF);
+  pCardInfo->SD_cid.ProdName1 = tmp << 24;
+
+  /* Byte 4 */
+  tmp = (uint8_t)((hsd->CID[1] & 0xFF000000) >> 24);
+  pCardInfo->SD_cid.ProdName1 |= tmp << 16;
+
+  /* Byte 5 */
+  tmp = (uint8_t)((hsd->CID[1] & 0x00FF0000) >> 16);
+  pCardInfo->SD_cid.ProdName1 |= tmp << 8;
+
+  /* Byte 6 */
+  tmp = (uint8_t)((hsd->CID[1] & 0x0000FF00) >> 8);
+  pCardInfo->SD_cid.ProdName1 |= tmp;
+
+  /* Byte 7 */
+  tmp = (uint8_t)(hsd->CID[1] & 0x000000FF);
+  pCardInfo->SD_cid.ProdName2 = tmp;
+
+  /* Byte 8 */
+  tmp = (uint8_t)((hsd->CID[2] & 0xFF000000) >> 24);
+  pCardInfo->SD_cid.ProdRev = tmp;
+
+  /* Byte 9 */
+  tmp = (uint8_t)((hsd->CID[2] & 0x00FF0000) >> 16);
+  pCardInfo->SD_cid.ProdSN = tmp << 24;
+
+  /* Byte 10 */
+  tmp = (uint8_t)((hsd->CID[2] & 0x0000FF00) >> 8);
+  pCardInfo->SD_cid.ProdSN |= tmp << 16;
+
+  /* Byte 11 */
+  tmp = (uint8_t)(hsd->CID[2] & 0x000000FF);
+  pCardInfo->SD_cid.ProdSN |= tmp << 8;
+
+  /* Byte 12 */
+  tmp = (uint8_t)((hsd->CID[3] & 0xFF000000) >> 24);
+  pCardInfo->SD_cid.ProdSN |= tmp;
+
+  /* Byte 13 */
+  tmp = (uint8_t)((hsd->CID[3] & 0x00FF0000) >> 16);
+  pCardInfo->SD_cid.Reserved1   |= (tmp & 0xF0) >> 4;
+  pCardInfo->SD_cid.ManufactDate = (tmp & 0x0F) << 8;
+
+  /* Byte 14 */
+  tmp = (uint8_t)((hsd->CID[3] & 0x0000FF00) >> 8);
+  pCardInfo->SD_cid.ManufactDate |= tmp;
+
+  /* Byte 15 */
+  tmp = (uint8_t)(hsd->CID[3] & 0x000000FF);
+  pCardInfo->SD_cid.CID_CRC   = (tmp & 0xFE) >> 1;
+  pCardInfo->SD_cid.Reserved2 = 1;
+
+  return errorstate;
+}
+
+/**
+  * @brief  Enables wide bus operation for the requested card if supported by
+  *         card.
+  * @param  hsd: SD handle
+  * @param  WideMode: Specifies the SD card wide bus mode
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_BUS_WIDE_8B: 8-bit data transfer (Only for MMC)
+  *            @arg SDMMC_BUS_WIDE_4B: 4-bit data transfer
+  *            @arg SDMMC_BUS_WIDE_1B: 1-bit data transfer
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_WideBusOperation_Config(SD_HandleTypeDef *hsd, uint32_t WideMode)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  SDMMC_InitTypeDef tmpinit;
+
+  /* MMC Card does not support this feature */
+  if (hsd->CardType == MULTIMEDIA_CARD)
+  {
+    errorstate = SD_UNSUPPORTED_FEATURE;
+
+    return errorstate;
+  }
+  else if ((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1) || (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0) ||\
+    (hsd->CardType == HIGH_CAPACITY_SD_CARD))
+  {
+    if (WideMode == SDMMC_BUS_WIDE_8B)
+    {
+      errorstate = SD_UNSUPPORTED_FEATURE;
+    }
+    else if (WideMode == SDMMC_BUS_WIDE_4B)
+    {
+      errorstate = SD_WideBus_Enable(hsd);
+    }
+    else if (WideMode == SDMMC_BUS_WIDE_1B)
+    {
+      errorstate = SD_WideBus_Disable(hsd);
+    }
+    else
+    {
+      /* WideMode is not a valid argument*/
+      errorstate = SD_INVALID_PARAMETER;
+    }
+
+    if (errorstate == SD_OK)
+    {
+      /* Configure the SDMMC peripheral */
+      tmpinit.ClockEdge           = hsd->Init.ClockEdge;
+      tmpinit.ClockBypass         = hsd->Init.ClockBypass;
+      tmpinit.ClockPowerSave      = hsd->Init.ClockPowerSave;
+      tmpinit.BusWide             = WideMode;
+      tmpinit.HardwareFlowControl = hsd->Init.HardwareFlowControl;
+      tmpinit.ClockDiv            = hsd->Init.ClockDiv;
+      SDMMC_Init(hsd->Instance, tmpinit);
+    }
+  }
+
+  return errorstate;
+}
+
+/**
+  * @brief  Aborts an ongoing data transfer.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_StopTransfer(SD_HandleTypeDef *hsd)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+
+  /* Send CMD12 STOP_TRANSMISSION  */
+  sdmmc_cmdinitstructure.Argument         = 0;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_STOP_TRANSMISSION;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_STOP_TRANSMISSION);
+
+  return errorstate;
+}
+
+/**
+  * @brief  Switches the SD card to High Speed mode.
+  *         This API must be used after "Transfer State"
+  * @note   This operation should be followed by the configuration
+  *         of PLL to have SDMMCCK clock between 67 and 75 MHz
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_HighSpeed (SD_HandleTypeDef *hsd)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+
+  uint8_t SD_hs[64]  = {0};
+  uint32_t SD_scr[2] = {0, 0};
+  uint32_t SD_SPEC   = 0 ;
+  uint32_t count = 0, *tempbuff = (uint32_t *)SD_hs;
+
+  /* Initialize the Data control register */
+  hsd->Instance->DCTRL = 0;
+
+  /* Get SCR Register */
+  errorstate = SD_FindSCR(hsd, SD_scr);
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Test the Version supported by the card*/
+  SD_SPEC = (SD_scr[1]  & 0x01000000) | (SD_scr[1]  & 0x02000000);
+
+  if (SD_SPEC != SD_ALLZERO)
+  {
+    /* Set Block Size for Card */
+    sdmmc_cmdinitstructure.Argument         = (uint32_t)64;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+    sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+    sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+
+    if (errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+
+    /* Configure the SD DPSM (Data Path State Machine) */
+    sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+    sdmmc_datainitstructure.DataLength    = 64;
+    sdmmc_datainitstructure.DataBlockSize = SDMMC_DATABLOCK_SIZE_64B ;
+    sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+    sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+    sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+    SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+
+    /* Send CMD6 switch mode */
+    sdmmc_cmdinitstructure.Argument         = 0x80FFFF01;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_HS_SWITCH;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_HS_SWITCH);
+
+    if (errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+
+    while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DBCKEND))
+    {
+      if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXFIFOHF))
+      {
+        for (count = 0; count < 8; count++)
+        {
+          *(tempbuff + count) = SDMMC_ReadFIFO(hsd->Instance);
+        }
+
+        tempbuff += 8;
+      }
+    }
+
+    if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DTIMEOUT))
+    {
+      __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DTIMEOUT);
+
+      errorstate = SD_DATA_TIMEOUT;
+
+      return errorstate;
+    }
+    else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DCRCFAIL))
+    {
+      __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DCRCFAIL);
+
+      errorstate = SD_DATA_CRC_FAIL;
+
+      return errorstate;
+    }
+    else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR))
+    {
+      __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_RXOVERR);
+
+      errorstate = SD_RX_OVERRUN;
+
+      return errorstate;
+    }
+    else
+    {
+      /* No error flag set */
+    }
+
+    count = SD_DATATIMEOUT;
+
+    while ((__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXDAVL)) && (count > 0))
+    {
+      *tempbuff = SDMMC_ReadFIFO(hsd->Instance);
+      tempbuff++;
+      count--;
+    }
+
+    /* Clear all the static flags */
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+    /* Test if the switch mode HS is ok */
+    if ((SD_hs[13]& 2) != 2)
+    {
+      errorstate = SD_UNSUPPORTED_FEATURE;
+    }
+  }
+
+  return errorstate;
+}
+
+/**
+  * @}
+  */
+
+/** @addtogroup SD_Exported_Functions_Group4
+ *  @brief   Peripheral State functions
+ *
+@verbatim
+  ==============================================================================
+                      ##### Peripheral State functions #####
+  ==============================================================================
+  [..]
+    This subsection permits to get in runtime the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the current SD card's status.
+  * @param  hsd: SD handle
+  * @param  pSDstatus: Pointer to the buffer that will contain the SD card status
+  *         SD Status register)
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_SendSDStatus(SD_HandleTypeDef *hsd, uint32_t *pSDstatus)
+{
+  SDMMC_CmdInitTypeDef  sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t count = 0;
+
+  /* Check SD response */
+  if ((SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1) & SD_CARD_LOCKED) == SD_CARD_LOCKED)
+  {
+    errorstate = SD_LOCK_UNLOCK_FAILED;
+
+    return errorstate;
+  }
+
+  /* Set block size for card if it is not equal to current block size for card */
+  sdmmc_cmdinitstructure.Argument         = 64;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Send CMD55 */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Configure the SD DPSM (Data Path State Machine) */
+  sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdmmc_datainitstructure.DataLength    = 64;
+  sdmmc_datainitstructure.DataBlockSize = SDMMC_DATABLOCK_SIZE_64B;
+  sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+  sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+  SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+
+  /* Send ACMD13 (SD_APP_STAUS)  with argument as card's RCA */
+  sdmmc_cmdinitstructure.Argument         = 0;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SD_APP_STATUS;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SD_APP_STATUS);
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Get status data */
+  while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DBCKEND))
+  {
+    if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXFIFOHF))
+    {
+      for (count = 0; count < 8; count++)
+      {
+        *(pSDstatus + count) = SDMMC_ReadFIFO(hsd->Instance);
+      }
+
+      pSDstatus += 8;
+    }
+  }
+
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DTIMEOUT))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DTIMEOUT);
+
+    errorstate = SD_DATA_TIMEOUT;
+
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DCRCFAIL))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DCRCFAIL);
+
+    errorstate = SD_DATA_CRC_FAIL;
+
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_RXOVERR);
+
+    errorstate = SD_RX_OVERRUN;
+
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }
+
+  count = SD_DATATIMEOUT;
+  while ((__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXDAVL)) && (count > 0))
+  {
+    *pSDstatus = SDMMC_ReadFIFO(hsd->Instance);
+    pSDstatus++;
+    count--;
+  }
+
+  /* Clear all the static status flags*/
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+  return errorstate;
+}
+
+/**
+  * @brief  Gets the current sd card data status.
+  * @param  hsd: SD handle
+  * @retval Data Transfer state
+  */
+HAL_SD_TransferStateTypedef HAL_SD_GetStatus(SD_HandleTypeDef *hsd)
+{
+  HAL_SD_CardStateTypedef cardstate =  SD_CARD_TRANSFER;
+
+  /* Get SD card state */
+  cardstate = SD_GetState(hsd);
+
+  /* Find SD status according to card state*/
+  if (cardstate == SD_CARD_TRANSFER)
+  {
+    return SD_TRANSFER_OK;
+  }
+  else if(cardstate == SD_CARD_ERROR)
+  {
+    return SD_TRANSFER_ERROR;
+  }
+  else
+  {
+    return SD_TRANSFER_BUSY;
+  }
+}
+
+/**
+  * @brief  Gets the SD card status.
+  * @param  hsd: SD handle
+  * @param  pCardStatus: Pointer to the HAL_SD_CardStatusTypedef structure that
+  *         will contain the SD card status information
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_GetCardStatus(SD_HandleTypeDef *hsd, HAL_SD_CardStatusTypedef *pCardStatus)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t tmp = 0;
+  uint32_t sd_status[16];
+
+  errorstate = HAL_SD_SendSDStatus(hsd, sd_status);
+
+  if (errorstate  != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Byte 0 */
+  tmp = (sd_status[0] & 0xC0) >> 6;
+  pCardStatus->DAT_BUS_WIDTH = (uint8_t)tmp;
+
+  /* Byte 0 */
+  tmp = (sd_status[0] & 0x20) >> 5;
+  pCardStatus->SECURED_MODE = (uint8_t)tmp;
+
+  /* Byte 2 */
+  tmp = (sd_status[2] & 0xFF);
+  pCardStatus->SD_CARD_TYPE = (uint8_t)(tmp << 8);
+
+  /* Byte 3 */
+  tmp = (sd_status[3] & 0xFF);
+  pCardStatus->SD_CARD_TYPE |= (uint8_t)tmp;
+
+  /* Byte 4 */
+  tmp = (sd_status[4] & 0xFF);
+  pCardStatus->SIZE_OF_PROTECTED_AREA = (uint8_t)(tmp << 24);
+
+  /* Byte 5 */
+  tmp = (sd_status[5] & 0xFF);
+  pCardStatus->SIZE_OF_PROTECTED_AREA |= (uint8_t)(tmp << 16);
+
+  /* Byte 6 */
+  tmp = (sd_status[6] & 0xFF);
+  pCardStatus->SIZE_OF_PROTECTED_AREA |= (uint8_t)(tmp << 8);
+
+  /* Byte 7 */
+  tmp = (sd_status[7] & 0xFF);
+  pCardStatus->SIZE_OF_PROTECTED_AREA |= (uint8_t)tmp;
+
+  /* Byte 8 */
+  tmp = (sd_status[8] & 0xFF);
+  pCardStatus->SPEED_CLASS = (uint8_t)tmp;
+
+  /* Byte 9 */
+  tmp = (sd_status[9] & 0xFF);
+  pCardStatus->PERFORMANCE_MOVE = (uint8_t)tmp;
+
+  /* Byte 10 */
+  tmp = (sd_status[10] & 0xF0) >> 4;
+  pCardStatus->AU_SIZE = (uint8_t)tmp;
+
+  /* Byte 11 */
+  tmp = (sd_status[11] & 0xFF);
+  pCardStatus->ERASE_SIZE = (uint8_t)(tmp << 8);
+
+  /* Byte 12 */
+  tmp = (sd_status[12] & 0xFF);
+  pCardStatus->ERASE_SIZE |= (uint8_t)tmp;
+
+  /* Byte 13 */
+  tmp = (sd_status[13] & 0xFC) >> 2;
+  pCardStatus->ERASE_TIMEOUT = (uint8_t)tmp;
+
+  /* Byte 13 */
+  tmp = (sd_status[13] & 0x3);
+  pCardStatus->ERASE_OFFSET = (uint8_t)tmp;
+
+  return errorstate;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private function ----------------------------------------------------------*/
+/** @addtogroup SD_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  SD DMA transfer complete Rx callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SD_DMA_RxCplt(DMA_HandleTypeDef *hdma)
+{
+  SD_HandleTypeDef *hsd = (SD_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  /* DMA transfer is complete */
+  hsd->DmaTransferCplt = 1;
+
+  /* Wait until SD transfer is complete */
+  while(hsd->SdTransferCplt == 0)
+  {
+  }
+
+  /* Disable the DMA channel */
+  HAL_DMA_Abort(hdma);
+
+  /* Transfer complete user callback */
+  HAL_SD_DMA_RxCpltCallback(hsd->hdmarx);
+}
+
+/**
+  * @brief  SD DMA transfer Error Rx callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SD_DMA_RxError(DMA_HandleTypeDef *hdma)
+{
+  SD_HandleTypeDef *hsd = (SD_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  /* Transfer complete user callback */
+  HAL_SD_DMA_RxErrorCallback(hsd->hdmarx);
+}
+
+/**
+  * @brief  SD DMA transfer complete Tx callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SD_DMA_TxCplt(DMA_HandleTypeDef *hdma)
+{
+  SD_HandleTypeDef *hsd = (SD_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  /* DMA transfer is complete */
+  hsd->DmaTransferCplt = 1;
+
+  /* Wait until SD transfer is complete */
+  while(hsd->SdTransferCplt == 0)
+  {
+  }
+
+  /* Disable the DMA channel */
+  HAL_DMA_Abort(hdma);
+
+  /* Transfer complete user callback */
+  HAL_SD_DMA_TxCpltCallback(hsd->hdmatx);
+}
+
+/**
+  * @brief  SD DMA transfer Error Tx callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SD_DMA_TxError(DMA_HandleTypeDef *hdma)
+{
+  SD_HandleTypeDef *hsd = ( SD_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Transfer complete user callback */
+  HAL_SD_DMA_TxErrorCallback(hsd->hdmatx);
+}
+
+/**
+  * @brief  Returns the SD current state.
+  * @param  hsd: SD handle
+  * @retval SD card current state
+  */
+static HAL_SD_CardStateTypedef SD_GetState(SD_HandleTypeDef *hsd)
+{
+  uint32_t resp1 = 0;
+
+  if (SD_SendStatus(hsd, &resp1) != SD_OK)
+  {
+    return SD_CARD_ERROR;
+  }
+  else
+  {
+    return (HAL_SD_CardStateTypedef)((resp1 >> 9) & 0x0F);
+  }
+}
+
+/**
+  * @brief  Initializes all cards or single card as the case may be Card(s) come
+  *         into standby state.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_Initialize_Cards(SD_HandleTypeDef *hsd)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint16_t sd_rca = 1;
+
+  if(SDMMC_GetPowerState(hsd->Instance) == 0) /* Power off */
+  {
+    errorstate = SD_REQUEST_NOT_APPLICABLE;
+
+    return errorstate;
+  }
+
+  if(hsd->CardType != SECURE_DIGITAL_IO_CARD)
+  {
+    /* Send CMD2 ALL_SEND_CID */
+    sdmmc_cmdinitstructure.Argument         = 0;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_ALL_SEND_CID;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_LONG;
+    sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+    sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+    /* Check for error conditions */
+    errorstate = SD_CmdResp2Error(hsd);
+
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+
+    /* Get Card identification number data */
+    hsd->CID[0] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+    hsd->CID[1] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP2);
+    hsd->CID[2] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP3);
+    hsd->CID[3] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP4);
+  }
+
+  if((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1)    || (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0) ||\
+     (hsd->CardType == SECURE_DIGITAL_IO_COMBO_CARD) || (hsd->CardType == HIGH_CAPACITY_SD_CARD))
+  {
+    /* Send CMD3 SET_REL_ADDR with argument 0 */
+    /* SD Card publishes its RCA. */
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_REL_ADDR;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+    /* Check for error conditions */
+    errorstate = SD_CmdResp6Error(hsd, SD_CMD_SET_REL_ADDR, &sd_rca);
+
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+  }
+
+  if (hsd->CardType != SECURE_DIGITAL_IO_CARD)
+  {
+    /* Get the SD card RCA */
+    hsd->RCA = sd_rca;
+
+    /* Send CMD9 SEND_CSD with argument as card's RCA */
+    sdmmc_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SEND_CSD;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_LONG;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+    /* Check for error conditions */
+    errorstate = SD_CmdResp2Error(hsd);
+
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+
+    /* Get Card Specific Data */
+    hsd->CSD[0] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+    hsd->CSD[1] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP2);
+    hsd->CSD[2] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP3);
+    hsd->CSD[3] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP4);
+  }
+
+  /* All cards are initialized */
+  return errorstate;
+}
+
+/**
+  * @brief  Selects od Deselects the corresponding card.
+  * @param  hsd: SD handle
+  * @param  addr: Address of the card to be selected
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_Select_Deselect(SD_HandleTypeDef *hsd, uint64_t addr)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+
+  /* Send CMD7 SDMMC_SEL_DESEL_CARD */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)addr;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SEL_DESEL_CARD;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SEL_DESEL_CARD);
+
+  return errorstate;
+}
+
+/**
+  * @brief  Enquires cards about their operating voltage and configures clock
+  *         controls and stores SD information that will be needed in future
+  *         in the SD handle.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_PowerON(SD_HandleTypeDef *hsd)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  __IO HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t response = 0, count = 0, validvoltage = 0;
+  uint32_t sdtype = SD_STD_CAPACITY;
+
+  /* Power ON Sequence -------------------------------------------------------*/
+  /* Disable SDMMC Clock */
+  __HAL_SD_SDMMC_DISABLE(hsd);
+
+  /* Set Power State to ON */
+  SDMMC_PowerState_ON(hsd->Instance);
+
+  /* 1ms: required power up waiting time before starting the SD initialization
+     sequence */
+  HAL_Delay(1);
+
+  /* Enable SDMMC Clock */
+  __HAL_SD_SDMMC_ENABLE(hsd);
+
+  /* CMD0: GO_IDLE_STATE -----------------------------------------------------*/
+  /* No CMD response required */
+  sdmmc_cmdinitstructure.Argument         = 0;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_GO_IDLE_STATE;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_NO;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdError(hsd);
+
+  if(errorstate != SD_OK)
+  {
+    /* CMD Response Timeout (wait for CMDSENT flag) */
+    return errorstate;
+  }
+
+  /* CMD8: SEND_IF_COND ------------------------------------------------------*/
+  /* Send CMD8 to verify SD card interface operating condition */
+  /* Argument: - [31:12]: Reserved (shall be set to '0')
+  - [11:8]: Supply Voltage (VHS) 0x1 (Range: 2.7-3.6 V)
+  - [7:0]: Check Pattern (recommended 0xAA) */
+  /* CMD Response: R7 */
+  sdmmc_cmdinitstructure.Argument         = SD_CHECK_PATTERN;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_SDMMC_SEND_IF_COND;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp7Error(hsd);
+
+  if (errorstate == SD_OK)
+  {
+    /* SD Card 2.0 */
+    hsd->CardType = STD_CAPACITY_SD_CARD_V2_0;
+    sdtype        = SD_HIGH_CAPACITY;
+  }
+
+  /* Send CMD55 */
+  sdmmc_cmdinitstructure.Argument         = 0;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+
+  /* If errorstate is Command Timeout, it is a MMC card */
+  /* If errorstate is SD_OK it is a SD card: SD card 2.0 (voltage range mismatch)
+     or SD card 1.x */
+  if(errorstate == SD_OK)
+  {
+    /* SD CARD */
+    /* Send ACMD41 SD_APP_OP_COND with Argument 0x80100000 */
+    while((!validvoltage) && (count < SD_MAX_VOLT_TRIAL))
+    {
+
+      /* SEND CMD55 APP_CMD with RCA as 0 */
+      sdmmc_cmdinitstructure.Argument         = 0;
+      sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+      sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+      sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+      sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+      SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+      /* Check for error conditions */
+      errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+
+      if(errorstate != SD_OK)
+      {
+        return errorstate;
+      }
+
+      /* Send CMD41 */
+      sdmmc_cmdinitstructure.Argument         = SD_VOLTAGE_WINDOW_SD | sdtype;
+      sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SD_APP_OP_COND;
+      sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+      sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+      sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+      SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+      /* Check for error conditions */
+      errorstate = SD_CmdResp3Error(hsd);
+
+      if(errorstate != SD_OK)
+      {
+        return errorstate;
+      }
+
+      /* Get command response */
+      response = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+
+      /* Get operating voltage*/
+      validvoltage = (((response >> 31) == 1) ? 1 : 0);
+
+      count++;
+    }
+
+    if(count >= SD_MAX_VOLT_TRIAL)
+    {
+      errorstate = SD_INVALID_VOLTRANGE;
+
+      return errorstate;
+    }
+
+    if((response & SD_HIGH_CAPACITY) == SD_HIGH_CAPACITY) /* (response &= SD_HIGH_CAPACITY) */
+    {
+      hsd->CardType = HIGH_CAPACITY_SD_CARD;
+    }
+
+  } /* else MMC Card */
+
+  return errorstate;
+}
+
+/**
+  * @brief  Turns the SDMMC output signals off.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_PowerOFF(SD_HandleTypeDef *hsd)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+
+  /* Set Power State to OFF */
+  SDMMC_PowerState_OFF(hsd->Instance);
+
+  return errorstate;
+}
+
+/**
+  * @brief  Returns the current card's status.
+  * @param  hsd: SD handle
+  * @param  pCardStatus: pointer to the buffer that will contain the SD card
+  *         status (Card Status register)
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_SendStatus(SD_HandleTypeDef *hsd, uint32_t *pCardStatus)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+
+  if(pCardStatus == NULL)
+  {
+    errorstate = SD_INVALID_PARAMETER;
+
+    return errorstate;
+  }
+
+  /* Send Status command */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SEND_STATUS;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SEND_STATUS);
+
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Get SD card status */
+  *pCardStatus = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+
+  return errorstate;
+}
+
+/**
+  * @brief  Checks for error conditions for CMD0.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_CmdError(SD_HandleTypeDef *hsd)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t timeout, tmp;
+
+  timeout = SDMMC_CMD0TIMEOUT;
+
+  tmp = __HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CMDSENT);
+
+  while((timeout > 0) && (!tmp))
+  {
+    tmp = __HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CMDSENT);
+    timeout--;
+  }
+
+  if(timeout == 0)
+  {
+    errorstate = SD_CMD_RSP_TIMEOUT;
+    return errorstate;
+  }
+
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+  return errorstate;
+}
+
+/**
+  * @brief  Checks for error conditions for R7 response.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_CmdResp7Error(SD_HandleTypeDef *hsd)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_ERROR;
+  uint32_t timeout = SDMMC_CMD0TIMEOUT, tmp;
+
+  tmp = __HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT);
+
+  while((!tmp) && (timeout > 0))
+  {
+    tmp = __HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT);
+    timeout--;
+  }
+
+  tmp = __HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+
+  if((timeout == 0) || tmp)
+  {
+    /* Card is not V2.0 compliant or card does not support the set voltage range */
+    errorstate = SD_CMD_RSP_TIMEOUT;
+
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+
+    return errorstate;
+  }
+
+  if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CMDREND))
+  {
+    /* Card is SD V2.0 compliant */
+    errorstate = SD_OK;
+
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CMDREND);
+
+    return errorstate;
+  }
+
+  return errorstate;
+}
+
+/**
+  * @brief  Checks for error conditions for R1 response.
+  * @param  hsd: SD handle
+  * @param  SD_CMD: The sent command index
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_CmdResp1Error(SD_HandleTypeDef *hsd, uint8_t SD_CMD)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t response_r1;
+
+  while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT))
+  {
+  }
+
+  if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CTIMEOUT))
+  {
+    errorstate = SD_CMD_RSP_TIMEOUT;
+
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+
+    return errorstate;
+  }
+  else if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL))
+  {
+    errorstate = SD_CMD_CRC_FAIL;
+
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CCRCFAIL);
+
+    return errorstate;
+  }
+
+  /* Check response received is of desired command */
+  if(SDMMC_GetCommandResponse(hsd->Instance) != SD_CMD)
+  {
+    errorstate = SD_ILLEGAL_CMD;
+
+    return errorstate;
+  }
+
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+  /* We have received response, retrieve it for analysis  */
+  response_r1 = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+
+  if((response_r1 & SD_OCR_ERRORBITS) == SD_ALLZERO)
+  {
+    return errorstate;
+  }
+
+  if((response_r1 & SD_OCR_ADDR_OUT_OF_RANGE) == SD_OCR_ADDR_OUT_OF_RANGE)
+  {
+    return(SD_ADDR_OUT_OF_RANGE);
+  }
+
+  if((response_r1 & SD_OCR_ADDR_MISALIGNED) == SD_OCR_ADDR_MISALIGNED)
+  {
+    return(SD_ADDR_MISALIGNED);
+  }
+
+  if((response_r1 & SD_OCR_BLOCK_LEN_ERR) == SD_OCR_BLOCK_LEN_ERR)
+  {
+    return(SD_BLOCK_LEN_ERR);
+  }
+
+  if((response_r1 & SD_OCR_ERASE_SEQ_ERR) == SD_OCR_ERASE_SEQ_ERR)
+  {
+    return(SD_ERASE_SEQ_ERR);
+  }
+
+  if((response_r1 & SD_OCR_BAD_ERASE_PARAM) == SD_OCR_BAD_ERASE_PARAM)
+  {
+    return(SD_BAD_ERASE_PARAM);
+  }
+
+  if((response_r1 & SD_OCR_WRITE_PROT_VIOLATION) == SD_OCR_WRITE_PROT_VIOLATION)
+  {
+    return(SD_WRITE_PROT_VIOLATION);
+  }
+
+  if((response_r1 & SD_OCR_LOCK_UNLOCK_FAILED) == SD_OCR_LOCK_UNLOCK_FAILED)
+  {
+    return(SD_LOCK_UNLOCK_FAILED);
+  }
+
+  if((response_r1 & SD_OCR_COM_CRC_FAILED) == SD_OCR_COM_CRC_FAILED)
+  {
+    return(SD_COM_CRC_FAILED);
+  }
+
+  if((response_r1 & SD_OCR_ILLEGAL_CMD) == SD_OCR_ILLEGAL_CMD)
+  {
+    return(SD_ILLEGAL_CMD);
+  }
+
+  if((response_r1 & SD_OCR_CARD_ECC_FAILED) == SD_OCR_CARD_ECC_FAILED)
+  {
+    return(SD_CARD_ECC_FAILED);
+  }
+
+  if((response_r1 & SD_OCR_CC_ERROR) == SD_OCR_CC_ERROR)
+  {
+    return(SD_CC_ERROR);
+  }
+
+  if((response_r1 & SD_OCR_GENERAL_UNKNOWN_ERROR) == SD_OCR_GENERAL_UNKNOWN_ERROR)
+  {
+    return(SD_GENERAL_UNKNOWN_ERROR);
+  }
+
+  if((response_r1 & SD_OCR_STREAM_READ_UNDERRUN) == SD_OCR_STREAM_READ_UNDERRUN)
+  {
+    return(SD_STREAM_READ_UNDERRUN);
+  }
+
+  if((response_r1 & SD_OCR_STREAM_WRITE_OVERRUN) == SD_OCR_STREAM_WRITE_OVERRUN)
+  {
+    return(SD_STREAM_WRITE_OVERRUN);
+  }
+
+  if((response_r1 & SD_OCR_CID_CSD_OVERWRITE) == SD_OCR_CID_CSD_OVERWRITE)
+  {
+    return(SD_CID_CSD_OVERWRITE);
+  }
+
+  if((response_r1 & SD_OCR_WP_ERASE_SKIP) == SD_OCR_WP_ERASE_SKIP)
+  {
+    return(SD_WP_ERASE_SKIP);
+  }
+
+  if((response_r1 & SD_OCR_CARD_ECC_DISABLED) == SD_OCR_CARD_ECC_DISABLED)
+  {
+    return(SD_CARD_ECC_DISABLED);
+  }
+
+  if((response_r1 & SD_OCR_ERASE_RESET) == SD_OCR_ERASE_RESET)
+  {
+    return(SD_ERASE_RESET);
+  }
+
+  if((response_r1 & SD_OCR_AKE_SEQ_ERROR) == SD_OCR_AKE_SEQ_ERROR)
+  {
+    return(SD_AKE_SEQ_ERROR);
+  }
+
+  return errorstate;
+}
+
+/**
+  * @brief  Checks for error conditions for R3 (OCR) response.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_CmdResp3Error(SD_HandleTypeDef *hsd)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+
+  while (!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT))
+  {
+  }
+
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CTIMEOUT))
+  {
+    errorstate = SD_CMD_RSP_TIMEOUT;
+
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+
+    return errorstate;
+  }
+
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+  return errorstate;
+}
+
+/**
+  * @brief  Checks for error conditions for R2 (CID or CSD) response.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_CmdResp2Error(SD_HandleTypeDef *hsd)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+
+  while (!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT))
+  {
+  }
+
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CTIMEOUT))
+  {
+    errorstate = SD_CMD_RSP_TIMEOUT;
+
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL))
+  {
+    errorstate = SD_CMD_CRC_FAIL;
+
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CCRCFAIL);
+
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }
+
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+  return errorstate;
+}
+
+/**
+  * @brief  Checks for error conditions for R6 (RCA) response.
+  * @param  hsd: SD handle
+  * @param  SD_CMD: The sent command index
+  * @param  pRCA: Pointer to the variable that will contain the SD card relative
+  *         address RCA
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_CmdResp6Error(SD_HandleTypeDef *hsd, uint8_t SD_CMD, uint16_t *pRCA)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t response_r1;
+
+  while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT))
+  {
+  }
+
+  if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CTIMEOUT))
+  {
+    errorstate = SD_CMD_RSP_TIMEOUT;
+
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+
+    return errorstate;
+  }
+  else if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL))
+  {
+    errorstate = SD_CMD_CRC_FAIL;
+
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CCRCFAIL);
+
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }
+
+  /* Check response received is of desired command */
+  if(SDMMC_GetCommandResponse(hsd->Instance) != SD_CMD)
+  {
+    errorstate = SD_ILLEGAL_CMD;
+
+    return errorstate;
+  }
+
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+  /* We have received response, retrieve it.  */
+  response_r1 = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+
+  if((response_r1 & (SD_R6_GENERAL_UNKNOWN_ERROR | SD_R6_ILLEGAL_CMD | SD_R6_COM_CRC_FAILED)) == SD_ALLZERO)
+  {
+    *pRCA = (uint16_t) (response_r1 >> 16);
+
+    return errorstate;
+  }
+
+  if((response_r1 & SD_R6_GENERAL_UNKNOWN_ERROR) == SD_R6_GENERAL_UNKNOWN_ERROR)
+  {
+    return(SD_GENERAL_UNKNOWN_ERROR);
+  }
+
+  if((response_r1 & SD_R6_ILLEGAL_CMD) == SD_R6_ILLEGAL_CMD)
+  {
+    return(SD_ILLEGAL_CMD);
+  }
+
+  if((response_r1 & SD_R6_COM_CRC_FAILED) == SD_R6_COM_CRC_FAILED)
+  {
+    return(SD_COM_CRC_FAILED);
+  }
+
+  return errorstate;
+}
+
+/**
+  * @brief  Enables the SDMMC wide bus mode.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_WideBus_Enable(SD_HandleTypeDef *hsd)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+
+  uint32_t scr[2] = {0, 0};
+
+  if((SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1) & SD_CARD_LOCKED) == SD_CARD_LOCKED)
+  {
+    errorstate = SD_LOCK_UNLOCK_FAILED;
+
+    return errorstate;
+  }
+
+  /* Get SCR Register */
+  errorstate = SD_FindSCR(hsd, scr);
+
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* If requested card supports wide bus operation */
+  if((scr[1] & SD_WIDE_BUS_SUPPORT) != SD_ALLZERO)
+  {
+    /* Send CMD55 APP_CMD with argument as card's RCA.*/
+    sdmmc_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+    sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+    sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+
+    /* Send ACMD6 APP_CMD with argument as 2 for wide bus mode */
+    sdmmc_cmdinitstructure.Argument         = 2;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_SD_SET_BUSWIDTH;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_SD_SET_BUSWIDTH);
+
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+
+    return errorstate;
+  }
+  else
+  {
+    errorstate = SD_REQUEST_NOT_APPLICABLE;
+
+    return errorstate;
+  }
+}
+
+/**
+  * @brief  Disables the SDMMC wide bus mode.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_WideBus_Disable(SD_HandleTypeDef *hsd)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+
+  uint32_t scr[2] = {0, 0};
+
+  if((SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1) & SD_CARD_LOCKED) == SD_CARD_LOCKED)
+  {
+    errorstate = SD_LOCK_UNLOCK_FAILED;
+
+    return errorstate;
+  }
+
+  /* Get SCR Register */
+  errorstate = SD_FindSCR(hsd, scr);
+
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* If requested card supports 1 bit mode operation */
+  if((scr[1] & SD_SINGLE_BUS_SUPPORT) != SD_ALLZERO)
+  {
+    /* Send CMD55 APP_CMD with argument as card's RCA */
+    sdmmc_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+    sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+    sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+
+    /* Send ACMD6 APP_CMD with argument as 0 for single bus mode */
+    sdmmc_cmdinitstructure.Argument         = 0;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_SD_SET_BUSWIDTH;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_SD_SET_BUSWIDTH);
+
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+
+    return errorstate;
+  }
+  else
+  {
+    errorstate = SD_REQUEST_NOT_APPLICABLE;
+
+    return errorstate;
+  }
+}
+
+
+/**
+  * @brief  Finds the SD card SCR register value.
+  * @param  hsd: SD handle
+  * @param  pSCR: pointer to the buffer that will contain the SCR value
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_FindSCR(SD_HandleTypeDef *hsd, uint32_t *pSCR)
+{
+  SDMMC_CmdInitTypeDef  sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t index = 0;
+  uint32_t tempscr[2] = {0, 0};
+
+  /* Set Block Size To 8 Bytes */
+  /* Send CMD55 APP_CMD with argument as card's RCA */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)8;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  /* Send CMD55 APP_CMD with argument as card's RCA */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)((hsd->RCA) << 16);
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdmmc_datainitstructure.DataLength    = 8;
+  sdmmc_datainitstructure.DataBlockSize = SDMMC_DATABLOCK_SIZE_8B;
+  sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+  sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+  SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+
+  /* Send ACMD51 SD_APP_SEND_SCR with argument as 0 */
+  sdmmc_cmdinitstructure.Argument         = 0;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SD_APP_SEND_SCR;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SD_APP_SEND_SCR);
+
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+
+  while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DBCKEND))
+  {
+    if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXDAVL))
+    {
+      *(tempscr + index) = SDMMC_ReadFIFO(hsd->Instance);
+      index++;
+    }
+  }
+
+  if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DTIMEOUT))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DTIMEOUT);
+
+    errorstate = SD_DATA_TIMEOUT;
+
+    return errorstate;
+  }
+  else if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DCRCFAIL))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DCRCFAIL);
+
+    errorstate = SD_DATA_CRC_FAIL;
+
+    return errorstate;
+  }
+  else if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_RXOVERR);
+
+    errorstate = SD_RX_OVERRUN;
+
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }
+
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+  *(pSCR + 1) = ((tempscr[0] & SD_0TO7BITS) << 24)  | ((tempscr[0] & SD_8TO15BITS) << 8) |\
+    ((tempscr[0] & SD_16TO23BITS) >> 8) | ((tempscr[0] & SD_24TO31BITS) >> 24);
+
+  *(pSCR) = ((tempscr[1] & SD_0TO7BITS) << 24)  | ((tempscr[1] & SD_8TO15BITS) << 8) |\
+    ((tempscr[1] & SD_16TO23BITS) >> 8) | ((tempscr[1] & SD_24TO31BITS) >> 24);
+
+  return errorstate;
+}
+
+/**
+  * @brief  Checks if the SD card is in programming state.
+  * @param  hsd: SD handle
+  * @param  pStatus: pointer to the variable that will contain the SD card state
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_IsCardProgramming(SD_HandleTypeDef *hsd, uint8_t *pStatus)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  __IO uint32_t responseR1 = 0;
+
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SEND_STATUS;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT))
+  {
+  }
+
+  if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CTIMEOUT))
+  {
+    errorstate = SD_CMD_RSP_TIMEOUT;
+
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+
+    return errorstate;
+  }
+  else if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL))
+  {
+    errorstate = SD_CMD_CRC_FAIL;
+
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CCRCFAIL);
+
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }
+
+  /* Check response received is of desired command */
+  if((uint32_t)SDMMC_GetCommandResponse(hsd->Instance) != SD_CMD_SEND_STATUS)
+  {
+    errorstate = SD_ILLEGAL_CMD;
+
+    return errorstate;
+  }
+
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+
+
+  /* We have received response, retrieve it for analysis */
+  responseR1 = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+
+  /* Find out card status */
+  *pStatus = (uint8_t)((responseR1 >> 9) & 0x0000000F);
+
+  if((responseR1 & SD_OCR_ERRORBITS) == SD_ALLZERO)
+  {
+    return errorstate;
+  }
+
+  if((responseR1 & SD_OCR_ADDR_OUT_OF_RANGE) == SD_OCR_ADDR_OUT_OF_RANGE)
+  {
+    return(SD_ADDR_OUT_OF_RANGE);
+  }
+
+  if((responseR1 & SD_OCR_ADDR_MISALIGNED) == SD_OCR_ADDR_MISALIGNED)
+  {
+    return(SD_ADDR_MISALIGNED);
+  }
+
+  if((responseR1 & SD_OCR_BLOCK_LEN_ERR) == SD_OCR_BLOCK_LEN_ERR)
+  {
+    return(SD_BLOCK_LEN_ERR);
+  }
+
+  if((responseR1 & SD_OCR_ERASE_SEQ_ERR) == SD_OCR_ERASE_SEQ_ERR)
+  {
+    return(SD_ERASE_SEQ_ERR);
+  }
+
+  if((responseR1 & SD_OCR_BAD_ERASE_PARAM) == SD_OCR_BAD_ERASE_PARAM)
+  {
+    return(SD_BAD_ERASE_PARAM);
+  }
+
+  if((responseR1 & SD_OCR_WRITE_PROT_VIOLATION) == SD_OCR_WRITE_PROT_VIOLATION)
+  {
+    return(SD_WRITE_PROT_VIOLATION);
+  }
+
+  if((responseR1 & SD_OCR_LOCK_UNLOCK_FAILED) == SD_OCR_LOCK_UNLOCK_FAILED)
+  {
+    return(SD_LOCK_UNLOCK_FAILED);
+  }
+
+  if((responseR1 & SD_OCR_COM_CRC_FAILED) == SD_OCR_COM_CRC_FAILED)
+  {
+    return(SD_COM_CRC_FAILED);
+  }
+
+  if((responseR1 & SD_OCR_ILLEGAL_CMD) == SD_OCR_ILLEGAL_CMD)
+  {
+    return(SD_ILLEGAL_CMD);
+  }
+
+  if((responseR1 & SD_OCR_CARD_ECC_FAILED) == SD_OCR_CARD_ECC_FAILED)
+  {
+    return(SD_CARD_ECC_FAILED);
+  }
+
+  if((responseR1 & SD_OCR_CC_ERROR) == SD_OCR_CC_ERROR)
+  {
+    return(SD_CC_ERROR);
+  }
+
+  if((responseR1 & SD_OCR_GENERAL_UNKNOWN_ERROR) == SD_OCR_GENERAL_UNKNOWN_ERROR)
+  {
+    return(SD_GENERAL_UNKNOWN_ERROR);
+  }
+
+  if((responseR1 & SD_OCR_STREAM_READ_UNDERRUN) == SD_OCR_STREAM_READ_UNDERRUN)
+  {
+    return(SD_STREAM_READ_UNDERRUN);
+  }
+
+  if((responseR1 & SD_OCR_STREAM_WRITE_OVERRUN) == SD_OCR_STREAM_WRITE_OVERRUN)
+  {
+    return(SD_STREAM_WRITE_OVERRUN);
+  }
+
+  if((responseR1 & SD_OCR_CID_CSD_OVERWRITE) == SD_OCR_CID_CSD_OVERWRITE)
+  {
+    return(SD_CID_CSD_OVERWRITE);
+  }
+
+  if((responseR1 & SD_OCR_WP_ERASE_SKIP) == SD_OCR_WP_ERASE_SKIP)
+  {
+    return(SD_WP_ERASE_SKIP);
+  }
+
+  if((responseR1 & SD_OCR_CARD_ECC_DISABLED) == SD_OCR_CARD_ECC_DISABLED)
+  {
+    return(SD_CARD_ECC_DISABLED);
+  }
+
+  if((responseR1 & SD_OCR_ERASE_RESET) == SD_OCR_ERASE_RESET)
+  {
+    return(SD_ERASE_RESET);
+  }
+
+  if((responseR1 & SD_OCR_AKE_SEQ_ERROR) == SD_OCR_AKE_SEQ_ERROR)
+  {
+    return(SD_AKE_SEQ_ERROR);
+  }
+
+  return errorstate;
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_SD_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_spi.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_spi.c
@@ -1,0 +1,2728 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_spi.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   SPI HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Serial Peripheral Interface (SPI) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      The SPI HAL driver can be used as follows:
+
+      (#) Declare a SPI_HandleTypeDef handle structure, for example:
+          SPI_HandleTypeDef  hspi;
+
+      (#)Initialize the SPI low level resources by implementing the HAL_SPI_MspInit ()API:
+          (##) Enable the SPIx interface clock
+          (##) SPI pins configuration
+              (+++) Enable the clock for the SPI GPIOs
+              (+++) Configure these SPI pins as alternate function push-pull
+          (##) NVIC configuration if you need to use interrupt process
+              (+++) Configure the SPIx interrupt priority
+              (+++) Enable the NVIC SPI IRQ handle
+          (##) DMA Configuration if you need to use DMA process
+              (+++) Declare a DMA_HandleTypeDef handle structure for the transmit or receive channel
+              (+++) Enable the DMAx clock
+              (+++) Configure the DMA handle parameters
+              (+++) Configure the DMA Tx or Rx channel
+              (+++) Associate the initialized hdma_tx handle to the hspi DMA Tx or Rx handle
+              (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx or Rx channel
+
+      (#) Program the Mode, BidirectionalMode , Data size, Baudrate Prescaler, NSS
+          management, Clock polarity and phase, FirstBit and CRC configuration in the hspi Init structure.
+
+      (#) Initialize the SPI registers by calling the HAL_SPI_Init() API:
+          (++) This API configures also the low level Hardware GPIO, CLOCK, CORTEX...etc)
+              by calling the customised HAL_SPI_MspInit() API.
+     [..]
+       Circular mode restriction:
+      (#) The DMA circular mode cannot be used when the SPI is configured in these modes:
+          (##) Master 2Lines RxOnly
+          (##) Master 1Line Rx
+      (#) The CRC feature is not managed when the DMA circular mode is enabled
+      (#) When the SPI DMA Pause/Stop features are used, we must use the following APIs
+          the HAL_SPI_DMAPause()/ HAL_SPI_DMAStop() only under the SPI callbacks
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SPI SPI
+  * @brief SPI HAL module driver
+  * @{
+  */
+#ifdef HAL_SPI_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/
+/** @defgroup SPI_Private_Constants SPI Private Constants
+  * @{
+  */
+#define SPI_DEFAULT_TIMEOUT 50
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @addtogroup SPI_Private_Functions
+  * @{
+  */
+static void SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAHalfTransmitCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAHalfReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAHalfTransmitReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAError(DMA_HandleTypeDef *hdma);
+static HAL_StatusTypeDef SPI_WaitFlagStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Flag, uint32_t State, uint32_t Timeout);
+static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Fifo, uint32_t State, uint32_t Timeout);
+static void SPI_TxISR_8BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_TxISR_16BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_RxISR_8BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_RxISR_8BITCRC(struct __SPI_HandleTypeDef *hspi);
+static void SPI_RxISR_16BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_RxISR_16BITCRC(struct __SPI_HandleTypeDef *hspi);
+static void SPI_2linesRxISR_8BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_2linesRxISR_8BITCRC(struct __SPI_HandleTypeDef *hspi);
+static void SPI_2linesTxISR_8BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_2linesTxISR_16BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_2linesRxISR_16BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_2linesRxISR_16BITCRC(struct __SPI_HandleTypeDef *hspi);
+static void SPI_CloseRxTx_ISR(SPI_HandleTypeDef *hspi);
+static void SPI_CloseRx_ISR(SPI_HandleTypeDef *hspi);
+static void SPI_CloseTx_ISR(SPI_HandleTypeDef *hspi);
+static HAL_StatusTypeDef SPI_EndRxTransaction(SPI_HandleTypeDef *hspi, uint32_t Timeout);
+static HAL_StatusTypeDef SPI_EndRxTxTransaction(SPI_HandleTypeDef *hspi, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/* Exported functions ---------------------------------------------------------*/
+
+/** @defgroup SPI_Exported_Functions SPI Exported Functions
+  * @{
+  */
+
+/** @defgroup SPI_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This subsection provides a set of functions allowing to initialize and
+          de-initialize the SPIx peripheral:
+
+      (+) User must implement HAL_SPI_MspInit() function in which he configures
+          all related peripherals resources (CLOCK, GPIO, DMA, IT and NVIC ).
+
+      (+) Call the function HAL_SPI_Init() to configure the selected device with
+          the selected configuration:
+        (++) Mode
+        (++) Direction
+        (++) Data Size
+        (++) Clock Polarity and Phase
+        (++) NSS Management
+        (++) BaudRate Prescaler
+        (++) FirstBit
+        (++) TIMode
+        (++) CRC Calculation
+        (++) CRC Polynomial if CRC enabled
+        (++) CRC Length, used only with Data8 and Data16
+        (++) FIFO reception threshold
+
+      (+) Call the function HAL_SPI_DeInit() to restore the default configuration
+          of the selected SPIx peripheral.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the SPI according to the specified parameters
+  *         in the SPI_InitTypeDef and create the associated handle.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
+{
+  uint32_t frxth;
+
+  /* Check the SPI handle allocation */
+  if(hspi == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_SPI_ALL_INSTANCE(hspi->Instance));
+  assert_param(IS_SPI_MODE(hspi->Init.Mode));
+  assert_param(IS_SPI_DIRECTION(hspi->Init.Direction));
+  assert_param(IS_SPI_DATASIZE(hspi->Init.DataSize));
+  assert_param(IS_SPI_CPOL(hspi->Init.CLKPolarity));
+  assert_param(IS_SPI_CPHA(hspi->Init.CLKPhase));
+  assert_param(IS_SPI_NSS(hspi->Init.NSS));
+  assert_param(IS_SPI_NSSP(hspi->Init.NSSPMode));
+  assert_param(IS_SPI_BAUDRATE_PRESCALER(hspi->Init.BaudRatePrescaler));
+  assert_param(IS_SPI_FIRST_BIT(hspi->Init.FirstBit));
+  assert_param(IS_SPI_TIMODE(hspi->Init.TIMode));
+  assert_param(IS_SPI_CRC_CALCULATION(hspi->Init.CRCCalculation));
+  assert_param(IS_SPI_CRC_POLYNOMIAL(hspi->Init.CRCPolynomial));
+  assert_param(IS_SPI_CRC_LENGTH(hspi->Init.CRCLength));
+
+  if(hspi->State == HAL_SPI_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hspi->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK, NVIC... */
+    HAL_SPI_MspInit(hspi);
+  }
+
+  hspi->State = HAL_SPI_STATE_BUSY;
+
+  /* Disable the selected SPI peripheral */
+  __HAL_SPI_DISABLE(hspi);
+
+  /* Align by default the rs fifo threshold on the data size */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+  {
+    frxth = SPI_RXFIFO_THRESHOLD_HF;
+  }
+  else
+  {
+    frxth = SPI_RXFIFO_THRESHOLD_QF;
+  }
+
+  /* CRC calculation is valid only for 16Bit and 8 Bit */
+  if(( hspi->Init.DataSize != SPI_DATASIZE_16BIT ) && ( hspi->Init.DataSize != SPI_DATASIZE_8BIT ))
+  {
+    /* CRC must be disabled */
+    hspi->Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
+  }
+
+  /* Align the CRC Length on the data size */
+  if( hspi->Init.CRCLength == SPI_CRC_LENGTH_DATASIZE)
+  {
+    /* CRC Length aligned on the data size : value set by default */
+    if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+    {
+      hspi->Init.CRCLength = SPI_CRC_LENGTH_16BIT;
+    }
+    else
+    {
+      hspi->Init.CRCLength = SPI_CRC_LENGTH_8BIT;
+    }
+  }
+
+  /*---------------------------- SPIx CR1 & CR2 Configuration ------------------------*/
+  /* Configure : SPI Mode, Communication Mode, Clock polarity and phase, NSS management,
+  Communication speed, First bit, CRC calculation state, CRC Length */
+  hspi->Instance->CR1 = (hspi->Init.Mode | hspi->Init.Direction |
+                         hspi->Init.CLKPolarity | hspi->Init.CLKPhase | (hspi->Init.NSS & SPI_CR1_SSM) |
+                         hspi->Init.BaudRatePrescaler | hspi->Init.FirstBit  | hspi->Init.CRCCalculation);
+
+  if( hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT)
+  {
+    hspi->Instance->CR1|= SPI_CR1_CRCL;
+  }
+
+  /* Configure : NSS management */
+  /* Configure : Rx Fifo Threshold */
+  hspi->Instance->CR2 = (((hspi->Init.NSS >> 16) & SPI_CR2_SSOE) | hspi->Init.TIMode | hspi->Init.NSSPMode |
+                         hspi->Init.DataSize ) | frxth;
+
+  /*---------------------------- SPIx CRCPOLY Configuration --------------------*/
+  /* Configure : CRC Polynomial */
+  hspi->Instance->CRCPR = hspi->Init.CRCPolynomial;
+
+  hspi->ErrorCode = HAL_SPI_ERROR_NONE;
+  hspi->State= HAL_SPI_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the SPI peripheral
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_DeInit(SPI_HandleTypeDef *hspi)
+{
+  /* Check the SPI handle allocation */
+  if(hspi == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_SPI_ALL_INSTANCE(hspi->Instance));
+
+  hspi->State = HAL_SPI_STATE_BUSY;
+
+  /* check flag before the SPI disable */
+  SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FTLVL, SPI_FTLVL_EMPTY, SPI_DEFAULT_TIMEOUT);
+  SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_BSY, RESET, SPI_DEFAULT_TIMEOUT);
+  SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT);
+
+  /* Disable the SPI Peripheral Clock */
+  __HAL_SPI_DISABLE(hspi);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC... */
+  HAL_SPI_MspDeInit(hspi);
+
+  hspi->ErrorCode = HAL_SPI_ERROR_NONE;
+  hspi->State = HAL_SPI_STATE_RESET;
+
+  __HAL_UNLOCK(hspi);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief SPI MSP Init
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+ __weak void HAL_SPI_MspInit(SPI_HandleTypeDef *hspi)
+ {
+   /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_MspInit should be implemented in the user file
+   */
+}
+
+/**
+  * @brief SPI MSP DeInit
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+ __weak void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_MspDeInit should be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Exported_Functions_Group2 IO operation functions
+ *  @brief   Data transfers functions
+ *
+@verbatim
+  ==============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    This subsection provides a set of functions allowing to manage the SPI
+    data transfers.
+
+    [..] The SPI supports master and slave mode :
+
+    (#) There are two modes of transfer:
+       (++) Blocking mode: The communication is performed in polling mode.
+            The HAL status of all data processing is returned by the same function
+            after finishing transfer.
+       (++) No-Blocking mode: The communication is performed using Interrupts
+           or DMA, These APIs return the HAL status.
+           The end of the data processing will be indicated through the
+           dedicated SPI IRQ when using Interrupt mode or the DMA IRQ when
+           using DMA mode.
+           The HAL_SPI_TxCpltCallback(), HAL_SPI_RxCpltCallback() and HAL_SPI_TxRxCpltCallback() user callbacks
+           will be executed respectively at the end of the transmit or Receive process
+           The HAL_SPI_ErrorCallback()user callback will be executed when a communication error is detected
+
+    (#) APIs provided for these 2 transfer modes (Blocking mode or Non blocking mode using either Interrupt or DMA)
+        exist for 1Line (simplex) and 2Lines (full duplex) modes.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Transmit an amount of data in blocking mode
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  if(hspi->State != HAL_SPI_STATE_READY)
+  {
+    hspi->State = HAL_SPI_STATE_READY;
+   /* Process Unlocked */
+   __HAL_UNLOCK(hspi);
+   return HAL_BUSY;
+  }
+
+  if((pData == NULL ) || (Size == 0))
+  {
+    hspi->State = HAL_SPI_STATE_READY;
+   /* Process Unlocked */
+   __HAL_UNLOCK(hspi);
+    return HAL_ERROR;
+  }
+
+  /* Set the transaction information */
+  hspi->State       = HAL_SPI_STATE_BUSY_TX;
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pTxBuffPtr  = pData;
+  hspi->TxXferSize  = Size;
+  hspi->TxXferCount = Size;
+  hspi->pRxBuffPtr  = (uint8_t *)NULL;
+  hspi->RxXferSize  = 0;
+  hspi->RxXferCount = 0;
+
+  /* Configure communication direction : 1Line */
+  if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+  {
+    SPI_1LINE_TX(hspi);
+  }
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+  }
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+  /* Transmit data in 16 Bit mode */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+  {
+    /* Transmit data in 16 Bit mode */
+    while (hspi->TxXferCount > 0)
+    {
+      /* Wait until TXE flag is set to send data */
+      if(SPI_WaitFlagStateUntilTimeout(hspi,SPI_FLAG_TXE,SPI_FLAG_TXE,Timeout) != HAL_OK)
+      {
+        hspi->State = HAL_SPI_STATE_READY;
+        /* Process Unlocked */
+       __HAL_UNLOCK(hspi);
+        return HAL_TIMEOUT;
+      }
+      hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+      hspi->pTxBuffPtr += sizeof(uint16_t);
+      hspi->TxXferCount--;
+    }
+  }
+  /* Transmit data in 8 Bit mode */
+  else
+  {
+    while (hspi->TxXferCount > 0)
+    {
+      if(hspi->TxXferCount != 0x1)
+      {
+        /* Wait until TXE flag is set to send data */
+        if(SPI_WaitFlagStateUntilTimeout(hspi,SPI_FLAG_TXE,SPI_FLAG_TXE,Timeout) != HAL_OK)
+        {
+          hspi->State = HAL_SPI_STATE_READY;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hspi);
+          return HAL_TIMEOUT;
+        }
+        hspi->Instance->DR = *((uint16_t*)hspi->pTxBuffPtr);
+        hspi->pTxBuffPtr += sizeof(uint16_t);
+        hspi->TxXferCount -= 2;
+      }
+      else
+      {
+        /* Wait until TXE flag is set to send data */
+        if(SPI_WaitFlagStateUntilTimeout(hspi,SPI_FLAG_TXE,SPI_FLAG_TXE,Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+        *((__IO uint8_t*)&hspi->Instance->DR) = (*hspi->pTxBuffPtr++);
+        hspi->TxXferCount--;
+      }
+    }
+  }
+
+  /* Enable CRC Transmission */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+     hspi->Instance->CR1|= SPI_CR1_CRCNEXT;
+  }
+
+  /* Check the end of the transaction */
+  if(SPI_EndRxTxTransaction(hspi,Timeout) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Clear OVERUN flag in 2 Lines communication mode because received is not read */
+  if(hspi->Init.Direction == SPI_DIRECTION_2LINES)
+  {
+    __HAL_SPI_CLEAR_OVRFLAG(hspi);
+  }
+
+  hspi->State = HAL_SPI_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+
+  if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+  {
+    return HAL_ERROR;
+  }
+  else
+  {
+    return HAL_OK;
+  }
+}
+
+/**
+  * @brief  Receive an amount of data in blocking mode
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be received
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  __IO uint16_t tmpreg;
+
+  if(hspi->State != HAL_SPI_STATE_READY)
+  {
+    return HAL_BUSY;
+  }
+
+  if((pData == NULL ) || (Size == 0))
+  {
+    return HAL_ERROR;
+  }
+
+  if((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES))
+  {
+    /* the receive process is not supported in 2Lines direction master mode */
+    /* in this case we call the transmitReceive process                     */
+    return HAL_SPI_TransmitReceive(hspi,pData,pData,Size,Timeout);
+  }
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  hspi->State       = HAL_SPI_STATE_BUSY_RX;
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pRxBuffPtr  = pData;
+  hspi->RxXferSize  = Size;
+  hspi->RxXferCount = Size;
+  hspi->pTxBuffPtr  = (uint8_t *)NULL;
+  hspi->TxXferSize  = 0;
+  hspi->TxXferCount = 0;
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+    /* this is done to handle the CRCNEXT before the latest data */
+    hspi->RxXferCount--;
+  }
+
+  /* Set the Rx Fido threshold */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+  {
+    /* set fiforxthreshold according the reception data length: 16bit */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+  else
+  {
+    /* set fiforxthreshold according the reception data length: 8bit */
+    SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+
+  /* Configure communication direction 1Line and enabled SPI if needed */
+  if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+  {
+    SPI_1LINE_RX(hspi);
+  }
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+  /* Receive data in 8 Bit mode */
+  if(hspi->Init.DataSize <= SPI_DATASIZE_8BIT)
+  {
+    while(hspi->RxXferCount > 1)
+    {
+      /* Wait until the RXNE flag */
+      if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
+      {
+        return HAL_TIMEOUT;
+      }
+      (*hspi->pRxBuffPtr++)= *(__IO uint8_t *)&hspi->Instance->DR;
+      hspi->RxXferCount--;
+    }
+  }
+  else /* Receive data in 16 Bit mode */
+  {
+    while(hspi->RxXferCount > 1 )
+    {
+      /* Wait until RXNE flag is reset to read data */
+      if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
+      {
+        return HAL_TIMEOUT;
+      }
+      *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+      hspi->pRxBuffPtr += sizeof(uint16_t);
+      hspi->RxXferCount--;
+    }
+  }
+
+  /* Enable CRC Transmission */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+  }
+
+  /* Wait until RXNE flag is set */
+  if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Receive last data in 16 Bit mode */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+  {
+    *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+    hspi->pRxBuffPtr += sizeof(uint16_t);
+  }
+  /* Receive last data in 8 Bit mode */
+  else
+  {
+    (*hspi->pRxBuffPtr++) = *(__IO uint8_t *)&hspi->Instance->DR;
+  }
+  hspi->RxXferCount--;
+
+  /* Read CRC from DR to close CRC calculation process */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    /* Wait until TXE flag */
+    if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
+    {
+      /* Error on the CRC reception */
+      hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+    }
+    if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+    {
+      tmpreg = hspi->Instance->DR;
+      UNUSED(tmpreg); /* To avoid GCC warning */
+    }
+    else
+    {
+      tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+      UNUSED(tmpreg); /* To avoid GCC warning */
+
+      if((hspi->Init.DataSize == SPI_DATASIZE_8BIT) && (hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT))
+      {
+        if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
+        {
+          /* Error on the CRC reception */
+          hspi->ErrorCode|= HAL_SPI_ERROR_FLAG;
+        }
+        tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+        UNUSED(tmpreg); /* To avoid GCC warning */
+      }
+    }
+  }
+
+  /* Check the end of the transaction */
+  if(SPI_EndRxTransaction(hspi,Timeout) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  hspi->State = HAL_SPI_STATE_READY;
+
+  /* Check if CRC error occurred */
+  if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+  {
+    hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+    __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+    return HAL_ERROR;
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+
+  if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+  {
+    return HAL_ERROR;
+  }
+  else
+  {
+    return HAL_OK;
+  }
+}
+
+/**
+  * @brief  Transmit and Receive an amount of data in blocking mode
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pTxData: pointer to transmission data buffer
+  * @param  pRxData: pointer to reception data buffer
+  * @param  Size: amount of data to be sent and received
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout)
+{
+  __IO uint16_t tmpreg = 0;
+  uint32_t tickstart = HAL_GetTick();
+
+  assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
+
+  if(hspi->State != HAL_SPI_STATE_READY)
+  {
+    return HAL_BUSY;
+  }
+
+  if((pTxData == NULL) || (pRxData == NULL) || (Size == 0))
+  {
+    return HAL_ERROR;
+  }
+
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  hspi->State       = HAL_SPI_STATE_BUSY_TX_RX;
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pRxBuffPtr  = pRxData;
+  hspi->RxXferCount = Size;
+  hspi->RxXferSize  = Size;
+  hspi->pTxBuffPtr  = pTxData;
+  hspi->TxXferCount = Size;
+  hspi->TxXferSize  = Size;
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+  }
+
+  /* Set the Rx Fido threshold */
+  if((hspi->Init.DataSize > SPI_DATASIZE_8BIT) || (hspi->RxXferCount > 1))
+  {
+    /* set fiforxthreshold according the reception data length: 16bit */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+  else
+  {
+    /* set fiforxthreshold according the reception data length: 8bit */
+    SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+  /* Transmit and Receive data in 16 Bit mode */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+  {
+    while ((hspi->TxXferCount > 0 ) || (hspi->RxXferCount > 0))
+    {
+      /* Check TXE flag */
+      if((hspi->TxXferCount > 0) && ((hspi->Instance->SR & SPI_FLAG_TXE) == SPI_FLAG_TXE))
+      {
+        hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+        hspi->pTxBuffPtr += sizeof(uint16_t);
+        hspi->TxXferCount--;
+
+        /* Enable CRC Transmission */
+        if((hspi->TxXferCount == 0) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE))
+        {
+          SET_BIT(hspi->Instance->CR1, SPI_CR1_CRCNEXT);
+        }
+      }
+
+      /* Check RXNE flag */
+      if((hspi->RxXferCount > 0) && ((hspi->Instance->SR & SPI_FLAG_RXNE) == SPI_FLAG_RXNE))
+      {
+        *((uint16_t *)hspi->pRxBuffPtr) = hspi->Instance->DR;
+        hspi->pRxBuffPtr += sizeof(uint16_t);
+        hspi->RxXferCount--;
+      }
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
+        {
+          hspi->State = HAL_SPI_STATE_READY;
+          __HAL_UNLOCK(hspi);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  /* Transmit and Receive data in 8 Bit mode */
+  else
+  {
+    while((hspi->TxXferCount > 0) || (hspi->RxXferCount > 0))
+    {
+      /* check TXE flag */
+      if((hspi->TxXferCount > 0) && ((hspi->Instance->SR & SPI_FLAG_TXE) == SPI_FLAG_TXE))
+      {
+        if(hspi->TxXferCount > 1)
+        {
+          hspi->Instance->DR = *((uint16_t*)hspi->pTxBuffPtr);
+          hspi->pTxBuffPtr += sizeof(uint16_t);
+          hspi->TxXferCount -= 2;
+        }
+        else
+        {
+          *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+          hspi->TxXferCount--;
+        }
+
+        /* Enable CRC Transmission */
+        if((hspi->TxXferCount == 0) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE))
+        {
+          SET_BIT(hspi->Instance->CR1, SPI_CR1_CRCNEXT);
+        }
+      }
+
+      /* Wait until RXNE flag is reset */
+      if((hspi->RxXferCount > 0) && ((hspi->Instance->SR & SPI_FLAG_RXNE) == SPI_FLAG_RXNE))
+      {
+        if(hspi->RxXferCount > 1)
+        {
+          *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+          hspi->pRxBuffPtr += sizeof(uint16_t);
+          hspi->RxXferCount -= 2;
+          if(hspi->RxXferCount <= 1)
+          {
+            /* set fiforxthreshold before to switch on 8 bit data size */
+            SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+          }
+        }
+        else
+        {
+          (*hspi->pRxBuffPtr++) =  *(__IO uint8_t *)&hspi->Instance->DR;
+          hspi->RxXferCount--;
+        }
+      }
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
+        {
+          hspi->State = HAL_SPI_STATE_READY;
+          __HAL_UNLOCK(hspi);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+
+  /* Read CRC from DR to close CRC calculation process */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    /* Wait until TXE flag */
+    if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
+    {
+      /* Error on the CRC reception */
+      hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+    }
+
+    if(hspi->Init.DataSize == SPI_DATASIZE_16BIT)
+    {
+      tmpreg = hspi->Instance->DR;
+      UNUSED(tmpreg); /* To avoid GCC warning */
+    }
+    else
+    {
+      tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+      UNUSED(tmpreg); /* To avoid GCC warning */
+
+      if(hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT)
+      {
+        if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
+        {
+          /* Error on the CRC reception */
+          hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+        }
+        tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+        UNUSED(tmpreg); /* To avoid GCC warning */
+      }
+    }
+  }
+
+  /* Check the end of the transaction */
+  if(SPI_EndRxTxTransaction(hspi,Timeout) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  hspi->State = HAL_SPI_STATE_READY;
+
+  /* Check if CRC error occurred */
+  if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+  {
+    hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+    /* Clear CRC Flag */
+    __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    return HAL_ERROR;
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+
+  if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+  {
+    return HAL_ERROR;
+  }
+  else
+  {
+    return HAL_OK;
+  }
+}
+
+/**
+  * @brief  Transmit an amount of data in no-blocking mode with Interrupt
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+{
+  assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
+
+  if(hspi->State == HAL_SPI_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hspi);
+
+    hspi->State       = HAL_SPI_STATE_BUSY_TX;
+    hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+    hspi->pTxBuffPtr  = pData;
+    hspi->TxXferSize  = Size;
+    hspi->TxXferCount = Size;
+    hspi->pRxBuffPtr  = NULL;
+    hspi->RxXferSize  = 0;
+    hspi->RxXferCount = 0;
+
+    /* Set the function for IT treatement */
+    if(hspi->Init.DataSize > SPI_DATASIZE_8BIT )
+    {
+      hspi->RxISR = NULL;
+      hspi->TxISR = SPI_TxISR_16BIT;
+    }
+    else
+    {
+      hspi->RxISR = NULL;
+      hspi->TxISR = SPI_TxISR_8BIT;
+    }
+
+    /* Configure communication direction : 1Line */
+    if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+    {
+      SPI_1LINE_TX(hspi);
+    }
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      SPI_RESET_CRC(hspi);
+    }
+
+    /* Enable TXE and ERR interrupt */
+    __HAL_SPI_ENABLE_IT(hspi,(SPI_IT_TXE));
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    /* Note : The SPI must be enabled after unlocking current process
+              to avoid the risk of SPI interrupt handle execution before current
+              process unlock */
+
+    /* Check if the SPI is already enabled */
+    if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive an amount of data in no-blocking mode with Interrupt
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+{
+  if(hspi->State == HAL_SPI_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hspi);
+
+    /* Configure communication */
+    hspi->State       = HAL_SPI_STATE_BUSY_RX;
+    hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+    hspi->pRxBuffPtr  = pData;
+    hspi->RxXferSize  = Size;
+    hspi->RxXferCount = Size;
+    hspi->pTxBuffPtr  = NULL;
+    hspi->TxXferSize  = 0;
+    hspi->TxXferCount = 0;
+
+    if((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES))
+    {
+      /* Process Unlocked */
+      __HAL_UNLOCK(hspi);
+      /* the receive process is not supported in 2Lines direction master mode */
+      /* in this we call the transmitReceive process          */
+      return HAL_SPI_TransmitReceive_IT(hspi,pData,pData,Size);
+    }
+
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      hspi->CRCSize = 1;
+      if((hspi->Init.DataSize <= SPI_DATASIZE_8BIT) && (hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT))
+      {
+        hspi->CRCSize = 2;
+      }
+    }
+    else
+    {
+      hspi->CRCSize = 0;
+    }
+
+    /* check the data size to adapt Rx threshold and the set the function for IT treatment */
+    if(hspi->Init.DataSize > SPI_DATASIZE_8BIT )
+    {
+      /* set fiforxthreshold according the reception data length: 16 bit */
+      CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+      hspi->RxISR = SPI_RxISR_16BIT;
+      hspi->TxISR = NULL;
+    }
+    else
+    {
+      /* set fiforxthreshold according the reception data length: 8 bit */
+      SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+      hspi->RxISR = SPI_RxISR_8BIT;
+      hspi->TxISR = NULL;
+    }
+
+    /* Configure communication direction : 1Line */
+    if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+    {
+      SPI_1LINE_RX(hspi);
+    }
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      SPI_RESET_CRC(hspi);
+    }
+
+    /* Enable TXE and ERR interrupt */
+    __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_RXNE | SPI_IT_ERR));
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    /* Note : The SPI must be enabled after unlocking current process
+    to avoid the risk of SPI interrupt handle execution before current
+    process unlock */
+
+    /* Check if the SPI is already enabled */
+    if((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit and Receive an amount of data in no-blocking mode with Interrupt
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pTxData: pointer to transmission data buffer
+  * @param  pRxData: pointer to reception data buffer
+  * @param  Size: amount of data to be sent and received
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size)
+{
+  assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
+
+  if((hspi->State == HAL_SPI_STATE_READY) || \
+     ((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->State == HAL_SPI_STATE_BUSY_RX)))
+  {
+    if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process locked */
+    __HAL_LOCK(hspi);
+
+    hspi->CRCSize = 0;
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      hspi->CRCSize = 1;
+      if((hspi->Init.DataSize <= SPI_DATASIZE_8BIT) && (hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT))
+      {
+        hspi->CRCSize = 2;
+      }
+    }
+
+    if(hspi->State != HAL_SPI_STATE_BUSY_RX)
+    {
+      hspi->State = HAL_SPI_STATE_BUSY_TX_RX;
+    }
+
+    hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+    hspi->pTxBuffPtr  = pTxData;
+    hspi->TxXferSize  = Size;
+    hspi->TxXferCount = Size;
+    hspi->pRxBuffPtr  = pRxData;
+    hspi->RxXferSize  = Size;
+    hspi->RxXferCount = Size;
+
+    /* Set the function for IT treatement */
+    if(hspi->Init.DataSize > SPI_DATASIZE_8BIT )
+    {
+      hspi->RxISR = SPI_2linesRxISR_16BIT;
+      hspi->TxISR = SPI_2linesTxISR_16BIT;
+    }
+    else
+    {
+      hspi->RxISR = SPI_2linesRxISR_8BIT;
+      hspi->TxISR = SPI_2linesTxISR_8BIT;
+    }
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      SPI_RESET_CRC(hspi);
+    }
+
+    /* check if packing mode is enabled and if there is more than 2 data to receive */
+    if((hspi->Init.DataSize > SPI_DATASIZE_8BIT) || (hspi->RxXferCount >= 2))
+    {
+      /* set fiforxthreshold according the reception data length: 16 bit */
+      CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+    }
+    else
+    {
+      /* set fiforxthreshold according the reception data length: 8 bit */
+      SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+    }
+
+    /* Enable TXE, RXNE and ERR interrupt */
+    __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    /* Check if the SPI is already enabled */
+    if((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit an amount of data in no-blocking mode with DMA
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+{
+  assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
+
+  if(hspi->State != HAL_SPI_STATE_READY)
+  {
+    return HAL_BUSY;
+  }
+
+  if((pData == NULL) || (Size == 0))
+  {
+    return HAL_ERROR;
+  }
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  hspi->State       = HAL_SPI_STATE_BUSY_TX;
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pTxBuffPtr  = pData;
+  hspi->TxXferSize  = Size;
+  hspi->TxXferCount = Size;
+  hspi->pRxBuffPtr  = (uint8_t *)NULL;
+  hspi->RxXferSize  = 0;
+  hspi->RxXferCount = 0;
+
+  /* Configure communication direction : 1Line */
+  if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+  {
+    SPI_1LINE_TX(hspi);
+  }
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+  }
+
+  /* Set the SPI TxDMA Half transfer complete callback */
+  hspi->hdmatx->XferHalfCpltCallback = SPI_DMAHalfTransmitCplt;
+
+  /* Set the SPI TxDMA transfer complete callback */
+  hspi->hdmatx->XferCpltCallback = SPI_DMATransmitCplt;
+
+  /* Set the DMA error callback */
+  hspi->hdmatx->XferErrorCallback = SPI_DMAError;
+
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX);
+  /* packing mode is enabled only if the DMA setting is HALWORD */
+  if((hspi->Init.DataSize <= SPI_DATASIZE_8BIT) && (hspi->hdmatx->Init.MemDataAlignment == DMA_MDATAALIGN_HALFWORD))
+  {
+    /* Check the even/odd of the data size + crc if enabled */
+    if((hspi->TxXferCount & 0x1) == 0)
+    {
+      CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX);
+      hspi->TxXferCount = (hspi->TxXferCount >> 1);
+    }
+    else
+    {
+      SET_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX);
+      hspi->TxXferCount = (hspi->TxXferCount >> 1) + 1;
+    }
+  }
+
+  /* Enable the Tx DMA channel */
+  HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->DR, hspi->TxXferCount);
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+  /* Enable Tx DMA Request */
+  hspi->Instance->CR2 |= SPI_CR2_TXDMAEN;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+
+  return HAL_OK;
+}
+
+/**
+* @brief  Receive an amount of data in no-blocking mode with DMA
+* @param  hspi: SPI handle
+* @param  pData: pointer to data buffer
+* @param  Size: amount of data to be sent
+* @retval HAL status
+*/
+HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+{
+  if(hspi->State != HAL_SPI_STATE_READY)
+  {
+    return HAL_BUSY;
+  }
+
+  if((pData == NULL) || (Size == 0))
+  {
+    return HAL_ERROR;
+  }
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  hspi->State       = HAL_SPI_STATE_BUSY_RX;
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pRxBuffPtr  = pData;
+  hspi->RxXferSize  = Size;
+  hspi->RxXferCount = Size;
+  hspi->pTxBuffPtr  = (uint8_t *)NULL;
+  hspi->TxXferSize  = 0;
+  hspi->TxXferCount = 0;
+
+  if((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES))
+  {
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+    /* the receive process is not supported in 2Lines direction master mode */
+    /* in this case we call the transmitReceive process                     */
+    return HAL_SPI_TransmitReceive_DMA(hspi,pData,pData,Size);
+  }
+
+  /* Configure communication direction : 1Line */
+  if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+  {
+    SPI_1LINE_RX(hspi);
+  }
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+  }
+
+  /* packing mode management is enabled by the DMA settings */
+  if((hspi->Init.DataSize <= SPI_DATASIZE_8BIT) && (hspi->hdmarx->Init.MemDataAlignment == DMA_MDATAALIGN_HALFWORD))
+  {
+    /* Process Locked */
+    __HAL_UNLOCK(hspi);
+    /* Restriction the DMA data received is not allowed in this mode */
+    return HAL_ERROR;
+  }
+
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMARX);
+  if( hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+  {
+    /* set fiforxthreshold according the reception data length: 16bit */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+  else
+  {
+    /* set fiforxthreshold according the reception data length: 8bit */
+    SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+
+  /* Set the SPI RxDMA Half transfer complete callback */
+  hspi->hdmarx->XferHalfCpltCallback = SPI_DMAHalfReceiveCplt;
+
+  /* Set the SPI Rx DMA transfer complete callback */
+  hspi->hdmarx->XferCpltCallback = SPI_DMAReceiveCplt;
+
+  /* Set the DMA error callback */
+  hspi->hdmarx->XferErrorCallback = SPI_DMAError;
+
+  /* Enable Rx DMA Request */
+  hspi->Instance->CR2 |= SPI_CR2_RXDMAEN;
+
+  /* Enable the Rx DMA channel */
+  HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t)hspi->pRxBuffPtr, hspi->RxXferCount);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Transmit and Receive an amount of data in no-blocking mode with DMA
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pTxData: pointer to transmission data buffer
+  * @param  pRxData: pointer to reception data buffer
+  * @note  When the CRC feature is enabled the pRxData Length must be Size + 1
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size)
+{
+  assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
+
+  if((hspi->State == HAL_SPI_STATE_READY) ||
+     ((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->State == HAL_SPI_STATE_BUSY_RX)))
+  {
+    if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process locked */
+    __HAL_LOCK(hspi);
+
+    /* check if the transmit Receive function is not called by a receive master */
+    if(hspi->State != HAL_SPI_STATE_BUSY_RX)
+    {
+      hspi->State = HAL_SPI_STATE_BUSY_TX_RX;
+    }
+
+    hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+    hspi->pTxBuffPtr  = (uint8_t *)pTxData;
+    hspi->TxXferSize  = Size;
+    hspi->TxXferCount = Size;
+    hspi->pRxBuffPtr  = (uint8_t *)pRxData;
+    hspi->RxXferSize  = Size;
+    hspi->RxXferCount = Size;
+
+    /* Reset CRC Calculation + increase the rxsize */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      SPI_RESET_CRC(hspi);
+    }
+
+    /* Reset the threshold bit */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX);
+    CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMARX);
+
+    /* the packing mode management is enabled by the DMA settings according the spi data size */
+    if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+    {
+      /* set fiforxthreshold according the reception data length: 16bit */
+      CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+    }
+    else
+    {
+      /* set fiforxthreshold according the reception data length: 8bit */
+      SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+
+      if(hspi->hdmatx->Init.MemDataAlignment == DMA_MDATAALIGN_HALFWORD)
+      {
+        if((hspi->TxXferSize & 0x1) == 0x0 )
+        {
+          CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX);
+          hspi->TxXferCount = hspi->TxXferCount >> 1;
+        }
+        else
+        {
+          SET_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX);
+          hspi->TxXferCount = (hspi->TxXferCount >> 1) + 1;
+        }
+      }
+
+      if(hspi->hdmarx->Init.MemDataAlignment == DMA_MDATAALIGN_HALFWORD)
+      {
+        /* set fiforxthreshold according the reception data length: 16bit */
+        CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+
+        /* Size must include the CRC length */
+        if((hspi->RxXferCount & 0x1) == 0x0 )
+        {
+          CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMARX);
+          hspi->RxXferCount = hspi->RxXferCount >> 1;
+        }
+        else
+        {
+          SET_BIT(hspi->Instance->CR2, SPI_CR2_LDMARX);
+          hspi->RxXferCount = (hspi->RxXferCount >> 1) + 1;
+        }
+      }
+    }
+
+    /* Set the SPI Rx DMA transfer complete callback because the last generated transfer request is
+    the reception request (RXNE) */
+    if(hspi->State == HAL_SPI_STATE_BUSY_RX)
+    {
+      hspi->hdmarx->XferHalfCpltCallback = SPI_DMAHalfReceiveCplt;
+      hspi->hdmarx->XferCpltCallback = SPI_DMAReceiveCplt;
+    }
+    else
+    {
+       hspi->hdmarx->XferHalfCpltCallback = SPI_DMAHalfTransmitReceiveCplt;
+      hspi->hdmarx->XferCpltCallback = SPI_DMATransmitReceiveCplt;
+    }
+    /* Set the DMA error callback */
+    hspi->hdmarx->XferErrorCallback = SPI_DMAError;
+
+    /* Enable Rx DMA Request */
+    hspi->Instance->CR2 |= SPI_CR2_RXDMAEN;
+
+    /* Enable the Rx DMA channel */
+    HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t) hspi->pRxBuffPtr, hspi->RxXferCount);
+
+    /* Set the SPI Tx DMA transfer complete callback as NULL because the communication closing
+    is performed in DMA reception complete callback  */
+    hspi->hdmatx->XferHalfCpltCallback = NULL;
+    hspi->hdmatx->XferCpltCallback = NULL;
+
+    if(hspi->State == HAL_SPI_STATE_BUSY_TX_RX)
+    {
+      /* Set the DMA error callback */
+      hspi->hdmatx->XferErrorCallback = SPI_DMAError;
+    }
+    else
+    {
+      hspi->hdmatx->XferErrorCallback = NULL;
+    }
+
+    /* Enable the Tx DMA channel */
+    HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->DR, hspi->TxXferCount);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    /* Check if the SPI is already enabled */
+    if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    /* Enable Tx DMA Request */
+    hspi->Instance->CR2 |= SPI_CR2_TXDMAEN;
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Pauses the DMA Transfer.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for the specified SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_DMAPause(SPI_HandleTypeDef *hspi)
+{
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  /* Disable the SPI DMA Tx & Rx requests */
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Resumes the DMA Transfer.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for the specified SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_DMAResume(SPI_HandleTypeDef *hspi)
+{
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  /* Enable the SPI DMA Tx & Rx requests */
+  SET_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Stops the DMA Transfer.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for the specified SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_DMAStop(SPI_HandleTypeDef *hspi)
+{
+  /* The Lock is not implemented on this API to allow the user application
+     to call the HAL SPI API under callbacks HAL_SPI_TxCpltCallback() or HAL_SPI_RxCpltCallback() or HAL_SPI_TxRxCpltCallback():
+     when calling HAL_DMA_Abort() API the DMA TX/RX Transfer complete interrupt is generated
+     and the correspond call back is executed HAL_SPI_TxCpltCallback() or HAL_SPI_RxCpltCallback() or HAL_SPI_TxRxCpltCallback()
+     */
+
+  /* Abort the SPI DMA tx Stream */
+  if(hspi->hdmatx != NULL)
+  {
+    HAL_DMA_Abort(hspi->hdmatx);
+  }
+  /* Abort the SPI DMA rx Stream */
+  if(hspi->hdmarx != NULL)
+  {
+    HAL_DMA_Abort(hspi->hdmarx);
+  }
+
+  /* Disable the SPI DMA Tx & Rx requests */
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+  hspi->State = HAL_SPI_STATE_READY;
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles SPI interrupt request.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for the specified SPI module.
+  * @retval None
+  */
+void HAL_SPI_IRQHandler(SPI_HandleTypeDef *hspi)
+{
+  /* SPI in mode Receiver ----------------------------------------------------*/
+  if((__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_OVR) == RESET) &&
+     (__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_RXNE) != RESET) && (__HAL_SPI_GET_IT_SOURCE(hspi, SPI_IT_RXNE) != RESET))
+  {
+    hspi->RxISR(hspi);
+    return;
+  }
+
+  /* SPI in mode Transmitter ---------------------------------------------------*/
+  if((__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_TXE) != RESET) && (__HAL_SPI_GET_IT_SOURCE(hspi, SPI_IT_TXE) != RESET))
+  {
+    hspi->TxISR(hspi);
+    return;
+  }
+
+  /* SPI in ERROR Treatment ---------------------------------------------------*/
+  if((hspi->Instance->SR & (SPI_FLAG_MODF | SPI_FLAG_OVR | SPI_FLAG_FRE)) != RESET)
+  {
+    /* SPI Overrun error interrupt occurred -------------------------------------*/
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_OVR) != RESET)
+    {
+      if(hspi->State != HAL_SPI_STATE_BUSY_TX)
+      {
+        hspi->ErrorCode |= HAL_SPI_ERROR_OVR;
+        __HAL_SPI_CLEAR_OVRFLAG(hspi);
+      }
+      else
+      {
+        return;
+      }
+    }
+
+    /* SPI Mode Fault error interrupt occurred -------------------------------------*/
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_MODF) != RESET)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_MODF;
+      __HAL_SPI_CLEAR_MODFFLAG(hspi);
+    }
+
+    /* SPI Frame error interrupt occurred ----------------------------------------*/
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_FRE) != RESET)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FRE;
+      __HAL_SPI_CLEAR_FREFLAG(hspi);
+    }
+
+    __HAL_SPI_DISABLE_IT(hspi, SPI_IT_RXNE | SPI_IT_TXE | SPI_IT_ERR);
+    hspi->State = HAL_SPI_STATE_READY;
+    HAL_SPI_ErrorCallback(hspi);
+
+    return;
+  }
+}
+
+/**
+  * @brief Tx Transfer completed callback
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_TxCpltCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @brief Rx Transfer completed callbacks
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_RxCpltCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @brief Tx and Rx Transfer completed callback
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_TxRxCpltCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @brief Tx Half Transfer completed callback
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_TxHalfCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_TxHalfCpltCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @brief Rx Half Transfer completed callback
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_RxHalfCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_RxHalfCpltCallback() should be implemented in the user file
+   */
+}
+
+/**
+  * @brief Tx and Rx Half Transfer callback
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_TxRxHalfCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_TxRxHalfCpltCallback() should be implemented in the user file
+   */
+}
+
+/**
+  * @brief SPI error callback
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+ __weak void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_ErrorCallback should be implemented in the user file
+   */
+  /* NOTE : The ErrorCode parameter in the hspi handle is updated by the SPI processes
+            and user can use HAL_SPI_GetError() API to check the latest error occurred
+   */
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Exported_Functions_Group3 Peripheral State and Errors functions
+  *  @brief   SPI control functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral State and Errors functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the SPI.
+     (+) HAL_SPI_GetState() API can be helpful to check in run-time the state of the SPI peripheral
+     (+) HAL_SPI_GetError() check in run-time Errors occurring during communication
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the SPI state
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval SPI state
+  */
+HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi)
+{
+  return hspi->State;
+}
+
+/**
+  * @brief  Return the SPI error code
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval SPI error code in bitmap format
+  */
+uint32_t HAL_SPI_GetError(SPI_HandleTypeDef *hspi)
+{
+  return hspi->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Private_Functions SPI Private Functions
+  * @{
+  */
+
+/**
+  * @brief DMA SPI transmit process complete callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* DMA Normal Mode */
+  if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
+  {
+    /* Disable Tx DMA Request */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN);
+
+    /* Clear OVERUN flag in 2 Lines communication mode because received data is not read */
+    if(hspi->Init.Direction == SPI_DIRECTION_2LINES)
+    {
+      __HAL_SPI_CLEAR_OVRFLAG(hspi);
+    }
+
+    hspi->TxXferCount = 0;
+    hspi->State = HAL_SPI_STATE_READY;
+
+    if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+    {
+      HAL_SPI_ErrorCallback(hspi);
+      return;
+    }
+  }
+  HAL_SPI_TxCpltCallback(hspi);
+}
+
+/**
+  * @brief DMA SPI receive process complete callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  __IO uint16_t tmpreg;
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* DMA Normal mode */
+  if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
+  {
+    /* CRC handling */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      /* Wait until TXE flag */
+      if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, SPI_DEFAULT_TIMEOUT) != HAL_OK)
+      {
+        /* Error on the CRC reception */
+        hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+      }
+      if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+      {
+        tmpreg = hspi->Instance->DR;
+        UNUSED(tmpreg); /* To avoid GCC warning */
+      }
+      else
+      {
+        tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+        UNUSED(tmpreg); /* To avoid GCC warning */
+
+        if(hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT)
+        {
+          if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, SPI_DEFAULT_TIMEOUT) != HAL_OK)
+          {
+            /* Error on the CRC reception */
+            hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+          }
+          tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+          UNUSED(tmpreg); /* To avoid GCC warning */
+        }
+      }
+    }
+
+    /* Disable Rx DMA Request */
+    hspi->Instance->CR2 &= (uint32_t)(~SPI_CR2_RXDMAEN);
+    /* Disable Tx DMA Request (done by default to handle the case master rx direction 2 lines) */
+    hspi->Instance->CR2 &= (uint32_t)(~SPI_CR2_TXDMAEN);
+
+    /* Check the end of the transaction */
+    SPI_EndRxTransaction(hspi,SPI_DEFAULT_TIMEOUT);
+
+    hspi->RxXferCount = 0;
+    hspi->State = HAL_SPI_STATE_READY;
+
+    /* Check if CRC error occurred */
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+    {
+      hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+      __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+      HAL_SPI_RxCpltCallback(hspi);
+    }
+    else
+    {
+      if(hspi->ErrorCode == HAL_SPI_ERROR_NONE)
+      {
+        HAL_SPI_RxCpltCallback(hspi);
+      }
+      else
+      {
+        HAL_SPI_ErrorCallback(hspi);
+      }
+    }
+  }
+  else
+  {
+    HAL_SPI_RxCpltCallback(hspi);
+  }
+}
+
+/**
+  * @brief DMA SPI transmit receive process complete callback
+  * @param  hdma : pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  __IO int16_t tmpreg;
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* CRC handling */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    if((hspi->Init.DataSize == SPI_DATASIZE_8BIT) && (hspi->Init.CRCLength == SPI_CRC_LENGTH_8BIT))
+    {
+      if(SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_QUARTER_FULL, SPI_DEFAULT_TIMEOUT) != HAL_OK)
+      {
+        /* Error on the CRC reception */
+        hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+      }
+      tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+      UNUSED(tmpreg); /* To avoid GCC warning */
+    }
+    else
+    {
+      if(SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_HALF_FULL, SPI_DEFAULT_TIMEOUT) != HAL_OK)
+      {
+        /* Error on the CRC reception */
+        hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+      }
+      tmpreg = hspi->Instance->DR;
+      UNUSED(tmpreg); /* To avoid GCC warning */
+    }
+  }
+
+  /* Check the end of the transaction */
+  SPI_EndRxTxTransaction(hspi,SPI_DEFAULT_TIMEOUT);
+
+  /* Disable Tx DMA Request */
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN);
+
+  /* Disable Rx DMA Request */
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_RXDMAEN);
+
+  hspi->TxXferCount = 0;
+  hspi->RxXferCount = 0;
+  hspi->State = HAL_SPI_STATE_READY;
+
+  /* Check if CRC error occurred */
+  if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+  {
+    hspi->ErrorCode = HAL_SPI_ERROR_CRC;
+    __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+    HAL_SPI_ErrorCallback(hspi);
+  }
+  else
+  {
+    if(hspi->ErrorCode == HAL_SPI_ERROR_NONE)
+    {
+      HAL_SPI_TxRxCpltCallback(hspi);
+    }
+    else
+    {
+      HAL_SPI_ErrorCallback(hspi);
+    }
+  }
+}
+
+/**
+  * @brief DMA SPI half transmit process complete callback
+  * @param  hdma : pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAHalfTransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_SPI_TxHalfCpltCallback(hspi);
+}
+
+/**
+  * @brief DMA SPI half receive process complete callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAHalfReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_SPI_RxHalfCpltCallback(hspi);
+}
+
+/**
+  * @brief DMA SPI Half transmit receive process complete callback
+  * @param  hdma : pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAHalfTransmitReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_SPI_TxRxHalfCpltCallback(hspi);
+}
+
+/**
+  * @brief DMA SPI communication error callback
+  * @param  hdma : pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAError(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Stop the disable DMA transfer on SPI side */
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+
+  hspi->ErrorCode|= HAL_SPI_ERROR_DMA;
+  hspi->State = HAL_SPI_STATE_READY;
+  HAL_SPI_ErrorCallback(hspi);
+}
+
+/**
+  * @brief  Rx Handler for Transmit and Receive in Interrupt mode
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_2linesRxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  /* Receive data in packing mode */
+  if(hspi->RxXferCount > 1)
+  {
+    *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+    hspi->pRxBuffPtr += sizeof(uint16_t);
+    hspi->RxXferCount -= 2;
+    if(hspi->RxXferCount == 1)
+    {
+      /* set fiforxthreshold according the reception data length: 8bit */
+      SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+    }
+  }
+  /* Receive data in 8 Bit mode */
+  else
+  {
+    *hspi->pRxBuffPtr++ = *((__IO uint8_t *)&hspi->Instance->DR);
+    hspi->RxXferCount--;
+  }
+
+  /* check end of the reception */
+  if(hspi->RxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+      hspi->RxISR =  SPI_2linesRxISR_8BITCRC;
+      return;
+    }
+
+    /* Disable RXNE interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, SPI_IT_RXNE);
+
+    if(hspi->TxXferCount == 0)
+    {
+      SPI_CloseRxTx_ISR(hspi);
+    }
+  }
+}
+
+/**
+  * @brief  Rx Handler for Transmit and Receive in Interrupt mode
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_2linesRxISR_8BITCRC(struct __SPI_HandleTypeDef *hspi)
+{
+  __IO uint8_t tmpreg;
+
+  tmpreg = *((__IO uint8_t *)&hspi->Instance->DR);
+  UNUSED(tmpreg); /* To avoid GCC warning */
+
+  hspi->CRCSize--;
+
+  /* check end of the reception */
+  if(hspi->CRCSize == 0)
+  {
+    /* Disable RXNE interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, SPI_IT_RXNE);
+
+    if(hspi->TxXferCount == 0)
+    {
+      SPI_CloseRxTx_ISR(hspi);
+    }
+  }
+}
+
+/**
+  * @brief  Tx Handler for Transmit and Receive in Interrupt mode
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_2linesTxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  /* Transmit data in packing Bit mode */
+  if(hspi->TxXferCount >= 2)
+  {
+    hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+    hspi->pTxBuffPtr += sizeof(uint16_t);
+    hspi->TxXferCount -= 2;
+  }
+  /* Transmit data in 8 Bit mode */
+  else
+  {
+    *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+    hspi->TxXferCount--;
+  }
+
+  /* check the end of the transmission */
+  if(hspi->TxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+    }
+    /* Disable TXE interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, SPI_IT_TXE);
+
+    if(hspi->RxXferCount == 0)
+    {
+      SPI_CloseRxTx_ISR(hspi);
+    }
+  }
+}
+
+/**
+  * @brief  Rx 16Bit Handler for Transmit and Receive in Interrupt mode
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_2linesRxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  /* Receive data in 16 Bit mode */
+  *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+  hspi->pRxBuffPtr += sizeof(uint16_t);
+  hspi->RxXferCount--;
+
+  if(hspi->RxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      hspi->RxISR =  SPI_2linesRxISR_16BITCRC;
+      return;
+    }
+
+    /* Disable RXNE interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, SPI_IT_RXNE);
+
+    if(hspi->TxXferCount == 0)
+    {
+      SPI_CloseRxTx_ISR(hspi);
+    }
+  }
+}
+
+/**
+  * @brief  Manage the CRC 16bit receive for Transmit and Receive in Interrupt mode
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_2linesRxISR_16BITCRC(struct __SPI_HandleTypeDef *hspi)
+{
+  /* Receive data in 16 Bit mode */
+  __IO uint16_t tmpreg = hspi->Instance->DR;
+  UNUSED(tmpreg); /* To avoid GCC warning */
+
+  /* Disable RXNE interrupt */
+  __HAL_SPI_DISABLE_IT(hspi, SPI_IT_RXNE);
+
+  SPI_CloseRxTx_ISR(hspi);
+}
+
+/**
+  * @brief  Tx Handler for Transmit and Receive in Interrupt mode
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_2linesTxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  /* Transmit data in 16 Bit mode */
+  hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+  hspi->pTxBuffPtr += sizeof(uint16_t);
+  hspi->TxXferCount--;
+
+  /* Enable CRC Transmission */
+  if(hspi->TxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+    }
+    /* Disable TXE interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, SPI_IT_TXE);
+
+    if(hspi->RxXferCount == 0)
+    {
+      SPI_CloseRxTx_ISR(hspi);
+    }
+  }
+}
+
+/**
+  * @brief  Manage the CRC receive in Interrupt context
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_RxISR_8BITCRC(struct __SPI_HandleTypeDef *hspi)
+{
+  __IO uint8_t tmpreg;
+  tmpreg = *((__IO uint8_t*)&hspi->Instance->DR);
+  UNUSED(tmpreg); /* To avoid GCC warning */
+
+  hspi->CRCSize--;
+
+  if(hspi->CRCSize == 0)
+  {
+    SPI_CloseRx_ISR(hspi);
+  }
+}
+
+/**
+  * @brief  Manage the receive in Interrupt context
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_RxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  *hspi->pRxBuffPtr++ = (*(__IO uint8_t *)&hspi->Instance->DR);
+  hspi->RxXferCount--;
+
+  /* Enable CRC Transmission */
+  if((hspi->RxXferCount == 1) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE))
+  {
+    hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+  }
+
+  if(hspi->RxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      hspi->RxISR =  SPI_RxISR_8BITCRC;
+      return;
+    }
+    SPI_CloseRx_ISR(hspi);
+  }
+}
+
+/**
+  * @brief  Manage the CRC 16bit receive in Interrupt context
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_RxISR_16BITCRC(struct __SPI_HandleTypeDef *hspi)
+{
+  __IO uint16_t tmpreg;
+
+  tmpreg = hspi->Instance->DR;
+  UNUSED(tmpreg); /* To avoid GCC warning */
+
+  /* Disable RXNE and ERR interrupt */
+  __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_RXNE | SPI_IT_ERR));
+
+  SPI_CloseRx_ISR(hspi);
+}
+
+/**
+  * @brief  Manage the 16Bit receive in Interrupt context
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_RxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  *((uint16_t *)hspi->pRxBuffPtr) = hspi->Instance->DR;
+  hspi->pRxBuffPtr += sizeof(uint16_t);
+  hspi->RxXferCount--;
+
+  /* Enable CRC Transmission */
+  if((hspi->RxXferCount == 1) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE))
+  {
+    hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+  }
+
+  if(hspi->RxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      hspi->RxISR = SPI_RxISR_16BITCRC;
+      return;
+    }
+    SPI_CloseRx_ISR(hspi);
+  }
+}
+
+/**
+  * @brief  Handle the data 8Bit transmit in Interrupt mode
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_TxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+  hspi->TxXferCount--;
+
+  if(hspi->TxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      /* Enable CRC Transmission */
+      hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+    }
+    SPI_CloseTx_ISR(hspi);
+  }
+}
+
+/**
+  * @brief  Handle the data 16Bit transmit in Interrupt mode
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_TxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  /* Transmit data in 16 Bit mode */
+  hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+  hspi->pTxBuffPtr += sizeof(uint16_t);
+  hspi->TxXferCount--;
+
+  if(hspi->TxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      /* Enable CRC Transmission */
+      hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+    }
+    SPI_CloseTx_ISR(hspi);
+  }
+}
+
+/**
+  * @brief This function handles SPI Communication Timeout.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param Flag : SPI flag to check
+  * @param State : flag state to check
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SPI_WaitFlagStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Flag, uint32_t State, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+
+  while((hspi->Instance->SR & Flag) != State)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0) || ((HAL_GetTick()-tickstart) >= Timeout))
+      {
+        /* Disable the SPI and reset the CRC: the CRC value should be cleared
+        on both master and slave sides in order to resynchronize the master
+        and slave for their respective CRC calculation */
+
+        /* Disable TXE, RXNE and ERR interrupts for the interrupt process */
+        __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
+
+        if((hspi->Init.Mode == SPI_MODE_MASTER)&&((hspi->Init.Direction == SPI_DIRECTION_1LINE)||(hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY)))
+        {
+          /* Disable SPI peripheral */
+          __HAL_SPI_DISABLE(hspi);
+        }
+
+        /* Reset CRC Calculation */
+        if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+        {
+          SPI_RESET_CRC(hspi);
+        }
+
+        hspi->State= HAL_SPI_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hspi);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief This function handles SPI Communication Timeout.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param Fifo : Fifo to check
+  * @param State : Fifo state to check
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Fifo, uint32_t State, uint32_t Timeout)
+{
+  __IO uint8_t tmpreg;
+  uint32_t tickstart = HAL_GetTick();
+
+  while((hspi->Instance->SR & Fifo) != State)
+  {
+    if((Fifo == SPI_SR_FRLVL) && (State == SPI_FRLVL_EMPTY))
+    {
+      tmpreg = *((__IO uint8_t*)&hspi->Instance->DR);
+      UNUSED(tmpreg); /* To avoid GCC warning */
+    }
+
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0) || ((HAL_GetTick()-tickstart) >= Timeout))
+      {
+        /* Disable the SPI and reset the CRC: the CRC value should be cleared
+                  on both master and slave sides in order to resynchronize the master
+                 and slave for their respective CRC calculation */
+
+        /* Disable TXE, RXNE and ERR interrupts for the interrupt process */
+        __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
+
+        if((hspi->Init.Mode == SPI_MODE_MASTER)&&((hspi->Init.Direction == SPI_DIRECTION_1LINE)||(hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY)))
+        {
+          /* Disable SPI peripheral */
+          __HAL_SPI_DISABLE(hspi);
+        }
+
+        /* Reset CRC Calculation */
+        if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+        {
+          SPI_RESET_CRC(hspi);
+        }
+
+        hspi->State = HAL_SPI_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hspi);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief This function handles the check of the RX transaction complete.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param Timeout : Timeout duration
+  * @retval None
+  */
+static HAL_StatusTypeDef SPI_EndRxTransaction(SPI_HandleTypeDef *hspi,  uint32_t Timeout)
+{
+  if((hspi->Init.Mode == SPI_MODE_MASTER)&&((hspi->Init.Direction == SPI_DIRECTION_1LINE)||(hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY)))
+  {
+    /* Disable SPI peripheral */
+    __HAL_SPI_DISABLE(hspi);
+  }
+  if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_BSY, RESET, Timeout) != HAL_OK)
+  {
+    hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    return HAL_TIMEOUT;
+  }
+  if(SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, Timeout) != HAL_OK)
+  {
+    hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    return HAL_TIMEOUT;
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief This function handles the check of the RXTX or TX transaction complete.
+  * @param hspi: SPI handle
+  * @param Timeout : Timeout duration
+  */
+static HAL_StatusTypeDef SPI_EndRxTxTransaction(SPI_HandleTypeDef *hspi, uint32_t Timeout)
+{
+  /* Procedure to check the transaction complete */
+  if(SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FTLVL, SPI_FTLVL_EMPTY, Timeout) != HAL_OK)
+  {
+    hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    return HAL_TIMEOUT;
+  }
+  if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_BSY, RESET, Timeout) != HAL_OK)
+  {
+    hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    return HAL_TIMEOUT;
+  }
+  if(SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, Timeout) != HAL_OK)
+  {
+    hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    return HAL_TIMEOUT;
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief This function handles the close of the RXTX transaction.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_CloseRxTx_ISR(SPI_HandleTypeDef *hspi)
+{
+  /* Disable ERR interrupt */
+  __HAL_SPI_DISABLE_IT(hspi, SPI_IT_ERR);
+
+  /* Check if CRC error occurred */
+  if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+  {
+    hspi->State = HAL_SPI_STATE_READY;
+    hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+    __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+    HAL_SPI_ErrorCallback(hspi);
+  }
+  else
+  {
+    if(hspi->ErrorCode == HAL_SPI_ERROR_NONE)
+    {
+      if(hspi->State == HAL_SPI_STATE_BUSY_RX)
+      {
+      	hspi->State = HAL_SPI_STATE_READY;
+        HAL_SPI_RxCpltCallback(hspi);
+      }
+      else
+      {
+      	hspi->State = HAL_SPI_STATE_READY;
+        HAL_SPI_TxRxCpltCallback(hspi);
+      }
+    }
+    else
+    {
+      hspi->State = HAL_SPI_STATE_READY;
+      HAL_SPI_ErrorCallback(hspi);
+    }
+  }
+}
+
+/**
+  * @brief This function handles the close of the RX transaction.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_CloseRx_ISR(SPI_HandleTypeDef *hspi)
+{
+    /* Disable RXNE and ERR interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_RXNE | SPI_IT_ERR));
+
+    /* Check the end of the transaction */
+    SPI_EndRxTransaction(hspi,SPI_DEFAULT_TIMEOUT);
+
+    hspi->State = HAL_SPI_STATE_READY;
+
+    /* Check if CRC error occurred */
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+    {
+      hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+      __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+      HAL_SPI_ErrorCallback(hspi);
+    }
+    else
+    {
+      if(hspi->ErrorCode == HAL_SPI_ERROR_NONE)
+      {
+        HAL_SPI_RxCpltCallback(hspi);
+      }
+      else
+      {
+        HAL_SPI_ErrorCallback(hspi);
+      }
+    }
+}
+
+/**
+  * @brief This function handles the close of the TX transaction.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_CloseTx_ISR(SPI_HandleTypeDef *hspi)
+{
+  /* Disable TXE and ERR interrupt */
+  __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_ERR));
+
+  /* Clear OVERUN flag in 2 Lines communication mode because received is not read */
+  if(hspi->Init.Direction == SPI_DIRECTION_2LINES)
+  {
+    __HAL_SPI_CLEAR_OVRFLAG(hspi);
+  }
+
+  hspi->State = HAL_SPI_STATE_READY;
+  if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+  {
+    HAL_SPI_ErrorCallback(hspi);
+  }
+  else
+  {
+    HAL_SPI_TxCpltCallback(hspi);
+  }
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_SPI_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_tim.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_tim.c
@@ -1,0 +1,5459 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_tim.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   TIM HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Timer (TIM) peripheral:
+  *           + Time Base Initialization
+  *           + Time Base Start
+  *           + Time Base Start Interruption
+  *           + Time Base Start DMA
+  *           + Time Output Compare/PWM Initialization
+  *           + Time Output Compare/PWM Channel Configuration
+  *           + Time Output Compare/PWM  Start
+  *           + Time Output Compare/PWM  Start Interruption
+  *           + Time Output Compare/PWM Start DMA
+  *           + Time Input Capture Initialization
+  *           + Time Input Capture Channel Configuration
+  *           + Time Input Capture Start
+  *           + Time Input Capture Start Interruption
+  *           + Time Input Capture Start DMA
+  *           + Time One Pulse Initialization
+  *           + Time One Pulse Channel Configuration
+  *           + Time One Pulse Start
+  *           + Time Encoder Interface Initialization
+  *           + Time Encoder Interface Start
+  *           + Time Encoder Interface Start Interruption
+  *           + Time Encoder Interface Start DMA
+  *           + Commutation Event configuration with Interruption and DMA
+  *           + Time OCRef clear configuration
+  *           + Time External Clock configuration
+  @verbatim
+  ==============================================================================
+                      ##### TIMER Generic features #####
+  ==============================================================================
+  [..] The Timer features include:
+       (#) 16-bit up, down, up/down auto-reload counter.
+       (#) 16-bit programmable prescaler allowing dividing (also on the fly) the
+           counter clock frequency either by any factor between 1 and 65536.
+       (#) Up to 4 independent channels for:
+           (++) Input Capture
+           (++) Output Compare
+           (++) PWM generation (Edge and Center-aligned Mode)
+           (++) One-pulse mode output
+
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]
+     (#) Initialize the TIM low level resources by implementing the following functions
+         depending from feature used :
+           (++) Time Base : HAL_TIM_Base_MspInit()
+           (++) Input Capture : HAL_TIM_IC_MspInit()
+           (++) Output Compare : HAL_TIM_OC_MspInit()
+           (++) PWM generation : HAL_TIM_PWM_MspInit()
+           (++) One-pulse mode output : HAL_TIM_OnePulse_MspInit()
+           (++) Encoder mode output : HAL_TIM_Encoder_MspInit()
+
+     (#) Initialize the TIM low level resources :
+        (##) Enable the TIM interface clock using __TIMx_CLK_ENABLE();
+        (##) TIM pins configuration
+            (+++) Enable the clock for the TIM GPIOs using the following function:
+                 __GPIOx_CLK_ENABLE();
+            (+++) Configure these TIM pins in Alternate function mode using HAL_GPIO_Init();
+
+     (#) The external Clock can be configured, if needed (the default clock is the
+         internal clock from the APBx), using the following function:
+         HAL_TIM_ConfigClockSource, the clock configuration should be done before
+         any start function.
+
+     (#) Configure the TIM in the desired functioning mode using one of the
+         initialization function of this driver:
+         (++) HAL_TIM_Base_Init: to use the Timer to generate a simple time base
+         (++) HAL_TIM_OC_Init and HAL_TIM_OC_ConfigChannel: to use the Timer to generate an
+              Output Compare signal.
+         (++) HAL_TIM_PWM_Init and HAL_TIM_PWM_ConfigChannel: to use the Timer to generate a
+              PWM signal.
+         (++) HAL_TIM_IC_Init and HAL_TIM_IC_ConfigChannel: to use the Timer to measure an
+              external signal.
+         (++) HAL_TIM_OnePulse_Init and HAL_TIM_OnePulse_ConfigChannel: to use the Timer
+              in One Pulse Mode.
+         (++) HAL_TIM_Encoder_Init: to use the Timer Encoder Interface.
+
+     (#) Activate the TIM peripheral using one of the start functions depending from the feature used:
+           (++) Time Base : HAL_TIM_Base_Start(), HAL_TIM_Base_Start_DMA(), HAL_TIM_Base_Start_IT()
+           (++) Input Capture :  HAL_TIM_IC_Start(), HAL_TIM_IC_Start_DMA(), HAL_TIM_IC_Start_IT()
+           (++) Output Compare : HAL_TIM_OC_Start(), HAL_TIM_OC_Start_DMA(), HAL_TIM_OC_Start_IT()
+           (++) PWM generation : HAL_TIM_PWM_Start(), HAL_TIM_PWM_Start_DMA(), HAL_TIM_PWM_Start_IT()
+           (++) One-pulse mode output : HAL_TIM_OnePulse_Start(), HAL_TIM_OnePulse_Start_IT()
+           (++) Encoder mode output : HAL_TIM_Encoder_Start(), HAL_TIM_Encoder_Start_DMA(), HAL_TIM_Encoder_Start_IT().
+
+     (#) The DMA Burst is managed with the two following functions:
+         HAL_TIM_DMABurst_WriteStart()
+         HAL_TIM_DMABurst_ReadStart()
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup TIM TIM
+  * @brief TIM HAL module driver
+  * @{
+  */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/** @addtogroup TIM_Private_Functions
+  * @{
+  */
+/* Private function prototypes -----------------------------------------------*/
+static void TIM_TI1_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter);
+static void TIM_TI2_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter);
+static void TIM_TI2_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter);
+static void TIM_TI3_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter);
+static void TIM_TI4_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter);
+
+static void TIM_ITRx_SetConfig(TIM_TypeDef* TIMx, uint16_t TIM_ITRx);
+static void TIM_DMAPeriodElapsedCplt(DMA_HandleTypeDef *hdma);
+static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma);
+static void TIM_SlaveTimer_SetConfig(TIM_HandleTypeDef *htim,
+                                     TIM_SlaveConfigTypeDef * sSlaveConfig);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup TIM_Exported_Functions TIM Exported Functions
+  * @{
+  */
+
+/** @defgroup TIM_Exported_Functions_Group1 Time Base functions
+ *  @brief    Time Base functions
+ *
+@verbatim
+  ==============================================================================
+              ##### Time Base functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Initialize and configure the TIM base.
+    (+) De-initialize the TIM base.
+    (+) Start the Time Base.
+    (+) Stop the Time Base.
+    (+) Start the Time Base and enable interrupt.
+    (+) Stop the Time Base and disable interrupt.
+    (+) Start the Time Base and enable DMA transfer.
+    (+) Stop the Time Base and disable DMA transfer.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM Time base Unit according to the specified
+  *         parameters in the TIM_HandleTypeDef and create the associated handle.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Init the low level hardware : GPIO, CLOCK, NVIC */
+    HAL_TIM_Base_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Set the Time Base configuration */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM Base peripheral
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_TIM_Base_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Base MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_Base_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM Base MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_Base_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the TIM Base generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Start(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Change the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Base generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Stop(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Base generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Start_IT(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  /* Enable the TIM Update interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_UPDATE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Base generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Stop_IT(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  /* Disable the TIM Update interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_UPDATE);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Base generation in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_INSTANCE(htim->Instance));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  /* Set the DMA Period elapsed callback */
+  htim->hdma[TIM_DMA_ID_UPDATE]->XferCpltCallback = TIM_DMAPeriodElapsedCplt;
+
+  /* Set the DMA error callback */
+  htim->hdma[TIM_DMA_ID_UPDATE]->XferErrorCallback = HAL_TIM_DMAError ;
+
+  /* Enable the DMA Stream */
+  HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)pData, (uint32_t)&htim->Instance->ARR, Length);
+
+  /* Enable the TIM Update DMA request */
+  __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_UPDATE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Base generation in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Stop_DMA(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_INSTANCE(htim->Instance));
+
+  /* Disable the TIM Update DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_UPDATE);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group2 Time Output Compare functions
+ *  @brief    Time Output Compare functions
+ *
+@verbatim
+  ==============================================================================
+                  ##### Time Output Compare functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Initialize and configure the TIM Output Compare.
+    (+) De-initialize the TIM Output Compare.
+    (+) Start the Time Output Compare.
+    (+) Stop the Time Output Compare.
+    (+) Start the Time Output Compare and enable interrupt.
+    (+) Stop the Time Output Compare and disable interrupt.
+    (+) Start the Time Output Compare and enable DMA transfer.
+    (+) Stop the Time Output Compare and disable DMA transfer.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM Output Compare according to the specified
+  *         parameters in the TIM_HandleTypeDef and create the associated handle.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Init(TIM_HandleTypeDef* htim)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    htim->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_OC_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Init the base time for the Output Compare */
+  TIM_Base_SetConfig(htim->Instance,  &htim->Init);
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM peripheral
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+   htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC and DMA */
+  HAL_TIM_OC_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Output Compare MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_OC_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_OC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM Output Compare MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_OC_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_OC_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Enable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Disable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Enable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to TIM peripheral
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if(((uint32_t)pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length);
+
+      /* Enable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length);
+
+      /* Enable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,Length);
+
+      /* Enable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+     /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length);
+
+      /* Enable the TIM Capture/Compare 4 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group3 Time PWM functions
+ *  @brief    Time PWM functions
+ *
+@verbatim
+  ==============================================================================
+                          ##### Time PWM functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Initialize and configure the TIM OPWM.
+    (+) De-initialize the TIM PWM.
+    (+) Start the Time PWM.
+    (+) Stop the Time PWM.
+    (+) Start the Time PWM and enable interrupt.
+    (+) Stop the Time PWM and disable interrupt.
+    (+) Start the Time PWM and enable DMA transfer.
+    (+) Stop the Time PWM and disable DMA transfer.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM PWM Time Base according to the specified
+  *         parameters in the TIM_HandleTypeDef and create the associated handle.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Init(TIM_HandleTypeDef *htim)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    htim->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_PWM_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Init the base time for the PWM */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM peripheral
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC and DMA */
+  HAL_TIM_PWM_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM PWM MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_PWM_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM PWM MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_PWM_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the PWM signal generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Enable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the PWM signal generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Disable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the PWM signal generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Enable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the PWM signal generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT (TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM PWM signal generation in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to TIM peripheral
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if(((uint32_t)pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length);
+
+      /* Enable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length);
+
+      /* Enable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,Length);
+
+      /* Enable the TIM Output Capture/Compare 3 request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+     /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length);
+
+      /* Enable the TIM Capture/Compare 4 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM PWM signal generation in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group4 Time Input Capture functions
+ *  @brief    Time Input Capture functions
+ *
+@verbatim
+  ==============================================================================
+              ##### Time Input Capture functions #####
+  ==============================================================================
+ [..]
+   This section provides functions allowing to:
+   (+) Initialize and configure the TIM Input Capture.
+   (+) De-initialize the TIM Input Capture.
+   (+) Start the Time Input Capture.
+   (+) Stop the Time Input Capture.
+   (+) Start the Time Input Capture and enable interrupt.
+   (+) Stop the Time Input Capture and disable interrupt.
+   (+) Start the Time Input Capture and enable DMA transfer.
+   (+) Stop the Time Input Capture and disable DMA transfer.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM Input Capture Time base according to the specified
+  *         parameters in the TIM_HandleTypeDef and create the associated handle.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Init(TIM_HandleTypeDef *htim)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    htim->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_IC_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Init the base time for the input capture */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM peripheral
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC and DMA */
+  HAL_TIM_IC_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM INput Capture MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_IC_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_IC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM Input Capture MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_IC_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_IC_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the TIM Input Capture measurement.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Start (TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Enable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Input Capture measurement.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Disable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Input Capture measurement in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Start_IT (TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Enable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+  /* Enable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Input Capture measurement in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Input Capture measurement on in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  pData: The destination Buffer address.
+  * @param  Length: The length of data to be transferred from TIM peripheral to memory.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData, Length);
+
+      /* Enable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData, Length);
+
+      /* Enable the TIM Capture/Compare 2  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)&htim->Instance->CCR3, (uint32_t)pData, Length);
+
+      /* Enable the TIM Capture/Compare 3  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)&htim->Instance->CCR4, (uint32_t)pData, Length);
+
+      /* Enable the TIM Capture/Compare 4  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Input Capture measurement on in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3  DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4  DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group5 Time One Pulse functions
+ *  @brief    Time One Pulse functions
+ *
+@verbatim
+  ==============================================================================
+                        ##### Time One Pulse functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Initialize and configure the TIM One Pulse.
+    (+) De-initialize the TIM One Pulse.
+    (+) Start the Time One Pulse.
+    (+) Stop the Time One Pulse.
+    (+) Start the Time One Pulse and enable interrupt.
+    (+) Stop the Time One Pulse and disable interrupt.
+    (+) Start the Time One Pulse and enable DMA transfer.
+    (+) Stop the Time One Pulse and disable DMA transfer.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM One Pulse Time Base according to the specified
+  *         parameters in the TIM_HandleTypeDef and create the associated handle.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OnePulseMode: Select the One pulse mode.
+  *         This parameter can be one of the following values:
+  *            @arg TIM_OPMODE_SINGLE: Only one pulse will be generated.
+  *            @arg TIM_OPMODE_REPETITIVE: Repetitive pulses will be generated.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Init(TIM_HandleTypeDef *htim, uint32_t OnePulseMode)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+  assert_param(IS_TIM_OPM_MODE(OnePulseMode));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    htim->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_OnePulse_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Configure the Time base in the One Pulse Mode */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+
+  /* Reset the OPM Bit */
+  htim->Instance->CR1 &= ~TIM_CR1_OPM;
+
+  /* Configure the OPM Mode */
+  htim->Instance->CR1 |= OnePulseMode;
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM One Pulse
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_TIM_OnePulse_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM One Pulse MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_OnePulse_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_OnePulse_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM One Pulse MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_OnePulse_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_OnePulse_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the TIM One Pulse signal generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OutputChannel : TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Enable the Capture compare and the Input Capture channels
+    (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
+    if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
+    if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output
+    in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be enabled together
+
+    No need to enable the counter, it's enabled automatically by hardware
+    (the counter starts in response to a stimulus and generate a pulse */
+
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM One Pulse signal generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OutputChannel : TIM Channels to be disable.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Stop(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Disable the Capture compare and the Input Capture channels
+  (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
+  if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
+  if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output
+  in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be disabled together */
+
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM One Pulse signal generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OutputChannel : TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Enable the Capture compare and the Input Capture channels
+    (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
+    if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
+    if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output
+    in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be enabled together
+
+    No need to enable the counter, it's enabled automatically by hardware
+    (the counter starts in response to a stimulus and generate a pulse */
+
+  /* Enable the TIM Capture/Compare 1 interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+
+  /* Enable the TIM Capture/Compare 2 interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM One Pulse signal generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OutputChannel : TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Disable the TIM Capture/Compare 1 interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+
+  /* Disable the TIM Capture/Compare 2 interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+
+  /* Disable the Capture compare and the Input Capture channels
+  (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
+  if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
+  if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output
+  in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be disabled together */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+   __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group6 Time Encoder functions
+ *  @brief    Time Encoder functions
+ *
+@verbatim
+  ==============================================================================
+                          ##### Time Encoder functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Initialize and configure the TIM Encoder.
+    (+) De-initialize the TIM Encoder.
+    (+) Start the Time Encoder.
+    (+) Stop the Time Encoder.
+    (+) Start the Time Encoder and enable interrupt.
+    (+) Stop the Time Encoder and disable interrupt.
+    (+) Start the Time Encoder and enable DMA transfer.
+    (+) Stop the Time Encoder and disable DMA transfer.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM Encoder Interface and create the associated handle.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sConfig: TIM Encoder Interface configuration structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_InitTypeDef* sConfig)
+{
+  uint32_t tmpsmcr = 0;
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_ENCODER_MODE(sConfig->EncoderMode));
+  assert_param(IS_TIM_IC_SELECTION(sConfig->IC1Selection));
+  assert_param(IS_TIM_IC_SELECTION(sConfig->IC2Selection));
+  assert_param(IS_TIM_IC_POLARITY(sConfig->IC1Polarity));
+  assert_param(IS_TIM_IC_POLARITY(sConfig->IC2Polarity));
+  assert_param(IS_TIM_IC_PRESCALER(sConfig->IC1Prescaler));
+  assert_param(IS_TIM_IC_PRESCALER(sConfig->IC2Prescaler));
+  assert_param(IS_TIM_IC_FILTER(sConfig->IC1Filter));
+  assert_param(IS_TIM_IC_FILTER(sConfig->IC2Filter));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    htim->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_Encoder_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Reset the SMS bits */
+  htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+
+  /* Configure the Time base in the Encoder Mode */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+
+  /* Get the TIMx SMCR register value */
+  tmpsmcr = htim->Instance->SMCR;
+
+  /* Get the TIMx CCMR1 register value */
+  tmpccmr1 = htim->Instance->CCMR1;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = htim->Instance->CCER;
+
+  /* Set the encoder Mode */
+  tmpsmcr |= sConfig->EncoderMode;
+
+  /* Select the Capture Compare 1 and the Capture Compare 2 as input */
+  tmpccmr1 &= ~(TIM_CCMR1_CC1S | TIM_CCMR1_CC2S);
+  tmpccmr1 |= (sConfig->IC1Selection | (sConfig->IC2Selection << 8));
+
+  /* Set the Capture Compare 1 and the Capture Compare 2 prescalers and filters */
+  tmpccmr1 &= ~(TIM_CCMR1_IC1PSC | TIM_CCMR1_IC2PSC);
+  tmpccmr1 &= ~(TIM_CCMR1_IC1F | TIM_CCMR1_IC2F);
+  tmpccmr1 |= sConfig->IC1Prescaler | (sConfig->IC2Prescaler << 8);
+  tmpccmr1 |= (sConfig->IC1Filter << 4) | (sConfig->IC2Filter << 12);
+
+  /* Set the TI1 and the TI2 Polarities */
+  tmpccer &= ~(TIM_CCER_CC1P | TIM_CCER_CC2P);
+  tmpccer &= ~(TIM_CCER_CC1NP | TIM_CCER_CC2NP);
+  tmpccer |= sConfig->IC1Polarity | (sConfig->IC2Polarity << 4);
+
+  /* Write to TIMx SMCR */
+  htim->Instance->SMCR = tmpsmcr;
+
+  /* Write to TIMx CCMR1 */
+  htim->Instance->CCMR1 = tmpccmr1;
+
+  /* Write to TIMx CCER */
+  htim->Instance->CCER = tmpccer;
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM Encoder interface
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_TIM_Encoder_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Encoder Interface MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_Encoder_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM Encoder Interface MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_Encoder_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the TIM Encoder Interface.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_ALL: TIM Channel 1 and TIM Channel 2 are selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+  /* Enable the encoder interface channels */
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+      break;
+    }
+    case TIM_CHANNEL_2:
+    {
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+      break;
+    }
+    default :
+    {
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+     break;
+    }
+  }
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Encoder Interface.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_ALL: TIM Channel 1 and TIM Channel 2 are selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+    assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+   /* Disable the Input Capture channels 1 and 2
+    (in the EncoderInterface the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2) */
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+      break;
+    }
+    case TIM_CHANNEL_2:
+    {
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+      break;
+    }
+    default :
+    {
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+     break;
+    }
+  }
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Encoder Interface in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_ALL: TIM Channel 1 and TIM Channel 2 are selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+  /* Enable the encoder interface channels */
+  /* Enable the capture compare Interrupts 1 and/or 2 */
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+      break;
+    }
+    case TIM_CHANNEL_2:
+    {
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+      break;
+    }
+    default :
+    {
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+     __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+     __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+     break;
+    }
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Encoder Interface in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_ALL: TIM Channel 1 and TIM Channel 2 are selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+  /* Disable the Input Capture channels 1 and 2
+    (in the EncoderInterface the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2) */
+  if(Channel == TIM_CHANNEL_1)
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+
+    /* Disable the capture compare Interrupts 1 */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+  }
+  else if(Channel == TIM_CHANNEL_2)
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+
+    /* Disable the capture compare Interrupts 2 */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+  }
+  else
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+
+    /* Disable the capture compare Interrupts 1 and 2 */
+    __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Encoder Interface in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_ALL: TIM Channel 1 and TIM Channel 2 are selected
+  * @param  pData1: The destination Buffer address for IC1.
+  * @param  pData2: The destination Buffer address for IC2.
+  * @param  Length: The length of data to be transferred from TIM peripheral to memory.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData1, uint32_t *pData2, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((((pData1 == 0) || (pData2 == 0) )) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t )pData1, Length);
+
+      /* Enable the TIM Input Capture DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+
+      /* Enable the Peripheral */
+      __HAL_TIM_ENABLE(htim);
+
+      /* Enable the Capture compare channel */
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError;
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData2, Length);
+
+      /* Enable the TIM Input Capture  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+
+      /* Enable the Peripheral */
+      __HAL_TIM_ENABLE(htim);
+
+      /* Enable the Capture compare channel */
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+    }
+    break;
+
+    case TIM_CHANNEL_ALL:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData1, Length);
+
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData2, Length);
+
+     /* Enable the Peripheral */
+      __HAL_TIM_ENABLE(htim);
+
+      /* Enable the Capture compare channel */
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+
+      /* Enable the TIM Input Capture  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+      /* Enable the TIM Input Capture  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    default:
+    break;
+  }
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Encoder Interface in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_ALL: TIM Channel 1 and TIM Channel 2 are selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+
+  /* Disable the Input Capture channels 1 and 2
+    (in the EncoderInterface the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2) */
+  if(Channel == TIM_CHANNEL_1)
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+
+    /* Disable the capture compare DMA Request 1 */
+    __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+  }
+  else if(Channel == TIM_CHANNEL_2)
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+
+    /* Disable the capture compare DMA Request 2 */
+    __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+  }
+  else
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+
+    /* Disable the capture compare DMA Request 1 and 2 */
+    __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+/** @defgroup TIM_Exported_Functions_Group7 TIM IRQ handler management
+ *  @brief    IRQ handler management
+ *
+@verbatim
+  ==============================================================================
+                        ##### IRQ handler management #####
+  ==============================================================================
+  [..]
+    This section provides Timer IRQ handler function.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  This function handles TIM interrupts requests.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
+{
+  /* Capture compare 1 event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC1) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC1) !=RESET)
+    {
+      {
+        __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC1);
+        htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+
+        /* Input capture event */
+        if((htim->Instance->CCMR1 & TIM_CCMR1_CC1S) != 0x00)
+        {
+          HAL_TIM_IC_CaptureCallback(htim);
+        }
+        /* Output compare event */
+        else
+        {
+          HAL_TIM_OC_DelayElapsedCallback(htim);
+          HAL_TIM_PWM_PulseFinishedCallback(htim);
+        }
+        htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+      }
+    }
+  }
+  /* Capture compare 2 event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC2) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC2) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC2);
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
+      /* Input capture event */
+      if((htim->Instance->CCMR1 & TIM_CCMR1_CC2S) != 0x00)
+      {
+        HAL_TIM_IC_CaptureCallback(htim);
+      }
+      /* Output compare event */
+      else
+      {
+        HAL_TIM_OC_DelayElapsedCallback(htim);
+        HAL_TIM_PWM_PulseFinishedCallback(htim);
+      }
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+    }
+  }
+  /* Capture compare 3 event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC3) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC3) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC3);
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+      /* Input capture event */
+      if((htim->Instance->CCMR2 & TIM_CCMR2_CC3S) != 0x00)
+      {
+        HAL_TIM_IC_CaptureCallback(htim);
+      }
+      /* Output compare event */
+      else
+      {
+        HAL_TIM_OC_DelayElapsedCallback(htim);
+        HAL_TIM_PWM_PulseFinishedCallback(htim);
+      }
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+    }
+  }
+  /* Capture compare 4 event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC4) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC4) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC4);
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
+      /* Input capture event */
+      if((htim->Instance->CCMR2 & TIM_CCMR2_CC4S) != 0x00)
+      {
+        HAL_TIM_IC_CaptureCallback(htim);
+      }
+      /* Output compare event */
+      else
+      {
+        HAL_TIM_OC_DelayElapsedCallback(htim);
+        HAL_TIM_PWM_PulseFinishedCallback(htim);
+      }
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+    }
+  }
+  /* TIM Update event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_UPDATE) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_UPDATE) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_UPDATE);
+      HAL_TIM_PeriodElapsedCallback(htim);
+    }
+  }
+  /* TIM Break input event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_BREAK) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_BREAK) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_BREAK);
+      HAL_TIMEx_BreakCallback(htim);
+    }
+  }
+
+    /* TIM Break input event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_BREAK2) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_BREAK) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_BREAK);
+      HAL_TIMEx_BreakCallback(htim);
+    }
+  }
+
+  /* TIM Trigger detection event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_TRIGGER) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_TRIGGER) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_TRIGGER);
+      HAL_TIM_TriggerCallback(htim);
+    }
+  }
+  /* TIM commutation event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_COM) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_COM) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_FLAG_COM);
+      HAL_TIMEx_CommutationCallback(htim);
+    }
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group8 Peripheral Control functions
+ *  @brief   	Peripheral Control functions
+ *
+@verbatim
+  ==============================================================================
+                   ##### Peripheral Control functions #####
+  ==============================================================================
+ [..]
+   This section provides functions allowing to:
+   (+) Configure The Input Output channels for OC, PWM, IC or One Pulse mode.
+   (+) Configure External Clock source.
+   (+) Configure Complementary channels, break features and dead time.
+   (+) Configure Master and the Slave synchronization.
+   (+) Configure the DMA Burst Mode.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the TIM Output Compare Channels according to the specified
+  *         parameters in the TIM_OC_InitTypeDef.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sConfig: TIM Output Compare configuration structure
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CHANNELS(Channel));
+  assert_param(IS_TIM_OC_MODE(sConfig->OCMode));
+  assert_param(IS_TIM_OC_POLARITY(sConfig->OCPolarity));
+  assert_param(IS_TIM_OCN_POLARITY(sConfig->OCNPolarity));
+  assert_param(IS_TIM_OCNIDLE_STATE(sConfig->OCNIdleState));
+  assert_param(IS_TIM_OCIDLE_STATE(sConfig->OCIdleState));
+
+  /* Check input state */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      /* Configure the TIM Channel 1 in Output Compare */
+      TIM_OC1_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      /* Configure the TIM Channel 2 in Output Compare */
+      TIM_OC2_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+       assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+      /* Configure the TIM Channel 3 in Output Compare */
+      TIM_OC3_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+      /* Configure the TIM Channel 4 in Output Compare */
+      TIM_OC4_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    default:
+    break;
+  }
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Input Capture Channels according to the specified
+  *         parameters in the TIM_IC_InitTypeDef.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sConfig: TIM Input Capture configuration structure
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitTypeDef* sConfig, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_IC_POLARITY(sConfig->ICPolarity));
+  assert_param(IS_TIM_IC_SELECTION(sConfig->ICSelection));
+  assert_param(IS_TIM_IC_PRESCALER(sConfig->ICPrescaler));
+  assert_param(IS_TIM_IC_FILTER(sConfig->ICFilter));
+
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  if (Channel == TIM_CHANNEL_1)
+  {
+    /* TI1 Configuration */
+    TIM_TI1_SetConfig(htim->Instance,
+               sConfig->ICPolarity,
+               sConfig->ICSelection,
+               sConfig->ICFilter);
+
+    /* Reset the IC1PSC Bits */
+    htim->Instance->CCMR1 &= ~TIM_CCMR1_IC1PSC;
+
+    /* Set the IC1PSC value */
+    htim->Instance->CCMR1 |= sConfig->ICPrescaler;
+  }
+  else if (Channel == TIM_CHANNEL_2)
+  {
+    /* TI2 Configuration */
+    assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+    TIM_TI2_SetConfig(htim->Instance,
+                      sConfig->ICPolarity,
+                      sConfig->ICSelection,
+                      sConfig->ICFilter);
+
+    /* Reset the IC2PSC Bits */
+    htim->Instance->CCMR1 &= ~TIM_CCMR1_IC2PSC;
+
+    /* Set the IC2PSC value */
+    htim->Instance->CCMR1 |= (sConfig->ICPrescaler << 8);
+  }
+  else if (Channel == TIM_CHANNEL_3)
+  {
+    /* TI3 Configuration */
+    assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+
+    TIM_TI3_SetConfig(htim->Instance,
+               sConfig->ICPolarity,
+               sConfig->ICSelection,
+               sConfig->ICFilter);
+
+    /* Reset the IC3PSC Bits */
+    htim->Instance->CCMR2 &= ~TIM_CCMR2_IC3PSC;
+
+    /* Set the IC3PSC value */
+    htim->Instance->CCMR2 |= sConfig->ICPrescaler;
+  }
+  else
+  {
+    /* TI4 Configuration */
+    assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+
+    TIM_TI4_SetConfig(htim->Instance,
+               sConfig->ICPolarity,
+               sConfig->ICSelection,
+               sConfig->ICFilter);
+
+    /* Reset the IC4PSC Bits */
+    htim->Instance->CCMR2 &= ~TIM_CCMR2_IC4PSC;
+
+    /* Set the IC4PSC value */
+    htim->Instance->CCMR2 |= (sConfig->ICPrescaler << 8);
+  }
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM PWM  channels according to the specified
+  *         parameters in the TIM_OC_InitTypeDef.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sConfig: TIM PWM configuration structure
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel)
+{
+  __HAL_LOCK(htim);
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CHANNELS(Channel));
+  assert_param(IS_TIM_PWM_MODE(sConfig->OCMode));
+  assert_param(IS_TIM_OC_POLARITY(sConfig->OCPolarity));
+  assert_param(IS_TIM_OCN_POLARITY(sConfig->OCNPolarity));
+  assert_param(IS_TIM_OCNIDLE_STATE(sConfig->OCNIdleState));
+  assert_param(IS_TIM_OCIDLE_STATE(sConfig->OCIdleState));
+  assert_param(IS_TIM_FAST_STATE(sConfig->OCFastMode));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      /* Configure the Channel 1 in PWM mode */
+      TIM_OC1_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel1 */
+      htim->Instance->CCMR1 |= TIM_CCMR1_OC1PE;
+
+      /* Configure the Output Fast mode */
+      htim->Instance->CCMR1 &= ~TIM_CCMR1_OC1FE;
+      htim->Instance->CCMR1 |= sConfig->OCFastMode;
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      /* Configure the Channel 2 in PWM mode */
+      TIM_OC2_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel2 */
+      htim->Instance->CCMR1 |= TIM_CCMR1_OC2PE;
+
+      /* Configure the Output Fast mode */
+      htim->Instance->CCMR1 &= ~TIM_CCMR1_OC2FE;
+      htim->Instance->CCMR1 |= sConfig->OCFastMode << 8;
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+      /* Configure the Channel 3 in PWM mode */
+      TIM_OC3_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel3 */
+      htim->Instance->CCMR2 |= TIM_CCMR2_OC3PE;
+
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR2 &= ~TIM_CCMR2_OC3FE;
+      htim->Instance->CCMR2 |= sConfig->OCFastMode;
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+      /* Configure the Channel 4 in PWM mode */
+      TIM_OC4_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel4 */
+      htim->Instance->CCMR2 |= TIM_CCMR2_OC4PE;
+
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR2 &= ~TIM_CCMR2_OC4FE;
+      htim->Instance->CCMR2 |= sConfig->OCFastMode << 8;
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM One Pulse Channels according to the specified
+  *         parameters in the TIM_OnePulse_InitTypeDef.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sConfig: TIM One Pulse configuration structure
+  * @param  OutputChannel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @param  InputChannel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim,  TIM_OnePulse_InitTypeDef* sConfig, uint32_t OutputChannel,  uint32_t InputChannel)
+{
+  TIM_OC_InitTypeDef temp1;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_OPM_CHANNELS(OutputChannel));
+  assert_param(IS_TIM_OPM_CHANNELS(InputChannel));
+
+  if(OutputChannel != InputChannel)
+  {
+    __HAL_LOCK(htim);
+
+    htim->State = HAL_TIM_STATE_BUSY;
+
+    /* Extract the Output compare configuration from sConfig structure */
+    temp1.OCMode = sConfig->OCMode;
+    temp1.Pulse = sConfig->Pulse;
+    temp1.OCPolarity = sConfig->OCPolarity;
+    temp1.OCNPolarity = sConfig->OCNPolarity;
+    temp1.OCIdleState = sConfig->OCIdleState;
+    temp1.OCNIdleState = sConfig->OCNIdleState;
+
+    switch (OutputChannel)
+    {
+      case TIM_CHANNEL_1:
+      {
+        assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+
+        TIM_OC1_SetConfig(htim->Instance, &temp1);
+      }
+      break;
+      case TIM_CHANNEL_2:
+      {
+        assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+        TIM_OC2_SetConfig(htim->Instance, &temp1);
+      }
+      break;
+      default:
+      break;
+    }
+    switch (InputChannel)
+    {
+      case TIM_CHANNEL_1:
+      {
+        assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+
+        TIM_TI1_SetConfig(htim->Instance, sConfig->ICPolarity,
+                        sConfig->ICSelection, sConfig->ICFilter);
+
+        /* Reset the IC1PSC Bits */
+        htim->Instance->CCMR1 &= ~TIM_CCMR1_IC1PSC;
+
+        /* Select the Trigger source */
+        htim->Instance->SMCR &= ~TIM_SMCR_TS;
+        htim->Instance->SMCR |= TIM_TS_TI1FP1;
+
+        /* Select the Slave Mode */
+        htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+        htim->Instance->SMCR |= TIM_SLAVEMODE_TRIGGER;
+      }
+      break;
+      case TIM_CHANNEL_2:
+      {
+        assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+        TIM_TI2_SetConfig(htim->Instance, sConfig->ICPolarity,
+                 sConfig->ICSelection, sConfig->ICFilter);
+
+        /* Reset the IC2PSC Bits */
+        htim->Instance->CCMR1 &= ~TIM_CCMR1_IC2PSC;
+
+        /* Select the Trigger source */
+        htim->Instance->SMCR &= ~TIM_SMCR_TS;
+        htim->Instance->SMCR |= TIM_TS_TI2FP2;
+
+        /* Select the Slave Mode */
+        htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+        htim->Instance->SMCR |= TIM_SLAVEMODE_TRIGGER;
+      }
+      break;
+
+      default:
+      break;
+    }
+
+    htim->State = HAL_TIM_STATE_READY;
+
+    __HAL_UNLOCK(htim);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Configure the DMA Burst to transfer Data from the memory to the TIM peripheral
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  BurstBaseAddress: TIM Base address from when the DMA will starts the Data write.
+  *         This parameters can be on of the following values:
+  *            @arg TIM_DMABASE_CR1
+  *            @arg TIM_DMABASE_CR2
+  *            @arg TIM_DMABASE_SMCR
+  *            @arg TIM_DMABASE_DIER
+  *            @arg TIM_DMABASE_SR
+  *            @arg TIM_DMABASE_EGR
+  *            @arg TIM_DMABASE_CCMR1
+  *            @arg TIM_DMABASE_CCMR2
+  *            @arg TIM_DMABASE_CCER
+  *            @arg TIM_DMABASE_CNT
+  *            @arg TIM_DMABASE_PSC
+  *            @arg TIM_DMABASE_ARR
+  *            @arg TIM_DMABASE_RCR
+  *            @arg TIM_DMABASE_CCR1
+  *            @arg TIM_DMABASE_CCR2
+  *            @arg TIM_DMABASE_CCR3
+  *            @arg TIM_DMABASE_CCR4
+  *            @arg TIM_DMABASE_BDTR
+  *            @arg TIM_DMABASE_DCR
+  * @param  BurstRequestSrc: TIM DMA Request sources.
+  *         This parameters can be on of the following values:
+  *            @arg TIM_DMA_UPDATE: TIM update Interrupt source
+  *            @arg TIM_DMA_CC1: TIM Capture Compare 1 DMA source
+  *            @arg TIM_DMA_CC2: TIM Capture Compare 2 DMA source
+  *            @arg TIM_DMA_CC3: TIM Capture Compare 3 DMA source
+  *            @arg TIM_DMA_CC4: TIM Capture Compare 4 DMA source
+  *            @arg TIM_DMA_COM: TIM Commutation DMA source
+  *            @arg TIM_DMA_TRIGGER: TIM Trigger DMA source
+  * @param  BurstBuffer: The Buffer address.
+  * @param  BurstLength: DMA Burst length. This parameter can be one value
+  *         between TIM_DMABURSTLENGTH_1TRANSFER and TIM_DMABURSTLENGTH_18TRANSFERS.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc,
+                                              uint32_t* BurstBuffer, uint32_t  BurstLength)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMABURST_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_DMA_BASE(BurstBaseAddress));
+  assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
+  assert_param(IS_TIM_DMA_LENGTH(BurstLength));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((BurstBuffer == 0 ) && (BurstLength > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch(BurstRequestSrc)
+  {
+    case TIM_DMA_UPDATE:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_UPDATE]->XferCpltCallback = TIM_DMAPeriodElapsedCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_UPDATE]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC4:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_COM:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_COMMUTATION]->XferCpltCallback = HAL_TIMEx_DMACommutationCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_COMMUTATION]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_COMMUTATION], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_TRIGGER:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_TRIGGER]->XferCpltCallback = TIM_DMATriggerCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_TRIGGER]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_TRIGGER], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    default:
+    break;
+  }
+   /* configure the DMA Burst Mode */
+   htim->Instance->DCR = BurstBaseAddress | BurstLength;
+
+   /* Enable the TIM DMA Request */
+   __HAL_TIM_ENABLE_DMA(htim, BurstRequestSrc);
+
+   htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM DMA Burst mode
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  BurstRequestSrc: TIM DMA Request sources to disable
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
+
+  /* Abort the DMA transfer (at least disable the DMA channel) */
+  switch(BurstRequestSrc)
+  {
+    case TIM_DMA_UPDATE:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_UPDATE]);
+    }
+    break;
+    case TIM_DMA_CC1:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC1]);
+    }
+    break;
+    case TIM_DMA_CC2:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC2]);
+    }
+    break;
+    case TIM_DMA_CC3:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC3]);
+    }
+    break;
+    case TIM_DMA_CC4:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC4]);
+    }
+    break;
+    case TIM_DMA_COM:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_COMMUTATION]);
+    }
+    break;
+    case TIM_DMA_TRIGGER:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_TRIGGER]);
+    }
+    break;
+    default:
+    break;
+  }
+
+  /* Disable the TIM Update DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configure the DMA Burst to transfer Data from the TIM peripheral to the memory
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  BurstBaseAddress: TIM Base address from when the DMA will starts the Data read.
+  *         This parameters can be on of the following values:
+  *            @arg TIM_DMABASE_CR1
+  *            @arg TIM_DMABASE_CR2
+  *            @arg TIM_DMABASE_SMCR
+  *            @arg TIM_DMABASE_DIER
+  *            @arg TIM_DMABASE_SR
+  *            @arg TIM_DMABASE_EGR
+  *            @arg TIM_DMABASE_CCMR1
+  *            @arg TIM_DMABASE_CCMR2
+  *            @arg TIM_DMABASE_CCER
+  *            @arg TIM_DMABASE_CNT
+  *            @arg TIM_DMABASE_PSC
+  *            @arg TIM_DMABASE_ARR
+  *            @arg TIM_DMABASE_RCR
+  *            @arg TIM_DMABASE_CCR1
+  *            @arg TIM_DMABASE_CCR2
+  *            @arg TIM_DMABASE_CCR3
+  *            @arg TIM_DMABASE_CCR4
+  *            @arg TIM_DMABASE_BDTR
+  *            @arg TIM_DMABASE_DCR
+  * @param  BurstRequestSrc: TIM DMA Request sources.
+  *         This parameters can be on of the following values:
+  *            @arg TIM_DMA_UPDATE: TIM update Interrupt source
+  *            @arg TIM_DMA_CC1: TIM Capture Compare 1 DMA source
+  *            @arg TIM_DMA_CC2: TIM Capture Compare 2 DMA source
+  *            @arg TIM_DMA_CC3: TIM Capture Compare 3 DMA source
+  *            @arg TIM_DMA_CC4: TIM Capture Compare 4 DMA source
+  *            @arg TIM_DMA_COM: TIM Commutation DMA source
+  *            @arg TIM_DMA_TRIGGER: TIM Trigger DMA source
+  * @param  BurstBuffer: The Buffer address.
+  * @param  BurstLength: DMA Burst length. This parameter can be one value
+  *         between TIM_DMABURSTLENGTH_1TRANSFER and TIM_DMABURSTLENGTH_18TRANSFERS.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc,
+                                             uint32_t  *BurstBuffer, uint32_t  BurstLength)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMABURST_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_DMA_BASE(BurstBaseAddress));
+  assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
+  assert_param(IS_TIM_DMA_LENGTH(BurstLength));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((BurstBuffer == 0 ) && (BurstLength > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch(BurstRequestSrc)
+  {
+    case TIM_DMA_UPDATE:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_UPDATE]->XferCpltCallback = TIM_DMAPeriodElapsedCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_UPDATE]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+       HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC4:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_COM:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_COMMUTATION]->XferCpltCallback = HAL_TIMEx_DMACommutationCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_COMMUTATION]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_COMMUTATION], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_TRIGGER:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_TRIGGER]->XferCpltCallback = TIM_DMATriggerCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_TRIGGER]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_TRIGGER], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    default:
+    break;
+  }
+
+  /* configure the DMA Burst Mode */
+  htim->Instance->DCR = BurstBaseAddress | BurstLength;
+
+  /* Enable the TIM DMA Request */
+  __HAL_TIM_ENABLE_DMA(htim, BurstRequestSrc);
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop the DMA burst reading
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  BurstRequestSrc: TIM DMA Request sources to disable.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
+
+  /* Abort the DMA transfer (at least disable the DMA channel) */
+  switch(BurstRequestSrc)
+  {
+    case TIM_DMA_UPDATE:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_UPDATE]);
+    }
+    break;
+    case TIM_DMA_CC1:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC1]);
+    }
+    break;
+    case TIM_DMA_CC2:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC2]);
+    }
+    break;
+    case TIM_DMA_CC3:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC3]);
+    }
+    break;
+    case TIM_DMA_CC4:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC4]);
+    }
+    break;
+    case TIM_DMA_COM:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_COMMUTATION]);
+    }
+    break;
+    case TIM_DMA_TRIGGER:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_TRIGGER]);
+    }
+    break;
+    default:
+    break;
+  }
+
+  /* Disable the TIM Update DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Generate a software event
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  EventSource: specifies the event source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_EVENTSOURCE_UPDATE: Timer update Event source
+  *            @arg TIM_EVENTSOURCE_CC1: Timer Capture Compare 1 Event source
+  *            @arg TIM_EVENTSOURCE_CC2: Timer Capture Compare 2 Event source
+  *            @arg TIM_EVENTSOURCE_CC3: Timer Capture Compare 3 Event source
+  *            @arg TIM_EVENTSOURCE_CC4: Timer Capture Compare 4 Event source
+  *            @arg TIM_EVENTSOURCE_COM: Timer COM event source
+  *            @arg TIM_EVENTSOURCE_TRIGGER: Timer Trigger Event source
+  *            @arg TIM_EVENTSOURCE_BREAK: Timer Break event source
+  *            @arg TIM_EVENTSOURCE_BREAK2: Timer Break2 event source
+  * @note   TIM6 and TIM7 can only generate an update event.
+  * @note   TIM_EVENTSOURCE_COM, TIM_EVENTSOURCE_BREAK and TIM_EVENTSOURCE_BREAK2 are used only with TIM1 and TIM8.
+  * @retval HAL status
+  */
+
+HAL_StatusTypeDef HAL_TIM_GenerateEvent(TIM_HandleTypeDef *htim, uint32_t EventSource)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_EVENT_SOURCE(EventSource));
+
+  /* Process Locked */
+  __HAL_LOCK(htim);
+
+  /* Change the TIM state */
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Set the event sources */
+  htim->Instance->EGR = EventSource;
+
+  /* Change the TIM state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the OCRef clear feature
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sClearInputConfig: pointer to a TIM_ClearInputConfigTypeDef structure that
+  *         contains the OCREF clear feature and parameters for the TIM peripheral.
+  * @param  Channel: specifies the TIM Channel.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim, TIM_ClearInputConfigTypeDef * sClearInputConfig, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_CHANNELS(Channel));
+  assert_param(IS_TIM_CLEARINPUT_SOURCE(sClearInputConfig->ClearInputSource));
+
+  /* Process Locked */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  if(sClearInputConfig->ClearInputSource == TIM_CLEARINPUTSOURCE_ETR)
+  {
+    assert_param(IS_TIM_CLEARINPUT_POLARITY(sClearInputConfig->ClearInputPolarity));
+    assert_param(IS_TIM_CLEARINPUT_PRESCALER(sClearInputConfig->ClearInputPrescaler));
+    assert_param(IS_TIM_CLEARINPUT_FILTER(sClearInputConfig->ClearInputFilter));
+
+    TIM_ETR_SetConfig(htim->Instance,
+                      sClearInputConfig->ClearInputPrescaler,
+                      sClearInputConfig->ClearInputPolarity,
+                      sClearInputConfig->ClearInputFilter);
+  }
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      if(sClearInputConfig->ClearInputState != RESET)
+      {
+        /* Enable the Ocref clear feature for Channel 1 */
+        htim->Instance->CCMR1 |= TIM_CCMR1_OC1CE;
+      }
+      else
+      {
+        /* Disable the Ocref clear feature for Channel 1 */
+        htim->Instance->CCMR1 &= ~TIM_CCMR1_OC1CE;
+      }
+    }
+    break;
+    case TIM_CHANNEL_2:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      if(sClearInputConfig->ClearInputState != RESET)
+      {
+        /* Enable the Ocref clear feature for Channel 2 */
+        htim->Instance->CCMR1 |= TIM_CCMR1_OC2CE;
+      }
+      else
+      {
+        /* Disable the Ocref clear feature for Channel 2 */
+        htim->Instance->CCMR1 &= ~TIM_CCMR1_OC2CE;
+      }
+    }
+    break;
+    case TIM_CHANNEL_3:
+    {
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+      if(sClearInputConfig->ClearInputState != RESET)
+      {
+        /* Enable the Ocref clear feature for Channel 3 */
+        htim->Instance->CCMR2 |= TIM_CCMR2_OC3CE;
+      }
+      else
+      {
+        /* Disable the Ocref clear feature for Channel 3 */
+        htim->Instance->CCMR2 &= ~TIM_CCMR2_OC3CE;
+      }
+    }
+    break;
+    case TIM_CHANNEL_4:
+    {
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+      if(sClearInputConfig->ClearInputState != RESET)
+      {
+        /* Enable the Ocref clear feature for Channel 4 */
+        htim->Instance->CCMR2 |= TIM_CCMR2_OC4CE;
+      }
+      else
+      {
+        /* Disable the Ocref clear feature for Channel 4 */
+        htim->Instance->CCMR2 &= ~TIM_CCMR2_OC4CE;
+      }
+    }
+    break;
+    default:
+    break;
+  }
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief   Configures the clock source to be used
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sClockSourceConfig: pointer to a TIM_ClockConfigTypeDef structure that
+  *         contains the clock source information for the TIM peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_ConfigClockSource(TIM_HandleTypeDef *htim, TIM_ClockConfigTypeDef * sClockSourceConfig)
+{
+  uint32_t tmpsmcr = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CLOCKSOURCE(sClockSourceConfig->ClockSource));
+  assert_param(IS_TIM_CLOCKPOLARITY(sClockSourceConfig->ClockPolarity));
+  assert_param(IS_TIM_CLOCKPRESCALER(sClockSourceConfig->ClockPrescaler));
+  assert_param(IS_TIM_CLOCKFILTER(sClockSourceConfig->ClockFilter));
+
+  /* Reset the SMS, TS, ECE, ETPS and ETRF bits */
+  tmpsmcr = htim->Instance->SMCR;
+  tmpsmcr &= ~(TIM_SMCR_SMS | TIM_SMCR_TS);
+  tmpsmcr &= ~(TIM_SMCR_ETF | TIM_SMCR_ETPS | TIM_SMCR_ECE | TIM_SMCR_ETP);
+  htim->Instance->SMCR = tmpsmcr;
+
+  switch (sClockSourceConfig->ClockSource)
+  {
+    case TIM_CLOCKSOURCE_INTERNAL:
+    {
+      assert_param(IS_TIM_INSTANCE(htim->Instance));
+      /* Disable slave mode to clock the prescaler directly with the internal clock */
+      htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+    }
+    break;
+
+    case TIM_CLOCKSOURCE_ETRMODE1:
+    {
+      assert_param(IS_TIM_ETR_INSTANCE(htim->Instance));
+      /* Configure the ETR Clock source */
+      TIM_ETR_SetConfig(htim->Instance,
+                        sClockSourceConfig->ClockPrescaler,
+                        sClockSourceConfig->ClockPolarity,
+                        sClockSourceConfig->ClockFilter);
+      /* Get the TIMx SMCR register value */
+      tmpsmcr = htim->Instance->SMCR;
+      /* Reset the SMS and TS Bits */
+      tmpsmcr &= ~(TIM_SMCR_SMS | TIM_SMCR_TS);
+      /* Select the External clock mode1 and the ETRF trigger */
+      tmpsmcr |= (TIM_SLAVEMODE_EXTERNAL1 | TIM_CLOCKSOURCE_ETRMODE1);
+      /* Write to TIMx SMCR */
+      htim->Instance->SMCR = tmpsmcr;
+    }
+    break;
+
+    case TIM_CLOCKSOURCE_ETRMODE2:
+    {
+      assert_param(IS_TIM_ETR_INSTANCE(htim->Instance));
+      /* Configure the ETR Clock source */
+      TIM_ETR_SetConfig(htim->Instance,
+                        sClockSourceConfig->ClockPrescaler,
+                        sClockSourceConfig->ClockPolarity,
+                        sClockSourceConfig->ClockFilter);
+      /* Enable the External clock mode2 */
+      htim->Instance->SMCR |= TIM_SMCR_ECE;
+    }
+    break;
+
+    case TIM_CLOCKSOURCE_TI1:
+    {
+      assert_param(IS_TIM_CLOCKSOURCE_TIX_INSTANCE(htim->Instance));
+      TIM_TI1_ConfigInputStage(htim->Instance,
+                        sClockSourceConfig->ClockPolarity,
+                        sClockSourceConfig->ClockFilter);
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_TI1);
+    }
+    break;
+    case TIM_CLOCKSOURCE_TI2:
+    {
+      assert_param(IS_TIM_CLOCKSOURCE_TIX_INSTANCE(htim->Instance));
+      TIM_TI2_ConfigInputStage(htim->Instance,
+                        sClockSourceConfig->ClockPolarity,
+                        sClockSourceConfig->ClockFilter);
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_TI2);
+    }
+    break;
+    case TIM_CLOCKSOURCE_TI1ED:
+    {
+      assert_param(IS_TIM_CLOCKSOURCE_TIX_INSTANCE(htim->Instance));
+      TIM_TI1_ConfigInputStage(htim->Instance,
+                        sClockSourceConfig->ClockPolarity,
+                        sClockSourceConfig->ClockFilter);
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_TI1ED);
+    }
+    break;
+    case TIM_CLOCKSOURCE_ITR0:
+    {
+      assert_param(IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(htim->Instance));
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_ITR0);
+    }
+    break;
+    case TIM_CLOCKSOURCE_ITR1:
+    {
+      assert_param(IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(htim->Instance));
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_ITR1);
+    }
+    break;
+    case TIM_CLOCKSOURCE_ITR2:
+    {
+      assert_param(IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(htim->Instance));
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_ITR2);
+    }
+    break;
+    case TIM_CLOCKSOURCE_ITR3:
+    {
+      assert_param(IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(htim->Instance));
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_ITR3);
+    }
+    break;
+
+    default:
+    break;
+  }
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Selects the signal connected to the TI1 input: direct from CH1_input
+  *         or a XOR combination between CH1_input, CH2_input & CH3_input
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  TI1_Selection: Indicate whether or not channel 1 is connected to the
+  *         output of a XOR gate.
+  *         This parameter can be one of the following values:
+  *            @arg TIM_TI1SELECTION_CH1: The TIMx_CH1 pin is connected to TI1 input
+  *            @arg TIM_TI1SELECTION_XORCOMBINATION: The TIMx_CH1, CH2 and CH3
+  *            pins are connected to the TI1 input (XOR combination)
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_ConfigTI1Input(TIM_HandleTypeDef *htim, uint32_t TI1_Selection)
+{
+  uint32_t tmpcr2 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_TI1SELECTION(TI1_Selection));
+
+  /* Get the TIMx CR2 register value */
+  tmpcr2 = htim->Instance->CR2;
+
+  /* Reset the TI1 selection */
+  tmpcr2 &= ~TIM_CR2_TI1S;
+
+  /* Set the TI1 selection */
+  tmpcr2 |= TI1_Selection;
+
+  /* Write to TIMxCR2 */
+  htim->Instance->CR2 = tmpcr2;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the TIM in Slave mode
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sSlaveConfig: pointer to a TIM_SlaveConfigTypeDef structure that
+  *         contains the selected trigger (internal trigger input, filtered
+  *         timer input or external trigger input) and the ) and the Slave
+  *         mode (Disable, Reset, Gated, Trigger, External clock mode 1).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchronization(TIM_HandleTypeDef *htim, TIM_SlaveConfigTypeDef * sSlaveConfig)
+{
+  uint32_t tmpsmcr  = 0;
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_SLAVE_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_SLAVE_MODE(sSlaveConfig->SlaveMode));
+  assert_param(IS_TIM_TRIGGER_SELECTION(sSlaveConfig->InputTrigger));
+
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Get the TIMx SMCR register value */
+  tmpsmcr = htim->Instance->SMCR;
+
+  /* Reset the Trigger Selection Bits */
+  tmpsmcr &= ~TIM_SMCR_TS;
+  /* Set the Input Trigger source */
+  tmpsmcr |= sSlaveConfig->InputTrigger;
+
+  /* Reset the slave mode Bits */
+  tmpsmcr &= ~TIM_SMCR_SMS;
+  /* Set the slave mode */
+  tmpsmcr |= sSlaveConfig->SlaveMode;
+
+  /* Write to TIMx SMCR */
+  htim->Instance->SMCR = tmpsmcr;
+
+  /* Configure the trigger prescaler, filter, and polarity */
+  switch (sSlaveConfig->InputTrigger)
+  {
+  case TIM_TS_ETRF:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_ETR_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPRESCALER(sSlaveConfig->TriggerPrescaler));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+      /* Configure the ETR Trigger source */
+      TIM_ETR_SetConfig(htim->Instance,
+                        sSlaveConfig->TriggerPrescaler,
+                        sSlaveConfig->TriggerPolarity,
+                        sSlaveConfig->TriggerFilter);
+    }
+    break;
+
+  case TIM_TS_TI1F_ED:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+
+      /* Disable the Channel 1: Reset the CC1E Bit */
+      tmpccer = htim->Instance->CCER;
+      htim->Instance->CCER &= ~TIM_CCER_CC1E;
+      tmpccmr1 = htim->Instance->CCMR1;
+
+      /* Set the filter */
+      tmpccmr1 &= ~TIM_CCMR1_IC1F;
+      tmpccmr1 |= ((sSlaveConfig->TriggerFilter) << 4);
+
+      /* Write to TIMx CCMR1 and CCER registers */
+      htim->Instance->CCMR1 = tmpccmr1;
+      htim->Instance->CCER = tmpccer;
+
+    }
+    break;
+
+  case TIM_TS_TI1FP1:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+
+      /* Configure TI1 Filter and Polarity */
+      TIM_TI1_ConfigInputStage(htim->Instance,
+                               sSlaveConfig->TriggerPolarity,
+                               sSlaveConfig->TriggerFilter);
+    }
+    break;
+
+  case TIM_TS_TI2FP2:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+
+      /* Configure TI2 Filter and Polarity */
+      TIM_TI2_ConfigInputStage(htim->Instance,
+                                sSlaveConfig->TriggerPolarity,
+                                sSlaveConfig->TriggerFilter);
+    }
+    break;
+
+  case TIM_TS_ITR0:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+
+  case TIM_TS_ITR1:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+
+  case TIM_TS_ITR2:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+
+  case TIM_TS_ITR3:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+
+  default:
+    break;
+  }
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the TIM in Slave mode in interrupt mode
+  * @param  htim: TIM handle.
+  * @param  sSlaveConfig: pointer to a TIM_SlaveConfigTypeDef structure that
+  *         contains the selected trigger (internal trigger input, filtered
+  *         timer input or external trigger input) and the ) and the Slave
+  *         mode (Disable, Reset, Gated, Trigger, External clock mode 1).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchronization_IT(TIM_HandleTypeDef *htim,
+                                                        TIM_SlaveConfigTypeDef * sSlaveConfig)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_SLAVE_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_SLAVE_MODE(sSlaveConfig->SlaveMode));
+  assert_param(IS_TIM_TRIGGER_SELECTION(sSlaveConfig->InputTrigger));
+
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  TIM_SlaveTimer_SetConfig(htim, sSlaveConfig);
+
+  /* Enable Trigger Interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_TRIGGER);
+
+  /* Disable Trigger DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_TRIGGER);
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Read the captured value from Capture Compare unit
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval Captured value
+  */
+uint32_t HAL_TIM_ReadCapturedValue(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  uint32_t tmpreg = 0;
+
+  __HAL_LOCK(htim);
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+
+      /* Return the capture 1 value */
+      tmpreg = htim->Instance->CCR1;
+
+      break;
+    }
+    case TIM_CHANNEL_2:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+      /* Return the capture 2 value */
+      tmpreg = htim->Instance->CCR2;
+
+      break;
+    }
+
+    case TIM_CHANNEL_3:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+
+      /* Return the capture 3 value */
+      tmpreg = htim->Instance->CCR3;
+
+      break;
+    }
+
+    case TIM_CHANNEL_4:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+
+      /* Return the capture 4 value */
+      tmpreg = htim->Instance->CCR4;
+
+      break;
+    }
+
+    default:
+    break;
+  }
+
+  __HAL_UNLOCK(htim);
+  return tmpreg;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group9 TIM Callbacks functions
+ *  @brief    TIM Callbacks functions
+ *
+@verbatim
+  ==============================================================================
+                        ##### TIM Callbacks functions #####
+  ==============================================================================
+ [..]
+   This section provides TIM callback functions:
+   (+) Timer Period elapsed callback
+   (+) Timer Output Compare callback
+   (+) Timer Input capture callback
+   (+) Timer Trigger callback
+   (+) Timer Error callback
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Period elapsed callback in non blocking mode
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the __HAL_TIM_PeriodElapsedCallback could be implemented in the user file
+   */
+
+}
+/**
+  * @brief  Output Compare callback in non blocking mode
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the __HAL_TIM_OC_DelayElapsedCallback could be implemented in the user file
+   */
+}
+/**
+  * @brief  Input Capture callback in non blocking mode
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the __HAL_TIM_IC_CaptureCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  PWM Pulse finished callback in non blocking mode
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the __HAL_TIM_PWM_PulseFinishedCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Hall Trigger detection callback in non blocking mode
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_TriggerCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_TriggerCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Timer error callback in non blocking mode
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_ErrorCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group10 Peripheral State functions
+ *  @brief   Peripheral State functions
+ *
+@verbatim
+  ==============================================================================
+                        ##### Peripheral State functions #####
+  ==============================================================================
+  [..]
+    This subsection permits to get in run-time the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the TIM Base state
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM OC state
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_OC_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM PWM state
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM Input Capture state
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM One Pulse Mode state
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM Encoder Mode state
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  TIM DMA error callback
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void HAL_TIM_DMAError(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  htim->State= HAL_TIM_STATE_READY;
+
+  HAL_TIM_ErrorCallback(htim);
+}
+
+/**
+  * @brief  TIM DMA Delay Pulse complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void HAL_TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  htim->State= HAL_TIM_STATE_READY;
+
+  if (hdma == htim->hdma[TIM_DMA_ID_CC1])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC2])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC3])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
+  }
+
+  HAL_TIM_PWM_PulseFinishedCallback(htim);
+
+  htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+}
+/**
+  * @brief  TIM DMA Capture complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void HAL_TIM_DMACaptureCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+   htim->State= HAL_TIM_STATE_READY;
+
+  if (hdma == htim->hdma[TIM_DMA_ID_CC1])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC2])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC3])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
+  }
+
+  HAL_TIM_IC_CaptureCallback(htim);
+
+  htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+
+}
+
+/**
+  * @brief  TIM DMA Period Elapse complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void TIM_DMAPeriodElapsedCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  htim->State= HAL_TIM_STATE_READY;
+
+  HAL_TIM_PeriodElapsedCallback(htim);
+}
+
+/**
+  * @brief  TIM DMA Trigger callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  htim->State= HAL_TIM_STATE_READY;
+
+  HAL_TIM_TriggerCallback(htim);
+}
+
+/**
+  * @brief  Time Base configuration
+  * @param  TIMx: TIM peripheral
+  * @param  Structure: pointer on TIM Time Base required parameters
+  * @retval None
+  */
+void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure)
+{
+  uint32_t tmpcr1 = 0;
+  tmpcr1 = TIMx->CR1;
+
+  /* Set TIM Time Base Unit parameters ---------------------------------------*/
+  if(IS_TIM_CC3_INSTANCE(TIMx) != RESET)
+  {
+    /* Select the Counter Mode */
+    tmpcr1 &= ~(TIM_CR1_DIR | TIM_CR1_CMS);
+    tmpcr1 |= Structure->CounterMode;
+  }
+
+  if(IS_TIM_CC1_INSTANCE(TIMx) != RESET)
+  {
+    /* Set the clock division */
+    tmpcr1 &= ~TIM_CR1_CKD;
+    tmpcr1 |= (uint32_t)Structure->ClockDivision;
+  }
+
+  TIMx->CR1 = tmpcr1;
+
+  /* Set the Auto-reload value */
+  TIMx->ARR = (uint32_t)Structure->Period ;
+
+  /* Set the Prescaler value */
+  TIMx->PSC = (uint32_t)Structure->Prescaler;
+
+  if(IS_TIM_ADVANCED_INSTANCE(TIMx) != RESET)
+  {
+    /* Set the Repetition Counter value */
+    TIMx->RCR = Structure->RepetitionCounter;
+  }
+
+  /* Generate an update event to reload the Prescaler
+     and the repetition counter(only for TIM1 and TIM8) value immediately */
+  TIMx->EGR = TIM_EGR_UG;
+}
+
+/**
+  * @brief  Time Output Compare 1 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The output configuration structure
+  * @retval None
+  */
+void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+  /* Disable the Channel 1: Reset the CC1E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC1E;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 = TIMx->CR2;
+
+  /* Get the TIMx CCMR1 register value */
+  tmpccmrx = TIMx->CCMR1;
+
+  /* Reset the Output Compare Mode Bits */
+  tmpccmrx &= ~TIM_CCMR1_OC1M;
+  tmpccmrx &= ~TIM_CCMR1_CC1S;
+  /* Select the Output Compare Mode */
+  tmpccmrx |= OC_Config->OCMode;
+
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC1P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= OC_Config->OCPolarity;
+
+
+  if(IS_TIM_ADVANCED_INSTANCE(TIMx) != RESET)
+  {
+    /* Reset the Output N Polarity level */
+    tmpccer &= ~TIM_CCER_CC1NP;
+    /* Set the Output N Polarity */
+    tmpccer |= OC_Config->OCNPolarity;
+    /* Reset the Output N State */
+    tmpccer &= ~TIM_CCER_CC1NE;
+
+    /* Reset the Output Compare and Output Compare N IDLE State */
+    tmpcr2 &= ~TIM_CR2_OIS1;
+    tmpcr2 &= ~TIM_CR2_OIS1N;
+    /* Set the Output Idle state */
+    tmpcr2 |= OC_Config->OCIdleState;
+    /* Set the Output N Idle state */
+    tmpcr2 |= OC_Config->OCNIdleState;
+  }
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+
+  /* Write to TIMx CCMR1 */
+  TIMx->CCMR1 = tmpccmrx;
+
+  /* Set the Capture Compare Register value */
+  TIMx->CCR1 = OC_Config->Pulse;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Time Output Compare 2 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The output configuration structure
+  * @retval None
+  */
+void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+  /* Disable the Channel 2: Reset the CC2E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC2E;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 = TIMx->CR2;
+
+  /* Get the TIMx CCMR1 register value */
+  tmpccmrx = TIMx->CCMR1;
+
+  /* Reset the Output Compare mode and Capture/Compare selection Bits */
+  tmpccmrx &= ~TIM_CCMR1_OC2M;
+  tmpccmrx &= ~TIM_CCMR1_CC2S;
+
+  /* Select the Output Compare Mode */
+  tmpccmrx |= (OC_Config->OCMode << 8);
+
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC2P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 4);
+
+  if(IS_TIM_ADVANCED_INSTANCE(TIMx) != RESET)
+  {
+    assert_param(IS_TIM_OCN_POLARITY(OC_Config->OCNPolarity));
+    assert_param(IS_TIM_OCNIDLE_STATE(OC_Config->OCNIdleState));
+    assert_param(IS_TIM_OCIDLE_STATE(OC_Config->OCIdleState));
+
+    /* Reset the Output N Polarity level */
+    tmpccer &= ~TIM_CCER_CC2NP;
+    /* Set the Output N Polarity */
+    tmpccer |= (OC_Config->OCNPolarity << 4);
+    /* Reset the Output N State */
+    tmpccer &= ~TIM_CCER_CC2NE;
+
+    /* Reset the Output Compare and Output Compare N IDLE State */
+    tmpcr2 &= ~TIM_CR2_OIS2;
+    tmpcr2 &= ~TIM_CR2_OIS2N;
+    /* Set the Output Idle state */
+    tmpcr2 |= (OC_Config->OCIdleState << 2);
+    /* Set the Output N Idle state */
+    tmpcr2 |= (OC_Config->OCNIdleState << 2);
+  }
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+
+  /* Write to TIMx CCMR1 */
+  TIMx->CCMR1 = tmpccmrx;
+
+  /* Set the Capture Compare Register value */
+  TIMx->CCR2 = OC_Config->Pulse;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Time Output Compare 3 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The output configuration structure
+  * @retval None
+  */
+void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+  /* Disable the Channel 3: Reset the CC2E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC3E;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 = TIMx->CR2;
+
+  /* Get the TIMx CCMR2 register value */
+  tmpccmrx = TIMx->CCMR2;
+
+  /* Reset the Output Compare mode and Capture/Compare selection Bits */
+  tmpccmrx &= ~TIM_CCMR2_OC3M;
+  tmpccmrx &= ~TIM_CCMR2_CC3S;
+  /* Select the Output Compare Mode */
+  tmpccmrx |= OC_Config->OCMode;
+
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC3P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 8);
+
+  if(IS_TIM_ADVANCED_INSTANCE(TIMx) != RESET)
+  {
+    assert_param(IS_TIM_OCN_POLARITY(OC_Config->OCNPolarity));
+    assert_param(IS_TIM_OCNIDLE_STATE(OC_Config->OCNIdleState));
+    assert_param(IS_TIM_OCIDLE_STATE(OC_Config->OCIdleState));
+
+    /* Reset the Output N Polarity level */
+    tmpccer &= ~TIM_CCER_CC3NP;
+    /* Set the Output N Polarity */
+    tmpccer |= (OC_Config->OCNPolarity << 8);
+    /* Reset the Output N State */
+    tmpccer &= ~TIM_CCER_CC3NE;
+
+    /* Reset the Output Compare and Output Compare N IDLE State */
+    tmpcr2 &= ~TIM_CR2_OIS3;
+    tmpcr2 &= ~TIM_CR2_OIS3N;
+    /* Set the Output Idle state */
+    tmpcr2 |= (OC_Config->OCIdleState << 4);
+    /* Set the Output N Idle state */
+    tmpcr2 |= (OC_Config->OCNIdleState << 4);
+  }
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+
+  /* Write to TIMx CCMR2 */
+  TIMx->CCMR2 = tmpccmrx;
+
+  /* Set the Capture Compare Register value */
+  TIMx->CCR3 = OC_Config->Pulse;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Time Output Compare 4 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The output configuration structure
+  * @retval None
+  */
+void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+  /* Disable the Channel 4: Reset the CC4E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC4E;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 = TIMx->CR2;
+
+  /* Get the TIMx CCMR2 register value */
+  tmpccmrx = TIMx->CCMR2;
+
+  /* Reset the Output Compare mode and Capture/Compare selection Bits */
+  tmpccmrx &= ~TIM_CCMR2_OC4M;
+  tmpccmrx &= ~TIM_CCMR2_CC4S;
+
+  /* Select the Output Compare Mode */
+  tmpccmrx |= (OC_Config->OCMode << 8);
+
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC4P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 12);
+
+  /*if((TIMx == TIM1) || (TIMx == TIM8))*/
+  if(IS_TIM_ADVANCED_INSTANCE(TIMx) != RESET)
+  {
+    assert_param(IS_TIM_OCIDLE_STATE(OC_Config->OCIdleState));
+    /* Reset the Output Compare IDLE State */
+    tmpcr2 &= ~TIM_CR2_OIS4;
+    /* Set the Output Idle state */
+    tmpcr2 |= (OC_Config->OCIdleState << 6);
+  }
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+
+  /* Write to TIMx CCMR2 */
+  TIMx->CCMR2 = tmpccmrx;
+
+  /* Set the Capture Compare Register value */
+  TIMx->CCR4 = OC_Config->Pulse;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Time Output Compare 4 configuration
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sSlaveConfig: The slave configuration structure
+  * @retval None
+  */
+static void TIM_SlaveTimer_SetConfig(TIM_HandleTypeDef *htim,
+                              TIM_SlaveConfigTypeDef * sSlaveConfig)
+{
+  uint32_t tmpsmcr = 0;
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+ /* Get the TIMx SMCR register value */
+  tmpsmcr = htim->Instance->SMCR;
+
+  /* Reset the Trigger Selection Bits */
+  tmpsmcr &= ~TIM_SMCR_TS;
+  /* Set the Input Trigger source */
+  tmpsmcr |= sSlaveConfig->InputTrigger;
+
+  /* Reset the slave mode Bits */
+  tmpsmcr &= ~TIM_SMCR_SMS;
+  /* Set the slave mode */
+  tmpsmcr |= sSlaveConfig->SlaveMode;
+
+  /* Write to TIMx SMCR */
+  htim->Instance->SMCR = tmpsmcr;
+
+  /* Configure the trigger prescaler, filter, and polarity */
+  switch (sSlaveConfig->InputTrigger)
+  {
+  case TIM_TS_ETRF:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_ETR_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPRESCALER(sSlaveConfig->TriggerPrescaler));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+      /* Configure the ETR Trigger source */
+      TIM_ETR_SetConfig(htim->Instance,
+                        sSlaveConfig->TriggerPrescaler,
+                        sSlaveConfig->TriggerPolarity,
+                        sSlaveConfig->TriggerFilter);
+    }
+    break;
+
+  case TIM_TS_TI1F_ED:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+
+      /* Disable the Channel 1: Reset the CC1E Bit */
+      tmpccer = htim->Instance->CCER;
+      htim->Instance->CCER &= ~TIM_CCER_CC1E;
+      tmpccmr1 = htim->Instance->CCMR1;
+
+      /* Set the filter */
+      tmpccmr1 &= ~TIM_CCMR1_IC1F;
+      tmpccmr1 |= ((sSlaveConfig->TriggerFilter) << 4);
+
+      /* Write to TIMx CCMR1 and CCER registers */
+      htim->Instance->CCMR1 = tmpccmr1;
+      htim->Instance->CCER = tmpccer;
+
+    }
+    break;
+
+  case TIM_TS_TI1FP1:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+
+      /* Configure TI1 Filter and Polarity */
+      TIM_TI1_ConfigInputStage(htim->Instance,
+                               sSlaveConfig->TriggerPolarity,
+                               sSlaveConfig->TriggerFilter);
+    }
+    break;
+
+  case TIM_TS_TI2FP2:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+
+      /* Configure TI2 Filter and Polarity */
+      TIM_TI2_ConfigInputStage(htim->Instance,
+                                sSlaveConfig->TriggerPolarity,
+                                sSlaveConfig->TriggerFilter);
+    }
+    break;
+
+  case TIM_TS_ITR0:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+
+  case TIM_TS_ITR1:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+
+  case TIM_TS_ITR2:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+
+  case TIM_TS_ITR3:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+
+  default:
+    break;
+  }
+}
+
+/**
+  * @brief  Configure the TI1 as Input.
+  * @param  TIMx to select the TIM peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 1 is selected to be connected to IC1.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 1 is selected to be connected to IC2.
+  *            @arg TIM_ICSelection_TRC: TIM Input 1 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  * @note TIM_ICFilter and TIM_ICPolarity are not used in INDIRECT mode as TI2FP1
+  *       (on channel2 path) is used as the input signal. Therefore CCMR1 must be
+  *        protected against un-initialized filter and polarity values.
+  */
+void TIM_TI1_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 1: Reset the CC1E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC1E;
+  tmpccmr1 = TIMx->CCMR1;
+  tmpccer = TIMx->CCER;
+
+  /* Select the Input */
+  if(IS_TIM_CC2_INSTANCE(TIMx) != RESET)
+  {
+    tmpccmr1 &= ~TIM_CCMR1_CC1S;
+    tmpccmr1 |= TIM_ICSelection;
+  }
+  else
+  {
+    tmpccmr1 |= TIM_CCMR1_CC1S_0;
+  }
+
+  /* Set the filter */
+  tmpccmr1 &= ~TIM_CCMR1_IC1F;
+  tmpccmr1 |= ((TIM_ICFilter << 4) & TIM_CCMR1_IC1F);
+
+  /* Select the Polarity and set the CC1E Bit */
+  tmpccer &= ~(TIM_CCER_CC1P | TIM_CCER_CC1NP);
+  tmpccer |= (TIM_ICPolarity & (TIM_CCER_CC1P | TIM_CCER_CC1NP));
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the Polarity and Filter for TI1.
+  * @param  TIMx to select the TIM peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TIM_TI1_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 1: Reset the CC1E Bit */
+  tmpccer = TIMx->CCER;
+  TIMx->CCER &= ~TIM_CCER_CC1E;
+  tmpccmr1 = TIMx->CCMR1;
+
+  /* Set the filter */
+  tmpccmr1 &= ~TIM_CCMR1_IC1F;
+  tmpccmr1 |= (TIM_ICFilter << 4);
+
+  /* Select the Polarity and set the CC1E Bit */
+  tmpccer &= ~(TIM_CCER_CC1P | TIM_CCER_CC1NP);
+  tmpccer |= TIM_ICPolarity;
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI2 as Input.
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 2 is selected to be connected to IC2.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 2 is selected to be connected to IC1.
+  *            @arg TIM_ICSelection_TRC: TIM Input 2 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  * @note TIM_ICFilter and TIM_ICPolarity are not used in INDIRECT mode as TI1FP2
+  *       (on channel1 path) is used as the input signal. Therefore CCMR1 must be
+  *        protected against un-initialized filter and polarity values.
+  */
+static void TIM_TI2_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 2: Reset the CC2E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC2E;
+  tmpccmr1 = TIMx->CCMR1;
+  tmpccer = TIMx->CCER;
+
+  /* Select the Input */
+  tmpccmr1 &= ~TIM_CCMR1_CC2S;
+  tmpccmr1 |= (TIM_ICSelection << 8);
+
+  /* Set the filter */
+  tmpccmr1 &= ~TIM_CCMR1_IC2F;
+  tmpccmr1 |= ((TIM_ICFilter << 12) & TIM_CCMR1_IC2F);
+
+  /* Select the Polarity and set the CC2E Bit */
+  tmpccer &= ~(TIM_CCER_CC2P | TIM_CCER_CC2NP);
+  tmpccer |= ((TIM_ICPolarity << 4) & (TIM_CCER_CC2P | TIM_CCER_CC2NP));
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1 ;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the Polarity and Filter for TI2.
+  * @param  TIMx to select the TIM peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TIM_TI2_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter)
+{
+uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 2: Reset the CC2E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC2E;
+  tmpccmr1 = TIMx->CCMR1;
+  tmpccer = TIMx->CCER;
+
+  /* Set the filter */
+  tmpccmr1 &= ~TIM_CCMR1_IC2F;
+  tmpccmr1 |= (TIM_ICFilter << 12);
+
+  /* Select the Polarity and set the CC2E Bit */
+  tmpccer &= ~(TIM_CCER_CC2P | TIM_CCER_CC2NP);
+  tmpccer |= (TIM_ICPolarity << 4);
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1 ;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI3 as Input.
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 3 is selected to be connected to IC3.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 3 is selected to be connected to IC4.
+  *            @arg TIM_ICSelection_TRC: TIM Input 3 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  * @note TIM_ICFilter and TIM_ICPolarity are not used in INDIRECT mode as TI3FP4
+  *       (on channel1 path) is used as the input signal. Therefore CCMR2 must be
+  *        protected against un-initialized filter and polarity values.
+  */
+static void TIM_TI3_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr2 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 3: Reset the CC3E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC3E;
+  tmpccmr2 = TIMx->CCMR2;
+  tmpccer = TIMx->CCER;
+
+  /* Select the Input */
+  tmpccmr2 &= ~TIM_CCMR2_CC3S;
+  tmpccmr2 |= TIM_ICSelection;
+
+  /* Set the filter */
+  tmpccmr2 &= ~TIM_CCMR2_IC3F;
+  tmpccmr2 |= ((TIM_ICFilter << 4) & TIM_CCMR2_IC3F);
+
+  /* Select the Polarity and set the CC3E Bit */
+  tmpccer &= ~(TIM_CCER_CC3P | TIM_CCER_CC3NP);
+  tmpccer |= ((TIM_ICPolarity << 8) & (TIM_CCER_CC3P | TIM_CCER_CC3NP));
+
+  /* Write to TIMx CCMR2 and CCER registers */
+  TIMx->CCMR2 = tmpccmr2;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI4 as Input.
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 4 is selected to be connected to IC4.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 4 is selected to be connected to IC3.
+  *            @arg TIM_ICSelection_TRC: TIM Input 4 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  * @note TIM_ICFilter and TIM_ICPolarity are not used in INDIRECT mode as TI4FP3
+  *       (on channel1 path) is used as the input signal. Therefore CCMR2 must be
+  *        protected against un-initialized filter and polarity values.
+  */
+static void TIM_TI4_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr2 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 4: Reset the CC4E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC4E;
+  tmpccmr2 = TIMx->CCMR2;
+  tmpccer = TIMx->CCER;
+
+  /* Select the Input */
+  tmpccmr2 &= ~TIM_CCMR2_CC4S;
+  tmpccmr2 |= (TIM_ICSelection << 8);
+
+  /* Set the filter */
+  tmpccmr2 &= ~TIM_CCMR2_IC4F;
+  tmpccmr2 |= ((TIM_ICFilter << 12) & TIM_CCMR2_IC4F);
+
+  /* Select the Polarity and set the CC4E Bit */
+  tmpccer &= ~(TIM_CCER_CC4P | TIM_CCER_CC4NP);
+  tmpccer |= ((TIM_ICPolarity << 12) & (TIM_CCER_CC4P | TIM_CCER_CC4NP));
+
+  /* Write to TIMx CCMR2 and CCER registers */
+  TIMx->CCMR2 = tmpccmr2;
+  TIMx->CCER = tmpccer ;
+}
+
+/**
+  * @brief  Selects the Input Trigger source
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ITRx: The Input Trigger source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TS_ITR0: Internal Trigger 0
+  *            @arg TIM_TS_ITR1: Internal Trigger 1
+  *            @arg TIM_TS_ITR2: Internal Trigger 2
+  *            @arg TIM_TS_ITR3: Internal Trigger 3
+  *            @arg TIM_TS_TI1F_ED: TI1 Edge Detector
+  *            @arg TIM_TS_TI1FP1: Filtered Timer Input 1
+  *            @arg TIM_TS_TI2FP2: Filtered Timer Input 2
+  *            @arg TIM_TS_ETRF: External Trigger input
+  * @retval None
+  */
+static void TIM_ITRx_SetConfig(TIM_TypeDef *TIMx, uint16_t TIM_ITRx)
+{
+  uint32_t tmpsmcr = 0;
+
+   /* Get the TIMx SMCR register value */
+   tmpsmcr = TIMx->SMCR;
+   /* Reset the TS Bits */
+   tmpsmcr &= ~TIM_SMCR_TS;
+   /* Set the Input Trigger source and the slave mode*/
+   tmpsmcr |= TIM_ITRx | TIM_SLAVEMODE_EXTERNAL1;
+   /* Write to TIMx SMCR */
+   TIMx->SMCR = tmpsmcr;
+}
+
+/**
+  * @brief  Configures the TIMx External Trigger (ETR).
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ExtTRGPrescaler: The external Trigger Prescaler.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ExtTRGPSC_DIV1: ETRP Prescaler OFF.
+  *            @arg TIM_ExtTRGPSC_DIV2: ETRP frequency divided by 2.
+  *            @arg TIM_ExtTRGPSC_DIV4: ETRP frequency divided by 4.
+  *            @arg TIM_ExtTRGPSC_DIV8: ETRP frequency divided by 8.
+  * @param  TIM_ExtTRGPolarity: The external Trigger Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ExtTRGPolarity_Inverted: active low or falling edge active.
+  *            @arg TIM_ExtTRGPolarity_NonInverted: active high or rising edge active.
+  * @param  ExtTRGFilter: External Trigger Filter.
+  *          This parameter must be a value between 0x00 and 0x0F
+  * @retval None
+  */
+void TIM_ETR_SetConfig(TIM_TypeDef* TIMx, uint32_t TIM_ExtTRGPrescaler,
+                       uint32_t TIM_ExtTRGPolarity, uint32_t ExtTRGFilter)
+{
+  uint32_t tmpsmcr = 0;
+
+  tmpsmcr = TIMx->SMCR;
+
+  /* Reset the ETR Bits */
+  tmpsmcr &= ~(TIM_SMCR_ETF | TIM_SMCR_ETPS | TIM_SMCR_ECE | TIM_SMCR_ETP);
+
+  /* Set the Prescaler, the Filter value and the Polarity */
+  tmpsmcr |= (uint32_t)(TIM_ExtTRGPrescaler | (TIM_ExtTRGPolarity | (ExtTRGFilter << 8)));
+
+  /* Write to TIMx SMCR */
+  TIMx->SMCR = tmpsmcr;
+}
+
+/**
+  * @brief  Enables or disables the TIM Capture Compare Channel x.
+  * @param  TIMx to select the TIM peripheral
+  * @param  Channel: specifies the TIM Channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_Channel_1: TIM Channel 1
+  *            @arg TIM_Channel_2: TIM Channel 2
+  *            @arg TIM_Channel_3: TIM Channel 3
+  *            @arg TIM_Channel_4: TIM Channel 4
+  * @param  ChannelState: specifies the TIM Channel CCxE bit new state.
+  *          This parameter can be: TIM_CCx_ENABLE or TIM_CCx_Disable.
+  * @retval None
+  */
+void TIM_CCxChannelCmd(TIM_TypeDef* TIMx, uint32_t Channel, uint32_t ChannelState)
+{
+  uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CC1_INSTANCE(TIMx));
+  assert_param(IS_TIM_CHANNELS(Channel));
+
+  tmp = TIM_CCER_CC1E << Channel;
+
+  /* Reset the CCxE Bit */
+  TIMx->CCER &= ~tmp;
+
+  /* Set or reset the CCxE Bit */
+  TIMx->CCER |= (uint32_t)(ChannelState << Channel);
+}
+
+
+/**
+  * @}
+  */
+
+#endif /* HAL_TIM_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_tim_ex.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_tim_ex.c
@@ -1,0 +1,2481 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_tim_ex.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   TIM HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Timer extension peripheral:
+  *           + Time Hall Sensor Interface Initialization
+  *           + Time Hall Sensor Interface Start
+  *           + Time Complementary signal bread and dead time configuration
+  *           + Time Master and Slave synchronization configuration
+  *           + Time Output Compare/PWM Channel Configuration (for channels 5 and 6)
+  *           + Time OCRef clear configuration
+  *           + Timer remapping capabilities configuration
+  @verbatim
+  ==============================================================================
+                      ##### TIMER Extended features #####
+  ==============================================================================
+  [..]
+    The Timer Extension features include:
+    (#) Complementary outputs with programmable dead-time for :
+        (++) Input Capture
+        (++) Output Compare
+        (++) PWM generation (Edge and Center-aligned Mode)
+        (++) One-pulse mode output
+    (#) Synchronization circuit to control the timer with external signals and to
+        interconnect several timers together.
+    (#) Break input to put the timer output signals in reset state or in a known state.
+    (#) Supports incremental (quadrature) encoder and hall-sensor circuitry for
+        positioning purposes
+
+                        ##### How to use this driver #####
+  ==============================================================================
+  [..]
+     (#) Initialize the TIM low level resources by implementing the following functions
+         depending from feature used :
+           (++) Complementary Output Compare : HAL_TIM_OC_MspInit()
+           (++) Complementary PWM generation : HAL_TIM_PWM_MspInit()
+           (++) Complementary One-pulse mode output : HAL_TIM_OnePulse_MspInit()
+           (++) Hall Sensor output : HAL_TIM_HallSensor_MspInit()
+
+     (#) Initialize the TIM low level resources :
+        (##) Enable the TIM interface clock using __TIMx_CLK_ENABLE();
+        (##) TIM pins configuration
+            (+++) Enable the clock for the TIM GPIOs using the following function:
+                 __GPIOx_CLK_ENABLE();
+            (+++) Configure these TIM pins in Alternate function mode using HAL_GPIO_Init();
+
+     (#) The external Clock can be configured, if needed (the default clock is the
+         internal clock from the APBx), using the following function:
+         HAL_TIM_ConfigClockSource, the clock configuration should be done before
+         any start function.
+
+    (#) Configure the TIM in the desired functioning mode using one of the
+        initialization function of this driver:
+        (++) HAL_TIMEx_HallSensor_Init and HAL_TIMEx_ConfigCommutationEvent: to use the
+             Timer Hall Sensor Interface and the commutation event with the corresponding
+             Interrupt and DMA request if needed (Note that One Timer is used to interface
+             with the Hall sensor Interface and another Timer should be used to use
+             the commutation event).
+
+    (#) Activate the TIM peripheral using one of the start functions:
+           (++) Complementary Output Compare : HAL_TIMEx_OCN_Start(), HAL_TIMEx_OCN_Start_DMA(), HAL_TIMEx_OC_Start_IT()
+           (++) Complementary PWM generation : HAL_TIMEx_PWMN_Start(), HAL_TIMEx_PWMN_Start_DMA(), HAL_TIMEx_PWMN_Start_IT()
+           (++) Complementary One-pulse mode output : HAL_TIMEx_OnePulseN_Start(), HAL_TIMEx_OnePulseN_Start_IT()
+           (++) Hall Sensor output : HAL_TIMEx_HallSensor_Start(), HAL_TIMEx_HallSensor_Start_DMA(), HAL_TIMEx_HallSensor_Start_IT().
+
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup TIMEx TIMEx
+  * @brief TIM Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define BDTR_BKF_SHIFT  (16)
+#define BDTR_BK2F_SHIFT (20)
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @addtogroup TIMEx_Private_Functions
+  * @{
+  */
+static void TIM_CCxNChannelCmd(TIM_TypeDef* TIMx, uint32_t Channel, uint32_t ChannelNState);
+static void TIM_OC5_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+static void TIM_OC6_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+/**
+  * @}
+  */
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup TIMEx_Exported_Functions TIMEx Exported Functions
+  * @{
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group1 Extended Timer Hall Sensor functions
+ *  @brief    Timer Hall Sensor functions
+ *
+@verbatim
+  ==============================================================================
+                      ##### Timer Hall Sensor functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Initialize and configure TIM HAL Sensor.
+    (+) De-initialize TIM HAL Sensor.
+    (+) Start the Hall Sensor Interface.
+    (+) Stop the Hall Sensor Interface.
+    (+) Start the Hall Sensor Interface and enable interrupts.
+    (+) Stop the Hall Sensor Interface and disable interrupts.
+    (+) Start the Hall Sensor Interface and enable DMA transfers.
+    (+) Stop the Hall Sensor Interface and disable DMA transfers.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM Hall Sensor Interface and create the associated handle.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sConfig: TIM Hall Sensor configuration structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef *htim, TIM_HallSensor_InitTypeDef* sConfig)
+{
+  TIM_OC_InitTypeDef OC_Config;
+
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+  assert_param(IS_TIM_IC_POLARITY(sConfig->IC1Polarity));
+  assert_param(IS_TIM_IC_PRESCALER(sConfig->IC1Prescaler));
+  assert_param(IS_TIM_IC_FILTER(sConfig->IC1Filter));
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+  HAL_TIMEx_HallSensor_MspInit(htim);
+
+  /* Configure the Time base in the Encoder Mode */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+
+  /* Configure the Channel 1 as Input Channel to interface with the three Outputs of the  Hall sensor */
+  TIM_TI1_SetConfig(htim->Instance, sConfig->IC1Polarity, TIM_ICSELECTION_TRC, sConfig->IC1Filter);
+
+  /* Reset the IC1PSC Bits */
+  htim->Instance->CCMR1 &= ~TIM_CCMR1_IC1PSC;
+  /* Set the IC1PSC value */
+  htim->Instance->CCMR1 |= sConfig->IC1Prescaler;
+
+  /* Enable the Hall sensor interface (XOR function of the three inputs) */
+  htim->Instance->CR2 |= TIM_CR2_TI1S;
+
+  /* Select the TIM_TS_TI1F_ED signal as Input trigger for the TIM */
+  htim->Instance->SMCR &= ~TIM_SMCR_TS;
+  htim->Instance->SMCR |= TIM_TS_TI1F_ED;
+
+  /* Use the TIM_TS_TI1F_ED signal to reset the TIM counter each edge detection */
+  htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+  htim->Instance->SMCR |= TIM_SLAVEMODE_RESET;
+
+  /* Program channel 2 in PWM 2 mode with the desired Commutation_Delay*/
+  OC_Config.OCFastMode = TIM_OCFAST_DISABLE;
+  OC_Config.OCIdleState = TIM_OCIDLESTATE_RESET;
+  OC_Config.OCMode = TIM_OCMODE_PWM2;
+  OC_Config.OCNIdleState = TIM_OCNIDLESTATE_RESET;
+  OC_Config.OCNPolarity = TIM_OCNPOLARITY_HIGH;
+  OC_Config.OCPolarity = TIM_OCPOLARITY_HIGH;
+  OC_Config.Pulse = sConfig->Commutation_Delay;
+
+  TIM_OC2_SetConfig(htim->Instance, &OC_Config);
+
+  /* Select OC2REF as trigger output on TRGO: write the MMS bits in the TIMx_CR2
+    register to 101 */
+  htim->Instance->CR2 &= ~TIM_CR2_MMS;
+  htim->Instance->CR2 |= TIM_TRGO_OC2REF;
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM Hall Sensor interface
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_TIMEx_HallSensor_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Hall Sensor MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIMEx_HallSensor_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIMEx_HallSensor_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM Hall Sensor MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIMEx_HallSensor_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIMEx_HallSensor_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the TIM Hall Sensor Interface.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+
+  /* Enable the Input Capture channels 1
+    (in the Hall Sensor Interface the Three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Hall sensor Interface.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+
+  /* Disable the Input Capture channels 1, 2 and 3
+    (in the Hall Sensor Interface the Three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Hall Sensor Interface in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_IT(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+
+  /* Enable the capture compare Interrupts 1 event */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+
+  /* Enable the Input Capture channels 1
+    (in the Hall Sensor Interface the Three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Hall Sensor Interface in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_IT(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+
+  /* Disable the Input Capture channels 1
+    (in the Hall Sensor Interface the Three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+
+  /* Disable the capture compare Interrupts event */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Hall Sensor Interface in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  pData: The destination Buffer address.
+  * @param  Length: The length of data to be transferred from TIM peripheral to memory.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+
+   if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if(((uint32_t)pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  /* Enable the Input Capture channels 1
+    (in the Hall Sensor Interface the Three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+
+  /* Set the DMA Input Capture 1 Callback */
+  htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+  /* Set the DMA error callback */
+  htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+
+  /* Enable the DMA Stream for Capture 1*/
+  HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData, Length);
+
+  /* Enable the capture compare 1 Interrupt */
+  __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Hall Sensor Interface in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_DMA(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+
+  /* Disable the Input Capture channels 1
+    (in the Hall Sensor Interface the Three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+
+
+  /* Disable the capture compare Interrupts 1 event */
+  __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group2 Extended Timer Complementary Output Compare functions
+ *  @brief    Timer Complementary Output Compare functions
+ *
+@verbatim
+  ==============================================================================
+              ##### Timer Complementary Output Compare functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Start the Complementary Output Compare/PWM.
+    (+) Stop the Complementary Output Compare/PWM.
+    (+) Start the Complementary Output Compare/PWM and enable interrupts.
+    (+) Stop the Complementary Output Compare/PWM and disable interrupts.
+    (+) Start the Complementary Output Compare/PWM and enable DMA transfers.
+    (+) Stop the Complementary Output Compare/PWM and disable DMA transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation on the complementary
+  *         output.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+     /* Enable the Capture compare channel N */
+     TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Output */
+    __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation on the complementary
+  *         output.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+    /* Disable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+  /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation in interrupt mode
+  *         on the complementary output.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Enable the TIM Output Compare interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Output Compare interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Output Compare interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Output Compare interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the TIM Break interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_BREAK);
+
+  /* Enable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Output */
+ __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation in interrupt mode
+  *         on the complementary output.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  uint32_t tmpccer = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Output Compare interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Output Compare interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Output Compare interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Output Compare interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+  /* Disable the TIM Break interrupt (only if no more channel is active) */
+  tmpccer = htim->Instance->CCER;
+  if ((tmpccer & (TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE)) == RESET)
+  {
+    __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
+  }
+
+  /* Disable the Main Output */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation in DMA mode
+  *         on the complementary output.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to TIM peripheral
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if(((uint32_t)pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length);
+
+      /* Enable the TIM Output Compare DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length);
+
+      /* Enable the TIM Output Compare DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+{
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,Length);
+
+      /* Enable the TIM Output Compare DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+     /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length);
+
+      /* Enable the TIM Output Compare DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Output */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation in DMA mode
+  *         on the complementary output.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Output Compare DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Output Compare DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Output Compare DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Output Compare interrupt */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+  /* Disable the Main Output */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group3 Extended Timer Complementary PWM functions
+ *  @brief    Timer Complementary PWM functions
+ *
+@verbatim
+  ==============================================================================
+                 ##### Timer Complementary PWM functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Start the Complementary PWM.
+    (+) Stop the Complementary PWM.
+    (+) Start the Complementary PWM and enable interrupts.
+    (+) Stop the Complementary PWM and disable interrupts.
+    (+) Start the Complementary PWM and enable DMA transfers.
+    (+) Stop the Complementary PWM and disable DMA transfers.
+    (+) Start the Complementary Input Capture measurement.
+    (+) Stop the Complementary Input Capture.
+    (+) Start the Complementary Input Capture and enable interrupts.
+    (+) Stop the Complementary Input Capture and disable interrupts.
+    (+) Start the Complementary Input Capture and enable DMA transfers.
+    (+) Stop the Complementary Input Capture and disable DMA transfers.
+    (+) Start the Complementary One Pulse generation.
+    (+) Stop the Complementary One Pulse.
+    (+) Start the Complementary One Pulse and enable interrupts.
+    (+) Stop the Complementary One Pulse and disable interrupts.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Starts the PWM signal generation on the complementary output.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  /* Enable the complementary PWM output  */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Output */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the PWM signal generation on the complementary output.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  /* Disable the complementary PWM output  */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+  /* Disable the Main Output */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the PWM signal generation in interrupt mode on the
+  *         complementary output.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Enable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the TIM Break interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_BREAK);
+
+  /* Enable the complementary PWM output  */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Output */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the PWM signal generation in interrupt mode on the
+  *         complementary output.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT (TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  uint32_t tmpccer = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the complementary PWM output  */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+  /* Disable the TIM Break interrupt (only if no more channel is active) */
+  tmpccer = htim->Instance->CCER;
+  if ((tmpccer & (TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE)) == RESET)
+  {
+    __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
+  }
+
+  /* Disable the Main Output */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM PWM signal generation in DMA mode on the
+  *         complementary output
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to TIM peripheral
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if(((uint32_t)pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length);
+
+      /* Enable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length);
+
+      /* Enable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,Length);
+
+      /* Enable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+     /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = HAL_TIM_DMAError ;
+
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length);
+
+      /* Enable the TIM Capture/Compare 4 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the complementary PWM output  */
+     TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Output */
+    __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM PWM signal generation in DMA mode on the complementary
+  *         output
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the complementary PWM output */
+    TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+  /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group4 Extended Timer Complementary One Pulse functions
+ *  @brief    Timer Complementary One Pulse functions
+ *
+@verbatim
+  ==============================================================================
+                ##### Timer Complementary One Pulse functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Start the Complementary One Pulse generation.
+    (+) Stop the Complementary One Pulse.
+    (+) Start the Complementary One Pulse and enable interrupts.
+    (+) Stop the Complementary One Pulse and disable interrupts.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Starts the TIM One Pulse signal generation on the complemetary
+  *         output.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OutputChannel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+  {
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
+
+  /* Enable the complementary One Pulse output */
+  TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Output */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM One Pulse signal generation on the complementary
+  *         output.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OutputChannel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
+
+  /* Disable the complementary One Pulse output */
+    TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_DISABLE);
+
+  /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM One Pulse signal generation in interrupt mode on the
+  *         complementary channel.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OutputChannel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
+
+  /* Enable the TIM Capture/Compare 1 interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+
+  /* Enable the TIM Capture/Compare 2 interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+
+  /* Enable the complementary One Pulse output */
+  TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Output */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+  }
+
+/**
+  * @brief  Stops the TIM One Pulse signal generation in interrupt mode on the
+  *         complementary channel.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OutputChannel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
+
+  /* Disable the TIM Capture/Compare 1 interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+
+  /* Disable the TIM Capture/Compare 2 interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+
+  /* Disable the complementary One Pulse output */
+  TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_DISABLE);
+
+  /* Disable the Main Output */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+   __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group5 Extended Peripheral Control functions
+ *  @brief   	Peripheral Control functions
+ *
+@verbatim
+  ==============================================================================
+                    ##### Peripheral Control functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Configure The Input Output channels for OC, PWM, IC or One Pulse mode.
+    (+) Configure External Clock source.
+    (+) Configure Complementary channels, break features and dead time.
+    (+) Configure Master and the Slave synchronization.
+    (+) Configure the commutation event in case of use of the Hall sensor interface.
+    (+) Configure the DMA Burst Mode.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Configure the TIM commutation event sequence.
+  * @note  This function is mandatory to use the commutation event in order to
+  *        update the configuration at each commutation detection on the TRGI input of the Timer,
+  *        the typical use of this feature is with the use of another Timer(interface Timer)
+  *        configured in Hall sensor interface, this interface Timer will generate the
+  *        commutation at its TRGO output (connected to Timer used in this function) each time
+  *        the TI1 of the Interface Timer detect a commutation at its input TI1.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  InputTrigger: the Internal trigger corresponding to the Timer Interfacing with the Hall sensor.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TS_ITR0: Internal trigger 0 selected
+  *            @arg TIM_TS_ITR1: Internal trigger 1 selected
+  *            @arg TIM_TS_ITR2: Internal trigger 2 selected
+  *            @arg TIM_TS_ITR3: Internal trigger 3 selected
+  *            @arg TIM_TS_NONE: No trigger is needed
+  * @param  CommutationSource: the Commutation Event source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_COMMUTATION_TRGI: Commutation source is the TRGI of the Interface Timer
+  *            @arg TIM_COMMUTATION_SOFTWARE:  Commutation source is set by software using the COMG bit
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent(TIM_HandleTypeDef *htim, uint32_t  InputTrigger, uint32_t  CommutationSource)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ADVANCED_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_INTERNAL_TRIGGEREVENT_SELECTION(InputTrigger));
+
+  __HAL_LOCK(htim);
+
+  if ((InputTrigger == TIM_TS_ITR0) || (InputTrigger == TIM_TS_ITR1) ||
+      (InputTrigger == TIM_TS_ITR2) || (InputTrigger == TIM_TS_ITR3))
+  {
+    /* Select the Input trigger */
+    htim->Instance->SMCR &= ~TIM_SMCR_TS;
+    htim->Instance->SMCR |= InputTrigger;
+  }
+
+  /* Select the Capture Compare preload feature */
+  htim->Instance->CR2 |= TIM_CR2_CCPC;
+  /* Select the Commutation event source */
+  htim->Instance->CR2 &= ~TIM_CR2_CCUS;
+  htim->Instance->CR2 |= CommutationSource;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configure the TIM commutation event sequence with interrupt.
+  * @note  This function is mandatory to use the commutation event in order to
+  *        update the configuration at each commutation detection on the TRGI input of the Timer,
+  *        the typical use of this feature is with the use of another Timer(interface Timer)
+  *        configured in Hall sensor interface, this interface Timer will generate the
+  *        commutation at its TRGO output (connected to Timer used in this function) each time
+  *        the TI1 of the Interface Timer detect a commutation at its input TI1.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  InputTrigger: the Internal trigger corresponding to the Timer Interfacing with the Hall sensor.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TS_ITR0: Internal trigger 0 selected
+  *            @arg TIM_TS_ITR1: Internal trigger 1 selected
+  *            @arg TIM_TS_ITR2: Internal trigger 2 selected
+  *            @arg TIM_TS_ITR3: Internal trigger 3 selected
+  *            @arg TIM_TS_NONE: No trigger is needed
+  * @param  CommutationSource: the Commutation Event source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_COMMUTATION_TRGI: Commutation source is the TRGI of the Interface Timer
+  *            @arg TIM_COMMUTATION_SOFTWARE:  Commutation source is set by software using the COMG bit
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent_IT(TIM_HandleTypeDef *htim, uint32_t  InputTrigger, uint32_t  CommutationSource)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ADVANCED_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_INTERNAL_TRIGGEREVENT_SELECTION(InputTrigger));
+
+  __HAL_LOCK(htim);
+
+  if ((InputTrigger == TIM_TS_ITR0) || (InputTrigger == TIM_TS_ITR1) ||
+      (InputTrigger == TIM_TS_ITR2) || (InputTrigger == TIM_TS_ITR3))
+  {
+    /* Select the Input trigger */
+    htim->Instance->SMCR &= ~TIM_SMCR_TS;
+    htim->Instance->SMCR |= InputTrigger;
+  }
+
+  /* Select the Capture Compare preload feature */
+  htim->Instance->CR2 |= TIM_CR2_CCPC;
+  /* Select the Commutation event source */
+  htim->Instance->CR2 &= ~TIM_CR2_CCUS;
+  htim->Instance->CR2 |= CommutationSource;
+
+  /* Enable the Commutation Interrupt Request */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_COM);
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configure the TIM commutation event sequence with DMA.
+  * @note  This function is mandatory to use the commutation event in order to
+  *        update the configuration at each commutation detection on the TRGI input of the Timer,
+  *        the typical use of this feature is with the use of another Timer(interface Timer)
+  *        configured in Hall sensor interface, this interface Timer will generate the
+  *        commutation at its TRGO output (connected to Timer used in this function) each time
+  *        the TI1 of the Interface Timer detect a commutation at its input TI1.
+  * @note: The user should configure the DMA in his own software, in This function only the COMDE bit is set
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  InputTrigger: the Internal trigger corresponding to the Timer Interfacing with the Hall sensor.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TS_ITR0: Internal trigger 0 selected
+  *            @arg TIM_TS_ITR1: Internal trigger 1 selected
+  *            @arg TIM_TS_ITR2: Internal trigger 2 selected
+  *            @arg TIM_TS_ITR3: Internal trigger 3 selected
+  *            @arg TIM_TS_NONE: No trigger is needed
+  * @param  CommutationSource: the Commutation Event source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_COMMUTATION_TRGI: Commutation source is the TRGI of the Interface Timer
+  *            @arg TIM_COMMUTATION_SOFTWARE:  Commutation source is set by software using the COMG bit
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent_DMA(TIM_HandleTypeDef *htim, uint32_t  InputTrigger, uint32_t  CommutationSource)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ADVANCED_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_INTERNAL_TRIGGEREVENT_SELECTION(InputTrigger));
+
+  __HAL_LOCK(htim);
+
+  if ((InputTrigger == TIM_TS_ITR0) || (InputTrigger == TIM_TS_ITR1) ||
+      (InputTrigger == TIM_TS_ITR2) || (InputTrigger == TIM_TS_ITR3))
+  {
+    /* Select the Input trigger */
+    htim->Instance->SMCR &= ~TIM_SMCR_TS;
+    htim->Instance->SMCR |= InputTrigger;
+  }
+
+  /* Select the Capture Compare preload feature */
+  htim->Instance->CR2 |= TIM_CR2_CCPC;
+  /* Select the Commutation event source */
+  htim->Instance->CR2 &= ~TIM_CR2_CCUS;
+  htim->Instance->CR2 |= CommutationSource;
+
+  /* Enable the Commutation DMA Request */
+  /* Set the DMA Commutation Callback */
+  htim->hdma[TIM_DMA_ID_COMMUTATION]->XferCpltCallback = HAL_TIMEx_DMACommutationCplt;
+  /* Set the DMA error callback */
+  htim->hdma[TIM_DMA_ID_COMMUTATION]->XferErrorCallback = HAL_TIM_DMAError;
+
+  /* Enable the Commutation DMA Request */
+  __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_COM);
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Output Compare Channels according to the specified
+  *         parameters in the TIM_OC_InitTypeDef.
+  * @param  htim: TIM Output Compare handle
+  * @param  sConfig: TIM Output Compare configuration structure
+  * @param  Channel : TIM Channels to configure
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  *            @arg TIM_CHANNEL_ALL: all output channels supported by the timer instance selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CHANNELS(Channel));
+  assert_param(IS_TIM_OC_MODE(sConfig->OCMode));
+  assert_param(IS_TIM_OC_POLARITY(sConfig->OCPolarity));
+  assert_param(IS_TIM_OCN_POLARITY(sConfig->OCNPolarity));
+  assert_param(IS_TIM_OCNIDLE_STATE(sConfig->OCNIdleState));
+  assert_param(IS_TIM_OCIDLE_STATE(sConfig->OCIdleState));
+
+  /* Check input state */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+
+     /* Configure the TIM Channel 1 in Output Compare */
+      TIM_OC1_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+      /* Configure the TIM Channel 2 in Output Compare */
+      TIM_OC2_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+
+      /* Configure the TIM Channel 3 in Output Compare */
+      TIM_OC3_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+
+       /* Configure the TIM Channel 4 in Output Compare */
+       TIM_OC4_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_5:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC5_INSTANCE(htim->Instance));
+
+       /* Configure the TIM Channel 5 in Output Compare */
+       TIM_OC5_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_6:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC6_INSTANCE(htim->Instance));
+
+       /* Configure the TIM Channel 6 in Output Compare */
+       TIM_OC6_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM PWM  channels according to the specified
+  *         parameters in the TIM_OC_InitTypeDef.
+  * @param  htim: TIM PWM handle
+  * @param  sConfig: TIM PWM configuration structure
+  * @param  Channel : TIM Channels to be configured
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  *            @arg TIM_CHANNEL_ALL: all PWM channels supported by the timer instance selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim,
+                                            TIM_OC_InitTypeDef* sConfig,
+                                            uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CHANNELS(Channel));
+  assert_param(IS_TIM_PWM_MODE(sConfig->OCMode));
+  assert_param(IS_TIM_OC_POLARITY(sConfig->OCPolarity));
+  assert_param(IS_TIM_OCN_POLARITY(sConfig->OCNPolarity));
+  assert_param(IS_TIM_FAST_STATE(sConfig->OCFastMode));
+  assert_param(IS_TIM_OCNIDLE_STATE(sConfig->OCNIdleState));
+  assert_param(IS_TIM_OCIDLE_STATE(sConfig->OCIdleState));
+
+  /* Check input state */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+
+      /* Configure the Channel 1 in PWM mode */
+      TIM_OC1_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel1 */
+      htim->Instance->CCMR1 |= TIM_CCMR1_OC1PE;
+
+      /* Configure the Output Fast mode */
+      htim->Instance->CCMR1 &= ~TIM_CCMR1_OC1FE;
+      htim->Instance->CCMR1 |= sConfig->OCFastMode;
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+      /* Configure the Channel 2 in PWM mode */
+      TIM_OC2_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel2 */
+      htim->Instance->CCMR1 |= TIM_CCMR1_OC2PE;
+
+      /* Configure the Output Fast mode */
+      htim->Instance->CCMR1 &= ~TIM_CCMR1_OC2FE;
+      htim->Instance->CCMR1 |= sConfig->OCFastMode << 8;
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+
+      /* Configure the Channel 3 in PWM mode */
+      TIM_OC3_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel3 */
+      htim->Instance->CCMR2 |= TIM_CCMR2_OC3PE;
+
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR2 &= ~TIM_CCMR2_OC3FE;
+      htim->Instance->CCMR2 |= sConfig->OCFastMode;
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+
+      /* Configure the Channel 4 in PWM mode */
+      TIM_OC4_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel4 */
+      htim->Instance->CCMR2 |= TIM_CCMR2_OC4PE;
+
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR2 &= ~TIM_CCMR2_OC4FE;
+      htim->Instance->CCMR2 |= sConfig->OCFastMode << 8;
+    }
+    break;
+
+    case TIM_CHANNEL_5:
+    {
+       /* Check the parameters */
+      assert_param(IS_TIM_CC5_INSTANCE(htim->Instance));
+
+     /* Configure the Channel 5 in PWM mode */
+      TIM_OC5_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel5*/
+      htim->Instance->CCMR3 |= TIM_CCMR3_OC5PE;
+
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR3 &= ~TIM_CCMR3_OC5FE;
+      htim->Instance->CCMR3 |= sConfig->OCFastMode;
+    }
+    break;
+
+    case TIM_CHANNEL_6:
+    {
+       /* Check the parameters */
+      assert_param(IS_TIM_CC6_INSTANCE(htim->Instance));
+
+     /* Configure the Channel 5 in PWM mode */
+      TIM_OC6_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel6 */
+      htim->Instance->CCMR3 |= TIM_CCMR3_OC6PE;
+
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR3 &= ~TIM_CCMR3_OC6FE;
+      htim->Instance->CCMR3 |= sConfig->OCFastMode << 8;
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the OCRef clear feature
+  * @param  htim: TIM handle
+  * @param  sClearInputConfig: pointer to a TIM_ClearInputConfigTypeDef structure that
+  *         contains the OCREF clear feature and parameters for the TIM peripheral.
+  * @param  Channel: specifies the TIM Channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_Channel_1: TIM Channel 1
+  *            @arg TIM_Channel_2: TIM Channel 2
+  *            @arg TIM_Channel_3: TIM Channel 3
+  *            @arg TIM_Channel_4: TIM Channel 4
+  *            @arg TIM_Channel_5: TIM Channel 5
+  *            @arg TIM_Channel_6: TIM Channel 6
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim,
+                                           TIM_ClearInputConfigTypeDef *sClearInputConfig,
+                                           uint32_t Channel)
+{
+  uint32_t tmpsmcr = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_OCXREF_CLEAR_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_CLEARINPUT_SOURCE(sClearInputConfig->ClearInputSource));
+
+  /* Check input state */
+  __HAL_LOCK(htim);
+
+  switch (sClearInputConfig->ClearInputSource)
+  {
+    case TIM_CLEARINPUTSOURCE_NONE:
+    {
+      /* Clear the OCREF clear selection bit */
+      tmpsmcr &= ~TIM_SMCR_OCCS;
+
+      /* Clear the ETR Bits */
+      tmpsmcr &= ~(TIM_SMCR_ETF | TIM_SMCR_ETPS | TIM_SMCR_ECE | TIM_SMCR_ETP);
+
+      /* Set TIMx_SMCR */
+      htim->Instance->SMCR = tmpsmcr;
+   }
+    break;
+
+    case TIM_CLEARINPUTSOURCE_OCREFCLR:
+    {
+      /* Clear the OCREF clear selection bit */
+      htim->Instance->SMCR &= ~TIM_SMCR_OCCS;
+    }
+    break;
+
+    case TIM_CLEARINPUTSOURCE_ETR:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CLEARINPUT_POLARITY(sClearInputConfig->ClearInputPolarity));
+      assert_param(IS_TIM_CLEARINPUT_PRESCALER(sClearInputConfig->ClearInputPrescaler));
+      assert_param(IS_TIM_CLEARINPUT_FILTER(sClearInputConfig->ClearInputFilter));
+
+      TIM_ETR_SetConfig(htim->Instance,
+                        sClearInputConfig->ClearInputPrescaler,
+                        sClearInputConfig->ClearInputPolarity,
+                        sClearInputConfig->ClearInputFilter);
+
+      /* Set the OCREF clear selection bit */
+      htim->Instance->SMCR |= TIM_SMCR_OCCS;
+    }
+    break;
+    default:
+    break;
+  }
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+      {
+        if(sClearInputConfig->ClearInputState != RESET)
+        {
+          /* Enable the Ocref clear feature for Channel 1 */
+          htim->Instance->CCMR1 |= TIM_CCMR1_OC1CE;
+        }
+        else
+        {
+          /* Disable the Ocref clear feature for Channel 1 */
+          htim->Instance->CCMR1 &= ~TIM_CCMR1_OC1CE;
+        }
+      }
+      break;
+    case TIM_CHANNEL_2:
+      {
+        if(sClearInputConfig->ClearInputState != RESET)
+        {
+          /* Enable the Ocref clear feature for Channel 2 */
+          htim->Instance->CCMR1 |= TIM_CCMR1_OC2CE;
+        }
+        else
+        {
+          /* Disable the Ocref clear feature for Channel 2 */
+          htim->Instance->CCMR1 &= ~TIM_CCMR1_OC2CE;
+        }
+      }
+    break;
+    case TIM_CHANNEL_3:
+      {
+        if(sClearInputConfig->ClearInputState != RESET)
+        {
+          /* Enable the Ocref clear feature for Channel 3 */
+          htim->Instance->CCMR2 |= TIM_CCMR2_OC3CE;
+        }
+        else
+        {
+          /* Disable the Ocref clear feature for Channel 3 */
+          htim->Instance->CCMR2 &= ~TIM_CCMR2_OC3CE;
+        }
+      }
+    break;
+    case TIM_CHANNEL_4:
+      {
+        if(sClearInputConfig->ClearInputState != RESET)
+        {
+          /* Enable the Ocref clear feature for Channel 4 */
+          htim->Instance->CCMR2 |= TIM_CCMR2_OC4CE;
+        }
+        else
+        {
+          /* Disable the Ocref clear feature for Channel 4 */
+          htim->Instance->CCMR2 &= ~TIM_CCMR2_OC4CE;
+        }
+      }
+    break;
+    case TIM_CHANNEL_5:
+      {
+        if(sClearInputConfig->ClearInputState != RESET)
+        {
+          /* Enable the Ocref clear feature for Channel 1 */
+          htim->Instance->CCMR3 |= TIM_CCMR3_OC5CE;
+        }
+        else
+        {
+          /* Disable the Ocref clear feature for Channel 1 */
+          htim->Instance->CCMR3 &= ~TIM_CCMR3_OC5CE;
+        }
+      }
+    break;
+    case TIM_CHANNEL_6:
+      {
+        if(sClearInputConfig->ClearInputState != RESET)
+        {
+          /* Enable the Ocref clear feature for Channel 1 */
+          htim->Instance->CCMR3 |= TIM_CCMR3_OC6CE;
+        }
+        else
+        {
+          /* Disable the Ocref clear feature for Channel 1 */
+          htim->Instance->CCMR3 &= ~TIM_CCMR3_OC6CE;
+        }
+      }
+    break;
+    default:
+    break;
+  }
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the TIM in master mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sMasterConfig: pointer to a TIM_MasterConfigTypeDef structure that
+  *         contains the selected trigger output (TRGO) and the Master/Slave
+  *         mode.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim, TIM_MasterConfigTypeDef * sMasterConfig)
+{
+  uint32_t tmpcr2;
+  uint32_t tmpsmcr;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_SYNCHRO_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_TRGO_SOURCE(sMasterConfig->MasterOutputTrigger));
+  assert_param(IS_TIM_MSM_STATE(sMasterConfig->MasterSlaveMode));
+
+  /* Check input state */
+  __HAL_LOCK(htim);
+
+ /* Get the TIMx CR2 register value */
+  tmpcr2 = htim->Instance->CR2;
+
+  /* Get the TIMx SMCR register value */
+  tmpsmcr = htim->Instance->SMCR;
+
+  /* If the timer supports ADC synchronization through TRGO2, set the master mode selection 2 */
+  if (IS_TIM_TRGO2_INSTANCE(htim->Instance))
+  {
+    /* Check the parameters */
+    assert_param(IS_TIM_TRGO2_SOURCE(sMasterConfig->MasterOutputTrigger2));
+
+    /* Clear the MMS2 bits */
+    tmpcr2 &= ~TIM_CR2_MMS2;
+    /* Select the TRGO2 source*/
+    tmpcr2 |= sMasterConfig->MasterOutputTrigger2;
+  }
+
+  /* Reset the MMS Bits */
+  tmpcr2 &= ~TIM_CR2_MMS;
+  /* Select the TRGO source */
+  tmpcr2 |=  sMasterConfig->MasterOutputTrigger;
+
+  /* Reset the MSM Bit */
+  tmpsmcr &= ~TIM_SMCR_MSM;
+  /* Set master mode */
+  tmpsmcr |= sMasterConfig->MasterSlaveMode;
+
+  /* Update TIMx CR2 */
+  htim->Instance->CR2 = tmpcr2;
+
+  /* Update TIMx SMCR */
+  htim->Instance->SMCR = tmpsmcr;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief   Configures the Break feature, dead time, Lock level, OSSI/OSSR State
+  *         and the AOE(automatic output enable).
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sBreakDeadTimeConfig: pointer to a TIM_ConfigBreakDeadConfig_TypeDef structure that
+  *         contains the BDTR Register configuration  information for the TIM peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
+                                              TIM_BreakDeadTimeConfigTypeDef * sBreakDeadTimeConfig)
+{
+  uint32_t tmpbdtr = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_BREAK_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_OSSR_STATE(sBreakDeadTimeConfig->OffStateRunMode));
+  assert_param(IS_TIM_OSSI_STATE(sBreakDeadTimeConfig->OffStateIDLEMode));
+  assert_param(IS_TIM_LOCK_LEVEL(sBreakDeadTimeConfig->LockLevel));
+  assert_param(IS_TIM_DEADTIME(sBreakDeadTimeConfig->DeadTime));
+  assert_param(IS_TIM_BREAK_STATE(sBreakDeadTimeConfig->BreakState));
+  assert_param(IS_TIM_BREAK_POLARITY(sBreakDeadTimeConfig->BreakPolarity));
+  assert_param(IS_TIM_BREAK_FILTER(sBreakDeadTimeConfig->BreakFilter));
+  assert_param(IS_TIM_AUTOMATIC_OUTPUT_STATE(sBreakDeadTimeConfig->AutomaticOutput));
+  assert_param(IS_TIM_BREAK2_STATE(sBreakDeadTimeConfig->Break2State));
+  assert_param(IS_TIM_BREAK2_POLARITY(sBreakDeadTimeConfig->Break2Polarity));
+  assert_param(IS_TIM_BREAK_FILTER(sBreakDeadTimeConfig->Break2Filter));
+
+  /* Check input state */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Set the Lock level, the Break enable Bit and the Polarity, the OSSR State,
+     the OSSI State, the dead time value and the Automatic Output Enable Bit */
+
+  /* Clear the BDTR bits */
+  tmpbdtr &= ~(TIM_BDTR_DTG | TIM_BDTR_LOCK |  TIM_BDTR_OSSI |
+               TIM_BDTR_OSSR | TIM_BDTR_BKE | TIM_BDTR_BKP |
+               TIM_BDTR_AOE | TIM_BDTR_MOE | TIM_BDTR_BKF |
+               TIM_BDTR_BK2F | TIM_BDTR_BK2E | TIM_BDTR_BK2P);
+
+  /* Set the BDTR bits */
+  tmpbdtr |= sBreakDeadTimeConfig->DeadTime;
+  tmpbdtr |= sBreakDeadTimeConfig->LockLevel;
+  tmpbdtr |= sBreakDeadTimeConfig->OffStateIDLEMode;
+  tmpbdtr |= sBreakDeadTimeConfig->OffStateRunMode;
+  tmpbdtr |= sBreakDeadTimeConfig->BreakState;
+  tmpbdtr |= sBreakDeadTimeConfig->BreakPolarity;
+  tmpbdtr |= sBreakDeadTimeConfig->AutomaticOutput;
+  tmpbdtr |= (sBreakDeadTimeConfig->BreakFilter << BDTR_BKF_SHIFT);
+  tmpbdtr |= (sBreakDeadTimeConfig->Break2Filter << BDTR_BK2F_SHIFT);
+  tmpbdtr |= sBreakDeadTimeConfig->Break2State;
+  tmpbdtr |= sBreakDeadTimeConfig->Break2Polarity;
+
+  /* Set TIMx_BDTR */
+  htim->Instance->BDTR = tmpbdtr;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the TIM2, TIM5 and TIM11 Remapping input capabilities.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Remap: specifies the TIM input remapping source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TIM2_TIM8_TRGO: TIM2 ITR1 input is connected to TIM8 Trigger output(default)
+  *            @arg TIM_TIM2_ETH_PTP:   TIM2 ITR1 input is connected to ETH PTP trigger output.
+  *            @arg TIM_TIM2_USBFS_SOF: TIM2 ITR1 input is connected to USB FS SOF.
+  *            @arg TIM_TIM2_USBHS_SOF: TIM2 ITR1 input is connected to USB HS SOF.
+  *            @arg TIM_TIM5_GPIO:      TIM5 CH4 input is connected to dedicated Timer pin(default)
+  *            @arg TIM_TIM5_LSI:       TIM5 CH4 input is connected to LSI clock.
+  *            @arg TIM_TIM5_LSE:       TIM5 CH4 input is connected to LSE clock.
+  *            @arg TIM_TIM5_RTC:       TIM5 CH4 input is connected to RTC Output event.
+  *            @arg TIM_TIM11_GPIO:     TIM11 CH4 input is connected to dedicated Timer pin(default)
+  *            @arg TIM_TIM11_SPDIF:    SPDIF Frame synchronous
+  *            @arg TIM_TIM11_HSE:      TIM11 CH4 input is connected to HSE_RTC clock
+  *                                     (HSE divided by a programmable prescaler)
+  *            @arg TIM_TIM11_MCO1:     TIM11 CH1 input is connected to MCO1
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap)
+{
+  __HAL_LOCK(htim);
+
+  /* Check parameters */
+  assert_param(IS_TIM_REMAP_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_REMAP(Remap));
+
+  /* Set the Timer remapping configuration */
+  htim->Instance->OR = Remap;
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Group channel 5 and channel 1, 2 or 3
+  * @param  htim: TIM handle.
+  * @param  OCRef: specifies the reference signal(s) the OC5REF is combined with.
+  *         This parameter can be any combination of the following values:
+  *         TIM_GROUPCH5_NONE: No effect of OC5REF on OC1REFC, OC2REFC and OC3REFC
+  *         TIM_GROUPCH5_OC1REFC: OC1REFC is the logical AND of OC1REFC and OC5REF
+  *         TIM_GROUPCH5_OC2REFC: OC2REFC is the logical AND of OC2REFC and OC5REF
+  *         TIM_GROUPCH5_OC3REFC: OC3REFC is the logical AND of OC3REFC and OC5REF
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_GroupChannel5(TIM_HandleTypeDef *htim, uint32_t OCRef)
+{
+  /* Check parameters */
+  assert_param(IS_TIM_COMBINED3PHASEPWM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_GROUPCH5(OCRef));
+
+  /* Process Locked */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Clear GC5Cx bit fields */
+  htim->Instance->CCR5 &= ~(TIM_CCR5_GC5C3|TIM_CCR5_GC5C2|TIM_CCR5_GC5C1);
+
+  /* Set GC5Cx bit fields */
+  htim->Instance->CCR5 |= OCRef;
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group6 Extended Callbacks functions
+  * @brief    Extended Callbacks functions
+ *
+@verbatim
+  ==============================================================================
+                    ##### Extension Callbacks functions #####
+  ==============================================================================
+  [..]
+    This section provides Extension TIM callback functions:
+    (+) Timer Commutation callback
+    (+) Timer Break callback
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Hall commutation changed callback in non blocking mode
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIMEx_CommutationCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIMEx_CommutationCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Hall Break detection callback in non blocking mode
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIMEx_BreakCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIMEx_BreakCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group7 Extended Peripheral State functions
+ *  @brief    Extended Peripheral State functions
+ *
+@verbatim
+  ==============================================================================
+                ##### Extension Peripheral State functions #####
+  ==============================================================================
+  [..]
+    This subsection permits to get in run-time the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the TIM Hall Sensor interface state
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIMEx_HallSensor_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  TIM DMA Commutation callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void HAL_TIMEx_DMACommutationCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  htim->State= HAL_TIM_STATE_READY;
+
+  HAL_TIMEx_CommutationCallback(htim);
+}
+
+/**
+  * @brief  Enables or disables the TIM Capture Compare Channel xN.
+  * @param  TIMx to select the TIM peripheral
+  * @param  Channel: specifies the TIM Channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_Channel_1: TIM Channel 1
+  *            @arg TIM_Channel_2: TIM Channel 2
+  *            @arg TIM_Channel_3: TIM Channel 3
+  * @param  ChannelNState: specifies the TIM Channel CCxNE bit new state.
+  *          This parameter can be: TIM_CCxN_ENABLE or TIM_CCxN_Disable.
+  * @retval None
+  */
+static void TIM_CCxNChannelCmd(TIM_TypeDef* TIMx, uint32_t Channel, uint32_t ChannelNState)
+{
+  uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_ADVANCED_INSTANCE(TIMx));
+  assert_param(IS_TIM_COMPLEMENTARY_CHANNELS(Channel));
+
+  tmp = TIM_CCER_CC1NE << Channel;
+
+  /* Reset the CCxNE Bit */
+  TIMx->CCER &= ~tmp;
+
+  /* Set or reset the CCxNE Bit */
+  TIMx->CCER |= (uint32_t)(ChannelNState << Channel);
+}
+
+/**
+  * @brief  Timer Output Compare 5 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The output configuration structure
+  * @retval None
+  */
+static void TIM_OC5_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+  /* Disable the output: Reset the CCxE Bit */
+  TIMx->CCER &= ~TIM_CCER_CC5E;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 =  TIMx->CR2;
+  /* Get the TIMx CCMR1 register value */
+  tmpccmrx = TIMx->CCMR3;
+
+  /* Reset the Output Compare Mode Bits */
+  tmpccmrx &= ~(TIM_CCMR3_OC5M);
+  /* Select the Output Compare Mode */
+  tmpccmrx |= OC_Config->OCMode;
+
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC5P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 16);
+
+  if(IS_TIM_BREAK_INSTANCE(TIMx))
+  {
+    /* Reset the Output Compare IDLE State */
+    tmpcr2 &= ~TIM_CR2_OIS5;
+    /* Set the Output Idle state */
+    tmpcr2 |= (OC_Config->OCIdleState << 8);
+  }
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+
+  /* Write to TIMx CCMR3 */
+  TIMx->CCMR3 = tmpccmrx;
+
+  /* Set the Capture Compare Register value */
+  TIMx->CCR5 = OC_Config->Pulse;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Timer Output Compare 6 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The output configuration structure
+  * @retval None
+  */
+static void TIM_OC6_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+  /* Disable the output: Reset the CCxE Bit */
+  TIMx->CCER &= ~TIM_CCER_CC6E;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 =  TIMx->CR2;
+  /* Get the TIMx CCMR1 register value */
+  tmpccmrx = TIMx->CCMR3;
+
+  /* Reset the Output Compare Mode Bits */
+  tmpccmrx &= ~(TIM_CCMR3_OC6M);
+  /* Select the Output Compare Mode */
+  tmpccmrx |= (OC_Config->OCMode << 8);
+
+  /* Reset the Output Polarity level */
+  tmpccer &= (uint32_t)~TIM_CCER_CC6P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 20);
+
+  if(IS_TIM_BREAK_INSTANCE(TIMx))
+  {
+    /* Reset the Output Compare IDLE State */
+    tmpcr2 &= ~TIM_CR2_OIS6;
+    /* Set the Output Idle state */
+    tmpcr2 |= (OC_Config->OCIdleState << 10);
+  }
+
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+
+  /* Write to TIMx CCMR3 */
+  TIMx->CCMR3 = tmpccmrx;
+
+  /* Set the Capture Compare Register value */
+  TIMx->CCR6 = OC_Config->Pulse;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_TIM_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_hal_uart.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_uart.c
@@ -1,0 +1,1996 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_uart.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   UART HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Universal Asynchronous Receiver Transmitter (UART) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State and Errors functions
+  *
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+  [..]
+    The UART HAL driver can be used as follows:
+
+    (#) Declare a UART_HandleTypeDef handle structure.
+
+    (#) Initialize the UART low level resources by implementing the HAL_UART_MspInit() API:
+        (##) Enable the USARTx interface clock.
+        (##) UART pins configuration:
+            (+++) Enable the clock for the UART GPIOs.
+            (+++) Configure these UART pins as alternate function pull-up.
+        (##) NVIC configuration if you need to use interrupt process (HAL_UART_Transmit_IT()
+             and HAL_UART_Receive_IT() APIs):
+            (+++) Configure the USARTx interrupt priority.
+            (+++) Enable the NVIC USART IRQ handle.
+        (##) DMA Configuration if you need to use DMA process (HAL_UART_Transmit_DMA()
+             and HAL_UART_Receive_DMA() APIs):
+            (+++) Declare a DMA handle structure for the Tx/Rx stream.
+            (+++) Enable the DMAx interface clock.
+            (+++) Configure the declared DMA handle structure with the required
+                  Tx/Rx parameters.
+            (+++) Configure the DMA Tx/Rx Stream.
+            (+++) Associate the initialized DMA handle to the UART DMA Tx/Rx handle.
+            (+++) Configure the priority and enable the NVIC for the transfer complete
+                  interrupt on the DMA Tx/Rx Stream.
+
+    (#) Program the Baud Rate, Word Length, Stop Bit, Parity, Hardware
+        flow control and Mode(Receiver/Transmitter) in the Init structure.
+
+    (#) For the UART asynchronous mode, initialize the UART registers by calling
+        the HAL_UART_Init() API.
+
+    (#) For the UART Half duplex mode, initialize the UART registers by calling
+        the HAL_HalfDuplex_Init() API.
+
+    (#) For the LIN mode, initialize the UART registers by calling the HAL_LIN_Init() API.
+
+    (#) For the Multi-Processor mode, initialize the UART registers by calling
+        the HAL_MultiProcessor_Init() API.
+
+     [..]
+       (@) The specific UART interrupts (Transmission complete interrupt,
+            RXNE interrupt and Error Interrupts) will be managed using the macros
+            __HAL_UART_ENABLE_IT() and __HAL_UART_DISABLE_IT() inside the transmit
+            and receive process.
+
+     [..]
+       (@) These APIs (HAL_UART_Init() and HAL_HalfDuplex_Init()) configure also the
+            low level Hardware GPIO, CLOCK, CORTEX...etc) by calling the customized
+            HAL_UART_MspInit() API.
+
+     [..]
+        Three operation modes are available within this driver :
+
+     *** Polling mode IO operation ***
+     =================================
+     [..]
+       (+) Send an amount of data in blocking mode using HAL_UART_Transmit()
+       (+) Receive an amount of data in blocking mode using HAL_UART_Receive()
+
+     *** Interrupt mode IO operation ***
+     ===================================
+     [..]
+       (+) Send an amount of data in non blocking mode using HAL_UART_Transmit_IT()
+       (+) At transmission end of transfer HAL_UART_TxCpltCallback is executed and user can
+            add his own code by customization of function pointer HAL_UART_TxCpltCallback
+       (+) Receive an amount of data in non blocking mode using HAL_UART_Receive_IT()
+       (+) At reception end of transfer HAL_UART_RxCpltCallback is executed and user can
+            add his own code by customization of function pointer HAL_UART_RxCpltCallback
+       (+) In case of transfer Error, HAL_UART_ErrorCallback() function is executed and user can
+            add his own code by customization of function pointer HAL_UART_ErrorCallback
+
+     *** DMA mode IO operation ***
+     ==============================
+     [..]
+       (+) Send an amount of data in non blocking mode (DMA) using HAL_UART_Transmit_DMA()
+       (+) At transmission end of half transfer HAL_UART_TxHalfCpltCallback is executed and user can
+            add his own code by customization of function pointer HAL_UART_TxHalfCpltCallback
+       (+) At transmission end of transfer HAL_UART_TxCpltCallback is executed and user can
+            add his own code by customization of function pointer HAL_UART_TxCpltCallback
+       (+) Receive an amount of data in non blocking mode (DMA) using HAL_UART_Receive_DMA()
+       (+) At reception end of half transfer HAL_UART_RxHalfCpltCallback is executed and user can
+            add his own code by customization of function pointer HAL_UART_RxHalfCpltCallback
+       (+) At reception end of transfer HAL_UART_RxCpltCallback is executed and user can
+            add his own code by customization of function pointer HAL_UART_RxCpltCallback
+       (+) In case of transfer Error, HAL_UART_ErrorCallback() function is executed and user can
+            add his own code by customization of function pointer HAL_UART_ErrorCallback
+       (+) Pause the DMA Transfer using HAL_UART_DMAPause()
+       (+) Resume the DMA Transfer using HAL_UART_DMAResume()
+       (+) Stop the DMA Transfer using HAL_UART_DMAStop()
+
+     *** UART HAL driver macros list ***
+     =============================================
+     [..]
+       Below the list of most used macros in UART HAL driver.
+
+      (+) __HAL_UART_ENABLE: Enable the UART peripheral
+      (+) __HAL_UART_DISABLE: Disable the UART peripheral
+      (+) __HAL_UART_GET_FLAG : Check whether the specified UART flag is set or not
+      (+) __HAL_UART_CLEAR_IT : Clears the specified UART ISR flag
+      (+) __HAL_UART_ENABLE_IT: Enable the specified UART interrupt
+      (+) __HAL_UART_DISABLE_IT: Disable the specified UART interrupt
+      (+) __HAL_UART_GET_IT_SOURCE: Check whether the specified UART interrupt has occurred or not
+
+     [..]
+       (@) You can refer to the UART HAL driver header file for more useful macros
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup UART UART
+  * @brief HAL UART module driver
+  * @{
+  */
+#ifdef HAL_UART_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define HAL_UART_TXDMA_TIMEOUTVALUE                      22000
+#define UART_CR1_FIELDS  ((uint32_t)(USART_CR1_M | USART_CR1_PCE | USART_CR1_PS | \
+                                     USART_CR1_TE | USART_CR1_RE | USART_CR1_OVER8))
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void UART_DMATransmitCplt(DMA_HandleTypeDef *hdma);
+static void UART_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
+static void UART_DMARxHalfCplt(DMA_HandleTypeDef *hdma);
+static void UART_DMATxHalfCplt(DMA_HandleTypeDef *hdma);
+static void UART_DMAError(DMA_HandleTypeDef *hdma);
+static HAL_StatusTypeDef UART_Transmit_IT(UART_HandleTypeDef *huart);
+static HAL_StatusTypeDef UART_EndTransmit_IT(UART_HandleTypeDef *huart);
+static HAL_StatusTypeDef UART_Receive_IT(UART_HandleTypeDef *huart);
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup UART_Exported_Functions UART Exported Functions
+  * @{
+  */
+
+/** @defgroup UART_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and Configuration functions
+  *
+@verbatim
+===============================================================================
+            ##### Initialization and Configuration functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to initialize the USARTx or the UARTy
+    in asynchronous mode.
+      (+) For the asynchronous mode only these parameters can be configured:
+        (++) Baud Rate
+        (++) Word Length
+        (++) Stop Bit
+        (++) Parity: If the parity is enabled, then the MSB bit of the data written
+             in the data register is transmitted but is changed by the parity bit.
+             Depending on the frame length defined by the M bit (8-bits or 9-bits),
+             please refer to Reference manual for possible UART frame formats.
+        (++) Hardware flow control
+        (++) Receiver/transmitter modes
+        (++) Over Sampling Method
+    [..]
+    The HAL_UART_Init(), HAL_HalfDuplex_Init(), HAL_LIN_Init() and HAL_MultiProcessor_Init() APIs
+    follow respectively the UART asynchronous, UART Half duplex, LIN and Multi-Processor
+    configuration procedures (details for the procedures are available in reference manual (RM0329)).
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Initializes the UART mode according to the specified
+  *         parameters in the UART_InitTypeDef and creates the associated handle .
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Init(UART_HandleTypeDef *huart)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  if(huart->Init.HwFlowCtl != UART_HWCONTROL_NONE)
+  {
+    /* Check the parameters */
+    assert_param(IS_UART_HWFLOW_INSTANCE(huart->Instance));
+  }
+  else
+  {
+    /* Check the parameters */
+    assert_param(IS_UART_INSTANCE(huart->Instance));
+  }
+
+  if(huart->State == HAL_UART_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    huart->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK */
+    HAL_UART_MspInit(huart);
+  }
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  /* Set the UART Communication parameters */
+  if (UART_SetConfig(huart) == HAL_ERROR)
+  {
+    return HAL_ERROR;
+  }
+
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
+  /* In asynchronous mode, the following bits must be kept cleared:
+  - LINEN and CLKEN bits in the USART_CR2 register,
+  - SCEN, HDSEL and IREN  bits in the USART_CR3 register.*/
+  huart->Instance->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
+  huart->Instance->CR3 &= ~(USART_CR3_SCEN | USART_CR3_HDSEL | USART_CR3_IREN);
+
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief Initializes the half-duplex mode according to the specified
+  *         parameters in the UART_InitTypeDef and creates the associated handle .
+  * @param huart: UART handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HalfDuplex_Init(UART_HandleTypeDef *huart)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  if(huart->State == HAL_UART_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    huart->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware : GPIO, CLOCK */
+    HAL_UART_MspInit(huart);
+  }
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  /* Set the UART Communication parameters */
+  if (UART_SetConfig(huart) == HAL_ERROR)
+  {
+    return HAL_ERROR;
+  }
+
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
+  /* In half-duplex mode, the following bits must be kept cleared:
+  - LINEN and CLKEN bits in the USART_CR2 register,
+  - SCEN and IREN bits in the USART_CR3 register.*/
+  huart->Instance->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
+  huart->Instance->CR3 &= ~(USART_CR3_IREN | USART_CR3_SCEN);
+
+  /* Enable the Half-Duplex mode by setting the HDSEL bit in the CR3 register */
+  huart->Instance->CR3 |= USART_CR3_HDSEL;
+
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+
+/**
+  * @brief Initializes the LIN mode according to the specified
+  *         parameters in the UART_InitTypeDef and creates the associated handle .
+  * @param huart: uart handle
+  * @param BreakDetectLength: specifies the LIN break detection length.
+  *        This parameter can be one of the following values:
+  *          @arg UART_LINBREAKDETECTLENGTH_10B: 10-bit break detection
+  *          @arg UART_LINBREAKDETECTLENGTH_11B: 11-bit break detection
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LIN_Init(UART_HandleTypeDef *huart, uint32_t BreakDetectLength)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_UART_INSTANCE(huart->Instance));
+  assert_param(IS_UART_LIN_BREAK_DETECT_LENGTH(BreakDetectLength));
+  assert_param(IS_LIN_WORD_LENGTH(huart->Init.WordLength));
+
+  if(huart->State == HAL_UART_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    huart->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware : GPIO, CLOCK */
+    HAL_UART_MspInit(huart);
+  }
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  /* Set the UART Communication parameters */
+  if (UART_SetConfig(huart) == HAL_ERROR)
+  {
+    return HAL_ERROR;
+  }
+
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
+  /* In LIN mode, the following bits must be kept cleared:
+  - LINEN and CLKEN bits in the USART_CR2 register,
+  - SCEN and IREN bits in the USART_CR3 register.*/
+  huart->Instance->CR2 &= ~(USART_CR2_CLKEN);
+  huart->Instance->CR3 &= ~(USART_CR3_HDSEL | USART_CR3_IREN | USART_CR3_SCEN);
+
+  /* Enable the LIN mode by setting the LINEN bit in the CR2 register */
+  huart->Instance->CR2 |= USART_CR2_LINEN;
+
+  /* Set the USART LIN Break detection length. */
+  MODIFY_REG(huart->Instance->CR2, USART_CR2_LBDL, BreakDetectLength);
+
+    /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+
+
+/**
+  * @brief Initializes the multiprocessor mode according to the specified
+  *         parameters in the UART_InitTypeDef and creates the associated handle.
+  * @param huart: UART handle
+  * @param Address: UART node address (4-, 6-, 7- or 8-bit long)
+  * @param WakeUpMethod: specifies the UART wakeup method.
+  *        This parameter can be one of the following values:
+  *          @arg UART_WAKEUPMETHOD_IDLELINE: WakeUp by an idle line detection
+  *          @arg UART_WAKEUPMETHOD_ADDRESSMARK: WakeUp by an address mark
+  * @note  If the user resorts to idle line detection wake up, the Address parameter
+  *        is useless and ignored by the initialization function.
+  * @note  If the user resorts to address mark wake up, the address length detection
+  *        is configured by default to 4 bits only. For the UART to be able to
+  *        manage 6-, 7- or 8-bit long addresses detection
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_MultiProcessor_Init(UART_HandleTypeDef *huart, uint8_t Address, uint32_t WakeUpMethod)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the wake up method parameter */
+  assert_param(IS_UART_WAKEUPMETHOD(WakeUpMethod));
+
+  if(huart->State == HAL_UART_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    huart->Lock = HAL_UNLOCKED;
+    /* Init the low level hardware : GPIO, CLOCK */
+    HAL_UART_MspInit(huart);
+  }
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  /* Set the UART Communication parameters */
+  if (UART_SetConfig(huart) == HAL_ERROR)
+  {
+    return HAL_ERROR;
+  }
+
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
+  /* In multiprocessor mode, the following bits must be kept cleared:
+  - LINEN and CLKEN bits in the USART_CR2 register,
+  - SCEN, HDSEL and IREN  bits in the USART_CR3 register. */
+  huart->Instance->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
+  huart->Instance->CR3 &= ~(USART_CR3_SCEN | USART_CR3_HDSEL | USART_CR3_IREN);
+
+  if (WakeUpMethod == UART_WAKEUPMETHOD_ADDRESSMARK)
+  {
+    /* If address mark wake up method is chosen, set the USART address node */
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_ADD, ((uint32_t)Address << UART_CR2_ADDRESS_LSB_POS));
+  }
+
+  /* Set the wake up method by setting the WAKE bit in the CR1 register */
+  MODIFY_REG(huart->Instance->CR1, USART_CR1_WAKE, WakeUpMethod);
+
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+
+
+
+/**
+  * @brief DeInitializes the UART peripheral
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_DeInit(UART_HandleTypeDef *huart)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_UART_INSTANCE(huart->Instance));
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  huart->Instance->CR1 = 0x0;
+  huart->Instance->CR2 = 0x0;
+  huart->Instance->CR3 = 0x0;
+
+  /* DeInit the low level hardware */
+  HAL_UART_MspDeInit(huart);
+
+  huart->ErrorCode = HAL_UART_ERROR_NONE;
+  huart->State = HAL_UART_STATE_RESET;
+
+  /* Process Unlock */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief UART MSP Init
+  * @param huart: uart handle
+  * @retval None
+  */
+ __weak void HAL_UART_MspInit(UART_HandleTypeDef *huart)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_MspInit can be implemented in the user file
+   */
+}
+
+/**
+  * @brief UART MSP DeInit
+  * @param huart: uart handle
+  * @retval None
+  */
+ __weak void HAL_UART_MspDeInit(UART_HandleTypeDef *huart)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_MspDeInit can be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup UART_Exported_Functions_Group2 IO operation functions
+  *  @brief UART Transmit/Receive functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    This subsection provides a set of functions allowing to manage the UART asynchronous
+    and Half duplex data transfers.
+
+    (#) There are two mode of transfer:
+       (+) Blocking mode: The communication is performed in polling mode.
+            The HAL status of all data processing is returned by the same function
+            after finishing transfer.
+       (+) No-Blocking mode: The communication is performed using Interrupts
+           or DMA, These API's return the HAL status.
+           The end of the data processing will be indicated through the
+           dedicated UART IRQ when using Interrupt mode or the DMA IRQ when
+           using DMA mode.
+           The HAL_UART_TxCpltCallback(), HAL_UART_RxCpltCallback() user callbacks
+           will be executed respectively at the end of the transmit or Receive process
+           The HAL_UART_ErrorCallback()user callback will be executed when a communication error is detected
+
+    (#) Blocking mode API's are :
+        (+) HAL_UART_Transmit()
+        (+) HAL_UART_Receive()
+
+    (#) Non-Blocking mode API's with Interrupt are :
+        (+) HAL_UART_Transmit_IT()
+        (+) HAL_UART_Receive_IT()
+        (+) HAL_UART_IRQHandler()
+        (+) UART_Transmit_IT()
+        (+) UART_Receive_IT()
+
+    (#) No-Blocking mode API's with DMA are :
+        (+) HAL_UART_Transmit_DMA()
+        (+) HAL_UART_Receive_DMA()
+        (+) HAL_UART_DMAPause()
+        (+) HAL_UART_DMAResume()
+        (+) HAL_UART_DMAStop()
+
+    (#) A set of Transfer Complete Callbacks are provided in No_Blocking mode:
+        (+) HAL_UART_TxHalfCpltCallback()
+        (+) HAL_UART_TxCpltCallback()
+        (+) HAL_UART_RxHalfCpltCallback()
+        (+) HAL_UART_RxCpltCallback()
+        (+) HAL_UART_ErrorCallback()
+
+
+    -@- In the Half duplex communication, it is forbidden to run the transmit
+        and receive process in parallel, the UART state HAL_UART_STATE_BUSY_TX_RX can't be useful.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Send an amount of data in blocking mode
+  * @param huart: uart handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+   uint16_t* tmp;
+
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_RX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a non-blocking receive process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_RX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+
+    huart->TxXferSize = Size;
+    huart->TxXferCount = Size;
+    while(huart->TxXferCount > 0)
+    {
+      huart->TxXferCount--;
+        if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TXE, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) pData;
+        huart->Instance->TDR = (*tmp & (uint16_t)0x01FF);
+        pData += 2;
+      }
+      else
+      {
+        huart->Instance->TDR = (*pData++ & (uint8_t)0xFF);
+      }
+    }
+    if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TC, RESET, Timeout) != HAL_OK)
+    {
+      return HAL_TIMEOUT;
+    }
+    /* Check if a non-blocking receive Process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_READY;
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in blocking mode
+  * @param huart: uart handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint16_t* tmp;
+  uint16_t uhMask;
+
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_TX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a non-blocking transmit process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_RX;
+    }
+
+    huart->RxXferSize = Size;
+    huart->RxXferCount = Size;
+
+    /* Computation of UART mask to apply to RDR register */
+    UART_MASK_COMPUTATION(huart);
+    uhMask = huart->Mask;
+
+    /* as long as data have to be received */
+    while(huart->RxXferCount > 0)
+    {
+      huart->RxXferCount--;
+        if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) pData ;
+        *tmp = (uint16_t)(huart->Instance->RDR & uhMask);
+        pData +=2;
+      }
+      else
+      {
+        *pData++ = (uint8_t)(huart->Instance->RDR & (uint8_t)uhMask);
+      }
+    }
+
+    /* Check if a non-blocking transmit Process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_READY;
+    }
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Send an amount of data in interrupt mode
+  * @param huart: uart handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_RX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->pTxBuffPtr = pData;
+    huart->TxXferSize = Size;
+    huart->TxXferCount = Size;
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a receive process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_RX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+
+    /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_ERR);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    /* Enable the UART Transmit Data Register Empty Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in interrupt mode
+  * @param huart: uart handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_TX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->pRxBuffPtr = pData;
+    huart->RxXferSize = Size;
+    huart->RxXferCount = Size;
+
+    /* Computation of UART mask to apply to RDR register */
+    UART_MASK_COMPUTATION(huart);
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a transmit process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_RX;
+    }
+
+    /* Enable the UART Parity Error Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_PE);
+
+    /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_ERR);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    /* Enable the UART Data Register not empty Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_RXNE);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Send an amount of data in DMA mode
+  * @param huart: uart handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_RX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->pTxBuffPtr = pData;
+    huart->TxXferSize = Size;
+    huart->TxXferCount = Size;
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a receive process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_RX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+
+    /* Set the UART DMA transfer complete callback */
+    huart->hdmatx->XferCpltCallback = UART_DMATransmitCplt;
+
+    /* Set the UART DMA Half transfer complete callback */
+    huart->hdmatx->XferHalfCpltCallback = UART_DMATxHalfCplt;
+
+    /* Set the DMA error callback */
+    huart->hdmatx->XferErrorCallback = UART_DMAError;
+
+    /* Enable the UART transmit DMA channel */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(huart->hdmatx, *(uint32_t*)tmp, (uint32_t)&huart->Instance->TDR, Size);
+
+    /* Clear the TC flag in the SR register by writing 0 to it */
+    __HAL_UART_CLEAR_IT(huart, UART_FLAG_TC);
+
+
+    /* Enable the DMA transfer for transmit request by setting the DMAT bit
+       in the UART CR3 register */
+    huart->Instance->CR3 |= USART_CR3_DMAT;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in DMA mode
+  * @param huart: uart handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @note   When the UART parity is enabled (PCE = 1), the received data contain
+  *         the parity bit (MSB position)
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_TX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->pRxBuffPtr = pData;
+    huart->RxXferSize = Size;
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a transmit process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_RX;
+    }
+
+    /* Set the UART DMA transfer complete callback */
+    huart->hdmarx->XferCpltCallback = UART_DMAReceiveCplt;
+
+    /* Set the UART DMA Half transfer complete callback */
+    huart->hdmarx->XferHalfCpltCallback = UART_DMARxHalfCplt;
+
+    /* Set the DMA error callback */
+    huart->hdmarx->XferErrorCallback = UART_DMAError;
+
+    /* Enable the DMA channel */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(huart->hdmarx, (uint32_t)&huart->Instance->RDR, *(uint32_t*)tmp, Size);
+
+    /* Enable the DMA transfer for the receiver request by setting the DMAR bit
+       in the UART CR3 register */
+     huart->Instance->CR3 |= USART_CR3_DMAR;
+
+     /* Process Unlocked */
+     __HAL_UNLOCK(huart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Pauses the DMA Transfer.
+  * @param huart: UART handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_UART_DMAPause(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  if(huart->State == HAL_UART_STATE_BUSY_TX)
+  {
+    /* Disable the UART DMA Tx request */
+    huart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAT);
+  }
+  else if(huart->State == HAL_UART_STATE_BUSY_RX)
+  {
+    /* Disable the UART DMA Rx request */
+    huart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAR);
+  }
+  else if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+  {
+    /* Disable the UART DMA Tx request */
+    huart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAT);
+    /* Disable the UART DMA Rx request */
+    huart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAR);
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Resumes the DMA Transfer.
+  * @param huart: UART handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_UART_DMAResume(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  if(huart->State == HAL_UART_STATE_BUSY_TX)
+  {
+    /* Enable the UART DMA Tx request */
+    huart->Instance->CR3 |= USART_CR3_DMAT;
+  }
+  else if(huart->State == HAL_UART_STATE_BUSY_RX)
+  {
+		/* Clear the Overrun flag before resuming the Rx transfer*/
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
+
+    /* Enable the UART DMA Rx request */
+    huart->Instance->CR3 |= USART_CR3_DMAR;
+  }
+  else if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+  {
+		/* Clear the Overrun flag before resuming the Rx transfer*/
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
+
+    /* Enable the UART DMA Rx request  before the DMA Tx request */
+    huart->Instance->CR3 |= USART_CR3_DMAR;
+
+    /* Enable the UART DMA Tx request */
+    huart->Instance->CR3 |= USART_CR3_DMAT;
+  }
+
+  /* If the UART peripheral is still not enabled, enable it */
+  if ((huart->Instance->CR1 & USART_CR1_UE) == 0)
+  {
+    /* Enable UART peripheral */
+    __HAL_UART_ENABLE(huart);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Stops the DMA Transfer.
+  * @param huart: UART handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_UART_DMAStop(UART_HandleTypeDef *huart)
+{
+  /* The Lock is not implemented on this API to allow the user application
+     to call the HAL UART API under callbacks HAL_UART_TxCpltCallback() / HAL_UART_RxCpltCallback() /
+     HAL_UART_TxHalfCpltCallback / HAL_UART_RxHalfCpltCallback:
+     indeed, when HAL_DMA_Abort() API is called, the DMA TX/RX Transfer or Half Transfer complete
+     interrupt is generated if the DMA transfer interruption occurs at the middle or at the end of
+     the stream and the corresponding call back is executed. */
+
+  /* Disable the UART Tx/Rx DMA requests */
+  huart->Instance->CR3 &= ~USART_CR3_DMAT;
+  huart->Instance->CR3 &= ~USART_CR3_DMAR;
+
+  /* Abort the UART DMA tx channel */
+  if(huart->hdmatx != NULL)
+  {
+    HAL_DMA_Abort(huart->hdmatx);
+  }
+  /* Abort the UART DMA rx channel */
+  if(huart->hdmarx != NULL)
+  {
+    HAL_DMA_Abort(huart->hdmarx);
+  }
+
+  huart->State = HAL_UART_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief This function handles UART interrupt request.
+  * @param huart: uart handle
+  * @retval None
+  */
+void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
+{
+  /* UART parity error interrupt occurred -------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_PE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_PE) != RESET))
+  {
+		__HAL_UART_CLEAR_PEFLAG(huart);
+
+    huart->ErrorCode |= HAL_UART_ERROR_PE;
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+  }
+
+  /* UART frame error interrupt occurred --------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_FE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET))
+  {
+    __HAL_UART_CLEAR_FEFLAG(huart);
+
+    huart->ErrorCode |= HAL_UART_ERROR_FE;
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+  }
+
+  /* UART noise error interrupt occurred --------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_NE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET))
+  {
+    __HAL_UART_CLEAR_NEFLAG(huart);
+
+    huart->ErrorCode |= HAL_UART_ERROR_NE;
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+  }
+
+  /* UART Over-Run interrupt occurred -----------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET))
+  {
+    __HAL_UART_CLEAR_OREFLAG(huart);
+
+    huart->ErrorCode |= HAL_UART_ERROR_ORE;
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+  }
+
+   /* Call UART Error Call back function if need be --------------------------*/
+  if(huart->ErrorCode != HAL_UART_ERROR_NONE)
+  {
+    HAL_UART_ErrorCallback(huart);
+  }
+
+  /* UART in mode Receiver ---------------------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET))
+  {
+    UART_Receive_IT(huart);
+    /* Clear RXNE interrupt flag */
+    __HAL_UART_SEND_REQ(huart, UART_RXDATA_FLUSH_REQUEST);
+  }
+
+
+  /* UART in mode Transmitter ------------------------------------------------*/
+ if((__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) &&(__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET))
+  {
+    UART_Transmit_IT(huart);
+  }
+
+  /* UART in mode Transmitter (transmission end) -----------------------------*/
+ if((__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET) &&(__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TC) != RESET))
+  {
+    UART_EndTransmit_IT(huart);
+  }
+
+}
+
+
+/**
+  * @brief  This function handles UART Communication Timeout.
+  * @param  huart: UART handle
+  * @param  Flag: specifies the UART flag to check.
+  * @param  Status: The new Flag status (SET or RESET).
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_t Flag, FlagStatus Status, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {
+    while(__HAL_UART_GET_FLAG(huart, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick()-tickstart) >=  Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_RXNE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+
+          huart->State= HAL_UART_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(huart);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_UART_GET_FLAG(huart, Flag) != RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick()-tickstart) >=  Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_RXNE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+
+          huart->State= HAL_UART_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(huart);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+
+
+/**
+  * @brief DMA UART transmit process complete callback
+  * @param hdma: DMA handle
+  * @retval None
+  */
+static void UART_DMATransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  UART_HandleTypeDef* huart = ( UART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* DMA Normal mode*/
+  if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
+  {
+    huart->TxXferCount = 0;
+
+    /* Disable the DMA transfer for transmit request by setting the DMAT bit
+       in the UART CR3 register */
+    huart->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_DMAT);
+
+    /* Enable the UART Transmit Complete Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+  }
+  /* DMA Circular mode */
+  else
+  {
+    HAL_UART_TxCpltCallback(huart);
+  }
+}
+
+/**
+  * @brief DMA UART transmit process half complete callback
+  * @param hdma : DMA handle
+  * @retval None
+  */
+static void UART_DMATxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  UART_HandleTypeDef* huart = (UART_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_UART_TxHalfCpltCallback(huart);
+}
+
+/**
+  * @brief DMA UART receive process complete callback
+  * @param hdma: DMA handle
+  * @retval None
+  */
+static void UART_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  UART_HandleTypeDef* huart = ( UART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* DMA Normal mode */
+  if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
+  {
+    huart->RxXferCount = 0;
+
+    /* Disable the DMA transfer for the receiver request by setting the DMAR bit
+    in the UART CR3 register */
+    huart->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_DMAR);
+
+    /* Check if a transmit Process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_READY;
+    }
+  }
+  HAL_UART_RxCpltCallback(huart);
+}
+
+/**
+  * @brief DMA UART receive process half complete callback
+  * @param hdma : DMA handle
+  * @retval None
+  */
+static void UART_DMARxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  UART_HandleTypeDef* huart = (UART_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_UART_RxHalfCpltCallback(huart);
+}
+
+/**
+  * @brief DMA UART communication error callback
+  * @param hdma: DMA handle
+  * @retval None
+  */
+static void UART_DMAError(DMA_HandleTypeDef *hdma)
+{
+  UART_HandleTypeDef* huart = ( UART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  huart->RxXferCount = 0;
+  huart->TxXferCount = 0;
+  huart->State= HAL_UART_STATE_READY;
+  huart->ErrorCode |= HAL_UART_ERROR_DMA;
+  HAL_UART_ErrorCallback(huart);
+}
+
+/**
+  * @brief Tx Transfer completed callbacks
+  * @param huart: uart handle
+  * @retval None
+  */
+ __weak void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_TxCpltCallback can be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Tx Half Transfer completed callbacks.
+  * @param  huart: UART handle
+  * @retval None
+  */
+ __weak void HAL_UART_TxHalfCpltCallback(UART_HandleTypeDef *huart)
+{
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_UART_TxHalfCpltCallback can be implemented in the user file
+   */
+}
+
+/**
+  * @brief Rx Transfer completed callbacks
+  * @param huart: uart handle
+  * @retval None
+  */
+__weak void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_RxCpltCallback can be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Rx Half Transfer completed callbacks.
+  * @param  huart: UART handle
+  * @retval None
+  */
+__weak void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart)
+{
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_UART_RxHalfCpltCallback can be implemented in the user file
+   */
+}
+
+/**
+  * @brief UART error callbacks
+  * @param huart: uart handle
+  * @retval None
+  */
+ __weak void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_ErrorCallback can be implemented in the user file
+   */
+}
+
+/**
+  * @brief Send an amount of data in interrupt mode
+  *         Function called under interruption only, once
+  *         interruptions have been enabled by HAL_UART_Transmit_IT()
+  * @param  huart: UART handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef UART_Transmit_IT(UART_HandleTypeDef *huart)
+{
+  uint16_t* tmp;
+
+  if ((huart->State == HAL_UART_STATE_BUSY_TX) || (huart->State == HAL_UART_STATE_BUSY_TX_RX))
+  {
+
+    if(huart->TxXferCount == 0)
+    {
+      /* Disable the UART Transmit Data Register Empty Interrupt */
+      __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
+
+      /* Check if a receive Process is ongoing or not */
+      if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+      {
+        huart->State = HAL_UART_STATE_BUSY_RX;
+      }
+      else
+      {
+        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+        __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+
+        huart->State = HAL_UART_STATE_READY;
+      }
+
+      /* Wait on TC flag to be able to start a second transfer */
+      if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TC, RESET, HAL_UART_TIMEOUT_VALUE) != HAL_OK)
+      {
+        return HAL_TIMEOUT;
+      }
+
+      HAL_UART_TxCpltCallback(huart);
+
+      return HAL_OK;
+    }
+    else
+    {
+      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) huart->pTxBuffPtr;
+        huart->Instance->TDR = (*tmp & (uint16_t)0x01FF);
+        huart->pTxBuffPtr += 2;
+      }
+      else
+      {
+        huart->Instance->TDR = (uint8_t)(*huart->pTxBuffPtr++ & (uint8_t)0xFF);
+      }
+
+      huart->TxXferCount--;
+
+      return HAL_OK;
+    }
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Wrap up transmission in non-blocking mode.
+  * @param  huart: pointer to a UART_HandleTypeDef structure that contains
+  *                the configuration information for the specified UART module.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef UART_EndTransmit_IT(UART_HandleTypeDef *huart)
+{
+  /* Disable the UART Transmit Complete Interrupt */
+  __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
+
+  /* Check if a receive process is ongoing or not */
+  if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+  {
+    huart->State = HAL_UART_STATE_BUSY_RX;
+  }
+  else
+  {
+    /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+
+    huart->State = HAL_UART_STATE_READY;
+  }
+
+  HAL_UART_TxCpltCallback(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Receive an amount of data in interrupt mode
+  *         Function called under interruption only, once
+  *         interruptions have been enabled by HAL_UART_Receive_IT()
+  * @param  huart: UART handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef UART_Receive_IT(UART_HandleTypeDef *huart)
+{
+  uint16_t* tmp;
+  uint16_t uhMask = huart->Mask;
+
+  if((huart->State == HAL_UART_STATE_BUSY_RX) || (huart->State == HAL_UART_STATE_BUSY_TX_RX))
+  {
+
+    if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+    {
+      tmp = (uint16_t*) huart->pRxBuffPtr ;
+      *tmp = (uint16_t)(huart->Instance->RDR & uhMask);
+      huart->pRxBuffPtr +=2;
+    }
+    else
+    {
+      *huart->pRxBuffPtr++ = (uint8_t)(huart->Instance->RDR & (uint8_t)uhMask);
+    }
+
+    if(--huart->RxXferCount == 0)
+    {
+      __HAL_UART_DISABLE_IT(huart, UART_IT_RXNE);
+
+      /* Check if a transmit Process is ongoing or not */
+      if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+      {
+        huart->State = HAL_UART_STATE_BUSY_TX;
+      }
+      else
+      {
+        /* Disable the UART Parity Error Interrupt */
+        __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
+
+        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+        __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+
+        huart->State = HAL_UART_STATE_READY;
+      }
+
+      HAL_UART_RxCpltCallback(huart);
+
+      return HAL_OK;
+    }
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup UART_Exported_Functions_Group3 Peripheral Control functions
+  *  @brief   UART control functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the UART.
+     (+) HAL_UART_GetState() API is helpful to check in run-time the state of the UART peripheral.
+     (+) HAL_MultiProcessor_EnableMuteMode() API enables mute mode
+     (+) HAL_MultiProcessor_DisableMuteMode() API disables mute mode
+     (+) HAL_MultiProcessor_EnterMuteMode() API enters mute mode
+     (+) HAL_MultiProcessor_EnableMuteMode() API enables mute mode
+     (+) UART_SetConfig() API configures the UART peripheral
+     (+) UART_AdvFeatureConfig() API optionally configures the UART advanced features
+     (+) UART_CheckIdleState() API ensures that TEACK and/or REACK are set after initialization
+     (+) HAL_HalfDuplex_EnableTransmitter() API disables receiver and enables transmitter
+     (+) HAL_HalfDuplex_EnableReceiver() API disables transmitter and enables receiver
+     (+) HAL_LIN_SendBreak() API transmits the break characters
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Enable UART in mute mode (doesn't mean UART enters mute mode;
+  * to enter mute mode, HAL_MultiProcessor_EnterMuteMode() API must be called)
+  * @param huart: UART handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_MultiProcessor_EnableMuteMode(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Enable USART mute mode by setting the MME bit in the CR1 register */
+  huart->Instance->CR1 |= USART_CR1_MME;
+
+  huart->State = HAL_UART_STATE_READY;
+
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief Disable UART mute mode (doesn't mean it actually wakes up the software,
+  * as it may not have been in mute mode at this very moment).
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_MultiProcessor_DisableMuteMode(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+   /* Disable USART mute mode by clearing the MME bit in the CR1 register */
+  huart->Instance->CR1 &= ~(USART_CR1_MME);
+
+  huart->State = HAL_UART_STATE_READY;
+
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief Enter UART mute mode (means UART actually enters mute mode).
+  * To exit from mute mode, HAL_MultiProcessor_DisableMuteMode() API must be called.
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+void HAL_MultiProcessor_EnterMuteMode(UART_HandleTypeDef *huart)
+{
+  __HAL_UART_SEND_REQ(huart, UART_MUTE_MODE_REQUEST);
+}
+
+
+
+/**
+  * @brief return the UART state
+  * @param huart: uart handle
+  * @retval HAL state
+  */
+HAL_UART_StateTypeDef HAL_UART_GetState(UART_HandleTypeDef *huart)
+{
+  return huart->State;
+}
+
+/**
+* @brief  Return the UART error code
+* @param  huart : pointer to a UART_HandleTypeDef structure that contains
+  *              the configuration information for the specified UART.
+* @retval UART Error Code
+*/
+uint32_t HAL_UART_GetError(UART_HandleTypeDef *huart)
+{
+  return huart->ErrorCode;
+}
+
+/**
+  * @brief Configure the UART peripheral
+  * @param huart: uart handle
+  * @retval None
+  */
+HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
+{
+  uint32_t tmpreg                     = 0x00000000;
+  UART_ClockSourceTypeDef clocksource = UART_CLOCKSOURCE_UNDEFINED;
+  uint16_t brrtemp                    = 0x0000;
+  uint16_t usartdiv                   = 0x0000;
+  HAL_StatusTypeDef ret               = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_UART_BAUDRATE(huart->Init.BaudRate));
+  assert_param(IS_UART_WORD_LENGTH(huart->Init.WordLength));
+  assert_param(IS_UART_STOPBITS(huart->Init.StopBits));
+  assert_param(IS_UART_PARITY(huart->Init.Parity));
+  assert_param(IS_UART_MODE(huart->Init.Mode));
+  assert_param(IS_UART_HARDWARE_FLOW_CONTROL(huart->Init.HwFlowCtl));
+  assert_param(IS_UART_ONE_BIT_SAMPLE(huart->Init.OneBitSampling));
+
+
+  /*-------------------------- USART CR1 Configuration -----------------------*/
+  /* Clear M, PCE, PS, TE, RE and OVER8 bits and configure
+   *  the UART Word Length, Parity, Mode and oversampling:
+   *  set the M bits according to huart->Init.WordLength value
+   *  set PCE and PS bits according to huart->Init.Parity value
+   *  set TE and RE bits according to huart->Init.Mode value
+   *  set OVER8 bit according to huart->Init.OverSampling value */
+  tmpreg = (uint32_t)huart->Init.WordLength | huart->Init.Parity | huart->Init.Mode | huart->Init.OverSampling ;
+  MODIFY_REG(huart->Instance->CR1, UART_CR1_FIELDS, tmpreg);
+
+  /*-------------------------- USART CR2 Configuration -----------------------*/
+  /* Configure the UART Stop Bits: Set STOP[13:12] bits according
+   * to huart->Init.StopBits value */
+  MODIFY_REG(huart->Instance->CR2, USART_CR2_STOP, huart->Init.StopBits);
+
+  /*-------------------------- USART CR3 Configuration -----------------------*/
+  /* Configure
+   * - UART HardWare Flow Control: set CTSE and RTSE bits according
+   *   to huart->Init.HwFlowCtl value
+   * - one-bit sampling method versus three samples' majority rule according
+   *   to huart->Init.OneBitSampling */
+  tmpreg = (uint32_t)huart->Init.HwFlowCtl | huart->Init.OneBitSampling ;
+  MODIFY_REG(huart->Instance->CR3, (USART_CR3_RTSE | USART_CR3_CTSE | USART_CR3_ONEBIT), tmpreg);
+
+  /*-------------------------- USART BRR Configuration -----------------------*/
+  UART_GETCLOCKSOURCE(huart, clocksource);
+
+  /* Check UART Over Sampling to set Baud Rate Register */
+  if (huart->Init.OverSampling == UART_OVERSAMPLING_8)
+  {
+    switch (clocksource)
+    {
+    case UART_CLOCKSOURCE_PCLK1:
+        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(HAL_RCC_GetPCLK1Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_PCLK2:
+        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_HSI:
+        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(HSI_VALUE, huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_SYSCLK:
+        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(HAL_RCC_GetSysClockFreq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_LSE:
+        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(LSE_VALUE, huart->Init.BaudRate));
+      break;
+      case UART_CLOCKSOURCE_UNDEFINED:
+    default:
+        ret = HAL_ERROR;
+      break;
+    }
+
+    brrtemp = usartdiv & 0xFFF0;
+    brrtemp |= (uint16_t)((usartdiv & (uint16_t)0x000F) >> 1U);
+    huart->Instance->BRR = brrtemp;
+  }
+  else
+  {
+    switch (clocksource)
+    {
+    case UART_CLOCKSOURCE_PCLK1:
+        huart->Instance->BRR = (uint16_t)(UART_DIV_SAMPLING16(HAL_RCC_GetPCLK1Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_PCLK2:
+        huart->Instance->BRR = (uint16_t)(UART_DIV_SAMPLING16(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_HSI:
+        huart->Instance->BRR = (uint16_t)(UART_DIV_SAMPLING16(HSI_VALUE, huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_SYSCLK:
+        huart->Instance->BRR = (uint16_t)(UART_DIV_SAMPLING16(HAL_RCC_GetSysClockFreq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_LSE:
+        huart->Instance->BRR = (uint16_t)(UART_DIV_SAMPLING16(LSE_VALUE, huart->Init.BaudRate));
+      break;
+      case UART_CLOCKSOURCE_UNDEFINED:
+    default:
+        ret = HAL_ERROR;
+      break;
+    }
+  }
+
+  return ret;
+
+}
+
+
+/**
+  * @brief Configure the UART peripheral advanced features
+  * @param huart: uart handle
+  * @retval None
+  */
+void UART_AdvFeatureConfig(UART_HandleTypeDef *huart)
+{
+  /* Check whether the set of advanced features to configure is properly set */
+  assert_param(IS_UART_ADVFEATURE_INIT(huart->AdvancedInit.AdvFeatureInit));
+
+  /* if required, configure TX pin active level inversion */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_TXINVERT_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_TXINV(huart->AdvancedInit.TxPinLevelInvert));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_TXINV, huart->AdvancedInit.TxPinLevelInvert);
+  }
+
+  /* if required, configure RX pin active level inversion */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_RXINVERT_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_RXINV(huart->AdvancedInit.RxPinLevelInvert));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_RXINV, huart->AdvancedInit.RxPinLevelInvert);
+  }
+
+  /* if required, configure data inversion */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_DATAINVERT_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_DATAINV(huart->AdvancedInit.DataInvert));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_DATAINV, huart->AdvancedInit.DataInvert);
+  }
+
+  /* if required, configure RX/TX pins swap */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_SWAP_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_SWAP(huart->AdvancedInit.Swap));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_SWAP, huart->AdvancedInit.Swap);
+  }
+
+  /* if required, configure RX overrun detection disabling */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_RXOVERRUNDISABLE_INIT))
+  {
+    assert_param(IS_UART_OVERRUN(huart->AdvancedInit.OverrunDisable));
+    MODIFY_REG(huart->Instance->CR3, USART_CR3_OVRDIS, huart->AdvancedInit.OverrunDisable);
+  }
+
+  /* if required, configure DMA disabling on reception error */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_DMADISABLEONERROR_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_DMAONRXERROR(huart->AdvancedInit.DMADisableonRxError));
+    MODIFY_REG(huart->Instance->CR3, USART_CR3_DDRE, huart->AdvancedInit.DMADisableonRxError);
+  }
+
+  /* if required, configure auto Baud rate detection scheme */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_AUTOBAUDRATE_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_AUTOBAUDRATE(huart->AdvancedInit.AutoBaudRateEnable));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_ABREN, huart->AdvancedInit.AutoBaudRateEnable);
+    /* set auto Baudrate detection parameters if detection is enabled */
+    if(huart->AdvancedInit.AutoBaudRateEnable == UART_ADVFEATURE_AUTOBAUDRATE_ENABLE)
+    {
+      assert_param(IS_UART_ADVFEATURE_AUTOBAUDRATEMODE(huart->AdvancedInit.AutoBaudRateMode));
+      MODIFY_REG(huart->Instance->CR2, USART_CR2_ABRMODE, huart->AdvancedInit.AutoBaudRateMode);
+    }
+  }
+
+  /* if required, configure MSB first on communication line */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_MSBFIRST_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_MSBFIRST(huart->AdvancedInit.MSBFirst));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_MSBFIRST, huart->AdvancedInit.MSBFirst);
+  }
+}
+
+
+
+/**
+  * @brief Check the UART Idle State
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart)
+{
+  /* Initialize the UART ErrorCode */
+  huart->ErrorCode = HAL_UART_ERROR_NONE;
+
+  /* Check if the Transmitter is enabled */
+  if((huart->Instance->CR1 & USART_CR1_TE) == USART_CR1_TE)
+  {
+    /* Wait until TEACK flag is set */
+    if(UART_WaitOnFlagUntilTimeout(huart, USART_ISR_TEACK, RESET, HAL_UART_TIMEOUT_VALUE) != HAL_OK)
+    {
+      /* Timeout Occurred */
+      return HAL_TIMEOUT;
+    }
+  }
+  /* Check if the Receiver is enabled */
+  if((huart->Instance->CR1 & USART_CR1_RE) == USART_CR1_RE)
+  {
+    /* Wait until REACK flag is set */
+    if(UART_WaitOnFlagUntilTimeout(huart, USART_ISR_REACK, RESET,  HAL_UART_TIMEOUT_VALUE) != HAL_OK)
+    {
+      /* Timeout Occurred */
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Initialize the UART State */
+  huart->State= HAL_UART_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables the UART transmitter and disables the UART receiver.
+  * @param  huart: UART handle
+  * @retval HAL status
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_HalfDuplex_EnableTransmitter(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Clear TE and RE bits */
+  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TE | USART_CR1_RE));
+  /* Enable the USART's transmit interface by setting the TE bit in the USART CR1 register */
+  SET_BIT(huart->Instance->CR1, USART_CR1_TE);
+
+  huart->State= HAL_UART_STATE_READY;
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables the UART receiver and disables the UART transmitter.
+  * @param  huart: UART handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HalfDuplex_EnableReceiver(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Clear TE and RE bits */
+  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TE | USART_CR1_RE));
+  /* Enable the USART's receive interface by setting the RE bit in the USART CR1 register */
+  SET_BIT(huart->Instance->CR1, USART_CR1_RE);
+
+  huart->State = HAL_UART_STATE_READY;
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Transmits break characters.
+  * @param  huart: UART handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LIN_SendBreak(UART_HandleTypeDef *huart)
+{
+  /* Check the parameters */
+  assert_param(IS_UART_INSTANCE(huart->Instance));
+
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Send break characters */
+  huart->Instance->RQR |= UART_SENDBREAK_REQUEST;
+
+  huart->State = HAL_UART_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_UART_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_ll_sdmmc.c
+++ b/stmhal/hal/f7/src/stm32f7xx_ll_sdmmc.c
@@ -1,0 +1,510 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_ll_sdmmc.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   SDMMC Low Layer HAL module driver.
+  *
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the SDMMC peripheral:
+  *           + Initialization/de-initialization functions
+  *           + I/O operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *
+  @verbatim
+  ==============================================================================
+                       ##### SDMMC peripheral features #####
+  ==============================================================================
+    [..] The SD/SDMMC MMC card host interface (SDMMC) provides an interface between the APB2
+         peripheral bus and MultiMedia cards (MMCs), SD memory cards, SDMMC cards and CE-ATA
+         devices.
+
+    [..] The SDMMC features include the following:
+         (+) Full compliance with MultiMedia Card System Specification Version 4.2. Card support
+             for three different databus modes: 1-bit (default), 4-bit and 8-bit
+         (+) Full compatibility with previous versions of MultiMedia Cards (forward compatibility)
+         (+) Full compliance with SD Memory Card Specifications Version 2.0
+         (+) Full compliance with SD I/O Card Specification Version 2.0: card support for two
+             different data bus modes: 1-bit (default) and 4-bit
+         (+) Full support of the CE-ATA features (full compliance with CE-ATA digital protocol
+             Rev1.1)
+         (+) Data transfer up to 48 MHz for the 8 bit mode
+         (+) Data and command output enable signals to control external bidirectional drivers.
+
+
+                           ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      This driver is a considered as a driver of service for external devices drivers
+      that interfaces with the SDMMC peripheral.
+      According to the device used (SD card/ MMC card / SDMMC card ...), a set of APIs
+      is used in the device's driver to perform SDMMC operations and functionalities.
+
+      This driver is almost transparent for the final user, it is only used to implement other
+      functionalities of the external device.
+
+    [..]
+      (+) The SDMMC clock (SDMMCCLK = 48 MHz) is coming from a specific output of PLL
+          (PLL48CLK). Before start working with SDMMC peripheral make sure that the
+          PLL is well configured.
+          The SDMMC peripheral uses two clock signals:
+          (++) SDMMC adapter clock (SDMMCCLK = 48 MHz)
+          (++) APB2 bus clock (PCLK2)
+
+          -@@- PCLK2 and SDMMC_CK clock frequencies must respect the following condition:
+               Frequency(PCLK2) >= (3 / 8 x Frequency(SDMMC_CK))
+
+      (+) Enable/Disable peripheral clock using RCC peripheral macros related to SDMMC
+          peripheral.
+
+      (+) Enable the Power ON State using the SDMMC_PowerState_ON(SDMMCx)
+          function and disable it using the function SDMMC_PowerState_OFF(SDMMCx).
+
+      (+) Enable/Disable the clock using the __SDMMC_ENABLE()/__SDMMC_DISABLE() macros.
+
+      (+) Enable/Disable the peripheral interrupts using the macros __SDMMC_ENABLE_IT(hSDMMC, IT)
+          and __SDMMC_DISABLE_IT(hSDMMC, IT) if you need to use interrupt mode.
+
+      (+) When using the DMA mode
+          (++) Configure the DMA in the MSP layer of the external device
+          (++) Active the needed channel Request
+          (++) Enable the DMA using __SDMMC_DMA_ENABLE() macro or Disable it using the macro
+               __SDMMC_DMA_DISABLE().
+
+      (+) To control the CPSM (Command Path State Machine) and send
+          commands to the card use the SDMMC_SendCommand(SDMMCx),
+          SDMMC_GetCommandResponse() and SDMMC_GetResponse() functions. First, user has
+          to fill the command structure (pointer to SDMMC_CmdInitTypeDef) according
+          to the selected command to be sent.
+          The parameters that should be filled are:
+           (++) Command Argument
+           (++) Command Index
+           (++) Command Response type
+           (++) Command Wait
+           (++) CPSM Status (Enable or Disable).
+
+          -@@- To check if the command is well received, read the SDMMC_CMDRESP
+              register using the SDMMC_GetCommandResponse().
+              The SDMMC responses registers (SDMMC_RESP1 to SDMMC_RESP2), use the
+              SDMMC_GetResponse() function.
+
+      (+) To control the DPSM (Data Path State Machine) and send/receive
+           data to/from the card use the SDMMC_DataConfig(), SDMMC_GetDataCounter(),
+          SDMMC_ReadFIFO(), DIO_WriteFIFO() and SDMMC_GetFIFOCount() functions.
+
+    *** Read Operations ***
+    =======================
+    [..]
+      (#) First, user has to fill the data structure (pointer to
+          SDMMC_DataInitTypeDef) according to the selected data type to be received.
+          The parameters that should be filled are:
+           (++) Data TimeOut
+           (++) Data Length
+           (++) Data Block size
+           (++) Data Transfer direction: should be from card (To SDMMC)
+           (++) Data Transfer mode
+           (++) DPSM Status (Enable or Disable)
+
+      (#) Configure the SDMMC resources to receive the data from the card
+          according to selected transfer mode (Refer to Step 8, 9 and 10).
+
+      (#) Send the selected Read command (refer to step 11).
+
+      (#) Use the SDMMC flags/interrupts to check the transfer status.
+
+    *** Write Operations ***
+    ========================
+    [..]
+     (#) First, user has to fill the data structure (pointer to
+         SDMMC_DataInitTypeDef) according to the selected data type to be received.
+         The parameters that should be filled are:
+          (++) Data TimeOut
+          (++) Data Length
+          (++) Data Block size
+          (++) Data Transfer direction:  should be to card (To CARD)
+          (++) Data Transfer mode
+          (++) DPSM Status (Enable or Disable)
+
+     (#) Configure the SDMMC resources to send the data to the card according to
+         selected transfer mode.
+
+     (#) Send the selected Write command.
+
+     (#) Use the SDMMC flags/interrupts to check the transfer status.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SDMMC_LL SDMMC Low Layer
+  * @brief Low layer module for SD
+  * @{
+  */
+
+#if defined (HAL_SD_MODULE_ENABLED) || defined(HAL_MMC_MODULE_ENABLED)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup SDMMC_LL_Exported_Functions SDMMC Low Layer Exported Functions
+  * @{
+  */
+
+/** @defgroup HAL_SDMMC_LL_Group1 Initialization de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization/de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the SDMMC according to the specified
+  *         parameters in the SDMMC_InitTypeDef and create the associated handle.
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @param  Init: SDMMC initialization structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef SDMMC_Init(SDMMC_TypeDef *SDMMCx, SDMMC_InitTypeDef Init)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_SDMMC_ALL_INSTANCE(SDMMCx));
+  assert_param(IS_SDMMC_CLOCK_EDGE(Init.ClockEdge));
+  assert_param(IS_SDMMC_CLOCK_BYPASS(Init.ClockBypass));
+  assert_param(IS_SDMMC_CLOCK_POWER_SAVE(Init.ClockPowerSave));
+  assert_param(IS_SDMMC_BUS_WIDE(Init.BusWide));
+  assert_param(IS_SDMMC_HARDWARE_FLOW_CONTROL(Init.HardwareFlowControl));
+  assert_param(IS_SDMMC_CLKDIV(Init.ClockDiv));
+
+  /* Set SDMMC configuration parameters */
+  tmpreg |= (Init.ClockEdge           |\
+             Init.ClockBypass         |\
+             Init.ClockPowerSave      |\
+             Init.BusWide             |\
+             Init.HardwareFlowControl |\
+             Init.ClockDiv
+             );
+
+  /* Write to SDMMC CLKCR */
+  MODIFY_REG(SDMMCx->CLKCR, CLKCR_CLEAR_MASK, tmpreg);
+
+  return HAL_OK;
+}
+
+
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SDMMC_LL_Group2 IO operation functions
+ *  @brief   Data transfers functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### I/O operation functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to manage the SDMMC data
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Read data (word) from Rx FIFO in blocking mode (polling)
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval HAL status
+  */
+uint32_t SDMMC_ReadFIFO(SDMMC_TypeDef *SDMMCx)
+{
+  /* Read data from Rx FIFO */
+  return (SDMMCx->FIFO);
+}
+
+/**
+  * @brief  Write data (word) to Tx FIFO in blocking mode (polling)
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @param  pWriteData: pointer to data to write
+  * @retval HAL status
+  */
+HAL_StatusTypeDef SDMMC_WriteFIFO(SDMMC_TypeDef *SDMMCx, uint32_t *pWriteData)
+{
+  /* Write data to FIFO */
+  SDMMCx->FIFO = *pWriteData;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SDMMC_LL_Group3 Peripheral Control functions
+ *  @brief   management functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the SDMMC data
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Set SDMMC Power state to ON.
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval HAL status
+  */
+HAL_StatusTypeDef SDMMC_PowerState_ON(SDMMC_TypeDef *SDMMCx)
+{
+  /* Set power state to ON */
+  SDMMCx->POWER = SDMMC_POWER_PWRCTRL;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set SDMMC Power state to OFF.
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval HAL status
+  */
+HAL_StatusTypeDef SDMMC_PowerState_OFF(SDMMC_TypeDef *SDMMCx)
+{
+  /* Set power state to OFF */
+  SDMMCx->POWER = (uint32_t)0x00000000;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get SDMMC Power state.
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval Power status of the controller. The returned value can be one of the
+  *         following values:
+  *            - 0x00: Power OFF
+  *            - 0x02: Power UP
+  *            - 0x03: Power ON
+  */
+uint32_t SDMMC_GetPowerState(SDMMC_TypeDef *SDMMCx)
+{
+  return (SDMMCx->POWER & SDMMC_POWER_PWRCTRL);
+}
+
+/**
+  * @brief  Configure the SDMMC command path according to the specified parameters in
+  *         SDMMC_CmdInitTypeDef structure and send the command
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @param  Command: pointer to a SDMMC_CmdInitTypeDef structure that contains
+  *         the configuration information for the SDMMC command
+  * @retval HAL status
+  */
+HAL_StatusTypeDef SDMMC_SendCommand(SDMMC_TypeDef *SDMMCx, SDMMC_CmdInitTypeDef *Command)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_SDMMC_CMD_INDEX(Command->CmdIndex));
+  assert_param(IS_SDMMC_RESPONSE(Command->Response));
+  assert_param(IS_SDMMC_WAIT(Command->WaitForInterrupt));
+  assert_param(IS_SDMMC_CPSM(Command->CPSM));
+
+  /* Set the SDMMC Argument value */
+  SDMMCx->ARG = Command->Argument;
+
+  /* Set SDMMC command parameters */
+  tmpreg |= (uint32_t)(Command->CmdIndex         |\
+                       Command->Response         |\
+                       Command->WaitForInterrupt |\
+                       Command->CPSM);
+
+  /* Write to SDMMC CMD register */
+  MODIFY_REG(SDMMCx->CMD, CMD_CLEAR_MASK, tmpreg);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Return the command index of last command for which response received
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval Command index of the last command response received
+  */
+uint8_t SDMMC_GetCommandResponse(SDMMC_TypeDef *SDMMCx)
+{
+  return (uint8_t)(SDMMCx->RESPCMD);
+}
+
+
+/**
+  * @brief  Return the response received from the card for the last command
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @param  Response: Specifies the SDMMC response register.
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_RESP1: Response Register 1
+  *            @arg SDMMC_RESP2: Response Register 2
+  *            @arg SDMMC_RESP3: Response Register 3
+  *            @arg SDMMC_RESP4: Response Register 4
+  * @retval The Corresponding response register value
+  */
+uint32_t SDMMC_GetResponse(SDMMC_TypeDef *SDMMCx, uint32_t Response)
+{
+  __IO uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_SDMMC_RESP(Response));
+
+  /* Get the response */
+  tmp = (uint32_t)&(SDMMCx->RESP1) + Response;
+
+  return (*(__IO uint32_t *) tmp);
+}
+
+/**
+  * @brief  Configure the SDMMC data path according to the specified
+  *         parameters in the SDMMC_DataInitTypeDef.
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @param  Data : pointer to a SDMMC_DataInitTypeDef structure
+  *         that contains the configuration information for the SDMMC data.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef SDMMC_DataConfig(SDMMC_TypeDef *SDMMCx, SDMMC_DataInitTypeDef* Data)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_SDMMC_DATA_LENGTH(Data->DataLength));
+  assert_param(IS_SDMMC_BLOCK_SIZE(Data->DataBlockSize));
+  assert_param(IS_SDMMC_TRANSFER_DIR(Data->TransferDir));
+  assert_param(IS_SDMMC_TRANSFER_MODE(Data->TransferMode));
+  assert_param(IS_SDMMC_DPSM(Data->DPSM));
+
+  /* Set the SDMMC Data TimeOut value */
+  SDMMCx->DTIMER = Data->DataTimeOut;
+
+  /* Set the SDMMC DataLength value */
+  SDMMCx->DLEN = Data->DataLength;
+
+  /* Set the SDMMC data configuration parameters */
+  tmpreg |= (uint32_t)(Data->DataBlockSize |\
+                       Data->TransferDir   |\
+                       Data->TransferMode  |\
+                       Data->DPSM);
+
+  /* Write to SDMMC DCTRL */
+  MODIFY_REG(SDMMCx->DCTRL, DCTRL_CLEAR_MASK, tmpreg);
+
+  return HAL_OK;
+
+}
+
+/**
+  * @brief  Returns number of remaining data bytes to be transferred.
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval Number of remaining data bytes to be transferred
+  */
+uint32_t SDMMC_GetDataCounter(SDMMC_TypeDef *SDMMCx)
+{
+  return (SDMMCx->DCOUNT);
+}
+
+/**
+  * @brief  Get the FIFO data
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval Data received
+  */
+uint32_t SDMMC_GetFIFOCount(SDMMC_TypeDef *SDMMCx)
+{
+  return (SDMMCx->FIFO);
+}
+
+
+/**
+  * @brief  Sets one of the two options of inserting read wait interval.
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @param  SDMMC_ReadWaitMode: SDMMC Read Wait operation mode.
+  *          This parameter can be:
+  *            @arg SDMMC_READ_WAIT_MODE_CLK: Read Wait control by stopping SDMMCCLK
+  *            @arg SDMMC_READ_WAIT_MODE_DATA2: Read Wait control using SDMMC_DATA2
+  * @retval None
+  */
+HAL_StatusTypeDef SDMMC_SetSDMMCReadWaitMode(SDMMC_TypeDef *SDMMCx, uint32_t SDMMC_ReadWaitMode)
+{
+  /* Check the parameters */
+  assert_param(IS_SDMMC_READWAIT_MODE(SDMMC_ReadWaitMode));
+
+  /* Set SDMMC read wait mode */
+  SDMMCx->DCTRL |= SDMMC_ReadWaitMode;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* (HAL_SD_MODULE_ENABLED) || (HAL_MMC_MODULE_ENABLED) */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/f7/src/stm32f7xx_ll_usb.c
+++ b/stmhal/hal/f7/src/stm32f7xx_ll_usb.c
@@ -1,0 +1,1696 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_ll_usb.c
+  * @author  MCD Application Team
+  * @version V1.0.1
+  * @date    25-June-2015
+  * @brief   USB Low Layer HAL module driver.
+  *
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the USB Peripheral Controller:
+  *           + Initialization/de-initialization functions
+  *           + I/O operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *
+  @verbatim
+  ==============================================================================
+                    ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      (#) Fill parameters of Init structure in USB_OTG_CfgTypeDef structure.
+
+      (#) Call USB_CoreInit() API to initialize the USB Core peripheral.
+
+      (#) The upper HAL HCD/PCD driver will call the right routines for its internal processes.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_LL_USB_DRIVER
+  * @{
+  */
+
+#if defined (HAL_PCD_MODULE_ENABLED) || defined (HAL_HCD_MODULE_ENABLED)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx);
+
+/** @defgroup PCD_Private_Functions
+  * @{
+  */
+
+/** @defgroup LL_USB_Group1 Initialization/de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization/de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the USB Core
+  * @param  USBx: USB Instance
+  * @param  cfg : pointer to a USB_OTG_CfgTypeDef structure that contains
+  *         the configuration information for the specified USBx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+{
+  if (cfg.phy_itface == USB_OTG_ULPI_PHY)
+  {
+
+    USBx->GCCFG &= ~(USB_OTG_GCCFG_PWRDWN);
+
+    /* Init The ULPI Interface */
+    USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_TSDPS | USB_OTG_GUSBCFG_ULPIFSLS | USB_OTG_GUSBCFG_PHYSEL);
+
+    /* Select vbus source */
+    USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_ULPIEVBUSD | USB_OTG_GUSBCFG_ULPIEVBUSI);
+    if(cfg.use_external_vbus == 1)
+    {
+      USBx->GUSBCFG |= USB_OTG_GUSBCFG_ULPIEVBUSD;
+    }
+    /* Reset after a PHY select  */
+    USB_CoreReset(USBx);
+  }
+  else /* FS interface (embedded Phy) */
+  {
+
+    /* Select FS Embedded PHY */
+    USBx->GUSBCFG |= USB_OTG_GUSBCFG_PHYSEL;
+
+    /* Reset after a PHY select and set Host mode */
+    USB_CoreReset(USBx);
+
+    /* Deactivate the power down*/
+    USBx->GCCFG = USB_OTG_GCCFG_PWRDWN;
+  }
+
+  if(cfg.dma_enable == ENABLE)
+  {
+    USBx->GAHBCFG |= (USB_OTG_GAHBCFG_HBSTLEN_1 | USB_OTG_GAHBCFG_HBSTLEN_2);
+    USBx->GAHBCFG |= USB_OTG_GAHBCFG_DMAEN;
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_EnableGlobalInt
+  *         Enables the controller's Global Int in the AHB Config reg
+  * @param  USBx : Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EnableGlobalInt(USB_OTG_GlobalTypeDef *USBx)
+{
+  USBx->GAHBCFG |= USB_OTG_GAHBCFG_GINT;
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  USB_DisableGlobalInt
+  *         Disable the controller's Global Int in the AHB Config reg
+  * @param  USBx : Selected device
+  * @retval HAL status
+*/
+HAL_StatusTypeDef USB_DisableGlobalInt(USB_OTG_GlobalTypeDef *USBx)
+{
+  USBx->GAHBCFG &= ~USB_OTG_GAHBCFG_GINT;
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_SetCurrentMode : Set functional mode
+  * @param  USBx : Selected device
+  * @param  mode :  current core mode
+  *          This parameter can be one of the these values:
+  *            @arg USB_OTG_DEVICE_MODE: Peripheral mode
+  *            @arg USB_OTG_HOST_MODE: Host mode
+  *            @arg USB_OTG_DRD_MODE: Dual Role Device mode
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_SetCurrentMode(USB_OTG_GlobalTypeDef *USBx , USB_OTG_ModeTypeDef mode)
+{
+  USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_FHMOD | USB_OTG_GUSBCFG_FDMOD);
+
+  if ( mode == USB_OTG_HOST_MODE)
+  {
+    USBx->GUSBCFG |= USB_OTG_GUSBCFG_FHMOD;
+  }
+  else if ( mode == USB_OTG_DEVICE_MODE)
+  {
+    USBx->GUSBCFG |= USB_OTG_GUSBCFG_FDMOD;
+  }
+  HAL_Delay(50);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_DevInit : Initializes the USB_OTG controller registers
+  *         for device mode
+  * @param  USBx : Selected device
+  * @param  cfg  : pointer to a USB_OTG_CfgTypeDef structure that contains
+  *         the configuration information for the specified USBx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+{
+  uint32_t i = 0;
+
+  /*Activate VBUS Sensing B */
+  USBx->GCCFG |= USB_OTG_GCCFG_VBDEN;
+
+  if (cfg.vbus_sensing_enable == 0)
+  {
+    /*Desactivate VBUS Sensing B */
+    USBx->GCCFG &= ~ USB_OTG_GCCFG_VBDEN;
+
+    /* B-peripheral session valid override enable*/
+    USBx->GOTGCTL |= USB_OTG_GOTGCTL_BVALOEN;
+    USBx->GOTGCTL |= USB_OTG_GOTGCTL_BVALOVAL;
+  }
+
+  /* Restart the Phy Clock */
+  USBx_PCGCCTL = 0;
+
+  /* Device mode configuration */
+  USBx_DEVICE->DCFG |= DCFG_FRAME_INTERVAL_80;
+
+  if(cfg.phy_itface  == USB_OTG_ULPI_PHY)
+  {
+    if(cfg.speed == USB_OTG_SPEED_HIGH)
+    {
+      /* Set High speed phy */
+      USB_SetDevSpeed (USBx , USB_OTG_SPEED_HIGH);
+    }
+    else
+    {
+      /* set High speed phy in Full speed mode */
+      USB_SetDevSpeed (USBx , USB_OTG_SPEED_HIGH_IN_FULL);
+    }
+  }
+  else
+  {
+    /* Set Full speed phy */
+    USB_SetDevSpeed (USBx , USB_OTG_SPEED_FULL);
+  }
+
+  /* Flush the FIFOs */
+  USB_FlushTxFifo(USBx , 0x10); /* all Tx FIFOs */
+  USB_FlushRxFifo(USBx);
+
+
+  /* Clear all pending Device Interrupts */
+  USBx_DEVICE->DIEPMSK = 0;
+  USBx_DEVICE->DOEPMSK = 0;
+  USBx_DEVICE->DAINT = 0xFFFFFFFF;
+  USBx_DEVICE->DAINTMSK = 0;
+
+  for (i = 0; i < cfg.dev_endpoints; i++)
+  {
+    if ((USBx_INEP(i)->DIEPCTL & USB_OTG_DIEPCTL_EPENA) == USB_OTG_DIEPCTL_EPENA)
+    {
+      USBx_INEP(i)->DIEPCTL = (USB_OTG_DIEPCTL_EPDIS | USB_OTG_DIEPCTL_SNAK);
+    }
+    else
+    {
+      USBx_INEP(i)->DIEPCTL = 0;
+    }
+
+    USBx_INEP(i)->DIEPTSIZ = 0;
+    USBx_INEP(i)->DIEPINT  = 0xFF;
+  }
+
+  for (i = 0; i < cfg.dev_endpoints; i++)
+  {
+    if ((USBx_OUTEP(i)->DOEPCTL & USB_OTG_DOEPCTL_EPENA) == USB_OTG_DOEPCTL_EPENA)
+    {
+      USBx_OUTEP(i)->DOEPCTL = (USB_OTG_DOEPCTL_EPDIS | USB_OTG_DOEPCTL_SNAK);
+    }
+    else
+    {
+      USBx_OUTEP(i)->DOEPCTL = 0;
+    }
+
+    USBx_OUTEP(i)->DOEPTSIZ = 0;
+    USBx_OUTEP(i)->DOEPINT  = 0xFF;
+  }
+
+  USBx_DEVICE->DIEPMSK &= ~(USB_OTG_DIEPMSK_TXFURM);
+
+  if (cfg.dma_enable == 1)
+  {
+    /*Set threshold parameters */
+    USBx_DEVICE->DTHRCTL = (USB_OTG_DTHRCTL_TXTHRLEN_6 | USB_OTG_DTHRCTL_RXTHRLEN_6);
+    USBx_DEVICE->DTHRCTL |= (USB_OTG_DTHRCTL_RXTHREN | USB_OTG_DTHRCTL_ISOTHREN | USB_OTG_DTHRCTL_NONISOTHREN);
+
+    i= USBx_DEVICE->DTHRCTL;
+  }
+
+  /* Disable all interrupts. */
+  USBx->GINTMSK = 0;
+
+  /* Clear any pending interrupts */
+  USBx->GINTSTS = 0xBFFFFFFF;
+
+  /* Enable the common interrupts */
+  if (cfg.dma_enable == DISABLE)
+  {
+    USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
+  }
+
+  /* Enable interrupts matching to the Device mode ONLY */
+  USBx->GINTMSK |= (USB_OTG_GINTMSK_USBSUSPM | USB_OTG_GINTMSK_USBRST |\
+                    USB_OTG_GINTMSK_ENUMDNEM | USB_OTG_GINTMSK_IEPINT |\
+                    USB_OTG_GINTMSK_OEPINT   | USB_OTG_GINTMSK_IISOIXFRM|\
+                    USB_OTG_GINTMSK_PXFRM_IISOOXFRM | USB_OTG_GINTMSK_WUIM);
+
+  if(cfg.Sof_enable)
+  {
+    USBx->GINTMSK |= USB_OTG_GINTMSK_SOFM;
+  }
+
+  if (cfg.vbus_sensing_enable == ENABLE)
+  {
+    USBx->GINTMSK |= (USB_OTG_GINTMSK_SRQIM | USB_OTG_GINTMSK_OTGINT);
+  }
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  USB_OTG_FlushTxFifo : Flush a Tx FIFO
+  * @param  USBx : Selected device
+  * @param  num : FIFO number
+  *         This parameter can be a value from 1 to 15
+            15 means Flush all Tx FIFOs
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_FlushTxFifo (USB_OTG_GlobalTypeDef *USBx, uint32_t num )
+{
+  uint32_t count = 0;
+
+  USBx->GRSTCTL = ( USB_OTG_GRSTCTL_TXFFLSH |(uint32_t)( num << 6));
+
+  do
+  {
+    if (++count > 200000)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_TXFFLSH) == USB_OTG_GRSTCTL_TXFFLSH);
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  USB_FlushRxFifo : Flush Rx FIFO
+  * @param  USBx : Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_FlushRxFifo(USB_OTG_GlobalTypeDef *USBx)
+{
+  uint32_t count = 0;
+
+  USBx->GRSTCTL = USB_OTG_GRSTCTL_RXFFLSH;
+
+  do
+  {
+    if (++count > 200000)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_RXFFLSH) == USB_OTG_GRSTCTL_RXFFLSH);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_SetDevSpeed :Initializes the DevSpd field of DCFG register
+  *         depending the PHY type and the enumeration speed of the device.
+  * @param  USBx : Selected device
+  * @param  speed : device speed
+  *          This parameter can be one of the these values:
+  *            @arg USB_OTG_SPEED_HIGH: High speed mode
+  *            @arg USB_OTG_SPEED_HIGH_IN_FULL: High speed core in Full Speed mode
+  *            @arg USB_OTG_SPEED_FULL: Full speed mode
+  *            @arg USB_OTG_SPEED_LOW: Low speed mode
+  * @retval  Hal status
+  */
+HAL_StatusTypeDef USB_SetDevSpeed(USB_OTG_GlobalTypeDef *USBx , uint8_t speed)
+{
+  USBx_DEVICE->DCFG |= speed;
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_GetDevSpeed :Return the  Dev Speed
+  * @param  USBx : Selected device
+  * @retval speed : device speed
+  *          This parameter can be one of the these values:
+  *            @arg USB_OTG_SPEED_HIGH: High speed mode
+  *            @arg USB_OTG_SPEED_FULL: Full speed mode
+  *            @arg USB_OTG_SPEED_LOW: Low speed mode
+  */
+uint8_t USB_GetDevSpeed(USB_OTG_GlobalTypeDef *USBx)
+{
+  uint8_t speed = 0;
+
+  if((USBx_DEVICE->DSTS & USB_OTG_DSTS_ENUMSPD) == DSTS_ENUMSPD_HS_PHY_30MHZ_OR_60MHZ)
+  {
+    speed = USB_OTG_SPEED_HIGH;
+  }
+  else if (((USBx_DEVICE->DSTS & USB_OTG_DSTS_ENUMSPD) == DSTS_ENUMSPD_FS_PHY_30MHZ_OR_60MHZ)||
+           ((USBx_DEVICE->DSTS & USB_OTG_DSTS_ENUMSPD) == DSTS_ENUMSPD_FS_PHY_48MHZ))
+  {
+    speed = USB_OTG_SPEED_FULL;
+  }
+  else if((USBx_DEVICE->DSTS & USB_OTG_DSTS_ENUMSPD) == DSTS_ENUMSPD_LS_PHY_6MHZ)
+  {
+    speed = USB_OTG_SPEED_LOW;
+  }
+
+  return speed;
+}
+
+/**
+  * @brief  Activate and configure an endpoint
+  * @param  USBx : Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_ActivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
+{
+  if (ep->is_in == 1)
+  {
+   USBx_DEVICE->DAINTMSK |= USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num)));
+
+    if (((USBx_INEP(ep->num)->DIEPCTL) & USB_OTG_DIEPCTL_USBAEP) == 0)
+    {
+      USBx_INEP(ep->num)->DIEPCTL |= ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP));
+    }
+
+  }
+  else
+  {
+     USBx_DEVICE->DAINTMSK |= USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16);
+
+    if (((USBx_OUTEP(ep->num)->DOEPCTL) & USB_OTG_DOEPCTL_USBAEP) == 0)
+    {
+      USBx_OUTEP(ep->num)->DOEPCTL |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+       (USB_OTG_DIEPCTL_SD0PID_SEVNFRM)| (USB_OTG_DOEPCTL_USBAEP));
+    }
+  }
+  return HAL_OK;
+}
+/**
+  * @brief  Activate and configure a dedicated endpoint
+  * @param  USBx : Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
+{
+  static __IO uint32_t debug = 0;
+
+  /* Read DEPCTLn register */
+  if (ep->is_in == 1)
+  {
+    if (((USBx_INEP(ep->num)->DIEPCTL) & USB_OTG_DIEPCTL_USBAEP) == 0)
+    {
+      USBx_INEP(ep->num)->DIEPCTL |= ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP));
+    }
+
+
+    debug  |= ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP));
+
+   USBx_DEVICE->DEACHMSK |= USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num)));
+  }
+  else
+  {
+    if (((USBx_OUTEP(ep->num)->DOEPCTL) & USB_OTG_DOEPCTL_USBAEP) == 0)
+    {
+      USBx_OUTEP(ep->num)->DOEPCTL |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+        ((ep->num) << 22 ) | (USB_OTG_DOEPCTL_USBAEP));
+
+      debug = (uint32_t)(((uint32_t )USBx) + USB_OTG_OUT_ENDPOINT_BASE + (0)*USB_OTG_EP_REG_SIZE);
+      debug = (uint32_t )&USBx_OUTEP(ep->num)->DOEPCTL;
+      debug |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+        ((ep->num) << 22 ) | (USB_OTG_DOEPCTL_USBAEP));
+    }
+
+     USBx_DEVICE->DEACHMSK |= USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16);
+  }
+
+  return HAL_OK;
+}
+/**
+  * @brief  De-activate and de-initialize an endpoint
+  * @param  USBx : Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_DeactivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
+{
+  /* Read DEPCTLn register */
+  if (ep->is_in == 1)
+  {
+   USBx_DEVICE->DEACHMSK &= ~(USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num))));
+   USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num))));
+   USBx_INEP(ep->num)->DIEPCTL &= ~ USB_OTG_DIEPCTL_USBAEP;
+  }
+  else
+  {
+
+     USBx_DEVICE->DEACHMSK &= ~(USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16));
+     USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16));
+     USBx_OUTEP(ep->num)->DOEPCTL &= ~USB_OTG_DOEPCTL_USBAEP;
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  De-activate and de-initialize a dedicated endpoint
+  * @param  USBx : Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_DeactivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
+{
+  /* Read DEPCTLn register */
+  if (ep->is_in == 1)
+  {
+   USBx_INEP(ep->num)->DIEPCTL &= ~ USB_OTG_DIEPCTL_USBAEP;
+   USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num))));
+  }
+  else
+  {
+     USBx_OUTEP(ep->num)->DOEPCTL &= ~USB_OTG_DOEPCTL_USBAEP;
+     USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16));
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_EPStartXfer : setup and starts a transfer over an EP
+  * @param  USBx : Selected device
+  * @param  ep: pointer to endpoint structure
+  * @param  dma: USB dma enabled or disabled
+  *          This parameter can be one of the these values:
+  *           0 : DMA feature not used
+  *           1 : DMA feature used
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EPStartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma)
+{
+  uint16_t pktcnt = 0;
+
+  /* IN endpoint */
+  if (ep->is_in == 1)
+  {
+    /* Zero Length Packet? */
+    if (ep->xfer_len == 0)
+    {
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT);
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_PKTCNT & (1 << 19)) ;
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ);
+    }
+    else
+    {
+      /* Program the transfer size and packet count
+      * as follows: xfersize = N * maxpacket +
+      * short_packet pktcnt = N + (short_packet
+      * exist ? 1 : 0)
+      */
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ);
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT);
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_PKTCNT & (((ep->xfer_len + ep->maxpacket -1)/ ep->maxpacket) << 19)) ;
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_XFRSIZ & ep->xfer_len);
+
+      if (ep->type == EP_TYPE_ISOC)
+      {
+        USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_MULCNT);
+        USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_MULCNT & (1 << 29));
+      }
+    }
+
+    if (dma == 1)
+    {
+      USBx_INEP(ep->num)->DIEPDMA = (uint32_t)(ep->dma_addr);
+    }
+    else
+    {
+      if (ep->type != EP_TYPE_ISOC)
+      {
+        /* Enable the Tx FIFO Empty Interrupt for this EP */
+        if (ep->xfer_len > 0)
+        {
+          USBx_DEVICE->DIEPEMPMSK |= 1 << ep->num;
+        }
+      }
+    }
+
+    if (ep->type == EP_TYPE_ISOC)
+    {
+      if ((USBx_DEVICE->DSTS & ( 1 << 8 )) == 0)
+      {
+        USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_SODDFRM;
+      }
+      else
+      {
+        USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_SD0PID_SEVNFRM;
+      }
+    }
+
+    /* EP enable, IN data in FIFO */
+    USBx_INEP(ep->num)->DIEPCTL |= (USB_OTG_DIEPCTL_CNAK | USB_OTG_DIEPCTL_EPENA);
+
+    if (ep->type == EP_TYPE_ISOC)
+    {
+      USB_WritePacket(USBx, ep->xfer_buff, ep->num, ep->xfer_len, dma);
+    }
+  }
+  else /* OUT endpoint */
+  {
+    /* Program the transfer size and packet count as follows:
+    * pktcnt = N
+    * xfersize = N * maxpacket
+    */
+    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_XFRSIZ);
+    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_PKTCNT);
+
+    if (ep->xfer_len == 0)
+    {
+      USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_XFRSIZ & ep->maxpacket);
+      USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (1 << 19)) ;
+    }
+    else
+    {
+      pktcnt = (ep->xfer_len + ep->maxpacket -1)/ ep->maxpacket;
+      USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (pktcnt << 19));
+      USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_XFRSIZ & (ep->maxpacket * pktcnt));
+    }
+
+    if (dma == 1)
+    {
+      USBx_OUTEP(ep->num)->DOEPDMA = (uint32_t)ep->xfer_buff;
+    }
+
+    if (ep->type == EP_TYPE_ISOC)
+    {
+      if ((USBx_DEVICE->DSTS & ( 1 << 8 )) == 0)
+      {
+        USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_SODDFRM;
+      }
+      else
+      {
+        USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_SD0PID_SEVNFRM;
+      }
+    }
+    /* EP enable */
+    USBx_OUTEP(ep->num)->DOEPCTL |= (USB_OTG_DOEPCTL_CNAK | USB_OTG_DOEPCTL_EPENA);
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_EP0StartXfer : setup and starts a transfer over the EP  0
+  * @param  USBx : Selected device
+  * @param  ep: pointer to endpoint structure
+  * @param  dma: USB dma enabled or disabled
+  *          This parameter can be one of the these values:
+  *           0 : DMA feature not used
+  *           1 : DMA feature used
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EP0StartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma)
+{
+  /* IN endpoint */
+  if (ep->is_in == 1)
+  {
+    /* Zero Length Packet? */
+    if (ep->xfer_len == 0)
+    {
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT);
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_PKTCNT & (1 << 19)) ;
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ);
+    }
+    else
+    {
+      /* Program the transfer size and packet count
+      * as follows: xfersize = N * maxpacket +
+      * short_packet pktcnt = N + (short_packet
+      * exist ? 1 : 0)
+      */
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ);
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT);
+
+      if(ep->xfer_len > ep->maxpacket)
+      {
+        ep->xfer_len = ep->maxpacket;
+      }
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_PKTCNT & (1 << 19)) ;
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_XFRSIZ & ep->xfer_len);
+
+    }
+
+    if (dma == 1)
+    {
+      USBx_INEP(ep->num)->DIEPDMA = (uint32_t)(ep->dma_addr);
+    }
+    else
+    {
+      /* Enable the Tx FIFO Empty Interrupt for this EP */
+      if (ep->xfer_len > 0)
+      {
+        USBx_DEVICE->DIEPEMPMSK |= 1 << (ep->num);
+      }
+    }
+
+    /* EP enable, IN data in FIFO */
+    USBx_INEP(ep->num)->DIEPCTL |= (USB_OTG_DIEPCTL_CNAK | USB_OTG_DIEPCTL_EPENA);
+  }
+  else /* OUT endpoint */
+  {
+    /* Program the transfer size and packet count as follows:
+    * pktcnt = N
+    * xfersize = N * maxpacket
+    */
+    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_XFRSIZ);
+    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_PKTCNT);
+
+    if (ep->xfer_len > 0)
+    {
+      ep->xfer_len = ep->maxpacket;
+    }
+
+    USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (1 << 19));
+    USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_XFRSIZ & (ep->maxpacket));
+
+
+    if (dma == 1)
+    {
+      USBx_OUTEP(ep->num)->DOEPDMA = (uint32_t)(ep->xfer_buff);
+    }
+
+    /* EP enable */
+    USBx_OUTEP(ep->num)->DOEPCTL |= (USB_OTG_DOEPCTL_CNAK | USB_OTG_DOEPCTL_EPENA);
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_WritePacket : Writes a packet into the Tx FIFO associated
+  *         with the EP/channel
+  * @param  USBx : Selected device
+  * @param  src :  pointer to source buffer
+  * @param  ch_ep_num : endpoint or host channel number
+  * @param  len : Number of bytes to write
+  * @param  dma: USB dma enabled or disabled
+  *          This parameter can be one of the these values:
+  *           0 : DMA feature not used
+  *           1 : DMA feature used
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uint8_t ch_ep_num, uint16_t len, uint8_t dma)
+{
+  uint32_t count32b= 0 , i= 0;
+
+  if (dma == 0)
+  {
+    count32b =  (len + 3) / 4;
+    for (i = 0; i < count32b; i++, src += 4)
+    {
+      USBx_DFIFO(ch_ep_num) = *((__packed uint32_t *)src);
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_ReadPacket : read a packet from the Tx FIFO associated
+  *         with the EP/channel
+  * @param  USBx : Selected device
+  * @param  src : source pointer
+  * @param  ch_ep_num : endpoint or host channel number
+  * @param  len : Number of bytes to read
+  * @param  dma: USB dma enabled or disabled
+  *          This parameter can be one of the these values:
+  *           0 : DMA feature not used
+  *           1 : DMA feature used
+  * @retval pointer to destination buffer
+  */
+void *USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len)
+{
+  uint32_t i=0;
+  uint32_t count32b = (len + 3) / 4;
+
+  for ( i = 0; i < count32b; i++, dest += 4 )
+  {
+    *(__packed uint32_t *)dest = USBx_DFIFO(0);
+
+  }
+  return ((void *)dest);
+}
+
+/**
+  * @brief  USB_EPSetStall : set a stall condition over an EP
+  * @param  USBx : Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EPSetStall(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep)
+{
+  if (ep->is_in == 1)
+  {
+    if (((USBx_INEP(ep->num)->DIEPCTL) & USB_OTG_DIEPCTL_EPENA) == 0)
+    {
+      USBx_INEP(ep->num)->DIEPCTL &= ~(USB_OTG_DIEPCTL_EPDIS);
+    }
+    USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_STALL;
+  }
+  else
+  {
+    if (((USBx_OUTEP(ep->num)->DOEPCTL) & USB_OTG_DOEPCTL_EPENA) == 0)
+    {
+      USBx_OUTEP(ep->num)->DOEPCTL &= ~(USB_OTG_DOEPCTL_EPDIS);
+    }
+    USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_STALL;
+  }
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  USB_EPClearStall : Clear a stall condition over an EP
+  * @param  USBx : Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EPClearStall(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
+{
+  if (ep->is_in == 1)
+  {
+    USBx_INEP(ep->num)->DIEPCTL &= ~USB_OTG_DIEPCTL_STALL;
+    if (ep->type == EP_TYPE_INTR || ep->type == EP_TYPE_BULK)
+    {
+       USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_SD0PID_SEVNFRM; /* DATA0 */
+    }
+  }
+  else
+  {
+    USBx_OUTEP(ep->num)->DOEPCTL &= ~USB_OTG_DOEPCTL_STALL;
+    if (ep->type == EP_TYPE_INTR || ep->type == EP_TYPE_BULK)
+    {
+      USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_SD0PID_SEVNFRM; /* DATA0 */
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_StopDevice : Stop the usb device mode
+  * @param  USBx : Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_StopDevice(USB_OTG_GlobalTypeDef *USBx)
+{
+  uint32_t i;
+
+  /* Clear Pending interrupt */
+  for (i = 0; i < 15 ; i++)
+  {
+    USBx_INEP(i)->DIEPINT  = 0xFF;
+    USBx_OUTEP(i)->DOEPINT  = 0xFF;
+  }
+  USBx_DEVICE->DAINT = 0xFFFFFFFF;
+
+  /* Clear interrupt masks */
+  USBx_DEVICE->DIEPMSK  = 0;
+  USBx_DEVICE->DOEPMSK  = 0;
+  USBx_DEVICE->DAINTMSK = 0;
+
+  /* Flush the FIFO */
+  USB_FlushRxFifo(USBx);
+  USB_FlushTxFifo(USBx ,  0x10 );
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_SetDevAddress : Stop the usb device mode
+  * @param  USBx : Selected device
+  * @param  address : new device address to be assigned
+  *          This parameter can be a value from 0 to 255
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  USB_SetDevAddress (USB_OTG_GlobalTypeDef *USBx, uint8_t address)
+{
+  USBx_DEVICE->DCFG &= ~ (USB_OTG_DCFG_DAD);
+  USBx_DEVICE->DCFG |= (address << 4) & USB_OTG_DCFG_DAD ;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_DevConnect : Connect the USB device by enabling the pull-up/pull-down
+  * @param  USBx : Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  USB_DevConnect (USB_OTG_GlobalTypeDef *USBx)
+{
+  USBx_DEVICE->DCTL &= ~USB_OTG_DCTL_SDIS ;
+  HAL_Delay(3);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_DevDisconnect : Disconnect the USB device by disabling the pull-up/pull-down
+  * @param  USBx : Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  USB_DevDisconnect (USB_OTG_GlobalTypeDef *USBx)
+{
+  USBx_DEVICE->DCTL |= USB_OTG_DCTL_SDIS ;
+  HAL_Delay(3);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_ReadInterrupts: return the global USB interrupt status
+  * @param  USBx : Selected device
+  * @retval HAL status
+  */
+uint32_t  USB_ReadInterrupts (USB_OTG_GlobalTypeDef *USBx)
+{
+  uint32_t v = 0;
+
+  v = USBx->GINTSTS;
+  v &= USBx->GINTMSK;
+  return v;
+}
+
+/**
+  * @brief  USB_ReadDevAllOutEpInterrupt: return the USB device OUT endpoints interrupt status
+  * @param  USBx : Selected device
+  * @retval HAL status
+  */
+uint32_t USB_ReadDevAllOutEpInterrupt (USB_OTG_GlobalTypeDef *USBx)
+{
+  uint32_t v;
+  v  = USBx_DEVICE->DAINT;
+  v &= USBx_DEVICE->DAINTMSK;
+  return ((v & 0xffff0000) >> 16);
+}
+
+/**
+  * @brief  USB_ReadDevAllInEpInterrupt: return the USB device IN endpoints interrupt status
+  * @param  USBx : Selected device
+  * @retval HAL status
+  */
+uint32_t USB_ReadDevAllInEpInterrupt (USB_OTG_GlobalTypeDef *USBx)
+{
+  uint32_t v;
+  v  = USBx_DEVICE->DAINT;
+  v &= USBx_DEVICE->DAINTMSK;
+  return ((v & 0xFFFF));
+}
+
+/**
+  * @brief  Returns Device OUT EP Interrupt register
+  * @param  USBx : Selected device
+  * @param  epnum : endpoint number
+  *          This parameter can be a value from 0 to 15
+  * @retval Device OUT EP Interrupt register
+  */
+uint32_t USB_ReadDevOutEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum)
+{
+  uint32_t v;
+  v  = USBx_OUTEP(epnum)->DOEPINT;
+  v &= USBx_DEVICE->DOEPMSK;
+  return v;
+}
+
+/**
+  * @brief  Returns Device IN EP Interrupt register
+  * @param  USBx : Selected device
+  * @param  epnum : endpoint number
+  *          This parameter can be a value from 0 to 15
+  * @retval Device IN EP Interrupt register
+  */
+uint32_t USB_ReadDevInEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum)
+{
+  uint32_t v, msk, emp;
+
+  msk = USBx_DEVICE->DIEPMSK;
+  emp = USBx_DEVICE->DIEPEMPMSK;
+  msk |= ((emp >> epnum) & 0x1) << 7;
+  v = USBx_INEP(epnum)->DIEPINT & msk;
+  return v;
+}
+
+/**
+  * @brief  USB_ClearInterrupts: clear a USB interrupt
+  * @param  USBx : Selected device
+  * @param  interrupt : interrupt flag
+  * @retval None
+  */
+void  USB_ClearInterrupts (USB_OTG_GlobalTypeDef *USBx, uint32_t interrupt)
+{
+  USBx->GINTSTS |= interrupt;
+}
+
+/**
+  * @brief  Returns USB core mode
+  * @param  USBx : Selected device
+  * @retval return core mode : Host or Device
+  *          This parameter can be one of the these values:
+  *           0 : Host
+  *           1 : Device
+  */
+uint32_t USB_GetMode(USB_OTG_GlobalTypeDef *USBx)
+{
+  return ((USBx->GINTSTS ) & 0x1);
+}
+
+
+/**
+  * @brief  Activate EP0 for Setup transactions
+  * @param  USBx : Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  USB_ActivateSetup (USB_OTG_GlobalTypeDef *USBx)
+{
+  /* Set the MPS of the IN EP based on the enumeration speed */
+  USBx_INEP(0)->DIEPCTL &= ~USB_OTG_DIEPCTL_MPSIZ;
+
+  if((USBx_DEVICE->DSTS & USB_OTG_DSTS_ENUMSPD) == DSTS_ENUMSPD_LS_PHY_6MHZ)
+  {
+    USBx_INEP(0)->DIEPCTL |= 3;
+  }
+  USBx_DEVICE->DCTL |= USB_OTG_DCTL_CGINAK;
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Prepare the EP0 to start the first control setup
+  * @param  USBx : Selected device
+  * @param  dma: USB dma enabled or disabled
+  *          This parameter can be one of the these values:
+  *           0 : DMA feature not used
+  *           1 : DMA feature used
+  * @param  psetup : pointer to setup packet
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EP0_OutStart(USB_OTG_GlobalTypeDef *USBx, uint8_t dma, uint8_t *psetup)
+{
+  USBx_OUTEP(0)->DOEPTSIZ = 0;
+  USBx_OUTEP(0)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (1 << 19)) ;
+  USBx_OUTEP(0)->DOEPTSIZ |= (3 * 8);
+  USBx_OUTEP(0)->DOEPTSIZ |=  USB_OTG_DOEPTSIZ_STUPCNT;
+
+  if (dma == 1)
+  {
+    USBx_OUTEP(0)->DOEPDMA = (uint32_t)psetup;
+    /* EP enable */
+    USBx_OUTEP(0)->DOEPCTL = 0x80008000;
+  }
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Reset the USB Core (needed after USB clock settings change)
+  * @param  USBx : Selected device
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx)
+{
+  uint32_t count = 0;
+
+  /* Wait for AHB master IDLE state. */
+  do
+  {
+    if (++count > 200000)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_AHBIDL) == 0);
+
+  /* Core Soft Reset */
+  count = 0;
+  USBx->GRSTCTL |= USB_OTG_GRSTCTL_CSRST;
+
+  do
+  {
+    if (++count > 200000)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_CSRST) == USB_OTG_GRSTCTL_CSRST);
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  USB_HostInit : Initializes the USB OTG controller registers
+  *         for Host mode
+  * @param  USBx : Selected device
+  * @param  cfg  : pointer to a USB_OTG_CfgTypeDef structure that contains
+  *         the configuration information for the specified USBx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+{
+  uint32_t i;
+
+  /* Restart the Phy Clock */
+  USBx_PCGCCTL = 0;
+
+  /*Activate VBUS Sensing B */
+  USBx->GCCFG |= USB_OTG_GCCFG_VBDEN;
+
+  /* Disable the FS/LS support mode only */
+  if((cfg.speed == USB_OTG_SPEED_FULL)&&
+     (USBx != USB_OTG_FS))
+  {
+    USBx_HOST->HCFG |= USB_OTG_HCFG_FSLSS;
+  }
+  else
+  {
+    USBx_HOST->HCFG &= ~(USB_OTG_HCFG_FSLSS);
+  }
+
+  /* Make sure the FIFOs are flushed. */
+  USB_FlushTxFifo(USBx, 0x10 ); /* all Tx FIFOs */
+  USB_FlushRxFifo(USBx);
+
+  /* Clear all pending HC Interrupts */
+  for (i = 0; i < cfg.Host_channels; i++)
+  {
+    USBx_HC(i)->HCINT = 0xFFFFFFFF;
+    USBx_HC(i)->HCINTMSK = 0;
+  }
+
+  /* Enable VBUS driving */
+  USB_DriveVbus(USBx, 1);
+
+  HAL_Delay(200);
+
+  /* Disable all interrupts. */
+  USBx->GINTMSK = 0;
+
+  /* Clear any pending interrupts */
+  USBx->GINTSTS = 0xFFFFFFFF;
+
+
+  if(USBx == USB_OTG_FS)
+  {
+    /* set Rx FIFO size */
+    USBx->GRXFSIZ  = (uint32_t )0x80;
+    USBx->DIEPTXF0_HNPTXFSIZ = (uint32_t )(((0x60 << 16)& USB_OTG_NPTXFD) | 0x80);
+    USBx->HPTXFSIZ = (uint32_t )(((0x40 << 16)& USB_OTG_HPTXFSIZ_PTXFD) | 0xE0);
+
+  }
+
+  else
+  {
+    /* set Rx FIFO size */
+    USBx->GRXFSIZ  = (uint32_t )0x200;
+    USBx->DIEPTXF0_HNPTXFSIZ = (uint32_t )(((0x100 << 16)& USB_OTG_NPTXFD) | 0x200);
+    USBx->HPTXFSIZ = (uint32_t )(((0xE0 << 16)& USB_OTG_HPTXFSIZ_PTXFD) | 0x300);
+  }
+
+  /* Enable the common interrupts */
+  if (cfg.dma_enable == DISABLE)
+  {
+    USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
+  }
+
+  /* Enable interrupts matching to the Host mode ONLY */
+  USBx->GINTMSK |= (USB_OTG_GINTMSK_PRTIM            | USB_OTG_GINTMSK_HCIM |\
+                    USB_OTG_GINTMSK_SOFM             |USB_OTG_GINTSTS_DISCINT|\
+                    USB_OTG_GINTMSK_PXFRM_IISOOXFRM  | USB_OTG_GINTMSK_WUIM);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_InitFSLSPClkSel : Initializes the FSLSPClkSel field of the
+  *         HCFG register on the PHY type and set the right frame interval
+  * @param  USBx : Selected device
+  * @param  freq : clock frequency
+  *          This parameter can be one of the these values:
+  *           HCFG_48_MHZ : Full Speed 48 MHz Clock
+  *           HCFG_6_MHZ : Low Speed 6 MHz Clock
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_InitFSLSPClkSel(USB_OTG_GlobalTypeDef *USBx , uint8_t freq)
+{
+  USBx_HOST->HCFG &= ~(USB_OTG_HCFG_FSLSPCS);
+  USBx_HOST->HCFG |= (freq & USB_OTG_HCFG_FSLSPCS);
+
+  if (freq ==  HCFG_48_MHZ)
+  {
+    USBx_HOST->HFIR = (uint32_t)48000;
+  }
+  else if (freq ==  HCFG_6_MHZ)
+  {
+    USBx_HOST->HFIR = (uint32_t)6000;
+  }
+  return HAL_OK;
+}
+
+/**
+* @brief  USB_OTG_ResetPort : Reset Host Port
+  * @param  USBx : Selected device
+  * @retval HAL status
+  * @note : (1)The application must wait at least 10 ms
+  *   before clearing the reset bit.
+  */
+HAL_StatusTypeDef USB_ResetPort(USB_OTG_GlobalTypeDef *USBx)
+{
+  __IO uint32_t hprt0;
+
+  hprt0 = USBx_HPRT0;
+
+  hprt0 &= ~(USB_OTG_HPRT_PENA    | USB_OTG_HPRT_PCDET |\
+    USB_OTG_HPRT_PENCHNG | USB_OTG_HPRT_POCCHNG );
+
+  USBx_HPRT0 = (USB_OTG_HPRT_PRST | hprt0);
+  HAL_Delay (10);                                /* See Note #1 */
+  USBx_HPRT0 = ((~USB_OTG_HPRT_PRST) & hprt0);
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_DriveVbus : activate or de-activate vbus
+  * @param  state : VBUS state
+  *          This parameter can be one of the these values:
+  *           0 : VBUS Active
+  *           1 : VBUS Inactive
+  * @retval HAL status
+*/
+HAL_StatusTypeDef USB_DriveVbus (USB_OTG_GlobalTypeDef *USBx, uint8_t state)
+{
+  __IO uint32_t hprt0;
+
+  hprt0 = USBx_HPRT0;
+  hprt0 &= ~(USB_OTG_HPRT_PENA    | USB_OTG_HPRT_PCDET |\
+                         USB_OTG_HPRT_PENCHNG | USB_OTG_HPRT_POCCHNG );
+
+  if (((hprt0 & USB_OTG_HPRT_PPWR) == 0 ) && (state == 1 ))
+  {
+    USBx_HPRT0 = (USB_OTG_HPRT_PPWR | hprt0);
+  }
+  if (((hprt0 & USB_OTG_HPRT_PPWR) == USB_OTG_HPRT_PPWR) && (state == 0 ))
+  {
+    USBx_HPRT0 = ((~USB_OTG_HPRT_PPWR) & hprt0);
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Return Host Core speed
+  * @param  USBx : Selected device
+  * @retval speed : Host speed
+  *          This parameter can be one of the these values:
+  *            @arg USB_OTG_SPEED_HIGH: High speed mode
+  *            @arg USB_OTG_SPEED_FULL: Full speed mode
+  *            @arg USB_OTG_SPEED_LOW: Low speed mode
+  */
+uint32_t USB_GetHostSpeed (USB_OTG_GlobalTypeDef *USBx)
+{
+  __IO uint32_t hprt0;
+
+  hprt0 = USBx_HPRT0;
+  return ((hprt0 & USB_OTG_HPRT_PSPD) >> 17);
+}
+
+/**
+  * @brief  Return Host Current Frame number
+  * @param  USBx : Selected device
+  * @retval current frame number
+*/
+uint32_t USB_GetCurrentFrame (USB_OTG_GlobalTypeDef *USBx)
+{
+  return (USBx_HOST->HFNUM & USB_OTG_HFNUM_FRNUM);
+}
+
+/**
+  * @brief  Initialize a host channel
+  * @param  USBx : Selected device
+  * @param  ch_num : Channel number
+  *         This parameter can be a value from 1 to 15
+  * @param  epnum : Endpoint number
+  *          This parameter can be a value from 1 to 15
+  * @param  dev_address : Current device address
+  *          This parameter can be a value from 0 to 255
+  * @param  speed : Current device speed
+  *          This parameter can be one of the these values:
+  *            @arg USB_OTG_SPEED_HIGH: High speed mode
+  *            @arg USB_OTG_SPEED_FULL: Full speed mode
+  *            @arg USB_OTG_SPEED_LOW: Low speed mode
+  * @param  ep_type : Endpoint Type
+  *          This parameter can be one of the these values:
+  *            @arg EP_TYPE_CTRL: Control type
+  *            @arg EP_TYPE_ISOC: Isochronous type
+  *            @arg EP_TYPE_BULK: Bulk type
+  *            @arg EP_TYPE_INTR: Interrupt type
+  * @param  mps : Max Packet Size
+  *          This parameter can be a value from 0 to32K
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_HC_Init(USB_OTG_GlobalTypeDef *USBx,
+                              uint8_t ch_num,
+                              uint8_t epnum,
+                              uint8_t dev_address,
+                              uint8_t speed,
+                              uint8_t ep_type,
+                              uint16_t mps)
+{
+
+  /* Clear old interrupt conditions for this host channel. */
+  USBx_HC(ch_num)->HCINT = 0xFFFFFFFF;
+
+  /* Enable channel interrupts required for this transfer. */
+  switch (ep_type)
+  {
+  case EP_TYPE_CTRL:
+  case EP_TYPE_BULK:
+
+    USBx_HC(ch_num)->HCINTMSK = USB_OTG_HCINTMSK_XFRCM  |\
+                                USB_OTG_HCINTMSK_STALLM |\
+                                USB_OTG_HCINTMSK_TXERRM |\
+                                USB_OTG_HCINTMSK_DTERRM |\
+                                USB_OTG_HCINTMSK_AHBERR |\
+                                USB_OTG_HCINTMSK_NAKM ;
+
+    if (epnum & 0x80)
+    {
+      USBx_HC(ch_num)->HCINTMSK |= USB_OTG_HCINTMSK_BBERRM;
+    }
+    else
+    {
+      if(USBx != USB_OTG_FS)
+      {
+        USBx_HC(ch_num)->HCINTMSK |= (USB_OTG_HCINTMSK_NYET | USB_OTG_HCINTMSK_ACKM);
+      }
+    }
+    break;
+  case EP_TYPE_INTR:
+
+    USBx_HC(ch_num)->HCINTMSK = USB_OTG_HCINTMSK_XFRCM  |\
+                                USB_OTG_HCINTMSK_STALLM |\
+                                USB_OTG_HCINTMSK_TXERRM |\
+                                USB_OTG_HCINTMSK_DTERRM |\
+                                USB_OTG_HCINTMSK_NAKM   |\
+                                USB_OTG_HCINTMSK_AHBERR |\
+                                USB_OTG_HCINTMSK_FRMORM ;
+
+    if (epnum & 0x80)
+    {
+      USBx_HC(ch_num)->HCINTMSK |= USB_OTG_HCINTMSK_BBERRM;
+    }
+
+    break;
+  case EP_TYPE_ISOC:
+
+    USBx_HC(ch_num)->HCINTMSK = USB_OTG_HCINTMSK_XFRCM  |\
+                                USB_OTG_HCINTMSK_ACKM   |\
+                                USB_OTG_HCINTMSK_AHBERR |\
+                                USB_OTG_HCINTMSK_FRMORM ;
+
+    if (epnum & 0x80)
+    {
+      USBx_HC(ch_num)->HCINTMSK |= (USB_OTG_HCINTMSK_TXERRM | USB_OTG_HCINTMSK_BBERRM);
+    }
+    break;
+  }
+
+  /* Enable the top level host channel interrupt. */
+  USBx_HOST->HAINTMSK |= (1 << ch_num);
+
+  /* Make sure host channel interrupts are enabled. */
+  USBx->GINTMSK |= USB_OTG_GINTMSK_HCIM;
+
+  /* Program the HCCHAR register */
+  USBx_HC(ch_num)->HCCHAR = (((dev_address << 22) & USB_OTG_HCCHAR_DAD)  |\
+                             (((epnum & 0x7F)<< 11) & USB_OTG_HCCHAR_EPNUM)|\
+                             ((((epnum & 0x80) == 0x80)<< 15) & USB_OTG_HCCHAR_EPDIR)|\
+                             (((speed == HPRT0_PRTSPD_LOW_SPEED)<< 17) & USB_OTG_HCCHAR_LSDEV)|\
+                             ((ep_type << 18) & USB_OTG_HCCHAR_EPTYP)|\
+                             (mps & USB_OTG_HCCHAR_MPSIZ));
+
+  if (ep_type == EP_TYPE_INTR)
+  {
+    USBx_HC(ch_num)->HCCHAR |= USB_OTG_HCCHAR_ODDFRM ;
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Start a transfer over a host channel
+  * @param  USBx : Selected device
+  * @param  hc : pointer to host channel structure
+  * @param  dma: USB dma enabled or disabled
+  *          This parameter can be one of the these values:
+  *           0 : DMA feature not used
+  *           1 : DMA feature used
+  * @retval HAL state
+  */
+#if defined   (__CC_ARM) /*!< ARM Compiler */
+#pragma O0
+#elif defined (__GNUC__) /*!< GNU Compiler */
+#pragma GCC optimize ("O0")
+#endif /* __CC_ARM */
+HAL_StatusTypeDef USB_HC_StartXfer(USB_OTG_GlobalTypeDef *USBx, USB_OTG_HCTypeDef *hc, uint8_t dma)
+{
+  uint8_t  is_oddframe = 0;
+  uint16_t len_words = 0;
+  uint16_t num_packets = 0;
+  uint16_t max_hc_pkt_count = 256;
+  uint32_t tmpreg = 0;
+
+  if((USBx != USB_OTG_FS) && (hc->speed == USB_OTG_SPEED_HIGH))
+  {
+    if((dma == 0) && (hc->do_ping == 1))
+    {
+      USB_DoPing(USBx, hc->ch_num);
+      return HAL_OK;
+    }
+    else if(dma == 1)
+    {
+      USBx_HC(hc->ch_num)->HCINTMSK &= ~(USB_OTG_HCINTMSK_NYET | USB_OTG_HCINTMSK_ACKM);
+      hc->do_ping = 0;
+    }
+  }
+
+  /* Compute the expected number of packets associated to the transfer */
+  if (hc->xfer_len > 0)
+  {
+    num_packets = (hc->xfer_len + hc->max_packet - 1) / hc->max_packet;
+
+    if (num_packets > max_hc_pkt_count)
+    {
+      num_packets = max_hc_pkt_count;
+      hc->xfer_len = num_packets * hc->max_packet;
+    }
+  }
+  else
+  {
+    num_packets = 1;
+  }
+  if (hc->ep_is_in)
+  {
+    hc->xfer_len = num_packets * hc->max_packet;
+  }
+
+
+
+  /* Initialize the HCTSIZn register */
+  USBx_HC(hc->ch_num)->HCTSIZ = (((hc->xfer_len) & USB_OTG_HCTSIZ_XFRSIZ)) |\
+    ((num_packets << 19) & USB_OTG_HCTSIZ_PKTCNT) |\
+      (((hc->data_pid) << 29) & USB_OTG_HCTSIZ_DPID);
+
+  if (dma)
+  {
+    /* xfer_buff MUST be 32-bits aligned */
+    USBx_HC(hc->ch_num)->HCDMA = (uint32_t)hc->xfer_buff;
+  }
+
+  is_oddframe = (USBx_HOST->HFNUM & 0x01) ? 0 : 1;
+  USBx_HC(hc->ch_num)->HCCHAR &= ~USB_OTG_HCCHAR_ODDFRM;
+  USBx_HC(hc->ch_num)->HCCHAR |= (is_oddframe << 29);
+
+  /* Set host channel enable */
+  tmpreg = USBx_HC(hc->ch_num)->HCCHAR;
+  tmpreg &= ~USB_OTG_HCCHAR_CHDIS;
+  tmpreg |= USB_OTG_HCCHAR_CHENA;
+  USBx_HC(hc->ch_num)->HCCHAR = tmpreg;
+
+  if (dma == 0) /* Slave mode */
+  {
+    if((hc->ep_is_in == 0) && (hc->xfer_len > 0))
+    {
+      switch(hc->ep_type)
+      {
+        /* Non periodic transfer */
+      case EP_TYPE_CTRL:
+      case EP_TYPE_BULK:
+
+        len_words = (hc->xfer_len + 3) / 4;
+
+        /* check if there is enough space in FIFO space */
+        if(len_words > (USBx->HNPTXSTS & 0xFFFF))
+        {
+          /* need to process data in nptxfempty interrupt */
+          USBx->GINTMSK |= USB_OTG_GINTMSK_NPTXFEM;
+        }
+        break;
+        /* Periodic transfer */
+      case EP_TYPE_INTR:
+      case EP_TYPE_ISOC:
+        len_words = (hc->xfer_len + 3) / 4;
+        /* check if there is enough space in FIFO space */
+        if(len_words > (USBx_HOST->HPTXSTS & 0xFFFF)) /* split the transfer */
+        {
+          /* need to process data in ptxfempty interrupt */
+          USBx->GINTMSK |= USB_OTG_GINTMSK_PTXFEM;
+        }
+        break;
+
+      default:
+        break;
+      }
+
+      /* Write packet into the Tx FIFO. */
+      USB_WritePacket(USBx, hc->xfer_buff, hc->ch_num, hc->xfer_len, 0);
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Read all host channel interrupts status
+  * @param  USBx : Selected device
+  * @retval HAL state
+  */
+uint32_t USB_HC_ReadInterrupt (USB_OTG_GlobalTypeDef *USBx)
+{
+  return ((USBx_HOST->HAINT) & 0xFFFF);
+}
+
+/**
+  * @brief  Halt a host channel
+  * @param  USBx : Selected device
+  * @param  hc_num : Host Channel number
+  *         This parameter can be a value from 1 to 15
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_HC_Halt(USB_OTG_GlobalTypeDef *USBx , uint8_t hc_num)
+{
+  uint32_t count = 0;
+
+  /* Check for space in the request queue to issue the halt. */
+  if (((USBx_HC(hc_num)->HCCHAR) & (HCCHAR_CTRL << 18)) || ((USBx_HC(hc_num)->HCCHAR) & (HCCHAR_BULK << 18)))
+  {
+    USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHDIS;
+
+    if ((USBx->HNPTXSTS & 0xFFFF) == 0)
+    {
+      USBx_HC(hc_num)->HCCHAR &= ~USB_OTG_HCCHAR_CHENA;
+      USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
+      USBx_HC(hc_num)->HCCHAR &= ~USB_OTG_HCCHAR_EPDIR;
+      do
+      {
+        if (++count > 1000)
+        {
+          break;
+        }
+      }
+      while ((USBx_HC(hc_num)->HCCHAR & USB_OTG_HCCHAR_CHENA) == USB_OTG_HCCHAR_CHENA);
+    }
+    else
+    {
+      USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
+    }
+  }
+  else
+  {
+    USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHDIS;
+
+    if ((USBx_HOST->HPTXSTS & 0xFFFF) == 0)
+    {
+      USBx_HC(hc_num)->HCCHAR &= ~USB_OTG_HCCHAR_CHENA;
+      USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
+      USBx_HC(hc_num)->HCCHAR &= ~USB_OTG_HCCHAR_EPDIR;
+      do
+      {
+        if (++count > 1000)
+        {
+          break;
+        }
+      }
+      while ((USBx_HC(hc_num)->HCCHAR & USB_OTG_HCCHAR_CHENA) == USB_OTG_HCCHAR_CHENA);
+    }
+    else
+    {
+       USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initiate Do Ping protocol
+  * @param  USBx : Selected device
+  * @param  hc_num : Host Channel number
+  *         This parameter can be a value from 1 to 15
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_DoPing(USB_OTG_GlobalTypeDef *USBx , uint8_t ch_num)
+{
+  uint8_t  num_packets = 1;
+  uint32_t tmpreg = 0;
+
+  USBx_HC(ch_num)->HCTSIZ = ((num_packets << 19) & USB_OTG_HCTSIZ_PKTCNT) |\
+                                USB_OTG_HCTSIZ_DOPING;
+
+  /* Set host channel enable */
+  tmpreg = USBx_HC(ch_num)->HCCHAR;
+  tmpreg &= ~USB_OTG_HCCHAR_CHDIS;
+  tmpreg |= USB_OTG_HCCHAR_CHENA;
+  USBx_HC(ch_num)->HCCHAR = tmpreg;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop Host Core
+  * @param  USBx : Selected device
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_StopHost(USB_OTG_GlobalTypeDef *USBx)
+{
+  uint8_t i;
+  uint32_t count = 0;
+  uint32_t value;
+
+  USB_DisableGlobalInt(USBx);
+
+    /* Flush FIFO */
+  USB_FlushTxFifo(USBx, 0x10);
+  USB_FlushRxFifo(USBx);
+
+  /* Flush out any leftover queued requests. */
+  for (i = 0; i <= 15; i++)
+  {
+
+    value = USBx_HC(i)->HCCHAR ;
+    value |=  USB_OTG_HCCHAR_CHDIS;
+    value &= ~USB_OTG_HCCHAR_CHENA;
+    value &= ~USB_OTG_HCCHAR_EPDIR;
+    USBx_HC(i)->HCCHAR = value;
+  }
+
+  /* Halt all channels to put them into a known state. */
+  for (i = 0; i <= 15; i++)
+  {
+
+    value = USBx_HC(i)->HCCHAR ;
+
+    value |= USB_OTG_HCCHAR_CHDIS;
+    value |= USB_OTG_HCCHAR_CHENA;
+    value &= ~USB_OTG_HCCHAR_EPDIR;
+
+    USBx_HC(i)->HCCHAR = value;
+    do
+    {
+      if (++count > 1000)
+      {
+        break;
+      }
+    }
+    while ((USBx_HC(i)->HCCHAR & USB_OTG_HCCHAR_CHENA) == USB_OTG_HCCHAR_CHENA);
+  }
+
+  /* Clear any pending Host interrupts */
+  USBx_HOST->HAINT = 0xFFFFFFFF;
+  USBx->GINTSTS = 0xFFFFFFFF;
+  USB_EnableGlobalInt(USBx);
+  return HAL_OK;
+}
+/**
+  * @}
+  */
+
+#endif /* defined (HAL_PCD_MODULE_ENABLED) || defined (HAL_HCD_MODULE_ENABLED) */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
This includes the same set of files as are currently in the f4 directory plus a couple .h that were needed.
It looks like i2s got renamed as sai, so I kept the _sai_ files.
All files were converted to linux line endings using 2unix from:
https://github.com/dhylands/projects/tree/master/utils/src/2dos
All trailing whitespace was removed using:
for f in f7/inc/\* f7/src/*; do sed --in-place 's/[[:space:]]+$//' $f; done
