### PR TITLE
stmhal: Print exception information in nlr_jump_failed

### DIFF
--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -103,6 +103,7 @@ void NORETURN __fatal_error(const char *msg) {
 
 void nlr_jump_fail(void *val) {
     printf("FATAL: uncaught exception %p\n", val);
+    mp_obj_print_exception(&mp_plat_print, (mp_obj_t)val);
     __fatal_error("");
 }
 


### PR DESCRIPTION
Currently nlr_jump_fail prints that there was an uncaught exception
but nothing about the exception.
This patch causes nlr_jump_failed to try to print the exception.
Given that printf was called on the line above, I think that
the call to mp_obj_print_exception has about as much likelyhood
of succeeding as the printf does.
