### PR TITLE
Fix for build under Windows with MSYS2 - gcc version 4.9.2 (GCC) Target: x86_64-pc-msys + ure.sub

### DIFF
--- a/extmod/modmachine.c
+++ b/extmod/modmachine.c
@@ -37,7 +37,9 @@
 
 #if MICROPY_PY_MACHINE
 
+#ifndef PAGE_SIZE
 #define PAGE_SIZE 4096
+#endif
 #define PAGE_MASK (PAGE_SIZE - 1)
 
 STATIC mp_uint_t get_addr(mp_obj_t addr_o, uint align) {

--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -190,7 +190,7 @@ STATIC mp_obj_t re_exec_sub(bool is_anchored, uint n_args, const mp_obj_t *args)
     subj.begin = mp_obj_str_get_data(where, &len);
     subj.end = subj.begin + len;
     int caps_num = (self->re.sub + 1) * 2;
-    size_t pre_m_l = -1, post_m_l = -1;
+    int pre_m_l = -1, post_m_l = -1;
 
     const char* where_str = subj.begin;
 

--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -167,10 +167,181 @@ STATIC mp_obj_t re_split(uint n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(re_split_obj, 2, 3, re_split);
 
+// str_to_int ... from objstr.c
+STATIC int str_to_int(const char *str, int *num) {
+    const char *s = str;
+    if ('0' <= *s && *s <= '9') {
+        *num = 0;
+        do {
+            *num = *num * 10 + (*s - '0');
+            s++;
+        } while ('0' <= *s && *s <= '9');
+    }
+    return s - str;
+}
+
+STATIC mp_obj_t re_exec_sub(bool is_anchored, uint n_args, const mp_obj_t *args) {
+    mp_obj_re_t *self = args[0];
+    mp_obj_t where = args[2];
+    int count = (n_args > 3 ? mp_obj_get_int(args[3]) : 0);
+
+    Subject subj;
+    mp_uint_t len;
+    subj.begin = mp_obj_str_get_data(where, &len);
+    subj.end = subj.begin + len;
+    int caps_num = (self->re.sub + 1) * 2;
+    size_t pre_m_l = -1, post_m_l = -1;
+
+    const char* where_str = subj.begin;
+
+    vstr_t *vstr_return = NULL;
+    if ((vstr_return = vstr_new_size(0)) != NULL) {
+        while (true) {
+
+            mp_obj_match_t *match = m_new_obj_var(mp_obj_match_t, char*, caps_num);
+            // cast is a workaround for a bug in msvc: it treats const char** as a const pointer instead of a pointer to pointer to const char
+            memset((char*)match->caps, 0, caps_num * sizeof(char*));
+            int res = re1_5_recursiveloopprog(&self->re, &subj, match->caps, caps_num, is_anchored);
+
+            // if we didn't have a match, or had an empty match, it's time to stop
+            if (!res || match->caps[0] == match->caps[1]) {
+                break;
+            }
+            else {
+
+                // process match
+                match->base.type = &match_type;
+                match->num_matches = caps_num / 2; // caps_num counts start and end pointers
+                match->str = where;
+
+                mp_obj_t replace = args[1];
+                const char* replace_str = mp_obj_str_get_str((mp_obj_is_callable(replace) ? mp_call_function_1(replace, match) : replace));
+
+                // add pre-match string
+                pre_m_l = (match->caps[0] - subj.begin);
+                if (pre_m_l != -1) {
+                    vstr_add_strn(vstr_return, subj.begin, pre_m_l);
+                }
+
+                vstr_t *vstr_repl = NULL;
+                if ((vstr_repl = vstr_new_size(0)) != NULL) {
+                    vstr_add_str(vstr_repl, replace_str);
+                    const char *repl_p = vstr_null_terminated_str(vstr_repl);
+                    do {
+                        const char *group = NULL, *start_group = NULL, *end_group = NULL;
+                        int match_no = -1, is_group_number = -1;
+                        if (*repl_p == '\\') {
+                            start_group = repl_p;
+                            group = ++repl_p;
+
+                            if (*group != 0 && *group == 'g') {
+                                // search group with syntax "\g<number>"
+                                const char *left_angle_bracket = ++group;
+                                if (left_angle_bracket != 0 && *left_angle_bracket == '<') {
+                                    const char *value = ++left_angle_bracket;
+                                    if (value != 0) {
+
+                                        if (unichar_isalpha(*value)) {
+                                            mp_not_implemented("group with syntax \"\\g<name>\"");
+                                        }
+
+                                        int value_l = str_to_int(value, &match_no);
+                                        if (match_no == -1) {
+                                            nlr_raise(mp_obj_new_exception_msg(&mp_type_RuntimeError, "missing group number"));
+                                        }
+
+                                        const char *right_angle_bracket = value += value_l;
+                                        if (right_angle_bracket != 0 && *right_angle_bracket == '>' && match_no < match->num_matches) {
+                                            is_group_number = 1;
+                                            end_group = value + 1;
+                                        }
+                                    }
+                                }
+
+                            }
+                            else if (group != 0 && unichar_isdigit(*group)) {
+                                // search group with syntax "\number"
+                                const char *value = group;
+                                int value_l = str_to_int(value, &match_no);
+                                if (match_no > -1 && match_no < match->num_matches) {
+                                    is_group_number = 0;
+                                    end_group = value += value_l;
+                                }
+                            }
+
+                            if (match_no > -1 && is_group_number > -1 && start_group != NULL && end_group != NULL) {
+
+                                const char *start_match = match->caps[match_no * 2];
+                                if (start_match == NULL) {
+                                    // no match for this group
+                                    return where;
+                                }
+                                size_t mg_l = (match->caps[match_no * 2 + 1] - start_match);
+                                size_t gv_l = (end_group - start_group);
+
+                                const char *prev_repl_p = repl_p - 1;
+
+                                if (gv_l < mg_l) {
+                                    vstr_add_len(vstr_repl, (mg_l - gv_l));
+                                    repl_p += gv_l;
+                                }
+                                else if (gv_l > mg_l) {
+                                    vstr_cut_out_bytes(vstr_repl, (prev_repl_p - replace_str), (gv_l - mg_l));
+                                    repl_p -= mg_l;
+                                }
+
+                                // replace the substring matched by group
+                                memmove((char *)(prev_repl_p + mg_l), (prev_repl_p + gv_l), strlen(prev_repl_p));
+                                memcpy((char *)(prev_repl_p), start_match, mg_l);
+
+                            }
+                        }
+
+                    } while (*(++repl_p) != 0);
+
+                    // add replace
+                    vstr_add_str(vstr_return, vstr_str(vstr_repl));
+
+                    // post-match string
+                    post_m_l = (match->caps[1] - where_str);
+
+                    vstr_free(vstr_repl);
+                }
+
+            }
+
+            subj.begin = match->caps[1];
+            subj.end = subj.begin + strlen(match->caps[1]);
+
+            if (count > 0 && --count == 0) {
+                break;
+            }
+
+            m_del_var(mp_obj_match_t, char*, match->num_matches, match);
+
+        }
+
+    }
+
+    // add post-match string
+    if (post_m_l != -1) {
+        vstr_add_str(vstr_return, &where_str[post_m_l]);
+    }
+
+    return (!vstr_len(vstr_return) ? where : mp_obj_new_str_from_vstr(&mp_type_str, vstr_return));
+}
+
+STATIC mp_obj_t re_sub(uint n_args, const mp_obj_t *args) {
+    return re_exec_sub(false, n_args, args);
+}
+
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(re_sub_obj, 3, 4, re_sub);
+
 STATIC const mp_map_elem_t re_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_match), (mp_obj_t) &re_match_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_search), (mp_obj_t) &re_search_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_split), (mp_obj_t) &re_split_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_sub), (mp_obj_t)&re_sub_obj },
 };
 
 STATIC MP_DEFINE_CONST_DICT(re_locals_dict, re_locals_dict_table);
