### PR TITLE
stmhal: If you turn off uctypes, then stmhal fails to build.

### DIFF
--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -487,6 +487,7 @@ Q(print_exception)
 #endif
 
 #if MICROPY_PY_STRUCT
+Q(struct)
 Q(ustruct)
 Q(pack)
 Q(unpack)


### PR DESCRIPTION
It uses the MP_QSTR_struct here:
https://github.com/micropython/micropython/blob/master/stmhal/mpconfigport.h#L142
