### PR TITLE
py: Clear finalizer flag when calling gc_free.

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -454,6 +454,9 @@ void gc_free(void *ptr_in) {
     if (VERIFY_PTR(ptr)) {
         mp_uint_t block = BLOCK_FROM_PTR(ptr);
         if (ATB_GET_KIND(block) == AT_HEAD) {
+            #if MICROPY_ENABLE_FINALISER
+            FTB_CLEAR(block);
+            #endif
             // set the last_free pointer to this block if it's earlier in the heap
             if (block / BLOCKS_PER_ATB < MP_STATE_MEM(gc_last_free_atb_index)) {
                 MP_STATE_MEM(gc_last_free_atb_index) = block / BLOCKS_PER_ATB;


### PR DESCRIPTION
Currently, the only place that clears the bit is in gc_collect.
So if a block with a finalizer is allocated, and subsequently
freed, and then the block is reallocated with no finalizer then
the bit remains set.

This could also be fixed by having gc_alloc clear the bit, but
I'm pretty sure that free is called way less than alloc, so doing
it in free is more efficient.