@@ -221,11 +392,26 @@ STATIC mp_obj_t mod_re_search(uint n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_re_search_obj, 2, 4, mod_re_search);
 
+STATIC mp_obj_t mod_re_exec_sub(bool is_anchored, uint n_args, const mp_obj_t *args) {
+    (void)n_args;
+    mp_obj_re_t *self = mod_re_compile(1, args);
+
+    const mp_obj_t args3[] = { self, args[1], args[2], (n_args>3 ? args[3] : 0) };
+    mp_obj_t retval = re_exec_sub(is_anchored, n_args, args3);
+    return retval;
+}
+
+STATIC mp_obj_t mod_re_sub(uint n_args, const mp_obj_t *args) {
+    return mod_re_exec_sub(false, n_args, args);
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_re_sub_obj, 3, 5, mod_re_sub);
+
 STATIC const mp_map_elem_t mp_module_re_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_ure) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_compile), (mp_obj_t)&mod_re_compile_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_match), (mp_obj_t)&mod_re_match_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_search), (mp_obj_t)&mod_re_search_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_sub), (mp_obj_t)&mod_re_sub_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_DEBUG), MP_OBJ_NEW_SMALL_INT(FLAG_DEBUG) },
 };
 

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -571,6 +571,7 @@ Q(compile)
 Q(match)
 Q(search)
 Q(group)
