### PR TITLE
py: Add support for _ in REPL to hold last computed value.

### DIFF
--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -416,6 +416,10 @@ STATIC mp_obj_t mp_builtin___repl_print__(mp_obj_t o) {
         mp_obj_print_helper(&mp_plat_print, o, PRINT_REPR);
         mp_print_str(&mp_plat_print, "\n");
         #endif
+        #if MICROPY_CAN_OVERRIDE_BUILTINS
+        mp_obj_t dest[2] = {MP_OBJ_SENTINEL, o};
+        mp_type_module.attr((mp_obj_t)&mp_module_builtins, MP_QSTR__, dest);
+        #endif
     }
     return mp_const_none;
 }

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -35,6 +35,7 @@ QCFG(BYTES_IN_HASH, MICROPY_QSTR_BYTES_IN_HASH)
 
 Q()
 Q(*)
+Q(_)
 Q(__build_class__)
 Q(__class__)
 Q(__doc__)


### PR DESCRIPTION
This adds support for _ in the REPL, to give the result of the last computed expression.  Useful when you're at the prompt and executing something which yielded a value that you want to keep.

Only available when MICROPY_CAN_OVERRIDE_BUILTINS is enabled.

Do we want it?

(I'm going through my list of patches that have been sitting around for ages...)
