### PR TITLE
py/modmicropython: Add stack_use, heap_lock and heap_unlock functions.

### DIFF
--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -91,7 +91,28 @@ STATIC mp_obj_t mp_micropython_qstr_info(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_micropython_qstr_info_obj, 0, 1, mp_micropython_qstr_info);
 
+#if MICROPY_STACK_CHECK
+STATIC mp_obj_t mp_micropython_stack_use(void) {
+    return MP_OBJ_NEW_SMALL_INT(mp_stack_usage());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_stack_use_obj, mp_micropython_stack_use);
+#endif
+
 #endif // MICROPY_PY_MICROPYTHON_MEM_INFO
+
+#if MICROPY_ENABLE_GC
+STATIC mp_obj_t mp_micropython_heap_lock(void) {
+    gc_lock();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_heap_lock_obj, mp_micropython_heap_lock);
+
+STATIC mp_obj_t mp_micropython_heap_unlock(void) {
+    gc_unlock();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_heap_unlock_obj, mp_micropython_heap_unlock);
+#endif
 
 #if MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF && (MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE == 0)
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_alloc_emergency_exception_buf_obj, mp_alloc_emergency_exception_buf);
@@ -107,10 +128,17 @@ STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
 #endif
     { MP_ROM_QSTR(MP_QSTR_mem_info), MP_ROM_PTR(&mp_micropython_mem_info_obj) },
     { MP_ROM_QSTR(MP_QSTR_qstr_info), MP_ROM_PTR(&mp_micropython_qstr_info_obj) },
+    #if MICROPY_STACK_CHECK
+    { MP_ROM_QSTR(MP_QSTR_stack_use), MP_ROM_PTR(&mp_micropython_stack_use_obj) },
+    #endif
 #endif
 #if MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF && (MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE == 0)
     { MP_ROM_QSTR(MP_QSTR_alloc_emergency_exception_buf), MP_ROM_PTR(&mp_alloc_emergency_exception_buf_obj) },
 #endif
+    #if MICROPY_ENABLE_GC
+    { MP_ROM_QSTR(MP_QSTR_heap_lock), MP_ROM_PTR(&mp_micropython_heap_lock_obj) },
+    { MP_ROM_QSTR(MP_QSTR_heap_unlock), MP_ROM_PTR(&mp_micropython_heap_unlock_obj) },
+    #endif
 };
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_micropython_globals, mp_module_micropython_globals_table);

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -432,6 +432,13 @@ Q(mem_peak)
 #endif
 Q(mem_info)
 Q(qstr_info)
+#if MICROPY_STACK_CHECK
+Q(stack_use)
+#endif
+#endif
+#if MICROPY_ENABLE_GC
+Q(heap_lock)
+Q(heap_unlock)
 #endif
 
 #if MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF && (MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE == 0)


### PR DESCRIPTION
These are a few simple functions that I find useful and I think should be part of the core.

micropython.stack_use() returns an integer being the number of bytes used
on the stack.

micropython.heap_lock() and heap_unlock() can be used to prevent the
memory manager from allocating anything on the heap.  Calls to these are
allowed to be nested.

Comments welcome!
