### PR TITLE
windows: Rename "time" module to "utime" for consistency with the oth…

### DIFF
--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -145,7 +145,7 @@ extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
 extern const struct _mp_obj_module_t mp_module_os;
 extern const struct _mp_obj_module_t mp_module_time;
 #define MICROPY_PORT_BUILTIN_MODULES \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_time), (mp_obj_t)&mp_module_time }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_utime), (mp_obj_t)&mp_module_time }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR__os), (mp_obj_t)&mp_module_os }, \
 
 #if MICROPY_USE_READLINE == 1


### PR DESCRIPTION
…er ports/tests
