### PR TITLE
windows: Use write() instead of fwrite() to avoid out-of-order output.

### DIFF
--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -134,7 +134,8 @@ typedef long mp_off_t;
 typedef void *machine_ptr_t; // must be of pointer size
 typedef const void *machine_const_ptr_t; // must be of pointer size
 
-#define MP_PLAT_PRINT_STRN(str, len) fwrite(str, 1, len, stdout)
+#include <unistd.h>
+#define MP_PLAT_PRINT_STRN(str, len) do { int ret = write(1, str, len); (void)ret; } while (0)
 
 extern const struct _mp_obj_fun_builtin_t mp_builtin_input_obj;
 extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;


### PR DESCRIPTION
This fixes the basics/exception_chain.py test, also see #1500 for more
info and [4300c7d] where the same change was done for the other ports.
