### PR TITLE
extmod: Fix uctypes size calculation for bitfields

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -230,6 +230,9 @@ STATIC mp_uint_t uctypes_struct_size(mp_obj_t desc_in, int layout_type, mp_uint_
                 mp_uint_t offset = MP_OBJ_SMALL_INT_VALUE(v);
                 mp_uint_t val_type = GET_TYPE(offset, VAL_TYPE_BITS);
                 offset &= VALUE_MASK(VAL_TYPE_BITS);
+                if (val_type >= BFUINT8 && val_type <= BFINT32) {
+                    offset &= (1 << OFFSET_BITS) - 1;
+                }
                 mp_uint_t s = uctypes_struct_scalar_size(val_type);
                 if (s > *max_field_size) {
                     *max_field_size = s;

--- a/tests/extmod/uctypes_sizeof.py
+++ b/tests/extmod/uctypes_sizeof.py
@@ -6,7 +6,11 @@ desc = {
     # arr2 is array at offset 0, size 2, of structures defined recursively
     "arr2": (uctypes.ARRAY | 0, 2, {"b": uctypes.UINT8 | 0}),
     "arr3": (uctypes.ARRAY | 2, uctypes.UINT16 | 2),
-    "arr4": (uctypes.ARRAY | 0, 2, {"b": uctypes.UINT8 | 0, "w": uctypes.UINT16 | 1})
+    "arr4": (uctypes.ARRAY | 0, 2, {"b": uctypes.UINT8 | 0, "w": uctypes.UINT16 | 1}),
+    "sub": (0, {
+        'b1': uctypes.BFUINT8 | 0 | 4 << uctypes.BF_POS | 4 << uctypes.BF_LEN,
+        'b2': uctypes.BFUINT8 | 0 | 0 << uctypes.BF_POS | 4 << uctypes.BF_LEN,
+    }),
 }
 
 data = bytearray(b"01234567")
@@ -28,4 +32,7 @@ except TypeError:
 
 print(uctypes.sizeof(S.arr4))
 assert uctypes.sizeof(S.arr4) == 6
+
+print(uctypes.sizeof(S.sub))
+assert uctypes.sizeof(S.sub) == 1
 

--- a/tests/extmod/uctypes_sizeof.py.exp
+++ b/tests/extmod/uctypes_sizeof.py.exp
@@ -3,3 +3,4 @@
 4
 TypeError
 6
+1


### PR DESCRIPTION
When you have a struct of bit fields, uctypes wasn't masking off the bit field size & len fields which led to very strange results.
