### PR TITLE
tests: Remove over-specification of startup banner

### DIFF
--- a/tests/cmdline/repl_cont.py.exp
+++ b/tests/cmdline/repl_cont.py.exp
@@ -1,4 +1,4 @@
-Micro Python \.\+ linux version
+Micro Python \.\+ version
 >>> # check REPL allows to continue input
 >>> 1 \\\\
 ... + 2


### PR DESCRIPTION
#1409 fixed <code>sys.platform</code> which value forms part of startup banner. The <code>repl_cont</code> test expected <code>linux</code> regardless. This change removes that over-specification.
