### PR TITLE
docs: several minor changes including to inline asm

### DIFF
--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -8,7 +8,8 @@
 This module provides network drivers and routing configuration.  Network
 drivers for specific hardware are available within this module and are
 used to configure a hardware network interface.  Configured interfaces
-are then available for use via the :mod:`socket` module.
+are then available for use via the :mod:`socket` module. To use this module
+the network build of firmware must be installed.
 
 For example::
 

--- a/docs/library/pyb.ADC.rst
+++ b/docs/library/pyb.ADC.rst
@@ -54,7 +54,7 @@ Methods
 
        To support previous behaviour of this function, ``timer`` can also be an
        integer which specifies the frequency (in Hz) to sample at.  In this case
-       Timer(6) will be automatically configured to run at the given frequency.The
+       Timer(6) will be automatically configured to run at the given frequency.
 
        Example using a Timer object (preferred way)::
 

--- a/docs/library/pyb.ADC.rst
+++ b/docs/library/pyb.ADC.rst
@@ -54,7 +54,7 @@ Methods
 
        To support previous behaviour of this function, ``timer`` can also be an
        integer which specifies the frequency (in Hz) to sample at.  In this case
-       Timer(6) will be automatically configured to run at the given frequency.
+       Timer(6) will be automatically configured to run at the given frequency.The
 
        Example using a Timer object (preferred way)::
 
@@ -74,3 +74,9 @@ Methods
 
        This function does not allocate any memory.
 
+The ADCAll Object
+-----------------
+
+Instantiating this changes all ADC pins to analog inputs. It is possible to read the
+MCU temperature, VREF and VBAT without using ADCAll. The raw data can be accessed on
+ADC channels 16, 17 and 18 respectively. However appropriate scaling will need to be applied.

--- a/docs/library/pyb.rst
+++ b/docs/library/pyb.rst
@@ -25,6 +25,10 @@ Time related functions
    after 2^30 milliseconds (about 12.4 days) this will start to return
    negative numbers.
 
+   Note that if :meth:`pyb.stop()` is issued the hardware counter supporting this
+   function will pause for the duration of the "sleeping" state. This
+   will affect the outcome of :meth:`pyb.elapsed_millis()`.
+
 .. function:: micros()
 
    Returns the number of microseconds since the board was last reset.
@@ -32,6 +36,10 @@ Time related functions
    The result is always a micropython smallint (31-bit signed number), so
    after 2^30 microseconds (about 17.8 minutes) this will start to return
    negative numbers.
+
+   Note that if :meth:`pyb.stop()` is issued the hardware counter supporting this
+   function will pause for the duration of the "sleeping" state. This
+   will affect the outcome of :meth:`pyb.elapsed_micros()`.
 
 .. function:: elapsed_millis(start)
 

--- a/docs/reference/asm_thumb2_hints_tips.rst
+++ b/docs/reference/asm_thumb2_hints_tips.rst
@@ -78,11 +78,11 @@ three arguments, which must (if used) be named ``r0``, ``r1`` and ``r2``. When
 the code executes the registers will be initialised to those values.
 
 The data types which can be passed in this way are integers and memory
-addresses. Further, integers are restricted in that the top two bits
-must be identical, limiting the range to -2**30 to 2**30 -1. Return
-values are similarly limited. These limitations can be overcome by means
-of the ``array`` module to allow any number of values of any type to
-be accessed.
+addresses. With current firmware all possible 32 bit values may be passed.
+Returned integers are restricted in that the top two bits must be identical,
+limiting the range to -2**30 to 2**30 -1. The limitations on number of arguments
+and return values can be overcome by means of the ``array`` module which enables
+any number of values of any type to be accessed.
 
 Multiple arguments
 ~~~~~~~~~~~~~~~~~~

--- a/docs/reference/asm_thumb2_misc.rst
+++ b/docs/reference/asm_thumb2_misc.rst
@@ -5,6 +5,9 @@ Miscellaneous instructions
 * wfi() Suspend execution in a low power state until an interrupt occurs.
 * cpsid(flags) set the Priority Mask Register - disable interrupts.
 * cpsie(flags) clear the Priority Mask Register - enable interrupts.
+* mrs(Rd, special_reg) ``Rd = special_reg`` copy a special register to a general register. The special register
+  may be IPSR (Interrupt Status Register) or BASEPRI (Base Priority Register). The IPSR provides a means of determining
+  the exception number of an interrupt being processed. It contains zero if no interrupt is being processed.
 
 Currently the ``cpsie()`` and ``cpsid()`` functions are partially implemented.
 They require but ignore the flags argument and serve as a means of enabling and disabling interrupts.


### PR DESCRIPTION
These reflect changes to the inline assembler and issues arising in the forum. Docs affected:
network.rst (appropriate firmware build required)
pyb.ADC.rst (detail ADCall)
pyb.rst (clocks stopped when sleeping)
asm_thumb2_hints_tips.rst (improved argument passing)
asm_thumb2_misc.rst (added opcode)
