### PR TITLE
USB Phy device can be defined board specific.

### DIFF
--- a/stmhal/boards/CERB40/stm32f4xx_hal_conf.h
+++ b/stmhal/boards/CERB40/stm32f4xx_hal_conf.h
@@ -47,6 +47,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 #define USE_USB_FS
+#define USE_USB_PHY_1  USB_PHY_FS_ID
 
 /* ########################## Module Selection ############################## */
 /**

--- a/stmhal/boards/ESPRUINO_PICO/stm32f4xx_hal_conf.h
+++ b/stmhal/boards/ESPRUINO_PICO/stm32f4xx_hal_conf.h
@@ -47,6 +47,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 #define USE_USB_FS
+#define USE_USB_PHY_1  USB_PHY_FS_ID
 
 /* ########################## Module Selection ############################## */
 /**

--- a/stmhal/boards/HYDRABUS/stm32f4xx_hal_conf.h
+++ b/stmhal/boards/HYDRABUS/stm32f4xx_hal_conf.h
@@ -47,6 +47,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 #define USE_USB_FS
+#define USE_USB_PHY_1  USB_PHY_FS_ID
 
 /* ########################## Module Selection ############################## */
 /**

--- a/stmhal/boards/NETDUINO_PLUS_2/stm32f4xx_hal_conf.h
+++ b/stmhal/boards/NETDUINO_PLUS_2/stm32f4xx_hal_conf.h
@@ -47,6 +47,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 #define USE_USB_FS
+#define USE_USB_PHY_1  USB_PHY_FS_ID
 
 /* ########################## Module Selection ############################## */
 /**

--- a/stmhal/boards/PYBLITEV10/stm32f4xx_hal_conf.h
+++ b/stmhal/boards/PYBLITEV10/stm32f4xx_hal_conf.h
@@ -47,6 +47,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 #define USE_USB_FS
+#define USE_USB_PHY_1  USB_PHY_FS_ID
 
 /* ########################## Module Selection ############################## */
 /**

--- a/stmhal/boards/PYBV10/stm32f4xx_hal_conf.h
+++ b/stmhal/boards/PYBV10/stm32f4xx_hal_conf.h
@@ -48,6 +48,7 @@
 
 #define USE_USB_FS
 //#define USE_USB_HS
+#define USE_USB_PHY_1  USB_PHY_FS_ID
 
 /* ########################## Module Selection ############################## */
 /**

--- a/stmhal/boards/PYBV11/stm32f4xx_hal_conf.h
+++ b/stmhal/boards/PYBV11/stm32f4xx_hal_conf.h
@@ -47,6 +47,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 #define USE_USB_FS
+#define USE_USB_PHY_1  USB_PHY_FS_ID
 
 /* ########################## Module Selection ############################## */
 /**

--- a/stmhal/boards/PYBV3/stm32f4xx_hal_conf.h
+++ b/stmhal/boards/PYBV3/stm32f4xx_hal_conf.h
@@ -47,6 +47,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 #define USE_USB_FS
+#define USE_USB_PHY_1  USB_PHY_FS_ID
 
 /* ########################## Module Selection ############################## */
 /**

--- a/stmhal/boards/PYBV4/stm32f4xx_hal_conf.h
+++ b/stmhal/boards/PYBV4/stm32f4xx_hal_conf.h
@@ -47,6 +47,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 #define USE_USB_FS
+#define USE_USB_PHY_1  USB_PHY_FS_ID
 
 /* ########################## Module Selection ############################## */
 /**

--- a/stmhal/boards/STM32F411DISC/stm32f4xx_hal_conf.h
+++ b/stmhal/boards/STM32F411DISC/stm32f4xx_hal_conf.h
@@ -47,6 +47,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 #define USE_USB_FS
+#define USE_USB_PHY_1  USB_PHY_FS_ID
 
 /* ########################## Module Selection ############################## */
 /**

--- a/stmhal/boards/STM32F429DISC/stm32f4xx_hal_conf.h
+++ b/stmhal/boards/STM32F429DISC/stm32f4xx_hal_conf.h
@@ -48,7 +48,7 @@
 
 #define USE_USB_HS
 #define USE_USB_HS_IN_FS
-
+#define USE_USB_PHY_1  USB_PHY_HS_IN_FS_ID
  /* ########################## Module Selection ############################## */
 /**
   * @brief This is the list of modules to be used in the HAL driver 

--- a/stmhal/boards/STM32F4DISC/stm32f4xx_hal_conf.h
+++ b/stmhal/boards/STM32F4DISC/stm32f4xx_hal_conf.h
@@ -47,6 +47,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 #define USE_USB_FS
+#define USE_USB_PHY_1  USB_PHY_FS_ID
 
 /* ########################## Module Selection ############################## */
 /**

--- a/stmhal/mpconfigport.h
+++ b/stmhal/mpconfigport.h
@@ -235,7 +235,6 @@ static inline mp_uint_t disable_irq(void) {
 #define realloc gc_realloc
 
 // see stm32f4XX_hal_conf.h USE_USB_FS & USE_USB_HS
-// at the moment only USB_FS is supported
 #define USE_DEVICE_MODE
 //#define USE_HOST_MODE
 

--- a/stmhal/usb.c
+++ b/stmhal/usb.c
@@ -102,7 +102,7 @@ bool pyb_usb_dev_init(uint16_t vid, uint16_t pid, usb_device_mode_t mode, USBD_H
         if (USBD_SelectMode(mode, hid_info) != 0) {
             return false;
         }
-        USBD_Init(&hUSBDDevice, (USBD_DescriptorsTypeDef*)&USBD_Descriptors, USB_PHY_FS_ID);
+        USBD_Init(&hUSBDDevice, (USBD_DescriptorsTypeDef*)&USBD_Descriptors, USE_USB_PHY_1);
         USBD_RegisterClass(&hUSBDDevice, &USBD_CDC_MSC_HID);
         USBD_CDC_RegisterInterface(&hUSBDDevice, (USBD_CDC_ItfTypeDef*)&USBD_CDC_fops);
         switch (pyb_usb_storage_medium) {

--- a/stmhal/usb.h
+++ b/stmhal/usb.h
@@ -43,7 +43,8 @@ typedef enum {
 
 typedef enum {
 	USB_PHY_FS_ID = 0,
-	USB_PHY_HS_ID = 1,
+    USB_PHY_HS_IN_FS_ID = 1,
+    USB_PHY_HS_ID = 2,
 } USB_PHY_ID;
 
 extern mp_uint_t pyb_usb_flags;

--- a/stmhal/usbd_conf.c
+++ b/stmhal/usbd_conf.c
@@ -103,7 +103,9 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
 #if defined(USE_USB_HS)
   else if(hpcd->Instance == USB_OTG_HS)
   {
-#if defined(USE_USB_HS_IN_FS)
+    // We just have to check if the embedded or an external phy is used.
+    if(hpcd->Init.phy_itface == PCD_PHY_EMBEDDED)
+    {
 
     /* Configure USB FS GPIOs */
     __GPIOB_CLK_ENABLE();
