### PR TITLE
Towards FatFS VFS

### DIFF
--- a/cc3200/application.mk
+++ b/cc3200/application.mk
@@ -158,6 +158,7 @@ APP_LIB_SRC_C = $(addprefix lib/,\
 APP_STM_SRC_C = $(addprefix stmhal/,\
 	bufhelper.c \
 	file.c \
+	builtin_open.c \
 	import.c \
 	input.c \
 	irq.c \

--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -154,6 +154,7 @@ SRC_C = \
 	flash.c \
 	storage.c \
 	file.c \
+	builtin_open.c \
 	sdcard.c \
 	diskio.c \
 	fatfs_port.c \

--- a/stmhal/builtin_open.c
+++ b/stmhal/builtin_open.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-extern const byte fresult_to_errno_table[20];
+#include "py/runtime.h"
+#include "file.h"
 
-mp_obj_t fatfs_builtin_open(mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
-MP_DECLARE_CONST_FUN_OBJ(mp_builtin_open_obj);
+MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, fatfs_builtin_open);

--- a/stmhal/file.c
+++ b/stmhal/file.c
@@ -33,6 +33,11 @@
 #include "lib/fatfs/ff.h"
 #include "file.h"
 
+#if MICROPY_VFS_FAT
+#define mp_type_fileio fatfs_type_fileio
+#define mp_type_textio fatfs_type_textio
+#endif
+
 extern const mp_obj_type_t mp_type_fileio;
 extern const mp_obj_type_t mp_type_textio;
 

--- a/stmhal/file.c
+++ b/stmhal/file.c
@@ -271,10 +271,9 @@ const mp_obj_type_t mp_type_textio = {
 };
 
 // Factory function for I/O stream classes
-mp_obj_t mp_builtin_open(mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+mp_obj_t fatfs_builtin_open(mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
     // TODO: analyze buffering args and instantiate appropriate type
     mp_arg_val_t arg_vals[FILE_OPEN_NUM_ARGS];
     mp_arg_parse_all(n_args, args, kwargs, FILE_OPEN_NUM_ARGS, file_open_args, arg_vals);
     return file_open(&mp_type_textio, arg_vals);
 }
-MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);


### PR DESCRIPTION
This patch makes further progress towards idea mentioned in https://github.com/micropython/micropython/pull/1645#issuecomment-159576904 .

With this patch applied and further changes to unix/ and extmod/ following code works:

```
import uos
bdev = RAMFS(48)
vfs = uos.VfsFat(bdev, mkfs=True)

f = vfs.open("foo", "w")
f.write("hello!")
f.close()
```

unix/extmod part still requires more work (currently it's just dup of extmod/fsusermount.c), but at least for basic VFS.open() support, that's what needed from stmhal, so I'd like to merge it.
