### PR TITLE
stmhal: ringbuffer support for USB VCP

### DIFF
--- a/stmhal/timer.c
+++ b/stmhal/timer.c
@@ -250,9 +250,7 @@ TIM_HandleTypeDef *timer_tim6_init(uint freq) {
 
 // Interrupt dispatch
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
-    if (htim == &TIM3_Handle) {
-        USBD_CDC_HAL_TIM_PeriodElapsedCallback();
-    } else if (htim == &TIM5_Handle) {
+    if (htim == &TIM5_Handle) {
         servo_timer_irq_callback();
     }
 }
@@ -1124,7 +1122,7 @@ STATIC mp_obj_t pyb_timer_period(mp_uint_t n_args, const mp_obj_t *args) {
         // Reset the counter to zero. Otherwise, if counter >= period it will
         // continue counting until it wraps (at either 16 or 32 bits depending
         // on the timer).
-        __HAL_TIM_SetCounter(&self->tim, 0); 
+        __HAL_TIM_SetCounter(&self->tim, 0);
         return mp_const_none;
     }
 }

--- a/stmhal/usbd_cdc_interface.h
+++ b/stmhal/usbd_cdc_interface.h
@@ -31,8 +31,6 @@
 
 extern const USBD_CDC_ItfTypeDef USBD_CDC_fops;
 
-void USBD_CDC_HAL_TIM_PeriodElapsedCallback(void);
-
 int USBD_CDC_IsConnected(void);
 void USBD_CDC_SetInterrupt(int chr, void *data);
 

--- a/stmhal/usbdev/class/inc/usbd_cdc_msc_hid.h
+++ b/stmhal/usbdev/class/inc/usbd_cdc_msc_hid.h
@@ -31,6 +31,7 @@ typedef struct _USBD_CDC_Itf {
   int8_t (* DeInit)        (void);
   int8_t (* Control)       (uint8_t, uint8_t * , uint16_t);   
   int8_t (* Receive)       (uint8_t *, uint32_t *);  
+  void   (* Transmit)      (void);
 } USBD_CDC_ItfTypeDef;
 
 typedef struct {

--- a/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
+++ b/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
@@ -904,6 +904,8 @@ static uint8_t USBD_CDC_MSC_HID_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 static uint8_t USBD_CDC_MSC_HID_DataIn(USBD_HandleTypeDef *pdev, uint8_t epnum) {
     if ((usbd_mode & USBD_MODE_CDC) && (epnum == (CDC_IN_EP & 0x7f) || epnum == (CDC_CMD_EP & 0x7f))) {
         CDC_ClassData.TxState = 0;
+        // added to support TxComplete callback
+        CDC_fops->Transmit();
         return USBD_OK;
     } else if ((usbd_mode & USBD_MODE_MSC) && epnum == (MSC_IN_EP & 0x7f)) {
         MSC_BOT_DataIn(pdev, epnum);


### PR DESCRIPTION
- adds ringbuffer for rx/tx over USB VCP
- uses a "txComplete" callback rather than TIM3 so it frees up the timer
