### PR TITLE
64bit mingw build support

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -849,10 +849,14 @@ typedef double mp_float_t;
 
 // printf format spec to use for mp_int_t and friends
 #ifndef INT_FMT
-#ifdef __LP64__
+#if defined(__LP64__)
 // Archs where mp_int_t == long, long != int
 #define UINT_FMT "%lu"
 #define INT_FMT "%ld"
+#elif defined(_WIN64)
+#include <inttypes.h>
+#define UINT_FMT "%"PRIu64
+#define INT_FMT "%"PRId64
 #else
 // Archs where mp_int_t == int
 #define UINT_FMT "%u"

--- a/py/mpz.h
+++ b/py/mpz.h
@@ -73,7 +73,11 @@ typedef int8_t mpz_dbl_dig_signed_t;
 #endif
 
 #ifdef _WIN64
-  #define MPZ_LONG_1 1i64
+  #ifdef __MINGW32__
+    #define MPZ_LONG_1 1LL
+  #else
+    #define MPZ_LONG_1 1i64
+  #endif
 #else
   #define MPZ_LONG_1 1L
 #endif

--- a/py/nlrx64.S
+++ b/py/nlrx64.S
@@ -41,10 +41,14 @@
 #define NLR_TOP (mp_state_ctx + NLR_TOP_OFFSET)
 #endif
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define NLR_OS_WINDOWS
+#endif
+
     .file   "nlr.s"
     .text
 
-#if !defined(__CYGWIN__)
+#if !defined(NLR_OS_WINDOWS)
 
 /******************************************************************************/
 //
@@ -140,11 +144,11 @@ nlr_jump:
     je      _nlr_jump_fail          # transfer control to nlr_jump_fail
 #endif
 
-#else // !defined(__CYGWIN__)
+#else // !defined(NLR_OS_WINDOWS)
 
 /******************************************************************************/
 //
-// Functions for Cygwin
+// Functions for Windows
 //
 /******************************************************************************/
 
@@ -210,6 +214,6 @@ nlr_jump:
     movq    %rax, %rcx              # put argument back in first-arg register
     je      nlr_jump_fail           # transfer control to nlr_jump_fail
 
-#endif // !defined(__CYGWIN__)
+#endif // !defined(NLR_OS_WINDOWS)
 
 #endif // defined(__x86_64__) && !MICROPY_NLR_SETJMP

--- a/py/nlrx86.S
+++ b/py/nlrx86.S
@@ -36,6 +36,7 @@
 #define NLR_TOP_OFFSET (2 * 4)
 
 #if defined(_WIN32) || defined(__CYGWIN__)
+#define NLR_OS_WINDOWS
 #define NLR_TOP (_mp_state_ctx + NLR_TOP_OFFSET)
 #else
 #define NLR_TOP (mp_state_ctx + NLR_TOP_OFFSET)
@@ -47,7 +48,7 @@
 /**************************************/
 // mp_uint_t nlr_push(4(%esp)=nlr_buf_t *nlr)
 
-#if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(NLR_OS_WINDOWS)
     .globl  _nlr_push
     .def    _nlr_push; .scl 2; .type 32; .endef
 _nlr_push:
@@ -69,14 +70,14 @@ nlr_push:
     mov     %edx, NLR_TOP           # stor new nlr_buf (to make linked list)
     xor     %eax, %eax              # return 0, normal return
     ret                             # return
-#if !(defined(_WIN32) || defined(__CYGWIN__))
+#if !defined(NLR_OS_WINDOWS)
     .size   nlr_push, .-nlr_push
 #endif
 
 /**************************************/
 // void nlr_pop()
 
-#if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(NLR_OS_WINDOWS)
     .globl  _nlr_pop
     .def    _nlr_pop; .scl 2; .type 32; .endef
 _nlr_pop:
@@ -89,14 +90,14 @@ nlr_pop:
     mov     (%eax), %eax            # load prev nlr_buf
     mov     %eax, NLR_TOP           # store nlr_top (to unlink list)
     ret                             # return
