### PR TITLE
Fix call args when a stararg is followed by keyword args

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -2203,6 +2203,7 @@ STATIC void compile_trailer_paren_helper(compiler_t *comp, mp_parse_node_t pn_ar
     int n_positional = n_positional_extra;
     uint n_keyword = 0;
     uint star_flags = 0;
+    mp_parse_node_struct_t *star_args_node = NULL, *dblstar_args_node = NULL;
     for (int i = 0; i < n_args; i++) {
         if (MP_PARSE_NODE_IS_STRUCT(args[i])) {
             mp_parse_node_struct_t *pns_arg = (mp_parse_node_struct_t*)args[i];
@@ -2212,14 +2213,14 @@ STATIC void compile_trailer_paren_helper(compiler_t *comp, mp_parse_node_t pn_ar
                     return;
                 }
                 star_flags |= MP_EMIT_STAR_FLAG_SINGLE;
-                compile_node(comp, pns_arg->nodes[0]);
+                star_args_node = pns_arg;
             } else if (MP_PARSE_NODE_STRUCT_KIND(pns_arg) == PN_arglist_dbl_star) {
                 if (star_flags & MP_EMIT_STAR_FLAG_DOUBLE) {
                     compile_syntax_error(comp, (mp_parse_node_t)pns_arg, "can't have multiple **x");
                     return;
                 }
                 star_flags |= MP_EMIT_STAR_FLAG_DOUBLE;
-                compile_node(comp, pns_arg->nodes[0]);
+                dblstar_args_node = pns_arg;
             } else if (MP_PARSE_NODE_STRUCT_KIND(pns_arg) == PN_argument) {
                 assert(MP_PARSE_NODE_IS_STRUCT(pns_arg->nodes[1])); // should always be
                 mp_parse_node_struct_t *pns2 = (mp_parse_node_struct_t*)pns_arg->nodes[1];
@@ -2249,6 +2250,11 @@ STATIC void compile_trailer_paren_helper(compiler_t *comp, mp_parse_node_t pn_ar
             n_positional++;
         }
     }
+
+    if (star_args_node)
+        compile_node(comp, star_args_node->nodes[0]);
+    if (dblstar_args_node)
+        compile_node(comp, dblstar_args_node->nodes[0]);
 
     // emit the function/method call
     if (is_method_call) {

--- a/tests/basics/starargs.py
+++ b/tests/basics/starargs.py
@@ -1,0 +1,9 @@
+
+def f(*args, **kwargs):
+    print(args, kwargs)
+
+def print_ret(x):
+    print(x)
+    return x
+
+f(*print_ret(['a', 'b']), kw_arg=print_ret(None))


### PR DESCRIPTION
Compile star-arg and double-star-arg after all other arguments.
This fixes #1476 and does not break any existing test. Is there a better way to do it?
