### PR TITLE
stmhal: Add support for building frozen files.

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -264,6 +264,19 @@ $(BUILD)/$(HAL_DIR)/src/stm32$(MCU_SERIES)xx_hal_sd.o: COPT += -Os
 
 all: $(BUILD)/firmware.dfu $(BUILD)/firmware.hex
 
+ifneq ($(FROZEN_DIR),)
+CFLAGS += -DMICROPY_MODULE_FROZEN
+OBJ += $(BUILD)/frozen-files.o
+MAKE_FROZEN = ../tools/make-frozen.py
+
+$(BUILD)/frozen-files.o: $(BUILD)/frozen-files.c
+	$(call compile_c)
+
+$(BUILD)/frozen-files.c: $(shell find $(FROZEN_DIR) -type f)
+	@$(ECHO) "Creating $@"
+	$(Q)$(PYTHON) $(MAKE_FROZEN) $(FROZEN_DIR) > $@
+endif
+
 .PHONY: deploy
 
 deploy: $(BUILD)/firmware.dfu


### PR DESCRIPTION
This allows FROZEN_DIR=some-directory to be specified on the make
command line, which will then add all of the files contained within
the indicated frozen directory as frozen files in the image.

There is no change in flash/ram usage if not using the feature.

This is especially useful on smaller MCUs (like the 401) which only
has 64K flash file system.
