### PR TITLE
unix: machine_mem improvements

### DIFF
--- a/extmod/machine_mem.h
+++ b/extmod/machine_mem.h
@@ -25,8 +25,8 @@
  */
 
 
-#ifndef MICROPY_EXTMOD_MACHINE_MEM
-#define MICROPY_EXTMOD_MACHINE_MEM
+#ifndef __MICROPY_INCLUDED_EXTMOD_MACHINE_MEM_H__
+#define __MICROPY_INCLUDED_EXTMOD_MACHINE_MEM_H__
 
 #include "py/obj.h"
 
@@ -41,10 +41,11 @@ extern const machine_mem_obj_t machine_mem8_obj;
 extern const machine_mem_obj_t machine_mem16_obj;
 extern const machine_mem_obj_t machine_mem32_obj;
 
-// It is expected that a port will provide the following 2 functions.
-// We define the prototypes here, but the modmachine.c file for a port should
-// provide the implementation
-uintptr_t machine_mem_get_read_addr(mp_obj_t addr_o, uint align);
-uintptr_t machine_mem_get_write_addr(mp_obj_t addr_o, uint align);
+#if defined(MICROPY_MACHINE_MEM_GET_READ_ADDR)
+uintptr_t MICROPY_MACHINE_MEM_GET_READ_ADDR(mp_obj_t addr_o, uint align);
+#endif
+#if defined(MICROPY_MACHINE_MEM_GET_WRITE_ADDR)
+uintptr_t MICROPY_MACHINE_MEM_GET_WRITE_ADDR(mp_obj_t addr_o, uint align);
+#endif
 
-#endif /*  MICROPY_EXTMOD_MACHINE_MEM */
+#endif // __MICROPY_INCLUDED_EXTMOD_MACHINE_MEM_H__

--- a/unix/modmachine.c
+++ b/unix/modmachine.c
@@ -42,7 +42,7 @@
 
 #if MICROPY_PY_MACHINE
 
-uintptr_t machine_mem_get_read_addr(mp_obj_t addr_o, uint align) {
+uintptr_t mod_machine_mem_get_addr(mp_obj_t addr_o, uint align) {
     uintptr_t addr = mp_obj_int_get_truncated(addr_o);
     if ((addr & (align - 1)) != 0) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "address %08x is not aligned to %d bytes", addr, align));
@@ -70,10 +70,6 @@ uintptr_t machine_mem_get_read_addr(mp_obj_t addr_o, uint align) {
     #endif
 
     return addr;
-}
-
-uintptr_t machine_mem_get_write_addr(mp_obj_t addr_o, uint align) {
-    return machine_mem_get_read_addr(addr_o, align);
 }
 
 STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -108,6 +108,8 @@
 #define MICROPY_PY_USELECT          (1)
 #endif
 #define MICROPY_PY_MACHINE          (1)
+#define MICROPY_MACHINE_MEM_GET_READ_ADDR   mod_machine_mem_get_addr
+#define MICROPY_MACHINE_MEM_GET_WRITE_ADDR  mod_machine_mem_get_addr
 
 // Define to MICROPY_ERROR_REPORTING_DETAILED to get function, etc.
 // names in exception messages (may require more RAM).


### PR DESCRIPTION
This basically introduces the MICROPY_MACHINE_MEM_GET_READ_ADDR
and MICROPY_MACHINE_MEM_GET_WRITE_ADDR macros. If one of them is
not defined, then a default identity function is provided.
