### PR TITLE
Add support for 30-bit stuffed float

### DIFF
--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -93,7 +93,7 @@ STATIC mp_obj_t mp_builtin_abs(mp_obj_t o_in) {
     if (0) {
         // dummy
 #if MICROPY_PY_BUILTINS_FLOAT
-    } else if (MP_OBJ_IS_TYPE(o_in, &mp_type_float)) {
+    } else if (mp_obj_is_float(o_in)) {
         mp_float_t value = mp_obj_float_get(o_in);
         // TODO check for NaN etc
         if (value < 0) {

--- a/py/modcmath.c
+++ b/py/modcmath.c
@@ -35,12 +35,6 @@
 /// The `cmath` module provides some basic mathematical funtions for
 /// working with complex numbers.
 
-// These are defined in modmath.c
-/// \constant e - base of the natural logarithm
-extern const mp_obj_float_t mp_math_e_obj;
-/// \constant pi - the ratio of a circle's circumference to its diameter
-extern const mp_obj_float_t mp_math_pi_obj;
-
 /// \function phase(z)
 /// Returns the phase of the number `z`, in the range (-pi, +pi].
 STATIC mp_obj_t mp_cmath_phase(mp_obj_t z_obj) {
@@ -132,8 +126,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_cmath_sin_obj, mp_cmath_sin);
 
 STATIC const mp_map_elem_t mp_module_cmath_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_cmath) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_e), (mp_obj_t)&mp_math_e_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_pi), (mp_obj_t)&mp_math_pi_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_e), mp_const_float_e },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_pi), mp_const_float_pi },
     { MP_OBJ_NEW_QSTR(MP_QSTR_phase), (mp_obj_t)&mp_cmath_phase_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_polar), (mp_obj_t)&mp_cmath_polar_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_rect), (mp_obj_t)&mp_cmath_rect_obj },

--- a/py/modmath.c
+++ b/py/modmath.c
@@ -52,12 +52,6 @@
     STATIC mp_obj_t mp_math_ ## py_name(mp_obj_t x_obj) { mp_int_t x = MICROPY_FLOAT_C_FUN(c_name)(mp_obj_get_float(x_obj)); return mp_obj_new_int(x); } \
     STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_math_## py_name ## _obj, mp_math_ ## py_name);
 
-// These are also used by cmath.c
-/// \constant e - base of the natural logarithm
-const mp_obj_float_t mp_math_e_obj = {{&mp_type_float}, M_E};
-/// \constant pi - the ratio of a circle's circumference to its diameter
-const mp_obj_float_t mp_math_pi_obj = {{&mp_type_float}, M_PI};
-
 /// \function sqrt(x)
 /// Returns the square root of `x`.
 MATH_FUN_1(sqrt, sqrt)
@@ -188,8 +182,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_math_degrees_obj, mp_math_degrees);
 
 STATIC const mp_map_elem_t mp_module_math_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_math) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_e), (mp_obj_t)&mp_math_e_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_pi), (mp_obj_t)&mp_math_pi_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_e), mp_const_float_e },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_pi), mp_const_float_pi },
     { MP_OBJ_NEW_QSTR(MP_QSTR_sqrt), (mp_obj_t)&mp_math_sqrt_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_pow), (mp_obj_t)&mp_math_pow_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_exp), (mp_obj_t)&mp_math_exp_obj },

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -63,6 +63,16 @@
 //  - xxxx...xxx0 : a pointer to an mp_obj_base_t (unless a fake object)
 #define MICROPY_OBJ_REPR_B (1)
 
