### PR TITLE
Add support for Linux / ARM platform (Raspberry Pi)

### DIFF
--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -403,7 +403,7 @@ mp_raw_code_t *mp_raw_code_load_mem(const byte *buf, size_t len) {
 // here we define mp_raw_code_load_file depending on the port
 // TODO abstract this away properly
 
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(__x86_64__) || (defined(__arm__) && (defined(__unix__)))
 // unix file reader
 
 #include <sys/stat.h>
@@ -637,7 +637,7 @@ void mp_raw_code_save(mp_raw_code_t *rc, mp_print_t *print) {
 // here we define mp_raw_code_save_file depending on the port
 // TODO abstract this away properly
 
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(__x86_64__) || (defined(__arm__) && (defined(__unix__)))
 
 #include <unistd.h>
 #include <sys/stat.h>

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -10,6 +10,9 @@ QSTR_DEFS = qstrdefsport.h
 # OS name, for simple autoconfig
 UNAME_S := $(shell uname -s)
 
+# Machine name
+UNAME_M := $(shell uname -m)
+
 # include py core make definitions
 include ../py/py.mk
 
@@ -74,7 +77,11 @@ ifeq ($(MICROPY_FORCE_32BIT),1)
 # starting with linux-libc-dev:i386
 ifeq ($(MICROPY_PY_FFI),1)
 ifeq ($(UNAME_S),Linux)
+ifeq ($(UNAME_M), armv7l)
+CFLAGS_MOD += -I/usr/include/arm-linux-gnueabihf
+else
 CFLAGS_MOD += -I/usr/include/i686-linux-gnu
+endif
 endif
 endif
 endif

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -10,9 +10,6 @@ QSTR_DEFS = qstrdefsport.h
 # OS name, for simple autoconfig
 UNAME_S := $(shell uname -s)
 
-# Machine name
-UNAME_M := $(shell uname -m)
-
 # include py core make definitions
 include ../py/py.mk
 
@@ -77,11 +74,7 @@ ifeq ($(MICROPY_FORCE_32BIT),1)
 # starting with linux-libc-dev:i386
 ifeq ($(MICROPY_PY_FFI),1)
 ifeq ($(UNAME_S),Linux)
-ifeq ($(UNAME_M), armv7l)
-CFLAGS_MOD += -I/usr/include/arm-linux-gnueabihf
-else
 CFLAGS_MOD += -I/usr/include/i686-linux-gnu
-endif
 endif
 endif
 endif


### PR DESCRIPTION
To build on the Raspberry Pi we need additional flags in the
Makefile and in emitglue.c.

Add: Makefile conditionals and GCC conditionals
