### PR TITLE
stmhal: Fix CDC only mode under Windows

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -299,7 +299,7 @@ GEN_PINS_AF_PY = $(BUILD)/pins_af.py
 INSERT_USB_IDS = ../tools/insert-usb-ids.py
 FILE2H = ../tools/file2h.py
 
-USB_IDS_FILE = usbd_desc.c
+USB_IDS_FILE = usb.h
 CDCINF_TEMPLATE = pybcdc.inf_template
 GEN_CDCINF_FILE = $(HEADER_BUILD)/pybcdc.inf
 GEN_CDCINF_HEADER = $(HEADER_BUILD)/pybcdc_inf.h

--- a/stmhal/pybcdc.inf_template
+++ b/stmhal/pybcdc.inf_template
@@ -77,10 +77,10 @@ ServiceBinary=%12%\usbser.sys
 [SourceDisksFiles]
 [SourceDisksNames]
 [DeviceList]
-%DESCRIPTION%=DriverInstall, USB\VID_${USB_VID}&PID_${USB_PID}&MI_00, USB\VID_${USB_VID}&PID_${USB_PID}&MI_01
+%DESCRIPTION%=DriverInstall, USB\VID_${USB_VID}&PID_${USB_PID_CDC_MSC}&MI_00, USB\VID_${USB_VID}&PID_${USB_PID_CDC_MSC}&MI_01, USB\VID_${USB_VID}&PID_${USB_PID_CDC_HID}&MI_00, USB\VID_${USB_VID}&PID_${USB_PID_CDC_HID}&MI_01, USB\VID_${USB_VID}&PID_${USB_PID_CDC}
 
 [DeviceList.NTamd64]
-%DESCRIPTION%=DriverInstall, USB\VID_${USB_VID}&PID_${USB_PID}&MI_00, USB\VID_${USB_VID}&PID_${USB_PID}&MI_01
+%DESCRIPTION%=DriverInstall, USB\VID_${USB_VID}&PID_${USB_PID_CDC_MSC}&MI_00, USB\VID_${USB_VID}&PID_${USB_PID_CDC_MSC}&MI_01, USB\VID_${USB_VID}&PID_${USB_PID_CDC_HID}&MI_00, USB\VID_${USB_VID}&PID_${USB_PID_CDC_HID}&MI_01, USB\VID_${USB_VID}&PID_${USB_PID_CDC}
 
 ;---------------------------------------------------------------------
 ;  String Definitions

