### PR TITLE
Change PLL configuration

### DIFF
--- a/stmhal/boards/STM32F7DISC/mpconfigboard.h
+++ b/stmhal/boards/STM32F7DISC/mpconfigboard.h
@@ -18,11 +18,11 @@
 #define MICROPY_BOARD_EARLY_INIT    STM32F7DISC_board_early_init
 void STM32F7DISC_board_early_init(void);
 
-// HSE is 8MHz
+// HSE is 25MHz
 #define MICROPY_HW_CLK_PLLM (25)
-#define MICROPY_HW_CLK_PLLN (400)
+#define MICROPY_HW_CLK_PLLN (336)
 #define MICROPY_HW_CLK_PLLP (RCC_PLLP_DIV2)
-#define MICROPY_HW_CLK_PLLQ (8)
+#define MICROPY_HW_CLK_PLLQ (7)
 
 #define MICROPY_HW_FLASH_LATENCY    FLASH_LATENCY_6
 


### PR DESCRIPTION
Changes USB clock from 50MHz to 48MHz which improves USB communication on the STM32F7-DISCO.
