### PR TITLE
py: Allow CC=gcc-4.7 to be specified and have 32-bit builds still work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
   - sudo apt-get update -qq
-  - sudo apt-get install -y python3.4 python3 gcc-4.7 gcc-multilib gcc-arm-none-eabi qemu-system mingw32
+  - sudo apt-get install -y python3.4 python3 gcc-4.7 gcc-4.7-multilib gcc-multilib gcc-arm-none-eabi qemu-system mingw32 libffi-dev:i386
   # For teensy build
   - sudo apt-get install realpath
   # For coverage testing

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -53,9 +53,12 @@ SIZE = $(CROSS_COMPILE)size
 STRIP = $(CROSS_COMPILE)strip
 AR = $(CROSS_COMPILE)ar
 ifeq ($(MICROPY_FORCE_32BIT),1)
-CC += -m32
-CXX += -m32
-LD += -m32
+# It's not uncommon to specify CC=something on the command line. When that's
+# done, the += on the CC += line is ignored. By using override, it allows us
+# to add the CC option passed on the command line.
+override CC += -m32
+override CXX += -m32
+override LD += -m32
 endif
 
 all:


### PR DESCRIPTION
Checking this patch to see if it fixes the travis breakage.

The issue is that when CC=gcc-4.7 is specified on the make command line, the CC += -m32 is ignored.
