### PR TITLE
The ESP PORT can be set it the environment.

### DIFF
--- a/esp8266/Makefile
+++ b/esp8266/Makefile
@@ -9,7 +9,7 @@ include ../py/py.mk
 MAKE_FROZEN = ../tools/make-frozen.py
 
 SCRIPTDIR = scripts
-PORT = /dev/ttyACM0
+PORT ?= /dev/ttyACM0
 BAUD = 115200
 CROSS_COMPILE = xtensa-lx106-elf-
 ESP_SDK = $(shell $(CC) -print-sysroot)/usr


### PR DESCRIPTION
The ESP port can be different than /dev/ttyACM0. This change makes it possible to read the PORT variable directly from the environment so one can flash his esp device using:

``` bash
PORT=/dev/ttyUSB0 make deploy
```
