### PR TITLE
unix/modffi.c: cast first to intptr_t when casting from/to pointer

### DIFF
--- a/unix/modffi.c
+++ b/unix/modffi.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <dlfcn.h>
 #include <ffi.h>
+#include <stdint.h>
 
 #include "py/nlr.h"
 #include "py/runtime.h"
@@ -140,7 +141,7 @@ STATIC mp_obj_t return_ffi_value(ffi_arg val, char type)
 {
     switch (type) {
         case 's': {
-            const char *s = (const char *)val;
+            const char *s = (const char *)(intptr_t)val;
             if (!s) {
                 return mp_const_none;
             }
@@ -159,7 +160,7 @@ STATIC mp_obj_t return_ffi_value(ffi_arg val, char type)
         }
         #endif
         case 'O':
-            return (mp_obj_t)val;
+            return (mp_obj_t)(intptr_t)val;
         default:
             return mp_obj_new_int(val);
     }
@@ -355,7 +356,7 @@ STATIC mp_obj_t ffifunc_call(mp_obj_t self_in, mp_uint_t n_args, mp_uint_t n_kw,
     for (uint i = 0; i < n_args; i++, argtype++) {
         mp_obj_t a = args[i];
         if (*argtype == 'O') {
-            values[i] = (ffi_arg)a;
+            values[i] = (ffi_arg)(intptr_t)a;
         #if MICROPY_PY_BUILTINS_FLOAT
         } else if (*argtype == 'f') {
             float *p = (float*)&values[i];
@@ -370,7 +371,7 @@ STATIC mp_obj_t ffifunc_call(mp_obj_t self_in, mp_uint_t n_args, mp_uint_t n_kw,
             values[i] = mp_obj_int_get_truncated(a);
         } else if (MP_OBJ_IS_STR(a)) {
             const char *s = mp_obj_str_get_str(a);
-            values[i] = (ffi_arg)s;
+            values[i] = (ffi_arg)(intptr_t)s;
         } else if (((mp_obj_base_t*)a)->type->buffer_p.get_buffer != NULL) {
             mp_obj_base_t *o = (mp_obj_base_t*)a;
             mp_buffer_info_t bufinfo;
@@ -378,10 +379,10 @@ STATIC mp_obj_t ffifunc_call(mp_obj_t self_in, mp_uint_t n_args, mp_uint_t n_kw,
             if (ret != 0) {
                 goto error;
             }
-            values[i] = (ffi_arg)bufinfo.buf;
+            values[i] = (ffi_arg)(intptr_t)bufinfo.buf;
         } else if (MP_OBJ_IS_TYPE(a, &fficallback_type)) {
             mp_obj_fficallback_t *p = a;
-            values[i] = (ffi_arg)p->func;
+            values[i] = (ffi_arg)(intptr_t)p->func;
         } else {
             goto error;
         }


### PR DESCRIPTION
This fixes errors like these ones:

modffi.c: In function 'return_ffi_value':
modffi.c:143:29: error: cast to pointer from integer of different size
[-Werror=int-to-pointer-cast]
             const char *s = (const char *)val;
                             ^
modffi.c:162:20: error: cast to pointer from integer of different size
[-Werror=int-to-pointer-cast]
             return (mp_obj_t)val;
                    ^
modffi.c: In function 'ffifunc_call':
modffi.c:358:25: error: cast from pointer to integer of different size
[-Werror=pointer-to-int-cast]
             values[i] = (ffi_arg)a;
                         ^
modffi.c:373:25: error: cast from pointer to integer of different size
[-Werror=pointer-to-int-cast]
             values[i] = (ffi_arg)s;
                         ^
modffi.c:381:25: error: cast from pointer to integer of different size
[-Werror=pointer-to-int-cast]
             values[i] = (ffi_arg)bufinfo.buf;
                         ^
modffi.c:384:25: error: cast from pointer to integer of different size
[-Werror=pointer-to-int-cast]
             values[i] = (ffi_arg)p->func;
                         ^

These errors can be highlighted when building micropython for MIPS64 n32 because ffi_arg is 64-bit wide and the pointers on MIPS64 n32 are 32-bit wide, so it's trying to case an integer to a pointer (or vice versa) of a different size. We should cast first the pointer (or the integer) to a pointer sized integer (intptr_t) to fix that problem.

Signed-off-by: Vicente Olivert Riera Vincent.Riera@imgtec.com