+Q(sub)
 Q(DEBUG)
 #endif
 

--- a/tests/extmod/ure_sub.py
+++ b/tests/extmod/ure_sub.py
@@ -5,71 +5,30 @@ except ImportError:
 
 
 def multiply(m):
-    v = int(m.group(0))
-    return str(v * 2)
+    return str(int(m.group(0)) * 2)
 
-result = re.sub("\d+", multiply, "10 20 30 40 50")
-print(result)
+print(re.sub("\d+", multiply, "10 20 30 40 50"))
 
-result = re.sub("\d+", lambda m: str(int(m.group(0)) * 2), "10 20 30 40 50")
-print(result)
+print(re.sub("\d+", lambda m: str(int(m.group(0)) // 2), "10 20 30 40 50"))
 
-print(re.sub('a', 'A', 'aa678gjhg989000asadsadsasa'))
-print(re.sub('a', 'A', 'ab'))
+def A():
+    return "A"
+print(re.sub('a', A(), 'aBCBABCDabcda.'))
 
 print(
     re.sub(
         r'def\s+([a-zA-Z_][a-zA-Z_0-9]*)\s*\(\s*\):', 
         'static PyObject*\npy_\\1(void){\n  return;\n}\n', 
-        'AAAdef myfunc():AAAA\ndef myfunc1():AAAAA\ndef myfunc2():\n'
+        '\n\ndef myfunc():\n\ndef myfunc1():\n\ndef myfunc2():'
     )
 ) 
 
-where = 'abcdefghijklmnopqrstuvwxyz' + '0123456789' + 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-replacement = "".join( [ 
-        (
-            "\\g<{0}>" if r%2 else "\\{0}"
-        ).format(r) for r in range(1, len(where) + 1)
-    ][::-1] 
-) 
-regex = "([a-zA-Z0-9])" * len(where)
+print(
+    re.compile(
+         '(calzino) (blu|bianco|verde) e (scarpa) (blu|bianco|verde)'
+    ).sub(
+        r'\g<1> colore \2 con \g<3> colore \4? ...',
+        'calzino blu e scarpa verde'
+    )
+)
 
-s0 = re.sub(regex, replacement, where)
-print(s0, len(s0)) 
-
-if True:
-    
-    regex = r'(calzino)(\ )(blu|bianco|rossa).*(scarpa).*(blu|bianco|rossa)'
-    replacement = r'\g<1> \2colore (\3) ma veramente tanto (\g<3>) \g<4> colore (\5) ma veramente tanto (\g<5>)'
-    where = 'calzino blu e scarpa rossa!'
-    
-    for index in range(1):
-
-        p1 = re.compile(regex)
-        s1 = p1.sub(replacement, where)
-        print(s1, len(s1))
-
-        s2 = re.sub(regex, replacement, where)
-        print(s2, len(s2))
-
-        p3 = re.compile(regex)
-        s3 = p3.sub(replacement, where, 1)
-        print(s3, len(s3))
-
-        def callable(value):
-            return value
-
-        s4 = re.sub(
-            regex, 
-            callable(replacement), 
-            where
-        )
-        print(s4, len(s4))
-
-        p5 = re.compile(regex)
-        s5 = p5.sub(
-            callable(replacement), 
-            where, 
-            1
-        )
-        print(s5, len(s5))

--- a/tests/extmod/ure_sub.py
+++ b/tests/extmod/ure_sub.py
@@ -1,0 +1,75 @@
+try:
+    import ure as re
+except ImportError:
+    import re
+
+
+def multiply(m):
+    v = int(m.group(0))
+    return str(v * 2)
+
+result = re.sub("\d+", multiply, "10 20 30 40 50")
+print(result)
+
+result = re.sub("\d+", lambda m: str(int(m.group(0)) * 2), "10 20 30 40 50")
+print(result)
+
+print(re.sub('a', 'A', 'aa678gjhg989000asadsadsasa'))
+print(re.sub('a', 'A', 'ab'))
+
+print(
+    re.sub(
+        r'def\s+([a-zA-Z_][a-zA-Z_0-9]*)\s*\(\s*\):', 
+        'static PyObject*\npy_\\1(void){\n  return;\n}\n', 
+        'AAAdef myfunc():AAAA\ndef myfunc1():AAAAA\ndef myfunc2():\n'
+    )
+) 
+
+where = 'abcdefghijklmnopqrstuvwxyz' + '0123456789' + 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+replacement = "".join( [ 
+        (
+            "\\g<{0}>" if r%2 else "\\{0}"
+        ).format(r) for r in range(1, len(where) + 1)
+    ][::-1] 
+) 
+regex = "([a-zA-Z0-9])" * len(where)
+
+s0 = re.sub(regex, replacement, where)
+print(s0, len(s0)) 
+
+if True:
+    
+    regex = r'(calzino)(\ )(blu|bianco|rossa).*(scarpa).*(blu|bianco|rossa)'
+    replacement = r'\g<1> \2colore (\3) ma veramente tanto (\g<3>) \g<4> colore (\5) ma veramente tanto (\g<5>)'
+    where = 'calzino blu e scarpa rossa!'
+    
+    for index in range(1):
+
+        p1 = re.compile(regex)
+        s1 = p1.sub(replacement, where)
+        print(s1, len(s1))
+
+        s2 = re.sub(regex, replacement, where)
+        print(s2, len(s2))
+
+        p3 = re.compile(regex)
+        s3 = p3.sub(replacement, where, 1)
+        print(s3, len(s3))
+
+        def callable(value):
+            return value
+
+        s4 = re.sub(
+            regex, 
+            callable(replacement), 
+            where
+        )
+        print(s4, len(s4))
+
+        p5 = re.compile(regex)
+        s5 = p5.sub(
+            callable(replacement), 
+            where, 
+            1
+        )
+        print(s5, len(s5))

--- a/unix/main.c
+++ b/unix/main.c
@@ -416,7 +416,7 @@ int main(int argc, char **argv) {
             } else if (strcmp(argv[a], "-v") == 0) {
                 mp_verbose_flag++;
             } else if (strncmp(argv[a], "-O", 2) == 0) {
-                if (isdigit((byte)argv[a][2])) {
+                if (unichar_isdigit(argv[a][2])) {
                     MP_STATE_VM(mp_optimise_value) = argv[a][2] & 0xf;
                 } else {
                     MP_STATE_VM(mp_optimise_value) = 0;

--- a/unix/main.c
+++ b/unix/main.c
@@ -416,7 +416,7 @@ int main(int argc, char **argv) {
             } else if (strcmp(argv[a], "-v") == 0) {
                 mp_verbose_flag++;
             } else if (strncmp(argv[a], "-O", 2) == 0) {
-                if (isdigit(argv[a][2])) {
+                if (isdigit((byte)argv[a][2])) {
                     MP_STATE_VM(mp_optimise_value) = argv[a][2] & 0xf;
                 } else {
                     MP_STATE_VM(mp_optimise_value) = 0;


### PR DESCRIPTION
- Fix for build under Windows with MSYS2

$ uname
MSYS_NT-10.0

$ gcc --version
gcc (GCC) 4.9.2
Copyright (C) 2014 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- Added sub into modure and relative tests
