### PR TITLE
py/mpprint: Handle %lld and similar format specifiers

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -898,9 +898,8 @@ typedef double mp_float_t;
 #define UINT_FMT "%lu"
 #define INT_FMT "%ld"
 #elif defined(_WIN64)
-#include <inttypes.h>
-#define UINT_FMT "%"PRIu64
-#define INT_FMT "%"PRId64
+#define UINT_FMT "%llu"
+#define INT_FMT "%lld"
 #else
 // Archs where mp_int_t == int
 #define UINT_FMT "%u"

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -529,7 +529,7 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
             // Because 'l' is eaten above, another 'l' means %ll.  We need to support
             // this length specifier for OBJ_REPR_D (64-bit NaN boxing).
             // TODO Either enable this unconditionally, or provide a specific config var.
-            #if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_D
+            #if (MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_D) || defined(_WIN64)
             case 'l': {
                 unsigned long long int arg_value = va_arg(args, unsigned long long int);
                 ++fmt;


### PR DESCRIPTION
Just also ignore the second 'l' if one is found already.

For 64bit windows builds (both msvc and mingw-w64) the format specifier for
64bit integers is %lld or %llu for the unsigned version. These are fetched
from inttypes.h which is apparently the C99 way of working with printf/scanf
now; this just to illustrate why uPy should probably support them.

More importantly this makes all tests pass again for 64bit windows builds
which would previously fail for anything printing ranges (builtin_range/unpack1)
because they were printed as range( ld, ld )
