### PR TITLE
Port changes made to the f4 hal over to the f7 hal

### DIFF
--- a/stmhal/hal/f7/inc/stm32f7xx_hal_sd.h
+++ b/stmhal/hal/f7/inc/stm32f7xx_hal_sd.h
@@ -643,8 +643,9 @@ void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd);
   * @{
   */
 /* Blocking mode: Polling */
-HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
-HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
+// dpgeorge: read/write functions renamed to emphasise that address is given by block number
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_BlockNumber(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint32_t BlockNumber, uint32_t BlockSize, uint32_t NumberOfBlocks);
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_BlockNumber(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint32_t BlockNumber, uint32_t BlockSize, uint32_t NumberOfBlocks);
 HAL_SD_ErrorTypedef HAL_SD_Erase(SD_HandleTypeDef *hsd, uint64_t startaddr, uint64_t endaddr);
 
 /* Non-Blocking mode: Interrupt */
@@ -659,8 +660,9 @@ void HAL_SD_XferCpltCallback(SD_HandleTypeDef *hsd);
 void HAL_SD_XferErrorCallback(SD_HandleTypeDef *hsd);
 
 /* Non-Blocking mode: DMA */
-HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
-HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
+// dpgeorge: read/write functions renamed to emphasise that address is given by block number
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_BlockNumber_DMA(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint32_t BlockNumber, uint32_t BlockSize, uint32_t NumberOfBlocks);
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_BlockNumber_DMA(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint32_t BlockNumber, uint32_t BlockSize, uint32_t NumberOfBlocks);
 HAL_SD_ErrorTypedef HAL_SD_CheckWriteOperation(SD_HandleTypeDef *hsd, uint32_t Timeout);
 HAL_SD_ErrorTypedef HAL_SD_CheckReadOperation(SD_HandleTypeDef *hsd, uint32_t Timeout);
 /**

--- a/stmhal/hal/f7/src/stm32f7xx_hal_rcc.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_rcc.c
@@ -981,7 +981,12 @@ uint32_t HAL_RCC_GetSysClockFreq(void)
       if (__HAL_RCC_GET_PLL_OSCSOURCE() != RCC_PLLCFGR_PLLSRC_HSI)
       {
         /* HSE used as PLL clock source */
-        pllvco = ((HSE_VALUE / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> POSITION_VAL(RCC_PLLCFGR_PLLN)));
+        //pllvco = ((HSE_VALUE / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> POSITION_VAL(RCC_PLLCFGR_PLLN)));
+        // dpgeorge: Adjust the way the arithmetic is done so it retains
+        // precision for the case that pllm doesn't evenly divide HSE_VALUE.
+        // Must be sure not to overflow, so divide by 4 first.  HSE_VALUE
+        // should be a multiple of 4 (being a multiple of 100 is enough).
+        pllvco = ((HSE_VALUE / 4) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> POSITION_VAL(RCC_PLLCFGR_PLLN))) / pllm * 4;
       }
       else
       {

--- a/stmhal/hal/f7/src/stm32f7xx_hal_sd.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_sd.c
@@ -1557,7 +1557,7 @@ HAL_SD_ErrorTypedef HAL_SD_Get_CardInfo(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTy
     /* Byte 10 */
     tmp = (uint8_t)((hsd->CSD[2] & 0x0000FF00) >> 8);
 
-    pCardInfo->CardCapacity  = ((pCardInfo->SD_csd.DeviceSize + 1)) * 512 * 1024;
+    pCardInfo->CardCapacity  = ((pCardInfo->SD_csd.DeviceSize + 1ULL)) * 512 * 1024;
     pCardInfo->CardBlockSize = 512;
   }
   else

--- a/stmhal/hal/f7/src/stm32f7xx_hal_sd.c
+++ b/stmhal/hal/f7/src/stm32f7xx_hal_sd.c
@@ -453,14 +453,14 @@ __weak void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd)
   * @brief  Reads block(s) from a specified address in a card. The Data transfer
   *         is managed by polling mode.
   * @param  hsd: SD handle
-  * @param  pReadBuffer: pointer to the buffer that will contain the received data
-  * @param  ReadAddr: Address from where data is to be read
+  * @param  pReadBuffer: pointer to the buffer that will contain the received data 
+  * @param  BlockNumber: Block number from where data is to be read (byte address = BlockNumber * BlockSize)
   * @param  BlockSize: SD card Data block size
   *   @note BlockSize must be 512 bytes.
   * @param  NumberOfBlocks: Number of SD blocks to read
   * @retval SD Card error state
   */
-HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_BlockNumber(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint32_t BlockNumber, uint32_t BlockSize, uint32_t NumberOfBlocks)
 {
   SDMMC_CmdInitTypeDef  sdmmc_cmdinitstructure;
   SDMMC_DataInitTypeDef sdmmc_datainitstructure;
@@ -470,10 +470,16 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuff
   /* Initialize data control register */
   hsd->Instance->DCTRL = 0;
 
+  uint32_t ReadAddr;
   if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
   {
     BlockSize = 512;
-    ReadAddr /= 512;
+    ReadAddr = BlockNumber;
+  }
+  else
+  {
+    // should not overflow for standard-capacity cards
+    ReadAddr = BlockNumber * BlockSize;
   }
 
   /* Set Block Size for Card */
@@ -512,7 +518,7 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuff
     sdmmc_cmdinitstructure.CmdIndex = SD_CMD_READ_SINGLE_BLOCK;
   }
 
