### PR TITLE
pyboard: Add -c argument to run a program passed as a string

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -242,17 +242,16 @@ def main():
     cmd_parser.add_argument('-b', '--baudrate', default=115200, help='the baud rate of the serial device')
     cmd_parser.add_argument('-u', '--user', default='micro', help='the telnet login username')
     cmd_parser.add_argument('-p', '--password', default='python', help='the telnet login password')
+    cmd_parser.add_argument('-c', '--cmd', help='program passed in as string')
     cmd_parser.add_argument('--follow', action='store_true', help='follow the output after running the scripts [default if no scripts given]')
     cmd_parser.add_argument('files', nargs='*', help='input files')
     args = cmd_parser.parse_args()
 
-    for filename in args.files:
+    def execbuffer(buf):
         try:
             pyb = Pyboard(args.device, args.baudrate, args.user, args.password)
             pyb.enter_raw_repl()
-            with open(filename, 'rb') as f:
-                pyfile = f.read()
-            ret, ret_err = pyb.exec_raw(pyfile, timeout=None, data_consumer=stdout_write_bytes)
+            ret, ret_err = pyb.exec_raw(buf, timeout=None, data_consumer=stdout_write_bytes)
             pyb.exit_raw_repl()
             pyb.close()
         except PyboardError as er:
@@ -263,6 +262,16 @@ def main():
         if ret_err:
             stdout_write_bytes(ret_err)
             sys.exit(1)
+
+    if args.cmd:
+        execbuffer(bytes(args.cmd, 'utf-8'))
+        if len(args.files) == 0:
+            sys.exit(0)
+
+    for filename in args.files:
+        with open(filename, 'rb') as f:
+            pyfile = f.read()
+            execbuffer(pyfile)
 
     if args.follow or len(args.files) == 0:
         try:


### PR DESCRIPTION
Handy for those little things:

<pre>
$ python3 pyboard.py --device /dev/tty.usbmodem1422 -c 'for i in range(4): pyb.LED(i+1).on()'
</pre>
