### PR TITLE
unix: Move modmachine into unix directory

### DIFF
--- a/extmod/machine_mem.h
+++ b/extmod/machine_mem.h
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#ifndef MICROPY_EXTMOD_MACHINE_MEM
+#define MICROPY_EXTMOD_MACHINE_MEM
+
+#include "py/obj.h"
+
+typedef struct _machine_mem_obj_t {
+    mp_obj_base_t base;
+    unsigned elem_size; // in bytes
+} machine_mem_obj_t;
+
+extern const mp_obj_type_t machine_mem_type;
+
+extern const machine_mem_obj_t machine_mem8_obj;
+extern const machine_mem_obj_t machine_mem16_obj;
+extern const machine_mem_obj_t machine_mem32_obj;
+
+// It is expected that a port will provide the following 2 functions.
+// We define the prototypes here, but the modmachine.c file for a port should
+// provide the implementation
+uintptr_t machine_mem_get_read_addr(mp_obj_t addr_o, uint align);
+uintptr_t machine_mem_get_write_addr(mp_obj_t addr_o, uint align);
+
+#endif /*  MICROPY_EXTMOD_MACHINE_MEM */

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -184,9 +184,6 @@ STATIC const mp_rom_map_elem_t mp_builtin_module_table[] = {
 #if MICROPY_PY_UBINASCII
     { MP_ROM_QSTR(MP_QSTR_ubinascii), MP_ROM_PTR(&mp_module_ubinascii) },
 #endif
-#if MICROPY_PY_MACHINE
-    { MP_ROM_QSTR(MP_QSTR_machine), MP_ROM_PTR(&mp_module_machine) },
-#endif
 #if MICROPY_PY_USSL
     { MP_ROM_QSTR(MP_QSTR_ussl), MP_ROM_PTR(&mp_module_ussl) },
 #endif

--- a/py/py.mk
+++ b/py/py.mk
@@ -165,7 +165,7 @@ PY_O_BASENAME = \
 	../extmod/moduheapq.o \
 	../extmod/moduhashlib.o \
 	../extmod/modubinascii.o \
-	../extmod/modmachine.o \
+	../extmod/machine_mem.o \
 	../extmod/modussl.o \
 	../extmod/fsusermount.o \
 

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -114,6 +114,7 @@ SRC_C = \
 	unix_mphal.c \
 	input.c \
 	file.c \
+	modmachine.c \
 	modos.c \
 	moduselect.c \
 	alloc.c \

--- a/unix/modmachine.c
+++ b/unix/modmachine.c
@@ -1,0 +1,95 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "py/nlr.h"
+#include "py/obj.h"
+
+#include "extmod/machine_mem.h"
+
+#if MICROPY_PLAT_DEV_MEM
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#define MICROPY_PAGE_SIZE 4096
+#define MICROPY_PAGE_MASK (MICROPY_PAGE_SIZE - 1)
+#endif
+
+#if MICROPY_PY_MACHINE
+
+uintptr_t machine_mem_get_read_addr(mp_obj_t addr_o, uint align) {
+    uintptr_t addr = mp_obj_int_get_truncated(addr_o);
+    if ((addr & (align - 1)) != 0) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "address %08x is not aligned to %d bytes", addr, align));
+    }
+    #if MICROPY_PLAT_DEV_MEM
+    {
+        // Not thread-safe
+        static int fd;
+        static uintptr_t last_base = (uintptr_t)-1;
+        static uintptr_t map_page;
+        if (!fd) {
+            fd = open("/dev/mem", O_RDWR | O_SYNC);
+            if (fd == -1) {
+                nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(errno)));
+            }
+        }
+
+        uintptr_t cur_base = addr & ~MICROPY_PAGE_MASK;
+        if (cur_base != last_base) {
+            map_page = (uintptr_t)mmap(NULL, MICROPY_PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, cur_base);
+            last_base = cur_base;
+        }
+        addr = map_page + (addr & MICROPY_PAGE_MASK);
+    }
+    #endif
+
+    return addr;
+}
+
+uintptr_t machine_mem_get_write_addr(mp_obj_t addr_o, uint align) {
+    return machine_mem_get_read_addr(addr_o, align);
+}
+
+STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_machine) },
+
+    { MP_ROM_QSTR(MP_QSTR_mem8), MP_ROM_PTR(&machine_mem8_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mem16), MP_ROM_PTR(&machine_mem16_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mem32), MP_ROM_PTR(&machine_mem32_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table);
+
+const mp_obj_module_t mp_module_machine = {
+    .base = { &mp_type_module },
+    .name = MP_QSTR_machine,
+    .globals = (mp_obj_dict_t*)&machine_module_globals,
+};
+
+#endif // MICROPY_PY_MACHINE

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -124,6 +124,7 @@
 #define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF   (1)
 #define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE  (256)
 
+extern const struct _mp_obj_module_t mp_module_machine;
 extern const struct _mp_obj_module_t mp_module_os;
 extern const struct _mp_obj_module_t mp_module_uselect;
 extern const struct _mp_obj_module_t mp_module_time;
@@ -163,6 +164,7 @@ extern const struct _mp_obj_module_t mp_module_jni;
     MICROPY_PY_JNI_DEF \
     MICROPY_PY_TIME_DEF \
     MICROPY_PY_SOCKET_DEF \
+    { MP_ROM_QSTR(MP_QSTR_machine), MP_ROM_PTR(&mp_module_machine) }, \
     { MP_ROM_QSTR(MP_QSTR_uos), MP_ROM_PTR(&mp_module_os) }, \
     { MP_ROM_QSTR(MP_QSTR_uselect), MP_ROM_PTR(&mp_module_uselect) }, \
     MICROPY_PY_TERMIOS_DEF \

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -32,6 +32,7 @@ SRC_C = \
 	unix/file.c \
 	unix/input.c \
 	unix/modos.c \
+	unix/modmachine.c \
 	unix/modtime.c \
 	unix/gccollect.c \
 	windows_mphal.c \


### PR DESCRIPTION
This leaves behind the common functionality in extmod/machine_mem.c
which can be used by all ports.
