### PR TITLE
docs: Add missing functions in time documentation.

### DIFF
--- a/docs/library/time.rst
+++ b/docs/library/time.rst
@@ -44,7 +44,7 @@ Functions
     
        Sleep for the given number of seconds.
 
-.. only:: port_wipy
+.. only:: port_wipy or port_pyboard
 
     .. function::  sleep_ms(ms)
 


### PR DESCRIPTION
Documentation of some functions in the time module is missing due to a ".. only::" statement in the .rst file. 