-  sdmmc_cmdinitstructure.Argument         = (uint32_t)ReadAddr;
+  sdmmc_cmdinitstructure.Argument         = ReadAddr;
   SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
 
   /* Read block(s) in polling mode */
@@ -630,13 +636,13 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuff
   *         transfer is managed by polling mode.
   * @param  hsd: SD handle
   * @param  pWriteBuffer: pointer to the buffer that will contain the data to transmit
-  * @param  WriteAddr: Address from where data is to be written
+  * @param  BlockNumber: Block number to where data is to be written (byte address = BlockNumber * BlockSize)
   * @param  BlockSize: SD card Data block size
   * @note   BlockSize must be 512 bytes.
   * @param  NumberOfBlocks: Number of SD blocks to write
   * @retval SD Card error state
   */
-HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_BlockNumber(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint32_t BlockNumber, uint32_t BlockSize, uint32_t NumberOfBlocks)
 {
   SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
   SDMMC_DataInitTypeDef sdmmc_datainitstructure;
@@ -648,10 +654,16 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBu
   /* Initialize data control register */
   hsd->Instance->DCTRL = 0;
 
+  uint32_t WriteAddr;
   if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
   {
     BlockSize = 512;
-    WriteAddr /= 512;
+    WriteAddr = BlockNumber;
+  }
+  else
+  {
+    // should not overflow for standard-capacity cards
+    WriteAddr = BlockNumber * BlockSize;
   }
 
   /* Set Block Size for Card */
@@ -681,7 +693,7 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBu
     sdmmc_cmdinitstructure.CmdIndex = SD_CMD_WRITE_SINGLE_BLOCK;
   }
 
-  sdmmc_cmdinitstructure.Argument         = (uint32_t)WriteAddr;
+  sdmmc_cmdinitstructure.Argument         = WriteAddr;
   SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
 
   /* Check for error conditions */
@@ -840,13 +852,13 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBu
   *         to check the completion of the read process
   * @param  hsd: SD handle
   * @param  pReadBuffer: Pointer to the buffer that will contain the received data
-  * @param  ReadAddr: Address from where data is to be read
+  * @param  BlockNumber: Block number from where data is to be read (byte address = BlockNumber * BlockSize)
   * @param  BlockSize: SD card Data block size
   * @note   BlockSize must be 512 bytes.
   * @param  NumberOfBlocks: Number of blocks to read.
   * @retval SD Card error state
   */
-HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_BlockNumber_DMA(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint32_t BlockNumber, uint32_t BlockSize, uint32_t NumberOfBlocks)
 {
   SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
   SDMMC_DataInitTypeDef sdmmc_datainitstructure;
@@ -886,10 +898,16 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pRead
   /* Enable the DMA Channel */
   HAL_DMA_Start_IT(hsd->hdmarx, (uint32_t)&hsd->Instance->FIFO, (uint32_t)pReadBuffer, (uint32_t)(BlockSize * NumberOfBlocks)/4);
 
+  uint32_t ReadAddr;
   if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
   {
     BlockSize = 512;
-    ReadAddr /= 512;
+    ReadAddr = BlockNumber;
+  }
+  else
+  {
+    // should not overflow for standard-capacity cards
+    ReadAddr = BlockNumber * BlockSize;
   }
 
   /* Set Block Size for Card */
@@ -929,7 +947,7 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pRead
     sdmmc_cmdinitstructure.CmdIndex = SD_CMD_READ_SINGLE_BLOCK;
   }
 
-  sdmmc_cmdinitstructure.Argument         = (uint32_t)ReadAddr;
+  sdmmc_cmdinitstructure.Argument         = ReadAddr;
   SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
 
   /* Check for error conditions */
@@ -956,13 +974,13 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pRead
   *         to check the completion of the write process (by SD current status polling).
   * @param  hsd: SD handle
   * @param  pWriteBuffer: pointer to the buffer that will contain the data to transmit
-  * @param  WriteAddr: Address from where data is to be read
+  * @param  BlockNumber: Block number to where data is to be written (byte address = BlockNumber * BlockSize)
   * @param  BlockSize: the SD card Data block size
   * @note   BlockSize must be 512 bytes.
   * @param  NumberOfBlocks: Number of blocks to write
   * @retval SD Card error state
   */
-HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_BlockNumber_DMA(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint32_t BlockNumber, uint32_t BlockSize, uint32_t NumberOfBlocks)
 {
   SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
   SDMMC_DataInitTypeDef sdmmc_datainitstructure;
@@ -1002,10 +1020,16 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWri
   /* Enable SDMMC DMA transfer */
   __HAL_SD_SDMMC_DMA_ENABLE(hsd);
 
+  uint32_t WriteAddr;
   if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
   {
     BlockSize = 512;
-    WriteAddr /= 512;
+    WriteAddr = BlockNumber;
+  }
+  else
+  {
+    // should not overflow for standard-capacity cards
+    WriteAddr = BlockNumber * BlockSize;
   }
 
   /* Set Block Size for Card */


### PR DESCRIPTION
I went through the history and found these 3 commits

```
c568a2b stmhal: Adjust computation of SYSCLK to retain precision.
1d7fb82 stmhal: Change 64-bit arithmetic to 32-bit for SD card block addressing.
09de030 stmhal/hal/src/stm32f4xx_hal_sd.c: fix SDHC card capacity
```

and ported the hal portions of those commits to the f7 hal.