+// A MicroPython object is a machine word having the following form:
+//  - iiiiiiii iiiiiiii iiiiiiii iiiiiii1 small int with 31-bit signed value
+//  - x1111111 1qqqqqqq qqqqqqqq qqqqq110 str with 20-bit qstr value
+//  - s1111111 10000000 00000000 00000010 +/- inf
+//  - s1111111 1xxxxxxx xxxxxxxx xxxxx010 nan, x != 0
+//  - seeeeeee efffffff ffffffff ffffff10 30-bit fp, e != 0xff
+//  - pppppppp pppppppp pppppppp pppppp00 ptr (4 byte alignment)
+// This scheme only works with 32-bit word size.
+#define MICROPY_OBJ_REPR_C (2)
+
 #ifndef MICROPY_OBJ_REPR
 #define MICROPY_OBJ_REPR (MICROPY_OBJ_REPR_A)
 #endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -70,7 +70,7 @@
 //  - s1111111 1xxxxxxx xxxxxxxx xxxxx010 nan, x != 0
 //  - seeeeeee efffffff ffffffff ffffff10 30-bit fp, e != 0xff
 //  - pppppppp pppppppp pppppppp pppppp00 ptr (4 byte alignment)
-// This scheme only works with 32-bit word size.
+// This scheme only works with 32-bit word size and with float enabled.
 #define MICROPY_OBJ_REPR_C (2)
 
 #ifndef MICROPY_OBJ_REPR

--- a/py/obj.c
+++ b/py/obj.c
@@ -44,6 +44,10 @@ mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in) {
         return (mp_obj_t)&mp_type_int;
     } else if (MP_OBJ_IS_QSTR(o_in)) {
         return (mp_obj_t)&mp_type_str;
+    #if MICROPY_PY_BUILTINS_FLOAT
+    } else if (mp_obj_is_float(o_in)) {
+        return (mp_obj_t)&mp_type_float;
+    #endif
     } else {
         const mp_obj_base_t *o = o_in;
         return (mp_obj_t)o->type;

--- a/py/obj.c
+++ b/py/obj.c
@@ -268,7 +268,7 @@ mp_float_t mp_obj_get_float(mp_obj_t arg) {
         return MP_OBJ_SMALL_INT_VALUE(arg);
     } else if (MP_OBJ_IS_TYPE(arg, &mp_type_int)) {
         return mp_obj_int_as_float(arg);
-    } else if (MP_OBJ_IS_TYPE(arg, &mp_type_float)) {
+    } else if (mp_obj_is_float(arg)) {
         return mp_obj_float_get(arg);
     } else {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
@@ -295,7 +295,7 @@ void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
     } else if (MP_OBJ_IS_TYPE(arg, &mp_type_int)) {
         *real = mp_obj_int_as_float(arg);
         *imag = 0;
-    } else if (MP_OBJ_IS_TYPE(arg, &mp_type_float)) {
+    } else if (mp_obj_is_float(arg)) {
         *real = mp_obj_float_get(arg);
         *imag = 0;
     } else if (MP_OBJ_IS_TYPE(arg, &mp_type_complex)) {

--- a/py/obj.h
+++ b/py/obj.h
@@ -119,6 +119,41 @@ mp_obj_t mp_obj_new_float(mp_float_t value);
 static inline bool MP_OBJ_IS_OBJ(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 1) == 0); }
 
