### PR TITLE
stmhal: Make USB serial number actually be unique.

### DIFF
--- a/stmhal/usbd_desc.c
+++ b/stmhal/usbd_desc.c
@@ -40,9 +40,7 @@
 #define USBD_LANGID_STRING            0x409
 #define USBD_MANUFACTURER_STRING      "MicroPython"
 #define USBD_PRODUCT_HS_STRING        "Pyboard Virtual Comm Port in HS Mode"
-#define USBD_SERIALNUMBER_HS_STRING   "000000000010"
 #define USBD_PRODUCT_FS_STRING        "Pyboard Virtual Comm Port in FS Mode"
-#define USBD_SERIALNUMBER_FS_STRING   "000000000011"
 #define USBD_CONFIGURATION_HS_STRING  "Pyboard Config"
 #define USBD_INTERFACE_HS_STRING      "Pyboard Interface"
 #define USBD_CONFIGURATION_FS_STRING  "Pyboard Config"
@@ -158,11 +156,31 @@ STATIC uint8_t *USBD_ManufacturerStrDescriptor(USBD_SpeedTypeDef speed, uint16_t
   * @retval Pointer to descriptor buffer
   */
 STATIC uint8_t *USBD_SerialStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length) {
-    if(speed == USBD_SPEED_HIGH) {
-        USBD_GetString((uint8_t *)USBD_SERIALNUMBER_HS_STRING, USBD_StrDesc, length);
-    } else {
-        USBD_GetString((uint8_t *)USBD_SERIALNUMBER_FS_STRING, USBD_StrDesc, length);
-    }
+    // This document: http://www.usb.org/developers/docs/devclass_docs/usbmassbulk_10.pdf
+    // says that the serial number has to be at least 12 digits long and that
+    // the last 12 digits need to be unique. It also stipulates that the valid
+    // character set is that of upper-case hexadecimal digits.
+    //
+    // Our 96-bit number gets translated
+    // to 24 digits, but since the actual format isn't documented (online
+    // sources suggest that its comprised of lot number, wafer position,
+    // and some type of date code) we can't be 100% sure.
+    //
+    // The onboard DFU bootloader produces a 12-digit serial number based on
+    // the unique ID, so for consistency, I've opted to go with their
+    // algorithm. You can see the serial number if you do:
+    //
+    //     dfu-util -l
+    //
+    // See: https://my.st.com/52d187b7 for the algorithim used.
+    //
+    uint8_t *id = (uint8_t *)0x1fff7a10;
+    char serial_buf[32];
+    snprintf(serial_buf, sizeof(serial_buf),
+             "%02X%02X%02X%02X%02X%02X",
+             id[11], id[10] + id[2], id[9], id[8] + id[0], id[7], id[6]);
+
+    USBD_GetString((uint8_t *)serial_buf, USBD_StrDesc, length);
     return USBD_StrDesc;
 }
 


### PR DESCRIPTION
This allows multiple pyboards to be connected to a host and setup persistent udev rules, or under windows, allows the com port to be the same for a given pyboard.

The serial number is formatted the same as the ID line in pyb.info() (which is the 96-bit unique id).
