### PR TITLE
stmhal: Execute boot.py when formatting the file system

### DIFF
--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -529,7 +529,7 @@ soft_reset:
 
     // run boot.py, if it exists
     // TODO perhaps have pyb.reboot([bootpy]) function to soft-reboot and execute custom boot.py
-    if (reset_mode == 1) {
+    if (reset_mode == 1 || reset_mode == 3) {
         const char *boot_py = "boot.py";
         FRESULT res = f_stat(boot_py, NULL);
         if (res == FR_OK) {
@@ -585,7 +585,7 @@ soft_reset:
     // At this point everything is fully configured and initialised.
 
     // Run the main script from the current directory.
-    if (reset_mode == 1 && pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
+    if ((reset_mode == 1 || reset_mode == 3) && pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
         const char *main_py;
         if (MP_STATE_PORT(pyb_config_main) == MP_OBJ_NULL) {
             main_py = "main.py";


### PR DESCRIPTION
When you use the USER button to perform a filesystem reset
at boot time, then it wipes out the filesystem and creates
a new boot.py. However it doesn't execute it, so neither
pyb nor machine modules get imported.

Before this patch, if you do a filesystem reset and then you
see:

```
>>> MicroPython v1.5.1-71-gf2d532c-dirty on 2015-12-05; PYBv1.0 with STM32F405RG
Type "help()" for more information.
>>> dir()
['__name__']
```

If you then do a hard reset, you'll see:

```
MicroPython v1.5.1-71-gf2d532c-dirty on 2015-12-05; PYBv1.0 with STM32F405RG
Type "help()" for more information.
>>> dir()
['__name__', 'machine', 'pyb']
```

I'd argue that we should have the same behaviour in both cases.
