### PR TITLE
py/modsys: Implement sys.modules.

### DIFF
--- a/py/modsys.c
+++ b/py/modsys.c
@@ -185,6 +185,9 @@ STATIC const mp_map_elem_t mp_module_sys_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_stderr), (mp_obj_t)&mp_sys_stderr_obj },
     #endif
 
+    #if MICROPY_PY_SYS_MODULES
+    { MP_OBJ_NEW_QSTR(MP_QSTR_modules), (mp_obj_t)&MP_STATE_VM(mp_loaded_modules_dict) },
+    #endif
     #if MICROPY_PY_SYS_EXC_INFO
     { MP_OBJ_NEW_QSTR(MP_QSTR_exc_info), (mp_obj_t)&mp_sys_exc_info_obj },
     #endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -685,6 +685,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_SYS_MAXSIZE (0)
 #endif
 
+// Whether to provide "sys.modules" dictionary
+#ifndef MICROPY_PY_SYS_MODULES
+#define MICROPY_PY_SYS_MODULES (1)
+#endif
+
 // Whether to provide "sys.exc_info" function
 // Avoid enabling this, this function is Python2 heritage
 #ifndef MICROPY_PY_SYS_EXC_INFO

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -102,7 +102,7 @@ typedef struct _mp_state_vm_t {
 
     // map with loaded modules
     // TODO: expose as sys.modules
-    mp_map_t mp_loaded_modules_map;
+    mp_obj_dict_t mp_loaded_modules_dict;
 
     // pending exception object (MP_OBJ_NULL if not pending)
     volatile mp_obj_t mp_pending_exception;

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -95,7 +95,8 @@ const mp_obj_type_t mp_type_module = {
 };
 
 mp_obj_t mp_obj_new_module(qstr module_name) {
-    mp_map_elem_t *el = mp_map_lookup(&MP_STATE_VM(mp_loaded_modules_map), MP_OBJ_NEW_QSTR(module_name), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
+    mp_map_t *mp_loaded_modules_map = mp_obj_dict_get_map(&MP_STATE_VM(mp_loaded_modules_dict));
+    mp_map_elem_t *el = mp_map_lookup(mp_loaded_modules_map, MP_OBJ_NEW_QSTR(module_name), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
     // We could error out if module already exists, but let C extensions
     // add new members to existing modules.
     if (el->value != MP_OBJ_NULL) {
@@ -200,17 +201,18 @@ STATIC const mp_map_elem_t mp_builtin_module_table[] = {
 STATIC MP_DEFINE_CONST_MAP(mp_builtin_module_map, mp_builtin_module_table);
 
 void mp_module_init(void) {
-    mp_map_init(&MP_STATE_VM(mp_loaded_modules_map), 3);
+    mp_obj_dict_init(&MP_STATE_VM(mp_loaded_modules_dict), 3);
 }
 
 void mp_module_deinit(void) {
-    mp_map_deinit(&MP_STATE_VM(mp_loaded_modules_map));
+    //mp_map_deinit(&MP_STATE_VM(mp_loaded_modules_map));
 }
 
 // returns MP_OBJ_NULL if not found
 mp_obj_t mp_module_get(qstr module_name) {
+    mp_map_t *mp_loaded_modules_map = mp_obj_dict_get_map(&MP_STATE_VM(mp_loaded_modules_dict));
     // lookup module
-    mp_map_elem_t *el = mp_map_lookup(&MP_STATE_VM(mp_loaded_modules_map), MP_OBJ_NEW_QSTR(module_name), MP_MAP_LOOKUP);
+    mp_map_elem_t *el = mp_map_lookup(mp_loaded_modules_map, MP_OBJ_NEW_QSTR(module_name), MP_MAP_LOOKUP);
 
     if (el == NULL) {
         // module not found, look for builtin module names
@@ -236,5 +238,6 @@ mp_obj_t mp_module_get(qstr module_name) {
 }
 
 void mp_module_register(qstr qst, mp_obj_t module) {
-    mp_map_lookup(&MP_STATE_VM(mp_loaded_modules_map), MP_OBJ_NEW_QSTR(qst), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = module;
+    mp_map_t *mp_loaded_modules_map = mp_obj_dict_get_map(&MP_STATE_VM(mp_loaded_modules_dict));
+    mp_map_lookup(mp_loaded_modules_map, MP_OBJ_NEW_QSTR(qst), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = module;
 }

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -474,6 +474,9 @@ Q(implementation)
 #if MICROPY_PY_SYS_MAXSIZE
 Q(maxsize)
 #endif
+#if MICROPY_PY_SYS_MODULES
+Q(modules)
+#endif
 #if MICROPY_PY_SYS_EXC_INFO
 Q(exc_info)
 #endif

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -21,7 +21,7 @@ ame__
 __name__        path            argv            version
 version_info    implementation  platform        byteorder
 maxsize         exit            stdin           stdout
-stderr          exc_info        print_exception
+stderr          modules         exc_info        print_exception
 ementation
 # attrtuple
 (start=1, stop=2, step=3)


### PR DESCRIPTION
This for example will allow people to reload modules which didn't load
successfully (e.g. due to syntax error).
