### PR TITLE
py/stream.[ch]: create new public functions mp_stream_read and mp_stream_op_supported

### DIFF
--- a/py/stream.c
+++ b/py/stream.c
@@ -47,14 +47,25 @@
 
 STATIC mp_obj_t stream_readall(mp_obj_t self_in);
 
+mp_obj_t mp_stream_op_supported(mp_obj_t self_in, mp_stream_op_t op) {
+    struct _mp_obj_base_t *o = (struct _mp_obj_base_t *)self_in;
+    if (o->type->stream_p == NULL) {
+        // CPython: io.UnsupportedOperation, OSError subclass
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "stream object required"));
+    } else if (op == MP_STREAM_OP_READ && o->type->stream_p->read == NULL) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "object with stream.read required"));
+    } else if (op == MP_STREAM_OP_WRITE && o->type->stream_p->write == NULL) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "object with stream.write required"));
+    } else if (op == MP_STREAM_OP_IOCTL && o->type->stream_p->ioctl == NULL) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "object with stream.ioctl required"));
+    }
+    return o;
+}
+        
 #define STREAM_CONTENT_TYPE(stream) (((stream)->is_text) ? &mp_type_str : &mp_type_bytes)
 
 STATIC mp_obj_t stream_read(mp_uint_t n_args, const mp_obj_t *args) {
-    struct _mp_obj_base_t *o = (struct _mp_obj_base_t *)args[0];
-    if (o->type->stream_p == NULL || o->type->stream_p->read == NULL) {
-        // CPython: io.UnsupportedOperation, OSError subclass
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Operation not supported"));
-    }
+    struct _mp_obj_base_t *o = mp_stream_op_supported(args[0], MP_STREAM_OP_READ);
 
     // What to do if sz < -1?  Python docs don't specify this case.
     // CPython does a readall, but here we silently let negatives through,
@@ -175,12 +186,7 @@ STATIC mp_obj_t stream_read(mp_uint_t n_args, const mp_obj_t *args) {
 }
 
 mp_obj_t mp_stream_write(mp_obj_t self_in, const void *buf, mp_uint_t len) {
-    struct _mp_obj_base_t *o = (struct _mp_obj_base_t *)self_in;
-    if (o->type->stream_p == NULL || o->type->stream_p->write == NULL) {
-        // CPython: io.UnsupportedOperation, OSError subclass
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Operation not supported"));
-    }
-
+    struct _mp_obj_base_t *o = mp_stream_op_supported(self_in, MP_STREAM_OP_WRITE);
     int error;
     mp_uint_t out_sz = o->type->stream_p->write(self_in, buf, len, &error);
     if (out_sz == MP_STREAM_ERROR) {
@@ -205,11 +211,7 @@ STATIC mp_obj_t stream_write_method(mp_obj_t self_in, mp_obj_t arg) {
 }
 
 STATIC mp_obj_t stream_readinto(mp_uint_t n_args, const mp_obj_t *args) {
-    struct _mp_obj_base_t *o = (struct _mp_obj_base_t *)args[0];
-    if (o->type->stream_p == NULL || o->type->stream_p->read == NULL) {
-        // CPython: io.UnsupportedOperation, OSError subclass
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Operation not supported"));
-    }
+    struct _mp_obj_base_t *o = mp_stream_op_supported(args[0], MP_STREAM_OP_READ);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_WRITE);
 
@@ -237,12 +239,7 @@ STATIC mp_obj_t stream_readinto(mp_uint_t n_args, const mp_obj_t *args) {
 }
 
 STATIC mp_obj_t stream_readall(mp_obj_t self_in) {
-    struct _mp_obj_base_t *o = (struct _mp_obj_base_t *)self_in;
-    if (o->type->stream_p == NULL || o->type->stream_p->read == NULL) {
-        // CPython: io.UnsupportedOperation, OSError subclass
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Operation not supported"));
-    }
-
+    struct _mp_obj_base_t *o = mp_stream_op_supported(self_in, MP_STREAM_OP_READ);
     mp_uint_t total_size = 0;
     vstr_t vstr;
     vstr_init(&vstr, DEFAULT_BUFFER_SIZE);
@@ -286,12 +283,7 @@ STATIC mp_obj_t stream_readall(mp_obj_t self_in) {
 
 // Unbuffered, inefficient implementation of readline() for raw I/O files.
 STATIC mp_obj_t stream_unbuffered_readline(mp_uint_t n_args, const mp_obj_t *args) {
-    struct _mp_obj_base_t *o = (struct _mp_obj_base_t *)args[0];
-    if (o->type->stream_p == NULL || o->type->stream_p->read == NULL) {
-        // CPython: io.UnsupportedOperation, OSError subclass
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Operation not supported"));
-    }
-
+    struct _mp_obj_base_t *o = mp_stream_op_supported(args[0], MP_STREAM_OP_READ);
     mp_int_t max_size = -1;
     if (n_args > 1) {
         max_size = MP_OBJ_SMALL_INT_VALUE(args[1]);
@@ -368,12 +360,7 @@ mp_obj_t mp_stream_unbuffered_iter(mp_obj_t self) {
 }
 
 STATIC mp_obj_t stream_seek(mp_uint_t n_args, const mp_obj_t *args) {
-    struct _mp_obj_base_t *o = (struct _mp_obj_base_t *)args[0];
-    if (o->type->stream_p == NULL || o->type->stream_p->ioctl == NULL) {
-        // CPython: io.UnsupportedOperation, OSError subclass
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Operation not supported"));
-    }
-
+    struct _mp_obj_base_t *o = mp_stream_op_supported(args[0], MP_STREAM_OP_IOCTL);
     struct mp_stream_seek_t seek_s;
     // TODO: Could be uint64
     seek_s.offset = mp_obj_get_int(args[1]);

--- a/py/stream.h
+++ b/py/stream.h
@@ -40,6 +40,14 @@ MP_DECLARE_CONST_FUN_OBJ(mp_stream_tell_obj);
 // Iterator which uses mp_stream_unbuffered_readline_obj
 mp_obj_t mp_stream_unbuffered_iter(mp_obj_t self);
 
+typedef enum {
+    STREAM_READ,
+    STREAM_WRITE,
+    STREAM_IOCTL,
+} supported_stream_op_t;
+
+mp_obj_t mp_stream_op_supported(mp_obj_t self_in, supported_stream_op_t op);
+
 mp_obj_t mp_stream_write(mp_obj_t self_in, const void *buf, mp_uint_t len);
 
 #if MICROPY_STREAMS_NON_BLOCK

--- a/py/stream.h
+++ b/py/stream.h
@@ -49,6 +49,7 @@ typedef enum {
 mp_obj_t mp_stream_op_supported(mp_obj_t self_in, supported_stream_op_t op);
 
 mp_obj_t mp_stream_write(mp_obj_t self_in, const void *buf, mp_uint_t len);
+mp_obj_t mp_stream_read(mp_obj_t self_in, void *buf, mp_uint_t len);
 
 #if MICROPY_STREAMS_NON_BLOCK
 // TODO: This is POSIX-specific (but then POSIX is the only real thing,

--- a/py/stream.h
+++ b/py/stream.h
@@ -40,6 +40,14 @@ MP_DECLARE_CONST_FUN_OBJ(mp_stream_tell_obj);
 // Iterator which uses mp_stream_unbuffered_readline_obj
 mp_obj_t mp_stream_unbuffered_iter(mp_obj_t self);
 
+typedef enum {
+    MP_STREAM_OP_READ,
+    MP_STREAM_OP_WRITE,
+    MP_STREAM_OP_IOCTL,
+} mp_stream_op_t;
+
+mp_obj_t mp_stream_op_supported(mp_obj_t self_in, mp_stream_op_t op);
+
 mp_obj_t mp_stream_write(mp_obj_t self_in, const void *buf, mp_uint_t len);
 
 #if MICROPY_STREAMS_NON_BLOCK


### PR DESCRIPTION
This PR comes from this discussion of the forum: http://forum.micropython.org/viewtopic.php?f=3&t=1100

I found myself having to cut-and-paste some blocks of code from py/stream.c in my I2S dev branch; realizing that there was duplication even within stream.c I decided to attempt a refactor.
I am less certain about the second commit; most of the stream_read functions use vstr's internally but I didn't try to generalize these operations into mp_stream_read, so it only gets used once in stream.c
