### PR TITLE
Upy cross compiler

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -36,6 +36,8 @@
 #include "py/builtin.h"
 #include "py/frozenmod.h"
 
+#if MICROPY_ENABLE_RUNTIME
+
 #if 0 // print debugging info
 #define DEBUG_PRINT (1)
 #define DEBUG_printf DEBUG_printf
@@ -465,3 +467,5 @@ mp_obj_t mp_builtin___import__(mp_uint_t n_args, const mp_obj_t *args) {
     return top_module_obj;
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin___import___obj, 1, 5, mp_builtin___import__);
+
+#endif

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -549,6 +549,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(mp_builtin_globals_obj, mp_globals_get);
 MP_DEFINE_CONST_FUN_OBJ_0(mp_builtin_locals_obj, mp_locals_get);
 
 STATIC const mp_rom_map_elem_t mp_module_builtins_globals_table[] = {
+#if MICROPY_ENABLE_RUNTIME
     // built-in core functions
     { MP_ROM_QSTR(MP_QSTR___build_class__), MP_ROM_PTR(&mp_builtin___build_class___obj) },
     { MP_ROM_QSTR(MP_QSTR___import__), MP_ROM_PTR(&mp_builtin___import___obj) },
@@ -686,6 +687,7 @@ STATIC const mp_rom_map_elem_t mp_module_builtins_globals_table[] = {
 
     // Extra builtins as defined by a port
     MICROPY_PORT_BUILTINS
+#endif // MICROPY_ENABLE_RUNTIME
 };
 
 MP_DEFINE_CONST_DICT(mp_module_builtins_globals, mp_module_builtins_globals_table);

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -340,6 +340,11 @@
 /*****************************************************************************/
 /* Python internal features                                                  */
 
+// Whether to enable the runtime and VM
+#ifndef MICROPY_ENABLE_RUNTIME
+#define MICROPY_ENABLE_RUNTIME (1)
+#endif
+
 // Whether to include the garbage collector
 #ifndef MICROPY_ENABLE_GC
 #define MICROPY_ENABLE_GC (0)

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -197,6 +197,9 @@ mp_code_state *mp_obj_fun_bc_prepare_codestate(mp_obj_t self_in, mp_uint_t n_arg
 #endif
 
 STATIC mp_obj_t fun_bc_call(mp_obj_t self_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+#if !MICROPY_ENABLE_RUNTIME
+    mp_not_implemented("function execution");
+#else
     MP_STACK_CHECK();
 
     DEBUG_printf("Input n_args: " UINT_FMT ", n_kw: " UINT_FMT "\n", n_args, n_kw);
@@ -295,6 +298,7 @@ STATIC mp_obj_t fun_bc_call(mp_obj_t self_in, mp_uint_t n_args, mp_uint_t n_kw, 
     } else { // MP_VM_RETURN_EXCEPTION
         nlr_raise(result);
     }
+#endif
 }
 
 #if MICROPY_PY_FUNCTION_ATTRS

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -96,6 +96,9 @@ STATIC void gen_instance_print(const mp_print_t *print, mp_obj_t self_in, mp_pri
 }
 
 mp_vm_return_kind_t mp_obj_gen_resume(mp_obj_t self_in, mp_obj_t send_value, mp_obj_t throw_value, mp_obj_t *ret_val) {
+#if !MICROPY_ENABLE_RUNTIME
+    mp_not_implemented("function execution");
+#else
     assert(MP_OBJ_IS_TYPE(self_in, &mp_type_gen_instance));
     mp_obj_gen_instance_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->code_state.ip == 0) {
@@ -140,6 +143,7 @@ mp_vm_return_kind_t mp_obj_gen_resume(mp_obj_t self_in, mp_obj_t send_value, mp_
     }
 
     return ret_kind;
+#endif
 }
 
 STATIC mp_obj_t gen_resume_and_raise(mp_obj_t self_in, mp_obj_t send_value, mp_obj_t throw_value) {

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1222,6 +1222,8 @@ mp_obj_t mp_make_raise_obj(mp_obj_t o) {
     }
 }
 
+#if MICROPY_ENABLE_RUNTIME
+
 mp_obj_t mp_import_name(qstr name, mp_obj_t fromlist, mp_obj_t level) {
     DEBUG_printf("import name '%s' level=%d\n", qstr_str(name), MP_OBJ_SMALL_INT_VALUE(level));
 
@@ -1295,6 +1297,8 @@ void mp_import_all(mp_obj_t module) {
         }
     }
 }
+
+#endif // MICROPY_ENABLE_RUNTIME
 
 // this is implemented in this file so it can optimise access to locals/globals
 mp_obj_t mp_parse_compile_execute(mp_lexer_t *lex, mp_parse_input_kind_t parse_input_kind, mp_obj_dict_t *globals, mp_obj_dict_t *locals) {

--- a/py/vm.c
+++ b/py/vm.c
@@ -37,6 +37,8 @@
 #include "py/bc0.h"
 #include "py/bc.h"
 
+#if MICROPY_ENABLE_RUNTIME
+
 #if 0
 //#define TRACE(ip) printf("sp=" INT_FMT " ", sp - code_state->sp); mp_bytecode_print2(ip, 1);
 #define TRACE(ip) printf("sp=%d ", sp - code_state->sp); mp_bytecode_print2(ip, 1);
@@ -1386,3 +1388,5 @@ unwind_loop:
         }
     }
 }