+#elif MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_C
+
+static inline bool MP_OBJ_IS_SMALL_INT(mp_const_obj_t o)
+    { return ((((mp_int_t)(o)) & 1) != 0); }
+#define MP_OBJ_SMALL_INT_VALUE(o) (((mp_int_t)(o)) >> 1)
+#define MP_OBJ_NEW_SMALL_INT(small_int) ((mp_obj_t)((((mp_int_t)(small_int)) << 1) | 1))
+
+#define mp_const_float_e ((mp_obj_t)((0x402df854 & ~3) | 2))
+#define mp_const_float_pi ((mp_obj_t)((0x40490fdb & ~3) | 2))
+
+static inline bool mp_obj_is_float(mp_const_obj_t o)
+    { return (((mp_uint_t)(o)) & 3) == 2 && (((mp_uint_t)(o)) & 0x7f800004) != 0x7f800004; }
+static inline mp_float_t mp_obj_float_get(mp_const_obj_t o) {
+    union {
+        mp_float_t f;
+        mp_uint_t u;
+    } num = {.u = (mp_uint_t)o & ~3};
+    return num.f;
+}
+static inline mp_obj_t mp_obj_new_float(mp_float_t f) {
+    union {
+        mp_float_t f;
+        mp_uint_t u;
+    } num = {.f = f};
+    return (mp_obj_t)((num.u & ~0x3) | 2);
+}
+
+static inline bool MP_OBJ_IS_QSTR(mp_const_obj_t o)
+    { return (((mp_uint_t)(o)) & 0x7f800007) == 0x7f800006; }
+#define MP_OBJ_QSTR_VALUE(o) ((((mp_uint_t)(o)) >> 3) & 0xfffff)
+#define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 3) | 0x7f800006))
+
+static inline bool MP_OBJ_IS_OBJ(mp_const_obj_t o)
+    { return ((((mp_int_t)(o)) & 3) == 0); }
+
 #endif
 
 // Macros to convert between mp_obj_t and concrete object types.

--- a/py/obj.h
+++ b/py/obj.h
@@ -83,6 +83,15 @@ static inline bool MP_OBJ_IS_QSTR(mp_const_obj_t o)
 #define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 2)
 #define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 2) | 2))
 
+#define mp_const_float_e ((mp_obj_t)&mp_const_float_e_obj)
+#define mp_const_float_pi ((mp_obj_t)&mp_const_float_pi_obj)
+extern const struct _mp_obj_float_t mp_const_float_e_obj;
+extern const struct _mp_obj_float_t mp_const_float_pi_obj;
+
+#define mp_obj_is_float(o) MP_OBJ_IS_TYPE((o), &mp_type_float)
+mp_float_t mp_obj_float_get(mp_obj_t self_in);
+mp_obj_t mp_obj_new_float(mp_float_t value);
+
 static inline bool MP_OBJ_IS_OBJ(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 3) == 0); }
 
@@ -97,6 +106,15 @@ static inline bool MP_OBJ_IS_QSTR(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 3) == 3); }
 #define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 2)
 #define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 2) | 3))
+
+#define mp_const_float_e ((mp_obj_t)&mp_const_float_e_obj)
+#define mp_const_float_pi ((mp_obj_t)&mp_const_float_pi_obj)
+extern const struct _mp_obj_float_t mp_const_float_e_obj;
+extern const struct _mp_obj_float_t mp_const_float_pi_obj;
+
+#define mp_obj_is_float(o) MP_OBJ_IS_TYPE((o), &mp_type_float)
+mp_float_t mp_obj_float_get(mp_obj_t self_in);
+mp_obj_t mp_obj_new_float(mp_float_t value);
 
 static inline bool MP_OBJ_IS_OBJ(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 1) == 0); }
@@ -473,7 +491,6 @@ mp_obj_t mp_obj_new_bytearray(mp_uint_t n, void *items);
 mp_obj_t mp_obj_new_bytearray_by_ref(mp_uint_t n, void *items);
 #if MICROPY_PY_BUILTINS_FLOAT
 mp_obj_t mp_obj_new_int_from_float(mp_float_t val);
-mp_obj_t mp_obj_new_float(mp_float_t val);
 mp_obj_t mp_obj_new_complex(mp_float_t real, mp_float_t imag);
 #endif
 mp_obj_t mp_obj_new_exception(const mp_obj_type_t *exc_type);
