### PR TITLE
stmhal: USB CDC speed improvements, TIM3 release

### DIFF
--- a/stmhal/hal/f4/src/stm32f4xx_hal_pcd.c
+++ b/stmhal/hal/f4/src/stm32f4xx_hal_pcd.c
@@ -292,7 +292,6 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
   uint32_t i = 0, ep_intr = 0, epint = 0, epnum = 0;
   uint32_t fifoemptymsk = 0, temp = 0;
   USB_OTG_EPTypeDef *ep;
-    
   /* ensure that we are in device mode */
   if (USB_GetMode(hpcd->Instance) == USB_OTG_MODE_DEVICE)
   {

--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -398,7 +398,7 @@ int main(void) {
     HAL_NVIC_SetPriority(PVD_IRQn, 6, 0); // same priority as USB
     HAL_NVIC_EnableIRQ(PVD_IRQn);
     #else
-    timer_tim3_init();
+    // timer_tim3_init();
     #endif
     led_init();
 #if MICROPY_HW_HAS_SWITCH

--- a/stmhal/stm32_it.c
+++ b/stmhal/stm32_it.c
@@ -500,7 +500,7 @@ void TIM3_IRQHandler(void) {
     #if defined(MICROPY_HW_USE_ALT_IRQ_FOR_CDC)
     timer_irq_handler(3);
     #else
-    HAL_TIM_IRQHandler(&TIM3_Handle);
+    // HAL_TIM_IRQHandler(&TIM3_Handle);
     #endif
 }
 

--- a/stmhal/timer.c
+++ b/stmhal/timer.c
@@ -252,7 +252,7 @@ TIM_HandleTypeDef *timer_tim6_init(uint freq) {
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
     #if !defined(MICROPY_HW_USE_ALT_IRQ_FOR_CDC)
     if (htim == &TIM3_Handle) {
-        USBD_CDC_HAL_TIM_PeriodElapsedCallback();
+        // USBD_CDC_HAL_TIM_PeriodElapsedCallback();
     } else
     #endif
     if (htim == &TIM5_Handle) {

--- a/stmhal/usbd_conf.c
+++ b/stmhal/usbd_conf.c
@@ -271,6 +271,7 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
   USBD_LL_DataInStage(hpcd->pData, epnum, hpcd->IN_ep[epnum].xfer_buff);
 }
 
+extern void USBD_CDC_SOF_callback(PCD_HandleTypeDef *hpcd);
 /**
   * @brief  SOF callback.
   * @param  hpcd: PCD handle
@@ -278,7 +279,7 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
   */
 void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd)
 {
-  USBD_LL_SOF(hpcd->pData);
+  USBD_CDC_SOF_callback(hpcd);
 }
 
 /**
@@ -394,7 +395,7 @@ if (pdev->id ==  USB_PHY_FS_ID)
   pcd_fs_handle.Init.dma_enable = 0;
   pcd_fs_handle.Init.low_power_enable = 0;
   pcd_fs_handle.Init.phy_itface = PCD_PHY_EMBEDDED;
-  pcd_fs_handle.Init.Sof_enable = 0;
+  pcd_fs_handle.Init.Sof_enable = 1;
   pcd_fs_handle.Init.speed = PCD_SPEED_FULL;
 #if !defined(MICROPY_HW_USB_VBUS_DETECT_PIN)
   pcd_fs_handle.Init.vbus_sensing_enable = 0; // No VBUS Sensing on USB0

--- a/stmhal/usbdev/class/inc/usbd_cdc_msc_hid.h
+++ b/stmhal/usbdev/class/inc/usbd_cdc_msc_hid.h
@@ -31,6 +31,7 @@ typedef struct _USBD_CDC_Itf {
   int8_t (* DeInit)        (void);
   int8_t (* Control)       (uint8_t, uint8_t * , uint16_t);   
   int8_t (* Receive)       (uint8_t *, uint32_t *);  
+  void (* TxComplete)      (void);  
 } USBD_CDC_ItfTypeDef;
 
 typedef struct {

--- a/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
+++ b/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
@@ -90,7 +90,7 @@ static const uint8_t *hid_report_desc;
 static USBD_CDC_ItfTypeDef *CDC_fops;
 static USBD_StorageTypeDef *MSC_fops;
 
-static USBD_CDC_HandleTypeDef CDC_ClassData;
+USBD_CDC_HandleTypeDef CDC_ClassData;
 static USBD_MSC_BOT_HandleTypeDef MSC_BOT_ClassData;
 static USBD_HID_HandleTypeDef HID_ClassData;
 
@@ -904,6 +904,8 @@ static uint8_t USBD_CDC_MSC_HID_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 static uint8_t USBD_CDC_MSC_HID_DataIn(USBD_HandleTypeDef *pdev, uint8_t epnum) {
     if ((usbd_mode & USBD_MODE_CDC) && (epnum == (CDC_IN_EP & 0x7f) || epnum == (CDC_CMD_EP & 0x7f))) {
         CDC_ClassData.TxState = 0;
+        // added tx_complete callback here
+        CDC_fops->TxComplete();
         return USBD_OK;
     } else if ((usbd_mode & USBD_MODE_MSC) && epnum == (MSC_IN_EP & 0x7f)) {
         MSC_BOT_DataIn(pdev, epnum);


### PR DESCRIPTION
This patch releases TIM3 from periodically polling the CDC-USB tx state
- no overhead of periodically polling tx state (e.g. if USB is not connected)
- TIM3 is free to use
- faster response and improved data rate because the callback is directly called
