### PR TITLE
Added the barrier instructions to the inline assembler

### DIFF
--- a/docs/reference/asm_thumb2_misc.rst
+++ b/docs/reference/asm_thumb2_misc.rst
@@ -8,6 +8,16 @@ Miscellaneous instructions
 * mrs(Rd, special_reg) ``Rd = special_reg`` copy a special register to a general register. The special register
   may be IPSR (Interrupt Status Register) or BASEPRI (Base Priority Register). The IPSR provides a means of determining
   the exception number of an interrupt being processed. It contains zero if no interrupt is being processed.
+* dsb() ``dsb`` acts as a special data synchronization memory barrier. Instructions that come after the
+  ``dsb``, in program order, do not execute until the ``dsb`` instruction completes. The ``dsb``
+  instruction completes when all explicit memory accesses before it complete. Conditional execution is not supported.
+* dmb() ``dmb`` acts as a data memory barrier. It ensures that all explicit memory accesses that
+  appear, in program order, before the ``dmb`` instruction are completed before any explicit
+  memory accesses that appear, in program order, after the ``dmb`` instruction. ``dmb`` does not
+  affect the ordering or execution of instructions that do not access memory.
+* isb() ``isb`` acts as an instruction synchronization barrier. It flushes the pipeline of the processor, so
+  that all instructions following the ``isb`` are fetched from cache or memory again, after the ``isb``
+  instruction has been completed.
 
 Currently the ``cpsie()`` and ``cpsid()`` functions are partially implemented.
 They require but ignore the flags argument and serve as a means of enabling and disabling interrupts.

--- a/py/emitinlinethumb.c
+++ b/py/emitinlinethumb.c
@@ -533,6 +533,12 @@ STATIC void emit_inline_thumb_op(emit_inline_asm_t *emit, qstr op, mp_uint_t n_a
             asm_thumb_op16(emit->as, ASM_THUMB_OP_NOP);
         } else if (strcmp(op_str, "wfi") == 0) {
             asm_thumb_op16(emit->as, ASM_THUMB_OP_WFI);
+        } else if (strcmp(op_str, "dsb") == 0) {
+            asm_thumb_op32(emit->as, 0xf3bf, 0x8f4f);
+        } else if (strcmp(op_str, "dmb") == 0) {
+            asm_thumb_op32(emit->as, 0xf3bf, 0x8f5f);
+        } else if (strcmp(op_str, "isb") == 0) {
+            asm_thumb_op32(emit->as, 0xf3bf, 0x8f6f);
         } else {
             goto unknown_op;
         }


### PR DESCRIPTION
I have added the barrier instructions dsb() dmb() and isb() to the inline assembler. They serve to ensure proper timing and/or proper execution sequence of instructions. Writing code which show that they are effective is a little bit tricky. For verification, I have written a short inline assembler function with only these three instructions, and extracted and disassembled the generated binaries, using Damiens inspect() function, and compared that to the initial script.. I wrote  a second functions, which creates a pulse burst on Pin X1, and compared the result with and w/o the dsb() instructions. The result met the expectation.
The scripts, listing files and screen dumps are attached.
[barrier_test.zip](https://github.com/micropython/micropython/files/135113/barrier_test.zip)
