### PR TITLE
tools: Temp fix for pyboard.py to make it work with the new pyserial

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -126,7 +126,10 @@ class Pyboard:
             delayed = False
             for attempt in range(wait + 1):
                 try:
-                    self.serial = serial.Serial(device, baudrate=baudrate, interCharTimeout=1)
+                    if serial.VERSION == '3.0':
+                        self.serial = serial.Serial(device, baudrate=baudrate, inter_byte_timeout=1)
+                    else:
+                        self.serial = serial.Serial(device, baudrate=baudrate, interCharTimeout=1)
                     break
                 except (OSError, IOError): # Py2 and Py3 have different errors
                     if wait == 0:


### PR DESCRIPTION
The new pyserial on PyPI (version 3.0) doesn't have support for the interCharTimeout kwarg.

However, it appears that support for this was just added (on Jan 2).
https://github.com/pyserial/pyserial/commit/c14bba80d4fac598c719301d309724b3515a8162

This patch is just a temp hack to make pyboard.py work if you happen to have one of the bad pyserial's installed on your system.
