### PR TITLE
stmhal: M7 Reset clocksources changed by DFU bootloader

### DIFF
--- a/stmhal/system_stm32.c
+++ b/stmhal/system_stm32.c
@@ -307,4 +307,12 @@ void SystemClock_Config(void)
   {
     __fatal_error("HAL_RCC_ClockConfig");
   }
+
+#if defined(STM32F7)
+  // The DFU bootloader changes the clocksource register from its default power
+  // on reset value, so we set it back here, so the clocksources are the same
+  // whether we were started from DFU or from a power on reset.
+
+  RCC->DCKCFGR2 = 0;
+#endif
 }


### PR DESCRIPTION
The DFU bootloader on the ST32F7 chip changes the clocksource
for various possible boot sources (UART1, UART3, I2C1-3).
This commit resets those clock sources back to their cold
reset values.
