### PR TITLE
tests/README: Explain how tests get skipped

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -1,7 +1,17 @@
 This directory contains tests for various functionality areas of MicroPython.
-To run all stable tests, run "run-tests" script in this directory. Note
-that bytecode tests are not yet stable and should be run separately in
-"bytecode" subdirectory.
+To run all stable tests, run "run-tests" script in this directory.
+
+Tests of capabilities not supported on all platforms should be written
+to check for the capability being present. If it is not, the test
+should merely output 'SKIP' followed by the line terminator, and call
+sys.exit() to raise SystemExit, instead of attempting to test the
+missing capability. The testing framework (run-tests in this
+directory, test_main.c in qemu_arm) recognizes this as a skipped test.
+
+There are a few features for which this mechanism cannot be used to
+condition a test. The run-tests script uses small scripts in the
+feature_check directory to check whether each such feature is present,
+and skips the relevant tests if not.
 
 When creating new tests, anything that relies on float support should go in the 
 float/ subdirectory.  Anything that relies on import x, where x is not a built-in


### PR DESCRIPTION
Explains a bit about how test skipping is configured. The purpose is to ease the learning necessary for people to include tests in their contributions.
