### PR TITLE
extmod/fsusermount: Introduce separate mkfs() function.

### DIFF
--- a/extmod/fsusermount.h
+++ b/extmod/fsusermount.h
@@ -34,4 +34,5 @@ typedef struct _fs_user_mount_t {
     FATFS fatfs;
 } fs_user_mount_t;
 
-MP_DECLARE_CONST_FUN_OBJ(pyb_mount_obj);
+MP_DECLARE_CONST_FUN_OBJ(fsuser_mount_obj);
+MP_DECLARE_CONST_FUN_OBJ(fsuser_mkfs_obj);


### PR DESCRIPTION
Per the previously discussed plan. mount() still stays backward-compatible,
and new mkfs() is rought and takes more args than needed. But is a step
in a forward direction.
