### PR TITLE
lib/libffi: Add libffi as a submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = lib/axtls
 	url = https://github.com/pfalcon/axtls
 	branch = micropython
+[submodule "lib/libffi"]
+	path = lib/libffi
+	url = https://github.com/atgreen/libffi


### PR DESCRIPTION
This allows to build libffi from source together with micropython, and is
useful for cross-compilation. Support for this was already merged
previously, to use:

make libffi
make MICROPY_STANDALONE=1

(To both commands appropriate cross-compilition flags can be added).
