### PR TITLE
esp8266: Update documentation to match the code

### DIFF
--- a/docs/library/esp.rst
+++ b/docs/library/esp.rst
@@ -10,18 +10,12 @@ The ``esp`` module contains specific functions related to the ESP8266 module.
 Functions
 ---------
 
-.. function:: status()
+.. function:: mac(address)
 
-    Return the current status of the wireless connection.
+    Get or set the network interface's MAC address.
 
-    The possible statuses are defined as constants:
-
-        * ``STAT_IDLE`` -- no connection and no activity,
-        * ``STAT_CONNECTING`` -- connecting in progress,
-        * ``STAT_WRONG_PASSWORD`` -- failed due to incorrect password,
-        * ``STAT_NO_AP_FOUND`` -- failed because no access point replied,
-        * ``STAT_CONNECT_FAIL`` -- failed due to other problems,
-        * ``STAT_GOT_IP`` -- connection susccessful.
+    If the ``address`` parameter is provided, sets the address to its value. If
+    the function is called wihout parameters, returns the current address.
 
 .. function:: getaddrinfo((hostname, port, lambda))
 
@@ -30,6 +24,61 @@ Functions
     When the hostname is resolved, the provided ``lambda`` callback will be
     called with two arguments, first being the hostname being resolved,
     second a tuple with information about that hostname.
+
+.. function:: wifi_mode(mode)
+
+    Get or set the wireless network operating mode.
+
+    If the ``mode`` parameter is provided, sets the mode to its value. If
+    the function is called wihout parameters, returns the current mode.
+
+    The possible modes are defined as constants:
+
+        * ``STA_MODE`` -- station mode,
+        * ``AP_MODE`` -- software access point mode,
+        * ``STA_AP_MODE`` -- mixed station and software access point mode.
+
+.. function:: phy_mode(mode)
+
+    Get or set the network interface mode.
+
+    If the ``mode`` parameter is provided, sets the mode to its value. If
+    the function is called wihout parameters, returns the current mode.
+
+    The possible modes are defined as constants:
+        * ``MODE_11B`` -- IEEE 802.11b,
+        * ``MODE_11G`` -- IEEE 802.11g,
+        * ``MODE_11N`` -- IEEE 802.11n.
+
+.. function:: sleep_type(sleep_type)
+
+    Get or set the sleep type.
+
+    If the ``sleep_type`` parameter is provided, sets the sleep type to its
+    value. If the function is called wihout parameters, returns the current
+    sleep type.
+
+    The possible sleep types are defined as constants:
+
+        * ``SLEEP_NONE`` -- all functions enabled,
+        * ``SLEEP_MODEM`` -- modem sleep, shuts down the WiFi Modem circuit.
+        * ``SLEEP_LIGHT`` -- light sleep, shuts down the WiFi Modem circuit
+          and suspends the processor periodically.
+
+    The board enters the set sleep mode automatically when possible.
+
+.. function:: deepsleep(time)
+
+    Enter deep sleep.
+
+    The whole module powers down, except for the RTC clock circuit, which can
+    be used to restart the module after the specified time if the pin 16 is
+    connected to the reset pin. Otherwise the module will sleep until manually
+    reset.
+
+.. function:: flash_id()
+
+    Read the device ID of the flash memory.
 
 Classes
 -------

--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -204,7 +204,8 @@ class WLAN
 
     .. method:: wlan.connect(ssid, password)
 
-        Connect to the specified wireless network, using the specified password.
+        Connect to the specified wireless network, using the specified
+        password.
 
     .. method:: wlan.disconnect()
 
@@ -214,12 +215,13 @@ class WLAN
 
         Initiate scanning for the available wireless networks.
 
-        Scanning is only possible if the radio is in station or station+AP mode; if
-        called while in AP only mode, an OSError exception will be raised.
+        Scanning is only possible if the radio is in station or station+AP
+        mode; if called while in AP only mode, an OSError exception will be
+        raised.
 
-        Once the scanning is complete, the provided callback function ``cb`` will
-        be called once for each network found, and passed a tuple with information
-        about that network:
+        Once the scanning is complete, the provided callback function ``cb``
+        will be called once for each network found, and passed a tuple with
+        information about that network:
 
             (ssid, bssid, channel, RSSI, authmode, hidden)
 
@@ -235,6 +237,26 @@ class WLAN
 
             * 0 -- visible
             * 1 -- hidden
+
+    .. method:: status()
+
+        Return the current status of the wireless connection.
+
+        The possible statuses are defined as constants:
+
+            * ``STAT_IDLE`` -- no connection and no activity,
+            * ``STAT_CONNECTING`` -- connecting in progress,
+            * ``STAT_WRONG_PASSWORD`` -- failed due to incorrect password,
+            * ``STAT_NO_AP_FOUND`` -- failed because no access point replied,
+            * ``STAT_CONNECT_FAIL`` -- failed due to other problems,
+            * ``STAT_GOT_IP`` -- connection susccessful.
+
+    .. method:: wlan.isconnected()
+
+        In case of STA mode, returns ``True`` if connected to a wifi access
+        point and has a valid IP address.  In AP mode returns ``True`` when a
+        station is connected. Returns ``False`` otherwise.
+
 
 .. only:: port_wipy
 


### PR DESCRIPTION
- Move the esp.status() to network module.
- Describe the wifi.isconnected() method.
- Describe esp.mac(), esp.wifi_mode(), esp.phy_mode(), esp.sleep_type(),
  esp.deepsleep(), and esp.flash_id() functions.
