### PR TITLE
Update README to change pyb to machine

### DIFF
--- a/cc3200/README.md
+++ b/cc3200/README.md
@@ -80,8 +80,8 @@ the file was successfully transferred, and it has been signed with a MD5 checksu
 Now, reset the MCU by pressing the switch on the board, or by typing:
 
 ```python
-import pyb
-pyb.reset()
+import machine
+machine.reset()
 ```
 
 ### Note regarding FileZilla:


### PR DESCRIPTION
In commit c92e6a4 in this cc3200 directory, "the pyb module was changed to machine", and according to http://micropython.org/resources/docs/en/latest/wipy/wipy/general.html, the upgrade procedure now uses "machine" rather than "pyb".

Update the README accordingly.
