### PR TITLE
extmod/modlwip: slip: Use stream protocol and be port-independent.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -25,12 +25,15 @@
  * THE SOFTWARE.
  */
 
+#include <stdio.h>
 #include <string.h>
 #include <errno.h>
 
 #include "py/nlr.h"
 #include "py/objlist.h"
 #include "py/runtime.h"
+#include "py/stream.h"
+#include MICROPY_HAL_H
 
 #include "netutils.h"
 
@@ -43,6 +46,7 @@
 
 #ifdef MICROPY_PY_LWIP_SLIP
 #include "netif/slipif.h"
+#include "lwip/sio.h"
 #endif
 
 // FIXME FIXME FIXME
@@ -55,7 +59,6 @@
 
 typedef struct _lwip_slip_obj_t {
     mp_obj_base_t base;
-    u8_t uart_id;
     struct netif lwip_netif;
 } lwip_slip_obj_t;
 
@@ -72,13 +75,42 @@ STATIC void slip_lwip_poll(void *netif) {
 
 STATIC const mp_obj_type_t lwip_slip_type;
 
+// lwIP SLIP callback functions
+sio_fd_t sio_open(u8_t dvnum) {
+    // We support singleton SLIP interface, so just return any truish value.
+    return (sio_fd_t)1;
+}
+
+void sio_send(u8_t c, sio_fd_t fd) {
+    mp_obj_type_t *type = mp_obj_get_type(MP_STATE_VM(lwip_slip_stream));
+    int error;
+    type->stream_p->write(MP_STATE_VM(lwip_slip_stream), &c, 1, &error);
+}
+
+u32_t sio_tryread(sio_fd_t fd, u8_t *data, u32_t len) {
+    mp_obj_type_t *type = mp_obj_get_type(MP_STATE_VM(lwip_slip_stream));
+    int error;
+    mp_uint_t out_sz = type->stream_p->read(MP_STATE_VM(lwip_slip_stream), data, len, &error);
+    if (out_sz == MP_STREAM_ERROR) {
+        if (mp_is_nonblocking_error(error)) {
+//printf("sio_tryread(%p, %d)=%d EAGAIN\n", data, len, out_sz);
+            return 0;
+        }
+//printf("sio_tryread(%p, %d)=%d ERROR\n", data, len, out_sz);
+        // Can't do much else, can we?
+        return 0;
+    }
+//printf("sio_tryread(%p, %d)=%d\n", data, len, out_sz);
+    return out_sz;
+}
+
 // constructor lwip.slip(device=integer, iplocal=string, ipremote=string)
 STATIC mp_obj_t lwip_slip_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 3, 3, false);
 
     lwip_slip_obj.base.type = &lwip_slip_type;
 
-    lwip_slip_obj.uart_id = (u8_t)mp_obj_get_int(args[0]);
+    MP_STATE_VM(lwip_slip_stream) = args[0];
 
     ip_addr_t iplocal, ipremote;
     if (!ipaddr_aton(mp_obj_str_get_str(args[1]), &iplocal)) {
@@ -89,7 +121,7 @@ STATIC mp_obj_t lwip_slip_make_new(mp_obj_t type_in, mp_uint_t n_args, mp_uint_t
     }
 
     struct netif *n = &(lwip_slip_obj.lwip_netif);
-    if (netif_add(n, &iplocal, IP_ADDR_BROADCAST, &ipremote, (void *)&lwip_slip_obj.uart_id, slipif_init, ip_input) == NULL) {
+    if (netif_add(n, &iplocal, IP_ADDR_BROADCAST, &ipremote, NULL, slipif_init, ip_input) == NULL) {
        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "out of memory"));
     }
     netif_set_up(n);

--- a/extmod/modlwip.h
+++ b/extmod/modlwip.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014 Damien P. George
+ * Copyright (c) 2015 Galen Hazelwood
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mpconfig.h"
+
+#if MICROPY_PY_LWIP_SLIP
+#define MP_MODLWIP_ROOT_POINTERS \
+    mp_obj_t lwip_slip_stream;
+#else
+#define MP_MODLWIP_ROOT_POINTERS
+#endif

--- a/py/builtin.h
+++ b/py/builtin.h
@@ -103,5 +103,6 @@ extern const mp_obj_module_t mp_module_uhashlib;
 extern const mp_obj_module_t mp_module_ubinascii;
 extern const mp_obj_module_t mp_module_ussl;
 extern const mp_obj_module_t mp_module_machine;
