### PR TITLE
README.md: Document "Ctrl+D" shell exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Then to give it a try:
     $ ./micropython
     >>> list(5 * x + y for x in range(10) for y in [4, 2, 1])
 
+Use `Ctrl-D` (i.e. EOF) to exit the shell.
+
 Run complete testsuite:
 
     $ make test

--- a/unix/main.c
+++ b/unix/main.c
@@ -149,7 +149,7 @@ STATIC char *strjoin(const char *s1, int sep_char, const char *s2) {
 }
 
 STATIC int do_repl(void) {
-    mp_hal_stdout_tx_str("Micro Python " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_PY_SYS_PLATFORM " version\n");
+    mp_hal_stdout_tx_str("Micro Python " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_PY_SYS_PLATFORM " version\nUse Ctrl-D (i.e. EOF) to exit.\n");
 
     for (;;) {
         char *line = prompt(">>> ");


### PR DESCRIPTION
This keybind tends to slip my mind. And I noticed that newer uPy does trap CTRL+C/Ctrl+Z now and neither is quit() implemented to drop a hint either.
So after some absence I was quite a bit peeved about this behaviour until finally figuring out how to get out of that shell again (unix build).

In case it's something to put into the shell banner as a hint,

```
$ ./micropython
Micro Python v1.4.5-1-gb7d5906 on 2015-08-12; linux version
Use Ctrl-D (i.e. EOF) to exit.
>>> 
```

I added a second commit for that, but feel free to disregard it.