+
+#endif // MICROPY_ENABLE_RUNTIME

--- a/stmhal/mpconfigport.h
+++ b/stmhal/mpconfigport.h
@@ -31,6 +31,7 @@
 // options to control how Micro Python is built
 
 #define MICROPY_ALLOC_PATH_MAX      (128)
+#define MICROPY_PERSISTENT_CODE_LOAD (1)
 #define MICROPY_EMIT_THUMB          (1)
 #define MICROPY_EMIT_INLINE_THUMB   (1)
 #define MICROPY_COMP_MODULE_CONST   (1)

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -168,6 +168,10 @@ fast:
 minimal:
 	$(MAKE) COPT="-Os -DNDEBUG" CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_minimal.h>"' BUILD=build-minimal PROG=micropython_minimal MICROPY_PY_TIME=0 MICROPY_PY_TERMIOS=0 MICROPY_PY_SOCKET=0 MICROPY_PY_FFI=0 MICROPY_USE_READLINE=0
 
+# build a cross compiler
+cross:
+	$(MAKE) COPT="-Os -DNDEBUG" CFLAGS_EXTRA='-fdata-sections -ffunction-sections -DMP_CONFIGFILE="<mpconfigport_cross.h>"' LDFLAGS_EXTRA='-Wl,--gc-sections' BUILD=build-cross PROG=micropython_cross MICROPY_PY_TIME=0 MICROPY_PY_TERMIOS=0 MICROPY_PY_SOCKET=0 MICROPY_PY_FFI=0 MICROPY_USE_READLINE=0
+
 # build an interpreter for coverage testing and do the testing
 coverage:
 	$(MAKE) COPT="-O0" CFLAGS_EXTRA='-fprofile-arcs -ftest-coverage -Wdouble-promotion -Wformat -Wmissing-declarations -Wmissing-prototypes -Wold-style-definition -Wpointer-arith -Wshadow -Wsign-compare -Wuninitialized -Wunused-parameter -DMICROPY_UNIX_COVERAGE' LDFLAGS_EXTRA='-fprofile-arcs -ftest-coverage' BUILD=build-coverage PROG=micropython_coverage

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -27,6 +27,7 @@
 // options to control how Micro Python is built
 
 #define MICROPY_ALLOC_PATH_MAX      (PATH_MAX)
+#define MICROPY_PERSISTENT_CODE_LOAD (1)
 #if !defined(MICROPY_EMIT_X64) && defined(__x86_64__)
     #define MICROPY_EMIT_X64        (1)
 #endif
