### PR TITLE
Range slice

### DIFF
--- a/py/objrange.c
+++ b/py/objrange.c
@@ -148,9 +148,9 @@ STATIC mp_obj_t range_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
             mp_seq_get_fast_slice_indexes(len, index, &slice);
             mp_obj_range_t *o = m_new_obj(mp_obj_range_t);
             o->base.type = &mp_type_range;
-            o->start = slice.start;
-            o->stop = slice.stop;
-            o->step = slice.step;
+            o->start = self->start + slice.start * self->step;
+            o->stop = self->start + slice.stop * self->step;
+            o->step = slice.step * self->step;
             return o;
         }
 #endif

--- a/tests/basics/builtin_range.py
+++ b/tests/basics/builtin_range.py
@@ -28,6 +28,11 @@ print(range(4)[1:2])
 print(range(4)[1:3])
 print(range(4)[1::2])
 print(range(4)[1:-2:2])
+print(range(1,4)[:])
+print(range(1,4)[0:])
+print(range(1,4)[1:])
+print(range(1,4)[:-1])
+print(range(7,-2,-4)[:])
 
 # attrs
 print(range(1, 2, 3).start)


### PR DESCRIPTION
Slicing of ranges was failing to include the attributes of the range in the slicing. See tests.
