### PR TITLE
Disable L1 caches

### DIFF
--- a/stmhal/system_stm32.c
+++ b/stmhal/system_stm32.c
@@ -363,9 +363,10 @@ void SystemClock_Config(void)
 void HAL_MspInit(void) {
 #if defined(MCU_SERIES_F7)
     /* Enable I-Cache */
-    SCB_EnableICache();
+    //SCB_EnableICache();
 
     /* Enable D-Cache */
-    SCB_EnableDCache();
+    //SCB_EnableDCache();
+ 
 #endif
 }


### PR DESCRIPTION
Allows to use DMA on the STM32F7 series.
Workaround for issue #1677
