### PR TITLE
Add makefile target and configuration to deploy stmhal build via OpenOCD

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -29,6 +29,8 @@ USE_PYDFU ?= 1
 PYDFU ?= ../tools/pydfu.py
 DFU_UTIL ?= dfu-util
 DEVICE=0483:df11
+OPENOCD ?= openocd
+OPENOCD_CONFIG ?= boards/openocd_stm32f4.cfg
 
 CROSS_COMPILE = arm-none-eabi-
 
@@ -285,6 +287,10 @@ ifeq ($(USE_PYDFU),1)
 else
 	$(Q)$(DFU_UTIL) -a 0 -d $(DEVICE) -D $<
 endif
+
+deploy-openocd: $(BUILD)/firmware.dfu
+	$(ECHO) "Writing $(BUILD)/firmware{0,1}.bin to the board via ST-LINK using OpenOCD"
+	$(Q)$(OPENOCD) -f $(OPENOCD_CONFIG) -c "stm_flash $(BUILD)/firmware0.bin $(BUILD)/firmware1.bin"
 
 $(BUILD)/firmware.dfu: $(BUILD)/firmware.elf
 	$(ECHO) "Create $@"

--- a/stmhal/README.md
+++ b/stmhal/README.md
@@ -57,6 +57,23 @@ Or using `dfu-util` directly:
 
     $ sudo dfu-util -a 0 -d 0483:df11 -D build-PYBV11/firmware.dfu
 
+
+### Flashing the Firmware with OpenOCD
+
+Another option to deploy the firmware on ST Discovery or Nucleo boards with a
+ST-LINK interface uses [OpenOCD](http://openocd.org/). Connect the board with
+a mini USB cable to its ST-LINK USB port and then use the make target
+`deploy-openocd`. For example, if you have the STM32F4DISCOVERY board:
+
+    $ make BOARD=STM32F4DISC deploy-openocd
+
+The `openocd` program, which writes the firmware to the target board's flash,
+is configured via the file `stmhal/boards/openocd_stm32f4.cfg`. This
+configuration should work for all boards based on a STM32F4xx MCU with a
+ST-LINKv2 interface. You can override the path to this configuration by setting
+`OPENOCD_CONFIG` in your Makefile or on the command line.
+
+
 Accessing the board
 -------------------
 

--- a/stmhal/boards/openocd_stm32f4.cfg
+++ b/stmhal/boards/openocd_stm32f4.cfg
@@ -1,0 +1,42 @@
+# This script configures OpenOCD for use with an ST-Link V2 programmer/debugger
+# and an STM32F4 target microcontroller.
+#
+# To flash your firmware:
+#
+#    $ openocd -f openocd_stm32f4.cfg \
+#        -c "stm_flash build-BOARD/firmware0.bin build-BOARD/firmware1.bin"
+#
+# For a gdb server on port 3333:
+#
+#    $ openocd -f openocd_stm32f4.cfg
+
+
+source [find interface/stlink-v2.cfg]
+transport select hla_swd
+source [find target/stm32f4x.cfg]
+reset_config srst_only
+init
+
+proc stm_flash { BIN0 BIN1 } {
+    reset halt
+    sleep 100
+    wait_halt 2
+    flash write_image erase $BIN0 0x08000000
+    sleep 100
+    verify_image $BIN0 0x08000000
+    sleep 100
+    flash write_image erase $BIN1 0x08020000
+    sleep 100
+    verify_image $BIN1 0x08020000
+    sleep 100
+    reset run
+    shutdown
+}
+
+proc stm_erase {} {
+    reset halt
+    sleep 100
+    stm32f4x mass_erase 0
+    sleep 100
+    shutdown
+}


### PR DESCRIPTION
Another Makefile target for deployment via OpenOCD.

I put the openocd configuration file in the `boards` directory, because it should work for all boards with a STM32F4xx processor and a ST-LINKv2 interface. Is that ok or is there a better place?

Documentation (to be added to a future `stmhal/README.md`):
## Flashing the Firmware (OpenOCD)

To deploy the `stmhal` firmware to a STM32 Discovery or Nucleo board with a ST-LINK interface using [OpenOCD](http://openocd.org/), use the make target `deploy-openocd`. Connect the board with a mini USB cable to its ST-LINK USB port and then run make. An example for the STM32F4DISCOVERY board:

$ make BOARD=STM32F4DISC deploy-openocd

The configuration for the `openocd` command, which writes the firmware to the target board's flash, is in the file `stmhal/boards/openocd_stm32f4.cfg` and should work for all ports for boards based on a STM32F4xx MCU with a ST-LINKv2 interface. You can override the path to this configuration by setting `OPENOCD_CONFIG` in your Makefile or on the command line.
