### PR TITLE
stmhal: Fix typo in stm32f401.ld file

### DIFF
--- a/stmhal/boards/stm32f401.ld
+++ b/stmhal/boards/stm32f401.ld
@@ -8,7 +8,8 @@ MEMORY
 {
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 0x080000 /* entire flash, 512 KiB */
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 0x004000 /* sector 0, 16 KiB */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 0x080000 /* sectors 5,6,7,8, 4*128KiB = 512 KiB */
+                                                             /* sector 1, 2, 3 are 16K, sector 4 is 64K = 96K for filesystem */
+    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 0x080000 /* sectors 5,6,7 3*128KiB = 384 KiB */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x018000 /* 96 KiB */
 }
 


### PR DESCRIPTION
The 411 has some af definitions which disagree with af definitions for the 405
