### PR TITLE
all: Add py/mphal.h and use it in all ports.

### DIFF
--- a/bare-arm/mphalport.h
+++ b/bare-arm/mphalport.h
@@ -1,0 +1,1 @@
+// empty file

--- a/cc3200/bootmgr/main.c
+++ b/cc3200/bootmgr/main.c
@@ -30,7 +30,6 @@
 #include "std.h"
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "hw_ints.h"
 #include "hw_types.h"
 #include "hw_gpio.h"

--- a/cc3200/fatfs/src/drivers/sd_diskio.c
+++ b/cc3200/fatfs/src/drivers/sd_diskio.c
@@ -38,7 +38,7 @@
 #include <stdbool.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 #include "hw_types.h"
 #include "hw_memmap.h"
 #include "hw_ints.h"

--- a/cc3200/fatfs/src/drivers/sflash_diskio.c
+++ b/cc3200/fatfs/src/drivers/sflash_diskio.c
@@ -3,7 +3,6 @@
 #include "std.h"
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "simplelink.h"
 #include "diskio.h"

--- a/cc3200/ftp/ftp.c
+++ b/cc3200/ftp/ftp.c
@@ -29,7 +29,6 @@
 #include "std.h"
 
 #include "py/mpstate.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "inc/hw_types.h"
 #include "inc/hw_ints.h"

--- a/cc3200/ftp/updater.c
+++ b/cc3200/ftp/updater.c
@@ -28,7 +28,6 @@
 #include <stdbool.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "simplelink.h"
 #include "flc.h"

--- a/cc3200/hal/cc3200_hal.c
+++ b/cc3200/hal/cc3200_hal.c
@@ -34,7 +34,7 @@
 
 
 #include "py/mpstate.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 #include "py/runtime.h"
 #include "py/objstr.h"
 #include "inc/hw_types.h"
@@ -104,11 +104,11 @@ void HAL_IncrementTick(void) {
     HAL_tickCount++;
 }
 
