### PR TITLE
stmhal: DMA support for sdcard

### DIFF
--- a/stmhal/dma.c
+++ b/stmhal/dma.c
@@ -103,7 +103,9 @@ void dma_init(DMA_HandleTypeDef *dma, DMA_Stream_TypeDef *dma_stream, const DMA_
     int dma_id = get_dma_id(dma_stream);
     //printf("dma_init(%p, %p(%d), 0x%x, 0x%x, %p)\n", dma, dma_stream, dma_id, (uint)dma_channel, (uint)direction, data);
 
-    // TODO possibly don't need to clear the entire structure
+    // Some drivers allocate the DMA_HandleTypeDef from the stack
+    // (i.e. dac, i2c, spi) and for those cases we need to clear the
+    // structure so we don't get random values from the stack)
     memset(dma, 0, sizeof(*dma));
 
     // set global pointer for IRQ handler

--- a/stmhal/dma.h
+++ b/stmhal/dma.h
@@ -24,6 +24,13 @@
  * THE SOFTWARE.
  */
 
+//TODO: Put stream/channel defs for i2c/spi/can, etc here
+#define DMA_STREAM_SDIO_RX      DMA2_Stream3
+#define DMA_CHANNEL_SDIO_RX     DMA_CHANNEL_4
+
+#define DMA_STREAM_SDIO_TX      DMA2_Stream6
+#define DMA_CHANNEL_SDIO_TX     DMA_CHANNEL_4
+
 extern const DMA_InitTypeDef dma_init_struct_spi_i2c;
 
 void dma_init(DMA_HandleTypeDef *dma, DMA_Stream_TypeDef *dma_stream, const DMA_InitTypeDef *dma_init, uint32_t dma_channel, uint32_t direction, void *data);

--- a/stmhal/irq.h
+++ b/stmhal/irq.h
@@ -82,3 +82,5 @@ MP_DECLARE_CONST_FUN_OBJ(pyb_enable_irq_obj);
 #define IRQ_PRI_UART 0xd
 #define IRQ_SUBPRI_UART 0xd
 
+#define IRQ_PRI_SDIO    5
+#define IRQ_SUBPRI_SDIO 0


### PR DESCRIPTION
This takes the work done by IgorLektorovEpam in PR #1389
and fixes up a few small mistakes and does some cleanup
based on the comments.

I tested with rshell over serial and I can now copy files to the sdcard (previously serial characters were being dropped due to interrupts being disabled while doing sdcard transfers).