@@ -143,8 +145,9 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
     __OTGHS_CLK_SLEEP_ENABLE();
     /* Enable USB HS Clocks */
     __USB_OTG_HS_CLK_ENABLE();
-
-#else // !USE_USB_HS_IN_FS
+    }
+    else if (hpcd->Init.phy_itface == PCD_PHY_ULPI)
+    {
 
     /* Configure USB HS GPIOs */
     __GPIOA_CLK_ENABLE();
@@ -201,7 +204,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
     /* Enable USB HS Clocks */
     __USB_OTG_HS_CLK_ENABLE();
     __USB_OTG_HS_ULPI_CLK_ENABLE();
-#endif // !USE_USB_HS_IN_FS
+}
     
     /* Set USBHS Interrupt to the lowest priority */
     HAL_NVIC_SetPriority(OTG_HS_IRQn, IRQ_PRI_OTG_HS, IRQ_SUBPRI_OTG_HS);
@@ -415,9 +418,8 @@ if (pdev->id ==  USB_PHY_FS_ID)
 }
 #endif
 #if defined(USE_USB_HS)
-if (pdev->id == USB_PHY_HS_ID)
+if (pdev->id == USB_PHY_HS_IN_FS_ID)
 {
-#if defined(USE_USB_HS_IN_FS)
   /*Set LL Driver parameters */
   pcd_hs_handle.Instance = USB_OTG_HS;
   pcd_hs_handle.Init.dev_endpoints = 4;
@@ -444,7 +446,9 @@ if (pdev->id == USB_PHY_HS_ID)
   HAL_PCD_SetTxFiFo(&pcd_hs_handle, 1, 0x40);
   HAL_PCD_SetTxFiFo(&pcd_hs_handle, 2, 0x20);
   HAL_PCD_SetTxFiFo(&pcd_hs_handle, 3, 0x40);
-#else // !defined(USE_USB_HS_IN_FS)
+  }
+  else if (pdev->id == USB_PHY_HS_ID)
+  {
   /*Set LL Driver parameters */
   pcd_hs_handle.Instance = USB_OTG_HS;
   pcd_hs_handle.Init.dev_endpoints = 6;
@@ -473,7 +477,6 @@ if (pdev->id == USB_PHY_HS_ID)
   HAL_PCD_SetTxFiFo(&pcd_hs_handle, 0, 0x80);
   HAL_PCD_SetTxFiFo(&pcd_hs_handle, 1, 0x174);
 
-#endif  // !USE_USB_HS_IN_FS
 }
 #endif  // USE_USB_HS
   return USBD_OK;


### PR DESCRIPTION
With the commit of "stmhal: Enable two USB phys to be supported together. " the definition of the used USB Phy is made in usb.c. If you would like to compile for the ST32F429 platform you have to edit the usb.c file.

This is a proposal how to make the usage of a USB Phy specific to a certain board. Please look at this PROPOSAL and give me feedback.

In essence I extend the the `USB_PHY_ID` enum with an additional entry `USB_PHY_HS_IN_FS_ID`, In the board configuration an addtional #define is used for Phy 1 (`USE_USB_PHY_1`) which is used in usb.c to instantiate the related usb Phy.
