### PR TITLE
stmhal: Add define for UNIQUE_ID address (differs per MCU)

### DIFF
--- a/stmhal/modmachine.c
+++ b/stmhal/modmachine.c
@@ -28,9 +28,11 @@
 
 #include "modmachine.h"
 #include "py/gc.h"
+#include "py/misc.h"
 #include "py/runtime.h"
 #include "lib/fatfs/ff.h"
 #include "lib/fatfs/diskio.h"
+#include "mphal.h"
 #include "gccollect.h"
 #include "irq.h"
 #include "rng.h"
@@ -44,7 +46,7 @@
 STATIC mp_obj_t machine_info(mp_uint_t n_args, const mp_obj_t *args) {
     // get and print unique id; 96 bits
     {
-        byte *id = (byte*)0x1fff7a10;
+        byte *id = (byte*)MP_HAL_UNIQUE_ID_ADDRESS;
         printf("ID=%02x%02x%02x%02x:%02x%02x%02x%02x:%02x%02x%02x%02x\n", id[0], id[1], id[2], id[3], id[4], id[5], id[6], id[7], id[8], id[9], id[10], id[11]);
     }
 

--- a/stmhal/mphal.h
+++ b/stmhal/mphal.h
@@ -1,6 +1,15 @@
 // We use the ST Cube HAL library for most hardware peripherals
 #include STM32_HAL_H
 
+#if defined(MCU_SERIES_F4)
+#define MP_HAL_UNIQUE_ID_ADDRESS    0x1fff7a10
+#elif defined(MCU_SERIES_F7)
+#define MP_HAL_UNIQUE_ID_ADDRESS    0x1ff0f420
+#else
+#error mphal.h: Unrecognized MCU_SERIES
+#endif
+
+
 // Basic GPIO functions
 #define GPIO_read_pin(gpio, pin)        (((gpio)->IDR >> (pin)) & 1)
 #if defined(MCU_SERIES_F7)

--- a/stmhal/usbd_desc.c
+++ b/stmhal/usbd_desc.c
@@ -32,6 +32,8 @@
 #include "usbd_core.h"
 #include "usbd_desc.h"
 #include "usbd_conf.h"
+#include "py/misc.h"
+#include "mphal.h"
 
 // So we don't clash with existing ST boards, we use the unofficial FOSS VID.
 // This needs a proper solution.
@@ -169,7 +171,7 @@ STATIC uint8_t *USBD_SerialStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *leng
     //
     // See: https://my.st.com/52d187b7 for the algorithim used.
 
-    uint8_t *id = (uint8_t *)0x1fff7a10;
+    uint8_t *id = (uint8_t *)MP_HAL_UNIQUE_ID_ADDRESS;
     char serial_buf[16];
     snprintf(serial_buf, sizeof(serial_buf),
         "%02X%02X%02X%02X%02X%02X",


### PR DESCRIPTION
It seems that each processor series has the unique id register in a different location.

I spent a fair amount of time looking, but was unable to come up with any predefined constant which would give me the correct information.

It seems that the builtin DFU on the F7 got it wrong too, since the serial number reported in DFU mode is incorrect.
