### PR TITLE
Add Appveyor CI builds for msvc port

### DIFF
--- a/windows/.appveyor.yml
+++ b/windows/.appveyor.yml
@@ -1,0 +1,32 @@
+environment:
+  # Python version used
+  MICROPY_CPYTHON3: c:/python34/python.exe
+
+init:
+  # Set build version number to commit to be travis-like
+- ps: Update-AppveyorBuild -Version $env:appveyor_repo_commit.substring(0,8)
+
+configuration:
+- Debug
+- Release
+
+platform:
+- x86
+- x64
+
+build:
+  project: windows/micropython.vcxproj
+  verbosity: normal
+
+test_script:
+- cmd: >-
+    cd tests
+
+    %MICROPY_CPYTHON3% run-tests
+
+skip_tags: true
+
+deploy: off
+
+nuget:
+  disable_publish_on_pr: true


### PR DESCRIPTION
Appveyor is like Travis, but for Windows builds. The appveyor.yml configuration file will build the msvc port in all configuration/platform conbinations and run the tests for each fo those.

If there is interest for this it can be put to use and @dpgeorge needs to go to http://www.appveyor.com/, create an account and add a project pointing to the uPy repository on GitHub (no further configuration needed, the yml takes care of that). The process is self-explanatory and GitHub integration setup is automatic. Once that is done a 'badge' for these builds can be added to the README just like for Travis. If I understand it correctly GitHub will also show status on pull requests just like for Travis.

Appveyor can also build/test using minw/msys2 and whatnot, which would be a welcome addition to the current cross-compile in Travis.
