### PR TITLE
stmhal/modmachine: Try to add I2C & SPI classes.

### DIFF
--- a/stmhal/i2c.c
+++ b/stmhal/i2c.c
@@ -349,7 +349,7 @@ STATIC void pyb_i2c_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
 ///   - `gencall` is whether to support general call mode
 STATIC mp_obj_t pyb_i2c_init_helper(const pyb_i2c_obj_t *self, mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_mode,     MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_mode,     MP_ARG_INT, {.u_int = PYB_I2C_MASTER} },
         { MP_QSTR_addr,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0x12} },
         { MP_QSTR_baudrate, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = MICROPY_HW_I2C_BAUDRATE_DEFAULT} },
         { MP_QSTR_gencall,  MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },

--- a/stmhal/modmachine.c
+++ b/stmhal/modmachine.c
@@ -39,6 +39,8 @@
 #include "pin.h"
 #include "timer.h"
 #include "usb.h"
+#include "i2c.h"
+#include "spi.h"
 
 // machine.info([dump_alloc_table])
 // Print out lots of information about the board.
@@ -417,8 +419,12 @@ STATIC const mp_map_elem_t machine_module_globals_table[] = {
 #if 0
     { MP_OBJ_NEW_QSTR(MP_QSTR_RTC),                 (mp_obj_t)&pyb_rtc_type },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ADC),                 (mp_obj_t)&pyb_adc_type },
+#endif
+    // TODO: Per new API, both types below, if called with 1 arg (ID), should still
+    // initialize master mode on the peripheral.
     { MP_OBJ_NEW_QSTR(MP_QSTR_I2C),                 (mp_obj_t)&pyb_i2c_type },
     { MP_OBJ_NEW_QSTR(MP_QSTR_SPI),                 (mp_obj_t)&pyb_spi_type },
+#if 0
     { MP_OBJ_NEW_QSTR(MP_QSTR_UART),                (mp_obj_t)&pyb_uart_type },
     { MP_OBJ_NEW_QSTR(MP_QSTR_Timer),               (mp_obj_t)&pyb_timer_type },
     { MP_OBJ_NEW_QSTR(MP_QSTR_WDT),                 (mp_obj_t)&pyb_wdt_type },


### PR DESCRIPTION
In new hardware API, these classes implement master modes of interfaces,
and "mode" parameter is not accepted. Trying to implement new HW API
in terms of older pyb module leaves variuos corner cases:

In new HW API, I2C(1) means "I2C #1 in master mode" (? depends on
interpretation), while in old API, it means "I2C #1, with no settings
changes".

For I2C class, it's easy to make mode optional, because that's last
positional param, but for SPI, there's "baudrate" after it (which
is inconsistent with I2C, which requires "baudrate" to be kwonly-arg).
