### PR TITLE
unix: Use MICROPY_HAL_H macro for header inclusion.

### DIFF
--- a/unix/main.c
+++ b/unix/main.c
@@ -45,7 +45,7 @@
 #include "py/gc.h"
 #include "py/stackctrl.h"
 #include "genhdr/mpversion.h"
-#include "unix_mphal.h"
+#include MICROPY_HAL_H
 #include "input.h"
 
 // Command line options, with their defaults

--- a/unix/unix_mphal.c
+++ b/unix/unix_mphal.c
@@ -29,7 +29,7 @@
 #include <string.h>
 
 #include "py/mpstate.h"
-#include "unix_mphal.h"
+#include MICROPY_HAL_H
 
 #ifndef _WIN32
 #include <signal.h>


### PR DESCRIPTION
Follow the same format as other ports using the macro to include the HAL header.
