### PR TITLE
stmhal: Fix hardfault when configured as a SPI slave

### DIFF
--- a/stmhal/spi.c
+++ b/stmhal/spi.c
@@ -528,7 +528,9 @@ STATIC mp_obj_t pyb_spi_recv(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_
         if (status == HAL_OK) {
             status = spi_wait_dma_finished(self->spi, args[1].u_int);
         }
-        dma_deinit(&tx_dma);
+        if (self->spi->hdmatx != NULL) {
+            dma_deinit(&tx_dma);
+        }
         dma_deinit(&rx_dma);
     }
 


### PR DESCRIPTION
When configured as a slave, the spi recv code would try to deinit a dma for which it didn't init.

I added an if to check if that handle had been initialized and now if I execute:

```
spi = pyb.SPI(1, pyb.SPI.SLAVE)
spi.recv(1)
```

it no longer hard faults after 5 seconds, but throws the TIMEOUT exception instead.

Original issue raised on the forum: http://forum.micropython.org/viewtopic.php?f=2&t=844
