### PR TITLE
Interrupt defines

### DIFF
--- a/stmhal/can.c
+++ b/stmhal/can.c
@@ -37,6 +37,7 @@
 #include "bufhelper.h"
 #include "can.h"
 #include "pybioctl.h"
+#include "irq.h"
 
 #if MICROPY_HW_ENABLE_CAN
 
@@ -747,7 +748,7 @@ STATIC mp_obj_t pyb_can_rxcallback(mp_obj_t self_in, mp_obj_t fifo_in, mp_obj_t 
         } else {
             irq = (fifo == 0) ? CAN2_RX0_IRQn : CAN2_RX1_IRQn;
         }
-        HAL_NVIC_SetPriority(irq, 7, 0);
+        HAL_NVIC_SetPriority(irq, IRQ_PRI_CAN, IRQ_SUBPRI_CAN);
         HAL_NVIC_EnableIRQ(irq);
         __HAL_CAN_ENABLE_IT(&self->can, (fifo == 0) ? CAN_IT_FMP0 : CAN_IT_FMP1);
         __HAL_CAN_ENABLE_IT(&self->can, (fifo == 0) ? CAN_IT_FF0  : CAN_IT_FF1);

--- a/stmhal/dma.c
+++ b/stmhal/dma.c
@@ -30,6 +30,8 @@
 #include STM32_HAL_H
 
 #include "dma.h"
+#include "py/obj.h"
+#include "irq.h"
 
 #define NSTREAM (16)
 
