### PR TITLE
windows: Add usleep() implementation for msvc port

### DIFF
--- a/windows/init.c
+++ b/windows/init.c
@@ -26,12 +26,10 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <windows.h>
-
-HANDLE hSleepEvent = NULL;
+#include "sleep.h"
 
 void init() {
-    hSleepEvent = CreateEvent(NULL, TRUE, FALSE, FALSE);
+    init_sleep();
 #ifdef __MINGW32__
     putenv("PRINTF_EXPONENT_DIGITS=2");
 #else
@@ -40,7 +38,5 @@ void init() {
 }
 
 void deinit() {
-    if (hSleepEvent != NULL) {
-        CloseHandle(hSleepEvent);
-    }
+    deinit_sleep();
 }

--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -162,9 +162,7 @@ extern const struct _mp_obj_module_t mp_module_time;
 
 #include "realpath.h"
 #include "init.h"
-
-// sleep for given number of milliseconds
-void msec_sleep(double msec);
+#include "sleep.h"
 
 // MSVC specifics
 #ifdef _MSC_VER

--- a/windows/sleep.h
+++ b/windows/sleep.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013, 2014 Damien P. George
+ * Copyright (c) 2015 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,53 +24,9 @@
  * THE SOFTWARE.
  */
 
-#include <windows.h>
-#include <errno.h>
-#include <limits.h>
-
-HANDLE waitTimer = NULL;
-
-void init_sleep(void) {
-    waitTimer = CreateWaitableTimer(NULL, TRUE, NULL); 
-}
-
-void deinit_sleep(void) {
-    if (waitTimer != NULL) {
-        CloseHandle(waitTimer);
-        waitTimer = NULL;
-    }
-}
-
-int usleep_impl(__int64 usec) {
-    if (waitTimer == NULL) {
-        errno = EAGAIN;
-        return -1;
-    }
-    if (usec < 0 || usec > LLONG_MAX / 10) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    LARGE_INTEGER ft;
-    ft.QuadPart = -10 * usec; // 100 nanosecond interval, negative value = relative time
-    if (SetWaitableTimer(waitTimer, &ft, 0, NULL, NULL, 0) == 0) {
-        errno = EINVAL;
-        return -1;
-    }
-    if (WaitForSingleObject(waitTimer, INFINITE) != WAIT_OBJECT_0) {
-        errno = EAGAIN;
-        return -1;
-    }
-    return 0;
-}
-
-#ifdef _MSC_VER // mingw and the likes provide their own usleep()
-int usleep(__int64 usec) {
-    return usleep_impl(usec);
-}
+void init_sleep(void);
+void deinit_sleep(void);
+void msec_sleep(double msec);
+#ifdef _MSC_VER
+int usleep(__int64 usec);
 #endif
-
-void msec_sleep(double msec) {
-    const double usec = msec * 1000.0;
-    usleep_impl(usec > (double)LLONG_MAX ? LLONG_MAX : (__int64)usec);
-}


### PR DESCRIPTION
Also make sleep.c self-contained by moving initialization code,
instead of having part of the code in init.c, and add a header file
to accomodate this.
msec_sleep() now uses the usleep() implementation as well.