@@ -61,7 +62,7 @@
 #define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_MPZ)
 #define MICROPY_STREAMS_NON_BLOCK   (1)
 #define MICROPY_OPT_COMPUTED_GOTO   (1)
-#define MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE (1)
+#define MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE (0)
 #define MICROPY_CAN_OVERRIDE_BUILTINS (1)
 #define MICROPY_PY_FUNCTION_ATTRS   (1)
 #define MICROPY_PY_DESCRIPTORS      (1)

--- a/unix/mpconfigport_cross.h
+++ b/unix/mpconfigport_cross.h
@@ -1,0 +1,126 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// options to control how Micro Python is built
+
+#define MICROPY_ALLOC_PATH_MAX      (PATH_MAX)
+#define MICROPY_PERSISTENT_CODE_LOAD (0)
+#define MICROPY_PERSISTENT_CODE_SAVE (1)
+
+#define MICROPY_EMIT_X64            (0)
+#define MICROPY_EMIT_X86            (0)
+#define MICROPY_EMIT_THUMB          (0)
+#define MICROPY_EMIT_INLINE_THUMB   (0)
+#define MICROPY_EMIT_INLINE_THUMB_ARMV7M (1)
+#define MICROPY_EMIT_INLINE_THUMB_FLOAT (1)
+#define MICROPY_EMIT_ARM            (0)
+
+#define MICROPY_COMP_CONST_FOLDING  (1)
+#define MICROPY_COMP_MODULE_CONST   (1)
+#define MICROPY_COMP_CONST          (1)
+#define MICROPY_COMP_DOUBLE_TUPLE_ASSIGN (1)
+#define MICROPY_COMP_TRIPLE_TUPLE_ASSIGN (1)
+
+#define MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE (0)
+
+#define MICROPY_ENABLE_RUNTIME      (0)
+#define MICROPY_ENABLE_GC           (1)
+#define MICROPY_STACK_CHECK         (1)
+#define MICROPY_HELPER_LEXER_UNIX   (1)
+#define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_MPZ)
+#define MICROPY_ENABLE_SOURCE_LINE  (1)
+#define MICROPY_ENABLE_DOC_STRING   (0)
+#define MICROPY_ERROR_REPORTING     (MICROPY_ERROR_REPORTING_DETAILED)
+#define MICROPY_WARNINGS            (1)
+
+#define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_DOUBLE)
+#define MICROPY_CPYTHON_COMPAT      (1)
+
+// Define to 1 to use undertested inefficient GC helper implementation
+// (if more efficient arch-specific one is not available).
+#ifndef MICROPY_GCREGS_SETJMP
+    #ifdef __mips__
+        #define MICROPY_GCREGS_SETJMP (1)
+    #else
+        #define MICROPY_GCREGS_SETJMP (0)
+    #endif
+#endif
+
+#define MICROPY_PY___FILE__         (0)
+#define MICROPY_PY_ARRAY            (0)
+#define MICROPY_PY_ATTRTUPLE        (0)
+#define MICROPY_PY_COLLECTIONS      (0)
+#define MICROPY_PY_MATH             (0)
+#define MICROPY_PY_CMATH            (0)
+#define MICROPY_PY_GC               (0)
+#define MICROPY_PY_IO               (0)
+#define MICROPY_PY_SYS              (0)
+
+// type definitions for the specific machine
+
+#ifdef __LP64__
+typedef long mp_int_t; // must be pointer size
+typedef unsigned long mp_uint_t; // must be pointer size
+#else
+// These are definitions for machines where sizeof(int) == sizeof(void*),
+// regardless for actual size.
+typedef int mp_int_t; // must be pointer size
+typedef unsigned int mp_uint_t; // must be pointer size
+#endif
+
+#define BYTES_PER_WORD sizeof(mp_int_t)
+
+// Cannot include <sys/types.h>, as it may lead to symbol name clashes
+#if _FILE_OFFSET_BITS == 64 && !defined(__LP64__)
+typedef long long mp_off_t;
+#else
+typedef long mp_off_t;
+#endif
+
+typedef void *machine_ptr_t; // must be of pointer size
+typedef const void *machine_const_ptr_t; // must be of pointer size
+
+#define MP_PLAT_PRINT_STRN(str, len) (void)0
+
+#ifdef __ANDROID__
+#include <android/api-level.h>
+#if __ANDROID_API__ < 4
+// Bionic libc in Android 1.5 misses these 2 functions
+// 1.442695040888963407354163704 is 1/_M_LN2
+#define log2(x) (log(x) * 1.442695040888963407354163704)
+#define nan(x) NAN
+#endif
+#endif
+
+// We need to provide a declaration/definition of alloca()
+#ifdef __FreeBSD__
+#include <stdlib.h>
+#else
+#include <alloca.h>
+#endif
+
+// for uintptr.h in py/obj.h (should fix another way)
+#include <stdint.h>

