### PR TITLE
unix: Make REPL check for pending exceptions on empty lines

### DIFF
--- a/unix/main.c
+++ b/unix/main.c
@@ -211,6 +211,11 @@ STATIC int do_repl(void) {
             if (ret != 0) {
                 printf("\n");
             }
+            if (MP_STATE_VM(mp_pending_exception) != MP_OBJ_NULL) {
+                mp_obj_t obj = MP_STATE_VM(mp_pending_exception);
+                MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
+                handle_uncaught_exception(obj);
+            }
             goto input_restart;
         } else {
             // got a line with non-zero length, see if it needs continuing


### PR DESCRIPTION
This assures pending KeyboardInterrupts generated by pressing Ctrl-C in the
previously executed code are propagated to the REPL when pressing Enter or Ctrl-C,
like CPython does. Else the pending exception will only propagate upon the next execution of code which is somewhat confusing.
