### PR TITLE
resolves visual studio FileNotFoundError: [Errno 2] 

### DIFF
--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -57,7 +57,12 @@ def get_version_info_from_git():
     return git_tag, git_hash, ver
 
 def get_version_info_from_docs_conf():
-    with open("%s/docs/conf.py" % sys.argv[0].rsplit("/", 2)[0]) as f:
+    if sys.platform == "win32":
+        conf_path = "%s\\docs\\conf.py" % sys.argv[0].rsplit(os.path.sep,2)[0]
+    else:
+        conf_path = "%s/docs/conf.py" % sys.argv[0].rsplit(os.path.sep,2)[0]
+        
+    with open(conf_path) as f:
         for line in f:
             if line.startswith("release = '"):
                 ver = line.strip()[10:].strip("'")


### PR DESCRIPTION
resolves visual studio FileNotFoundError: [Errno 2] No such file or directory:
'path_to_python_src\py\makeversionhdr.py/docs/conf.py'

this happens because of windows \ separators