@@ -564,13 +581,6 @@ void mp_str_print_quoted(const mp_print_t *print, const byte *str_data, mp_uint_
 
 #if MICROPY_PY_BUILTINS_FLOAT
 // float
-#define mp_const_float_e ((mp_obj_t)&mp_const_float_e_obj)
-#define mp_const_float_pi ((mp_obj_t)&mp_const_float_pi_obj)
-extern const struct _mp_obj_float_t mp_const_float_e_obj;
-extern const struct _mp_obj_float_t mp_const_float_pi_obj;
-
-#define mp_obj_is_float(o) MP_OBJ_IS_TYPE((o), &mp_type_float)
-mp_float_t mp_obj_float_get(mp_obj_t self_in);
 mp_obj_t mp_obj_float_binary_op(mp_uint_t op, mp_float_t lhs_val, mp_obj_t rhs); // can return MP_OBJ_NULL if op not supported
 
 // complex

--- a/py/obj.h
+++ b/py/obj.h
@@ -568,6 +568,7 @@ typedef struct _mp_obj_float_t {
     mp_obj_base_t base;
     mp_float_t value;
 } mp_obj_float_t;
+#define mp_obj_is_float(o) MP_OBJ_IS_TYPE((o), &mp_type_float)
 mp_float_t mp_obj_float_get(mp_obj_t self_in);
 mp_obj_t mp_obj_float_binary_op(mp_uint_t op, mp_float_t lhs_val, mp_obj_t rhs); // can return MP_OBJ_NULL if op not supported
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -564,10 +564,11 @@ void mp_str_print_quoted(const mp_print_t *print, const byte *str_data, mp_uint_
 
 #if MICROPY_PY_BUILTINS_FLOAT
 // float
-typedef struct _mp_obj_float_t {
-    mp_obj_base_t base;
-    mp_float_t value;
-} mp_obj_float_t;
+#define mp_const_float_e ((mp_obj_t)&mp_const_float_e_obj)
+#define mp_const_float_pi ((mp_obj_t)&mp_const_float_pi_obj)
+extern const struct _mp_obj_float_t mp_const_float_e_obj;
+extern const struct _mp_obj_float_t mp_const_float_pi_obj;
+
 #define mp_obj_is_float(o) MP_OBJ_IS_TYPE((o), &mp_type_float)
 mp_float_t mp_obj_float_get(mp_obj_t self_in);
 mp_obj_t mp_obj_float_binary_op(mp_uint_t op, mp_float_t lhs_val, mp_obj_t rhs); // can return MP_OBJ_NULL if op not supported

--- a/py/obj.h
+++ b/py/obj.h
@@ -83,6 +83,7 @@ static inline bool MP_OBJ_IS_QSTR(mp_const_obj_t o)
 #define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 2)
 #define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 2) | 2))
 
+#if MICROPY_PY_BUILTINS_FLOAT
 #define mp_const_float_e ((mp_obj_t)&mp_const_float_e_obj)
 #define mp_const_float_pi ((mp_obj_t)&mp_const_float_pi_obj)
 extern const struct _mp_obj_float_t mp_const_float_e_obj;
@@ -91,6 +92,7 @@ extern const struct _mp_obj_float_t mp_const_float_pi_obj;
 #define mp_obj_is_float(o) MP_OBJ_IS_TYPE((o), &mp_type_float)
 mp_float_t mp_obj_float_get(mp_obj_t self_in);
 mp_obj_t mp_obj_new_float(mp_float_t value);
+#endif
 
 static inline bool MP_OBJ_IS_OBJ(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 3) == 0); }
@@ -107,6 +109,7 @@ static inline bool MP_OBJ_IS_QSTR(mp_const_obj_t o)
 #define MP_OBJ_QSTR_VALUE(o) (((mp_uint_t)(o)) >> 2)
 #define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 2) | 3))
 
+#if MICROPY_PY_BUILTINS_FLOAT
 #define mp_const_float_e ((mp_obj_t)&mp_const_float_e_obj)
 #define mp_const_float_pi ((mp_obj_t)&mp_const_float_pi_obj)
 extern const struct _mp_obj_float_t mp_const_float_e_obj;
