### PR TITLE
unix: Improve error handling of invalid heap options

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -94,6 +94,10 @@
 #define FTB_CLEAR(block) do { MP_STATE_MEM(gc_finaliser_table_start)[(block) / BLOCKS_PER_FTB] &= (~(1 << ((block) & 7))); } while (0)
 #endif
 
+int gc_block_size(void) {
+    return BYTES_PER_BLOCK;
+}
+
 // TODO waste less memory; currently requires that all entries in alloc_table have a corresponding block in pool
 void gc_init(void *start, void *end) {
     // align end pointer on block boundary

--- a/py/gc.h
+++ b/py/gc.h
@@ -31,6 +31,8 @@
 #include "py/mpconfig.h"
 #include "py/misc.h"
 
+int gc_block_size(void);
+
 void gc_init(void *start, void *end);
 
 // These lock/unlock functions can be nested.


### PR DESCRIPTION
Prior to this patch:
- passing in -X heap_size=1G causes a segfault
- passing in -X heap_size=800 causes a segfault

The segfaults were due to uncaught NLR exceptions while calling mp_init. And even if the exception is caught, it fails while trying to report the exception.
