### PR TITLE
Upgrade block protocol to use ioctl method, and support fatfs sectors > 512 bytes

### DIFF
--- a/extmod/fsusermount.c
+++ b/extmod/fsusermount.c
@@ -76,8 +76,15 @@ STATIC mp_obj_t fatfs_mount_mkfs(mp_uint_t n_args, const mp_obj_t *pos_args, mp_
         // load block protocol methods
         mp_load_method(device, MP_QSTR_readblocks, vfs->readblocks);
         mp_load_method_maybe(device, MP_QSTR_writeblocks, vfs->writeblocks);
-        mp_load_method_maybe(device, MP_QSTR_sync, vfs->sync);
-        mp_load_method(device, MP_QSTR_count, vfs->count);
+        mp_load_method_maybe(device, MP_QSTR_ioctl, vfs->u.ioctl);
+        if (vfs->u.ioctl[0] != MP_OBJ_NULL) {
+            // device supports new block protocol, so indicate it
+            vfs->u.old.count[1] = MP_OBJ_SENTINEL;
+        } else {
+            // no ioctl method, so assume the device uses the old block protocol
+            mp_load_method_maybe(device, MP_QSTR_sync, vfs->u.old.sync);
+            mp_load_method(device, MP_QSTR_count, vfs->u.old.count);
+        }
 
         // Read-only device indicated by writeblocks[0] == MP_OBJ_NULL.
         // User can specify read-only device by:

--- a/extmod/fsusermount.h
+++ b/extmod/fsusermount.h
@@ -29,8 +29,15 @@ typedef struct _fs_user_mount_t {
     mp_uint_t len;
     mp_obj_t readblocks[4];
     mp_obj_t writeblocks[4];
-    mp_obj_t sync[2];
-    mp_obj_t count[2];
+    // new protocol uses just ioctl, old uses sync (optional) and count
+    // if ioctl[3]=count[1]=MP_OBJ_SENTINEL then we have the new protocol, else old
+    union {
+        mp_obj_t ioctl[4];
+        struct {
+            mp_obj_t sync[2];
+            mp_obj_t count[2];
+        } old;
+    } u;
     FATFS fatfs;
 } fs_user_mount_t;
 

--- a/lib/fatfs/ffconf.h
+++ b/lib/fatfs/ffconf.h
@@ -217,7 +217,11 @@
 
 
 #define	_MIN_SS		512
+#ifdef MICROPY_FATFS_MAX_SS
+#define _MAX_SS		(MICROPY_FATFS_MAX_SS)
+#else
 #define	_MAX_SS		512
+#endif
 /* These options configure the range of sector size to be supported. (512, 1024,
 /  2048 or 4096) Always set both 512 for most systems, all type of memory cards and
 /  harddisk. But a larger value may be required for on-board flash memory and some

--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -675,6 +675,7 @@ Q(readonly)
 Q(mkfs)
 Q(readblocks)
 Q(writeblocks)
+Q(ioctl)
 Q(sync)
 Q(count)
 #endif

--- a/stmhal/diskio.c
+++ b/stmhal/diskio.c
@@ -44,6 +44,7 @@
 //#define BP_IOCTL_DEINIT         (2) // unused
 #define BP_IOCTL_SYNC           (3)
 #define BP_IOCTL_SEC_COUNT      (4)
+#define BP_IOCTL_SEC_SIZE       (5)
 
 /*-----------------------------------------------------------------------*/
 /* Initialize a Drive                                                    */
@@ -273,6 +274,15 @@ DRESULT disk_ioctl (
                         return RES_OK;
                     }
 
+                    case GET_SECTOR_SIZE: {
+                        vfs->u.ioctl[2] = MP_OBJ_NEW_SMALL_INT(BP_IOCTL_SEC_SIZE);
+                        vfs->u.ioctl[3] = MP_OBJ_NEW_SMALL_INT(0); // unused
+                        mp_obj_t ret = mp_call_method_n_kw(2, 0, vfs->u.ioctl);
+                        *((WORD*)buff) = mp_obj_get_int(ret);
+                        vfs->u.ioctl[3] = MP_OBJ_SENTINEL; // indicate new protocol
+                        return RES_OK;
+                    }
+
                     case GET_BLOCK_SIZE:
                         *((DWORD*)buff) = 1; // erase block size in units of sector size
                         return RES_OK;
@@ -291,6 +301,10 @@ DRESULT disk_ioctl (
                         *((DWORD*)buff) = mp_obj_get_int(ret);
                         return RES_OK;
                     }
+
+                    case GET_SECTOR_SIZE:
+                        *((WORD*)buff) = 512; // old protocol had fixed sector size
+                        return RES_OK;
 
                     case GET_BLOCK_SIZE:
                         *((DWORD*)buff) = 1; // erase block size in units of sector size


### PR DESCRIPTION
This PR adds the ioctl method to the block protocol, and retains backwards compatibility with the old version (which would now be deprecated).

New protocol consists of:
- readblocks(self, n, buf)
- writeblocks(self, n, buf)
- ioctl(self, cmd); 0=sync, 1=sec_count, 2=sec_size

Some open questions:
1. What values to use for the cmd?  Maybe 0 should be reserved to catch errors.
2. For now these numbers can be "magic" but would somehow need to define them as constants on the C and Python side.
3. Should ioctl take a third argument?  If so we should do it now so that ioctl implementations don't need to be changed later.
