### PR TITLE
Add activation of unix file reader for ARM

### DIFF
--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -403,7 +403,7 @@ mp_raw_code_t *mp_raw_code_load_mem(const byte *buf, size_t len) {
 // here we define mp_raw_code_load_file depending on the port
 // TODO abstract this away properly
 
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(__x86_64__) || defined(__arm__)
 // unix file reader
 
 #include <sys/stat.h>


### PR DESCRIPTION
This fixes the "undefined reference to `mp_raw_code_load_file" issue when compiling on Linux / Raspberry Pi
