### PR TITLE
lib/fatfs: Support sector sizes beyond 512 bytes.

### DIFF
--- a/extmod/fsusermount.c
+++ b/extmod/fsusermount.c
@@ -76,6 +76,7 @@ STATIC mp_obj_t pyb_mount(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *
         mp_load_method_maybe(device, MP_QSTR_writeblocks, vfs->writeblocks);
         mp_load_method_maybe(device, MP_QSTR_sync, vfs->sync);
         mp_load_method(device, MP_QSTR_count, vfs->count);
+        mp_load_method_maybe(device, MP_QSTR_secsize, vfs->secsize);
 
         // Read-only device indicated by writeblocks[0] == MP_OBJ_NULL.
         // User can specify read-only device by:

--- a/extmod/fsusermount.h
+++ b/extmod/fsusermount.h
@@ -31,6 +31,7 @@ typedef struct _fs_user_mount_t {
     mp_obj_t writeblocks[4];
     mp_obj_t sync[2];
     mp_obj_t count[2];
+    mp_obj_t secsize[2];
     FATFS fatfs;
 } fs_user_mount_t;
 

--- a/lib/fatfs/ffconf.h
+++ b/lib/fatfs/ffconf.h
@@ -217,7 +217,11 @@
 
 
 #define	_MIN_SS		512
+#ifdef MICROPY_FATFS_MAX_SS
+#define	_MAX_SS		(MICROPY_FATFS_MAX_SS)
+#else
 #define	_MAX_SS		512
+#endif
 /* These options configure the range of sector size to be supported. (512, 1024,
 /  2048 or 4096) Always set both 512 for most systems, all type of memory cards and
 /  harddisk. But a larger value may be required for on-board flash memory and some

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -677,6 +677,7 @@ Q(readblocks)
 Q(writeblocks)
 Q(sync)
 Q(count)
+Q(secsize)
 #endif
 
 #if MICROPY_PY_OS_DUPTERM

--- a/stmhal/diskio.c
+++ b/stmhal/diskio.c
@@ -263,6 +263,16 @@ DRESULT disk_ioctl (
                     *((DWORD*)buff) = mp_obj_get_int(ret);
                     return RES_OK;
                 }
+
+                case GET_SECTOR_SIZE: {
+                    if (MP_STATE_PORT(fs_user_mount)->secsize[0] != MP_OBJ_NULL) {
+                        mp_obj_t ret = mp_call_method_n_kw(0, 0, MP_STATE_PORT(fs_user_mount)->secsize);
+                        *((DWORD*)buff) = mp_obj_get_int(ret);
+                        return RES_OK;
+                    }
+                    *((DWORD*)buff) = 512;
+                    return RES_OK;
+                }
             }
             break;
     }


### PR DESCRIPTION
If MICROPY_FATFS_MAX_SS is defined to power of 2 value between 1024 and
4096, support for dynamic sector size in FatFs will be enabled. Initial
target if fsusermount subsystem, whose block device object should provide
secsize() method returning sector size. Note that FatFs reserves static
buffer of MICROPY_FATFS_MAX_SS size for each filesystem in use, so that
value should be set sparingly.
