### PR TITLE
py/compile: Remove "return if" optimisation, it's rarely used.

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -935,17 +935,6 @@ STATIC void compile_return_stmt(compiler_t *comp, mp_parse_node_struct_t *pns) {
     if (MP_PARSE_NODE_IS_NULL(pns->nodes[0])) {
         // no argument to 'return', so return None
         EMIT_ARG(load_const_tok, MP_TOKEN_KW_NONE);
-    } else if (MP_PARSE_NODE_IS_STRUCT_KIND(pns->nodes[0], PN_test_if_expr)) {
-        // special case when returning an if-expression; to match CPython optimisation
-        mp_parse_node_struct_t *pns_test_if_expr = (mp_parse_node_struct_t*)pns->nodes[0];
-        mp_parse_node_struct_t *pns_test_if_else = (mp_parse_node_struct_t*)pns_test_if_expr->nodes[1];
-
-        uint l_fail = comp_next_label(comp);
-        c_if_cond(comp, pns_test_if_else->nodes[0], false, l_fail); // condition
-        compile_node(comp, pns_test_if_expr->nodes[0]); // success value
-        EMIT(return_value);
-        EMIT_ARG(label_assign, l_fail);
-        compile_node(comp, pns_test_if_else->nodes[1]); // failure value
     } else {
         compile_node(comp, pns->nodes[0]);
     }


### PR DESCRIPTION
Motivation for this PR is purely to reduce complexity of compiler.

The code that is being removed would optimise "return x if y else z" patterns, to save 2 bytes of RAM in the generated bytecode and eliminate a jump.  It costs 56 bytes of code.  It was there originally to agree with CPython generated bytecode.

This coding pattern is not common and there are better places to spend 56 bytes of code space.

I'm putting this up as a PR to see what other people's opinions are: is it worth optimising for a rarely used coding pattern?  Arguably there are much more common patterns than this that could be optimised instead.
