### PR TITLE
stmhal/diskio: Make reusable for other ports

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -156,6 +156,7 @@ SRC_C = \
 	file.c \
 	sdcard.c \
 	diskio.c \
+	fatfs_port.c \
 	ffconf.c \
 	lcd.c \
 	accel.c \

--- a/stmhal/diskio.c
+++ b/stmhal/diskio.c
@@ -35,21 +35,9 @@
 #include "py/runtime.h"
 #include "lib/fatfs/ff.h"        /* FatFs lower layer API */
 #include "lib/fatfs/diskio.h"    /* FatFs lower layer API */
-#include "rtc.h"
 #include "storage.h"
 #include "sdcard.h"
 #include "extmod/fsusermount.h"
-
-const PARTITION VolToPart[] = {
-    {0, 1},     // Logical drive 0 ==> Physical drive 0, 1st partition
-    {1, 0},     // Logical drive 1 ==> Physical drive 1 (auto detection)
-    {2, 0},     // Logical drive 2 ==> Physical drive 2 (auto detection)
-    /*
-    {0, 2},     // Logical drive 2 ==> Physical drive 0, 2nd partition
-    {0, 3},     // Logical drive 3 ==> Physical drive 0, 3rd partition
-    */
-};
-
 
 /*-----------------------------------------------------------------------*/
 /* Initialize a Drive                                                    */
@@ -282,15 +270,3 @@ DRESULT disk_ioctl (
     return RES_PARERR;
 }
 #endif
-
-DWORD get_fattime (
-    void
-)
-{
-    rtc_init_finalise();
-    RTC_TimeTypeDef time;
-    RTC_DateTypeDef date;
-    HAL_RTC_GetTime(&RTCHandle, &time, FORMAT_BIN);
-    HAL_RTC_GetDate(&RTCHandle, &date, FORMAT_BIN);
-    return ((2000 + date.Year - 1980) << 25) | ((date.Month) << 21) | ((date.Date) << 16) | ((time.Hours) << 11) | ((time.Minutes) << 5) | (time.Seconds / 2);
-}

--- a/stmhal/fatfs_port.c
+++ b/stmhal/fatfs_port.c
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mphal.h"
+#include "py/runtime.h"
+#include "lib/fatfs/ff.h"        /* FatFs lower layer API */
+#include "lib/fatfs/diskio.h"    /* FatFs lower layer API */
+#include "rtc.h"
+
+const PARTITION VolToPart[] = {
+    {0, 1},     // Logical drive 0 ==> Physical drive 0, 1st partition
+    {1, 0},     // Logical drive 1 ==> Physical drive 1 (auto detection)
+    {2, 0},     // Logical drive 2 ==> Physical drive 2 (auto detection)
+    /*
+    {0, 2},     // Logical drive 2 ==> Physical drive 0, 2nd partition
+    {0, 3},     // Logical drive 3 ==> Physical drive 0, 3rd partition
+    */
+};
+
+DWORD get_fattime(void) {
+    rtc_init_finalise();
+    RTC_TimeTypeDef time;
+    RTC_DateTypeDef date;
+    HAL_RTC_GetTime(&RTCHandle, &time, FORMAT_BIN);
+    HAL_RTC_GetDate(&RTCHandle, &date, FORMAT_BIN);
+    return ((2000 + date.Year - 1980) << 25) | ((date.Month) << 21) | ((date.Date) << 16) | ((time.Hours) << 11) | ((time.Minutes) << 5) | (time.Seconds / 2);
+}


### PR DESCRIPTION
Undefining it would leave only support for user mounts, and that may be
useful for some ports (starting with unix one).

"#if 0" sections represent code which is stmhal-specific, which is to be moved
to fatfs_port.c file.