@@ -134,7 +136,7 @@ void dma_init(DMA_HandleTypeDef *dma, DMA_Stream_TypeDef *dma_stream, const DMA_
     // reset and configure DMA peripheral
     HAL_DMA_DeInit(dma);
     HAL_DMA_Init(dma);
-    HAL_NVIC_SetPriority(dma_irqn[dma_id], 6, 0);
+    HAL_NVIC_SetPriority(dma_irqn[dma_id], IRQ_PRI_DMA, IRQ_SUBPRI_DMA);
 
 same_channel:
     HAL_NVIC_EnableIRQ(dma_irqn[dma_id]);

--- a/stmhal/extint.c
+++ b/stmhal/extint.c
@@ -34,6 +34,7 @@
 #include "py/mphal.h"
 #include "pin.h"
 #include "extint.h"
+#include "irq.h"
 
 /// \moduleref pyb
 /// \class ExtInt - configure I/O pins to interrupt on external events
@@ -178,7 +179,7 @@ uint extint_register(mp_obj_t pin_obj, uint32_t mode, uint32_t pull, mp_obj_t ca
         // Calling HAL_GPIO_Init does an implicit extint_enable
 
         /* Enable and set NVIC Interrupt to the lowest priority */
-        HAL_NVIC_SetPriority(nvic_irq_channel[v_line], 0x0F, 0x0F);
+        HAL_NVIC_SetPriority(nvic_irq_channel[v_line], IRQ_PRI_EXTINT, IRQ_SUBPRI_EXTINT);
         HAL_NVIC_EnableIRQ(nvic_irq_channel[v_line]);
     }
     return v_line;

--- a/stmhal/irq.h
+++ b/stmhal/irq.h
@@ -37,3 +37,48 @@ static inline mp_uint_t query_irq(void) {
 MP_DECLARE_CONST_FUN_OBJ(pyb_wfi_obj);
 MP_DECLARE_CONST_FUN_OBJ(pyb_disable_irq_obj);
 MP_DECLARE_CONST_FUN_OBJ(pyb_enable_irq_obj);
+
+// IRQ priority definitions.
+// Lower number implies higher interrupt priority.
+
+#define IRQ_PRI_CAN 0x7
+#define IRQ_SUBPRI_CAN 0x0
+
+#define IRQ_PRI_DMA 0x6
+#define IRQ_SUBPRI_DMA 0x0
+
+#define IRQ_PRI_EXTINT 0xf
+#define IRQ_SUBPRI_EXTINT 0xf
+
+// Flash IRQ must be higher priority than interrupts of all those components
+// that rely on the flash storage.
+#define IRQ_PRI_FLASH 0x1
+#define IRQ_SUBPRI_FLASH 0x1
+
+#define IRQ_PRI_OTG_FS 0x6
+#define IRQ_SUBPRI_OTG_FS 0x0
+
+#define IRQ_PRI_OTG_HS 0x6
+#define IRQ_SUBPRI_OTG_HS 0x0
+
+// PENDSV should be at the lowst priority so that other interrupts complete
+// before exception is raised.
+#define IRQ_PRI_PENDSV 0xf
+#define IRQ_SUBPRI_PENDSV 0xf
+
+#define IRQ_PRI_RTC_WKUP 0xf
+#define IRQ_SUBPRI_RTC_WKUP 0xf
+
+#define IRQ_PRI_TIM3 0x6
+#define IRQ_SUBPRI_TIM3 0x0
+
+#define IRQ_PRI_TIM5 0x6
+#define IRQ_SUBPRI_TIM5 0x0
+
+// Interrupt priority for non-special timers.
+#define IRQ_PRI_TIMX 0xe
+#define IRQ_SUBPRI_TIMX 0xe
+
+#define IRQ_PRI_UART 0xd
+#define IRQ_SUBPRI_UART 0xd
+

--- a/stmhal/pendsv.c
+++ b/stmhal/pendsv.c
@@ -30,6 +30,7 @@
 #include "py/mpstate.h"
 #include "py/runtime.h"
 #include "pendsv.h"
+#include "irq.h"
 
 // This variable is used to save the exception object between a ctrl-C and the
 // PENDSV call that actually raises the exception.  It must be non-static
@@ -40,7 +41,7 @@ void *pendsv_object;
 
 void pendsv_init(void) {
     // set PendSV interrupt at lowest priority
-    HAL_NVIC_SetPriority(PendSV_IRQn, 0xf, 0xf);
+    HAL_NVIC_SetPriority(PendSV_IRQn, IRQ_PRI_PENDSV, IRQ_SUBPRI_PENDSV);
 }
 
 // Call this function to raise a pending exception during an interrupt.

--- a/stmhal/rtc.c
+++ b/stmhal/rtc.c
@@ -30,6 +30,7 @@
 
 #include "py/runtime.h"
 #include "rtc.h"
+#include "irq.h"
 
 /// \moduleref pyb
 /// \class RTC - real time clock
@@ -496,7 +497,7 @@ mp_obj_t pyb_rtc_wakeup(mp_uint_t n_args, const mp_obj_t *args) {
         RTC->ISR &= ~(1 << 10);
         EXTI->PR = 1 << 22;
 
-        HAL_NVIC_SetPriority(RTC_WKUP_IRQn, 0x0f, 0x0f);
+        HAL_NVIC_SetPriority(RTC_WKUP_IRQn, IRQ_PRI_RTC_WKUP, IRQ_SUBPRI_RTC_WKUP);
         HAL_NVIC_EnableIRQ(RTC_WKUP_IRQn);
 
         //printf("wut=%d wucksel=%d\n", wut, wucksel);

--- a/stmhal/storage.c
+++ b/stmhal/storage.c
@@ -33,6 +33,7 @@
 #include "led.h"
 #include "flash.h"
 #include "storage.h"
+#include "irq.h"
 
 #if defined(STM32F405xx) || defined(STM32F407xx)
 
@@ -138,7 +139,7 @@ void storage_init(void) {
     // Enable the flash IRQ, which is used to also call our storage IRQ handler
     // It needs to go at a higher priority than all those components that rely on
     // the flash storage (eg higher than USB MSC).
-    HAL_NVIC_SetPriority(FLASH_IRQn, 1, 1);
+    HAL_NVIC_SetPriority(FLASH_IRQn, IRQ_PRI_FLASH, IRQ_SUBPRI_FLASH);
     HAL_NVIC_EnableIRQ(FLASH_IRQn);
 }
 

--- a/stmhal/timer.c
+++ b/stmhal/timer.c
@@ -38,6 +38,7 @@
 #include "timer.h"
 #include "servo.h"
 #include "pin.h"
+#include "irq.h"
 
 /// \moduleref pyb
 /// \class Timer - periodically call a function
@@ -186,7 +187,7 @@ void timer_tim3_init(void) {
     TIM3_Handle.Init.CounterMode = TIM_COUNTERMODE_UP;
     HAL_TIM_Base_Init(&TIM3_Handle);
 
-    HAL_NVIC_SetPriority(TIM3_IRQn, 6, 0);
+    HAL_NVIC_SetPriority(TIM3_IRQn, IRQ_PRI_TIM3, IRQ_SUBPRI_TIM3);
     HAL_NVIC_EnableIRQ(TIM3_IRQn);
 
     if (HAL_TIM_Base_Start(&TIM3_Handle) != HAL_OK) {
@@ -209,7 +210,7 @@ void timer_tim5_init(void) {
     __TIM5_CLK_ENABLE();
 
     // set up and enable interrupt
-    HAL_NVIC_SetPriority(TIM5_IRQn, 6, 0);
+    HAL_NVIC_SetPriority(TIM5_IRQn, IRQ_PRI_TIM5, IRQ_SUBPRI_TIM5);
     HAL_NVIC_EnableIRQ(TIM5_IRQn);
 
     // PWM clock configuration
@@ -623,7 +624,7 @@ STATIC mp_obj_t pyb_timer_init_helper(pyb_timer_obj_t *self, mp_uint_t n_args, c
 
     // set IRQ priority (if not a special timer)
     if (self->tim_id != 3 && self->tim_id != 5) {
-        HAL_NVIC_SetPriority(self->irqn, 0xe, 0xe); // next-to lowest priority
+        HAL_NVIC_SetPriority(self->irqn, IRQ_PRI_TIMX, IRQ_SUBPRI_TIMX);
     }
 
     // init TIM

--- a/stmhal/uart.c
+++ b/stmhal/uart.c
@@ -35,6 +35,7 @@
 #include "py/mphal.h"
 #include "uart.h"
 #include "pybioctl.h"
+#include "irq.h"
 
 //TODO: Add UART7/8 support for MCU_SERIES_F7
 
@@ -503,7 +504,7 @@ STATIC mp_obj_t pyb_uart_init_helper(pyb_uart_obj_t *self, mp_uint_t n_args, con
         self->read_buf_len = args[7].u_int;
         self->read_buf = m_new(byte, args[7].u_int << self->char_width);
         __HAL_UART_ENABLE_IT(&self->uart, UART_IT_RXNE);
-        HAL_NVIC_SetPriority(self->irqn, 0xd, 0xd); // next-to-next-to lowest priority
+        HAL_NVIC_SetPriority(self->irqn, IRQ_PRI_UART, IRQ_SUBPRI_UART); 
         HAL_NVIC_EnableIRQ(self->irqn);
     }
 

--- a/stmhal/usbd_conf.c
+++ b/stmhal/usbd_conf.c
@@ -32,6 +32,8 @@
 /* Includes ------------------------------------------------------------------*/
 #include STM32_HAL_H
 #include "usbd_core.h"
+#include "py/obj.h"
+#include "irq.h"
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
@@ -88,7 +90,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
     __USB_OTG_FS_CLK_ENABLE();
     
     /* Set USBFS Interrupt priority */
-    HAL_NVIC_SetPriority(OTG_FS_IRQn, 6, 0);
+    HAL_NVIC_SetPriority(OTG_FS_IRQn, IRQ_PRI_OTG_FS, IRQ_SUBPRI_OTG_FS);
     
     /* Enable USBFS Interrupt */
     HAL_NVIC_EnableIRQ(OTG_FS_IRQn);
@@ -154,7 +156,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
     __USB_OTG_HS_ULPI_CLK_ENABLE();
     
     /* Set USBHS Interrupt to the lowest priority */
-    HAL_NVIC_SetPriority(OTG_HS_IRQn, 6, 0);
+    HAL_NVIC_SetPriority(OTG_HS_IRQn, IRQ_PRI_OTG_HS, IRQ_SUBPRI_OTG_HS);
     
     /* Enable USBHS Interrupt */
     HAL_NVIC_EnableIRQ(OTG_HS_IRQn);


### PR DESCRIPTION
As noted in issue #1555 , for the stmhal currently the interrupt priorities are hard-coded and spread across several source files. This patch is purely a code clean-up text substitution, creating #defines for interrupt levels in the new file stm_hal/interrupt_priorities.h.

It might be debatable whether or not a small hand full of defines need their own file. mphalport.h might be a reasonable place for them, reducing file clutter in the main development directory. Some also might object to the length of the file name.  
