### PR TITLE
stmhal: Add os.statvfs

### DIFF
--- a/stmhal/qstrdefsport.h
+++ b/stmhal/qstrdefsport.h
@@ -396,6 +396,7 @@ Q(rmdir)
 Q(unlink)
 Q(sep)
 Q(stat)
+Q(statvfs)
 Q(urandom)
 Q(dupterm)
 


### PR DESCRIPTION
Implement enough of statvfs to determine the amount of free
space on a volume.

Adds 136 bytes to flash for stmhal.
