### PR TITLE
py/mpprint: Workaround issues with printing doubles after recent refactor.

### DIFF
--- a/py/formatfloat.c
+++ b/py/formatfloat.c
@@ -406,7 +406,7 @@ int mp_format_float(double value, char *buf, size_t bufSize, char fmt, int prec,
         *fmt_s++ = fmt;
         *fmt_s = '\0';
 
-        return snprintf(buf, bufSize, fmt_buf, prec, value);
+        return __snprintf_chk(buf, bufSize, 0, bufSize, fmt_buf, prec, value);
 #ifdef _MSC_VER
     }
 #endif

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -528,7 +528,8 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
                 // use MICROPY_FLOAT_IMPL_DOUBLE, don't call mp_vprintf()
                 // with float format specifier at all.
                 // TODO: resolve this completely
-                assert(0);
+                mp_float_t f = va_arg(args, double);
+                chrs += mp_print_float(print, f, *fmt, flags, fill, width, prec);
 //#error Calling mp_print_float with double not supported from within printf
 #else
 #error Unknown MICROPY FLOAT IMPL


### PR DESCRIPTION
Ok, so folks didn't grow grumpy that I keep master broken for a long time, here's a patch which unbreaks it. Of course, it's a dirty workaround and I don't recommend to merge it. Neither I like going back and forth and reverting previous commit. Instead, I'm working to resolve it in much productive way (providing portable routine to print any floating-point numbers).