-uint32_t mp_hal_ticks_ms(void) {
+mp_uint_t mp_hal_ticks_ms(void) {
     return HAL_tickCount;
 }
 
-void mp_hal_delay_ms(uint32_t delay) {
+void mp_hal_delay_ms(mp_uint_t delay) {
     // only if we are not within interrupt context and interrupts are enabled
     if ((HAL_NVIC_INT_CTRL_REG & HAL_VECTACTIVE_MASK) == 0 && query_irq() == IRQ_STATE_ENABLED) {
         #ifdef USE_FREERTOS
@@ -140,7 +140,7 @@ void mp_hal_stdout_tx_str(const char *str) {
     mp_hal_stdout_tx_strn(str, strlen(str));
 }
 
-void mp_hal_stdout_tx_strn(const char *str, uint32_t len) {
+void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     if (MP_STATE_PORT(os_term_dup_obj)) {
         if (MP_OBJ_IS_TYPE(MP_STATE_PORT(os_term_dup_obj)->stream_o, &pyb_uart_type)) {
             uart_tx_strn(MP_STATE_PORT(os_term_dup_obj)->stream_o, str, len);
@@ -153,7 +153,7 @@ void mp_hal_stdout_tx_strn(const char *str, uint32_t len) {
     telnet_tx_strn(str, len);
 }
 
-void mp_hal_stdout_tx_strn_cooked (const char *str, uint32_t len) {
+void mp_hal_stdout_tx_strn_cooked (const char *str, size_t len) {
     int32_t nslen = 0;
     const char *_str = str;
 

--- a/cc3200/hal/cc3200_hal.h
+++ b/cc3200/hal/cc3200_hal.h
@@ -62,14 +62,7 @@
 extern void HAL_SystemInit (void);
 extern void HAL_SystemDeInit (void);
 extern void HAL_IncrementTick(void);
-extern uint32_t mp_hal_ticks_ms(void);
-extern void mp_hal_delay_ms(uint32_t delay);
 extern NORETURN void mp_hal_raise(int errno);
 extern void mp_hal_set_interrupt_char (int c);
-
-int mp_hal_stdin_rx_chr(void);
-void mp_hal_stdout_tx_str(const char *str);
-void mp_hal_stdout_tx_strn(const char *str, uint32_t len);
-void mp_hal_stdout_tx_strn_cooked(const char *str, uint32_t len);
 
 #endif /* CC3200_LAUNCHXL_HAL_CC3200_HAL_H_ */

--- a/cc3200/main.c
+++ b/cc3200/main.c
@@ -29,7 +29,7 @@
 #include <ctype.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 #include "mptask.h"
 #include "simplelink.h"
 #include "pybwdt.h"

--- a/cc3200/misc/FreeRTOSHooks.c
+++ b/cc3200/misc/FreeRTOSHooks.c
@@ -29,7 +29,7 @@
 #include <string.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 #include "py/obj.h"
 #include "inc/hw_memmap.h"
 #include "pybuart.h"

--- a/cc3200/misc/mperror.c
+++ b/cc3200/misc/mperror.c
@@ -30,9 +30,9 @@
 #include <string.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "hw_ints.h"
 #include "hw_types.h"
 #include "hw_gpio.h"

--- a/cc3200/misc/mpirq.c
+++ b/cc3200/misc/mpirq.c
@@ -27,7 +27,6 @@
 #include "std.h"
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "py/gc.h"

--- a/cc3200/misc/mpsystick.c
+++ b/cc3200/misc/mpsystick.c
@@ -26,8 +26,8 @@
  */
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
+#include "py/mphal.h"
 #include "mpsystick.h"
 #include "systick.h"
 #include "inc/hw_types.h"

--- a/cc3200/mods/modmachine.c
+++ b/cc3200/mods/modmachine.c
@@ -30,7 +30,7 @@
 
 #include "py/mpstate.h"
 #include "py/runtime.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 #include "irq.h"
 #include "inc/hw_types.h"
 #include "inc/hw_gpio.h"

--- a/cc3200/mods/modnetwork.c
+++ b/cc3200/mods/modnetwork.c
@@ -28,10 +28,10 @@
 #include <std.h>
 
 #include "py/mpstate.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/nlr.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "modnetwork.h"
 #include "mpexception.h"
 #include "serverstask.h"

--- a/cc3200/mods/modubinascii.c
+++ b/cc3200/mods/modubinascii.c
@@ -26,7 +26,6 @@
  */
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/nlr.h"
 #include "py/runtime.h"
 #include "py/binary.h"

--- a/cc3200/mods/modusocket.c
+++ b/cc3200/mods/modusocket.c
@@ -30,7 +30,6 @@
 
 #include "simplelink.h"
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/objstr.h"
 #include "py/runtime.h"

--- a/cc3200/mods/modussl.c
+++ b/cc3200/mods/modussl.c
@@ -29,7 +29,6 @@
 
 #include "simplelink.h"
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/objstr.h"
 #include "py/runtime.h"

--- a/cc3200/mods/modutime.c
+++ b/cc3200/mods/modutime.c
@@ -29,10 +29,10 @@
 #include <string.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/nlr.h"
 #include "py/obj.h"
 #include "py/smallint.h"
+#include "py/mphal.h"
 #include "timeutils.h"
 #include "inc/hw_types.h"
 #include "inc/hw_ints.h"

--- a/cc3200/mods/modwipy.c
+++ b/cc3200/mods/modwipy.c
@@ -1,5 +1,4 @@
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "mperror.h"

--- a/cc3200/mods/modwlan.c
+++ b/cc3200/mods/modwlan.c
@@ -30,10 +30,10 @@
 
 #include "simplelink.h"
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/objstr.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "inc/hw_types.h"
 #include "inc/hw_ints.h"
 #include "inc/hw_memmap.h"

--- a/cc3200/mods/pybadc.c
+++ b/cc3200/mods/pybadc.c
@@ -29,7 +29,6 @@
 #include <string.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/nlr.h"
 #include "py/runtime.h"
 #include "py/binary.h"

--- a/cc3200/mods/pybi2c.c
+++ b/cc3200/mods/pybi2c.c
@@ -29,8 +29,8 @@
 #include <string.h>
 
 #include "py/mpstate.h"
-#include MICROPY_HAL_H
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "bufhelper.h"
 #include "inc/hw_types.h"
 #include "inc/hw_i2c.h"

--- a/cc3200/mods/pybpin.c
+++ b/cc3200/mods/pybpin.c
@@ -30,7 +30,6 @@
 #include <string.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "py/gc.h"

--- a/cc3200/mods/pybrtc.c
+++ b/cc3200/mods/pybrtc.c
@@ -28,7 +28,6 @@
 #include <std.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "inc/hw_types.h"

--- a/cc3200/mods/pybsd.c
+++ b/cc3200/mods/pybsd.c
@@ -25,7 +25,6 @@
  */
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "inc/hw_types.h"

--- a/cc3200/mods/pybsleep.c
+++ b/cc3200/mods/pybsleep.c
@@ -28,8 +28,8 @@
 #include <string.h>
 
 #include "py/mpstate.h"
-#include MICROPY_HAL_H
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "inc/hw_types.h"
 #include "inc/hw_ints.h"
 #include "inc/hw_nvic.h"

--- a/cc3200/mods/pybspi.c
+++ b/cc3200/mods/pybspi.c
@@ -29,7 +29,6 @@
 #include <string.h>
 
 #include "py/mpstate.h"
-#include MICROPY_HAL_H
 #include "py/runtime.h"
 #include "bufhelper.h"
 #include "inc/hw_types.h"

--- a/cc3200/mods/pybtimer.c
+++ b/cc3200/mods/pybtimer.c
@@ -30,11 +30,11 @@
 #include <string.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/nlr.h"
 #include "py/runtime.h"
 #include "py/gc.h"
+#include "py/mphal.h"
 #include "inc/hw_types.h"
 #include "inc/hw_ints.h"
 #include "inc/hw_memmap.h"

--- a/cc3200/mods/pybuart.c
+++ b/cc3200/mods/pybuart.c
@@ -31,11 +31,11 @@
 #include <string.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "py/objlist.h"
 #include "py/stream.h"
+#include "py/mphal.h"
 #include "inc/hw_types.h"
 #include "inc/hw_ints.h"
 #include "inc/hw_memmap.h"

--- a/cc3200/mods/pybwdt.c
+++ b/cc3200/mods/pybwdt.c
@@ -27,9 +27,9 @@
 #include <stdint.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "inc/hw_types.h"
 #include "inc/hw_gpio.h"
 #include "inc/hw_ints.h"

--- a/cc3200/mpconfigport.h
+++ b/cc3200/mpconfigport.h
@@ -180,7 +180,6 @@ typedef void            *machine_ptr_t;             // must be of pointer size
 typedef const void      *machine_const_ptr_t;       // must be of pointer size
 typedef long            mp_off_t;
 
-void mp_hal_stdout_tx_strn_cooked(const char *str, uint32_t len);
 #define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
 
 #define MICROPY_BEGIN_ATOMIC_SECTION()              disable_irq()
@@ -204,7 +203,7 @@ void mp_hal_stdout_tx_strn_cooked(const char *str, uint32_t len);
 // Include board specific configuration
 #include "mpconfigboard.h"
 
-#define MICROPY_HAL_H                               "cc3200_hal.h"
+#define MICROPY_MPHALPORT_H                         "cc3200_hal.h"
 #define MICROPY_PORT_HAS_TELNET                     (1)
 #define MICROPY_PORT_HAS_FTP                        (1)
 #define MICROPY_PY_SYS_PLATFORM                     "WiPy"

--- a/cc3200/mptask.c
+++ b/cc3200/mptask.c
@@ -28,10 +28,10 @@
 #include <stdint.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "py/gc.h"
+#include "py/mphal.h"
 #include "inc/hw_memmap.h"
 #include "inc/hw_types.h"
 #include "inc/hw_ints.h"

--- a/cc3200/serverstask.c
+++ b/cc3200/serverstask.c
@@ -28,9 +28,9 @@
 #include <string.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/misc.h"
 #include "py/nlr.h"
+#include "py/mphal.h"
 #include "serverstask.h"
 #include "simplelink.h"
 #include "debug.h"

--- a/cc3200/telnet/telnet.c
+++ b/cc3200/telnet/telnet.c
@@ -27,8 +27,8 @@
 #include <stdint.h>
 
 #include "py/mpconfig.h"
-#include MICROPY_HAL_H
 #include "py/obj.h"
+#include "py/mphal.h"
 #include "telnet.h"
 #include "simplelink.h"
 #include "modnetwork.h"

--- a/esp8266/esp_mphal.h
+++ b/esp8266/esp_mphal.h
@@ -32,13 +32,7 @@ void ets_isr_mask(unsigned);
 
 void mp_hal_init(void);
 void mp_hal_feed_watchdog(void);
-int mp_hal_stdin_rx_chr(void);
-void mp_hal_stdout_tx_str(const char *str);
-void mp_hal_stdout_tx_strn(const char *str, uint32_t len);
-void mp_hal_stdout_tx_strn_cooked(const char *str, uint32_t len);
 
-uint32_t mp_hal_ticks_ms(void);
-void mp_hal_delay_ms(uint32_t delay);
 void mp_hal_delay_us(uint32_t);
 void mp_hal_set_interrupt_char(int c);
 uint32_t mp_hal_get_cpu_freq(void);

--- a/esp8266/main.c
+++ b/esp8266/main.c
@@ -33,10 +33,10 @@
 #include "py/runtime.h"
 #include "py/stackctrl.h"
 #include "py/frozenmod.h"
+#include "py/mphal.h"
 #include "py/gc.h"
 #include "pyexec.h"
 #include "gccollect.h"
-#include MICROPY_HAL_H
 #include "user_interface.h"
 
 STATIC char heap[16384];

--- a/esp8266/modesp.c
+++ b/esp8266/modesp.c
@@ -32,7 +32,6 @@
 #include "py/obj.h"
 #include "py/gc.h"
 #include "py/runtime.h"
-#include MICROPY_HAL_H
 #include "netutils.h"
 #include "queue.h"
 #include "user_interface.h"

--- a/esp8266/modpyb.c
+++ b/esp8266/modpyb.c
@@ -29,9 +29,9 @@
 #include "py/nlr.h"
 #include "py/obj.h"
 #include "py/gc.h"
+#include "py/mphal.h"
 #include "gccollect.h"
 #include "pyexec.h"
-#include MICROPY_HAL_H
 #include "user_interface.h"
 #include "modpyb.h"
 

--- a/esp8266/modpybadc.c
+++ b/esp8266/modpybadc.c
@@ -30,7 +30,6 @@
 #include "py/nlr.h"
 #include "py/obj.h"
 #include "py/runtime.h"
-#include MICROPY_HAL_H
 #include "user_interface.h"
 
 const mp_obj_type_t pyb_adc_type;

--- a/esp8266/modpybrtc.c
+++ b/esp8266/modpybrtc.c
@@ -30,7 +30,6 @@
 #include "py/nlr.h"
 #include "py/obj.h"
 #include "py/runtime.h"
-#include MICROPY_HAL_H
 #include "timeutils.h"
 #include "user_interface.h"
 #include "modpyb.h"

--- a/esp8266/modutime.c
+++ b/esp8266/modutime.c
@@ -32,7 +32,7 @@
 #include "py/obj.h"
 #include "py/gc.h"
 #include "py/runtime.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 #include "modpyb.h"
 #include "modpybrtc.h"
 #include "timeutils.h"

--- a/esp8266/mpconfigport.h
+++ b/esp8266/mpconfigport.h
@@ -54,7 +54,6 @@ typedef void *machine_ptr_t; // must be of pointer size
 typedef const void *machine_const_ptr_t; // must be of pointer size
 typedef long mp_off_t;
 
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
 #define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
 
 // extra built in names to add to the global namespace
@@ -94,7 +93,7 @@ extern const struct _mp_obj_module_t uos_module;
 
 // board specifics
 
-#define MICROPY_HAL_H "esp_mphal.h"
+#define MICROPY_MPHALPORT_H "esp_mphal.h"
 #define MICROPY_HW_BOARD_NAME "ESP module"
 #define MICROPY_HW_MCU_NAME "ESP8266"
 #define MICROPY_PY_SYS_PLATFORM "ESP8266"

--- a/lib/mp-readline/readline.c
+++ b/lib/mp-readline/readline.c
@@ -30,10 +30,8 @@
 
 #include "py/mpstate.h"
 #include "py/repl.h"
+#include "py/mphal.h"
 #include "readline.h"
-#ifdef MICROPY_HAL_H
-#include MICROPY_HAL_H
-#endif
 
 #if 0 // print debugging info
 #define DEBUG_PRINT (1)

--- a/minimal/mpconfigport.h
+++ b/minimal/mpconfigport.h
@@ -65,7 +65,6 @@ typedef void *machine_ptr_t; // must be of pointer size
 typedef const void *machine_const_ptr_t; // must be of pointer size
 typedef long mp_off_t;
 
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
 #define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
 
 // extra built in names to add to the global namespace
@@ -75,14 +74,6 @@ extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
 
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
-
-#define mp_hal_ticks_ms() 0
-int mp_hal_stdin_rx_chr(void);
-void mp_hal_stdout_tx_str(const char *str);
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len);
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
-
-static inline void mp_hal_set_interrupt_char(char c) {}
 
 #define MICROPY_HW_BOARD_NAME "minimal"
 #define MICROPY_HW_MCU_NAME "unknown-cpu"

--- a/minimal/mphalport.h
+++ b/minimal/mphalport.h
@@ -1,0 +1,2 @@
+static inline mp_uint_t mp_hal_ticks_ms(void) { return 0; }
+static inline void mp_hal_set_interrupt_char(char c) {}

--- a/minimal/uart_extra.c
+++ b/minimal/uart_extra.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <unistd.h>
 #include "py/mpconfig.h"
+#include "py/mphal.h"
 
 /*
  * Extra UART functions

--- a/pic16bit/main.c
+++ b/pic16bit/main.c
@@ -32,9 +32,9 @@
 #include "py/compile.h"
 #include "py/runtime.h"
 #include "py/gc.h"
+#include "py/mphal.h"
 #include "pyexec.h"
 #include "readline.h"
-#include MICROPY_HAL_H
 #include "board.h"
 #include "modpyb.h"
 
@@ -59,7 +59,7 @@ soft_reset:
     led_state(1, 0);
     led_state(2, 0);
     led_state(3, 1);
-    mp_hal_milli_delay(150);
+    mp_hal_delay_ms(150);
     led_state(3, 0);
 
     // init MicroPython runtime

--- a/pic16bit/modpyb.c
+++ b/pic16bit/modpyb.c
@@ -27,17 +27,17 @@
 #include <stdio.h>
 
 #include "py/obj.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 #include "modpyb.h"
 
 STATIC mp_obj_t pyb_millis(void) {
-    return MP_OBJ_NEW_SMALL_INT(mp_hal_get_milliseconds());
+    return MP_OBJ_NEW_SMALL_INT(mp_hal_ticks_ms());
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(pyb_millis_obj, pyb_millis);
 
 STATIC mp_obj_t pyb_elapsed_millis(mp_obj_t start) {
     uint32_t startMillis = mp_obj_get_int(start);
-    uint32_t currMillis = mp_hal_get_milliseconds();
+    uint32_t currMillis = mp_hal_ticks_ms();
     return MP_OBJ_NEW_SMALL_INT((currMillis - startMillis) & 0x1fff);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_elapsed_millis_obj, pyb_elapsed_millis);
@@ -45,7 +45,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_elapsed_millis_obj, pyb_elapsed_millis);
 STATIC mp_obj_t pyb_delay(mp_obj_t ms_in) {
     mp_int_t ms = mp_obj_get_int(ms_in);
     if (ms >= 0) {
-        mp_hal_milli_delay(ms);
+        mp_hal_delay_ms(ms);
     }
     return mp_const_none;
 }

--- a/pic16bit/mpconfigport.h
+++ b/pic16bit/mpconfigport.h
@@ -86,7 +86,6 @@ typedef void *machine_ptr_t; // must be pointer size
 typedef const void *machine_const_ptr_t; // must be pointer size
 typedef int mp_off_t;
 
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
 #define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
 
 // extra builtin names to add to the global namespace
@@ -108,6 +107,6 @@ extern const struct _mp_obj_module_t pyb_module;
     char *readline_hist[8]; \
     mp_obj_t keyboard_interrupt_obj; \
 
-#define MICROPY_HAL_H "pic16bit_mphal.h"
+#define MICROPY_MPHALPORT_H "pic16bit_mphal.h"
 #define MICROPY_HW_BOARD_NAME "dsPICSK"
 #define MICROPY_HW_MCU_NAME "dsPIC33"

--- a/pic16bit/pic16bit_mphal.c
+++ b/pic16bit/pic16bit_mphal.c
@@ -25,7 +25,7 @@
  */
 
 #include <string.h>
-#include "pic16bit_mphal.h"
+#include "py/mphal.h"
 #include "board.h"
 
 static int interrupt_char;
@@ -34,12 +34,12 @@ void mp_hal_init(void) {
     MP_STATE_PORT(keyboard_interrupt_obj) = mp_obj_new_exception(&mp_type_KeyboardInterrupt);
 }
 
-mp_uint_t mp_hal_get_milliseconds(void) {
+mp_uint_t mp_hal_ticks_ms(void) {
     // TODO
     return 0;
 }
 
-void mp_hal_milli_delay(mp_uint_t ms) {
+void mp_hal_delay_ms(mp_uint_t ms) {
     // tuned for fixed CPU frequency
     for (int i = ms; i > 0; i--) {
         for (volatile int j = 0; j < 5000; j++) {
@@ -63,13 +63,13 @@ void mp_hal_stdout_tx_str(const char *str) {
     mp_hal_stdout_tx_strn(str, strlen(str));
 }
 
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     for (; len > 0; --len) {
         uart_tx_char(*str++);
     }
 }
 
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len) {
+void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
     for (; len > 0; --len) {
         if (*str == '\n') {
             uart_tx_char('\r');

--- a/pic16bit/pic16bit_mphal.h
+++ b/pic16bit/pic16bit_mphal.h
@@ -26,19 +26,10 @@
 #ifndef __MICROPY_INCLUDED_PIC16BIT_PIC16BIT_MPHAL_H__
 #define __MICROPY_INCLUDED_PIC16BIT_PIC16BIT_MPHAL_H__
 
-#define HAL_GetTick mp_hal_get_milliseconds
-
 #include "py/mpstate.h"
 
 void mp_hal_init(void);
 
-mp_uint_t mp_hal_get_milliseconds(void);
-void mp_hal_milli_delay(mp_uint_t ms);
-
 void mp_hal_set_interrupt_char(int c);
-int mp_hal_stdin_rx_chr(void);
-void mp_hal_stdout_tx_str(const char *str);
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len);
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
 
 #endif // __MICROPY_INCLUDED_PIC16BIT_PIC16BIT_MPHAL_H__

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -34,13 +34,28 @@
 #include <mphalport.h>
 #endif
 
+#ifndef mp_hal_stdin_rx_chr
 int mp_hal_stdin_rx_chr(void);
-void mp_hal_stdout_tx_str(const char *str);
-void mp_hal_stdout_tx_strn(const char *str, size_t len);
-void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len);
+#endif
 
-// what should be the integer types here? I'd say word size
+#ifndef mp_hal_stdout_tx_str
+void mp_hal_stdout_tx_str(const char *str);
+#endif
+
+#ifndef mp_hal_stdout_tx_strn
+void mp_hal_stdout_tx_strn(const char *str, size_t len);
+#endif
+
+#ifndef mp_hal_stdout_tx_strn_cooked
+void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len);
+#endif
+
+#ifndef mp_hal_delay_ms
 void mp_hal_delay_ms(mp_uint_t ms);
+#endif
+
+#ifndef mp_hal_ticks_ms
 mp_uint_t mp_hal_ticks_ms(void);
+#endif
 
 #endif // __MICROPY_INCLUDED_PY_MPHAL_H__

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -3,8 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013, 2014 Damien P. George
- * Copyright (c) 2015 Daniel Campora
+ * Copyright (c) 2015 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,39 +23,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
-#include <stdio.h>
-#include <stdint.h>
+#ifndef __MICROPY_INCLUDED_PY_MPHAL_H__
+#define __MICROPY_INCLUDED_PY_MPHAL_H__
 
 #include "py/mpconfig.h"
-#include "py/gc.h"
-#include "gccollect.h"
-#include "gchelper.h"
 
-/******************************************************************************
-DECLARE PRIVATE DATA
- ******************************************************************************/
-static uint32_t stackend;
+#ifdef MICROPY_MPHALPORT_H
+#include MICROPY_MPHALPORT_H
+#else
+#include <mphalport.h>
+#endif
 
+int mp_hal_stdin_rx_chr(void);
+void mp_hal_stdout_tx_str(const char *str);
+void mp_hal_stdout_tx_strn(const char *str, size_t len);
+void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len);
 
-/******************************************************************************
-DECLARE PUBLIC FUNCTIONS
- ******************************************************************************/
-void gc_collect_init (uint32_t sp) {
-    stackend = sp;
-}
+// what should be the integer types here? I'd say word size
+void mp_hal_delay_ms(mp_uint_t ms);
+mp_uint_t mp_hal_ticks_ms(void);
 
-void gc_collect(void) {
-    // start the GC
-    gc_collect_start();
-
-    // get the registers and the sp
-    mp_uint_t regs[10];
-    mp_uint_t sp = gc_helper_get_regs_and_sp(regs);
-
-    // trace the stack, including the registers (since they live on the stack in this function)
-    gc_collect_root((void**)sp, (stackend - sp) / sizeof(uint32_t));
-
-    // end the GC
-    gc_collect_end();
-}
+#endif // __MICROPY_INCLUDED_PY_MPHAL_H__

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "py/mphal.h"
 #include "py/mpprint.h"
 #include "py/obj.h"
 #include "py/objint.h"

--- a/qemu-arm/mphalport.h
+++ b/qemu-arm/mphalport.h
@@ -1,0 +1,1 @@
+// empty file

--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -113,7 +113,7 @@ SRC_C = \
 	usbd_desc.c \
 	usbd_cdc_interface.c \
 	usbd_msc_storage.c \
-	mphal.c \
+	mphalport.c \
 	irq.c \
 	pendsv.c \
 	systick.c  \

--- a/stmhal/adc.c
+++ b/stmhal/adc.c
@@ -25,16 +25,15 @@
  */
 
 #include <stdio.h>
-#include STM32_HAL_H
 #include <string.h>
 
 #include "py/nlr.h"
 #include "py/runtime.h"
 #include "py/binary.h"
+#include "py/mphal.h"
 #include "adc.h"
 #include "pin.h"
 #include "genhdr/pins.h"
-#include "mphal.h"
 #include "timer.h"
 
 /// \moduleref pyb

--- a/stmhal/boards/stm32f4xx_prefix.c
+++ b/stmhal/boards/stm32f4xx_prefix.c
@@ -3,8 +3,8 @@
 #include <stdio.h>
 
 #include "py/obj.h"
+#include "py/mphal.h"
 #include "pin.h"
-#include MICROPY_HAL_H
 
 #define AF(af_idx, af_fn, af_unit, af_type, af_ptr) \
 { \

--- a/stmhal/can.c
+++ b/stmhal/can.c
@@ -33,10 +33,10 @@
 #include "py/objtuple.h"
 #include "py/runtime.h"
 #include "py/gc.h"
+#include "py/mphal.h"
 #include "bufhelper.h"
 #include "can.h"
 #include "pybioctl.h"
-#include MICROPY_HAL_H
 
 #if MICROPY_HW_ENABLE_CAN
 

--- a/stmhal/extint.c
+++ b/stmhal/extint.c
@@ -31,7 +31,7 @@
 #include "py/nlr.h"
 #include "py/runtime.h"
 #include "py/gc.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 #include "pin.h"
 #include "extint.h"
 

--- a/stmhal/i2c.c
+++ b/stmhal/i2c.c
@@ -29,13 +29,13 @@
 
 #include "py/nlr.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "irq.h"
 #include "pin.h"
 #include "genhdr/pins.h"
 #include "bufhelper.h"
 #include "dma.h"
 #include "i2c.h"
-#include MICROPY_HAL_H
 
 #if !defined(MICROPY_HW_I2C_BAUDRATE_DEFAULT)
 #define MICROPY_HW_I2C_BAUDRATE_DEFAULT 400000

--- a/stmhal/irq.c
+++ b/stmhal/irq.c
@@ -26,9 +26,8 @@
 
 #include "py/nlr.h"
 #include "py/obj.h"
+#include "py/mphal.h"
 #include "irq.h"
-
-#include MICROPY_HAL_H
 
 /// \moduleref pyb
 

--- a/stmhal/led.c
+++ b/stmhal/led.c
@@ -25,15 +25,14 @@
  */
 
 #include <stdio.h>
-#include STM32_HAL_H
 
 #include "py/nlr.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "timer.h"
 #include "led.h"
 #include "pin.h"
 #include "genhdr/pins.h"
-#include "mphal.h"
 
 #if defined(MICROPY_HW_LED1)
 

--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -34,6 +34,7 @@
 #include "py/runtime.h"
 #include "py/stackctrl.h"
 #include "py/gc.h"
+#include "py/mphal.h"
 
 #include "lib/fatfs/ff.h"
 
@@ -60,7 +61,6 @@
 #include "dac.h"
 #include "can.h"
 #include "modnetwork.h"
-#include MICROPY_HAL_H
 
 void SystemClock_Config(void);
 

--- a/stmhal/modmachine.c
+++ b/stmhal/modmachine.c
@@ -29,6 +29,7 @@
 #include "modmachine.h"
 #include "py/gc.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "lib/fatfs/ff.h"
 #include "lib/fatfs/diskio.h"
 #include "gccollect.h"
@@ -38,7 +39,6 @@
 #include "pin.h"
 #include "timer.h"
 #include "usb.h"
-#include MICROPY_HAL_H
 
 // machine.info([dump_alloc_table])
 // Print out lots of information about the board.

--- a/stmhal/modnwwiznet5k.c
+++ b/stmhal/modnwwiznet5k.c
@@ -32,12 +32,12 @@
 #include "py/nlr.h"
 #include "py/objlist.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "netutils.h"
 #include "modnetwork.h"
 #include "pin.h"
 #include "genhdr/pins.h"
 #include "spi.h"
-#include MICROPY_HAL_H
 
 #include "ethernet/wizchip_conf.h"
 #include "ethernet/socket.h"

--- a/stmhal/moduselect.c
+++ b/stmhal/moduselect.c
@@ -30,8 +30,8 @@
 #include "py/nlr.h"
 #include "py/obj.h"
 #include "py/objlist.h"
+#include "py/mphal.h"
 #include "pybioctl.h"
-#include MICROPY_HAL_H
 
 /// \module select - Provides select function to wait for events on a stream
 ///

--- a/stmhal/mpconfigport.h
+++ b/stmhal/mpconfigport.h
@@ -199,7 +199,6 @@ typedef void *machine_ptr_t; // must be of pointer size
 typedef const void *machine_const_ptr_t; // must be of pointer size
 typedef long mp_off_t;
 
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
 #define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
 
 // We have inlined IRQ functions for efficiency (they are generally
@@ -242,7 +241,6 @@ static inline mp_uint_t disable_irq(void) {
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
 
-#define MICROPY_HAL_H           "mphal.h"
 #define MICROPY_PIN_DEFS_PORT_H "pin_defs_stmhal.h"
 
 #endif // __INCLUDED_MPCONFIGPORT_H

--- a/stmhal/mphalport.c
+++ b/stmhal/mphalport.c
@@ -48,7 +48,7 @@ void mp_hal_stdout_tx_str(const char *str) {
     mp_hal_stdout_tx_strn(str, strlen(str));
 }
 
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
         uart_tx_strn(MP_STATE_PORT(pyb_stdio_uart), str, len);
     }
@@ -60,7 +60,7 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
     }
 }
 
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len) {
+void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
     // send stdout to UART and USB CDC VCP
     if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
         uart_tx_strn_cooked(MP_STATE_PORT(pyb_stdio_uart), str, len);

--- a/stmhal/mphalport.c
+++ b/stmhal/mphalport.c
@@ -2,9 +2,9 @@
 #include <string.h>
 
 #include "py/mpstate.h"
+#include "py/mphal.h"
 #include "usb.h"
 #include "uart.h"
-#include "mphal.h"
 
 // this table converts from HAL_StatusTypeDef to POSIX errno
 const byte mp_hal_status_to_errno_table[4] = {

--- a/stmhal/mphalport.h
+++ b/stmhal/mphalport.h
@@ -29,5 +29,5 @@ extern const unsigned char mp_hal_status_to_errno_table[4];
 NORETURN void mp_hal_raise(HAL_StatusTypeDef status);
 void mp_hal_set_interrupt_char(int c); // -1 to disable
 
-static inline void mp_hal_delay_ms(mp_uint_t ms) { HAL_Delay(ms); }
-static inline mp_uint_t mp_hal_ticks_ms(void) { return HAL_GetTick(); }
+#define mp_hal_delay_ms HAL_Delay
+#define mp_hal_ticks_ms HAL_GetTick

--- a/stmhal/mphalport.h
+++ b/stmhal/mphalport.h
@@ -8,7 +8,7 @@
 #elif defined(MCU_SERIES_F7)
 #define MP_HAL_UNIQUE_ID_ADDRESS (0x1ff0f420)
 #else
-#error mphal.h: Unrecognized MCU_SERIES
+#error mphalport.h: Unrecognized MCU_SERIES
 #endif
 
 // Basic GPIO functions
@@ -24,15 +24,10 @@
 
 void mp_hal_gpio_clock_enable(GPIO_TypeDef *gpio);
 
-extern const byte mp_hal_status_to_errno_table[4];
+extern const unsigned char mp_hal_status_to_errno_table[4];
 
 NORETURN void mp_hal_raise(HAL_StatusTypeDef status);
 void mp_hal_set_interrupt_char(int c); // -1 to disable
 
-int mp_hal_stdin_rx_chr(void);
-void mp_hal_stdout_tx_str(const char *str);
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len);
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
-
-#define mp_hal_delay_ms HAL_Delay
-#define mp_hal_ticks_ms HAL_GetTick
+static inline void mp_hal_delay_ms(mp_uint_t ms) { HAL_Delay(ms); }
+static inline mp_uint_t mp_hal_ticks_ms(void) { return HAL_GetTick(); }

--- a/stmhal/pin.c
+++ b/stmhal/pin.c
@@ -30,7 +30,7 @@
 
 #include "py/nlr.h"
 #include "py/runtime.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 #include "pin.h"
 
 /// \moduleref pyb

--- a/stmhal/pin_defs_stmhal.c
+++ b/stmhal/pin_defs_stmhal.c
@@ -1,6 +1,5 @@
 #include "py/obj.h"
 #include "pin.h"
-#include MICROPY_HAL_H
 
 // Returns the pin mode. This value returned by this macro should be one of:
 // GPIO_MODE_INPUT, GPIO_MODE_OUTPUT_PP, GPIO_MODE_OUTPUT_OD,

--- a/stmhal/pin_named_pins.c
+++ b/stmhal/pin_named_pins.c
@@ -28,7 +28,7 @@
 #include <string.h>
 
 #include "py/runtime.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 #include "pin.h"
 
 STATIC void pin_named_pins_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {

--- a/stmhal/printf.c
+++ b/stmhal/printf.c
@@ -29,9 +29,7 @@
 #include <stdarg.h>
 
 #include "py/obj.h"
-#ifdef MICROPY_HAL_H
-#include MICROPY_HAL_H
-#endif
+#include "py/mphal.h"
 
 #if MICROPY_PY_BUILTINS_FLOAT
 #include "py/formatfloat.h"

--- a/stmhal/pybstdio.c
+++ b/stmhal/pybstdio.c
@@ -30,7 +30,7 @@
 
 #include "py/obj.h"
 #include "py/stream.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 
 // TODO make stdin, stdout and stderr writable objects so they can
 // be changed by Python code.  This requires some changes, as these

--- a/stmhal/pyexec.c
+++ b/stmhal/pyexec.c
@@ -33,9 +33,7 @@
 #include "py/runtime.h"
 #include "py/repl.h"
 #include "py/gc.h"
-#ifdef MICROPY_HAL_H
-#include MICROPY_HAL_H
-#endif
+#include "py/mphal.h"
 #if defined(USE_DEVICE_MODE)
 #include "irq.h"
 #include "usb.h"

--- a/stmhal/spi.c
+++ b/stmhal/spi.c
@@ -29,13 +29,13 @@
 
 #include "py/nlr.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "irq.h"
 #include "pin.h"
 #include "genhdr/pins.h"
 #include "bufhelper.h"
 #include "dma.h"
 #include "spi.h"
-#include MICROPY_HAL_H
 
 // The following defines are for compatability with the '405
 #if !defined(MICROPY_HW_SPI1_NSS)

--- a/stmhal/stm32_it.c
+++ b/stmhal/stm32_it.c
@@ -92,7 +92,7 @@ extern PCD_HandleTypeDef pcd_handle;
 
 #if REPORT_HARD_FAULT_REGS
 
-#include "mphal.h"
+#include "py/mphal.h"
 
 char *fmt_hex(uint32_t val, char *buf) {
     const char *hexDig = "0123456789abcdef";

--- a/stmhal/timer.c
+++ b/stmhal/timer.c
@@ -35,7 +35,6 @@
 #include "py/nlr.h"
 #include "py/runtime.h"
 #include "py/gc.h"
-#include MICROPY_HAL_H
 #include "timer.h"
 #include "servo.h"
 #include "pin.h"

--- a/stmhal/uart.c
+++ b/stmhal/uart.c
@@ -32,9 +32,9 @@
 #include "py/nlr.h"
 #include "py/runtime.h"
 #include "py/stream.h"
+#include "py/mphal.h"
 #include "uart.h"
 #include "pybioctl.h"
-#include MICROPY_HAL_H
 
 //TODO: Add UART7/8 support for MCU_SERIES_F7
 

--- a/stmhal/usbd_desc.c
+++ b/stmhal/usbd_desc.c
@@ -35,7 +35,7 @@
 
 // need these headers just for MP_HAL_UNIQUE_ID_ADDRESS
 #include "py/misc.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 
 // So we don't clash with existing ST boards, we use the unofficial FOSS VID.
 // This needs a proper solution.

--- a/stmhal/usrsw.c
+++ b/stmhal/usrsw.c
@@ -27,10 +27,10 @@
 #include <stdio.h>
 
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "extint.h"
 #include "pin.h"
 #include "genhdr/pins.h"
-#include "mphal.h"
 #include "usrsw.h"
 
 #if MICROPY_HW_HAS_SWITCH

--- a/teensy/led.c
+++ b/teensy/led.c
@@ -4,8 +4,8 @@
 
 #include "py/nlr.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
 #include "led.h"
-#include MICROPY_HAL_H
 #include "pin.h"
 #include "genhdr/pins.h"
 

--- a/teensy/main.c
+++ b/teensy/main.c
@@ -9,13 +9,13 @@
 #include "py/runtime.h"
 #include "py/stackctrl.h"
 #include "py/gc.h"
+#include "py/mphal.h"
 #include "gccollect.h"
 #include "pyexec.h"
 #include "readline.h"
 #include "lexermemzip.h"
 
 #include "Arduino.h"
-#include MICROPY_HAL_H
 
 #include "servo.h"
 #include "led.h"

--- a/teensy/modpyb.c
+++ b/teensy/modpyb.c
@@ -31,8 +31,7 @@
 
 #include "py/obj.h"
 #include "py/gc.h"
-
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 
 #include "gccollect.h"
 #include "irq.h"

--- a/teensy/mpconfigport.h
+++ b/teensy/mpconfigport.h
@@ -66,7 +66,6 @@ typedef void *machine_ptr_t; // must be of pointer size
 typedef const void *machine_const_ptr_t; // must be of pointer size
 typedef long mp_off_t;
 
-void mp_hal_stdout_tx_strn_cooked(const char *str, uint32_t len);
 #define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)
 
 // We have inlined IRQ functions for efficiency (they are generally
@@ -149,5 +148,5 @@ __attribute__(( always_inline )) static inline mp_uint_t disable_irq(void) {
 
 #define MICROPY_MATH_SQRT_ASM     (1)
 
-#define MICROPY_HAL_H           "teensy_hal.h"
+#define MICROPY_MPHALPORT_H     "teensy_hal.h"
 #define MICROPY_PIN_DEFS_PORT_H "pin_defs_teensy.h"

--- a/teensy/pin_defs_teensy.c
+++ b/teensy/pin_defs_teensy.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include <mk20dx128.h>
 #include "py/runtime.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 #include "pin.h"
 
 // Returns the pin mode. This value returned by this macro should be one of:

--- a/teensy/teensy_hal.c
+++ b/teensy/teensy_hal.c
@@ -2,16 +2,16 @@
 #include <string.h>
 
 #include "py/mpstate.h"
+#include "py/mphal.h"
 #include "usb.h"
 #include "uart.h"
 #include "Arduino.h"
-#include MICROPY_HAL_H
 
-uint32_t mp_hal_ticks_ms(void) {
+mp_uint_t mp_hal_ticks_ms(void) {
   return millis();
 }
 
-void mp_hal_delay_ms(uint32_t ms) {
+void mp_hal_delay_ms(mp_uint_t ms) {
   delay(ms);
 }
 
@@ -37,7 +37,7 @@ void mp_hal_stdout_tx_str(const char *str) {
     mp_hal_stdout_tx_strn(str, strlen(str));
 }
 
-void mp_hal_stdout_tx_strn(const char *str, uint32_t len) {
+void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
         uart_tx_strn(MP_STATE_PORT(pyb_stdio_uart), str, len);
     }
@@ -46,7 +46,7 @@ void mp_hal_stdout_tx_strn(const char *str, uint32_t len) {
     }
 }
 
-void mp_hal_stdout_tx_strn_cooked(const char *str, uint32_t len) {
+void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
     // send stdout to UART and USB CDC VCP
     if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
         uart_tx_strn_cooked(MP_STATE_PORT(pyb_stdio_uart), str, len);

--- a/teensy/teensy_hal.h
+++ b/teensy/teensy_hal.h
@@ -112,16 +112,9 @@ __attribute__(( always_inline )) static inline void __WFI(void) {
   __asm volatile ("wfi");
 }
 
-uint32_t mp_hal_ticks_ms(void);
-void mp_hal_delay_ms(uint32_t delay);
 void mp_hal_set_interrupt_char(int c);
 
 void mp_hal_gpio_clock_enable(GPIO_TypeDef *gpio);
-
-int mp_hal_stdin_rx_chr(void);
-void mp_hal_stdout_tx_str(const char *str);
-void mp_hal_stdout_tx_strn(const char *str, uint32_t len);
-void mp_hal_stdout_tx_strn_cooked(const char *str, uint32_t len);
 
 void HAL_GPIO_Init(GPIO_TypeDef *GPIOx, GPIO_InitTypeDef *init);
 

--- a/teensy/timer.c
+++ b/teensy/timer.c
@@ -32,7 +32,7 @@
 #include "py/nlr.h"
 #include "py/runtime.h"
 #include "py/gc.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 #include "pin.h"
 #include "reg.h"
 #include "timer.h"

--- a/teensy/uart.c
+++ b/teensy/uart.c
@@ -29,7 +29,6 @@
 
 #include "py/nlr.h"
 #include "py/runtime.h"
-#include MICROPY_HAL_H
 #include "bufhelper.h"
 #include "uart.h"
 

--- a/unix/input.c
+++ b/unix/input.c
@@ -29,10 +29,10 @@
 #include <string.h>
 
 #include "py/mpstate.h"
+#include "py/mphal.h"
 #include "input.h"
 
 #if MICROPY_USE_READLINE == 1
-#include MICROPY_HAL_H
 #include "lib/mp-readline/readline.h"
 #elif MICROPY_USE_READLINE == 2
 #include <readline/readline.h>

--- a/unix/main.c
+++ b/unix/main.c
@@ -44,8 +44,8 @@
 #include "py/repl.h"
 #include "py/gc.h"
 #include "py/stackctrl.h"
+#include "py/mphal.h"
 #include "genhdr/mpversion.h"
-#include MICROPY_HAL_H
 #include "input.h"
 
 // Command line options, with their defaults

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -223,7 +223,7 @@ extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
     mp_obj_t keyboard_interrupt_obj; \
     void *mmap_region_head; \
 
-#define MICROPY_HAL_H "unix_mphal.h"
+#define MICROPY_MPHALPORT_H "unix_mphal.h"
 
 // We need to provide a declaration/definition of alloca()
 #ifdef __FreeBSD__

--- a/unix/unix_mphal.c
+++ b/unix/unix_mphal.c
@@ -30,7 +30,7 @@
 #include <sys/time.h>
 
 #include "py/mpstate.h"
-#include MICROPY_HAL_H
+#include "py/mphal.h"
 
 #ifndef _WIN32
 #include <signal.h>
@@ -119,7 +119,7 @@ void mp_hal_stdout_tx_str(const char *str) {
     mp_hal_stdout_tx_strn(str, strlen(str));
 }
 
-uint32_t mp_hal_ticks_ms(void) {
+mp_uint_t mp_hal_ticks_ms(void) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return tv.tv_sec * 1000 + tv.tv_usec / 1000;

--- a/unix/unix_mphal.h
+++ b/unix/unix_mphal.h
@@ -33,10 +33,4 @@ void mp_hal_set_interrupt_char(char c);
 void mp_hal_stdio_mode_raw(void);
 void mp_hal_stdio_mode_orig(void);
 
-int mp_hal_stdin_rx_chr(void);
-void mp_hal_stdout_tx_str(const char *str);
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len);
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
-
-#define mp_hal_delay_ms(ms) usleep((ms) * 1000)
-uint32_t mp_hal_ticks_ms(void);
+static inline void mp_hal_delay_ms(mp_uint_t ms) { usleep((ms) * 1000); }

--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -155,7 +155,7 @@ extern const struct _mp_obj_module_t mp_module_time;
 
 #define MP_STATE_PORT               MP_STATE_VM
 
-#define MICROPY_HAL_H               "windows_mphal.h"
+#define MICROPY_MPHALPORT_H         "windows_mphal.h"
 
 // We need to provide a declaration/definition of alloca()
 #include <malloc.h>

--- a/windows/windows_mphal.c
+++ b/windows/windows_mphal.c
@@ -26,8 +26,8 @@
 
 
 #include "py/mpstate.h"
+#include "py/mphal.h"
 
-#include MICROPY_HAL_H
 #include <windows.h>
 #include <unistd.h>
 
@@ -170,11 +170,11 @@ int mp_hal_stdin_rx_chr(void) {
     }
 }
 
-void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     write(1, str, len);
 }
 
-void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len) {
+void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
     mp_hal_stdout_tx_strn(str, len);
 }
 

--- a/windows/windows_mphal.h
+++ b/windows/windows_mphal.h
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "sleep.h"
 #include "unix/unix_mphal.h"
 
 #define MICROPY_HAL_HAS_VT100 (0)


### PR DESCRIPTION
py/mphal.h contains declarations for generic mp_hal_XXX functions, such
as stdio and delay/ticks, which ports should provide definitions for.  A
port will also provide mphalport.h with further HAL declarations.

A lot of boring changes here.  Should be no change in functionality.

A few issues/remarks:
- What is the correct integer type for delay_ms and ticks_ms?  I chose word size mp_uint_t.
- The ports like to provide their own stuff in mphalport.h, such as GPIO definitions.  To then use these port-specific definitions you need to #include "py/mphal.h", which seems a bit strange (stuff from py/mphal.h should be port agnostic), and means that py/ core is now "contaminated" with port specific things like GPIO.
- Instead of #defining things like delas_ms to HAL_Delay, I just used inline functions.
