### PR TITLE
unix: set MICROPY_PY_SYS_PLATFORM to "darwin" if compiled on OSX

### DIFF
--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -73,7 +73,11 @@
 #define MICROPY_PY_ALL_SPECIAL_METHODS (1)
 #define MICROPY_PY_ARRAY_SLICE_ASSIGN (1)
 #define MICROPY_PY_SYS_EXIT         (1)
-#define MICROPY_PY_SYS_PLATFORM     "linux"
+#if defined(__APPLE__) && defined(__MACH__)
+    #define MICROPY_PY_SYS_PLATFORM  "darwin"
+#else
+    #define MICROPY_PY_SYS_PLATFORM  "linux"
+#endif
 #define MICROPY_PY_SYS_MAXSIZE      (1)
 #define MICROPY_PY_SYS_STDFILES     (1)
 #define MICROPY_PY_SYS_EXC_INFO     (1)


### PR DESCRIPTION
Currently `sys.platform` returns a different value from CPython when running on OSX:

```
bryans-computer:unix bryan$ ./micropython
Micro Python v1.4.4-172-g4434e43 on 2015-08-03; linux version
>>> import sys
>>> sys.platform
'linux'
>>> 
bryans-computer:unix bryan$ python3
Python 3.4.3 (default, May 25 2015, 18:55:23) 
[GCC 4.2.1 Compatible Apple LLVM 4.2 (clang-425.0.28)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.platform
'darwin'
>>> 
```

With this change both the greeting and `sys.platform` show 'darwin' instead of 'linux':

```
bryan-morrisseys-computer:unix bryan$ ./micropython
Micro Python v1.4.4-173-g2dfb1e5 on 2015-08-03; darwin version
>>> import sys
>>> sys.platform
'darwin'
>>> 
```

EDIT: Original commit has been amended to match indentation style
