### PR TITLE
docs: Fix a typo in the REPL documentation.

### DIFF
--- a/docs/reference/repl.rst
+++ b/docs/reference/repl.rst
@@ -3,7 +3,7 @@ The MicroPython Interactive Interpreter Mode (aka REPL)
 
 This section covers some characteristics of the MicroPython Interactive
 Interpreter Mode. A commonly used term for this is REPL (read-eval-print-loop)
-which will used to refer to this interactive prompt.
+which will be used to refer to this interactive prompt.
 
 Auto-indent
 -----------


### PR DESCRIPTION
Pointed out here: http://forum.micropython.org/viewtopic.php?f=2&t=1088&p=6731#p6731
