### PR TITLE
Makefiles: Remove duplicate object files when linking.

### DIFF
--- a/bare-arm/Makefile
+++ b/bare-arm/Makefile
@@ -42,7 +42,7 @@ all: $(BUILD)/firmware.elf
 
 $(BUILD)/firmware.elf: $(OBJ)
 	$(ECHO) "LINK $@"
-	$(Q)$(LD) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)
+	$(Q)$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(Q)$(SIZE) $@
 
 include ../py/mkrules.mk

--- a/esp8266/Makefile
+++ b/esp8266/Makefile
@@ -124,7 +124,7 @@ $(BUILD)/firmware-combined.bin: $(BUILD)/firmware.elf
 
 $(BUILD)/firmware.elf: $(OBJ)
 	$(ECHO) "LINK $@"
-	$(Q)$(LD) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)
+	$(Q)$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(Q)$(SIZE) $@
 
 #MAKE_PINS = boards/make-pins.py

--- a/minimal/Makefile
+++ b/minimal/Makefile
@@ -59,7 +59,7 @@ all: $(BUILD)/firmware.elf
 
 $(BUILD)/firmware.elf: $(OBJ)
 	$(ECHO) "LINK $@"
-	$(Q)$(LD) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)
+	$(Q)$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(Q)$(SIZE) $@
 
 # Run emulation build on a POSIX system with suitable terminal settings

--- a/pic16bit/Makefile
+++ b/pic16bit/Makefile
@@ -57,7 +57,7 @@ $(BUILD)/firmware.hex: $(BUILD)/firmware.elf
 
 $(BUILD)/firmware.elf: $(OBJ)
 	$(ECHO) "LINK $@"
-	$(Q)$(LD) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)
+	$(Q)$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(Q)size $@
 
 $(PY_BUILD)/gc.o: CFLAGS += -O1

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -81,14 +81,14 @@ all: $(PROG)
 
 $(PROG): $(OBJ)
 	$(ECHO) "LINK $@"
-	$(Q)$(CC) $(COPT) -o $@ $(OBJ) $(LIB) $(LDFLAGS)
+	$(Q)$(CC) $(COPT) -o $@ $^ $(LIB) $(LDFLAGS)
 ifndef DEBUG
 	$(Q)$(STRIP) $(STRIPFLAGS_EXTRA) $(PROG)
 endif
 	$(Q)$(SIZE) $(PROG)
 
 lib: $(OBJ)
-	$(AR) rcs libmicropython.a $(OBJ)
+	$(AR) rcs libmicropython.a $^
 
 clean: clean-prog
 clean-prog:

--- a/qemu-arm/Makefile
+++ b/qemu-arm/Makefile
@@ -74,11 +74,11 @@ $(BUILD)/tinytest.o:
 
 ## `$(LD)` doesn't seem to like `--specs` for some reason, but we can just use `$(CC)` here.
 $(BUILD)/firmware.elf: $(OBJ)
-	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)
+	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(Q)$(SIZE) $@
 
 $(BUILD)/firmware-test.elf: $(OBJ_TEST)
-	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJ_TEST) $(LIBS)
+	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(Q)$(SIZE) $@
 
 include ../py/mkrules.mk

--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -285,7 +285,7 @@ $(BUILD)/firmware.hex: $(BUILD)/firmware.elf
 
 $(BUILD)/firmware.elf: $(OBJ)
 	$(ECHO) "LINK $@"
-	$(Q)$(LD) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)
+	$(Q)$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(Q)$(SIZE) $@
 
 MAKE_PINS = boards/make-pins.py

--- a/teensy/Makefile
+++ b/teensy/Makefile
@@ -156,7 +156,7 @@ deploy: post_compile reboot
 
 $(BUILD)/micropython.elf: $(OBJ)
 	$(ECHO) "LINK $@"
-	$(Q)$(CC) $(LDFLAGS) -o "$@" -Wl,-Map,$(@:.elf=.map) $(OBJ) $(LIBS)
+	$(Q)$(CC) $(LDFLAGS) -o "$@" -Wl,-Map,$(@:.elf=.map) $^ $(LIBS)
 	$(Q)$(SIZE) $@
 
 ifeq ($(MEMZIP_DIR),)


### PR DESCRIPTION
Scenario: module1 depends on some common file from lib/, so specifies it
in its SRC_MOD, and the same situation with module2, then common file
from lib/ eventually ends up listed twice in $(OBJ), which leads to link
errors.

Make is equipped to deal with such situation easily, quoting the manual:
"The value of $^ omits duplicate prerequisites, while $+ retains them and
preserves their order." So, just use $^ consistently in all link targets.