@@ -115,6 +118,7 @@ extern const struct _mp_obj_float_t mp_const_float_pi_obj;
 #define mp_obj_is_float(o) MP_OBJ_IS_TYPE((o), &mp_type_float)
 mp_float_t mp_obj_float_get(mp_obj_t self_in);
 mp_obj_t mp_obj_new_float(mp_float_t value);
+#endif
 
 static inline bool MP_OBJ_IS_OBJ(mp_const_obj_t o)
     { return ((((mp_int_t)(o)) & 1) == 0); }

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -39,6 +39,8 @@
 #include <math.h>
 #include "py/formatfloat.h"
 
+#if MICROPY_OBJ_REPR != MICROPY_OBJ_REPR_C
+
 typedef struct _mp_obj_float_t {
     mp_obj_base_t base;
     mp_float_t value;
@@ -46,6 +48,8 @@ typedef struct _mp_obj_float_t {
 
 const mp_obj_float_t mp_const_float_e_obj = {{&mp_type_float}, M_E};
 const mp_obj_float_t mp_const_float_pi_obj = {{&mp_type_float}, M_PI};
+
+#endif
 
 STATIC void float_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     (void)kind;
@@ -121,6 +125,8 @@ const mp_obj_type_t mp_type_float = {
     .binary_op = float_binary_op,
 };
 
+#if MICROPY_OBJ_REPR != MICROPY_OBJ_REPR_C
+
 mp_obj_t mp_obj_new_float(mp_float_t value) {
     mp_obj_float_t *o = m_new(mp_obj_float_t, 1);
     o->base.type = &mp_type_float;
@@ -133,6 +139,8 @@ mp_float_t mp_obj_float_get(mp_obj_t self_in) {
     mp_obj_float_t *self = self_in;
     return self->value;
 }
+
+#endif
 
 STATIC void mp_obj_float_divmod(mp_float_t *x, mp_float_t *y) {
     // logic here follows that of CPython

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -72,7 +72,7 @@ STATIC mp_obj_t float_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_k
                 mp_uint_t l;
                 const char *s = mp_obj_str_get_data(args[0], &l);
                 return mp_parse_num_decimal(s, l, false, false, NULL);
-            } else if (MP_OBJ_IS_TYPE(args[0], &mp_type_float)) {
+            } else if (mp_obj_is_float(args[0])) {
                 // a float, just return it
                 return args[0];
             } else {
@@ -121,7 +121,7 @@ mp_obj_t mp_obj_new_float(mp_float_t value) {
 }
 
 mp_float_t mp_obj_float_get(mp_obj_t self_in) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_float));
+    assert(mp_obj_is_float(self_in));
     mp_obj_float_t *self = self_in;
     return self->value;
 }

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -49,7 +49,7 @@ const mp_obj_float_t mp_const_float_pi_obj = {{&mp_type_float}, M_PI};
 
 STATIC void float_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     (void)kind;
-    mp_obj_float_t *o = o_in;
+    mp_float_t o_val = mp_obj_float_get(o_in);
 #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
     char buf[16];
     const int precision = 7;
@@ -57,7 +57,7 @@ STATIC void float_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t 
     char buf[32];
     const int precision = 16;
 #endif
-    mp_format_float(o->value, buf, sizeof(buf), 'g', precision, '\0');
+    mp_format_float(o_val, buf, sizeof(buf), 'g', precision, '\0');
     mp_print_str(print, buf);
     if (strchr(buf, '.') == NULL && strchr(buf, 'e') == NULL && strchr(buf, 'n') == NULL) {
         // Python floats always have decimal point (unless inf or nan)
@@ -91,24 +91,24 @@ STATIC mp_obj_t float_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_k
 }
 
 STATIC mp_obj_t float_unary_op(mp_uint_t op, mp_obj_t o_in) {
-    mp_obj_float_t *o = o_in;
+    mp_float_t val = mp_obj_float_get(o_in);
     switch (op) {
-        case MP_UNARY_OP_BOOL: return mp_obj_new_bool(o->value != 0);
+        case MP_UNARY_OP_BOOL: return mp_obj_new_bool(val != 0);
         case MP_UNARY_OP_POSITIVE: return o_in;
-        case MP_UNARY_OP_NEGATIVE: return mp_obj_new_float(-o->value);
+        case MP_UNARY_OP_NEGATIVE: return mp_obj_new_float(-val);
         default: return MP_OBJ_NULL; // op not supported
     }
 }
 
 STATIC mp_obj_t float_binary_op(mp_uint_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
-    mp_obj_float_t *lhs = lhs_in;
+    mp_float_t lhs_val = mp_obj_float_get(lhs_in);
 #if MICROPY_PY_BUILTINS_COMPLEX
     if (MP_OBJ_IS_TYPE(rhs_in, &mp_type_complex)) {
-        return mp_obj_complex_binary_op(op, lhs->value, 0, rhs_in);
+        return mp_obj_complex_binary_op(op, lhs_val, 0, rhs_in);
     } else
 #endif
     {
-        return mp_obj_float_binary_op(op, lhs->value, rhs_in);
+        return mp_obj_float_binary_op(op, lhs_val, rhs_in);
     }
 }
 

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -39,6 +39,14 @@
 #include <math.h>
 #include "py/formatfloat.h"
 
+typedef struct _mp_obj_float_t {
+    mp_obj_base_t base;
+    mp_float_t value;
+} mp_obj_float_t;
+
+const mp_obj_float_t mp_const_float_e_obj = {{&mp_type_float}, M_E};
+const mp_obj_float_t mp_const_float_pi_obj = {{&mp_type_float}, M_PI};
+
 STATIC void float_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_float_t *o = o_in;

--- a/py/objint.c
+++ b/py/objint.c
@@ -60,7 +60,7 @@ STATIC mp_obj_t mp_obj_int_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_
                 const char *s = mp_obj_str_get_data(args[0], &l);
                 return mp_parse_num_integer(s, l, 0, NULL);
 #if MICROPY_PY_BUILTINS_FLOAT
-            } else if (MP_OBJ_IS_TYPE(args[0], &mp_type_float)) {
+            } else if (mp_obj_is_float(args[0])) {
                 return mp_obj_new_int_from_float(mp_obj_float_get(args[0]));
 #endif
             } else {

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -178,7 +178,7 @@ mp_obj_t mp_obj_int_binary_op(mp_uint_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
     } else if (MP_OBJ_IS_TYPE(rhs_in, &mp_type_int)) {
         zrhs = &((mp_obj_int_t*)rhs_in)->mpz;
 #if MICROPY_PY_BUILTINS_FLOAT
-    } else if (MP_OBJ_IS_TYPE(rhs_in, &mp_type_float)) {
+    } else if (mp_obj_is_float(rhs_in)) {
         return mp_obj_float_binary_op(op, mpz_as_float(zlhs), rhs_in);
 #if MICROPY_PY_BUILTINS_COMPLEX
     } else if (MP_OBJ_IS_TYPE(rhs_in, &mp_type_complex)) {

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -827,15 +827,15 @@ STATIC bool arg_looks_integer(mp_obj_t arg) {
 STATIC bool arg_looks_numeric(mp_obj_t arg) {
     return arg_looks_integer(arg)
 #if MICROPY_PY_BUILTINS_FLOAT
-        || MP_OBJ_IS_TYPE(arg, &mp_type_float)
+        || mp_obj_is_float(arg)
 #endif
     ;
 }
 
 STATIC mp_obj_t arg_as_int(mp_obj_t arg) {
 #if MICROPY_PY_BUILTINS_FLOAT
-    if (MP_OBJ_IS_TYPE(arg, &mp_type_float)) {
-        return mp_obj_new_int_from_float(mp_obj_get_float(arg));
+    if (mp_obj_is_float(arg)) {
+        return mp_obj_new_int_from_float(mp_obj_float_get(arg));
     }
 #endif
     return arg;

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -2038,6 +2038,17 @@ const char *mp_obj_str_get_data(mp_obj_t self_in, mp_uint_t *len) {
     }
 }
 
+#if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_C
+const byte *mp_obj_str_get_data_no_check(mp_obj_t self_in, mp_uint_t *len) {
+    if (MP_OBJ_IS_QSTR(self_in)) {
+        return qstr_data(MP_OBJ_QSTR_VALUE(self_in), len);
+    } else {
+        *len = ((mp_obj_str_t*)self_in)->len;
+        return ((mp_obj_str_t*)self_in)->data;
+    }
+}
+#endif
+
 /******************************************************************************/
 /* str iterator                                                               */
 

--- a/py/objstr.h
+++ b/py/objstr.h
@@ -49,10 +49,16 @@ typedef struct _mp_obj_str_t {
     { str_len = qstr_len(MP_OBJ_QSTR_VALUE(str_obj_in)); } else { str_len = ((mp_obj_str_t*)str_obj_in)->len; }
 
 // use this macro to extract the string data and length
+#if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_C
+const byte *mp_obj_str_get_data_no_check(mp_obj_t self_in, mp_uint_t *len);
+#define GET_STR_DATA_LEN(str_obj_in, str_data, str_len) \
+    mp_uint_t str_len; const byte *str_data = mp_obj_str_get_data_no_check(str_obj_in, &str_len);
+#else
 #define GET_STR_DATA_LEN(str_obj_in, str_data, str_len) \
     const byte *str_data; mp_uint_t str_len; if (MP_OBJ_IS_QSTR(str_obj_in)) \
     { str_data = qstr_data(MP_OBJ_QSTR_VALUE(str_obj_in), &str_len); } \
     else { str_len = ((mp_obj_str_t*)str_obj_in)->len; str_data = ((mp_obj_str_t*)str_obj_in)->data; }
+#endif
 
 mp_obj_t mp_obj_str_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args);
 void mp_str_print_json(const mp_print_t *print, const byte *str_data, mp_uint_t str_len);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -458,7 +458,7 @@ mp_obj_t mp_binary_op(mp_uint_t op, mp_obj_t lhs, mp_obj_t rhs) {
                 return mp_obj_new_int(lhs_val);
             }
 #if MICROPY_PY_BUILTINS_FLOAT
-        } else if (MP_OBJ_IS_TYPE(rhs, &mp_type_float)) {
+        } else if (mp_obj_is_float(rhs)) {
             mp_obj_t res = mp_obj_float_binary_op(op, lhs_val, rhs);
             if (res == MP_OBJ_NULL) {
                 goto unsupported_op;

--- a/py/smallint.h
+++ b/py/smallint.h
@@ -32,7 +32,7 @@
 // Functions for small integer arithmetic
 
 // In SMALL_INT, next-to-highest bits is used as sign, so both must match for value in range
-#if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A
+#if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A || MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_C
 
 #define MP_SMALL_INT_MIN ((mp_int_t)(((mp_int_t)WORD_MSBIT_HIGH) >> 1))
 #define MP_SMALL_INT_FITS(n) ((((n) ^ ((n) << 1)) & WORD_MSBIT_HIGH) == 0)


### PR DESCRIPTION
The first 3 patches here make the float object representation configurable.  The 4th patch adds a new object representation "C" which has 30-bit floats stuffed into the object word, so that floats don't need allocating on the heap.

See #1504 for discussion.

The first 3 patches are solid and don't change any functionality, they just make the object model more configurable.

The 4th patch is useful for ports that have little RAM but still want to use floats, and accept that 30-bit precision is enough.  Unfortunately this "C" representation adds about 1400 bytes to the code size, due to the more complex way of packing, testing and unpacking qstrs.  [In an alternative implementation that I tried, floats only had 29-bits and qstrs were much more efficient to pack/test/unpack, but 29-bit floats is really starting to degrade precision.]
