### PR TITLE
Smart auto indent

### DIFF
--- a/unix/main.c
+++ b/unix/main.c
@@ -134,6 +134,7 @@ STATIC int execute_from_lexer(mp_lexer_t *lex, mp_parse_input_kind_t input_kind,
     }
 }
 
+#if 0
 STATIC char *strjoin(const char *s1, int sep_char, const char *s2) {
     int l1 = strlen(s1);
     int l2 = strlen(s2);
@@ -147,11 +148,17 @@ STATIC char *strjoin(const char *s1, int sep_char, const char *s2) {
     s[l1 + l2] = 0;
     return s;
 }
+#endif
+
+#include "lib/mp-readline/readline.h"
 
 STATIC int do_repl(void) {
     mp_hal_stdout_tx_str("Micro Python " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_PY_SYS_PLATFORM " version\n");
 
+    vstr_t line;
+    vstr_init(&line, 16);
     for (;;) {
+        #if 0
         char *line = prompt(">>> ");
         if (line == NULL) {
             // EOF
@@ -174,6 +181,47 @@ STATIC int do_repl(void) {
             return ret;
         }
         free(line);
+        #else
+    input_restart:
+        vstr_reset(&line);
+        mp_hal_stdio_mode_raw();
+        int ret = readline(&line, ">>> ");
+
+        if (ret == CHAR_CTRL_D) {
+            // EOF
+            printf("\n");
+            mp_hal_stdio_mode_orig();
+            vstr_clear(&line);
+            return 0;
+        } else if (line.len == 0) {
+            if (ret != 0) {
+                printf("\n");
+            }
+            mp_hal_stdio_mode_orig();
+            continue;
+        }
+
+        while (mp_repl_continue_with_input(vstr_null_terminated_str(&line))) {
+            vstr_add_byte(&line, '\n');
+            ret = readline(&line, "... ");
+            if (ret == CHAR_CTRL_C) {
+                // cancel everything
+                printf("\n");
+                mp_hal_stdio_mode_orig();
+                goto input_restart;
+            } else if (ret == CHAR_CTRL_D) {
+                // stop entering compound statement
+                break;
+            }
+        }
+        mp_hal_stdio_mode_orig();
+
+        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, line.buf, line.len, false);
+        ret = execute_from_lexer(lex, MP_PARSE_SINGLE_INPUT, true);
+        if (ret & FORCED_EXIT) {
+            return ret;
+        }
+        #endif
     }
 }
 


### PR DESCRIPTION
I'm convinced that #1368 is a good idea, and this is my (preliminary) patch to support auto indentation.

It's as minimal a change as I could make it.  There are basically 2 changes to the mp-readline code:
1. When readline is called it checks to see (based on the whole input so far) if it should auto indent the line.
2. Backspace will delete 4 spaces if the line is pure spaces.

It requires no state.  It doesn't (yet) work with event-driven readline.  It doesn't (yet) have a paste mode.

It works on pyboard.  It works on unix but I had to rewrite the unix REPL loop to use mp-readline directly (not via the old prompt function that also supported GNU readline).
