### PR TITLE
windows: Update build instructions in the README

### DIFF
--- a/windows/README
+++ b/windows/README
@@ -9,8 +9,8 @@ To cross-compile under Debian/Ubuntu Linux system:
 sudo apt-get install gcc-mingw-w64
 make CROSS_COMPILE=i686-w64-mingw32-
 
-If for some reason mingw64 crosscompiler is not available, you can try
-mingw32 instead, but it come with really old gcc which may produce some
+If for some reason the mingw-w64 crosscompiler is not available, you can try
+mingw32 instead, but it comes with a really old gcc which may produce some
 spurious errors (you may need to disable -Werror):
 
 sudo apt-get install mingw32 mingw32-binutils mingw32-runtime
@@ -19,26 +19,29 @@ make CROSS_COMPILE=i586-mingw32msvc-
 
 To compile under Cygwin:
 
-Install following packages using cygwin's setup.exe: mingw-gcc-g++ make
-make CROSS_COMPILE=i686-pc-mingw32-
+Install following packages using cygwin's setup.exe:
+mingw64-i686-gcc-core, make
+Build using:
+
+make CROSS_COMPILE=i686-w64-mingw32-
 
 
-To compile using Visual Studio 2013:
+To compile using Visual Studio 2013 (or higher):
 
 Open micropython.vcxproj and build
 
 
-To compile using Visual Studio 2013 commandline:
+To compile using Visual Studio 2013 (or higher) commandline:
 
 msbuild micropython.vcxproj
 
 
 To run on Linux using Wine:
 
-Default build (MICROPY_USE_READLINE=1) uses extended Windows console
+The default build (MICROPY_USE_READLINE=1) uses extended Windows console
 functions and thus should be run using "wineconsole" tool. Depending
-on Wine build configuration, you may also want to select curses backend
-which has look&feel of a standard Unix console:
+on the Wine build configuration, you may also want to select the curses
+backend which has the look&feel of a standard Unix console:
 
     wineconsole --backend=curses ./micropython.exe
 


### PR DESCRIPTION
- use correct 'mingw-w64' package name
- small grammar fixes
- modify Cygwin build instructions to use that same compiler as well: the
  original mingw is stuck at gcc v4.7 and does not seem to be updated anymore
- make it clear thet uPy also builds using Visual Studio versions > 2013
