### PR TITLE
py/objstr: str.format miss spec for strings without explicit type field

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -832,6 +832,10 @@ STATIC bool arg_looks_numeric(mp_obj_t arg) {
     ;
 }
 
+STATIC bool arg_looks_string(mp_obj_t arg) {
+    return MP_OBJ_IS_TYPE(arg, &mp_type_str) || MP_OBJ_IS_STR(arg);
+}
+
 STATIC mp_obj_t arg_as_int(mp_obj_t arg) {
 #if MICROPY_PY_BUILTINS_FLOAT
     if (mp_obj_is_float(arg)) {
@@ -1093,6 +1097,9 @@ mp_obj_t mp_obj_str_format(mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kwa
         }
         if (!fill) {
             fill = ' ';
+        }
+        if(!type && arg_looks_string(arg)) {
+            type = 's';
         }
 
         if (sign) {

--- a/tests/basics/string_format.py
+++ b/tests/basics/string_format.py
@@ -62,6 +62,10 @@ test("{:@<6d}",  -123)
 test("{:@=6d}",  -123)
 test("{:06d}",  -123)
 
+test("{:>20}", "foo")
+test("{:^20}", "foo")
+test("{:<20}", "foo")
+
 print("{foo}/foo".format(foo="bar"))
 print("{}".format(123, foo="bar"))
 print("{}-{foo}".format(123, foo="bar"))


### PR DESCRIPTION
#1708
