### PR TITLE
stmhal: Add definitions for MCU_SERIES_F4 and MCU_SERIES_F7

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -45,8 +45,8 @@ INC += -I../lib/netutils
 INC += -I../lib/timeutils
 
 CFLAGS_CORTEX_M = -mthumb -mabi=aapcs-linux -mfpu=fpv4-sp-d16 -mfloat-abi=hard -fsingle-precision-constant -Wdouble-promotion
-CFLAGS_MCU_f4 = $(CFLAGS_CORTEX_M) -mtune=cortex-m4 -mcpu=cortex-m4
-CFLAGS_MCU_f7 = $(CFLAGS_CORTEX_M) -mtune=cortex-m7 -mcpu=cortex-m7
+CFLAGS_MCU_f4 = $(CFLAGS_CORTEX_M) -mtune=cortex-m4 -mcpu=cortex-m4 -DMCU_SERIES_F4
+CFLAGS_MCU_f7 = $(CFLAGS_CORTEX_M) -mtune=cortex-m7 -mcpu=cortex-m7 -DMCU_SERIES_F7
 
 CFLAGS = $(INC) -Wall -Wpointer-arith -Werror -ansi -std=gnu99 -nostdlib $(CFLAGS_MOD)
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))

--- a/stmhal/extint.c
+++ b/stmhal/extint.c
@@ -188,7 +188,7 @@ void extint_enable(uint line) {
     if (line >= EXTI_NUM_VECTORS) {
         return;
     }
-    #if defined(STM32F7)
+    #if defined(MCU_SERIES_F7)
     // The Cortex-M7 doesn't have bitband support.
     mp_uint_t irq_state = disable_irq();
     if (pyb_extint_mode[line] == EXTI_Mode_Interrupt) {
@@ -210,7 +210,7 @@ void extint_disable(uint line) {
         return;
     }
 
-    #if defined(STM32F7)
+    #if defined(MCU_SERIES_F7)
     // The Cortex-M7 doesn't have bitband support.
     mp_uint_t irq_state = disable_irq();
     EXTI->IMR &= ~(1 << line);

--- a/stmhal/extint.h
+++ b/stmhal/extint.h
@@ -36,7 +36,7 @@
 #define EXTI_USB_OTG_HS_WAKEUP  (20)
 #define EXTI_RTC_TIMESTAMP      (21)
 #define EXTI_RTC_WAKEUP         (22)
-#if defined(STM32F7)
+#if defined(MCU_SERIES_F7)
 #define EXTI_LPTIM1_ASYNC_EVENT (23)
 #endif
 

--- a/stmhal/flash.c
+++ b/stmhal/flash.c
@@ -28,13 +28,11 @@
 
 #include "flash.h"
 
-#if defined(STM32F7)
+#if defined(MCU_SERIES_F7)
+
 // FLASH_FLAG_PGSERR (Programming Sequence Error) was renamed to
 // FLASH_FLAG_ERSERR (Erasing Sequence Error) in STM32F7
 #define FLASH_FLAG_PGSERR FLASH_FLAG_ERSERR
-#endif
-
-#if defined(STM32F7)
 
 /* Base address of the Flash sectors */
 #define ADDR_FLASH_SECTOR_0     ((uint32_t)0x08000000) /* Base @ of Sector 0, 32 Kbytes */
@@ -68,7 +66,7 @@
 #define ADDR_FLASH_END          ((uint32_t)0x08100000) /* 1 Mbytes total */
 #endif
 
-#endif
+#endif // MCU_SERIES_F7
 
 static const uint32_t flash_info_table[26] = {
     ADDR_FLASH_SECTOR_0, FLASH_SECTOR_0,

--- a/stmhal/modpyb.c
+++ b/stmhal/modpyb.c
@@ -74,7 +74,7 @@ STATIC NORETURN mp_obj_t pyb_bootloader(void) {
     HAL_RCC_DeInit();
     HAL_DeInit();
 
-#if defined(STM32F7)
+#if defined(MCU_SERIES_F7)
     // arm-none-eabi-gcc 4.9.0 does not correctly inline this
     // MSP function, so we write it out explicitly here.
     //__set_MSP(*((uint32_t*) 0x1FF00000));
@@ -462,7 +462,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(pyb_stop_obj, pyb_stop);
 
 /// \function standby()
 STATIC mp_obj_t pyb_standby(void) {
-#if defined(STM32F7)
+#if defined(MCU_SERIES_F7)
     printf("pyb.standby not supported yet\n");
 #else
     // We need to clear the PWR wake-up-flag before entering standby, since

--- a/stmhal/mpconfigport.h
+++ b/stmhal/mpconfigport.h
@@ -135,7 +135,7 @@ extern const struct _mp_obj_module_t mp_module_network;
     { MP_OBJ_NEW_QSTR(MP_QSTR_pyb), (mp_obj_t)&pyb_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_stm), (mp_obj_t)&stm_module }, \
 
-#if defined(STM32F7)
+#if defined(MCU_SERIES_F7)
 #define PYB_EXTI_NUM_VECTORS (24)
 #else
 #define PYB_EXTI_NUM_VECTORS (23)

--- a/stmhal/mphal.h
+++ b/stmhal/mphal.h
@@ -3,7 +3,7 @@
 
 // Basic GPIO functions
 #define GPIO_read_pin(gpio, pin)        (((gpio)->IDR >> (pin)) & 1)
-#if defined(STM32F7)
+#if defined(MCU_SERIES_F7)
 #define GPIO_set_pin(gpio, pin_mask)    (((gpio)->BSRR) = (pin_mask))
 #define GPIO_clear_pin(gpio, pin_mask)  (((gpio)->BSRR) = ((pin_mask) << 16))
 #else

--- a/stmhal/startup_stm32.S
+++ b/stmhal/startup_stm32.S
@@ -44,7 +44,7 @@
   */
 
   .syntax unified
-#if STM32F7
+#if defined(MCU_SERIES_M7)
   .cpu cortex-m7
 #else
   .cpu cortex-m4
@@ -211,7 +211,7 @@ g_pfnVectors:
   .word     TIM8_TRG_COM_TIM14_IRQHandler     /* TIM8 Trigger and Commutation and TIM14 */
   .word     TIM8_CC_IRQHandler                /* TIM8 Capture Compare         */
   .word     DMA1_Stream7_IRQHandler           /* DMA1 Stream7                 */
-#if defined(STM32F7)
+#if defined(MCU_SERIES_F7)
   .word     FMC_IRQHandler                    /* FMC                          */
   .word     SDMMC1_IRQHandler                 /* SDMMC1                       */
 #else
@@ -251,7 +251,7 @@ g_pfnVectors:
   .word     HASH_RNG_IRQHandler               /* Hash and Rng                 */
   .word     FPU_IRQHandler                    /* FPU                          */
 
-#if defined(STM32F7)
+#if defined(MCU_SERIES_F7)
   .word     UART7_IRQHandler                  /* UART7                        */
   .word     UART8_IRQHandler                  /* UART8                        */
   .word     SPI4_IRQHandler                   /* SPI4                         */
@@ -448,7 +448,7 @@ g_pfnVectors:
    .weak      DMA1_Stream7_IRQHandler
    .thumb_set DMA1_Stream7_IRQHandler,Default_Handler
 
-#if defined(STM32F7)
+#if defined(MCU_SERIES_F7)
    .weak      FMC_IRQHandler
    .thumb_set FMC_IRQHandler,Default_Handler
 
@@ -554,7 +554,7 @@ g_pfnVectors:
 
    .weak      FPU_IRQHandler
    .thumb_set FPU_IRQHandler,Default_Handler
-#if defined(STM32F7)
+#if defined(MCU_SERIES_F7)
    .weak      UART7_IRQHandler
    .thumb_set UART7_IRQHandler,Default_Handler
 

--- a/stmhal/system_stm32.c
+++ b/stmhal/system_stm32.c
@@ -283,7 +283,7 @@ void SystemClock_Config(void)
     __fatal_error("HAL_RCC_OscConfig");
   }
 
-#if defined(STM32F7)
+#if defined(MCU_SERIES_F7)
   /* Activate the OverDrive to reach the 200 MHz Frequency */
   if (HAL_PWREx_EnableOverDrive() != HAL_OK)
   {
@@ -308,7 +308,7 @@ void SystemClock_Config(void)
     __fatal_error("HAL_RCC_ClockConfig");
   }
 
-#if defined(STM32F7)
+#if defined(MCU_SERIES_F7)
   // The DFU bootloader changes the clocksource register from its default power
   // on reset value, so we set it back here, so the clocksources are the same
   // whether we were started from DFU or from a power on reset.

--- a/stmhal/uart.c
+++ b/stmhal/uart.c
@@ -36,7 +36,7 @@
 #include "pybioctl.h"
 #include MICROPY_HAL_H
 
-//TODO: Add UART7/8 support for STM32F7
+//TODO: Add UART7/8 support for MCU_SERIES_F7
 
 /// \moduleref pyb
 /// \class UART - duplex serial communication bus
@@ -316,7 +316,7 @@ int uart_rx_char(pyb_uart_obj_t *self) {
         return data;
     } else {
         // no buffering
-        #if defined(STM32F7)
+        #if defined(MCU_SERIES_F7)
         return self->uart.Instance->RDR & self->char_mask;
         #else
         return self->uart.Instance->DR & self->char_mask;
@@ -354,7 +354,7 @@ void uart_irq_handler(mp_uint_t uart_id) {
     }
 
     if (__HAL_UART_GET_FLAG(&self->uart, UART_FLAG_RXNE) != RESET) {
-        #if defined(STM32F7)
+        #if defined(MCU_SERIES_F7)
         int data = self->uart.Instance->RDR; // clears UART_FLAG_RXNE
         #else
         int data = self->uart.Instance->DR; // clears UART_FLAG_RXNE
@@ -714,7 +714,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_uart_readchar_obj, pyb_uart_readchar);
 // uart.sendbreak()
 STATIC mp_obj_t pyb_uart_sendbreak(mp_obj_t self_in) {
     pyb_uart_obj_t *self = self_in;
-    #if defined(STM32F7)
+    #if defined(MCU_SERIES_F7)
     self->uart.Instance->RQR = USART_RQR_SBKRQ; // write-only register
     #else
     self->uart.Instance->CR1 |= USART_CR1_SBK;


### PR DESCRIPTION
I noticed that there was a #if STM32F7 which should have been #if defined(STM32F7) and I also noticed that the STM32F7 flag wasn't being defined when assembling startup_stm32.S
