### PR TITLE
Fix bug in iteration of a sequence object

### DIFF
--- a/py/objgetitemiter.c
+++ b/py/objgetitemiter.c
@@ -47,8 +47,8 @@ STATIC mp_obj_t it_iternext(mp_obj_t self_in) {
         return value;
     } else {
         // an exception was raised
-        if (mp_obj_get_type(nlr.ret_val) == &mp_type_StopIteration
-	    || mp_obj_get_type(nlr.ret_val) == &mp_type_IndexError) {
+        mp_obj_type_t *t = mp_obj_get_type(nlr.ret_val);
+        if (t == &mp_type_StopIteration || t == &mp_type_IndexError) {
             // return MP_OBJ_STOP_ITERATION instead of raising
             return MP_OBJ_STOP_ITERATION;
         } else {

--- a/py/objgetitemiter.c
+++ b/py/objgetitemiter.c
@@ -47,8 +47,9 @@ STATIC mp_obj_t it_iternext(mp_obj_t self_in) {
         return value;
     } else {
         // an exception was raised
-        if (mp_obj_get_type(nlr.ret_val) == &mp_type_StopIteration) {
-            // return MP_OBJ_STOP_ITERATION instead of raising StopIteration
+        if (mp_obj_get_type(nlr.ret_val) == &mp_type_StopIteration
+	    || mp_obj_get_type(nlr.ret_val) == &mp_type_IndexError) {
+            // return MP_OBJ_STOP_ITERATION instead of raising
             return MP_OBJ_STOP_ITERATION;
         } else {
             // re-raise exception

--- a/tests/basics/iter3.py
+++ b/tests/basics/iter3.py
@@ -1,0 +1,19 @@
+# user defined iterator used in something other than a for loop
+
+class MyStopIteration(StopIteration):
+    pass
+
+class mygettable():
+    def __init__(self, iterable):
+        self.values = list(iterable)
+
+    def __len__(self):
+        return len(self.values)
+
+    def __getitem__(self, index):
+        return self.values[index]
+
+    def __setitem__(self, index, value):
+        self.values[index] = value
+
+print(list(mygettable(range(3))))

--- a/tests/basics/iter3.py
+++ b/tests/basics/iter3.py
@@ -1,7 +1,4 @@
-# user defined iterator used in something other than a for loop
-
-class MyStopIteration(StopIteration):
-    pass
+# iter from user defined sequence protocol object
 
 class mygettable():
     def __init__(self, iterable):


### PR DESCRIPTION
Fixes an oversight: `iter()` of a sequence protocol object:

> Without a second argument, object must be a collection object which supports the iteration protocol (the `__iter__()` method), or it must support the sequence protocol (the `__getitem__()` method with integer arguments starting at 0)

https://docs.python.org/3/library/functions.html#iter 
