### PR TITLE
extmod/modurandom: Add some extra random functions.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -787,6 +787,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_URANDOM (0)
 #endif
 
+// Whether to include: randrange, randint, choice, random, uniform
+#ifndef MICROPY_PY_URANDOM_EXTRA_FUNCS
+#define MICROPY_PY_URANDOM_EXTRA_FUNCS (0)
+#endif
+
 #ifndef MICROPY_PY_MACHINE
 #define MICROPY_PY_MACHINE (0)
 #endif

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -686,4 +686,11 @@ Q(dupterm)
 Q(urandom)
 Q(getrandbits)
 Q(seed)
+#if MICROPY_PY_URANDOM_EXTRA_FUNCS
+Q(randrange)
+Q(randint)
+Q(choice)
+Q(random)
+Q(uniform)
+#endif
 #endif

--- a/stmhal/mpconfigport.h
+++ b/stmhal/mpconfigport.h
@@ -80,6 +80,7 @@
 #define MICROPY_PY_IO_FILEIO        (1)
 #define MICROPY_PY_UBINASCII        (1)
 #define MICROPY_PY_URANDOM          (1)
+#define MICROPY_PY_URANDOM_EXTRA_FUNCS (1)
 #define MICROPY_PY_UCTYPES          (1)
 #define MICROPY_PY_UZLIB            (1)
 #define MICROPY_PY_UJSON            (1)

--- a/tests/extmod/urandom_basic.py
+++ b/tests/extmod/urandom_basic.py
@@ -1,0 +1,19 @@
+try:
+    import urandom as random
+except ImportError:
+    import random
+
+# check getrandbits returns a value within the bit range
+for b in (1, 2, 3, 4, 16, 32):
+    for i in range(50):
+        assert random.getrandbits(b) < (1 << b)
+
+# check that seed(0) gives a non-zero value
+random.seed(0)
+print(random.getrandbits(16) != 0)
+
+# check that PRNG is repeatable
+random.seed(1)
+r = random.getrandbits(16)
+random.seed(1)
+print(random.getrandbits(16) == r)

--- a/tests/extmod/urandom_extra.py
+++ b/tests/extmod/urandom_extra.py
@@ -1,0 +1,39 @@
+try:
+    import urandom as random
+except ImportError:
+    import random
+
+try:
+    random.randint
+except AttributeError:
+    import sys
+    print('SKIP')
+    sys.exit(1)
+
+print('randrange')
+for i in range(50):
+    assert 0 <= random.randrange(4) < 4
+    assert 2 <= random.randrange(2, 6) < 6
+    assert -2 <= random.randrange(-2, 2) < 2
+    assert random.randrange(1, 9, 2) in (1, 3, 5, 7)
+
+print('randint')
+for i in range(50):
+    assert 0 <= random.randint(0, 4) <= 4
+    assert 2 <= random.randint(2, 6) <= 6
+    assert -2 <= random.randint(-2, 2) <= 2
+
+print('choice')
+lst = [1, 2, 5, 6]
+for i in range(50):
+    assert random.choice(lst) in lst
+
+print('random')
+for i in range(50):
+    assert 0 <= random.random() < 1
+
+print('uniform')
+for i in range(50):
+    assert 0 <= random.uniform(0, 4) <= 4
+    assert 2 <= random.uniform(2, 6) <= 6
+    assert -2 <= random.uniform(-2, 2) <= 2

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -193,7 +193,7 @@ freedos:
 
 # build an interpreter for coverage testing and do the testing
 coverage:
-	$(MAKE) COPT="-O0" CFLAGS_EXTRA='-fprofile-arcs -ftest-coverage -Wdouble-promotion -Wformat -Wmissing-declarations -Wmissing-prototypes -Wold-style-definition -Wpointer-arith -Wshadow -Wsign-compare -Wuninitialized -Wunused-parameter -DMICROPY_UNIX_COVERAGE' LDFLAGS_EXTRA='-fprofile-arcs -ftest-coverage' BUILD=build-coverage PROG=micropython_coverage
+	$(MAKE) COPT="-O0" CFLAGS_EXTRA='-fprofile-arcs -ftest-coverage -Wdouble-promotion -Wformat -Wmissing-declarations -Wmissing-prototypes -Wold-style-definition -Wpointer-arith -Wshadow -Wsign-compare -Wuninitialized -Wunused-parameter -DMICROPY_UNIX_COVERAGE -DMICROPY_PY_URANDOM_EXTRA_FUNCS' LDFLAGS_EXTRA='-fprofile-arcs -ftest-coverage' BUILD=build-coverage PROG=micropython_coverage
 
 coverage_test: coverage
 	$(eval DIRNAME=$(notdir $(CURDIR)))

--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -89,6 +89,7 @@
 #define MICROPY_PY_UHEAPQ           (1)
 #define MICROPY_PY_UHASHLIB         (1)
 #define MICROPY_PY_UBINASCII        (1)
+#define MICROPY_PY_URANDOM          (1)
 #define MICROPY_PY_MACHINE          (1)
 
 #define MICROPY_ERROR_REPORTING     (MICROPY_ERROR_REPORTING_DETAILED)


### PR DESCRIPTION
I implemented these for the microbit and some were non trivial (eg random float between 0 and 1) so thought they would be nice to have here, upstream.

Functions added are:
- randint
- randrange
- choice
- random
- uniform

Probably we want to have them configurable and disabled by default.  A lot of them can easily be coded in Python (ie in micropython-lib).  At the very least I think the random() function should stay.