-#if !(defined(_WIN32) || defined(__CYGWIN__))
+#if !defined(NLR_OS_WINDOWS)
     .size   nlr_pop, .-nlr_pop
 #endif
 
 /**************************************/
 // void nlr_jump(4(%esp)=mp_uint_t val)
 
-#if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(NLR_OS_WINDOWS)
     .globl  _nlr_jump
     .def    _nlr_jump; .scl 2; .type 32; .endef
 _nlr_jump:
@@ -107,7 +108,7 @@ nlr_jump:
 #endif
     mov     NLR_TOP, %edx           # load nlr_top
     test    %edx, %edx              # check for nlr_top being NULL
-#if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(NLR_OS_WINDOWS)
     je      _nlr_jump_fail           # fail if nlr_top is NULL
 #else
     je      nlr_jump_fail           # fail if nlr_top is NULL
@@ -126,7 +127,7 @@ nlr_jump:
     xor     %eax, %eax              # clear return register
     inc     %al                     # increase to make 1, non-local return
     ret                             # return
-#if !(defined(_WIN32) || defined(__CYGWIN__))
+#if !defined(NLR_OS_WINDOWS)
     .size   nlr_jump, .-nlr_jump
 #endif
 

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -49,6 +49,10 @@ CFLAGS_MOD += -DMICROPY_USE_READLINE=2
 LDFLAGS_MOD += -lreadline
 endif
 
+ifeq ($(CROSS_COMPILE),x86_64-w64-mingw32-)
+CFLAGS_MOD += -DMICROPY_NLR_SETJMP=1
+endif
+
 LIB += -lws2_32
 
 include ../py/mkrules.mk

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -47,12 +47,8 @@ SRC_C += lib/mp-readline/readline.c
 else ifeq ($(MICROPY_USE_READLINE),2)
 CFLAGS_MOD += -DMICROPY_USE_READLINE=2
 LDFLAGS_MOD += -lreadline
-# the following is needed for BSD
-#LDFLAGS_MOD += -ltermcap
 endif
 
 LIB += -lws2_32
-#LIB += -lmman
 
 include ../py/mkrules.mk
-

--- a/windows/README
+++ b/windows/README
@@ -20,10 +20,14 @@ make CROSS_COMPILE=i586-mingw32msvc-
 To compile under Cygwin:
 
 Install following packages using cygwin's setup.exe:
-mingw64-i686-gcc-core, make
+mingw64-i686-gcc-core, mingw64-x86_64-gcc-core, make
 Build using:
 
 make CROSS_COMPILE=i686-w64-mingw32-
+
+or for 64bit:
+
+make CROSS_COMPILE=x86_64-w64-mingw32-
 
 
 To compile using Visual Studio 2013 (or higher):

--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -108,6 +108,11 @@
 #if defined( __MINGW32__ ) && defined( __LP64__ )
 typedef long mp_int_t; // must be pointer size
 typedef unsigned long mp_uint_t; // must be pointer size
+#elif defined ( __MINGW32__ ) && defined( _WIN64 )
+#include <stdint.h>
+typedef __int64 mp_int_t;
+typedef unsigned __int64 mp_uint_t;
+#define MP_SSIZE_MAX __INT64_MAX__
 #elif defined ( _MSC_VER ) && defined( _WIN64 )
 typedef __int64 mp_int_t;
 typedef unsigned __int64 mp_uint_t;


### PR DESCRIPTION
Changes to nlr as per comments to #1632

Sidenote: the nlrx64.S implementation (originally enabled just for cygwin ) compiles fine using both cygwin and mingw gcc versions but it might be broken as the produced executables do not function for me on two different machines. The cygwin one just exits with no info whatsoever, the mingw one hits the second `assert(!"bad free");` in gc_free() and segfaults from the moment anything is interpreted/executed.
