### PR TITLE
lib/mp-readline: Make it easy to exit auto-indent mode by pressing enter

### DIFF
--- a/docs/reference/repl.rst
+++ b/docs/reference/repl.rst
@@ -49,6 +49,10 @@ Finally type ``print(i)``, press RETURN, press BACKSPACE and press RETURN again:
     3
     >>>
 
+Auto-indent won't be applied if the previous two lines were all spaces.  This
+means that you can finish entering a compound statment by pressing RETURN
+twice, and then a third press will finish and execute.
+
 Auto-completion
 ---------------
 

--- a/lib/mp-readline/readline.c
+++ b/lib/mp-readline/readline.c
@@ -370,6 +370,18 @@ STATIC void readline_auto_indent(void) {
             }
         }
         // i=start of line; j=first non-space
+        if (i > 0 && j + 1 == line->len) {
+            // previous line is not first line and is all spaces
+            for (size_t k = i - 1; k > 0; --k) {
+                if (line->buf[k - 1] == '\n') {
+                    // don't auto-indent if last 2 lines are all spaces
+                    return;
+                } else if (line->buf[k - 1] != ' ') {
+                    // 2nd previous line is not all spaces
+                    break;
+                }
+            }
+        }
         int n = (j - i) / 4;
         if (line->buf[line->len - 2] == ':') {
             n += 1;


### PR DESCRIPTION
Last night at the Cambridge Python Users Group we had about 40 people playing with uPy on the microbit, getting to know the device and writing some cool programs.

One of the notable things was that people got stuck in auto-indent mode.  They'd keep hitting "enter" and just kept getting an indented line.

This patch allows you to exit auto-indent mode by pressing enter on a blank line.  Easier than having to use backspace, and prevents new users from getting stuck in auto-indent mode.
