### PR TITLE
windows: Make unistd.h more posix compatible

### DIFF
--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -186,9 +186,6 @@ void msec_sleep(double msec);
 #define restrict
 #define inline                      __inline
 #define alignof(t)                  __alignof(t)
-#define STDIN_FILENO                0
-#define STDOUT_FILENO               1
-#define STDERR_FILENO               2
 #define PATH_MAX                    MICROPY_ALLOC_PATH_MAX
 #define S_ISREG(m)                  (((m) & S_IFMT) == S_IFREG)
 #define S_ISDIR(m)                  (((m) & S_IFMT) == S_IFDIR)

--- a/windows/msvc/unistd.h
+++ b/windows/msvc/unistd.h
@@ -26,3 +26,15 @@
 
 // There's no unistd.h, but this is the equivalent
 #include <io.h>
+
+#define F_OK 0
+#define W_OK 2
+#define R_OK 4
+
+#define STDIN_FILENO  0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+
+#define SEEK_CUR 1
+#define SEEK_END 2
+#define SEEK_SET 0

--- a/windows/realpath.c
+++ b/windows/realpath.c
@@ -26,11 +26,7 @@
 
 #include <stdlib.h>
 #include <errno.h>
-#include <io.h>
-
-#ifndef R_OK
-    #define R_OK 4
-#endif
+#include <unistd.h>
 
 // Make sure a path only has forward slashes.
 char *to_unix_path(char *p) {


### PR DESCRIPTION
- add SEEK_XXX definitions, this fixes missing definition in py/stream.c
- move R_OK from realpath.c and add W_OK/F_OK defintions
- move STDXXX_FILENO definitions from mpconfigport for consistency
