### PR TITLE
tests: Make sure test output has \r\n line-ends when running on Windows

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -135,6 +135,8 @@ def run_micropython(pyb, args, test_file):
                 if i_mupy >= len(lines_mupy):
                     break
             output_mupy = b''.join(lines_mupy)
+            if os.name == 'nt':
+                output_mupy = output_mupy.replace(b'\n', b'\r\n')
 
         else:
             # a standard test


### PR DESCRIPTION
This is the case already when using just subprocess.check_output, but in
the special cases (cmdline, meminfo, ...) the carriage return gets lost
during output processing so restore it in the end.
This fixes the micropython/meminfo.py test on Windows.
