### PR TITLE
stmhal: add option to query for the current usb mode

### DIFF
--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -35,6 +35,7 @@ codepoint2name[ord('}')] = 'brace_close'
 codepoint2name[ord('*')] = 'star'
 codepoint2name[ord('!')] = 'bang'
 codepoint2name[ord('\\')] = 'backslash'
+codepoint2name[ord('+')] = 'plus'
 
 # this must match the equivalent function in qstr.c
 def compute_hash(qstr, bytes_hash):

--- a/stmhal/qstrdefsport.h
+++ b/stmhal/qstrdefsport.h
@@ -97,6 +97,19 @@ Q(hid)
 Q(hid_mouse)
 Q(hid_keyboard)
 
+// for usb modes
+Q(host)
+Q(VCP)
+Q(MSC)
+Q(HID)
+Q(MSC+HID)
+Q(VCP+MSC)
+Q(VCP+HID)
+// CDC is a synonym for VCP for backwards compatibility
+Q(CDC)
+Q(CDC+MSC)
+Q(CDC+HID)
+
 // for USB VCP class
 Q(USB_VCP)
 Q(setinterrupt)

--- a/stmhal/usbdev/class/inc/usbd_cdc_msc_hid.h
+++ b/stmhal/usbdev/class/inc/usbd_cdc_msc_hid.h
@@ -94,6 +94,8 @@ extern USBD_ClassTypeDef USBD_CDC_MSC_HID;
 
 // returns 0 on success, -1 on failure
 int USBD_SelectMode(uint32_t mode, USBD_HID_ModeInfoTypeDef *hid_info);
+// returns the current usb mode
+uint8_t USBD_GetMode();
 
 uint8_t USBD_CDC_RegisterInterface  (USBD_HandleTypeDef   *pdev, USBD_CDC_ItfTypeDef *fops);
 uint8_t USBD_CDC_SetTxBuffer  (USBD_HandleTypeDef   *pdev, uint8_t  *pbuff, uint16_t length);

--- a/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
+++ b/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
@@ -559,6 +559,11 @@ __ALIGN_BEGIN const uint8_t USBD_HID_KEYBOARD_ReportDesc[USBD_HID_KEYBOARD_REPOR
     0xC0            // End Collection
 };
 
+// return the saved usb mode
+uint8_t USBD_GetMode() {
+    return usbd_mode;
+}
+
 int USBD_SelectMode(uint32_t mode, USBD_HID_ModeInfoTypeDef *hid_info) {
     // save mode
     usbd_mode = mode;


### PR DESCRIPTION
This pull request is in response to #1443 . There is still the concern over disabling the usb with pyb.usb_mode(None), but I wanted to start the conversation with this request. Also, this is my first ever pull request / open source contribution, so I would appreciate any feedback possible. 