--- a/unix/mphalport.h
+++ b/unix/mphalport.h
@@ -25,6 +25,8 @@
  */
 #include <unistd.h>
 
+#if MICROPY_ENABLE_RUNTIME
+
 #ifndef CHAR_CTRL_C
 #define CHAR_CTRL_C (3)
 #endif
@@ -35,6 +37,8 @@ void mp_hal_stdio_mode_raw(void);
 void mp_hal_stdio_mode_orig(void);
 
 static inline void mp_hal_delay_ms(mp_uint_t ms) { usleep((ms) * 1000); }
+
+#endif
 
 #define RAISE_ERRNO(err_flag, error_val) \
     { if (err_flag == -1) \

--- a/unix/unix_mphal.c
+++ b/unix/unix_mphal.c
@@ -32,6 +32,8 @@
 #include "py/mpstate.h"
 #include "py/mphal.h"
 
+#if MICROPY_ENABLE_RUNTIME
+
 #ifndef _WIN32
 #include <signal.h>
 
@@ -105,6 +107,8 @@ int mp_hal_stdin_rx_chr(void) {
     return c;
 }
 
+#endif // MICROPY_ENABLE_RUNTIME
+
 void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     int ret = write(1, str, len);
     (void)ret; // to suppress compiler warning
@@ -119,8 +123,12 @@ void mp_hal_stdout_tx_str(const char *str) {
     mp_hal_stdout_tx_strn(str, strlen(str));
 }
 
+#if MICROPY_ENABLE_RUNTIME
+
 mp_uint_t mp_hal_ticks_ms(void) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return tv.tv_sec * 1000 + tv.tv_usec / 1000;
 }
+
+#endif // MICROPY_ENABLE_RUNTIME


### PR DESCRIPTION
The patches in this PR add support for building a uPy cross compiler, which compiles .py files into .mpy files, and targets a specific VM/runtime configuration.

At the moment it can be used to build .mpy files for stmhal:

```
$ cd unix
$ make MICROPY_FORCE_32BIT=1 cross
$ ./micropython_cross test.py
```

This will produce test.mpy.  You don't need to use the MICROPY_FORCE_32BIT=1 option, it just makes the binary smaller on 64-bit machines.

Then build stmhal and deploy the firmware, and copy test.mpy to the board (flash or sd card will work).  Then do `import test` and it should execute.

This PR brings a couple of things that need thinking/discussion:
- I added MICROPY_ENABLE_RUNTIME option which can be used to disable the VM (and parts of the runtime) when building "cross compilers".  It's nice to have a small binary for the cross compiler (which anyway doesn't need to execute the code), and would help if/when we make a standalone binary for the cross compiler for easy distribution.
- I hacked unix/main.c to remove all the unnecessary parts for the cross compiler, and added mpconfigport_cross.h, and a target "cross" in the Makefile.  I think it might be cleaner to have a new top-level directory with the cross compiler, instead of messing up the unix port.  We will want to make a few cross compilers with different build options, so will need to have an mpconfigport.h for each of those.

The bottom line is that this PR now completes the first step in persistent bytecode, namely the ability to create .mpy files and import them.
