### PR TITLE
tests/afl: add easy way of running afl (american fuzzy lop) fuzzer

### DIFF
--- a/tests/afl/.gitignore
+++ b/tests/afl/.gitignore
@@ -1,0 +1,3 @@
+fuzz/
+tests/
+afltest.mpy

--- a/tests/afl/Makefile
+++ b/tests/afl/Makefile
@@ -1,0 +1,28 @@
+all:
+	@echo
+	@echo 'Use the following sequence:'
+	@echo
+	@echo '  make build    -  build micropython unix port with afl instrumentation and mpy-cross'
+	@echo '  make prepare  -  pre-compile tests using mpy-cross'
+	@echo '  make params   -  set optimal kernel parameters for testing (this one has to be run as root!)'
+	@echo '  make run      -  run american fuzzy lop'
+
+build:
+	make -C ../../mpy-cross
+	make -C ../../unix CC=afl-gcc
+
+prepare:
+	find ../basics -name '*.py' -exec ../../mpy-cross/mpy-cross -mcache-lookup-bc {} \;
+	mkdir tests/
+	mv ../basics/*.mpy tests/
+
+# must be run as root
+params:
+	echo core > /proc/sys/kernel/core_pattern
+	echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+
+run:
+	afl-fuzz -i tests -o fuzz -f afltest.mpy ../../unix/micropython -c 'import afltest'
+
+clean:
+	rm -rf fuzz/ tests/


### PR DESCRIPTION
Inspired by the [Segfaulting Python with afl-fuzz](https://tomforb.es/segfaulting-python-with-afl-fuzz) post, I created the script which is able to setup environment for [American Fuzzy Lop](http://lcamtuf.coredump.cx/afl/).

One just needs to install afl and follow the instructions in the Makefile.

Using this process, AFL found lots of crashes, around half of them on SIGABRT emitted by assert (which are OK IMO) and the other half on SIGSEGV (probably not so OK and might be worth investigating, as they might point to serious bugs in code).

The process might be optimized in the future, to be quicker, but I am sending this PR so more people can try this already.