+extern const mp_obj_module_t mp_module_lwip;
 
 #endif // __MICROPY_INCLUDED_PY_BUILTIN_H__

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -189,6 +189,9 @@ STATIC const mp_map_elem_t mp_builtin_module_table[] = {
 #if MICROPY_PY_USSL
     { MP_OBJ_NEW_QSTR(MP_QSTR_ussl), (mp_obj_t)&mp_module_ussl },
 #endif
+#if MICROPY_PY_LWIP
+    { MP_OBJ_NEW_QSTR(MP_QSTR_lwip), (mp_obj_t)&mp_module_lwip },
+#endif
 
     // extra builtin modules as defined by a port
     MICROPY_PORT_BUILTIN_MODULES

--- a/py/py.mk
+++ b/py/py.mk
@@ -17,6 +17,46 @@ CFLAGS_MOD += -DMICROPY_PY_USSL=1 -I../lib/axtls/ssl -I../lib/axtls/crypto -I../
 LDFLAGS_MOD += -L../lib/axtls/_stage -laxtls
 endif
 
+#ifeq ($(MICROPY_PY_LWIP),1)
+#CFLAGS_MOD += -DMICROPY_PY_LWIP=1 -I../lib/lwip/src/include -I../lib/lwip/src/include/ipv4 -I../extmod/lwip-include
+#endif
+
+ifeq ($(MICROPY_PY_LWIP),1)
+LWIP_DIR = lib/lwip/src
+INC += -I../lib/lwip/src/include -I../lib/lwip/src/include/ipv4 -I../extmod/lwip-include
+CFLAGS_MOD += -DMICROPY_PY_LWIP=1
+SRC_MOD += extmod/modlwip.c lib/netutils/netutils.c
+SRC_MOD += $(addprefix $(LWIP_DIR)/,\
+	core/def.c \
+	core/dns.c \
+	core/init.c \
+	core/mem.c \
+	core/memp.c \
+	core/netif.c \
+	core/pbuf.c \
+	core/raw.c \
+	core/stats.c \
+	core/sys.c \
+	core/tcp.c \
+	core/tcp_in.c \
+	core/tcp_out.c \
+	core/timers.c \
+	core/udp.c \
+	core/ipv4/autoip.c \
+	core/ipv4/icmp.c \
+	core/ipv4/igmp.c \
+	core/ipv4/inet.c \
+	core/ipv4/inet_chksum.c \
+	core/ipv4/ip_addr.c \
+	core/ipv4/ip.c \
+	core/ipv4/ip_frag.c \
+	)
+ifeq ($(MICROPY_PY_LWIP_SLIP),1)
+CFLAGS_MOD += -DMICROPY_PY_LWIP_SLIP=1
+SRC_MOD += $(LWIP_DIR)/netif/slipif.c
+endif
+endif
+
 # py object files
 PY_O_BASENAME = \
 	mpstate.o \

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -614,3 +614,32 @@ Q(mem32)
 Q(ussl)
 Q(wrap_socket)
 #endif
+
+#if MICROPY_PY_LWIP
+// for lwip module
+Q(lwip)
+Q(reset)
+Q(callback)
+Q(socket)
+Q(AF_INET)
+Q(AF_INET6)
+Q(SOCK_STREAM)
+Q(SOCK_DGRAM)
+Q(SOCK_RAW)
+// for lwip.socket
+Q(close)
+Q(bind)
+Q(listen)
+Q(accept)
+Q(connect)
+Q(send)
+Q(recv)
+Q(sendto)
+Q(recvfrom)
+Q(settimeout)
+#if MICROPY_PY_LWIP_SLIP
+// for lwip.slip
+Q(slip)
+Q(status)
+#endif
+#endif

--- a/stmhal/mpconfigport.h
+++ b/stmhal/mpconfigport.h
@@ -149,6 +149,9 @@ extern const struct _mp_obj_module_t mp_module_network;
 
 #define MP_STATE_PORT MP_STATE_VM
 
+// To collect root pointers
+#include "extmod/modlwip.h"
+
 #define MICROPY_PORT_ROOT_POINTERS \
     const char *readline_hist[8]; \
     \
@@ -181,6 +184,7 @@ extern const struct _mp_obj_module_t mp_module_network;
     \
     /* list of registered NICs */ \
     mp_obj_list_t mod_network_nic_list; \
+    MP_MODLWIP_ROOT_POINTERS
 
 // type definitions for the specific machine
 

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -218,10 +218,14 @@ extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
 
 #define MP_STATE_PORT MP_STATE_VM
 
+// To collect root pointers
+#include "extmod/modlwip.h"
+
 #define MICROPY_PORT_ROOT_POINTERS \
     const char *readline_hist[50]; \
     mp_obj_t keyboard_interrupt_obj; \
     void *mmap_region_head; \
+    MP_MODLWIP_ROOT_POINTERS
 
 #define MICROPY_HAL_H "unix_mphal.h"
 


### PR DESCRIPTION
Based on the original patch by Galen Hazelwood
https://github.com/micropython/micropython/pull/1517
