### PR TITLE
lib/utils/printf: Fix printf on release builds

### DIFF
--- a/lib/utils/printf.c
+++ b/lib/utils/printf.c
@@ -51,6 +51,19 @@ int printf(const char *fmt, ...) {
     return ret;
 }
 
+#ifdef __GLIBC__
+int __printf_chk(int flag, const char *fmt, ...) {
+    (void)flag;
+    va_list ap;
+    va_start(ap, fmt);
+    int ret = mp_vprintf(&mp_plat_print, fmt, ap);
+    va_end(ap);
+    return ret;
+}
+#endif
+
+
+
 int vprintf(const char *fmt, va_list ap) {
     return mp_vprintf(&mp_plat_print, fmt, ap);
 }


### PR DESCRIPTION
In addition to optimizing printf to puts and/or putc, glibc adds
an inline function for printf which remaps it to __printf_chk.

This causes some very strange out-of-order prints. In particular
calls to printf which have no format strings and end in \n wind
up being optimized to puts, but other calls wind up calling
__printf_chk which will call glibc's printf rather than the one
provided.

By adding the our own version of **printf_chk** then all printf
calls will get remapped to mp_printf.

In DEBUG builds, this optimization doesn't occur.