--- a/stmhal/usb.c
+++ b/stmhal/usb.c
@@ -98,7 +98,7 @@ bool pyb_usb_dev_init(uint16_t vid, uint16_t pid, usb_device_mode_t mode, USBD_H
 #ifdef USE_DEVICE_MODE
     if (!(pyb_usb_flags & PYB_USB_FLAG_DEV_ENABLED)) {
         // only init USB once in the device's power-lifetime
-        USBD_SetVIDPIDRelease(vid, pid, 0x0200);
+        USBD_SetVIDPIDRelease(vid, pid, 0x0200, mode == USBD_MODE_CDC);
         if (USBD_SelectMode(mode, hid_info) != 0) {
             return false;
         }

--- a/stmhal/usbd_desc.c
+++ b/stmhal/usbd_desc.c
@@ -81,7 +81,20 @@ __ALIGN_BEGIN static uint8_t USBD_LangIDDesc[USB_LEN_LANGID_STR_DESC] __ALIGN_EN
 __ALIGN_BEGIN static uint8_t USBD_StrDesc[USBD_MAX_STR_DESC_SIZ] __ALIGN_END;
 
 // set the VID, PID and device release number
-void USBD_SetVIDPIDRelease(uint16_t vid, uint16_t pid, uint16_t device_release_num) {
+void USBD_SetVIDPIDRelease(uint16_t vid, uint16_t pid, uint16_t device_release_num, int cdc_only) {
+    if (cdc_only) {
+        // Make it look like a Communications device if we're only
+        // using CDC. Otherwise, windows gets confused when we tell it that
+        // its a composite device with only a cdc serial interface.
+        hUSBDDeviceDesc[4] = 0x02;
+        hUSBDDeviceDesc[5] = 0x00;
+        hUSBDDeviceDesc[6] = 0x00;
+    } else {
+        // For the other modes, we make this look like a composite device.
+        hUSBDDeviceDesc[4] = 0xef;
+        hUSBDDeviceDesc[5] = 0x02;
+        hUSBDDeviceDesc[6] = 0x01;
+    }
     hUSBDDeviceDesc[8] = LOBYTE(vid);
     hUSBDDeviceDesc[9] = HIBYTE(vid);
     hUSBDDeviceDesc[10] = LOBYTE(pid);

--- a/stmhal/usbd_desc.h
+++ b/stmhal/usbd_desc.h
@@ -26,4 +26,4 @@
 
 extern const USBD_DescriptorsTypeDef USBD_Descriptors;
 
-void USBD_SetVIDPIDRelease(uint16_t vid, uint16_t pid, uint16_t device_release_num);
+void USBD_SetVIDPIDRelease(uint16_t vid, uint16_t pid, uint16_t device_release_num, int cdc_only);

--- a/tools/insert-usb-ids.py
+++ b/tools/insert-usb-ids.py
@@ -8,22 +8,20 @@ import sys
 import re
 import string
 
+needed_keys = ('USB_PID_CDC_MSC', 'USB_PID_CDC_HID', 'USB_PID_CDC', 'USB_VID')
+
 def parse_usb_ids(filename):
     rv = dict()
-    if filename == 'usbd_desc.c':
-        for line in open(filename).readlines():
-            line = line.rstrip('\r\n')
-            match = re.match('^#define\s+(\w+)\s+0x([0-9A-Fa-f]+)$', line)
-            if match:
-                if match.group(1) == 'USBD_VID':
-                    rv['USB_VID'] = match.group(2)
-                elif match.group(1) == 'USBD_PID':
-                    rv['USB_PID'] = match.group(2)
-                if 'USB_VID' in rv and 'USB_PID' in rv:
-                    break
-    else:
-        raise Exception("Don't (yet) know how to parse USB IDs from %s" % filename)
-    for k in ('USB_PID', 'USB_VID'):
+    for line in open(filename).readlines():
+        line = line.rstrip('\r\n')
+        match = re.match('^#define\s+(\w+)\s+\(0x([0-9A-Fa-f]+)\)$', line)
+        if match and match.group(1).startswith('USBD_'):
+            key = match.group(1).replace('USBD', 'USB')
+            val = match.group(2)
+            print("key =", key, "val =", val)
+            if key in needed_keys:
+                rv[key] = val
+    for k in needed_keys:
         if k not in rv:
             raise Exception("Unable to parse %s from %s" % (k, filename))
     return rv


### PR DESCRIPTION
This fix adds PIDs 9801 and 9802 to the pybcdc.inf file.

With this patch, when in CDC only mode, it presents itself as a
Communcations device rather than as a composite device.
Presenting as a composite device with only the CDC interface
seems to confuse windows.

To test and make sure that the correct pybcdc.inf was being used,
I used USBDeview from http://www.nirsoft.net/utils/usb_devices_view.html
to uninstall any old pyboard drivers (Use Control-F and search
for pyboard). I found running USBDeview as administrator worked best.

Installing the driver in CDC+MSC mode first is recommended (since the
pybcdc.inf file is on the internal flash drive). Then when you switch
modes everything seems to work properly.

I used https://github.com/dhylands/upy-examples/blob/master/boot_switch.py
to easily switch the pyboard between the various USB modes for testing.

I tested this under linux (ubuntu 14.04 LTS) and under Windows 7.
