### PR TITLE
py: Detect python version installed on build system.

### DIFF
--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -42,7 +42,15 @@ ECHO = @echo
 CP = cp
 MKDIR = mkdir
 SED = sed
+ifneq (,$(shell which python3))
+PYTHON = python3
+else
+ifneq (,$(shell which python))
 PYTHON = python
+else
+PYTHON = python2
+endif
+endif
 
 AS = $(CROSS_COMPILE)as
 CC = $(CROSS_COMPILE)gcc


### PR DESCRIPTION
This particular patch checks the following:

  python3, python, and falls back to python2

Based on discussion from #1616  and https://mail.python.org/pipermail/python-dev/2015-November/142157.html
