### PR TITLE
fatfs: NORTC config macro to exclude get_fattime() compilation.

### DIFF
--- a/lib/fatfs/ffconf.h
+++ b/lib/fatfs/ffconf.h
@@ -248,8 +248,11 @@
 /*---------------------------------------------------------------------------/
 / System Configurations
 /---------------------------------------------------------------------------*/
-
+#ifdef MICROPY_FATFS_NORTC
+#define _FS_NORTC	(MICROPY_FATFS_NORTC)
+#else
 #define _FS_NORTC	0
+#endif
 #define _NORTC_MON	2
 #define _NORTC_MDAY	1
 #define _NORTC_YEAR	2015


### PR DESCRIPTION
Following up on the #1816. I have been trying to reuse the diskio.c in the esp8266. This wouldn't build without the get_fattime() which has been removed. With this patch, the port config can define a MICROPY_FATFS_NORTC to 1, thus excluding the get_fattime() from [ff.c#L62](https://github.com/micropython/micropython/blob/master/lib/fatfs/ff.c#L62).
