### PR TITLE
py: unary_op enum type fix, and a cast to remove clang warning

### DIFF
--- a/py/parse.c
+++ b/py/parse.c
@@ -519,7 +519,7 @@ STATIC bool fold_constants(parser_t *parser, const rule_t *rule, size_t num_args
                 MP_BINARY_OP_RSHIFT,
             };
             mp_binary_op_t op = token_to_op[tok - MP_TOKEN_OP_PLUS];
-            if (op == 255) {
+            if (op == (mp_binary_op_t)255) {
                 return false;
             }
             int rhs_sign = mp_obj_int_sign(arg1);
@@ -543,7 +543,7 @@ STATIC bool fold_constants(parser_t *parser, const rule_t *rule, size_t num_args
             return false;
         }
         mp_token_kind_t tok = MP_PARSE_NODE_LEAF_ARG(peek_result(parser, 1));
-        mp_binary_op_t op;
+        mp_unary_op_t op;
         if (tok == MP_TOKEN_OP_PLUS) {
             op = MP_UNARY_OP_POSITIVE;
         } else if (tok == MP_TOKEN_OP_MINUS) {


### PR DESCRIPTION
Fix a few harmless clang warnings : 

```
../py/parse.c:548:18: error: implicit conversion from enumeration type 'mp_unary_op_t' to different enumeration
      type 'mp_binary_op_t' [-Werror,-Wenum-conversion]
            op = MP_UNARY_OP_POSITIVE;
               ~ ^~~~~~~~~~~~~~~~~~~~
../py/parse.c:550:18: error: implicit conversion from enumeration type 'mp_unary_op_t' to different enumeration
      type 'mp_binary_op_t' [-Werror,-Wenum-conversion]
            op = MP_UNARY_OP_NEGATIVE;
               ~ ^~~~~~~~~~~~~~~~~~~~
../py/parse.c:553:18: error: implicit conversion from enumeration type 'mp_unary_op_t' to different enumeration
      type 'mp_binary_op_t' [-Werror,-Wenum-conversion]
            op = MP_UNARY_OP_INVERT;
               ~ ^~~~~~~~~~~~~~~~~~
../py/parse.c:522:20: error: comparison of constant 255 with expression of type 'mp_binary_op_t' is always false
      [-Werror,-Wtautological-constant-out-of-range-compare]
            if (op == 255) {
                ~~ ^  ~~~
4 errors generated.
```
