### PR TITLE
pyboard: fails with python2 so run python3

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 pyboard interface


### PR DESCRIPTION
<code>pyboard</code> requires python3:

<pre>
$ python2.7 pyboard.py -h
  File "pyboard.py", line 211
    ret = self.exec('print({})'.format(expression))
                  ^
SyntaxError: invalid syntax
</pre>
