### PR TITLE
Add makefile target to deploy stmhal build via ST-LINK

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -29,6 +29,7 @@ USE_PYDFU ?= 1
 PYDFU ?= ../tools/pydfu.py
 DFU_UTIL ?= dfu-util
 DEVICE=0483:df11
+STFLASH ?= st-flash
 
 CROSS_COMPILE = arm-none-eabi-
 
@@ -285,6 +286,12 @@ ifeq ($(USE_PYDFU),1)
 else
 	$(Q)$(DFU_UTIL) -a 0 -d $(DEVICE) -D $<
 endif
+
+deploy-stlink: $(BUILD)/firmware.dfu
+	$(ECHO) "Writing $(BUILD)/firmware0.bin to the board via ST-LINK"
+	$(Q)$(STFLASH) write $(BUILD)/firmware0.bin 0x08000000
+	$(ECHO) "Writing $(BUILD)/firmware1.bin to the board via ST-LINK"
+	$(Q)$(STFLASH) --reset write $(BUILD)/firmware1.bin 0x08020000
 
 $(BUILD)/firmware.dfu: $(BUILD)/firmware.elf
 	$(ECHO) "Create $@"

--- a/stmhal/README.md
+++ b/stmhal/README.md
@@ -57,6 +57,31 @@ Or using `dfu-util` directly:
 
     $ sudo dfu-util -a 0 -d 0483:df11 -D build-PYBV11/firmware.dfu
 
+
+### Flashing the Firmware with stlink
+
+ST Discovery or Nucleo boards have a builtin programmer called ST-LINK. With
+these boards and using Linux or OS X, you have the option to upload the
+`stmhal` firmware using the `st-flash` utility from the
+[stlink](https://github.com/texane/stlink) project. To do so, connect the board
+with a mini USB cable to its ST-LINK USB port and then use the make target
+`deploy-stlink`. For example, if you have the STM32F4DISCOVERY board, you can
+run:
+
+    $ make BOARD=STM32F4DISC deploy-stlink
+
+The `st-flash` program should detect the USB connection to the board
+automatically. If not, run `lsusb` to determine its USB bus and device number
+and set the `STLINK_DEVICE` environment variable accordingly, using the format
+`<USB_BUS>:<USB_ADDR>`. Example:
+
+    $ lsusb
+    [...]
+    Bus 002 Device 035: ID 0483:3748 STMicroelectronics ST-LINK/V2
+    $ export STLINK_DEVICE="002:0035"
+    $ make BOARD=STM32F4DISC deploy-stlink
+
+
 Accessing the board
 -------------------
 


### PR DESCRIPTION
In addition to the commit, here's some basic documentation for flashing the firmware via the ST-LINK interface. Where should I add it?
## Flashing the Firmware (stlink)

To deploy the `stmhal` firmware to a STM32 Discovery or Nucleo board with a ST-LINK interface using the `st-flash` utility from the [stlink](https://github.com/texane/stlink) project, use the make target `deploy-stlink`. Connect the board with a mini USB cable to its ST-LINK USB port and then run make. An example for the STM32F4DISCOVERY board:

```
$ make BOARD=STM32F4DISC deploy-stlink
```

The `st-flash` program should detect the USB connection to the board automatically.If not, run `lsusb` to determine its USB bus and device number and set the `STLINK_DEVICE` environment variable accordingly, using the format `<USB_BUS>:<USB_ADDR>`. Example:

```
$ lsusb
[...]
Bus 002 Device 035: ID 0483:3748 STMicroelectronics ST-LINK/V2
$ export STLINK_DEVICE="002:0035"
$ make BOARD=STM32F4DISC deploy-stlink
```
