### PR TITLE
full kwargs handling for property()

### DIFF
--- a/py/objproperty.c
+++ b/py/objproperty.c
@@ -39,9 +39,9 @@ typedef struct _mp_obj_property_t {
 
 STATIC mp_obj_t property_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_fget, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
-        { MP_QSTR_fset, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
-        { MP_QSTR_fdel, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+        { MP_QSTR_, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+        { MP_QSTR_, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+        { MP_QSTR_, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
         { MP_QSTR_doc, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
     };
     mp_arg_val_t vals[MP_ARRAY_SIZE(allowed_args)];

--- a/py/objproperty.c
+++ b/py/objproperty.c
@@ -38,6 +38,7 @@ typedef struct _mp_obj_property_t {
 } mp_obj_property_t;
 
 STATIC mp_obj_t property_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    enum { ARG_fget, ARG_fset, ARG_fdel, ARG_doc };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
         { MP_QSTR_, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
@@ -51,12 +52,12 @@ STATIC mp_obj_t property_make_new(const mp_obj_type_t *type, size_t n_args, size
 
     mp_obj_property_t *o = m_new_obj(mp_obj_property_t);
     o->base.type = type;
-    if (vals[3].u_obj != mp_const_none) {
+    if (vals[ARG_doc].u_obj != mp_const_none) {
         // doc ignored
     }
-    o->proxy[0] = vals[0].u_obj;
-    o->proxy[1] = vals[1].u_obj;
-    o->proxy[2] = vals[2].u_obj;
+    o->proxy[ARG_fget] = vals[0].u_obj;
+    o->proxy[ARG_fset] = vals[1].u_obj;
+    o->proxy[ARG_fdel] = vals[2].u_obj;
     return MP_OBJ_FROM_PTR(o);
 }
 

--- a/py/objproperty.c
+++ b/py/objproperty.c
@@ -46,9 +46,7 @@ STATIC mp_obj_t property_make_new(const mp_obj_type_t *type, size_t n_args, size
         { MP_QSTR_doc, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
     };
     mp_arg_val_t vals[MP_ARRAY_SIZE(allowed_args)];
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
-    mp_arg_parse_all(n_args, args, &kw_args, MP_ARRAY_SIZE(vals), allowed_args, vals);
+    mp_arg_parse_all_kw_array(n_args, n_kw, args, MP_ARRAY_SIZE(allowed_args), allowed_args, vals);
 
     mp_obj_property_t *o = m_new_obj(mp_obj_property_t);
     o->base.type = type;

--- a/py/objproperty.c
+++ b/py/objproperty.c
@@ -38,28 +38,25 @@ typedef struct _mp_obj_property_t {
 } mp_obj_property_t;
 
 STATIC mp_obj_t property_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 0, 4, false);
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_fget, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+        { MP_QSTR_fset, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+        { MP_QSTR_fdel, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+        { MP_QSTR_doc, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+    };
+    mp_arg_val_t vals[MP_ARRAY_SIZE(allowed_args)];
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+    mp_arg_parse_all(n_args, args, &kw_args, MP_ARRAY_SIZE(vals), allowed_args, vals);
 
     mp_obj_property_t *o = m_new_obj(mp_obj_property_t);
     o->base.type = type;
-    if (n_args >= 4) {
+    if (vals[3].u_obj != mp_const_none) {
         // doc ignored
     }
-    if (n_args >= 3) {
-        o->proxy[2] = args[2];
-    } else {
-        o->proxy[2] = mp_const_none;
-    }
-    if (n_args >= 2) {
-        o->proxy[1] = args[1];
-    } else {
-        o->proxy[1] = mp_const_none;
-    }
-    if (n_args >= 1) {
-        o->proxy[0] = args[0];
-    } else {
-        o->proxy[0] = mp_const_none;
-    }
+    o->proxy[0] = vals[0].u_obj;
+    o->proxy[1] = vals[1].u_obj;
+    o->proxy[2] = vals[2].u_obj;
     return MP_OBJ_FROM_PTR(o);
 }
 

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -570,9 +570,6 @@ Q(property)
 Q(getter)
 Q(setter)
 Q(deleter)
-Q(fget)
-Q(fset)
-Q(fdel)
 Q(doc)
 #endif
 

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -570,6 +570,10 @@ Q(property)
 Q(getter)
 Q(setter)
 Q(deleter)
+Q(fget)
+Q(fset)
+Q(fdel)
+Q(doc)
 #endif
 
 #if MICROPY_PY_UZLIB

--- a/tests/basics/builtin_property.py
+++ b/tests/basics/builtin_property.py
@@ -93,3 +93,8 @@ try:
     del d.prop
 except AttributeError:
     print('AttributeError')
+
+# properties take keyword arguments
+class E:
+    p = property(fget=lambda self: 42, doc="This is truth.")
+print(E().p)

--- a/tests/basics/builtin_property.py
+++ b/tests/basics/builtin_property.py
@@ -96,5 +96,7 @@ except AttributeError:
 
 # properties take keyword arguments
 class E:
-    p = property(fget=lambda self: 42, doc="This is truth.")
+    p = property(lambda self: 42, doc="This is truth.")
+    # not tested for because the other keyword arguments are not accepted
+    # q = property(fget=lambda self: 21, doc="Half the truth.")
 print(E().p)


### PR DESCRIPTION
given it simplifies the handling of different numbers of arguments (deleted code portion), i'd offer this as my preferred solution to #1778, providing maximum compatibility with cpython at the cost of four additional qstr, and probably slightly increased stack size and runtime for property calls (not measured).
