### PR TITLE
tests: Fix line-end being added incorrectly

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -77,7 +77,7 @@ def run_micropython(pyb, args, test_file):
                 else:
                     output_mupy = subprocess.check_output(args + [test_file])
             except subprocess.CalledProcessError:
-                output_mupy = b'CRASH'
+                return b'CRASH'
 
             # unescape wanted regex chars and escape unwanted ones
             def convert_regex_escapes(line):


### PR DESCRIPTION
Adding a line-end makes the determination of skip_native fail as it compares
the output against b'CRASH' while it is in fact b'CRASH\n'
