### PR TITLE
L4 integration: Added hal files for stm32l4xx.

### DIFF
--- a/stmhal/hal/l4/inc/Legacy/stm32_hal_legacy.h
+++ b/stmhal/hal/l4/inc/Legacy/stm32_hal_legacy.h
@@ -1,0 +1,2962 @@
+/**
+  ******************************************************************************
+  * @file    stm32_hal_legacy.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   This file contains aliases definition for the STM32Cube HAL constants 
+  *          macros and functions maintained for legacy purpose.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32_HAL_LEGACY
+#define __STM32_HAL_LEGACY
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup HAL_AES_Aliased_Defines HAL CRYP Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define AES_FLAG_RDERR                  CRYP_FLAG_RDERR
+#define AES_FLAG_WRERR                  CRYP_FLAG_WRERR
+#define AES_CLEARFLAG_CCF               CRYP_CLEARFLAG_CCF
+#define AES_CLEARFLAG_RDERR             CRYP_CLEARFLAG_RDERR
+#define AES_CLEARFLAG_WRERR             CRYP_CLEARFLAG_WRERR
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_ADC_Aliased_Defines HAL ADC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define ADC_RESOLUTION12b               ADC_RESOLUTION_12B
+#define ADC_RESOLUTION10b               ADC_RESOLUTION_10B
+#define ADC_RESOLUTION8b                ADC_RESOLUTION_8B
+#define ADC_RESOLUTION6b                ADC_RESOLUTION_6B
+#define OVR_DATA_OVERWRITTEN            ADC_OVR_DATA_OVERWRITTEN
+#define OVR_DATA_PRESERVED              ADC_OVR_DATA_PRESERVED
+#define EOC_SINGLE_CONV                 ADC_EOC_SINGLE_CONV
+#define EOC_SEQ_CONV                    ADC_EOC_SEQ_CONV
+#define EOC_SINGLE_SEQ_CONV             ADC_EOC_SINGLE_SEQ_CONV
+#define REGULAR_GROUP                   ADC_REGULAR_GROUP
+#define INJECTED_GROUP                  ADC_INJECTED_GROUP
+#define REGULAR_INJECTED_GROUP          ADC_REGULAR_INJECTED_GROUP
+#define AWD_EVENT                       ADC_AWD_EVENT
+#define AWD1_EVENT                      ADC_AWD1_EVENT
+#define AWD2_EVENT                      ADC_AWD2_EVENT
+#define AWD3_EVENT                      ADC_AWD3_EVENT
+#define OVR_EVENT                       ADC_OVR_EVENT
+#define JQOVF_EVENT                     ADC_JQOVF_EVENT
+#define ALL_CHANNELS                    ADC_ALL_CHANNELS
+#define REGULAR_CHANNELS                ADC_REGULAR_CHANNELS
+#define INJECTED_CHANNELS               ADC_INJECTED_CHANNELS
+#define SYSCFG_FLAG_SENSOR_ADC          ADC_FLAG_SENSOR
+#define SYSCFG_FLAG_VREF_ADC            ADC_FLAG_VREFINT
+#define ADC_CLOCKPRESCALER_PCLK_DIV1    ADC_CLOCK_SYNC_PCLK_DIV1
+#define ADC_CLOCKPRESCALER_PCLK_DIV2    ADC_CLOCK_SYNC_PCLK_DIV2
+#define ADC_CLOCKPRESCALER_PCLK_DIV4    ADC_CLOCK_SYNC_PCLK_DIV4
+#define ADC_CLOCKPRESCALER_PCLK_DIV6    ADC_CLOCK_SYNC_PCLK_DIV6
+#define ADC_CLOCKPRESCALER_PCLK_DIV8    ADC_CLOCK_SYNC_PCLK_DIV8
+#define ADC_EXTERNALTRIG0_T6_TRGO       ADC_EXTERNALTRIGCONV_T6_TRGO 
+#define ADC_EXTERNALTRIG1_T21_CC2       ADC_EXTERNALTRIGCONV_T21_CC2 
+#define ADC_EXTERNALTRIG2_T2_TRGO       ADC_EXTERNALTRIGCONV_T2_TRGO 
+#define ADC_EXTERNALTRIG3_T2_CC4        ADC_EXTERNALTRIGCONV_T2_CC4  
+#define ADC_EXTERNALTRIG4_T22_TRGO      ADC_EXTERNALTRIGCONV_T22_TRGO
+#define ADC_EXTERNALTRIG7_EXT_IT11      ADC_EXTERNALTRIGCONV_EXT_IT11
+#define ADC_CLOCK_ASYNC                 ADC_CLOCK_ASYNC_DIV1
+#define ADC_EXTERNALTRIG_EDGE_NONE      ADC_EXTERNALTRIGCONVEDGE_NONE
+#define ADC_EXTERNALTRIG_EDGE_RISING    ADC_EXTERNALTRIGCONVEDGE_RISING
+#define ADC_EXTERNALTRIG_EDGE_FALLING   ADC_EXTERNALTRIGCONVEDGE_FALLING
+#define ADC_EXTERNALTRIG_EDGE_RISINGFALLING ADC_EXTERNALTRIGCONVEDGE_RISINGFALLING
+#define ADC_SAMPLETIME_2CYCLE_5         ADC_SAMPLETIME_2CYCLES_5
+
+#define HAL_ADC_STATE_BUSY_REG          HAL_ADC_STATE_REG_BUSY
+#define HAL_ADC_STATE_BUSY_INJ          HAL_ADC_STATE_INJ_BUSY
+#define HAL_ADC_STATE_EOC_REG           HAL_ADC_STATE_REG_EOC
+#define HAL_ADC_STATE_EOC_INJ           HAL_ADC_STATE_INJ_EOC
+#define HAL_ADC_STATE_ERROR             HAL_ADC_STATE_ERROR_INTERNAL
+#define HAL_ADC_STATE_BUSY              HAL_ADC_STATE_BUSY_INTERNAL
+#define HAL_ADC_STATE_AWD               HAL_ADC_STATE_AWD1 
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_CEC_Aliased_Defines HAL CEC Aliased Defines maintained for legacy purpose
+  * @{
+  */ 
+  
+#define __HAL_CEC_GET_IT __HAL_CEC_GET_FLAG 
+
+/**
+  * @}
+  */   
+   
+/** @defgroup HAL_COMP_Aliased_Defines HAL COMP Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+#define COMP_WINDOWMODE_DISABLED       COMP_WINDOWMODE_DISABLE
+#define COMP_WINDOWMODE_ENABLED        COMP_WINDOWMODE_ENABLE
+#define COMP_EXTI_LINE_COMP1_EVENT     COMP_EXTI_LINE_COMP1
+#define COMP_EXTI_LINE_COMP2_EVENT     COMP_EXTI_LINE_COMP2
+#define COMP_EXTI_LINE_COMP3_EVENT     COMP_EXTI_LINE_COMP3
+#define COMP_EXTI_LINE_COMP4_EVENT     COMP_EXTI_LINE_COMP4
+#define COMP_EXTI_LINE_COMP5_EVENT     COMP_EXTI_LINE_COMP5
+#define COMP_EXTI_LINE_COMP6_EVENT     COMP_EXTI_LINE_COMP6
+#define COMP_EXTI_LINE_COMP7_EVENT     COMP_EXTI_LINE_COMP7
+#define COMP_OUTPUT_COMP6TIM2OCREFCLR  COMP_OUTPUT_COMP6_TIM2OCREFCLR
+#if defined(STM32F373xC) || defined(STM32F378xx)
+#define COMP_OUTPUT_TIM3IC1            COMP_OUTPUT_COMP1_TIM3IC1
+#define COMP_OUTPUT_TIM3OCREFCLR       COMP_OUTPUT_COMP1_TIM3OCREFCLR
+#endif /* STM32F373xC || STM32F378xx */
+/**
+  * @}
+  */
+
+/** @defgroup HAL_CORTEX_Aliased_Defines HAL CORTEX Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define __HAL_CORTEX_SYSTICKCLK_CONFIG HAL_SYSTICK_CLKSourceConfig
+/**
+  * @}
+  */
+
+/** @defgroup HAL_CRC_Aliased_Defines HAL CRC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+#define CRC_OUTPUTDATA_INVERSION_DISABLED    CRC_OUTPUTDATA_INVERSION_DISABLE
+#define CRC_OUTPUTDATA_INVERSION_ENABLED     CRC_OUTPUTDATA_INVERSION_ENABLE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_DAC_Aliased_Defines HAL DAC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+
+#define DAC1_CHANNEL_1                                  DAC_CHANNEL_1
+#define DAC1_CHANNEL_2                                  DAC_CHANNEL_2
+#define DAC2_CHANNEL_1                                  DAC_CHANNEL_1
+#define DAC_WAVE_NONE                                   ((uint32_t)0x00000000U)
+#define DAC_WAVE_NOISE                                  ((uint32_t)DAC_CR_WAVE1_0)
+#define DAC_WAVE_TRIANGLE                               ((uint32_t)DAC_CR_WAVE1_1)                           
+#define DAC_WAVEGENERATION_NONE                         DAC_WAVE_NONE
+#define DAC_WAVEGENERATION_NOISE                        DAC_WAVE_NOISE
+#define DAC_WAVEGENERATION_TRIANGLE                     DAC_WAVE_TRIANGLE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_DMA_Aliased_Defines HAL DMA Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define HAL_REMAPDMA_ADC_DMA_CH2                DMA_REMAP_ADC_DMA_CH2       
+#define HAL_REMAPDMA_USART1_TX_DMA_CH4          DMA_REMAP_USART1_TX_DMA_CH4 
+#define HAL_REMAPDMA_USART1_RX_DMA_CH5          DMA_REMAP_USART1_RX_DMA_CH5   
+#define HAL_REMAPDMA_TIM16_DMA_CH4              DMA_REMAP_TIM16_DMA_CH4       
+#define HAL_REMAPDMA_TIM17_DMA_CH2              DMA_REMAP_TIM17_DMA_CH2       
+#define HAL_REMAPDMA_USART3_DMA_CH32            DMA_REMAP_USART3_DMA_CH32
+#define HAL_REMAPDMA_TIM16_DMA_CH6              DMA_REMAP_TIM16_DMA_CH6
+#define HAL_REMAPDMA_TIM17_DMA_CH7              DMA_REMAP_TIM17_DMA_CH7      
+#define HAL_REMAPDMA_SPI2_DMA_CH67              DMA_REMAP_SPI2_DMA_CH67  
+#define HAL_REMAPDMA_USART2_DMA_CH67            DMA_REMAP_USART2_DMA_CH67 
+#define HAL_REMAPDMA_USART3_DMA_CH32            DMA_REMAP_USART3_DMA_CH32  
+#define HAL_REMAPDMA_I2C1_DMA_CH76              DMA_REMAP_I2C1_DMA_CH76   
+#define HAL_REMAPDMA_TIM1_DMA_CH6               DMA_REMAP_TIM1_DMA_CH6     
+#define HAL_REMAPDMA_TIM2_DMA_CH7               DMA_REMAP_TIM2_DMA_CH7      
+#define HAL_REMAPDMA_TIM3_DMA_CH6               DMA_REMAP_TIM3_DMA_CH6    
+  
+#define IS_HAL_REMAPDMA                          IS_DMA_REMAP  
+#define __HAL_REMAPDMA_CHANNEL_ENABLE            __HAL_DMA_REMAP_CHANNEL_ENABLE
+#define __HAL_REMAPDMA_CHANNEL_DISABLE           __HAL_DMA_REMAP_CHANNEL_DISABLE
+  
+  
+  
+/**
+  * @}
+  */
+
+/** @defgroup HAL_FLASH_Aliased_Defines HAL FLASH Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+#define TYPEPROGRAM_BYTE              FLASH_TYPEPROGRAM_BYTE
+#define TYPEPROGRAM_HALFWORD          FLASH_TYPEPROGRAM_HALFWORD
+#define TYPEPROGRAM_WORD              FLASH_TYPEPROGRAM_WORD
+#define TYPEPROGRAM_DOUBLEWORD        FLASH_TYPEPROGRAM_DOUBLEWORD
+#define TYPEERASE_SECTORS             FLASH_TYPEERASE_SECTORS
+#define TYPEERASE_PAGES               FLASH_TYPEERASE_PAGES
+#define TYPEERASE_PAGEERASE           FLASH_TYPEERASE_PAGES
+#define TYPEERASE_MASSERASE           FLASH_TYPEERASE_MASSERASE
+#define WRPSTATE_DISABLE              OB_WRPSTATE_DISABLE
+#define WRPSTATE_ENABLE               OB_WRPSTATE_ENABLE
+#define HAL_FLASH_TIMEOUT_VALUE       FLASH_TIMEOUT_VALUE
+#define OBEX_PCROP                    OPTIONBYTE_PCROP
+#define OBEX_BOOTCONFIG               OPTIONBYTE_BOOTCONFIG
+#define PCROPSTATE_DISABLE            OB_PCROP_STATE_DISABLE
+#define PCROPSTATE_ENABLE             OB_PCROP_STATE_ENABLE
+#define TYPEERASEDATA_BYTE            FLASH_TYPEERASEDATA_BYTE
+#define TYPEERASEDATA_HALFWORD        FLASH_TYPEERASEDATA_HALFWORD
+#define TYPEERASEDATA_WORD            FLASH_TYPEERASEDATA_WORD
+#define TYPEPROGRAMDATA_BYTE          FLASH_TYPEPROGRAMDATA_BYTE
+#define TYPEPROGRAMDATA_HALFWORD      FLASH_TYPEPROGRAMDATA_HALFWORD
+#define TYPEPROGRAMDATA_WORD          FLASH_TYPEPROGRAMDATA_WORD
+#define TYPEPROGRAMDATA_FASTBYTE      FLASH_TYPEPROGRAMDATA_FASTBYTE
+#define TYPEPROGRAMDATA_FASTHALFWORD  FLASH_TYPEPROGRAMDATA_FASTHALFWORD
+#define TYPEPROGRAMDATA_FASTWORD      FLASH_TYPEPROGRAMDATA_FASTWORD
+#define PAGESIZE                      FLASH_PAGE_SIZE
+#define TYPEPROGRAM_FASTBYTE          FLASH_TYPEPROGRAM_BYTE
+#define TYPEPROGRAM_FASTHALFWORD      FLASH_TYPEPROGRAM_HALFWORD
+#define TYPEPROGRAM_FASTWORD          FLASH_TYPEPROGRAM_WORD
+#define VOLTAGE_RANGE_1               FLASH_VOLTAGE_RANGE_1
+#define VOLTAGE_RANGE_2               FLASH_VOLTAGE_RANGE_2
+#define VOLTAGE_RANGE_3               FLASH_VOLTAGE_RANGE_3
+#define VOLTAGE_RANGE_4               FLASH_VOLTAGE_RANGE_4
+#define TYPEPROGRAM_FAST              FLASH_TYPEPROGRAM_FAST
+#define TYPEPROGRAM_FAST_AND_LAST     FLASH_TYPEPROGRAM_FAST_AND_LAST
+#define WRPAREA_BANK1_AREAA           OB_WRPAREA_BANK1_AREAA
+#define WRPAREA_BANK1_AREAB           OB_WRPAREA_BANK1_AREAB
+#define WRPAREA_BANK2_AREAA           OB_WRPAREA_BANK2_AREAA
+#define WRPAREA_BANK2_AREAB           OB_WRPAREA_BANK2_AREAB
+#define IWDG_STDBY_FREEZE             OB_IWDG_STDBY_FREEZE
+#define IWDG_STDBY_ACTIVE             OB_IWDG_STDBY_RUN
+#define IWDG_STOP_FREEZE              OB_IWDG_STOP_FREEZE
+#define IWDG_STOP_ACTIVE              OB_IWDG_STOP_RUN
+#define FLASH_ERROR_NONE              HAL_FLASH_ERROR_NONE
+#define FLASH_ERROR_RD                HAL_FLASH_ERROR_RD
+#define FLASH_ERROR_PG                HAL_FLASH_ERROR_PROG
+#define FLASH_ERROR_PGP               HAL_FLASH_ERROR_PGS
+#define FLASH_ERROR_WRP               HAL_FLASH_ERROR_WRP
+#define FLASH_ERROR_OPTV              HAL_FLASH_ERROR_OPTV
+#define FLASH_ERROR_OPTVUSR           HAL_FLASH_ERROR_OPTVUSR
+#define FLASH_ERROR_PROG              HAL_FLASH_ERROR_PROG
+#define FLASH_ERROR_OP                HAL_FLASH_ERROR_OPERATION
+#define FLASH_ERROR_PGA               HAL_FLASH_ERROR_PGA
+#define FLASH_ERROR_SIZE              HAL_FLASH_ERROR_SIZE
+#define FLASH_ERROR_SIZ               HAL_FLASH_ERROR_SIZE
+#define FLASH_ERROR_PGS               HAL_FLASH_ERROR_PGS
+#define FLASH_ERROR_MIS               HAL_FLASH_ERROR_MIS
+#define FLASH_ERROR_FAST              HAL_FLASH_ERROR_FAST
+#define FLASH_ERROR_FWWERR            HAL_FLASH_ERROR_FWWERR
+#define FLASH_ERROR_NOTZERO           HAL_FLASH_ERROR_NOTZERO
+#define FLASH_ERROR_OPERATION         HAL_FLASH_ERROR_OPERATION
+#define FLASH_ERROR_ERS               HAL_FLASH_ERROR_ERS
+#define OB_WDG_SW                     OB_IWDG_SW
+#define OB_WDG_HW                     OB_IWDG_HW
+#define OB_SDADC12_VDD_MONITOR_SET    OB_SDACD_VDD_MONITOR_SET
+#define OB_SDADC12_VDD_MONITOR_RESET  OB_SDACD_VDD_MONITOR_RESET
+#define OB_RAM_PARITY_CHECK_SET       OB_SRAM_PARITY_SET
+#define OB_RAM_PARITY_CHECK_RESET     OB_SRAM_PARITY_RESET
+#define IS_OB_SDADC12_VDD_MONITOR     IS_OB_SDACD_VDD_MONITOR
+#define OB_RDP_LEVEL0                 OB_RDP_LEVEL_0
+#define OB_RDP_LEVEL1                 OB_RDP_LEVEL_1
+#define OB_RDP_LEVEL2                 OB_RDP_LEVEL_2
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_SYSCFG_Aliased_Defines HAL SYSCFG Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+#define HAL_SYSCFG_FASTMODEPLUS_I2C_PA9    I2C_FASTMODEPLUS_PA9
+#define HAL_SYSCFG_FASTMODEPLUS_I2C_PA10   I2C_FASTMODEPLUS_PA10
+#define HAL_SYSCFG_FASTMODEPLUS_I2C_PB6    I2C_FASTMODEPLUS_PB6
+#define HAL_SYSCFG_FASTMODEPLUS_I2C_PB7    I2C_FASTMODEPLUS_PB7
+#define HAL_SYSCFG_FASTMODEPLUS_I2C_PB8    I2C_FASTMODEPLUS_PB8
+#define HAL_SYSCFG_FASTMODEPLUS_I2C_PB9    I2C_FASTMODEPLUS_PB9
+#define HAL_SYSCFG_FASTMODEPLUS_I2C1       I2C_FASTMODEPLUS_I2C1
+#define HAL_SYSCFG_FASTMODEPLUS_I2C2       I2C_FASTMODEPLUS_I2C2
+#define HAL_SYSCFG_FASTMODEPLUS_I2C3       I2C_FASTMODEPLUS_I2C3
+/**
+  * @}
+  */
+  
+
+/** @defgroup LL_FMC_Aliased_Defines LL FMC Aliased Defines maintained for compatibility purpose
+  * @{
+  */
+#if defined(STM32L4) || defined(STM32F7)
+#define FMC_NAND_PCC_WAIT_FEATURE_DISABLE       FMC_NAND_WAIT_FEATURE_DISABLE
+#define FMC_NAND_PCC_WAIT_FEATURE_ENABLE        FMC_NAND_WAIT_FEATURE_ENABLE
+#define FMC_NAND_PCC_MEM_BUS_WIDTH_8            FMC_NAND_MEM_BUS_WIDTH_8
+#define FMC_NAND_PCC_MEM_BUS_WIDTH_16           FMC_NAND_MEM_BUS_WIDTH_16
+#else
+#define FMC_NAND_WAIT_FEATURE_DISABLE           FMC_NAND_PCC_WAIT_FEATURE_DISABLE
+#define FMC_NAND_WAIT_FEATURE_ENABLE            FMC_NAND_PCC_WAIT_FEATURE_ENABLE
+#define FMC_NAND_MEM_BUS_WIDTH_8                FMC_NAND_PCC_MEM_BUS_WIDTH_8
+#define FMC_NAND_MEM_BUS_WIDTH_16               FMC_NAND_PCC_MEM_BUS_WIDTH_16
+#endif
+/**
+  * @}
+  */
+
+/** @defgroup LL_FSMC_Aliased_Defines LL FSMC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+#define FSMC_NORSRAM_TYPEDEF                      FSMC_NORSRAM_TypeDef
+#define FSMC_NORSRAM_EXTENDED_TYPEDEF             FSMC_NORSRAM_EXTENDED_TypeDef
+/**
+  * @}
+  */
+
+/** @defgroup HAL_GPIO_Aliased_Macros HAL GPIO Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define GET_GPIO_SOURCE                           GPIO_GET_INDEX
+#define GET_GPIO_INDEX                            GPIO_GET_INDEX
+
+#if defined(STM32F4)
+#define GPIO_AF12_SDMMC                           GPIO_AF12_SDIO
+#define GPIO_AF12_SDMMC1                          GPIO_AF12_SDIO
+#endif
+
+#if defined(STM32F7)
+#define GPIO_AF12_SDIO                            GPIO_AF12_SDMMC1
+#define GPIO_AF12_SDMMC                           GPIO_AF12_SDMMC1
+#endif
+
+#if defined(STM32L4)
+#define GPIO_AF12_SDIO                            GPIO_AF12_SDMMC1
+#define GPIO_AF12_SDMMC                           GPIO_AF12_SDMMC1
+#endif
+
+#define GPIO_AF0_LPTIM                            GPIO_AF0_LPTIM1
+#define GPIO_AF1_LPTIM                            GPIO_AF1_LPTIM1
+#define GPIO_AF2_LPTIM                            GPIO_AF2_LPTIM1
+
+#if defined(STM32L0) || defined(STM32L4) || defined(STM32F4) || defined(STM32F2) || defined(STM32F7)
+#define  GPIO_SPEED_LOW                           GPIO_SPEED_FREQ_LOW     
+#define  GPIO_SPEED_MEDIUM                        GPIO_SPEED_FREQ_MEDIUM     
+#define  GPIO_SPEED_FAST                          GPIO_SPEED_FREQ_HIGH     
+#define  GPIO_SPEED_HIGH                          GPIO_SPEED_FREQ_VERY_HIGH       
+#endif /* STM32L0 || STM32L4 || STM32F4 || STM32F2 || STM32F7 */
+
+#if defined(STM32L1) 
+ #define  GPIO_SPEED_VERY_LOW    GPIO_SPEED_FREQ_LOW     
+ #define  GPIO_SPEED_LOW         GPIO_SPEED_FREQ_MEDIUM     
+ #define  GPIO_SPEED_MEDIUM      GPIO_SPEED_FREQ_HIGH     
+ #define  GPIO_SPEED_HIGH        GPIO_SPEED_FREQ_VERY_HIGH     
+#endif /* STM32L1 */
+
+#if defined(STM32F0) || defined(STM32F3) || defined(STM32F1)
+ #define  GPIO_SPEED_LOW    GPIO_SPEED_FREQ_LOW
+ #define  GPIO_SPEED_MEDIUM GPIO_SPEED_FREQ_MEDIUM
+ #define  GPIO_SPEED_HIGH   GPIO_SPEED_FREQ_HIGH
+#endif /* STM32F0 || STM32F3 || STM32F1 */
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_HRTIM_Aliased_Macros HAL HRTIM Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define HRTIM_TIMDELAYEDPROTECTION_DISABLED           HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DISABLED
+#define HRTIM_TIMDELAYEDPROTECTION_DELAYEDOUT1_EEV68  HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DELAYEDOUT1_EEV6
+#define HRTIM_TIMDELAYEDPROTECTION_DELAYEDOUT2_EEV68  HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DELAYEDOUT2_EEV6
+#define HRTIM_TIMDELAYEDPROTECTION_DELAYEDBOTH_EEV68  HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DELAYEDBOTH_EEV6
+#define HRTIM_TIMDELAYEDPROTECTION_BALANCED_EEV68     HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_BALANCED_EEV6
+#define HRTIM_TIMDELAYEDPROTECTION_DELAYEDOUT1_DEEV79 HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DELAYEDOUT1_DEEV7
+#define HRTIM_TIMDELAYEDPROTECTION_DELAYEDOUT2_DEEV79 HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DELAYEDOUT2_DEEV7
+#define HRTIM_TIMDELAYEDPROTECTION_DELAYEDBOTH_EEV79  HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_DELAYEDBOTH_EEV7
+#define HRTIM_TIMDELAYEDPROTECTION_BALANCED_EEV79     HRTIM_TIMER_A_B_C_DELAYEDPROTECTION_BALANCED_EEV7
+   
+#define __HAL_HRTIM_SetCounter        __HAL_HRTIM_SETCOUNTER
+#define __HAL_HRTIM_GetCounter        __HAL_HRTIM_GETCOUNTER
+#define __HAL_HRTIM_SetPeriod         __HAL_HRTIM_SETPERIOD
+#define __HAL_HRTIM_GetPeriod         __HAL_HRTIM_GETPERIOD
+#define __HAL_HRTIM_SetClockPrescaler __HAL_HRTIM_SETCLOCKPRESCALER
+#define __HAL_HRTIM_GetClockPrescaler __HAL_HRTIM_GETCLOCKPRESCALER
+#define __HAL_HRTIM_SetCompare        __HAL_HRTIM_SETCOMPARE
+#define __HAL_HRTIM_GetCompare        __HAL_HRTIM_GETCOMPARE
+/**
+  * @}
+  */
+
+/** @defgroup HAL_I2C_Aliased_Defines HAL I2C Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define I2C_DUALADDRESS_DISABLED                I2C_DUALADDRESS_DISABLE
+#define I2C_DUALADDRESS_ENABLED                 I2C_DUALADDRESS_ENABLE
+#define I2C_GENERALCALL_DISABLED                I2C_GENERALCALL_DISABLE
+#define I2C_GENERALCALL_ENABLED                 I2C_GENERALCALL_ENABLE
+#define I2C_NOSTRETCH_DISABLED                  I2C_NOSTRETCH_DISABLE
+#define I2C_NOSTRETCH_ENABLED                   I2C_NOSTRETCH_ENABLE
+#define I2C_ANALOGFILTER_ENABLED                I2C_ANALOGFILTER_ENABLE
+#define I2C_ANALOGFILTER_DISABLED               I2C_ANALOGFILTER_DISABLE
+#if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32G0) || defined(STM32L4)
+#define HAL_I2C_STATE_MEM_BUSY_TX               HAL_I2C_STATE_BUSY_TX
+#define HAL_I2C_STATE_MEM_BUSY_RX               HAL_I2C_STATE_BUSY_RX
+#define HAL_I2C_STATE_MASTER_BUSY_TX            HAL_I2C_STATE_BUSY_TX
+#define HAL_I2C_STATE_MASTER_BUSY_RX            HAL_I2C_STATE_BUSY_RX
+#define HAL_I2C_STATE_SLAVE_BUSY_TX             HAL_I2C_STATE_BUSY_TX
+#define HAL_I2C_STATE_SLAVE_BUSY_RX             HAL_I2C_STATE_BUSY_RX
+#endif
+/**
+  * @}
+  */
+
+/** @defgroup HAL_IRDA_Aliased_Defines HAL IRDA Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define IRDA_ONE_BIT_SAMPLE_DISABLED            IRDA_ONE_BIT_SAMPLE_DISABLE
+#define IRDA_ONE_BIT_SAMPLE_ENABLED             IRDA_ONE_BIT_SAMPLE_ENABLE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_IWDG_Aliased_Defines HAL IWDG Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define KR_KEY_RELOAD                   IWDG_KEY_RELOAD
+#define KR_KEY_ENABLE                   IWDG_KEY_ENABLE
+#define KR_KEY_EWA                      IWDG_KEY_WRITE_ACCESS_ENABLE
+#define KR_KEY_DWA                      IWDG_KEY_WRITE_ACCESS_DISABLE
+/**
+  * @}
+  */
+
+/** @defgroup HAL_LPTIM_Aliased_Defines HAL LPTIM Aliased Defines maintained for legacy purpose
+  * @{
+  */
+
+#define LPTIM_CLOCKSAMPLETIME_DIRECTTRANSISTION LPTIM_CLOCKSAMPLETIME_DIRECTTRANSITION
+#define LPTIM_CLOCKSAMPLETIME_2TRANSISTIONS     LPTIM_CLOCKSAMPLETIME_2TRANSITIONS
+#define LPTIM_CLOCKSAMPLETIME_4TRANSISTIONS     LPTIM_CLOCKSAMPLETIME_4TRANSITIONS
+#define LPTIM_CLOCKSAMPLETIME_8TRANSISTIONS     LPTIM_CLOCKSAMPLETIME_8TRANSITIONS
+
+#define LPTIM_CLOCKPOLARITY_RISINGEDGE          LPTIM_CLOCKPOLARITY_RISING
+#define LPTIM_CLOCKPOLARITY_FALLINGEDGE         LPTIM_CLOCKPOLARITY_FALLING
+#define LPTIM_CLOCKPOLARITY_BOTHEDGES           LPTIM_CLOCKPOLARITY_RISING_FALLING
+
+#define LPTIM_TRIGSAMPLETIME_DIRECTTRANSISTION  LPTIM_TRIGSAMPLETIME_DIRECTTRANSITION
+#define LPTIM_TRIGSAMPLETIME_2TRANSISTIONS      LPTIM_TRIGSAMPLETIME_2TRANSITIONS
+#define LPTIM_TRIGSAMPLETIME_4TRANSISTIONS      LPTIM_TRIGSAMPLETIME_4TRANSITIONS
+#define LPTIM_TRIGSAMPLETIME_8TRANSISTIONS      LPTIM_TRIGSAMPLETIME_8TRANSITIONS        
+
+/* The following 3 definition have also been present in a temporary version of lptim.h */
+/* They need to be renamed also to the right name, just in case */
+#define LPTIM_TRIGSAMPLETIME_2TRANSITION        LPTIM_TRIGSAMPLETIME_2TRANSITIONS
+#define LPTIM_TRIGSAMPLETIME_4TRANSITION        LPTIM_TRIGSAMPLETIME_4TRANSITIONS
+#define LPTIM_TRIGSAMPLETIME_8TRANSITION        LPTIM_TRIGSAMPLETIME_8TRANSITIONS
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_NAND_Aliased_Defines HAL NAND Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define NAND_AddressTypedef             NAND_AddressTypeDef
+
+#define __ARRAY_ADDRESS                 ARRAY_ADDRESS
+#define __ADDR_1st_CYCLE                ADDR_1ST_CYCLE
+#define __ADDR_2nd_CYCLE                ADDR_2ND_CYCLE
+#define __ADDR_3rd_CYCLE                ADDR_3RD_CYCLE
+#define __ADDR_4th_CYCLE                ADDR_4TH_CYCLE
+/**
+  * @}
+  */
+   
+/** @defgroup HAL_NOR_Aliased_Defines HAL NOR Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define NOR_StatusTypedef              HAL_NOR_StatusTypeDef
+#define NOR_SUCCESS                    HAL_NOR_STATUS_SUCCESS
+#define NOR_ONGOING                    HAL_NOR_STATUS_ONGOING
+#define NOR_ERROR                      HAL_NOR_STATUS_ERROR
+#define NOR_TIMEOUT                    HAL_NOR_STATUS_TIMEOUT
+
+#define __NOR_WRITE                    NOR_WRITE
+#define __NOR_ADDR_SHIFT               NOR_ADDR_SHIFT
+/**
+  * @}
+  */
+
+/** @defgroup HAL_OPAMP_Aliased_Defines HAL OPAMP Aliased Defines maintained for legacy purpose
+  * @{
+  */
+
+#define OPAMP_NONINVERTINGINPUT_VP0           OPAMP_NONINVERTINGINPUT_IO0
+#define OPAMP_NONINVERTINGINPUT_VP1           OPAMP_NONINVERTINGINPUT_IO1
+#define OPAMP_NONINVERTINGINPUT_VP2           OPAMP_NONINVERTINGINPUT_IO2
+#define OPAMP_NONINVERTINGINPUT_VP3           OPAMP_NONINVERTINGINPUT_IO3
+                                              
+#define OPAMP_SEC_NONINVERTINGINPUT_VP0       OPAMP_SEC_NONINVERTINGINPUT_IO0
+#define OPAMP_SEC_NONINVERTINGINPUT_VP1       OPAMP_SEC_NONINVERTINGINPUT_IO1
+#define OPAMP_SEC_NONINVERTINGINPUT_VP2       OPAMP_SEC_NONINVERTINGINPUT_IO2
+#define OPAMP_SEC_NONINVERTINGINPUT_VP3       OPAMP_SEC_NONINVERTINGINPUT_IO3   
+
+#define OPAMP_INVERTINGINPUT_VM0              OPAMP_INVERTINGINPUT_IO0
+#define OPAMP_INVERTINGINPUT_VM1              OPAMP_INVERTINGINPUT_IO1
+
+#define IOPAMP_INVERTINGINPUT_VM0             OPAMP_INVERTINGINPUT_IO0
+#define IOPAMP_INVERTINGINPUT_VM1             OPAMP_INVERTINGINPUT_IO1
+
+#define OPAMP_SEC_INVERTINGINPUT_VM0          OPAMP_SEC_INVERTINGINPUT_IO0
+#define OPAMP_SEC_INVERTINGINPUT_VM1          OPAMP_SEC_INVERTINGINPUT_IO1    
+
+#define OPAMP_INVERTINGINPUT_VINM             OPAMP_SEC_INVERTINGINPUT_IO1
+                                                                      
+#define OPAMP_PGACONNECT_NO                   OPAMP_PGA_CONNECT_INVERTINGINPUT_NO             
+#define OPAMP_PGACONNECT_VM0                  OPAMP_PGA_CONNECT_INVERTINGINPUT_IO0            
+#define OPAMP_PGACONNECT_VM1                  OPAMP_PGA_CONNECT_INVERTINGINPUT_IO1          
+                                                        
+/**
+  * @}
+  */
+
+/** @defgroup HAL_I2S_Aliased_Defines HAL I2S Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define I2S_STANDARD_PHILLIPS      I2S_STANDARD_PHILIPS
+/**
+  * @}
+  */
+
+/** @defgroup HAL_PCCARD_Aliased_Defines HAL PCCARD Aliased Defines maintained for legacy purpose
+  * @{
+  */
+
+/* Compact Flash-ATA registers description */
+#define CF_DATA                       ATA_DATA                
+#define CF_SECTOR_COUNT               ATA_SECTOR_COUNT        
+#define CF_SECTOR_NUMBER              ATA_SECTOR_NUMBER       
+#define CF_CYLINDER_LOW               ATA_CYLINDER_LOW        
+#define CF_CYLINDER_HIGH              ATA_CYLINDER_HIGH       
+#define CF_CARD_HEAD                  ATA_CARD_HEAD           
+#define CF_STATUS_CMD                 ATA_STATUS_CMD          
+#define CF_STATUS_CMD_ALTERNATE       ATA_STATUS_CMD_ALTERNATE
+#define CF_COMMON_DATA_AREA           ATA_COMMON_DATA_AREA    
+
+/* Compact Flash-ATA commands */
+#define CF_READ_SECTOR_CMD            ATA_READ_SECTOR_CMD 
+#define CF_WRITE_SECTOR_CMD           ATA_WRITE_SECTOR_CMD
+#define CF_ERASE_SECTOR_CMD           ATA_ERASE_SECTOR_CMD
+#define CF_IDENTIFY_CMD               ATA_IDENTIFY_CMD
+
+#define PCCARD_StatusTypedef          HAL_PCCARD_StatusTypeDef
+#define PCCARD_SUCCESS                HAL_PCCARD_STATUS_SUCCESS
+#define PCCARD_ONGOING                HAL_PCCARD_STATUS_ONGOING
+#define PCCARD_ERROR                  HAL_PCCARD_STATUS_ERROR
+#define PCCARD_TIMEOUT                HAL_PCCARD_STATUS_TIMEOUT
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_RTC_Aliased_Defines HAL RTC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+#define FORMAT_BIN                  RTC_FORMAT_BIN
+#define FORMAT_BCD                  RTC_FORMAT_BCD
+
+#define RTC_ALARMSUBSECONDMASK_None     RTC_ALARMSUBSECONDMASK_NONE
+#define RTC_TAMPERERASEBACKUP_ENABLED   RTC_TAMPER_ERASE_BACKUP_ENABLE
+#define RTC_TAMPERERASEBACKUP_DISABLED  RTC_TAMPER_ERASE_BACKUP_DISABLE
+#define RTC_TAMPERMASK_FLAG_DISABLED    RTC_TAMPERMASK_FLAG_DISABLE
+#define RTC_TAMPERMASK_FLAG_ENABLED     RTC_TAMPERMASK_FLAG_ENABLE
+
+#define RTC_MASKTAMPERFLAG_DISABLED     RTC_TAMPERMASK_FLAG_DISABLE 
+#define RTC_MASKTAMPERFLAG_ENABLED      RTC_TAMPERMASK_FLAG_ENABLE 
+#define RTC_TAMPERERASEBACKUP_ENABLED   RTC_TAMPER_ERASE_BACKUP_ENABLE
+#define RTC_TAMPERERASEBACKUP_DISABLED  RTC_TAMPER_ERASE_BACKUP_DISABLE 
+#define RTC_MASKTAMPERFLAG_DISABLED     RTC_TAMPERMASK_FLAG_DISABLE 
+#define RTC_MASKTAMPERFLAG_ENABLED      RTC_TAMPERMASK_FLAG_ENABLE
+#define RTC_TAMPER1_2_INTERRUPT         RTC_ALL_TAMPER_INTERRUPT 
+#define RTC_TAMPER1_2_3_INTERRUPT       RTC_ALL_TAMPER_INTERRUPT 
+
+#define RTC_TIMESTAMPPIN_PC13  RTC_TIMESTAMPPIN_DEFAULT
+#define RTC_TIMESTAMPPIN_PA0 RTC_TIMESTAMPPIN_POS1 
+#define RTC_TIMESTAMPPIN_PI8 RTC_TIMESTAMPPIN_POS1
+#define RTC_TIMESTAMPPIN_PC1   RTC_TIMESTAMPPIN_POS2
+
+#define RTC_OUTPUT_REMAP_PC13  RTC_OUTPUT_REMAP_NONE
+#define RTC_OUTPUT_REMAP_PB14  RTC_OUTPUT_REMAP_POS1
+#define RTC_OUTPUT_REMAP_PB2   RTC_OUTPUT_REMAP_POS1
+
+#define RTC_TAMPERPIN_PC13 RTC_TAMPERPIN_DEFAULT 
+#define RTC_TAMPERPIN_PA0  RTC_TAMPERPIN_POS1 
+#define RTC_TAMPERPIN_PI8  RTC_TAMPERPIN_POS1
+
+/**
+  * @}
+  */
+
+  
+/** @defgroup HAL_SMARTCARD_Aliased_Defines HAL SMARTCARD Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define SMARTCARD_NACK_ENABLED                  SMARTCARD_NACK_ENABLE
+#define SMARTCARD_NACK_DISABLED                 SMARTCARD_NACK_DISABLE
+
+#define SMARTCARD_ONEBIT_SAMPLING_DISABLED      SMARTCARD_ONE_BIT_SAMPLE_DISABLE
+#define SMARTCARD_ONEBIT_SAMPLING_ENABLED       SMARTCARD_ONE_BIT_SAMPLE_ENABLE
+#define SMARTCARD_ONEBIT_SAMPLING_DISABLE       SMARTCARD_ONE_BIT_SAMPLE_DISABLE
+#define SMARTCARD_ONEBIT_SAMPLING_ENABLE        SMARTCARD_ONE_BIT_SAMPLE_ENABLE
+
+#define SMARTCARD_TIMEOUT_DISABLED              SMARTCARD_TIMEOUT_DISABLE
+#define SMARTCARD_TIMEOUT_ENABLED               SMARTCARD_TIMEOUT_ENABLE
+
+#define SMARTCARD_LASTBIT_DISABLED              SMARTCARD_LASTBIT_DISABLE
+#define SMARTCARD_LASTBIT_ENABLED               SMARTCARD_LASTBIT_ENABLE
+/**
+  * @}
+  */
+
+  
+  /** @defgroup HAL_SMBUS_Aliased_Defines HAL SMBUS Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define SMBUS_DUALADDRESS_DISABLED      SMBUS_DUALADDRESS_DISABLE
+#define SMBUS_DUALADDRESS_ENABLED       SMBUS_DUALADDRESS_ENABLE
+#define SMBUS_GENERALCALL_DISABLED      SMBUS_GENERALCALL_DISABLE
+#define SMBUS_GENERALCALL_ENABLED       SMBUS_GENERALCALL_ENABLE
+#define SMBUS_NOSTRETCH_DISABLED        SMBUS_NOSTRETCH_DISABLE
+#define SMBUS_NOSTRETCH_ENABLED         SMBUS_NOSTRETCH_ENABLE
+#define SMBUS_ANALOGFILTER_ENABLED      SMBUS_ANALOGFILTER_ENABLE
+#define SMBUS_ANALOGFILTER_DISABLED     SMBUS_ANALOGFILTER_DISABLE
+#define SMBUS_PEC_DISABLED              SMBUS_PEC_DISABLE
+#define SMBUS_PEC_ENABLED               SMBUS_PEC_ENABLE
+#define HAL_SMBUS_STATE_SLAVE_LISTEN    HAL_SMBUS_STATE_LISTEN
+/**
+  * @}
+  */
+  
+  /** @defgroup HAL_SPI_Aliased_Defines HAL SPI Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define SPI_TIMODE_DISABLED             SPI_TIMODE_DISABLE
+#define SPI_TIMODE_ENABLED              SPI_TIMODE_ENABLE
+
+#define SPI_CRCCALCULATION_DISABLED     SPI_CRCCALCULATION_DISABLE
+#define SPI_CRCCALCULATION_ENABLED      SPI_CRCCALCULATION_ENABLE
+
+#define SPI_NSS_PULSE_DISABLED          SPI_NSS_PULSE_DISABLE
+#define SPI_NSS_PULSE_ENABLED           SPI_NSS_PULSE_ENABLE
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_TIM_Aliased_Defines HAL TIM Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define CCER_CCxE_MASK                   TIM_CCER_CCxE_MASK
+#define CCER_CCxNE_MASK                  TIM_CCER_CCxNE_MASK
+  
+#define TIM_DMABase_CR1                  TIM_DMABASE_CR1
+#define TIM_DMABase_CR2                  TIM_DMABASE_CR2
+#define TIM_DMABase_SMCR                 TIM_DMABASE_SMCR
+#define TIM_DMABase_DIER                 TIM_DMABASE_DIER
+#define TIM_DMABase_SR                   TIM_DMABASE_SR
+#define TIM_DMABase_EGR                  TIM_DMABASE_EGR
+#define TIM_DMABase_CCMR1                TIM_DMABASE_CCMR1
+#define TIM_DMABase_CCMR2                TIM_DMABASE_CCMR2
+#define TIM_DMABase_CCER                 TIM_DMABASE_CCER
+#define TIM_DMABase_CNT                  TIM_DMABASE_CNT
+#define TIM_DMABase_PSC                  TIM_DMABASE_PSC
+#define TIM_DMABase_ARR                  TIM_DMABASE_ARR
+#define TIM_DMABase_RCR                  TIM_DMABASE_RCR
+#define TIM_DMABase_CCR1                 TIM_DMABASE_CCR1
+#define TIM_DMABase_CCR2                 TIM_DMABASE_CCR2
+#define TIM_DMABase_CCR3                 TIM_DMABASE_CCR3
+#define TIM_DMABase_CCR4                 TIM_DMABASE_CCR4
+#define TIM_DMABase_BDTR                 TIM_DMABASE_BDTR
+#define TIM_DMABase_DCR                  TIM_DMABASE_DCR
+#define TIM_DMABase_DMAR                 TIM_DMABASE_DMAR
+#define TIM_DMABase_OR1                  TIM_DMABASE_OR1
+#define TIM_DMABase_CCMR3                TIM_DMABASE_CCMR3
+#define TIM_DMABase_CCR5                 TIM_DMABASE_CCR5
+#define TIM_DMABase_CCR6                 TIM_DMABASE_CCR6
+#define TIM_DMABase_OR2                  TIM_DMABASE_OR2
+#define TIM_DMABase_OR3                  TIM_DMABASE_OR3
+#define TIM_DMABase_OR                   TIM_DMABASE_OR
+
+#define TIM_EventSource_Update           TIM_EVENTSOURCE_UPDATE
+#define TIM_EventSource_CC1              TIM_EVENTSOURCE_CC1
+#define TIM_EventSource_CC2              TIM_EVENTSOURCE_CC2
+#define TIM_EventSource_CC3              TIM_EVENTSOURCE_CC3
+#define TIM_EventSource_CC4              TIM_EVENTSOURCE_CC4
+#define TIM_EventSource_COM              TIM_EVENTSOURCE_COM
+#define TIM_EventSource_Trigger          TIM_EVENTSOURCE_TRIGGER
+#define TIM_EventSource_Break            TIM_EVENTSOURCE_BREAK
+#define TIM_EventSource_Break2           TIM_EVENTSOURCE_BREAK2
+
+#define TIM_DMABurstLength_1Transfer     TIM_DMABURSTLENGTH_1TRANSFER
+#define TIM_DMABurstLength_2Transfers    TIM_DMABURSTLENGTH_2TRANSFERS
+#define TIM_DMABurstLength_3Transfers    TIM_DMABURSTLENGTH_3TRANSFERS
+#define TIM_DMABurstLength_4Transfers    TIM_DMABURSTLENGTH_4TRANSFERS
+#define TIM_DMABurstLength_5Transfers    TIM_DMABURSTLENGTH_5TRANSFERS
+#define TIM_DMABurstLength_6Transfers    TIM_DMABURSTLENGTH_6TRANSFERS
+#define TIM_DMABurstLength_7Transfers    TIM_DMABURSTLENGTH_7TRANSFERS
+#define TIM_DMABurstLength_8Transfers    TIM_DMABURSTLENGTH_8TRANSFERS
+#define TIM_DMABurstLength_9Transfers    TIM_DMABURSTLENGTH_9TRANSFERS
+#define TIM_DMABurstLength_10Transfers   TIM_DMABURSTLENGTH_10TRANSFERS
+#define TIM_DMABurstLength_11Transfers   TIM_DMABURSTLENGTH_11TRANSFERS
+#define TIM_DMABurstLength_12Transfers   TIM_DMABURSTLENGTH_12TRANSFERS
+#define TIM_DMABurstLength_13Transfers   TIM_DMABURSTLENGTH_13TRANSFERS
+#define TIM_DMABurstLength_14Transfers   TIM_DMABURSTLENGTH_14TRANSFERS
+#define TIM_DMABurstLength_15Transfers   TIM_DMABURSTLENGTH_15TRANSFERS
+#define TIM_DMABurstLength_16Transfers   TIM_DMABURSTLENGTH_16TRANSFERS
+#define TIM_DMABurstLength_17Transfers   TIM_DMABURSTLENGTH_17TRANSFERS
+#define TIM_DMABurstLength_18Transfers   TIM_DMABURSTLENGTH_18TRANSFERS
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_TSC_Aliased_Defines HAL TSC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define TSC_SYNC_POL_FALL        TSC_SYNC_POLARITY_FALLING
+#define TSC_SYNC_POL_RISE_HIGH   TSC_SYNC_POLARITY_RISING
+/**
+  * @}
+  */
+
+/** @defgroup HAL_UART_Aliased_Defines HAL UART Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define UART_ONEBIT_SAMPLING_DISABLED   UART_ONE_BIT_SAMPLE_DISABLE
+#define UART_ONEBIT_SAMPLING_ENABLED    UART_ONE_BIT_SAMPLE_ENABLE
+#define UART_ONE_BIT_SAMPLE_DISABLED    UART_ONE_BIT_SAMPLE_DISABLE
+#define UART_ONE_BIT_SAMPLE_ENABLED     UART_ONE_BIT_SAMPLE_ENABLE
+
+#define __HAL_UART_ONEBIT_ENABLE        __HAL_UART_ONE_BIT_SAMPLE_ENABLE
+#define __HAL_UART_ONEBIT_DISABLE       __HAL_UART_ONE_BIT_SAMPLE_DISABLE
+
+#define __DIV_SAMPLING16                UART_DIV_SAMPLING16
+#define __DIVMANT_SAMPLING16            UART_DIVMANT_SAMPLING16
+#define __DIVFRAQ_SAMPLING16            UART_DIVFRAQ_SAMPLING16
+#define __UART_BRR_SAMPLING16           UART_BRR_SAMPLING16
+
+#define __DIV_SAMPLING8                 UART_DIV_SAMPLING8
+#define __DIVMANT_SAMPLING8             UART_DIVMANT_SAMPLING8
+#define __DIVFRAQ_SAMPLING8             UART_DIVFRAQ_SAMPLING8
+#define __UART_BRR_SAMPLING8            UART_BRR_SAMPLING8
+
+#define UART_WAKEUPMETHODE_IDLELINE     UART_WAKEUPMETHOD_IDLELINE
+#define UART_WAKEUPMETHODE_ADDRESSMARK  UART_WAKEUPMETHOD_ADDRESSMARK
+
+/**
+  * @}
+  */
+
+  
+/** @defgroup HAL_USART_Aliased_Defines HAL USART Aliased Defines maintained for legacy purpose
+  * @{
+  */
+
+#define USART_CLOCK_DISABLED            USART_CLOCK_DISABLE
+#define USART_CLOCK_ENABLED             USART_CLOCK_ENABLE
+
+#define USARTNACK_ENABLED               USART_NACK_ENABLE
+#define USARTNACK_DISABLED              USART_NACK_DISABLE
+/**
+  * @}
+  */
+
+/** @defgroup HAL_WWDG_Aliased_Defines HAL WWDG Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define CFR_BASE                    WWDG_CFR_BASE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_CAN_Aliased_Defines HAL CAN Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define CAN_FilterFIFO0             CAN_FILTER_FIFO0
+#define CAN_FilterFIFO1             CAN_FILTER_FIFO1
+#define CAN_IT_RQCP0                CAN_IT_TME
+#define CAN_IT_RQCP1                CAN_IT_TME
+#define CAN_IT_RQCP2                CAN_IT_TME
+#define INAK_TIMEOUT                CAN_TIMEOUT_VALUE
+#define SLAK_TIMEOUT                CAN_TIMEOUT_VALUE
+#define CAN_TXSTATUS_FAILED         ((uint8_t)0x00U)
+#define CAN_TXSTATUS_OK             ((uint8_t)0x01U)
+#define CAN_TXSTATUS_PENDING        ((uint8_t)0x02U)
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_ETH_Aliased_Defines HAL ETH Aliased Defines maintained for legacy purpose
+  * @{
+  */
+
+#define VLAN_TAG                ETH_VLAN_TAG
+#define MIN_ETH_PAYLOAD         ETH_MIN_ETH_PAYLOAD
+#define MAX_ETH_PAYLOAD         ETH_MAX_ETH_PAYLOAD
+#define JUMBO_FRAME_PAYLOAD     ETH_JUMBO_FRAME_PAYLOAD
+#define MACMIIAR_CR_MASK        ETH_MACMIIAR_CR_MASK
+#define MACCR_CLEAR_MASK        ETH_MACCR_CLEAR_MASK
+#define MACFCR_CLEAR_MASK       ETH_MACFCR_CLEAR_MASK
+#define DMAOMR_CLEAR_MASK       ETH_DMAOMR_CLEAR_MASK
+
+#define ETH_MMCCR              ((uint32_t)0x00000100U)  
+#define ETH_MMCRIR             ((uint32_t)0x00000104U)  
+#define ETH_MMCTIR             ((uint32_t)0x00000108U)  
+#define ETH_MMCRIMR            ((uint32_t)0x0000010CU)  
+#define ETH_MMCTIMR            ((uint32_t)0x00000110U)  
+#define ETH_MMCTGFSCCR         ((uint32_t)0x0000014CU)  
+#define ETH_MMCTGFMSCCR        ((uint32_t)0x00000150U)  
+#define ETH_MMCTGFCR           ((uint32_t)0x00000168U)  
+#define ETH_MMCRFCECR          ((uint32_t)0x00000194U)  
+#define ETH_MMCRFAECR          ((uint32_t)0x00000198U)  
+#define ETH_MMCRGUFCR          ((uint32_t)0x000001C4U)
+ 
+#define ETH_MAC_TXFIFO_FULL          ((uint32_t)0x02000000)  /* Tx FIFO full */
+#define ETH_MAC_TXFIFONOT_EMPTY      ((uint32_t)0x01000000)  /* Tx FIFO not empty */
+#define ETH_MAC_TXFIFO_WRITE_ACTIVE  ((uint32_t)0x00400000)  /* Tx FIFO write active */
+#define ETH_MAC_TXFIFO_IDLE     ((uint32_t)0x00000000)  /* Tx FIFO read status: Idle */
+#define ETH_MAC_TXFIFO_READ     ((uint32_t)0x00100000)  /* Tx FIFO read status: Read (transferring data to the MAC transmitter) */
+#define ETH_MAC_TXFIFO_WAITING  ((uint32_t)0x00200000)  /* Tx FIFO read status: Waiting for TxStatus from MAC transmitter */
+#define ETH_MAC_TXFIFO_WRITING  ((uint32_t)0x00300000)  /* Tx FIFO read status: Writing the received TxStatus or flushing the TxFIFO */
+#define ETH_MAC_TRANSMISSION_PAUSE     ((uint32_t)0x00080000)  /* MAC transmitter in pause */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE            ((uint32_t)0x00000000)  /* MAC transmit frame controller: Idle */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING         ((uint32_t)0x00020000)  /* MAC transmit frame controller: Waiting for Status of previous frame or IFG/backoff period to be over */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF   ((uint32_t)0x00040000)  /* MAC transmit frame controller: Generating and transmitting a Pause control frame (in full duplex mode) */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING    ((uint32_t)0x00060000)  /* MAC transmit frame controller: Transferring input frame for transmission */
+#define ETH_MAC_MII_TRANSMIT_ACTIVE      ((uint32_t)0x00010000)  /* MAC MII transmit engine active */
+#define ETH_MAC_RXFIFO_EMPTY             ((uint32_t)0x00000000)  /* Rx FIFO fill level: empty */
+#define ETH_MAC_RXFIFO_BELOW_THRESHOLD   ((uint32_t)0x00000100)  /* Rx FIFO fill level: fill-level below flow-control de-activate threshold */
+#define ETH_MAC_RXFIFO_ABOVE_THRESHOLD   ((uint32_t)0x00000200)  /* Rx FIFO fill level: fill-level above flow-control activate threshold */
+#define ETH_MAC_RXFIFO_FULL              ((uint32_t)0x00000300)  /* Rx FIFO fill level: full */
+#define ETH_MAC_READCONTROLLER_IDLE               ((uint32_t)0x00000000)  /* Rx FIFO read controller IDLE state */
+#define ETH_MAC_READCONTROLLER_READING_DATA       ((uint32_t)0x00000020)  /* Rx FIFO read controller Reading frame data */
+#define ETH_MAC_READCONTROLLER_READING_STATUS     ((uint32_t)0x00000040)  /* Rx FIFO read controller Reading frame status (or time-stamp) */
+#define ETH_MAC_READCONTROLLER_FLUSHING           ((uint32_t)0x00000060)  /* Rx FIFO read controller Flushing the frame data and status */
+#define ETH_MAC_RXFIFO_WRITE_ACTIVE     ((uint32_t)0x00000010)  /* Rx FIFO write controller active */
+#define ETH_MAC_SMALL_FIFO_NOTACTIVE    ((uint32_t)0x00000000)  /* MAC small FIFO read / write controllers not active */
+#define ETH_MAC_SMALL_FIFO_READ_ACTIVE  ((uint32_t)0x00000002)  /* MAC small FIFO read controller active */
+#define ETH_MAC_SMALL_FIFO_WRITE_ACTIVE ((uint32_t)0x00000004)  /* MAC small FIFO write controller active */
+#define ETH_MAC_SMALL_FIFO_RW_ACTIVE    ((uint32_t)0x00000006)  /* MAC small FIFO read / write controllers active */
+#define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE   ((uint32_t)0x00000001)  /* MAC MII receive protocol engine active */
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_PPP_Aliased_Defines HAL PPP Aliased Defines maintained for legacy purpose
+  * @{
+  */
+  
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup HAL_CRYP_Aliased_Functions HAL CRYP Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define HAL_CRYP_ComputationCpltCallback     HAL_CRYPEx_ComputationCpltCallback
+/**
+  * @}
+  */  
+
+/** @defgroup HAL_HASH_Aliased_Functions HAL HASH Aliased Functions maintained for legacy purpose
+  * @{
+  */ 
+#define HAL_HASH_STATETypeDef        HAL_HASH_StateTypeDef
+#define HAL_HASHPhaseTypeDef         HAL_HASH_PhaseTypeDef
+#define HAL_HMAC_MD5_Finish          HAL_HASH_MD5_Finish
+#define HAL_HMAC_SHA1_Finish         HAL_HASH_SHA1_Finish
+#define HAL_HMAC_SHA224_Finish       HAL_HASH_SHA224_Finish
+#define HAL_HMAC_SHA256_Finish       HAL_HASH_SHA256_Finish
+
+/*HASH Algorithm Selection*/
+
+#define HASH_AlgoSelection_SHA1      HASH_ALGOSELECTION_SHA1 
+#define HASH_AlgoSelection_SHA224    HASH_ALGOSELECTION_SHA224
+#define HASH_AlgoSelection_SHA256    HASH_ALGOSELECTION_SHA256
+#define HASH_AlgoSelection_MD5       HASH_ALGOSELECTION_MD5
+
+#define HASH_AlgoMode_HASH         HASH_ALGOMODE_HASH 
+#define HASH_AlgoMode_HMAC         HASH_ALGOMODE_HMAC
+
+#define HASH_HMACKeyType_ShortKey  HASH_HMAC_KEYTYPE_SHORTKEY
+#define HASH_HMACKeyType_LongKey   HASH_HMAC_KEYTYPE_LONGKEY
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_Aliased_Functions HAL Generic Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define HAL_EnableDBGSleepMode HAL_DBGMCU_EnableDBGSleepMode
+#define HAL_DisableDBGSleepMode HAL_DBGMCU_DisableDBGSleepMode
+#define HAL_EnableDBGStopMode HAL_DBGMCU_EnableDBGStopMode
+#define HAL_DisableDBGStopMode HAL_DBGMCU_DisableDBGStopMode
+#define HAL_EnableDBGStandbyMode HAL_DBGMCU_EnableDBGStandbyMode
+#define HAL_DisableDBGStandbyMode HAL_DBGMCU_DisableDBGStandbyMode
+#define HAL_DBG_LowPowerConfig(Periph, cmd) (((cmd)==ENABLE)? HAL_DBGMCU_DBG_EnableLowPowerConfig(Periph) : HAL_DBGMCU_DBG_DisableLowPowerConfig(Periph))
+#define HAL_VREFINT_OutputSelect  HAL_SYSCFG_VREFINT_OutputSelect
+#define HAL_Lock_Cmd(cmd) (((cmd)==ENABLE) ? HAL_SYSCFG_Enable_Lock_VREFINT() : HAL_SYSCFG_Disable_Lock_VREFINT())
+#define HAL_VREFINT_Cmd(cmd) (((cmd)==ENABLE)? HAL_SYSCFG_EnableVREFINT() : HAL_SYSCFG_DisableVREFINT())
+#define HAL_ADC_EnableBuffer_Cmd(cmd)  (((cmd)==ENABLE) ? HAL_ADCEx_EnableVREFINT() : HAL_ADCEx_DisableVREFINT())
+#define HAL_ADC_EnableBufferSensor_Cmd(cmd) (((cmd)==ENABLE) ?  HAL_ADCEx_EnableVREFINTTempSensor() : HAL_ADCEx_DisableVREFINTTempSensor())
+/**
+  * @}
+  */
+
+/** @defgroup HAL_FLASH_Aliased_Functions HAL FLASH Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define FLASH_HalfPageProgram      HAL_FLASHEx_HalfPageProgram
+#define FLASH_EnableRunPowerDown   HAL_FLASHEx_EnableRunPowerDown
+#define FLASH_DisableRunPowerDown  HAL_FLASHEx_DisableRunPowerDown
+#define HAL_DATA_EEPROMEx_Unlock   HAL_FLASHEx_DATAEEPROM_Unlock
+#define HAL_DATA_EEPROMEx_Lock     HAL_FLASHEx_DATAEEPROM_Lock
+#define HAL_DATA_EEPROMEx_Erase    HAL_FLASHEx_DATAEEPROM_Erase
+#define HAL_DATA_EEPROMEx_Program  HAL_FLASHEx_DATAEEPROM_Program
+
+ /**
+  * @}
+  */
+
+/** @defgroup HAL_I2C_Aliased_Functions HAL I2C Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define HAL_I2CEx_AnalogFilter_Config         HAL_I2CEx_ConfigAnalogFilter
+#define HAL_I2CEx_DigitalFilter_Config        HAL_I2CEx_ConfigDigitalFilter
+#define HAL_FMPI2CEx_AnalogFilter_Config      HAL_FMPI2CEx_ConfigAnalogFilter
+#define HAL_FMPI2CEx_DigitalFilter_Config     HAL_FMPI2CEx_ConfigDigitalFilter
+
+#define HAL_I2CFastModePlusConfig(SYSCFG_I2CFastModePlus, cmd) (((cmd)==ENABLE)? HAL_I2CEx_EnableFastModePlus(SYSCFG_I2CFastModePlus): HAL_I2CEx_DisableFastModePlus(SYSCFG_I2CFastModePlus))
+ /**
+  * @}
+  */
+
+/** @defgroup HAL_PWR_Aliased HAL PWR Aliased maintained for legacy purpose
+  * @{
+  */
+#define HAL_PWR_PVDConfig                             HAL_PWR_ConfigPVD
+#define HAL_PWR_DisableBkUpReg                        HAL_PWREx_DisableBkUpReg
+#define HAL_PWR_DisableFlashPowerDown                 HAL_PWREx_DisableFlashPowerDown
+#define HAL_PWR_DisableVddio2Monitor                  HAL_PWREx_DisableVddio2Monitor
+#define HAL_PWR_EnableBkUpReg                         HAL_PWREx_EnableBkUpReg
+#define HAL_PWR_EnableFlashPowerDown                  HAL_PWREx_EnableFlashPowerDown
+#define HAL_PWR_EnableVddio2Monitor                   HAL_PWREx_EnableVddio2Monitor
+#define HAL_PWR_PVD_PVM_IRQHandler                    HAL_PWREx_PVD_PVM_IRQHandler
+#define HAL_PWR_PVDLevelConfig                        HAL_PWR_ConfigPVD
+#define HAL_PWR_Vddio2Monitor_IRQHandler              HAL_PWREx_Vddio2Monitor_IRQHandler
+#define HAL_PWR_Vddio2MonitorCallback                 HAL_PWREx_Vddio2MonitorCallback
+#define HAL_PWREx_ActivateOverDrive                   HAL_PWREx_EnableOverDrive
+#define HAL_PWREx_DeactivateOverDrive                 HAL_PWREx_DisableOverDrive
+#define HAL_PWREx_DisableSDADCAnalog                  HAL_PWREx_DisableSDADC
+#define HAL_PWREx_EnableSDADCAnalog                   HAL_PWREx_EnableSDADC
+#define HAL_PWREx_PVMConfig                           HAL_PWREx_ConfigPVM
+
+#define PWR_MODE_NORMAL                               PWR_PVD_MODE_NORMAL
+#define PWR_MODE_IT_RISING                            PWR_PVD_MODE_IT_RISING
+#define PWR_MODE_IT_FALLING                           PWR_PVD_MODE_IT_FALLING
+#define PWR_MODE_IT_RISING_FALLING                    PWR_PVD_MODE_IT_RISING_FALLING
+#define PWR_MODE_EVENT_RISING                         PWR_PVD_MODE_EVENT_RISING
+#define PWR_MODE_EVENT_FALLING                        PWR_PVD_MODE_EVENT_FALLING
+#define PWR_MODE_EVENT_RISING_FALLING                 PWR_PVD_MODE_EVENT_RISING_FALLING
+
+#define CR_OFFSET_BB                                  PWR_CR_OFFSET_BB
+#define CSR_OFFSET_BB                                 PWR_CSR_OFFSET_BB
+
+#define DBP_BitNumber                                 DBP_BIT_NUMBER
+#define PVDE_BitNumber                                PVDE_BIT_NUMBER
+#define PMODE_BitNumber                               PMODE_BIT_NUMBER
+#define EWUP_BitNumber                                EWUP_BIT_NUMBER
+#define FPDS_BitNumber                                FPDS_BIT_NUMBER
+#define ODEN_BitNumber                                ODEN_BIT_NUMBER
+#define ODSWEN_BitNumber                              ODSWEN_BIT_NUMBER
+#define MRLVDS_BitNumber                              MRLVDS_BIT_NUMBER
+#define LPLVDS_BitNumber                              LPLVDS_BIT_NUMBER
+#define BRE_BitNumber                                 BRE_BIT_NUMBER
+
+#define PWR_MODE_EVT                                  PWR_PVD_MODE_NORMAL
+ 
+ /**
+  * @}
+  */  
+  
+/** @defgroup HAL_SMBUS_Aliased_Functions HAL SMBUS Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define HAL_SMBUS_Slave_Listen_IT          HAL_SMBUS_EnableListen_IT
+#define HAL_SMBUS_SlaveAddrCallback        HAL_SMBUS_AddrCallback         
+#define HAL_SMBUS_SlaveListenCpltCallback  HAL_SMBUS_ListenCpltCallback   
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SPI_Aliased_Functions HAL SPI Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define HAL_SPI_FlushRxFifo                HAL_SPIEx_FlushRxFifo
+/**
+  * @}
+  */  
+
+/** @defgroup HAL_TIM_Aliased_Functions HAL TIM Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#define HAL_TIM_DMADelayPulseCplt                       TIM_DMADelayPulseCplt
+#define HAL_TIM_DMAError                                TIM_DMAError
+#define HAL_TIM_DMACaptureCplt                          TIM_DMACaptureCplt
+#define HAL_TIMEx_DMACommutationCplt                    TIMEx_DMACommutationCplt
+/**
+  * @}
+  */
+   
+/** @defgroup HAL_UART_Aliased_Functions HAL UART Aliased Functions maintained for legacy purpose
+  * @{
+  */ 
+#define HAL_UART_WakeupCallback HAL_UARTEx_WakeupCallback
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_LTDC_Aliased_Functions HAL LTDC Aliased Functions maintained for legacy purpose
+  * @{
+  */ 
+#define HAL_LTDC_LineEvenCallback HAL_LTDC_LineEventCallback
+/**
+  * @}
+  */  
+   
+  
+   /** @defgroup HAL_PPP_Aliased_Functions HAL PPP Aliased Functions maintained for legacy purpose
+  * @{
+  */
+  
+/**
+  * @}
+  */
+
+/* Exported macros ------------------------------------------------------------*/
+
+/** @defgroup HAL_AES_Aliased_Macros HAL CRYP Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define AES_IT_CC                      CRYP_IT_CC
+#define AES_IT_ERR                     CRYP_IT_ERR
+#define AES_FLAG_CCF                   CRYP_FLAG_CCF
+/**
+  * @}
+  */  
+  
+/** @defgroup HAL_Aliased_Macros HAL Generic Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_GET_BOOT_MODE                   __HAL_SYSCFG_GET_BOOT_MODE
+#define __HAL_REMAPMEMORY_FLASH               __HAL_SYSCFG_REMAPMEMORY_FLASH
+#define __HAL_REMAPMEMORY_SYSTEMFLASH         __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH
+#define __HAL_REMAPMEMORY_SRAM                __HAL_SYSCFG_REMAPMEMORY_SRAM
+#define __HAL_REMAPMEMORY_FMC                 __HAL_SYSCFG_REMAPMEMORY_FMC
+#define __HAL_REMAPMEMORY_FMC_SDRAM           __HAL_SYSCFG_REMAPMEMORY_FMC_SDRAM 
+#define __HAL_REMAPMEMORY_FSMC                __HAL_SYSCFG_REMAPMEMORY_FSMC
+#define __HAL_REMAPMEMORY_QUADSPI             __HAL_SYSCFG_REMAPMEMORY_QUADSPI
+#define __HAL_FMC_BANK                        __HAL_SYSCFG_FMC_BANK
+#define __HAL_GET_FLAG                        __HAL_SYSCFG_GET_FLAG
+#define __HAL_CLEAR_FLAG                      __HAL_SYSCFG_CLEAR_FLAG
+#define __HAL_VREFINT_OUT_ENABLE              __HAL_SYSCFG_VREFINT_OUT_ENABLE
+#define __HAL_VREFINT_OUT_DISABLE             __HAL_SYSCFG_VREFINT_OUT_DISABLE
+
+#define SYSCFG_FLAG_VREF_READY                SYSCFG_FLAG_VREFINT_READY
+#define SYSCFG_FLAG_RC48                      RCC_FLAG_HSI48
+#define IS_SYSCFG_FASTMODEPLUS_CONFIG         IS_I2C_FASTMODEPLUS
+#define UFB_MODE_BitNumber                    UFB_MODE_BIT_NUMBER
+#define CMP_PD_BitNumber                      CMP_PD_BIT_NUMBER
+
+/**
+  * @}
+  */
+
+   
+/** @defgroup HAL_ADC_Aliased_Macros HAL ADC Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __ADC_ENABLE                                     __HAL_ADC_ENABLE
+#define __ADC_DISABLE                                    __HAL_ADC_DISABLE
+#define __HAL_ADC_ENABLING_CONDITIONS                    ADC_ENABLING_CONDITIONS
+#define __HAL_ADC_DISABLING_CONDITIONS                   ADC_DISABLING_CONDITIONS
+#define __HAL_ADC_IS_ENABLED                             ADC_IS_ENABLE
+#define __ADC_IS_ENABLED                                 ADC_IS_ENABLE
+#define __HAL_ADC_IS_SOFTWARE_START_REGULAR              ADC_IS_SOFTWARE_START_REGULAR
+#define __HAL_ADC_IS_SOFTWARE_START_INJECTED             ADC_IS_SOFTWARE_START_INJECTED
+#define __HAL_ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED
+#define __HAL_ADC_IS_CONVERSION_ONGOING_REGULAR          ADC_IS_CONVERSION_ONGOING_REGULAR
+#define __HAL_ADC_IS_CONVERSION_ONGOING_INJECTED         ADC_IS_CONVERSION_ONGOING_INJECTED
+#define __HAL_ADC_IS_CONVERSION_ONGOING                  ADC_IS_CONVERSION_ONGOING
+#define __HAL_ADC_CLEAR_ERRORCODE                        ADC_CLEAR_ERRORCODE
+
+#define __HAL_ADC_GET_RESOLUTION                         ADC_GET_RESOLUTION
+#define __HAL_ADC_JSQR_RK                                ADC_JSQR_RK
+#define __HAL_ADC_CFGR_AWD1CH                            ADC_CFGR_AWD1CH_SHIFT
+#define __HAL_ADC_CFGR_AWD23CR                           ADC_CFGR_AWD23CR
+#define __HAL_ADC_CFGR_INJECT_AUTO_CONVERSION            ADC_CFGR_INJECT_AUTO_CONVERSION
+#define __HAL_ADC_CFGR_INJECT_CONTEXT_QUEUE              ADC_CFGR_INJECT_CONTEXT_QUEUE
+#define __HAL_ADC_CFGR_INJECT_DISCCONTINUOUS             ADC_CFGR_INJECT_DISCCONTINUOUS
+#define __HAL_ADC_CFGR_REG_DISCCONTINUOUS                ADC_CFGR_REG_DISCCONTINUOUS
+#define __HAL_ADC_CFGR_DISCONTINUOUS_NUM                 ADC_CFGR_DISCONTINUOUS_NUM
+#define __HAL_ADC_CFGR_AUTOWAIT                          ADC_CFGR_AUTOWAIT
+#define __HAL_ADC_CFGR_CONTINUOUS                        ADC_CFGR_CONTINUOUS
+#define __HAL_ADC_CFGR_OVERRUN                           ADC_CFGR_OVERRUN
+#define __HAL_ADC_CFGR_DMACONTREQ                        ADC_CFGR_DMACONTREQ
+#define __HAL_ADC_CFGR_EXTSEL                            ADC_CFGR_EXTSEL_SET
+#define __HAL_ADC_JSQR_JEXTSEL                           ADC_JSQR_JEXTSEL_SET
+#define __HAL_ADC_OFR_CHANNEL                            ADC_OFR_CHANNEL
+#define __HAL_ADC_DIFSEL_CHANNEL                         ADC_DIFSEL_CHANNEL
+#define __HAL_ADC_CALFACT_DIFF_SET                       ADC_CALFACT_DIFF_SET
+#define __HAL_ADC_CALFACT_DIFF_GET                       ADC_CALFACT_DIFF_GET
+#define __HAL_ADC_TRX_HIGHTHRESHOLD                      ADC_TRX_HIGHTHRESHOLD
+
+#define __HAL_ADC_OFFSET_SHIFT_RESOLUTION                ADC_OFFSET_SHIFT_RESOLUTION
+#define __HAL_ADC_AWD1THRESHOLD_SHIFT_RESOLUTION         ADC_AWD1THRESHOLD_SHIFT_RESOLUTION
+#define __HAL_ADC_AWD23THRESHOLD_SHIFT_RESOLUTION        ADC_AWD23THRESHOLD_SHIFT_RESOLUTION
+#define __HAL_ADC_COMMON_REGISTER                        ADC_COMMON_REGISTER
+#define __HAL_ADC_COMMON_CCR_MULTI                       ADC_COMMON_CCR_MULTI
+#define __HAL_ADC_MULTIMODE_IS_ENABLED                   ADC_MULTIMODE_IS_ENABLE
+#define __ADC_MULTIMODE_IS_ENABLED                       ADC_MULTIMODE_IS_ENABLE
+#define __HAL_ADC_NONMULTIMODE_OR_MULTIMODEMASTER        ADC_NONMULTIMODE_OR_MULTIMODEMASTER
+#define __HAL_ADC_COMMON_ADC_OTHER                       ADC_COMMON_ADC_OTHER
+#define __HAL_ADC_MULTI_SLAVE                            ADC_MULTI_SLAVE
+
+#define __HAL_ADC_SQR1_L                                 ADC_SQR1_L_SHIFT
+#define __HAL_ADC_JSQR_JL                                ADC_JSQR_JL_SHIFT
+#define __HAL_ADC_JSQR_RK_JL                             ADC_JSQR_RK_JL
+#define __HAL_ADC_CR1_DISCONTINUOUS_NUM                  ADC_CR1_DISCONTINUOUS_NUM
+#define __HAL_ADC_CR1_SCAN                               ADC_CR1_SCAN_SET
+#define __HAL_ADC_CONVCYCLES_MAX_RANGE                   ADC_CONVCYCLES_MAX_RANGE
+#define __HAL_ADC_CLOCK_PRESCALER_RANGE                  ADC_CLOCK_PRESCALER_RANGE
+#define __HAL_ADC_GET_CLOCK_PRESCALER                    ADC_GET_CLOCK_PRESCALER
+
+#define __HAL_ADC_SQR1                                   ADC_SQR1
+#define __HAL_ADC_SMPR1                                  ADC_SMPR1
+#define __HAL_ADC_SMPR2                                  ADC_SMPR2
+#define __HAL_ADC_SQR3_RK                                ADC_SQR3_RK
+#define __HAL_ADC_SQR2_RK                                ADC_SQR2_RK
+#define __HAL_ADC_SQR1_RK                                ADC_SQR1_RK
+#define __HAL_ADC_CR2_CONTINUOUS                         ADC_CR2_CONTINUOUS
+#define __HAL_ADC_CR1_DISCONTINUOUS                      ADC_CR1_DISCONTINUOUS
+#define __HAL_ADC_CR1_SCANCONV                           ADC_CR1_SCANCONV
+#define __HAL_ADC_CR2_EOCSelection                       ADC_CR2_EOCSelection
+#define __HAL_ADC_CR2_DMAContReq                         ADC_CR2_DMAContReq
+#define __HAL_ADC_GET_RESOLUTION                         ADC_GET_RESOLUTION
+#define __HAL_ADC_JSQR                                   ADC_JSQR
+
+#define __HAL_ADC_CHSELR_CHANNEL                         ADC_CHSELR_CHANNEL
+#define __HAL_ADC_CFGR1_REG_DISCCONTINUOUS               ADC_CFGR1_REG_DISCCONTINUOUS
+#define __HAL_ADC_CFGR1_AUTOOFF                          ADC_CFGR1_AUTOOFF
+#define __HAL_ADC_CFGR1_AUTOWAIT                         ADC_CFGR1_AUTOWAIT
+#define __HAL_ADC_CFGR1_CONTINUOUS                       ADC_CFGR1_CONTINUOUS
+#define __HAL_ADC_CFGR1_OVERRUN                          ADC_CFGR1_OVERRUN
+#define __HAL_ADC_CFGR1_SCANDIR                          ADC_CFGR1_SCANDIR
+#define __HAL_ADC_CFGR1_DMACONTREQ                       ADC_CFGR1_DMACONTREQ
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_DAC_Aliased_Macros HAL DAC Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_DHR12R1_ALIGNEMENT                        DAC_DHR12R1_ALIGNMENT
+#define __HAL_DHR12R2_ALIGNEMENT                        DAC_DHR12R2_ALIGNMENT
+#define __HAL_DHR12RD_ALIGNEMENT                        DAC_DHR12RD_ALIGNMENT
+#define IS_DAC_GENERATE_WAVE                            IS_DAC_WAVE
+
+/**
+  * @}
+  */
+   
+/** @defgroup HAL_DBGMCU_Aliased_Macros HAL DBGMCU Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_FREEZE_TIM1_DBGMCU __HAL_DBGMCU_FREEZE_TIM1
+#define __HAL_UNFREEZE_TIM1_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM1
+#define __HAL_FREEZE_TIM2_DBGMCU __HAL_DBGMCU_FREEZE_TIM2
+#define __HAL_UNFREEZE_TIM2_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM2
+#define __HAL_FREEZE_TIM3_DBGMCU __HAL_DBGMCU_FREEZE_TIM3
+#define __HAL_UNFREEZE_TIM3_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM3
+#define __HAL_FREEZE_TIM4_DBGMCU __HAL_DBGMCU_FREEZE_TIM4
+#define __HAL_UNFREEZE_TIM4_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM4
+#define __HAL_FREEZE_TIM5_DBGMCU __HAL_DBGMCU_FREEZE_TIM5
+#define __HAL_UNFREEZE_TIM5_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM5
+#define __HAL_FREEZE_TIM6_DBGMCU __HAL_DBGMCU_FREEZE_TIM6
+#define __HAL_UNFREEZE_TIM6_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM6
+#define __HAL_FREEZE_TIM7_DBGMCU __HAL_DBGMCU_FREEZE_TIM7
+#define __HAL_UNFREEZE_TIM7_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM7
+#define __HAL_FREEZE_TIM8_DBGMCU __HAL_DBGMCU_FREEZE_TIM8
+#define __HAL_UNFREEZE_TIM8_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM8
+
+#define __HAL_FREEZE_TIM9_DBGMCU __HAL_DBGMCU_FREEZE_TIM9
+#define __HAL_UNFREEZE_TIM9_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM9
+#define __HAL_FREEZE_TIM10_DBGMCU __HAL_DBGMCU_FREEZE_TIM10
+#define __HAL_UNFREEZE_TIM10_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM10
+#define __HAL_FREEZE_TIM11_DBGMCU __HAL_DBGMCU_FREEZE_TIM11
+#define __HAL_UNFREEZE_TIM11_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM11
+#define __HAL_FREEZE_TIM12_DBGMCU __HAL_DBGMCU_FREEZE_TIM12
+#define __HAL_UNFREEZE_TIM12_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM12
+#define __HAL_FREEZE_TIM13_DBGMCU __HAL_DBGMCU_FREEZE_TIM13
+#define __HAL_UNFREEZE_TIM13_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM13
+#define __HAL_FREEZE_TIM14_DBGMCU __HAL_DBGMCU_FREEZE_TIM14
+#define __HAL_UNFREEZE_TIM14_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM14
+#define __HAL_FREEZE_CAN2_DBGMCU __HAL_DBGMCU_FREEZE_CAN2
+#define __HAL_UNFREEZE_CAN2_DBGMCU __HAL_DBGMCU_UNFREEZE_CAN2
+
+
+#define __HAL_FREEZE_TIM15_DBGMCU __HAL_DBGMCU_FREEZE_TIM15
+#define __HAL_UNFREEZE_TIM15_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM15
+#define __HAL_FREEZE_TIM16_DBGMCU __HAL_DBGMCU_FREEZE_TIM16
+#define __HAL_UNFREEZE_TIM16_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM16
+#define __HAL_FREEZE_TIM17_DBGMCU __HAL_DBGMCU_FREEZE_TIM17
+#define __HAL_UNFREEZE_TIM17_DBGMCU __HAL_DBGMCU_UNFREEZE_TIM17
+#define __HAL_FREEZE_RTC_DBGMCU __HAL_DBGMCU_FREEZE_RTC
+#define __HAL_UNFREEZE_RTC_DBGMCU __HAL_DBGMCU_UNFREEZE_RTC
+#define __HAL_FREEZE_WWDG_DBGMCU __HAL_DBGMCU_FREEZE_WWDG
+#define __HAL_UNFREEZE_WWDG_DBGMCU __HAL_DBGMCU_UNFREEZE_WWDG
+#define __HAL_FREEZE_IWDG_DBGMCU __HAL_DBGMCU_FREEZE_IWDG
+#define __HAL_UNFREEZE_IWDG_DBGMCU __HAL_DBGMCU_UNFREEZE_IWDG
+#define __HAL_FREEZE_I2C1_TIMEOUT_DBGMCU __HAL_DBGMCU_FREEZE_I2C1_TIMEOUT
+#define __HAL_UNFREEZE_I2C1_TIMEOUT_DBGMCU __HAL_DBGMCU_UNFREEZE_I2C1_TIMEOUT
+#define __HAL_FREEZE_I2C2_TIMEOUT_DBGMCU __HAL_DBGMCU_FREEZE_I2C2_TIMEOUT
+#define __HAL_UNFREEZE_I2C2_TIMEOUT_DBGMCU __HAL_DBGMCU_UNFREEZE_I2C2_TIMEOUT
+#define __HAL_FREEZE_I2C3_TIMEOUT_DBGMCU __HAL_DBGMCU_FREEZE_I2C3_TIMEOUT
+#define __HAL_UNFREEZE_I2C3_TIMEOUT_DBGMCU __HAL_DBGMCU_UNFREEZE_I2C3_TIMEOUT
+#define __HAL_FREEZE_CAN1_DBGMCU __HAL_DBGMCU_FREEZE_CAN1
+#define __HAL_UNFREEZE_CAN1_DBGMCU __HAL_DBGMCU_UNFREEZE_CAN1
+#define __HAL_FREEZE_LPTIM1_DBGMCU __HAL_DBGMCU_FREEZE_LPTIM1
+#define __HAL_UNFREEZE_LPTIM1_DBGMCU __HAL_DBGMCU_UNFREEZE_LPTIM1
+#define __HAL_FREEZE_LPTIM2_DBGMCU __HAL_DBGMCU_FREEZE_LPTIM2
+#define __HAL_UNFREEZE_LPTIM2_DBGMCU __HAL_DBGMCU_UNFREEZE_LPTIM2
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_COMP_Aliased_Macros HAL COMP Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#if defined(STM32F3)
+#define COMP_START                                       __HAL_COMP_ENABLE
+#define COMP_STOP                                        __HAL_COMP_DISABLE
+#define COMP_LOCK                                        __HAL_COMP_LOCK
+   
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_RISING_EDGE() : \
+                                                          __HAL_COMP_COMP6_EXTI_ENABLE_RISING_EDGE())
+#define __HAL_COMP_EXTI_RISING_IT_DISABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_DISABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_DISABLE_RISING_EDGE() : \
+                                                          __HAL_COMP_COMP6_EXTI_DISABLE_RISING_EDGE())
+#define __HAL_COMP_EXTI_FALLING_IT_ENABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          __HAL_COMP_COMP6_EXTI_ENABLE_FALLING_EDGE())
+#define __HAL_COMP_EXTI_FALLING_IT_DISABLE(__EXTILINE__) (((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          __HAL_COMP_COMP6_EXTI_DISABLE_FALLING_EDGE())
+#define __HAL_COMP_EXTI_ENABLE_IT(__EXTILINE__)          (((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_IT() : \
+                                                          __HAL_COMP_COMP6_EXTI_ENABLE_IT())
+#define __HAL_COMP_EXTI_DISABLE_IT(__EXTILINE__)         (((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_DISABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_DISABLE_IT() : \
+                                                          __HAL_COMP_COMP6_EXTI_DISABLE_IT())
+#define __HAL_COMP_EXTI_GET_FLAG(__FLAG__)               (((__FLAG__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_GET_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_GET_FLAG() : \
+                                                          __HAL_COMP_COMP6_EXTI_GET_FLAG())
+#define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)             (((__FLAG__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_CLEAR_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_CLEAR_FLAG() : \
+                                                          __HAL_COMP_COMP6_EXTI_CLEAR_FLAG())
+# endif
+# if defined(STM32F302xE) || defined(STM32F302xC)
+#define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_RISING_EDGE() : \
+                                                          __HAL_COMP_COMP6_EXTI_ENABLE_RISING_EDGE())
+#define __HAL_COMP_EXTI_RISING_IT_DISABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_DISABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_DISABLE_RISING_EDGE() : \
+                                                          __HAL_COMP_COMP6_EXTI_DISABLE_RISING_EDGE())
+#define __HAL_COMP_EXTI_FALLING_IT_ENABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          __HAL_COMP_COMP6_EXTI_ENABLE_FALLING_EDGE())
+#define __HAL_COMP_EXTI_FALLING_IT_DISABLE(__EXTILINE__) (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          __HAL_COMP_COMP6_EXTI_DISABLE_FALLING_EDGE())
+#define __HAL_COMP_EXTI_ENABLE_IT(__EXTILINE__)          (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_IT() : \
+                                                          __HAL_COMP_COMP6_EXTI_ENABLE_IT())
+#define __HAL_COMP_EXTI_DISABLE_IT(__EXTILINE__)         (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_DISABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_DISABLE_IT() : \
+                                                          __HAL_COMP_COMP6_EXTI_DISABLE_IT())
+#define __HAL_COMP_EXTI_GET_FLAG(__FLAG__)               (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_GET_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_GET_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_GET_FLAG() : \
+                                                          __HAL_COMP_COMP6_EXTI_GET_FLAG())
+#define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)             (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_CLEAR_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_CLEAR_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_CLEAR_FLAG() : \
+                                                          __HAL_COMP_COMP6_EXTI_CLEAR_FLAG())
+# endif
+# if defined(STM32F303xE) || defined(STM32F398xx) || defined(STM32F303xC) || defined(STM32F358xx)
+#define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP3) ? __HAL_COMP_COMP3_EXTI_ENABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP5) ? __HAL_COMP_COMP5_EXTI_ENABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP6) ? __HAL_COMP_COMP6_EXTI_ENABLE_RISING_EDGE() : \
+                                                          __HAL_COMP_COMP7_EXTI_ENABLE_RISING_EDGE())
+#define __HAL_COMP_EXTI_RISING_IT_DISABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_DISABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP3) ? __HAL_COMP_COMP3_EXTI_DISABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_DISABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP5) ? __HAL_COMP_COMP5_EXTI_DISABLE_RISING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP6) ? __HAL_COMP_COMP6_EXTI_DISABLE_RISING_EDGE() : \
+                                                          __HAL_COMP_COMP7_EXTI_DISABLE_RISING_EDGE())
+#define __HAL_COMP_EXTI_FALLING_IT_ENABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP3) ? __HAL_COMP_COMP3_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP5) ? __HAL_COMP_COMP5_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP6) ? __HAL_COMP_COMP6_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          __HAL_COMP_COMP7_EXTI_ENABLE_FALLING_EDGE())
+#define __HAL_COMP_EXTI_FALLING_IT_DISABLE(__EXTILINE__) (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP3) ? __HAL_COMP_COMP3_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP5) ? __HAL_COMP_COMP5_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP6) ? __HAL_COMP_COMP6_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          __HAL_COMP_COMP7_EXTI_DISABLE_FALLING_EDGE())
+#define __HAL_COMP_EXTI_ENABLE_IT(__EXTILINE__)          (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP3) ? __HAL_COMP_COMP3_EXTI_ENABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP5) ? __HAL_COMP_COMP5_EXTI_ENABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP6) ? __HAL_COMP_COMP6_EXTI_ENABLE_IT() : \
+                                                          __HAL_COMP_COMP7_EXTI_ENABLE_IT())
+#define __HAL_COMP_EXTI_DISABLE_IT(__EXTILINE__)         (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_DISABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP3) ? __HAL_COMP_COMP3_EXTI_DISABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_DISABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP5) ? __HAL_COMP_COMP5_EXTI_DISABLE_IT() : \
+                                                          ((__EXTILINE__)  == COMP_EXTI_LINE_COMP6) ? __HAL_COMP_COMP6_EXTI_DISABLE_IT() : \
+                                                          __HAL_COMP_COMP7_EXTI_DISABLE_IT())
+#define __HAL_COMP_EXTI_GET_FLAG(__FLAG__)               (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_GET_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_GET_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP3) ? __HAL_COMP_COMP3_EXTI_GET_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_GET_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP5) ? __HAL_COMP_COMP5_EXTI_GET_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP6) ? __HAL_COMP_COMP6_EXTI_GET_FLAG() : \
+                                                          __HAL_COMP_COMP7_EXTI_GET_FLAG())
+#define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)             (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_CLEAR_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_CLEAR_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP3) ? __HAL_COMP_COMP3_EXTI_CLEAR_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_CLEAR_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP5) ? __HAL_COMP_COMP5_EXTI_CLEAR_FLAG() : \
+                                                          ((__FLAG__)  == COMP_EXTI_LINE_COMP6) ? __HAL_COMP_COMP6_EXTI_CLEAR_FLAG() : \
+                                                          __HAL_COMP_COMP7_EXTI_CLEAR_FLAG())
+# endif
+# if defined(STM32F373xC) ||defined(STM32F378xx)
+#define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
+                                                          __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE())
+#define __HAL_COMP_EXTI_RISING_IT_DISABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_RISING_EDGE() : \
+                                                          __HAL_COMP_COMP2_EXTI_DISABLE_RISING_EDGE())
+#define __HAL_COMP_EXTI_FALLING_IT_ENABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          __HAL_COMP_COMP2_EXTI_ENABLE_FALLING_EDGE())
+#define __HAL_COMP_EXTI_FALLING_IT_DISABLE(__EXTILINE__) (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          __HAL_COMP_COMP2_EXTI_DISABLE_FALLING_EDGE())
+#define __HAL_COMP_EXTI_ENABLE_IT(__EXTILINE__)          (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_IT() : \
+                                                          __HAL_COMP_COMP2_EXTI_ENABLE_IT())
+#define __HAL_COMP_EXTI_DISABLE_IT(__EXTILINE__)         (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_IT() : \
+                                                          __HAL_COMP_COMP2_EXTI_DISABLE_IT())
+#define __HAL_COMP_EXTI_GET_FLAG(__FLAG__)               (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_GET_FLAG() : \
+                                                          __HAL_COMP_COMP2_EXTI_GET_FLAG())
+#define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)             (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_CLEAR_FLAG() : \
+                                                          __HAL_COMP_COMP2_EXTI_CLEAR_FLAG())
+# endif
+#else
+#define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
+                                                          __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE())
+#define __HAL_COMP_EXTI_RISING_IT_DISABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_RISING_EDGE() : \
+                                                          __HAL_COMP_COMP2_EXTI_DISABLE_RISING_EDGE())
+#define __HAL_COMP_EXTI_FALLING_IT_ENABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_FALLING_EDGE() : \
+                                                          __HAL_COMP_COMP2_EXTI_ENABLE_FALLING_EDGE())
+#define __HAL_COMP_EXTI_FALLING_IT_DISABLE(__EXTILINE__) (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_FALLING_EDGE() : \
+                                                          __HAL_COMP_COMP2_EXTI_DISABLE_FALLING_EDGE())
+#define __HAL_COMP_EXTI_ENABLE_IT(__EXTILINE__)          (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_IT() : \
+                                                          __HAL_COMP_COMP2_EXTI_ENABLE_IT())
+#define __HAL_COMP_EXTI_DISABLE_IT(__EXTILINE__)         (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_IT() : \
+                                                          __HAL_COMP_COMP2_EXTI_DISABLE_IT())
+#define __HAL_COMP_EXTI_GET_FLAG(__FLAG__)               (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_GET_FLAG() : \
+                                                          __HAL_COMP_COMP2_EXTI_GET_FLAG())
+#define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)             (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_CLEAR_FLAG() : \
+                                                          __HAL_COMP_COMP2_EXTI_CLEAR_FLAG())
+#endif
+
+#define __HAL_COMP_GET_EXTI_LINE  COMP_GET_EXTI_LINE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_DAC_Aliased_Macros HAL DAC Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define IS_DAC_WAVE(WAVE) (((WAVE) == DAC_WAVE_NONE) || \
+                          ((WAVE) == DAC_WAVE_NOISE)|| \
+                          ((WAVE) == DAC_WAVE_TRIANGLE))
+  
+/**
+  * @}
+  */
+
+/** @defgroup HAL_FLASH_Aliased_Macros HAL FLASH Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define IS_WRPAREA          IS_OB_WRPAREA
+#define IS_TYPEPROGRAM      IS_FLASH_TYPEPROGRAM
+#define IS_TYPEPROGRAMFLASH IS_FLASH_TYPEPROGRAM
+#define IS_TYPEERASE        IS_FLASH_TYPEERASE
+#define IS_NBSECTORS        IS_FLASH_NBSECTORS
+#define IS_OB_WDG_SOURCE    IS_OB_IWDG_SOURCE
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_I2C_Aliased_Macros HAL I2C Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+#define __HAL_I2C_RESET_CR2             I2C_RESET_CR2
+#define __HAL_I2C_GENERATE_START        I2C_GENERATE_START
+#define __HAL_I2C_FREQ_RANGE            I2C_FREQ_RANGE
+#define __HAL_I2C_RISE_TIME             I2C_RISE_TIME
+#define __HAL_I2C_SPEED_STANDARD        I2C_SPEED_STANDARD
+#define __HAL_I2C_SPEED_FAST            I2C_SPEED_FAST
+#define __HAL_I2C_SPEED                 I2C_SPEED
+#define __HAL_I2C_7BIT_ADD_WRITE        I2C_7BIT_ADD_WRITE
+#define __HAL_I2C_7BIT_ADD_READ         I2C_7BIT_ADD_READ
+#define __HAL_I2C_10BIT_ADDRESS         I2C_10BIT_ADDRESS
+#define __HAL_I2C_10BIT_HEADER_WRITE    I2C_10BIT_HEADER_WRITE
+#define __HAL_I2C_10BIT_HEADER_READ     I2C_10BIT_HEADER_READ
+#define __HAL_I2C_MEM_ADD_MSB           I2C_MEM_ADD_MSB
+#define __HAL_I2C_MEM_ADD_LSB           I2C_MEM_ADD_LSB
+#define __HAL_I2C_FREQRANGE             I2C_FREQRANGE
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_I2S_Aliased_Macros HAL I2S Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+#define IS_I2S_INSTANCE                 IS_I2S_ALL_INSTANCE
+#define IS_I2S_INSTANCE_EXT             IS_I2S_ALL_INSTANCE_EXT
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_IRDA_Aliased_Macros HAL IRDA Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+#define __IRDA_DISABLE                  __HAL_IRDA_DISABLE
+#define __IRDA_ENABLE                   __HAL_IRDA_ENABLE
+
+#define __HAL_IRDA_GETCLOCKSOURCE       IRDA_GETCLOCKSOURCE
+#define __HAL_IRDA_MASK_COMPUTATION     IRDA_MASK_COMPUTATION
+#define __IRDA_GETCLOCKSOURCE           IRDA_GETCLOCKSOURCE
+#define __IRDA_MASK_COMPUTATION         IRDA_MASK_COMPUTATION
+
+#define IS_IRDA_ONEBIT_SAMPLE           IS_IRDA_ONE_BIT_SAMPLE                  
+
+
+/**
+  * @}
+  */
+
+
+/** @defgroup HAL_IWDG_Aliased_Macros HAL IWDG Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_IWDG_ENABLE_WRITE_ACCESS  IWDG_ENABLE_WRITE_ACCESS
+#define __HAL_IWDG_DISABLE_WRITE_ACCESS IWDG_DISABLE_WRITE_ACCESS
+/**
+  * @}
+  */
+
+
+/** @defgroup HAL_LPTIM_Aliased_Macros HAL LPTIM Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define __HAL_LPTIM_ENABLE_INTERRUPT    __HAL_LPTIM_ENABLE_IT
+#define __HAL_LPTIM_DISABLE_INTERRUPT   __HAL_LPTIM_DISABLE_IT
+#define __HAL_LPTIM_GET_ITSTATUS        __HAL_LPTIM_GET_IT_SOURCE
+
+/**
+  * @}
+  */
+  
+  
+/** @defgroup HAL_OPAMP_Aliased_Macros HAL OPAMP Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __OPAMP_CSR_OPAXPD                OPAMP_CSR_OPAXPD
+#define __OPAMP_CSR_S3SELX                OPAMP_CSR_S3SELX
+#define __OPAMP_CSR_S4SELX                OPAMP_CSR_S4SELX
+#define __OPAMP_CSR_S5SELX                OPAMP_CSR_S5SELX
+#define __OPAMP_CSR_S6SELX                OPAMP_CSR_S6SELX
+#define __OPAMP_CSR_OPAXCAL_L             OPAMP_CSR_OPAXCAL_L
+#define __OPAMP_CSR_OPAXCAL_H             OPAMP_CSR_OPAXCAL_H
+#define __OPAMP_CSR_OPAXLPM               OPAMP_CSR_OPAXLPM
+#define __OPAMP_CSR_ALL_SWITCHES          OPAMP_CSR_ALL_SWITCHES
+#define __OPAMP_CSR_ANAWSELX              OPAMP_CSR_ANAWSELX
+#define __OPAMP_CSR_OPAXCALOUT            OPAMP_CSR_OPAXCALOUT
+#define __OPAMP_OFFSET_TRIM_BITSPOSITION  OPAMP_OFFSET_TRIM_BITSPOSITION
+#define __OPAMP_OFFSET_TRIM_SET           OPAMP_OFFSET_TRIM_SET
+
+/**
+  * @}
+  */
+
+
+/** @defgroup HAL_PWR_Aliased_Macros HAL PWR Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_PVD_EVENT_DISABLE                                  __HAL_PWR_PVD_EXTI_DISABLE_EVENT
+#define __HAL_PVD_EVENT_ENABLE                                   __HAL_PWR_PVD_EXTI_ENABLE_EVENT
+#define __HAL_PVD_EXTI_FALLINGTRIGGER_DISABLE                    __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE
+#define __HAL_PVD_EXTI_FALLINGTRIGGER_ENABLE                     __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_PVD_EXTI_RISINGTRIGGER_DISABLE                     __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE
+#define __HAL_PVD_EXTI_RISINGTRIGGER_ENABLE                      __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE
+#define __HAL_PVM_EVENT_DISABLE                                  __HAL_PWR_PVM_EVENT_DISABLE
+#define __HAL_PVM_EVENT_ENABLE                                   __HAL_PWR_PVM_EVENT_ENABLE
+#define __HAL_PVM_EXTI_FALLINGTRIGGER_DISABLE                    __HAL_PWR_PVM_EXTI_FALLINGTRIGGER_DISABLE
+#define __HAL_PVM_EXTI_FALLINGTRIGGER_ENABLE                     __HAL_PWR_PVM_EXTI_FALLINGTRIGGER_ENABLE
+#define __HAL_PVM_EXTI_RISINGTRIGGER_DISABLE                     __HAL_PWR_PVM_EXTI_RISINGTRIGGER_DISABLE
+#define __HAL_PVM_EXTI_RISINGTRIGGER_ENABLE                      __HAL_PWR_PVM_EXTI_RISINGTRIGGER_ENABLE
+#define __HAL_PWR_INTERNALWAKEUP_DISABLE                         HAL_PWREx_DisableInternalWakeUpLine
+#define __HAL_PWR_INTERNALWAKEUP_ENABLE                          HAL_PWREx_EnableInternalWakeUpLine
+#define __HAL_PWR_PULL_UP_DOWN_CONFIG_DISABLE                    HAL_PWREx_DisablePullUpPullDownConfig
+#define __HAL_PWR_PULL_UP_DOWN_CONFIG_ENABLE                     HAL_PWREx_EnablePullUpPullDownConfig
+#define __HAL_PWR_PVD_EXTI_CLEAR_EGDE_TRIGGER()                  do { __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE();__HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE(); } while(0)
+#define __HAL_PWR_PVD_EXTI_EVENT_DISABLE                         __HAL_PWR_PVD_EXTI_DISABLE_EVENT
+#define __HAL_PWR_PVD_EXTI_EVENT_ENABLE                          __HAL_PWR_PVD_EXTI_ENABLE_EVENT
+#define __HAL_PWR_PVD_EXTI_FALLINGTRIGGER_DISABLE                __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE
+#define __HAL_PWR_PVD_EXTI_FALLINGTRIGGER_ENABLE                 __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_PWR_PVD_EXTI_RISINGTRIGGER_DISABLE                 __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE
+#define __HAL_PWR_PVD_EXTI_RISINGTRIGGER_ENABLE                  __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE
+#define __HAL_PWR_PVD_EXTI_SET_FALLING_EGDE_TRIGGER              __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_PWR_PVD_EXTI_SET_RISING_EDGE_TRIGGER               __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE
+#define __HAL_PWR_PVM_DISABLE()                                  do { HAL_PWREx_DisablePVM1();HAL_PWREx_DisablePVM2();HAL_PWREx_DisablePVM3();HAL_PWREx_DisablePVM4(); } while(0)
+#define __HAL_PWR_PVM_ENABLE()                                   do { HAL_PWREx_EnablePVM1();HAL_PWREx_EnablePVM2();HAL_PWREx_EnablePVM3();HAL_PWREx_EnablePVM4(); } while(0)
+#define __HAL_PWR_SRAM2CONTENT_PRESERVE_DISABLE                  HAL_PWREx_DisableSRAM2ContentRetention
+#define __HAL_PWR_SRAM2CONTENT_PRESERVE_ENABLE                   HAL_PWREx_EnableSRAM2ContentRetention
+#define __HAL_PWR_VDDIO2_DISABLE                                 HAL_PWREx_DisableVddIO2
+#define __HAL_PWR_VDDIO2_ENABLE                                  HAL_PWREx_EnableVddIO2
+#define __HAL_PWR_VDDIO2_EXTI_CLEAR_EGDE_TRIGGER                 __HAL_PWR_VDDIO2_EXTI_DISABLE_FALLING_EDGE
+#define __HAL_PWR_VDDIO2_EXTI_SET_FALLING_EGDE_TRIGGER           __HAL_PWR_VDDIO2_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_PWR_VDDUSB_DISABLE                                 HAL_PWREx_DisableVddUSB
+#define __HAL_PWR_VDDUSB_ENABLE                                  HAL_PWREx_EnableVddUSB
+
+#if defined (STM32F4)
+#define __HAL_PVD_EXTI_ENABLE_IT(PWR_EXTI_LINE_PVD)         __HAL_PWR_PVD_EXTI_ENABLE_IT()
+#define __HAL_PVD_EXTI_DISABLE_IT(PWR_EXTI_LINE_PVD)        __HAL_PWR_PVD_EXTI_DISABLE_IT()
+#define __HAL_PVD_EXTI_GET_FLAG(PWR_EXTI_LINE_PVD)          __HAL_PWR_PVD_EXTI_GET_FLAG()   
+#define __HAL_PVD_EXTI_CLEAR_FLAG(PWR_EXTI_LINE_PVD)        __HAL_PWR_PVD_EXTI_CLEAR_FLAG()
+#define __HAL_PVD_EXTI_GENERATE_SWIT(PWR_EXTI_LINE_PVD)     __HAL_PWR_PVD_EXTI_GENERATE_SWIT()
+#else
+#define __HAL_PVD_EXTI_CLEAR_FLAG                                __HAL_PWR_PVD_EXTI_CLEAR_FLAG
+#define __HAL_PVD_EXTI_DISABLE_IT                                __HAL_PWR_PVD_EXTI_DISABLE_IT
+#define __HAL_PVD_EXTI_ENABLE_IT                                 __HAL_PWR_PVD_EXTI_ENABLE_IT
+#define __HAL_PVD_EXTI_GENERATE_SWIT                             __HAL_PWR_PVD_EXTI_GENERATE_SWIT
+#define __HAL_PVD_EXTI_GET_FLAG                                  __HAL_PWR_PVD_EXTI_GET_FLAG 
+#endif /* STM32F4 */
+/**   
+  * @}
+  */  
+  
+  
+/** @defgroup HAL_RCC_Aliased HAL RCC Aliased maintained for legacy purpose
+  * @{
+  */
+  
+#define RCC_StopWakeUpClock_MSI     RCC_STOP_WAKEUPCLOCK_MSI
+#define RCC_StopWakeUpClock_HSI     RCC_STOP_WAKEUPCLOCK_HSI
+
+#define HAL_RCC_CCSCallback HAL_RCC_CSSCallback
+#define HAL_RC48_EnableBuffer_Cmd(cmd) (((cmd)==ENABLE) ? HAL_RCCEx_EnableHSI48_VREFINT() : HAL_RCCEx_DisableHSI48_VREFINT())
+
+#define __ADC_CLK_DISABLE __HAL_RCC_ADC_CLK_DISABLE
+#define __ADC_CLK_ENABLE __HAL_RCC_ADC_CLK_ENABLE
+#define __ADC_CLK_SLEEP_DISABLE __HAL_RCC_ADC_CLK_SLEEP_DISABLE
+#define __ADC_CLK_SLEEP_ENABLE __HAL_RCC_ADC_CLK_SLEEP_ENABLE
+#define __ADC_FORCE_RESET __HAL_RCC_ADC_FORCE_RESET
+#define __ADC_RELEASE_RESET __HAL_RCC_ADC_RELEASE_RESET
+#define __ADC1_CLK_DISABLE        __HAL_RCC_ADC1_CLK_DISABLE
+#define __ADC1_CLK_ENABLE         __HAL_RCC_ADC1_CLK_ENABLE
+#define __ADC1_FORCE_RESET        __HAL_RCC_ADC1_FORCE_RESET
+#define __ADC1_RELEASE_RESET      __HAL_RCC_ADC1_RELEASE_RESET
+#define __ADC1_CLK_SLEEP_ENABLE   __HAL_RCC_ADC1_CLK_SLEEP_ENABLE  
+#define __ADC1_CLK_SLEEP_DISABLE  __HAL_RCC_ADC1_CLK_SLEEP_DISABLE  
+#define __ADC2_CLK_DISABLE __HAL_RCC_ADC2_CLK_DISABLE
+#define __ADC2_CLK_ENABLE __HAL_RCC_ADC2_CLK_ENABLE
+#define __ADC2_FORCE_RESET __HAL_RCC_ADC2_FORCE_RESET
+#define __ADC2_RELEASE_RESET __HAL_RCC_ADC2_RELEASE_RESET
+#define __ADC3_CLK_DISABLE __HAL_RCC_ADC3_CLK_DISABLE
+#define __ADC3_CLK_ENABLE __HAL_RCC_ADC3_CLK_ENABLE
+#define __ADC3_FORCE_RESET __HAL_RCC_ADC3_FORCE_RESET
+#define __ADC3_RELEASE_RESET __HAL_RCC_ADC3_RELEASE_RESET
+#define __AES_CLK_DISABLE __HAL_RCC_AES_CLK_DISABLE
+#define __AES_CLK_ENABLE __HAL_RCC_AES_CLK_ENABLE
+#define __AES_CLK_SLEEP_DISABLE __HAL_RCC_AES_CLK_SLEEP_DISABLE
+#define __AES_CLK_SLEEP_ENABLE __HAL_RCC_AES_CLK_SLEEP_ENABLE
+#define __AES_FORCE_RESET __HAL_RCC_AES_FORCE_RESET
+#define __AES_RELEASE_RESET __HAL_RCC_AES_RELEASE_RESET
+#define __CRYP_CLK_SLEEP_ENABLE      __HAL_RCC_CRYP_CLK_SLEEP_ENABLE
+#define __CRYP_CLK_SLEEP_DISABLE  __HAL_RCC_CRYP_CLK_SLEEP_DISABLE
+#define __CRYP_CLK_ENABLE  __HAL_RCC_CRYP_CLK_ENABLE
+#define __CRYP_CLK_DISABLE  __HAL_RCC_CRYP_CLK_DISABLE
+#define __CRYP_FORCE_RESET  __HAL_RCC_CRYP_FORCE_RESET
+#define __CRYP_RELEASE_RESET  __HAL_RCC_CRYP_RELEASE_RESET
+#define __AFIO_CLK_DISABLE __HAL_RCC_AFIO_CLK_DISABLE
+#define __AFIO_CLK_ENABLE __HAL_RCC_AFIO_CLK_ENABLE
+#define __AFIO_FORCE_RESET __HAL_RCC_AFIO_FORCE_RESET
+#define __AFIO_RELEASE_RESET __HAL_RCC_AFIO_RELEASE_RESET
+#define __AHB_FORCE_RESET __HAL_RCC_AHB_FORCE_RESET
+#define __AHB_RELEASE_RESET __HAL_RCC_AHB_RELEASE_RESET
+#define __AHB1_FORCE_RESET __HAL_RCC_AHB1_FORCE_RESET
+#define __AHB1_RELEASE_RESET __HAL_RCC_AHB1_RELEASE_RESET
+#define __AHB2_FORCE_RESET __HAL_RCC_AHB2_FORCE_RESET
+#define __AHB2_RELEASE_RESET __HAL_RCC_AHB2_RELEASE_RESET
+#define __AHB3_FORCE_RESET __HAL_RCC_AHB3_FORCE_RESET
+#define __AHB3_RELEASE_RESET __HAL_RCC_AHB3_RELEASE_RESET
+#define __APB1_FORCE_RESET __HAL_RCC_APB1_FORCE_RESET
+#define __APB1_RELEASE_RESET __HAL_RCC_APB1_RELEASE_RESET
+#define __APB2_FORCE_RESET __HAL_RCC_APB2_FORCE_RESET
+#define __APB2_RELEASE_RESET __HAL_RCC_APB2_RELEASE_RESET
+#define __BKP_CLK_DISABLE __HAL_RCC_BKP_CLK_DISABLE
+#define __BKP_CLK_ENABLE __HAL_RCC_BKP_CLK_ENABLE
+#define __BKP_FORCE_RESET __HAL_RCC_BKP_FORCE_RESET
+#define __BKP_RELEASE_RESET __HAL_RCC_BKP_RELEASE_RESET
+#define __CAN1_CLK_DISABLE __HAL_RCC_CAN1_CLK_DISABLE
+#define __CAN1_CLK_ENABLE __HAL_RCC_CAN1_CLK_ENABLE
+#define __CAN1_CLK_SLEEP_DISABLE __HAL_RCC_CAN1_CLK_SLEEP_DISABLE
+#define __CAN1_CLK_SLEEP_ENABLE __HAL_RCC_CAN1_CLK_SLEEP_ENABLE
+#define __CAN1_FORCE_RESET __HAL_RCC_CAN1_FORCE_RESET
+#define __CAN1_RELEASE_RESET __HAL_RCC_CAN1_RELEASE_RESET
+#define __CAN_CLK_DISABLE         __HAL_RCC_CAN1_CLK_DISABLE
+#define __CAN_CLK_ENABLE          __HAL_RCC_CAN1_CLK_ENABLE
+#define __CAN_FORCE_RESET         __HAL_RCC_CAN1_FORCE_RESET
+#define __CAN_RELEASE_RESET       __HAL_RCC_CAN1_RELEASE_RESET
+#define __CAN2_CLK_DISABLE __HAL_RCC_CAN2_CLK_DISABLE
+#define __CAN2_CLK_ENABLE __HAL_RCC_CAN2_CLK_ENABLE
+#define __CAN2_FORCE_RESET __HAL_RCC_CAN2_FORCE_RESET
+#define __CAN2_RELEASE_RESET __HAL_RCC_CAN2_RELEASE_RESET
+#define __CEC_CLK_DISABLE __HAL_RCC_CEC_CLK_DISABLE
+#define __CEC_CLK_ENABLE __HAL_RCC_CEC_CLK_ENABLE
+#define __COMP_CLK_DISABLE        __HAL_RCC_COMP_CLK_DISABLE
+#define __COMP_CLK_ENABLE         __HAL_RCC_COMP_CLK_ENABLE
+#define __COMP_FORCE_RESET        __HAL_RCC_COMP_FORCE_RESET
+#define __COMP_RELEASE_RESET      __HAL_RCC_COMP_RELEASE_RESET
+#define __COMP_CLK_SLEEP_ENABLE   __HAL_RCC_COMP_CLK_SLEEP_ENABLE
+#define __COMP_CLK_SLEEP_DISABLE  __HAL_RCC_COMP_CLK_SLEEP_DISABLE
+#define __CEC_FORCE_RESET __HAL_RCC_CEC_FORCE_RESET
+#define __CEC_RELEASE_RESET __HAL_RCC_CEC_RELEASE_RESET
+#define __CRC_CLK_DISABLE __HAL_RCC_CRC_CLK_DISABLE
+#define __CRC_CLK_ENABLE __HAL_RCC_CRC_CLK_ENABLE
+#define __CRC_CLK_SLEEP_DISABLE __HAL_RCC_CRC_CLK_SLEEP_DISABLE
+#define __CRC_CLK_SLEEP_ENABLE __HAL_RCC_CRC_CLK_SLEEP_ENABLE
+#define __CRC_FORCE_RESET __HAL_RCC_CRC_FORCE_RESET
+#define __CRC_RELEASE_RESET __HAL_RCC_CRC_RELEASE_RESET
+#define __DAC_CLK_DISABLE __HAL_RCC_DAC_CLK_DISABLE
+#define __DAC_CLK_ENABLE __HAL_RCC_DAC_CLK_ENABLE
+#define __DAC_FORCE_RESET __HAL_RCC_DAC_FORCE_RESET
+#define __DAC_RELEASE_RESET __HAL_RCC_DAC_RELEASE_RESET
+#define __DAC1_CLK_DISABLE __HAL_RCC_DAC1_CLK_DISABLE
+#define __DAC1_CLK_ENABLE __HAL_RCC_DAC1_CLK_ENABLE
+#define __DAC1_CLK_SLEEP_DISABLE __HAL_RCC_DAC1_CLK_SLEEP_DISABLE
+#define __DAC1_CLK_SLEEP_ENABLE __HAL_RCC_DAC1_CLK_SLEEP_ENABLE
+#define __DAC1_FORCE_RESET __HAL_RCC_DAC1_FORCE_RESET
+#define __DAC1_RELEASE_RESET __HAL_RCC_DAC1_RELEASE_RESET
+#define __DBGMCU_CLK_ENABLE     __HAL_RCC_DBGMCU_CLK_ENABLE
+#define __DBGMCU_CLK_DISABLE     __HAL_RCC_DBGMCU_CLK_DISABLE
+#define __DBGMCU_FORCE_RESET    __HAL_RCC_DBGMCU_FORCE_RESET
+#define __DBGMCU_RELEASE_RESET  __HAL_RCC_DBGMCU_RELEASE_RESET
+#define __DFSDM_CLK_DISABLE __HAL_RCC_DFSDM_CLK_DISABLE
+#define __DFSDM_CLK_ENABLE __HAL_RCC_DFSDM_CLK_ENABLE
+#define __DFSDM_CLK_SLEEP_DISABLE __HAL_RCC_DFSDM_CLK_SLEEP_DISABLE
+#define __DFSDM_CLK_SLEEP_ENABLE __HAL_RCC_DFSDM_CLK_SLEEP_ENABLE
+#define __DFSDM_FORCE_RESET __HAL_RCC_DFSDM_FORCE_RESET
+#define __DFSDM_RELEASE_RESET __HAL_RCC_DFSDM_RELEASE_RESET
+#define __DMA1_CLK_DISABLE __HAL_RCC_DMA1_CLK_DISABLE
+#define __DMA1_CLK_ENABLE __HAL_RCC_DMA1_CLK_ENABLE
+#define __DMA1_CLK_SLEEP_DISABLE __HAL_RCC_DMA1_CLK_SLEEP_DISABLE
+#define __DMA1_CLK_SLEEP_ENABLE __HAL_RCC_DMA1_CLK_SLEEP_ENABLE
+#define __DMA1_FORCE_RESET __HAL_RCC_DMA1_FORCE_RESET
+#define __DMA1_RELEASE_RESET __HAL_RCC_DMA1_RELEASE_RESET
+#define __DMA2_CLK_DISABLE __HAL_RCC_DMA2_CLK_DISABLE
+#define __DMA2_CLK_ENABLE __HAL_RCC_DMA2_CLK_ENABLE
+#define __DMA2_CLK_SLEEP_DISABLE __HAL_RCC_DMA2_CLK_SLEEP_DISABLE
+#define __DMA2_CLK_SLEEP_ENABLE __HAL_RCC_DMA2_CLK_SLEEP_ENABLE
+#define __DMA2_FORCE_RESET __HAL_RCC_DMA2_FORCE_RESET
+#define __DMA2_RELEASE_RESET __HAL_RCC_DMA2_RELEASE_RESET
+#define __ETHMAC_CLK_DISABLE __HAL_RCC_ETHMAC_CLK_DISABLE
+#define __ETHMAC_CLK_ENABLE __HAL_RCC_ETHMAC_CLK_ENABLE
+#define __ETHMAC_FORCE_RESET __HAL_RCC_ETHMAC_FORCE_RESET
+#define __ETHMAC_RELEASE_RESET __HAL_RCC_ETHMAC_RELEASE_RESET
+#define __ETHMACRX_CLK_DISABLE __HAL_RCC_ETHMACRX_CLK_DISABLE
+#define __ETHMACRX_CLK_ENABLE __HAL_RCC_ETHMACRX_CLK_ENABLE
+#define __ETHMACTX_CLK_DISABLE __HAL_RCC_ETHMACTX_CLK_DISABLE
+#define __ETHMACTX_CLK_ENABLE __HAL_RCC_ETHMACTX_CLK_ENABLE
+#define __FIREWALL_CLK_DISABLE __HAL_RCC_FIREWALL_CLK_DISABLE
+#define __FIREWALL_CLK_ENABLE __HAL_RCC_FIREWALL_CLK_ENABLE
+#define __FLASH_CLK_DISABLE __HAL_RCC_FLASH_CLK_DISABLE
+#define __FLASH_CLK_ENABLE __HAL_RCC_FLASH_CLK_ENABLE
+#define __FLASH_CLK_SLEEP_DISABLE __HAL_RCC_FLASH_CLK_SLEEP_DISABLE
+#define __FLASH_CLK_SLEEP_ENABLE __HAL_RCC_FLASH_CLK_SLEEP_ENABLE
+#define __FLASH_FORCE_RESET __HAL_RCC_FLASH_FORCE_RESET
+#define __FLASH_RELEASE_RESET __HAL_RCC_FLASH_RELEASE_RESET
+#define __FLITF_CLK_DISABLE       __HAL_RCC_FLITF_CLK_DISABLE
+#define __FLITF_CLK_ENABLE        __HAL_RCC_FLITF_CLK_ENABLE
+#define __FLITF_FORCE_RESET       __HAL_RCC_FLITF_FORCE_RESET
+#define __FLITF_RELEASE_RESET     __HAL_RCC_FLITF_RELEASE_RESET
+#define __FLITF_CLK_SLEEP_ENABLE  __HAL_RCC_FLITF_CLK_SLEEP_ENABLE
+#define __FLITF_CLK_SLEEP_DISABLE __HAL_RCC_FLITF_CLK_SLEEP_DISABLE
+#define __FMC_CLK_DISABLE __HAL_RCC_FMC_CLK_DISABLE
+#define __FMC_CLK_ENABLE __HAL_RCC_FMC_CLK_ENABLE
+#define __FMC_CLK_SLEEP_DISABLE __HAL_RCC_FMC_CLK_SLEEP_DISABLE
+#define __FMC_CLK_SLEEP_ENABLE __HAL_RCC_FMC_CLK_SLEEP_ENABLE
+#define __FMC_FORCE_RESET __HAL_RCC_FMC_FORCE_RESET
+#define __FMC_RELEASE_RESET __HAL_RCC_FMC_RELEASE_RESET
+#define __FSMC_CLK_DISABLE __HAL_RCC_FSMC_CLK_DISABLE
+#define __FSMC_CLK_ENABLE __HAL_RCC_FSMC_CLK_ENABLE
+#define __GPIOA_CLK_DISABLE __HAL_RCC_GPIOA_CLK_DISABLE
+#define __GPIOA_CLK_ENABLE __HAL_RCC_GPIOA_CLK_ENABLE
+#define __GPIOA_CLK_SLEEP_DISABLE __HAL_RCC_GPIOA_CLK_SLEEP_DISABLE
+#define __GPIOA_CLK_SLEEP_ENABLE __HAL_RCC_GPIOA_CLK_SLEEP_ENABLE
+#define __GPIOA_FORCE_RESET __HAL_RCC_GPIOA_FORCE_RESET
+#define __GPIOA_RELEASE_RESET __HAL_RCC_GPIOA_RELEASE_RESET
+#define __GPIOB_CLK_DISABLE __HAL_RCC_GPIOB_CLK_DISABLE
+#define __GPIOB_CLK_ENABLE __HAL_RCC_GPIOB_CLK_ENABLE
+#define __GPIOB_CLK_SLEEP_DISABLE __HAL_RCC_GPIOB_CLK_SLEEP_DISABLE
+#define __GPIOB_CLK_SLEEP_ENABLE __HAL_RCC_GPIOB_CLK_SLEEP_ENABLE
+#define __GPIOB_FORCE_RESET __HAL_RCC_GPIOB_FORCE_RESET
+#define __GPIOB_RELEASE_RESET __HAL_RCC_GPIOB_RELEASE_RESET
+#define __GPIOC_CLK_DISABLE __HAL_RCC_GPIOC_CLK_DISABLE
+#define __GPIOC_CLK_ENABLE __HAL_RCC_GPIOC_CLK_ENABLE
+#define __GPIOC_CLK_SLEEP_DISABLE __HAL_RCC_GPIOC_CLK_SLEEP_DISABLE
+#define __GPIOC_CLK_SLEEP_ENABLE __HAL_RCC_GPIOC_CLK_SLEEP_ENABLE
+#define __GPIOC_FORCE_RESET __HAL_RCC_GPIOC_FORCE_RESET
+#define __GPIOC_RELEASE_RESET __HAL_RCC_GPIOC_RELEASE_RESET
+#define __GPIOD_CLK_DISABLE __HAL_RCC_GPIOD_CLK_DISABLE
+#define __GPIOD_CLK_ENABLE __HAL_RCC_GPIOD_CLK_ENABLE
+#define __GPIOD_CLK_SLEEP_DISABLE __HAL_RCC_GPIOD_CLK_SLEEP_DISABLE
+#define __GPIOD_CLK_SLEEP_ENABLE __HAL_RCC_GPIOD_CLK_SLEEP_ENABLE
+#define __GPIOD_FORCE_RESET __HAL_RCC_GPIOD_FORCE_RESET
+#define __GPIOD_RELEASE_RESET __HAL_RCC_GPIOD_RELEASE_RESET
+#define __GPIOE_CLK_DISABLE __HAL_RCC_GPIOE_CLK_DISABLE
+#define __GPIOE_CLK_ENABLE __HAL_RCC_GPIOE_CLK_ENABLE
+#define __GPIOE_CLK_SLEEP_DISABLE __HAL_RCC_GPIOE_CLK_SLEEP_DISABLE
+#define __GPIOE_CLK_SLEEP_ENABLE __HAL_RCC_GPIOE_CLK_SLEEP_ENABLE
+#define __GPIOE_FORCE_RESET __HAL_RCC_GPIOE_FORCE_RESET
+#define __GPIOE_RELEASE_RESET __HAL_RCC_GPIOE_RELEASE_RESET
+#define __GPIOF_CLK_DISABLE __HAL_RCC_GPIOF_CLK_DISABLE
+#define __GPIOF_CLK_ENABLE __HAL_RCC_GPIOF_CLK_ENABLE
+#define __GPIOF_CLK_SLEEP_DISABLE __HAL_RCC_GPIOF_CLK_SLEEP_DISABLE
+#define __GPIOF_CLK_SLEEP_ENABLE __HAL_RCC_GPIOF_CLK_SLEEP_ENABLE
+#define __GPIOF_FORCE_RESET __HAL_RCC_GPIOF_FORCE_RESET
+#define __GPIOF_RELEASE_RESET __HAL_RCC_GPIOF_RELEASE_RESET
+#define __GPIOG_CLK_DISABLE __HAL_RCC_GPIOG_CLK_DISABLE
+#define __GPIOG_CLK_ENABLE __HAL_RCC_GPIOG_CLK_ENABLE
+#define __GPIOG_CLK_SLEEP_DISABLE __HAL_RCC_GPIOG_CLK_SLEEP_DISABLE
+#define __GPIOG_CLK_SLEEP_ENABLE __HAL_RCC_GPIOG_CLK_SLEEP_ENABLE
+#define __GPIOG_FORCE_RESET __HAL_RCC_GPIOG_FORCE_RESET
+#define __GPIOG_RELEASE_RESET __HAL_RCC_GPIOG_RELEASE_RESET
+#define __GPIOH_CLK_DISABLE __HAL_RCC_GPIOH_CLK_DISABLE
+#define __GPIOH_CLK_ENABLE __HAL_RCC_GPIOH_CLK_ENABLE
+#define __GPIOH_CLK_SLEEP_DISABLE __HAL_RCC_GPIOH_CLK_SLEEP_DISABLE
+#define __GPIOH_CLK_SLEEP_ENABLE __HAL_RCC_GPIOH_CLK_SLEEP_ENABLE
+#define __GPIOH_FORCE_RESET __HAL_RCC_GPIOH_FORCE_RESET
+#define __GPIOH_RELEASE_RESET __HAL_RCC_GPIOH_RELEASE_RESET
+#define __I2C1_CLK_DISABLE __HAL_RCC_I2C1_CLK_DISABLE
+#define __I2C1_CLK_ENABLE __HAL_RCC_I2C1_CLK_ENABLE
+#define __I2C1_CLK_SLEEP_DISABLE __HAL_RCC_I2C1_CLK_SLEEP_DISABLE
+#define __I2C1_CLK_SLEEP_ENABLE __HAL_RCC_I2C1_CLK_SLEEP_ENABLE
+#define __I2C1_FORCE_RESET __HAL_RCC_I2C1_FORCE_RESET
+#define __I2C1_RELEASE_RESET __HAL_RCC_I2C1_RELEASE_RESET
+#define __I2C2_CLK_DISABLE __HAL_RCC_I2C2_CLK_DISABLE
+#define __I2C2_CLK_ENABLE __HAL_RCC_I2C2_CLK_ENABLE
+#define __I2C2_CLK_SLEEP_DISABLE __HAL_RCC_I2C2_CLK_SLEEP_DISABLE
+#define __I2C2_CLK_SLEEP_ENABLE __HAL_RCC_I2C2_CLK_SLEEP_ENABLE
+#define __I2C2_FORCE_RESET __HAL_RCC_I2C2_FORCE_RESET
+#define __I2C2_RELEASE_RESET __HAL_RCC_I2C2_RELEASE_RESET
+#define __I2C3_CLK_DISABLE __HAL_RCC_I2C3_CLK_DISABLE
+#define __I2C3_CLK_ENABLE __HAL_RCC_I2C3_CLK_ENABLE
+#define __I2C3_CLK_SLEEP_DISABLE __HAL_RCC_I2C3_CLK_SLEEP_DISABLE
+#define __I2C3_CLK_SLEEP_ENABLE __HAL_RCC_I2C3_CLK_SLEEP_ENABLE
+#define __I2C3_FORCE_RESET __HAL_RCC_I2C3_FORCE_RESET
+#define __I2C3_RELEASE_RESET __HAL_RCC_I2C3_RELEASE_RESET
+#define __LCD_CLK_DISABLE __HAL_RCC_LCD_CLK_DISABLE
+#define __LCD_CLK_ENABLE __HAL_RCC_LCD_CLK_ENABLE
+#define __LCD_CLK_SLEEP_DISABLE __HAL_RCC_LCD_CLK_SLEEP_DISABLE
+#define __LCD_CLK_SLEEP_ENABLE __HAL_RCC_LCD_CLK_SLEEP_ENABLE
+#define __LCD_FORCE_RESET __HAL_RCC_LCD_FORCE_RESET
+#define __LCD_RELEASE_RESET __HAL_RCC_LCD_RELEASE_RESET
+#define __LPTIM1_CLK_DISABLE __HAL_RCC_LPTIM1_CLK_DISABLE
+#define __LPTIM1_CLK_ENABLE __HAL_RCC_LPTIM1_CLK_ENABLE
+#define __LPTIM1_CLK_SLEEP_DISABLE __HAL_RCC_LPTIM1_CLK_SLEEP_DISABLE
+#define __LPTIM1_CLK_SLEEP_ENABLE __HAL_RCC_LPTIM1_CLK_SLEEP_ENABLE
+#define __LPTIM1_FORCE_RESET __HAL_RCC_LPTIM1_FORCE_RESET
+#define __LPTIM1_RELEASE_RESET __HAL_RCC_LPTIM1_RELEASE_RESET
+#define __LPTIM2_CLK_DISABLE __HAL_RCC_LPTIM2_CLK_DISABLE
+#define __LPTIM2_CLK_ENABLE __HAL_RCC_LPTIM2_CLK_ENABLE
+#define __LPTIM2_CLK_SLEEP_DISABLE __HAL_RCC_LPTIM2_CLK_SLEEP_DISABLE
+#define __LPTIM2_CLK_SLEEP_ENABLE __HAL_RCC_LPTIM2_CLK_SLEEP_ENABLE
+#define __LPTIM2_FORCE_RESET __HAL_RCC_LPTIM2_FORCE_RESET
+#define __LPTIM2_RELEASE_RESET __HAL_RCC_LPTIM2_RELEASE_RESET
+#define __LPUART1_CLK_DISABLE __HAL_RCC_LPUART1_CLK_DISABLE
+#define __LPUART1_CLK_ENABLE __HAL_RCC_LPUART1_CLK_ENABLE
+#define __LPUART1_CLK_SLEEP_DISABLE __HAL_RCC_LPUART1_CLK_SLEEP_DISABLE
+#define __LPUART1_CLK_SLEEP_ENABLE __HAL_RCC_LPUART1_CLK_SLEEP_ENABLE
+#define __LPUART1_FORCE_RESET __HAL_RCC_LPUART1_FORCE_RESET
+#define __LPUART1_RELEASE_RESET __HAL_RCC_LPUART1_RELEASE_RESET
+#define __OPAMP_CLK_DISABLE __HAL_RCC_OPAMP_CLK_DISABLE
+#define __OPAMP_CLK_ENABLE __HAL_RCC_OPAMP_CLK_ENABLE
+#define __OPAMP_CLK_SLEEP_DISABLE __HAL_RCC_OPAMP_CLK_SLEEP_DISABLE
+#define __OPAMP_CLK_SLEEP_ENABLE __HAL_RCC_OPAMP_CLK_SLEEP_ENABLE
+#define __OPAMP_FORCE_RESET __HAL_RCC_OPAMP_FORCE_RESET
+#define __OPAMP_RELEASE_RESET __HAL_RCC_OPAMP_RELEASE_RESET
+#define __OTGFS_CLK_DISABLE __HAL_RCC_OTGFS_CLK_DISABLE
+#define __OTGFS_CLK_ENABLE __HAL_RCC_OTGFS_CLK_ENABLE
+#define __OTGFS_CLK_SLEEP_DISABLE __HAL_RCC_OTGFS_CLK_SLEEP_DISABLE
+#define __OTGFS_CLK_SLEEP_ENABLE __HAL_RCC_OTGFS_CLK_SLEEP_ENABLE
+#define __OTGFS_FORCE_RESET __HAL_RCC_OTGFS_FORCE_RESET
+#define __OTGFS_RELEASE_RESET __HAL_RCC_OTGFS_RELEASE_RESET
+#define __PWR_CLK_DISABLE __HAL_RCC_PWR_CLK_DISABLE
+#define __PWR_CLK_ENABLE __HAL_RCC_PWR_CLK_ENABLE
+#define __PWR_CLK_SLEEP_DISABLE __HAL_RCC_PWR_CLK_SLEEP_DISABLE
+#define __PWR_CLK_SLEEP_ENABLE __HAL_RCC_PWR_CLK_SLEEP_ENABLE
+#define __PWR_FORCE_RESET __HAL_RCC_PWR_FORCE_RESET
+#define __PWR_RELEASE_RESET __HAL_RCC_PWR_RELEASE_RESET
+#define __QSPI_CLK_DISABLE __HAL_RCC_QSPI_CLK_DISABLE
+#define __QSPI_CLK_ENABLE __HAL_RCC_QSPI_CLK_ENABLE
+#define __QSPI_CLK_SLEEP_DISABLE __HAL_RCC_QSPI_CLK_SLEEP_DISABLE
+#define __QSPI_CLK_SLEEP_ENABLE __HAL_RCC_QSPI_CLK_SLEEP_ENABLE
+#define __QSPI_FORCE_RESET __HAL_RCC_QSPI_FORCE_RESET
+#define __QSPI_RELEASE_RESET __HAL_RCC_QSPI_RELEASE_RESET
+#define __RNG_CLK_DISABLE __HAL_RCC_RNG_CLK_DISABLE
+#define __RNG_CLK_ENABLE __HAL_RCC_RNG_CLK_ENABLE
+#define __RNG_CLK_SLEEP_DISABLE __HAL_RCC_RNG_CLK_SLEEP_DISABLE
+#define __RNG_CLK_SLEEP_ENABLE __HAL_RCC_RNG_CLK_SLEEP_ENABLE
+#define __RNG_FORCE_RESET __HAL_RCC_RNG_FORCE_RESET
+#define __RNG_RELEASE_RESET __HAL_RCC_RNG_RELEASE_RESET
+#define __SAI1_CLK_DISABLE __HAL_RCC_SAI1_CLK_DISABLE
+#define __SAI1_CLK_ENABLE __HAL_RCC_SAI1_CLK_ENABLE
+#define __SAI1_CLK_SLEEP_DISABLE __HAL_RCC_SAI1_CLK_SLEEP_DISABLE
+#define __SAI1_CLK_SLEEP_ENABLE __HAL_RCC_SAI1_CLK_SLEEP_ENABLE
+#define __SAI1_FORCE_RESET __HAL_RCC_SAI1_FORCE_RESET
+#define __SAI1_RELEASE_RESET __HAL_RCC_SAI1_RELEASE_RESET
+#define __SAI2_CLK_DISABLE __HAL_RCC_SAI2_CLK_DISABLE
+#define __SAI2_CLK_ENABLE __HAL_RCC_SAI2_CLK_ENABLE
+#define __SAI2_CLK_SLEEP_DISABLE __HAL_RCC_SAI2_CLK_SLEEP_DISABLE
+#define __SAI2_CLK_SLEEP_ENABLE __HAL_RCC_SAI2_CLK_SLEEP_ENABLE
+#define __SAI2_FORCE_RESET __HAL_RCC_SAI2_FORCE_RESET
+#define __SAI2_RELEASE_RESET __HAL_RCC_SAI2_RELEASE_RESET
+#define __SDIO_CLK_DISABLE __HAL_RCC_SDIO_CLK_DISABLE
+#define __SDIO_CLK_ENABLE __HAL_RCC_SDIO_CLK_ENABLE
+#define __SDMMC_CLK_DISABLE __HAL_RCC_SDMMC_CLK_DISABLE
+#define __SDMMC_CLK_ENABLE __HAL_RCC_SDMMC_CLK_ENABLE
+#define __SDMMC_CLK_SLEEP_DISABLE __HAL_RCC_SDMMC_CLK_SLEEP_DISABLE
+#define __SDMMC_CLK_SLEEP_ENABLE __HAL_RCC_SDMMC_CLK_SLEEP_ENABLE
+#define __SDMMC_FORCE_RESET __HAL_RCC_SDMMC_FORCE_RESET
+#define __SDMMC_RELEASE_RESET __HAL_RCC_SDMMC_RELEASE_RESET
+#define __SPI1_CLK_DISABLE __HAL_RCC_SPI1_CLK_DISABLE
+#define __SPI1_CLK_ENABLE __HAL_RCC_SPI1_CLK_ENABLE
+#define __SPI1_CLK_SLEEP_DISABLE __HAL_RCC_SPI1_CLK_SLEEP_DISABLE
+#define __SPI1_CLK_SLEEP_ENABLE __HAL_RCC_SPI1_CLK_SLEEP_ENABLE
+#define __SPI1_FORCE_RESET __HAL_RCC_SPI1_FORCE_RESET
+#define __SPI1_RELEASE_RESET __HAL_RCC_SPI1_RELEASE_RESET
+#define __SPI2_CLK_DISABLE __HAL_RCC_SPI2_CLK_DISABLE
+#define __SPI2_CLK_ENABLE __HAL_RCC_SPI2_CLK_ENABLE
+#define __SPI2_CLK_SLEEP_DISABLE __HAL_RCC_SPI2_CLK_SLEEP_DISABLE
+#define __SPI2_CLK_SLEEP_ENABLE __HAL_RCC_SPI2_CLK_SLEEP_ENABLE
+#define __SPI2_FORCE_RESET __HAL_RCC_SPI2_FORCE_RESET
+#define __SPI2_RELEASE_RESET __HAL_RCC_SPI2_RELEASE_RESET
+#define __SPI3_CLK_DISABLE __HAL_RCC_SPI3_CLK_DISABLE
+#define __SPI3_CLK_ENABLE __HAL_RCC_SPI3_CLK_ENABLE
+#define __SPI3_CLK_SLEEP_DISABLE __HAL_RCC_SPI3_CLK_SLEEP_DISABLE
+#define __SPI3_CLK_SLEEP_ENABLE __HAL_RCC_SPI3_CLK_SLEEP_ENABLE
+#define __SPI3_FORCE_RESET __HAL_RCC_SPI3_FORCE_RESET
+#define __SPI3_RELEASE_RESET __HAL_RCC_SPI3_RELEASE_RESET
+#define __SRAM_CLK_DISABLE __HAL_RCC_SRAM_CLK_DISABLE
+#define __SRAM_CLK_ENABLE __HAL_RCC_SRAM_CLK_ENABLE
+#define __SRAM1_CLK_SLEEP_DISABLE __HAL_RCC_SRAM1_CLK_SLEEP_DISABLE
+#define __SRAM1_CLK_SLEEP_ENABLE __HAL_RCC_SRAM1_CLK_SLEEP_ENABLE
+#define __SRAM2_CLK_SLEEP_DISABLE __HAL_RCC_SRAM2_CLK_SLEEP_DISABLE
+#define __SRAM2_CLK_SLEEP_ENABLE __HAL_RCC_SRAM2_CLK_SLEEP_ENABLE
+#define __SWPMI1_CLK_DISABLE __HAL_RCC_SWPMI1_CLK_DISABLE
+#define __SWPMI1_CLK_ENABLE __HAL_RCC_SWPMI1_CLK_ENABLE
+#define __SWPMI1_CLK_SLEEP_DISABLE __HAL_RCC_SWPMI1_CLK_SLEEP_DISABLE
+#define __SWPMI1_CLK_SLEEP_ENABLE __HAL_RCC_SWPMI1_CLK_SLEEP_ENABLE
+#define __SWPMI1_FORCE_RESET __HAL_RCC_SWPMI1_FORCE_RESET
+#define __SWPMI1_RELEASE_RESET __HAL_RCC_SWPMI1_RELEASE_RESET
+#define __SYSCFG_CLK_DISABLE __HAL_RCC_SYSCFG_CLK_DISABLE
+#define __SYSCFG_CLK_ENABLE __HAL_RCC_SYSCFG_CLK_ENABLE
+#define __SYSCFG_CLK_SLEEP_DISABLE __HAL_RCC_SYSCFG_CLK_SLEEP_DISABLE
+#define __SYSCFG_CLK_SLEEP_ENABLE __HAL_RCC_SYSCFG_CLK_SLEEP_ENABLE
+#define __SYSCFG_FORCE_RESET __HAL_RCC_SYSCFG_FORCE_RESET
+#define __SYSCFG_RELEASE_RESET __HAL_RCC_SYSCFG_RELEASE_RESET
+#define __TIM1_CLK_DISABLE __HAL_RCC_TIM1_CLK_DISABLE
+#define __TIM1_CLK_ENABLE __HAL_RCC_TIM1_CLK_ENABLE
+#define __TIM1_CLK_SLEEP_DISABLE __HAL_RCC_TIM1_CLK_SLEEP_DISABLE
+#define __TIM1_CLK_SLEEP_ENABLE __HAL_RCC_TIM1_CLK_SLEEP_ENABLE
+#define __TIM1_FORCE_RESET __HAL_RCC_TIM1_FORCE_RESET
+#define __TIM1_RELEASE_RESET __HAL_RCC_TIM1_RELEASE_RESET
+#define __TIM10_CLK_DISABLE __HAL_RCC_TIM10_CLK_DISABLE
+#define __TIM10_CLK_ENABLE __HAL_RCC_TIM10_CLK_ENABLE
+#define __TIM10_FORCE_RESET __HAL_RCC_TIM10_FORCE_RESET
+#define __TIM10_RELEASE_RESET __HAL_RCC_TIM10_RELEASE_RESET
+#define __TIM11_CLK_DISABLE __HAL_RCC_TIM11_CLK_DISABLE
+#define __TIM11_CLK_ENABLE __HAL_RCC_TIM11_CLK_ENABLE
+#define __TIM11_FORCE_RESET __HAL_RCC_TIM11_FORCE_RESET
+#define __TIM11_RELEASE_RESET __HAL_RCC_TIM11_RELEASE_RESET
+#define __TIM12_CLK_DISABLE __HAL_RCC_TIM12_CLK_DISABLE
+#define __TIM12_CLK_ENABLE __HAL_RCC_TIM12_CLK_ENABLE
+#define __TIM12_FORCE_RESET __HAL_RCC_TIM12_FORCE_RESET
+#define __TIM12_RELEASE_RESET __HAL_RCC_TIM12_RELEASE_RESET
+#define __TIM13_CLK_DISABLE __HAL_RCC_TIM13_CLK_DISABLE
+#define __TIM13_CLK_ENABLE __HAL_RCC_TIM13_CLK_ENABLE
+#define __TIM13_FORCE_RESET __HAL_RCC_TIM13_FORCE_RESET
+#define __TIM13_RELEASE_RESET __HAL_RCC_TIM13_RELEASE_RESET
+#define __TIM14_CLK_DISABLE __HAL_RCC_TIM14_CLK_DISABLE
+#define __TIM14_CLK_ENABLE __HAL_RCC_TIM14_CLK_ENABLE
+#define __TIM14_FORCE_RESET __HAL_RCC_TIM14_FORCE_RESET
+#define __TIM14_RELEASE_RESET __HAL_RCC_TIM14_RELEASE_RESET
+#define __TIM15_CLK_DISABLE __HAL_RCC_TIM15_CLK_DISABLE
+#define __TIM15_CLK_ENABLE __HAL_RCC_TIM15_CLK_ENABLE
+#define __TIM15_CLK_SLEEP_DISABLE __HAL_RCC_TIM15_CLK_SLEEP_DISABLE
+#define __TIM15_CLK_SLEEP_ENABLE __HAL_RCC_TIM15_CLK_SLEEP_ENABLE
+#define __TIM15_FORCE_RESET __HAL_RCC_TIM15_FORCE_RESET
+#define __TIM15_RELEASE_RESET __HAL_RCC_TIM15_RELEASE_RESET
+#define __TIM16_CLK_DISABLE __HAL_RCC_TIM16_CLK_DISABLE
+#define __TIM16_CLK_ENABLE __HAL_RCC_TIM16_CLK_ENABLE
+#define __TIM16_CLK_SLEEP_DISABLE __HAL_RCC_TIM16_CLK_SLEEP_DISABLE
+#define __TIM16_CLK_SLEEP_ENABLE __HAL_RCC_TIM16_CLK_SLEEP_ENABLE
+#define __TIM16_FORCE_RESET __HAL_RCC_TIM16_FORCE_RESET
+#define __TIM16_RELEASE_RESET __HAL_RCC_TIM16_RELEASE_RESET
+#define __TIM17_CLK_DISABLE __HAL_RCC_TIM17_CLK_DISABLE
+#define __TIM17_CLK_ENABLE __HAL_RCC_TIM17_CLK_ENABLE
+#define __TIM17_CLK_SLEEP_DISABLE __HAL_RCC_TIM17_CLK_SLEEP_DISABLE
+#define __TIM17_CLK_SLEEP_ENABLE __HAL_RCC_TIM17_CLK_SLEEP_ENABLE
+#define __TIM17_FORCE_RESET __HAL_RCC_TIM17_FORCE_RESET
+#define __TIM17_RELEASE_RESET __HAL_RCC_TIM17_RELEASE_RESET
+#define __TIM2_CLK_DISABLE __HAL_RCC_TIM2_CLK_DISABLE
+#define __TIM2_CLK_ENABLE __HAL_RCC_TIM2_CLK_ENABLE
+#define __TIM2_CLK_SLEEP_DISABLE __HAL_RCC_TIM2_CLK_SLEEP_DISABLE
+#define __TIM2_CLK_SLEEP_ENABLE __HAL_RCC_TIM2_CLK_SLEEP_ENABLE
+#define __TIM2_FORCE_RESET __HAL_RCC_TIM2_FORCE_RESET
+#define __TIM2_RELEASE_RESET __HAL_RCC_TIM2_RELEASE_RESET
+#define __TIM3_CLK_DISABLE __HAL_RCC_TIM3_CLK_DISABLE
+#define __TIM3_CLK_ENABLE __HAL_RCC_TIM3_CLK_ENABLE
+#define __TIM3_CLK_SLEEP_DISABLE __HAL_RCC_TIM3_CLK_SLEEP_DISABLE
+#define __TIM3_CLK_SLEEP_ENABLE __HAL_RCC_TIM3_CLK_SLEEP_ENABLE
+#define __TIM3_FORCE_RESET __HAL_RCC_TIM3_FORCE_RESET
+#define __TIM3_RELEASE_RESET __HAL_RCC_TIM3_RELEASE_RESET
+#define __TIM4_CLK_DISABLE __HAL_RCC_TIM4_CLK_DISABLE
+#define __TIM4_CLK_ENABLE __HAL_RCC_TIM4_CLK_ENABLE
+#define __TIM4_CLK_SLEEP_DISABLE __HAL_RCC_TIM4_CLK_SLEEP_DISABLE
+#define __TIM4_CLK_SLEEP_ENABLE __HAL_RCC_TIM4_CLK_SLEEP_ENABLE
+#define __TIM4_FORCE_RESET __HAL_RCC_TIM4_FORCE_RESET
+#define __TIM4_RELEASE_RESET __HAL_RCC_TIM4_RELEASE_RESET
+#define __TIM5_CLK_DISABLE __HAL_RCC_TIM5_CLK_DISABLE
+#define __TIM5_CLK_ENABLE __HAL_RCC_TIM5_CLK_ENABLE
+#define __TIM5_CLK_SLEEP_DISABLE __HAL_RCC_TIM5_CLK_SLEEP_DISABLE
+#define __TIM5_CLK_SLEEP_ENABLE __HAL_RCC_TIM5_CLK_SLEEP_ENABLE
+#define __TIM5_FORCE_RESET __HAL_RCC_TIM5_FORCE_RESET
+#define __TIM5_RELEASE_RESET __HAL_RCC_TIM5_RELEASE_RESET
+#define __TIM6_CLK_DISABLE __HAL_RCC_TIM6_CLK_DISABLE
+#define __TIM6_CLK_ENABLE __HAL_RCC_TIM6_CLK_ENABLE
+#define __TIM6_CLK_SLEEP_DISABLE __HAL_RCC_TIM6_CLK_SLEEP_DISABLE
+#define __TIM6_CLK_SLEEP_ENABLE __HAL_RCC_TIM6_CLK_SLEEP_ENABLE
+#define __TIM6_FORCE_RESET __HAL_RCC_TIM6_FORCE_RESET
+#define __TIM6_RELEASE_RESET __HAL_RCC_TIM6_RELEASE_RESET
+#define __TIM7_CLK_DISABLE __HAL_RCC_TIM7_CLK_DISABLE
+#define __TIM7_CLK_ENABLE __HAL_RCC_TIM7_CLK_ENABLE
+#define __TIM7_CLK_SLEEP_DISABLE __HAL_RCC_TIM7_CLK_SLEEP_DISABLE
+#define __TIM7_CLK_SLEEP_ENABLE __HAL_RCC_TIM7_CLK_SLEEP_ENABLE
+#define __TIM7_FORCE_RESET __HAL_RCC_TIM7_FORCE_RESET
+#define __TIM7_RELEASE_RESET __HAL_RCC_TIM7_RELEASE_RESET
+#define __TIM8_CLK_DISABLE __HAL_RCC_TIM8_CLK_DISABLE
+#define __TIM8_CLK_ENABLE __HAL_RCC_TIM8_CLK_ENABLE
+#define __TIM8_CLK_SLEEP_DISABLE __HAL_RCC_TIM8_CLK_SLEEP_DISABLE
+#define __TIM8_CLK_SLEEP_ENABLE __HAL_RCC_TIM8_CLK_SLEEP_ENABLE
+#define __TIM8_FORCE_RESET __HAL_RCC_TIM8_FORCE_RESET
+#define __TIM8_RELEASE_RESET __HAL_RCC_TIM8_RELEASE_RESET
+#define __TIM9_CLK_DISABLE __HAL_RCC_TIM9_CLK_DISABLE
+#define __TIM9_CLK_ENABLE __HAL_RCC_TIM9_CLK_ENABLE
+#define __TIM9_FORCE_RESET __HAL_RCC_TIM9_FORCE_RESET
+#define __TIM9_RELEASE_RESET __HAL_RCC_TIM9_RELEASE_RESET
+#define __TSC_CLK_DISABLE __HAL_RCC_TSC_CLK_DISABLE
+#define __TSC_CLK_ENABLE __HAL_RCC_TSC_CLK_ENABLE
+#define __TSC_CLK_SLEEP_DISABLE __HAL_RCC_TSC_CLK_SLEEP_DISABLE
+#define __TSC_CLK_SLEEP_ENABLE __HAL_RCC_TSC_CLK_SLEEP_ENABLE
+#define __TSC_FORCE_RESET __HAL_RCC_TSC_FORCE_RESET
+#define __TSC_RELEASE_RESET __HAL_RCC_TSC_RELEASE_RESET
+#define __UART4_CLK_DISABLE __HAL_RCC_UART4_CLK_DISABLE
+#define __UART4_CLK_ENABLE __HAL_RCC_UART4_CLK_ENABLE
+#define __UART4_CLK_SLEEP_DISABLE __HAL_RCC_UART4_CLK_SLEEP_DISABLE
+#define __UART4_CLK_SLEEP_ENABLE __HAL_RCC_UART4_CLK_SLEEP_ENABLE
+#define __UART4_FORCE_RESET __HAL_RCC_UART4_FORCE_RESET
+#define __UART4_RELEASE_RESET __HAL_RCC_UART4_RELEASE_RESET
+#define __UART5_CLK_DISABLE __HAL_RCC_UART5_CLK_DISABLE
+#define __UART5_CLK_ENABLE __HAL_RCC_UART5_CLK_ENABLE
+#define __UART5_CLK_SLEEP_DISABLE __HAL_RCC_UART5_CLK_SLEEP_DISABLE
+#define __UART5_CLK_SLEEP_ENABLE __HAL_RCC_UART5_CLK_SLEEP_ENABLE
+#define __UART5_FORCE_RESET __HAL_RCC_UART5_FORCE_RESET
+#define __UART5_RELEASE_RESET __HAL_RCC_UART5_RELEASE_RESET
+#define __USART1_CLK_DISABLE __HAL_RCC_USART1_CLK_DISABLE
+#define __USART1_CLK_ENABLE __HAL_RCC_USART1_CLK_ENABLE
+#define __USART1_CLK_SLEEP_DISABLE __HAL_RCC_USART1_CLK_SLEEP_DISABLE
+#define __USART1_CLK_SLEEP_ENABLE __HAL_RCC_USART1_CLK_SLEEP_ENABLE
+#define __USART1_FORCE_RESET __HAL_RCC_USART1_FORCE_RESET
+#define __USART1_RELEASE_RESET __HAL_RCC_USART1_RELEASE_RESET
+#define __USART2_CLK_DISABLE __HAL_RCC_USART2_CLK_DISABLE
+#define __USART2_CLK_ENABLE __HAL_RCC_USART2_CLK_ENABLE
+#define __USART2_CLK_SLEEP_DISABLE __HAL_RCC_USART2_CLK_SLEEP_DISABLE
+#define __USART2_CLK_SLEEP_ENABLE __HAL_RCC_USART2_CLK_SLEEP_ENABLE
+#define __USART2_FORCE_RESET __HAL_RCC_USART2_FORCE_RESET
+#define __USART2_RELEASE_RESET __HAL_RCC_USART2_RELEASE_RESET
+#define __USART3_CLK_DISABLE __HAL_RCC_USART3_CLK_DISABLE
+#define __USART3_CLK_ENABLE __HAL_RCC_USART3_CLK_ENABLE
+#define __USART3_CLK_SLEEP_DISABLE __HAL_RCC_USART3_CLK_SLEEP_DISABLE
+#define __USART3_CLK_SLEEP_ENABLE __HAL_RCC_USART3_CLK_SLEEP_ENABLE
+#define __USART3_FORCE_RESET __HAL_RCC_USART3_FORCE_RESET
+#define __USART3_RELEASE_RESET __HAL_RCC_USART3_RELEASE_RESET
+#define __USART4_CLK_DISABLE        __HAL_RCC_USART4_CLK_DISABLE
+#define __USART4_CLK_ENABLE         __HAL_RCC_USART4_CLK_ENABLE
+#define __USART4_CLK_SLEEP_ENABLE   __HAL_RCC_USART4_CLK_SLEEP_ENABLE
+#define __USART4_CLK_SLEEP_DISABLE  __HAL_RCC_USART4_CLK_SLEEP_DISABLE 
+#define __USART4_FORCE_RESET        __HAL_RCC_USART4_FORCE_RESET
+#define __USART4_RELEASE_RESET      __HAL_RCC_USART4_RELEASE_RESET
+#define __USART5_CLK_DISABLE        __HAL_RCC_USART5_CLK_DISABLE
+#define __USART5_CLK_ENABLE         __HAL_RCC_USART5_CLK_ENABLE
+#define __USART5_CLK_SLEEP_ENABLE   __HAL_RCC_USART5_CLK_SLEEP_ENABLE
+#define __USART5_CLK_SLEEP_DISABLE  __HAL_RCC_USART5_CLK_SLEEP_DISABLE 
+#define __USART5_FORCE_RESET        __HAL_RCC_USART5_FORCE_RESET
+#define __USART5_RELEASE_RESET      __HAL_RCC_USART5_RELEASE_RESET
+#define __USART7_CLK_DISABLE        __HAL_RCC_USART7_CLK_DISABLE
+#define __USART7_CLK_ENABLE         __HAL_RCC_USART7_CLK_ENABLE
+#define __USART7_FORCE_RESET        __HAL_RCC_USART7_FORCE_RESET
+#define __USART7_RELEASE_RESET      __HAL_RCC_USART7_RELEASE_RESET
+#define __USART8_CLK_DISABLE        __HAL_RCC_USART8_CLK_DISABLE
+#define __USART8_CLK_ENABLE         __HAL_RCC_USART8_CLK_ENABLE
+#define __USART8_FORCE_RESET        __HAL_RCC_USART8_FORCE_RESET
+#define __USART8_RELEASE_RESET      __HAL_RCC_USART8_RELEASE_RESET
+#define __USB_CLK_DISABLE         __HAL_RCC_USB_CLK_DISABLE
+#define __USB_CLK_ENABLE          __HAL_RCC_USB_CLK_ENABLE
+#define __USB_FORCE_RESET         __HAL_RCC_USB_FORCE_RESET
+#define __USB_CLK_SLEEP_ENABLE    __HAL_RCC_USB_CLK_SLEEP_ENABLE
+#define __USB_CLK_SLEEP_DISABLE   __HAL_RCC_USB_CLK_SLEEP_DISABLE
+#define __USB_OTG_FS_CLK_DISABLE __HAL_RCC_USB_OTG_FS_CLK_DISABLE
+#define __USB_OTG_FS_CLK_ENABLE __HAL_RCC_USB_OTG_FS_CLK_ENABLE
+#define __USB_RELEASE_RESET __HAL_RCC_USB_RELEASE_RESET
+#define __WWDG_CLK_DISABLE __HAL_RCC_WWDG_CLK_DISABLE
+#define __WWDG_CLK_ENABLE __HAL_RCC_WWDG_CLK_ENABLE
+#define __WWDG_CLK_SLEEP_DISABLE __HAL_RCC_WWDG_CLK_SLEEP_DISABLE
+#define __WWDG_CLK_SLEEP_ENABLE __HAL_RCC_WWDG_CLK_SLEEP_ENABLE
+#define __WWDG_FORCE_RESET __HAL_RCC_WWDG_FORCE_RESET
+#define __WWDG_RELEASE_RESET __HAL_RCC_WWDG_RELEASE_RESET
+#define __TIM21_CLK_ENABLE   __HAL_RCC_TIM21_CLK_ENABLE
+#define __TIM21_CLK_DISABLE   __HAL_RCC_TIM21_CLK_DISABLE
+#define __TIM21_FORCE_RESET   __HAL_RCC_TIM21_FORCE_RESET
+#define __TIM21_RELEASE_RESET  __HAL_RCC_TIM21_RELEASE_RESET
+#define __TIM21_CLK_SLEEP_ENABLE   __HAL_RCC_TIM21_CLK_SLEEP_ENABLE
+#define __TIM21_CLK_SLEEP_DISABLE   __HAL_RCC_TIM21_CLK_SLEEP_DISABLE
+#define __TIM22_CLK_ENABLE   __HAL_RCC_TIM22_CLK_ENABLE
+#define __TIM22_CLK_DISABLE   __HAL_RCC_TIM22_CLK_DISABLE
+#define __TIM22_FORCE_RESET   __HAL_RCC_TIM22_FORCE_RESET
+#define __TIM22_RELEASE_RESET  __HAL_RCC_TIM22_RELEASE_RESET
+#define __TIM22_CLK_SLEEP_ENABLE   __HAL_RCC_TIM22_CLK_SLEEP_ENABLE
+#define __TIM22_CLK_SLEEP_DISABLE   __HAL_RCC_TIM22_CLK_SLEEP_DISABLE
+#define __CRS_CLK_DISABLE __HAL_RCC_CRS_CLK_DISABLE
+#define __CRS_CLK_ENABLE __HAL_RCC_CRS_CLK_ENABLE
+#define __CRS_CLK_SLEEP_DISABLE __HAL_RCC_CRS_CLK_SLEEP_DISABLE
+#define __CRS_CLK_SLEEP_ENABLE __HAL_RCC_CRS_CLK_SLEEP_ENABLE
+#define __CRS_FORCE_RESET __HAL_RCC_CRS_FORCE_RESET
+#define __CRS_RELEASE_RESET __HAL_RCC_CRS_RELEASE_RESET
+#define __RCC_BACKUPRESET_FORCE __HAL_RCC_BACKUPRESET_FORCE
+#define __RCC_BACKUPRESET_RELEASE __HAL_RCC_BACKUPRESET_RELEASE
+
+#define __USB_OTG_FS_FORCE_RESET  __HAL_RCC_USB_OTG_FS_FORCE_RESET
+#define __USB_OTG_FS_RELEASE_RESET  __HAL_RCC_USB_OTG_FS_RELEASE_RESET
+#define __USB_OTG_FS_CLK_SLEEP_ENABLE  __HAL_RCC_USB_OTG_FS_CLK_SLEEP_ENABLE
+#define __USB_OTG_FS_CLK_SLEEP_DISABLE  __HAL_RCC_USB_OTG_FS_CLK_SLEEP_DISABLE
+#define __USB_OTG_HS_CLK_DISABLE  __HAL_RCC_USB_OTG_HS_CLK_DISABLE
+#define __USB_OTG_HS_CLK_ENABLE          __HAL_RCC_USB_OTG_HS_CLK_ENABLE
+#define __USB_OTG_HS_ULPI_CLK_ENABLE  __HAL_RCC_USB_OTG_HS_ULPI_CLK_ENABLE
+#define __USB_OTG_HS_ULPI_CLK_DISABLE  __HAL_RCC_USB_OTG_HS_ULPI_CLK_DISABLE  
+#define __TIM9_CLK_SLEEP_ENABLE          __HAL_RCC_TIM9_CLK_SLEEP_ENABLE
+#define __TIM9_CLK_SLEEP_DISABLE  __HAL_RCC_TIM9_CLK_SLEEP_DISABLE  
+#define __TIM10_CLK_SLEEP_ENABLE  __HAL_RCC_TIM10_CLK_SLEEP_ENABLE
+#define __TIM10_CLK_SLEEP_DISABLE  __HAL_RCC_TIM10_CLK_SLEEP_DISABLE  
+#define __TIM11_CLK_SLEEP_ENABLE  __HAL_RCC_TIM11_CLK_SLEEP_ENABLE
+#define __TIM11_CLK_SLEEP_DISABLE  __HAL_RCC_TIM11_CLK_SLEEP_DISABLE  
+#define __ETHMACPTP_CLK_SLEEP_ENABLE  __HAL_RCC_ETHMACPTP_CLK_SLEEP_ENABLE
+#define __ETHMACPTP_CLK_SLEEP_DISABLE  __HAL_RCC_ETHMACPTP_CLK_SLEEP_DISABLE
+#define __ETHMACPTP_CLK_ENABLE          __HAL_RCC_ETHMACPTP_CLK_ENABLE
+#define __ETHMACPTP_CLK_DISABLE          __HAL_RCC_ETHMACPTP_CLK_DISABLE  
+#define __HASH_CLK_ENABLE          __HAL_RCC_HASH_CLK_ENABLE
+#define __HASH_FORCE_RESET          __HAL_RCC_HASH_FORCE_RESET
+#define __HASH_RELEASE_RESET          __HAL_RCC_HASH_RELEASE_RESET
+#define __HASH_CLK_SLEEP_ENABLE          __HAL_RCC_HASH_CLK_SLEEP_ENABLE
+#define __HASH_CLK_SLEEP_DISABLE  __HAL_RCC_HASH_CLK_SLEEP_DISABLE
+#define __HASH_CLK_DISABLE            __HAL_RCC_HASH_CLK_DISABLE  
+#define __SPI5_CLK_ENABLE          __HAL_RCC_SPI5_CLK_ENABLE
+#define __SPI5_CLK_DISABLE              __HAL_RCC_SPI5_CLK_DISABLE
+#define __SPI5_FORCE_RESET          __HAL_RCC_SPI5_FORCE_RESET
+#define __SPI5_RELEASE_RESET          __HAL_RCC_SPI5_RELEASE_RESET
+#define __SPI5_CLK_SLEEP_ENABLE          __HAL_RCC_SPI5_CLK_SLEEP_ENABLE
+#define __SPI5_CLK_SLEEP_DISABLE  __HAL_RCC_SPI5_CLK_SLEEP_DISABLE  
+#define __SPI6_CLK_ENABLE          __HAL_RCC_SPI6_CLK_ENABLE
+#define __SPI6_CLK_DISABLE          __HAL_RCC_SPI6_CLK_DISABLE
+#define __SPI6_FORCE_RESET          __HAL_RCC_SPI6_FORCE_RESET
+#define __SPI6_RELEASE_RESET         __HAL_RCC_SPI6_RELEASE_RESET
+#define __SPI6_CLK_SLEEP_ENABLE          __HAL_RCC_SPI6_CLK_SLEEP_ENABLE
+#define __SPI6_CLK_SLEEP_DISABLE  __HAL_RCC_SPI6_CLK_SLEEP_DISABLE  
+#define __LTDC_CLK_ENABLE          __HAL_RCC_LTDC_CLK_ENABLE
+#define __LTDC_CLK_DISABLE          __HAL_RCC_LTDC_CLK_DISABLE
+#define __LTDC_FORCE_RESET          __HAL_RCC_LTDC_FORCE_RESET
+#define __LTDC_RELEASE_RESET          __HAL_RCC_LTDC_RELEASE_RESET
+#define __LTDC_CLK_SLEEP_ENABLE          __HAL_RCC_LTDC_CLK_SLEEP_ENABLE  
+#define __ETHMAC_CLK_SLEEP_ENABLE  __HAL_RCC_ETHMAC_CLK_SLEEP_ENABLE
+#define __ETHMAC_CLK_SLEEP_DISABLE  __HAL_RCC_ETHMAC_CLK_SLEEP_DISABLE  
+#define __ETHMACTX_CLK_SLEEP_ENABLE  __HAL_RCC_ETHMACTX_CLK_SLEEP_ENABLE
+#define __ETHMACTX_CLK_SLEEP_DISABLE  __HAL_RCC_ETHMACTX_CLK_SLEEP_DISABLE  
+#define __ETHMACRX_CLK_SLEEP_ENABLE  __HAL_RCC_ETHMACRX_CLK_SLEEP_ENABLE
+#define __ETHMACRX_CLK_SLEEP_DISABLE  __HAL_RCC_ETHMACRX_CLK_SLEEP_DISABLE  
+#define __TIM12_CLK_SLEEP_ENABLE  __HAL_RCC_TIM12_CLK_SLEEP_ENABLE
+#define __TIM12_CLK_SLEEP_DISABLE  __HAL_RCC_TIM12_CLK_SLEEP_DISABLE  
+#define __TIM13_CLK_SLEEP_ENABLE  __HAL_RCC_TIM13_CLK_SLEEP_ENABLE
+#define __TIM13_CLK_SLEEP_DISABLE  __HAL_RCC_TIM13_CLK_SLEEP_DISABLE  
+#define __TIM14_CLK_SLEEP_ENABLE  __HAL_RCC_TIM14_CLK_SLEEP_ENABLE
+#define __TIM14_CLK_SLEEP_DISABLE  __HAL_RCC_TIM14_CLK_SLEEP_DISABLE  
+#define __BKPSRAM_CLK_ENABLE          __HAL_RCC_BKPSRAM_CLK_ENABLE
+#define __BKPSRAM_CLK_DISABLE          __HAL_RCC_BKPSRAM_CLK_DISABLE
+#define __BKPSRAM_CLK_SLEEP_ENABLE  __HAL_RCC_BKPSRAM_CLK_SLEEP_ENABLE
+#define __BKPSRAM_CLK_SLEEP_DISABLE  __HAL_RCC_BKPSRAM_CLK_SLEEP_DISABLE  
+#define __CCMDATARAMEN_CLK_ENABLE  __HAL_RCC_CCMDATARAMEN_CLK_ENABLE
+#define __CCMDATARAMEN_CLK_DISABLE  __HAL_RCC_CCMDATARAMEN_CLK_DISABLE  
+#define __USART6_CLK_ENABLE          __HAL_RCC_USART6_CLK_ENABLE
+#define __USART6_CLK_DISABLE          __HAL_RCC_USART6_CLK_DISABLE
+#define __USART6_FORCE_RESET        __HAL_RCC_USART6_FORCE_RESET
+#define __USART6_RELEASE_RESET        __HAL_RCC_USART6_RELEASE_RESET
+#define __USART6_CLK_SLEEP_ENABLE  __HAL_RCC_USART6_CLK_SLEEP_ENABLE
+#define __USART6_CLK_SLEEP_DISABLE  __HAL_RCC_USART6_CLK_SLEEP_DISABLE  
+#define __SPI4_CLK_ENABLE          __HAL_RCC_SPI4_CLK_ENABLE
+#define __SPI4_CLK_DISABLE          __HAL_RCC_SPI4_CLK_DISABLE
+#define __SPI4_FORCE_RESET          __HAL_RCC_SPI4_FORCE_RESET
+#define __SPI4_RELEASE_RESET        __HAL_RCC_SPI4_RELEASE_RESET
+#define __SPI4_CLK_SLEEP_ENABLE   __HAL_RCC_SPI4_CLK_SLEEP_ENABLE
+#define __SPI4_CLK_SLEEP_DISABLE  __HAL_RCC_SPI4_CLK_SLEEP_DISABLE  
+#define __GPIOI_CLK_ENABLE          __HAL_RCC_GPIOI_CLK_ENABLE
+#define __GPIOI_CLK_DISABLE          __HAL_RCC_GPIOI_CLK_DISABLE
+#define __GPIOI_FORCE_RESET          __HAL_RCC_GPIOI_FORCE_RESET
+#define __GPIOI_RELEASE_RESET          __HAL_RCC_GPIOI_RELEASE_RESET
+#define __GPIOI_CLK_SLEEP_ENABLE  __HAL_RCC_GPIOI_CLK_SLEEP_ENABLE
+#define __GPIOI_CLK_SLEEP_DISABLE  __HAL_RCC_GPIOI_CLK_SLEEP_DISABLE  
+#define __GPIOJ_CLK_ENABLE          __HAL_RCC_GPIOJ_CLK_ENABLE
+#define __GPIOJ_CLK_DISABLE          __HAL_RCC_GPIOJ_CLK_DISABLE
+#define __GPIOJ_FORCE_RESET         __HAL_RCC_GPIOJ_FORCE_RESET
+#define __GPIOJ_RELEASE_RESET          __HAL_RCC_GPIOJ_RELEASE_RESET
+#define __GPIOJ_CLK_SLEEP_ENABLE  __HAL_RCC_GPIOJ_CLK_SLEEP_ENABLE
+#define __GPIOJ_CLK_SLEEP_DISABLE  __HAL_RCC_GPIOJ_CLK_SLEEP_DISABLE  
+#define __GPIOK_CLK_ENABLE          __HAL_RCC_GPIOK_CLK_ENABLE
+#define __GPIOK_CLK_DISABLE          __HAL_RCC_GPIOK_CLK_DISABLE
+#define __GPIOK_RELEASE_RESET          __HAL_RCC_GPIOK_RELEASE_RESET
+#define __GPIOK_CLK_SLEEP_ENABLE  __HAL_RCC_GPIOK_CLK_SLEEP_ENABLE
+#define __GPIOK_CLK_SLEEP_DISABLE  __HAL_RCC_GPIOK_CLK_SLEEP_DISABLE  
+#define __ETH_CLK_ENABLE          __HAL_RCC_ETH_CLK_ENABLE
+#define __ETH_CLK_DISABLE          __HAL_RCC_ETH_CLK_DISABLE  
+#define __DCMI_CLK_ENABLE          __HAL_RCC_DCMI_CLK_ENABLE
+#define __DCMI_CLK_DISABLE          __HAL_RCC_DCMI_CLK_DISABLE
+#define __DCMI_FORCE_RESET          __HAL_RCC_DCMI_FORCE_RESET
+#define __DCMI_RELEASE_RESET          __HAL_RCC_DCMI_RELEASE_RESET
+#define __DCMI_CLK_SLEEP_ENABLE   __HAL_RCC_DCMI_CLK_SLEEP_ENABLE
+#define __DCMI_CLK_SLEEP_DISABLE  __HAL_RCC_DCMI_CLK_SLEEP_DISABLE  
+#define __UART7_CLK_ENABLE          __HAL_RCC_UART7_CLK_ENABLE
+#define __UART7_CLK_DISABLE          __HAL_RCC_UART7_CLK_DISABLE
+#define __UART7_RELEASE_RESET       __HAL_RCC_UART7_RELEASE_RESET
+#define __UART7_FORCE_RESET       __HAL_RCC_UART7_FORCE_RESET
+#define __UART7_CLK_SLEEP_ENABLE  __HAL_RCC_UART7_CLK_SLEEP_ENABLE
+#define __UART7_CLK_SLEEP_DISABLE  __HAL_RCC_UART7_CLK_SLEEP_DISABLE  
+#define __UART8_CLK_ENABLE          __HAL_RCC_UART8_CLK_ENABLE
+#define __UART8_CLK_DISABLE          __HAL_RCC_UART8_CLK_DISABLE
+#define __UART8_FORCE_RESET          __HAL_RCC_UART8_FORCE_RESET
+#define __UART8_RELEASE_RESET          __HAL_RCC_UART8_RELEASE_RESET
+#define __UART8_CLK_SLEEP_ENABLE  __HAL_RCC_UART8_CLK_SLEEP_ENABLE
+#define __UART8_CLK_SLEEP_DISABLE  __HAL_RCC_UART8_CLK_SLEEP_DISABLE  
+#define __OTGHS_CLK_SLEEP_ENABLE  __HAL_RCC_USB_OTG_HS_CLK_SLEEP_ENABLE
+#define __OTGHS_CLK_SLEEP_DISABLE  __HAL_RCC_USB_OTG_HS_CLK_SLEEP_DISABLE
+#define __OTGHS_FORCE_RESET          __HAL_RCC_USB_OTG_HS_FORCE_RESET
+#define __OTGHS_RELEASE_RESET          __HAL_RCC_USB_OTG_HS_RELEASE_RESET  
+#define __OTGHSULPI_CLK_SLEEP_ENABLE  __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_ENABLE
+#define __OTGHSULPI_CLK_SLEEP_DISABLE  __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_DISABLE
+#define __HAL_RCC_OTGHS_CLK_SLEEP_ENABLE  __HAL_RCC_USB_OTG_HS_CLK_SLEEP_ENABLE
+#define __HAL_RCC_OTGHS_CLK_SLEEP_DISABLE  __HAL_RCC_USB_OTG_HS_CLK_SLEEP_DISABLE
+#define __HAL_RCC_OTGHS_IS_CLK_SLEEP_ENABLED __HAL_RCC_USB_OTG_HS_IS_CLK_SLEEP_ENABLED
+#define __HAL_RCC_OTGHS_IS_CLK_SLEEP_DISABLED __HAL_RCC_USB_OTG_HS_IS_CLK_SLEEP_DISABLED
+#define __HAL_RCC_OTGHS_FORCE_RESET          __HAL_RCC_USB_OTG_HS_FORCE_RESET
+#define __HAL_RCC_OTGHS_RELEASE_RESET          __HAL_RCC_USB_OTG_HS_RELEASE_RESET  
+#define __HAL_RCC_OTGHSULPI_CLK_SLEEP_ENABLE      __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_ENABLE
+#define __HAL_RCC_OTGHSULPI_CLK_SLEEP_DISABLE     __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_DISABLE 
+#define __HAL_RCC_OTGHSULPI_IS_CLK_SLEEP_ENABLED  __HAL_RCC_USB_OTG_HS_ULPI_IS_CLK_SLEEP_ENABLED
+#define __HAL_RCC_OTGHSULPI_IS_CLK_SLEEP_DISABLED __HAL_RCC_USB_OTG_HS_ULPI_IS_CLK_SLEEP_DISABLED   
+#define __CRYP_FORCE_RESET             __HAL_RCC_CRYP_FORCE_RESET  
+#define __SRAM3_CLK_SLEEP_ENABLE       __HAL_RCC_SRAM3_CLK_SLEEP_ENABLE  
+#define __CAN2_CLK_SLEEP_ENABLE        __HAL_RCC_CAN2_CLK_SLEEP_ENABLE
+#define __CAN2_CLK_SLEEP_DISABLE       __HAL_RCC_CAN2_CLK_SLEEP_DISABLE  
+#define __DAC_CLK_SLEEP_ENABLE         __HAL_RCC_DAC_CLK_SLEEP_ENABLE
+#define __DAC_CLK_SLEEP_DISABLE        __HAL_RCC_DAC_CLK_SLEEP_DISABLE  
+#define __ADC2_CLK_SLEEP_ENABLE        __HAL_RCC_ADC2_CLK_SLEEP_ENABLE
+#define __ADC2_CLK_SLEEP_DISABLE       __HAL_RCC_ADC2_CLK_SLEEP_DISABLE  
+#define __ADC3_CLK_SLEEP_ENABLE        __HAL_RCC_ADC3_CLK_SLEEP_ENABLE
+#define __ADC3_CLK_SLEEP_DISABLE       __HAL_RCC_ADC3_CLK_SLEEP_DISABLE  
+#define __FSMC_FORCE_RESET             __HAL_RCC_FSMC_FORCE_RESET
+#define __FSMC_RELEASE_RESET           __HAL_RCC_FSMC_RELEASE_RESET
+#define __FSMC_CLK_SLEEP_ENABLE        __HAL_RCC_FSMC_CLK_SLEEP_ENABLE
+#define __FSMC_CLK_SLEEP_DISABLE       __HAL_RCC_FSMC_CLK_SLEEP_DISABLE  
+#define __SDIO_FORCE_RESET             __HAL_RCC_SDIO_FORCE_RESET
+#define __SDIO_RELEASE_RESET           __HAL_RCC_SDIO_RELEASE_RESET
+#define __SDIO_CLK_SLEEP_DISABLE       __HAL_RCC_SDIO_CLK_SLEEP_DISABLE
+#define __SDIO_CLK_SLEEP_ENABLE        __HAL_RCC_SDIO_CLK_SLEEP_ENABLE  
+#define __DMA2D_CLK_ENABLE             __HAL_RCC_DMA2D_CLK_ENABLE
+#define __DMA2D_CLK_DISABLE            __HAL_RCC_DMA2D_CLK_DISABLE
+#define __DMA2D_FORCE_RESET            __HAL_RCC_DMA2D_FORCE_RESET
+#define __DMA2D_RELEASE_RESET          __HAL_RCC_DMA2D_RELEASE_RESET
+#define __DMA2D_CLK_SLEEP_ENABLE       __HAL_RCC_DMA2D_CLK_SLEEP_ENABLE
+#define __DMA2D_CLK_SLEEP_DISABLE      __HAL_RCC_DMA2D_CLK_SLEEP_DISABLE
+
+/* alias define maintained for legacy */
+#define __HAL_RCC_OTGFS_FORCE_RESET    __HAL_RCC_USB_OTG_FS_FORCE_RESET
+#define __HAL_RCC_OTGFS_RELEASE_RESET  __HAL_RCC_USB_OTG_FS_RELEASE_RESET
+
+#define __ADC12_CLK_ENABLE          __HAL_RCC_ADC12_CLK_ENABLE
+#define __ADC12_CLK_DISABLE         __HAL_RCC_ADC12_CLK_DISABLE
+#define __ADC34_CLK_ENABLE          __HAL_RCC_ADC34_CLK_ENABLE
+#define __ADC34_CLK_DISABLE         __HAL_RCC_ADC34_CLK_DISABLE
+#define __ADC12_CLK_ENABLE          __HAL_RCC_ADC12_CLK_ENABLE
+#define __ADC12_CLK_DISABLE         __HAL_RCC_ADC12_CLK_DISABLE
+#define __DAC2_CLK_ENABLE           __HAL_RCC_DAC2_CLK_ENABLE
+#define __DAC2_CLK_DISABLE          __HAL_RCC_DAC2_CLK_DISABLE
+#define __TIM18_CLK_ENABLE          __HAL_RCC_TIM18_CLK_ENABLE
+#define __TIM18_CLK_DISABLE         __HAL_RCC_TIM18_CLK_DISABLE
+#define __TIM19_CLK_ENABLE          __HAL_RCC_TIM19_CLK_ENABLE
+#define __TIM19_CLK_DISABLE         __HAL_RCC_TIM19_CLK_DISABLE
+#define __TIM20_CLK_ENABLE          __HAL_RCC_TIM20_CLK_ENABLE
+#define __TIM20_CLK_DISABLE         __HAL_RCC_TIM20_CLK_DISABLE
+#define __HRTIM1_CLK_ENABLE         __HAL_RCC_HRTIM1_CLK_ENABLE
+#define __HRTIM1_CLK_DISABLE        __HAL_RCC_HRTIM1_CLK_DISABLE
+#define __SDADC1_CLK_ENABLE         __HAL_RCC_SDADC1_CLK_ENABLE
+#define __SDADC2_CLK_ENABLE         __HAL_RCC_SDADC2_CLK_ENABLE
+#define __SDADC3_CLK_ENABLE         __HAL_RCC_SDADC3_CLK_ENABLE
+#define __SDADC1_CLK_DISABLE        __HAL_RCC_SDADC1_CLK_DISABLE
+#define __SDADC2_CLK_DISABLE        __HAL_RCC_SDADC2_CLK_DISABLE
+#define __SDADC3_CLK_DISABLE        __HAL_RCC_SDADC3_CLK_DISABLE
+
+#define __ADC12_FORCE_RESET         __HAL_RCC_ADC12_FORCE_RESET
+#define __ADC12_RELEASE_RESET       __HAL_RCC_ADC12_RELEASE_RESET
+#define __ADC34_FORCE_RESET         __HAL_RCC_ADC34_FORCE_RESET
+#define __ADC34_RELEASE_RESET       __HAL_RCC_ADC34_RELEASE_RESET
+#define __ADC12_FORCE_RESET         __HAL_RCC_ADC12_FORCE_RESET
+#define __ADC12_RELEASE_RESET       __HAL_RCC_ADC12_RELEASE_RESET
+#define __DAC2_FORCE_RESET          __HAL_RCC_DAC2_FORCE_RESET
+#define __DAC2_RELEASE_RESET        __HAL_RCC_DAC2_RELEASE_RESET
+#define __TIM18_FORCE_RESET         __HAL_RCC_TIM18_FORCE_RESET
+#define __TIM18_RELEASE_RESET       __HAL_RCC_TIM18_RELEASE_RESET
+#define __TIM19_FORCE_RESET         __HAL_RCC_TIM19_FORCE_RESET
+#define __TIM19_RELEASE_RESET       __HAL_RCC_TIM19_RELEASE_RESET
+#define __TIM20_FORCE_RESET         __HAL_RCC_TIM20_FORCE_RESET
+#define __TIM20_RELEASE_RESET       __HAL_RCC_TIM20_RELEASE_RESET
+#define __HRTIM1_FORCE_RESET        __HAL_RCC_HRTIM1_FORCE_RESET
+#define __HRTIM1_RELEASE_RESET      __HAL_RCC_HRTIM1_RELEASE_RESET
+#define __SDADC1_FORCE_RESET        __HAL_RCC_SDADC1_FORCE_RESET
+#define __SDADC2_FORCE_RESET        __HAL_RCC_SDADC2_FORCE_RESET
+#define __SDADC3_FORCE_RESET        __HAL_RCC_SDADC3_FORCE_RESET
+#define __SDADC1_RELEASE_RESET      __HAL_RCC_SDADC1_RELEASE_RESET
+#define __SDADC2_RELEASE_RESET      __HAL_RCC_SDADC2_RELEASE_RESET
+#define __SDADC3_RELEASE_RESET      __HAL_RCC_SDADC3_RELEASE_RESET
+
+#define __ADC1_IS_CLK_ENABLED       __HAL_RCC_ADC1_IS_CLK_ENABLED
+#define __ADC1_IS_CLK_DISABLED      __HAL_RCC_ADC1_IS_CLK_DISABLED
+#define __ADC12_IS_CLK_ENABLED      __HAL_RCC_ADC12_IS_CLK_ENABLED
+#define __ADC12_IS_CLK_DISABLED     __HAL_RCC_ADC12_IS_CLK_DISABLED
+#define __ADC34_IS_CLK_ENABLED      __HAL_RCC_ADC34_IS_CLK_ENABLED
+#define __ADC34_IS_CLK_DISABLED     __HAL_RCC_ADC34_IS_CLK_DISABLED
+#define __CEC_IS_CLK_ENABLED        __HAL_RCC_CEC_IS_CLK_ENABLED
+#define __CEC_IS_CLK_DISABLED       __HAL_RCC_CEC_IS_CLK_DISABLED
+#define __CRC_IS_CLK_ENABLED        __HAL_RCC_CRC_IS_CLK_ENABLED
+#define __CRC_IS_CLK_DISABLED       __HAL_RCC_CRC_IS_CLK_DISABLED
+#define __DAC1_IS_CLK_ENABLED       __HAL_RCC_DAC1_IS_CLK_ENABLED
+#define __DAC1_IS_CLK_DISABLED      __HAL_RCC_DAC1_IS_CLK_DISABLED
+#define __DAC2_IS_CLK_ENABLED       __HAL_RCC_DAC2_IS_CLK_ENABLED
+#define __DAC2_IS_CLK_DISABLED      __HAL_RCC_DAC2_IS_CLK_DISABLED
+#define __DMA1_IS_CLK_ENABLED       __HAL_RCC_DMA1_IS_CLK_ENABLED
+#define __DMA1_IS_CLK_DISABLED      __HAL_RCC_DMA1_IS_CLK_DISABLED
+#define __DMA2_IS_CLK_ENABLED       __HAL_RCC_DMA2_IS_CLK_ENABLED
+#define __DMA2_IS_CLK_DISABLED      __HAL_RCC_DMA2_IS_CLK_DISABLED
+#define __FLITF_IS_CLK_ENABLED      __HAL_RCC_FLITF_IS_CLK_ENABLED
+#define __FLITF_IS_CLK_DISABLED     __HAL_RCC_FLITF_IS_CLK_DISABLED
+#define __FMC_IS_CLK_ENABLED        __HAL_RCC_FMC_IS_CLK_ENABLED
+#define __FMC_IS_CLK_DISABLED       __HAL_RCC_FMC_IS_CLK_DISABLED
+#define __GPIOA_IS_CLK_ENABLED      __HAL_RCC_GPIOA_IS_CLK_ENABLED
+#define __GPIOA_IS_CLK_DISABLED     __HAL_RCC_GPIOA_IS_CLK_DISABLED
+#define __GPIOB_IS_CLK_ENABLED      __HAL_RCC_GPIOB_IS_CLK_ENABLED
+#define __GPIOB_IS_CLK_DISABLED     __HAL_RCC_GPIOB_IS_CLK_DISABLED
+#define __GPIOC_IS_CLK_ENABLED      __HAL_RCC_GPIOC_IS_CLK_ENABLED
+#define __GPIOC_IS_CLK_DISABLED     __HAL_RCC_GPIOC_IS_CLK_DISABLED
+#define __GPIOD_IS_CLK_ENABLED      __HAL_RCC_GPIOD_IS_CLK_ENABLED
+#define __GPIOD_IS_CLK_DISABLED     __HAL_RCC_GPIOD_IS_CLK_DISABLED
+#define __GPIOE_IS_CLK_ENABLED      __HAL_RCC_GPIOE_IS_CLK_ENABLED
+#define __GPIOE_IS_CLK_DISABLED     __HAL_RCC_GPIOE_IS_CLK_DISABLED
+#define __GPIOF_IS_CLK_ENABLED      __HAL_RCC_GPIOF_IS_CLK_ENABLED
+#define __GPIOF_IS_CLK_DISABLED     __HAL_RCC_GPIOF_IS_CLK_DISABLED
+#define __GPIOG_IS_CLK_ENABLED      __HAL_RCC_GPIOG_IS_CLK_ENABLED
+#define __GPIOG_IS_CLK_DISABLED     __HAL_RCC_GPIOG_IS_CLK_DISABLED
+#define __GPIOH_IS_CLK_ENABLED      __HAL_RCC_GPIOH_IS_CLK_ENABLED
+#define __GPIOH_IS_CLK_DISABLED     __HAL_RCC_GPIOH_IS_CLK_DISABLED
+#define __HRTIM1_IS_CLK_ENABLED     __HAL_RCC_HRTIM1_IS_CLK_ENABLED
+#define __HRTIM1_IS_CLK_DISABLED    __HAL_RCC_HRTIM1_IS_CLK_DISABLED
+#define __I2C1_IS_CLK_ENABLED       __HAL_RCC_I2C1_IS_CLK_ENABLED
+#define __I2C1_IS_CLK_DISABLED      __HAL_RCC_I2C1_IS_CLK_DISABLED
+#define __I2C2_IS_CLK_ENABLED       __HAL_RCC_I2C2_IS_CLK_ENABLED
+#define __I2C2_IS_CLK_DISABLED      __HAL_RCC_I2C2_IS_CLK_DISABLED
+#define __I2C3_IS_CLK_ENABLED       __HAL_RCC_I2C3_IS_CLK_ENABLED
+#define __I2C3_IS_CLK_DISABLED      __HAL_RCC_I2C3_IS_CLK_DISABLED
+#define __PWR_IS_CLK_ENABLED        __HAL_RCC_PWR_IS_CLK_ENABLED
+#define __PWR_IS_CLK_DISABLED       __HAL_RCC_PWR_IS_CLK_DISABLED
+#define __SYSCFG_IS_CLK_ENABLED     __HAL_RCC_SYSCFG_IS_CLK_ENABLED
+#define __SYSCFG_IS_CLK_DISABLED    __HAL_RCC_SYSCFG_IS_CLK_DISABLED
+#define __SPI1_IS_CLK_ENABLED       __HAL_RCC_SPI1_IS_CLK_ENABLED
+#define __SPI1_IS_CLK_DISABLED      __HAL_RCC_SPI1_IS_CLK_DISABLED
+#define __SPI2_IS_CLK_ENABLED       __HAL_RCC_SPI2_IS_CLK_ENABLED
+#define __SPI2_IS_CLK_DISABLED      __HAL_RCC_SPI2_IS_CLK_DISABLED
+#define __SPI3_IS_CLK_ENABLED       __HAL_RCC_SPI3_IS_CLK_ENABLED
+#define __SPI3_IS_CLK_DISABLED      __HAL_RCC_SPI3_IS_CLK_DISABLED
+#define __SPI4_IS_CLK_ENABLED       __HAL_RCC_SPI4_IS_CLK_ENABLED
+#define __SPI4_IS_CLK_DISABLED      __HAL_RCC_SPI4_IS_CLK_DISABLED
+#define __SDADC1_IS_CLK_ENABLED     __HAL_RCC_SDADC1_IS_CLK_ENABLED
+#define __SDADC1_IS_CLK_DISABLED    __HAL_RCC_SDADC1_IS_CLK_DISABLED
+#define __SDADC2_IS_CLK_ENABLED     __HAL_RCC_SDADC2_IS_CLK_ENABLED
+#define __SDADC2_IS_CLK_DISABLED    __HAL_RCC_SDADC2_IS_CLK_DISABLED
+#define __SDADC3_IS_CLK_ENABLED     __HAL_RCC_SDADC3_IS_CLK_ENABLED
+#define __SDADC3_IS_CLK_DISABLED    __HAL_RCC_SDADC3_IS_CLK_DISABLED
+#define __SRAM_IS_CLK_ENABLED       __HAL_RCC_SRAM_IS_CLK_ENABLED
+#define __SRAM_IS_CLK_DISABLED      __HAL_RCC_SRAM_IS_CLK_DISABLED
+#define __TIM1_IS_CLK_ENABLED       __HAL_RCC_TIM1_IS_CLK_ENABLED
+#define __TIM1_IS_CLK_DISABLED      __HAL_RCC_TIM1_IS_CLK_DISABLED
+#define __TIM2_IS_CLK_ENABLED       __HAL_RCC_TIM2_IS_CLK_ENABLED
+#define __TIM2_IS_CLK_DISABLED      __HAL_RCC_TIM2_IS_CLK_DISABLED
+#define __TIM3_IS_CLK_ENABLED       __HAL_RCC_TIM3_IS_CLK_ENABLED
+#define __TIM3_IS_CLK_DISABLED      __HAL_RCC_TIM3_IS_CLK_DISABLED
+#define __TIM4_IS_CLK_ENABLED       __HAL_RCC_TIM4_IS_CLK_ENABLED
+#define __TIM4_IS_CLK_DISABLED      __HAL_RCC_TIM4_IS_CLK_DISABLED
+#define __TIM5_IS_CLK_ENABLED       __HAL_RCC_TIM5_IS_CLK_ENABLED
+#define __TIM5_IS_CLK_DISABLED      __HAL_RCC_TIM5_IS_CLK_DISABLED
+#define __TIM6_IS_CLK_ENABLED       __HAL_RCC_TIM6_IS_CLK_ENABLED
+#define __TIM6_IS_CLK_DISABLED      __HAL_RCC_TIM6_IS_CLK_DISABLED
+#define __TIM7_IS_CLK_ENABLED       __HAL_RCC_TIM7_IS_CLK_ENABLED
+#define __TIM7_IS_CLK_DISABLED      __HAL_RCC_TIM7_IS_CLK_DISABLED
+#define __TIM8_IS_CLK_ENABLED       __HAL_RCC_TIM8_IS_CLK_ENABLED
+#define __TIM8_IS_CLK_DISABLED      __HAL_RCC_TIM8_IS_CLK_DISABLED
+#define __TIM12_IS_CLK_ENABLED      __HAL_RCC_TIM12_IS_CLK_ENABLED
+#define __TIM12_IS_CLK_DISABLED     __HAL_RCC_TIM12_IS_CLK_DISABLED
+#define __TIM13_IS_CLK_ENABLED      __HAL_RCC_TIM13_IS_CLK_ENABLED
+#define __TIM13_IS_CLK_DISABLED     __HAL_RCC_TIM13_IS_CLK_DISABLED
+#define __TIM14_IS_CLK_ENABLED      __HAL_RCC_TIM14_IS_CLK_ENABLED
+#define __TIM14_IS_CLK_DISABLED     __HAL_RCC_TIM14_IS_CLK_DISABLED
+#define __TIM15_IS_CLK_ENABLED      __HAL_RCC_TIM15_IS_CLK_ENABLED
+#define __TIM15_IS_CLK_DISABLED     __HAL_RCC_TIM15_IS_CLK_DISABLED
+#define __TIM16_IS_CLK_ENABLED      __HAL_RCC_TIM16_IS_CLK_ENABLED
+#define __TIM16_IS_CLK_DISABLED     __HAL_RCC_TIM16_IS_CLK_DISABLED
+#define __TIM17_IS_CLK_ENABLED      __HAL_RCC_TIM17_IS_CLK_ENABLED
+#define __TIM17_IS_CLK_DISABLED     __HAL_RCC_TIM17_IS_CLK_DISABLED
+#define __TIM18_IS_CLK_ENABLED      __HAL_RCC_TIM18_IS_CLK_ENABLED
+#define __TIM18_IS_CLK_DISABLED     __HAL_RCC_TIM18_IS_CLK_DISABLED
+#define __TIM19_IS_CLK_ENABLED      __HAL_RCC_TIM19_IS_CLK_ENABLED
+#define __TIM19_IS_CLK_DISABLED     __HAL_RCC_TIM19_IS_CLK_DISABLED
+#define __TIM20_IS_CLK_ENABLED      __HAL_RCC_TIM20_IS_CLK_ENABLED
+#define __TIM20_IS_CLK_DISABLED     __HAL_RCC_TIM20_IS_CLK_DISABLED
+#define __TSC_IS_CLK_ENABLED        __HAL_RCC_TSC_IS_CLK_ENABLED
+#define __TSC_IS_CLK_DISABLED       __HAL_RCC_TSC_IS_CLK_DISABLED
+#define __UART4_IS_CLK_ENABLED      __HAL_RCC_UART4_IS_CLK_ENABLED
+#define __UART4_IS_CLK_DISABLED     __HAL_RCC_UART4_IS_CLK_DISABLED
+#define __UART5_IS_CLK_ENABLED      __HAL_RCC_UART5_IS_CLK_ENABLED
+#define __UART5_IS_CLK_DISABLED     __HAL_RCC_UART5_IS_CLK_DISABLED
+#define __USART1_IS_CLK_ENABLED     __HAL_RCC_USART1_IS_CLK_ENABLED
+#define __USART1_IS_CLK_DISABLED    __HAL_RCC_USART1_IS_CLK_DISABLED
+#define __USART2_IS_CLK_ENABLED     __HAL_RCC_USART2_IS_CLK_ENABLED
+#define __USART2_IS_CLK_DISABLED    __HAL_RCC_USART2_IS_CLK_DISABLED
+#define __USART3_IS_CLK_ENABLED     __HAL_RCC_USART3_IS_CLK_ENABLED
+#define __USART3_IS_CLK_DISABLED    __HAL_RCC_USART3_IS_CLK_DISABLED
+#define __USB_IS_CLK_ENABLED        __HAL_RCC_USB_IS_CLK_ENABLED
+#define __USB_IS_CLK_DISABLED       __HAL_RCC_USB_IS_CLK_DISABLED
+#define __WWDG_IS_CLK_ENABLED       __HAL_RCC_WWDG_IS_CLK_ENABLED
+#define __WWDG_IS_CLK_DISABLED      __HAL_RCC_WWDG_IS_CLK_DISABLED
+
+#if defined(STM32F4)
+#define __HAL_RCC_SDMMC1_FORCE_RESET       __HAL_RCC_SDIO_FORCE_RESET
+#define __HAL_RCC_SDMMC1_RELEASE_RESET     __HAL_RCC_SDIO_RELEASE_RESET
+#define __HAL_RCC_SDMMC1_CLK_SLEEP_ENABLE  __HAL_RCC_SDIO_CLK_SLEEP_ENABLE
+#define __HAL_RCC_SDMMC1_CLK_SLEEP_DISABLE __HAL_RCC_SDIO_CLK_SLEEP_DISABLE
+#define __HAL_RCC_SDMMC1_CLK_ENABLE        __HAL_RCC_SDIO_CLK_ENABLE
+#define __HAL_RCC_SDMMC1_CLK_DISABLE       __HAL_RCC_SDIO_CLK_DISABLE
+#define __HAL_RCC_SDMMC1_IS_CLK_ENABLED    __HAL_RCC_SDIO_IS_CLK_ENABLED
+#define __HAL_RCC_SDMMC1_IS_CLK_DISABLED   __HAL_RCC_SDIO_IS_CLK_DISABLED
+#define Sdmmc1ClockSelection               SdioClockSelection
+#define RCC_PERIPHCLK_SDMMC1               RCC_PERIPHCLK_SDIO
+#define RCC_SDMMC1CLKSOURCE_CLK48          RCC_SDIOCLKSOURCE_CK48
+#define RCC_SDMMC1CLKSOURCE_SYSCLK         RCC_SDIOCLKSOURCE_SYSCLK
+#define __HAL_RCC_SDMMC1_CONFIG            __HAL_RCC_SDIO_CONFIG
+#define __HAL_RCC_GET_SDMMC1_SOURCE        __HAL_RCC_GET_SDIO_SOURCE
+#endif
+
+#if defined(STM32F7) || defined(STM32L4)
+#define __HAL_RCC_SDIO_FORCE_RESET         __HAL_RCC_SDMMC1_FORCE_RESET
+#define __HAL_RCC_SDIO_RELEASE_RESET       __HAL_RCC_SDMMC1_RELEASE_RESET
+#define __HAL_RCC_SDIO_CLK_SLEEP_ENABLE    __HAL_RCC_SDMMC1_CLK_SLEEP_ENABLE
+#define __HAL_RCC_SDIO_CLK_SLEEP_DISABLE   __HAL_RCC_SDMMC1_CLK_SLEEP_DISABLE
+#define __HAL_RCC_SDIO_CLK_ENABLE          __HAL_RCC_SDMMC1_CLK_ENABLE
+#define __HAL_RCC_SDIO_CLK_DISABLE         __HAL_RCC_SDMMC1_CLK_DISABLE
+#define __HAL_RCC_SDIO_IS_CLK_ENABLED      __HAL_RCC_SDMMC1_IS_CLK_ENABLED
+#define __HAL_RCC_SDIO_IS_CLK_DISABLED     __HAL_RCC_SDMMC1_IS_CLK_DISABLED
+#define SdioClockSelection                 Sdmmc1ClockSelection
+#define RCC_PERIPHCLK_SDIO                 RCC_PERIPHCLK_SDMMC1
+#define __HAL_RCC_SDIO_CONFIG              __HAL_RCC_SDMMC1_CONFIG
+#define __HAL_RCC_GET_SDIO_SOURCE          __HAL_RCC_GET_SDMMC1_SOURCE	
+#endif
+
+#if defined(STM32F7)
+#define RCC_SDIOCLKSOURCE_CK48             RCC_SDMMC1CLKSOURCE_CLK48
+#define RCC_SDIOCLKSOURCE_SYSCLK           RCC_SDMMC1CLKSOURCE_SYSCLK
+#endif
+
+#define __HAL_RCC_I2SCLK            __HAL_RCC_I2S_CONFIG
+#define __HAL_RCC_I2SCLK_CONFIG     __HAL_RCC_I2S_CONFIG
+
+#define __RCC_PLLSRC                RCC_GET_PLL_OSCSOURCE
+
+#define IS_RCC_MSIRANGE             IS_RCC_MSI_CLOCK_RANGE
+#define IS_RCC_RTCCLK_SOURCE        IS_RCC_RTCCLKSOURCE
+#define IS_RCC_SYSCLK_DIV           IS_RCC_HCLK
+#define IS_RCC_HCLK_DIV             IS_RCC_PCLK
+#define IS_RCC_PERIPHCLK            IS_RCC_PERIPHCLOCK
+
+#define RCC_IT_HSI14                RCC_IT_HSI14RDY
+
+#if defined(STM32L0)
+#define RCC_IT_LSECSS              RCC_IT_CSSLSE 
+#define RCC_IT_CSS                 RCC_IT_CSSHSE
+#endif
+
+#define IS_RCC_MCOSOURCE            IS_RCC_MCO1SOURCE
+#define __HAL_RCC_MCO_CONFIG        __HAL_RCC_MCO1_CONFIG
+#define RCC_MCO_NODIV               RCC_MCODIV_1
+#define RCC_MCO_DIV1                RCC_MCODIV_1
+#define RCC_MCO_DIV2                RCC_MCODIV_2
+#define RCC_MCO_DIV4                RCC_MCODIV_4
+#define RCC_MCO_DIV8                RCC_MCODIV_8
+#define RCC_MCO_DIV16               RCC_MCODIV_16
+#define RCC_MCO_DIV32               RCC_MCODIV_32
+#define RCC_MCO_DIV64               RCC_MCODIV_64
+#define RCC_MCO_DIV128              RCC_MCODIV_128
+#define RCC_MCOSOURCE_NONE          RCC_MCO1SOURCE_NOCLOCK
+#define RCC_MCOSOURCE_LSI           RCC_MCO1SOURCE_LSI
+#define RCC_MCOSOURCE_LSE           RCC_MCO1SOURCE_LSE
+#define RCC_MCOSOURCE_SYSCLK        RCC_MCO1SOURCE_SYSCLK
+#define RCC_MCOSOURCE_HSI           RCC_MCO1SOURCE_HSI
+#define RCC_MCOSOURCE_HSI14         RCC_MCO1SOURCE_HSI14
+#define RCC_MCOSOURCE_HSI48         RCC_MCO1SOURCE_HSI48
+#define RCC_MCOSOURCE_HSE           RCC_MCO1SOURCE_HSE
+#define RCC_MCOSOURCE_PLLCLK_DIV1   RCC_MCO1SOURCE_PLLCLK
+#define RCC_MCOSOURCE_PLLCLK_NODIV  RCC_MCO1SOURCE_PLLCLK
+#define RCC_MCOSOURCE_PLLCLK_DIV2   RCC_MCO1SOURCE_PLLCLK_DIV2
+
+#define RCC_RTCCLKSOURCE_NONE       RCC_RTCCLKSOURCE_NO_CLK
+
+#define RCC_USBCLK_PLLSAI1          RCC_USBCLKSOURCE_PLLSAI1
+#define RCC_USBCLK_PLL              RCC_USBCLKSOURCE_PLL
+#define RCC_USBCLK_MSI              RCC_USBCLKSOURCE_MSI
+#define RCC_USBCLKSOURCE_PLLCLK     RCC_USBCLKSOURCE_PLL
+#define RCC_USBPLLCLK_DIV1          RCC_USBCLKSOURCE_PLL
+#define RCC_USBPLLCLK_DIV1_5        RCC_USBCLKSOURCE_PLL_DIV1_5
+#define RCC_USBPLLCLK_DIV2          RCC_USBCLKSOURCE_PLL_DIV2
+#define RCC_USBPLLCLK_DIV3          RCC_USBCLKSOURCE_PLL_DIV3
+
+#define HSION_BitNumber        RCC_HSION_BIT_NUMBER
+#define HSION_BITNUMBER        RCC_HSION_BIT_NUMBER
+#define HSEON_BitNumber        RCC_HSEON_BIT_NUMBER
+#define HSEON_BITNUMBER        RCC_HSEON_BIT_NUMBER
+#define MSION_BITNUMBER        RCC_MSION_BIT_NUMBER
+#define CSSON_BitNumber        RCC_CSSON_BIT_NUMBER
+#define CSSON_BITNUMBER        RCC_CSSON_BIT_NUMBER
+#define PLLON_BitNumber        RCC_PLLON_BIT_NUMBER
+#define PLLON_BITNUMBER        RCC_PLLON_BIT_NUMBER
+#define PLLI2SON_BitNumber     RCC_PLLI2SON_BIT_NUMBER
+#define I2SSRC_BitNumber       RCC_I2SSRC_BIT_NUMBER
+#define RTCEN_BitNumber        RCC_RTCEN_BIT_NUMBER
+#define RTCEN_BITNUMBER        RCC_RTCEN_BIT_NUMBER
+#define BDRST_BitNumber        RCC_BDRST_BIT_NUMBER
+#define BDRST_BITNUMBER        RCC_BDRST_BIT_NUMBER
+#define RTCRST_BITNUMBER       RCC_RTCRST_BIT_NUMBER
+#define LSION_BitNumber        RCC_LSION_BIT_NUMBER
+#define LSION_BITNUMBER        RCC_LSION_BIT_NUMBER
+#define LSEON_BitNumber        RCC_LSEON_BIT_NUMBER
+#define LSEON_BITNUMBER        RCC_LSEON_BIT_NUMBER
+#define LSEBYP_BITNUMBER       RCC_LSEBYP_BIT_NUMBER
+#define PLLSAION_BitNumber     RCC_PLLSAION_BIT_NUMBER
+#define TIMPRE_BitNumber       RCC_TIMPRE_BIT_NUMBER
+#define RMVF_BitNumber         RCC_RMVF_BIT_NUMBER
+#define RMVF_BITNUMBER         RCC_RMVF_BIT_NUMBER
+#define RCC_CR2_HSI14TRIM_BitNumber RCC_HSI14TRIM_BIT_NUMBER
+#define CR_BYTE2_ADDRESS       RCC_CR_BYTE2_ADDRESS
+#define CIR_BYTE1_ADDRESS      RCC_CIR_BYTE1_ADDRESS
+#define CIR_BYTE2_ADDRESS      RCC_CIR_BYTE2_ADDRESS
+#define BDCR_BYTE0_ADDRESS     RCC_BDCR_BYTE0_ADDRESS
+#define DBP_TIMEOUT_VALUE      RCC_DBP_TIMEOUT_VALUE
+#define LSE_TIMEOUT_VALUE      RCC_LSE_TIMEOUT_VALUE
+
+#define CR_HSION_BB            RCC_CR_HSION_BB
+#define CR_CSSON_BB            RCC_CR_CSSON_BB
+#define CR_PLLON_BB            RCC_CR_PLLON_BB
+#define CR_PLLI2SON_BB         RCC_CR_PLLI2SON_BB
+#define CR_MSION_BB            RCC_CR_MSION_BB
+#define CSR_LSION_BB           RCC_CSR_LSION_BB
+#define CSR_LSEON_BB           RCC_CSR_LSEON_BB
+#define CSR_LSEBYP_BB          RCC_CSR_LSEBYP_BB
+#define CSR_RTCEN_BB           RCC_CSR_RTCEN_BB
+#define CSR_RTCRST_BB          RCC_CSR_RTCRST_BB
+#define CFGR_I2SSRC_BB         RCC_CFGR_I2SSRC_BB
+#define BDCR_RTCEN_BB          RCC_BDCR_RTCEN_BB
+#define BDCR_BDRST_BB          RCC_BDCR_BDRST_BB
+#define CR_HSEON_BB            RCC_CR_HSEON_BB
+#define CSR_RMVF_BB            RCC_CSR_RMVF_BB
+#define CR_PLLSAION_BB         RCC_CR_PLLSAION_BB
+#define DCKCFGR_TIMPRE_BB      RCC_DCKCFGR_TIMPRE_BB
+
+#define __HAL_RCC_CRS_ENABLE_FREQ_ERROR_COUNTER     __HAL_RCC_CRS_FREQ_ERROR_COUNTER_ENABLE
+#define __HAL_RCC_CRS_DISABLE_FREQ_ERROR_COUNTER    __HAL_RCC_CRS_FREQ_ERROR_COUNTER_DISABLE
+#define __HAL_RCC_CRS_ENABLE_AUTOMATIC_CALIB        __HAL_RCC_CRS_AUTOMATIC_CALIB_ENABLE
+#define __HAL_RCC_CRS_DISABLE_AUTOMATIC_CALIB       __HAL_RCC_CRS_AUTOMATIC_CALIB_DISABLE
+#define __HAL_RCC_CRS_CALCULATE_RELOADVALUE         __HAL_RCC_CRS_RELOADVALUE_CALCULATE
+
+#define __HAL_RCC_GET_IT_SOURCE                     __HAL_RCC_GET_IT
+/**
+  * @}
+  */
+
+/** @defgroup HAL_RNG_Aliased_Macros HAL RNG Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define  HAL_RNG_ReadyCallback(__HANDLE__)  HAL_RNG_ReadyDataCallback((__HANDLE__), uint32_t random32bit)                                       
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_RTC_Aliased_Macros HAL RTC Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+#define __HAL_RTC_CLEAR_FLAG                      __HAL_RTC_EXTI_CLEAR_FLAG
+#define __HAL_RTC_DISABLE_IT                      __HAL_RTC_EXTI_DISABLE_IT
+#define __HAL_RTC_ENABLE_IT                       __HAL_RTC_EXTI_ENABLE_IT
+
+#if defined (STM32F1)
+#define __HAL_RTC_EXTI_CLEAR_FLAG(RTC_EXTI_LINE_ALARM_EVENT)  __HAL_RTC_ALARM_EXTI_CLEAR_FLAG()
+
+#define __HAL_RTC_EXTI_ENABLE_IT(RTC_EXTI_LINE_ALARM_EVENT)   __HAL_RTC_ALARM_EXTI_ENABLE_IT()
+
+#define __HAL_RTC_EXTI_DISABLE_IT(RTC_EXTI_LINE_ALARM_EVENT)  __HAL_RTC_ALARM_EXTI_DISABLE_IT()
+
+#define __HAL_RTC_EXTI_GET_FLAG(RTC_EXTI_LINE_ALARM_EVENT)    __HAL_RTC_ALARM_EXTI_GET_FLAG()
+
+#define __HAL_RTC_EXTI_GENERATE_SWIT(RTC_EXTI_LINE_ALARM_EVENT)   __HAL_RTC_ALARM_EXTI_GENERATE_SWIT()
+#else
+#define __HAL_RTC_EXTI_CLEAR_FLAG(__EXTI_LINE__)  (((__EXTI_LINE__) == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_CLEAR_FLAG() : \
+                                                   (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_CLEAR_FLAG() : \
+                                                      __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG()))
+#define __HAL_RTC_EXTI_ENABLE_IT(__EXTI_LINE__)   (((__EXTI_LINE__)  == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_ENABLE_IT() : \
+                                                  (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT() : \
+                                                      __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT()))
+#define __HAL_RTC_EXTI_DISABLE_IT(__EXTI_LINE__)  (((__EXTI_LINE__) == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_DISABLE_IT() : \
+                                                  (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_IT() : \
+                                                      __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_IT()))
+#define __HAL_RTC_EXTI_GET_FLAG(__EXTI_LINE__)    (((__EXTI_LINE__) == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_GET_FLAG() : \
+                                                  (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_GET_FLAG() : \
+                                                      __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GET_FLAG()))
+#define __HAL_RTC_EXTI_GENERATE_SWIT(__EXTI_LINE__)   (((__EXTI_LINE__) == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_GENERATE_SWIT() : \
+                                                      (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_GENERATE_SWIT() :  \
+                                                          __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GENERATE_SWIT()))
+#endif   /* STM32F1 */
+
+#define IS_ALARM                                  IS_RTC_ALARM
+#define IS_ALARM_MASK                             IS_RTC_ALARM_MASK
+#define IS_TAMPER                                 IS_RTC_TAMPER
+#define IS_TAMPER_ERASE_MODE                      IS_RTC_TAMPER_ERASE_MODE
+#define IS_TAMPER_FILTER                          IS_RTC_TAMPER_FILTER 
+#define IS_TAMPER_INTERRUPT                       IS_RTC_TAMPER_INTERRUPT
+#define IS_TAMPER_MASKFLAG_STATE                  IS_RTC_TAMPER_MASKFLAG_STATE
+#define IS_TAMPER_PRECHARGE_DURATION              IS_RTC_TAMPER_PRECHARGE_DURATION
+#define IS_TAMPER_PULLUP_STATE                    IS_RTC_TAMPER_PULLUP_STATE
+#define IS_TAMPER_SAMPLING_FREQ                   IS_RTC_TAMPER_SAMPLING_FREQ
+#define IS_TAMPER_TIMESTAMPONTAMPER_DETECTION     IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION
+#define IS_TAMPER_TRIGGER                         IS_RTC_TAMPER_TRIGGER
+#define IS_WAKEUP_CLOCK                           IS_RTC_WAKEUP_CLOCK
+#define IS_WAKEUP_COUNTER                         IS_RTC_WAKEUP_COUNTER
+
+#define __RTC_WRITEPROTECTION_ENABLE  __HAL_RTC_WRITEPROTECTION_ENABLE
+#define __RTC_WRITEPROTECTION_DISABLE  __HAL_RTC_WRITEPROTECTION_DISABLE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SD_Aliased_Macros HAL SD Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define SD_OCR_CID_CSD_OVERWRIETE   SD_OCR_CID_CSD_OVERWRITE
+#define SD_CMD_SD_APP_STAUS         SD_CMD_SD_APP_STATUS
+
+#if defined(STM32F4)
+#define  SD_SDMMC_DISABLED          SD_SDIO_DISABLED
+#define  SD_SDMMC_FUNCTION_BUSY     SD_SDIO_FUNCTION_BUSY     
+#define  SD_SDMMC_FUNCTION_FAILED   SD_SDIO_FUNCTION_FAILED   
+#define  SD_SDMMC_UNKNOWN_FUNCTION  SD_SDIO_UNKNOWN_FUNCTION  
+#define  SD_CMD_SDMMC_SEN_OP_COND   SD_CMD_SDIO_SEN_OP_COND   
+#define  SD_CMD_SDMMC_RW_DIRECT     SD_CMD_SDIO_RW_DIRECT     
+#define  SD_CMD_SDMMC_RW_EXTENDED   SD_CMD_SDIO_RW_EXTENDED   
+#define  __HAL_SD_SDMMC_ENABLE      __HAL_SD_SDIO_ENABLE      
+#define  __HAL_SD_SDMMC_DISABLE     __HAL_SD_SDIO_DISABLE     
+#define  __HAL_SD_SDMMC_DMA_ENABLE  __HAL_SD_SDIO_DMA_ENABLE  
+#define  __HAL_SD_SDMMC_DMA_DISABLE __HAL_SD_SDIO_DMA_DISABL  
+#define  __HAL_SD_SDMMC_ENABLE_IT   __HAL_SD_SDIO_ENABLE_IT   
+#define  __HAL_SD_SDMMC_DISABLE_IT  __HAL_SD_SDIO_DISABLE_IT  
+#define  __HAL_SD_SDMMC_GET_FLAG    __HAL_SD_SDIO_GET_FLAG    
+#define  __HAL_SD_SDMMC_CLEAR_FLAG  __HAL_SD_SDIO_CLEAR_FLAG  
+#define  __HAL_SD_SDMMC_GET_IT      __HAL_SD_SDIO_GET_IT      
+#define  __HAL_SD_SDMMC_CLEAR_IT    __HAL_SD_SDIO_CLEAR_IT    
+#define  SDMMC_STATIC_FLAGS         SDIO_STATIC_FLAGS	       
+#define  SDMMC_CMD0TIMEOUT          SDIO_CMD0TIMEOUT	       
+#define  SD_SDMMC_SEND_IF_COND      SD_SDIO_SEND_IF_COND
+/* alias CMSIS */
+#define  SDMMC1_IRQn                SDIO_IRQn
+#define  SDMMC1_IRQHandler          SDIO_IRQHandler
+#endif
+
+#if defined(STM32F7) || defined(STM32L4)
+#define  SD_SDIO_DISABLED           SD_SDMMC_DISABLED
+#define  SD_SDIO_FUNCTION_BUSY      SD_SDMMC_FUNCTION_BUSY    
+#define  SD_SDIO_FUNCTION_FAILED    SD_SDMMC_FUNCTION_FAILED  
+#define  SD_SDIO_UNKNOWN_FUNCTION   SD_SDMMC_UNKNOWN_FUNCTION
+#define  SD_CMD_SDIO_SEN_OP_COND    SD_CMD_SDMMC_SEN_OP_COND
+#define  SD_CMD_SDIO_RW_DIRECT      SD_CMD_SDMMC_RW_DIRECT
+#define  SD_CMD_SDIO_RW_EXTENDED    SD_CMD_SDMMC_RW_EXTENDED
+#define  __HAL_SD_SDIO_ENABLE       __HAL_SD_SDMMC_ENABLE
+#define  __HAL_SD_SDIO_DISABLE      __HAL_SD_SDMMC_DISABLE
+#define  __HAL_SD_SDIO_DMA_ENABLE   __HAL_SD_SDMMC_DMA_ENABLE
+#define  __HAL_SD_SDIO_DMA_DISABL   __HAL_SD_SDMMC_DMA_DISABLE
+#define  __HAL_SD_SDIO_ENABLE_IT    __HAL_SD_SDMMC_ENABLE_IT
+#define  __HAL_SD_SDIO_DISABLE_IT   __HAL_SD_SDMMC_DISABLE_IT
+#define  __HAL_SD_SDIO_GET_FLAG     __HAL_SD_SDMMC_GET_FLAG
+#define  __HAL_SD_SDIO_CLEAR_FLAG   __HAL_SD_SDMMC_CLEAR_FLAG
+#define  __HAL_SD_SDIO_GET_IT       __HAL_SD_SDMMC_GET_IT
+#define  __HAL_SD_SDIO_CLEAR_IT     __HAL_SD_SDMMC_CLEAR_IT
+#define  SDIO_STATIC_FLAGS	        SDMMC_STATIC_FLAGS
+#define  SDIO_CMD0TIMEOUT	          SDMMC_CMD0TIMEOUT
+#define  SD_SDIO_SEND_IF_COND	      SD_SDMMC_SEND_IF_COND
+/* alias CMSIS for compatibilities */
+#define  SDIO_IRQn                  SDMMC1_IRQn
+#define  SDIO_IRQHandler            SDMMC1_IRQHandler
+#endif
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SMARTCARD_Aliased_Macros HAL SMARTCARD Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define __SMARTCARD_ENABLE_IT           __HAL_SMARTCARD_ENABLE_IT
+#define __SMARTCARD_DISABLE_IT          __HAL_SMARTCARD_DISABLE_IT
+#define __SMARTCARD_ENABLE              __HAL_SMARTCARD_ENABLE
+#define __SMARTCARD_DISABLE             __HAL_SMARTCARD_DISABLE
+#define __SMARTCARD_DMA_REQUEST_ENABLE  __HAL_SMARTCARD_DMA_REQUEST_ENABLE
+#define __SMARTCARD_DMA_REQUEST_DISABLE __HAL_SMARTCARD_DMA_REQUEST_DISABLE
+
+#define __HAL_SMARTCARD_GETCLOCKSOURCE  SMARTCARD_GETCLOCKSOURCE
+#define __SMARTCARD_GETCLOCKSOURCE      SMARTCARD_GETCLOCKSOURCE
+
+#define IS_SMARTCARD_ONEBIT_SAMPLING    IS_SMARTCARD_ONE_BIT_SAMPLE                  
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SMBUS_Aliased_Macros HAL SMBUS Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_SMBUS_RESET_CR1           SMBUS_RESET_CR1
+#define __HAL_SMBUS_RESET_CR2           SMBUS_RESET_CR2
+#define __HAL_SMBUS_GENERATE_START      SMBUS_GENERATE_START
+#define __HAL_SMBUS_GET_ADDR_MATCH      SMBUS_GET_ADDR_MATCH
+#define __HAL_SMBUS_GET_DIR             SMBUS_GET_DIR
+#define __HAL_SMBUS_GET_STOP_MODE       SMBUS_GET_STOP_MODE
+#define __HAL_SMBUS_GET_PEC_MODE        SMBUS_GET_PEC_MODE
+#define __HAL_SMBUS_GET_ALERT_ENABLED   SMBUS_GET_ALERT_ENABLED
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SPI_Aliased_Macros HAL SPI Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define __HAL_SPI_1LINE_TX              SPI_1LINE_TX
+#define __HAL_SPI_1LINE_RX              SPI_1LINE_RX
+#define __HAL_SPI_RESET_CRC             SPI_RESET_CRC
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_UART_Aliased_Macros HAL UART Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define __HAL_UART_GETCLOCKSOURCE       UART_GETCLOCKSOURCE
+#define __HAL_UART_MASK_COMPUTATION     UART_MASK_COMPUTATION
+#define __UART_GETCLOCKSOURCE           UART_GETCLOCKSOURCE
+#define __UART_MASK_COMPUTATION         UART_MASK_COMPUTATION
+
+#define IS_UART_WAKEUPMETHODE           IS_UART_WAKEUPMETHOD
+
+#define IS_UART_ONEBIT_SAMPLE           IS_UART_ONE_BIT_SAMPLE                  
+#define IS_UART_ONEBIT_SAMPLING         IS_UART_ONE_BIT_SAMPLE                  
+
+/**
+  * @}
+  */
+
+
+/** @defgroup HAL_USART_Aliased_Macros HAL USART Aliased Macros maintained for legacy purpose
+  * @{
+  */
+
+#define __USART_ENABLE_IT               __HAL_USART_ENABLE_IT
+#define __USART_DISABLE_IT              __HAL_USART_DISABLE_IT
+#define __USART_ENABLE                  __HAL_USART_ENABLE
+#define __USART_DISABLE                 __HAL_USART_DISABLE
+
+#define __HAL_USART_GETCLOCKSOURCE      USART_GETCLOCKSOURCE
+#define __USART_GETCLOCKSOURCE          USART_GETCLOCKSOURCE
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_USB_Aliased_Macros HAL USB Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define USB_EXTI_LINE_WAKEUP                               USB_WAKEUP_EXTI_LINE
+
+#define USB_FS_EXTI_TRIGGER_RISING_EDGE                    USB_OTG_FS_WAKEUP_EXTI_RISING_EDGE
+#define USB_FS_EXTI_TRIGGER_FALLING_EDGE                   USB_OTG_FS_WAKEUP_EXTI_FALLING_EDGE
+#define USB_FS_EXTI_TRIGGER_BOTH_EDGE                      USB_OTG_FS_WAKEUP_EXTI_RISING_FALLING_EDGE
+#define USB_FS_EXTI_LINE_WAKEUP                            USB_OTG_FS_WAKEUP_EXTI_LINE
+
+#define USB_HS_EXTI_TRIGGER_RISING_EDGE                    USB_OTG_HS_WAKEUP_EXTI_RISING_EDGE
+#define USB_HS_EXTI_TRIGGER_FALLING_EDGE                   USB_OTG_HS_WAKEUP_EXTI_FALLING_EDGE
+#define USB_HS_EXTI_TRIGGER_BOTH_EDGE                      USB_OTG_HS_WAKEUP_EXTI_RISING_FALLING_EDGE
+#define USB_HS_EXTI_LINE_WAKEUP                            USB_OTG_HS_WAKEUP_EXTI_LINE
+
+#define __HAL_USB_EXTI_ENABLE_IT                           __HAL_USB_WAKEUP_EXTI_ENABLE_IT
+#define __HAL_USB_EXTI_DISABLE_IT                          __HAL_USB_WAKEUP_EXTI_DISABLE_IT
+#define __HAL_USB_EXTI_GET_FLAG                            __HAL_USB_WAKEUP_EXTI_GET_FLAG
+#define __HAL_USB_EXTI_CLEAR_FLAG                          __HAL_USB_WAKEUP_EXTI_CLEAR_FLAG
+#define __HAL_USB_EXTI_SET_RISING_EDGE_TRIGGER             __HAL_USB_WAKEUP_EXTI_ENABLE_RISING_EDGE
+#define __HAL_USB_EXTI_SET_FALLING_EDGE_TRIGGER            __HAL_USB_WAKEUP_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_USB_EXTI_SET_FALLINGRISING_TRIGGER           __HAL_USB_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE
+
+#define __HAL_USB_FS_EXTI_ENABLE_IT                        __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_IT
+#define __HAL_USB_FS_EXTI_DISABLE_IT                       __HAL_USB_OTG_FS_WAKEUP_EXTI_DISABLE_IT
+#define __HAL_USB_FS_EXTI_GET_FLAG                         __HAL_USB_OTG_FS_WAKEUP_EXTI_GET_FLAG
+#define __HAL_USB_FS_EXTI_CLEAR_FLAG                       __HAL_USB_OTG_FS_WAKEUP_EXTI_CLEAR_FLAG
+#define __HAL_USB_FS_EXTI_SET_RISING_EGDE_TRIGGER          __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_RISING_EDGE
+#define __HAL_USB_FS_EXTI_SET_FALLING_EGDE_TRIGGER         __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_USB_FS_EXTI_SET_FALLINGRISING_TRIGGER        __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE
+#define __HAL_USB_FS_EXTI_GENERATE_SWIT                    __HAL_USB_OTG_FS_WAKEUP_EXTI_GENERATE_SWIT
+
+#define __HAL_USB_HS_EXTI_ENABLE_IT                        __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_IT
+#define __HAL_USB_HS_EXTI_DISABLE_IT                       __HAL_USB_OTG_HS_WAKEUP_EXTI_DISABLE_IT
+#define __HAL_USB_HS_EXTI_GET_FLAG                         __HAL_USB_OTG_HS_WAKEUP_EXTI_GET_FLAG
+#define __HAL_USB_HS_EXTI_CLEAR_FLAG                       __HAL_USB_OTG_HS_WAKEUP_EXTI_CLEAR_FLAG
+#define __HAL_USB_HS_EXTI_SET_RISING_EGDE_TRIGGER          __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_RISING_EDGE
+#define __HAL_USB_HS_EXTI_SET_FALLING_EGDE_TRIGGER         __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_FALLING_EDGE
+#define __HAL_USB_HS_EXTI_SET_FALLINGRISING_TRIGGER        __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE
+#define __HAL_USB_HS_EXTI_GENERATE_SWIT                    __HAL_USB_OTG_HS_WAKEUP_EXTI_GENERATE_SWIT
+
+#define HAL_PCD_ActiveRemoteWakeup                         HAL_PCD_ActivateRemoteWakeup
+#define HAL_PCD_DeActiveRemoteWakeup                       HAL_PCD_DeActivateRemoteWakeup
+
+#define HAL_PCD_SetTxFiFo                                  HAL_PCDEx_SetTxFiFo
+#define HAL_PCD_SetRxFiFo                                  HAL_PCDEx_SetRxFiFo
+/**
+  * @}
+  */
+
+/** @defgroup HAL_TIM_Aliased_Macros HAL TIM Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_TIM_SetICPrescalerValue   TIM_SET_ICPRESCALERVALUE
+#define __HAL_TIM_ResetICPrescalerValue TIM_RESET_ICPRESCALERVALUE
+
+#define TIM_GET_ITSTATUS                __HAL_TIM_GET_IT_SOURCE
+#define TIM_GET_CLEAR_IT                __HAL_TIM_CLEAR_IT
+
+#define __HAL_TIM_GET_ITSTATUS          __HAL_TIM_GET_IT_SOURCE
+
+#define __HAL_TIM_DIRECTION_STATUS      __HAL_TIM_IS_TIM_COUNTING_DOWN
+#define __HAL_TIM_PRESCALER             __HAL_TIM_SET_PRESCALER
+#define __HAL_TIM_SetCounter            __HAL_TIM_SET_COUNTER
+#define __HAL_TIM_GetCounter            __HAL_TIM_GET_COUNTER
+#define __HAL_TIM_SetAutoreload         __HAL_TIM_SET_AUTORELOAD
+#define __HAL_TIM_GetAutoreload         __HAL_TIM_GET_AUTORELOAD
+#define __HAL_TIM_SetClockDivision      __HAL_TIM_SET_CLOCKDIVISION
+#define __HAL_TIM_GetClockDivision      __HAL_TIM_GET_CLOCKDIVISION
+#define __HAL_TIM_SetICPrescaler        __HAL_TIM_SET_ICPRESCALER
+#define __HAL_TIM_GetICPrescaler        __HAL_TIM_GET_ICPRESCALER
+#define __HAL_TIM_SetCompare            __HAL_TIM_SET_COMPARE
+#define __HAL_TIM_GetCompare            __HAL_TIM_GET_COMPARE
+/**
+  * @}
+  */
+
+/** @defgroup HAL_ETH_Aliased_Macros HAL ETH Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+#define __HAL_ETH_EXTI_ENABLE_IT                   __HAL_ETH_WAKEUP_EXTI_ENABLE_IT
+#define __HAL_ETH_EXTI_DISABLE_IT                  __HAL_ETH_WAKEUP_EXTI_DISABLE_IT
+#define __HAL_ETH_EXTI_GET_FLAG                    __HAL_ETH_WAKEUP_EXTI_GET_FLAG
+#define __HAL_ETH_EXTI_CLEAR_FLAG                  __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG
+#define __HAL_ETH_EXTI_SET_RISING_EGDE_TRIGGER     __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE_TRIGGER
+#define __HAL_ETH_EXTI_SET_FALLING_EGDE_TRIGGER    __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE_TRIGGER
+#define __HAL_ETH_EXTI_SET_FALLINGRISING_TRIGGER   __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLINGRISING_TRIGGER
+
+#define ETH_PROMISCIOUSMODE_ENABLE   ETH_PROMISCUOUS_MODE_ENABLE 
+#define ETH_PROMISCIOUSMODE_DISABLE  ETH_PROMISCUOUS_MODE_DISABLE
+#define IS_ETH_PROMISCIOUS_MODE      IS_ETH_PROMISCUOUS_MODE
+/**
+  * @}
+  */
+
+/** @defgroup HAL_LTDC_Aliased_Macros HAL LTDC Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define __HAL_LTDC_LAYER LTDC_LAYER
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SAI_Aliased_Macros HAL SAI Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#define SAI_OUTPUTDRIVE_DISABLED          SAI_OUTPUTDRIVE_DISABLE
+#define SAI_OUTPUTDRIVE_ENABLED           SAI_OUTPUTDRIVE_ENABLE
+#define SAI_MASTERDIVIDER_ENABLED         SAI_MASTERDIVIDER_ENABLE
+#define SAI_MASTERDIVIDER_DISABLED        SAI_MASTERDIVIDER_DISABLE
+#define SAI_STREOMODE                     SAI_STEREOMODE
+#define SAI_FIFOStatus_Empty              SAI_FIFOSTATUS_EMPTY
+#define SAI_FIFOStatus_Less1QuarterFull   SAI_FIFOSTATUS_LESS1QUARTERFULL
+#define SAI_FIFOStatus_1QuarterFull       SAI_FIFOSTATUS_1QUARTERFULL
+#define SAI_FIFOStatus_HalfFull           SAI_FIFOSTATUS_HALFFULL
+#define SAI_FIFOStatus_3QuartersFull      SAI_FIFOSTATUS_3QUARTERFULL
+#define SAI_FIFOStatus_Full               SAI_FIFOSTATUS_FULL
+#define IS_SAI_BLOCK_MONO_STREO_MODE      IS_SAI_BLOCK_MONO_STEREO_MODE
+#define SAI_SYNCHRONOUS_EXT               SAI_SYNCHRONOUS_EXT_SAI1
+#define SAI_SYNCEXT_IN_ENABLE             SAI_SYNCEXT_OUTBLOCKA_ENABLE
+/**
+  * @}
+  */
+
+
+/** @defgroup HAL_PPP_Aliased_Macros HAL PPP Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ___STM32_HAL_LEGACY */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/stmhal/hal/l4/inc/stm32l4xx_hal.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal.h
@@ -1,0 +1,569 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   This file contains all the functions prototypes for the HAL
+  *          module driver.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_H
+#define __STM32L4xx_HAL_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_conf.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup HAL
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup SYSCFG_Exported_Constants SYSCFG Exported Constants
+  * @{
+  */
+
+/** @defgroup SYSCFG_BootMode Boot Mode
+  * @{
+  */
+#define SYSCFG_BOOT_MAINFLASH          ((uint32_t)0x00000000)
+#define SYSCFG_BOOT_SYSTEMFLASH        SYSCFG_MEMRMP_MEM_MODE_0
+#define SYSCFG_BOOT_FMC                SYSCFG_MEMRMP_MEM_MODE_1
+#define SYSCFG_BOOT_SRAM               (SYSCFG_MEMRMP_MEM_MODE_1 | SYSCFG_MEMRMP_MEM_MODE_0)
+#define SYSCFG_BOOT_QUADSPI            (SYSCFG_MEMRMP_MEM_MODE_2 | SYSCFG_MEMRMP_MEM_MODE_1)
+
+/**
+  * @}
+  */
+
+/** @defgroup SYSCFG_FPU_Interrupts FPU Interrupts
+  * @{
+  */
+#define SYSCFG_IT_FPU_IOC              SYSCFG_CFGR1_FPU_IE_0  /*!< Floating Point Unit Invalid operation Interrupt */
+#define SYSCFG_IT_FPU_DZC              SYSCFG_CFGR1_FPU_IE_1  /*!< Floating Point Unit Divide-by-zero Interrupt */
+#define SYSCFG_IT_FPU_UFC              SYSCFG_CFGR1_FPU_IE_2  /*!< Floating Point Unit Underflow Interrupt */
+#define SYSCFG_IT_FPU_OFC              SYSCFG_CFGR1_FPU_IE_3  /*!< Floating Point Unit Overflow Interrupt */
+#define SYSCFG_IT_FPU_IDC              SYSCFG_CFGR1_FPU_IE_4  /*!< Floating Point Unit Input denormal Interrupt */
+#define SYSCFG_IT_FPU_IXC              SYSCFG_CFGR1_FPU_IE_5  /*!< Floating Point Unit Inexact Interrupt */
+
+/**
+  * @}
+  */
+
+/** @defgroup SYSCFG_SRAM2WRP SRAM2 Write protection
+  * @{
+  */
+#define SYSCFG_SRAM2WRP_PAGE0          SYSCFG_SWPR_PAGE0 /*!< SRAM2 Write protection page 0 */
+#define SYSCFG_SRAM2WRP_PAGE1          SYSCFG_SWPR_PAGE1 /*!< SRAM2 Write protection page 1 */
+#define SYSCFG_SRAM2WRP_PAGE2          SYSCFG_SWPR_PAGE2 /*!< SRAM2 Write protection page 2 */
+#define SYSCFG_SRAM2WRP_PAGE3          SYSCFG_SWPR_PAGE3 /*!< SRAM2 Write protection page 3 */
+#define SYSCFG_SRAM2WRP_PAGE4          SYSCFG_SWPR_PAGE4 /*!< SRAM2 Write protection page 4 */
+#define SYSCFG_SRAM2WRP_PAGE5          SYSCFG_SWPR_PAGE5 /*!< SRAM2 Write protection page 5 */
+#define SYSCFG_SRAM2WRP_PAGE6          SYSCFG_SWPR_PAGE6 /*!< SRAM2 Write protection page 6 */
+#define SYSCFG_SRAM2WRP_PAGE7          SYSCFG_SWPR_PAGE7 /*!< SRAM2 Write protection page 7 */
+#define SYSCFG_SRAM2WRP_PAGE8          SYSCFG_SWPR_PAGE8 /*!< SRAM2 Write protection page 8 */
+#define SYSCFG_SRAM2WRP_PAGE9          SYSCFG_SWPR_PAGE9 /*!< SRAM2 Write protection page 9 */
+#define SYSCFG_SRAM2WRP_PAGE10         SYSCFG_SWPR_PAGE10 /*!< SRAM2 Write protection page 10 */
+#define SYSCFG_SRAM2WRP_PAGE11         SYSCFG_SWPR_PAGE11 /*!< SRAM2 Write protection page 11 */
+#define SYSCFG_SRAM2WRP_PAGE12         SYSCFG_SWPR_PAGE12 /*!< SRAM2 Write protection page 12 */
+#define SYSCFG_SRAM2WRP_PAGE13         SYSCFG_SWPR_PAGE13 /*!< SRAM2 Write protection page 13 */
+#define SYSCFG_SRAM2WRP_PAGE14         SYSCFG_SWPR_PAGE14 /*!< SRAM2 Write protection page 14 */
+#define SYSCFG_SRAM2WRP_PAGE15         SYSCFG_SWPR_PAGE15 /*!< SRAM2 Write protection page 15 */
+#define SYSCFG_SRAM2WRP_PAGE16         SYSCFG_SWPR_PAGE16 /*!< SRAM2 Write protection page 16 */
+#define SYSCFG_SRAM2WRP_PAGE17         SYSCFG_SWPR_PAGE17 /*!< SRAM2 Write protection page 17 */
+#define SYSCFG_SRAM2WRP_PAGE18         SYSCFG_SWPR_PAGE18 /*!< SRAM2 Write protection page 18 */
+#define SYSCFG_SRAM2WRP_PAGE19         SYSCFG_SWPR_PAGE19 /*!< SRAM2 Write protection page 19 */
+#define SYSCFG_SRAM2WRP_PAGE20         SYSCFG_SWPR_PAGE20 /*!< SRAM2 Write protection page 20 */
+#define SYSCFG_SRAM2WRP_PAGE21         SYSCFG_SWPR_PAGE21 /*!< SRAM2 Write protection page 21 */
+#define SYSCFG_SRAM2WRP_PAGE22         SYSCFG_SWPR_PAGE22 /*!< SRAM2 Write protection page 22 */
+#define SYSCFG_SRAM2WRP_PAGE23         SYSCFG_SWPR_PAGE23 /*!< SRAM2 Write protection page 23 */
+#define SYSCFG_SRAM2WRP_PAGE24         SYSCFG_SWPR_PAGE24 /*!< SRAM2 Write protection page 24 */
+#define SYSCFG_SRAM2WRP_PAGE25         SYSCFG_SWPR_PAGE25 /*!< SRAM2 Write protection page 25 */
+#define SYSCFG_SRAM2WRP_PAGE26         SYSCFG_SWPR_PAGE26 /*!< SRAM2 Write protection page 26 */
+#define SYSCFG_SRAM2WRP_PAGE27         SYSCFG_SWPR_PAGE27 /*!< SRAM2 Write protection page 27 */
+#define SYSCFG_SRAM2WRP_PAGE28         SYSCFG_SWPR_PAGE28 /*!< SRAM2 Write protection page 28 */
+#define SYSCFG_SRAM2WRP_PAGE29         SYSCFG_SWPR_PAGE29 /*!< SRAM2 Write protection page 29 */
+#define SYSCFG_SRAM2WRP_PAGE30         SYSCFG_SWPR_PAGE30 /*!< SRAM2 Write protection page 30 */
+#define SYSCFG_SRAM2WRP_PAGE31         SYSCFG_SWPR_PAGE31 /*!< SRAM2 Write protection page 31 */
+
+/**
+  * @}
+  */
+
+#if defined(VREFBUF)
+/** @defgroup SYSCFG_VREFBUF_VoltageScale VREFBUF Voltage Scale
+  * @{
+  */
+#define SYSCFG_VREFBUF_VOLTAGE_SCALE0  ((uint32_t)0x00000000) /*!< Voltage reference scale 0 (VREF_OUT1) */
+#define SYSCFG_VREFBUF_VOLTAGE_SCALE1  VREFBUF_CSR_VRS        /*!< Voltage reference scale 1 (VREF_OUT2) */
+
+/**
+  * @}
+  */
+
+/** @defgroup SYSCFG_VREFBUF_HighImpedance VREFBUF High Impedance
+  * @{
+  */
+#define SYSCFG_VREFBUF_HIGH_IMPEDANCE_DISABLE  ((uint32_t)0x00000000) /*!< VREF_plus pin is internally connected to Voltage reference buffer output */
+#define SYSCFG_VREFBUF_HIGH_IMPEDANCE_ENABLE   VREFBUF_CSR_HIZ        /*!< VREF_plus pin is high impedance */
+
+/**
+  * @}
+  */
+#endif /* VREFBUF */
+
+/** @defgroup SYSCFG_flags_definition Flags
+  * @{
+  */
+
+#define SYSCFG_FLAG_SRAM2_PE            SYSCFG_CFGR2_SPF       /*!< SRAM2 parity error */
+#define SYSCFG_FLAG_SRAM2_BUSY          SYSCFG_SCSR_SRAM2BSY   /*!< SRAM2 busy by erase operation */
+
+/**
+  * @}
+  */
+
+/** @defgroup SYSCFG_FastModePlus_GPIO Fast-mode Plus on GPIO
+  * @{
+  */
+
+/** @brief  Fast-mode Plus driving capability on a specific GPIO
+  */  
+#define SYSCFG_FASTMODEPLUS_PB6        SYSCFG_CFGR1_I2C_PB6_FMP  /*!< Enable Fast-mode Plus on PB6 */
+#define SYSCFG_FASTMODEPLUS_PB7        SYSCFG_CFGR1_I2C_PB7_FMP  /*!< Enable Fast-mode Plus on PB7 */
+#if defined(SYSCFG_CFGR1_I2C_PB8_FMP)
+#define SYSCFG_FASTMODEPLUS_PB8        SYSCFG_CFGR1_I2C_PB8_FMP  /*!< Enable Fast-mode Plus on PB8 */
+#endif /* SYSCFG_CFGR1_I2C_PB8_FMP */
+#if defined(SYSCFG_CFGR1_I2C_PB9_FMP)
+#define SYSCFG_FASTMODEPLUS_PB9        SYSCFG_CFGR1_I2C_PB9_FMP  /*!< Enable Fast-mode Plus on PB9 */
+#endif /* SYSCFG_CFGR1_I2C_PB9_FMP */
+
+/**
+ * @}
+ */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+
+/** @defgroup DBGMCU_Exported_Macros DBGMCU Exported Macros
+  * @{
+  */
+
+/** @brief  Freeze/Unfreeze Peripherals in Debug mode
+  */
+#if defined(DBGMCU_APB1FZR1_DBG_TIM2_STOP)
+#define __HAL_DBGMCU_FREEZE_TIM2()           SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_TIM2_STOP)
+#define __HAL_DBGMCU_UNFREEZE_TIM2()         CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_TIM2_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_TIM3_STOP)
+#define __HAL_DBGMCU_FREEZE_TIM3()           SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_TIM3_STOP)
+#define __HAL_DBGMCU_UNFREEZE_TIM3()         CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_TIM3_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_TIM4_STOP)
+#define __HAL_DBGMCU_FREEZE_TIM4()           SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_TIM4_STOP)
+#define __HAL_DBGMCU_UNFREEZE_TIM4()         CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_TIM4_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_TIM5_STOP)
+#define __HAL_DBGMCU_FREEZE_TIM5()           SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_TIM5_STOP)
+#define __HAL_DBGMCU_UNFREEZE_TIM5()         CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_TIM5_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_TIM6_STOP)
+#define __HAL_DBGMCU_FREEZE_TIM6()           SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_TIM6_STOP)
+#define __HAL_DBGMCU_UNFREEZE_TIM6()         CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_TIM6_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_TIM7_STOP)
+#define __HAL_DBGMCU_FREEZE_TIM7()           SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_TIM7_STOP)
+#define __HAL_DBGMCU_UNFREEZE_TIM7()         CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_TIM7_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_RTC_STOP)
+#define __HAL_DBGMCU_FREEZE_RTC()            SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_RTC_STOP)
+#define __HAL_DBGMCU_UNFREEZE_RTC()          CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_RTC_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_WWDG_STOP)
+#define __HAL_DBGMCU_FREEZE_WWDG()           SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_WWDG_STOP)
+#define __HAL_DBGMCU_UNFREEZE_WWDG()         CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_WWDG_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_IWDG_STOP)
+#define __HAL_DBGMCU_FREEZE_IWDG()           SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_IWDG_STOP)
+#define __HAL_DBGMCU_UNFREEZE_IWDG()         CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_IWDG_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_I2C1_STOP)
+#define __HAL_DBGMCU_FREEZE_I2C1_TIMEOUT()   SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_I2C1_STOP)
+#define __HAL_DBGMCU_UNFREEZE_I2C1_TIMEOUT() CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_I2C1_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_I2C2_STOP)
+#define __HAL_DBGMCU_FREEZE_I2C2_TIMEOUT()   SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_I2C2_STOP)
+#define __HAL_DBGMCU_UNFREEZE_I2C2_TIMEOUT() CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_I2C2_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_I2C3_STOP)
+#define __HAL_DBGMCU_FREEZE_I2C3_TIMEOUT()   SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_I2C3_STOP)
+#define __HAL_DBGMCU_UNFREEZE_I2C3_TIMEOUT() CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_I2C3_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_CAN_STOP)
+#define __HAL_DBGMCU_FREEZE_CAN1()           SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_CAN_STOP)
+#define __HAL_DBGMCU_UNFREEZE_CAN1()         CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_CAN_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR1_DBG_LPTIM1_STOP)
+#define __HAL_DBGMCU_FREEZE_LPTIM1()         SET_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_LPTIM1_STOP)
+#define __HAL_DBGMCU_UNFREEZE_LPTIM1()       CLEAR_BIT(DBGMCU->APB1FZR1, DBGMCU_APB1FZR1_DBG_LPTIM1_STOP)
+#endif
+
+#if defined(DBGMCU_APB1FZR2_DBG_LPTIM2_STOP)
+#define __HAL_DBGMCU_FREEZE_LPTIM2()         SET_BIT(DBGMCU->APB1FZR2, DBGMCU_APB1FZR2_DBG_LPTIM2_STOP)
+#define __HAL_DBGMCU_UNFREEZE_LPTIM2()       CLEAR_BIT(DBGMCU->APB1FZR2, DBGMCU_APB1FZR2_DBG_LPTIM2_STOP)
+#endif
+
+#if defined(DBGMCU_APB2FZ_DBG_TIM1_STOP)
+#define __HAL_DBGMCU_FREEZE_TIM1()           SET_BIT(DBGMCU->APB2FZ, DBGMCU_APB2FZ_DBG_TIM1_STOP)
+#define __HAL_DBGMCU_UNFREEZE_TIM1()         CLEAR_BIT(DBGMCU->APB2FZ, DBGMCU_APB2FZ_DBG_TIM1_STOP)
+#endif
+
+#if defined(DBGMCU_APB2FZ_DBG_TIM8_STOP)
+#define __HAL_DBGMCU_FREEZE_TIM8()           SET_BIT(DBGMCU->APB2FZ, DBGMCU_APB2FZ_DBG_TIM8_STOP)
+#define __HAL_DBGMCU_UNFREEZE_TIM8()         CLEAR_BIT(DBGMCU->APB2FZ, DBGMCU_APB2FZ_DBG_TIM8_STOP)
+#endif
+
+#if defined(DBGMCU_APB2FZ_DBG_TIM15_STOP)
+#define __HAL_DBGMCU_FREEZE_TIM15()          SET_BIT(DBGMCU->APB2FZ, DBGMCU_APB2FZ_DBG_TIM15_STOP)
+#define __HAL_DBGMCU_UNFREEZE_TIM15()        CLEAR_BIT(DBGMCU->APB2FZ, DBGMCU_APB2FZ_DBG_TIM15_STOP)
+#endif
+
+#if defined(DBGMCU_APB2FZ_DBG_TIM16_STOP)
+#define __HAL_DBGMCU_FREEZE_TIM16()          SET_BIT(DBGMCU->APB2FZ, DBGMCU_APB2FZ_DBG_TIM16_STOP)
+#define __HAL_DBGMCU_UNFREEZE_TIM16()        CLEAR_BIT(DBGMCU->APB2FZ, DBGMCU_APB2FZ_DBG_TIM16_STOP)
+#endif
+
+#if defined(DBGMCU_APB2FZ_DBG_TIM17_STOP)
+#define __HAL_DBGMCU_FREEZE_TIM17()          SET_BIT(DBGMCU->APB2FZ, DBGMCU_APB2FZ_DBG_TIM17_STOP)
+#define __HAL_DBGMCU_UNFREEZE_TIM17()        CLEAR_BIT(DBGMCU->APB2FZ, DBGMCU_APB2FZ_DBG_TIM17_STOP)
+#endif
+
+/**
+  * @}
+  */
+
+/** @defgroup SYSCFG_Exported_Macros SYSCFG Exported Macros
+  * @{
+  */
+
+/** @brief  Main Flash memory mapped at 0x00000000.
+  */
+#define __HAL_SYSCFG_REMAPMEMORY_FLASH()       CLEAR_BIT(SYSCFG->MEMRMP, SYSCFG_MEMRMP_MEM_MODE)
+
+/** @brief  System Flash memory mapped at 0x00000000.
+  */
+#define __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH() MODIFY_REG(SYSCFG->MEMRMP, SYSCFG_MEMRMP_MEM_MODE, SYSCFG_MEMRMP_MEM_MODE_0)
+
+/** @brief  Embedded SRAM mapped at 0x00000000.
+  */
+#define __HAL_SYSCFG_REMAPMEMORY_SRAM()        MODIFY_REG(SYSCFG->MEMRMP, SYSCFG_MEMRMP_MEM_MODE, (SYSCFG_MEMRMP_MEM_MODE_1|SYSCFG_MEMRMP_MEM_MODE_0))
+
+/** @brief  FMC Bank1 (NOR/PSRAM 1 and 2) mapped at 0x00000000.
+  */
+#define __HAL_SYSCFG_REMAPMEMORY_FMC()         MODIFY_REG(SYSCFG->MEMRMP, SYSCFG_MEMRMP_MEM_MODE, SYSCFG_MEMRMP_MEM_MODE_1)
+
+/** @brief  QUADSPI mapped at 0x00000000.
+  */
+#define __HAL_SYSCFG_REMAPMEMORY_QUADSPI()     MODIFY_REG(SYSCFG->MEMRMP, SYSCFG_MEMRMP_MEM_MODE, (SYSCFG_MEMRMP_MEM_MODE_2|SYSCFG_MEMRMP_MEM_MODE_1))
+
+/**
+  * @brief  Return the boot mode as configured by user.
+  * @retval The boot mode as configured by user. The returned value can be one
+  *         of the following values:
+  *           @arg @ref SYSCFG_BOOT_MAINFLASH
+  *           @arg @ref SYSCFG_BOOT_SYSTEMFLASH
+  *           @arg @ref SYSCFG_BOOT_FMC
+  *           @arg @ref SYSCFG_BOOT_SRAM
+  *           @arg @ref SYSCFG_BOOT_QUADSPI
+  */
+#define __HAL_SYSCFG_GET_BOOT_MODE()           READ_BIT(SYSCFG->MEMRMP, SYSCFG_MEMRMP_MEM_MODE)
+
+/** @brief  SRAM2 page write protection enable macro
+  * @param __SRAM2WRP__: This parameter can be a value of @ref SYSCFG_SRAM2WRP
+  * @note   write protection can only be disabled by a system reset
+  */
+#define __HAL_SYSCFG_SRAM2_WRP_ENABLE(__SRAM2WRP__)   do {assert_param(IS_SYSCFG_SRAM2WRP_PAGE((__SRAM2WRP__)));\
+                                                         SET_BIT(SYSCFG->SWPR, (__SRAM2WRP__));\
+                                                        }while(0)
+
+/** @brief  SRAM2 page write protection unlock prior to erase
+  * @note   Writing a wrong key reactivates the write protection
+  */
+#define __HAL_SYSCFG_SRAM2_WRP_UNLOCK()      do {SYSCFG->SKR = 0xCA;\
+                                                 SYSCFG->SKR = 0x53;\
+                                                }while(0)
+
+/** @brief  SRAM2 erase
+  * @note   __SYSCFG_GET_FLAG(SYSCFG_FLAG_SRAM2_BUSY) may be used to check end of erase
+  */
+#define __HAL_SYSCFG_SRAM2_ERASE()           SET_BIT(SYSCFG->SCSR, SYSCFG_SCSR_SRAM2ER)
+
+/** @brief  Floating Point Unit interrupt enable/disable macros
+  * @param __INTERRUPT__: This parameter can be a value of @ref SYSCFG_FPU_Interrupts
+  */
+#define __HAL_SYSCFG_FPU_INTERRUPT_ENABLE(__INTERRUPT__)    do {assert_param(IS_SYSCFG_FPU_INTERRUPT((__INTERRUPT__)));\
+                                                                SET_BIT(SYSCFG->CFGR1, (__INTERRUPT__));\
+                                                            }while(0)
+
+#define __HAL_SYSCFG_FPU_INTERRUPT_DISABLE(__INTERRUPT__)   do {assert_param(IS_SYSCFG_FPU_INTERRUPT((__INTERRUPT__)));\
+                                                                CLEAR_BIT(SYSCFG->CFGR1, (__INTERRUPT__));\
+                                                            }while(0)
+
+/** @brief  SYSCFG Break ECC lock.
+  *         Enable and lock the connection of Flash ECC error connection to TIM1/8/15/16/17 Break input.
+  * @note   The selected configuration is locked and can be unlocked only by system reset.
+  */
+#define __HAL_SYSCFG_BREAK_ECC_LOCK()        SET_BIT(SYSCFG->CFGR2, SYSCFG_CFGR2_ECCL)
+
+/** @brief  SYSCFG Break Cortex-M4 Lockup lock.
+  *         Enable and lock the connection of Cortex-M4 LOCKUP (Hardfault) output to TIM1/8/15/16/17 Break input.
+  * @note   The selected configuration is locked and can be unlocked only by system reset.
+  */
+#define __HAL_SYSCFG_BREAK_LOCKUP_LOCK()     SET_BIT(SYSCFG->CFGR2, SYSCFG_CFGR2_CLL)
+
+/** @brief  SYSCFG Break PVD lock.
+  *         Enable and lock the PVD connection to Timer1/8/15/16/17 Break input, as well as the PVDE and PLS[2:0] in the PWR_CR2 register.
+  * @note   The selected configuration is locked and can be unlocked only by system reset.
+  */
+#define __HAL_SYSCFG_BREAK_PVD_LOCK()        SET_BIT(SYSCFG->CFGR2, SYSCFG_CFGR2_PVDL)
+
+/** @brief  SYSCFG Break SRAM2 parity lock.
+  *         Enable and lock the SRAM2 parity error signal connection to TIM1/8/15/16/17 Break input.
+  * @note   The selected configuration is locked and can be unlocked by system reset.
+  */
+#define __HAL_SYSCFG_BREAK_SRAM2PARITY_LOCK()  SET_BIT(SYSCFG->CFGR2, SYSCFG_CFGR2_SPL)
+
+/** @brief  Check SYSCFG flag is set or not.
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg @ref SYSCFG_FLAG_SRAM2_PE   SRAM2 Parity Error Flag
+  *            @arg @ref SYSCFG_FLAG_SRAM2_BUSY SRAM2 Erase Ongoing
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_SYSCFG_GET_FLAG(__FLAG__)      ((((((__FLAG__) == SYSCFG_SCSR_SRAM2BSY)? SYSCFG->SCSR : SYSCFG->CFGR2) & (__FLAG__))!= 0) ? 1 : 0)
+
+/** @brief  Set the SPF bit to clear the SRAM Parity Error Flag.
+  */
+#define __HAL_SYSCFG_CLEAR_FLAG()            SET_BIT(SYSCFG->CFGR2, SYSCFG_CFGR2_SPF)
+
+/** @brief  Fast-mode Plus driving capability enable/disable macros
+  * @param __FASTMODEPLUS__: This parameter can be a value of : 
+  *     @arg @ref SYSCFG_FASTMODEPLUS_PB6 Fast-mode Plus driving capability activation on PB6
+  *     @arg @ref SYSCFG_FASTMODEPLUS_PB7 Fast-mode Plus driving capability activation on PB7 
+  *     @arg @ref SYSCFG_FASTMODEPLUS_PB8 Fast-mode Plus driving capability activation on PB8
+  *     @arg @ref SYSCFG_FASTMODEPLUS_PB9 Fast-mode Plus driving capability activation on PB9
+  */
+#define __HAL_SYSCFG_FASTMODEPLUS_ENABLE(__FASTMODEPLUS__)  do {assert_param(IS_SYSCFG_FASTMODEPLUS((__FASTMODEPLUS__)));\
+                                                                SET_BIT(SYSCFG->CFGR1, (__FASTMODEPLUS__));\
+                                                               }while(0)
+
+#define __HAL_SYSCFG_FASTMODEPLUS_DISABLE(__FASTMODEPLUS__) do {assert_param(IS_SYSCFG_FASTMODEPLUS((__FASTMODEPLUS__)));\
+                                                                CLEAR_BIT(SYSCFG->CFGR1, (__FASTMODEPLUS__));\
+                                                               }while(0)
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup SYSCFG_Private_Macros SYSCFG Private Macros
+  * @{
+  */
+
+#define IS_SYSCFG_FPU_INTERRUPT(__INTERRUPT__) ((((__INTERRUPT__) & SYSCFG_IT_FPU_IOC) == SYSCFG_IT_FPU_IOC) || \
+                                                (((__INTERRUPT__) & SYSCFG_IT_FPU_DZC) == SYSCFG_IT_FPU_DZC) || \
+                                                (((__INTERRUPT__) & SYSCFG_IT_FPU_UFC) == SYSCFG_IT_FPU_UFC) || \
+                                                (((__INTERRUPT__) & SYSCFG_IT_FPU_OFC) == SYSCFG_IT_FPU_OFC) || \
+                                                (((__INTERRUPT__) & SYSCFG_IT_FPU_IDC) == SYSCFG_IT_FPU_IDC) || \
+                                                (((__INTERRUPT__) & SYSCFG_IT_FPU_IXC) == SYSCFG_IT_FPU_IXC))
+
+#define IS_SYSCFG_BREAK_CONFIG(__CONFIG__) (((__CONFIG__) == SYSCFG_BREAK_ECC)           || \
+                                            ((__CONFIG__) == SYSCFG_BREAK_PVD)           || \
+                                            ((__CONFIG__) == SYSCFG_BREAK_SRAM2_PARITY)  || \
+                                            ((__CONFIG__) == SYSCFG_BREAK_LOCKUP))
+
+#define IS_SYSCFG_SRAM2WRP_PAGE(__PAGE__)   (((__PAGE__) > 0) && ((__PAGE__) <= 0xFFFFFFFF))
+
+#if defined(VREFBUF)
+#define IS_SYSCFG_VREFBUF_VOLTAGE_SCALE(__SCALE__)  (((__SCALE__) == SYSCFG_VREFBUF_VOLTAGE_SCALE0) || \
+                                                     ((__SCALE__) == SYSCFG_VREFBUF_VOLTAGE_SCALE1))
+
+#define IS_SYSCFG_VREFBUF_HIGH_IMPEDANCE(__VALUE__)  (((__VALUE__) == SYSCFG_VREFBUF_HIGH_IMPEDANCE_DISABLE) || \
+                                                      ((__VALUE__) == SYSCFG_VREFBUF_HIGH_IMPEDANCE_ENABLE))
+
+#define IS_SYSCFG_VREFBUF_TRIMMING(__VALUE__)  (((__VALUE__) > 0) && ((__VALUE__) <= VREFBUF_CCR_TRIM))
+#endif /* VREFBUF */
+
+#if defined(SYSCFG_FASTMODEPLUS_PB8) && defined(SYSCFG_FASTMODEPLUS_PB9)
+#define IS_SYSCFG_FASTMODEPLUS(__PIN__) ((((__PIN__) & SYSCFG_FASTMODEPLUS_PB6) == SYSCFG_FASTMODEPLUS_PB6) || \
+                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB7) == SYSCFG_FASTMODEPLUS_PB7) || \
+                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB8) == SYSCFG_FASTMODEPLUS_PB8) || \
+                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB9) == SYSCFG_FASTMODEPLUS_PB9))
+#elif defined(SYSCFG_FASTMODEPLUS_PB8)
+#define IS_SYSCFG_FASTMODEPLUS(__PIN__) ((((__PIN__) & SYSCFG_FASTMODEPLUS_PB6) == SYSCFG_FASTMODEPLUS_PB6) || \
+                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB7) == SYSCFG_FASTMODEPLUS_PB7) || \
+                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB8) == SYSCFG_FASTMODEPLUS_PB8))
+#elif defined(SYSCFG_FASTMODEPLUS_PB9)
+#define IS_SYSCFG_FASTMODEPLUS(__PIN__) ((((__PIN__) & SYSCFG_FASTMODEPLUS_PB6) == SYSCFG_FASTMODEPLUS_PB6) || \
+                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB7) == SYSCFG_FASTMODEPLUS_PB7) || \
+                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB9) == SYSCFG_FASTMODEPLUS_PB9))
+#else
+#define IS_SYSCFG_FASTMODEPLUS(__PIN__) ((((__PIN__) & SYSCFG_FASTMODEPLUS_PB6) == SYSCFG_FASTMODEPLUS_PB6) || \
+                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB7) == SYSCFG_FASTMODEPLUS_PB7))
+#endif
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup HAL_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup HAL_Exported_Functions_Group1
+  * @{
+  */
+
+/* Initialization and de-initialization functions  ******************************/
+HAL_StatusTypeDef HAL_Init(void);
+HAL_StatusTypeDef HAL_DeInit(void);
+void HAL_MspInit(void);
+void HAL_MspDeInit(void);
+HAL_StatusTypeDef HAL_InitTick (uint32_t TickPriority);
+
+/**
+  * @}
+  */
+
+/** @addtogroup HAL_Exported_Functions_Group2
+  * @{
+  */
+
+/* Peripheral Control functions  ************************************************/
+void HAL_IncTick(void);
+void HAL_Delay(uint32_t Delay);
+uint32_t HAL_GetTick(void);
+void HAL_SuspendTick(void);
+void HAL_ResumeTick(void);
+uint32_t HAL_GetHalVersion(void);
+uint32_t HAL_GetREVID(void);
+uint32_t HAL_GetDEVID(void);
+
+/**
+  * @}
+  */
+
+/** @addtogroup HAL_Exported_Functions_Group3
+  * @{
+  */
+
+/* DBGMCU Peripheral Control functions  *****************************************/
+void HAL_DBGMCU_EnableDBGSleepMode(void);
+void HAL_DBGMCU_DisableDBGSleepMode(void);
+void HAL_DBGMCU_EnableDBGStopMode(void);
+void HAL_DBGMCU_DisableDBGStopMode(void);
+void HAL_DBGMCU_EnableDBGStandbyMode(void);
+void HAL_DBGMCU_DisableDBGStandbyMode(void);
+
+/**
+  * @}
+  */
+
+/** @addtogroup HAL_Exported_Functions_Group4
+  * @{
+  */
+
+/* SYSCFG Control functions  ****************************************************/
+void HAL_SYSCFG_SRAM2Erase(void);
+void HAL_SYSCFG_EnableMemorySwappingBank(void);
+void HAL_SYSCFG_DisableMemorySwappingBank(void);
+
+#if defined(VREFBUF)
+void HAL_SYSCFG_VREFBUF_VoltageScalingConfig(uint32_t VoltageScaling);
+void HAL_SYSCFG_VREFBUF_HighImpedanceConfig(uint32_t Mode);
+void HAL_SYSCFG_VREFBUF_TrimmingConfig(uint32_t TrimmingValue);
+HAL_StatusTypeDef HAL_SYSCFG_EnableVREFBUF(void);
+void HAL_SYSCFG_DisableVREFBUF(void);
+#endif /* VREFBUF */
+
+void HAL_SYSCFG_EnableIOAnalogSwitchBooster(void);
+void HAL_SYSCFG_DisableIOAnalogSwitchBooster(void);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_adc.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_adc.h
@@ -1,0 +1,1032 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_adc.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of ADC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_ADC_H
+#define __STM32L4xx_ADC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+   
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ADC
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup ADC_Exported_Types ADC Exported Types
+  * @{
+  */ 
+  
+                                                      
+/** 
+  * @brief  ADC Regular Conversion Oversampling structure definition  
+  */
+typedef struct
+{
+  uint32_t Ratio;                         /*!< Configures the oversampling ratio.
+                                               This parameter can be a value of @ref ADCEx_Oversampling_Ratio */
+                                               
+  uint32_t RightBitShift;                 /*!< Configures the division coefficient for the Oversampler.
+                                               This parameter can be a value of @ref ADCEx_Right_Bit_Shift */
+                                               
+  uint32_t TriggeredMode;                 /*!< Selects the regular triggered oversampling mode.
+                                               This parameter can be a value of @ref ADCEx_Triggered_Oversampling_Mode */
+                                               
+  uint32_t OversamplingStopReset;         /*!< Selects the regular oversampling mode.
+                                               The oversampling is either temporary stopped or reset upon an injected
+                                               sequence interruption. 
+                                               If oversampling is enabled on both regular and injected groups, this parameter 
+                                               is discarded and forced to setting "ADC_REGOVERSAMPLING_RESUMED_MODE" 
+                                               (the oversampling buffer is zeroed during injection sequence).   
+                                               This parameter can be a value of @ref ADCEx_Regular_Oversampling_Mode */                                               
+                                        
+}ADC_OversamplingTypeDef;  
+  
+  
+  
+  
+/**
+  * @brief  Structure definition of ADC initialization and regular group  
+  * @note   Parameters of this structure are shared within 2 scopes:
+  *          - Scope entire ADC (affects regular and injected groups): ClockPrescaler and ClockDivider, Resolution, DataAlign, 
+  *            ScanConvMode, EOCSelection, LowPowerAutoWait.
+  *          - Scope regular group: ContinuousConvMode, NbrOfConversion, DiscontinuousConvMode, NbrOfDiscConversion, ExternalTrigConvEdge, 
+  *            ExternalTrigConv, DMAContinuousRequests, Overrun, OversamplingMode, Oversampling.
+  * @note   The setting of these parameters by function HAL_ADC_Init() is conditioned by ADC state.
+  *         ADC state can be either:
+  *          - For all parameters: ADC disabled
+  *          - For all parameters except 'LowPowerAutoWait', 'DMAContinuousRequests' and 'Oversampling': ADC enabled without conversion on going on regular group.
+  *          - For parameters 'LowPowerAutoWait' and 'DMAContinuousRequests': ADC enabled without conversion on going on regular and injected groups.
+  *         If ADC is not in the appropriate state to modify some parameters, these parameters setting is bypassed
+  *         without error reporting (as it can be the expected behaviour in case of intended action to update another parameter 
+  *         (which fulfills the ADC state condition) on the fly).
+  */
+typedef struct
+{                                                                                                                          
+  uint32_t ClockPrescaler;        /*!< Selects ADC clock source (asynchronous System/PLLSAI1/PLLSAI2 clocks or synchronous AHB clock) as well as
+                                       the division factor applied to the clock.
+                                       This parameter can be a value of @ref ADC_ClockPrescaler.
+                                       Note: The clock is common for all the ADCs.
+                                       Note: In case of usage of channels on injected group, ADC frequency should be lower than AHB clock frequency /4 for resolution 12 or 10 bits, 
+                                             AHB clock frequency /3 for resolution 8 bits, AHB clock frequency /2 for resolution 6 bits.
+                                       Note: In case of usage of the ADC dedicated PLL clock, this clock must be preliminarily enabled and prescaler set at RCC top level.
+                                       Note: In case of synchronous clock mode based on HCLK/1, the configuration must be enabled only if the AHB clock prescaler is set to 1 
+                                       and if the system clock has a 50% duty cycle.                                       
+                                       Note: This parameter can be modified only if all ADCs are disabled. */
+                                       
+  uint32_t Resolution;            /*!< Configures the ADC resolution. 
+                                       This parameter can be a value of @ref ADC_Resolution */
+
+  uint32_t DataAlign;             /*!< Specifies ADC data alignment (right or left). 
+                                       See reference manual for alignments formats versus resolutions.
+                                       This parameter can be a value of @ref ADC_Data_align */
+
+  uint32_t ScanConvMode;          /*!< Configures the sequencer of regular and injected groups.
+                                       This parameter can be associated to parameter 'DiscontinuousConvMode' to have main sequence subdivided in successive parts.
+                                       If disabled: Conversion is performed in single mode (one channel converted, that defined in rank 1).
+                                                    Parameters 'NbrOfConversion' and 'InjectedNbrOfConversion' are discarded (equivalent to set to 1).
+                                       If enabled:  Conversions are performed in sequence mode (multiple ranks defined by 'NbrOfConversion' or'InjectedNbrOfConversion'). 
+                                                    Scan direction is upward: from rank 1 to rank 'n'.
+                                       This parameter can be a value of @ref ADC_Scan_mode */
+
+  uint32_t EOCSelection;          /*!< Specifies which EOC (End Of Conversion) flag is used for conversion by polling and interruption: end of conversion of each rank or complete sequence.
+                                       This parameter can be a value of @ref ADC_EOCSelection. */
+
+  uint32_t LowPowerAutoWait;      /*!< Selects the dynamic low power Auto Delay: new conversion start only when the previous
+                                       conversion (for regular group) or previous sequence (for injected group) has been processed by user software
+                                       (EOC bit cleared or DR read for regular conversions, JEOS cleared for injected conversions).
+                                       This feature automatically adapts the speed of ADC to the speed of the system that reads the data. Moreover, this avoids risk of overrun 
+                                       for low frequency applications. 
+                                       This parameter can be set to ENABLE or DISABLE.
+                                       Note: Do not use with interruption or DMA (HAL_ADC_Start_IT(), HAL_ADC_Start_DMA(), HAL_ADCEx_InjectedStart_IT()) when it is necessary 
+                                       to clear immediately the EOC flag to free the IRQ vector sequencer.
+                                       Do use with polling: 1. Start conversion with HAL_ADC_Start() or HAL_ADCEx_InjectedStart(), 2. When conversion data is available: use 
+                                       HAL_ADC_PollForConversion() to ensure that conversion is completed and HAL_ADC_GetValue() to retrieve conversion result and trig another 
+                                       conversion. For injected conversion, resort to HAL_ADCEx_InjectedPollForConversion() then HAL_ADCEx_InjectedGetValue() */
+
+  uint32_t ContinuousConvMode;    /*!< Specifies whether the conversion is performed in single mode (one conversion) or continuous mode for regular group,
+                                       after software start or external trigger occurred.
+                                       This parameter can be set to ENABLE or DISABLE. */
+
+  uint32_t NbrOfConversion;       /*!< Specifies the number of ranks that will be converted within the regular group sequencer.
+                                       To use the regular group sequencer and convert several ranks, parameter 'ScanConvMode' must be enabled.
+                                       This parameter must be a number between Min_Data = 1 and Max_Data = 16.
+                                       Note: This parameter must be modified when no conversion is on going on regular group (ADC disabled, or ADC enabled without 
+                                       continuous mode or external trigger that could launch a conversion). */
+
+  uint32_t DiscontinuousConvMode; /*!< Specifies whether the conversions sequence of regular group is performed in Complete-sequence/Discontinuous-sequence (main sequence 
+                                       subdivided in successive parts).
+                                       Discontinuous mode is used only if sequencer is enabled (parameter 'ScanConvMode'). If sequencer is disabled, this parameter is discarded.
+                                       Discontinuous mode can be enabled only if continuous mode is disabled.
+                                       This parameter can be set to ENABLE or DISABLE. */
+
+  uint32_t NbrOfDiscConversion;   /*!< Specifies the number of discontinuous conversions in which the  main sequence of regular group (parameter NbrOfConversion) will be subdivided.
+                                       If parameter 'DiscontinuousConvMode' is disabled, this parameter is discarded.
+                                       This parameter must be a number between Min_Data = 1 and Max_Data = 8. */
+
+  uint32_t ExternalTrigConv;      /*!< Selects the external event used to trigger the conversion start of regular group.
+                                       If set to ADC_SOFTWARE_START, external triggers are disabled and software trigger is used instead.
+                                       This parameter can be a value of @ref ADC_Regular_External_Trigger_Source.
+                                       Caution: external trigger source is common to ADCs.  */
+                                                                                                        
+  uint32_t ExternalTrigConvEdge;  /*!< Selects the external trigger edge of regular group.
+                                       If set to ADC_EXTERNALTRIGCONVEDGE_NONE, external triggers are disabled and software trigger is used instead.
+                                       This parameter can be a value of @ref ADC_Regular_External_Trigger_Source_Edge */
+
+  uint32_t DMAContinuousRequests; /*!< Specifies whether the DMA requests are performed in one shot mode (DMA transfer stops when number of conversions is reached)
+                                       or in Continuous mode (DMA transfer unlimited, whatever number of conversions).
+                                       Note: In continuous mode, DMA must be configured in circular mode. Otherwise an overrun will be triggered when DMA buffer maximum pointer is reached.
+                                       This parameter can be set to ENABLE or DISABLE.
+                                       Note: This parameter must be modified when no conversion is on going on both regular and injected groups 
+                                       (ADC disabled, or ADC enabled without continuous mode or external trigger that could launch a conversion). */
+
+  uint32_t Overrun;               /*!< Select the behaviour in case of overrun: data overwritten or preserved (default).
+                                       This parameter applies to regular group only.
+                                       This parameter can be a value of @ref ADC_Overrun.
+                                       Note: Case of overrun set to data preserved and usage with end on conversion interruption (HAL_Start_IT()): ADC IRQ handler has to clear 
+                                       end of conversion flags, this induces the release of the preserved data. If needed, this data can be saved by user-developped function 
+                                       HAL_ADC_ConvCpltCallback() (called before end of conversion flags clear).
+                                       Note: Error reporting with respect to the conversion mode:
+                                        - Usage with ADC conversion by polling for event or interruption: Error is reported only if overrun is set to data preserved. If overrun is set to data 
+                                          overwritten, user can willingly not read all the converted data, this is not considered as an erroneous case.
+                                        - Usage with ADC conversion by DMA: Error is reported whatever overrun setting (DMA is expected to process all data from data register). */
+                                        
+  uint32_t OversamplingMode;               /*!< Specifies whether the oversampling feature is enabled or disabled.
+                                                This parameter can be set to ENABLE or DISABLE.
+                                                Note: This parameter can be modified only if there is no conversion is ongoing (both ADSTART and JADSTART cleared). */
+                                              
+  ADC_OversamplingTypeDef  Oversampling;   /*!< Specifies the Oversampling parameters.
+                                                Caution: this setting overwrites the previous oversampling configuration if oversampling already enabled.  
+                                                Note: This parameter can be modified only if there is no conversion is ongoing (both ADSTART and JADSTART cleared). */                                        
+}ADC_InitTypeDef;  
+  
+
+/** @defgroup ADC_States ADC States
+  * @{
+  */ 
+    
+/** 
+  * @brief  HAL ADC state machine: ADC State bitfield definition  
+  */ 
+/* States of ADC global scope */
+#define HAL_ADC_STATE_RESET             ((uint32_t)0x00000000)    /*!< ADC not yet initialized or disabled */
+#define HAL_ADC_STATE_READY             ((uint32_t)0x00000001)    /*!< ADC peripheral ready for use */
+#define HAL_ADC_STATE_BUSY_INTERNAL     ((uint32_t)0x00000002)    /*!< ADC is busy because of an internal process (initialization, calibration) */   
+#define HAL_ADC_STATE_TIMEOUT           ((uint32_t)0x00000004)    /*!< TimeOut occurrence */
+
+/* States of ADC errors */
+#define HAL_ADC_STATE_ERROR_INTERNAL    ((uint32_t)0x00000010)    /*!< Internal error occurrence */
+#define HAL_ADC_STATE_ERROR_CONFIG      ((uint32_t)0x00000020)    /*!< Configuration error occurrence */  
+#define HAL_ADC_STATE_ERROR_DMA         ((uint32_t)0x00000040)    /*!< DMA error occurrence */ 
+
+/* States of ADC regular group */
+#define HAL_ADC_STATE_REG_BUSY          ((uint32_t)0x00000100)    /*!< A regular conversion is ongoing or can occur (either by continuous mode,
+                                                                       external trigger, low power auto power-on, multimode ADC master control) */ 
+#define HAL_ADC_STATE_REG_EOC           ((uint32_t)0x00000200)    /*!< Regular conversion data available */
+#define HAL_ADC_STATE_REG_OVR           ((uint32_t)0x00000400)    /*!< Overrun occurrence  */
+#define HAL_ADC_STATE_REG_EOSMP         ((uint32_t)0x00000800)    /*!< End Of Sampling flag raised  */
+
+/* States of ADC injected group */
+#define HAL_ADC_STATE_INJ_BUSY          ((uint32_t)0x00001000)    /*!< An injected conversion is ongoing or can occur (either by auto-injection mode,
+                                                                       external trigger, low power auto power-on, multimode ADC master control) */ 
+#define HAL_ADC_STATE_INJ_EOC           ((uint32_t)0x00002000)    /*!< Injected conversion data available */
+#define HAL_ADC_STATE_INJ_JQOVF         ((uint32_t)0x00004000)    /*!< Injected queue overflow occurrence */
+
+/* States of ADC analog watchdogs */
+#define HAL_ADC_STATE_AWD1              ((uint32_t)0x00010000)    /*!< Out-of-window occurrence of Analog Watchdog 1 */
+#define HAL_ADC_STATE_AWD2              ((uint32_t)0x00020000)    /*!< Out-of-window occurrence of Analog Watchdog 2 */
+#define HAL_ADC_STATE_AWD3              ((uint32_t)0x00040000)    /*!< Out-of-window occurrence of Analog Watchdog 3 */
+
+/* States of ADC multi-mode */
+#define HAL_ADC_STATE_MULTIMODE_SLAVE   ((uint32_t)0x00100000)    /*!< ADC in multimode slave state, controlled by another ADC master */
+
+/**
+  * @}
+  */
+  
+/** 
+  * @brief  ADC Injection Configuration 
+  */
+typedef struct
+{
+  uint32_t ContextQueue;                 /*!< Injected channel configuration context: build-up over each 
+                                              HAL_ADCEx_InjectedConfigChannel() call to finally initialize
+                                              JSQR register at HAL_ADCEx_InjectedConfigChannel() last call */
+                                               
+  uint32_t ChannelCount;                 /*!< Number of channels in the injected sequence */                                        
+}ADC_InjectionConfigTypeDef;  
+
+
+
+/** 
+  * @brief  ADC handle Structure definition  
+  */ 
+typedef struct
+{
+  ADC_TypeDef                   *Instance;              /*!< Register base address */
+
+  ADC_InitTypeDef               Init;                   /*!< ADC initialization parameters and regular conversions setting */
+
+  DMA_HandleTypeDef             *DMA_Handle;            /*!< Pointer DMA Handler */
+
+  HAL_LockTypeDef               Lock;                   /*!< ADC locking object */
+
+  __IO uint32_t                 State;                  /*!< ADC communication state (bit-map of ADC states) */
+
+  __IO uint32_t                 ErrorCode;              /*!< ADC Error code */
+  
+  ADC_InjectionConfigTypeDef    InjectionConfig ;       /*!< ADC injected channel configuration build-up structure */  
+}ADC_HandleTypeDef;
+
+
+
+/** 
+  * @brief  Structure definition of ADC channel for regular group  
+  * @note   The setting of these parameters with function HAL_ADC_ConfigChannel() is conditioned by ADC state.
+  *         ADC state can be either:
+  *          - For all parameters: ADC disabled (this is the only possible ADC state to modify parameter 'SingleDiff')
+  *          - For all except parameters 'SamplingTime', 'Offset', 'OffsetNumber': ADC enabled without conversion on going on regular group.
+  *          - For parameters 'SamplingTime', 'Offset', 'OffsetNumber': ADC enabled without conversion on going on regular and injected groups.
+  *         If ADC is not in the appropriate state to modify some parameters, these parameters setting is bypassed
+  *         without error reporting (as it can be the expected behaviour in case of intended action to update another parameter 
+  *        (which fulfills the ADC state condition) on the fly).
+  */
+typedef struct 
+{
+  uint32_t Channel;                /*!< Specifies the channel to configure into ADC regular group.
+                                        This parameter can be a value of @ref ADC_channels
+                                        Note: Depending on devices and ADC instances, some channels may not be available. Refer to device DataSheet for channels availability. */
+  uint32_t Rank;                   /*!< Specifies the rank in the regular group sequencer.
+                                        This parameter can be a value of @ref ADCEx_regular_rank
+                                        Note: to disable a channel or change order of conversion sequencer, rank containing a previous channel setting can be overwritten by 
+                                        the new channel setting (or parameter number of conversions adjusted) */
+  uint32_t SamplingTime;           /*!< Sampling time value to be set for the selected channel.
+                                        Unit: ADC clock cycles
+                                        Conversion time is the addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits, 10.5 cycles at 10 bits, 
+                                        8.5 cycles at 8 bits, 6.5 cycles at 6 bits).
+                                        This parameter can be a value of @ref ADC_sampling_times
+                                        Caution: This parameter applies to a channel that can be used in a regular and/or injected group.
+                                                 It overwrites the last setting.
+                                        Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
+                                              sampling time constraints must be respected (sampling time can be adjusted with respect to the ADC clock frequency and sampling time setting)
+                                              Refer to device DataSheet for timings values. */
+  uint32_t SingleDiff;             /*!< Selection of single-ended or differential input.
+                                        In differential mode: Differential measurement is carried out between the selected channel 'i' (positive input) and channel 'i+1' (negative input).
+                                                              Only channel 'i' has to be configured, channel 'i+1' is configured automatically.
+                                        This parameter must be a value of @ref ADCEx_SingleDifferential
+                                        Caution: This parameter applies to a channel that can be used in a regular and/or injected group.
+                                                 It overwrites the last setting.
+                                        Note: Refer to Reference Manual to ensure the selected channel is available in differential mode.
+                                        Note: When configuring a channel 'i' in differential mode, the channel 'i+1' is not usable separately.
+                                        Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion).
+                                              If ADC is enabled, this parameter setting is bypassed without error reporting (as it can be the expected behaviour in case 
+                                        of another parameter update on the fly) */
+  uint32_t OffsetNumber;           /*!< Selects the offset number
+                                        This parameter can be a value of @ref ADCEx_OffsetNumber
+                                        Caution: Only one offset is allowed per channel. This parameter overwrites the last setting. */
+  uint32_t Offset;                 /*!< Defines the offset to be subtracted from the raw converted data.
+                                        Offset value must be a positive number.
+                                        Depending of ADC resolution selected (12, 10, 8 or 6 bits), this parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFF, 
+                                        0x3FF, 0xFF or 0x3F respectively.
+                                        Note: This parameter must be modified when no conversion is on going on both regular and injected groups (ADC disabled, or ADC enabled 
+                                        without continuous mode or external trigger that could launch a conversion). */
+}ADC_ChannelConfTypeDef;
+
+
+/** 
+  * @brief  Structure definition of ADC analog watchdog
+  * @note   The setting of these parameters with function HAL_ADC_AnalogWDGConfig() is conditioned by ADC state.
+  *         ADC state can be either: ADC disabled or ADC enabled without conversion on going on regular and injected groups.
+  */
+typedef struct
+{
+  uint32_t WatchdogNumber;    /*!< Selects which ADC analog watchdog is applied to the selected channel.
+                                   For Analog Watchdog 1: Only 1 channel can be monitored (or overall group of channels by setting parameter 'WatchdogMode')
+                                   For Analog Watchdog 2 and 3: Several channels can be monitored (by successive calls of 'HAL_ADC_AnalogWDGConfig()' for each channel)
+                                   This parameter can be a value of @ref ADCEx_analog_watchdog_number. */
+  uint32_t WatchdogMode;      /*!< For Analog Watchdog 1: Configures the ADC analog watchdog mode: single channel/overall group of channels, regular/injected group.
+                                   For Analog Watchdog 2 and 3: There is no configuration for overall group of channels as AWD1. Set value 'ADC_ANALOGWATCHDOG_NONE' to reset 
+                                   channels group programmed with parameter 'Channel', set any other value to program the channel(s) to be monitored.
+                                   This parameter can be a value of @ref ADCEx_analog_watchdog_mode. */
+  uint32_t Channel;           /*!< Selects which ADC channel to monitor by analog watchdog.
+                                   For Analog Watchdog 1: this parameter has an effect only if parameter 'WatchdogMode' is configured on single channel (only 1 channel can be monitored).
+                                   For Analog Watchdog 2 and 3: Several channels can be monitored (successive calls of HAL_ADC_AnalogWDGConfig() must be done, one for each channel.
+                                   Channels group reset can be done by setting WatchdogMode to 'ADC_ANALOGWATCHDOG_NONE').
+                                   This parameter can be a value of @ref ADC_channels. */
+  uint32_t ITMode;            /*!< Specifies whether the analog watchdog is configured in interrupt or polling mode.
+                                   This parameter can be set to ENABLE or DISABLE */
+  uint32_t HighThreshold;     /*!< Configures the ADC analog watchdog High threshold value.
+                                   Depending of ADC resolution selected (12, 10, 8 or 6 bits), this parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFF, 
+                                   0x3FF, 0xFF or 0x3F respectively.
+                                   Note: Analog watchdog 2 and 3 are limited to a resolution of 8 bits: if ADC resolution is 12 bits 
+                                         the 4 LSB are ignored, if ADC resolution is 10 bits the 2 LSB are ignored. */
+  uint32_t LowThreshold;      /*!< Configures the ADC analog watchdog Low threshold value.
+                                   Depending of ADC resolution selected (12, 10, 8 or 6 bits), this parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFF, 0x3FF, 0xFF or 0x3F respectively.
+                                   Note: Analog watchdog 2 and 3 are limited to a resolution of 8 bits: if ADC resolution is 12 bits 
+                                         the 4 LSB are ignored, if ADC resolution is 10 bits the 2 LSB are ignored. */
+}ADC_AnalogWDGConfTypeDef;
+
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup ADC_Exported_Constants ADC Exported Constants
+  * @{
+  */
+
+/** @defgroup ADC_Error_Code ADC Error Code
+  * @{
+  */
+#define HAL_ADC_ERROR_NONE         ((uint32_t)0x00)   /*!< No error                                 */
+#define HAL_ADC_ERROR_INTERNAL     ((uint32_t)0x01)   /*!< ADC IP internal error: problem of
+                                                          clocking, enable/disable, erroneous state */
+#define HAL_ADC_ERROR_OVR          ((uint32_t)0x02)   /*!< Overrun error                            */
+#define HAL_ADC_ERROR_DMA          ((uint32_t)0x04)   /*!< DMA transfer error                       */
+#define HAL_ADC_ERROR_JQOVF        ((uint32_t)0x08)   /*!< Injected context queue overflow error    */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_ClockPrescaler ADC Clock Prescaler
+  * @{
+  */
+#define ADC_CLOCK_SYNC_PCLK_DIV1      ((uint32_t)ADC_CCR_CKMODE_0) /*!< ADC synchronous clock derived from AHB clock not divided  */
+#define ADC_CLOCK_SYNC_PCLK_DIV2      ((uint32_t)ADC_CCR_CKMODE_1) /*!< ADC synchronous clock derived from AHB clock divided by 2 */
+#define ADC_CLOCK_SYNC_PCLK_DIV4      ((uint32_t)ADC_CCR_CKMODE)   /*!< ADC synchronous clock derived from AHB clock divided by 4 */
+
+#define ADC_CLOCKPRESCALER_PCLK_DIV1   ADC_CLOCK_SYNC_PCLK_DIV1    /*!< Obsolete naming, kept for compatibility with some other devices */
+#define ADC_CLOCKPRESCALER_PCLK_DIV2   ADC_CLOCK_SYNC_PCLK_DIV2    /*!< Obsolete naming, kept for compatibility with some other devices */
+#define ADC_CLOCKPRESCALER_PCLK_DIV4   ADC_CLOCK_SYNC_PCLK_DIV4    /*!< Obsolete naming, kept for compatibility with some other devices */
+
+#define ADC_CLOCK_ASYNC_DIV1       ((uint32_t)0x00000000)                                        /*!< ADC asynchronous clock not divided    */
+#define ADC_CLOCK_ASYNC_DIV2       ((uint32_t)ADC_CCR_PRESC_0)                                   /*!< ADC asynchronous clock divided by 2   */
+#define ADC_CLOCK_ASYNC_DIV4       ((uint32_t)ADC_CCR_PRESC_1)                                   /*!< ADC asynchronous clock divided by 4   */
+#define ADC_CLOCK_ASYNC_DIV6       ((uint32_t)(ADC_CCR_PRESC_1|ADC_CCR_PRESC_0))                 /*!< ADC asynchronous clock divided by 6   */
+#define ADC_CLOCK_ASYNC_DIV8       ((uint32_t)(ADC_CCR_PRESC_2))                                 /*!< ADC asynchronous clock divided by 8   */
+#define ADC_CLOCK_ASYNC_DIV10      ((uint32_t)(ADC_CCR_PRESC_2|ADC_CCR_PRESC_0))                 /*!< ADC asynchronous clock divided by 10  */
+#define ADC_CLOCK_ASYNC_DIV12      ((uint32_t)(ADC_CCR_PRESC_2|ADC_CCR_PRESC_1))                 /*!< ADC asynchronous clock divided by 12  */
+#define ADC_CLOCK_ASYNC_DIV16      ((uint32_t)(ADC_CCR_PRESC_2|ADC_CCR_PRESC_1|ADC_CCR_PRESC_0)) /*!< ADC asynchronous clock divided by 16  */
+#define ADC_CLOCK_ASYNC_DIV32      ((uint32_t)(ADC_CCR_PRESC_3))                                 /*!< ADC asynchronous clock divided by 32  */
+#define ADC_CLOCK_ASYNC_DIV64      ((uint32_t)(ADC_CCR_PRESC_3|ADC_CCR_PRESC_0))                 /*!< ADC asynchronous clock divided by 64  */
+#define ADC_CLOCK_ASYNC_DIV128     ((uint32_t)(ADC_CCR_PRESC_3|ADC_CCR_PRESC_1))                 /*!< ADC asynchronous clock divided by 128 */
+#define ADC_CLOCK_ASYNC_DIV256     ((uint32_t)(ADC_CCR_PRESC_3|ADC_CCR_PRESC_1|ADC_CCR_PRESC_0)) /*!< ADC asynchronous clock divided by 256 */
+/**
+  * @}
+  */
+  
+
+/** @defgroup ADC_Resolution ADC Resolution
+  * @{
+  */
+#define ADC_RESOLUTION_12B      ((uint32_t)0x00000000)          /*!< ADC 12-bit resolution */
+#define ADC_RESOLUTION_10B      ((uint32_t)ADC_CFGR_RES_0)      /*!< ADC 10-bit resolution */
+#define ADC_RESOLUTION_8B       ((uint32_t)ADC_CFGR_RES_1)      /*!< ADC 8-bit resolution  */
+#define ADC_RESOLUTION_6B       ((uint32_t)ADC_CFGR_RES)        /*!< ADC 6-bit resolution  */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Data_align ADC Data Alignment
+  * @{
+  */
+#define ADC_DATAALIGN_RIGHT      ((uint32_t)0x00000000)         /*!< Data right alignment */
+#define ADC_DATAALIGN_LEFT       ((uint32_t)ADC_CFGR_ALIGN)     /*!< Data left alignment  */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Scan_mode ADC Scan Mode
+  * @{
+  */
+#define ADC_SCAN_DISABLE         ((uint32_t)0x00000000)        /*!< Scan mode disabled */
+#define ADC_SCAN_ENABLE          ((uint32_t)0x00000001)        /*!< Scan mode enabled  */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Regular_External_Trigger_Source_Edge ADC External Trigger Source Edge for Regular Group
+  * @{
+  */
+#define ADC_EXTERNALTRIGCONVEDGE_NONE           ((uint32_t)0x00000000)        /*!< Regular conversions hardware trigger detection disabled                             */
+#define ADC_EXTERNALTRIGCONVEDGE_RISING         ((uint32_t)ADC_CFGR_EXTEN_0)  /*!< Regular conversions hardware trigger detection on the rising edge                   */
+#define ADC_EXTERNALTRIGCONVEDGE_FALLING        ((uint32_t)ADC_CFGR_EXTEN_1)  /*!< Regular conversions hardware trigger detection on the falling edge                  */
+#define ADC_EXTERNALTRIGCONVEDGE_RISINGFALLING  ((uint32_t)ADC_CFGR_EXTEN)    /*!< Regular conversions hardware trigger detection on both the rising and falling edges */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Regular_External_Trigger_Source ADC External Trigger Source for Regular Group
+  * @{
+  */
+
+/* External triggers of ADC regular group */                                                    
+#define ADC_EXTERNALTRIG_T1_CC1           ((uint32_t)0x00000000)                                                  /*!< Event 0 triggers regular group conversion start  */
+#define ADC_EXTERNALTRIG_T1_CC2           ((uint32_t)ADC_CFGR_EXTSEL_0)                                           /*!< Event 1 triggers regular group conversion start  */
+#define ADC_EXTERNALTRIG_T1_CC3           ((uint32_t)ADC_CFGR_EXTSEL_1)                                           /*!< Event 2 triggers regular group conversion start  */
+#define ADC_EXTERNALTRIG_T2_CC2           ((uint32_t)(ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))                     /*!< Event 3 triggers regular group conversion start  */
+#define ADC_EXTERNALTRIG_T3_TRGO          ((uint32_t)ADC_CFGR_EXTSEL_2)                                           /*!< Event 4 triggers regular group conversion start  */
+#define ADC_EXTERNALTRIG_T4_CC4           ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))                     /*!< Event 5 triggers regular group conversion start  */
+#define ADC_EXTERNALTRIG_EXT_IT11         ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))                     /*!< Event 6 triggers regular group conversion start  */
+#define ADC_EXTERNALTRIG_T8_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0)) /*!< Event 7 triggers regular group conversion start  */
+#define ADC_EXTERNALTRIG_T8_TRGO2         ((uint32_t) ADC_CFGR_EXTSEL_3)                                          /*!< Event 8 triggers regular group conversion start  */
+#define ADC_EXTERNALTRIG_T1_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_0))                     /*!< Event 9 triggers regular group conversion start  */
+#define ADC_EXTERNALTRIG_T1_TRGO2         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1))                     /*!< Event 10 triggers regular group conversion start */
+#define ADC_EXTERNALTRIG_T2_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0)) /*!< Event 11 triggers regular group conversion start */
+#define ADC_EXTERNALTRIG_T4_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2))                     /*!< Event 12 triggers regular group conversion start */
+#define ADC_EXTERNALTRIG_T6_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0)) /*!< Event 13 triggers regular group conversion start */
+#define ADC_EXTERNALTRIG_T15_TRGO         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1)) /*!< Event 14 triggers regular group conversion start */
+#define ADC_EXTERNALTRIG_T3_CC4           ((uint32_t)ADC_CFGR_EXTSEL)                                             /*!< Event 15 triggers regular group conversion start */
+
+#define ADC_SOFTWARE_START                ((uint32_t)0x00000001)                                                  /*!< Software triggers regular group conversion start */
+/**
+  * @}
+  */
+
+
+/** @defgroup ADC_EOCSelection ADC End of Regular Sequence/Conversion 
+  * @{
+  */
+#define ADC_EOC_SINGLE_CONV         ((uint32_t) ADC_ISR_EOC)                 /*!< End of conversion flag  */
+#define ADC_EOC_SEQ_CONV            ((uint32_t) ADC_ISR_EOS)                 /*!< End of sequence flag    */
+#define ADC_EOC_SINGLE_SEQ_CONV     ((uint32_t)(ADC_ISR_EOC | ADC_ISR_EOS))  /*!< Reserved for future use */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Overrun ADC overrun
+  * @{
+  */
+#define ADC_OVR_DATA_PRESERVED             ((uint32_t)0x00000000)           /*!< Data preserved in case of overrun   */
+#define ADC_OVR_DATA_OVERWRITTEN           ((uint32_t)ADC_CFGR_OVRMOD)      /*!< Data overwritten in case of overrun */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_channels ADC Channels
+  * @{
+  */
+#define ADC_CHANNEL_0           ((uint32_t)(0x00000000))                                                            /*!< ADC channel 0  */
+#define ADC_CHANNEL_1           ((uint32_t)(ADC_SQR3_SQ10_0))                                                       /*!< ADC channel 1  */
+#define ADC_CHANNEL_2           ((uint32_t)(ADC_SQR3_SQ10_1))                                                       /*!< ADC channel 2  */
+#define ADC_CHANNEL_3           ((uint32_t)(ADC_SQR3_SQ10_1 | ADC_SQR3_SQ10_0))                                     /*!< ADC channel 3  */
+#define ADC_CHANNEL_4           ((uint32_t)(ADC_SQR3_SQ10_2))                                                       /*!< ADC channel 4  */
+#define ADC_CHANNEL_5           ((uint32_t)(ADC_SQR3_SQ10_2 | ADC_SQR3_SQ10_0))                                     /*!< ADC channel 5  */
+#define ADC_CHANNEL_6           ((uint32_t)(ADC_SQR3_SQ10_2 | ADC_SQR3_SQ10_1))                                     /*!< ADC channel 6  */
+#define ADC_CHANNEL_7           ((uint32_t)(ADC_SQR3_SQ10_2 | ADC_SQR3_SQ10_1 | ADC_SQR3_SQ10_0))                   /*!< ADC channel 7  */
+#define ADC_CHANNEL_8           ((uint32_t)(ADC_SQR3_SQ10_3))                                                       /*!< ADC channel 8  */
+#define ADC_CHANNEL_9           ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_0))                                     /*!< ADC channel 9  */
+#define ADC_CHANNEL_10          ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_1))                                     /*!< ADC channel 10 */
+#define ADC_CHANNEL_11          ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_1 | ADC_SQR3_SQ10_0))                   /*!< ADC channel 11 */
+#define ADC_CHANNEL_12          ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_2))                                     /*!< ADC channel 12 */
+#define ADC_CHANNEL_13          ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_2 | ADC_SQR3_SQ10_0))                   /*!< ADC channel 13 */
+#define ADC_CHANNEL_14          ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_2 | ADC_SQR3_SQ10_1))                   /*!< ADC channel 14 */
+#define ADC_CHANNEL_15          ((uint32_t)(ADC_SQR3_SQ10_3 | ADC_SQR3_SQ10_2 | ADC_SQR3_SQ10_1 | ADC_SQR3_SQ10_0)) /*!< ADC channel 15 */
+#define ADC_CHANNEL_16          ((uint32_t)(ADC_SQR3_SQ10_4))                                                       /*!< ADC channel 16 */
+#define ADC_CHANNEL_17          ((uint32_t)(ADC_SQR3_SQ10_4 | ADC_SQR3_SQ10_0))                                     /*!< ADC channel 17 */
+#define ADC_CHANNEL_18          ((uint32_t)(ADC_SQR3_SQ10_4 | ADC_SQR3_SQ10_1))                                     /*!< ADC channel 18 */
+
+/* Note: VrefInt, TempSensor and Vbat internal channels are not available on all ADC's
+         (information present in Reference Manual) */ 
+#define ADC_CHANNEL_TEMPSENSOR  ADC_CHANNEL_17                                                                      /*!< ADC temperature sensor channel */
+#define ADC_CHANNEL_VBAT        ADC_CHANNEL_18                                                                      /*!< ADC Vbat channel               */
+#define ADC_CHANNEL_VREFINT     ADC_CHANNEL_0                                                                       /*!< ADC Vrefint channel            */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_sampling_times ADC Sampling Times
+  * @{
+  */
+#define ADC_SAMPLETIME_2CYCLES_5      ((uint32_t)0x00000000)                              /*!< Sampling time 2.5 ADC clock cycle    */
+#define ADC_SAMPLETIME_6CYCLES_5      ((uint32_t)ADC_SMPR2_SMP10_0)                       /*!< Sampling time 6.5 ADC clock cycles   */
+#define ADC_SAMPLETIME_12CYCLES_5     ((uint32_t)ADC_SMPR2_SMP10_1)                       /*!< Sampling time 12.5 ADC clock cycles  */
+#define ADC_SAMPLETIME_24CYCLES_5     ((uint32_t)(ADC_SMPR2_SMP10_1 | ADC_SMPR2_SMP10_0)) /*!< Sampling time 24.5 ADC clock cycles  */
+#define ADC_SAMPLETIME_47CYCLES_5     ((uint32_t)ADC_SMPR2_SMP10_2)                       /*!< Sampling time 47.5 ADC clock cycles  */
+#define ADC_SAMPLETIME_92CYCLES_5     ((uint32_t)(ADC_SMPR2_SMP10_2 | ADC_SMPR2_SMP10_0)) /*!< Sampling time 92.5 ADC clock cycles  */
+#define ADC_SAMPLETIME_247CYCLES_5    ((uint32_t)(ADC_SMPR2_SMP10_2 | ADC_SMPR2_SMP10_1)) /*!< Sampling time 247.5 ADC clock cycles */
+#define ADC_SAMPLETIME_640CYCLES_5    ((uint32_t)ADC_SMPR2_SMP10)                         /*!< Sampling time 640.5 ADC clock cycles */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+     
+/** @defgroup ADC_Private_Macro ADC Private Macros
+  * @{
+  */
+
+/**
+  * @brief Test if conversion trigger of regular group is software start
+  *        or external trigger.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (software start) or RESET (external trigger)
+  */
+#define ADC_IS_SOFTWARE_START_REGULAR(__HANDLE__)                        \
+       (((__HANDLE__)->Instance->CFGR & ADC_CFGR_EXTEN) == RESET)
+        
+/**
+  * @brief Return resolution bits in CFGR register RES[1:0] field.
+  * @param __HANDLE__: ADC handle.
+  * @retval 2-bit field RES of CFGR register.
+  */
+#define ADC_GET_RESOLUTION(__HANDLE__) (((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES)
+
+/**
+  * @brief Clear ADC error code (set it to no error code "HAL_ADC_ERROR_NONE").
+  * @param __HANDLE__: ADC handle.
+  * @retval None
+  */
+#define ADC_CLEAR_ERRORCODE(__HANDLE__) ((__HANDLE__)->ErrorCode = HAL_ADC_ERROR_NONE) 
+
+/**
+  * @brief Verification of ADC state: enabled or disabled.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (ADC enabled) or RESET (ADC disabled)
+  */
+#define ADC_IS_ENABLE(__HANDLE__)                                                    \
+       (( ((((__HANDLE__)->Instance->CR) & (ADC_CR_ADEN | ADC_CR_ADDIS)) == ADC_CR_ADEN) && \
+          ((((__HANDLE__)->Instance->ISR) & ADC_FLAG_RDY) == ADC_FLAG_RDY)                  \
+        ) ? SET : RESET)
+
+         
+/**
+  * @brief Check if conversion is on going on regular group.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (conversion is on going) or RESET (no conversion is on going)
+  */
+#define ADC_IS_CONVERSION_ONGOING_REGULAR(__HANDLE__)                    \
+       (( (((__HANDLE__)->Instance->CR) & ADC_CR_ADSTART) == RESET             \
+        ) ? RESET : SET)
+        
+        
+/**
+  * @brief Simultaneously clear and set specific bits of the handle State.
+  * @note  ADC_STATE_CLR_SET() macro is merely aliased to generic macro MODIFY_REG(),
+  *        the first parameter is the ADC handle State, the second parameter is the
+  *        bit field to clear, the third and last parameter is the bit field to set.    
+  * @retval None
+  */
+#define ADC_STATE_CLR_SET MODIFY_REG
+
+/**
+  * @brief Verify that a given value is aligned with the ADC resolution range.
+  * @param __RESOLUTION__: ADC resolution (12, 10, 8 or 6 bits).
+  * @param __ADC_VALUE__: value checked against the resolution.     
+  * @retval SET (__ADC_VALUE__ in line with __RESOLUTION__) or RESET (__ADC_VALUE__ not in line with __RESOLUTION__)
+  */  
+#define IS_ADC_RANGE(__RESOLUTION__, __ADC_VALUE__)                                         \
+   ((((__RESOLUTION__) == ADC_RESOLUTION_12B) && ((__ADC_VALUE__) <= ((uint32_t)0x0FFF))) || \
+    (((__RESOLUTION__) == ADC_RESOLUTION_10B) && ((__ADC_VALUE__) <= ((uint32_t)0x03FF))) || \
+    (((__RESOLUTION__) == ADC_RESOLUTION_8B)  && ((__ADC_VALUE__) <= ((uint32_t)0x00FF))) || \
+    (((__RESOLUTION__) == ADC_RESOLUTION_6B)  && ((__ADC_VALUE__) <= ((uint32_t)0x003F)))   )
+
+
+/**
+  * @brief Verify the length of the scheduled regular conversions group.
+  * @param __LENGTH__: number of programmed conversions.   
+  * @retval SET (__LENGTH__ is within the maximum number of possible programmable regular conversions) or RESET (__LENGTH__ is null or too large)
+  */    
+#define IS_ADC_REGULAR_NB_CONV(__LENGTH__) (((__LENGTH__) >= ((uint32_t)1)) && ((__LENGTH__) <= ((uint32_t)16)))
+
+
+/**
+  * @brief Verify the number of scheduled regular conversions in discontinuous mode.
+  * @param NUMBER: number of scheduled regular conversions in discontinuous mode.  
+  * @retval SET (NUMBER is within the maximum number of regular conversions in discontinous mode) or RESET (NUMBER is null or too large)
+  */   
+#define IS_ADC_REGULAR_DISCONT_NUMBER(NUMBER) (((NUMBER) >= ((uint32_t)1)) && ((NUMBER) <= ((uint32_t)8)))
+
+
+/**
+  * @brief Verify the ADC clock setting.
+  * @param __ADC_CLOCK__: programmed ADC clock. 
+  * @retval SET (__ADC_CLOCK__ is a valid value) or RESET (__ADC_CLOCK__ is invalid)
+  */       
+#define IS_ADC_CLOCKPRESCALER(__ADC_CLOCK__) (((__ADC_CLOCK__) == ADC_CLOCK_SYNC_PCLK_DIV1) || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_SYNC_PCLK_DIV2) || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_SYNC_PCLK_DIV4) || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV1)     || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV2)     || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV4)     || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV6)     || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV8)     || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV10)    || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV12)    || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV16)    || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV32)    || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV64)    || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV128)   || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV256) )  
+	
+
+/**
+  * @brief Verify the ADC resolution setting.
+  * @param __RESOLUTION__: programmed ADC resolution. 
+  * @retval SET (__RESOLUTION__ is a valid value) or RESET (__RESOLUTION__ is invalid)
+  */  	
+#define IS_ADC_RESOLUTION(__RESOLUTION__) (((__RESOLUTION__) == ADC_RESOLUTION_12B) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_10B) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_8B)  || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_6B)    )
+                             
+/**                          
+  * @brief Verify the ADC resolution setting when limited to 6 or 8 bits.
+  * @param __RESOLUTION__: programmed ADC resolution when limited to 6 or 8 bits. 
+  * @retval SET (__RESOLUTION__ is a valid value) or RESET (__RESOLUTION__ is invalid)
+  */ 
+#define IS_ADC_RESOLUTION_8_6_BITS(__RESOLUTION__) (((__RESOLUTION__) == ADC_RESOLUTION_8B) || \
+                                                    ((__RESOLUTION__) == ADC_RESOLUTION_6B)   )
+
+/**
+  * @brief Verify the ADC converted data alignment.
+  * @param __ALIGN__: programmed ADC converted data alignment. 
+  * @retval SET (__ALIGN__ is a valid value) or RESET (__ALIGN__ is invalid)
+  */ 		
+#define IS_ADC_DATA_ALIGN(__ALIGN__) (((__ALIGN__) == ADC_DATAALIGN_RIGHT) || \
+                                      ((__ALIGN__) == ADC_DATAALIGN_LEFT)    )
+	
+
+/**
+  * @brief Verify the ADC scan mode.
+  * @param __SCAN_MODE__: programmed ADC scan mode.
+  * @retval SET (__SCAN_MODE__ is valid) or RESET (__SCAN_MODE__ is invalid)
+  */ 	
+#define IS_ADC_SCAN_MODE(__SCAN_MODE__) (((__SCAN_MODE__) == ADC_SCAN_DISABLE) || \
+                                         ((__SCAN_MODE__) == ADC_SCAN_ENABLE)    )	
+									 
+/**
+  * @brief Verify the ADC edge trigger setting for regular group.
+  * @param __EDGE__: programmed ADC edge trigger setting.
+  * @retval SET (__EDGE__ is a valid value) or RESET (__EDGE__ is invalid)
+  */ 									 
+#define IS_ADC_EXTTRIG_EDGE(__EDGE__) (((__EDGE__) == ADC_EXTERNALTRIGCONVEDGE_NONE)         || \
+                                       ((__EDGE__) == ADC_EXTERNALTRIGCONVEDGE_RISING)       || \
+                                       ((__EDGE__) == ADC_EXTERNALTRIGCONVEDGE_FALLING)      || \
+                                       ((__EDGE__) == ADC_EXTERNALTRIGCONVEDGE_RISINGFALLING)  )
+	
+	
+
+/**
+  * @brief Verify the ADC regular conversions external trigger.
+  * @param __REGTRIG__: programmed ADC regular conversions external trigger.
+  * @retval SET (__REGTRIG__ is a valid value) or RESET (__REGTRIG__ is invalid)
+  */ 
+#define IS_ADC_EXTTRIG(__REGTRIG__) (((__REGTRIG__) == ADC_EXTERNALTRIG_T1_CC1)   || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_CC2)   || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_CC3)   || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T2_CC2)   || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T3_TRGO)  || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T4_CC4)   || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_EXT_IT11) || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T8_TRGO)  || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T8_TRGO2) || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_TRGO)  || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_TRGO2) || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T2_TRGO)  || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T4_TRGO)  || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T6_TRGO)  || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T15_TRGO) || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T3_CC4)   || \
+                                                                                 \
+                                     ((__REGTRIG__) == ADC_SOFTWARE_START)           )	
+								 
+
+
+/**
+  * @brief Verify the ADC regular conversions check for converted data availability.
+  * @param __EOC_SELECTION__: converted data availability check.
+  * @retval SET (__EOC_SELECTION__ is a valid value) or RESET (__EOC_SELECTION__ is invalid)
+  */ 								 
+#define IS_ADC_EOC_SELECTION(__EOC_SELECTION__) (((__EOC_SELECTION__) == ADC_EOC_SINGLE_CONV)    || \
+                                                 ((__EOC_SELECTION__) == ADC_EOC_SEQ_CONV)       || \
+                                                 ((__EOC_SELECTION__) == ADC_EOC_SINGLE_SEQ_CONV)  )
+	
+/**
+  * @brief Verify the ADC regular conversions overrun handling.
+  * @param __OVR__: ADC regular conversions overrun handling.
+  * @retval SET (__OVR__ is a valid value) or RESET (__OVR__ is invalid)
+  */ 		
+#define IS_ADC_OVERRUN(__OVR__) (((__OVR__) == ADC_OVR_DATA_PRESERVED)  || \
+                                 ((__OVR__) == ADC_OVR_DATA_OVERWRITTEN)  )	                                   
+	
+/**
+  * @brief Verify the ADC conversions sampling time.
+  * @param __TIME__: ADC conversions sampling time.
+  * @retval SET (__TIME__ is a valid value) or RESET (__TIME__ is invalid)
+  */
+#define IS_ADC_SAMPLE_TIME(__TIME__) (((__TIME__) == ADC_SAMPLETIME_2CYCLE_5)    || \
+                                      ((__TIME__) == ADC_SAMPLETIME_6CYCLES_5)   || \
+                                      ((__TIME__) == ADC_SAMPLETIME_12CYCLES_5)  || \
+                                      ((__TIME__) == ADC_SAMPLETIME_24CYCLES_5)  || \
+                                      ((__TIME__) == ADC_SAMPLETIME_47CYCLES_5)  || \
+                                      ((__TIME__) == ADC_SAMPLETIME_92CYCLES_5)  || \
+                                      ((__TIME__) == ADC_SAMPLETIME_247CYCLES_5) || \
+                                      ((__TIME__) == ADC_SAMPLETIME_640CYCLES_5)   )	     
+/**
+  * @}
+  */ 
+  
+  
+/* Private constants ---------------------------------------------------------*/  
+  
+/** @defgroup ADC_Private_Constants ADC Private Constants
+  * @{
+  */                         
+   
+/* Fixed timeout values for ADC conversion (including sampling time)        */
+/* Maximum sampling time is 640.5 ADC clock cycle (SMPx[2:0] = 0b111        */
+/* Maximum conversion time is 12.5 + Maximum sampling time                  */
+/*                       or 12.5  + 640.5 = 653 ADC clock cycles            */
+/* Minimum ADC Clock frequency is 0.14 MHz                                  */
+/* Maximum conversion time is                                               */
+/*              653 / 0.14 MHz = 4.66 ms                                    */
+#define ADC_STOP_CONVERSION_TIMEOUT     ((uint32_t) 5)      /*!< ADC stop time-out value */ 
+
+/* Delay for temperature sensor stabilization time.                         */
+/* Maximum delay is 120us (refer device datasheet, parameter tSTART).       */
+/* Unit: us                                                                 */
+#define ADC_TEMPSENSOR_DELAY_US         ((uint32_t) 120)
+
+/**
+  * @}
+  */ 
+
+/* Exported macros -----------------------------------------------------------*/
+         
+/** @defgroup ADC_Exported_Macro ADC Exported Macros
+  * @{
+  */
+      
+/** @brief  Reset ADC handle state.
+  * @param  __HANDLE__: ADC handle.
+  * @retval None
+  */
+#define __HAL_ADC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_ADC_STATE_RESET)                                                                        
+         
+         
+/** @brief  Check whether the specified ADC interrupt source is enabled or not.
+  * @param __HANDLE__: ADC handle.
+  * @param __INTERRUPT__: ADC interrupt source to check
+  *          This parameter can be one of the following values:
+  *            @arg @ref ADC_IT_RDY,    ADC Ready (ADRDY) interrupt source
+  *            @arg @ref ADC_IT_EOSMP,  ADC End of Sampling interrupt source
+  *            @arg @ref ADC_IT_EOC,    ADC End of Regular Conversion interrupt source
+  *            @arg @ref ADC_IT_EOS,    ADC End of Regular sequence of Conversions interrupt source
+  *            @arg @ref ADC_IT_OVR,    ADC overrun interrupt source
+  *            @arg @ref ADC_IT_JEOC,   ADC End of Injected Conversion interrupt source
+  *            @arg @ref ADC_IT_JEOS,   ADC End of Injected sequence of Conversions interrupt source
+  *            @arg @ref ADC_IT_AWD1,   ADC Analog watchdog 1 interrupt source (main analog watchdog)
+  *            @arg @ref ADC_IT_AWD2,   ADC Analog watchdog 2 interrupt source (additional analog watchdog)
+  *            @arg @ref ADC_IT_AWD3,   ADC Analog watchdog 3 interrupt source (additional analog watchdog)
+  *            @arg @ref ADC_IT_JQOVF,  ADC Injected Context Queue Overflow interrupt source.  
+  * @retval State of interruption (SET or RESET)
+  */
+#define __HAL_ADC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)                     \
+    (( ((__HANDLE__)->Instance->IER & (__INTERRUPT__)) == (__INTERRUPT__)      \
+     )? SET : RESET                                                            \
+    )
+
+/**
+  * @brief Enable an ADC interrupt.
+  * @param __HANDLE__: ADC handle.
+  * @param __INTERRUPT__: ADC Interrupt to enable
+   *          This parameter can be one of the following values:
+  *            @arg @ref ADC_IT_RDY,    ADC Ready (ADRDY) interrupt source
+  *            @arg @ref ADC_IT_EOSMP,  ADC End of Sampling interrupt source
+  *            @arg @ref ADC_IT_EOC,    ADC End of Regular Conversion interrupt source
+  *            @arg @ref ADC_IT_EOS,    ADC End of Regular sequence of Conversions interrupt source
+  *            @arg @ref ADC_IT_OVR,    ADC overrun interrupt source
+  *            @arg @ref ADC_IT_JEOC,   ADC End of Injected Conversion interrupt source
+  *            @arg @ref ADC_IT_JEOS,   ADC End of Injected sequence of Conversions interrupt source
+  *            @arg @ref ADC_IT_AWD1,   ADC Analog watchdog 1 interrupt source (main analog watchdog)
+  *            @arg @ref ADC_IT_AWD2,   ADC Analog watchdog 2 interrupt source (additional analog watchdog)
+  *            @arg @ref ADC_IT_AWD3,  ADC Analog watchdog 3 interrupt source (additional analog watchdog)
+  *            @arg @ref ADC_IT_JQOVF,  ADC Injected Context Queue Overflow interrupt source. 
+  * @retval None
+  */
+#define __HAL_ADC_ENABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->IER) |= (__INTERRUPT__))
+
+/**
+  * @brief Disable an ADC interrupt.
+  * @param __HANDLE__: ADC handle.
+  * @param __INTERRUPT__: ADC Interrupt to disable
+  *            @arg @ref ADC_IT_RDY,    ADC Ready (ADRDY) interrupt source
+  *            @arg @ref ADC_IT_EOSMP,  ADC End of Sampling interrupt source
+  *            @arg @ref ADC_IT_EOC,    ADC End of Regular Conversion interrupt source
+  *            @arg @ref ADC_IT_EOS,    ADC End of Regular sequence of Conversions interrupt source
+  *            @arg @ref ADC_IT_OVR,    ADC overrun interrupt source
+  *            @arg @ref ADC_IT_JEOC,   ADC End of Injected Conversion interrupt source
+  *            @arg @ref ADC_IT_JEOS,   ADC End of Injected sequence of Conversions interrupt source
+  *            @arg @ref ADC_IT_AWD1,   ADC Analog watchdog 1 interrupt source (main analog watchdog)
+  *            @arg @ref ADC_IT_AWD2,   ADC Analog watchdog 2 interrupt source (additional analog watchdog)
+  *            @arg @ref ADC_IT_AWD3,   ADC Analog watchdog 3 interrupt source (additional analog watchdog)
+  *            @arg @ref ADC_IT_JQOVF,  ADC Injected Context Queue Overflow interrupt source. 
+  * @retval None
+  */
+#define __HAL_ADC_DISABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->IER) &= ~(__INTERRUPT__))
+
+/**
+  * @brief Check whether the specified ADC flag is set or not.
+  * @param __HANDLE__: ADC handle.
+  * @param __FLAG__: ADC flag to check
+  *        This parameter can be one of the following values:
+  *            @arg @ref ADC_FLAG_RDY,     ADC Ready (ADRDY) flag                              
+  *            @arg @ref ADC_FLAG_EOSMP,   ADC End of Sampling flag                            
+  *            @arg @ref ADC_FLAG_EOC,     ADC End of Regular Conversion flag                  
+  *            @arg @ref ADC_FLAG_EOS,     ADC End of Regular sequence of Conversions flag     
+  *            @arg @ref ADC_FLAG_OVR,     ADC overrun flag        
+  *            @arg @ref ADC_FLAG_JEOC,    ADC End of Injected Conversion flag                 
+  *            @arg @ref ADC_FLAG_JEOS,    ADC End of Injected sequence of Conversions flag    
+  *            @arg @ref ADC_FLAG_AWD1,    ADC Analog watchdog 1 flag (main analog watchdog)
+  *            @arg @ref ADC_FLAG_AWD2,    ADC Analog watchdog 2 flag (additional analog watchdog)
+  *            @arg @ref ADC_FLAG_AWD3,    ADC Analog watchdog 3 flag (additional analog watchdog)
+  *            @arg @ref ADC_FLAG_JQOVF,   ADC Injected Context Queue Overflow flag.            
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_ADC_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->ISR) & (__FLAG__)) == (__FLAG__))
+
+/**
+  * @brief Clear a specified ADC flag.
+  * @param __HANDLE__: ADC handle.
+  * @param __FLAG__: ADC flag to clear
+  *        This parameter can be one of the following values:
+  *            @arg @ref ADC_FLAG_RDY,     ADC Ready (ADRDY) flag                              
+  *            @arg @ref ADC_FLAG_EOSMP,   ADC End of Sampling flag                            
+  *            @arg @ref ADC_FLAG_EOC,     ADC End of Regular Conversion flag                  
+  *            @arg @ref ADC_FLAG_EOS,     ADC End of Regular sequence of Conversions flag     
+  *            @arg @ref ADC_FLAG_OVR,     ADC overrun flag        
+  *            @arg @ref ADC_FLAG_JEOC,    ADC End of Injected Conversion flag                 
+  *            @arg @ref ADC_FLAG_JEOS,    ADC End of Injected sequence of Conversions flag    
+  *            @arg @ref ADC_FLAG_AWD1,    ADC Analog watchdog 1 flag (main analog watchdog)
+  *            @arg @ref ADC_FLAG_AWD2,    ADC Analog watchdog 2 flag (additional analog watchdog)
+  *            @arg @ref ADC_FLAG_AWD3,    ADC Analog watchdog 3 flag (additional analog watchdog)
+  *            @arg @ref ADC_FLAG_JQOVF,   ADC Injected Context Queue Overflow flag.   
+  * @note  Bit cleared bit by writing 1 (writing 0 has no effect on any bit of register ISR).
+  * @retval None
+  */
+#define __HAL_ADC_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->ISR) = (__FLAG__))
+       
+
+/**
+  * @}
+  */
+
+/* Include ADC HAL Extended module */
+#include "stm32l4xx_hal_adc_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup ADC_Exported_Functions ADC Exported Functions
+  * @{
+  */ 
+
+/** @addtogroup ADC_Exported_Functions_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ * @{
+ */ 
+/* Initialization and de-initialization functions  **********************************/
+HAL_StatusTypeDef       HAL_ADC_Init(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADC_DeInit(ADC_HandleTypeDef *hadc);
+void                    HAL_ADC_MspInit(ADC_HandleTypeDef* hadc);
+void                    HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc);
+/**
+  * @}
+  */
+
+/** @addtogroup ADC_Exported_Functions_Group2 Input and Output operation functions
+ *  @brief    IO operation functions 
+ * @{
+ */ 
+/* Blocking mode: Polling */
+HAL_StatusTypeDef       HAL_ADC_Start(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADC_Stop(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout);
+HAL_StatusTypeDef       HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout);
+
+/* Non-blocking mode: Interruption */
+HAL_StatusTypeDef       HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc);
+
+/* Non-blocking mode: DMA */
+HAL_StatusTypeDef       HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length);
+HAL_StatusTypeDef       HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc);
+
+/* ADC retrieve conversion value intended to be used with polling or interruption */
+uint32_t                HAL_ADC_GetValue(ADC_HandleTypeDef* hadc);
+
+/* ADC IRQHandler and Callbacks used in non-blocking modes (Interruption and DMA) */
+void                    HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc);
+void                    HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc);
+void                    HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc);
+void                    HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef* hadc);
+void                    HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc);
+/**
+  * @}
+  */
+
+/** @addtogroup ADC_Exported_Functions_Group3 Peripheral Control functions
+ *  @brief    Peripheral Control functions 
+ * @{
+ */ 
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef       HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig);
+HAL_StatusTypeDef       HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig);
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group4 Peripheral State functions
+ *  @brief   ADC Peripheral State functions 
+ * @{
+ */ 
+/* Peripheral State functions *************************************************/
+uint32_t      HAL_ADC_GetState(ADC_HandleTypeDef* hadc);
+uint32_t      HAL_ADC_GetError(ADC_HandleTypeDef *hadc);
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */   
+
+/* Private functions -----------------------------------------------------------*/
+/** @addtogroup ADC_Private_Functions ADC Private Functions
+  * @{
+  */
+ 
+HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef* hadc, uint32_t ConversionGroup);
+HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef* hadc);
+void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma);
+void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma);
+void ADC_DMAError(DMA_HandleTypeDef *hdma);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32L4xx_ADC_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_adc_ex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_adc_ex.h
@@ -1,0 +1,1494 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_adc_ex.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of ADC HAL extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_ADC_EX_H
+#define __STM32L4xx_ADC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+   
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ADCEx ADCEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup ADCEx_Exported_Types ADC Extended Exported Types
+  * @{
+  */
+
+/** 
+  * @brief  ADC Injected Conversion Oversampling structure definition  
+  */
+typedef struct
+{
+  uint32_t Ratio;                         /*!< Configures the oversampling ratio.
+                                               This parameter can be a value of @ref ADCEx_Oversampling_Ratio */
+                                               
+  uint32_t RightBitShift;                 /*!< Configures the division coefficient for the Oversampler.
+                                               This parameter can be a value of @ref ADCEx_Right_Bit_Shift */
+}ADC_InjOversamplingTypeDef;  
+
+
+
+/** 
+  * @brief  Structure definition of ADC injected group and ADC channel for injected group  
+  * @note   Parameters of this structure are shared within 2 scopes:
+  *          - Scope channel: InjectedChannel, InjectedRank, InjectedSamplingTime , InjectedSingleDiff, InjectedOffsetNumber, InjectedOffset
+  *          - Scope injected group (affects all channels of injected group): InjectedNbrOfConversion, InjectedDiscontinuousConvMode,
+  *            AutoInjectedConv, QueueInjectedContext, ExternalTrigInjecConvEdge, ExternalTrigInjecConv, InjecOversamplingMode, InjecOversampling.
+  * @note   The setting of these parameters by function HAL_ADCEx_InjectedConfigChannel() is conditioned by ADC state.
+  *         ADC state can be either:
+  *          - For all parameters: ADC disabled (this is the only possible ADC state to modify parameter 'InjectedSingleDiff')
+  *          - For parameters 'InjectedDiscontinuousConvMode', 'QueueInjectedContext', 'InjecOversampling': ADC enabled without conversion on going on injected group.
+  *          - For parameters 'InjectedSamplingTime', 'InjectedOffset', 'InjectedOffsetNumber', 'AutoInjectedConv': ADC enabled without conversion on going on regular and injected groups.
+  *          - For parameters 'InjectedChannel', 'InjectedRank', 'InjectedNbrOfConversion', 'ExternalTrigInjecConv', 'ExternalTrigInjecConvEdge': ADC enabled and while conversion on going 
+  *            on regular and injected groups.
+  *         If ADC is not in the appropriate state to modify some parameters, these parameters setting is bypassed
+  *         without error reporting (as it can be the expected behaviour in case of intended action to update another parameter (which fulfills the ADC state condition) on the fly).
+  */
+typedef struct 
+{
+  uint32_t InjectedChannel;               /*!< Configure the ADC injected channel.
+                                               This parameter can be a value of @ref ADC_channels
+                                                Note: Depending on devices and ADC instances, some channels may not be available. Refer to device DataSheet for channels availability. */
+  uint32_t InjectedRank;                  /*!< The rank in the injected group sequencer.
+                                               This parameter must be a value of @ref ADCEx_injected_rank.
+                                               Note: to disable a channel or change order of conversion sequencer, rank containing a previous channel setting can be overwritten by 
+                                               the new channel setting (or parameter number of conversions adjusted). */
+  uint32_t InjectedSamplingTime;          /*!< Sampling time value to be set for the selected channel.
+                                               Unit: ADC clock cycles.
+                                               Conversion time is the addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits, 10.5 cycles at 10 bits,
+                                               8.5 cycles at 8 bits, 6.5 cycles at 6 bits).
+                                               This parameter can be a value of @ref ADC_sampling_times.
+                                               Caution: This parameter applies to a channel that can be used in a regular and/or injected group.
+                                                        It overwrites the last setting.
+                                               Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
+                                                     sampling time constraints must be respected (sampling time can be adjusted with respect to the ADC clock frequency and sampling time 
+                                                     setting). Refer to device DataSheet for timings values. */
+  uint32_t InjectedSingleDiff;            /*!< Selection of single-ended or differential input.
+                                               In differential mode: Differential measurement is between the selected channel 'i' (positive input) and channel 'i+1' (negative input).
+                                               Only channel 'i' has to be configured, channel 'i+1' is configured automatically.
+                                               This parameter must be a value of @ref ADCEx_SingleDifferential.
+                                               Caution: This parameter applies to a channel that can be used in a regular and/or injected group.
+                                                        It overwrites the last setting.
+                                               Note: Refer to Reference Manual to ensure the selected channel is available in differential mode.
+                                               Note: When configuring a channel 'i' in differential mode, the channel 'i+1' is not usable separately.
+                                               Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion).
+                                               If ADC is enabled, this parameter setting is bypassed without error reporting (as it can be the expected behaviour in case 
+                                               of another parameter update on the fly) */
+  uint32_t InjectedOffsetNumber;          /*!< Selects the offset number.
+                                               This parameter can be a value of @ref ADCEx_OffsetNumber.
+                                               Caution: Only one offset is allowed per channel. This parameter overwrites the last setting. */
+  uint32_t InjectedOffset;                /*!< Defines the offset to be subtracted from the raw converted data.
+                                               Offset value must be a positive number.
+                                               Depending of ADC resolution selected (12, 10, 8 or 6 bits), this parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFF, 
+                                               0x3FF, 0xFF or 0x3F respectively.
+                                               Note: This parameter must be modified when no conversion is on going on both regular and injected groups (ADC disabled, or ADC enabled 
+                                               without continuous mode or external trigger that could launch a conversion). */
+  uint32_t InjectedNbrOfConversion;       /*!< Specifies the number of ranks that will be converted within the injected group sequencer.
+                                               To use the injected group sequencer and convert several ranks, parameter 'ScanConvMode' must be enabled.
+                                               This parameter must be a number between Min_Data = 1 and Max_Data = 4.
+                                               Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                        configure a channel on injected group can impact the configuration of other channels previously set. */
+  uint32_t InjectedDiscontinuousConvMode; /*!< Specifies whether the conversions sequence of injected group is performed in Complete-sequence/Discontinuous-sequence (main sequence 
+                                               subdivided in successive parts).
+                                               Discontinuous mode is used only if sequencer is enabled (parameter 'ScanConvMode'). If sequencer is disabled, this parameter is discarded.
+                                               Discontinuous mode can be enabled only if continuous mode is disabled. 
+                                               This parameter can be set to ENABLE or DISABLE.
+                                               Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion).
+                                               Note: For injected group, discontinuous mode converts the sequence channel by channel (only one channel at a time).
+                                               Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                        configure a channel on injected group can impact the configuration of other channels previously set. */
+  uint32_t AutoInjectedConv;              /*!< Enables or disables the selected ADC automatic injected group conversion after regular one
+                                               This parameter can be set to ENABLE or DISABLE.      
+                                               Note: To use Automatic injected conversion, discontinuous mode must be disabled ('DiscontinuousConvMode' and 'InjectedDiscontinuousConvMode' set to DISABLE)
+                                               Note: To use Automatic injected conversion, injected group external triggers must be disabled.
+                                               Note: In case of DMA used with regular group: if DMA configured in normal mode (single shot) JAUTO will be stopped upon DMA transfer complete.
+                                                     To maintain JAUTO always enabled, DMA must be configured in circular mode.
+                                               Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                        configure a channel on injected group can impact the configuration of other channels previously set. */
+  uint32_t QueueInjectedContext;          /*!< Specifies whether the context queue feature is enabled.
+                                               This parameter can be set to ENABLE or DISABLE.
+                                               If context queue is enabled, injected sequencer&channels configurations are queued on up to 2 contexts. If a
+                                               new injected context is set when queue is full, error is triggered by interruption and through function 
+                                               'HAL_ADCEx_InjectedQueueOverflowCallback'.
+                                               Caution: This feature request that the sequence is fully configured before injected conversion start.
+                                                        Therefore, configure channels with as many calls to HAL_ADCEx_InjectedConfigChannel() as the 'InjectedNbrOfConversion' parameter.
+                                               Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                        configure a channel on injected group can impact the configuration of other channels previously set.
+                                               Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion). */
+  uint32_t ExternalTrigInjecConv;         /*!< Selects the external event used to trigger the conversion start of injected group.
+                                               If set to ADC_INJECTED_SOFTWARE_START, external triggers are disabled and software trigger is used instead.
+                                               This parameter can be a value of @ref ADCEx_Injected_External_Trigger_Source.
+                                               Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                        configure a channel on injected group can impact the configuration of other channels previously set. */
+  uint32_t ExternalTrigInjecConvEdge;     /*!< Selects the external trigger edge of injected group.
+                                               This parameter can be a value of @ref ADCEx_Injected_External_Trigger_Source_Edge.
+                                               If trigger edge is set to ADC_EXTERNALTRIGINJECCONV_EDGE_NONE, external triggers are disabled and software trigger is used instead.
+                                               Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to 
+                                                        configure a channel on injected group can impact the configuration of other channels previously set. */
+                                                                                                
+  uint32_t InjecOversamplingMode;             /*!< Specifies whether the oversampling feature is enabled or disabled.
+                                              This parameter can be set to ENABLE or DISABLE.
+                                              Note: This parameter can be modified only if there is no conversion is ongoing (both ADSTART and JADSTART cleared). */
+                                              
+  ADC_InjOversamplingTypeDef  InjecOversampling;   /*!< Specifies the Oversampling parameters.
+                                                   Caution: this setting overwrites the previous oversampling configuration if oversampling already enabled.    
+                                                   Note: This parameter can be modified only if there is no conversion is ongoing (both ADSTART and JADSTART cleared). */                                                          
+}ADC_InjectionConfTypeDef;
+
+
+/** 
+  * @brief  Structure definition of ADC multimode
+  * @note   The setting of these parameters by function HAL_ADCEx_MultiModeConfigChannel() is conditioned by ADCs state (both Master and Slave ADCs).
+  *         Both Master and Slave ADCs must be disabled.
+  */
+typedef struct
+{
+  uint32_t Mode;              /*!< Configures the ADC to operate in independent or multimode. 
+                                   This parameter can be a value of @ref ADCEx_Common_mode. */
+  uint32_t DMAAccessMode;     /*!< Configures the DMA mode for multimode ADC:
+                                   selection whether 2 DMA channels (each ADC uses its own DMA channel) or 1 DMA channel (one DMA channel for both ADC, DMA of ADC master)
+                                   This parameter can be a value of @ref ADCEx_Direct_memory_access_mode_for_multimode. */
+  uint32_t TwoSamplingDelay;  /*!< Configures the Delay between 2 sampling phases.
+                                   This parameter can be a value of @ref ADCEx_delay_between_2_sampling_phases.
+                                   Delay range depends on selected resolution: 
+                                    from 1 to 12 clock cycles for 12 bits, from 1 to 10 clock cycles for 10 bits,
+                                    from 1 to 8 clock cycles for 8 bits, from 1 to 6 clock cycles for 6 bits.     */
+}ADC_MultiModeTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+  /** @defgroup ADCEx_Exported_Constants ADC Extended Exported Constants
+  * @{
+  */
+
+/** @defgroup ADCEx_SingleDifferential ADC Extended Single-ended/Differential input mode
+  * @{
+  */
+#define ADC_SINGLE_ENDED                ((uint32_t)0x00000000)       /*!< ADC channel set in single-ended input mode */
+#define ADC_DIFFERENTIAL_ENDED          ((uint32_t)ADC_CR_ADCALDIF)  /*!< ADC channel set in differential mode       */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_OffsetNumber ADC Extended Offset Number
+  * @{
+  */
+#define ADC_OFFSET_NONE               ((uint32_t)0x00)     /*!< No offset correction                           */
+#define ADC_OFFSET_1                  ((uint32_t)0x01)     /*!< Offset correction to apply to a first channel  */
+#define ADC_OFFSET_2                  ((uint32_t)0x02)     /*!< Offset correction to apply to a second channel */
+#define ADC_OFFSET_3                  ((uint32_t)0x03)     /*!< Offset correction to apply to a third channel  */
+#define ADC_OFFSET_4                  ((uint32_t)0x04)     /*!< Offset correction to apply to a fourth channel */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_regular_rank ADC Extended Regular Channel Rank
+  * @{
+  */
+#define ADC_REGULAR_RANK_1    ((uint32_t)0x00000001)       /*!< ADC regular conversion rank 1  */
+#define ADC_REGULAR_RANK_2    ((uint32_t)0x00000002)       /*!< ADC regular conversion rank 2  */
+#define ADC_REGULAR_RANK_3    ((uint32_t)0x00000003)       /*!< ADC regular conversion rank 3  */
+#define ADC_REGULAR_RANK_4    ((uint32_t)0x00000004)       /*!< ADC regular conversion rank 4  */
+#define ADC_REGULAR_RANK_5    ((uint32_t)0x00000005)       /*!< ADC regular conversion rank 5  */
+#define ADC_REGULAR_RANK_6    ((uint32_t)0x00000006)       /*!< ADC regular conversion rank 6  */
+#define ADC_REGULAR_RANK_7    ((uint32_t)0x00000007)       /*!< ADC regular conversion rank 7  */
+#define ADC_REGULAR_RANK_8    ((uint32_t)0x00000008)       /*!< ADC regular conversion rank 8  */
+#define ADC_REGULAR_RANK_9    ((uint32_t)0x00000009)       /*!< ADC regular conversion rank 9  */
+#define ADC_REGULAR_RANK_10   ((uint32_t)0x0000000A)       /*!< ADC regular conversion rank 10 */
+#define ADC_REGULAR_RANK_11   ((uint32_t)0x0000000B)       /*!< ADC regular conversion rank 11 */
+#define ADC_REGULAR_RANK_12   ((uint32_t)0x0000000C)       /*!< ADC regular conversion rank 12 */
+#define ADC_REGULAR_RANK_13   ((uint32_t)0x0000000D)       /*!< ADC regular conversion rank 13 */
+#define ADC_REGULAR_RANK_14   ((uint32_t)0x0000000E)       /*!< ADC regular conversion rank 14 */
+#define ADC_REGULAR_RANK_15   ((uint32_t)0x0000000F)       /*!< ADC regular conversion rank 15 */
+#define ADC_REGULAR_RANK_16   ((uint32_t)0x00000010)       /*!< ADC regular conversion rank 16 */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_injected_rank ADC Extended Injected Channel Rank
+  * @{
+  */
+#define ADC_INJECTED_RANK_1    ((uint32_t)0x00000001)      /*!< ADC injected conversion rank 1 */
+#define ADC_INJECTED_RANK_2    ((uint32_t)0x00000002)      /*!< ADC injected conversion rank 2 */
+#define ADC_INJECTED_RANK_3    ((uint32_t)0x00000003)      /*!< ADC injected conversion rank 3 */
+#define ADC_INJECTED_RANK_4    ((uint32_t)0x00000004)      /*!< ADC injected conversion rank 4 */
+/**injected
+  * @}
+  */
+                        
+/** @defgroup ADCEx_Injected_External_Trigger_Source_Edge ADC External Trigger Source Edge for Injected Group
+  * @{
+  */
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_NONE           ((uint32_t)0x00000000)          /*!< Injected conversions hardware trigger detection disabled                             */ 
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_RISING         ((uint32_t)ADC_JSQR_JEXTEN_0)   /*!< Injected conversions hardware trigger detection on the rising edge                   */ 
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_FALLING        ((uint32_t)ADC_JSQR_JEXTEN_1)   /*!< Injected conversions hardware trigger detection on the falling edge                  */ 
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_RISINGFALLING  ((uint32_t)ADC_JSQR_JEXTEN)     /*!< Injected conversions hardware trigger detection on both the rising and falling edges */ 
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Injected_External_Trigger_Source ADC Extended External Trigger Source for Injected Group
+  * @{
+  */
+#define ADC_EXTERNALTRIGINJEC_T1_TRGO    ((uint32_t)0x00000000)                                                     /*!< Event 0 triggers injected group conversion start  */
+#define ADC_EXTERNALTRIGINJEC_T1_CC4     ((uint32_t)ADC_JSQR_JEXTSEL_0)                                             /*!< Event 1 triggers injected group conversion start  */
+#define ADC_EXTERNALTRIGINJEC_T2_TRGO    ((uint32_t)ADC_JSQR_JEXTSEL_1)                                             /*!< Event 2 triggers injected group conversion start  */
+#define ADC_EXTERNALTRIGINJEC_T2_CC1     ((uint32_t)(ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))                      /*!< Event 3 triggers injected group conversion start  */
+#define ADC_EXTERNALTRIGINJEC_T3_CC4     ((uint32_t)ADC_JSQR_JEXTSEL_2)                                             /*!< Event 4 triggers injected group conversion start  */
+#define ADC_EXTERNALTRIGINJEC_T4_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))                      /*!< Event 5 triggers injected group conversion start  */
+#define ADC_EXTERNALTRIGINJEC_EXT_IT15   ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))                      /*!< Event 6 triggers injected group conversion start  */
+#define ADC_EXTERNALTRIGINJEC_T8_CC4     ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0)) /*!< Event 7 triggers injected group conversion start  */
+#define ADC_EXTERNALTRIGINJEC_T1_TRGO2   ((uint32_t)ADC_JSQR_JEXTSEL_3)                                             /*!< Event 8 triggers injected group conversion start  */
+#define ADC_EXTERNALTRIGINJEC_T8_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_0))                      /*!< Event 9 triggers injected group conversion start  */
+#define ADC_EXTERNALTRIGINJEC_T8_TRGO2   ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1))                      /*!< Event 10 triggers injected group conversion start */
+#define ADC_EXTERNALTRIGINJEC_T3_CC3     ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0)) /*!< Event 11 triggers injected group conversion start */
+#define ADC_EXTERNALTRIGINJEC_T3_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2))                      /*!< Event 12 triggers injected group conversion start */
+#define ADC_EXTERNALTRIGINJEC_T3_CC1     ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0)) /*!< Event 13 triggers injected group conversion start */
+#define ADC_EXTERNALTRIGINJEC_T6_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1)) /*!< Event 14 triggers injected group conversion start */
+#define ADC_EXTERNALTRIGINJEC_T15_TRGO   ((uint32_t)ADC_JSQR_JEXTSEL)                                               /*!< Event 15 triggers injected group conversion start */
+
+#define ADC_INJECTED_SOFTWARE_START      ((uint32_t)0x00000001)                                                     /*!< Software triggers injected group conversion start */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Common_mode ADC Extended Dual ADC Mode
+  * @{
+  */
+#define ADC_MODE_INDEPENDENT                  ((uint32_t)(0x00000000))                                       /*!< Independent ADC conversions mode                           */
+#define ADC_DUALMODE_REGSIMULT_INJECSIMULT    ((uint32_t)(ADC_CCR_DUAL_0))                                   /*!< Combined regular simultaneous + injected simultaneous mode */
+#define ADC_DUALMODE_REGSIMULT_ALTERTRIG      ((uint32_t)(ADC_CCR_DUAL_1))                                   /*!< Combined regular simultaneous + alternate trigger mode     */
+#define ADC_DUALMODE_REGINTERL_INJECSIMULT    ((uint32_t)(ADC_CCR_DUAL_1 | ADC_CCR_DUAL_0))                  /*!< Combined Interleaved mode + injected simultaneous mode     */
+#define ADC_DUALMODE_INJECSIMULT              ((uint32_t)(ADC_CCR_DUAL_2 | ADC_CCR_DUAL_0))                  /*!< Injected simultaneous mode only                            */
+#define ADC_DUALMODE_REGSIMULT                ((uint32_t)(ADC_CCR_DUAL_2 | ADC_CCR_DUAL_1))                  /*!< Regular simultaneous mode only                             */
+#define ADC_DUALMODE_INTERL                   ((uint32_t)(ADC_CCR_DUAL_2 | ADC_CCR_DUAL_1 | ADC_CCR_DUAL_0)) /*!< Interleaved mode only                                      */
+#define ADC_DUALMODE_ALTERTRIG                ((uint32_t)(ADC_CCR_DUAL_3 | ADC_CCR_DUAL_0))                  /*!< Alternate trigger mode only                                */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Direct_memory_access_mode_for_multimode ADC Extended DMA Mode for Dual ADC Mode
+  * @{
+  */
+#define ADC_DMAACCESSMODE_DISABLED      ((uint32_t)0x00000000)       /*!< DMA multimode disabled: each ADC uses its own DMA channel */
+#define ADC_DMAACCESSMODE_12_10_BITS    ((uint32_t)ADC_CCR_MDMA_1)   /*!< DMA multimode enabled (one DMA channel for both ADC, DMA of ADC master) for 12 and 10 bits resolution */
+#define ADC_DMAACCESSMODE_8_6_BITS      ((uint32_t)ADC_CCR_MDMA)     /*!< DMA multimode enabled (one DMA channel for both ADC, DMA of ADC master) for 8 and 6 bits resolution */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_delay_between_2_sampling_phases ADC Extended Delay Between 2 Sampling Phases
+  * @{
+  */
+#define ADC_TWOSAMPLINGDELAY_1CYCLE     ((uint32_t)(0x00000000))                                          /*!< 1 ADC clock cycle delay                                     */ 
+#define ADC_TWOSAMPLINGDELAY_2CYCLES    ((uint32_t)(ADC_CCR_DELAY_0))                                     /*!< 2 ADC clock cycles delay                                    */ 
+#define ADC_TWOSAMPLINGDELAY_3CYCLES    ((uint32_t)(ADC_CCR_DELAY_1))                                     /*!< 3 ADC clock cycles delay                                    */ 
+#define ADC_TWOSAMPLINGDELAY_4CYCLES    ((uint32_t)(ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0))                   /*!< 4 ADC clock cycles delay                                    */ 
+#define ADC_TWOSAMPLINGDELAY_5CYCLES    ((uint32_t)(ADC_CCR_DELAY_2))                                     /*!< 5 ADC clock cycles delay                                    */ 
+#define ADC_TWOSAMPLINGDELAY_6CYCLES    ((uint32_t)(ADC_CCR_DELAY_2 | ADC_CCR_DELAY_0))                   /*!< 6 ADC clock cycles delay                                    */ 
+#define ADC_TWOSAMPLINGDELAY_7CYCLES    ((uint32_t)(ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1))                   /*!< 7 ADC clock cycles delay (lower for non 12-bit resolution)  */ 
+#define ADC_TWOSAMPLINGDELAY_8CYCLES    ((uint32_t)(ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0)) /*!< 8 ADC clock cycles delay (lower for non 12-bit resolution)  */ 
+#define ADC_TWOSAMPLINGDELAY_9CYCLES    ((uint32_t)(ADC_CCR_DELAY_3))                                     /*!< 9 ADC clock cycles delay (lower for non 12-bit resolution)  */ 
+#define ADC_TWOSAMPLINGDELAY_10CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_0))                   /*!< 10 ADC clock cycles delay (lower for non 12-bit resolution) */ 
+#define ADC_TWOSAMPLINGDELAY_11CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_1))                   /*!< 11 ADC clock cycles delay (lower for non 12-bit resolution) */ 
+#define ADC_TWOSAMPLINGDELAY_12CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0)) /*!< 12 ADC clock cycles delay (lower for non 12-bit resolution) */ 
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_analog_watchdog_number ADC Extended Analog Watchdog Selection
+  * @{
+  */
+#define ADC_ANALOGWATCHDOG_1                    ((uint32_t)0x00000001)   /*!< Analog watchdog 1 selection */ 
+#define ADC_ANALOGWATCHDOG_2                    ((uint32_t)0x00000002)   /*!< Analog watchdog 2 selection */ 
+#define ADC_ANALOGWATCHDOG_3                    ((uint32_t)0x00000003)   /*!< Analog watchdog 3 selection */ 
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_analog_watchdog_mode ADC Extended Analog Watchdog Mode
+  * @{
+  */
+#define ADC_ANALOGWATCHDOG_NONE                 ((uint32_t) 0x00000000)                                             /*!< No analog watchdog selected                                             */
+#define ADC_ANALOGWATCHDOG_SINGLE_REG           ((uint32_t)(ADC_CFGR_AWD1SGL | ADC_CFGR_AWD1EN))                    /*!< Analog watchdog applied to a regular group single channel               */
+#define ADC_ANALOGWATCHDOG_SINGLE_INJEC         ((uint32_t)(ADC_CFGR_AWD1SGL | ADC_CFGR_JAWD1EN))                   /*!< Analog watchdog applied to an injected group single channel             */
+#define ADC_ANALOGWATCHDOG_SINGLE_REGINJEC      ((uint32_t)(ADC_CFGR_AWD1SGL | ADC_CFGR_AWD1EN | ADC_CFGR_JAWD1EN)) /*!< Analog watchdog applied to a regular and injected groups single channel */
+#define ADC_ANALOGWATCHDOG_ALL_REG              ((uint32_t) ADC_CFGR_AWD1EN)                                        /*!< Analog watchdog applied to regular group all channels                   */
+#define ADC_ANALOGWATCHDOG_ALL_INJEC            ((uint32_t) ADC_CFGR_JAWD1EN)                                       /*!< Analog watchdog applied to injected group all channels                  */
+#define ADC_ANALOGWATCHDOG_ALL_REGINJEC         ((uint32_t)(ADC_CFGR_AWD1EN | ADC_CFGR_JAWD1EN))                    /*!< Analog watchdog applied to regular and injected groups all channels     */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_conversion_group ADC Extended Conversion Group
+  * @{
+  */                                                                                                            
+#define ADC_REGULAR_GROUP             ((uint32_t)(ADC_FLAG_EOC | ADC_FLAG_EOS))                                 /*!< ADC regular group selection               */ 
+#define ADC_INJECTED_GROUP            ((uint32_t)(ADC_FLAG_JEOC | ADC_FLAG_JEOS))                               /*!< ADC injected group selection              */ 
+#define ADC_REGULAR_INJECTED_GROUP    ((uint32_t)(ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_JEOC | ADC_FLAG_JEOS)) /*!< ADC regular and injected groups selection */ 
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Event_type ADC Extended Event Type
+  * @{
+  */
+#define ADC_EOSMP_EVENT          ((uint32_t)ADC_FLAG_EOSMP) /*!< ADC End of Sampling event                                */
+#define ADC_AWD1_EVENT           ((uint32_t)ADC_FLAG_AWD1)  /*!< ADC Analog watchdog 1 event (main analog watchdog)       */
+#define ADC_AWD2_EVENT           ((uint32_t)ADC_FLAG_AWD2)  /*!< ADC Analog watchdog 2 event (additional analog watchdog) */
+#define ADC_AWD3_EVENT           ((uint32_t)ADC_FLAG_AWD3)  /*!< ADC Analog watchdog 3 event (additional analog watchdog) */
+#define ADC_OVR_EVENT            ((uint32_t)ADC_FLAG_OVR)   /*!< ADC overrun event                                        */
+#define ADC_JQOVF_EVENT          ((uint32_t)ADC_FLAG_JQOVF) /*!< ADC Injected Context Queue Overflow event                */
+
+#define ADC_AWD_EVENT            ADC_AWD1_EVENT      /*!< ADC Analog watchdog 1 event: Naming for compatibility with other STM32 devices having only one analog watchdog */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_interrupts_definition ADC Extended Interrupts Definition
+  * @{
+  */
+#define ADC_IT_RDY           ADC_IER_ADRDY      /*!< ADC Ready (ADRDY) interrupt source */
+#define ADC_IT_EOSMP         ADC_IER_EOSMP      /*!< ADC End of sampling interrupt source */
+#define ADC_IT_EOC           ADC_IER_EOC        /*!< ADC End of regular conversion interrupt source */
+#define ADC_IT_EOS           ADC_IER_EOS        /*!< ADC End of regular sequence of conversions interrupt source */
+#define ADC_IT_OVR           ADC_IER_OVR        /*!< ADC overrun interrupt source */
+#define ADC_IT_JEOC          ADC_IER_JEOC       /*!< ADC End of injected conversion interrupt source */
+#define ADC_IT_JEOS          ADC_IER_JEOS       /*!< ADC End of injected sequence of conversions interrupt source */
+#define ADC_IT_AWD1          ADC_IER_AWD1       /*!< ADC Analog watchdog 1 interrupt source (main analog watchdog) */
+#define ADC_IT_AWD2          ADC_IER_AWD2       /*!< ADC Analog watchdog 2 interrupt source (additional analog watchdog) */
+#define ADC_IT_AWD3          ADC_IER_AWD3       /*!< ADC Analog watchdog 3 interrupt source (additional analog watchdog) */
+#define ADC_IT_JQOVF         ADC_IER_JQOVF      /*!< ADC Injected Context Queue Overflow interrupt source */
+
+#define ADC_IT_AWD           ADC_IT_AWD1        /*!< ADC Analog watchdog 1 interrupt source: naming for compatibility with other STM32 devices having only one analog watchdog */
+
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_flags_definition ADC Extended Flags Definition
+  * @{
+  */
+#define ADC_FLAG_RDY           ADC_ISR_ADRDY    /*!< ADC Ready (ADRDY) flag */
+#define ADC_FLAG_EOSMP         ADC_ISR_EOSMP    /*!< ADC End of Sampling flag */
+#define ADC_FLAG_EOC           ADC_ISR_EOC      /*!< ADC End of Regular Conversion flag */
+#define ADC_FLAG_EOS           ADC_ISR_EOS      /*!< ADC End of Regular sequence of Conversions flag */
+#define ADC_FLAG_OVR           ADC_ISR_OVR      /*!< ADC overrun flag */
+#define ADC_FLAG_JEOC          ADC_ISR_JEOC     /*!< ADC End of Injected Conversion flag */
+#define ADC_FLAG_JEOS          ADC_ISR_JEOS     /*!< ADC End of Injected sequence of Conversions flag */
+#define ADC_FLAG_AWD1          ADC_ISR_AWD1     /*!< ADC Analog watchdog 1 flag (main analog watchdog) */
+#define ADC_FLAG_AWD2          ADC_ISR_AWD2     /*!< ADC Analog watchdog 2 flag (additional analog watchdog) */
+#define ADC_FLAG_AWD3          ADC_ISR_AWD3     /*!< ADC Analog watchdog 3 flag (additional analog watchdog) */
+#define ADC_FLAG_JQOVF         ADC_ISR_JQOVF    /*!< ADC Injected Context Queue Overflow flag */
+
+#define ADC_FLAG_AWD           ADC_FLAG_AWD1    /*!< ADC Analog watchdog 1 flag: Naming for compatibility with other STM32 devices having only one analog watchdog */
+
+#define ADC_FLAG_ALL    (ADC_FLAG_RDY | ADC_FLAG_EOSMP | ADC_FLAG_EOC | ADC_FLAG_EOS |  \
+                         ADC_FLAG_JEOC | ADC_FLAG_JEOS | ADC_FLAG_OVR | ADC_FLAG_AWD1 | \
+                         ADC_FLAG_AWD2 | ADC_FLAG_AWD3 | ADC_FLAG_JQOVF)   /*!< ADC all flags */
+
+/* Combination of all post-conversion flags bits: EOC/EOS, JEOC/JEOS, OVR, AWDx, JQOVF */
+#define ADC_FLAG_POSTCONV_ALL (ADC_FLAG_EOC | ADC_FLAG_EOS  | ADC_FLAG_JEOC | ADC_FLAG_JEOS | \
+                               ADC_FLAG_OVR | ADC_FLAG_AWD1 | ADC_FLAG_AWD2 | ADC_FLAG_AWD3 | \
+                               ADC_FLAG_JQOVF)                             /*!< ADC post-conversion all flags */
+
+/**
+  * @}
+  */
+
+       
+/** @defgroup ADCEx_injected_rank ADC Extended Injected Channel Rank
+  * @{
+  */
+#define ADC_INJECTED_RANK_1    ((uint32_t)0x00000001)   /*!< ADC injected conversion rank 1 */
+#define ADC_INJECTED_RANK_2    ((uint32_t)0x00000002)   /*!< ADC injected conversion rank 2 */
+#define ADC_INJECTED_RANK_3    ((uint32_t)0x00000003)   /*!< ADC injected conversion rank 3 */
+#define ADC_INJECTED_RANK_4    ((uint32_t)0x00000004)   /*!< ADC injected conversion rank 4 */
+/**
+  * @}
+  */
+
+
+
+/** @defgroup ADCEx_Oversampling_Ratio    ADC Extended Oversampling Ratio
+  * @{
+  */
+
+#define ADC_OVERSAMPLING_RATIO_2      ((uint32_t)0x00000000)                            /*!<  ADC Oversampling ratio 2x   */
+#define ADC_OVERSAMPLING_RATIO_4      ((uint32_t)ADC_CFGR2_OVSR_0)                      /*!<  ADC Oversampling ratio 4x   */
+#define ADC_OVERSAMPLING_RATIO_8      ((uint32_t)ADC_CFGR2_OVSR_1)                      /*!<  ADC Oversampling ratio 8x   */
+#define ADC_OVERSAMPLING_RATIO_16     ((uint32_t)(ADC_CFGR2_OVSR_1 | ADC_CFGR2_OVSR_0)) /*!<  ADC Oversampling ratio 16x  */
+#define ADC_OVERSAMPLING_RATIO_32     ((uint32_t)ADC_CFGR2_OVSR_2)                      /*!<  ADC Oversampling ratio 32x  */
+#define ADC_OVERSAMPLING_RATIO_64     ((uint32_t)(ADC_CFGR2_OVSR_2 | ADC_CFGR2_OVSR_0)) /*!<  ADC Oversampling ratio 64x  */
+#define ADC_OVERSAMPLING_RATIO_128    ((uint32_t)(ADC_CFGR2_OVSR_2 | ADC_CFGR2_OVSR_1)) /*!<  ADC Oversampling ratio 128x */
+#define ADC_OVERSAMPLING_RATIO_256    ((uint32_t)(ADC_CFGR2_OVSR))                      /*!<  ADC Oversampling ratio 256x */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Right_Bit_Shift   ADC Extended Oversampling Right Shift
+  * @{
+  */
+#define ADC_RIGHTBITSHIFT_NONE  ((uint32_t)0x00000000)                                               /*!<  ADC No bit shift for oversampling */
+#define ADC_RIGHTBITSHIFT_1     ((uint32_t)ADC_CFGR2_OVSS_0)                                         /*!<  ADC 1 bit shift for oversampling  */
+#define ADC_RIGHTBITSHIFT_2     ((uint32_t)ADC_CFGR2_OVSS_1)                                         /*!<  ADC 2 bits shift for oversampling */
+#define ADC_RIGHTBITSHIFT_3     ((uint32_t)(ADC_CFGR2_OVSS_1 | ADC_CFGR2_OVSS_0))                    /*!<  ADC 3 bits shift for oversampling */
+#define ADC_RIGHTBITSHIFT_4     ((uint32_t)ADC_CFGR2_OVSS_2)                                         /*!<  ADC 4 bits shift for oversampling */
+#define ADC_RIGHTBITSHIFT_5     ((uint32_t)(ADC_CFGR2_OVSS_2 | ADC_CFGR2_OVSS_0))                    /*!<  ADC 5 bits shift for oversampling */
+#define ADC_RIGHTBITSHIFT_6     ((uint32_t)(ADC_CFGR2_OVSS_2 | ADC_CFGR2_OVSS_1))                    /*!<  ADC 6 bits shift for oversampling */
+#define ADC_RIGHTBITSHIFT_7     ((uint32_t)(ADC_CFGR2_OVSS_2 | ADC_CFGR2_OVSS_1 | ADC_CFGR2_OVSS_0)) /*!<  ADC 7 bits shift for oversampling */
+#define ADC_RIGHTBITSHIFT_8     ((uint32_t)ADC_CFGR2_OVSS_3)                                         /*!<  ADC 8 bits shift for oversampling */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Triggered_Oversampling_Mode   ADC Extended Triggered Regular Oversampling
+  * @{
+  */
+#define ADC_TRIGGEREDMODE_SINGLE_TRIGGER      ((uint32_t)0x00000000)      /*!<  A single trigger for all channel oversampled conversions */
+#define ADC_TRIGGEREDMODE_MULTI_TRIGGER       ((uint32_t)ADC_CFGR2_TROVS) /*!<  A trigger for each oversampled conversion                */
+/**
+  * @}
+  */
+  
+/** @defgroup ADCEx_Regular_Oversampling_Mode   ADC Extended Regular Oversampling Continued or Resumed Mode
+  * @{
+  */
+#define ADC_REGOVERSAMPLING_CONTINUED_MODE    ((uint32_t)0x00000000)      /*!<  Oversampling buffer maintained during injection sequence */
+#define ADC_REGOVERSAMPLING_RESUMED_MODE      ((uint32_t)ADC_CFGR2_ROVSM) /*!<  Oversampling buffer zeroed during injection sequence     */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_CFGR_fields ADCx CFGR fields
+  * @{
+  */
+#define ADC_CFGR_FIELDS    (ADC_CFGR_AWD1CH  | ADC_CFGR_JAUTO   | ADC_CFGR_JAWD1EN |\
+                            ADC_CFGR_AWD1EN  | ADC_CFGR_AWD1SGL | ADC_CFGR_JQM     |\
+                            ADC_CFGR_JDISCEN | ADC_CFGR_DISCNUM | ADC_CFGR_DISCEN  |\
+                            ADC_CFGR_AUTDLY  | ADC_CFGR_CONT    | ADC_CFGR_OVRMOD  |\
+                            ADC_CFGR_EXTEN   | ADC_CFGR_EXTSEL  | ADC_CFGR_ALIGN   |\
+                            ADC_CFGR_RES     | ADC_CFGR_DMACFG  | ADC_CFGR_DMAEN   )
+/**
+  * @}
+  */  
+  
+/** @defgroup ADC_SMPR1_fields ADCx SMPR1 fields
+  * @{
+  */
+#define ADC_SMPR1_FIELDS    (ADC_SMPR1_SMP9 | ADC_SMPR1_SMP8 | ADC_SMPR1_SMP7 |\
+                             ADC_SMPR1_SMP6 | ADC_SMPR1_SMP5 | ADC_SMPR1_SMP4 |\
+                             ADC_SMPR1_SMP3 | ADC_SMPR1_SMP2 | ADC_SMPR1_SMP1 |\
+                             ADC_SMPR1_SMP0) 
+/**
+  * @}
+  */ 
+  
+/** @defgroup ADC_CFGR_fields_2 ADCx CFGR sub fields 
+  * @{
+  */
+/* ADC_CFGR fields of parameters that can be updated when no conversion
+   (neither regular nor injected) is on-going  */  
+#define ADC_CFGR_FIELDS_2  ((uint32_t)(ADC_CFGR_DMACFG | ADC_CFGR_AUTDLY))
+/**
+  * @}
+  */ 
+  
+/**
+  * @}
+  */
+
+
+
+/* Private macros -----------------------------------------------------------*/
+
+/** @defgroup ADCEx_Private_Macro_internal_HAL_driver ADC Extended Private Macros
+  * @{
+  */
+  
+/**
+  * @brief Test if conversion trigger of injected group is software start
+  *        or external trigger.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (software start) or RESET (external trigger).
+  */
+#define ADC_IS_SOFTWARE_START_INJECTED(__HANDLE__)                       \
+       (((__HANDLE__)->Instance->JSQR & ADC_JSQR_JEXTEN) == RESET)
+
+/**
+  * @brief Check if conversion is on going on regular or injected groups.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (conversion is on going) or RESET (no conversion is on going).
+  */
+#define ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(__HANDLE__)                    \
+       (( (((__HANDLE__)->Instance->CR) & (ADC_CR_ADSTART | ADC_CR_JADSTART)) == RESET  \
+        ) ? RESET : SET)
+        
+
+/**
+  * @brief Check if conversion is on going on injected group.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (conversion is on going) or RESET (no conversion is on going).
+  */
+#define ADC_IS_CONVERSION_ONGOING_INJECTED(__HANDLE__)                   \
+       (( (((__HANDLE__)->Instance->CR) & ADC_CR_JADSTART) == RESET            \
+        ) ? RESET : SET)  
+                      
+
+        
+/**
+  * @brief Check whether or not ADC is independent.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (ADC is independent) or RESET (ADC is not).
+  */
+#define ADC_IS_INDEPENDENT(__HANDLE__)    \
+  ( ( ( ((__HANDLE__)->Instance) == ADC3) \
+    )?                                    \
+     SET                                  \
+     :                                    \
+     RESET                                \
+  ) 
+      
+
+/**
+  * @brief Set the sample time for Channels numbers between 0 and 9.
+  * @param __SAMPLETIME__: Sample time parameter.
+  * @param __CHANNELNB__: Channel number.  
+  * @retval None
+  */
+#define ADC_SMPR1(__SAMPLETIME__, __CHANNELNB__) ((__SAMPLETIME__) << (POSITION_VAL(ADC_SMPR1_SMP1) * (__CHANNELNB__)))
+    
+/**
+  * @brief Set the sample time for Channels numbers between 10 and 18.
+  * @param __SAMPLETIME__: Sample time parameter.
+  * @param __CHANNELNB__: Channel number.  
+  * @retval None
+  */
+#define ADC_SMPR2(__SAMPLETIME__, __CHANNELNB__) ((__SAMPLETIME__) << ((POSITION_VAL(ADC_SMPR2_SMP11) * ((__CHANNELNB__) - 10))))
+
+/**
+  * @brief Write SMPR1 register.
+  * @param __HANDLE__    : ADC handle.
+  * @param __SAMPLETIME__: Sample time parameter.
+  * @param __CHANNELNB__ : Channel number.  
+  * @retval None
+  */
+#define ADC_SMPR1_SETTING(__HANDLE__, __SAMPLETIME__, __CHANNELNB__)           \
+                    MODIFY_REG((__HANDLE__)->Instance->SMPR1,                  \
+                               ADC_SMPR1(ADC_SMPR1_SMP0, (__CHANNELNB__)),     \
+                               ADC_SMPR1((__SAMPLETIME__), (__CHANNELNB__)))
+
+/**
+  * @brief Write SMPR2 register.
+  * @param __HANDLE__    : ADC handle.
+  * @param __SAMPLETIME__: Sample time parameter.
+  * @param __CHANNELNB__ : Channel number.  
+  * @retval None
+  */
+#define ADC_SMPR2_SETTING(__HANDLE__, __SAMPLETIME__, __CHANNELNB__)           \
+                    MODIFY_REG((__HANDLE__)->Instance->SMPR2,                  \
+                               ADC_SMPR2(ADC_SMPR2_SMP10, (__CHANNELNB__)),    \
+                               ADC_SMPR2((__SAMPLETIME__), (__CHANNELNB__)))
+
+
+/**
+  * @brief Set the selected regular Channel rank for rank between 1 and 4.
+  * @param __CHANNELNB__: Channel number.
+  * @param __RANKNB__: Rank number.    
+  * @retval None
+  */                                                                   
+#define ADC_SQR1_RK(__CHANNELNB__, __RANKNB__) ((__CHANNELNB__) << (POSITION_VAL(ADC_SQR1_SQ1) * (__RANKNB__)))
+
+/**
+  * @brief Set the selected regular Channel rank for rank between 5 and 9.
+  * @param __CHANNELNB__: Channel number.
+  * @param __RANKNB__: Rank number.    
+  * @retval None
+  */
+#define ADC_SQR2_RK(__CHANNELNB__, __RANKNB__) ((__CHANNELNB__) << (POSITION_VAL(ADC_SQR2_SQ6) * ((__RANKNB__) - 5)))
+
+/**
+  * @brief Set the selected regular Channel rank for rank between 10 and 14.
+  * @param __CHANNELNB__: Channel number.
+  * @param __RANKNB__: Rank number.    
+  * @retval None
+  */
+#define ADC_SQR3_RK(__CHANNELNB__, __RANKNB__) ((__CHANNELNB__) << (POSITION_VAL(ADC_SQR3_SQ11) * ((__RANKNB__) - 10)))
+
+/**
+  * @brief Set the selected regular Channel rank for rank between 15 and 16.
+  * @param __CHANNELNB__: Channel number.
+  * @param __RANKNB__: Rank number.    
+  * @retval None
+  */
+#define ADC_SQR4_RK(__CHANNELNB__, __RANKNB__) ((__CHANNELNB__) << (POSITION_VAL(ADC_SQR4_SQ16) * ((__RANKNB__) - 15)))
+
+/**
+  * @brief Set the selected injected Channel rank.
+  * @param __CHANNELNB__: Channel number.
+  * @param __RANKNB__: Rank number.   
+  * @retval None
+  */
+#define ADC_JSQR_RK(__CHANNELNB__, __RANKNB__) ((__CHANNELNB__) << ((POSITION_VAL(ADC_JSQR_JSQ1)-2) * (__RANKNB__) +2))
+
+
+/**
+  * @brief Set the Analog Watchdog 1 channel.
+  * @param __CHANNEL__: channel to be monitored by Analog Watchdog 1.
+  * @retval None
+  */
+#define ADC_CFGR_SET_AWD1CH(__CHANNEL__) ((__CHANNEL__) << POSITION_VAL(ADC_CFGR_AWD1CH))
+
+/**
+  * @brief Configure the channel number in Analog Watchdog 2 or 3.
+  * @param __CHANNEL__: ADC Channel
+  * @retval None
+  */
+#define ADC_CFGR_SET_AWD23CR(__CHANNEL__) (1U << (__CHANNEL__)) 
+
+/**
+  * @brief Configure ADC injected context queue
+  * @param __INJECT_CONTEXT_QUEUE_MODE__: Injected context queue mode.
+  * @retval None
+  */                                                                                            
+#define ADC_CFGR_INJECT_CONTEXT_QUEUE(__INJECT_CONTEXT_QUEUE_MODE__) ((__INJECT_CONTEXT_QUEUE_MODE__) << POSITION_VAL(ADC_CFGR_JQM))
+
+/**
+  * @brief Configure ADC discontinuous conversion mode for injected group
+  * @param __INJECT_DISCONTINUOUS_MODE__: Injected discontinuous mode.
+  * @retval None
+  */
+#define ADC_CFGR_INJECT_DISCCONTINUOUS(__INJECT_DISCONTINUOUS_MODE__) ((__INJECT_DISCONTINUOUS_MODE__) <<  POSITION_VAL(ADC_CFGR_JDISCEN))
+
+/**
+  * @brief Configure ADC discontinuous conversion mode for regular group
+  * @param __REG_DISCONTINUOUS_MODE__: Regular discontinuous mode.
+  * @retval None
+  */                                                                                                  
+#define ADC_CFGR_REG_DISCONTINUOUS(__REG_DISCONTINUOUS_MODE__) ((__REG_DISCONTINUOUS_MODE__) << POSITION_VAL(ADC_CFGR_DISCEN))
+/**
+  * @brief Configure the number of discontinuous conversions for regular group.
+  * @param __NBR_DISCONTINUOUS_CONV__: Number of discontinuous conversions.
+  * @retval None
+  */
+#define ADC_CFGR_DISCONTINUOUS_NUM(__NBR_DISCONTINUOUS_CONV__) (((__NBR_DISCONTINUOUS_CONV__) - 1) << POSITION_VAL(ADC_CFGR_DISCNUM))
+
+/**
+  * @brief Configure the ADC auto delay mode.
+  * @param __AUTOWAIT__: Auto delay bit enable or disable.
+  * @retval None
+  */
+#define ADC_CFGR_AUTOWAIT(__AUTOWAIT__) ((__AUTOWAIT__) << POSITION_VAL(ADC_CFGR_AUTDLY))
+
+/**
+  * @brief Configure ADC continuous conversion mode.
+  * @param __CONTINUOUS_MODE__: Continuous mode.
+  * @retval None
+  */
+#define ADC_CFGR_CONTINUOUS(__CONTINUOUS_MODE__) ((__CONTINUOUS_MODE__) << POSITION_VAL(ADC_CFGR_CONT))
+    
+/**
+  * @brief Configure the ADC DMA continuous request.
+  * @param __DMACONTREQ_MODE__: DMA continuous request mode.
+  * @retval None
+  */                                                                              
+#define ADC_CFGR_DMACONTREQ(__DMACONTREQ_MODE__) ((__DMACONTREQ_MODE__) <<  POSITION_VAL(ADC_CFGR_DMACFG))
+
+
+/**
+  * @brief Configure the channel number into offset OFRx register.
+  * @param __CHANNEL__: ADC Channel.
+  * @retval None
+  */
+#define ADC_OFR_CHANNEL(__CHANNEL__) ((__CHANNEL__) << POSITION_VAL(ADC_OFR1_OFFSET1_CH))
+
+/**
+  * @brief Configure the channel number into differential mode selection register.
+  * @param __CHANNEL__: ADC Channel.
+  * @retval None
+  */
+#define ADC_DIFSEL_CHANNEL(__CHANNEL__) (1U << (__CHANNEL__)) 
+
+/**
+  * @brief Configure calibration factor in differential mode to be set into calibration register.
+  * @param __CALIBRATION_FACTOR__: Calibration factor value.
+  * @retval None
+  */
+#define ADC_CALFACT_DIFF_SET(__CALIBRATION_FACTOR__) (((__CALIBRATION_FACTOR__) & (ADC_CALFACT_CALFACT_D >> POSITION_VAL(ADC_CALFACT_CALFACT_D)) ) << POSITION_VAL(ADC_CALFACT_CALFACT_D))
+/**
+  * @brief Calibration factor in differential mode to be retrieved from calibration register.
+  * @param __CALIBRATION_FACTOR__: Calibration factor value.
+  * @retval None
+  */                                                                                
+#define ADC_CALFACT_DIFF_GET(__CALIBRATION_FACTOR__) ((__CALIBRATION_FACTOR__) >> POSITION_VAL(ADC_CALFACT_CALFACT_D))
+     
+/**
+  * @brief Configure the analog watchdog high threshold into registers TR1, TR2 or TR3.
+  * @param __THRESHOLD__: Threshold value.
+  * @retval None
+  */
+#define ADC_TRX_HIGHTHRESHOLD(__THRESHOLD__) ((__THRESHOLD__) << 16)
+
+/**
+  * @brief Configure the ADC DMA continuous request for ADC multimode.
+  * @param __DMACONTREQ_MODE__: DMA continuous request mode.
+  * @retval None
+  */                                                                               
+#define ADC_CCR_MULTI_DMACONTREQ(__DMACONTREQ_MODE__) ((__DMACONTREQ_MODE__) << POSITION_VAL(ADC_CCR_DMACFG))
+
+/**
+  * @brief Enable the ADC peripheral.
+  * @param __HANDLE__: ADC handle.
+  * @retval None
+  */
+#define ADC_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR |= ADC_CR_ADEN)
+
+/**
+  * @brief Verification of hardware constraints before ADC can be enabled.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (ADC can be enabled) or RESET (ADC cannot be enabled)
+  */
+#define ADC_ENABLING_CONDITIONS(__HANDLE__)                             \
+       (( ( ((__HANDLE__)->Instance->CR) &                                    \
+            (ADC_CR_ADCAL | ADC_CR_JADSTP | ADC_CR_ADSTP | ADC_CR_JADSTART |  \
+             ADC_CR_ADSTART | ADC_CR_ADDIS | ADC_CR_ADEN                    ) \
+           ) == RESET                                                         \
+        ) ? SET : RESET)
+         
+/**
+  * @brief Disable the ADC peripheral.
+  * @param __HANDLE__: ADC handle.
+  * @retval None
+  */
+#define ADC_DISABLE(__HANDLE__)                                          \
+  do{                                                                          \
+         (__HANDLE__)->Instance->CR |= ADC_CR_ADDIS;                           \
+          __HAL_ADC_CLEAR_FLAG((__HANDLE__), (ADC_FLAG_EOSMP | ADC_FLAG_RDY)); \
+  } while(0)
+    
+/**
+  * @brief Verification of hardware constraints before ADC can be disabled.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (ADC can be disabled) or RESET (ADC cannot be disabled)
+  */
+#define ADC_DISABLING_CONDITIONS(__HANDLE__)                             \
+       (( ( ((__HANDLE__)->Instance->CR) &                                     \
+            (ADC_CR_JADSTART | ADC_CR_ADSTART | ADC_CR_ADEN)) == ADC_CR_ADEN   \
+        ) ? SET : RESET)
+         
+
+/**
+  * @brief Shift the offset with respect to the selected ADC resolution. 
+  * @note   Offset has to be left-aligned on bit 11, the LSB (right bits) are set to 0.
+  *         If resolution 12 bits, no shift.
+  *         If resolution 10 bits, shift of 2 ranks on the left.
+  *         If resolution 8 bits, shift of 4 ranks on the left.
+  *         If resolution 6 bits, shift of 6 ranks on the left.
+  *         Therefore, shift = (12 - resolution) = 12 - (12- (((RES[1:0]) >> 3)*2)).
+  * @param __HANDLE__: ADC handle
+  * @param __OFFSET__: Value to be shifted
+  * @retval None
+  */
+#define ADC_OFFSET_SHIFT_RESOLUTION(__HANDLE__, __OFFSET__) \
+        ((__OFFSET__) << ((((__HANDLE__)->Instance->CFGR & ADC_CFGR_RES) >> 3)*2))
+
+
+/**
+  * @brief Shift the AWD1 threshold with respect to the selected ADC resolution.
+  * @note  Thresholds have to be left-aligned on bit 11, the LSB (right bits) are set to 0.
+  *        If resolution 12 bits, no shift.
+  *        If resolution 10 bits, shift of 2 ranks on the left.
+  *        If resolution 8 bits, shift of 4 ranks on the left.
+  *        If resolution 6 bits, shift of 6 ranks on the left.
+  *        Therefore, shift = (12 - resolution) = 12 - (12- (((RES[1:0]) >> 3)*2)).
+  * @param __HANDLE__: ADC handle
+  * @param __THRESHOLD__: Value to be shifted
+  * @retval None
+  */
+#define ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(__HANDLE__, __THRESHOLD__) \
+        ((__THRESHOLD__) << ((((__HANDLE__)->Instance->CFGR & ADC_CFGR_RES) >> 3)*2))
+
+/**
+  * @brief Shift the AWD2 and AWD3 threshold with respect to the selected ADC resolution.
+  * @note  Thresholds have to be left-aligned on bit 7.
+  *        If resolution 12 bits, shift of 4 ranks on the right (the 4 LSB are discarded).
+  *        If resolution 10 bits, shift of 2 ranks on the right (the 2 LSB are discarded).
+  *        If resolution 8 bits, no shift.
+  *        If resolution 6 bits, shift of 2 ranks on the left (the 2 LSB are set to 0).
+  * @param __HANDLE__: ADC handle
+  * @param __THRESHOLD__: Value to be shifted
+  * @retval None
+  */
+#define ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(__HANDLE__, __THRESHOLD__) \
+         ( ((__HANDLE__)->Instance->CFGR & ADC_CFGR_RES) != (ADC_CFGR_RES_1 | ADC_CFGR_RES_0) ? \
+            ((__THRESHOLD__) >> (4- ((((__HANDLE__)->Instance->CFGR & ADC_CFGR_RES) >> 3)*2))) : \
+            (__THRESHOLD__) << 2 )
+
+        
+/**
+  * @brief Report ADC common register.
+  * @param __HANDLE__: ADC handle.
+  * @retval Common control register
+  */
+#define ADC_COMMON_REGISTER(__HANDLE__)   (ADC123_COMMON)       
+
+/**
+  * @brief Report Master Instance.
+  * @param __HANDLE__: ADC handle.
+  * @note return same instance if ADC of input handle is independent ADC.  
+  * @retval Master Instance
+  */
+#define ADC_MASTER_REGISTER(__HANDLE__)                                          \
+  ( ( ((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC3)) \
+    )?                                                                           \
+     ((__HANDLE__)->Instance)                                                    \
+     :                                                                           \
+     (ADC1)                                                                      \
+  )
+       
+
+/**
+  * @brief Clear Common Control Register.
+  * @param __HANDLE__: ADC handle.     
+  * @retval None
+  */
+#define ADC_CLEAR_COMMON_CONTROL_REGISTER(__HANDLE__) CLEAR_BIT(ADC_COMMON_REGISTER(__HANDLE__)->CCR, ADC_CCR_CKMODE | \
+                                                                                                      ADC_CCR_PRESC  | \
+                                                                                                      ADC_CCR_VBATEN | \
+                                                                                                      ADC_CCR_TSEN   | \
+                                                                                                      ADC_CCR_VREFEN | \
+                                                                                                      ADC_CCR_MDMA   | \
+                                                                                                      ADC_CCR_DMACFG | \
+                                                                                                      ADC_CCR_DELAY  | \
+                                                                                                      ADC_CCR_DUAL  )
+                                                      
+                                                      
+/**                                                   
+  * @brief Check whether or not dual conversions are enabled.
+  * @param __HANDLE__: ADC handle.
+  * @note Return RESET if ADC of input handle is independent ADC.   
+  * @retval SET (dual regular conversions are enabled) or RESET (ADC is independent or no dual regular conversions are enabled)
+  */
+#define ADC_IS_DUAL_CONVERSION_ENABLE(__HANDLE__)                                \
+  ( ( ((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC2)) \
+    )?                                                                           \
+     ( ((ADC123_COMMON->CCR & ADC_CCR_DUAL) != ADC_MODE_INDEPENDENT)  )          \
+     :                                                                           \
+     RESET                                                                       \
+  )
+       
+/**
+  * @brief Check whether or not dual regular conversions are enabled.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (dual regular conversions are enabled) or RESET (ADC is independent or no dual regular conversions are enabled)
+  */
+#define ADC_IS_DUAL_REGULAR_CONVERSION_ENABLE(__HANDLE__)                        \
+  ( ( ((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC2)) \
+    )?                                                                           \
+     ( (((ADC_COMMON_REGISTER(__HANDLE__))->CCR & ADC_CCR_DUAL) != ADC_MODE_INDEPENDENT)     &&      \
+       (((ADC_COMMON_REGISTER(__HANDLE__))->CCR & ADC_CCR_DUAL) != ADC_DUALMODE_INJECSIMULT) &&      \
+       (((ADC_COMMON_REGISTER(__HANDLE__))->CCR & ADC_CCR_DUAL) != ADC_DUALMODE_ALTERTRIG) )         \
+     :                                                                           \
+     RESET                                                                       \
+  )
+                        
+
+/**
+  * @brief Verification of condition for ADC start conversion: ADC must be in non-multimode or multimode with handle of ADC master.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (non-multimode or Master handle) or RESET (handle of Slave ADC in multimode)
+  */
+#define ADC_NONMULTIMODE_OR_MULTIMODEMASTER(__HANDLE__)                        \
+  ( ( ((__HANDLE__)->Instance == ADC1) || ((__HANDLE__)->Instance == ADC3)     \
+    )?                                                                         \
+     SET                                                                       \
+     :                                                                         \
+     ((ADC123_COMMON->CCR & ADC_CCR_DUAL) == RESET)                            \
+  )
+  
+/**
+  * @brief Ensure ADC Instance is Independent or Master, or is not Slave ADC with dual regular conversions enabled.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (Independent or Master, or Slave without dual regular conversions enabled) or RESET (Slave ADC with dual regular conversions enabled)
+  */
+#define ADC_INDEPENDENT_OR_NONMULTIMODEREGULAR_SLAVE(__HANDLE__)            \
+  ( ( ((__HANDLE__)->Instance == ADC1) || ((__HANDLE__)->Instance == ADC3)  \
+    )?                                                                      \
+     SET                                                                    \
+     :                                                                      \
+     ( ((ADC123_COMMON->CCR & ADC_CCR_DUAL) == ADC_MODE_INDEPENDENT)     || \
+       ((ADC123_COMMON->CCR & ADC_CCR_DUAL) == ADC_DUALMODE_INJECSIMULT) || \
+       ((ADC123_COMMON->CCR & ADC_CCR_DUAL) == ADC_DUALMODE_ALTERTRIG) ))  
+
+/**
+  * @brief Ensure ADC Instance is Independent or Master, or is not Slave ADC with dual injected conversions enabled.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (non-multimode or Master, or Slave without dual injected conversions enabled) or RESET (Slave ADC with dual injected conversions enabled)
+  */
+#define ADC_INDEPENDENT_OR_NONMULTIMODEINJECTED_SLAVE(__HANDLE__)          \
+  ( ( ((__HANDLE__)->Instance == ADC1) || ((__HANDLE__)->Instance == ADC3) \
+    )?                                                                     \
+     SET                                                                   \
+     :                                                                     \
+     ( ((ADC123_COMMON->CCR & ADC_CCR_DUAL) == ADC_MODE_INDEPENDENT)    || \
+       ((ADC123_COMMON->CCR & ADC_CCR_DUAL) == ADC_DUALMODE_REGSIMULT)  || \
+       ((ADC123_COMMON->CCR & ADC_CCR_DUAL) == ADC_DUALMODE_INTERL) ))
+  
+/**
+  * @brief Verification of ADC state: enabled or disabled, directly checked on instance as input parameter.
+  * @param __INSTANCE__: ADC instance.
+  * @retval SET (ADC enabled) or RESET (ADC disabled)
+  */
+#define ADC_INSTANCE_IS_ENABLED(__INSTANCE__)                                       \
+       (( ((((__INSTANCE__)->CR) & (ADC_CR_ADEN | ADC_CR_ADDIS)) == ADC_CR_ADEN) && \
+          ((((__INSTANCE__)->ISR) & ADC_FLAG_RDY) == ADC_FLAG_RDY)                  \
+        ) ? SET : RESET)  
+  
+/**
+  * @brief Verification of enabled/disabled status of ADCs other than that associated to the input parameter handle.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (at least one other ADC is enabled) or RESET (no other ADC is enabled, all other ADCs are disabled)
+  */ 
+#define ADC_ANY_OTHER_ENABLED(__HANDLE__)                                   \
+  ( ( ((__HANDLE__)->Instance == ADC1)                                      \
+    )?                                                                      \
+     (ADC_INSTANCE_IS_ENABLED(ADC2)) || (ADC_INSTANCE_IS_ENABLED(ADC3))     \
+     :                                                                      \
+     ( ( ((__HANDLE__)->Instance == ADC2)                                   \
+       )?                                                                   \
+         (ADC_INSTANCE_IS_ENABLED(ADC1)) || (ADC_INSTANCE_IS_ENABLED(ADC3)) \
+        :                                                                   \
+          ADC_INSTANCE_IS_ENABLED(ADC1)) || (ADC_INSTANCE_IS_ENABLED(ADC2)) \
+     )
+
+
+/**
+  * @brief Set handle instance of the ADC slave associated to the ADC master.
+  * @param __HANDLE_MASTER__: ADC master handle.
+  * @param __HANDLE_SLAVE__: ADC slave handle.
+  * @note if __HANDLE_MASTER__ is the handle of a slave ADC (ADC2) or an independent ADC (ADC3), __HANDLE_SLAVE__ instance is set to NULL.
+  * @retval None
+  */
+#define ADC_MULTI_SLAVE(__HANDLE_MASTER__, __HANDLE_SLAVE__)             \
+  ( (((__HANDLE_MASTER__)->Instance == ADC1)) ? ((__HANDLE_SLAVE__)->Instance = ADC2) : ((__HANDLE_SLAVE__)->Instance = NULL) ) 
+ 
+
+/**
+  * @brief Check whether or not multimode is configured in DMA mode.
+  * @retval SET (multimode is configured in DMA mode) or RESET (DMA multimode is disabled)
+  */ 
+#define ADC_MULTIMODE_DMA_ENABLED()                                     \
+    ((READ_BIT(ADC123_COMMON->CCR, ADC_CCR_MDMA) == ADC_DMAACCESSMODE_12_10_BITS) \
+  || (READ_BIT(ADC123_COMMON->CCR, ADC_CCR_MDMA) == ADC_DMAACCESSMODE_8_6_BITS))  
+ 
+
+/**
+  * @brief Verify the ADC instance connected to the temperature sensor.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (ADC instance is valid) or RESET (ADC instance is invalid)
+  */  
+/*  The temperature sensor measurement path (channel 17) is available on ADC1 and ADC3 */                        
+#define ADC_TEMPERATURE_SENSOR_INSTANCE(__HANDLE__)  ((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC3))
+
+/**
+  * @brief Verify the ADC instance connected to the battery voltage VBAT.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (ADC instance is valid) or RESET (ADC instance is invalid)
+  */  
+/*  The battery voltage measurement path (channel 18) is available on ADC1 and ADC3 */                        
+#define ADC_BATTERY_VOLTAGE_INSTANCE(__HANDLE__)  ((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC3))
+
+/**
+  * @brief Verify the ADC instance connected to the internal voltage reference VREFINT.
+  * @param __HANDLE__: ADC handle.
+  * @retval SET (ADC instance is valid) or RESET (ADC instance is invalid)
+  */  
+/*  The internal voltage reference  VREFINT measurement path (channel 0) is available on ADC1 */  
+#define ADC_VREFINT_INSTANCE(__HANDLE__)  (((__HANDLE__)->Instance) == ADC1)
+
+ 
+/**
+  * @brief Verify the length of scheduled injected conversions group.
+  * @param __LENGTH__: number of programmed conversions.   
+  * @retval SET (__LENGTH__ is within the maximum number of possible programmable injected conversions) or RESET (__LENGTH__ is null or too large)
+  */  
+#define IS_ADC_INJECTED_NB_CONV(__LENGTH__) (((__LENGTH__) >= ((uint32_t)1)) && ((__LENGTH__) <= ((uint32_t)4)))
+  
+  
+/**
+  * @brief Calibration factor size verification (7 bits maximum).
+  * @param __CALIBRATION_FACTOR__: Calibration factor value.
+  * @retval SET (__CALIBRATION_FACTOR__ is within the authorized size) or RESET (__CALIBRATION_FACTOR__ is too large)
+  */
+#define IS_ADC_CALFACT(__CALIBRATION_FACTOR__) ((__CALIBRATION_FACTOR__) <= ((uint32_t)0x7F))
+
+ 
+/**
+  * @brief Verify the ADC channel setting.
+  * @param __HANDLE__: ADC handle.
+  * @param __CHANNEL__: programmed ADC channel. 
+  * @retval SET (__CHANNEL__ is valid) or RESET (__CHANNEL__ is invalid)
+  */
+#define IS_ADC_CHANNEL(__HANDLE__, __CHANNEL__)  (((((__HANDLE__)->Instance) == ADC1)  && \
+                                                         (((__CHANNEL__) == ADC_CHANNEL_VREFINT)     || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_1)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_2)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_3)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_4)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_5)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_6)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_7)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_8)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_9)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_10)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_11)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_12)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_13)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_14)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_15)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_16)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_TEMPSENSOR)  || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_VBAT)))      || \
+                                                        ((((__HANDLE__)->Instance) == ADC2)  && \
+                                                         (((__CHANNEL__) == ADC_CHANNEL_1)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_2)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_3)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_4)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_5)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_6)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_7)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_8)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_9)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_10)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_11)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_12)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_13)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_14)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_15)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_16)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_17)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_18)))        || \
+                                                        ((((__HANDLE__)->Instance) == ADC3)  && \
+                                                         (((__CHANNEL__) == ADC_CHANNEL_1)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_2)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_3)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_4)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_6)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_7)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_8)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_9)           || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_10)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_11)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_12)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_13)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_14)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_15)          || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_TEMPSENSOR)  || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_VBAT)   ))) 
+ 
+/**
+  * @brief Verify the ADC channel setting in differential mode.
+  * @param __HANDLE__: ADC handle.
+  * @param __CHANNEL__: programmed ADC channel. 
+  * @retval SET (__CHANNEL__ is valid) or RESET (__CHANNEL__ is invalid)
+  */  
+    /* For ADC1 and ADC2, channels 1 to 15 are available in differential mode, 
+                          channels 0, 16 to 18 can be only used in single-ended mode. 
+       For ADC3, channels 1 to 3 and 6 to 12 are available in differential mode,
+                 channels 4, 5 and 13 to 18 can only be used in single-ended mode.  */                         
+#define IS_ADC_DIFF_CHANNEL(__HANDLE__, __CHANNEL__)  ((((((__HANDLE__)->Instance) == ADC1)   || \
+                                                         (((__HANDLE__)->Instance) == ADC2))  && \
+                                                         (((__CHANNEL__) == ADC_CHANNEL_1)    || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_2)    || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_3)    || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_4)    || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_5)    || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_6)    || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_7)    || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_8)    || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_9)    || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_10)   || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_11)   || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_12)   || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_13)   || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_14)   || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_15))) || \
+                                                        ((((__HANDLE__)->Instance) == ADC3)  && \
+                                                         (((__CHANNEL__) == ADC_CHANNEL_1)   || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_2)   || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_3)   || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_6)   || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_7)   || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_8)   || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_9)   || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_10)  || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_11)  || \
+                                                          ((__CHANNEL__) == ADC_CHANNEL_12)   )))
+                               
+/**                            
+  * @brief Verify the ADC single-ended input or differential mode setting.
+  * @param __SING_DIFF__: programmed channel setting. 
+  * @retval SET (__SING_DIFF__ is valid) or RESET (__SING_DIFF__ is invalid)
+  */                           
+#define IS_ADC_SINGLE_DIFFERENTIAL(__SING_DIFF__) (((__SING_DIFF__) == ADC_SINGLE_ENDED)      || \
+                                                   ((__SING_DIFF__) == ADC_DIFFERENTIAL_ENDED)  )
+                               
+/**
+  * @brief Verify the ADC offset management setting.
+  * @param __OFFSET_NUMBER__: ADC offset management. 
+  * @retval SET (__OFFSET_NUMBER__ is valid) or RESET (__OFFSET_NUMBER__ is invalid)
+  */ 
+#define IS_ADC_OFFSET_NUMBER(__OFFSET_NUMBER__) (((__OFFSET_NUMBER__) == ADC_OFFSET_NONE) || \
+                                                 ((__OFFSET_NUMBER__) == ADC_OFFSET_1)    || \
+                                                 ((__OFFSET_NUMBER__) == ADC_OFFSET_2)    || \
+                                                 ((__OFFSET_NUMBER__) == ADC_OFFSET_3)    || \
+                                                 ((__OFFSET_NUMBER__) == ADC_OFFSET_4)      ) 
+
+/**
+  * @brief Verify the ADC regular channel setting.
+  * @param __CHANNEL__: programmed ADC regular channel. 
+  * @retval SET (__CHANNEL__ is valid) or RESET (__CHANNEL__ is invalid)
+  */
+#define IS_ADC_REGULAR_RANK(__CHANNEL__) (((__CHANNEL__) == ADC_REGULAR_RANK_1 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_2 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_3 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_4 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_5 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_6 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_7 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_8 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_9 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_10) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_11) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_12) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_13) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_14) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_15) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_16)   )
+
+
+/**
+  * @brief Verify the ADC injected channel setting.
+  * @param __CHANNEL__: programmed ADC injected channel. 
+  * @retval SET (__CHANNEL__ is valid) or RESET (__CHANNEL__ is invalid)
+  */
+#define IS_ADC_INJECTED_RANK(__CHANNEL__) (((__CHANNEL__) == ADC_INJECTED_RANK_1) || \
+                                           ((__CHANNEL__) == ADC_INJECTED_RANK_2) || \
+                                           ((__CHANNEL__) == ADC_INJECTED_RANK_3) || \
+                                           ((__CHANNEL__) == ADC_INJECTED_RANK_4)   ) 
+
+/**
+  * @brief Verify the ADC edge trigger setting for injected group.
+  * @param __EDGE__: programmed ADC edge trigger setting.
+  * @retval SET (__EDGE__ is a valid value) or RESET (__EDGE__ is invalid)
+  */ 
+#define IS_ADC_EXTTRIGINJEC_EDGE(__EDGE__) (((__EDGE__) == ADC_EXTERNALTRIGINJECCONV_EDGE_NONE)        || \
+                                           ((__EDGE__) == ADC_EXTERNALTRIGINJECCONV_EDGE_RISING)       || \
+                                           ((__EDGE__) == ADC_EXTERNALTRIGINJECCONV_EDGE_FALLING)      || \
+                                           ((__EDGE__) == ADC_EXTERNALTRIGINJECCONV_EDGE_RISINGFALLING) ) 
+
+
+/**
+  * @brief Verify the ADC injected conversions external trigger.
+  * @param __INJTRIG__: programmed ADC injected conversions external trigger.
+  * @retval SET (__INJTRIG__ is a valid value) or RESET (__INJTRIG__ is invalid)
+  */ 
+#define IS_ADC_EXTTRIGINJEC(__INJTRIG__) (((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T1_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T1_CC4)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T2_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T2_CC1)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T3_CC4)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T4_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_EXT_IT15)    || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T8_CC4)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T1_TRGO2)    || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T8_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T8_TRGO2)    || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T3_CC3)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T3_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T3_CC1)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T6_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T15_TRGO)    || \
+                                                                                                  \
+                                          ((__INJTRIG__) == ADC_SOFTWARE_START)                   )  
+
+
+/**
+  * @brief Verify the ADC multimode setting.
+  * @param __MODE__: programmed ADC multimode setting.
+  * @retval SET (__MODE__ is valid) or RESET (__MODE__ is invalid)
+  */ 
+#define IS_ADC_MULTIMODE(__MODE__) (((__MODE__) == ADC_MODE_INDEPENDENT)          || \
+                               ((__MODE__) == ADC_DUALMODE_REGSIMULT_INJECSIMULT) || \
+                               ((__MODE__) == ADC_DUALMODE_REGSIMULT_ALTERTRIG)   || \
+                               ((__MODE__) == ADC_DUALMODE_REGINTERL_INJECSIMULT) || \
+                               ((__MODE__) == ADC_DUALMODE_INJECSIMULT)           || \
+                               ((__MODE__) == ADC_DUALMODE_REGSIMULT)             || \
+                               ((__MODE__) == ADC_DUALMODE_INTERL)                || \
+                               ((__MODE__) == ADC_DUALMODE_ALTERTRIG)               ) 
+
+/**
+  * @brief Verify the ADC multimode DMA access setting.
+  * @param __MODE__: programmed ADC multimode DMA access setting.
+  * @retval SET (__MODE__ is valid) or RESET (__MODE__ is invalid)
+  */
+#define IS_ADC_DMA_ACCESS_MULTIMODE(__MODE__) (((__MODE__) == ADC_DMAACCESSMODE_DISABLED)   || \
+                                               ((__MODE__) == ADC_DMAACCESSMODE_12_10_BITS) || \
+                                               ((__MODE__) == ADC_DMAACCESSMODE_8_6_BITS)     ) 
+
+/**
+  * @brief Verify the ADC multimode delay setting.
+  * @param __DELAY__: programmed ADC multimode delay setting.
+  * @retval SET (__DELAY__ is a valid value) or RESET (__DELAY__ is invalid)
+  */
+#define IS_ADC_SAMPLING_DELAY(__DELAY__) (((__DELAY__) == ADC_TWOSAMPLINGDELAY_1CYCLE)   || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_2CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_3CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_4CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_5CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_6CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_7CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_8CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_9CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_10CYCLES) || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_11CYCLES) || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_12CYCLES)   ) 
+
+/**
+  * @brief Verify the ADC analog watchdog setting.
+  * @param __WATCHDOG__: programmed ADC analog watchdog setting.
+  * @retval SET (__WATCHDOG__ is valid) or RESET (__WATCHDOG__ is invalid)
+  */
+#define IS_ADC_ANALOG_WATCHDOG_NUMBER(__WATCHDOG__) (((__WATCHDOG__) == ADC_ANALOGWATCHDOG_1) || \
+                                                     ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_2) || \
+                                                     ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_3)   ) 
+
+/**
+  * @brief Verify the ADC analog watchdog mode setting.
+  * @param __WATCHDOG_MODE__: programmed ADC analog watchdog mode setting.
+  * @retval SET (__WATCHDOG_MODE__ is valid) or RESET (__WATCHDOG_MODE__ is invalid)
+  */
+#define IS_ADC_ANALOG_WATCHDOG_MODE(__WATCHDOG_MODE__) (((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_NONE)             || \
+                                                        ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_SINGLE_REG)       || \
+                                                        ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_SINGLE_INJEC)     || \
+                                                        ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_SINGLE_REGINJEC)  || \
+                                                        ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_ALL_REG)          || \
+                                                        ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_ALL_INJEC)        || \
+                                                        ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_ALL_REGINJEC)       ) 
+
+/**
+  * @brief Verify the ADC conversion (regular or injected or both).
+  * @param __CONVERSION__: ADC conversion group.
+  * @retval SET (__CONVERSION__ is valid) or RESET (__CONVERSION__ is invalid)
+  */
+#define IS_ADC_CONVERSION_GROUP(__CONVERSION__) (((__CONVERSION__) == ADC_REGULAR_GROUP)     || \
+                                             ((__CONVERSION__) == ADC_INJECTED_GROUP)        || \
+                                             ((__CONVERSION__) == ADC_REGULAR_INJECTED_GROUP)  )
+
+/**
+  * @brief Verify the ADC event type.
+  * @param __EVENT__: ADC event.
+  * @retval SET (__EVENT__ is valid) or RESET (__EVENT__ is invalid)
+  */
+#define IS_ADC_EVENT_TYPE(__EVENT__) (((__EVENT__) == ADC_EOSMP_EVENT) || \
+                                     ((__EVENT__) == ADC_AWD_EVENT)    || \
+                                     ((__EVENT__) == ADC_AWD2_EVENT)   || \
+                                     ((__EVENT__) == ADC_AWD3_EVENT)   || \
+                                     ((__EVENT__) == ADC_OVR_EVENT)    || \
+                                     ((__EVENT__) == ADC_JQOVF_EVENT)  ) 
+
+/**
+  * @brief Verify the ADC oversampling ratio. 
+  * @param __RATIO__: programmed ADC oversampling ratio.
+  * @retval SET (__RATIO__ is a valid value) or RESET (__RATIO__ is invalid)
+  */   
+#define IS_ADC_OVERSAMPLING_RATIO(__RATIO__)      (((__RATIO__) == ADC_OVERSAMPLING_RATIO_2   ) || \
+                                                   ((__RATIO__) == ADC_OVERSAMPLING_RATIO_4   ) || \
+                                                   ((__RATIO__) == ADC_OVERSAMPLING_RATIO_8   ) || \
+                                                   ((__RATIO__) == ADC_OVERSAMPLING_RATIO_16  ) || \
+                                                   ((__RATIO__) == ADC_OVERSAMPLING_RATIO_32  ) || \
+                                                   ((__RATIO__) == ADC_OVERSAMPLING_RATIO_64  ) || \
+                                                   ((__RATIO__) == ADC_OVERSAMPLING_RATIO_128 ) || \
+                                                   ((__RATIO__) == ADC_OVERSAMPLING_RATIO_256 ))
+
+/**
+  * @brief Verify the ADC oversampling shift. 
+  * @param __SHIFT__: programmed ADC oversampling shift.
+  * @retval SET (__SHIFT__ is a valid value) or RESET (__SHIFT__ is invalid)
+  */                 
+#define IS_ADC_RIGHT_BIT_SHIFT(__SHIFT__)        (((__SHIFT__) == ADC_RIGHTBITSHIFT_NONE) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_1   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_2   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_3   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_4   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_5   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_6   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_7   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_8   ))
+
+/**
+  * @brief Verify the ADC oversampling triggered mode. 
+  * @param __MODE__: programmed ADC oversampling triggered mode. 
+  * @retval SET (__MODE__ is valid) or RESET (__MODE__ is invalid)
+  */ 
+#define IS_ADC_TRIGGERED_OVERSAMPLING_MODE(__MODE__) (((__MODE__) == ADC_TRIGGEREDMODE_SINGLE_TRIGGER) || \
+                                                      ((__MODE__) == ADC_TRIGGEREDMODE_MULTI_TRIGGER) ) 
+
+/**
+  * @brief Verify the ADC oversampling regular conversion resumed or continued mode. 
+  * @param __MODE__: programmed ADC oversampling regular conversion resumed or continued mode. 
+  * @retval SET (__MODE__ is valid) or RESET (__MODE__ is invalid)
+  */ 
+#define IS_ADC_REGOVERSAMPLING_MODE(__MODE__) (((__MODE__) == ADC_REGOVERSAMPLING_CONTINUED_MODE) || \
+                                               ((__MODE__) == ADC_REGOVERSAMPLING_RESUMED_MODE) )              
+
+ 
+
+                                                  
+/**
+  * @}
+  */
+
+
+/* Exported functions --------------------------------------------------------*/  
+/** @addtogroup ADCEx_Exported_Functions ADC Extended Exported Functions
+  * @{
+  */ 
+          
+/* Initialization/de-initialization functions *********************************/
+
+/** @addtogroup ADCEx_Exported_Functions_Group1 Extended Input and Output operation functions
+  * @brief    Extended IO operation functions
+  * @{
+  */ 
+/* I/O operation functions ****************************************************/
+
+/* ADC calibration */
+
+HAL_StatusTypeDef       HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc, uint32_t SingleDiff);
+uint32_t                HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef *hadc, uint32_t SingleDiff);
+HAL_StatusTypeDef       HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef *hadc, uint32_t SingleDiff, uint32_t CalibrationFactor);
+
+
+
+/* Blocking mode: Polling */
+HAL_StatusTypeDef       HAL_ADCEx_InjectedStart(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADCEx_InjectedStop(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADCEx_InjectedPollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout);
+
+/* Non-blocking mode: Interruption */
+HAL_StatusTypeDef       HAL_ADCEx_InjectedStart_IT(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADCEx_InjectedStop_IT(ADC_HandleTypeDef* hadc);
+     
+
+/* ADC multimode */
+HAL_StatusTypeDef       HAL_ADCEx_MultiModeStart_DMA(ADC_HandleTypeDef *hadc, uint32_t *pData, uint32_t Length);
+HAL_StatusTypeDef       HAL_ADCEx_MultiModeStop_DMA(ADC_HandleTypeDef *hadc); 
+uint32_t                HAL_ADCEx_MultiModeGetValue(ADC_HandleTypeDef *hadc);
+
+/* ADC retrieve conversion value intended to be used with polling or interruption */
+uint32_t                HAL_ADCEx_InjectedGetValue(ADC_HandleTypeDef* hadc, uint32_t InjectedRank);
+
+/* ADC IRQHandler and Callbacks used in non-blocking modes (Interruption) */
+void                    HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef* hadc);
+void                    HAL_ADCEx_InjectedQueueOverflowCallback(ADC_HandleTypeDef* hadc);
+void                    HAL_ADCEx_LevelOutOfWindow2Callback(ADC_HandleTypeDef* hadc);
+void                    HAL_ADCEx_LevelOutOfWindow3Callback(ADC_HandleTypeDef* hadc);
+void                    HAL_ADCEx_EndOfSamplingCallback(ADC_HandleTypeDef* hadc);
+
+
+/* ADC Regular conversions stop */
+HAL_StatusTypeDef HAL_ADCEx_RegularStop(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef HAL_ADCEx_RegularStop_IT(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef HAL_ADCEx_RegularStop_DMA(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef HAL_ADCEx_RegularMultiModeStop_DMA(ADC_HandleTypeDef* hadc);
+
+/**
+  * @}
+  */
+     
+/** @addtogroup ADCEx_Exported_Functions_Group2 Extended Peripheral Control functions
+  * @brief    Extended Peripheral Control functions
+  * @{
+  */ 
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef       HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef* hadc,ADC_InjectionConfTypeDef* sConfigInjected);
+HAL_StatusTypeDef       HAL_ADCEx_MultiModeConfigChannel(ADC_HandleTypeDef *hadc, ADC_MultiModeTypeDef *multimode);
+HAL_StatusTypeDef       HAL_ADCEx_EnableInjectedQueue(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADCEx_DisableInjectedQueue(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADCEx_DisableVoltageRegulator(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADCEx_EnterADCDeepPowerDownMode(ADC_HandleTypeDef* hadc);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32L4xx_ADC_EX_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_can.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_can.h
@@ -1,0 +1,768 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_can.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of CAN HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_CAN_H
+#define __STM32L4xx_CAN_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup CAN
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup CAN_Exported_Types CAN Exported Types
+  * @{
+  */
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef enum
+{
+  HAL_CAN_STATE_RESET             = 0x00,  /*!< CAN not yet initialized or disabled */
+  HAL_CAN_STATE_READY             = 0x01,  /*!< CAN initialized and ready for use   */
+  HAL_CAN_STATE_BUSY              = 0x02,  /*!< CAN process is ongoing              */
+  HAL_CAN_STATE_BUSY_TX           = 0x12,  /*!< CAN process is ongoing              */
+  HAL_CAN_STATE_BUSY_RX           = 0x22,  /*!< CAN process is ongoing              */
+  HAL_CAN_STATE_BUSY_TX_RX        = 0x32,  /*!< CAN process is ongoing              */
+  HAL_CAN_STATE_TIMEOUT           = 0x03,  /*!< Timeout state                       */
+  HAL_CAN_STATE_ERROR             = 0x04   /*!< CAN error state                     */
+
+}HAL_CAN_StateTypeDef;
+
+/**
+  * @brief  CAN init structure definition
+  */
+typedef struct
+{
+  uint32_t Prescaler;  /*!< Specifies the length of a time quantum.
+                            This parameter must be a number between Min_Data = 1 and Max_Data = 1024 */
+
+  uint32_t Mode;       /*!< Specifies the CAN operating mode.
+                            This parameter can be a value of @ref CAN_operating_mode */
+
+  uint32_t SJW;        /*!< Specifies the maximum number of time quanta
+                            the CAN hardware is allowed to lengthen or
+                            shorten a bit to perform resynchronization.
+                            This parameter can be a value of @ref CAN_synchronisation_jump_width */
+
+  uint32_t BS1;        /*!< Specifies the number of time quanta in Bit Segment 1.
+                            This parameter can be a value of @ref CAN_time_quantum_in_bit_segment_1 */
+
+  uint32_t BS2;        /*!< Specifies the number of time quanta in Bit Segment 2.
+                            This parameter can be a value of @ref CAN_time_quantum_in_bit_segment_2 */
+
+  uint32_t TTCM;       /*!< Enable or disable the time triggered communication mode.
+                            This parameter can be set to ENABLE or DISABLE. */
+
+  uint32_t ABOM;       /*!< Enable or disable the automatic bus-off management.
+                            This parameter can be set to ENABLE or DISABLE */
+
+  uint32_t AWUM;       /*!< Enable or disable the automatic wake-up mode.
+                            This parameter can be set to ENABLE or DISABLE */
+
+  uint32_t NART;       /*!< Enable or disable the non-automatic retransmission mode.
+                            This parameter can be set to ENABLE or DISABLE */
+
+  uint32_t RFLM;       /*!< Enable or disable the receive FIFO Locked mode.
+                            This parameter can be set to ENABLE or DISABLE */
+
+  uint32_t TXFP;       /*!< Enable or disable the transmit FIFO priority.
+                            This parameter can be set to ENABLE or DISABLE */
+}CAN_InitTypeDef;
+
+/**
+  * @brief  CAN filter configuration structure definition
+  */
+typedef struct
+{
+  uint32_t FilterIdHigh;          /*!< Specifies the filter identification number (MSBs for a 32-bit
+                                       configuration, first one for a 16-bit configuration).
+                                       This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t FilterIdLow;           /*!< Specifies the filter identification number (LSBs for a 32-bit
+                                       configuration, second one for a 16-bit configuration).
+                                       This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t FilterMaskIdHigh;      /*!< Specifies the filter mask number or identification number,
+                                       according to the mode (MSBs for a 32-bit configuration,
+                                       first one for a 16-bit configuration).
+                                       This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t FilterMaskIdLow;       /*!< Specifies the filter mask number or identification number,
+                                       according to the mode (LSBs for a 32-bit configuration,
+                                       second one for a 16-bit configuration).
+                                       This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t FilterFIFOAssignment;  /*!< Specifies the FIFO (0 or 1) which will be assigned to the filter.
+                                       This parameter can be a value of @ref CAN_filter_FIFO */
+
+  uint32_t FilterNumber;          /*!< Specifies the filter which will be initialized.
+                                       This parameter must be a number between Min_Data = 0 and Max_Data = 27 */
+
+  uint32_t FilterMode;            /*!< Specifies the filter mode to be initialized.
+                                       This parameter can be a value of @ref CAN_filter_mode */
+
+  uint32_t FilterScale;           /*!< Specifies the filter scale.
+                                       This parameter can be a value of @ref CAN_filter_scale */
+
+  uint32_t FilterActivation;      /*!< Enable or disable the filter.
+                                       This parameter can be set to ENABLE or DISABLE */
+
+  uint32_t BankNumber;            /*!< Select the start slave bank filter.
+                                       This parameter must be a number between Min_Data = 0 and Max_Data = 28 */ 
+
+}CAN_FilterConfTypeDef;
+
+/**
+  * @brief  CAN Tx message structure definition
+  */
+typedef struct
+{
+  uint32_t StdId;    /*!< Specifies the standard identifier.
+                          This parameter must be a number between Min_Data = 0 and Max_Data = 0x7FF */
+
+  uint32_t ExtId;    /*!< Specifies the extended identifier.
+                          This parameter must be a number between Min_Data = 0 and Max_Data = 0x1FFFFFFF */
+
+  uint32_t IDE;      /*!< Specifies the type of identifier for the message that will be transmitted.
+                          This parameter can be a value of @ref CAN_identifier_type */
+
+  uint32_t RTR;      /*!< Specifies the type of frame for the message that will be transmitted.
+                          This parameter can be a value of @ref CAN_remote_transmission_request */
+
+  uint32_t DLC;      /*!< Specifies the length of the frame that will be transmitted.
+                          This parameter must be a number between Min_Data = 0 and Max_Data = 8 */
+
+  uint8_t Data[8];   /*!< Contains the data to be transmitted.
+                          This parameter must be a number between Min_Data = 0 and Max_Data = 0xFF */
+
+}CanTxMsgTypeDef;
+
+/**
+  * @brief  CAN Rx message structure definition
+  */
+typedef struct
+{
+  uint32_t StdId;       /*!< Specifies the standard identifier.
+                             This parameter must be a number between Min_Data = 0 and Max_Data = 0x7FF */
+
+  uint32_t ExtId;       /*!< Specifies the extended identifier.
+                             This parameter must be a number between Min_Data = 0 and Max_Data = 0x1FFFFFFF */
+
+  uint32_t IDE;         /*!< Specifies the type of identifier for the message that will be received.
+                             This parameter can be a value of @ref CAN_identifier_type */
+
+  uint32_t RTR;         /*!< Specifies the type of frame for the received message.
+                             This parameter can be a value of @ref CAN_remote_transmission_request */
+
+  uint32_t DLC;         /*!< Specifies the length of the frame that will be received.
+                             This parameter must be a number between Min_Data = 0 and Max_Data = 8 */
+
+  uint32_t Data[8];     /*!< Contains the data to be received.
+                             This parameter must be a number between Min_Data = 0 and Max_Data = 0xFF */
+
+  uint32_t FMI;         /*!< Specifies the index of the filter the message stored in the mailbox passes through.
+                             This parameter must be a number between Min_Data = 0 and Max_Data = 0xFF */
+
+  uint32_t FIFONumber;  /*!< Specifies the receive FIFO number.
+                             This parameter can be CAN_FIFO0 or CAN_FIFO1 */
+
+}CanRxMsgTypeDef;
+
+/**
+  * @brief  CAN handle Structure definition
+  */
+typedef struct
+{
+  CAN_TypeDef                 *Instance;  /*!< Register base address          */
+
+  CAN_InitTypeDef             Init;       /*!< CAN required parameters        */
+
+  CanTxMsgTypeDef*            pTxMsg;     /*!< Pointer to transmit structure  */
+
+  CanRxMsgTypeDef*            pRxMsg;     /*!< Pointer to reception structure */
+
+  __IO HAL_CAN_StateTypeDef   State;      /*!< CAN communication state        */
+
+  HAL_LockTypeDef             Lock;       /*!< CAN locking object             */
+
+  __IO uint32_t               ErrorCode;  /*!< CAN Error code                 */
+
+}CAN_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup CAN_Exported_Constants CAN Exported Constants
+  * @{
+  */
+
+/** @defgroup CAN_Error_Code CAN Error Code
+  * @{
+  */
+#define   HAL_CAN_ERROR_NONE        ((uint32_t)0x00000000)    /*!< No error             */
+#define   HAL_CAN_ERROR_EWG         ((uint32_t)0x00000001)    /*!< EWG error            */
+#define   HAL_CAN_ERROR_EPV         ((uint32_t)0x00000002)    /*!< EPV error            */
+#define   HAL_CAN_ERROR_BOF         ((uint32_t)0x00000004)    /*!< BOF error            */
+#define   HAL_CAN_ERROR_STF         ((uint32_t)0x00000008)    /*!< Stuff error          */
+#define   HAL_CAN_ERROR_FOR         ((uint32_t)0x00000010)    /*!< Form error           */
+#define   HAL_CAN_ERROR_ACK         ((uint32_t)0x00000020)    /*!< Acknowledgment error */
+#define   HAL_CAN_ERROR_BR          ((uint32_t)0x00000040)    /*!< Bit recessive        */
+#define   HAL_CAN_ERROR_BD          ((uint32_t)0x00000080)    /*!< LEC dominant         */
+#define   HAL_CAN_ERROR_CRC         ((uint32_t)0x00000100)   /*!< LEC transfer error   */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_InitStatus CAN initialization Status
+  * @{
+  */
+#define CAN_INITSTATUS_FAILED       ((uint32_t)0x00000000)  /*!< CAN initialization failed */
+#define CAN_INITSTATUS_SUCCESS      ((uint32_t)0x00000001)  /*!< CAN initialization OK */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_operating_mode CAN Operating Mode
+  * @{
+  */
+#define CAN_MODE_NORMAL             ((uint32_t)0x00000000)                     /*!< Normal mode   */
+#define CAN_MODE_LOOPBACK           ((uint32_t)CAN_BTR_LBKM)                   /*!< Loopback mode */
+#define CAN_MODE_SILENT             ((uint32_t)CAN_BTR_SILM)                   /*!< Silent mode   */
+#define CAN_MODE_SILENT_LOOPBACK    ((uint32_t)(CAN_BTR_LBKM | CAN_BTR_SILM))  /*!< Loopback combined with silent mode */
+/**
+  * @}
+  */
+
+
+/** @defgroup CAN_synchronisation_jump_width CAN Synchronization Jump Width
+  * @{
+  */
+#define CAN_SJW_1TQ                 ((uint32_t)0x00000000)     /*!< 1 time quantum */
+#define CAN_SJW_2TQ                 ((uint32_t)CAN_BTR_SJW_0)  /*!< 2 time quantum */
+#define CAN_SJW_3TQ                 ((uint32_t)CAN_BTR_SJW_1)  /*!< 3 time quantum */
+#define CAN_SJW_4TQ                 ((uint32_t)CAN_BTR_SJW)    /*!< 4 time quantum */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_time_quantum_in_bit_segment_1 CAN Time Quantum in Bit Segment 1
+  * @{
+  */
+#define CAN_BS1_1TQ                 ((uint32_t)0x00000000)                                       /*!< 1 time quantum  */
+#define CAN_BS1_2TQ                 ((uint32_t)CAN_BTR_TS1_0)                                    /*!< 2 time quantum  */
+#define CAN_BS1_3TQ                 ((uint32_t)CAN_BTR_TS1_1)                                    /*!< 3 time quantum  */
+#define CAN_BS1_4TQ                 ((uint32_t)(CAN_BTR_TS1_1 | CAN_BTR_TS1_0))                  /*!< 4 time quantum  */
+#define CAN_BS1_5TQ                 ((uint32_t)CAN_BTR_TS1_2)                                    /*!< 5 time quantum  */
+#define CAN_BS1_6TQ                 ((uint32_t)(CAN_BTR_TS1_2 | CAN_BTR_TS1_0))                  /*!< 6 time quantum  */
+#define CAN_BS1_7TQ                 ((uint32_t)(CAN_BTR_TS1_2 | CAN_BTR_TS1_1))                  /*!< 7 time quantum  */
+#define CAN_BS1_8TQ                 ((uint32_t)(CAN_BTR_TS1_2 | CAN_BTR_TS1_1 | CAN_BTR_TS1_0))  /*!< 8 time quantum  */
+#define CAN_BS1_9TQ                 ((uint32_t)CAN_BTR_TS1_3)                                    /*!< 9 time quantum  */
+#define CAN_BS1_10TQ                ((uint32_t)(CAN_BTR_TS1_3 | CAN_BTR_TS1_0))                  /*!< 10 time quantum */
+#define CAN_BS1_11TQ                ((uint32_t)(CAN_BTR_TS1_3 | CAN_BTR_TS1_1))                  /*!< 11 time quantum */
+#define CAN_BS1_12TQ                ((uint32_t)(CAN_BTR_TS1_3 | CAN_BTR_TS1_1 | CAN_BTR_TS1_0))  /*!< 12 time quantum */
+#define CAN_BS1_13TQ                ((uint32_t)(CAN_BTR_TS1_3 | CAN_BTR_TS1_2))                  /*!< 13 time quantum */
+#define CAN_BS1_14TQ                ((uint32_t)(CAN_BTR_TS1_3 | CAN_BTR_TS1_2 | CAN_BTR_TS1_0))  /*!< 14 time quantum */
+#define CAN_BS1_15TQ                ((uint32_t)(CAN_BTR_TS1_3 | CAN_BTR_TS1_2 | CAN_BTR_TS1_1))  /*!< 15 time quantum */
+#define CAN_BS1_16TQ                ((uint32_t)CAN_BTR_TS1) /*!< 16 time quantum */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_time_quantum_in_bit_segment_2 CAN Time Quantum in Bit Segment 2
+  * @{
+  */
+#define CAN_BS2_1TQ                 ((uint32_t)0x00000000)                       /*!< 1 time quantum */
+#define CAN_BS2_2TQ                 ((uint32_t)CAN_BTR_TS2_0)                    /*!< 2 time quantum */
+#define CAN_BS2_3TQ                 ((uint32_t)CAN_BTR_TS2_1)                    /*!< 3 time quantum */
+#define CAN_BS2_4TQ                 ((uint32_t)(CAN_BTR_TS2_1 | CAN_BTR_TS2_0))  /*!< 4 time quantum */
+#define CAN_BS2_5TQ                 ((uint32_t)CAN_BTR_TS2_2)                    /*!< 5 time quantum */
+#define CAN_BS2_6TQ                 ((uint32_t)(CAN_BTR_TS2_2 | CAN_BTR_TS2_0))  /*!< 6 time quantum */
+#define CAN_BS2_7TQ                 ((uint32_t)(CAN_BTR_TS2_2 | CAN_BTR_TS2_1))  /*!< 7 time quantum */
+#define CAN_BS2_8TQ                 ((uint32_t)CAN_BTR_TS2)                      /*!< 8 time quantum */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_filter_mode CAN Filter Mode
+  * @{
+  */
+#define CAN_FILTERMODE_IDMASK       ((uint8_t)0x00)  /*!< Identifier mask mode */
+#define CAN_FILTERMODE_IDLIST       ((uint8_t)0x01)  /*!< Identifier list mode */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_filter_scale CAN Filter Scale
+  * @{
+  */
+#define CAN_FILTERSCALE_16BIT       ((uint8_t)0x00)  /*!< Two 16-bit filters */
+#define CAN_FILTERSCALE_32BIT       ((uint8_t)0x01)  /*!< One 32-bit filter  */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_filter_FIFO CAN Filter FIFO
+  * @{
+  */
+#define CAN_FILTER_FIFO0             ((uint8_t)0x00)  /*!< Filter FIFO 0 assignment for filter x */
+#define CAN_FILTER_FIFO1             ((uint8_t)0x01)  /*!< Filter FIFO 1 assignment for filter x */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_identifier_type CAN Identifier Type
+  * @{
+  */
+#define CAN_ID_STD             ((uint32_t)0x00000000)  /*!< Standard Id */
+#define CAN_ID_EXT             ((uint32_t)0x00000004)  /*!< Extended Id */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_remote_transmission_request CAN Remote Transmission Request
+  * @{
+  */
+#define CAN_RTR_DATA                ((uint32_t)0x00000000)  /*!< Data frame */
+#define CAN_RTR_REMOTE              ((uint32_t)0x00000002)  /*!< Remote frame */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_receive_FIFO_number_constants CAN Receive FIFO Number
+  * @{
+  */
+#define CAN_FIFO0                   ((uint8_t)0x00)  /*!< CAN FIFO 0 used to receive */
+#define CAN_FIFO1                   ((uint8_t)0x01)  /*!< CAN FIFO 1 used to receive */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_flags CAN Flags
+  * @{
+  */
+/* If the flag is 0x3XXXXXXX, it means that it can be used with CAN_GetFlagStatus()
+   and CAN_ClearFlag() functions. */
+/* If the flag is 0x1XXXXXXX, it means that it can only be used with
+   CAN_GetFlagStatus() function.  */
+
+/* Transmit Flags */
+#define CAN_FLAG_RQCP0             ((uint32_t)0x00000500)  /*!< Request MailBox0 flag         */
+#define CAN_FLAG_RQCP1             ((uint32_t)0x00000508)  /*!< Request MailBox1 flag         */
+#define CAN_FLAG_RQCP2             ((uint32_t)0x00000510)  /*!< Request MailBox2 flag         */
+#define CAN_FLAG_TXOK0             ((uint32_t)0x00000501)  /*!< Transmission OK MailBox0 flag */
+#define CAN_FLAG_TXOK1             ((uint32_t)0x00000509)  /*!< Transmission OK MailBox1 flag */
+#define CAN_FLAG_TXOK2             ((uint32_t)0x00000511)  /*!< Transmission OK MailBox2 flag */
+#define CAN_FLAG_TME0              ((uint32_t)0x0000051A)  /*!< Transmit mailbox 0 empty flag */
+#define CAN_FLAG_TME1              ((uint32_t)0x0000051B)  /*!< Transmit mailbox 0 empty flag */
+#define CAN_FLAG_TME2              ((uint32_t)0x0000051C)  /*!< Transmit mailbox 0 empty flag */
+
+/* Receive Flags */
+#define CAN_FLAG_FF0               ((uint32_t)0x00000203)  /*!< FIFO 0 Full flag    */
+#define CAN_FLAG_FOV0              ((uint32_t)0x00000204)  /*!< FIFO 0 Overrun flag */
+
+#define CAN_FLAG_FF1               ((uint32_t)0x00000403)  /*!< FIFO 1 Full flag    */
+#define CAN_FLAG_FOV1              ((uint32_t)0x00000404)  /*!< FIFO 1 Overrun flag */
+
+/* Operating Mode Flags */
+#define CAN_FLAG_WKU               ((uint32_t)0x00000103)  /*!< Wake up flag           */
+#define CAN_FLAG_SLAK              ((uint32_t)0x00000101)  /*!< Sleep acknowledge flag */
+#define CAN_FLAG_SLAKI             ((uint32_t)0x00000104)  /*!< Sleep acknowledge flag */
+/* @note When SLAK interrupt is disabled (SLKIE=0), no polling on SLAKI is possible.
+         In this case the SLAK bit can be polled.*/
+
+/* Error Flags */
+#define CAN_FLAG_EWG               ((uint32_t)0x00000300)  /*!< Error warning flag   */
+#define CAN_FLAG_EPV               ((uint32_t)0x00000301)  /*!< Error passive flag   */
+#define CAN_FLAG_BOF               ((uint32_t)0x00000302)  /*!< Bus-Off flag         */
+/**
+  * @}
+  */
+
+/** @defgroup CAN_interrupts CAN Interrupts
+  * @{
+  */
+#define CAN_IT_TME                  ((uint32_t)CAN_IER_TMEIE)   /*!< Transmit mailbox empty interrupt */
+
+/* Receive Interrupts */
+#define CAN_IT_FMP0                 ((uint32_t)CAN_IER_FMPIE0)  /*!< FIFO 0 message pending interrupt */
+#define CAN_IT_FF0                  ((uint32_t)CAN_IER_FFIE0)   /*!< FIFO 0 full interrupt            */
+#define CAN_IT_FOV0                 ((uint32_t)CAN_IER_FOVIE0)  /*!< FIFO 0 overrun interrupt         */
+#define CAN_IT_FMP1                 ((uint32_t)CAN_IER_FMPIE1)  /*!< FIFO 1 message pending interrupt */
+#define CAN_IT_FF1                  ((uint32_t)CAN_IER_FFIE1)   /*!< FIFO 1 full interrupt            */
+#define CAN_IT_FOV1                 ((uint32_t)CAN_IER_FOVIE1)  /*!< FIFO 1 overrun interrupt         */
+
+/* Operating Mode Interrupts */
+#define CAN_IT_WKU                  ((uint32_t)CAN_IER_WKUIE)  /*!< Wake-up interrupt           */
+#define CAN_IT_SLK                  ((uint32_t)CAN_IER_SLKIE)  /*!< Sleep acknowledge interrupt */
+
+/* Error Interrupts */
+#define CAN_IT_EWG                  ((uint32_t)CAN_IER_EWGIE) /*!< Error warning interrupt   */
+#define CAN_IT_EPV                  ((uint32_t)CAN_IER_EPVIE) /*!< Error passive interrupt   */
+#define CAN_IT_BOF                  ((uint32_t)CAN_IER_BOFIE) /*!< Bus-off interrupt         */
+#define CAN_IT_LEC                  ((uint32_t)CAN_IER_LECIE) /*!< Last error code interrupt */
+#define CAN_IT_ERR                  ((uint32_t)CAN_IER_ERRIE) /*!< Error Interrupt           */
+
+/**
+  * @}
+  */
+
+/* Mailboxes definition */
+#define CAN_TXMAILBOX_0   ((uint8_t)0x00)
+#define CAN_TXMAILBOX_1   ((uint8_t)0x01)
+#define CAN_TXMAILBOX_2   ((uint8_t)0x02)
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup CAN_Exported_Macro CAN Exported Macros
+  * @{
+  */
+
+/** @brief  Reset CAN handle state.
+  * @param  __HANDLE__: CAN handle.
+  * @retval None
+  */
+#define __HAL_CAN_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_CAN_STATE_RESET)
+
+/**
+  * @brief  Enable the specified CAN interrupt.
+  * @param  __HANDLE__: CAN handle.
+  * @param  __INTERRUPT__: CAN Interrupt.
+  * @retval None
+  */
+#define __HAL_CAN_ENABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->IER) |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the specified CAN interrupt.
+  * @param  __HANDLE__: CAN handle.
+  * @param  __INTERRUPT__: CAN Interrupt.
+  * @retval None
+  */
+#define __HAL_CAN_DISABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->IER) &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Return the number of pending received messages.
+  * @param  __HANDLE__: CAN handle.
+  * @param  __FIFONUMBER__: Receive FIFO number, CAN_FIFO0 or CAN_FIFO1.
+  * @retval The number of pending message.
+  */
+#define __HAL_CAN_MSG_PENDING(__HANDLE__, __FIFONUMBER__) (((__FIFONUMBER__) == CAN_FIFO0)? \
+((uint8_t)((__HANDLE__)->Instance->RF0R&(uint32_t)0x03)) : ((uint8_t)((__HANDLE__)->Instance->RF1R&(uint32_t)0x03)))
+
+/** @brief  Check whether the specified CAN flag is set or not.
+  * @param  __HANDLE__: specifies the CAN Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg CAN_TSR_RQCP0: Request MailBox0 Flag
+  *            @arg CAN_TSR_RQCP1: Request MailBox1 Flag
+  *            @arg CAN_TSR_RQCP2: Request MailBox2 Flag
+  *            @arg CAN_FLAG_TXOK0: Transmission OK MailBox0 Flag
+  *            @arg CAN_FLAG_TXOK1: Transmission OK MailBox1 Flag
+  *            @arg CAN_FLAG_TXOK2: Transmission OK MailBox2 Flag
+  *            @arg CAN_FLAG_TME0: Transmit mailbox 0 empty Flag
+  *            @arg CAN_FLAG_TME1: Transmit mailbox 1 empty Flag
+  *            @arg CAN_FLAG_TME2: Transmit mailbox 2 empty Flag
+  *            @arg CAN_FLAG_FMP0: FIFO 0 Message Pending Flag
+  *            @arg CAN_FLAG_FF0: FIFO 0 Full Flag
+  *            @arg CAN_FLAG_FOV0: FIFO 0 Overrun Flag
+  *            @arg CAN_FLAG_FMP1: FIFO 1 Message Pending Flag
+  *            @arg CAN_FLAG_FF1: FIFO 1 Full Flag
+  *            @arg CAN_FLAG_FOV1: FIFO 1 Overrun Flag
+  *            @arg CAN_FLAG_WKU: Wake up Flag
+  *            @arg CAN_FLAG_SLAK: Sleep acknowledge Flag
+  *            @arg CAN_FLAG_SLAKI: Sleep acknowledge Flag
+  *            @arg CAN_FLAG_EWG: Error Warning Flag
+  *            @arg CAN_FLAG_EPV: Error Passive Flag
+  *            @arg CAN_FLAG_BOF: Bus-Off Flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_CAN_GET_FLAG(__HANDLE__, __FLAG__) \
+((((__FLAG__) >> 8) == 5)? ((((__HANDLE__)->Instance->TSR) & (1U << ((__FLAG__) & CAN_FLAG_MASK))) == (1U << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8) == 2)? ((((__HANDLE__)->Instance->RF0R) & (1U << ((__FLAG__) & CAN_FLAG_MASK))) == (1U << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8) == 4)? ((((__HANDLE__)->Instance->RF1R) & (1U << ((__FLAG__) & CAN_FLAG_MASK))) == (1U << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8) == 1)? ((((__HANDLE__)->Instance->MSR) & (1U << ((__FLAG__) & CAN_FLAG_MASK))) == (1U << ((__FLAG__) & CAN_FLAG_MASK))): \
+ ((((__HANDLE__)->Instance->ESR) & (1U << ((__FLAG__) & CAN_FLAG_MASK))) == (1U << ((__FLAG__) & CAN_FLAG_MASK))))
+
+/** @brief  Clear the specified CAN pending flag.
+  * @param  __HANDLE__: specifies the CAN Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg CAN_TSR_RQCP0: Request MailBox0 Flag
+  *            @arg CAN_TSR_RQCP1: Request MailBox1 Flag
+  *            @arg CAN_TSR_RQCP2: Request MailBox2 Flag
+  *            @arg CAN_FLAG_TXOK0: Transmission OK MailBox0 Flag
+  *            @arg CAN_FLAG_TXOK1: Transmission OK MailBox1 Flag
+  *            @arg CAN_FLAG_TXOK2: Transmission OK MailBox2 Flag
+  *            @arg CAN_FLAG_TME0: Transmit mailbox 0 empty Flag
+  *            @arg CAN_FLAG_TME1: Transmit mailbox 1 empty Flag
+  *            @arg CAN_FLAG_TME2: Transmit mailbox 2 empty Flag
+  *            @arg CAN_FLAG_FMP0: FIFO 0 Message Pending Flag
+  *            @arg CAN_FLAG_FF0: FIFO 0 Full Flag
+  *            @arg CAN_FLAG_FOV0: FIFO 0 Overrun Flag
+  *            @arg CAN_FLAG_FMP1: FIFO 1 Message Pending Flag
+  *            @arg CAN_FLAG_FF1: FIFO 1 Full Flag
+  *            @arg CAN_FLAG_FOV1: FIFO 1 Overrun Flag
+  *            @arg CAN_FLAG_WKU: Wake up Flag
+  *            @arg CAN_FLAG_SLAKI: Sleep acknowledge Flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_CAN_CLEAR_FLAG(__HANDLE__, __FLAG__) \
+((((__FLAG__) >> 8U) == 5)? (((__HANDLE__)->Instance->TSR) = (1U << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8U) == 2)? (((__HANDLE__)->Instance->RF0R) = (1U << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8U) == 4)? (((__HANDLE__)->Instance->RF1R) = (1U << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8U) == 1)? (((__HANDLE__)->Instance->MSR) = (1U << ((__FLAG__) & CAN_FLAG_MASK))): 0)
+
+
+/** @brief  Check whether the specified CAN interrupt source is enabled or not.
+  * @param  __HANDLE__: specifies the CAN Handle.
+  * @param  __INTERRUPT__: specifies the CAN interrupt source to check.
+  *         This parameter can be one of the following values:
+  *            @arg CAN_IT_TME: Transmit mailbox empty interrupt enable
+  *            @arg CAN_IT_FMP0: FIFO0 message pending interrupt enable
+  *            @arg CAN_IT_FMP1: FIFO1 message pending interrupt enable
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_CAN_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->IER & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/**
+  * @brief  Check the transmission status of a CAN Frame.
+  * @param  __HANDLE__: specifies the CAN Handle.
+  * @param  __TRANSMITMAILBOX__: the number of the mailbox that is used for transmission.
+  * @retval The new status of transmission  (TRUE or FALSE).
+  */
+#define __HAL_CAN_TRANSMIT_STATUS(__HANDLE__, __TRANSMITMAILBOX__)\
+(((__TRANSMITMAILBOX__) == CAN_TXMAILBOX_0)? ((((__HANDLE__)->Instance->TSR) & (CAN_TSR_RQCP0 | CAN_TSR_TXOK0 | CAN_TSR_TME0)) == (CAN_TSR_RQCP0 | CAN_TSR_TXOK0 | CAN_TSR_TME0)) :\
+ ((__TRANSMITMAILBOX__) == CAN_TXMAILBOX_1)? ((((__HANDLE__)->Instance->TSR) & (CAN_TSR_RQCP1 | CAN_TSR_TXOK1 | CAN_TSR_TME1)) == (CAN_TSR_RQCP1 | CAN_TSR_TXOK1 | CAN_TSR_TME1)) :\
+ ((((__HANDLE__)->Instance->TSR) & (CAN_TSR_RQCP2 | CAN_TSR_TXOK2 | CAN_TSR_TME2)) == (CAN_TSR_RQCP2 | CAN_TSR_TXOK2 | CAN_TSR_TME2)))
+
+
+
+/**
+  * @brief  Release the specified receive FIFO.
+  * @param  __HANDLE__: CAN handle.
+  * @param  __FIFONUMBER__: Receive FIFO number, CAN_FIFO0 or CAN_FIFO1.
+  * @retval None
+  */
+#define __HAL_CAN_FIFO_RELEASE(__HANDLE__, __FIFONUMBER__) (((__FIFONUMBER__) == CAN_FIFO0)? \
+((__HANDLE__)->Instance->RF0R |= CAN_RF0R_RFOM0) : ((__HANDLE__)->Instance->RF1R |= CAN_RF1R_RFOM1)) 
+
+/**
+  * @brief  Cancel a transmit request.
+  * @param  __HANDLE__: specifies the CAN Handle.
+  * @param  __TRANSMITMAILBOX__: the number of the mailbox that is used for transmission.
+  * @retval None
+  */
+#define __HAL_CAN_CANCEL_TRANSMIT(__HANDLE__, __TRANSMITMAILBOX__)\
+(((__TRANSMITMAILBOX__) == CAN_TXMAILBOX_0)? ((__HANDLE__)->Instance->TSR |= CAN_TSR_ABRQ0) :\
+ ((__TRANSMITMAILBOX__) == CAN_TXMAILBOX_1)? ((__HANDLE__)->Instance->TSR |= CAN_TSR_ABRQ1) :\
+ ((__HANDLE__)->Instance->TSR |= CAN_TSR_ABRQ2))
+
+/**
+  * @brief  Enable or disable the DBG Freeze for CAN.
+  * @param  __HANDLE__: specifies the CAN Handle.
+  * @param  __NEWSTATE__: new state of the CAN peripheral. 
+  *         This parameter can be: ENABLE (CAN reception/transmission is frozen
+  *         during debug. Reception FIFO can still be accessed/controlled normally) 
+  *         or DISABLE (CAN is working during debug).
+  * @retval None
+  */
+#define __HAL_CAN_DBG_FREEZE(__HANDLE__, __NEWSTATE__) (((__NEWSTATE__) == ENABLE)? \
+((__HANDLE__)->Instance->MCR |= CAN_MCR_DBF) : ((__HANDLE__)->Instance->MCR &= ~CAN_MCR_DBF)) 
+
+/**
+ * @}
+ */  
+ 
+/* Exported functions --------------------------------------------------------*/  
+/** @addtogroup CAN_Exported_Functions CAN Exported Functions
+  * @{
+  */
+  
+/** @defgroup CAN_Exported_Functions_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ * @{
+ */
+/* addtogroup and de-initialization functions *****************************/ 
+HAL_StatusTypeDef HAL_CAN_Init(CAN_HandleTypeDef* hcan);
+HAL_StatusTypeDef HAL_CAN_ConfigFilter(CAN_HandleTypeDef* hcan, CAN_FilterConfTypeDef* sFilterConfig);
+HAL_StatusTypeDef HAL_CAN_DeInit(CAN_HandleTypeDef* hcan);
+void HAL_CAN_MspInit(CAN_HandleTypeDef* hcan);
+void HAL_CAN_MspDeInit(CAN_HandleTypeDef* hcan);
+/**
+ * @}
+ */ 
+ 
+/** @addtogroup CAN_Exported_Functions_Group2 Input and Output operation functions
+ *  @brief    I/O operation functions 
+ * @{
+ */
+/* IO operation functions *****************************************************/
+HAL_StatusTypeDef HAL_CAN_Transmit(CAN_HandleTypeDef *hcan, uint32_t Timeout);
+HAL_StatusTypeDef HAL_CAN_Transmit_IT(CAN_HandleTypeDef *hcan);
+HAL_StatusTypeDef HAL_CAN_Receive(CAN_HandleTypeDef *hcan, uint8_t FIFONumber, uint32_t Timeout);
+HAL_StatusTypeDef HAL_CAN_Receive_IT(CAN_HandleTypeDef *hcan, uint8_t FIFONumber);
+HAL_StatusTypeDef HAL_CAN_Sleep(CAN_HandleTypeDef *hcan);
+HAL_StatusTypeDef HAL_CAN_WakeUp(CAN_HandleTypeDef *hcan);
+void HAL_CAN_IRQHandler(CAN_HandleTypeDef* hcan);
+void HAL_CAN_TxCpltCallback(CAN_HandleTypeDef* hcan);
+void HAL_CAN_RxCpltCallback(CAN_HandleTypeDef* hcan);
+void HAL_CAN_ErrorCallback(CAN_HandleTypeDef *hcan);
+/**
+ * @}
+ */ 
+ 
+/** @addtogroup CAN_Exported_Functions_Group3 Peripheral State and Error functions
+ *  @brief   CAN Peripheral State functions 
+ * @{
+ */
+/* Peripheral State and Error functions ***************************************/
+uint32_t HAL_CAN_GetError(CAN_HandleTypeDef *hcan);
+HAL_CAN_StateTypeDef HAL_CAN_GetState(CAN_HandleTypeDef* hcan);
+/**
+ * @}
+ */ 
+
+/**
+ * @}
+ */ 
+
+/* Private types -------------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup CAN_Private_Constants CAN Private Constants
+  * @{
+  */
+/** @defgroup CAN_transmit_constants CAN Transmit Constants
+  * @{
+  */
+#define CAN_TXSTATUS_NOMAILBOX      ((uint8_t)0x04)  /*!< CAN cell did not provide CAN_TxStatus_NoMailBox */
+/**
+  * @}
+  */
+#define CAN_FLAG_MASK     ((uint32_t)0x000000FF)
+
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup CAN_Private_Macros CAN Private Macros
+  * @{
+  */
+
+#define IS_CAN_MODE(MODE) (((MODE) == CAN_MODE_NORMAL) || \
+                           ((MODE) == CAN_MODE_LOOPBACK)|| \
+                           ((MODE) == CAN_MODE_SILENT) || \
+                           ((MODE) == CAN_MODE_SILENT_LOOPBACK))
+
+#define IS_CAN_SJW(SJW) (((SJW) == CAN_SJW_1TQ) || ((SJW) == CAN_SJW_2TQ)|| \
+                         ((SJW) == CAN_SJW_3TQ) || ((SJW) == CAN_SJW_4TQ))
+
+#define IS_CAN_BS1(BS1) ((BS1) <= CAN_BS1_16TQ)
+
+#define IS_CAN_BS2(BS2) ((BS2) <= CAN_BS2_8TQ)
+
+#define IS_CAN_PRESCALER(PRESCALER) (((PRESCALER) >= 1) && ((PRESCALER) <= 1024))
+
+#define IS_CAN_FILTER_NUMBER(NUMBER) ((NUMBER) <= 27)
+
+#define IS_CAN_FILTER_MODE(MODE) (((MODE) == CAN_FILTERMODE_IDMASK) || \
+                                  ((MODE) == CAN_FILTERMODE_IDLIST))
+
+#define IS_CAN_FILTER_SCALE(SCALE) (((SCALE) == CAN_FILTERSCALE_16BIT) || \
+                                    ((SCALE) == CAN_FILTERSCALE_32BIT))
+
+#define IS_CAN_FILTER_FIFO(FIFO) (((FIFO) == CAN_FILTER_FIFO0) || \
+                                  ((FIFO) == CAN_FILTER_FIFO1))
+
+#define IS_CAN_BANKNUMBER(BANKNUMBER) ((BANKNUMBER) <= 28)
+
+#define IS_CAN_TRANSMITMAILBOX(TRANSMITMAILBOX) ((TRANSMITMAILBOX) <= ((uint8_t)0x02))
+
+#define IS_CAN_STDID(STDID)   ((STDID) <= ((uint32_t)0x7FF))
+
+#define IS_CAN_EXTID(EXTID)   ((EXTID) <= ((uint32_t)0x1FFFFFFF))
+
+#define IS_CAN_DLC(DLC)       ((DLC) <= ((uint8_t)0x08))
+
+#define IS_CAN_IDTYPE(IDTYPE)  (((IDTYPE) == CAN_ID_STD) || \
+                                ((IDTYPE) == CAN_ID_EXT))
+
+#define IS_CAN_RTR(RTR) (((RTR) == CAN_RTR_DATA) || ((RTR) == CAN_RTR_REMOTE))
+
+#define IS_CAN_FIFO(FIFO) (((FIFO) == CAN_FIFO0) || ((FIFO) == CAN_FIFO1))
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_CAN_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_cortex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_cortex.h
@@ -1,0 +1,467 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_cortex.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of CORTEX HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_CORTEX_H
+#define __STM32L4xx_HAL_CORTEX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup CORTEX CORTEX
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup CORTEX_Exported_Types CORTEX Exported Types
+  * @{
+  */
+
+#if (__MPU_PRESENT == 1)
+/** @defgroup CORTEX_MPU_Region_Initialization_Structure_definition MPU Region Initialization Structure Definition
+  * @{
+  */
+typedef struct
+{
+  uint8_t                Enable;                /*!< Specifies the status of the region. 
+                                                     This parameter can be a value of @ref CORTEX_MPU_Region_Enable                 */
+  uint8_t                Number;                /*!< Specifies the number of the region to protect. 
+                                                     This parameter can be a value of @ref CORTEX_MPU_Region_Number                 */
+  uint32_t               BaseAddress;           /*!< Specifies the base address of the region to protect.                           */
+  uint8_t                Size;                  /*!< Specifies the size of the region to protect. 
+                                                     This parameter can be a value of @ref CORTEX_MPU_Region_Size                   */
+  uint8_t                SubRegionDisable;      /*!< Specifies the number of the subregion protection to disable. 
+                                                     This parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFF    */
+  uint8_t                TypeExtField;          /*!< Specifies the TEX field level.
+                                                     This parameter can be a value of @ref CORTEX_MPU_TEX_Levels                    */
+  uint8_t                AccessPermission;      /*!< Specifies the region access permission type. 
+                                                     This parameter can be a value of @ref CORTEX_MPU_Region_Permission_Attributes  */
+  uint8_t                DisableExec;           /*!< Specifies the instruction access status. 
+                                                     This parameter can be a value of @ref CORTEX_MPU_Instruction_Access            */
+  uint8_t                IsShareable;           /*!< Specifies the shareability status of the protected region. 
+                                                     This parameter can be a value of @ref CORTEX_MPU_Access_Shareable              */
+  uint8_t                IsCacheable;           /*!< Specifies the cacheable status of the region protected. 
+                                                     This parameter can be a value of @ref CORTEX_MPU_Access_Cacheable              */
+  uint8_t                IsBufferable;          /*!< Specifies the bufferable status of the protected region. 
+                                                     This parameter can be a value of @ref CORTEX_MPU_Access_Bufferable             */
+}MPU_Region_InitTypeDef;
+/**
+  * @}
+  */
+#endif /* __MPU_PRESENT */
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup CORTEX_Exported_Constants CORTEX Exported Constants
+  * @{
+  */
+
+/** @defgroup CORTEX_Preemption_Priority_Group CORTEX Preemption Priority Group
+  * @{
+  */
+#define NVIC_PRIORITYGROUP_0         ((uint32_t)0x00000007) /*!< 0 bit  for pre-emption priority,
+                                                                 4 bits for subpriority */
+#define NVIC_PRIORITYGROUP_1         ((uint32_t)0x00000006) /*!< 1 bit  for pre-emption priority,
+                                                                 3 bits for subpriority */
+#define NVIC_PRIORITYGROUP_2         ((uint32_t)0x00000005) /*!< 2 bits for pre-emption priority,
+                                                                 2 bits for subpriority */
+#define NVIC_PRIORITYGROUP_3         ((uint32_t)0x00000004) /*!< 3 bits for pre-emption priority,
+                                                                 1 bit  for subpriority */
+#define NVIC_PRIORITYGROUP_4         ((uint32_t)0x00000003) /*!< 4 bits for pre-emption priority,
+                                                                 0 bit  for subpriority */
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_SysTick_clock_source CORTEX SysTick clock source
+  * @{
+  */
+#define SYSTICK_CLKSOURCE_HCLK_DIV8    ((uint32_t)0x00000000)
+#define SYSTICK_CLKSOURCE_HCLK         ((uint32_t)0x00000004)
+/**
+  * @}
+  */
+
+#if (__MPU_PRESENT == 1)
+/** @defgroup CORTEX_MPU_HFNMI_PRIVDEF_Control CORTEX MPU HFNMI and PRIVILEGED Access control
+  * @{
+  */
+#define  MPU_HFNMI_PRIVDEF_NONE      ((uint32_t)0x00000000)
+#define  MPU_HARDFAULT_NMI           ((uint32_t)0x00000002)
+#define  MPU_PRIVILEGED_DEFAULT      ((uint32_t)0x00000004)
+#define  MPU_HFNMI_PRIVDEF           ((uint32_t)0x00000006)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Region_Enable CORTEX MPU Region Enable
+  * @{
+  */
+#define  MPU_REGION_ENABLE           ((uint8_t)0x01)
+#define  MPU_REGION_DISABLE          ((uint8_t)0x00)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Instruction_Access CORTEX MPU Instruction Access
+  * @{
+  */
+#define  MPU_INSTRUCTION_ACCESS_ENABLE      ((uint8_t)0x00)
+#define  MPU_INSTRUCTION_ACCESS_DISABLE     ((uint8_t)0x01)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Access_Shareable CORTEX MPU Instruction Access Shareable
+  * @{
+  */
+#define  MPU_ACCESS_SHAREABLE        ((uint8_t)0x01)
+#define  MPU_ACCESS_NOT_SHAREABLE    ((uint8_t)0x00)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Access_Cacheable CORTEX MPU Instruction Access Cacheable
+  * @{
+  */
+#define  MPU_ACCESS_CACHEABLE        ((uint8_t)0x01)
+#define  MPU_ACCESS_NOT_CACHEABLE    ((uint8_t)0x00)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Access_Bufferable CORTEX MPU Instruction Access Bufferable
+  * @{
+  */
+#define  MPU_ACCESS_BUFFERABLE       ((uint8_t)0x01)
+#define  MPU_ACCESS_NOT_BUFFERABLE   ((uint8_t)0x00)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_TEX_Levels CORTEX MPU TEX Levels
+  * @{
+  */
+#define  MPU_TEX_LEVEL0              ((uint8_t)0x00)
+#define  MPU_TEX_LEVEL1              ((uint8_t)0x01)
+#define  MPU_TEX_LEVEL2              ((uint8_t)0x02)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Region_Size CORTEX MPU Region Size
+  * @{
+  */
+#define   MPU_REGION_SIZE_32B        ((uint8_t)0x04)
+#define   MPU_REGION_SIZE_64B        ((uint8_t)0x05)
+#define   MPU_REGION_SIZE_128B       ((uint8_t)0x06)
+#define   MPU_REGION_SIZE_256B       ((uint8_t)0x07)
+#define   MPU_REGION_SIZE_512B       ((uint8_t)0x08)
+#define   MPU_REGION_SIZE_1KB        ((uint8_t)0x09)
+#define   MPU_REGION_SIZE_2KB        ((uint8_t)0x0A)
+#define   MPU_REGION_SIZE_4KB        ((uint8_t)0x0B)
+#define   MPU_REGION_SIZE_8KB        ((uint8_t)0x0C)
+#define   MPU_REGION_SIZE_16KB       ((uint8_t)0x0D)
+#define   MPU_REGION_SIZE_32KB       ((uint8_t)0x0E)
+#define   MPU_REGION_SIZE_64KB       ((uint8_t)0x0F)
+#define   MPU_REGION_SIZE_128KB      ((uint8_t)0x10)
+#define   MPU_REGION_SIZE_256KB      ((uint8_t)0x11)
+#define   MPU_REGION_SIZE_512KB      ((uint8_t)0x12)
+#define   MPU_REGION_SIZE_1MB        ((uint8_t)0x13)
+#define   MPU_REGION_SIZE_2MB        ((uint8_t)0x14)
+#define   MPU_REGION_SIZE_4MB        ((uint8_t)0x15)
+#define   MPU_REGION_SIZE_8MB        ((uint8_t)0x16)
+#define   MPU_REGION_SIZE_16MB       ((uint8_t)0x17)
+#define   MPU_REGION_SIZE_32MB       ((uint8_t)0x18)
+#define   MPU_REGION_SIZE_64MB       ((uint8_t)0x19)
+#define   MPU_REGION_SIZE_128MB      ((uint8_t)0x1A)
+#define   MPU_REGION_SIZE_256MB      ((uint8_t)0x1B)
+#define   MPU_REGION_SIZE_512MB      ((uint8_t)0x1C)
+#define   MPU_REGION_SIZE_1GB        ((uint8_t)0x1D)
+#define   MPU_REGION_SIZE_2GB        ((uint8_t)0x1E)
+#define   MPU_REGION_SIZE_4GB        ((uint8_t)0x1F)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Region_Permission_Attributes CORTEX MPU Region Permission Attributes 
+  * @{
+  */
+#define  MPU_REGION_NO_ACCESS        ((uint8_t)0x00)
+#define  MPU_REGION_PRIV_RW          ((uint8_t)0x01)
+#define  MPU_REGION_PRIV_RW_URO      ((uint8_t)0x02)
+#define  MPU_REGION_FULL_ACCESS      ((uint8_t)0x03)
+#define  MPU_REGION_PRIV_RO          ((uint8_t)0x05)
+#define  MPU_REGION_PRIV_RO_URO      ((uint8_t)0x06)
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_MPU_Region_Number CORTEX MPU Region Number
+  * @{
+  */
+#define  MPU_REGION_NUMBER0          ((uint8_t)0x00)
+#define  MPU_REGION_NUMBER1          ((uint8_t)0x01)
+#define  MPU_REGION_NUMBER2          ((uint8_t)0x02)
+#define  MPU_REGION_NUMBER3          ((uint8_t)0x03)
+#define  MPU_REGION_NUMBER4          ((uint8_t)0x04)
+#define  MPU_REGION_NUMBER5          ((uint8_t)0x05)
+#define  MPU_REGION_NUMBER6          ((uint8_t)0x06)
+#define  MPU_REGION_NUMBER7          ((uint8_t)0x07)
+/**
+  * @}
+  */
+#endif /* __MPU_PRESENT */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup CORTEX_Exported_Macros CORTEX Exported Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup CORTEX_Exported_Functions CORTEX Exported Functions
+  * @{
+  */
+
+/** @defgroup CORTEX_Exported_Functions_Group1 Initialization and Configuration functions 
+  * @brief    Initialization and Configuration functions
+  * @{
+  */
+/* Initialization and Configuration functions *****************************/
+void HAL_NVIC_SetPriorityGrouping(uint32_t PriorityGroup);
+void HAL_NVIC_SetPriority(IRQn_Type IRQn, uint32_t PreemptPriority, uint32_t SubPriority);
+void HAL_NVIC_EnableIRQ(IRQn_Type IRQn);
+void HAL_NVIC_DisableIRQ(IRQn_Type IRQn);
+void HAL_NVIC_SystemReset(void);
+uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb);
+
+#if (__MPU_PRESENT == 1)
+/**
+  * @brief  Disable the MPU.
+  * @retval None
+  */
+__STATIC_INLINE void HAL_MPU_Disable(void)
+{
+  /* Disable fault exceptions */
+  SCB->SHCSR &= ~SCB_SHCSR_MEMFAULTENA_Msk;
+  
+  /* Disable the MPU */
+  MPU->CTRL  &= ~MPU_CTRL_ENABLE_Msk;
+}
+
+/**
+  * @brief  Enable the MPU.
+  * @param  MPU_Control: Specifies the control mode of the MPU during hard fault, 
+  *          NMI, FAULTMASK and privileged accessto the default memory 
+  *          This parameter can be one of the following values:
+  *            @arg MPU_HFNMI_PRIVDEF_NONE
+  *            @arg MPU_HARDFAULT_NMI
+  *            @arg MPU_PRIVILEGED_DEFAULT
+  *            @arg MPU_HFNMI_PRIVDEF
+  * @retval None
+  */
+__STATIC_INLINE void HAL_MPU_Enable(uint32_t MPU_Control)
+{
+  /* Enable the MPU */
+  MPU->CTRL   = MPU_Control | MPU_CTRL_ENABLE_Msk;
+  
+  /* Enable fault exceptions */
+  SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
+}
+#endif /* __MPU_PRESENT */
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_Exported_Functions_Group2 Peripheral Control functions 
+  * @brief   Cortex control functions
+  * @{
+  */
+/* Peripheral Control functions ***********************************************/
+uint32_t HAL_NVIC_GetPriorityGrouping(void);
+void HAL_NVIC_GetPriority(IRQn_Type IRQn, uint32_t PriorityGroup, uint32_t* pPreemptPriority, uint32_t* pSubPriority);
+uint32_t HAL_NVIC_GetPendingIRQ(IRQn_Type IRQn);
+void HAL_NVIC_SetPendingIRQ(IRQn_Type IRQn);
+void HAL_NVIC_ClearPendingIRQ(IRQn_Type IRQn);
+uint32_t HAL_NVIC_GetActive(IRQn_Type IRQn);
+void HAL_SYSTICK_CLKSourceConfig(uint32_t CLKSource);
+void HAL_SYSTICK_IRQHandler(void);
+void HAL_SYSTICK_Callback(void);
+
+#if (__MPU_PRESENT == 1)
+void HAL_MPU_ConfigRegion(MPU_Region_InitTypeDef *MPU_Init);
+#endif /* __MPU_PRESENT */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/ 
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup CORTEX_Private_Macros CORTEX Private Macros
+  * @{
+  */
+#define IS_NVIC_PRIORITY_GROUP(GROUP) (((GROUP) == NVIC_PRIORITYGROUP_0) || \
+                                       ((GROUP) == NVIC_PRIORITYGROUP_1) || \
+                                       ((GROUP) == NVIC_PRIORITYGROUP_2) || \
+                                       ((GROUP) == NVIC_PRIORITYGROUP_3) || \
+                                       ((GROUP) == NVIC_PRIORITYGROUP_4))
+
+#define IS_NVIC_PREEMPTION_PRIORITY(PRIORITY)  ((PRIORITY) < 0x10)
+
+#define IS_NVIC_SUB_PRIORITY(PRIORITY)         ((PRIORITY) < 0x10)
+
+#define IS_NVIC_DEVICE_IRQ(IRQ)                ((IRQ) >= 0x00)
+
+#define IS_SYSTICK_CLK_SOURCE(SOURCE) (((SOURCE) == SYSTICK_CLKSOURCE_HCLK) || \
+                                       ((SOURCE) == SYSTICK_CLKSOURCE_HCLK_DIV8))
+
+#if (__MPU_PRESENT == 1)
+#define IS_MPU_REGION_ENABLE(STATE) (((STATE) == MPU_REGION_ENABLE) || \
+                                     ((STATE) == MPU_REGION_DISABLE))
+
+#define IS_MPU_INSTRUCTION_ACCESS(STATE) (((STATE) == MPU_INSTRUCTION_ACCESS_ENABLE) || \
+                                          ((STATE) == MPU_INSTRUCTION_ACCESS_DISABLE))
+
+#define IS_MPU_ACCESS_SHAREABLE(STATE)   (((STATE) == MPU_ACCESS_SHAREABLE) || \
+                                          ((STATE) == MPU_ACCESS_NOT_SHAREABLE))
+
+#define IS_MPU_ACCESS_CACHEABLE(STATE)   (((STATE) == MPU_ACCESS_CACHEABLE) || \
+                                          ((STATE) == MPU_ACCESS_NOT_CACHEABLE))
+
+#define IS_MPU_ACCESS_BUFFERABLE(STATE)   (((STATE) == MPU_ACCESS_BUFFERABLE) || \
+                                          ((STATE) == MPU_ACCESS_NOT_BUFFERABLE))
+
+#define IS_MPU_TEX_LEVEL(TYPE) (((TYPE) == MPU_TEX_LEVEL0)  || \
+                                ((TYPE) == MPU_TEX_LEVEL1)  || \
+                                ((TYPE) == MPU_TEX_LEVEL2))
+
+#define IS_MPU_REGION_PERMISSION_ATTRIBUTE(TYPE) (((TYPE) == MPU_REGION_NO_ACCESS)   || \
+                                                  ((TYPE) == MPU_REGION_PRIV_RW)     || \
+                                                  ((TYPE) == MPU_REGION_PRIV_RW_URO) || \
+                                                  ((TYPE) == MPU_REGION_FULL_ACCESS) || \
+                                                  ((TYPE) == MPU_REGION_PRIV_RO)     || \
+                                                  ((TYPE) == MPU_REGION_PRIV_RO_URO))
+
+#define IS_MPU_REGION_NUMBER(NUMBER)    (((NUMBER) == MPU_REGION_NUMBER0) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER1) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER2) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER3) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER4) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER5) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER6) || \
+                                         ((NUMBER) == MPU_REGION_NUMBER7))
+
+#define IS_MPU_REGION_SIZE(SIZE)    (((SIZE) == MPU_REGION_SIZE_32B)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_64B)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_128B)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_256B)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_512B)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_1KB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_2KB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_4KB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_8KB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_16KB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_32KB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_64KB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_128KB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_256KB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_512KB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_1MB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_2MB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_4MB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_8MB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_16MB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_32MB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_64MB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_128MB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_256MB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_512MB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_1GB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_2GB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_4GB))
+
+#define IS_MPU_SUB_REGION_DISABLE(SUBREGION)  ((SUBREGION) < (uint16_t)0x00FF)
+#endif /* __MPU_PRESENT */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_CORTEX_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_dac.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_dac.h
@@ -1,0 +1,479 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_dac.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of DAC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_DAC_H
+#define __STM32L4xx_HAL_DAC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+   
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup DAC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup DAC_Exported_Types DAC Exported Types
+  * @{
+  */
+
+/** 
+  * @brief  HAL State structures definition  
+  */ 
+typedef enum
+{
+  HAL_DAC_STATE_RESET             = 0x00,  /*!< DAC not yet initialized or disabled  */
+  HAL_DAC_STATE_READY             = 0x01,  /*!< DAC initialized and ready for use    */
+  HAL_DAC_STATE_BUSY              = 0x02,  /*!< DAC internal processing is ongoing   */
+  HAL_DAC_STATE_TIMEOUT           = 0x03,  /*!< DAC timeout state                    */
+  HAL_DAC_STATE_ERROR             = 0x04   /*!< DAC error state                      */
+ 
+}HAL_DAC_StateTypeDef;
+ 
+/** 
+  * @brief  DAC handle Structure definition  
+  */ 
+typedef struct
+{
+  DAC_TypeDef                 *Instance;     /*!< Register base address             */
+  
+  __IO HAL_DAC_StateTypeDef   State;         /*!< DAC communication state           */
+
+  HAL_LockTypeDef             Lock;          /*!< DAC locking object                */
+  
+  DMA_HandleTypeDef           *DMA_Handle1;  /*!< Pointer DMA handler for channel 1 */
+  
+  DMA_HandleTypeDef           *DMA_Handle2;  /*!< Pointer DMA handler for channel 2 */ 
+  
+  __IO uint32_t               ErrorCode;     /*!< DAC Error code                    */
+  
+}DAC_HandleTypeDef;
+
+/** 
+  * @brief   DAC Configuration sample and hold Channel structure definition  
+  */ 
+typedef struct
+{
+  uint32_t DAC_SampleTime ;          /*!< Specifies the Sample time for the selected channel.
+                                          This parameter applies when DAC_SampleAndHold is DAC_SAMPLEANDHOLD_ENABLE. 
+                                          This parameter must be a number between Min_Data = 0 and Max_Data = 1023 */  
+
+  uint32_t DAC_HoldTime ;            /*!< Specifies the hold time for the selected channel
+                                          This parameter applies when DAC_SampleAndHold is DAC_SAMPLEANDHOLD_ENABLE. 
+                                          This parameter must be a number between Min_Data = 0 and Max_Data = 1023 */    
+  
+  uint32_t DAC_RefreshTime ;         /*!< Specifies the refresh time for the selected channel
+                                          This parameter applies when DAC_SampleAndHold is DAC_SAMPLEANDHOLD_ENABLE. 
+                                          This parameter must be a number between Min_Data = 0 and Max_Data = 255 */  
+}
+DAC_SampleAndHoldConfTypeDef;
+
+/** 
+  * @brief   DAC Configuration regular Channel structure definition  
+  */ 
+typedef struct
+{
+  uint32_t DAC_SampleAndHold;            /*!< Specifies whether the DAC mode.
+                                              This parameter can be a value of @ref DAC_SampleAndHold */
+  
+  uint32_t DAC_Trigger;                  /*!< Specifies the external trigger for the selected DAC channel.
+                                              This parameter can be a value of @ref DAC_trigger_selection */
+  
+  uint32_t DAC_OutputBuffer;             /*!< Specifies whether the DAC channel output buffer is enabled or disabled.
+                                               This parameter can be a value of @ref DAC_output_buffer */
+
+  uint32_t DAC_ConnectOnChipPeripheral ; /*!< Specifies whether the DAC output is connected or not to on chip peripheral .
+                                              This parameter can be a value of @ref DAC_ConnectOnChipPeripheral */
+  
+  uint32_t DAC_UserTrimming;             /*!< Specifies the trimming mode 
+                                              This parameter must be a value of @ref DAC_UserTrimming 
+                                              DAC_UserTrimming is either factory or user trimming */
+                                        
+  uint32_t DAC_TrimmingValue;             /*!< Specifies the offset trimming value 
+                                               i.e. when DAC_SampleAndHold is DAC_TRIMMING_USER. 
+                                               This parameter must be a number between Min_Data = 1 and Max_Data = 31 */
+
+  DAC_SampleAndHoldConfTypeDef  DAC_SampleAndHoldConfig;  /*!< Sample and Hold settings */ 
+      
+}DAC_ChannelConfTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup DAC_Exported_Constants DAC Exported Constants
+  * @{
+  */
+
+/** @defgroup DAC_Error_Code DAC Error Code
+  * @{
+  */
+#define  HAL_DAC_ERROR_NONE              0x00    /*!< No error                          */
+#define  HAL_DAC_ERROR_DMAUNDERRUNCH1    0x01    /*!< DAC channel1 DMA underrun error   */
+#define  HAL_DAC_ERROR_DMAUNDERRUNCH2    0x02    /*!< DAC channel2 DMA underrun error   */
+#define  HAL_DAC_ERROR_DMA               0x04    /*!< DMA error                         */
+#define  HAL_DAC_ERROR_TIMEOUT           0x08    /*!< Timeout error                     */
+/**
+  * @}
+  */
+
+/** @defgroup DAC_trigger_selection DAC trigger selection
+  * @{
+  */
+
+#define DAC_TRIGGER_NONE                   ((uint32_t)0x00000000) /*!< Conversion is automatic once the DAC_DHRxxxx register 
+                                                                       has been loaded, and not by external trigger */
+#define DAC_TRIGGER_T2_TRGO                ((uint32_t)(DAC_CR_TSEL1_2 | DAC_CR_TEN1)) /*!< TIM2 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T4_TRGO                ((uint32_t)(DAC_CR_TSEL1_2 |DAC_CR_TSEL1_0 | DAC_CR_TEN1)) /*!< TIM4 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T5_TRGO                ((uint32_t)(DAC_CR_TSEL1_1 | DAC_CR_TSEL1_0 | DAC_CR_TEN1)) /*!< TIM5 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T6_TRGO                ((uint32_t)DAC_CR_TEN1) /*!< TIM6 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T7_TRGO                ((uint32_t)(DAC_CR_TSEL1_1 | DAC_CR_TEN1)) /*!< TIM7 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T8_TRGO                ((uint32_t)(DAC_CR_TSEL1_0 | DAC_CR_TEN1)) /*!< TIM8 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_EXT_IT9                ((uint32_t)(DAC_CR_TSEL1_2 | DAC_CR_TSEL1_1 | DAC_CR_TEN1)) /*!< EXTI Line9 event selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_SOFTWARE               ((uint32_t)(DAC_CR_TSEL1 | DAC_CR_TEN1)) /*!< Conversion started by software trigger for DAC channel */
+
+/**
+  * @}
+  */   
+
+/** @defgroup DAC_output_buffer DAC output buffer
+  * @{
+  */
+#define DAC_OUTPUTBUFFER_ENABLE            ((uint32_t)0x00000000)
+#define DAC_OUTPUTBUFFER_DISABLE           ((uint32_t)DAC_MCR_MODE1_1)
+
+/**
+  * @}
+  */
+    
+/** @defgroup DAC_Channel_selection DAC Channel selection
+  * @{
+  */
+#define DAC_CHANNEL_1                      ((uint32_t)0x00000000)
+#define DAC_CHANNEL_2                      ((uint32_t)0x00000010)
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_data_alignment DAC data alignment
+  * @{
+  */
+#define DAC_ALIGN_12B_R                    ((uint32_t)0x00000000)
+#define DAC_ALIGN_12B_L                    ((uint32_t)0x00000004)
+#define DAC_ALIGN_8B_R                     ((uint32_t)0x00000008)
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_flags_definition DAC flags definition
+  * @{
+  */ 
+#define DAC_FLAG_DMAUDR1                   ((uint32_t)DAC_SR_DMAUDR1)
+#define DAC_FLAG_DMAUDR2                   ((uint32_t)DAC_SR_DMAUDR2)   
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_IT_definition  DAC IT definition
+  * @{
+  */ 
+#define DAC_IT_DMAUDR1                   ((uint32_t)DAC_SR_DMAUDR1)
+#define DAC_IT_DMAUDR2                   ((uint32_t)DAC_SR_DMAUDR2)   
+
+/**
+  * @}
+  */
+  
+/** @defgroup DAC_ConnectOnChipPeripheral DAC ConnectOnChipPeripheral
+  * @{
+  */
+#define DAC_CHIPCONNECT_DISABLE  ((uint32_t)0x00000000)
+#define DAC_CHIPCONNECT_ENABLE     ((uint32_t)DAC_MCR_MODE1_0)
+
+/**
+  * @}
+  */
+
+  /** @defgroup DAC_UserTrimming DAC User Trimming
+  * @{
+  */
+
+#define DAC_TRIMMING_FACTORY        ((uint32_t)0x00000000)           /*!< Factory trimming */
+#define DAC_TRIMMING_USER           ((uint32_t)0x00000001)           /*!< User trimming */
+   
+/**
+  * @}
+  */ 
+
+/** @defgroup DAC_SampleAndHold DAC power mode
+  * @{
+  */
+#define DAC_SAMPLEANDHOLD_DISABLE     ((uint32_t)0x00000000)
+#define DAC_SAMPLEANDHOLD_ENABLE      ((uint32_t)DAC_MCR_MODE1_2)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup DAC_Exported_Macros DAC Exported Macros
+  * @{
+  */
+
+/** @brief Reset DAC handle state.
+  * @param  __HANDLE__: specifies the DAC handle.
+  * @retval None
+  */
+#define __HAL_DAC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_DAC_STATE_RESET)
+
+/** @brief Enable the DAC channel.
+  * @param  __HANDLE__: specifies the DAC handle.
+  * @param  __DAC_Channel__: specifies the DAC channel
+  * @retval None
+  */
+#define __HAL_DAC_ENABLE(__HANDLE__, __DAC_Channel__) \
+((__HANDLE__)->Instance->CR |=  (DAC_CR_EN1 << (__DAC_Channel__)))
+
+/** @brief Disable the DAC channel.
+  * @param  __HANDLE__: specifies the DAC handle
+  * @param  __DAC_Channel__: specifies the DAC channel.
+  * @retval None
+  */
+#define __HAL_DAC_DISABLE(__HANDLE__, __DAC_Channel__) \
+((__HANDLE__)->Instance->CR &=  ~(DAC_CR_EN1 << (__DAC_Channel__)))
+ 
+/** @brief Set DHR12R1 alignment.
+  * @param  __ALIGNMENT__: specifies the DAC alignment
+  * @retval None
+  */
+#define DAC_DHR12R1_ALIGNMENT(__ALIGNMENT__) (((uint32_t)0x00000008) + (__ALIGNMENT__))
+
+/** @brief  Set DHR12R2 alignment.
+  * @param  __ALIGNMENT__: specifies the DAC alignment
+  * @retval None
+  */
+#define DAC_DHR12R2_ALIGNMENT(__ALIGNMENT__) (((uint32_t)0x00000014) + (__ALIGNMENT__))
+
+/** @brief  Set DHR12RD alignment.
+  * @param  __ALIGNMENT__: specifies the DAC alignment
+  * @retval None
+  */
+#define DAC_DHR12RD_ALIGNMENT(__ALIGNMENT__) (((uint32_t)0x00000020) + (__ALIGNMENT__))
+
+/** @brief Enable the DAC interrupt.
+  * @param  __HANDLE__: specifies the DAC handle
+  * @param  __INTERRUPT__: specifies the DAC interrupt.
+  *          This parameter can be any combination of the following values:
+  *            @arg DAC_IT_DMAUDR1: DAC channel 1 DMA underrun interrupt
+  *            @arg DAC_IT_DMAUDR2: DAC channel 2 DMA underrun interrupt
+  * @retval None
+  */
+#define __HAL_DAC_ENABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR) |= (__INTERRUPT__))
+
+/** @brief Disable the DAC interrupt.
+  * @param  __HANDLE__: specifies the DAC handle
+  * @param  __INTERRUPT__: specifies the DAC interrupt.
+  *          This parameter can be any combination of the following values:
+  *            @arg DAC_IT_DMAUDR1: DAC channel 1 DMA underrun interrupt
+  *            @arg DAC_IT_DMAUDR2: DAC channel 2 DMA underrun interrupt
+  * @retval None
+  */
+#define __HAL_DAC_DISABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR) &= ~(__INTERRUPT__))
+
+/** @brief  Check whether the specified DAC interrupt source is enabled or not.
+  * @param __HANDLE__: DAC handle
+  * @param __INTERRUPT__: DAC interrupt source to check
+  *          This parameter can be any combination of the following values:
+  *            @arg DAC_IT_DMAUDR1: DAC channel 1 DMA underrun interrupt
+  *            @arg DAC_IT_DMAUDR2: DAC channel 2 DMA underrun interrupt
+  * @retval State of interruption (SET or RESET)
+  */
+#define __HAL_DAC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR & (__INTERRUPT__)) == (__INTERRUPT__))
+
+/** @brief  Get the selected DAC's flag status.
+  * @param  __HANDLE__: specifies the DAC handle.
+  * @param  __FLAG__: specifies the DAC flag to get.
+  *          This parameter can be any combination of the following values:
+  *            @arg DAC_FLAG_DMAUDR1: DAC channel 1 DMA underrun flag
+  *            @arg DAC_FLAG_DMAUDR2: DAC channel 2 DMA underrun flag
+  * @retval None
+  */
+#define __HAL_DAC_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->SR) & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Clear the DAC's flag.
+  * @param  __HANDLE__: specifies the DAC handle.
+  * @param  __FLAG__: specifies the DAC flag to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg DAC_FLAG_DMAUDR1: DAC channel 1 DMA underrun flag
+  *            @arg DAC_FLAG_DMAUDR2: DAC channel 2 DMA underrun flag
+  * @retval None
+  */
+#define __HAL_DAC_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) = (__FLAG__))
+
+/**
+  * @}
+  */ 
+
+/* Private macro -------------------------------------------------------------*/
+
+/** @defgroup DAC_Private_Macros DAC Private Macros
+  * @{
+  */
+#define IS_DAC_OUTPUT_BUFFER_STATE(STATE) (((STATE) == DAC_OUTPUTBUFFER_ENABLE) || \
+                                           ((STATE) == DAC_OUTPUTBUFFER_DISABLE))
+
+#define IS_DAC_CHANNEL(CHANNEL) (((CHANNEL) == DAC_CHANNEL_1) || \
+                                ((CHANNEL) == DAC_CHANNEL_2))
+
+#define IS_DAC_ALIGN(ALIGN) (((ALIGN) == DAC_ALIGN_12B_R) || \
+                             ((ALIGN) == DAC_ALIGN_12B_L) || \
+                             ((ALIGN) == DAC_ALIGN_8B_R))
+
+#define IS_DAC_DATA(DATA) ((DATA) <= 0xFFF0)
+
+#define IS_DAC_REFRESHTIME(TIME)   ((TIME) <= 0x0000000FF)
+
+/**
+  * @}
+  */
+  
+/* Include DAC HAL Extended module */
+#include "stm32l4xx_hal_dac_ex.h"   
+
+/* Exported functions --------------------------------------------------------*/  
+
+/** @addtogroup DAC_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group1
+  * @{
+  */  
+/* Initialization and de-initialization functions *****************************/ 
+HAL_StatusTypeDef HAL_DAC_Init(DAC_HandleTypeDef* hdac);
+HAL_StatusTypeDef HAL_DAC_DeInit(DAC_HandleTypeDef* hdac);
+void HAL_DAC_MspInit(DAC_HandleTypeDef* hdac);
+void HAL_DAC_MspDeInit(DAC_HandleTypeDef* hdac);
+
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group2
+ * @{
+ */    
+/* IO operation functions *****************************************************/
+HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef* hdac, uint32_t Channel);
+HAL_StatusTypeDef HAL_DAC_Stop(DAC_HandleTypeDef* hdac, uint32_t Channel);
+HAL_StatusTypeDef HAL_DAC_Start_DMA(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t* pData, uint32_t Length, uint32_t Alignment);
+HAL_StatusTypeDef HAL_DAC_Stop_DMA(DAC_HandleTypeDef* hdac, uint32_t Channel);
+
+void HAL_DAC_IRQHandler(DAC_HandleTypeDef* hdac);
+
+HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t Alignment, uint32_t Data);
+
+void HAL_DAC_ConvCpltCallbackCh1(DAC_HandleTypeDef* hdac);
+void HAL_DAC_ConvHalfCpltCallbackCh1(DAC_HandleTypeDef* hdac);
+void HAL_DAC_ErrorCallbackCh1(DAC_HandleTypeDef *hdac);
+void HAL_DAC_DMAUnderrunCallbackCh1(DAC_HandleTypeDef *hdac);
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group3
+  * @{
+  */ 
+/* Peripheral Control functions ***********************************************/
+uint32_t HAL_DAC_GetValue(DAC_HandleTypeDef* hdac, uint32_t Channel);
+
+HAL_StatusTypeDef HAL_DAC_ConfigChannel(DAC_HandleTypeDef* hdac, DAC_ChannelConfTypeDef* sConfig, uint32_t Channel);
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group4
+  * @{
+  */     
+/* Peripheral State and Error functions ***************************************/
+HAL_DAC_StateTypeDef HAL_DAC_GetState(DAC_HandleTypeDef* hdac);
+uint32_t HAL_DAC_GetError(DAC_HandleTypeDef *hdac);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif 
+  
+
+#endif /*__STM32L4xx_HAL_DAC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_dac_ex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_dac_ex.h
@@ -1,0 +1,245 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_dac_ex.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of DAC HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_DAC_EX_H
+#define __STM32L4xx_HAL_DAC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+           
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup DACEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+   
+/** 
+  * @brief  HAL State structures definition  
+  */ 
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup DACEx_Exported_Constants DACEx Exported Constants
+  * @{
+  */ 
+    
+/** @defgroup DACEx_lfsrunmask_triangleamplitude DACEx lfsrunmask triangleamplitude
+  * @{
+  */
+#define DAC_LFSRUNMASK_BIT0                ((uint32_t)0x00000000) /*!< Unmask DAC channel LFSR bit0 for noise wave generation */
+#define DAC_LFSRUNMASK_BITS1_0             ((uint32_t)DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[1:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS2_0             ((uint32_t)DAC_CR_MAMP1_1) /*!< Unmask DAC channel LFSR bit[2:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS3_0             ((uint32_t)DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0)/*!< Unmask DAC channel LFSR bit[3:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS4_0             ((uint32_t)DAC_CR_MAMP1_2) /*!< Unmask DAC channel LFSR bit[4:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS5_0             ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[5:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS6_0             ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1) /*!< Unmask DAC channel LFSR bit[6:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS7_0             ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[7:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS8_0             ((uint32_t)DAC_CR_MAMP1_3) /*!< Unmask DAC channel LFSR bit[8:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS9_0             ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[9:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS10_0            ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1) /*!< Unmask DAC channel LFSR bit[10:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS11_0            ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[11:0] for noise wave generation */
+#define DAC_TRIANGLEAMPLITUDE_1            ((uint32_t)0x00000000) /*!< Select max triangle amplitude of 1 */
+#define DAC_TRIANGLEAMPLITUDE_3            ((uint32_t)DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 3 */
+#define DAC_TRIANGLEAMPLITUDE_7            ((uint32_t)DAC_CR_MAMP1_1) /*!< Select max triangle amplitude of 7 */
+#define DAC_TRIANGLEAMPLITUDE_15           ((uint32_t)DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 15 */
+#define DAC_TRIANGLEAMPLITUDE_31           ((uint32_t)DAC_CR_MAMP1_2) /*!< Select max triangle amplitude of 31 */
+#define DAC_TRIANGLEAMPLITUDE_63           ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 63 */
+#define DAC_TRIANGLEAMPLITUDE_127          ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1) /*!< Select max triangle amplitude of 127 */
+#define DAC_TRIANGLEAMPLITUDE_255          ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 255 */
+#define DAC_TRIANGLEAMPLITUDE_511          ((uint32_t)DAC_CR_MAMP1_3) /*!< Select max triangle amplitude of 511 */
+#define DAC_TRIANGLEAMPLITUDE_1023         ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 1023 */
+#define DAC_TRIANGLEAMPLITUDE_2047         ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1) /*!< Select max triangle amplitude of 2047 */
+#define DAC_TRIANGLEAMPLITUDE_4095         ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 4095 */
+
+/**
+  * @}
+  */       
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+
+/* Private macro -------------------------------------------------------------*/
+
+/** @defgroup DACEx_Private_Macros DACEx Private Macros
+  * @{
+  */
+
+#define IS_DAC_TRIGGER(TRIGGER) (((TRIGGER) == DAC_TRIGGER_NONE) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T2_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T4_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T5_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T6_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T7_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T8_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_EXT_IT9) || \
+                                 ((TRIGGER) == DAC_TRIGGER_SOFTWARE))      
+
+#define IS_DAC_SAMPLETIME(TIME) ((TIME) <= 0x0000003FF)
+
+#define IS_DAC_HOLDTIME(TIME)   ((TIME) <= 0x0000003FF)
+
+#define IS_DAC_SAMPLEANDHOLD(MODE) (((MODE) == DAC_SAMPLEANDHOLD_DISABLE) || \
+                                    ((MODE) == DAC_SAMPLEANDHOLD_ENABLE))
+
+
+#define IS_DAC_TRIMMINGVALUE(TRIMMINGVALUE) ((TRIMMINGVALUE) <= 0x1F)
+
+#define IS_DAC_NEWTRIMMINGVALUE(TRIMMINGVALUE) ((TRIMMINGVALUE) <= 0x1F)
+
+#define IS_DAC_CHIP_CONNECTION(CONNECT) (((CONNECT) == DAC_CHIPCONNECT_DISABLE) || \
+                                         ((CONNECT) == DAC_CHIPCONNECT_ENABLE))
+
+#define IS_DAC_TRIMMING(TRIMMING) (((TRIMMING) == DAC_TRIMMING_FACTORY) || \
+                                     ((TRIMMING) == DAC_TRIMMING_USER))
+
+#define IS_DAC_LFSR_UNMASK_TRIANGLE_AMPLITUDE(VALUE) (((VALUE) == DAC_LFSRUNMASK_BIT0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS1_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS2_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS3_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS4_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS5_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS6_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS7_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS8_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS9_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS10_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS11_0) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_1) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_3) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_7) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_15) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_31) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_63) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_127) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_255) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_511) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_1023) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_2047) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_4095))
+
+
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/  
+/* Extended features functions ***********************************************/
+
+/** @addtogroup DACEx_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup DACEx_Exported_Functions_Group2
+ * @{
+ */    
+/* IO operation functions *****************************************************/
+  
+HAL_StatusTypeDef HAL_DACEx_TriangleWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t Amplitude);
+HAL_StatusTypeDef HAL_DACEx_NoiseWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t Amplitude);
+HAL_StatusTypeDef HAL_DACEx_DualSetValue(DAC_HandleTypeDef* hdac, uint32_t Alignment, uint32_t Data1, uint32_t Data2);
+
+void HAL_DACEx_ConvCpltCallbackCh2(DAC_HandleTypeDef* hdac);
+void HAL_DACEx_ConvHalfCpltCallbackCh2(DAC_HandleTypeDef* hdac);
+void HAL_DACEx_ErrorCallbackCh2(DAC_HandleTypeDef* hdac);
+void HAL_DACEx_DMAUnderrunCallbackCh2(DAC_HandleTypeDef* hdac);
+
+HAL_StatusTypeDef HAL_DACEx_SelfCalibrate (DAC_HandleTypeDef* hdac, DAC_ChannelConfTypeDef* sConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_DACEx_SetUserTrimming (DAC_HandleTypeDef* hdac, DAC_ChannelConfTypeDef* sConfig, uint32_t Channel, uint32_t NewTrimmingValue);
+
+/**
+  * @}
+  */
+
+/** @addtogroup DACEx_Exported_Functions_Group3
+  * @{
+  */ 
+/* Peripheral Control functions ***********************************************/
+
+uint32_t HAL_DACEx_DualGetValue(DAC_HandleTypeDef* hdac);
+uint32_t HAL_DACEx_GetTrimOffset (DAC_HandleTypeDef *hdac, uint32_t Channel);
+   
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup DACEx_Private_Functions
+  * @{
+  */
+
+/* DAC_DMAConvCpltCh2 / DAC_DMAErrorCh2 / DAC_DMAHalfConvCpltCh2 */
+/* are called by HAL_DAC_Start_DMA */
+void DAC_DMAConvCpltCh2(DMA_HandleTypeDef *hdma);
+void DAC_DMAErrorCh2(DMA_HandleTypeDef *hdma);
+void DAC_DMAHalfConvCpltCh2(DMA_HandleTypeDef *hdma);
+
+/**
+ * @}
+ */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif   
+
+#endif /*__STM32L4xx_HAL_DAC_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_def.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_def.h
@@ -1,0 +1,215 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_def.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   This file contains HAL common defines, enumeration, macros and
+  *          structures definitions.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_DEF
+#define __STM32L4xx_HAL_DEF
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx.h"
+#include "Legacy/stm32_hal_legacy.h"  /* Aliases file for old names compatibility */
+#include <stdio.h>
+
+/* Exported types ------------------------------------------------------------*/
+
+/**
+  * @brief  HAL Status structures definition
+  */
+typedef enum
+{
+  HAL_OK       = 0x00,
+  HAL_ERROR    = 0x01,
+  HAL_BUSY     = 0x02,
+  HAL_TIMEOUT  = 0x03
+} HAL_StatusTypeDef;
+
+/**
+  * @brief  HAL Lock structures definition
+  */
+typedef enum
+{
+  HAL_UNLOCKED = 0x00,
+  HAL_LOCKED   = 0x01
+} HAL_LockTypeDef;
+
+/* Exported macros -----------------------------------------------------------*/
+
+#define HAL_MAX_DELAY      0xFFFFFFFF
+
+#define HAL_IS_BIT_SET(REG, BIT)         (((REG) & (BIT)) == (BIT))
+#define HAL_IS_BIT_CLR(REG, BIT)         (((REG) & (BIT)) == RESET)
+
+#define __HAL_LINKDMA(__HANDLE__, __PPP_DMA_FIELD__, __DMA_HANDLE__)             \
+                        do{                                                      \
+                            (__HANDLE__)->__PPP_DMA_FIELD__ = &(__DMA_HANDLE__); \
+                            (__DMA_HANDLE__).Parent = (__HANDLE__);              \
+                        } while(0)
+
+#define UNUSED(x) ((void)(x))
+                         
+/** @brief Reset the Handle's State field.
+  * @param __HANDLE__: specifies the Peripheral Handle.
+  * @note  This macro can be used for the following purpose: 
+  *          - When the Handle is declared as local variable; before passing it as parameter
+  *            to HAL_PPP_Init() for the first time, it is mandatory to use this macro 
+  *            to set to 0 the Handle's "State" field.
+  *            Otherwise, "State" field may have any random value and the first time the function 
+  *            HAL_PPP_Init() is called, the low level hardware initialization will be missed
+  *            (i.e. HAL_PPP_MspInit() will not be executed).
+  *          - When there is a need to reconfigure the low level hardware: instead of calling
+  *            HAL_PPP_DeInit() then HAL_PPP_Init(), user can make a call to this macro then HAL_PPP_Init().
+  *            In this later function, when the Handle's "State" field is set to 0, it will execute the function
+  *            HAL_PPP_MspInit() which will reconfigure the low level hardware.
+  * @retval None
+  */
+#define __HAL_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = 0)
+
+#if (USE_RTOS == 1)
+  /* Reserved for future use */
+  #error " USE_RTOS should be 0 in the current HAL release "
+#else
+  #define __HAL_LOCK(__HANDLE__)                                           \
+                                do{                                        \
+                                    if((__HANDLE__)->Lock == HAL_LOCKED)   \
+                                    {                                      \
+                                       return HAL_BUSY;                    \
+                                    }                                      \
+                                    else                                   \
+                                    {                                      \
+                                       (__HANDLE__)->Lock = HAL_LOCKED;    \
+                                    }                                      \
+                                  }while (0)
+
+  #define __HAL_UNLOCK(__HANDLE__)                                          \
+                                  do{                                       \
+                                      (__HANDLE__)->Lock = HAL_UNLOCKED;    \
+                                    }while (0)
+#endif /* USE_RTOS */
+
+#if  defined ( __GNUC__ )
+  #ifndef __weak
+    #define __weak   __attribute__((weak))
+  #endif /* __weak */
+  #ifndef __packed
+    #define __packed __attribute__((__packed__))
+  #endif /* __packed */
+#endif /* __GNUC__ */
+
+
+/* Macro to get variable aligned on 4-bytes, for __ICCARM__ the directive "#pragma data_alignment=4" must be used instead */
+#if defined   (__GNUC__)        /* GNU Compiler */
+  #ifndef __ALIGN_END
+    #define __ALIGN_END    __attribute__ ((aligned (4)))
+  #endif /* __ALIGN_END */
+  #ifndef __ALIGN_BEGIN
+    #define __ALIGN_BEGIN
+  #endif /* __ALIGN_BEGIN */
+#else
+  #ifndef __ALIGN_END
+    #define __ALIGN_END
+  #endif /* __ALIGN_END */
+  #ifndef __ALIGN_BEGIN
+    #if defined   (__CC_ARM)      /* ARM Compiler */
+      #define __ALIGN_BEGIN    __align(4)
+    #elif defined (__ICCARM__)    /* IAR Compiler */
+      #define __ALIGN_BEGIN
+    #endif /* __CC_ARM */
+  #endif /* __ALIGN_BEGIN */
+#endif /* __GNUC__ */
+
+/**
+  * @brief  __RAM_FUNC definition
+  */
+#if defined ( __CC_ARM   )
+/* ARM Compiler
+   ------------
+   RAM functions are defined using the toolchain options.
+   Functions that are executed in RAM should reside in a separate source module.
+   Using the 'Options for File' dialog you can simply change the 'Code / Const'
+   area of a module to a memory space in physical RAM.
+   Available memory areas are declared in the 'Target' tab of the 'Options for Target'
+   dialog.
+*/
+#define __RAM_FUNC HAL_StatusTypeDef
+
+#elif defined ( __ICCARM__ )
+/* ICCARM Compiler
+   ---------------
+   RAM functions are defined using a specific toolchain keyword "__ramfunc".
+*/
+#define __RAM_FUNC __ramfunc HAL_StatusTypeDef
+
+#elif defined   (  __GNUC__  )
+/* GNU Compiler
+   ------------
+  RAM functions are defined using a specific toolchain attribute
+   "__attribute__((section(".RamFunc")))".
+*/
+#define __RAM_FUNC HAL_StatusTypeDef  __attribute__((section(".RamFunc")))
+
+#endif
+
+/** 
+  * @brief  __NOINLINE definition
+  */ 
+#if defined ( __CC_ARM   ) || defined   (  __GNUC__  )
+/* ARM & GNUCompiler 
+   ---------------- 
+*/
+#define __NOINLINE __attribute__ ( (noinline) )  
+
+#elif defined ( __ICCARM__ )
+/* ICCARM Compiler
+   ---------------
+*/
+#define __NOINLINE _Pragma("optimize = no_inline")
+
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ___STM32L4xx_HAL_DEF */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_dma.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_dma.h
@@ -1,0 +1,588 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_dma.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of DMA HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_DMA_H
+#define __STM32L4xx_HAL_DMA_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup DMA
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup DMA_Exported_Types DMA Exported Types
+  * @{
+  */
+
+/**
+  * @brief  DMA Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t Request;                   /*!< Specifies the request selected for the specified channel.
+                                           This parameter can be a value of @ref DMA_request */
+
+  uint32_t Direction;                 /*!< Specifies if the data will be transferred from memory to peripheral,
+                                           from memory to memory or from peripheral to memory.
+                                           This parameter can be a value of @ref DMA_Data_transfer_direction */
+
+  uint32_t PeriphInc;                 /*!< Specifies whether the Peripheral address register should be incremented or not.
+                                           This parameter can be a value of @ref DMA_Peripheral_incremented_mode */
+
+  uint32_t MemInc;                    /*!< Specifies whether the memory address register should be incremented or not.
+                                           This parameter can be a value of @ref DMA_Memory_incremented_mode */
+
+  uint32_t PeriphDataAlignment;       /*!< Specifies the Peripheral data width.
+                                           This parameter can be a value of @ref DMA_Peripheral_data_size */
+
+  uint32_t MemDataAlignment;          /*!< Specifies the Memory data width.
+                                           This parameter can be a value of @ref DMA_Memory_data_size */
+
+  uint32_t Mode;                      /*!< Specifies the operation mode of the DMAy Channelx.
+                                           This parameter can be a value of @ref DMA_mode
+                                           @note The circular buffer mode cannot be used if the memory-to-memory
+                                                 data transfer is configured on the selected Channel */
+
+  uint32_t Priority;                  /*!< Specifies the software priority for the DMAy Channelx.
+                                           This parameter can be a value of @ref DMA_Priority_level */
+} DMA_InitTypeDef;
+
+/**
+  * @brief DMA Configuration enumeration values definition
+  */
+typedef enum
+{
+  DMA_MODE            = 0,      /*!< Control related DMA mode Parameter in DMA_InitTypeDef        */
+  DMA_PRIORITY        = 1       /*!< Control related priority level Parameter in DMA_InitTypeDef  */
+
+} DMA_ControlTypeDef;
+
+/**
+  * @brief  HAL DMA State structures definition
+  */
+typedef enum
+{
+  HAL_DMA_STATE_RESET             = 0x00,  /*!< DMA not yet initialized or disabled    */
+  HAL_DMA_STATE_READY             = 0x01,  /*!< DMA process success and ready for use  */
+  HAL_DMA_STATE_READY_HALF        = 0x11,  /*!< DMA Half process success               */
+  HAL_DMA_STATE_BUSY              = 0x02,  /*!< DMA process is ongoing                 */
+  HAL_DMA_STATE_TIMEOUT           = 0x03,  /*!< DMA timeout state                      */
+  HAL_DMA_STATE_ERROR             = 0x04   /*!< DMA error state                        */
+}HAL_DMA_StateTypeDef;
+
+/**
+  * @brief  HAL DMA Error Code structure definition
+  */
+typedef enum
+{
+  HAL_DMA_FULL_TRANSFER      = 0x00,    /*!< Full transfer     */
+  HAL_DMA_HALF_TRANSFER      = 0x01     /*!< Half Transfer     */
+}HAL_DMA_LevelCompleteTypeDef;
+
+/**
+  * @brief  DMA handle Structure definition
+  */
+typedef struct __DMA_HandleTypeDef
+{
+  DMA_Channel_TypeDef    *Instance;                                                /*!< Register base address                  */
+                                                                                
+  DMA_InitTypeDef       Init;                                                      /*!< DMA communication parameters           */
+                                                                                
+  HAL_LockTypeDef       Lock;                                                      /*!< DMA locking object                     */
+                                                                                
+  __IO HAL_DMA_StateTypeDef  State;                                                /*!< DMA transfer state                     */
+                                                                                
+  void                  *Parent;                                                   /*!< Parent object state                    */
+
+  void                  (* XferCpltCallback)(struct __DMA_HandleTypeDef * hdma);     /*!< DMA transfer complete callback       */
+
+  void                  (* XferHalfCpltCallback)(struct __DMA_HandleTypeDef * hdma); /*!< DMA Half transfer complete callback  */
+
+  void                  (* XferErrorCallback)(struct __DMA_HandleTypeDef * hdma);    /*!< DMA transfer error callback          */
+
+  __IO uint32_t          ErrorCode;                                                /*!< DMA Error code                         */
+}DMA_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup DMA_Exported_Constants DMA Exported Constants
+  * @{
+  */
+
+/** @defgroup DMA_Error_Code DMA Error Code
+  * @{
+  */
+#define HAL_DMA_ERROR_NONE      ((uint32_t)0x00000000)    /*!< No error             */
+#define HAL_DMA_ERROR_TE        ((uint32_t)0x00000001)    /*!< Transfer error       */
+#define HAL_DMA_ERROR_TIMEOUT   ((uint32_t)0x00000020)    /*!< Timeout error        */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_request DMA request
+  * @{
+  */
+#define DMA_REQUEST_0                     ((uint32_t)0x00000000)
+#define DMA_REQUEST_1                     ((uint32_t)0x00000001)
+#define DMA_REQUEST_2                     ((uint32_t)0x00000002)
+#define DMA_REQUEST_3                     ((uint32_t)0x00000003)
+#define DMA_REQUEST_4                     ((uint32_t)0x00000004)
+#define DMA_REQUEST_5                     ((uint32_t)0x00000005)
+#define DMA_REQUEST_6                     ((uint32_t)0x00000006)
+#define DMA_REQUEST_7                     ((uint32_t)0x00000007)
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Data_transfer_direction DMA Data transfer direction
+  * @{
+  */
+#define DMA_PERIPH_TO_MEMORY         ((uint32_t)0x00000000)        /*!< Peripheral to memory direction */
+#define DMA_MEMORY_TO_PERIPH         ((uint32_t)DMA_CCR_DIR)       /*!< Memory to peripheral direction */
+#define DMA_MEMORY_TO_MEMORY         ((uint32_t)DMA_CCR_MEM2MEM)   /*!< Memory to memory direction     */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Peripheral_incremented_mode DMA Peripheral incremented mode
+  * @{
+  */
+#define DMA_PINC_ENABLE        ((uint32_t)DMA_CCR_PINC)  /*!< Peripheral increment mode Enable */
+#define DMA_PINC_DISABLE       ((uint32_t)0x00000000)    /*!< Peripheral increment mode Disable */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Memory_incremented_mode DMA Memory incremented mode
+  * @{
+  */
+#define DMA_MINC_ENABLE         ((uint32_t)DMA_CCR_MINC)  /*!< Memory increment mode Enable  */
+#define DMA_MINC_DISABLE        ((uint32_t)0x00000000)    /*!< Memory increment mode Disable */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Peripheral_data_size DMA Peripheral data size
+  * @{
+  */
+#define DMA_PDATAALIGN_BYTE          ((uint32_t)0x00000000)       /*!< Peripheral data alignment : Byte     */
+#define DMA_PDATAALIGN_HALFWORD      ((uint32_t)DMA_CCR_PSIZE_0)  /*!< Peripheral data alignment : HalfWord */
+#define DMA_PDATAALIGN_WORD          ((uint32_t)DMA_CCR_PSIZE_1)  /*!< Peripheral data alignment : Word     */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Memory_data_size DMA Memory data size
+  * @{
+  */
+#define DMA_MDATAALIGN_BYTE          ((uint32_t)0x00000000)       /*!< Memory data alignment : Byte     */
+#define DMA_MDATAALIGN_HALFWORD      ((uint32_t)DMA_CCR_MSIZE_0)  /*!< Memory data alignment : HalfWord */
+#define DMA_MDATAALIGN_WORD          ((uint32_t)DMA_CCR_MSIZE_1)  /*!< Memory data alignment : Word     */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_mode DMA mode
+  * @{
+  */
+#define DMA_NORMAL         ((uint32_t)0x00000000)       /*!< Normal mode                  */
+#define DMA_CIRCULAR       ((uint32_t)DMA_CCR_CIRC)     /*!< Circular mode                */
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Priority_level DMA Priority level
+  * @{
+  */
+#define DMA_PRIORITY_LOW             ((uint32_t)0x00000000)    /*!< Priority level : Low       */
+#define DMA_PRIORITY_MEDIUM          ((uint32_t)DMA_CCR_PL_0)  /*!< Priority level : Medium    */
+#define DMA_PRIORITY_HIGH            ((uint32_t)DMA_CCR_PL_1)  /*!< Priority level : High      */
+#define DMA_PRIORITY_VERY_HIGH       ((uint32_t)DMA_CCR_PL)    /*!< Priority level : Very_High */
+/**
+  * @}
+  */
+
+
+/** @defgroup DMA_interrupt_enable_definitions DMA interrupt enable definitions
+  * @{
+  */
+#define DMA_IT_TC                         ((uint32_t)DMA_CCR_TCIE)
+#define DMA_IT_HT                         ((uint32_t)DMA_CCR_HTIE)
+#define DMA_IT_TE                         ((uint32_t)DMA_CCR_TEIE)
+/**
+  * @}
+  */
+
+/** @defgroup DMA_flag_definitions DMA flag definitions
+  * @{
+  */
+#define DMA_FLAG_GL1                      ((uint32_t)0x00000001)
+#define DMA_FLAG_TC1                      ((uint32_t)0x00000002)
+#define DMA_FLAG_HT1                      ((uint32_t)0x00000004)
+#define DMA_FLAG_TE1                      ((uint32_t)0x00000008)
+#define DMA_FLAG_GL2                      ((uint32_t)0x00000010)
+#define DMA_FLAG_TC2                      ((uint32_t)0x00000020)
+#define DMA_FLAG_HT2                      ((uint32_t)0x00000040)
+#define DMA_FLAG_TE2                      ((uint32_t)0x00000080)
+#define DMA_FLAG_GL3                      ((uint32_t)0x00000100)
+#define DMA_FLAG_TC3                      ((uint32_t)0x00000200)
+#define DMA_FLAG_HT3                      ((uint32_t)0x00000400)
+#define DMA_FLAG_TE3                      ((uint32_t)0x00000800)
+#define DMA_FLAG_GL4                      ((uint32_t)0x00001000)
+#define DMA_FLAG_TC4                      ((uint32_t)0x00002000)
+#define DMA_FLAG_HT4                      ((uint32_t)0x00004000)
+#define DMA_FLAG_TE4                      ((uint32_t)0x00008000)
+#define DMA_FLAG_GL5                      ((uint32_t)0x00010000)
+#define DMA_FLAG_TC5                      ((uint32_t)0x00020000)
+#define DMA_FLAG_HT5                      ((uint32_t)0x00040000)
+#define DMA_FLAG_TE5                      ((uint32_t)0x00080000)
+#define DMA_FLAG_GL6                      ((uint32_t)0x00100000)
+#define DMA_FLAG_TC6                      ((uint32_t)0x00200000)
+#define DMA_FLAG_HT6                      ((uint32_t)0x00400000)
+#define DMA_FLAG_TE6                      ((uint32_t)0x00800000)
+#define DMA_FLAG_GL7                      ((uint32_t)0x01000000)
+#define DMA_FLAG_TC7                      ((uint32_t)0x02000000)
+#define DMA_FLAG_HT7                      ((uint32_t)0x04000000)
+#define DMA_FLAG_TE7                      ((uint32_t)0x08000000)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup DMA_Exported_Macros DMA Exported Macros
+  * @{
+  */
+
+/** @brief  Reset DMA handle state.
+  * @param  __HANDLE__: DMA handle
+  * @retval None
+  */
+#define __HAL_DMA_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_DMA_STATE_RESET)
+
+/**
+  * @brief  Enable the specified DMA Channel.
+  * @param  __HANDLE__: DMA handle
+  * @retval None
+  */
+#define __HAL_DMA_ENABLE(__HANDLE__)        ((__HANDLE__)->Instance->CCR |=  DMA_CCR_EN)
+
+/**
+  * @brief  Disable the specified DMA Channel.
+  * @param  __HANDLE__: DMA handle
+  * @retval None
+  */
+#define __HAL_DMA_DISABLE(__HANDLE__)       ((__HANDLE__)->Instance->CCR &=  ~DMA_CCR_EN)
+
+
+/* Interrupt & Flag management */
+
+/**
+  * @brief  Return the current DMA Channel transfer complete flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified transfer complete flag index.
+  */
+
+#define __HAL_DMA_GET_TC_FLAG_INDEX(__HANDLE__) \
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TC1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_TC1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TC2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_TC2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TC3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_TC3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TC4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_TC4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TC5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_TC5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TC6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel6))? DMA_FLAG_TC6 :\
+   DMA_FLAG_TC7)
+
+/**
+  * @brief  Return the current DMA Channel half transfer complete flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified half transfer complete flag index.
+  */
+#define __HAL_DMA_GET_HT_FLAG_INDEX(__HANDLE__)\
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_HT1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_HT1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_HT2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_HT2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_HT3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_HT3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_HT4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_HT4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_HT5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_HT5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_HT6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel6))? DMA_FLAG_HT6 :\
+   DMA_FLAG_HT7)
+
+/**
+  * @brief  Return the current DMA Channel transfer error flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified transfer error flag index.
+  */
+#define __HAL_DMA_GET_TE_FLAG_INDEX(__HANDLE__)\
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TE1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_TE1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TE2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_TE2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TE3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_TE3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TE4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_TE4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TE5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_TE5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TE6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel6))? DMA_FLAG_TE6 :\
+   DMA_FLAG_TE7)
+
+/**
+  * @brief  Return the current DMA Channel Global interrupt flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified transfer error flag index.
+  */
+#define __HAL_DMA_GET_GI_FLAG_INDEX(__HANDLE__)\
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_ISR_GIF1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_ISR_GIF1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_ISR_GIF2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_ISR_GIF2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_ISR_GIF3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_ISR_GIF3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_ISR_GIF4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_ISR_GIF4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_ISR_GIF5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_ISR_GIF5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_ISR_GIF6 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel6))? DMA_ISR_GIF6 :\
+   DMA_ISR_GIF7)
+
+/**
+  * @brief  Get the DMA Channel pending flags.
+  * @param  __HANDLE__: DMA handle
+  * @param  __FLAG__: Get the specified flag.
+  *          This parameter can be any combination of the following values:
+  *            @arg DMA_FLAG_TCIFx:  Transfer complete flag
+  *            @arg DMA_FLAG_HTIFx:  Half transfer complete flag
+  *            @arg DMA_FLAG_TEIFx:  Transfer error flag
+  *            @arg DMA_ISR_GIFx: Global interrupt flag
+  *         Where x can be 0_4, 1_5, 2_6 or 3_7 to select the DMA Channel flag.
+  * @retval The state of FLAG (SET or RESET).
+  */
+#define __HAL_DMA_GET_FLAG(__HANDLE__, __FLAG__) (((uint32_t)((__HANDLE__)->Instance) > ((uint32_t)DMA1_Channel7))? \
+ (DMA2->ISR & (__FLAG__)) : (DMA1->ISR & (__FLAG__)))
+
+/**
+  * @brief  Clear the DMA Channel pending flags.
+  * @param  __HANDLE__: DMA handle
+  * @param  __FLAG__: specifies the flag to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg DMA_FLAG_TCIFx:  Transfer complete flag
+  *            @arg DMA_FLAG_HTIFx:  Half transfer complete flag
+  *            @arg DMA_FLAG_TEIFx:  Transfer error flag
+  *            @arg DMA_ISR_GIFx: Global interrupt flag
+  *         Where x can be 0_4, 1_5, 2_6 or 3_7 to select the DMA Channel flag.
+  * @retval None
+  */
+#define __HAL_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__) (((uint32_t)((__HANDLE__)->Instance) > ((uint32_t)DMA1_Channel7))? \
+ (DMA2->IFCR |= (__FLAG__)) : (DMA1->IFCR |= (__FLAG__)))
+
+/**
+  * @brief  Enable the specified DMA Channel interrupts.
+  * @param  __HANDLE__: DMA handle
+  * @param __INTERRUPT__: specifies the DMA interrupt sources to be enabled or disabled.
+  *          This parameter can be any combination of the following values:
+  *            @arg DMA_IT_TC:  Transfer complete interrupt mask
+  *            @arg DMA_IT_HT:  Half transfer complete interrupt mask
+  *            @arg DMA_IT_TE:  Transfer error interrupt mask
+  * @retval None
+  */
+#define __HAL_DMA_ENABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CCR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the specified DMA Channel interrupts.
+  * @param  __HANDLE__: DMA handle
+  * @param __INTERRUPT__: specifies the DMA interrupt sources to be enabled or disabled.
+  *          This parameter can be any combination of the following values:
+  *            @arg DMA_IT_TC:  Transfer complete interrupt mask
+  *            @arg DMA_IT_HT:  Half transfer complete interrupt mask
+  *            @arg DMA_IT_TE:  Transfer error interrupt mask
+  * @retval None
+  */
+#define __HAL_DMA_DISABLE_IT(__HANDLE__, __INTERRUPT__)  ((__HANDLE__)->Instance->CCR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified DMA Channel interrupt is enabled or not.
+  * @param  __HANDLE__: DMA handle
+  * @param  __INTERRUPT__: specifies the DMA interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg DMA_IT_TC:  Transfer complete interrupt mask
+  *            @arg DMA_IT_HT:  Half transfer complete interrupt mask
+  *            @arg DMA_IT_TE:  Transfer error interrupt mask
+  * @retval The state of DMA_IT (SET or RESET).
+  */
+#define __HAL_DMA_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)  (((__HANDLE__)->Instance->CCR & (__INTERRUPT__)))
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup DMA_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup DMA_Exported_Functions_Group1
+  * @{
+  */
+/* Initialization and de-initialization functions *****************************/
+HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma);
+HAL_StatusTypeDef HAL_DMA_DeInit (DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+
+/** @addtogroup DMA_Exported_Functions_Group2
+  * @{
+  */
+/* IO operation functions *****************************************************/
+HAL_StatusTypeDef HAL_DMA_Start (DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
+HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
+HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma);
+HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, uint32_t CompleteLevel, uint32_t Timeout);
+void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+
+/** @addtogroup DMA_Exported_Functions_Group3
+  * @{
+  */
+/* Peripheral State and Error functions ***************************************/
+HAL_DMA_StateTypeDef HAL_DMA_GetState(DMA_HandleTypeDef *hdma);
+uint32_t             HAL_DMA_GetError(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup DMA_Private_Macros DMA Private Macros
+  * @{
+  */
+
+#define IS_DMA_DIRECTION(DIRECTION) (((DIRECTION) == DMA_PERIPH_TO_MEMORY ) || \
+                                     ((DIRECTION) == DMA_MEMORY_TO_PERIPH)  || \
+                                     ((DIRECTION) == DMA_MEMORY_TO_MEMORY))
+
+#define IS_DMA_BUFFER_SIZE(SIZE) (((SIZE) >= 0x1) && ((SIZE) < 0x10000))
+
+#define IS_DMA_PERIPHERAL_INC_STATE(STATE) (((STATE) == DMA_PINC_ENABLE) || \
+                                            ((STATE) == DMA_PINC_DISABLE))
+
+#define IS_DMA_MEMORY_INC_STATE(STATE) (((STATE) == DMA_MINC_ENABLE)  || \
+                                        ((STATE) == DMA_MINC_DISABLE))
+
+#define IS_DMA_ALL_REQUEST(REQUEST) (((REQUEST) == DMA_REQUEST_0) || \
+                                     ((REQUEST) == DMA_REQUEST_1) || \
+                                     ((REQUEST) == DMA_REQUEST_2) || \
+                                     ((REQUEST) == DMA_REQUEST_3) || \
+                                     ((REQUEST) == DMA_REQUEST_4) || \
+                                     ((REQUEST) == DMA_REQUEST_5) || \
+                                     ((REQUEST) == DMA_REQUEST_6) || \
+                                     ((REQUEST) == DMA_REQUEST_7))
+
+#define IS_DMA_PERIPHERAL_DATA_SIZE(SIZE) (((SIZE) == DMA_PDATAALIGN_BYTE)     || \
+                                           ((SIZE) == DMA_PDATAALIGN_HALFWORD) || \
+                                           ((SIZE) == DMA_PDATAALIGN_WORD))
+
+#define IS_DMA_MEMORY_DATA_SIZE(SIZE) (((SIZE) == DMA_MDATAALIGN_BYTE)     || \
+                                       ((SIZE) == DMA_MDATAALIGN_HALFWORD) || \
+                                       ((SIZE) == DMA_MDATAALIGN_WORD ))
+
+#define IS_DMA_MODE(MODE) (((MODE) == DMA_NORMAL )  || \
+                           ((MODE) == DMA_CIRCULAR))
+
+#define IS_DMA_PRIORITY(PRIORITY) (((PRIORITY) == DMA_PRIORITY_LOW )   || \
+                                   ((PRIORITY) == DMA_PRIORITY_MEDIUM) || \
+                                   ((PRIORITY) == DMA_PRIORITY_HIGH)   || \
+                                   ((PRIORITY) == DMA_PRIORITY_VERY_HIGH))
+
+/**
+  * @}
+  */ 
+
+/* Private functions ---------------------------------------------------------*/
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_DMA_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_flash.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_flash.h
@@ -1,0 +1,829 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_flash.h
+  * @author  MCD Application Team
+  * @version V1.3.0 
+  * @date    29-January-2016
+  * @brief   Header file of FLASH HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_FLASH_H
+#define __STM32L4xx_HAL_FLASH_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup FLASH
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup FLASH_Exported_Types FLASH Exported Types
+  * @{
+  */
+
+/**
+  * @brief  FLASH Erase structure definition
+  */
+typedef struct
+{ 
+  uint32_t TypeErase;   /*!< Mass erase or page erase.
+                             This parameter can be a value of @ref FLASH_Type_Erase */
+  uint32_t Banks;       /*!< Select bank to erase.
+                             This parameter must be a value of @ref FLASH_Banks 
+                             (FLASH_BANK_BOTH should be used only for mass erase) */        
+  uint32_t Page;        /*!< Initial Flash page to erase when page erase is disabled
+                             This parameter must be a value between 0 and (max number of pages in the bank - 1) 
+                             (eg : 255 for 1MB dual bank) */
+  uint32_t NbPages;     /*!< Number of pages to be erased.
+                             This parameter must be a value between 1 and (max number of pages in the bank - value of initial page)*/           
+} FLASH_EraseInitTypeDef;
+
+/**
+  * @brief  FLASH Option Bytes Program structure definition
+  */
+typedef struct
+{
+  uint32_t OptionType;     /*!< Option byte to be configured.
+                                This parameter can be a combination of the values of @ref FLASH_OB_Type */
+  uint32_t WRPArea;        /*!< Write protection area to be programmed (used for OPTIONBYTE_WRP).
+                                Only one WRP area could be programmed at the same time.
+                                This parameter can be value of @ref FLASH_OB_WRP_Area */
+  uint32_t WRPStartOffset; /*!< Write protection start offset (used for OPTIONBYTE_WRP).
+                                This parameter must be a value between 0 and (max number of pages in the bank - 1)
+                                (eg : 25 for 1MB dual bank) */
+  uint32_t WRPEndOffset;   /*!< Write protection end offset (used for OPTIONBYTE_WRP).
+                                This parameter must be a value between WRPStartOffset and (max number of pages in the bank - 1) */
+  uint32_t RDPLevel;       /*!< Set the read protection level.. (used for OPTIONBYTE_RDP).
+                                This parameter can be a value of @ref FLASH_OB_Read_Protection */
+  uint32_t USERType;       /*!< User option byte(s) to be configured (used for OPTIONBYTE_USER).
+                                This parameter can be a combination of @ref FLASH_OB_USER_Type */
+  uint32_t USERConfig;     /*!< Value of the user option byte (used for OPTIONBYTE_USER).
+                                This parameter can be a combination of @ref FLASH_OB_USER_BOR_LEVEL,
+                                @ref FLASH_OB_USER_nRST_STOP, @ref FLASH_OB_USER_nRST_STANDBY,
+                                @ref FLASH_OB_USER_nRST_SHUTDOWN, @ref FLASH_OB_USER_IWDG_SW, 
+                                @ref FLASH_OB_USER_IWDG_STOP, @ref FLASH_OB_USER_IWDG_STANDBY, 
+                                @ref FLASH_OB_USER_WWDG_SW, @ref FLASH_OB_USER_BFB2, 
+                                @ref FLASH_OB_USER_DUALBANK, @ref FLASH_OB_USER_nBOOT1, 
+                                @ref FLASH_OB_USER_SRAM2_PE and @ref FLASH_OB_USER_SRAM2_RST */
+  uint32_t PCROPConfig;    /*!< Configuration of the PCROP (used for OPTIONBYTE_PCROP).
+                                This parameter must be a combination of @ref FLASH_Banks (except FLASH_BANK_BOTH) 
+                                and @ref FLASH_OB_PCROP_RDP */
+  uint32_t PCROPStartAddr; /*!< PCROP Start address (used for OPTIONBYTE_PCROP).
+                                This parameter must be a value between begin and end of bank 
+                                => Be careful of the bank swapping for the address */
+  uint32_t PCROPEndAddr;   /*!< PCROP End address (used for OPTIONBYTE_PCROP).
+                                This parameter must be a value between PCROP Start address and end of bank */
+} FLASH_OBProgramInitTypeDef;
+
+/**
+  * @brief  FLASH Procedure structure definition
+  */
+typedef enum 
+{
+  FLASH_PROC_NONE = 0,
+  FLASH_PROC_PAGE_ERASE,
+  FLASH_PROC_MASS_ERASE,
+  FLASH_PROC_PROGRAM,
+  FLASH_PROC_PROGRAM_LAST
+} FLASH_ProcedureTypeDef;
+
+/** 
+  * @brief  FLASH handle Structure definition  
+  */
+typedef struct
+{
+  HAL_LockTypeDef             Lock;              /* FLASH locking object */
+  __IO uint32_t               ErrorCode;         /* FLASH error code */
+  __IO FLASH_ProcedureTypeDef ProcedureOnGoing;  /* Internal variable to indicate which procedure is ongoing or not in IT context */
+  __IO uint32_t               Address;           /* Internal variable to save address selected for program in IT context */
+  __IO uint32_t               Bank;              /* Internal variable to save current bank selected during erase in IT context */
+  __IO uint32_t               Page;              /* Internal variable to define the current page which is erasing in IT context */
+  __IO uint32_t               NbPagesToErase;    /* Internal variable to save the remaining pages to erase in IT context */
+}FLASH_ProcessTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup FLASH_Exported_Constants FLASH Exported Constants
+  * @{
+  */
+
+/** @defgroup FLASH_Error FLASH Error
+  * @{
+  */ 
+#define HAL_FLASH_ERROR_NONE      ((uint32_t)0x00000000)
+#define HAL_FLASH_ERROR_OP        ((uint32_t)0x00000001)
+#define HAL_FLASH_ERROR_PROG      ((uint32_t)0x00000002)
+#define HAL_FLASH_ERROR_WRP       ((uint32_t)0x00000004)
+#define HAL_FLASH_ERROR_PGA       ((uint32_t)0x00000008)
+#define HAL_FLASH_ERROR_SIZ       ((uint32_t)0x00000010)
+#define HAL_FLASH_ERROR_PGS       ((uint32_t)0x00000020)
+#define HAL_FLASH_ERROR_MIS       ((uint32_t)0x00000040)
+#define HAL_FLASH_ERROR_FAST      ((uint32_t)0x00000080)
+#define HAL_FLASH_ERROR_RD        ((uint32_t)0x00000100)
+#define HAL_FLASH_ERROR_OPTV      ((uint32_t)0x00000200)
+#define HAL_FLASH_ERROR_ECCD      ((uint32_t)0x00000400)
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Type_Erase FLASH Erase Type
+  * @{
+  */ 
+#define FLASH_TYPEERASE_PAGES     ((uint32_t)0x00)  /*!<Pages erase only*/
+#define FLASH_TYPEERASE_MASSERASE ((uint32_t)0x01)  /*!<Flash mass erase activation*/
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Banks FLASH Banks
+  * @{
+  */
+#define FLASH_BANK_1              ((uint32_t)0x01)                          /*!< Bank 1   */
+#define FLASH_BANK_2              ((uint32_t)0x02)                          /*!< Bank 2   */
+#define FLASH_BANK_BOTH           ((uint32_t)(FLASH_BANK_1 | FLASH_BANK_2)) /*!< Bank1 and Bank2  */
+/**
+  * @}
+  */
+
+
+/** @defgroup FLASH_Type_Program FLASH Program Type
+  * @{
+  */
+#define FLASH_TYPEPROGRAM_DOUBLEWORD    ((uint32_t)0x00)  /*!<Program a double-word (64-bit) at a specified address.*/
+#define FLASH_TYPEPROGRAM_FAST          ((uint32_t)0x01)  /*!<Fast program a 32 row double-word (64-bit) at a specified address.
+                                                                 And another 32 row double-word (64-bit) will be programmed */
+#define FLASH_TYPEPROGRAM_FAST_AND_LAST ((uint32_t)0x02)  /*!<Fast program a 32 row double-word (64-bit) at a specified address.
+                                                                 And this is the last 32 row double-word (64-bit) programmed */
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_OB_Type FLASH Option Bytes Type
+  * @{
+  */
+#define OPTIONBYTE_WRP            ((uint32_t)0x01)  /*!< WRP option byte configuration */
+#define OPTIONBYTE_RDP            ((uint32_t)0x02)  /*!< RDP option byte configuration */
+#define OPTIONBYTE_USER           ((uint32_t)0x04)  /*!< USER option byte configuration */
+#define OPTIONBYTE_PCROP          ((uint32_t)0x08)  /*!< PCROP option byte configuration */
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_OB_WRP_Area FLASH WRP Area
+  * @{
+  */ 
+#define OB_WRPAREA_BANK1_AREAA    ((uint32_t)0x00)  /*!< Flash Bank 1 Area A */
+#define OB_WRPAREA_BANK1_AREAB    ((uint32_t)0x01)  /*!< Flash Bank 1 Area B */
+#define OB_WRPAREA_BANK2_AREAA    ((uint32_t)0x02)  /*!< Flash Bank 2 Area A */
+#define OB_WRPAREA_BANK2_AREAB    ((uint32_t)0x04)  /*!< Flash Bank 2 Area B */
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_OB_Read_Protection FLASH Option Bytes Read Protection
+  * @{
+  */
+#define OB_RDP_LEVEL_0            ((uint32_t)0xAA)
+#define OB_RDP_LEVEL_1            ((uint32_t)0xBB)
+#define OB_RDP_LEVEL_2            ((uint32_t)0xCC) /*!< Warning: When enabling read protection level 2 
+                                                        it's no more possible to go back to level 1 or 0 */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_Type FLASH Option Bytes User Type
+  * @{
+  */
+#define OB_USER_BOR_LEV           ((uint32_t)0x0001)                   /*!< BOR reset Level */
+#define OB_USER_nRST_STOP         ((uint32_t)0x0002)                   /*!< Reset generated when entering the stop mode */
+#define OB_USER_nRST_STDBY        ((uint32_t)0x0004)                   /*!< Reset generated when entering the standby mode */
+#define OB_USER_IWDG_SW           ((uint32_t)0x0008)                   /*!< Independent watchdog selection */
+#define OB_USER_IWDG_STOP         ((uint32_t)0x0010)                   /*!< Independent watchdog counter freeze in stop mode */
+#define OB_USER_IWDG_STDBY        ((uint32_t)0x0020)                   /*!< Independent watchdog counter freeze in standby mode */
+#define OB_USER_WWDG_SW           ((uint32_t)0x0040)                   /*!< Window watchdog selection */
+#define OB_USER_BFB2              ((uint32_t)0x0080)                   /*!< Dual-bank boot */
+#define OB_USER_DUALBANK          ((uint32_t)0x0100)                   /*!< Dual-Bank on 512KB or 256KB Flash memory devices */
+#define OB_USER_nBOOT1            ((uint32_t)0x0200)                   /*!< Boot configuration */
+#define OB_USER_SRAM2_PE          ((uint32_t)0x0400)                   /*!< SRAM2 parity check enable */
+#define OB_USER_SRAM2_RST         ((uint32_t)0x0800)                   /*!< SRAM2 Erase when system reset */
+#define OB_USER_nRST_SHDW         ((uint32_t)0x1000)                   /*!< Reset generated when entering the shutdown mode */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_BOR_LEVEL FLASH Option Bytes User BOR Level
+  * @{
+  */
+#define OB_BOR_LEVEL_0            ((uint32_t)FLASH_OPTR_BOR_LEV_0)     /*!< Reset level threshold is around 1.7V */
+#define OB_BOR_LEVEL_1            ((uint32_t)FLASH_OPTR_BOR_LEV_1)     /*!< Reset level threshold is around 2.0V */
+#define OB_BOR_LEVEL_2            ((uint32_t)FLASH_OPTR_BOR_LEV_2)     /*!< Reset level threshold is around 2.2V */
+#define OB_BOR_LEVEL_3            ((uint32_t)FLASH_OPTR_BOR_LEV_3)     /*!< Reset level threshold is around 2.5V */
+#define OB_BOR_LEVEL_4            ((uint32_t)FLASH_OPTR_BOR_LEV_4)     /*!< Reset level threshold is around 2.8V */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_nRST_STOP FLASH Option Bytes User Reset On Stop 
+  * @{
+  */
+#define OB_STOP_RST               ((uint32_t)0x0000)                   /*!< Reset generated when entering the stop mode */
+#define OB_STOP_NORST             ((uint32_t)FLASH_OPTR_nRST_STOP)     /*!< No reset generated when entering the stop mode */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_nRST_STANDBY FLASH Option Bytes User Reset On Standby
+  * @{
+  */
+#define OB_STANDBY_RST            ((uint32_t)0x0000)                   /*!< Reset generated when entering the standby mode */
+#define OB_STANDBY_NORST          ((uint32_t)FLASH_OPTR_nRST_STDBY)    /*!< No reset generated when entering the standby mode */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_nRST_SHUTDOWN FLASH Option Bytes User Reset On Shutdown
+  * @{
+  */
+#define OB_SHUTDOWN_RST           ((uint32_t)0x0000)                   /*!< Reset generated when entering the shutdown mode */
+#define OB_SHUTDOWN_NORST         ((uint32_t)FLASH_OPTR_nRST_SHDW)     /*!< No reset generated when entering the shutdown mode */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_IWDG_SW FLASH Option Bytes User IWDG Type
+  * @{
+  */
+#define OB_IWDG_HW                ((uint32_t)0x00000)                  /*!< Hardware independent watchdog */
+#define OB_IWDG_SW                ((uint32_t)FLASH_OPTR_IWDG_SW)       /*!< Software independent watchdog */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_IWDG_STOP FLASH Option Bytes User IWDG Mode On Stop
+  * @{
+  */
+#define OB_IWDG_STOP_FREEZE       ((uint32_t)0x00000)                  /*!< Independent watchdog counter is frozen in Stop mode */
+#define OB_IWDG_STOP_RUN          ((uint32_t)FLASH_OPTR_IWDG_STOP)     /*!< Independent watchdog counter is running in Stop mode */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_IWDG_STANDBY FLASH Option Bytes User IWDG Mode On Standby
+  * @{
+  */
+#define OB_IWDG_STDBY_FREEZE      ((uint32_t)0x00000)                  /*!< Independent watchdog counter is frozen in Standby mode */
+#define OB_IWDG_STDBY_RUN         ((uint32_t)FLASH_OPTR_IWDG_STDBY)    /*!< Independent watchdog counter is running in Standby mode */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_WWDG_SW FLASH Option Bytes User WWDG Type
+  * @{
+  */
+#define OB_WWDG_HW                ((uint32_t)0x00000)                  /*!< Hardware window watchdog */
+#define OB_WWDG_SW                ((uint32_t)FLASH_OPTR_WWDG_SW)       /*!< Software window watchdog */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_BFB2 FLASH Option Bytes User BFB2 Mode
+  * @{
+  */
+#define OB_BFB2_DISABLE           ((uint32_t)0x000000)                 /*!< Dual-bank boot disable */
+#define OB_BFB2_ENABLE            ((uint32_t)FLASH_OPTR_BFB2)          /*!< Dual-bank boot enable */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_DUALBANK FLASH Option Bytes User Dual-bank Type
+  * @{
+  */
+#define OB_DUALBANK_SINGLE        ((uint32_t)0x000000)                 /*!< 256 KB/512 KB Single-bank Flash */
+#define OB_DUALBANK_DUAL          ((uint32_t)FLASH_OPTR_DUALBANK)      /*!< 256 KB/512 KB Dual-bank Flash */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_nBOOT1 FLASH Option Bytes User BOOT1 Type
+  * @{
+  */
+#define OB_BOOT1_SRAM             ((uint32_t)0x000000)                 /*!< Embedded SRAM1 is selected as boot space (if BOOT0=1) */
+#define OB_BOOT1_SYSTEM           ((uint32_t)FLASH_OPTR_nBOOT1)        /*!< System memory is selected as boot space (if BOOT0=1) */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_SRAM2_PE FLASH Option Bytes User SRAM2 Parity Check Type
+  * @{
+  */
+#define OB_SRAM2_PARITY_ENABLE    ((uint32_t)0x0000000)                /*!< SRAM2 parity check enable */
+#define OB_SRAM2_PARITY_DISABLE   ((uint32_t)FLASH_OPTR_SRAM2_PE)      /*!< SRAM2 parity check disable */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_USER_SRAM2_RST FLASH Option Bytes User SRAM2 Erase On Reset Type
+  * @{
+  */
+#define OB_SRAM2_RST_ERASE        ((uint32_t)0x0000000)                /*!< SRAM2 erased when a system reset occurs */
+#define OB_SRAM2_RST_NOT_ERASE    ((uint32_t)FLASH_OPTR_SRAM2_RST)     /*!< SRAM2 is not erased when a system reset occurs */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_OB_PCROP_RDP FLASH Option Bytes PCROP On RDP Level Type
+  * @{
+  */
+#define OB_PCROP_RDP_NOT_ERASE    ((uint32_t)0x00000000)               /*!< PCROP area is not erased when the RDP level 
+                                                                            is decreased from Level 1 to Level 0 */
+#define OB_PCROP_RDP_ERASE        ((uint32_t)FLASH_PCROP1ER_PCROP_RDP) /*!< PCROP area is erased when the RDP level is 
+                                                                            decreased from Level 1 to Level 0 (full mass erase) */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_Latency FLASH Latency
+  * @{
+  */ 
+#define FLASH_LATENCY_0           FLASH_ACR_LATENCY_0WS                /*!< FLASH Zero wait state */
+#define FLASH_LATENCY_1           FLASH_ACR_LATENCY_1WS                /*!< FLASH One wait state */
+#define FLASH_LATENCY_2           FLASH_ACR_LATENCY_2WS                /*!< FLASH Two wait states */
+#define FLASH_LATENCY_3           FLASH_ACR_LATENCY_3WS                /*!< FLASH Three wait states */
+#define FLASH_LATENCY_4           FLASH_ACR_LATENCY_4WS                /*!< FLASH Four wait states */
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_Keys FLASH Keys
+  * @{
+  */ 
+#define FLASH_KEY1                ((uint32_t)0x45670123U)               /*!< Flash key1 */
+#define FLASH_KEY2                ((uint32_t)0xCDEF89ABU)               /*!< Flash key2: used with FLASH_KEY1 
+                                                                            to unlock the FLASH registers access */
+
+#define FLASH_PDKEY1              ((uint32_t)0x04152637U)               /*!< Flash power down key1 */
+#define FLASH_PDKEY2              ((uint32_t)0xFAFBFCFDU)               /*!< Flash power down key2: used with FLASH_PDKEY1 
+                                                                            to unlock the RUN_PD bit in FLASH_ACR */
+
+#define FLASH_OPTKEY1             ((uint32_t)0x08192A3BU)               /*!< Flash option byte key1 */
+#define FLASH_OPTKEY2             ((uint32_t)0x4C5D6E7FU)               /*!< Flash option byte key2: used with FLASH_OPTKEY1 
+                                                                            to allow option bytes operations */
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Flags FLASH Flags Definition
+  * @{
+  */ 
+#define FLASH_FLAG_EOP            FLASH_SR_EOP                         /*!< FLASH End of operation flag */
+#define FLASH_FLAG_OPERR          FLASH_SR_OPERR                       /*!< FLASH Operation error flag */
+#define FLASH_FLAG_PROGERR        FLASH_SR_PROGERR                     /*!< FLASH Programming error flag */
+#define FLASH_FLAG_WRPERR         FLASH_SR_WRPERR                      /*!< FLASH Write protection error flag */
+#define FLASH_FLAG_PGAERR         FLASH_SR_PGAERR                      /*!< FLASH Programming alignment error flag */
+#define FLASH_FLAG_SIZERR         FLASH_SR_SIZERR                      /*!< FLASH Size error flag  */
+#define FLASH_FLAG_PGSERR         FLASH_SR_PGSERR                      /*!< FLASH Programming sequence error flag */
+#define FLASH_FLAG_MISERR         FLASH_SR_MISERR                      /*!< FLASH Fast programming data miss error flag */
+#define FLASH_FLAG_FASTERR        FLASH_SR_FASTERR                     /*!< FLASH Fast programming error flag */
+#define FLASH_FLAG_RDERR          FLASH_SR_RDERR                       /*!< FLASH PCROP read error flag */
+#define FLASH_FLAG_OPTVERR        FLASH_SR_OPTVERR                     /*!< FLASH Option validity error flag  */
+#define FLASH_FLAG_BSY            FLASH_SR_BSY                         /*!< FLASH Busy flag */
+#define FLASH_FLAG_ECCC           FLASH_ECCR_ECCC                      /*!< FLASH ECC correction */
+#define FLASH_FLAG_ECCD           FLASH_ECCR_ECCD                      /*!< FLASH ECC detection */
+
+#define FLASH_FLAG_ALL_ERRORS     (FLASH_FLAG_OPERR   | FLASH_FLAG_PROGERR | FLASH_FLAG_WRPERR | \
+                                   FLASH_FLAG_PGAERR  | FLASH_FLAG_SIZERR  | FLASH_FLAG_PGSERR | \
+                                   FLASH_FLAG_MISERR  | FLASH_FLAG_FASTERR | FLASH_FLAG_RDERR  | \
+                                   FLASH_FLAG_OPTVERR | FLASH_FLAG_ECCD)
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_Interrupt_definition FLASH Interrupts Definition
+  * @brief FLASH Interrupt definition
+  * @{
+  */ 
+#define FLASH_IT_EOP              FLASH_CR_EOPIE                       /*!< End of FLASH Operation Interrupt source */
+#define FLASH_IT_OPERR            FLASH_CR_ERRIE                       /*!< Error Interrupt source */
+#define FLASH_IT_RDERR            FLASH_CR_RDERRIE                     /*!< PCROP Read Error Interrupt source*/
+#define FLASH_IT_ECCC             (FLASH_ECCR_ECCIE >> 24)             /*!< ECC Correction Interrupt source */
+/**
+  * @}
+  */  
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup FLASH_Exported_Macros FLASH Exported Macros
+ *  @brief macros to control FLASH features 
+ *  @{
+ */
+
+/**
+  * @brief  Set the FLASH Latency.
+  * @param  __LATENCY__: FLASH Latency                   
+  *         This parameter can be one of the following values :
+  *     @arg FLASH_LATENCY_0: FLASH Zero wait state
+  *     @arg FLASH_LATENCY_1: FLASH One wait state    
+  *     @arg FLASH_LATENCY_2: FLASH Two wait states
+  *     @arg FLASH_LATENCY_3: FLASH Three wait states
+  *     @arg FLASH_LATENCY_4: FLASH Four wait states
+  * @retval None
+  */ 
+#define __HAL_FLASH_SET_LATENCY(__LATENCY__)    (MODIFY_REG(FLASH->ACR, FLASH_ACR_LATENCY, (__LATENCY__)))
+
+/**
+  * @brief  Get the FLASH Latency.
+  * @retval FLASH Latency                   
+  *         This parameter can be one of the following values :
+  *     @arg FLASH_LATENCY_0: FLASH Zero wait state
+  *     @arg FLASH_LATENCY_1: FLASH One wait state    
+  *     @arg FLASH_LATENCY_2: FLASH Two wait states
+  *     @arg FLASH_LATENCY_3: FLASH Three wait states
+  *     @arg FLASH_LATENCY_4: FLASH Four wait states
+  */ 
+#define __HAL_FLASH_GET_LATENCY()               READ_BIT(FLASH->ACR, FLASH_ACR_LATENCY)
+
+/**
+  * @brief  Enable the FLASH prefetch buffer.
+  * @retval None
+  */ 
+#define __HAL_FLASH_PREFETCH_BUFFER_ENABLE()    SET_BIT(FLASH->ACR, FLASH_ACR_PRFTEN)
+
+/**
+  * @brief  Disable the FLASH prefetch buffer.
+  * @retval None
+  */
+#define __HAL_FLASH_PREFETCH_BUFFER_DISABLE()   CLEAR_BIT(FLASH->ACR, FLASH_ACR_PRFTEN)
+
+/**
+  * @brief  Enable the FLASH instruction cache.
+  * @retval none
+  */ 
+#define __HAL_FLASH_INSTRUCTION_CACHE_ENABLE()  SET_BIT(FLASH->ACR, FLASH_ACR_ICEN)
+
+/**
+  * @brief  Disable the FLASH instruction cache.
+  * @retval none
+  */ 
+#define __HAL_FLASH_INSTRUCTION_CACHE_DISABLE() CLEAR_BIT(FLASH->ACR, FLASH_ACR_ICEN)
+
+/**
+  * @brief  Enable the FLASH data cache.
+  * @retval none
+  */ 
+#define __HAL_FLASH_DATA_CACHE_ENABLE()         SET_BIT(FLASH->ACR, FLASH_ACR_DCEN)
+
+/**
+  * @brief  Disable the FLASH data cache.
+  * @retval none
+  */ 
+#define __HAL_FLASH_DATA_CACHE_DISABLE()        CLEAR_BIT(FLASH->ACR, FLASH_ACR_DCEN)
+
+/**
+  * @brief  Reset the FLASH instruction Cache.
+  * @note   This function must be used only when the Instruction Cache is disabled.  
+  * @retval None
+  */
+#define __HAL_FLASH_INSTRUCTION_CACHE_RESET()   do { SET_BIT(FLASH->ACR, FLASH_ACR_ICRST);   \
+                                                     CLEAR_BIT(FLASH->ACR, FLASH_ACR_ICRST); \
+                                                   } while (0)
+
+/**
+  * @brief  Reset the FLASH data Cache.
+  * @note   This function must be used only when the data Cache is disabled.  
+  * @retval None
+  */
+#define __HAL_FLASH_DATA_CACHE_RESET()          do { SET_BIT(FLASH->ACR, FLASH_ACR_DCRST);   \
+                                                     CLEAR_BIT(FLASH->ACR, FLASH_ACR_DCRST); \
+                                                   } while (0)
+
+/**
+  * @brief  Enable the FLASH power down during Low-power run mode.
+  * @note   Writing this bit  to 0 this bit, automatically the keys are
+  *         loss and a new unlock sequence is necessary to re-write it to 1.
+  */
+#define __HAL_FLASH_POWER_DOWN_ENABLE()         do { WRITE_REG(FLASH->PDKEYR, FLASH_PDKEY1); \
+                                                     WRITE_REG(FLASH->PDKEYR, FLASH_PDKEY2); \
+                                                     SET_BIT(FLASH->ACR, FLASH_ACR_RUN_PD);   \
+                                                   } while (0)
+
+/**
+  * @brief  Disable the FLASH power down during Low-power run mode.
+  * @note   Writing this bit  to 0 this bit, automatically the keys are
+  *         loss and a new unlock sequence is necessary to re-write it to 1.
+  */
+#define __HAL_FLASH_POWER_DOWN_DISABLE()        do { WRITE_REG(FLASH->PDKEYR, FLASH_PDKEY1); \
+                                                     WRITE_REG(FLASH->PDKEYR, FLASH_PDKEY2); \
+                                                     CLEAR_BIT(FLASH->ACR, FLASH_ACR_RUN_PD); \
+                                                   } while (0)
+
+/**
+  * @brief  Enable the FLASH power down during Low-Power sleep mode
+  * @retval none
+  */ 
+#define __HAL_FLASH_SLEEP_POWERDOWN_ENABLE()    SET_BIT(FLASH->ACR, FLASH_ACR_SLEEP_PD)
+
+/**
+  * @brief  Disable the FLASH power down during Low-Power sleep mode
+  * @retval none
+  */ 
+#define __HAL_FLASH_SLEEP_POWERDOWN_DISABLE()   CLEAR_BIT(FLASH->ACR, FLASH_ACR_SLEEP_PD)
+
+/**
+  * @}
+  */  
+
+/** @defgroup FLASH_Interrupt FLASH Interrupts Macros
+ *  @brief macros to handle FLASH interrupts
+ * @{
+ */ 
+
+/**
+  * @brief  Enable the specified FLASH interrupt.
+  * @param  __INTERRUPT__: FLASH interrupt 
+  *         This parameter can be any combination of the following values:
+  *     @arg FLASH_IT_EOP: End of FLASH Operation Interrupt
+  *     @arg FLASH_IT_OPERR: Error Interrupt    
+  *     @arg FLASH_IT_RDERR: PCROP Read Error Interrupt
+  *     @arg FLASH_IT_ECCC: ECC Correction Interrupt
+  * @retval none
+  */  
+#define __HAL_FLASH_ENABLE_IT(__INTERRUPT__)    do { if((__INTERRUPT__) & FLASH_IT_ECCC) { SET_BIT(FLASH->ECCR, FLASH_ECCR_ECCIE); }\
+                                                     if((__INTERRUPT__) & (~FLASH_IT_ECCC)) { SET_BIT(FLASH->CR, ((__INTERRUPT__) & (~FLASH_IT_ECCC))); }\
+                                                   } while(0)
+
+/**
+  * @brief  Disable the specified FLASH interrupt.
+  * @param  __INTERRUPT__: FLASH interrupt 
+  *         This parameter can be any combination of the following values:
+  *     @arg FLASH_IT_EOP: End of FLASH Operation Interrupt
+  *     @arg FLASH_IT_OPERR: Error Interrupt    
+  *     @arg FLASH_IT_RDERR: PCROP Read Error Interrupt
+  *     @arg FLASH_IT_ECCC: ECC Correction Interrupt
+  * @retval none
+  */  
+#define __HAL_FLASH_DISABLE_IT(__INTERRUPT__)   do { if((__INTERRUPT__) & FLASH_IT_ECCC) { CLEAR_BIT(FLASH->ECCR, FLASH_ECCR_ECCIE); }\
+                                                     if((__INTERRUPT__) & (~FLASH_IT_ECCC)) { CLEAR_BIT(FLASH->CR, ((__INTERRUPT__) & (~FLASH_IT_ECCC))); }\
+                                                   } while(0)
+
+/**
+  * @brief  Check whether the specified FLASH flag is set or not.
+  * @param  __FLAG__: specifies the FLASH flag to check.
+  *   This parameter can be one of the following values:
+  *     @arg FLASH_FLAG_EOP: FLASH End of Operation flag
+  *     @arg FLASH_FLAG_OPERR: FLASH Operation error flag
+  *     @arg FLASH_FLAG_PROGERR: FLASH Programming error flag
+  *     @arg FLASH_FLAG_WRPERR: FLASH Write protection error flag 
+  *     @arg FLASH_FLAG_PGAERR: FLASH Programming alignment error flag
+  *     @arg FLASH_FLAG_SIZERR: FLASH Size error flag
+  *     @arg FLASH_FLAG_PGSERR: FLASH Programming sequence error flag
+  *     @arg FLASH_FLAG_MISERR: FLASH Fast programming data miss error flag
+  *     @arg FLASH_FLAG_FASTERR: FLASH Fast programming error flag
+  *     @arg FLASH_FLAG_RDERR: FLASH PCROP read  error flag
+  *     @arg FLASH_FLAG_OPTVERR: FLASH Option validity error flag
+  *     @arg FLASH_FLAG_BSY: FLASH write/erase operations in progress flag 
+  *     @arg FLASH_FLAG_ECCC: FLASH one ECC error has been detected and corrected
+  *     @arg FLASH_FLAG_ECCD: FLASH two ECC errors have been detected
+  * @retval The new state of FLASH_FLAG (SET or RESET).
+  */
+#define __HAL_FLASH_GET_FLAG(__FLAG__)          (((__FLAG__) & (FLASH_FLAG_ECCC | FLASH_FLAG_ECCD)) ? \
+                                                 (READ_BIT(FLASH->ECCR, (__FLAG__)) == (__FLAG__))  : \
+                                                 (READ_BIT(FLASH->SR,   (__FLAG__)) == (__FLAG__)))
+
+/**
+  * @brief  Clear the FLASH's pending flags.
+  * @param  __FLAG__: specifies the FLASH flags to clear.
+  *   This parameter can be any combination of the following values:
+  *     @arg FLASH_FLAG_EOP: FLASH End of Operation flag
+  *     @arg FLASH_FLAG_OPERR: FLASH Operation error flag
+  *     @arg FLASH_FLAG_PROGERR: FLASH Programming error flag
+  *     @arg FLASH_FLAG_WRPERR: FLASH Write protection error flag 
+  *     @arg FLASH_FLAG_PGAERR: FLASH Programming alignment error flag
+  *     @arg FLASH_FLAG_SIZERR: FLASH Size error flag
+  *     @arg FLASH_FLAG_PGSERR: FLASH Programming sequence error flag
+  *     @arg FLASH_FLAG_MISERR: FLASH Fast programming data miss error flag
+  *     @arg FLASH_FLAG_FASTERR: FLASH Fast programming error flag
+  *     @arg FLASH_FLAG_RDERR: FLASH PCROP read  error flag
+  *     @arg FLASH_FLAG_OPTVERR: FLASH Option validity error flag
+  *     @arg FLASH_FLAG_ECCC: FLASH one ECC error has been detected and corrected
+  *     @arg FLASH_FLAG_ECCD: FLASH two ECC errors have been detected
+  *     @arg FLASH_FLAG_ALL_ERRORS: FLASH All errors flags
+  * @retval None
+  */
+#define __HAL_FLASH_CLEAR_FLAG(__FLAG__)        do { if((__FLAG__) & (FLASH_FLAG_ECCC | FLASH_FLAG_ECCD)) { SET_BIT(FLASH->ECCR, ((__FLAG__) & (FLASH_FLAG_ECCC | FLASH_FLAG_ECCD))); }\
+                                                     if((__FLAG__) & ~(FLASH_FLAG_ECCC | FLASH_FLAG_ECCD)) { WRITE_REG(FLASH->SR, ((__FLAG__) & ~(FLASH_FLAG_ECCC | FLASH_FLAG_ECCD))); }\
+                                                   } while(0)
+/**
+  * @}
+  */  
+
+/* Include FLASH HAL Extended module */
+#include "stm32l4xx_hal_flash_ex.h"
+#include "stm32l4xx_hal_flash_ramfunc.h"
+
+/* Exported functions --------------------------------------------------------*/ 
+/** @addtogroup FLASH_Exported_Functions
+  * @{
+  */
+
+/* Program operation functions  ***********************************************/
+/** @addtogroup FLASH_Exported_Functions_Group1
+  * @{
+  */
+HAL_StatusTypeDef  HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint64_t Data);
+HAL_StatusTypeDef  HAL_FLASH_Program_IT(uint32_t TypeProgram, uint32_t Address, uint64_t Data);
+/* FLASH IRQ handler method */
+void               HAL_FLASH_IRQHandler(void);
+/* Callbacks in non blocking modes */ 
+void               HAL_FLASH_EndOfOperationCallback(uint32_t ReturnValue);
+void               HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue);
+/**
+  * @}
+  */
+
+/* Peripheral Control functions  **********************************************/
+/** @addtogroup FLASH_Exported_Functions_Group2
+  * @{
+  */
+HAL_StatusTypeDef  HAL_FLASH_Unlock(void);
+HAL_StatusTypeDef  HAL_FLASH_Lock(void);
+/* Option bytes control */
+HAL_StatusTypeDef  HAL_FLASH_OB_Unlock(void);
+HAL_StatusTypeDef  HAL_FLASH_OB_Lock(void);
+HAL_StatusTypeDef  HAL_FLASH_OB_Launch(void);
+/**
+  * @}
+  */
+
+/* Peripheral State functions  ************************************************/
+/** @addtogroup FLASH_Exported_Functions_Group3
+  * @{
+  */
+uint32_t HAL_FLASH_GetError(void);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private constants --------------------------------------------------------*/
+/** @defgroup FLASH_Private_Constants FLASH Private Constants
+  * @{
+  */
+#define FLASH_SIZE_DATA_REGISTER           ((uint32_t)0x1FFF75E0)
+    
+#define FLASH_SIZE                         ((((*((uint16_t *)FLASH_SIZE_DATA_REGISTER)) == 0xFFFF)) ? (0x400 << 10) : \
+                                            (((*((uint16_t *)FLASH_SIZE_DATA_REGISTER)) & (0x0FFF)) << 10))
+
+#define FLASH_BANK_SIZE                    (FLASH_SIZE >> 1)
+
+#define FLASH_PAGE_SIZE                    ((uint32_t)0x800)
+
+#define FLASH_TIMEOUT_VALUE                ((uint32_t)50000)/* 50 s */
+/**
+  * @}
+  */
+ 
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup FLASH_Private_Macros FLASH Private Macros
+ *  @{
+ */
+
+#define IS_FLASH_TYPEERASE(VALUE)          (((VALUE) == FLASH_TYPEERASE_PAGES) || \
+                                            ((VALUE) == FLASH_TYPEERASE_MASSERASE))  
+
+#define IS_FLASH_BANK(BANK)                (((BANK) == FLASH_BANK_1)  || \
+                                            ((BANK) == FLASH_BANK_2)  || \
+                                            ((BANK) == FLASH_BANK_BOTH))
+
+#define IS_FLASH_BANK_EXCLUSIVE(BANK)      (((BANK) == FLASH_BANK_1)  || \
+                                            ((BANK) == FLASH_BANK_2))
+
+#define IS_FLASH_TYPEPROGRAM(VALUE)        (((VALUE) == FLASH_TYPEPROGRAM_DOUBLEWORD) || \
+                                            ((VALUE) == FLASH_TYPEPROGRAM_FAST) || \
+                                            ((VALUE) == FLASH_TYPEPROGRAM_FAST_AND_LAST))  
+
+#define IS_FLASH_MAIN_MEM_ADDRESS(ADDRESS) (((ADDRESS) >= FLASH_BASE)        && ((((*((uint16_t *)FLASH_SIZE_DATA_REGISTER)) & (0x0FFF)) == 0x400) ? \
+                                            ((ADDRESS) <= FLASH_BASE+0xFFFFF) : ((((*((uint16_t *)FLASH_SIZE_DATA_REGISTER)) & (0x0FFF)) == 0x200) ? \
+                                            ((ADDRESS) <= FLASH_BASE+0x7FFFF) : ((((*((uint16_t *)FLASH_SIZE_DATA_REGISTER)) & (0x0FFF)) == 0x100) ? \
+                                            ((ADDRESS) <= FLASH_BASE+0x3FFFF) : ((ADDRESS) <= FLASH_BASE+0xFFFFF))))) 
+
+#define IS_FLASH_OTP_ADDRESS(ADDRESS)      (((ADDRESS) >= 0x1FFF7000) && ((ADDRESS) <= 0x1FFF73FF))
+
+#define IS_FLASH_PROGRAM_ADDRESS(ADDRESS)  (IS_FLASH_MAIN_MEM_ADDRESS(ADDRESS) || IS_FLASH_OTP_ADDRESS(ADDRESS))
+
+#define IS_FLASH_PAGE(PAGE)                (((((*((uint16_t *)FLASH_SIZE_DATA_REGISTER)) & (0x0FFF)) == 0x400) ? ((PAGE) < 256) : \
+                                            ((((*((uint16_t *)FLASH_SIZE_DATA_REGISTER)) & (0x0FFF)) == 0x200) ? ((PAGE) < 128) : \
+                                            ((((*((uint16_t *)FLASH_SIZE_DATA_REGISTER)) & (0x0FFF)) == 0x100) ? ((PAGE) < 64) : \
+                                            ((PAGE) < 256)))))
+
+#define IS_OPTIONBYTE(VALUE)               (((VALUE) <= (OPTIONBYTE_WRP | OPTIONBYTE_RDP | OPTIONBYTE_USER | OPTIONBYTE_PCROP)))
+
+#define IS_OB_WRPAREA(VALUE)               (((VALUE) == OB_WRPAREA_BANK1_AREAA) || ((VALUE) == OB_WRPAREA_BANK1_AREAB) || \
+                                            ((VALUE) == OB_WRPAREA_BANK2_AREAA) || ((VALUE) == OB_WRPAREA_BANK2_AREAB))
+
+#define IS_OB_RDP_LEVEL(LEVEL)             (((LEVEL) == OB_RDP_LEVEL_0)   ||\
+                                            ((LEVEL) == OB_RDP_LEVEL_1)/* ||\
+                                            ((LEVEL) == OB_RDP_LEVEL_2)*/)
+
+#define IS_OB_USER_TYPE(TYPE)              (((TYPE) <= (uint32_t)0x1FFF) && ((TYPE) != 0))
+
+#define IS_OB_USER_BOR_LEVEL(LEVEL)        (((LEVEL) == OB_BOR_LEVEL_0) || ((LEVEL) == OB_BOR_LEVEL_1) || \
+                                            ((LEVEL) == OB_BOR_LEVEL_2) || ((LEVEL) == OB_BOR_LEVEL_3) || \
+                                            ((LEVEL) == OB_BOR_LEVEL_4))
+
+#define IS_OB_USER_STOP(VALUE)             (((VALUE) == OB_STOP_RST) || ((VALUE) == OB_STOP_NORST))
+
+#define IS_OB_USER_STANDBY(VALUE)          (((VALUE) == OB_STANDBY_RST) || ((VALUE) == OB_STANDBY_NORST))
+
+#define IS_OB_USER_SHUTDOWN(VALUE)         (((VALUE) == OB_SHUTDOWN_RST) || ((VALUE) == OB_SHUTDOWN_NORST))
+
+#define IS_OB_USER_IWDG(VALUE)             (((VALUE) == OB_IWDG_HW) || ((VALUE) == OB_IWDG_SW))
+
+#define IS_OB_USER_IWDG_STOP(VALUE)        (((VALUE) == OB_IWDG_STOP_FREEZE) || ((VALUE) == OB_IWDG_STOP_RUN))
+
+#define IS_OB_USER_IWDG_STDBY(VALUE)       (((VALUE) == OB_IWDG_STDBY_FREEZE) || ((VALUE) == OB_IWDG_STDBY_RUN))
+
+#define IS_OB_USER_WWDG(VALUE)             (((VALUE) == OB_WWDG_HW) || ((VALUE) == OB_WWDG_SW))
+
+#define IS_OB_USER_BFB2(VALUE)             (((VALUE) == OB_BFB2_DISABLE) || ((VALUE) == OB_BFB2_ENABLE))
+
+#define IS_OB_USER_DUALBANK(VALUE)         (((VALUE) == OB_DUALBANK_SINGLE) || ((VALUE) == OB_DUALBANK_DUAL))
+
+#define IS_OB_USER_BOOT1(VALUE)            (((VALUE) == OB_BOOT1_SRAM) || ((VALUE) == OB_BOOT1_SYSTEM))
+
+#define IS_OB_USER_SRAM2_PARITY(VALUE)     (((VALUE) == OB_SRAM2_PARITY_ENABLE) || ((VALUE) == OB_SRAM2_PARITY_DISABLE))
+
+#define IS_OB_USER_SRAM2_RST(VALUE)        (((VALUE) == OB_SRAM2_RST_ERASE) || ((VALUE) == OB_SRAM2_RST_NOT_ERASE))
+
+#define IS_OB_PCROP_RDP(VALUE)             (((VALUE) == OB_PCROP_RDP_NOT_ERASE) || ((VALUE) == OB_PCROP_RDP_ERASE))
+
+#define IS_FLASH_LATENCY(LATENCY)          (((LATENCY) == FLASH_LATENCY_0) || \
+                                            ((LATENCY) == FLASH_LATENCY_1) || \
+                                            ((LATENCY) == FLASH_LATENCY_2) || \
+                                            ((LATENCY) == FLASH_LATENCY_3) || \
+                                            ((LATENCY) == FLASH_LATENCY_4))
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_FLASH_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_flash_ex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_flash_ex.h
@@ -1,0 +1,98 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_flash_ex.h
+  * @author  MCD Application Team
+  * @version V1.3.0 
+  * @date    29-January-2016
+  * @brief   Header file of FLASH HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_FLASH_EX_H
+#define __STM32L4xx_HAL_FLASH_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup FLASHEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+
+/* Exported constants --------------------------------------------------------*/
+
+/* Exported macro ------------------------------------------------------------*/
+
+/* Exported functions --------------------------------------------------------*/ 
+/** @addtogroup FLASHEx_Exported_Functions
+  * @{
+  */
+
+/* Extended Program operation functions  *************************************/
+/** @addtogroup FLASHEx_Exported_Functions_Group1
+  * @{
+  */
+HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t *PageError);
+HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit);
+HAL_StatusTypeDef HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit);
+void              HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit);
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_FLASH_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_flash_ramfunc.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_flash_ramfunc.h
@@ -1,0 +1,125 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_flash_ramfunc.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of FLASH RAMFUNC driver.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_FLASH_RAMFUNC_H
+#define __STM32L4xx_FLASH_RAMFUNC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup FLASH_RAMFUNC
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/* Exported macro ------------------------------------------------------------*/
+/** 
+  * @brief  __RAM_FUNC definition
+  */ 
+#if defined ( __CC_ARM   )
+/* ARM Compiler
+   ------------
+   RAM functions are defined using the toolchain options. 
+   Functions that are executed in RAM should reside in a separate source module.
+   Using the 'Options for File' dialog you can simply change the 'Code / Const' 
+   area of a module to a memory space in physical RAM.
+   Available memory areas are declared in the 'Target' tab of the 'Options for Target'
+   dialog. 
+*/
+#define __RAM_FUNC HAL_StatusTypeDef 
+
+#elif defined ( __ICCARM__ )
+/* ICCARM Compiler
+   ---------------
+   RAM functions are defined using a specific toolchain keyword "__ramfunc". 
+*/
+#define __RAM_FUNC __ramfunc HAL_StatusTypeDef
+
+#elif defined   (  __GNUC__  )
+/* GNU Compiler
+   ------------
+  RAM functions are defined using a specific toolchain attribute 
+   "__attribute__((section(".RamFunc")))".
+*/
+#define __RAM_FUNC HAL_StatusTypeDef  __attribute__((section(".RamFunc")))
+
+#endif
+                                      
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup FLASH_RAMFUNC_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup FLASH_RAMFUNC_Exported_Functions_Group1
+  * @{
+  */
+/* Peripheral Control functions  ************************************************/
+__RAM_FUNC  HAL_FLASHEx_EnableRunPowerDown(void);
+__RAM_FUNC  HAL_FLASHEx_DisableRunPowerDown(void);
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_FLASH_RAMFUNC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_gpio.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_gpio.h
@@ -1,0 +1,317 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_gpio.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of GPIO HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_GPIO_H
+#define __STM32L4xx_HAL_GPIO_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup GPIO
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup GPIO_Exported_Types GPIO Exported Types
+  * @{
+  */
+/**
+  * @brief   GPIO Init structure definition
+  */
+typedef struct
+{
+  uint32_t Pin;        /*!< Specifies the GPIO pins to be configured.
+                           This parameter can be any value of @ref GPIO_pins */
+
+  uint32_t Mode;       /*!< Specifies the operating mode for the selected pins.
+                           This parameter can be a value of @ref GPIO_mode */
+
+  uint32_t Pull;       /*!< Specifies the Pull-up or Pull-Down activation for the selected pins.
+                           This parameter can be a value of @ref GPIO_pull */
+
+  uint32_t Speed;      /*!< Specifies the speed for the selected pins.
+                           This parameter can be a value of @ref GPIO_speed */
+
+  uint32_t Alternate;  /*!< Peripheral to be connected to the selected pins 
+                            This parameter can be a value of @ref GPIOEx_Alternate_function_selection */
+}GPIO_InitTypeDef;
+
+/**
+  * @brief  GPIO Bit SET and Bit RESET enumeration
+  */
+typedef enum
+{
+  GPIO_PIN_RESET = 0,
+  GPIO_PIN_SET
+}GPIO_PinState;
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup GPIO_Exported_Constants GPIO Exported Constants
+  * @{
+  */
+/** @defgroup GPIO_pins GPIO pins
+  * @{
+  */
+#define GPIO_PIN_0                 ((uint16_t)0x0001)  /* Pin 0 selected    */
+#define GPIO_PIN_1                 ((uint16_t)0x0002)  /* Pin 1 selected    */
+#define GPIO_PIN_2                 ((uint16_t)0x0004)  /* Pin 2 selected    */
+#define GPIO_PIN_3                 ((uint16_t)0x0008)  /* Pin 3 selected    */
+#define GPIO_PIN_4                 ((uint16_t)0x0010)  /* Pin 4 selected    */
+#define GPIO_PIN_5                 ((uint16_t)0x0020)  /* Pin 5 selected    */
+#define GPIO_PIN_6                 ((uint16_t)0x0040)  /* Pin 6 selected    */
+#define GPIO_PIN_7                 ((uint16_t)0x0080)  /* Pin 7 selected    */
+#define GPIO_PIN_8                 ((uint16_t)0x0100)  /* Pin 8 selected    */
+#define GPIO_PIN_9                 ((uint16_t)0x0200)  /* Pin 9 selected    */
+#define GPIO_PIN_10                ((uint16_t)0x0400)  /* Pin 10 selected   */
+#define GPIO_PIN_11                ((uint16_t)0x0800)  /* Pin 11 selected   */
+#define GPIO_PIN_12                ((uint16_t)0x1000)  /* Pin 12 selected   */
+#define GPIO_PIN_13                ((uint16_t)0x2000)  /* Pin 13 selected   */
+#define GPIO_PIN_14                ((uint16_t)0x4000)  /* Pin 14 selected   */
+#define GPIO_PIN_15                ((uint16_t)0x8000)  /* Pin 15 selected   */
+#define GPIO_PIN_All               ((uint16_t)0xFFFF)  /* All pins selected */
+
+#define GPIO_PIN_MASK              ((uint32_t)0x0000FFFF) /* PIN mask for assert test */
+/**
+  * @}
+  */
+
+/** @defgroup GPIO_mode GPIO mode
+  * @brief GPIO Configuration Mode
+  *        Elements values convention: 0xX0yz00YZ
+  *           - X  : GPIO mode or EXTI Mode
+  *           - y  : External IT or Event trigger detection
+  *           - z  : IO configuration on External IT or Event
+  *           - Y  : Output type (Push Pull or Open Drain)
+  *           - Z  : IO Direction mode (Input, Output, Alternate or Analog)
+  * @{
+  */
+#define  GPIO_MODE_INPUT                        ((uint32_t)0x00000000)   /*!< Input Floating Mode                   */
+#define  GPIO_MODE_OUTPUT_PP                    ((uint32_t)0x00000001)   /*!< Output Push Pull Mode                 */
+#define  GPIO_MODE_OUTPUT_OD                    ((uint32_t)0x00000011)   /*!< Output Open Drain Mode                */
+#define  GPIO_MODE_AF_PP                        ((uint32_t)0x00000002)   /*!< Alternate Function Push Pull Mode     */
+#define  GPIO_MODE_AF_OD                        ((uint32_t)0x00000012)   /*!< Alternate Function Open Drain Mode    */
+#define  GPIO_MODE_ANALOG                       ((uint32_t)0x00000003)   /*!< Analog Mode  */
+#define  GPIO_MODE_ANALOG_ADC_CONTROL           ((uint32_t)0x0000000B)   /*!< Analog Mode for ADC conversion */
+#define  GPIO_MODE_IT_RISING                    ((uint32_t)0x10110000)   /*!< External Interrupt Mode with Rising edge trigger detection          */
+#define  GPIO_MODE_IT_FALLING                   ((uint32_t)0x10210000)   /*!< External Interrupt Mode with Falling edge trigger detection         */
+#define  GPIO_MODE_IT_RISING_FALLING            ((uint32_t)0x10310000)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection  */
+#define  GPIO_MODE_EVT_RISING                   ((uint32_t)0x10120000)   /*!< External Event Mode with Rising edge trigger detection               */
+#define  GPIO_MODE_EVT_FALLING                  ((uint32_t)0x10220000)   /*!< External Event Mode with Falling edge trigger detection              */
+#define  GPIO_MODE_EVT_RISING_FALLING           ((uint32_t)0x10320000)   /*!< External Event Mode with Rising/Falling edge trigger detection       */
+/**
+  * @}
+  */
+
+/** @defgroup GPIO_speed GPIO speed
+  * @brief GPIO Output Maximum frequency
+  * @{
+  */
+#define  GPIO_SPEED_FREQ_LOW        ((uint32_t)0x00000000)   /*!< range up to 5 MHz, please refer to the product datasheet */
+#define  GPIO_SPEED_FREQ_MEDIUM     ((uint32_t)0x00000001)   /*!< range  5 MHz to 25 MHz, please refer to the product datasheet */
+#define  GPIO_SPEED_FREQ_HIGH       ((uint32_t)0x00000002)   /*!< range 25 MHz to 50 MHz, please refer to the product datasheet */
+#define  GPIO_SPEED_FREQ_VERY_HIGH  ((uint32_t)0x00000003)   /*!< range 50 MHz to 80 MHz, please refer to the product datasheet */
+/**
+  * @}
+  */
+
+ /** @defgroup GPIO_pull GPIO pull
+   * @brief GPIO Pull-Up or Pull-Down Activation
+   * @{
+   */
+#define  GPIO_NOPULL        ((uint32_t)0x00000000)   /*!< No Pull-up or Pull-down activation  */
+#define  GPIO_PULLUP        ((uint32_t)0x00000001)   /*!< Pull-up activation                  */
+#define  GPIO_PULLDOWN      ((uint32_t)0x00000002)   /*!< Pull-down activation                */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup GPIO_Exported_Macros GPIO Exported Macros
+  * @{
+  */
+  
+/**
+  * @brief  Check whether the specified EXTI line flag is set or not.
+  * @param  __EXTI_LINE__: specifies the EXTI line flag to check.
+  *         This parameter can be GPIO_PIN_x where x can be(0..15)
+  * @retval The new state of __EXTI_LINE__ (SET or RESET).
+  */
+#define __HAL_GPIO_EXTI_GET_FLAG(__EXTI_LINE__)       (EXTI->PR1 & (__EXTI_LINE__))
+
+/**
+  * @brief  Clear the EXTI's line pending flags.
+  * @param  __EXTI_LINE__: specifies the EXTI lines flags to clear.
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15)
+  * @retval None
+  */
+#define __HAL_GPIO_EXTI_CLEAR_FLAG(__EXTI_LINE__)     (EXTI->PR1 = (__EXTI_LINE__))
+
+/**
+  * @brief  Check whether the specified EXTI line is asserted or not.
+  * @param  __EXTI_LINE__: specifies the EXTI line to check.
+  *          This parameter can be GPIO_PIN_x where x can be(0..15)
+  * @retval The new state of __EXTI_LINE__ (SET or RESET).
+  */
+#define __HAL_GPIO_EXTI_GET_IT(__EXTI_LINE__)         (EXTI->PR1 & (__EXTI_LINE__))
+
+/**
+  * @brief  Clear the EXTI's line pending bits.
+  * @param  __EXTI_LINE__: specifies the EXTI lines to clear.
+  *          This parameter can be any combination of GPIO_PIN_x where x can be (0..15)
+  * @retval None
+  */
+#define __HAL_GPIO_EXTI_CLEAR_IT(__EXTI_LINE__)       (EXTI->PR1 = (__EXTI_LINE__))
+
+/**
+  * @brief  Generate a Software interrupt on selected EXTI line.
+  * @param  __EXTI_LINE__: specifies the EXTI line to check.
+  *          This parameter can be GPIO_PIN_x where x can be(0..15)
+  * @retval None
+  */
+#define __HAL_GPIO_EXTI_GENERATE_SWIT(__EXTI_LINE__)  (EXTI->SWIER1 |= (__EXTI_LINE__))
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @addtogroup GPIO_Private_Macros GPIO Private Macros
+  * @{
+  */
+#define IS_GPIO_PIN_ACTION(ACTION)  (((ACTION) == GPIO_PIN_RESET) || ((ACTION) == GPIO_PIN_SET))
+
+#define IS_GPIO_PIN(__PIN__)        (((__PIN__) & GPIO_PIN_MASK) != (uint32_t)0x00)
+
+#define IS_GPIO_MODE(__MODE__)      (((__MODE__) == GPIO_MODE_INPUT)              ||\
+                                     ((__MODE__) == GPIO_MODE_OUTPUT_PP)          ||\
+                                     ((__MODE__) == GPIO_MODE_OUTPUT_OD)          ||\
+                                     ((__MODE__) == GPIO_MODE_AF_PP)              ||\
+                                     ((__MODE__) == GPIO_MODE_AF_OD)              ||\
+                                     ((__MODE__) == GPIO_MODE_IT_RISING)          ||\
+                                     ((__MODE__) == GPIO_MODE_IT_FALLING)         ||\
+                                     ((__MODE__) == GPIO_MODE_IT_RISING_FALLING)  ||\
+                                     ((__MODE__) == GPIO_MODE_EVT_RISING)         ||\
+                                     ((__MODE__) == GPIO_MODE_EVT_FALLING)        ||\
+                                     ((__MODE__) == GPIO_MODE_EVT_RISING_FALLING) ||\
+                                     ((__MODE__) == GPIO_MODE_ANALOG)             ||\
+                                     ((__MODE__) == GPIO_MODE_ANALOG_ADC_CONTROL))
+
+#define IS_GPIO_SPEED(__SPEED__)    (((__SPEED__) == GPIO_SPEED_FREQ_LOW)       ||\
+                                     ((__SPEED__) == GPIO_SPEED_FREQ_MEDIUM)    ||\
+                                     ((__SPEED__) == GPIO_SPEED_FREQ_HIGH)      ||\
+                                     ((__SPEED__) == GPIO_SPEED_FREQ_VERY_HIGH))
+
+#define IS_GPIO_PULL(__PULL__)      (((__PULL__) == GPIO_NOPULL)   ||\
+                                     ((__PULL__) == GPIO_PULLUP)   || \
+                                     ((__PULL__) == GPIO_PULLDOWN))
+/**
+  * @}
+  */
+
+/* Include GPIO HAL Extended module */
+#include "stm32l4xx_hal_gpio_ex.h"
+
+/* Exported functions --------------------------------------------------------*/ 
+/** @addtogroup GPIO_Exported_Functions GPIO Exported Functions
+  * @{
+  */
+
+/** @addtogroup GPIO_Exported_Functions_Group1 Initialization/de-initialization functions 
+ *  @brief    Initialization and Configuration functions
+ * @{
+ */
+     
+/* Initialization and de-initialization functions *****************************/
+void              HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init);
+void              HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin);
+
+/**
+  * @}
+  */
+
+/** @addtogroup GPIO_Exported_Functions_Group2 IO operation functions 
+ * @{
+ */
+   
+/* IO operation functions *****************************************************/
+GPIO_PinState     HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+void              HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState);
+void              HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+void              HAL_GPIO_EXTI_IRQHandler(uint16_t GPIO_Pin);
+void              HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */  
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_GPIO_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_gpio_ex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_gpio_ex.h
@@ -1,0 +1,245 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_gpio_ex.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of GPIO HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_GPIO_EX_H
+#define __STM32L4xx_HAL_GPIO_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup GPIOEx GPIOEx
+  * @brief GPIO Extended HAL module driver
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup GPIOEx_Exported_Constants GPIOEx Exported Constants
+  * @{
+  */
+
+/** @defgroup GPIOEx_Alternate_function_selection GPIOEx Alternate function selection
+  * @{
+  */
+
+#if defined(STM32L471xx) || defined(STM32L475xx) || defined(STM32L476xx) || defined(STM32L485xx) || defined(STM32L486xx)
+/*--------------STM32L471xx/STM32L475xx/STM32L476xx/STM32L485xx/STM32L486xx----*/
+/**
+  * @brief   AF 0 selection
+  */
+#define GPIO_AF0_RTC_50Hz      ((uint8_t)0x00)  /* RTC_50Hz Alternate Function mapping                       */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /* MCO (MCO1 and MCO2) Alternate Function mapping            */
+#define GPIO_AF0_SWJ           ((uint8_t)0x00)  /* SWJ (SWD and JTAG) Alternate Function mapping             */
+#if defined(STM32L476xx) || defined(STM32L486xx)
+#define GPIO_AF0_LCDBIAS       ((uint8_t)0x00)  /* LCDBIAS Alternate Function mapping                        */
+#endif /* STM32L476xx || STM32L486xx */
+#define GPIO_AF0_TRACE         ((uint8_t)0x00)  /* TRACE Alternate Function mapping                          */
+
+/**
+  * @brief   AF 1 selection
+  */
+#define GPIO_AF1_TIM1          ((uint8_t)0x01)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF1_TIM2          ((uint8_t)0x01)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF1_TIM5          ((uint8_t)0x01)  /* TIM5 Alternate Function mapping */
+#define GPIO_AF1_TIM8          ((uint8_t)0x01)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF1_LPTIM1        ((uint8_t)0x01)  /* LPTIM1 Alternate Function mapping */
+#define GPIO_AF1_IR            ((uint8_t)0x01)  /* IR Alternate Function mapping */
+
+/**
+  * @brief   AF 2 selection
+  */
+#define GPIO_AF2_TIM1          ((uint8_t)0x02)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF2_TIM2          ((uint8_t)0x02)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF2_TIM3          ((uint8_t)0x02)  /* TIM3 Alternate Function mapping */
+#define GPIO_AF2_TIM4          ((uint8_t)0x02)  /* TIM4 Alternate Function mapping */
+#define GPIO_AF2_TIM5          ((uint8_t)0x02)  /* TIM5 Alternate Function mapping */
+
+/**
+  * @brief   AF 3 selection
+  */
+#define GPIO_AF3_TIM8          ((uint8_t)0x03)  /* TIM8 Alternate Function mapping  */
+#define GPIO_AF3_TIM1_COMP2    ((uint8_t)0x03)  /* TIM1/COMP2 Break in Alternate Function mapping  */
+#define GPIO_AF3_TIM1_COMP1    ((uint8_t)0x03)  /* TIM1/COMP1 Break in Alternate Function mapping  */
+
+/**
+  * @brief   AF 4 selection
+  */
+#define GPIO_AF4_I2C1          ((uint8_t)0x04)  /* I2C1 Alternate Function mapping   */
+#define GPIO_AF4_I2C2          ((uint8_t)0x04)  /* I2C2 Alternate Function mapping   */
+#define GPIO_AF4_I2C3          ((uint8_t)0x04)  /* I2C3 Alternate Function mapping   */
+
+/**
+  * @brief   AF 5 selection
+  */
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /* SPI1 Alternate Function mapping   */
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /* SPI2 Alternate Function mapping   */
+
+/**
+  * @brief   AF 6 selection
+  */
+#define GPIO_AF6_SPI3          ((uint8_t)0x06)  /* SPI3 Alternate Function mapping   */
+#define GPIO_AF6_DFSDM         ((uint8_t)0x06)  /* DFSDM Alternate Function mapping  */
+
+/**
+  * @brief   AF 7 selection
+  */
+#define GPIO_AF7_USART1        ((uint8_t)0x07)  /* USART1 Alternate Function mapping     */
+#define GPIO_AF7_USART2        ((uint8_t)0x07)  /* USART2 Alternate Function mapping     */
+#define GPIO_AF7_USART3        ((uint8_t)0x07)  /* USART3 Alternate Function mapping     */
+
+/**
+  * @brief   AF 8 selection
+  */
+#define GPIO_AF8_UART4         ((uint8_t)0x08)  /* UART4 Alternate Function mapping   */
+#define GPIO_AF8_UART5         ((uint8_t)0x08)  /* UART5 Alternate Function mapping   */
+#define GPIO_AF8_LPUART1       ((uint8_t)0x08)  /* LPUART1 Alternate Function mapping */
+
+
+/**
+  * @brief   AF 9 selection
+  */
+#define GPIO_AF9_CAN1          ((uint8_t)0x09)  /* CAN1 Alternate Function mapping  */
+#define GPIO_AF9_TSC           ((uint8_t)0x09)  /* TSC Alternate Function mapping   */
+
+/**
+  * @brief   AF 10 selection
+  */
+#if defined(STM32L475xx) || defined(STM32L476xx) || defined(STM32L485xx) || defined(STM32L486xx)
+#define GPIO_AF10_OTG_FS       ((uint8_t)0xA)  /* OTG_FS Alternate Function mapping */
+#endif /* STM32L475xx || STM32L476xx || STM32L485xx || STM32L486xx */
+#define GPIO_AF10_QUADSPI      ((uint8_t)0xA)  /* QUADSPI Alternate Function mapping */
+
+#if defined(STM32L476xx) || defined(STM32L486xx)
+/**
+  * @brief   AF 11 selection
+  */
+#define GPIO_AF11_LCD           ((uint8_t)0x0B)  /* LCD Alternate Function mapping */
+#endif /* STM32L476xx || STM32L486xx */
+
+/**
+  * @brief   AF 12 selection
+  */
+#define GPIO_AF12_FMC           ((uint8_t)0xC)  /* FMC Alternate Function mapping     */
+#define GPIO_AF12_SWPMI1        ((uint8_t)0xC)  /* SWPMI1 Alternate Function mapping  */
+#define GPIO_AF12_COMP1         ((uint8_t)0xC)  /* COMP1 Alternate Function mapping   */
+#define GPIO_AF12_COMP2         ((uint8_t)0xC)  /* COMP2 Alternate Function mapping   */
+#define GPIO_AF12_SDMMC1        ((uint8_t)0xC)  /* SDMMC1 Alternate Function mapping  */
+
+/**
+  * @brief   AF 13 selection
+  */
+#define GPIO_AF13_SAI1          ((uint8_t)0x0D)   /* SAI1 Alternate Function mapping */
+#define GPIO_AF13_SAI2          ((uint8_t)0x0D)   /* SAI2 Alternate Function mapping */
+#define GPIO_AF13_TIM8_COMP2    ((uint8_t)0x0D)   /* TIM8/COMP2 Break in Alternate Function mapping  */
+#define GPIO_AF13_TIM8_COMP1    ((uint8_t)0x0D)   /* TIM8/COMP1 Break in Alternate Function mapping  */
+
+/**
+  * @brief   AF 14 selection
+  */
+#define GPIO_AF14_TIM2          ((uint8_t)0x0E)   /* TIM2 Alternate Function mapping */
+#define GPIO_AF14_TIM15         ((uint8_t)0x0E)   /* TIM15 Alternate Function mapping */
+#define GPIO_AF14_TIM16         ((uint8_t)0x0E)   /* TIM16 Alternate Function mapping */
+#define GPIO_AF14_TIM17         ((uint8_t)0x0E)   /* TIM17 Alternate Function mapping */
+#define GPIO_AF14_LPTIM2        ((uint8_t)0x0E)   /* LPTIM2 Alternate Function mapping */
+#define GPIO_AF14_TIM8_COMP1    ((uint8_t)0x0E)   /* TIM8/COMP1 Break in Alternate Function mapping  */
+
+/**
+  * @brief   AF 15 selection
+  */
+#define GPIO_AF15_EVENTOUT      ((uint8_t)0x0F)  /* EVENTOUT Alternate Function mapping */
+
+#define IS_GPIO_AF(AF)   ((AF) <= (uint8_t)0x0F)
+
+#endif /* STM32L471xx || STM32L475xx || STM32L476xx || STM32L485xx || STM32L486xx */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup GPIOEx_Exported_Macros GPIOEx Exported Macros
+  * @{
+  */
+
+/** @defgroup GPIOEx_Get_Port_Index GPIOEx_Get Port Index
+* @{
+  */
+#define GPIO_GET_INDEX(__GPIOx__)    (((__GPIOx__) == (GPIOA))? 0U :\
+                                      ((__GPIOx__) == (GPIOB))? 1U :\
+                                      ((__GPIOx__) == (GPIOC))? 2U :\
+                                      ((__GPIOx__) == (GPIOD))? 3U :\
+                                      ((__GPIOx__) == (GPIOE))? 4U :\
+                                      ((__GPIOx__) == (GPIOF))? 5U :\
+                                      ((__GPIOx__) == (GPIOG))? 6U : 7U)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/ 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_GPIO_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_i2c.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_i2c.h
@@ -1,0 +1,665 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_i2c.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of I2C HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_I2C_H
+#define __STM32L4xx_HAL_I2C_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"  
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup I2C
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup I2C_Exported_Types I2C Exported Types
+  * @{
+  */
+
+/** @defgroup I2C_Configuration_Structure_definition I2C Configuration Structure definition
+  * @brief  I2C Configuration Structure definition  
+  * @{
+  */
+typedef struct
+{
+  uint32_t Timing;              /*!< Specifies the I2C_TIMINGR_register value.
+                                  This parameter calculated by referring to I2C initialization 
+                                         section in Reference manual */
+
+  uint32_t OwnAddress1;         /*!< Specifies the first device own address.
+                                  This parameter can be a 7-bit or 10-bit address. */
+
+  uint32_t AddressingMode;      /*!< Specifies if 7-bit or 10-bit addressing mode is selected.
+                                  This parameter can be a value of @ref I2C_addressing_mode */
+
+  uint32_t DualAddressMode;     /*!< Specifies if dual addressing mode is selected.
+                                  This parameter can be a value of @ref I2C_dual_addressing_mode */
+
+  uint32_t OwnAddress2;         /*!< Specifies the second device own address if dual addressing mode is selected
+                                  This parameter can be a 7-bit address. */
+
+  uint32_t OwnAddress2Masks;    /*!< Specifies the acknowledge mask address second device own address if dual addressing mode is selected
+                                  This parameter can be a value of @ref I2C_own_address2_masks */
+
+  uint32_t GeneralCallMode;     /*!< Specifies if general call mode is selected.
+                                  This parameter can be a value of @ref I2C_general_call_addressing_mode */
+
+  uint32_t NoStretchMode;       /*!< Specifies if nostretch mode is selected.
+                                  This parameter can be a value of @ref I2C_nostretch_mode */
+
+}I2C_InitTypeDef;
+
+/** 
+  * @}
+  */
+
+/** @defgroup HAL_state_structure_definition HAL state structure definition
+  * @brief  HAL State structure definition
+  * @{
+  */ 
+
+typedef enum
+{
+  HAL_I2C_STATE_RESET             = 0x00,   /*!< Peripheral is not yet Initialized         */
+  HAL_I2C_STATE_READY             = 0x20,   /*!< Peripheral Initialized and ready for use  */
+  HAL_I2C_STATE_BUSY              = 0x24,   /*!< An internal process is ongoing            */
+  HAL_I2C_STATE_BUSY_TX           = 0x21,   /*!< Data Transmission process is ongoing      */ 
+  HAL_I2C_STATE_BUSY_RX           = 0x22,   /*!< Data Reception process is ongoing         */
+  HAL_I2C_STATE_LISTEN            = 0x28,   /*!< Address Listen Mode is ongoing            */
+  HAL_I2C_STATE_BUSY_TX_LISTEN    = 0x29,   /*!< Address Listen Mode and Data Transmission
+                                                 process is ongoing                        */
+  HAL_I2C_STATE_BUSY_RX_LISTEN    = 0x2A,   /*!< Address Listen Mode and Data Reception
+                                                 process is ongoing                        */
+  HAL_I2C_STATE_TIMEOUT           = 0xA0,   /*!< Timeout state                             */
+  HAL_I2C_STATE_ERROR             = 0xE0    /*!< Error                                     */ 
+
+}HAL_I2C_StateTypeDef;
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_mode_structure_definition HAL mode structure definition
+  * @brief  HAL Mode structure definition
+  * @{
+  */
+typedef enum
+{
+  HAL_I2C_MODE_NONE               = 0x00,   /*!< No I2C communication on going             */
+  HAL_I2C_MODE_MASTER             = 0x10,   /*!< I2C communication is in Master Mode       */
+  HAL_I2C_MODE_SLAVE              = 0x20,   /*!< I2C communication is in Slave Mode        */
+  HAL_I2C_MODE_MEM                = 0x40    /*!< I2C communication is in Memory Mode       */
+
+}HAL_I2C_ModeTypeDef;
+
+/** 
+  * @}
+  */
+
+/** @defgroup I2C_Error_Code_definition I2C Error Code definition
+  * @brief  I2C Error Code definition  
+  * @{
+  */
+#define HAL_I2C_ERROR_NONE      ((uint32_t)0x00000000)    /*!< No error              */
+#define HAL_I2C_ERROR_BERR      ((uint32_t)0x00000001)    /*!< BERR error            */
+#define HAL_I2C_ERROR_ARLO      ((uint32_t)0x00000002)    /*!< ARLO error            */
+#define HAL_I2C_ERROR_AF        ((uint32_t)0x00000004)    /*!< ACKF error            */
+#define HAL_I2C_ERROR_OVR       ((uint32_t)0x00000008)    /*!< OVR error             */
+#define HAL_I2C_ERROR_DMA       ((uint32_t)0x00000010)    /*!< DMA transfer error    */
+#define HAL_I2C_ERROR_TIMEOUT   ((uint32_t)0x00000020)    /*!< Timeout error         */
+#define HAL_I2C_ERROR_SIZE      ((uint32_t)0x00000040)    /*!< Size Management error */
+/** 
+  * @}
+  */
+
+/** @defgroup I2C_XferOptions_definition  I2C XferOptions definition
+  * @{
+  */
+#define I2C_NO_OPTION_FRAME             ((uint32_t)0xFFFF0000)
+#define I2C_FIRST_FRAME                 ((uint32_t)I2C_SOFTEND_MODE)
+#define I2C_NEXT_FRAME                  ((uint32_t)(I2C_RELOAD_MODE | I2C_SOFTEND_MODE))
+#define I2C_FIRST_AND_LAST_FRAME        ((uint32_t)I2C_AUTOEND_MODE)
+#define I2C_LAST_FRAME                  ((uint32_t)I2C_AUTOEND_MODE)
+/**
+  * @}
+  */
+
+/** @defgroup I2C_handle_Structure_definition I2C handle Structure definition
+  * @brief  I2C handle Structure definition  
+  * @{
+  */
+typedef struct
+{
+  I2C_TypeDef                *Instance;        /*!< I2C registers base address       */
+
+  I2C_InitTypeDef            Init;             /*!< I2C communication parameters     */
+
+  uint8_t                    *pBuffPtr;        /*!< Pointer to I2C transfer buffer   */
+
+  uint16_t                   XferSize;         /*!< I2C transfer size                */
+
+  __IO uint16_t              XferCount;        /*!< I2C transfer counter             */
+
+  __IO uint32_t              XferOptions;      /*!< I2C transfer options             */
+
+  __IO uint32_t              PreviousState;    /*!< I2C communication Previous state */
+
+  DMA_HandleTypeDef          *hdmatx;          /*!< I2C Tx DMA handle parameters     */
+
+  DMA_HandleTypeDef          *hdmarx;          /*!< I2C Rx DMA handle parameters     */
+
+  HAL_LockTypeDef            Lock;             /*!< I2C locking object               */
+
+  __IO HAL_I2C_StateTypeDef  State;            /*!< I2C communication state          */
+
+  __IO HAL_I2C_ModeTypeDef   Mode;             /*!< I2C communication mode           */
+
+  __IO uint32_t              ErrorCode;        /*!< I2C Error code                   */
+
+  __IO uint32_t              AddrEventCount;   /*!< I2C Address Event counter        */
+}I2C_HandleTypeDef;
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */  
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup I2C_Exported_Constants I2C Exported Constants
+  * @{
+  */
+
+/** @defgroup I2C_addressing_mode I2C addressing mode
+  * @{
+  */
+#define I2C_ADDRESSINGMODE_7BIT         ((uint32_t)0x00000001)
+#define I2C_ADDRESSINGMODE_10BIT        ((uint32_t)0x00000002)
+/**
+  * @}
+  */
+
+/** @defgroup I2C_dual_addressing_mode I2C dual addressing mode
+  * @{
+  */
+#define I2C_DUALADDRESS_DISABLE         ((uint32_t)0x00000000)
+#define I2C_DUALADDRESS_ENABLE          I2C_OAR2_OA2EN
+/**
+  * @}
+  */
+
+/** @defgroup I2C_own_address2_masks I2C own address2 masks
+  * @{
+  */
+#define I2C_OA2_NOMASK                  ((uint8_t)0x00)
+#define I2C_OA2_MASK01                  ((uint8_t)0x01)
+#define I2C_OA2_MASK02                  ((uint8_t)0x02)
+#define I2C_OA2_MASK03                  ((uint8_t)0x03)
+#define I2C_OA2_MASK04                  ((uint8_t)0x04)
+#define I2C_OA2_MASK05                  ((uint8_t)0x05)
+#define I2C_OA2_MASK06                  ((uint8_t)0x06)
+#define I2C_OA2_MASK07                  ((uint8_t)0x07)
+/**
+  * @}
+  */
+
+/** @defgroup I2C_general_call_addressing_mode I2C general call addressing mode
+  * @{
+  */
+#define I2C_GENERALCALL_DISABLE         ((uint32_t)0x00000000)
+#define I2C_GENERALCALL_ENABLE          I2C_CR1_GCEN
+/**
+  * @}
+  */
+
+/** @defgroup I2C_nostretch_mode I2C nostretch mode
+  * @{
+  */
+#define I2C_NOSTRETCH_DISABLE           ((uint32_t)0x00000000)
+#define I2C_NOSTRETCH_ENABLE            I2C_CR1_NOSTRETCH
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Memory_Address_Size I2C Memory Address Size
+  * @{
+  */
+#define I2C_MEMADD_SIZE_8BIT            ((uint32_t)0x00000001)
+#define I2C_MEMADD_SIZE_16BIT           ((uint32_t)0x00000002)
+/**
+  * @}
+  */
+  
+/** @defgroup I2C_XferDirection_definition I2C XferDirection definition
+  * @{
+  */
+#define I2C_DIRECTION_TRANSMIT          ((uint32_t)0x00000000)
+#define I2C_DIRECTION_RECEIVE           ((uint32_t)0x00000001)
+/**
+  * @}
+  */
+
+/** @defgroup I2C_ReloadEndMode_definition I2C ReloadEndMode definition
+  * @{
+  */
+#define  I2C_RELOAD_MODE                I2C_CR2_RELOAD
+#define  I2C_AUTOEND_MODE               I2C_CR2_AUTOEND
+#define  I2C_SOFTEND_MODE               ((uint32_t)0x00000000)
+/**
+  * @}
+  */
+
+/** @defgroup I2C_StartStopMode_definition I2C StartStopMode definition
+  * @{
+  */
+#define  I2C_NO_STARTSTOP               ((uint32_t)0x00000000)
+#define  I2C_GENERATE_STOP              I2C_CR2_STOP
+#define  I2C_GENERATE_START_READ        (uint32_t)(I2C_CR2_START | I2C_CR2_RD_WRN)
+#define  I2C_GENERATE_START_WRITE       I2C_CR2_START
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Interrupt_configuration_definition I2C Interrupt configuration definition
+  * @brief I2C Interrupt definition
+  *        Elements values convention: 0xXXXXXXXX
+  *           - XXXXXXXX  : Interrupt control mask
+  * @{
+  */
+#define I2C_IT_ERRI                     I2C_CR1_ERRIE
+#define I2C_IT_TCI                      I2C_CR1_TCIE
+#define I2C_IT_STOPI                    I2C_CR1_STOPIE
+#define I2C_IT_NACKI                    I2C_CR1_NACKIE
+#define I2C_IT_ADDRI                    I2C_CR1_ADDRIE
+#define I2C_IT_RXI                      I2C_CR1_RXIE
+#define I2C_IT_TXI                      I2C_CR1_TXIE
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Flag_definition I2C Flag definition
+  * @{
+  */ 
+#define I2C_FLAG_TXE                    I2C_ISR_TXE
+#define I2C_FLAG_TXIS                   I2C_ISR_TXIS
+#define I2C_FLAG_RXNE                   I2C_ISR_RXNE
+#define I2C_FLAG_ADDR                   I2C_ISR_ADDR
+#define I2C_FLAG_AF                     I2C_ISR_NACKF
+#define I2C_FLAG_STOPF                  I2C_ISR_STOPF
+#define I2C_FLAG_TC                     I2C_ISR_TC
+#define I2C_FLAG_TCR                    I2C_ISR_TCR
+#define I2C_FLAG_BERR                   I2C_ISR_BERR
+#define I2C_FLAG_ARLO                   I2C_ISR_ARLO
+#define I2C_FLAG_OVR                    I2C_ISR_OVR
+#define I2C_FLAG_PECERR                 I2C_ISR_PECERR
+#define I2C_FLAG_TIMEOUT                I2C_ISR_TIMEOUT
+#define I2C_FLAG_ALERT                  I2C_ISR_ALERT
+#define I2C_FLAG_BUSY                   I2C_ISR_BUSY
+#define I2C_FLAG_DIR                    I2C_ISR_DIR
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+  
+/** @defgroup I2C_Exported_Macros I2C Exported Macros
+  * @{
+  */
+
+/** @brief Reset I2C handle state.
+  * @param  __HANDLE__ specifies the I2C Handle.
+  * @retval None
+  */
+#define __HAL_I2C_RESET_HANDLE_STATE(__HANDLE__)                ((__HANDLE__)->State = HAL_I2C_STATE_RESET)
+
+/** @brief  Enable the specified I2C interrupt.
+  * @param  __HANDLE__ specifies the I2C Handle.
+  * @param  __INTERRUPT__ specifies the interrupt source to enable.
+  *        This parameter can be one of the following values:
+  *            @arg @ref I2C_IT_ERRI  Errors interrupt enable
+  *            @arg @ref I2C_IT_TCI   Transfer complete interrupt enable
+  *            @arg @ref I2C_IT_STOPI STOP detection interrupt enable
+  *            @arg @ref I2C_IT_NACKI NACK received interrupt enable
+  *            @arg @ref I2C_IT_ADDRI Address match interrupt enable
+  *            @arg @ref I2C_IT_RXI   RX interrupt enable
+  *            @arg @ref I2C_IT_TXI   TX interrupt enable
+  *
+  * @retval None
+  */
+#define __HAL_I2C_ENABLE_IT(__HANDLE__, __INTERRUPT__)          ((__HANDLE__)->Instance->CR1 |= (__INTERRUPT__))
+
+/** @brief  Disable the specified I2C interrupt.
+  * @param  __HANDLE__ specifies the I2C Handle.
+  * @param  __INTERRUPT__ specifies the interrupt source to disable.
+  *        This parameter can be one of the following values:
+  *            @arg @ref I2C_IT_ERRI  Errors interrupt enable
+  *            @arg @ref I2C_IT_TCI   Transfer complete interrupt enable
+  *            @arg @ref I2C_IT_STOPI STOP detection interrupt enable
+  *            @arg @ref I2C_IT_NACKI NACK received interrupt enable
+  *            @arg @ref I2C_IT_ADDRI Address match interrupt enable
+  *            @arg @ref I2C_IT_RXI   RX interrupt enable
+  *            @arg @ref I2C_IT_TXI   TX interrupt enable
+  *   
+  * @retval None
+  */
+#define __HAL_I2C_DISABLE_IT(__HANDLE__, __INTERRUPT__)         ((__HANDLE__)->Instance->CR1 &= (~(__INTERRUPT__)))
+ 
+/** @brief  Check whether the specified I2C interrupt source is enabled or not.
+  * @param  __HANDLE__ specifies the I2C Handle.
+  * @param  __INTERRUPT__ specifies the I2C interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg @ref I2C_IT_ERRI  Errors interrupt enable
+  *            @arg @ref I2C_IT_TCI   Transfer complete interrupt enable
+  *            @arg @ref I2C_IT_STOPI STOP detection interrupt enable
+  *            @arg @ref I2C_IT_NACKI NACK received interrupt enable
+  *            @arg @ref I2C_IT_ADDRI Address match interrupt enable
+  *            @arg @ref I2C_IT_RXI   RX interrupt enable
+  *            @arg @ref I2C_IT_TXI   TX interrupt enable
+  *
+  * @retval The new state of __INTERRUPT__ (TRUE or FALSE).
+  */
+#define __HAL_I2C_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)      ((((__HANDLE__)->Instance->CR1 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/** @brief  Check whether the specified I2C flag is set or not.
+  * @param  __HANDLE__ specifies the I2C Handle.
+  * @param  __FLAG__ specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg @ref I2C_FLAG_TXE     Transmit data register empty
+  *            @arg @ref I2C_FLAG_TXIS    Transmit interrupt status
+  *            @arg @ref I2C_FLAG_RXNE    Receive data register not empty
+  *            @arg @ref I2C_FLAG_ADDR    Address matched (slave mode)
+  *            @arg @ref I2C_FLAG_AF      Acknowledge failure received flag
+  *            @arg @ref I2C_FLAG_STOPF   STOP detection flag
+  *            @arg @ref I2C_FLAG_TC      Transfer complete (master mode)
+  *            @arg @ref I2C_FLAG_TCR     Transfer complete reload
+  *            @arg @ref I2C_FLAG_BERR    Bus error
+  *            @arg @ref I2C_FLAG_ARLO    Arbitration lost
+  *            @arg @ref I2C_FLAG_OVR     Overrun/Underrun
+  *            @arg @ref I2C_FLAG_PECERR  PEC error in reception
+  *            @arg @ref I2C_FLAG_TIMEOUT Timeout or Tlow detection flag
+  *            @arg @ref I2C_FLAG_ALERT   SMBus alert
+  *            @arg @ref I2C_FLAG_BUSY    Bus busy
+  *            @arg @ref I2C_FLAG_DIR     Transfer direction (slave mode)
+  *
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_I2C_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->ISR) & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Clear the I2C pending flags which are cleared by writing 1 in a specific bit.
+  * @param  __HANDLE__ specifies the I2C Handle.
+  * @param  __FLAG__ specifies the flag to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg @ref I2C_FLAG_TXE     Transmit data register empty
+  *            @arg @ref I2C_FLAG_ADDR    Address matched (slave mode)
+  *            @arg @ref I2C_FLAG_AF      Acknowledge failure received flag
+  *            @arg @ref I2C_FLAG_STOPF   STOP detection flag
+  *            @arg @ref I2C_FLAG_BERR    Bus error
+  *            @arg @ref I2C_FLAG_ARLO    Arbitration lost
+  *            @arg @ref I2C_FLAG_OVR     Overrun/Underrun            
+  *            @arg @ref I2C_FLAG_PECERR  PEC error in reception
+  *            @arg @ref I2C_FLAG_TIMEOUT Timeout or Tlow detection flag 
+  *            @arg @ref I2C_FLAG_ALERT   SMBus alert
+  *
+  * @retval None
+  */
+#define __HAL_I2C_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__FLAG__) == I2C_FLAG_TXE) ? ((__HANDLE__)->Instance->ISR |= (__FLAG__)) \
+                                                                                 : ((__HANDLE__)->Instance->ICR = (__FLAG__)))
+ 
+/** @brief  Enable the specified I2C peripheral.
+  * @param  __HANDLE__ specifies the I2C Handle.
+  * @retval None
+  */
+#define __HAL_I2C_ENABLE(__HANDLE__)                            (SET_BIT((__HANDLE__)->Instance->CR1,  I2C_CR1_PE))
+
+/** @brief  Disable the specified I2C peripheral.
+  * @param  __HANDLE__ specifies the I2C Handle.
+  * @retval None
+  */
+#define __HAL_I2C_DISABLE(__HANDLE__)                           (CLEAR_BIT((__HANDLE__)->Instance->CR1, I2C_CR1_PE))
+
+/**
+  * @}
+  */
+
+/* Include I2C HAL Extended module */
+#include "stm32l4xx_hal_i2c_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup I2C_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup I2C_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+/* Initialization and de-initialization functions******************************/
+HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef HAL_I2C_DeInit (I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c);
+/**
+  * @}
+  */
+
+/** @addtogroup I2C_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
+/* IO operation functions  ****************************************************/
+ /******* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout);
+
+ /******* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+
+HAL_StatusTypeDef HAL_I2C_Master_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_I2C_Master_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_I2C_Slave_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_I2C_Slave_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_I2C_EnableListen_IT(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef HAL_I2C_DisableListen_IT(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef HAL_I2C_Master_Abort_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress);
+
+ /******* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+/**
+  * @}
+  */
+
+/** @addtogroup I2C_IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
+ * @{
+ */
+/******* I2C IRQHandler and Callbacks used in non blocking modes (Interrupt and DMA) */
+void HAL_I2C_EV_IRQHandler(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_ER_IRQHandler(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_SlaveTxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_AddrCallback(I2C_HandleTypeDef *hi2c, uint8_t TransferDirection, uint16_t AddrMatchCode);
+void HAL_I2C_ListenCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c);
+/**
+  * @}
+  */ 
+
+/** @addtogroup I2C_Exported_Functions_Group3 Peripheral State, Mode and Error functions
+  * @{
+  */
+/* Peripheral State, Mode and Error functions  *********************************/
+HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c);
+HAL_I2C_ModeTypeDef  HAL_I2C_GetMode(I2C_HandleTypeDef *hi2c);
+uint32_t             HAL_I2C_GetError(I2C_HandleTypeDef *hi2c);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup I2C_Private_Constants I2C Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */ 
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup I2C_Private_Macro I2C Private Macros
+  * @{
+  */
+
+#define IS_I2C_ADDRESSING_MODE(MODE)    (((MODE) == I2C_ADDRESSINGMODE_7BIT) || \
+                                         ((MODE) == I2C_ADDRESSINGMODE_10BIT))
+
+#define IS_I2C_DUAL_ADDRESS(ADDRESS)    (((ADDRESS) == I2C_DUALADDRESS_DISABLE) || \
+                                         ((ADDRESS) == I2C_DUALADDRESS_ENABLE))
+
+#define IS_I2C_OWN_ADDRESS2_MASK(MASK)  (((MASK) == I2C_OA2_NOMASK)  || \
+                                         ((MASK) == I2C_OA2_MASK01) || \
+                                         ((MASK) == I2C_OA2_MASK02) || \
+                                         ((MASK) == I2C_OA2_MASK03) || \
+                                         ((MASK) == I2C_OA2_MASK04) || \
+                                         ((MASK) == I2C_OA2_MASK05) || \
+                                         ((MASK) == I2C_OA2_MASK06) || \
+                                         ((MASK) == I2C_OA2_MASK07))
+
+#define IS_I2C_GENERAL_CALL(CALL)       (((CALL) == I2C_GENERALCALL_DISABLE) || \
+                                         ((CALL) == I2C_GENERALCALL_ENABLE))
+
+#define IS_I2C_NO_STRETCH(STRETCH)      (((STRETCH) == I2C_NOSTRETCH_DISABLE) || \
+                                         ((STRETCH) == I2C_NOSTRETCH_ENABLE))
+
+#define IS_I2C_MEMADD_SIZE(SIZE)        (((SIZE) == I2C_MEMADD_SIZE_8BIT) || \
+                                         ((SIZE) == I2C_MEMADD_SIZE_16BIT))
+
+#define IS_TRANSFER_MODE(MODE)          (((MODE) == I2C_RELOAD_MODE)   || \
+                                         ((MODE) == I2C_AUTOEND_MODE) || \
+                                         ((MODE) == I2C_SOFTEND_MODE))
+
+#define IS_TRANSFER_REQUEST(REQUEST)    (((REQUEST) == I2C_GENERATE_STOP)        || \
+                                         ((REQUEST) == I2C_GENERATE_START_READ)  || \
+                                         ((REQUEST) == I2C_GENERATE_START_WRITE) || \
+                                         ((REQUEST) == I2C_NO_STARTSTOP))
+
+#define IS_I2C_TRANSFER_OPTIONS_REQUEST(REQUEST)  (((REQUEST) == I2C_FIRST_FRAME)          || \
+                                                   ((REQUEST) == I2C_NEXT_FRAME)           || \
+                                                   ((REQUEST) == I2C_FIRST_AND_LAST_FRAME) || \
+                                                   ((REQUEST) == I2C_LAST_FRAME))
+
+#define I2C_RESET_CR2(__HANDLE__)                 ((__HANDLE__)->Instance->CR2 &= (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_HEAD10R | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_RD_WRN)))
+
+#define I2C_GET_ADDR_MATCH(__HANDLE__)            (((__HANDLE__)->Instance->ISR & I2C_ISR_ADDCODE) >> 16)
+#define I2C_GET_DIR(__HANDLE__)                   (((__HANDLE__)->Instance->ISR & I2C_ISR_DIR) >> 16)
+#define I2C_GET_STOP_MODE(__HANDLE__)             ((__HANDLE__)->Instance->CR2 & I2C_CR2_AUTOEND)
+#define I2C_GET_ISR_REG(__HANDLE__)               ((__HANDLE__)->Instance->ISR)
+#define I2C_CHECK_FLAG(__ISR__, __FLAG__)         (((__ISR__) & (__FLAG__)) == (__FLAG__))
+#define I2C_GET_OWN_ADDRESS1(__HANDLE__)          ((__HANDLE__)->Instance->OAR1 & I2C_OAR1_OA1)
+#define I2C_GET_OWN_ADDRESS2(__HANDLE__)          ((__HANDLE__)->Instance->OAR2 & I2C_OAR2_OA2)
+
+#define IS_I2C_OWN_ADDRESS1(ADDRESS1)             ((ADDRESS1) <= (uint32_t)0x000003FF)
+#define IS_I2C_OWN_ADDRESS2(ADDRESS2)             ((ADDRESS2) <= (uint16_t)0x00FF)
+
+#define I2C_MEM_ADD_MSB(__ADDRESS__)              ((uint8_t)((uint16_t)(((uint16_t)((__ADDRESS__) & (uint16_t)(0xFF00))) >> 8)))
+#define I2C_MEM_ADD_LSB(__ADDRESS__)              ((uint8_t)((uint16_t)((__ADDRESS__) & (uint16_t)(0x00FF))))
+
+#define I2C_GENERATE_START(__ADDMODE__,__ADDRESS__) (((__ADDMODE__) == I2C_ADDRESSINGMODE_7BIT) ? (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | (I2C_CR2_START) | (I2C_CR2_AUTOEND)) & (~I2C_CR2_RD_WRN)) : \
+                                                          (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | (I2C_CR2_ADD10) | (I2C_CR2_START)) & (~I2C_CR2_RD_WRN)))
+/**
+  * @}
+  */ 
+
+/* Private Functions ---------------------------------------------------------*/
+/** @defgroup I2C_Private_Functions I2C Private Functions
+  * @{
+  */
+/* Private functions are defined in stm32l4xx_hal_i2c.c file */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L4xx_HAL_I2C_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_i2c_ex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_i2c_ex.h
@@ -1,0 +1,171 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_i2c_ex.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of I2C HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_I2C_EX_H
+#define __STM32L4xx_HAL_I2C_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup I2CEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup I2CEx_Exported_Constants I2C Extended Exported Constants
+  * @{
+  */
+
+/** @defgroup I2CEx_Analog_Filter I2C Extended Analog Filter
+  * @{
+  */
+#define I2C_ANALOGFILTER_ENABLE         ((uint32_t)0x00000000)
+#define I2C_ANALOGFILTER_DISABLE        I2C_CR1_ANFOFF
+/**
+  * @}
+  */
+
+/** @defgroup I2CEx_FastModePlus I2CEx FastModePlus
+  * @{
+  */
+#define I2C_FASTMODEPLUS_PB6            SYSCFG_CFGR1_I2C_PB6_FMP  /*!< Enable Fast Mode Plus on PB6       */
+#define I2C_FASTMODEPLUS_PB7            SYSCFG_CFGR1_I2C_PB7_FMP  /*!< Enable Fast Mode Plus on PB7       */
+#define I2C_FASTMODEPLUS_PB8            SYSCFG_CFGR1_I2C_PB8_FMP  /*!< Enable Fast Mode Plus on PB8       */
+#define I2C_FASTMODEPLUS_PB9            SYSCFG_CFGR1_I2C_PB9_FMP  /*!< Enable Fast Mode Plus on PB9       */
+#define I2C_FASTMODEPLUS_I2C1           SYSCFG_CFGR1_I2C1_FMP     /*!< Enable Fast Mode Plus on I2C1 pins */
+#define I2C_FASTMODEPLUS_I2C2           SYSCFG_CFGR1_I2C2_FMP     /*!< Enable Fast Mode Plus on I2C2 pins */
+#define I2C_FASTMODEPLUS_I2C3           SYSCFG_CFGR1_I2C3_FMP     /*!< Enable Fast Mode Plus on I2C3 pins */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup I2CEx_Exported_Functions I2C Extended Exported Functions
+  * @{
+  */
+
+/** @addtogroup I2CEx_Exported_Functions_Group1 Extended features functions
+  * @brief    Extended features functions
+  * @{
+  */
+
+/* Peripheral Control functions  ************************************************/
+HAL_StatusTypeDef HAL_I2CEx_ConfigAnalogFilter(I2C_HandleTypeDef *hi2c, uint32_t AnalogFilter);
+HAL_StatusTypeDef HAL_I2CEx_ConfigDigitalFilter(I2C_HandleTypeDef *hi2c, uint32_t DigitalFilter);
+HAL_StatusTypeDef HAL_I2CEx_EnableWakeUp(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef HAL_I2CEx_DisableWakeUp(I2C_HandleTypeDef *hi2c);
+void HAL_I2CEx_EnableFastModePlus(uint32_t ConfigFastModePlus);
+void HAL_I2CEx_DisableFastModePlus(uint32_t ConfigFastModePlus);
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup I2C_Private_Constants I2C Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup I2C_Private_Macro I2C Private Macros
+  * @{
+  */
+#define IS_I2C_ANALOG_FILTER(FILTER)    (((FILTER) == I2C_ANALOGFILTER_ENABLE) || \
+                                          ((FILTER) == I2C_ANALOGFILTER_DISABLE))
+
+#define IS_I2C_DIGITAL_FILTER(FILTER)   ((FILTER) <= 0x0000000F)
+
+#define IS_I2C_FASTMODEPLUS(__CONFIG__) ((((__CONFIG__) & (I2C_FASTMODEPLUS_PB6)) == I2C_FASTMODEPLUS_PB6)    || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_PB7)) == I2C_FASTMODEPLUS_PB7)   || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_PB8)) == I2C_FASTMODEPLUS_PB8)   || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_PB9)) == I2C_FASTMODEPLUS_PB9)   || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_I2C1)) == I2C_FASTMODEPLUS_I2C1) || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_I2C2)) == I2C_FASTMODEPLUS_I2C2) || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_I2C3)) == I2C_FASTMODEPLUS_I2C3))
+/**
+  * @}
+  */ 
+
+/* Private Functions ---------------------------------------------------------*/
+/** @defgroup I2C_Private_Functions I2C Private Functions
+  * @{
+  */
+/* Private functions are defined in stm32l4xx_hal_i2c_ex.c file */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_I2C_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_pcd.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_pcd.h
@@ -1,0 +1,312 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_pcd.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of PCD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_PCD_H
+#define __STM32L4xx_HAL_PCD_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined(STM32L475xx) || defined(STM32L476xx) || defined(STM32L485xx) || defined(STM32L486xx)
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_ll_usb.h"
+   
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PCD
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/** @defgroup PCD_Exported_Types PCD Exported Types
+  * @{
+  */
+
+   /** 
+  * @brief  PCD State structure definition  
+  */  
+typedef enum 
+{
+  HAL_PCD_STATE_RESET   = 0x00,
+  HAL_PCD_STATE_READY   = 0x01,
+  HAL_PCD_STATE_ERROR   = 0x02,
+  HAL_PCD_STATE_BUSY    = 0x03,
+  HAL_PCD_STATE_TIMEOUT = 0x04
+} PCD_StateTypeDef;
+
+/* Device LPM suspend state */
+typedef enum  
+{
+  LPM_L0 = 0x00, /* on */
+  LPM_L1 = 0x01, /* LPM L1 sleep */
+  LPM_L2 = 0x02, /* suspend */
+  LPM_L3 = 0x03, /* off */
+}PCD_LPM_StateTypeDef;
+
+typedef USB_OTG_GlobalTypeDef  PCD_TypeDef;
+typedef USB_OTG_CfgTypeDef     PCD_InitTypeDef;
+typedef USB_OTG_EPTypeDef      PCD_EPTypeDef ;                          
+
+/** 
+  * @brief  PCD Handle Structure definition  
+  */ 
+typedef struct
+{
+  PCD_TypeDef             *Instance;   /*!< Register base address              */ 
+  PCD_InitTypeDef         Init;        /*!< PCD required parameters            */
+  PCD_EPTypeDef           IN_ep[15];    /*!< IN endpoint parameters             */
+  PCD_EPTypeDef           OUT_ep[15];   /*!< OUT endpoint parameters            */ 
+  HAL_LockTypeDef         Lock;        /*!< PCD peripheral status              */
+  __IO PCD_StateTypeDef   State;       /*!< PCD communication state            */
+  uint32_t                Setup[12];   /*!< Setup packet buffer                */
+  PCD_LPM_StateTypeDef    LPM_State;    /*!< LPM State                          */
+  uint32_t                BESL;
+  
+  
+  uint32_t lpm_active;                  /*!< Enable or disable the Link Power Management .                                  
+                                        This parameter can be set to ENABLE or DISABLE                      */
+
+  uint32_t battery_charging_active;     /*!< Enable or disable Battery charging.                                  
+                                        This parameter can be set to ENABLE or DISABLE                      */
+  void                    *pData;      /*!< Pointer to upper stack Handler     */    
+  
+} PCD_HandleTypeDef;
+
+/**
+  * @}
+  */
+  
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup PCD_Exported_Constants PCD Exported Constants
+  * @{
+  */
+
+/** @defgroup PCD_Speed PCD Speed
+  * @{
+  */
+#define PCD_SPEED_FULL               1
+/**
+  * @}
+  */
+  
+/** @defgroup PCD_PHY_Module PCD PHY Module
+  * @{
+  */
+#define PCD_PHY_EMBEDDED             1
+/**
+  * @}
+  */
+
+/** @defgroup PCD_Turnaround_Timeout Turnaround Timeout Value
+  * @{
+  */
+#ifndef USBD_FS_TRDT_VALUE
+ #define USBD_FS_TRDT_VALUE           5
+#endif /* USBD_FS_TRDT_VALUE */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+  
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup PCD_Exported_Macros PCD Exported Macros
+ *  @brief macros to handle interrupts and specific clock configurations
+ * @{
+ */
+#define __HAL_PCD_ENABLE(__HANDLE__)                       USB_EnableGlobalInt ((__HANDLE__)->Instance)
+#define __HAL_PCD_DISABLE(__HANDLE__)                      USB_DisableGlobalInt ((__HANDLE__)->Instance)
+   
+#define __HAL_PCD_GET_FLAG(__HANDLE__, __INTERRUPT__)      ((USB_ReadInterrupts((__HANDLE__)->Instance) & (__INTERRUPT__)) == (__INTERRUPT__))
+#define __HAL_PCD_CLEAR_FLAG(__HANDLE__, __INTERRUPT__)    (((__HANDLE__)->Instance->GINTSTS) &=  (__INTERRUPT__))
+#define __HAL_PCD_IS_INVALID_INTERRUPT(__HANDLE__)         (USB_ReadInterrupts((__HANDLE__)->Instance) == 0)
+
+
+#define __HAL_PCD_UNGATE_PHYCLOCK(__HANDLE__)             *(__IO uint32_t *)((uint32_t)((__HANDLE__)->Instance) + USB_OTG_PCGCCTL_BASE) &= \
+                                                          ~(USB_OTG_PCGCCTL_STOPCLK)
+
+#define __HAL_PCD_GATE_PHYCLOCK(__HANDLE__)               *(__IO uint32_t *)((uint32_t)((__HANDLE__)->Instance) + USB_OTG_PCGCCTL_BASE) |= USB_OTG_PCGCCTL_STOPCLK
+                                                      
+#define __HAL_PCD_IS_PHY_SUSPENDED(__HANDLE__)            ((*(__IO uint32_t *)((uint32_t)((__HANDLE__)->Instance) + USB_OTG_PCGCCTL_BASE))&0x10)
+                                                         
+#define USB_OTG_FS_WAKEUP_EXTI_RISING_EDGE                ((uint32_t)0x08) 
+#define USB_OTG_FS_WAKEUP_EXTI_FALLING_EDGE               ((uint32_t)0x0C) 
+#define USB_OTG_FS_WAKEUP_EXTI_RISING_FALLING_EDGE        ((uint32_t)0x10) 
+
+#define USB_OTG_FS_WAKEUP_EXTI_LINE                       ((uint32_t)0x00020000)  /*!< External interrupt line 17 Connected to the USB FS EXTI Line */
+
+                                                      
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_IT()    EXTI->IMR1 |= USB_OTG_FS_WAKEUP_EXTI_LINE
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_DISABLE_IT()   EXTI->IMR1 &= ~(USB_OTG_FS_WAKEUP_EXTI_LINE)
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_GET_FLAG()     EXTI->PR1 & (USB_OTG_FS_WAKEUP_EXTI_LINE)
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_CLEAR_FLAG()   EXTI->PR1 = USB_OTG_FS_WAKEUP_EXTI_LINE
+
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_RISING_EDGE()  do {\
+                                                             EXTI->FTSR1 &= ~(USB_OTG_FS_WAKEUP_EXTI_LINE);\
+                                                             EXTI->RTSR1 |= USB_OTG_FS_WAKEUP_EXTI_LINE;\
+                                                           } while(0)
+
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_FALLING_EDGE() do {\
+                                                             EXTI->FTSR1 |= (USB_OTG_FS_WAKEUP_EXTI_LINE);\
+                                                             EXTI->RTSR1 &= ~(USB_OTG_FS_WAKEUP_EXTI_LINE);\
+                                                           } while(0)
+
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE() do {\
+                                                                   EXTI->RTSR1 &= ~(USB_OTG_FS_WAKEUP_EXTI_LINE);\
+                                                                   EXTI->FTSR1 &= ~(USB_OTG_FS_WAKEUP_EXTI_LINE);\
+                                                                   EXTI->RTSR1 |= USB_OTG_FS_WAKEUP_EXTI_LINE;\
+                                                                   EXTI->FTSR1 |= USB_OTG_FS_WAKEUP_EXTI_LINE;\
+                                                                  } while(0)                                                                   
+                                                         
+#define __HAL_USB_OTG_FS_WAKEUP_EXTI_GENERATE_SWIT()   (EXTI->SWIER1 |= USB_OTG_FS_WAKEUP_EXTI_LINE)                                                          
+
+/**
+  * @}
+  */
+
+/* Include PCD HAL Extended module */
+#include "stm32l4xx_hal_pcd_ex.h"
+
+/** @addtogroup PCD_Exported_Functions PCD Exported Functions
+  * @{
+  */
+
+/* Initialization/de-initialization functions  ********************************/
+/** @addtogroup PCD_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_DeInit (PCD_HandleTypeDef *hpcd);
+void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd);
+/**
+  * @}
+  */
+
+/* I/O operation functions  ***************************************************/
+/* Non-Blocking mode: Interrupt */
+/** @addtogroup PCD_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
+ /* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_PCD_Start(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd);
+
+void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_ISOOUTIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd);
+/**
+  * @}
+  */
+
+/* Peripheral Control functions  **********************************************/
+/** @addtogroup PCD_Exported_Functions_Group3 Peripheral Control functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_PCD_DevConnect(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_DevDisconnect(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_SetAddress(PCD_HandleTypeDef *hpcd, uint8_t address);
+HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint16_t ep_mps, uint8_t ep_type);
+HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
+HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
+uint16_t          HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_ActivateRemoteWakeup(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_DeActivateRemoteWakeup(PCD_HandleTypeDef *hpcd);
+/**
+  * @}
+  */
+
+/* Peripheral State functions  ************************************************/
+/** @addtogroup PCD_Exported_Functions_Group4 Peripheral State functions
+  * @{
+  */
+PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup PCD_Private_Macros PCD Private Macros
+ * @{
+ */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#endif /* STM32L475xx || STM32L476xx || STM32L485xx || STM32L486xx */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L4xx_HAL_PCD_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_pcd_ex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_pcd_ex.h
@@ -1,0 +1,120 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_pcd_ex.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of PCD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_PCD_EX_H
+#define __STM32L4xx_HAL_PCD_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined(STM32L475xx) || defined(STM32L476xx) || defined(STM32L485xx) || defined(STM32L486xx)
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+   
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PCDEx
+  * @{
+  */
+/* Exported types ------------------------------------------------------------*/
+typedef enum  
+{
+  PCD_LPM_L0_ACTIVE = 0x00, /* on */
+  PCD_LPM_L1_ACTIVE = 0x01, /* LPM L1 sleep */
+}PCD_LPM_MsgTypeDef;
+
+typedef enum  
+{
+  PCD_BCD_ERROR                     = 0xFF, 
+  PCD_BCD_CONTACT_DETECTION         = 0xFE,
+  PCD_BCD_STD_DOWNSTREAM_PORT       = 0xFD,
+  PCD_BCD_CHARGING_DOWNSTREAM_PORT  = 0xFC,
+  PCD_BCD_DEDICATED_CHARGING_PORT   = 0xFB,
+  PCD_BCD_DISCOVERY_COMPLETED       = 0x00,
+  
+}PCD_BCD_MsgTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+/* Exported macros -----------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup PCDEx_Exported_Functions PCDEx Exported Functions
+  * @{
+  */
+/** @addtogroup PCDEx_Exported_Functions_Group1 Peripheral Control functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_PCDEx_SetTxFiFo(PCD_HandleTypeDef *hpcd, uint8_t fifo, uint16_t size);
+HAL_StatusTypeDef HAL_PCDEx_SetRxFiFo(PCD_HandleTypeDef *hpcd, uint16_t size);
+HAL_StatusTypeDef HAL_PCDEx_ActivateLPM(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCDEx_DeActivateLPM(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCDEx_ActivateBCD(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCDEx_DeActivateBCD(PCD_HandleTypeDef *hpcd);
+void HAL_PCDEx_BCD_VBUSDetect(PCD_HandleTypeDef *hpcd);
+void HAL_PCDEx_LPM_Callback(PCD_HandleTypeDef *hpcd, PCD_LPM_MsgTypeDef msg);
+void HAL_PCDEx_BCD_Callback(PCD_HandleTypeDef *hpcd, PCD_BCD_MsgTypeDef msg);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#endif /* STM32L475xx || STM32L476xx || STM32L485xx || STM32L486xx */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L4xx_HAL_PCD_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_pwr.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_pwr.h
@@ -1,0 +1,427 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_pwr.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of PWR HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_PWR_H
+#define __STM32L4xx_HAL_PWR_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PWR
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** @defgroup PWR_Exported_Types PWR Exported Types
+  * @{
+  */
+
+/**
+  * @brief  PWR PVD configuration structure definition
+  */
+typedef struct
+{
+  uint32_t PVDLevel;   /*!< PVDLevel: Specifies the PVD detection level.
+                            This parameter can be a value of @ref PWR_PVD_detection_level. */
+
+  uint32_t Mode;      /*!< Mode: Specifies the operating mode for the selected pins.
+                           This parameter can be a value of @ref PWR_PVD_Mode. */
+}PWR_PVDTypeDef;
+
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup PWR_Exported_Constants PWR Exported Constants
+  * @{
+  */
+
+
+/** @defgroup PWR_PVD_detection_level Programmable Voltage Detection levels
+  * @{
+  */
+#define PWR_PVDLEVEL_0                  PWR_CR2_PLS_LEV0  /*!< PVD threshold around 2.0 V */
+#define PWR_PVDLEVEL_1                  PWR_CR2_PLS_LEV1  /*!< PVD threshold around 2.2 V */
+#define PWR_PVDLEVEL_2                  PWR_CR2_PLS_LEV2  /*!< PVD threshold around 2.4 V */
+#define PWR_PVDLEVEL_3                  PWR_CR2_PLS_LEV3  /*!< PVD threshold around 2.5 V */
+#define PWR_PVDLEVEL_4                  PWR_CR2_PLS_LEV4  /*!< PVD threshold around 2.6 V */
+#define PWR_PVDLEVEL_5                  PWR_CR2_PLS_LEV5  /*!< PVD threshold around 2.8 V */
+#define PWR_PVDLEVEL_6                  PWR_CR2_PLS_LEV6  /*!< PVD threshold around 2.9 V */
+#define PWR_PVDLEVEL_7                  PWR_CR2_PLS_LEV7  /*!< External input analog voltage (compared internally to VREFINT) */
+/**
+  * @}
+  */
+
+/** @defgroup PWR_PVD_Mode  PWR PVD interrupt and event mode
+  * @{
+  */
+#define PWR_PVD_MODE_NORMAL                 ((uint32_t)0x00000000)   /*!< Basic mode is used */
+#define PWR_PVD_MODE_IT_RISING              ((uint32_t)0x00010001)   /*!< External Interrupt Mode with Rising edge trigger detection */
+#define PWR_PVD_MODE_IT_FALLING             ((uint32_t)0x00010002)   /*!< External Interrupt Mode with Falling edge trigger detection */
+#define PWR_PVD_MODE_IT_RISING_FALLING      ((uint32_t)0x00010003)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
+#define PWR_PVD_MODE_EVENT_RISING           ((uint32_t)0x00020001)   /*!< Event Mode with Rising edge trigger detection */
+#define PWR_PVD_MODE_EVENT_FALLING          ((uint32_t)0x00020002)   /*!< Event Mode with Falling edge trigger detection */
+#define PWR_PVD_MODE_EVENT_RISING_FALLING   ((uint32_t)0x00020003)   /*!< Event Mode with Rising/Falling edge trigger detection */                               
+/**
+  * @}
+  */
+  
+  
+
+
+/** @defgroup PWR_Regulator_state_in_SLEEP_STOP_mode  PWR regulator mode
+  * @{
+  */
+#define PWR_MAINREGULATOR_ON            ((uint32_t)0x00000000) /*!< Regulator in main mode      */
+#define PWR_LOWPOWERREGULATOR_ON        PWR_CR1_LPR            /*!< Regulator in low-power mode */
+/**
+  * @}
+  */
+
+/** @defgroup PWR_SLEEP_mode_entry  PWR SLEEP mode entry
+  * @{
+  */
+#define PWR_SLEEPENTRY_WFI              ((uint8_t)0x01)        /*!< Wait For Interruption instruction to enter Sleep mode */
+#define PWR_SLEEPENTRY_WFE              ((uint8_t)0x02)        /*!< Wait For Event instruction to enter Sleep mode        */
+/**
+  * @}
+  */
+
+/** @defgroup PWR_STOP_mode_entry  PWR STOP mode entry
+  * @{
+  */
+#define PWR_STOPENTRY_WFI               ((uint8_t)0x01)       /*!< Wait For Interruption instruction to enter Stop mode */
+#define PWR_STOPENTRY_WFE               ((uint8_t)0x02)       /*!< Wait For Event instruction to enter Stop mode        */
+/**
+  * @}
+  */
+  
+
+/** @defgroup PWR_PVD_EXTI_LINE  PWR PVD external interrupt line
+  * @{
+  */
+#define PWR_EXTI_LINE_PVD  ((uint32_t)0x00010000)   /*!< External interrupt line 16 Connected to the PVD EXTI Line */
+/**
+  * @}
+  */
+
+/** @defgroup PWR_PVD_EVENT_LINE  PWR PVD event line
+  * @{
+  */  
+#define PWR_EVENT_LINE_PVD  ((uint32_t)0x00010000)  /*!< Event line 16 Connected to the PVD Event Line */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup PWR_Exported_Macros  PWR Exported Macros
+  * @{
+  */
+
+/** @brief  Check whether or not a specific PWR flag is set.
+  * @param  __FLAG__: specifies the flag to check.
+  *           This parameter can be one of the following values:
+  *            @arg @ref PWR_FLAG_WUF1 Wake Up Flag 1. Indicates that a wakeup event
+  *                  was received from the WKUP pin 1.
+  *            @arg @ref PWR_FLAG_WUF2 Wake Up Flag 2. Indicates that a wakeup event
+  *                  was received from the WKUP pin 2.
+  *            @arg @ref PWR_FLAG_WUF3 Wake Up Flag 3. Indicates that a wakeup event
+  *                  was received from the WKUP pin 3.
+  *            @arg @ref PWR_FLAG_WUF4 Wake Up Flag 4. Indicates that a wakeup event
+  *                  was received from the WKUP pin 4.
+  *            @arg @ref PWR_FLAG_WUF5 Wake Up Flag 5. Indicates that a wakeup event
+  *                  was received from the WKUP pin 5.          
+  *            @arg @ref PWR_FLAG_SB StandBy Flag. Indicates that the system
+  *                  entered StandBy mode.
+  *            @arg @ref PWR_FLAG_WUFI Wake-Up Flag Internal. Set when a wakeup is detected on
+  *                 the internal wakeup line.
+  *            @arg @ref PWR_FLAG_REGLPS Low Power Regulator Started. Indicates whether or not the 
+  *                 low-power regulator is ready.
+  *            @arg @ref PWR_FLAG_REGLPF Low Power Regulator Flag. Indicates whether the 
+  *                 regulator is ready in main mode or is in low-power mode. 
+  *            @arg @ref PWR_FLAG_VOSF Voltage Scaling Flag. Indicates whether the regulator is ready 
+  *                 in the selected voltage range or is still changing to the required voltage level.
+  *            @arg @ref PWR_FLAG_PVDO Power Voltage Detector Output. Indicates whether VDD voltage is
+  *                  below or above the selected PVD threshold.
+  *            @arg @ref PWR_FLAG_PVMO1 Peripheral Voltage Monitoring Output 1. Indicates whether VDDUSB voltage is
+  *                  is below or above PVM1 threshold (applicable when USB feature is supported).
+  *            @arg @ref PWR_FLAG_PVMO2 Peripheral Voltage Monitoring Output 2. Indicates whether VDDIO2 voltage is
+  *                  is below or above PVM2 threshold (applicable when VDDIO2 is present on device). 
+  *            @arg @ref PWR_FLAG_PVMO3 Peripheral Voltage Monitoring Output 3. Indicates whether VDDA voltage is
+  *                  is below or above PVM3 threshold. 
+  *            @arg @ref PWR_FLAG_PVMO4 Peripheral Voltage Monitoring Output 4. Indicates whether VDDA voltage is
+  *                  is below or above PVM4 threshold.                           
+  *    
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_PWR_GET_FLAG(__FLAG__)  ( ((((uint8_t)(__FLAG__)) >> 5U) == 1)  ?\
+                                      (PWR->SR1 & (1U << ((__FLAG__) & 31U))) :\
+                                      (PWR->SR2 & (1U << ((__FLAG__) & 31U))) )
+
+/** @brief  Clear a specific PWR flag.
+  * @param  __FLAG__: specifies the flag to clear.
+  *          This parameter can be one of the following values:
+  *            @arg @ref PWR_FLAG_WUF1 Wake Up Flag 1. Indicates that a wakeup event
+  *                  was received from the WKUP pin 1.
+  *            @arg @ref PWR_FLAG_WUF2 Wake Up Flag 2. Indicates that a wakeup event
+  *                  was received from the WKUP pin 2.
+  *            @arg @ref PWR_FLAG_WUF3 Wake Up Flag 3. Indicates that a wakeup event
+  *                  was received from the WKUP pin 3.
+  *            @arg @ref PWR_FLAG_WUF4 Wake Up Flag 4. Indicates that a wakeup event
+  *                  was received from the WKUP pin 4.
+  *            @arg @ref PWR_FLAG_WUF5 Wake Up Flag 5. Indicates that a wakeup event
+  *                  was received from the WKUP pin 5.
+  *            @arg @ref PWR_FLAG_WU Encompasses all five Wake Up Flags.
+  *            @arg @ref PWR_FLAG_SB Standby Flag. Indicates that the system
+  *                  entered Standby mode.
+  * @retval None   
+  */
+#define __HAL_PWR_CLEAR_FLAG(__FLAG__)   ( (((uint8_t)(__FLAG__)) == PWR_FLAG_WU) ?\
+                                         (PWR->SCR  = (__FLAG__)) :\
+                                         (PWR->SCR = (1U << ((__FLAG__) & 31U))) )
+/**
+  * @brief Enable the PVD Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_IT()   SET_BIT(EXTI->IMR1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Disable the PVD Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_IT()  CLEAR_BIT(EXTI->IMR1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Enable the PVD Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_EVENT()   SET_BIT(EXTI->EMR1, PWR_EVENT_LINE_PVD)
+
+/**
+  * @brief Disable the PVD Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_EVENT()  CLEAR_BIT(EXTI->EMR1, PWR_EVENT_LINE_PVD)
+
+/**
+  * @brief Enable the PVD Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE()   SET_BIT(EXTI->RTSR1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Disable the PVD Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE()  CLEAR_BIT(EXTI->RTSR1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Enable the PVD Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE()   SET_BIT(EXTI->FTSR1, PWR_EXTI_LINE_PVD)
+
+
+/**
+  * @brief Disable the PVD Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE()  CLEAR_BIT(EXTI->FTSR1, PWR_EXTI_LINE_PVD)
+
+
+/**
+  * @brief  Enable the PVD Extended Interrupt Rising & Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_RISING_FALLING_EDGE()  \
+  do {                                                   \
+    __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE();             \
+    __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE();            \
+  } while(0)
+
+/**
+  * @brief Disable the PVD Extended Interrupt Rising & Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_RISING_FALLING_EDGE()  \
+  do {                                                    \
+    __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE();             \
+    __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE();            \
+  } while(0)
+
+/**
+  * @brief  Generate a Software interrupt on selected EXTI line.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_GENERATE_SWIT() SET_BIT(EXTI->SWIER1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Check whether or not the PVD EXTI interrupt flag is set.
+  * @retval EXTI PVD Line Status.
+  */
+#define __HAL_PWR_PVD_EXTI_GET_FLAG()  (EXTI->PR1 & PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Clear the PVD EXTI interrupt flag.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_CLEAR_FLAG()  WRITE_REG(EXTI->PR1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @}
+  */
+  
+
+/* Private macros --------------------------------------------------------*/
+/** @addtogroup  PWR_Private_Macros   PWR Private Macros
+  * @{
+  */
+
+#define IS_PWR_PVD_LEVEL(LEVEL) (((LEVEL) == PWR_PVDLEVEL_0) || ((LEVEL) == PWR_PVDLEVEL_1)|| \
+                                 ((LEVEL) == PWR_PVDLEVEL_2) || ((LEVEL) == PWR_PVDLEVEL_3)|| \
+                                 ((LEVEL) == PWR_PVDLEVEL_4) || ((LEVEL) == PWR_PVDLEVEL_5)|| \
+                                 ((LEVEL) == PWR_PVDLEVEL_6) || ((LEVEL) == PWR_PVDLEVEL_7))
+                                 
+#define IS_PWR_PVD_MODE(MODE)  (((MODE) == PWR_PVD_MODE_NORMAL)              ||\
+                                ((MODE) == PWR_PVD_MODE_IT_RISING)           ||\
+                                ((MODE) == PWR_PVD_MODE_IT_FALLING)          ||\
+                                ((MODE) == PWR_PVD_MODE_IT_RISING_FALLING)   ||\
+                                ((MODE) == PWR_PVD_MODE_EVENT_RISING)        ||\
+                                ((MODE) == PWR_PVD_MODE_EVENT_FALLING)       ||\
+                                ((MODE) == PWR_PVD_MODE_EVENT_RISING_FALLING)) 
+                                
+#define IS_PWR_REGULATOR(REGULATOR)      (((REGULATOR) == PWR_MAINREGULATOR_ON) || \
+                                          ((REGULATOR) == PWR_LOWPOWERREGULATOR_ON))
+                                          
+#define IS_PWR_SLEEP_ENTRY(ENTRY) (((ENTRY) == PWR_SLEEPENTRY_WFI) || ((ENTRY) == PWR_SLEEPENTRY_WFE))
+
+#define IS_PWR_STOP_ENTRY(ENTRY) (((ENTRY) == PWR_STOPENTRY_WFI) || ((ENTRY) == PWR_STOPENTRY_WFE) )
+                                      
+/**
+  * @}
+  */  
+
+/* Include PWR HAL Extended module */
+#include "stm32l4xx_hal_pwr_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup PWR_Exported_Functions PWR Exported Functions
+  * @{
+  */
+  
+/** @addtogroup PWR_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @{
+  */
+  
+/* Initialization and de-initialization functions *******************************/
+void HAL_PWR_DeInit(void);
+void HAL_PWR_EnableBkUpAccess(void);
+void HAL_PWR_DisableBkUpAccess(void);
+
+/**
+  * @}
+  */
+
+/** @addtogroup PWR_Exported_Functions_Group2 Peripheral Control functions 
+  * @{
+  */
+
+/* Peripheral Control functions  ************************************************/
+HAL_StatusTypeDef HAL_PWR_ConfigPVD(PWR_PVDTypeDef *sConfigPVD);
+void HAL_PWR_EnablePVD(void);
+void HAL_PWR_DisablePVD(void);
+
+
+/* WakeUp pins configuration functions ****************************************/
+void HAL_PWR_EnableWakeUpPin(uint32_t WakeUpPinPolarity);
+void HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx);
+
+/* Low Power modes configuration functions ************************************/
+void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry);
+void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry);
+void HAL_PWR_EnterSTANDBYMode(void);
+
+void HAL_PWR_EnableSleepOnExit(void);
+void HAL_PWR_DisableSleepOnExit(void);
+void HAL_PWR_EnableSEVOnPend(void);
+void HAL_PWR_DisableSEVOnPend(void);
+
+void HAL_PWR_PVDCallback(void);
+
+
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */  
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L4xx_HAL_PWR_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_pwr_ex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_pwr_ex.h
@@ -1,0 +1,825 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_pwr_ex.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of PWR HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_PWR_EX_H
+#define __STM32L4xx_HAL_PWR_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PWREx
+  * @{
+  */
+
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup PWREx_Exported_Types PWR Extended Exported Types
+  * @{
+  */
+
+
+/**
+  * @brief  PWR PVM configuration structure definition
+  */
+typedef struct
+{
+  uint32_t PVMType;   /*!< PVMType: Specifies which voltage is monitored and against which threshold. 
+                           This parameter can be a value of @ref PWREx_PVM_Type. 
+                           @arg @ref PWR_PVM_1 Peripheral Voltage Monitoring 1 enable: VDDUSB versus 1.2 V (applicable when USB feature is supported). 
+                           @arg @ref PWR_PVM_2 Peripheral Voltage Monitoring 2 enable: VDDIO2 versus 0.9 V (applicable when VDDIO2 is present on device). 
+                           @arg @ref PWR_PVM_3 Peripheral Voltage Monitoring 3 enable: VDDA versus 1.62 V. 
+                           @arg @ref PWR_PVM_4 Peripheral Voltage Monitoring 4 enable: VDDA versus 2.2 V. */
+
+  uint32_t Mode;      /*!< Mode: Specifies the operating mode for the selected pins.
+                           This parameter can be a value of @ref PWREx_PVM_Mode. */
+}PWR_PVMTypeDef;
+
+/**
+  * @}
+  */ 
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup PWREx_Exported_Constants  PWR Extended Exported Constants
+  * @{
+  */
+
+/** @defgroup PWREx_WUP_Polarity Shift to apply to retrieve polarity information from PWR_WAKEUP_PINy_xxx constants
+  * @{
+  */
+#define PWR_WUP_POLARITY_SHIFT                  0x05   /*!< Internal constant used to retrieve wakeup pin polariry */
+/**
+  * @}
+  */  
+
+
+/** @defgroup PWREx_WakeUp_Pins  PWR wake-up pins
+  * @{
+  */                                                      
+#define PWR_WAKEUP_PIN1                 PWR_CR3_EWUP1  /*!< Wakeup pin 1 (with high level polarity) */
+#define PWR_WAKEUP_PIN2                 PWR_CR3_EWUP2  /*!< Wakeup pin 2 (with high level polarity) */
+#define PWR_WAKEUP_PIN3                 PWR_CR3_EWUP3  /*!< Wakeup pin 3 (with high level polarity) */
+#define PWR_WAKEUP_PIN4                 PWR_CR3_EWUP4  /*!< Wakeup pin 4 (with high level polarity) */
+#define PWR_WAKEUP_PIN5                 PWR_CR3_EWUP5  /*!< Wakeup pin 5 (with high level polarity) */
+#define PWR_WAKEUP_PIN1_HIGH            PWR_CR3_EWUP1  /*!< Wakeup pin 1 (with high level polarity) */
+#define PWR_WAKEUP_PIN2_HIGH            PWR_CR3_EWUP2  /*!< Wakeup pin 2 (with high level polarity) */
+#define PWR_WAKEUP_PIN3_HIGH            PWR_CR3_EWUP3  /*!< Wakeup pin 3 (with high level polarity) */
+#define PWR_WAKEUP_PIN4_HIGH            PWR_CR3_EWUP4  /*!< Wakeup pin 4 (with high level polarity) */
+#define PWR_WAKEUP_PIN5_HIGH            PWR_CR3_EWUP5  /*!< Wakeup pin 5 (with high level polarity) */
+#define PWR_WAKEUP_PIN1_LOW             (uint32_t)((PWR_CR4_WP1<<PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP1) /*!< Wakeup pin 1 (with low level polarity) */
+#define PWR_WAKEUP_PIN2_LOW             (uint32_t)((PWR_CR4_WP2<<PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP2) /*!< Wakeup pin 2 (with low level polarity) */
+#define PWR_WAKEUP_PIN3_LOW             (uint32_t)((PWR_CR4_WP3<<PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP3) /*!< Wakeup pin 3 (with low level polarity) */
+#define PWR_WAKEUP_PIN4_LOW             (uint32_t)((PWR_CR4_WP4<<PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP4) /*!< Wakeup pin 4 (with low level polarity) */
+#define PWR_WAKEUP_PIN5_LOW             (uint32_t)((PWR_CR4_WP5<<PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP5) /*!< Wakeup pin 5 (with low level polarity) */
+/**
+  * @}
+  */
+
+/** @defgroup PWREx_PVM_Type Peripheral Voltage Monitoring type
+  * @{
+  */
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+#define PWR_PVM_1                  PWR_CR2_PVME1  /*!< Peripheral Voltage Monitoring 1 enable: VDDUSB versus 1.2 V (applicable when USB feature is supported) */
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */
+#define PWR_PVM_2                  PWR_CR2_PVME2  /*!< Peripheral Voltage Monitoring 2 enable: VDDIO2 versus 0.9 V (applicable when VDDIO2 is present on device) */
+#define PWR_PVM_3                  PWR_CR2_PVME3  /*!< Peripheral Voltage Monitoring 3 enable: VDDA versus 1.62 V */
+#define PWR_PVM_4                  PWR_CR2_PVME4  /*!< Peripheral Voltage Monitoring 4 enable: VDDA versus 2.2 V  */
+/**
+  * @}
+  */  
+  
+/** @defgroup PWREx_PVM_Mode  PWR PVM interrupt and event mode
+  * @{
+  */
+#define PWR_PVM_MODE_NORMAL                 ((uint32_t)0x00000000)   /*!< basic mode is used */
+#define PWR_PVM_MODE_IT_RISING              ((uint32_t)0x00010001)   /*!< External Interrupt Mode with Rising edge trigger detection */
+#define PWR_PVM_MODE_IT_FALLING             ((uint32_t)0x00010002)   /*!< External Interrupt Mode with Falling edge trigger detection */
+#define PWR_PVM_MODE_IT_RISING_FALLING      ((uint32_t)0x00010003)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
+#define PWR_PVM_MODE_EVENT_RISING           ((uint32_t)0x00020001)   /*!< Event Mode with Rising edge trigger detection */
+#define PWR_PVM_MODE_EVENT_FALLING          ((uint32_t)0x00020002)   /*!< Event Mode with Falling edge trigger detection */
+#define PWR_PVM_MODE_EVENT_RISING_FALLING   ((uint32_t)0x00020003)   /*!< Event Mode with Rising/Falling edge trigger detection */
+/**
+  * @}
+  */
+  
+  
+
+/** @defgroup PWREx_Regulator_Voltage_Scale  PWR Regulator voltage scale
+  * @{
+  */
+#define PWR_REGULATOR_VOLTAGE_SCALE1       PWR_CR1_VOS_0     /*!< Voltage scaling range 1 */
+#define PWR_REGULATOR_VOLTAGE_SCALE2       PWR_CR1_VOS_1     /*!< Voltage scaling range 2 */
+/**
+  * @}
+  */
+
+  
+/** @defgroup PWREx_VBAT_Battery_Charging_Selection PWR battery charging resistor selection
+  * @{
+  */
+#define PWR_BATTERY_CHARGING_RESISTOR_5          ((uint32_t)0x00000000) /*!< VBAT charging through a 5 kOhms resistor   */
+#define PWR_BATTERY_CHARGING_RESISTOR_1_5         PWR_CR4_VBRS          /*!< VBAT charging through a 1.5 kOhms resistor */
+/**
+  * @}
+  */
+  
+/** @defgroup PWREx_VBAT_Battery_Charging PWR battery charging
+  * @{
+  */
+#define PWR_BATTERY_CHARGING_DISABLE        ((uint32_t)0x00000000)
+#define PWR_BATTERY_CHARGING_ENABLE         PWR_CR4_VBE
+/**
+  * @}
+  */ 
+  
+/** @defgroup PWREx_GPIO_Bit_Number GPIO bit number for I/O setting in standby/shutdown mode
+  * @{
+  */
+#define PWR_GPIO_BIT_0   PWR_PUCRA_PA0    /*!< GPIO port I/O pin 0  */
+#define PWR_GPIO_BIT_1   PWR_PUCRA_PA1    /*!< GPIO port I/O pin 1  */
+#define PWR_GPIO_BIT_2   PWR_PUCRA_PA2    /*!< GPIO port I/O pin 2  */
+#define PWR_GPIO_BIT_3   PWR_PUCRA_PA3    /*!< GPIO port I/O pin 3  */
+#define PWR_GPIO_BIT_4   PWR_PUCRA_PA4    /*!< GPIO port I/O pin 4  */
+#define PWR_GPIO_BIT_5   PWR_PUCRA_PA5    /*!< GPIO port I/O pin 5  */
+#define PWR_GPIO_BIT_6   PWR_PUCRA_PA6    /*!< GPIO port I/O pin 6  */
+#define PWR_GPIO_BIT_7   PWR_PUCRA_PA7    /*!< GPIO port I/O pin 7  */
+#define PWR_GPIO_BIT_8   PWR_PUCRA_PA8    /*!< GPIO port I/O pin 8  */
+#define PWR_GPIO_BIT_9   PWR_PUCRA_PA9    /*!< GPIO port I/O pin 9  */
+#define PWR_GPIO_BIT_10  PWR_PUCRA_PA10   /*!< GPIO port I/O pin 10 */
+#define PWR_GPIO_BIT_11  PWR_PUCRA_PA11   /*!< GPIO port I/O pin 11 */
+#define PWR_GPIO_BIT_12  PWR_PUCRA_PA12   /*!< GPIO port I/O pin 12 */
+#define PWR_GPIO_BIT_13  PWR_PUCRA_PA13   /*!< GPIO port I/O pin 13 */
+#define PWR_GPIO_BIT_14  PWR_PDCRA_PA14   /*!< GPIO port I/O pin 14 */
+#define PWR_GPIO_BIT_15  PWR_PUCRA_PA15   /*!< GPIO port I/O pin 15 */
+/**
+  * @}
+  */ 
+  
+/** @defgroup PWREx_GPIO GPIO port
+  * @{
+  */
+#define PWR_GPIO_A   0x00000000      /*!< GPIO port A */
+#define PWR_GPIO_B   0x00000001      /*!< GPIO port B */
+#define PWR_GPIO_C   0x00000002      /*!< GPIO port C */
+#define PWR_GPIO_D   0x00000003      /*!< GPIO port D */
+#define PWR_GPIO_E   0x00000004      /*!< GPIO port E */
+#define PWR_GPIO_F   0x00000005      /*!< GPIO port F */
+#define PWR_GPIO_G   0x00000006      /*!< GPIO port G */
+#define PWR_GPIO_H   0x00000007      /*!< GPIO port H */
+/**
+  * @}
+  */ 
+  
+/** @defgroup PWREx_PVM_EXTI_LINE PWR PVM external interrupts lines
+  * @{
+  */    
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+#define PWR_EXTI_LINE_PVM1  ((uint32_t)0x00000008)  /*!< External interrupt line 35 Connected to the PVM1 EXTI Line   */
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */
+#define PWR_EXTI_LINE_PVM2  ((uint32_t)0x00000010)  /*!< External interrupt line 36 Connected to the PVM2 EXTI Line   */
+#define PWR_EXTI_LINE_PVM3  ((uint32_t)0x00000020)  /*!< External interrupt line 37 Connected to the PVM3 EXTI Line   */
+#define PWR_EXTI_LINE_PVM4  ((uint32_t)0x00000040)  /*!< External interrupt line 38 Connected to the PVM4 EXTI Line   */ 
+/**
+  * @}
+  */ 
+  
+/** @defgroup PWREx_PVM_EVENT_LINE PWR PVM event lines
+  * @{
+  */    
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+#define PWR_EVENT_LINE_PVM1 ((uint32_t)0x00000008)  /*!< Event line 35 Connected to the PVM1 EXTI Line */
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */
+#define PWR_EVENT_LINE_PVM2 ((uint32_t)0x00000010)  /*!< Event line 36 Connected to the PVM2 EXTI Line */
+#define PWR_EVENT_LINE_PVM3 ((uint32_t)0x00000020)  /*!< Event line 37 Connected to the PVM3 EXTI Line */
+#define PWR_EVENT_LINE_PVM4 ((uint32_t)0x00000040)  /*!< Event line 38 Connected to the PVM4 EXTI Line */ 
+/**
+  * @}
+  */ 
+  
+/** @defgroup PWREx_Flag  PWR Status Flags
+  *        Elements values convention: 0000 0000 0XXY YYYYb
+  *           - Y YYYY  : Flag position in the XX register (5 bits)
+  *           - XX  : Status register (2 bits)
+  *                 - 01: SR1 register
+  *                 - 10: SR2 register
+  *        The only exception is PWR_FLAG_WU, encompassing all
+  *        wake-up flags and set to PWR_SR1_WUF.    
+  * @{   
+  */  
+#define PWR_FLAG_WUF1                       ((uint32_t)0x0020)   /*!< Wakeup event on wakeup pin 1 */
+#define PWR_FLAG_WUF2                       ((uint32_t)0x0021)   /*!< Wakeup event on wakeup pin 2 */
+#define PWR_FLAG_WUF3                       ((uint32_t)0x0022)   /*!< Wakeup event on wakeup pin 3 */
+#define PWR_FLAG_WUF4                       ((uint32_t)0x0023)   /*!< Wakeup event on wakeup pin 4 */
+#define PWR_FLAG_WUF5                       ((uint32_t)0x0024)   /*!< Wakeup event on wakeup pin 5 */
+#define PWR_FLAG_WU                         PWR_SR1_WUF          /*!< Encompass wakeup event on all wakeup pins */
+#define PWR_FLAG_SB                         ((uint32_t)0x0028)   /*!< Standby flag */
+#define PWR_FLAG_WUFI                       ((uint32_t)0x002F)   /*!< Wakeup on internal wakeup line */
+
+#define PWR_FLAG_REGLPS                     ((uint32_t)0x0048)   /*!< Low-power regulator start flag */
+#define PWR_FLAG_REGLPF                     ((uint32_t)0x0049)   /*!< Low-power regulator flag */
+#define PWR_FLAG_VOSF                       ((uint32_t)0x004A)   /*!< Voltage scaling flag */
+#define PWR_FLAG_PVDO                       ((uint32_t)0x004B)   /*!< Power Voltage Detector output flag */
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+#define PWR_FLAG_PVMO1                      ((uint32_t)0x004C)   /*!< Power Voltage Monitoring 1 output flag */
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */
+#define PWR_FLAG_PVMO2                      ((uint32_t)0x004D)   /*!< Power Voltage Monitoring 2 output flag */
+#define PWR_FLAG_PVMO3                      ((uint32_t)0x004E)   /*!< Power Voltage Monitoring 3 output flag */
+#define PWR_FLAG_PVMO4                      ((uint32_t)0x004F)   /*!< Power Voltage Monitoring 4 output flag */
+/**
+  * @}
+  */        
+
+/**
+  * @}
+  */  
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup PWREx_Exported_Macros PWR Extended Exported Macros
+ * @{
+ */
+
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+/**
+  * @brief Enable the PVM1 Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM1_EXTI_ENABLE_IT()   SET_BIT(EXTI->IMR2, PWR_EXTI_LINE_PVM1)
+
+/**
+  * @brief Disable the PVM1 Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM1_EXTI_DISABLE_IT()  CLEAR_BIT(EXTI->IMR2, PWR_EXTI_LINE_PVM1)
+
+/**
+  * @brief Enable the PVM1 Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM1_EXTI_ENABLE_EVENT()   SET_BIT(EXTI->EMR2, PWR_EVENT_LINE_PVM1)
+
+/**
+  * @brief Disable the PVM1 Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM1_EXTI_DISABLE_EVENT()  CLEAR_BIT(EXTI->EMR2, PWR_EVENT_LINE_PVM1)
+
+/**
+  * @brief Enable the PVM1 Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM1_EXTI_ENABLE_RISING_EDGE()   SET_BIT(EXTI->RTSR2, PWR_EXTI_LINE_PVM1)
+
+/**
+  * @brief Disable the PVM1 Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM1_EXTI_DISABLE_RISING_EDGE()  CLEAR_BIT(EXTI->RTSR2, PWR_EXTI_LINE_PVM1)
+
+/**
+  * @brief Enable the PVM1 Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM1_EXTI_ENABLE_FALLING_EDGE()   SET_BIT(EXTI->FTSR2, PWR_EXTI_LINE_PVM1)
+
+
+/**
+  * @brief Disable the PVM1 Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM1_EXTI_DISABLE_FALLING_EDGE()  CLEAR_BIT(EXTI->FTSR2, PWR_EXTI_LINE_PVM1)
+
+
+/**
+  * @brief  PVM1 EXTI line configuration: set rising & falling edge trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM1_EXTI_ENABLE_RISING_FALLING_EDGE()  \
+  do {                                                    \
+    __HAL_PWR_PVM1_EXTI_ENABLE_RISING_EDGE();             \
+    __HAL_PWR_PVM1_EXTI_ENABLE_FALLING_EDGE();            \
+  } while(0)
+
+/**
+  * @brief Disable the PVM1 Extended Interrupt Rising & Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM1_EXTI_DISABLE_RISING_FALLING_EDGE()  \
+  do {                                                     \
+    __HAL_PWR_PVM1_EXTI_DISABLE_RISING_EDGE();             \
+    __HAL_PWR_PVM1_EXTI_DISABLE_FALLING_EDGE();            \
+  } while(0)
+
+/**
+  * @brief  Generate a Software interrupt on selected EXTI line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM1_EXTI_GENERATE_SWIT() SET_BIT(EXTI->SWIER2, PWR_EXTI_LINE_PVM1)
+
+/**
+  * @brief Check whether the specified PVM1 EXTI interrupt flag is set or not.
+  * @retval EXTI PVM1 Line Status.
+  */
+#define __HAL_PWR_PVM1_EXTI_GET_FLAG()  (EXTI->PR2 & PWR_EXTI_LINE_PVM1)
+
+/**
+  * @brief Clear the PVM1 EXTI flag.
+  * @retval None
+  */
+#define __HAL_PWR_PVM1_EXTI_CLEAR_FLAG()  WRITE_REG(EXTI->PR2, PWR_EXTI_LINE_PVM1)
+
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */
+
+
+/**
+  * @brief Enable the PVM2 Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM2_EXTI_ENABLE_IT()   SET_BIT(EXTI->IMR2, PWR_EXTI_LINE_PVM2)
+
+/**
+  * @brief Disable the PVM2 Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM2_EXTI_DISABLE_IT()  CLEAR_BIT(EXTI->IMR2, PWR_EXTI_LINE_PVM2)
+
+/**
+  * @brief Enable the PVM2 Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM2_EXTI_ENABLE_EVENT()   SET_BIT(EXTI->EMR2, PWR_EVENT_LINE_PVM2)
+
+/**
+  * @brief Disable the PVM2 Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM2_EXTI_DISABLE_EVENT()  CLEAR_BIT(EXTI->EMR2, PWR_EVENT_LINE_PVM2)
+
+/**
+  * @brief Enable the PVM2 Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM2_EXTI_ENABLE_RISING_EDGE()   SET_BIT(EXTI->RTSR2, PWR_EXTI_LINE_PVM2)
+
+/**
+  * @brief Disable the PVM2 Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM2_EXTI_DISABLE_RISING_EDGE()  CLEAR_BIT(EXTI->RTSR2, PWR_EXTI_LINE_PVM2)
+
+/**
+  * @brief Enable the PVM2 Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM2_EXTI_ENABLE_FALLING_EDGE()   SET_BIT(EXTI->FTSR2, PWR_EXTI_LINE_PVM2)
+
+
+/**
+  * @brief Disable the PVM2 Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM2_EXTI_DISABLE_FALLING_EDGE()  CLEAR_BIT(EXTI->FTSR2, PWR_EXTI_LINE_PVM2)
+
+
+/**
+  * @brief  PVM2 EXTI line configuration: set rising & falling edge trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM2_EXTI_ENABLE_RISING_FALLING_EDGE()  \
+  do {                                                    \
+    __HAL_PWR_PVM2_EXTI_ENABLE_RISING_EDGE();             \
+    __HAL_PWR_PVM2_EXTI_ENABLE_FALLING_EDGE();            \
+  } while(0)
+  
+/**
+  * @brief Disable the PVM2 Extended Interrupt Rising & Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM2_EXTI_DISABLE_RISING_FALLING_EDGE()  \
+  do {                                                     \
+    __HAL_PWR_PVM2_EXTI_DISABLE_RISING_EDGE();             \
+    __HAL_PWR_PVM2_EXTI_DISABLE_FALLING_EDGE();            \
+  } while(0)
+
+/**
+  * @brief  Generate a Software interrupt on selected EXTI line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM2_EXTI_GENERATE_SWIT() SET_BIT(EXTI->SWIER2, PWR_EXTI_LINE_PVM2)
+
+/**
+  * @brief Check whether the specified PVM2 EXTI interrupt flag is set or not.
+  * @retval EXTI PVM2 Line Status.
+  */
+#define __HAL_PWR_PVM2_EXTI_GET_FLAG()  (EXTI->PR2 & PWR_EXTI_LINE_PVM2)
+
+/**
+  * @brief Clear the PVM2 EXTI flag.
+  * @retval None
+  */
+#define __HAL_PWR_PVM2_EXTI_CLEAR_FLAG()  WRITE_REG(EXTI->PR2, PWR_EXTI_LINE_PVM2)
+
+
+
+/**
+  * @brief Enable the PVM3 Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM3_EXTI_ENABLE_IT()   SET_BIT(EXTI->IMR2, PWR_EXTI_LINE_PVM3)
+
+/**
+  * @brief Disable the PVM3 Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM3_EXTI_DISABLE_IT()  CLEAR_BIT(EXTI->IMR2, PWR_EXTI_LINE_PVM3)
+
+/**
+  * @brief Enable the PVM3 Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM3_EXTI_ENABLE_EVENT()   SET_BIT(EXTI->EMR2, PWR_EVENT_LINE_PVM3)
+
+/**
+  * @brief Disable the PVM3 Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM3_EXTI_DISABLE_EVENT()  CLEAR_BIT(EXTI->EMR2, PWR_EVENT_LINE_PVM3)
+
+/**
+  * @brief Enable the PVM3 Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM3_EXTI_ENABLE_RISING_EDGE()   SET_BIT(EXTI->RTSR2, PWR_EXTI_LINE_PVM3)
+
+/**
+  * @brief Disable the PVM3 Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM3_EXTI_DISABLE_RISING_EDGE()  CLEAR_BIT(EXTI->RTSR2, PWR_EXTI_LINE_PVM3)
+
+/**
+  * @brief Enable the PVM3 Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM3_EXTI_ENABLE_FALLING_EDGE()   SET_BIT(EXTI->FTSR2, PWR_EXTI_LINE_PVM3)
+
+
+/**
+  * @brief Disable the PVM3 Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM3_EXTI_DISABLE_FALLING_EDGE()  CLEAR_BIT(EXTI->FTSR2, PWR_EXTI_LINE_PVM3)
+
+
+/**
+  * @brief  PVM3 EXTI line configuration: set rising & falling edge trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM3_EXTI_ENABLE_RISING_FALLING_EDGE()  \
+  do {                                                    \
+    __HAL_PWR_PVM3_EXTI_ENABLE_RISING_EDGE();             \
+    __HAL_PWR_PVM3_EXTI_ENABLE_FALLING_EDGE();            \
+  } while(0)
+  
+/**
+  * @brief Disable the PVM3 Extended Interrupt Rising & Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM3_EXTI_DISABLE_RISING_FALLING_EDGE()  \
+  do {                                                     \
+    __HAL_PWR_PVM3_EXTI_DISABLE_RISING_EDGE();             \
+    __HAL_PWR_PVM3_EXTI_DISABLE_FALLING_EDGE();            \
+  } while(0)
+
+/**
+  * @brief  Generate a Software interrupt on selected EXTI line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM3_EXTI_GENERATE_SWIT() SET_BIT(EXTI->SWIER2, PWR_EXTI_LINE_PVM3)
+
+/**
+  * @brief Check whether the specified PVM3 EXTI interrupt flag is set or not.
+  * @retval EXTI PVM3 Line Status.
+  */
+#define __HAL_PWR_PVM3_EXTI_GET_FLAG()  (EXTI->PR2 & PWR_EXTI_LINE_PVM3)
+
+/**
+  * @brief Clear the PVM3 EXTI flag.
+  * @retval None
+  */
+#define __HAL_PWR_PVM3_EXTI_CLEAR_FLAG()  WRITE_REG(EXTI->PR2, PWR_EXTI_LINE_PVM3)
+
+
+
+
+/**
+  * @brief Enable the PVM4 Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM4_EXTI_ENABLE_IT()   SET_BIT(EXTI->IMR2, PWR_EXTI_LINE_PVM4)
+
+/**
+  * @brief Disable the PVM4 Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM4_EXTI_DISABLE_IT()  CLEAR_BIT(EXTI->IMR2, PWR_EXTI_LINE_PVM4)
+
+/**
+  * @brief Enable the PVM4 Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM4_EXTI_ENABLE_EVENT()   SET_BIT(EXTI->EMR2, PWR_EVENT_LINE_PVM4)
+
+/**
+  * @brief Disable the PVM4 Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM4_EXTI_DISABLE_EVENT()  CLEAR_BIT(EXTI->EMR2, PWR_EVENT_LINE_PVM4)
+
+/**
+  * @brief Enable the PVM4 Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM4_EXTI_ENABLE_RISING_EDGE()   SET_BIT(EXTI->RTSR2, PWR_EXTI_LINE_PVM4)
+
+/**
+  * @brief Disable the PVM4 Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM4_EXTI_DISABLE_RISING_EDGE()  CLEAR_BIT(EXTI->RTSR2, PWR_EXTI_LINE_PVM4)
+
+/**
+  * @brief Enable the PVM4 Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM4_EXTI_ENABLE_FALLING_EDGE()   SET_BIT(EXTI->FTSR2, PWR_EXTI_LINE_PVM4)
+
+
+/**
+  * @brief Disable the PVM4 Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM4_EXTI_DISABLE_FALLING_EDGE()  CLEAR_BIT(EXTI->FTSR2, PWR_EXTI_LINE_PVM4)
+
+
+/**
+  * @brief  PVM4 EXTI line configuration: set rising & falling edge trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM4_EXTI_ENABLE_RISING_FALLING_EDGE()  \
+  do {                                                    \
+    __HAL_PWR_PVM4_EXTI_ENABLE_RISING_EDGE();             \
+    __HAL_PWR_PVM4_EXTI_ENABLE_FALLING_EDGE();            \
+  } while(0)
+  
+/**
+  * @brief Disable the PVM4 Extended Interrupt Rising & Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM4_EXTI_DISABLE_RISING_FALLING_EDGE()  \
+  do {                                                     \
+    __HAL_PWR_PVM4_EXTI_DISABLE_RISING_EDGE();             \
+    __HAL_PWR_PVM4_EXTI_DISABLE_FALLING_EDGE();            \
+  } while(0)
+
+/**
+  * @brief  Generate a Software interrupt on selected EXTI line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM4_EXTI_GENERATE_SWIT() SET_BIT(EXTI->SWIER2, PWR_EXTI_LINE_PVM4)
+
+/**
+  * @brief Check whether or not the specified PVM4 EXTI interrupt flag is set.
+  * @retval EXTI PVM4 Line Status.
+  */
+#define __HAL_PWR_PVM4_EXTI_GET_FLAG()  (EXTI->PR2 & PWR_EXTI_LINE_PVM4)
+
+/**
+  * @brief Clear the PVM4 EXTI flag.
+  * @retval None
+  */
+#define __HAL_PWR_PVM4_EXTI_CLEAR_FLAG()  WRITE_REG(EXTI->PR2, PWR_EXTI_LINE_PVM4)
+
+
+/**
+  * @brief Configure the main internal regulator output voltage.
+  * @param  __REGULATOR__: specifies the regulator output voltage to achieve
+  *         a tradeoff between performance and power consumption.
+  *          This parameter can be one of the following values:
+  *            @arg @ref PWR_REGULATOR_VOLTAGE_SCALE1  Regulator voltage output range 1 mode,
+  *                                                typical output voltage at 1.2 V,  
+  *                                                system frequency up to 80 MHz.
+  *            @arg @ref PWR_REGULATOR_VOLTAGE_SCALE2  Regulator voltage output range 2 mode,
+  *                                                typical output voltage at 1.0 V,                
+  *                                                system frequency up to 26 MHz.  
+  * @note  This macro is similar to HAL_PWREx_ControlVoltageScaling() API but doesn't check
+  *        whether or not VOSF flag is cleared when moving from range 2 to range 1. User
+  *        may resort to __HAL_PWR_GET_FLAG() macro to check VOSF bit resetting.   
+  * @retval None
+  */
+#define __HAL_PWR_VOLTAGESCALING_CONFIG(__REGULATOR__) do {                                                     \
+                                                            __IO uint32_t tmpreg;                               \
+                                                            MODIFY_REG(PWR->CR1, PWR_CR1_VOS, (__REGULATOR__)); \
+                                                            /* Delay after an RCC peripheral clock enabling */  \
+                                                            tmpreg = READ_BIT(PWR->CR1, PWR_CR1_VOS);           \
+                                                            UNUSED(tmpreg);                                     \
+                                                          } while(0)
+
+/**
+  * @}
+  */
+  
+/* Private macros --------------------------------------------------------*/
+/** @addtogroup  PWREx_Private_Macros   PWR Extended Private Macros
+  * @{
+  */
+
+#define IS_PWR_WAKEUP_PIN(PIN) (((PIN) == PWR_WAKEUP_PIN1) || \
+                                ((PIN) == PWR_WAKEUP_PIN2) || \
+                                ((PIN) == PWR_WAKEUP_PIN3) || \
+                                ((PIN) == PWR_WAKEUP_PIN4) || \
+                                ((PIN) == PWR_WAKEUP_PIN5) || \
+                                ((PIN) == PWR_WAKEUP_PIN1_HIGH) || \
+                                ((PIN) == PWR_WAKEUP_PIN2_HIGH) || \
+                                ((PIN) == PWR_WAKEUP_PIN3_HIGH) || \
+                                ((PIN) == PWR_WAKEUP_PIN4_HIGH) || \
+                                ((PIN) == PWR_WAKEUP_PIN5_HIGH) || \
+                                ((PIN) == PWR_WAKEUP_PIN1_LOW) || \
+                                ((PIN) == PWR_WAKEUP_PIN2_LOW) || \
+                                ((PIN) == PWR_WAKEUP_PIN3_LOW) || \
+                                ((PIN) == PWR_WAKEUP_PIN4_LOW) || \
+                                ((PIN) == PWR_WAKEUP_PIN5_LOW))
+                                
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+#define IS_PWR_PVM_TYPE(TYPE) (((TYPE) == PWR_PVM_1) ||\
+                               ((TYPE) == PWR_PVM_2) ||\
+                               ((TYPE) == PWR_PVM_3) ||\
+                               ((TYPE) == PWR_PVM_4))
+#elif defined (STM32L471xx)
+#define IS_PWR_PVM_TYPE(TYPE) (((TYPE) == PWR_PVM_2) ||\
+                               ((TYPE) == PWR_PVM_3) ||\
+                               ((TYPE) == PWR_PVM_4))
+#endif
+
+#define IS_PWR_PVM_MODE(MODE)  (((MODE) == PWR_PVM_MODE_NORMAL)              ||\
+                                ((MODE) == PWR_PVM_MODE_IT_RISING)           ||\
+                                ((MODE) == PWR_PVM_MODE_IT_FALLING)          ||\
+                                ((MODE) == PWR_PVM_MODE_IT_RISING_FALLING)   ||\
+                                ((MODE) == PWR_PVM_MODE_EVENT_RISING)        ||\
+                                ((MODE) == PWR_PVM_MODE_EVENT_FALLING)       ||\
+                                ((MODE) == PWR_PVM_MODE_EVENT_RISING_FALLING))  
+                                
+#define IS_PWR_VOLTAGE_SCALING_RANGE(RANGE) (((RANGE) == PWR_REGULATOR_VOLTAGE_SCALE1) || \
+                                             ((RANGE) == PWR_REGULATOR_VOLTAGE_SCALE2))
+                                             
+#define IS_PWR_BATTERY_RESISTOR_SELECT(RESISTOR) (((RESISTOR) == PWR_BATTERY_CHARGING_RESISTOR_5) ||\
+                                                  ((RESISTOR) == PWR_BATTERY_CHARGING_RESISTOR_1_5))  
+                                                  
+#define IS_PWR_BATTERY_CHARGING(CHARGING) (((CHARGING) == PWR_BATTERY_CHARGING_DISABLE) ||\
+                                           ((CHARGING) == PWR_BATTERY_CHARGING_ENABLE)) 
+                                           
+#define IS_PWR_GPIO_BIT_NUMBER(BIT_NUMBER) (((BIT_NUMBER) & GPIO_PIN_MASK) != (uint32_t)0x00)
+                                           
+                             
+#define IS_PWR_GPIO(GPIO) (((GPIO) == PWR_GPIO_A) ||\
+                           ((GPIO) == PWR_GPIO_B) ||\
+                           ((GPIO) == PWR_GPIO_C) ||\
+                           ((GPIO) == PWR_GPIO_D) ||\
+                           ((GPIO) == PWR_GPIO_E) ||\
+                           ((GPIO) == PWR_GPIO_F) ||\
+                           ((GPIO) == PWR_GPIO_G) ||\
+                           ((GPIO) == PWR_GPIO_H))
+
+
+/**
+  * @}
+  */  
+  
+
+/** @addtogroup PWREx_Exported_Functions PWR Extended Exported Functions
+  * @{
+  */
+  
+/** @addtogroup PWREx_Exported_Functions_Group1 Extended Peripheral Control functions 
+  * @{
+  */
+
+
+/* Peripheral Control functions  **********************************************/
+uint32_t HAL_PWREx_GetVoltageRange(void);
+HAL_StatusTypeDef HAL_PWREx_ControlVoltageScaling(uint32_t VoltageScaling);
+void HAL_PWREx_EnableBatteryCharging(uint32_t ResistorSelection);
+void HAL_PWREx_DisableBatteryCharging(void);
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+void HAL_PWREx_EnableVddUSB(void);
+void HAL_PWREx_DisableVddUSB(void);
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */
+void HAL_PWREx_EnableVddIO2(void);
+void HAL_PWREx_DisableVddIO2(void);
+void HAL_PWREx_EnableInternalWakeUpLine(void);
+void HAL_PWREx_DisableInternalWakeUpLine(void);
+HAL_StatusTypeDef HAL_PWREx_EnableGPIOPullUp(uint32_t GPIO, uint32_t GPIONumber);
+HAL_StatusTypeDef HAL_PWREx_DisableGPIOPullUp(uint32_t GPIO, uint32_t GPIONumber);
+HAL_StatusTypeDef HAL_PWREx_EnableGPIOPullDown(uint32_t GPIO, uint32_t GPIONumber);
+HAL_StatusTypeDef HAL_PWREx_DisableGPIOPullDown(uint32_t GPIO, uint32_t GPIONumber);
+void HAL_PWREx_EnablePullUpPullDownConfig(void);
+void HAL_PWREx_DisablePullUpPullDownConfig(void);
+void HAL_PWREx_EnableSRAM2ContentRetention(void);
+void HAL_PWREx_DisableSRAM2ContentRetention(void);
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+void HAL_PWREx_EnablePVM1(void);
+void HAL_PWREx_DisablePVM1(void);
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */
+void HAL_PWREx_EnablePVM2(void);
+void HAL_PWREx_DisablePVM2(void);
+void HAL_PWREx_EnablePVM3(void);
+void HAL_PWREx_DisablePVM3(void);
+void HAL_PWREx_EnablePVM4(void);
+void HAL_PWREx_DisablePVM4(void);
+HAL_StatusTypeDef HAL_PWREx_ConfigPVM(PWR_PVMTypeDef *sConfigPVM);
+
+
+/* Low Power modes configuration functions ************************************/
+void HAL_PWREx_EnableLowPowerRunMode(void);
+HAL_StatusTypeDef HAL_PWREx_DisableLowPowerRunMode(void);
+void HAL_PWREx_EnterSTOP0Mode(uint8_t STOPEntry);
+void HAL_PWREx_EnterSTOP1Mode(uint8_t STOPEntry);
+void HAL_PWREx_EnterSTOP2Mode(uint8_t STOPEntry);
+void HAL_PWREx_EnterSHUTDOWNMode(void);
+
+void HAL_PWREx_PVD_PVM_IRQHandler(void);
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+void HAL_PWREx_PVM1Callback(void);
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */
+void HAL_PWREx_PVM2Callback(void);
+void HAL_PWREx_PVM3Callback(void);
+void HAL_PWREx_PVM4Callback(void);
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L4xx_HAL_PWR_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_qspi.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_qspi.h
@@ -1,0 +1,648 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_qspi.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of QSPI HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_QSPI_H
+#define __STM32L4xx_HAL_QSPI_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup QSPI
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/** @defgroup QSPI_Exported_Types QSPI Exported Types
+  * @{
+  */
+
+/** 
+  * @brief  QSPI Init structure definition  
+  */
+typedef struct
+{
+  uint32_t ClockPrescaler;     /* Specifies the prescaler factor for generating clock based on the AHB clock.
+                                  This parameter can be a number between 0 and 255 */ 
+  uint32_t FifoThreshold;      /* Specifies the threshold number of bytes in the FIFO (used only in indirect mode)
+                                  This parameter can be a value between 1 and 16 */
+  uint32_t SampleShifting;     /* Specifies the Sample Shift. The data is sampled 1/2 clock cycle delay later to 
+                                  take in account external signal delays. (It should be QSPI_SAMPLE_SHIFTING_NONE in DDR mode)
+                                  This parameter can be a value of @ref QSPI_SampleShifting */
+  uint32_t FlashSize;          /* Specifies the Flash Size. FlashSize+1 is effectively the number of address bits 
+                                  required to address the flash memory. The flash capacity can be up to 4GB 
+                                  (addressed using 32 bits) in indirect mode, but the addressable space in 
+                                  memory-mapped mode is limited to 256MB
+                                  This parameter can be a number between 0 and 31 */
+  uint32_t ChipSelectHighTime; /* Specifies the Chip Select High Time. ChipSelectHighTime+1 defines the minimum number 
+                                  of clock cycles which the chip select must remain high between commands.
+                                  This parameter can be a value of @ref QSPI_ChipSelectHighTime */   
+  uint32_t ClockMode;          /* Specifies the Clock Mode. It indicates the level that clock takes between commands.
+                                  This parameter can be a value of @ref QSPI_ClockMode */
+}QSPI_InitTypeDef;
+
+/** 
+  * @brief HAL QSPI State structures definition  
+  */ 
+typedef enum
+{
+  HAL_QSPI_STATE_RESET             = 0x00,    /*!< Peripheral not initialized                            */
+  HAL_QSPI_STATE_READY             = 0x01,    /*!< Peripheral initialized and ready for use              */
+  HAL_QSPI_STATE_BUSY              = 0x02,    /*!< Peripheral in indirect mode and busy                  */ 
+  HAL_QSPI_STATE_BUSY_INDIRECT_TX  = 0x12,    /*!< Peripheral in indirect mode with transmission ongoing */ 
+  HAL_QSPI_STATE_BUSY_INDIRECT_RX  = 0x22,    /*!< Peripheral in indirect mode with reception ongoing    */
+  HAL_QSPI_STATE_BUSY_AUTO_POLLING = 0x42,    /*!< Peripheral in auto polling mode ongoing               */
+  HAL_QSPI_STATE_BUSY_MEM_MAPPED   = 0x82,    /*!< Peripheral in memory mapped mode ongoing              */
+  HAL_QSPI_STATE_ERROR             = 0x04     /*!< Peripheral in error                                   */
+}HAL_QSPI_StateTypeDef;
+
+/** 
+  * @brief  QSPI Handle Structure definition  
+  */  
+typedef struct
+{
+  QUADSPI_TypeDef            *Instance;        /* QSPI registers base address        */
+  QSPI_InitTypeDef           Init;             /* QSPI communication parameters      */
+  uint8_t                    *pTxBuffPtr;      /* Pointer to QSPI Tx transfer Buffer */
+  __IO uint16_t              TxXferSize;       /* QSPI Tx Transfer size              */
+  __IO uint16_t              TxXferCount;      /* QSPI Tx Transfer Counter           */
+  uint8_t                    *pRxBuffPtr;      /* Pointer to QSPI Rx transfer Buffer */
+  __IO uint16_t              RxXferSize;       /* QSPI Rx Transfer size              */
+  __IO uint16_t              RxXferCount;      /* QSPI Rx Transfer Counter           */
+  DMA_HandleTypeDef          *hdma;            /* QSPI Rx/Tx DMA Handle parameters   */
+  __IO HAL_LockTypeDef       Lock;             /* Locking object                     */
+  __IO HAL_QSPI_StateTypeDef State;            /* QSPI communication state           */
+  __IO uint32_t              ErrorCode;        /* QSPI Error code                    */
+  uint32_t                   Timeout;          /* Timeout for the QSPI memory access */ 
+}QSPI_HandleTypeDef;
+
+/** 
+  * @brief  QSPI Command structure definition  
+  */
+typedef struct
+{
+  uint32_t Instruction;        /* Specifies the Instruction to be sent
+                                  This parameter can be a value (8-bit) between 0x00 and 0xFF */
+  uint32_t Address;            /* Specifies the Address to be sent (Size from 1 to 4 bytes according AddressSize)
+                                  This parameter can be a value (32-bits) between 0x0 and 0xFFFFFFFF */
+  uint32_t AlternateBytes;     /* Specifies the Alternate Bytes to be sent (Size from 1 to 4 bytes according AlternateBytesSize)
+                                  This parameter can be a value (32-bits) between 0x0 and 0xFFFFFFFF */
+  uint32_t AddressSize;        /* Specifies the Address Size
+                                  This parameter can be a value of @ref QSPI_AddressSize */
+  uint32_t AlternateBytesSize; /* Specifies the Alternate Bytes Size
+                                  This parameter can be a value of @ref QSPI_AlternateBytesSize */
+  uint32_t DummyCycles;        /* Specifies the Number of Dummy Cycles.
+                                  This parameter can be a number between 0 and 31 */
+  uint32_t InstructionMode;    /* Specifies the Instruction Mode
+                                  This parameter can be a value of @ref QSPI_InstructionMode */
+  uint32_t AddressMode;        /* Specifies the Address Mode
+                                  This parameter can be a value of @ref QSPI_AddressMode */
+  uint32_t AlternateByteMode;  /* Specifies the Alternate Bytes Mode
+                                  This parameter can be a value of @ref QSPI_AlternateBytesMode */
+  uint32_t DataMode;           /* Specifies the Data Mode (used for dummy cycles and data phases)
+                                  This parameter can be a value of @ref QSPI_DataMode */
+  uint32_t NbData;             /* Specifies the number of data to transfer. 
+                                  This parameter can be any value between 0 and 0xFFFFFFFF (0 means undefined length 
+                                  until end of memory)*/
+  uint32_t DdrMode;            /* Specifies the double data rate mode for address, alternate byte and data phase
+                                  This parameter can be a value of @ref QSPI_DdrMode */
+  uint32_t DdrHoldHalfCycle;   /* Specifies the DDR hold half cycle. It delays the data output by one half of 
+                                  system clock in DDR mode. Not available on STM32L4x6 devices but in future devices.
+                                  This parameter can be a value of @ref QSPI_DdrHoldHalfCycle */
+  uint32_t SIOOMode;           /* Specifies the send instruction only once mode
+                                  This parameter can be a value of @ref QSPI_SIOOMode */
+}QSPI_CommandTypeDef;
+
+/** 
+  * @brief  QSPI Auto Polling mode configuration structure definition  
+  */
+typedef struct
+{
+  uint32_t Match;              /* Specifies the value to be compared with the masked status register to get a match.
+                                  This parameter can be any value between 0 and 0xFFFFFFFF */
+  uint32_t Mask;               /* Specifies the mask to be applied to the status bytes received. 
+                                  This parameter can be any value between 0 and 0xFFFFFFFF */
+  uint32_t Interval;           /* Specifies the number of clock cycles between two read during automatic polling phases.
+                                  This parameter can be any value between 0 and 0xFFFF */
+  uint32_t StatusBytesSize;    /* Specifies the size of the status bytes received.
+                                  This parameter can be any value between 1 and 4 */
+  uint32_t MatchMode;          /* Specifies the method used for determining a match.
+                                  This parameter can be a value of @ref QSPI_MatchMode */
+  uint32_t AutomaticStop;      /* Specifies if automatic polling is stopped after a match.
+                                  This parameter can be a value of @ref QSPI_AutomaticStop */
+}QSPI_AutoPollingTypeDef;
+                           
+/** 
+  * @brief  QSPI Memory Mapped mode configuration structure definition  
+  */
+typedef struct
+{
+  uint32_t TimeOutPeriod;      /* Specifies the number of clock to wait when the FIFO is full before to release the chip select.
+                                  This parameter can be any value between 0 and 0xFFFF */
+  uint32_t TimeOutActivation;  /* Specifies if the timeout counter is enabled to release the chip select. 
+                                  This parameter can be a value of @ref QSPI_TimeOutActivation */
+}QSPI_MemoryMappedTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup QSPI_Exported_Constants QSPI Exported Constants
+  * @{
+  */
+
+/** @defgroup QSPI_ErrorCode QSPI Error Code
+  * @{
+  */ 
+#define HAL_QSPI_ERROR_NONE            ((uint32_t)0x00000000) /*!< No error           */
+#define HAL_QSPI_ERROR_TIMEOUT         ((uint32_t)0x00000001) /*!< Timeout error      */
+#define HAL_QSPI_ERROR_TRANSFER        ((uint32_t)0x00000002) /*!< Transfer error     */
+#define HAL_QSPI_ERROR_DMA             ((uint32_t)0x00000004) /*!< DMA transfer error */
+/**
+  * @}
+  */ 
+
+/** @defgroup QSPI_SampleShifting QSPI Sample Shifting
+  * @{
+  */
+#define QSPI_SAMPLE_SHIFTING_NONE      ((uint32_t)0x00000000)        /*!<No clock cycle shift to sample data*/
+#define QSPI_SAMPLE_SHIFTING_HALFCYCLE ((uint32_t)QUADSPI_CR_SSHIFT) /*!<1/2 clock cycle shift to sample data*/
+/**
+  * @}
+  */ 
+
+/** @defgroup QSPI_ChipSelectHighTime QSPI ChipSelect High Time
+  * @{
+  */
+#define QSPI_CS_HIGH_TIME_1_CYCLE      ((uint32_t)0x00000000)                              /*!<nCS stay high for at least 1 clock cycle between commands*/
+#define QSPI_CS_HIGH_TIME_2_CYCLE      ((uint32_t)QUADSPI_DCR_CSHT_0)                      /*!<nCS stay high for at least 2 clock cycles between commands*/
+#define QSPI_CS_HIGH_TIME_3_CYCLE      ((uint32_t)QUADSPI_DCR_CSHT_1)                      /*!<nCS stay high for at least 3 clock cycles between commands*/
+#define QSPI_CS_HIGH_TIME_4_CYCLE      ((uint32_t)QUADSPI_DCR_CSHT_0 | QUADSPI_DCR_CSHT_1) /*!<nCS stay high for at least 4 clock cycles between commands*/
+#define QSPI_CS_HIGH_TIME_5_CYCLE      ((uint32_t)QUADSPI_DCR_CSHT_2)                      /*!<nCS stay high for at least 5 clock cycles between commands*/
+#define QSPI_CS_HIGH_TIME_6_CYCLE      ((uint32_t)QUADSPI_DCR_CSHT_2 | QUADSPI_DCR_CSHT_0) /*!<nCS stay high for at least 6 clock cycles between commands*/
+#define QSPI_CS_HIGH_TIME_7_CYCLE      ((uint32_t)QUADSPI_DCR_CSHT_2 | QUADSPI_DCR_CSHT_1) /*!<nCS stay high for at least 7 clock cycles between commands*/
+#define QSPI_CS_HIGH_TIME_8_CYCLE      ((uint32_t)QUADSPI_DCR_CSHT)                        /*!<nCS stay high for at least 8 clock cycles between commands*/
+/**
+  * @}
+  */
+
+/** @defgroup QSPI_ClockMode QSPI Clock Mode
+  * @{
+  */
+#define QSPI_CLOCK_MODE_0              ((uint32_t)0x00000000)         /*!<Clk stays low while nCS is released*/
+#define QSPI_CLOCK_MODE_3              ((uint32_t)QUADSPI_DCR_CKMODE) /*!<Clk goes high while nCS is released*/
+/**
+  * @}
+  */
+
+/** @defgroup QSPI_AddressSize QSPI Address Size
+  * @{
+  */
+#define QSPI_ADDRESS_8_BITS            ((uint32_t)0x00000000)           /*!<8-bit address*/
+#define QSPI_ADDRESS_16_BITS           ((uint32_t)QUADSPI_CCR_ADSIZE_0) /*!<16-bit address*/
+#define QSPI_ADDRESS_24_BITS           ((uint32_t)QUADSPI_CCR_ADSIZE_1) /*!<24-bit address*/
+#define QSPI_ADDRESS_32_BITS           ((uint32_t)QUADSPI_CCR_ADSIZE)   /*!<32-bit address*/
+/**
+  * @}
+  */  
+
+/** @defgroup QSPI_AlternateBytesSize QSPI Alternate Bytes Size
+  * @{
+  */
+#define QSPI_ALTERNATE_BYTES_8_BITS    ((uint32_t)0x00000000)           /*!<8-bit alternate bytes*/
+#define QSPI_ALTERNATE_BYTES_16_BITS   ((uint32_t)QUADSPI_CCR_ABSIZE_0) /*!<16-bit alternate bytes*/
+#define QSPI_ALTERNATE_BYTES_24_BITS   ((uint32_t)QUADSPI_CCR_ABSIZE_1) /*!<24-bit alternate bytes*/
+#define QSPI_ALTERNATE_BYTES_32_BITS   ((uint32_t)QUADSPI_CCR_ABSIZE)   /*!<32-bit alternate bytes*/
+/**
+  * @}
+  */
+
+/** @defgroup QSPI_InstructionMode QSPI Instruction Mode
+* @{
+*/
+#define QSPI_INSTRUCTION_NONE          ((uint32_t)0x00000000)          /*!<No instruction*/
+#define QSPI_INSTRUCTION_1_LINE        ((uint32_t)QUADSPI_CCR_IMODE_0) /*!<Instruction on a single line*/
+#define QSPI_INSTRUCTION_2_LINES       ((uint32_t)QUADSPI_CCR_IMODE_1) /*!<Instruction on two lines*/
+#define QSPI_INSTRUCTION_4_LINES       ((uint32_t)QUADSPI_CCR_IMODE)   /*!<Instruction on four lines*/
+/**
+  * @}
+  */
+
+/** @defgroup QSPI_AddressMode QSPI Address Mode
+* @{
+*/
+#define QSPI_ADDRESS_NONE              ((uint32_t)0x00000000)           /*!<No address*/
+#define QSPI_ADDRESS_1_LINE            ((uint32_t)QUADSPI_CCR_ADMODE_0) /*!<Address on a single line*/
+#define QSPI_ADDRESS_2_LINES           ((uint32_t)QUADSPI_CCR_ADMODE_1) /*!<Address on two lines*/
+#define QSPI_ADDRESS_4_LINES           ((uint32_t)QUADSPI_CCR_ADMODE)   /*!<Address on four lines*/
+/**
+  * @}
+  */  
+
+/** @defgroup QSPI_AlternateBytesMode QSPI Alternate Bytes Mode
+* @{
+*/
+#define QSPI_ALTERNATE_BYTES_NONE      ((uint32_t)0x00000000)           /*!<No alternate bytes*/
+#define QSPI_ALTERNATE_BYTES_1_LINE    ((uint32_t)QUADSPI_CCR_ABMODE_0) /*!<Alternate bytes on a single line*/
+#define QSPI_ALTERNATE_BYTES_2_LINES   ((uint32_t)QUADSPI_CCR_ABMODE_1) /*!<Alternate bytes on two lines*/
+#define QSPI_ALTERNATE_BYTES_4_LINES   ((uint32_t)QUADSPI_CCR_ABMODE)   /*!<Alternate bytes on four lines*/
+/**
+  * @}
+  */  
+
+/** @defgroup QSPI_DataMode QSPI Data Mode
+  * @{
+  */
+#define QSPI_DATA_NONE                 ((uint32_t)0X00000000)           /*!<No data*/
+#define QSPI_DATA_1_LINE               ((uint32_t)QUADSPI_CCR_DMODE_0) /*!<Data on a single line*/
+#define QSPI_DATA_2_LINES              ((uint32_t)QUADSPI_CCR_DMODE_1) /*!<Data on two lines*/
+#define QSPI_DATA_4_LINES              ((uint32_t)QUADSPI_CCR_DMODE)   /*!<Data on four lines*/
+/**
+  * @}
+  */  
+
+/** @defgroup QSPI_DdrMode QSPI DDR Mode
+  * @{
+  */
+#define QSPI_DDR_MODE_DISABLE          ((uint32_t)0x00000000)       /*!<Double data rate mode disabled*/
+#define QSPI_DDR_MODE_ENABLE           ((uint32_t)QUADSPI_CCR_DDRM) /*!<Double data rate mode enabled*/
+/**
+  * @}
+  */
+
+/** @defgroup QSPI_DdrHoldHalfCycle QSPI DDR Data Output Delay
+  * @{
+  */
+#define QSPI_DDR_HHC_ANALOG_DELAY      ((uint32_t)0x00000000)       /*!<Delay the data output using analog delay in DDR mode*/
+/**
+  * @}
+  */
+
+/** @defgroup QSPI_SIOOMode QSPI Send Instruction Mode
+  * @{
+  */
+#define QSPI_SIOO_INST_EVERY_CMD       ((uint32_t)0x00000000)       /*!<Send instruction on every transaction*/
+#define QSPI_SIOO_INST_ONLY_FIRST_CMD  ((uint32_t)QUADSPI_CCR_SIOO) /*!<Send instruction only for the first command*/
+/**
+  * @}
+  */
+
+/** @defgroup QSPI_MatchMode QSPI Match Mode
+  * @{
+  */
+#define QSPI_MATCH_MODE_AND            ((uint32_t)0x00000000)     /*!<AND match mode between unmasked bits*/
+#define QSPI_MATCH_MODE_OR             ((uint32_t)QUADSPI_CR_PMM) /*!<OR match mode between unmasked bits*/
+/**
+  * @}
+  */  
+
+/** @defgroup QSPI_AutomaticStop QSPI Automatic Stop
+  * @{
+  */
+#define QSPI_AUTOMATIC_STOP_DISABLE    ((uint32_t)0x00000000)      /*!<AutoPolling stops only with abort or QSPI disabling*/
+#define QSPI_AUTOMATIC_STOP_ENABLE     ((uint32_t)QUADSPI_CR_APMS) /*!<AutoPolling stops as soon as there is a match*/
+/**
+  * @}
+  */  
+
+/** @defgroup QSPI_TimeOutActivation QSPI Timeout Activation
+  * @{
+  */
+#define QSPI_TIMEOUT_COUNTER_DISABLE   ((uint32_t)0x00000000)      /*!<Timeout counter disabled, nCS remains active*/
+#define QSPI_TIMEOUT_COUNTER_ENABLE    ((uint32_t)QUADSPI_CR_TCEN) /*!<Timeout counter enabled, nCS released when timeout expires*/
+/**
+  * @}
+  */  
+
+/** @defgroup QSPI_Flags QSPI Flags
+  * @{
+  */
+#define QSPI_FLAG_BUSY                 QUADSPI_SR_BUSY /*!<Busy flag: operation is ongoing*/
+#define QSPI_FLAG_TO                   QUADSPI_SR_TOF  /*!<Timeout flag: timeout occurs in memory-mapped mode*/
+#define QSPI_FLAG_SM                   QUADSPI_SR_SMF  /*!<Status match flag: received data matches in autopolling mode*/
+#define QSPI_FLAG_FT                   QUADSPI_SR_FTF  /*!<Fifo threshold flag: Fifo threshold reached or data left after read from memory is complete*/
+#define QSPI_FLAG_TC                   QUADSPI_SR_TCF  /*!<Transfer complete flag: programmed number of data have been transferred or the transfer has been aborted*/
+#define QSPI_FLAG_TE                   QUADSPI_SR_TEF  /*!<Transfer error flag: invalid address is being accessed*/
+/**
+  * @}
+  */
+
+/** @defgroup QSPI_Interrupts QSPI Interrupts
+  * @{
+  */  
+#define QSPI_IT_TO                     QUADSPI_CR_TOIE /*!<Interrupt on the timeout flag*/
+#define QSPI_IT_SM                     QUADSPI_CR_SMIE /*!<Interrupt on the status match flag*/
+#define QSPI_IT_FT                     QUADSPI_CR_FTIE /*!<Interrupt on the fifo threshold flag*/
+#define QSPI_IT_TC                     QUADSPI_CR_TCIE /*!<Interrupt on the transfer complete flag*/
+#define QSPI_IT_TE                     QUADSPI_CR_TEIE /*!<Interrupt on the transfer error flag*/
+/**
+  * @}
+  */
+
+/** @defgroup QSPI_Timeout_definition QSPI Timeout definition
+  * @brief QSPI Timeout definition
+  * @{
+  */ 
+#define HAL_QPSI_TIMEOUT_DEFAULT_VALUE ((uint32_t)5000)/* 5 s */
+/**
+  * @}
+  */  
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup QSPI_Exported_Macros QSPI Exported Macros
+  * @{
+  */
+/** @brief Reset QSPI handle state.
+  * @param  __HANDLE__: QSPI handle.
+  * @retval None
+  */
+#define __HAL_QSPI_RESET_HANDLE_STATE(__HANDLE__)           ((__HANDLE__)->State = HAL_QSPI_STATE_RESET)
+
+/** @brief  Enable the QSPI peripheral.
+  * @param  __HANDLE__: specifies the QSPI Handle.
+  * @retval None
+  */ 
+#define __HAL_QSPI_ENABLE(__HANDLE__)                       SET_BIT((__HANDLE__)->Instance->CR, QUADSPI_CR_EN)
+
+/** @brief  Disable the QSPI peripheral.
+  * @param  __HANDLE__: specifies the QSPI Handle.
+  * @retval None
+  */
+#define __HAL_QSPI_DISABLE(__HANDLE__)                      CLEAR_BIT((__HANDLE__)->Instance->CR, QUADSPI_CR_EN)
+
+/** @brief  Enable the specified QSPI interrupt.
+  * @param  __HANDLE__: specifies the QSPI Handle.
+  * @param  __INTERRUPT__: specifies the QSPI interrupt source to enable.
+  *          This parameter can be one of the following values:
+  *            @arg QSPI_IT_TO: QSPI Timeout interrupt
+  *            @arg QSPI_IT_SM: QSPI Status match interrupt
+  *            @arg QSPI_IT_FT: QSPI FIFO threshold interrupt
+  *            @arg QSPI_IT_TC: QSPI Transfer complete interrupt
+  *            @arg QSPI_IT_TE: QSPI Transfer error interrupt
+  * @retval None
+  */
+#define __HAL_QSPI_ENABLE_IT(__HANDLE__, __INTERRUPT__)     SET_BIT((__HANDLE__)->Instance->CR, (__INTERRUPT__))
+
+
+/** @brief  Disable the specified QSPI interrupt.
+  * @param  __HANDLE__: specifies the QSPI Handle.
+  * @param  __INTERRUPT__: specifies the QSPI interrupt source to disable.
+  *          This parameter can be one of the following values:
+  *            @arg QSPI_IT_TO: QSPI Timeout interrupt
+  *            @arg QSPI_IT_SM: QSPI Status match interrupt
+  *            @arg QSPI_IT_FT: QSPI FIFO threshold interrupt
+  *            @arg QSPI_IT_TC: QSPI Transfer complete interrupt
+  *            @arg QSPI_IT_TE: QSPI Transfer error interrupt
+  * @retval None
+  */
+#define __HAL_QSPI_DISABLE_IT(__HANDLE__, __INTERRUPT__)    CLEAR_BIT((__HANDLE__)->Instance->CR, (__INTERRUPT__))
+
+/** @brief  Check whether the specified QSPI interrupt source is enabled or not.
+  * @param  __HANDLE__: specifies the QSPI Handle.
+  * @param  __INTERRUPT__: specifies the QSPI interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg QSPI_IT_TO: QSPI Timeout interrupt
+  *            @arg QSPI_IT_SM: QSPI Status match interrupt
+  *            @arg QSPI_IT_FT: QSPI FIFO threshold interrupt
+  *            @arg QSPI_IT_TC: QSPI Transfer complete interrupt
+  *            @arg QSPI_IT_TE: QSPI Transfer error interrupt
+  * @retval The new state of __INTERRUPT__ (TRUE or FALSE).
+  */
+#define __HAL_QSPI_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) (READ_BIT((__HANDLE__)->Instance->CR, (__INTERRUPT__)) == (__INTERRUPT__)) 
+
+/**
+  * @brief  Check whether the selected QSPI flag is set or not.
+  * @param  __HANDLE__: specifies the QSPI Handle.
+  * @param  __FLAG__: specifies the QSPI flag to check.
+  *          This parameter can be one of the following values:
+  *            @arg QSPI_FLAG_BUSY: QSPI Busy flag
+  *            @arg QSPI_FLAG_TO:   QSPI Timeout flag
+  *            @arg QSPI_FLAG_SM:   QSPI Status match flag
+  *            @arg QSPI_FLAG_FT:   QSPI FIFO threshold flag
+  *            @arg QSPI_FLAG_TC:   QSPI Transfer complete flag
+  *            @arg QSPI_FLAG_TE:   QSPI Transfer error flag
+  * @retval None
+  */
+#define __HAL_QSPI_GET_FLAG(__HANDLE__, __FLAG__)           (READ_BIT((__HANDLE__)->Instance->SR, (__FLAG__)) != 0)
+
+/** @brief  Clears the specified QSPI's flag status.
+  * @param  __HANDLE__: specifies the QSPI Handle.
+  * @param  __FLAG__: specifies the QSPI clear register flag that needs to be set
+  *          This parameter can be one of the following values:
+  *            @arg QSPI_FLAG_TO: QSPI Timeout flag
+  *            @arg QSPI_FLAG_SM: QSPI Status match flag
+  *            @arg QSPI_FLAG_TC: QSPI Transfer complete flag
+  *            @arg QSPI_FLAG_TE: QSPI Transfer error flag
+  * @retval None
+  */
+#define __HAL_QSPI_CLEAR_FLAG(__HANDLE__, __FLAG__)         WRITE_REG((__HANDLE__)->Instance->FCR, (__FLAG__))
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/  
+/** @addtogroup QSPI_Exported_Functions
+  * @{
+  */
+/* Initialization/de-initialization functions  ********************************/
+HAL_StatusTypeDef     HAL_QSPI_Init     (QSPI_HandleTypeDef *hqspi);
+HAL_StatusTypeDef     HAL_QSPI_DeInit   (QSPI_HandleTypeDef *hqspi);
+void                  HAL_QSPI_MspInit  (QSPI_HandleTypeDef *hqspi);
+void                  HAL_QSPI_MspDeInit(QSPI_HandleTypeDef *hqspi);
+
+/* IO operation functions *****************************************************/
+/* QSPI IRQ handler method */
+void                  HAL_QSPI_IRQHandler(QSPI_HandleTypeDef *hqspi);
+
+/* QSPI indirect mode */
+HAL_StatusTypeDef     HAL_QSPI_Command      (QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, uint32_t Timeout);
+HAL_StatusTypeDef     HAL_QSPI_Transmit     (QSPI_HandleTypeDef *hqspi, uint8_t *pData, uint32_t Timeout);
+HAL_StatusTypeDef     HAL_QSPI_Receive      (QSPI_HandleTypeDef *hqspi, uint8_t *pData, uint32_t Timeout);
+HAL_StatusTypeDef     HAL_QSPI_Command_IT   (QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd);
+HAL_StatusTypeDef     HAL_QSPI_Transmit_IT  (QSPI_HandleTypeDef *hqspi, uint8_t *pData);
+HAL_StatusTypeDef     HAL_QSPI_Receive_IT   (QSPI_HandleTypeDef *hqspi, uint8_t *pData);
+HAL_StatusTypeDef     HAL_QSPI_Transmit_DMA (QSPI_HandleTypeDef *hqspi, uint8_t *pData);
+HAL_StatusTypeDef     HAL_QSPI_Receive_DMA  (QSPI_HandleTypeDef *hqspi, uint8_t *pData);
+
+/* QSPI status flag polling mode */
+HAL_StatusTypeDef     HAL_QSPI_AutoPolling   (QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, QSPI_AutoPollingTypeDef *cfg, uint32_t Timeout);
+HAL_StatusTypeDef     HAL_QSPI_AutoPolling_IT(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, QSPI_AutoPollingTypeDef *cfg);
+
+/* QSPI memory-mapped mode */
+HAL_StatusTypeDef     HAL_QSPI_MemoryMapped(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, QSPI_MemoryMappedTypeDef *cfg);
+
+/* Callback functions in non-blocking modes ***********************************/
+void                  HAL_QSPI_ErrorCallback        (QSPI_HandleTypeDef *hqspi);
+void                  HAL_QSPI_FifoThresholdCallback(QSPI_HandleTypeDef *hqspi);
+
+/* QSPI indirect mode */
+void                  HAL_QSPI_CmdCpltCallback      (QSPI_HandleTypeDef *hqspi);
+void                  HAL_QSPI_RxCpltCallback       (QSPI_HandleTypeDef *hqspi);
+void                  HAL_QSPI_TxCpltCallback       (QSPI_HandleTypeDef *hqspi);
+void                  HAL_QSPI_RxHalfCpltCallback   (QSPI_HandleTypeDef *hqspi);
+void                  HAL_QSPI_TxHalfCpltCallback   (QSPI_HandleTypeDef *hqspi);
+
+/* QSPI status flag polling mode */
+void                  HAL_QSPI_StatusMatchCallback  (QSPI_HandleTypeDef *hqspi);
+
+/* QSPI memory-mapped mode */
+void                  HAL_QSPI_TimeOutCallback      (QSPI_HandleTypeDef *hqspi);
+
+/* Peripheral Control and State functions  ************************************/
+HAL_QSPI_StateTypeDef HAL_QSPI_GetState  (QSPI_HandleTypeDef *hqspi);
+uint32_t              HAL_QSPI_GetError  (QSPI_HandleTypeDef *hqspi);
+HAL_StatusTypeDef     HAL_QSPI_Abort     (QSPI_HandleTypeDef *hqspi);
+void                  HAL_QSPI_SetTimeout(QSPI_HandleTypeDef *hqspi, uint32_t Timeout);
+/**
+  * @}
+  */
+/* End of exported functions -------------------------------------------------*/  
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup QSPI_Private_Macros QSPI Private Macros
+* @{
+*/
+#define IS_QSPI_CLOCK_PRESCALER(PRESCALER) ((PRESCALER) <= 0xFF)
+
+#define IS_QSPI_FIFO_THRESHOLD(THR)        (((THR) > 0) && ((THR) <= 16))
+
+#define IS_QSPI_SSHIFT(SSHIFT)             (((SSHIFT) == QSPI_SAMPLE_SHIFTING_NONE) || \
+                                            ((SSHIFT) == QSPI_SAMPLE_SHIFTING_HALFCYCLE))
+
+#define IS_QSPI_FLASH_SIZE(FSIZE)          (((FSIZE) <= 31))
+
+#define IS_QSPI_CS_HIGH_TIME(CSHTIME)      (((CSHTIME) == QSPI_CS_HIGH_TIME_1_CYCLE) || \
+                                            ((CSHTIME) == QSPI_CS_HIGH_TIME_2_CYCLE) || \
+                                            ((CSHTIME) == QSPI_CS_HIGH_TIME_3_CYCLE) || \
+                                            ((CSHTIME) == QSPI_CS_HIGH_TIME_4_CYCLE) || \
+                                            ((CSHTIME) == QSPI_CS_HIGH_TIME_5_CYCLE) || \
+                                            ((CSHTIME) == QSPI_CS_HIGH_TIME_6_CYCLE) || \
+                                            ((CSHTIME) == QSPI_CS_HIGH_TIME_7_CYCLE) || \
+                                            ((CSHTIME) == QSPI_CS_HIGH_TIME_8_CYCLE))
+
+#define IS_QSPI_CLOCK_MODE(CLKMODE)        (((CLKMODE) == QSPI_CLOCK_MODE_0) || \
+                                            ((CLKMODE) == QSPI_CLOCK_MODE_3))
+
+#define IS_QSPI_INSTRUCTION(INSTRUCTION)   ((INSTRUCTION) <= 0xFF) 
+
+#define IS_QSPI_ADDRESS_SIZE(ADDR_SIZE)    (((ADDR_SIZE) == QSPI_ADDRESS_8_BITS)  || \
+                                            ((ADDR_SIZE) == QSPI_ADDRESS_16_BITS) || \
+                                            ((ADDR_SIZE) == QSPI_ADDRESS_24_BITS) || \
+                                            ((ADDR_SIZE) == QSPI_ADDRESS_32_BITS))
+
+#define IS_QSPI_ALTERNATE_BYTES_SIZE(SIZE) (((SIZE) == QSPI_ALTERNATE_BYTES_8_BITS)  || \
+                                            ((SIZE) == QSPI_ALTERNATE_BYTES_16_BITS) || \
+                                            ((SIZE) == QSPI_ALTERNATE_BYTES_24_BITS) || \
+                                            ((SIZE) == QSPI_ALTERNATE_BYTES_32_BITS))
+
+#define IS_QSPI_DUMMY_CYCLES(DCY)          ((DCY) <= 31) 
+
+#define IS_QSPI_INSTRUCTION_MODE(MODE)     (((MODE) == QSPI_INSTRUCTION_NONE)    || \
+                                            ((MODE) == QSPI_INSTRUCTION_1_LINE)  || \
+                                            ((MODE) == QSPI_INSTRUCTION_2_LINES) || \
+                                            ((MODE) == QSPI_INSTRUCTION_4_LINES))
+
+#define IS_QSPI_ADDRESS_MODE(MODE)         (((MODE) == QSPI_ADDRESS_NONE)    || \
+                                            ((MODE) == QSPI_ADDRESS_1_LINE)  || \
+                                            ((MODE) == QSPI_ADDRESS_2_LINES) || \
+                                            ((MODE) == QSPI_ADDRESS_4_LINES))
+
+#define IS_QSPI_ALTERNATE_BYTES_MODE(MODE) (((MODE) == QSPI_ALTERNATE_BYTES_NONE)    || \
+                                            ((MODE) == QSPI_ALTERNATE_BYTES_1_LINE)  || \
+                                            ((MODE) == QSPI_ALTERNATE_BYTES_2_LINES) || \
+                                            ((MODE) == QSPI_ALTERNATE_BYTES_4_LINES))
+
+#define IS_QSPI_DATA_MODE(MODE)            (((MODE) == QSPI_DATA_NONE)    || \
+                                            ((MODE) == QSPI_DATA_1_LINE)  || \
+                                            ((MODE) == QSPI_DATA_2_LINES) || \
+                                            ((MODE) == QSPI_DATA_4_LINES))
+
+#define IS_QSPI_DDR_MODE(DDR_MODE)         (((DDR_MODE) == QSPI_DDR_MODE_DISABLE) || \
+                                            ((DDR_MODE) == QSPI_DDR_MODE_ENABLE))
+
+#define IS_QSPI_DDR_HHC(DDR_HHC)           (((DDR_HHC) == QSPI_DDR_HHC_ANALOG_DELAY))
+
+#define IS_QSPI_SIOO_MODE(SIOO_MODE)       (((SIOO_MODE) == QSPI_SIOO_INST_EVERY_CMD) || \
+                                            ((SIOO_MODE) == QSPI_SIOO_INST_ONLY_FIRST_CMD))
+
+#define IS_QSPI_INTERVAL(INTERVAL)         ((INTERVAL) <= QUADSPI_PIR_INTERVAL) 
+
+#define IS_QSPI_STATUS_BYTES_SIZE(SIZE)    (((SIZE) >= 1) && ((SIZE) <= 4)) 
+
+#define IS_QSPI_MATCH_MODE(MODE)           (((MODE) == QSPI_MATCH_MODE_AND) || \
+                                            ((MODE) == QSPI_MATCH_MODE_OR)) 
+
+#define IS_QSPI_AUTOMATIC_STOP(APMS)       (((APMS) == QSPI_AUTOMATIC_STOP_DISABLE) || \
+                                            ((APMS) == QSPI_AUTOMATIC_STOP_ENABLE)) 
+
+#define IS_QSPI_TIMEOUT_ACTIVATION(TCEN)   (((TCEN) == QSPI_TIMEOUT_COUNTER_DISABLE) || \
+                                            ((TCEN) == QSPI_TIMEOUT_COUNTER_ENABLE)) 
+
+#define IS_QSPI_TIMEOUT_PERIOD(PERIOD)     ((PERIOD) <= 0xFFFF) 
+/**
+* @}
+*/ 
+/* End of private macros -----------------------------------------------------*/
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_QSPI_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_rcc.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_rcc.h
@@ -1,0 +1,3208 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_rcc.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of RCC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_RCC_H
+#define __STM32L4xx_HAL_RCC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RCC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup RCC_Exported_Types RCC Exported Types
+  * @{
+  */
+
+/**
+  * @brief  RCC PLL configuration structure definition
+  */
+typedef struct
+{
+  uint32_t PLLState;   /*!< The new state of the PLL.
+                            This parameter can be a value of @ref RCC_PLL_Config                      */
+
+  uint32_t PLLSource;  /*!< RCC_PLLSource: PLL entry clock source.
+                            This parameter must be a value of @ref RCC_PLL_Clock_Source               */
+
+  uint32_t PLLM;       /*!< PLLM: Division factor for PLL VCO input clock.
+                            This parameter must be a number between Min_Data = 0 and Max_Data = 8     */
+
+  uint32_t PLLN;       /*!< PLLN: Multiplication factor for PLL VCO output clock.
+                            This parameter must be a number between Min_Data = 8 and Max_Data = 86    */
+
+  uint32_t PLLP;       /*!< PLLP: Division factor for SAI clock.
+                            This parameter must be a value of @ref RCC_PLLP_Clock_Divider             */
+
+  uint32_t PLLQ;       /*!< PLLQ: Division factor for SDMMC1, RNG and USB clocks.
+                            This parameter must be a value of @ref RCC_PLLQ_Clock_Divider             */
+
+  uint32_t PLLR;       /*!< PLLR: Division for the main system clock.
+                            User have to set the PLLR parameter correctly to not exceed max frequency 80MHZ.
+                            This parameter must be a value of @ref RCC_PLLR_Clock_Divider             */
+
+}RCC_PLLInitTypeDef;
+
+/**
+  * @brief  RCC Internal/External Oscillator (HSE, HSI, MSI, LSE and LSI) configuration structure definition
+  */
+typedef struct
+{
+  uint32_t OscillatorType;       /*!< The oscillators to be configured.
+                                      This parameter can be a value of @ref RCC_Oscillator_Type                   */
+
+  uint32_t HSEState;             /*!< The new state of the HSE.
+                                      This parameter can be a value of @ref RCC_HSE_Config                        */
+
+  uint32_t LSEState;             /*!< The new state of the LSE.
+                                      This parameter can be a value of @ref RCC_LSE_Config                        */
+
+  uint32_t HSIState;             /*!< The new state of the HSI.
+                                      This parameter can be a value of @ref RCC_HSI_Config                        */
+
+  uint32_t HSICalibrationValue;  /*!< The calibration trimming value (default is RCC_HSICALIBRATION_DEFAULT).
+                                      This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x1F */
+
+  uint32_t LSIState;             /*!< The new state of the LSI.
+                                      This parameter can be a value of @ref RCC_LSI_Config                        */
+
+  uint32_t MSIState;             /*!< The new state of the MSI.
+                                      This parameter can be a value of @ref RCC_MSI_Config */
+
+  uint32_t MSICalibrationValue;  /*!< The calibration trimming value (default is RCC_MSICALIBRATION_DEFAULT).
+                                      This parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFF */
+
+  uint32_t MSIClockRange;        /*!< The MSI frequency range.
+                                      This parameter can be a value of @ref RCC_MSI_Clock_Range  */
+
+  RCC_PLLInitTypeDef PLL;        /*!< Main PLL structure parameters                                               */
+
+}RCC_OscInitTypeDef;
+
+/**
+  * @brief  RCC System, AHB and APB busses clock configuration structure definition
+  */
+typedef struct
+{
+  uint32_t ClockType;             /*!< The clock to be configured.
+                                       This parameter can be a value of @ref RCC_System_Clock_Type      */
+
+  uint32_t SYSCLKSource;          /*!< The clock source used as system clock (SYSCLK).
+                                       This parameter can be a value of @ref RCC_System_Clock_Source    */
+
+  uint32_t AHBCLKDivider;         /*!< The AHB clock (HCLK) divider. This clock is derived from the system clock (SYSCLK).
+                                       This parameter can be a value of @ref RCC_AHB_Clock_Source       */
+
+  uint32_t APB1CLKDivider;        /*!< The APB1 clock (PCLK1) divider. This clock is derived from the AHB clock (HCLK).
+                                       This parameter can be a value of @ref RCC_APB1_APB2_Clock_Source */
+
+  uint32_t APB2CLKDivider;        /*!< The APB2 clock (PCLK2) divider. This clock is derived from the AHB clock (HCLK).
+                                       This parameter can be a value of @ref RCC_APB1_APB2_Clock_Source */
+
+}RCC_ClkInitTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RCC_Exported_Constants RCC Exported Constants
+  * @{
+  */
+
+/** @defgroup RCC_Timeout_Value Timeout Values
+  * @{
+  */
+#define RCC_DBP_TIMEOUT_VALUE          ((uint32_t)2U)    /* 2 ms (minimum Tick + 1) */
+#define RCC_LSE_TIMEOUT_VALUE          LSE_STARTUP_TIMEOUT
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Oscillator_Type Oscillator Type
+  * @{
+  */
+#define RCC_OSCILLATORTYPE_NONE        ((uint32_t)0x00000000U)   /*!< Oscillator configuration unchanged */
+#define RCC_OSCILLATORTYPE_HSE         ((uint32_t)0x00000001U)   /*!< HSE to configure */
+#define RCC_OSCILLATORTYPE_HSI         ((uint32_t)0x00000002U)   /*!< HSI to configure */
+#define RCC_OSCILLATORTYPE_LSE         ((uint32_t)0x00000004U)   /*!< LSE to configure */
+#define RCC_OSCILLATORTYPE_LSI         ((uint32_t)0x00000008U)   /*!< LSI to configure */
+#define RCC_OSCILLATORTYPE_MSI         ((uint32_t)0x00000010U)   /*!< MSI to configure */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_HSE_Config HSE Config
+  * @{
+  */
+#define RCC_HSE_OFF                    ((uint32_t)0x00000000U)                     /*!< HSE clock deactivation */
+#define RCC_HSE_ON                     RCC_CR_HSEON                               /*!< HSE clock activation */
+#define RCC_HSE_BYPASS                 ((uint32_t)(RCC_CR_HSEBYP | RCC_CR_HSEON)) /*!< External clock source for HSE clock */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_LSE_Config LSE Config
+  * @{
+  */
+#define RCC_LSE_OFF                    ((uint32_t)0x00000000U)                         /*!< LSE clock deactivation */
+#define RCC_LSE_ON                     RCC_BDCR_LSEON                                 /*!< LSE clock activation */
+#define RCC_LSE_BYPASS                 ((uint32_t)(RCC_BDCR_LSEBYP | RCC_BDCR_LSEON)) /*!< External clock source for LSE clock */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_HSI_Config HSI Config
+  * @{
+  */
+#define RCC_HSI_OFF                    ((uint32_t)0x00000000U) /*!< HSI clock deactivation */
+#define RCC_HSI_ON                     RCC_CR_HSION           /*!< HSI clock activation */
+
+#define RCC_HSICALIBRATION_DEFAULT     ((uint32_t)16)   /*!< Default HSI calibration trimming value */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_LSI_Config LSI Config
+  * @{
+  */
+#define RCC_LSI_OFF                    ((uint32_t)0x00000000U) /*!< LSI clock deactivation */
+#define RCC_LSI_ON                     RCC_CSR_LSION          /*!< LSI clock activation */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_MSI_Config MSI Config
+  * @{
+  */
+#define RCC_MSI_OFF                    ((uint32_t)0x00000000U) /*!< MSI clock deactivation */
+#define RCC_MSI_ON                     RCC_CR_MSION           /*!< MSI clock activation */
+
+#define RCC_MSICALIBRATION_DEFAULT     ((uint32_t)0)   /*!< Default MSI calibration trimming value */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLL_Config PLL Config
+  * @{
+  */
+#define RCC_PLL_NONE                   ((uint32_t)0x00000000U) /*!< PLL configuration unchanged */
+#define RCC_PLL_OFF                    ((uint32_t)0x00000001U) /*!< PLL deactivation */
+#define RCC_PLL_ON                     ((uint32_t)0x00000002U) /*!< PLL activation */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLLP_Clock_Divider PLLP Clock Divider
+  * @{
+  */
+#define RCC_PLLP_DIV7                  ((uint32_t)0x00000007U) /*!< PLLP division factor = 7  */
+#define RCC_PLLP_DIV17                 ((uint32_t)0x00000011U) /*!< PLLP division factor = 17 */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLLQ_Clock_Divider PLLQ Clock Divider
+  * @{
+  */
+#define RCC_PLLQ_DIV2                  ((uint32_t)0x00000002U) /*!< PLLQ division factor = 2 */
+#define RCC_PLLQ_DIV4                  ((uint32_t)0x00000004U) /*!< PLLQ division factor = 4 */
+#define RCC_PLLQ_DIV6                  ((uint32_t)0x00000006U) /*!< PLLQ division factor = 6 */
+#define RCC_PLLQ_DIV8                  ((uint32_t)0x00000008U) /*!< PLLQ division factor = 8 */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLLR_Clock_Divider PLLR Clock Divider
+  * @{
+  */
+#define RCC_PLLR_DIV2                  ((uint32_t)0x00000002U) /*!< PLLR division factor = 2 */
+#define RCC_PLLR_DIV4                  ((uint32_t)0x00000004U) /*!< PLLR division factor = 4 */
+#define RCC_PLLR_DIV6                  ((uint32_t)0x00000006U) /*!< PLLR division factor = 6 */
+#define RCC_PLLR_DIV8                  ((uint32_t)0x00000008U) /*!< PLLR division factor = 8 */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLL_Clock_Source PLL Clock Source
+  * @{
+  */
+#define RCC_PLLSOURCE_NONE             ((uint32_t)0x00000000U)  /*!< No clock selected as PLL entry clock source  */
+#define RCC_PLLSOURCE_MSI              RCC_PLLCFGR_PLLSRC_MSI  /*!< MSI clock selected as PLL entry clock source */
+#define RCC_PLLSOURCE_HSI              RCC_PLLCFGR_PLLSRC_HSI  /*!< HSI clock selected as PLL entry clock source */
+#define RCC_PLLSOURCE_HSE              RCC_PLLCFGR_PLLSRC_HSE  /*!< HSE clock selected as PLL entry clock source */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLL_Clock_Output PLL Clock Output
+  * @{
+  */
+#define RCC_PLL_SAI3CLK                RCC_PLLCFGR_PLLPEN      /*!< PLLSAI3CLK selection from main PLL */
+#define RCC_PLL_48M1CLK                RCC_PLLCFGR_PLLQEN      /*!< PLL48M1CLK selection from main PLL */
+#define RCC_PLL_SYSCLK                 RCC_PLLCFGR_PLLREN      /*!< PLLCLK selection from main PLL */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLLSAI1_Clock_Output PLLSAI1 Clock Output
+  * @{
+  */
+#define RCC_PLLSAI1_SAI1CLK            RCC_PLLSAI1CFGR_PLLSAI1PEN /*!< PLLSAI1CLK selection from PLLSAI1 */
+#define RCC_PLLSAI1_48M2CLK            RCC_PLLSAI1CFGR_PLLSAI1QEN /*!< PLL48M2CLK selection from PLLSAI1 */
+#define RCC_PLLSAI1_ADC1CLK            RCC_PLLSAI1CFGR_PLLSAI1REN /*!< PLLADC1CLK selection from PLLSAI1 */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLLSAI2_Clock_Output PLLSAI2 Clock Output
+  * @{
+  */
+#define RCC_PLLSAI2_SAI2CLK            RCC_PLLSAI2CFGR_PLLSAI2PEN /*!< PLLSAI2CLK selection from PLLSAI2 */
+#define RCC_PLLSAI2_ADC2CLK            RCC_PLLSAI2CFGR_PLLSAI2REN /*!< PLLADC2CLK selection from PLLSAI2 */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_MSI_Clock_Range MSI Clock Range
+  * @{
+  */
+#define RCC_MSIRANGE_0                 RCC_CR_MSIRANGE_0  /*!< MSI = 100 KHz  */
+#define RCC_MSIRANGE_1                 RCC_CR_MSIRANGE_1  /*!< MSI = 200 KHz  */
+#define RCC_MSIRANGE_2                 RCC_CR_MSIRANGE_2  /*!< MSI = 400 KHz  */
+#define RCC_MSIRANGE_3                 RCC_CR_MSIRANGE_3  /*!< MSI = 800 KHz  */
+#define RCC_MSIRANGE_4                 RCC_CR_MSIRANGE_4  /*!< MSI = 1 MHz    */
+#define RCC_MSIRANGE_5                 RCC_CR_MSIRANGE_5  /*!< MSI = 2 MHz    */
+#define RCC_MSIRANGE_6                 RCC_CR_MSIRANGE_6  /*!< MSI = 4 MHz    */
+#define RCC_MSIRANGE_7                 RCC_CR_MSIRANGE_7  /*!< MSI = 8 MHz    */
+#define RCC_MSIRANGE_8                 RCC_CR_MSIRANGE_8  /*!< MSI = 16 MHz   */
+#define RCC_MSIRANGE_9                 RCC_CR_MSIRANGE_9  /*!< MSI = 24 MHz   */
+#define RCC_MSIRANGE_10                RCC_CR_MSIRANGE_10 /*!< MSI = 32 MHz   */
+#define RCC_MSIRANGE_11                RCC_CR_MSIRANGE_11 /*!< MSI = 48 MHz   */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_System_Clock_Type System Clock Type
+  * @{
+  */
+#define RCC_CLOCKTYPE_SYSCLK           ((uint32_t)0x00000001U)  /*!< SYSCLK to configure */
+#define RCC_CLOCKTYPE_HCLK             ((uint32_t)0x00000002U)  /*!< HCLK to configure */
+#define RCC_CLOCKTYPE_PCLK1            ((uint32_t)0x00000004U)  /*!< PCLK1 to configure */
+#define RCC_CLOCKTYPE_PCLK2            ((uint32_t)0x00000008U)  /*!< PCLK2 to configure */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_System_Clock_Source System Clock Source
+  * @{
+  */
+#define RCC_SYSCLKSOURCE_MSI           RCC_CFGR_SW_MSI    /*!< MSI selection as system clock */
+#define RCC_SYSCLKSOURCE_HSI           RCC_CFGR_SW_HSI    /*!< HSI selection as system clock */
+#define RCC_SYSCLKSOURCE_HSE           RCC_CFGR_SW_HSE    /*!< HSE selection as system clock */
+#define RCC_SYSCLKSOURCE_PLLCLK        RCC_CFGR_SW_PLL    /*!< PLL selection as system clock */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_System_Clock_Source_Status System Clock Source Status
+  * @{
+  */
+#define RCC_SYSCLKSOURCE_STATUS_MSI    RCC_CFGR_SWS_MSI   /*!< MSI used as system clock */
+#define RCC_SYSCLKSOURCE_STATUS_HSI    RCC_CFGR_SWS_HSI   /*!< HSI used as system clock */
+#define RCC_SYSCLKSOURCE_STATUS_HSE    RCC_CFGR_SWS_HSE   /*!< HSE used as system clock */
+#define RCC_SYSCLKSOURCE_STATUS_PLLCLK RCC_CFGR_SWS_PLL   /*!< PLL used as system clock */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB_Clock_Source AHB Clock Source
+  * @{
+  */
+#define RCC_SYSCLK_DIV1                RCC_CFGR_HPRE_DIV1   /*!< SYSCLK not divided */
+#define RCC_SYSCLK_DIV2                RCC_CFGR_HPRE_DIV2   /*!< SYSCLK divided by 2 */
+#define RCC_SYSCLK_DIV4                RCC_CFGR_HPRE_DIV4   /*!< SYSCLK divided by 4 */
+#define RCC_SYSCLK_DIV8                RCC_CFGR_HPRE_DIV8   /*!< SYSCLK divided by 8 */
+#define RCC_SYSCLK_DIV16               RCC_CFGR_HPRE_DIV16  /*!< SYSCLK divided by 16 */
+#define RCC_SYSCLK_DIV64               RCC_CFGR_HPRE_DIV64  /*!< SYSCLK divided by 64 */
+#define RCC_SYSCLK_DIV128              RCC_CFGR_HPRE_DIV128 /*!< SYSCLK divided by 128 */
+#define RCC_SYSCLK_DIV256              RCC_CFGR_HPRE_DIV256 /*!< SYSCLK divided by 256 */
+#define RCC_SYSCLK_DIV512              RCC_CFGR_HPRE_DIV512 /*!< SYSCLK divided by 512 */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB1_APB2_Clock_Source APB1 APB2 Clock Source
+  * @{
+  */
+#define RCC_HCLK_DIV1                  RCC_CFGR_PPRE1_DIV1  /*!< HCLK not divided */
+#define RCC_HCLK_DIV2                  RCC_CFGR_PPRE1_DIV2  /*!< HCLK divided by 2 */
+#define RCC_HCLK_DIV4                  RCC_CFGR_PPRE1_DIV4  /*!< HCLK divided by 4 */
+#define RCC_HCLK_DIV8                  RCC_CFGR_PPRE1_DIV8  /*!< HCLK divided by 8 */
+#define RCC_HCLK_DIV16                 RCC_CFGR_PPRE1_DIV16 /*!< HCLK divided by 16 */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_RTC_Clock_Source RTC Clock Source
+  * @{
+  */
+#define RCC_RTCCLKSOURCE_LSE           RCC_BDCR_RTCSEL_0  /*!< LSE oscillator clock used as RTC clock */
+#define RCC_RTCCLKSOURCE_LSI           RCC_BDCR_RTCSEL_1  /*!< LSI oscillator clock used as RTC clock */
+#define RCC_RTCCLKSOURCE_HSE_DIV32     RCC_BDCR_RTCSEL    /*!< HSE oscillator clock divided by 32 used as RTC clock */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_MCO_Index MCO Index
+  * @{
+  */
+#define RCC_MCO1                       ((uint32_t)0x00000000U)
+#define RCC_MCO                        RCC_MCO1               /*!< MCO1 to be compliant with other families with 2 MCOs*/
+/**
+  * @}
+  */
+
+/** @defgroup RCC_MCO1_Clock_Source MCO1 Clock Source
+  * @{
+  */
+#define RCC_MCO1SOURCE_NOCLOCK         ((uint32_t)0x00000000U)                 /*!< MCO1 output disabled, no clock on MCO1 */
+#define RCC_MCO1SOURCE_SYSCLK          RCC_CFGR_MCOSEL_0                      /*!< SYSCLK selection as MCO1 source */
+#define RCC_MCO1SOURCE_MSI             RCC_CFGR_MCOSEL_1                      /*!< MSI selection as MCO1 source */
+#define RCC_MCO1SOURCE_HSI             (RCC_CFGR_MCOSEL_0| RCC_CFGR_MCOSEL_1) /*!< HSI selection as MCO1 source */
+#define RCC_MCO1SOURCE_HSE             RCC_CFGR_MCOSEL_2                      /*!< HSE selection as MCO1 source */
+#define RCC_MCO1SOURCE_PLLCLK          (RCC_CFGR_MCOSEL_0|RCC_CFGR_MCOSEL_2)  /*!< PLLCLK selection as MCO1 source */
+#define RCC_MCO1SOURCE_LSI             (RCC_CFGR_MCOSEL_1|RCC_CFGR_MCOSEL_2)  /*!< LSI selection as MCO1 source */
+#define RCC_MCO1SOURCE_LSE             (RCC_CFGR_MCOSEL_0|RCC_CFGR_MCOSEL_1|RCC_CFGR_MCOSEL_2) /*!< LSE selection as MCO1 source */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_MCOx_Clock_Prescaler MCO1 Clock Prescaler
+  * @{
+  */
+#define RCC_MCODIV_1                   RCC_CFGR_MCOPRE_DIV1     /*!< MCO not divided  */      
+#define RCC_MCODIV_2                   RCC_CFGR_MCOPRE_DIV2     /*!< MCO divided by 2 */
+#define RCC_MCODIV_4                   RCC_CFGR_MCOPRE_DIV4     /*!< MCO divided by 4 */
+#define RCC_MCODIV_8                   RCC_CFGR_MCOPRE_DIV8     /*!< MCO divided by 8 */
+#define RCC_MCODIV_16                  RCC_CFGR_MCOPRE_DIV16    /*!< MCO divided by 16 */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Interrupt Interrupts
+  * @{
+  */
+#define RCC_IT_LSIRDY                  RCC_CIFR_LSIRDYF      /*!< LSI Ready Interrupt flag */
+#define RCC_IT_LSERDY                  RCC_CIFR_LSERDYF      /*!< LSE Ready Interrupt flag */
+#define RCC_IT_MSIRDY                  RCC_CIFR_MSIRDYF      /*!< MSI Ready Interrupt flag */
+#define RCC_IT_HSIRDY                  RCC_CIFR_HSIRDYF      /*!< HSI16 Ready Interrupt flag */
+#define RCC_IT_HSERDY                  RCC_CIFR_HSERDYF      /*!< HSE Ready Interrupt flag */
+#define RCC_IT_PLLRDY                  RCC_CIFR_PLLRDYF      /*!< PLL Ready Interrupt flag */
+#define RCC_IT_PLLSAI1RDY              RCC_CIFR_PLLSAI1RDYF  /*!< PLLSAI1 Ready Interrupt flag */
+#define RCC_IT_PLLSAI2RDY              RCC_CIFR_PLLSAI2RDYF  /*!< PLLSAI2 Ready Interrupt flag */
+#define RCC_IT_CSS                     RCC_CIFR_CSSF        /*!< Clock Security System Interrupt flag */
+#define RCC_IT_LSECSS                  RCC_CIFR_LSECSSF     /*!< LSE Clock Security System Interrupt flag */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Flag Flags
+  *        Elements values convention: XXXYYYYYb
+  *           - YYYYY  : Flag position in the register
+  *           - XXX  : Register index
+  *                 - 001: CR register
+  *                 - 010: BDCR register
+  *                 - 011: CSR register
+  * @{
+  */
+/* Flags in the CR register */
+#define RCC_FLAG_MSIRDY                ((uint32_t)((CR_REG_INDEX << 5U) | POSITION_VAL(RCC_CR_MSIRDY))) /*!< MSI Ready flag */
+#define RCC_FLAG_HSIRDY                ((uint32_t)((CR_REG_INDEX << 5U) | POSITION_VAL(RCC_CR_HSIRDY))) /*!< HSI Ready flag */
+#define RCC_FLAG_HSERDY                ((uint32_t)((CR_REG_INDEX << 5U) | POSITION_VAL(RCC_CR_HSERDY))) /*!< HSE Ready flag */
+#define RCC_FLAG_PLLRDY                ((uint32_t)((CR_REG_INDEX << 5U) | POSITION_VAL(RCC_CR_PLLRDY))) /*!< PLL Ready flag */
+#define RCC_FLAG_PLLSAI1RDY            ((uint32_t)((CR_REG_INDEX << 5U) | POSITION_VAL(RCC_CR_PLLSAI1RDY))) /*!< PLLSAI1 Ready flag */
+#define RCC_FLAG_PLLSAI2RDY            ((uint32_t)((CR_REG_INDEX << 5U) | POSITION_VAL(RCC_CR_PLLSAI2RDY))) /*!< PLLSAI2 Ready flag */
+
+/* Flags in the BDCR register */
+#define RCC_FLAG_LSERDY                ((uint32_t)((BDCR_REG_INDEX << 5U) | POSITION_VAL(RCC_BDCR_LSERDY))) /*!< LSE Ready flag */
+#define RCC_FLAG_LSECSSD               ((uint32_t)((BDCR_REG_INDEX << 5U) | POSITION_VAL(RCC_BDCR_LSECSSD))) /*!< LSE Clock Security System Interrupt flag */
+
+/* Flags in the CSR register */
+#define RCC_FLAG_LSIRDY                ((uint32_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_LSIRDY)))   /*!< LSI Ready flag */
+#define RCC_FLAG_RMVF                  ((uint32_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_RMVF)))     /*!< Remove reset flag */
+#define RCC_FLAG_FWRST                 ((uint32_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_FWRSTF)))   /*!< Firewall reset flag */
+#define RCC_FLAG_OBLRST                ((uint32_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_OBLRSTF)))  /*!< Option Byte Loader reset flag */
+#define RCC_FLAG_PINRST                ((uint32_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_PINRSTF)))  /*!< PIN reset flag */
+#define RCC_FLAG_BORRST                ((uint32_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_BORRSTF)))  /*!< BOR reset flag */
+#define RCC_FLAG_SFTRST                ((uint32_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_SFTRSTF)))  /*!< Software Reset flag */
+#define RCC_FLAG_IWDGRST               ((uint32_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_IWDGRSTF))) /*!< Independent Watchdog reset flag */
+#define RCC_FLAG_WWDGRST               ((uint32_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_WWDGRSTF))) /*!< Window watchdog reset flag */
+#define RCC_FLAG_LPWRRST               ((uint32_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_LPWRRSTF))) /*!< Low-Power reset flag */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_LSEDrive_Config LSE Drive Config
+  * @{
+  */
+#define RCC_LSEDRIVE_LOW                 ((uint32_t)0x00000000U) /*!< LSE low drive capability */
+#define RCC_LSEDRIVE_MEDIUMLOW           RCC_BDCR_LSEDRV_0      /*!< LSE medium low drive capability */
+#define RCC_LSEDRIVE_MEDIUMHIGH          RCC_BDCR_LSEDRV_1      /*!< LSE medium high drive capability */ 
+#define RCC_LSEDRIVE_HIGH                RCC_BDCR_LSEDRV        /*!< LSE high drive capability */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Stop_WakeUpClock Wake-Up from STOP Clock 
+  * @{
+  */
+#define RCC_STOP_WAKEUPCLOCK_MSI       ((uint32_t)0x00000000U)  /*!< MSI selection after wake-up from STOP */
+#define RCC_STOP_WAKEUPCLOCK_HSI       RCC_CFGR_STOPWUCK       /*!< HSI selection after wake-up from STOP */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+
+/** @defgroup RCC_Exported_Macros RCC Exported Macros
+  * @{
+  */
+
+/** @defgroup RCC_AHB1_Peripheral_Clock_Enable_Disable AHB1 Peripheral Clock Enable Disable
+  * @brief  Enable or disable the AHB1 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+
+#define __HAL_RCC_DMA1_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA1EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA1EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_DMA2_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA2EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA2EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_FLASH_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_FLASHEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_FLASHEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_CRC_CLK_ENABLE()             do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_CRCEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_CRCEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_TSC_CLK_ENABLE()             do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB1ENR, RCC_AHB1ENR_TSCEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_TSCEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_DMA1_CLK_DISABLE()           CLEAR_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA1EN)
+
+#define __HAL_RCC_DMA2_CLK_DISABLE()           CLEAR_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA2EN)
+
+#define __HAL_RCC_FLASH_CLK_DISABLE()          CLEAR_BIT(RCC->AHB1ENR, RCC_AHB1ENR_FLASHEN)
+
+#define __HAL_RCC_CRC_CLK_DISABLE()            CLEAR_BIT(RCC->AHB1ENR, RCC_AHB1ENR_CRCEN)
+
+#define __HAL_RCC_TSC_CLK_DISABLE()            CLEAR_BIT(RCC->AHB1ENR, RCC_AHB1ENR_TSCEN)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB2_Peripheral_Clock_Enable_Disable AHB2 Peripheral Clock Enable Disable
+  * @brief  Enable or disable the AHB2 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+
+#define __HAL_RCC_GPIOA_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOAEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOAEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_GPIOB_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOBEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOBEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_GPIOC_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOCEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOCEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_GPIOD_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIODEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIODEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_GPIOE_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOEEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOEEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_GPIOF_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOFEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOFEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_GPIOG_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOGEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOGEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_GPIOH_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOHEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOHEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#if defined(USB_OTG_FS)
+#define __HAL_RCC_USB_OTG_FS_CLK_ENABLE()      do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_OTGFSEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_OTGFSEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+#endif /* USB_OTG_FS */
+
+#define __HAL_RCC_ADC_CLK_ENABLE()             do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_ADCEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_ADCEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#if defined(AES)
+#define __HAL_RCC_AES_CLK_ENABLE()             do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_AESEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_AESEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+#endif /* AES */
+
+#define __HAL_RCC_RNG_CLK_ENABLE()             do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB2ENR, RCC_AHB2ENR_RNGEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_RNGEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_GPIOA_CLK_DISABLE()          CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOAEN)
+
+#define __HAL_RCC_GPIOB_CLK_DISABLE()          CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOBEN)
+
+#define __HAL_RCC_GPIOC_CLK_DISABLE()          CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOCEN)
+
+#define __HAL_RCC_GPIOD_CLK_DISABLE()          CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIODEN)
+
+#define __HAL_RCC_GPIOE_CLK_DISABLE()          CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOEEN)
+
+#define __HAL_RCC_GPIOF_CLK_DISABLE()          CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOFEN)
+
+#define __HAL_RCC_GPIOG_CLK_DISABLE()          CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOGEN)
+
+#define __HAL_RCC_GPIOH_CLK_DISABLE()          CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOHEN)
+
+#if defined(USB_OTG_FS)
+#define __HAL_RCC_USB_OTG_FS_CLK_DISABLE()     CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_OTGFSEN);
+#endif /* USB_OTG_FS */
+
+#define __HAL_RCC_ADC_CLK_DISABLE()            CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_ADCEN)
+
+#if defined(AES)
+#define __HAL_RCC_AES_CLK_DISABLE()            CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_AESEN);
+#endif /* AES */
+
+#define __HAL_RCC_RNG_CLK_DISABLE()            CLEAR_BIT(RCC->AHB2ENR, RCC_AHB2ENR_RNGEN)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB3_Clock_Enable_Disable AHB3 Peripheral Clock Enable Disable
+  * @brief  Enable or disable the AHB3 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+
+#define __HAL_RCC_FMC_CLK_ENABLE()             do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB3ENR, RCC_AHB3ENR_FMCEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB3ENR, RCC_AHB3ENR_FMCEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_QSPI_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHB3ENR, RCC_AHB3ENR_QSPIEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHB3ENR, RCC_AHB3ENR_QSPIEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_FMC_CLK_DISABLE()            CLEAR_BIT(RCC->AHB3ENR, RCC_AHB3ENR_FMCEN)
+
+#define __HAL_RCC_QSPI_CLK_DISABLE()           CLEAR_BIT(RCC->AHB3ENR, RCC_AHB3ENR_QSPIEN)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB1_Clock_Enable_Disable APB1 Peripheral Clock Enable Disable
+  * @brief  Enable or disable the APB1 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+
+#define __HAL_RCC_TIM2_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM2EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM2EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_TIM3_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM3EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM3EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_TIM4_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM4EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM4EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_TIM5_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM5EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM5EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_TIM6_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM6EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM6EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_TIM7_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM7EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM7EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#if defined(LCD)
+#define __HAL_RCC_LCD_CLK_ENABLE()             do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_LCDEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_LCDEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+#endif /* LCD */
+
+#define __HAL_RCC_WWDG_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_WWDGEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_WWDGEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_SPI2_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_SPI2EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_SPI2EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_SPI3_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_SPI3EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_SPI3EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_USART2_CLK_ENABLE()          do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_USART2EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_USART2EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_USART3_CLK_ENABLE()          do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_USART3EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_USART3EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_UART4_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_UART4EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_UART4EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_UART5_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_UART5EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_UART5EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_I2C1_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C1EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C1EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_I2C2_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C2EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C2EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_I2C3_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C3EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C3EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_CAN1_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_CAN1EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_CAN1EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_PWR_CLK_ENABLE()             do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_PWREN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_PWREN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_DAC1_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_DAC1EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_DAC1EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_OPAMP_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_OPAMPEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_OPAMPEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_LPTIM1_CLK_ENABLE()          do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR1, RCC_APB1ENR1_LPTIM1EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_LPTIM1EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_LPUART1_CLK_ENABLE()         do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR2, RCC_APB1ENR2_LPUART1EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR2, RCC_APB1ENR2_LPUART1EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_SWPMI1_CLK_ENABLE()          do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR2, RCC_APB1ENR2_SWPMI1EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR2, RCC_APB1ENR2_SWPMI1EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_LPTIM2_CLK_ENABLE()          do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB1ENR2, RCC_APB1ENR2_LPTIM2EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB1ENR2, RCC_APB1ENR2_LPTIM2EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_TIM2_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM2EN)
+
+#define __HAL_RCC_TIM3_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM3EN)
+
+#define __HAL_RCC_TIM4_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM4EN)
+
+#define __HAL_RCC_TIM5_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM5EN)
+
+#define __HAL_RCC_TIM6_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM6EN)
+
+#define __HAL_RCC_TIM7_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM7EN)
+
+#if defined(LCD)
+#define __HAL_RCC_LCD_CLK_DISABLE()            CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_LCDEN);
+#endif /* LCD */
+
+#define __HAL_RCC_SPI2_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_SPI2EN)
+
+#define __HAL_RCC_SPI3_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_SPI3EN)
+
+#define __HAL_RCC_USART2_CLK_DISABLE()         CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_USART2EN)
+
+#define __HAL_RCC_USART3_CLK_DISABLE()         CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_USART3EN)
+
+#define __HAL_RCC_UART4_CLK_DISABLE()          CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_UART4EN)
+
+#define __HAL_RCC_UART5_CLK_DISABLE()          CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_UART5EN)
+
+#define __HAL_RCC_I2C1_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C1EN)
+
+#define __HAL_RCC_I2C2_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C2EN)
+
+#define __HAL_RCC_I2C3_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C3EN)
+
+#define __HAL_RCC_CAN1_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_CAN1EN)
+
+#define __HAL_RCC_PWR_CLK_DISABLE()            CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_PWREN)
+
+#define __HAL_RCC_DAC1_CLK_DISABLE()           CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_DAC1EN)
+
+#define __HAL_RCC_OPAMP_CLK_DISABLE()          CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_OPAMPEN)
+
+#define __HAL_RCC_LPTIM1_CLK_DISABLE()         CLEAR_BIT(RCC->APB1ENR1, RCC_APB1ENR1_LPTIM1EN)
+
+#define __HAL_RCC_LPUART1_CLK_DISABLE()        CLEAR_BIT(RCC->APB1ENR2, RCC_APB1ENR2_LPUART1EN)
+
+#define __HAL_RCC_SWPMI1_CLK_DISABLE()         CLEAR_BIT(RCC->APB1ENR2, RCC_APB1ENR2_SWPMI1EN)
+
+#define __HAL_RCC_LPTIM2_CLK_DISABLE()         CLEAR_BIT(RCC->APB1ENR2, RCC_APB1ENR2_LPTIM2EN)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB2_Clock_Enable_Disable APB2 Peripheral Clock Enable Disable
+  * @brief  Enable or disable the APB2 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+
+#define __HAL_RCC_SYSCFG_CLK_ENABLE()          do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SYSCFGEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SYSCFGEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_FIREWALL_CLK_ENABLE()        do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_FWEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_FWEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_SDMMC1_CLK_ENABLE()          do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SDMMC1EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SDMMC1EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_TIM1_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM1EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM1EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_SPI1_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_TIM8_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM8EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM8EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_USART1_CLK_ENABLE()          do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+
+#define __HAL_RCC_TIM15_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM15EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM15EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_TIM16_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_TIM17_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM17EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM17EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_SAI1_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI1EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI1EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_SAI2_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI2EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI2EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_DFSDM_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APB2ENR, RCC_APB2ENR_DFSDMEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_DFSDMEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+
+#define __HAL_RCC_SYSCFG_CLK_DISABLE()         CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_SYSCFGEN)
+
+#define __HAL_RCC_SDMMC1_CLK_DISABLE()         CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_SDMMC1EN)
+
+#define __HAL_RCC_TIM1_CLK_DISABLE()           CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM1EN)
+
+#define __HAL_RCC_SPI1_CLK_DISABLE()           CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN)
+
+#define __HAL_RCC_TIM8_CLK_DISABLE()           CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM8EN)
+
+#define __HAL_RCC_USART1_CLK_DISABLE()         CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN)
+
+#define __HAL_RCC_TIM15_CLK_DISABLE()          CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM15EN)
+
+#define __HAL_RCC_TIM16_CLK_DISABLE()          CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN)
+
+#define __HAL_RCC_TIM17_CLK_DISABLE()          CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM17EN)
+
+#define __HAL_RCC_SAI1_CLK_DISABLE()           CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI1EN)
+
+#define __HAL_RCC_SAI2_CLK_DISABLE()           CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI2EN)
+
+#define __HAL_RCC_DFSDM_CLK_DISABLE()          CLEAR_BIT(RCC->APB2ENR, RCC_APB2ENR_DFSDMEN)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB1_Peripheral_Clock_Enable_Disable_Status AHB1 Peripheral Clock Enabled or Disabled Status
+  * @brief  Check whether the AHB1 peripheral clock is enabled or not.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+
+#define __HAL_RCC_DMA1_IS_CLK_ENABLED()        (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA1EN) != RESET)
+
+#define __HAL_RCC_DMA2_IS_CLK_ENABLED()        (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA2EN) != RESET)
+
+#define __HAL_RCC_FLASH_IS_CLK_ENABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_FLASHEN) != RESET)
+
+#define __HAL_RCC_CRC_IS_CLK_ENABLED()         (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_CRCEN) != RESET)
+
+#define __HAL_RCC_TSC_IS_CLK_ENABLED()         (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_TSCEN) != RESET)
+
+#define __HAL_RCC_DMA1_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA1EN) == RESET)
+
+#define __HAL_RCC_DMA2_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_DMA2EN) == RESET)
+
+#define __HAL_RCC_FLASH_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_FLASHEN) == RESET)
+
+#define __HAL_RCC_CRC_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_CRCEN) == RESET)
+
+#define __HAL_RCC_TSC_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB1ENR, RCC_AHB1ENR_TSCEN) == RESET)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB2_Clock_Enable_Disable_Status AHB2 Peripheral Clock Enabled or Disabled Status
+  * @brief  Check whether the AHB2 peripheral clock is enabled or not.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+
+#define __HAL_RCC_GPIOA_IS_CLK_ENABLED()       (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOAEN) != RESET)
+
+#define __HAL_RCC_GPIOB_IS_CLK_ENABLED()       (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOCEN) != RESET)
+
+#define __HAL_RCC_GPIOC_IS_CLK_ENABLED()       (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOCEN) != RESET)
+
+#define __HAL_RCC_GPIOD_IS_CLK_ENABLED()       (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIODEN) != RESET)
+
+#define __HAL_RCC_GPIOE_IS_CLK_ENABLED()       (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOEEN) != RESET)
+
+#define __HAL_RCC_GPIOF_IS_CLK_ENABLED()       (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOFEN) != RESET)
+
+#define __HAL_RCC_GPIOG_IS_CLK_ENABLED()       (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOGEN) != RESET)
+
+#define __HAL_RCC_GPIOH_IS_CLK_ENABLED()       (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOHEN) != RESET)
+
+#if defined(USB_OTG_FS)
+#define __HAL_RCC_USB_OTG_FS_IS_CLK_ENABLED()  (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_OTGFSEN) != RESET)
+#endif /* USB_OTG_FS */
+
+#define __HAL_RCC_ADC_IS_CLK_ENABLED()         (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_ADCEN) != RESET)
+
+#if defined(AES)
+#define __HAL_RCC_AES_IS_CLK_ENABLED()         (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_AESEN) != RESET)
+#endif /* AES */
+
+#define __HAL_RCC_RNG_IS_CLK_ENABLED()         (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_RNGEN) != RESET)
+
+#define __HAL_RCC_GPIOA_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOAEN) == RESET)
+
+#define __HAL_RCC_GPIOB_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOBEN) == RESET)
+
+#define __HAL_RCC_GPIOC_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOCEN) == RESET)
+
+#define __HAL_RCC_GPIOD_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIODEN) == RESET)
+
+#define __HAL_RCC_GPIOE_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOEEN) == RESET)
+
+#define __HAL_RCC_GPIOF_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOFEN) == RESET)
+
+#define __HAL_RCC_GPIOG_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOGEN) == RESET)
+
+#define __HAL_RCC_GPIOH_IS_CLK_DISABLED()      (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_GPIOHEN) == RESET)
+
+#if defined(USB_OTG_FS)
+#define __HAL_RCC_USB_OTG_FS_IS_CLK_DISABLED() (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_OTGFSEN) == RESET)
+#endif /* USB_OTG_FS */
+
+#define __HAL_RCC_ADC_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_ADCEN) == RESET)
+
+#if defined(AES)
+#define __HAL_RCC_AES_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_AESEN) == RESET)
+#endif /* AES */
+
+#define __HAL_RCC_RNG_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB2ENR, RCC_AHB2ENR_RNGEN) == RESET)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB3_Clock_Enable_Disable_Status AHB3 Peripheral Clock Enabled or Disabled Status
+  * @brief  Check whether the AHB3 peripheral clock is enabled or not.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+
+#define __HAL_RCC_FMC_IS_CLK_ENABLED()         (READ_BIT(RCC->AHB3ENR, RCC_AHB3ENR_FMCEN) != RESET)
+
+#define __HAL_RCC_QSPI_IS_CLK_ENABLED()        (READ_BIT(RCC->AHB3ENR, RCC_AHB3ENR_QSPIEN) != RESET)
+
+#define __HAL_RCC_FMC_IS_CLK_DISABLED()        (READ_BIT(RCC->AHB3ENR, RCC_AHB3ENR_FMCEN) == RESET)
+
+#define __HAL_RCC_QSPI_IS_CLK_DISABLED()       (READ_BIT(RCC->AHB3ENR, RCC_AHB3ENR_QSPIEN) == RESET)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB1_Clock_Enable_Disable_Status APB1 Peripheral Clock Enabled or Disabled Status
+  * @brief  Check whether the APB1 peripheral clock is enabled or not.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+
+#define __HAL_RCC_TIM2_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM2EN) != RESET)
+
+#define __HAL_RCC_TIM3_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM3EN) != RESET)
+
+#define __HAL_RCC_TIM4_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM4EN) != RESET)
+
+#define __HAL_RCC_TIM5_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM5EN) != RESET)
+
+#define __HAL_RCC_TIM6_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM6EN) != RESET)
+
+#define __HAL_RCC_TIM7_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM7EN) != RESET)
+
+#if defined(LCD)
+#define __HAL_RCC_LCD_IS_CLK_ENABLED()         (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_LCDEN) != RESET)
+#endif /* LCD */
+
+#define __HAL_RCC_WWDG_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_WWDGEN) != RESET)
+
+#define __HAL_RCC_SPI2_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_SPI2EN) != RESET)
+
+#define __HAL_RCC_SPI3_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_SPI3EN) != RESET)
+
+#define __HAL_RCC_USART2_IS_CLK_ENABLED()      (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_USART2EN) != RESET)
+
+#define __HAL_RCC_USART3_IS_CLK_ENABLED()      (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_USART3EN) != RESET)
+
+#define __HAL_RCC_UART4_IS_CLK_ENABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_UART4EN) != RESET)
+
+#define __HAL_RCC_UART5_IS_CLK_ENABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_UART5EN) != RESET)
+
+#define __HAL_RCC_I2C1_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C1EN) != RESET)
+
+#define __HAL_RCC_I2C2_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C2EN) != RESET)
+
+#define __HAL_RCC_I2C3_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C3EN) != RESET)
+
+#define __HAL_RCC_CAN1_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_CAN1EN) != RESET)
+
+#define __HAL_RCC_PWR_IS_CLK_ENABLED()         (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_PWREN) != RESET)
+
+#define __HAL_RCC_DAC1_IS_CLK_ENABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_DAC1EN) != RESET)
+
+#define __HAL_RCC_OPAMP_IS_CLK_ENABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_OPAMPEN) != RESET)
+
+#define __HAL_RCC_LPTIM1_IS_CLK_ENABLED()      (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_LPTIM1EN) != RESET)
+
+#define __HAL_RCC_LPUART1_IS_CLK_ENABLED()     (READ_BIT(RCC->APB1ENR2, RCC_APB1ENR2_LPUART1EN) != RESET)
+
+#define __HAL_RCC_SWPMI1_IS_CLK_ENABLED()      (READ_BIT(RCC->APB1ENR2, RCC_APB1ENR2_SWPMI1EN) != RESET)
+
+#define __HAL_RCC_LPTIM2_IS_CLK_ENABLED()      (READ_BIT(RCC->APB1ENR2, RCC_APB1ENR2_LPTIM2EN) != RESET)
+
+#define __HAL_RCC_TIM2_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM2EN) == RESET)
+
+#define __HAL_RCC_TIM3_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM3EN) == RESET)
+
+#define __HAL_RCC_TIM4_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM4EN) == RESET)
+
+#define __HAL_RCC_TIM5_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM5EN) == RESET)
+
+#define __HAL_RCC_TIM6_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM6EN) == RESET)
+
+#define __HAL_RCC_TIM7_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_TIM7EN) == RESET)
+
+#if defined(LCD)
+#define __HAL_RCC_LCD_IS_CLK_DISABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_LCDEN) == RESET)
+#endif /* LCD */
+
+#define __HAL_RCC_WWDG_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_WWDGEN) == RESET)
+
+#define __HAL_RCC_SPI2_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_SPI2EN) == RESET)
+
+#define __HAL_RCC_SPI3_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_SPI3EN) == RESET)
+
+#define __HAL_RCC_USART2_IS_CLK_DISABLED()     (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_USART2EN) == RESET)
+
+#define __HAL_RCC_USART3_IS_CLK_DISABLED()     (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_USART3EN) == RESET)
+
+#define __HAL_RCC_UART4_IS_CLK_DISABLED()      (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_UART4EN) == RESET)
+
+#define __HAL_RCC_UART5_IS_CLK_DISABLED()      (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_UART5EN) == RESET)
+
+#define __HAL_RCC_I2C1_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C1EN) == RESET)
+
+#define __HAL_RCC_I2C2_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C2EN) == RESET)
+
+#define __HAL_RCC_I2C3_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_I2C3EN) == RESET)
+
+#define __HAL_RCC_CAN1_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_CAN1EN) == RESET)
+
+#define __HAL_RCC_PWR_IS_CLK_DISABLED()        (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_PWREN) == RESET)
+
+#define __HAL_RCC_DAC1_IS_CLK_DISABLED()       (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_DAC1EN) == RESET)
+
+#define __HAL_RCC_OPAMP_IS_CLK_DISABLED()      (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_OPAMPEN) == RESET)
+
+#define __HAL_RCC_LPTIM1_IS_CLK_DISABLED()     (READ_BIT(RCC->APB1ENR1, RCC_APB1ENR1_LPTIM1EN) == RESET)
+
+#define __HAL_RCC_LPUART1_IS_CLK_DISABLED()    (READ_BIT(RCC->APB1ENR2, RCC_APB1ENR2_LPUART1EN) == RESET)
+
+#define __HAL_RCC_SWPMI1_IS_CLK_DISABLED()     (READ_BIT(RCC->APB1ENR2, RCC_APB1ENR2_SWPMI1EN) == RESET)
+
+#define __HAL_RCC_LPTIM2_IS_CLK_DISABLED()     (READ_BIT(RCC->APB1ENR2, RCC_APB1ENR2_LPTIM2EN) == RESET)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB2_Clock_Enable_Disable_Status APB2 Peripheral Clock Enabled or Disabled Status
+  * @brief  Check whether the APB2 peripheral clock is enabled or not.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  * @{
+  */
+
+#define __HAL_RCC_SYSCFG_IS_CLK_ENABLED()      (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SYSCFGEN) != RESET)
+
+#define __HAL_RCC_FIREWALL_IS_CLK_ENABLED()    (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_FWEN) != RESET)
+
+#define __HAL_RCC_SDMMC1_IS_CLK_ENABLED()      (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SDMMC1EN) != RESET)
+
+#define __HAL_RCC_TIM1_IS_CLK_ENABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM1EN) != RESET)
+
+#define __HAL_RCC_SPI1_IS_CLK_ENABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN) != RESET)
+
+#define __HAL_RCC_TIM8_IS_CLK_ENABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM8EN) != RESET)
+
+#define __HAL_RCC_USART1_IS_CLK_ENABLED()      (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN) != RESET)
+
+#define __HAL_RCC_TIM15_IS_CLK_ENABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM15EN) != RESET)
+
+#define __HAL_RCC_TIM16_IS_CLK_ENABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN) != RESET)
+
+#define __HAL_RCC_TIM17_IS_CLK_ENABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM17EN) != RESET)
+
+#define __HAL_RCC_SAI1_IS_CLK_ENABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI1EN) != RESET)
+
+#define __HAL_RCC_SAI2_IS_CLK_ENABLED()        (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI2EN) != RESET)
+
+#define __HAL_RCC_DFSDM_IS_CLK_ENABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_DFSDMEN) != RESET)
+
+#define __HAL_RCC_SYSCFG_IS_CLK_DISABLED()     (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SYSCFGEN) == RESET)
+
+#define __HAL_RCC_SDMMC1_IS_CLK_DISABLED()     (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SDMMC1EN) == RESET)
+
+#define __HAL_RCC_TIM1_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM1EN) == RESET)
+
+#define __HAL_RCC_SPI1_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN) == RESET)
+
+#define __HAL_RCC_TIM8_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM8EN) == RESET)
+
+#define __HAL_RCC_USART1_IS_CLK_DISABLED()     (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN) == RESET)
+
+#define __HAL_RCC_TIM15_IS_CLK_DISABLED()      (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM15EN) == RESET)
+
+#define __HAL_RCC_TIM16_IS_CLK_DISABLED()      (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN) == RESET)
+
+#define __HAL_RCC_TIM17_IS_CLK_DISABLED()      (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM17EN) == RESET)
+
+#define __HAL_RCC_SAI1_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI1EN) == RESET)
+
+#define __HAL_RCC_SAI2_IS_CLK_DISABLED()       (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SAI2EN) == RESET)
+
+#define __HAL_RCC_DFSDM_IS_CLK_DISABLED()      (READ_BIT(RCC->APB2ENR, RCC_APB2ENR_DFSDMEN) == RESET)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB1_Force_Release_Reset AHB1 Peripheral Force Release Reset
+  * @brief  Force or release AHB1 peripheral reset.
+  * @{
+  */
+#define __HAL_RCC_AHB1_FORCE_RESET()           WRITE_REG(RCC->AHB1RSTR, 0xFFFFFFFFU)
+
+#define __HAL_RCC_DMA1_FORCE_RESET()           SET_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_DMA1RST)
+
+#define __HAL_RCC_DMA2_FORCE_RESET()           SET_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_DMA2RST)
+
+#define __HAL_RCC_FLASH_FORCE_RESET()          SET_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_FLASHRST)
+
+#define __HAL_RCC_CRC_FORCE_RESET()            SET_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_CRCRST)
+
+#define __HAL_RCC_TSC_FORCE_RESET()            SET_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_TSCRST)
+
+#define __HAL_RCC_AHB1_RELEASE_RESET()         WRITE_REG(RCC->AHB1RSTR, 0x00000000U)
+
+#define __HAL_RCC_DMA1_RELEASE_RESET()         CLEAR_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_DMA1RST)
+
+#define __HAL_RCC_DMA2_RELEASE_RESET()         CLEAR_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_DMA2RST)
+
+#define __HAL_RCC_FLASH_RELEASE_RESET()        CLEAR_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_FLASHRST)
+
+#define __HAL_RCC_CRC_RELEASE_RESET()          CLEAR_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_CRCRST)
+
+#define __HAL_RCC_TSC_RELEASE_RESET()          CLEAR_BIT(RCC->AHB1RSTR, RCC_AHB1RSTR_TSCRST)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB2_Force_Release_Reset AHB2 Peripheral Force Release Reset
+  * @brief  Force or release AHB2 peripheral reset.
+  * @{
+  */
+#define __HAL_RCC_AHB2_FORCE_RESET()           WRITE_REG(RCC->AHB2RSTR, 0xFFFFFFFFU)
+
+#define __HAL_RCC_GPIOA_FORCE_RESET()          SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOARST)
+
+#define __HAL_RCC_GPIOB_FORCE_RESET()          SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOBRST)
+
+#define __HAL_RCC_GPIOC_FORCE_RESET()          SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOCRST)
+
+#define __HAL_RCC_GPIOD_FORCE_RESET()          SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIODRST)
+
+#define __HAL_RCC_GPIOE_FORCE_RESET()          SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOERST)
+
+#define __HAL_RCC_GPIOF_FORCE_RESET()          SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOFRST)
+
+#define __HAL_RCC_GPIOG_FORCE_RESET()          SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOGRST)
+
+#define __HAL_RCC_GPIOH_FORCE_RESET()          SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOHRST)
+
+#if defined(USB_OTG_FS)
+#define __HAL_RCC_USB_OTG_FS_FORCE_RESET()     SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_OTGFSRST)
+#endif /* USB_OTG_FS */
+
+#define __HAL_RCC_ADC_FORCE_RESET()            SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_ADCRST)
+
+#if defined(AES)
+#define __HAL_RCC_AES_FORCE_RESET()            SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_AESRST)
+#endif /* AES */
+
+#define __HAL_RCC_RNG_FORCE_RESET()            SET_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_RNGRST)
+
+#define __HAL_RCC_AHB2_RELEASE_RESET()         WRITE_REG(RCC->AHB2RSTR, 0x00000000U)
+
+#define __HAL_RCC_GPIOA_RELEASE_RESET()        CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOARST)
+
+#define __HAL_RCC_GPIOB_RELEASE_RESET()        CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOBRST)
+
+#define __HAL_RCC_GPIOC_RELEASE_RESET()        CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOCRST)
+
+#define __HAL_RCC_GPIOD_RELEASE_RESET()        CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIODRST)
+
+#define __HAL_RCC_GPIOE_RELEASE_RESET()        CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOERST)
+
+#define __HAL_RCC_GPIOF_RELEASE_RESET()        CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOFRST)
+
+#define __HAL_RCC_GPIOG_RELEASE_RESET()        CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOGRST)
+
+#define __HAL_RCC_GPIOH_RELEASE_RESET()        CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_GPIOHRST)
+
+#if defined(USB_OTG_FS)
+#define __HAL_RCC_USB_OTG_FS_RELEASE_RESET()   CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_OTGFSRST)
+#endif /* USB_OTG_FS */
+
+#define __HAL_RCC_ADC_RELEASE_RESET()          CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_ADCRST)
+
+#if defined(AES)
+#define __HAL_RCC_AES_RELEASE_RESET()          CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_AESRST)
+#endif /* AES */
+
+#define __HAL_RCC_RNG_RELEASE_RESET()          CLEAR_BIT(RCC->AHB2RSTR, RCC_AHB2RSTR_RNGRST)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB3_Force_Release_Reset AHB3 Peripheral Force Release Reset
+  * @brief  Force or release AHB3 peripheral reset.
+  * @{
+  */
+#define __HAL_RCC_AHB3_FORCE_RESET()           WRITE_REG(RCC->AHB3RSTR, 0xFFFFFFFFU)
+
+#define __HAL_RCC_FMC_FORCE_RESET()            SET_BIT(RCC->AHB3RSTR, RCC_AHB3RSTR_FMCRST)
+
+#define __HAL_RCC_QSPI_FORCE_RESET()           SET_BIT(RCC->AHB3RSTR, RCC_AHB3RSTR_QSPIRST)
+
+#define __HAL_RCC_AHB3_RELEASE_RESET()         WRITE_REG(RCC->AHB3RSTR, 0x00000000U)
+
+#define __HAL_RCC_FMC_RELEASE_RESET()          CLEAR_BIT(RCC->AHB3RSTR, RCC_AHB3RSTR_FMCRST)
+
+#define __HAL_RCC_QSPI_RELEASE_RESET()         CLEAR_BIT(RCC->AHB3RSTR, RCC_AHB3RSTR_QSPIRST)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB1_Force_Release_Reset APB1 Peripheral Force Release Reset
+  * @brief  Force or release APB1 peripheral reset.
+  * @{
+  */
+#define __HAL_RCC_APB1_FORCE_RESET()           WRITE_REG(RCC->APB1RSTR1, 0xFFFFFFFFU)
+
+#define __HAL_RCC_TIM2_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_TIM2RST)
+
+#define __HAL_RCC_TIM3_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_TIM3RST)
+
+#define __HAL_RCC_TIM4_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_TIM4RST)
+
+#define __HAL_RCC_TIM5_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_TIM5RST)
+
+#define __HAL_RCC_TIM6_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_TIM6RST)
+
+#define __HAL_RCC_TIM7_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_TIM7RST)
+
+#if defined(LCD)
+#define __HAL_RCC_LCD_FORCE_RESET()            SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_LCDRST)
+#endif /* LCD */
+
+#define __HAL_RCC_SPI2_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_SPI2RST)
+
+#define __HAL_RCC_SPI3_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_SPI3RST)
+
+#define __HAL_RCC_USART2_FORCE_RESET()         SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_USART2RST)
+
+#define __HAL_RCC_USART3_FORCE_RESET()         SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_USART3RST)
+
+#define __HAL_RCC_UART4_FORCE_RESET()          SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_UART4RST)
+
+#define __HAL_RCC_UART5_FORCE_RESET()          SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_UART5RST)
+
+#define __HAL_RCC_I2C1_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_I2C1RST)
+
+#define __HAL_RCC_I2C2_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_I2C2RST)
+
+#define __HAL_RCC_I2C3_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_I2C3RST)
+
+#define __HAL_RCC_CAN1_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_CAN1RST)
+
+#define __HAL_RCC_PWR_FORCE_RESET()            SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_PWRRST)
+
+#define __HAL_RCC_DAC1_FORCE_RESET()           SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_DAC1RST)
+
+#define __HAL_RCC_OPAMP_FORCE_RESET()          SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_OPAMPRST)
+
+#define __HAL_RCC_LPTIM1_FORCE_RESET()         SET_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_LPTIM1RST)
+
+#define __HAL_RCC_LPUART1_FORCE_RESET()        SET_BIT(RCC->APB1RSTR2, RCC_APB1RSTR2_LPUART1RST)
+
+#define __HAL_RCC_SWPMI1_FORCE_RESET()         SET_BIT(RCC->APB1RSTR2, RCC_APB1RSTR2_SWPMI1RST)
+
+#define __HAL_RCC_LPTIM2_FORCE_RESET()         SET_BIT(RCC->APB1RSTR2, RCC_APB1RSTR2_LPTIM2RST)
+
+#define __HAL_RCC_APB1_RELEASE_RESET()         WRITE_REG(RCC->APB1RSTR1, 0x00000000U)
+
+#define __HAL_RCC_TIM2_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_TIM2RST)
+
+#define __HAL_RCC_TIM3_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_TIM3RST)
+
+#define __HAL_RCC_TIM4_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_TIM4RST)
+
+#define __HAL_RCC_TIM5_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_TIM5RST)
+
+#define __HAL_RCC_TIM6_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_TIM6RST)
+
+#define __HAL_RCC_TIM7_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_TIM7RST)
+
+#if defined(LCD)
+#define __HAL_RCC_LCD_RELEASE_RESET()          CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_LCDRST)
+#endif /* LCD */
+
+#define __HAL_RCC_SPI2_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_SPI2RST)
+
+#define __HAL_RCC_SPI3_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_SPI3RST)
+
+#define __HAL_RCC_USART2_RELEASE_RESET()       CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_USART2RST)
+
+#define __HAL_RCC_USART3_RELEASE_RESET()       CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_USART3RST)
+
+#define __HAL_RCC_UART4_RELEASE_RESET()        CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_UART4RST)
+
+#define __HAL_RCC_UART5_RELEASE_RESET()        CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_UART5RST)
+
+#define __HAL_RCC_I2C1_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_I2C1RST)
+
+#define __HAL_RCC_I2C2_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_I2C2RST)
+
+#define __HAL_RCC_I2C3_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_I2C3RST)
+
+#define __HAL_RCC_CAN1_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_CAN1RST)
+
+#define __HAL_RCC_PWR_RELEASE_RESET()          CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_PWRRST)
+
+#define __HAL_RCC_DAC1_RELEASE_RESET()         CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_DAC1RST)
+
+#define __HAL_RCC_OPAMP_RELEASE_RESET()        CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_OPAMPRST)
+
+#define __HAL_RCC_LPTIM1_RELEASE_RESET()       CLEAR_BIT(RCC->APB1RSTR1, RCC_APB1RSTR1_LPTIM1RST)
+
+#define __HAL_RCC_LPUART1_RELEASE_RESET()      CLEAR_BIT(RCC->APB1RSTR2, RCC_APB1RSTR2_LPUART1RST)
+
+#define __HAL_RCC_SWPMI1_RELEASE_RESET()       CLEAR_BIT(RCC->APB1RSTR2, RCC_APB1RSTR2_SWPMI1RST)
+
+#define __HAL_RCC_LPTIM2_RELEASE_RESET()       CLEAR_BIT(RCC->APB1RSTR2, RCC_APB1RSTR2_LPTIM2RST)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB2_Force_Release_Reset APB2 Peripheral Force Release Reset
+  * @brief  Force or release APB2 peripheral reset.
+  * @{
+  */
+#define __HAL_RCC_APB2_FORCE_RESET()           WRITE_REG(RCC->APB2RSTR, 0xFFFFFFFFU)
+
+#define __HAL_RCC_SYSCFG_FORCE_RESET()         SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_SYSCFGRST)
+
+#define __HAL_RCC_SDMMC1_FORCE_RESET()         SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_SDMMC1RST)
+
+#define __HAL_RCC_TIM1_FORCE_RESET()           SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_TIM1RST)
+
+#define __HAL_RCC_SPI1_FORCE_RESET()           SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_SPI1RST)
+
+#define __HAL_RCC_TIM8_FORCE_RESET()           SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_TIM8RST)
+
+#define __HAL_RCC_USART1_FORCE_RESET()         SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_USART1RST)
+
+#define __HAL_RCC_TIM15_FORCE_RESET()          SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_TIM15RST)
+
+#define __HAL_RCC_TIM16_FORCE_RESET()          SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_TIM16RST)
+
+#define __HAL_RCC_TIM17_FORCE_RESET()          SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_TIM17RST)
+
+#define __HAL_RCC_SAI1_FORCE_RESET()           SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_SAI1RST)
+
+#define __HAL_RCC_SAI2_FORCE_RESET()           SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_SAI2RST)
+
+#define __HAL_RCC_DFSDM_FORCE_RESET()          SET_BIT(RCC->APB2RSTR, RCC_APB2RSTR_DFSDMRST)
+
+#define __HAL_RCC_APB2_RELEASE_RESET()         WRITE_REG(RCC->APB2RSTR, 0x00000000U)
+
+#define __HAL_RCC_SYSCFG_RELEASE_RESET()       CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_SYSCFGRST)
+
+#define __HAL_RCC_SDMMC1_RELEASE_RESET()       CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_SDMMC1RST)
+
+#define __HAL_RCC_TIM1_RELEASE_RESET()         CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_TIM1RST)
+
+#define __HAL_RCC_SPI1_RELEASE_RESET()         CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_SPI1RST)
+
+#define __HAL_RCC_TIM8_RELEASE_RESET()         CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_TIM8RST)
+
+#define __HAL_RCC_USART1_RELEASE_RESET()       CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_USART1RST)
+
+#define __HAL_RCC_TIM15_RELEASE_RESET()        CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_TIM15RST)
+
+#define __HAL_RCC_TIM16_RELEASE_RESET()        CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_TIM16RST)
+
+#define __HAL_RCC_TIM17_RELEASE_RESET()        CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_TIM17RST)
+
+#define __HAL_RCC_SAI1_RELEASE_RESET()         CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_SAI1RST)
+
+#define __HAL_RCC_SAI2_RELEASE_RESET()         CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_SAI2RST)
+
+#define __HAL_RCC_DFSDM_RELEASE_RESET()        CLEAR_BIT(RCC->APB2RSTR, RCC_APB2RSTR_DFSDMRST)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB1_Clock_Sleep_Enable_Disable AHB1 Peripheral Clock Sleep Enable Disable
+  * @brief  Enable or disable the AHB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+
+#define __HAL_RCC_DMA1_CLK_SLEEP_ENABLE()      SET_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMA1SMEN)
+
+#define __HAL_RCC_DMA2_CLK_SLEEP_ENABLE()      SET_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMA2SMEN)
+
+#define __HAL_RCC_FLASH_CLK_SLEEP_ENABLE()     SET_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_FLASHSMEN)
+
+#define __HAL_RCC_SRAM1_CLK_SLEEP_ENABLE()     SET_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_SRAM1SMEN)
+
+#define __HAL_RCC_CRC_CLK_SLEEP_ENABLE()       SET_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_CRCSMEN)
+
+#define __HAL_RCC_TSC_CLK_SLEEP_ENABLE()       SET_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_TSCSMEN)
+
+#define __HAL_RCC_DMA1_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMA1SMEN)
+
+#define __HAL_RCC_DMA2_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMA2SMEN)
+
+#define __HAL_RCC_FLASH_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_FLASHSMEN)
+
+#define __HAL_RCC_SRAM1_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_SRAM1SMEN)
+
+#define __HAL_RCC_CRC_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_CRCSMEN)
+
+#define __HAL_RCC_TSC_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_TSCSMEN)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB2_Clock_Sleep_Enable_Disable AHB2 Peripheral Clock Sleep Enable Disable
+  * @brief  Enable or disable the AHB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+
+#define __HAL_RCC_GPIOA_CLK_SLEEP_ENABLE()     SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOASMEN)
+
+#define __HAL_RCC_GPIOB_CLK_SLEEP_ENABLE()     SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOBSMEN)
+
+#define __HAL_RCC_GPIOC_CLK_SLEEP_ENABLE()     SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOCSMEN)
+
+#define __HAL_RCC_GPIOD_CLK_SLEEP_ENABLE()     SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIODSMEN)
+
+#define __HAL_RCC_GPIOE_CLK_SLEEP_ENABLE()     SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOESMEN)
+
+#define __HAL_RCC_GPIOF_CLK_SLEEP_ENABLE()     SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOFSMEN)
+
+#define __HAL_RCC_GPIOG_CLK_SLEEP_ENABLE()     SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOGSMEN)
+
+#define __HAL_RCC_GPIOH_CLK_SLEEP_ENABLE()     SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOHSMEN)
+
+#define __HAL_RCC_SRAM2_CLK_SLEEP_ENABLE()     SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_SRAM2SMEN)
+
+#if defined(USB_OTG_FS)
+#define __HAL_RCC_USB_OTG_FS_CLK_SLEEP_ENABLE()  SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_OTGFSSMEN)
+#endif /* USB_OTG_FS */
+
+#define __HAL_RCC_ADC_CLK_SLEEP_ENABLE()       SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_ADCSMEN)
+
+#if defined(AES)
+#define __HAL_RCC_AES_CLK_SLEEP_ENABLE()       SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_AESSMEN)
+#endif /* AES */
+
+#define __HAL_RCC_RNG_CLK_SLEEP_ENABLE()       SET_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_RNGSMEN)
+
+#define __HAL_RCC_GPIOA_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOASMEN)
+
+#define __HAL_RCC_GPIOB_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOBSMEN)
+
+#define __HAL_RCC_GPIOC_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOCSMEN)
+
+#define __HAL_RCC_GPIOD_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIODSMEN)
+
+#define __HAL_RCC_GPIOE_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOESMEN)
+
+#define __HAL_RCC_GPIOF_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOFSMEN)
+
+#define __HAL_RCC_GPIOG_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOGSMEN)
+
+#define __HAL_RCC_GPIOH_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOHSMEN)
+
+#define __HAL_RCC_SRAM2_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_SRAM2SMEN)
+
+#if defined(USB_OTG_FS)
+#define __HAL_RCC_USB_OTG_FS_CLK_SLEEP_DISABLE() CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_OTGFSSMEN)
+#endif /* USB_OTG_FS */
+
+#define __HAL_RCC_ADC_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_ADCSMEN)
+
+#if defined(AES)
+#define __HAL_RCC_AES_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_AESSMEN)
+#endif /* AES */
+
+#define __HAL_RCC_RNG_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_RNGSMEN)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB3_Clock_Sleep_Enable_Disable AHB3 Peripheral Clock Sleep Enable Disable
+  * @brief  Enable or disable the AHB3 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+
+#define __HAL_RCC_QSPI_CLK_SLEEP_ENABLE()      SET_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_QSPISMEN)
+
+#define __HAL_RCC_FMC_CLK_SLEEP_ENABLE()       SET_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_FMCSMEN)
+
+#define __HAL_RCC_QSPI_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_QSPISMEN)
+
+#define __HAL_RCC_FMC_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_FMCSMEN)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB1_Clock_Sleep_Enable_Disable APB1 Peripheral Clock Sleep Enable Disable
+  * @brief  Enable or disable the APB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+
+#define __HAL_RCC_TIM2_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM2SMEN)
+
+#define __HAL_RCC_TIM3_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM3SMEN)
+
+#define __HAL_RCC_TIM4_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM4SMEN)
+
+#define __HAL_RCC_TIM5_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM5SMEN)
+
+#define __HAL_RCC_TIM6_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM6SMEN)
+
+#define __HAL_RCC_TIM7_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM7SMEN)
+
+#if defined(LCD)
+#define __HAL_RCC_LCD_CLK_SLEEP_ENABLE()       SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LCDSMEN)
+#endif /* LCD */
+
+#define __HAL_RCC_WWDG_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_WWDGSMEN)
+
+#define __HAL_RCC_SPI2_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_SPI2SMEN)
+
+#define __HAL_RCC_SPI3_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_SPI3SMEN)
+
+#define __HAL_RCC_USART2_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_USART2SMEN)
+
+#define __HAL_RCC_USART3_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_USART3SMEN)
+
+#define __HAL_RCC_UART4_CLK_SLEEP_ENABLE()     SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_UART4SMEN)
+
+#define __HAL_RCC_UART5_CLK_SLEEP_ENABLE()     SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_UART5SMEN)
+
+#define __HAL_RCC_I2C1_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C1SMEN)
+
+#define __HAL_RCC_I2C2_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C2SMEN)
+
+#define __HAL_RCC_I2C3_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C3SMEN)
+
+#define __HAL_RCC_CAN1_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_CAN1SMEN)
+
+#define __HAL_RCC_PWR_CLK_SLEEP_ENABLE()       SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_PWRSMEN)
+
+#define __HAL_RCC_DAC1_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_DAC1SMEN)
+
+#define __HAL_RCC_OPAMP_CLK_SLEEP_ENABLE()     SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_OPAMPSMEN)
+
+#define __HAL_RCC_LPTIM1_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LPTIM1SMEN)
+
+#define __HAL_RCC_LPUART1_CLK_SLEEP_ENABLE()   SET_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPUART1SMEN)
+
+#define __HAL_RCC_SWPMI1_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_SWPMI1SMEN)
+
+#define __HAL_RCC_LPTIM2_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPTIM2SMEN)
+
+#define __HAL_RCC_TIM2_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM2SMEN)
+
+#define __HAL_RCC_TIM3_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM3SMEN)
+
+#define __HAL_RCC_TIM4_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM4SMEN)
+
+#define __HAL_RCC_TIM5_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM5SMEN)
+
+#define __HAL_RCC_TIM6_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM6SMEN)
+
+#define __HAL_RCC_TIM7_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM7SMEN)
+
+#if defined(LCD)
+#define __HAL_RCC_LCD_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LCDSMEN)
+#endif /* LCD */
+
+#define __HAL_RCC_WWDG_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_WWDGSMEN)
+
+#define __HAL_RCC_SPI2_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_SPI2SMEN)
+
+#define __HAL_RCC_SPI3_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_SPI3SMEN)
+
+#define __HAL_RCC_USART2_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_USART2SMEN)
+
+#define __HAL_RCC_USART3_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_USART3SMEN)
+
+#define __HAL_RCC_UART4_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_UART4SMEN)
+
+#define __HAL_RCC_UART5_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_UART5SMEN)
+
+#define __HAL_RCC_I2C1_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C1SMEN)
+
+#define __HAL_RCC_I2C2_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C2SMEN)
+
+#define __HAL_RCC_I2C3_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C3SMEN)
+
+#define __HAL_RCC_CAN1_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_CAN1SMEN)
+
+#define __HAL_RCC_PWR_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_PWRSMEN)
+
+#define __HAL_RCC_DAC1_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_DAC1SMEN)
+
+#define __HAL_RCC_OPAMP_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_OPAMPSMEN)
+
+#define __HAL_RCC_LPTIM1_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LPTIM1SMEN)
+
+#define __HAL_RCC_LPUART1_CLK_SLEEP_DISABLE()  CLEAR_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPUART1SMEN)
+
+#define __HAL_RCC_SWPMI1_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_SWPMI1SMEN)
+
+#define __HAL_RCC_LPTIM2_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPTIM2SMEN)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB2_Clock_Sleep_Enable_Disable APB2 Peripheral Clock Sleep Enable Disable
+  * @brief  Enable or disable the APB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+
+#define __HAL_RCC_SYSCFG_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SYSCFGSMEN)
+
+#define __HAL_RCC_SDMMC1_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SDMMC1SMEN)
+
+#define __HAL_RCC_TIM1_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM1SMEN)
+
+#define __HAL_RCC_SPI1_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SPI1SMEN)
+
+#define __HAL_RCC_TIM8_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM8SMEN)
+
+#define __HAL_RCC_USART1_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APB2SMENR, RCC_APB2SMENR_USART1SMEN)
+
+#define __HAL_RCC_TIM15_CLK_SLEEP_ENABLE()     SET_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM15SMEN)
+
+#define __HAL_RCC_TIM16_CLK_SLEEP_ENABLE()     SET_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM16SMEN)
+
+#define __HAL_RCC_TIM17_CLK_SLEEP_ENABLE()     SET_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM17SMEN)
+
+#define __HAL_RCC_SAI1_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SAI1SMEN)
+
+#define __HAL_RCC_SAI2_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SAI2SMEN)
+
+#define __HAL_RCC_DFSDM_CLK_SLEEP_ENABLE()     SET_BIT(RCC->APB2SMENR, RCC_APB2SMENR_DFSDMSMEN)
+
+#define __HAL_RCC_SYSCFG_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SYSCFGSMEN)
+
+#define __HAL_RCC_SDMMC1_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SDMMC1SMEN)
+
+#define __HAL_RCC_TIM1_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM1SMEN)
+
+#define __HAL_RCC_SPI1_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SPI1SMEN)
+
+#define __HAL_RCC_TIM8_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM8SMEN)
+
+#define __HAL_RCC_USART1_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APB2SMENR, RCC_APB2SMENR_USART1SMEN)
+
+#define __HAL_RCC_TIM15_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM15SMEN)
+
+#define __HAL_RCC_TIM16_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM16SMEN)
+
+#define __HAL_RCC_TIM17_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM17SMEN)
+
+#define __HAL_RCC_SAI1_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SAI1SMEN)
+
+#define __HAL_RCC_SAI2_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SAI2SMEN)
+
+#define __HAL_RCC_DFSDM_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->APB2SMENR, RCC_APB2SMENR_DFSDMSMEN)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB1_Clock_Sleep_Enable_Disable_Status AHB1 Peripheral Clock Sleep Enabled or Disabled Status
+  * @brief  Check whether the AHB1 peripheral clock during Low Power (Sleep) mode is enabled or not.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+
+#define __HAL_RCC_DMA1_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMA1SMEN) != RESET)
+
+#define __HAL_RCC_DMA2_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMA2SMEN) != RESET)
+
+#define __HAL_RCC_FLASH_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_FLASHSMEN) != RESET)
+
+#define __HAL_RCC_SRAM1_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_SRAM1SMEN) != RESET)
+
+#define __HAL_RCC_CRC_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_CRCSMEN) != RESET)
+
+#define __HAL_RCC_TSC_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_TSCSMEN) != RESET)
+
+#define __HAL_RCC_DMA1_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMA1SMEN) == RESET)
+
+#define __HAL_RCC_DMA2_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMA2SMEN) == RESET)
+
+#define __HAL_RCC_FLASH_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_FLASHSMEN) == RESET)
+
+#define __HAL_RCC_SRAM1_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_SRAM1SMEN) == RESET)
+
+#define __HAL_RCC_CRC_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_CRCSMEN) == RESET)
+
+#define __HAL_RCC_TSC_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_TSCSMEN) == RESET)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB2_Clock_Sleep_Enable_Disable_Status AHB2 Peripheral Clock Sleep Enabled or Disabled Status
+  * @brief  Check whether the AHB2 peripheral clock during Low Power (Sleep) mode is enabled or not.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+
+#define __HAL_RCC_GPIOA_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOASMEN) != RESET)
+
+#define __HAL_RCC_GPIOB_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOBSMEN) != RESET)
+
+#define __HAL_RCC_GPIOC_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOCSMEN) != RESET)
+
+#define __HAL_RCC_GPIOD_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIODSMEN) != RESET)
+
+#define __HAL_RCC_GPIOE_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOESMEN) != RESET)
+
+#define __HAL_RCC_GPIOF_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOFSMEN) != RESET)
+
+#define __HAL_RCC_GPIOG_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOGSMEN) != RESET)
+
+#define __HAL_RCC_GPIOH_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOHSMEN) != RESET)
+
+#define __HAL_RCC_SRAM2_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_SRAM2SMEN) != RESET)
+
+#if defined(USB_OTG_FS)
+#define __HAL_RCC_USB_OTG_FS_IS_CLK_SLEEP_ENABLED()  (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_OTGFSSMEN) != RESET)
+#endif /* USB_OTG_FS */
+
+#define __HAL_RCC_ADC_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_ADCSMEN) != RESET)
+
+#if defined(AES)
+#define __HAL_RCC_AES_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_AESSMEN) != RESET)
+#endif /* AES */
+
+#define __HAL_RCC_RNG_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_RNGSMEN) != RESET)
+
+#define __HAL_RCC_GPIOA_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOASMEN) == RESET)
+
+#define __HAL_RCC_GPIOB_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOBSMEN) == RESET)
+
+#define __HAL_RCC_GPIOC_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOCSMEN) == RESET)
+
+#define __HAL_RCC_GPIOD_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIODSMEN) == RESET)
+
+#define __HAL_RCC_GPIOE_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOESMEN) == RESET)
+
+#define __HAL_RCC_GPIOF_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOFSMEN) == RESET)
+
+#define __HAL_RCC_GPIOG_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOGSMEN) == RESET)
+
+#define __HAL_RCC_GPIOH_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOHSMEN) == RESET)
+
+#define __HAL_RCC_SRAM2_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_SRAM2SMEN) == RESET)
+
+#if defined(USB_OTG_FS)
+#define __HAL_RCC_USB_OTG_FS_IS_CLK_SLEEP_DISABLED() (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_OTGFSSMEN) == RESET)
+#endif /* USB_OTG_FS */
+
+#define __HAL_RCC_ADC_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_ADCSMEN) == RESET)
+
+#if defined(AES)
+#define __HAL_RCC_AES_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_AESSMEN) == RESET)
+#endif /* AES */
+
+#define __HAL_RCC_RNG_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_RNGSMEN) == RESET)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_AHB3_Clock_Sleep_Enable_Disable_Status AHB3 Peripheral Clock Sleep Enabled or Disabled Status
+  * @brief  Check whether the AHB3 peripheral clock during Low Power (Sleep) mode is enabled or not.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+
+#define __HAL_RCC_QSPI_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_QSPISMEN) != RESET)
+
+#define __HAL_RCC_FMC_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_FMCSMEN) != RESET)
+
+#define __HAL_RCC_QSPI_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_QSPISMEN) == RESET)
+
+#define __HAL_RCC_FMC_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_FMCSMEN) == RESET)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB1_Clock_Sleep_Enable_Disable_Status APB1 Peripheral Clock Sleep Enabled or Disabled Status
+  * @brief  Check whether the APB1 peripheral clock during Low Power (Sleep) mode is enabled or not.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+
+#define __HAL_RCC_TIM2_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM2SMEN) != RESET)
+
+#define __HAL_RCC_TIM3_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM3SMEN) != RESET)
+
+#define __HAL_RCC_TIM4_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM4SMEN) != RESET)
+
+#define __HAL_RCC_TIM5_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM5SMEN) != RESET)
+
+#define __HAL_RCC_TIM6_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM6SMEN) != RESET)
+
+#define __HAL_RCC_TIM7_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM7SMEN) != RESET)
+
+#if defined(LCD)
+#define __HAL_RCC_LCD_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LCDSMEN) != RESET)
+#endif /* LCD */
+
+#define __HAL_RCC_WWDG_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_WWDGSMEN) != RESET)
+
+#define __HAL_RCC_SPI2_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_SPI2SMEN) != RESET)
+
+#define __HAL_RCC_SPI3_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_SPI3SMEN) != RESET)
+
+#define __HAL_RCC_USART2_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_USART2SMEN) != RESET)
+
+#define __HAL_RCC_USART3_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_USART3SMEN) != RESET)
+
+#define __HAL_RCC_UART4_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_UART4SMEN) != RESET)
+
+#define __HAL_RCC_UART5_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_UART5SMEN) != RESET)
+
+#define __HAL_RCC_I2C1_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C1SMEN) != RESET)
+
+#define __HAL_RCC_I2C2_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C2SMEN) != RESET)
+
+#define __HAL_RCC_I2C3_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C3SMEN) != RESET)
+
+#define __HAL_RCC_CAN1_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_CAN1SMEN) != RESET)
+
+#define __HAL_RCC_PWR_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_PWRSMEN) != RESET)
+
+#define __HAL_RCC_DAC1_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_DAC1SMEN) != RESET)
+
+#define __HAL_RCC_OPAMP_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_OPAMPSMEN) != RESET)
+
+#define __HAL_RCC_LPTIM1_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LPTIM1SMEN) != RESET)
+
+#define __HAL_RCC_LPUART1_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPUART1SMEN) != RESET)
+
+#define __HAL_RCC_SWPMI1_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_SWPMI1SMEN) != RESET)
+
+#define __HAL_RCC_LPTIM2_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPTIM2SMEN) != RESET)
+
+#define __HAL_RCC_TIM2_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM2SMEN) == RESET)
+
+#define __HAL_RCC_TIM3_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM3SMEN) == RESET)
+
+#define __HAL_RCC_TIM4_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM4SMEN) == RESET)
+
+#define __HAL_RCC_TIM5_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM5SMEN) == RESET)
+
+#define __HAL_RCC_TIM6_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM6SMEN) == RESET)
+
+#define __HAL_RCC_TIM7_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM7SMEN) == RESET)
+
+#if defined(LCD)
+#define __HAL_RCC_LCD_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LCDSMEN) == RESET)
+#endif /* LCD */
+
+#define __HAL_RCC_WWDG_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_WWDGSMEN) == RESET)
+
+#define __HAL_RCC_SPI2_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_SPI2SMEN) == RESET)
+
+#define __HAL_RCC_SPI3_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_SPI3SMEN) == RESET)
+
+#define __HAL_RCC_USART2_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_USART2SMEN) == RESET)
+
+#define __HAL_RCC_USART3_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_USART3SMEN) == RESET)
+
+#define __HAL_RCC_UART4_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_UART4SMEN) == RESET)
+
+#define __HAL_RCC_UART5_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_UART5SMEN) == RESET)
+
+#define __HAL_RCC_I2C1_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C1SMEN) == RESET)
+
+#define __HAL_RCC_I2C2_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C2SMEN) == RESET)
+
+#define __HAL_RCC_I2C3_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C3SMEN) == RESET)
+
+#define __HAL_RCC_CAN1_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_CAN1SMEN) == RESET)
+
+#define __HAL_RCC_PWR_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_PWRSMEN) == RESET)
+
+#define __HAL_RCC_DAC1_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_DAC1SMEN) == RESET)
+
+#define __HAL_RCC_OPAMP_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_OPAMPSMEN) == RESET)
+
+#define __HAL_RCC_LPTIM1_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LPTIM1SMEN) == RESET)
+
+#define __HAL_RCC_LPUART1_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPUART1SMEN) == RESET)
+
+#define __HAL_RCC_SWPMI1_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_SWPMI1SMEN) == RESET)
+
+#define __HAL_RCC_LPTIM2_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPTIM2SMEN) == RESET)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_APB2_Clock_Sleep_Enable_Disable_Status APB2 Peripheral Clock Sleep Enabled or Disabled Status
+  * @brief  Check whether the APB2 peripheral clock during Low Power (Sleep) mode is enabled or not.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @{
+  */
+
+#define __HAL_RCC_SYSCFG_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SYSCFGSMEN) != RESET)
+
+#define __HAL_RCC_SDMMC1_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SDMMC1SMEN) != RESET)
+
+#define __HAL_RCC_TIM1_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM1SMEN) != RESET)
+
+#define __HAL_RCC_SPI1_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SPI1SMEN) != RESET)
+
+#define __HAL_RCC_TIM8_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM8SMEN) != RESET)
+
+#define __HAL_RCC_USART1_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_USART1SMEN) != RESET)
+
+#define __HAL_RCC_TIM15_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM15SMEN) != RESET)
+
+#define __HAL_RCC_TIM16_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM16SMEN) != RESET)
+
+#define __HAL_RCC_TIM17_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM17SMEN) != RESET)
+
+#define __HAL_RCC_SAI1_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SAI1SMEN) != RESET)
+
+#define __HAL_RCC_SAI2_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SAI2SMEN) != RESET)
+
+#define __HAL_RCC_DFSDM_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_DFSDMSMEN) != RESET)
+
+#define __HAL_RCC_SYSCFG_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SYSCFGSMEN) == RESET)
+
+#define __HAL_RCC_SDMMC1_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SDMMC1SMEN) == RESET)
+
+#define __HAL_RCC_TIM1_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM1SMEN) == RESET)
+
+#define __HAL_RCC_SPI1_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SPI1SMEN) == RESET)
+
+#define __HAL_RCC_TIM8_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM8SMEN) == RESET)
+
+#define __HAL_RCC_USART1_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_USART1SMEN) == RESET)
+
+#define __HAL_RCC_TIM15_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM15SMEN) == RESET)
+
+#define __HAL_RCC_TIM16_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM16SMEN) == RESET)
+
+#define __HAL_RCC_TIM17_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM17SMEN) == RESET)
+
+#define __HAL_RCC_SAI1_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SAI1SMEN) == RESET)
+
+#define __HAL_RCC_SAI2_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SAI2SMEN) == RESET)
+
+#define __HAL_RCC_DFSDM_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_DFSDMSMEN) == RESET)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Backup_Domain_Reset RCC Backup Domain Reset
+  * @{   
+  */ 
+
+/** @brief  Macros to force or release the Backup domain reset.
+  * @note   This function resets the RTC peripheral (including the backup registers)
+  *         and the RTC clock source selection in RCC_CSR register.
+  * @note   The BKPSRAM is not affected by this reset.
+  * @retval None
+  */
+#define __HAL_RCC_BACKUPRESET_FORCE()   SET_BIT(RCC->BDCR, RCC_BDCR_BDRST)
+
+#define __HAL_RCC_BACKUPRESET_RELEASE() CLEAR_BIT(RCC->BDCR, RCC_BDCR_BDRST)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_RTC_Clock_Configuration RCC RTC Clock Configuration
+  * @{   
+  */ 
+
+/** @brief  Macros to enable or disable the RTC clock.
+  * @note   As the RTC is in the Backup domain and write access is denied to
+  *         this domain after reset, you have to enable write access using
+  *         HAL_PWR_EnableBkUpAccess() function before to configure the RTC
+  *         (to be done once after reset).
+  * @note   These macros must be used after the RTC clock source was selected.
+  * @retval None
+  */
+#define __HAL_RCC_RTC_ENABLE()         SET_BIT(RCC->BDCR, RCC_BDCR_RTCEN)
+
+#define __HAL_RCC_RTC_DISABLE()        CLEAR_BIT(RCC->BDCR, RCC_BDCR_RTCEN)
+
+/**
+  * @}
+  */
+
+/** @brief  Macros to enable or disable the Internal High Speed 16MHz oscillator (HSI).
+  * @note   The HSI is stopped by hardware when entering STOP and STANDBY modes.
+  *         It is used (enabled by hardware) as system clock source after startup
+  *         from Reset, wakeup from STOP and STANDBY mode, or in case of failure
+  *         of the HSE used directly or indirectly as system clock (if the Clock
+  *         Security System CSS is enabled).
+  * @note   HSI can not be stopped if it is used as system clock source. In this case,
+  *         you have to select another source of the system clock then stop the HSI.
+  * @note   After enabling the HSI, the application software should wait on HSIRDY
+  *         flag to be set indicating that HSI clock is stable and can be used as
+  *         system clock source.
+  *         This parameter can be: ENABLE or DISABLE.
+  * @note   When the HSI is stopped, HSIRDY flag goes low after 6 HSI oscillator
+  *         clock cycles.
+  * @retval None
+  */
+#define __HAL_RCC_HSI_ENABLE()  SET_BIT(RCC->CR, RCC_CR_HSION)
+
+#define __HAL_RCC_HSI_DISABLE() CLEAR_BIT(RCC->CR, RCC_CR_HSION)
+
+/** @brief  Macro to adjust the Internal High Speed 16MHz oscillator (HSI) calibration value.
+  * @note   The calibration is used to compensate for the variations in voltage
+  *         and temperature that influence the frequency of the internal HSI RC.
+  * @param  __HSICALIBRATIONVALUE__: specifies the calibration trimming value
+  *         (default is RCC_HSICALIBRATION_DEFAULT).
+  *         This parameter must be a number between 0 and 31.
+  * @retval None
+  */
+#define __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(__HSICALIBRATIONVALUE__) \
+                  MODIFY_REG(RCC->ICSCR, RCC_ICSCR_HSITRIM, (uint32_t)(__HSICALIBRATIONVALUE__) << POSITION_VAL(RCC_ICSCR_HSITRIM))
+
+/**
+  * @brief    Macros to enable or disable the wakeup the Internal High Speed oscillator (HSI)
+  *           in parallel to the Internal Multi Speed oscillator (MSI) used at system wakeup.
+  * @note     The enable of this function has not effect on the HSION bit.
+  *           This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+#define __HAL_RCC_HSIAUTOMATIC_START_ENABLE()   SET_BIT(RCC->CR, RCC_CR_HSIASFS)
+
+#define __HAL_RCC_HSIAUTOMATIC_START_DISABLE()  CLEAR_BIT(RCC->CR, RCC_CR_HSIASFS)
+
+/**
+  * @brief    Macros to enable or disable the force of the Internal High Speed oscillator (HSI)
+  *           in STOP mode to be quickly available as kernel clock for USARTs and I2Cs.
+  * @note     Keeping the HSI ON in STOP mode allows to avoid slowing down the communication
+  *           speed because of the HSI startup time.
+  * @note     The enable of this function has not effect on the HSION bit.
+  *           This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+#define __HAL_RCC_HSISTOP_ENABLE()     SET_BIT(RCC->CR, RCC_CR_HSIKERON)
+
+#define __HAL_RCC_HSISTOP_DISABLE()    CLEAR_BIT(RCC->CR, RCC_CR_HSIKERON)
+
+/**
+  * @brief  Macros to enable or disable the Internal Multi Speed oscillator (MSI).
+  * @note     The MSI is stopped by hardware when entering STOP and STANDBY modes.
+  *           It is used (enabled by hardware) as system clock source after
+  *           startup from Reset, wakeup from STOP and STANDBY mode, or in case
+  *           of failure of the HSE used directly or indirectly as system clock
+  *           (if the Clock Security System CSS is enabled).
+  * @note     MSI can not be stopped if it is used as system clock source.
+  *           In this case, you have to select another source of the system
+  *           clock then stop the MSI.
+  * @note     After enabling the MSI, the application software should wait on
+  *           MSIRDY flag to be set indicating that MSI clock is stable and can
+  *           be used as system clock source.
+  * @note   When the MSI is stopped, MSIRDY flag goes low after 6 MSI oscillator
+  *         clock cycles.
+  * @retval None
+  */
+#define __HAL_RCC_MSI_ENABLE()  SET_BIT(RCC->CR, RCC_CR_MSION)
+
+#define __HAL_RCC_MSI_DISABLE() CLEAR_BIT(RCC->CR, RCC_CR_MSION)
+
+/** @brief  Macro Adjusts the Internal Multi Speed oscillator (MSI) calibration value.
+  * @note   The calibration is used to compensate for the variations in voltage
+  *         and temperature that influence the frequency of the internal MSI RC.
+  *         Refer to the Application Note AN3300 for more details on how to
+  *         calibrate the MSI.
+  * @param  __MSICALIBRATIONVALUE__: specifies the calibration trimming value
+  *         (default is RCC_MSICALIBRATION_DEFAULT).
+  *         This parameter must be a number between 0 and 255.
+  * @retval None
+  */
+#define __HAL_RCC_MSI_CALIBRATIONVALUE_ADJUST(__MSICALIBRATIONVALUE__) \
+                  MODIFY_REG(RCC->ICSCR, RCC_ICSCR_MSITRIM, (uint32_t)(__MSICALIBRATIONVALUE__) << 8)
+
+/**
+  * @brief  Macro configures the Internal Multi Speed oscillator (MSI) clock range in run mode
+  * @note     After restart from Reset , the MSI clock is around 4 MHz.
+  *           After stop the startup clock can be MSI (at any of its possible
+  *           frequencies, the one that was used before entering stop mode) or HSI.
+  *          After Standby its frequency can be selected between 4 possible values
+  *          (1, 2, 4 or 8 MHz).
+  * @note     MSIRANGE can be modified when MSI is OFF (MSION=0) or when MSI is ready
+  *          (MSIRDY=1).
+  * @note    The MSI clock range after reset can be modified on the fly.
+  * @param  __MSIRANGEVALUE__: specifies the MSI clock range.
+  *         This parameter must be one of the following values:
+  *            @arg @ref RCC_MSIRANGE_0  MSI clock is around 100 KHz
+  *            @arg @ref RCC_MSIRANGE_1  MSI clock is around 200 KHz
+  *            @arg @ref RCC_MSIRANGE_2  MSI clock is around 400 KHz
+  *            @arg @ref RCC_MSIRANGE_3  MSI clock is around 800 KHz
+  *            @arg @ref RCC_MSIRANGE_4  MSI clock is around 1 MHz
+  *            @arg @ref RCC_MSIRANGE_5  MSI clock is around 2MHz
+  *            @arg @ref RCC_MSIRANGE_6  MSI clock is around 4MHz (default after Reset)
+  *            @arg @ref RCC_MSIRANGE_7  MSI clock is around 8  MHz
+  *            @arg @ref RCC_MSIRANGE_8  MSI clock is around 16 MHz
+  *            @arg @ref RCC_MSIRANGE_9  MSI clock is around 24 MHz
+  *            @arg @ref RCC_MSIRANGE_10  MSI clock is around 32 MHz
+  *            @arg @ref RCC_MSIRANGE_11  MSI clock is around 48 MHz
+  * @retval None
+  */
+#define __HAL_RCC_MSI_RANGE_CONFIG(__MSIRANGEVALUE__) \
+                  do {                                                         \
+                    SET_BIT(RCC->CR, RCC_CR_MSIRGSEL);                         \
+                    MODIFY_REG(RCC->CR, RCC_CR_MSIRANGE, (__MSIRANGEVALUE__)); \
+                  } while(0)
+
+/**
+  * @brief  Macro configures the Internal Multi Speed oscillator (MSI) clock range after Standby mode
+  *         After Standby its frequency can be selected between 4 possible values (1, 2, 4 or 8 MHz).
+  * @param  __MSIRANGEVALUE__: specifies the MSI clock range.
+  *         This parameter must be one of the following values:
+  *            @arg @ref RCC_MSIRANGE_4  MSI clock is around 1 MHz
+  *            @arg @ref RCC_MSIRANGE_5  MSI clock is around 2MHz
+  *            @arg @ref RCC_MSIRANGE_6  MSI clock is around 4MHz (default after Reset)
+  *            @arg @ref RCC_MSIRANGE_7  MSI clock is around 8  MHz
+  * @retval None
+  */
+#define __HAL_RCC_MSI_STANDBY_RANGE_CONFIG(__MSIRANGEVALUE__) \
+                  MODIFY_REG(RCC->CSR, RCC_CSR_MSISRANGE, (__MSIRANGEVALUE__) << 4U)
+
+/** @brief  Macro to get the Internal Multi Speed oscillator (MSI) clock range in run mode
+  * @retval MSI clock range.
+  *         This parameter must be one of the following values:
+  *            @arg @ref RCC_MSIRANGE_0  MSI clock is around 100 KHz
+  *            @arg @ref RCC_MSIRANGE_1  MSI clock is around 200 KHz
+  *            @arg @ref RCC_MSIRANGE_2  MSI clock is around 400 KHz
+  *            @arg @ref RCC_MSIRANGE_3  MSI clock is around 800 KHz
+  *            @arg @ref RCC_MSIRANGE_4  MSI clock is around 1 MHz
+  *            @arg @ref RCC_MSIRANGE_5  MSI clock is around 2MHz
+  *            @arg @ref RCC_MSIRANGE_6  MSI clock is around 4MHz (default after Reset)
+  *            @arg @ref RCC_MSIRANGE_7  MSI clock is around 8  MHz
+  *            @arg @ref RCC_MSIRANGE_8  MSI clock is around 16 MHz
+  *            @arg @ref RCC_MSIRANGE_9  MSI clock is around 24 MHz
+  *            @arg @ref RCC_MSIRANGE_10  MSI clock is around 32 MHz
+  *            @arg @ref RCC_MSIRANGE_11  MSI clock is around 48 MHz
+  */
+#define __HAL_RCC_GET_MSI_RANGE()                                              \
+                  ((READ_BIT(RCC->CR, RCC_CR_MSIRGSEL) != RESET) ?             \
+                   (uint32_t)(READ_BIT(RCC->CR, RCC_CR_MSIRANGE)) :            \
+                   (uint32_t)(READ_BIT(RCC->CSR, RCC_CSR_MSISRANGE) >> 4))
+
+/** @brief  Macros to enable or disable the Internal Low Speed oscillator (LSI).
+  * @note   After enabling the LSI, the application software should wait on
+  *         LSIRDY flag to be set indicating that LSI clock is stable and can
+  *         be used to clock the IWDG and/or the RTC.
+  * @note   LSI can not be disabled if the IWDG is running.
+  * @note   When the LSI is stopped, LSIRDY flag goes low after 6 LSI oscillator
+  *         clock cycles.
+  * @retval None
+  */
+#define __HAL_RCC_LSI_ENABLE()         SET_BIT(RCC->CSR, RCC_CSR_LSION)
+
+#define __HAL_RCC_LSI_DISABLE()        CLEAR_BIT(RCC->CSR, RCC_CSR_LSION)
+
+/**
+  * @brief  Macro to configure the External High Speed oscillator (HSE).
+  * @note   Transition HSE Bypass to HSE On and HSE On to HSE Bypass are not
+  *         supported by this macro. User should request a transition to HSE Off
+  *         first and then HSE On or HSE Bypass.
+  * @note   After enabling the HSE (RCC_HSE_ON or RCC_HSE_Bypass), the application
+  *         software should wait on HSERDY flag to be set indicating that HSE clock
+  *         is stable and can be used to clock the PLL and/or system clock.
+  * @note   HSE state can not be changed if it is used directly or through the
+  *         PLL as system clock. In this case, you have to select another source
+  *         of the system clock then change the HSE state (ex. disable it).
+  * @note   The HSE is stopped by hardware when entering STOP and STANDBY modes.
+  * @note   This function reset the CSSON bit, so if the clock security system(CSS)
+  *         was previously enabled you have to enable it again after calling this
+  *         function.
+  * @param  __STATE__: specifies the new state of the HSE.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_HSE_OFF  Turn OFF the HSE oscillator, HSERDY flag goes low after
+  *                              6 HSE oscillator clock cycles.
+  *            @arg @ref RCC_HSE_ON  Turn ON the HSE oscillator.
+  *            @arg @ref RCC_HSE_BYPASS  HSE oscillator bypassed with external clock.
+  * @retval None
+  */
+#define __HAL_RCC_HSE_CONFIG(__STATE__)                      \
+                    do {                                     \
+                      if((__STATE__) == RCC_HSE_ON)          \
+                      {                                      \
+                        SET_BIT(RCC->CR, RCC_CR_HSEON);      \
+                      }                                      \
+                      else if((__STATE__) == RCC_HSE_BYPASS) \
+                      {                                      \
+                        CLEAR_BIT(RCC->CR, RCC_CR_HSEON);    \
+                        SET_BIT(RCC->CR, RCC_CR_HSEBYP);     \
+                        SET_BIT(RCC->CR, RCC_CR_HSEON);      \
+                      }                                      \
+                      else                                   \
+                      {                                      \
+                        CLEAR_BIT(RCC->CR, RCC_CR_HSEON);    \
+                        CLEAR_BIT(RCC->CR, RCC_CR_HSEBYP);   \
+                      }                                      \
+                    } while(0)
+
+/**
+  * @brief  Macro to configure the External Low Speed oscillator (LSE).
+  * @note   Transitions LSE Bypass to LSE On and LSE On to LSE Bypass are not
+  *         supported by this macro. User should request a transition to LSE Off 
+  *         first and then LSE On or LSE Bypass.  
+  * @note   As the LSE is in the Backup domain and write access is denied to
+  *         this domain after reset, you have to enable write access using
+  *         HAL_PWR_EnableBkUpAccess() function before to configure the LSE
+  *         (to be done once after reset).
+  * @note   After enabling the LSE (RCC_LSE_ON or RCC_LSE_BYPASS), the application
+  *         software should wait on LSERDY flag to be set indicating that LSE clock
+  *         is stable and can be used to clock the RTC.
+  * @param  __STATE__: specifies the new state of the LSE.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_LSE_OFF  Turn OFF the LSE oscillator, LSERDY flag goes low after
+  *                              6 LSE oscillator clock cycles.
+  *            @arg @ref RCC_LSE_ON  Turn ON the LSE oscillator.
+  *            @arg @ref RCC_LSE_BYPASS  LSE oscillator bypassed with external clock.
+  * @retval None
+  */
+#define __HAL_RCC_LSE_CONFIG(__STATE__)                        \
+                    do {                                       \
+                      if((__STATE__) == RCC_LSE_ON)            \
+                      {                                        \
+                        SET_BIT(RCC->BDCR, RCC_BDCR_LSEON);    \
+                      }                                        \
+                      else if((__STATE__) == RCC_LSE_OFF)      \
+                      {                                        \
+                        CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEON);  \
+                        CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEBYP); \
+                      }                                        \
+                      else if((__STATE__) == RCC_LSE_BYPASS)   \
+                      {                                        \
+                        CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEON);  \
+                        SET_BIT(RCC->BDCR, RCC_BDCR_LSEBYP);   \
+                        SET_BIT(RCC->BDCR, RCC_BDCR_LSEON);    \
+                      }                                        \
+                      else                                     \
+                      {                                        \
+                        CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEON);  \
+                        CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEBYP); \
+                      }                                        \
+                    } while(0)
+
+/** @brief  Macros to configure the RTC clock (RTCCLK).
+  * @note   As the RTC clock configuration bits are in the Backup domain and write
+  *         access is denied to this domain after reset, you have to enable write
+  *         access using the Power Backup Access macro before to configure
+  *         the RTC clock source (to be done once after reset).
+  * @note   Once the RTC clock is configured it cannot be changed unless the
+  *         Backup domain is reset using __HAL_RCC_BACKUPRESET_FORCE() macro, or by
+  *         a Power On Reset (POR).
+  *
+  * @param  __RTC_CLKSOURCE__: specifies the RTC clock source.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_RTCCLKSOURCE_LSE  LSE selected as RTC clock.
+  *            @arg @ref RCC_RTCCLKSOURCE_LSI  LSI selected as RTC clock.
+  *            @arg @ref RCC_RTCCLKSOURCE_HSE_DIV32  HSE clock divided by 32 selected
+  *
+  * @note   If the LSE or LSI is used as RTC clock source, the RTC continues to
+  *         work in STOP and STANDBY modes, and can be used as wakeup source.
+  *         However, when the HSE clock is used as RTC clock source, the RTC
+  *         cannot be used in STOP and STANDBY modes.
+  * @note   The maximum input clock frequency for RTC is 1MHz (when using HSE as
+  *         RTC clock source).
+  * @retval None
+  */
+#define __HAL_RCC_RTC_CONFIG(__RTC_CLKSOURCE__)  \
+                  MODIFY_REG( RCC->BDCR, RCC_BDCR_RTCSEL, (__RTC_CLKSOURCE__))
+
+
+/** @brief  Macro to get the RTC clock source.
+  * @retval The returned value can be one of the following:
+  *            @arg @ref RCC_RTCCLKSOURCE_LSE  LSE selected as RTC clock.
+  *            @arg @ref RCC_RTCCLKSOURCE_LSI  LSI selected as RTC clock.
+  *            @arg @ref RCC_RTCCLKSOURCE_HSE_DIV32  HSE clock divided by 32 selected
+  */
+#define  __HAL_RCC_GET_RTC_SOURCE() ((uint32_t)(READ_BIT(RCC->BDCR, RCC_BDCR_RTCSEL)))
+
+/** @brief  Macros to enable or disable the main PLL.
+  * @note   After enabling the main PLL, the application software should wait on
+  *         PLLRDY flag to be set indicating that PLL clock is stable and can
+  *         be used as system clock source.
+  * @note   The main PLL can not be disabled if it is used as system clock source
+  * @note   The main PLL is disabled by hardware when entering STOP and STANDBY modes.
+  * @retval None
+  */
+#define __HAL_RCC_PLL_ENABLE()         SET_BIT(RCC->CR, RCC_CR_PLLON)
+
+#define __HAL_RCC_PLL_DISABLE()        CLEAR_BIT(RCC->CR, RCC_CR_PLLON)
+
+/** @brief  Macro to configure the PLL clock source.
+  * @note   This function must be used only when the main PLL is disabled.
+  * @param  __PLLSOURCE__: specifies the PLL entry clock source.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_PLLSOURCE_NONE  No clock selected as PLL clock entry
+  *            @arg @ref RCC_PLLSOURCE_MSI  MSI oscillator clock selected as PLL clock entry
+  *            @arg @ref RCC_PLLSOURCE_HSI  HSI oscillator clock selected as PLL clock entry
+  *            @arg @ref RCC_PLLSOURCE_HSE  HSE oscillator clock selected as PLL clock entry
+  * @note   This clock source is common for the main PLL and audio PLL (PLLSAI1 and PLLSAI2).
+  * @retval None
+  *      
+  */
+#define __HAL_RCC_PLL_PLLSOURCE_CONFIG(__PLLSOURCE__) \
+                  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC, (__PLLSOURCE__))
+
+/** @brief  Macro to configure the PLL multiplication factor.
+  * @note   This function must be used only when the main PLL is disabled.
+  * @param  __PLLM__: specifies the division factor for PLL VCO input clock
+  *         This parameter must be a number between Min_Data = 1 and Max_Data = 8.
+  * @note   You have to set the PLLM parameter correctly to ensure that the VCO input
+  *         frequency ranges from 4 to 16 MHz. It is recommended to select a frequency
+  *         of 16 MHz to limit PLL jitter.
+  * @retval None
+  *      
+  */
+#define __HAL_RCC_PLL_PLLM_CONFIG(__PLLM__) \
+                  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLM, ((__PLLM__) - 1) << 4U)
+
+/**
+  * @brief  Macro to configure the main PLL clock source, multiplication and division factors.
+  * @note   This function must be used only when the main PLL is disabled.
+  *
+  * @param  __PLLSOURCE__: specifies the PLL entry clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_PLLSOURCE_NONE  No clock selected as PLL clock entry
+  *            @arg @ref RCC_PLLSOURCE_MSI  MSI oscillator clock selected as PLL clock entry
+  *            @arg @ref RCC_PLLSOURCE_HSI  HSI oscillator clock selected as PLL clock entry
+  *            @arg @ref RCC_PLLSOURCE_HSE  HSE oscillator clock selected as PLL clock entry
+  * @note   This clock source is common for the main PLL and audio PLL (PLLSAI1 and PLLSAI2).
+  *
+  * @param  __PLLM__: specifies the division factor for PLL VCO input clock.
+  *          This parameter must be a number between 1 and 8.
+  * @note   You have to set the PLLM parameter correctly to ensure that the VCO input
+  *         frequency ranges from 4 to 16 MHz. It is recommended to select a frequency
+  *         of 16 MHz to limit PLL jitter.
+  *
+  * @param  __PLLN__: specifies the multiplication factor for PLL VCO output clock.
+  *          This parameter must be a number between 8 and 86.
+  * @note   You have to set the PLLN parameter correctly to ensure that the VCO
+  *         output frequency is between 64 and 344 MHz.
+  *
+  * @param  __PLLP__: specifies the division factor for SAI clock.
+  *          This parameter must be a number in the range (7 or 17).
+  *
+  * @param  __PLLQ__: specifies the division factor for OTG FS, SDMMC1 and RNG clocks.
+  *          This parameter must be in the range (2, 4, 6 or 8).
+  * @note   If the USB OTG FS is used in your application, you have to set the
+  *         PLLQ parameter correctly to have 48 MHz clock for the USB. However,
+  *         the SDMMC1 and RNG need a frequency lower than or equal to 48 MHz to work
+  *         correctly.
+  * @param  __PLLR__: specifies the division factor for the main system clock.
+  * @note   You have to set the PLLR parameter correctly to not exceed 80MHZ.
+  *          This parameter must be in the range (2, 4, 6 or 8).
+  * @retval None
+  */
+#define __HAL_RCC_PLL_CONFIG(__PLLSOURCE__, __PLLM__, __PLLN__, __PLLP__, __PLLQ__,__PLLR__ ) \
+                  (RCC->PLLCFGR = (uint32_t)(((__PLLM__) - 1U) << 4U) | (uint32_t)((__PLLN__) << 8U) | (uint32_t)(((__PLLP__) >> 4U ) << 17U) | \
+                   (uint32_t)(__PLLSOURCE__) | (uint32_t)((((__PLLQ__) >> 1U) - 1U) << 21U) | (uint32_t)((((__PLLR__) >> 1U) - 1U) << 25U))
+
+/** @brief  Macro to get the oscillator used as PLL clock source.
+  * @retval The oscillator used as PLL clock source. The returned value can be one
+  *         of the following:
+  *              - RCC_PLLSOURCE_NONE: No oscillator is used as PLL clock source.
+  *              - RCC_PLLSOURCE_MSI: MSI oscillator is used as PLL clock source.
+  *              - RCC_PLLSOURCE_HSI: HSI oscillator is used as PLL clock source.
+  *              - RCC_PLLSOURCE_HSE: HSE oscillator is used as PLL clock source.
+  */
+#define __HAL_RCC_GET_PLL_OSCSOURCE() ((uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC))
+
+/**
+  * @brief  Enable or disable each clock output (RCC_PLL_SYSCLK, RCC_PLL_48M1CLK, RCC_PLL_SAI3CLK)
+  * @note   Enabling/disabling clock outputs RCC_PLL_SAI3CLK and RCC_PLL_48M1CLK can be done at anytime 
+  *         without the need to stop the PLL in order to save power. But RCC_PLL_SYSCLK cannot  
+  *         be stopped if used as System Clock.
+  * @param  __PLLCLOCKOUT__: specifies the PLL clock to be output.
+  *          This parameter can be one or a combination of the following values:
+  *            @arg @ref RCC_PLL_SAI3CLK  This clock is used to generate an accurate clock to achieve
+  *                                   high-quality audio performance on SAI interface in case.
+  *            @arg @ref RCC_PLL_48M1CLK  This Clock is used to generate the clock for the USB OTG FS (48 MHz),
+  *                                   the random analog generator (<=48 MHz) and the SDMMC1 (<= 48 MHz).
+  *            @arg @ref RCC_PLL_SYSCLK  This Clock is used to generate the high speed system clock (up to 80MHz)
+  * @retval None
+  */
+#define __HAL_RCC_PLLCLKOUT_ENABLE(__PLLCLOCKOUT__)   SET_BIT(RCC->PLLCFGR, (__PLLCLOCKOUT__))
+
+#define __HAL_RCC_PLLCLKOUT_DISABLE(__PLLCLOCKOUT__)  CLEAR_BIT(RCC->PLLCFGR, (__PLLCLOCKOUT__))
+
+/**
+  * @brief  Get clock output enable status (RCC_PLL_SYSCLK, RCC_PLL_48M1CLK, RCC_PLL_SAI3CLK)
+  * @param  __PLLCLOCKOUT__: specifies the output PLL clock to be checked.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_PLL_SAI3CLK  This clock is used to generate an accurate clock to achieve
+  *                                   high-quality audio performance on SAI interface in case.
+  *            @arg @ref RCC_PLL_48M1CLK  This Clock is used to generate the clock for the USB OTG FS (48 MHz),
+  *                                   the random analog generator (<=48 MHz) and the SDMMC1 (<= 48 MHz).
+  *            @arg @ref RCC_PLL_SYSCLK  This Clock is used to generate the high speed system clock (up to 80MHz)
+  * @retval SET / RESET
+  */
+#define __HAL_RCC_GET_PLLCLKOUT_CONFIG(__PLLCLOCKOUT__)  READ_BIT(RCC->PLLCFGR, (__PLLCLOCKOUT__))
+
+/**
+  * @brief  Macro to configure the system clock source.
+  * @param  __SYSCLKSOURCE__: specifies the system clock source.
+  *          This parameter can be one of the following values:
+  *              - RCC_SYSCLKSOURCE_MSI: MSI oscillator is used as system clock source.
+  *              - RCC_SYSCLKSOURCE_HSI: HSI oscillator is used as system clock source.
+  *              - RCC_SYSCLKSOURCE_HSE: HSE oscillator is used as system clock source.
+  *              - RCC_SYSCLKSOURCE_PLLCLK: PLL output is used as system clock source.
+  * @retval None
+  */
+#define __HAL_RCC_SYSCLK_CONFIG(__SYSCLKSOURCE__) \
+                  MODIFY_REG(RCC->CFGR, RCC_CFGR_SW, (__SYSCLKSOURCE__))
+
+/** @brief  Macro to get the clock source used as system clock.
+  * @retval The clock source used as system clock. The returned value can be one
+  *         of the following:
+  *              - RCC_SYSCLKSOURCE_STATUS_MSI: MSI used as system clock.
+  *              - RCC_SYSCLKSOURCE_STATUS_HSI: HSI used as system clock.
+  *              - RCC_SYSCLKSOURCE_STATUS_HSE: HSE used as system clock.
+  *              - RCC_SYSCLKSOURCE_STATUS_PLLCLK: PLL used as system clock.
+  */
+#define __HAL_RCC_GET_SYSCLK_SOURCE() ((uint32_t)(RCC->CFGR & RCC_CFGR_SWS))
+
+/**
+  * @brief  Macro to configure the External Low Speed oscillator (LSE) drive capability.
+  * @note   As the LSE is in the Backup domain and write access is denied to
+  *         this domain after reset, you have to enable write access using
+  *         HAL_PWR_EnableBkUpAccess() function before to configure the LSE
+  *         (to be done once after reset).
+  * @param  __LSEDRIVE__: specifies the new state of the LSE drive capability.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_LSEDRIVE_LOW  LSE oscillator low drive capability.
+  *            @arg @ref RCC_LSEDRIVE_MEDIUMLOW  LSE oscillator medium low drive capability.
+  *            @arg @ref RCC_LSEDRIVE_MEDIUMHIGH  LSE oscillator medium high drive capability.
+  *            @arg @ref RCC_LSEDRIVE_HIGH  LSE oscillator high drive capability.
+  * @retval None
+  */
+#define __HAL_RCC_LSEDRIVE_CONFIG(__LSEDRIVE__) \
+                  MODIFY_REG(RCC->BDCR, RCC_BDCR_LSEDRV, (uint32_t)(__LSEDRIVE__))
+
+/**
+  * @brief  Macro to configure the wake up from stop clock.
+  * @param  __STOPWUCLK__: specifies the clock source used after wake up from stop.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_STOP_WAKEUPCLOCK_MSI  MSI selected as system clock source
+  *            @arg @ref RCC_STOP_WAKEUPCLOCK_HSI  HSI selected as system clock source
+  * @retval None
+  */
+#define __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(__STOPWUCLK__) \
+                  MODIFY_REG(RCC->CFGR, RCC_CFGR_STOPWUCK, (__STOPWUCLK__))
+
+
+/** @brief  Macro to configure the MCO clock.
+  * @param  __MCOCLKSOURCE__ specifies the MCO clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_MCO1SOURCE_NOCLOCK  MCO output disabled
+  *            @arg @ref RCC_MCO1SOURCE_SYSCLK  System  clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_MSI  MSI clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_HSI  HSI clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_HSE  HSE clock selected as MCO sourcee
+  *            @arg @ref RCC_MCO1SOURCE_PLLCLK  Main PLL clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_LSI  LSI clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_LSE  LSE clock selected as MCO source
+  * @param  __MCODIV__ specifies the MCO clock prescaler.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_MCODIV_1   MCO clock source is divided by 1
+  *            @arg @ref RCC_MCODIV_2   MCO clock source is divided by 2
+  *            @arg @ref RCC_MCODIV_4   MCO clock source is divided by 4
+  *            @arg @ref RCC_MCODIV_8   MCO clock source is divided by 8
+  *            @arg @ref RCC_MCODIV_16  MCO clock source is divided by 16
+  */
+#define __HAL_RCC_MCO1_CONFIG(__MCOCLKSOURCE__, __MCODIV__) \
+                 MODIFY_REG(RCC->CFGR, (RCC_CFGR_MCOSEL | RCC_CFGR_MCOPRE), ((__MCOCLKSOURCE__) | (__MCODIV__)))
+
+/** @defgroup RCC_Flags_Interrupts_Management Flags Interrupts Management
+  * @brief macros to manage the specified RCC Flags and interrupts.
+  * @{
+  */
+
+/** @brief  Enable RCC interrupt (Perform Byte access to RCC_CIR[14:8] bits to enable
+  *         the selected interrupts).
+  * @param  __INTERRUPT__: specifies the RCC interrupt sources to be enabled.
+  *         This parameter can be any combination of the following values:
+  *            @arg @ref RCC_IT_LSIRDY  LSI ready interrupt
+  *            @arg @ref RCC_IT_LSERDY  LSE ready interrupt
+  *            @arg @ref RCC_IT_MSIRDY  HSI ready interrupt
+  *            @arg @ref RCC_IT_HSIRDY  HSI ready interrupt
+  *            @arg @ref RCC_IT_HSERDY  HSE ready interrupt
+  *            @arg @ref RCC_IT_PLLRDY  Main PLL ready interrupt
+  *            @arg @ref RCC_IT_PLLSAI1RDY  PLLSAI1 ready interrupt
+  *            @arg @ref RCC_IT_PLLSAI2RDY  PLLSAI2 ready interrupt
+  *            @arg @ref RCC_IT_LSECSS  LSE Clock security system interrupt
+  * @retval None
+  */
+#define __HAL_RCC_ENABLE_IT(__INTERRUPT__) SET_BIT(RCC->CIER, (__INTERRUPT__))
+
+/** @brief Disable RCC interrupt (Perform Byte access to RCC_CIR[14:8] bits to disable
+  *        the selected interrupts).
+  * @param  __INTERRUPT__: specifies the RCC interrupt sources to be disabled.
+  *         This parameter can be any combination of the following values:
+  *            @arg @ref RCC_IT_LSIRDY  LSI ready interrupt
+  *            @arg @ref RCC_IT_LSERDY  LSE ready interrupt
+  *            @arg @ref RCC_IT_MSIRDY  HSI ready interrupt
+  *            @arg @ref RCC_IT_HSIRDY  HSI ready interrupt
+  *            @arg @ref RCC_IT_HSERDY  HSE ready interrupt
+  *            @arg @ref RCC_IT_PLLRDY  Main PLL ready interrupt
+  *            @arg @ref RCC_IT_PLLSAI1RDY  PLLSAI1 ready interrupt
+  *            @arg @ref RCC_IT_PLLSAI2RDY  PLLSAI2 ready interrupt
+  *            @arg @ref RCC_IT_LSECSS  LSE Clock security system interrupt
+  * @retval None
+  */
+#define __HAL_RCC_DISABLE_IT(__INTERRUPT__) CLEAR_BIT(RCC->CIER, (__INTERRUPT__))
+
+/** @brief  Clear the RCC's interrupt pending bits (Perform Byte access to RCC_CIR[23:16]
+  *         bits to clear the selected interrupt pending bits.
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
+  *         This parameter can be any combination of the following values:
+  *            @arg @ref RCC_IT_LSIRDY  LSI ready interrupt
+  *            @arg @ref RCC_IT_LSERDY  LSE ready interrupt
+  *            @arg @ref RCC_IT_MSIRDY  MSI ready interrupt
+  *            @arg @ref RCC_IT_HSIRDY  HSI ready interrupt
+  *            @arg @ref RCC_IT_HSERDY  HSE ready interrupt
+  *            @arg @ref RCC_IT_PLLRDY  Main PLL ready interrupt
+  *            @arg @ref RCC_IT_PLLSAI1RDY  PLLSAI1 ready interrupt
+  *            @arg @ref RCC_IT_PLLSAI2RDY  PLLSAI2 ready interrupt
+  *            @arg @ref RCC_IT_CSS  HSE Clock security system interrupt
+  *            @arg @ref RCC_IT_LSECSS  LSE Clock security system interrupt
+  * @retval None
+  */
+#define __HAL_RCC_CLEAR_IT(__INTERRUPT__) (RCC->CICR = (__INTERRUPT__))
+
+/** @brief  Check whether the RCC interrupt has occurred or not.
+  * @param  __INTERRUPT__: specifies the RCC interrupt source to check.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_IT_LSIRDY  LSI ready interrupt
+  *            @arg @ref RCC_IT_LSERDY  LSE ready interrupt
+  *            @arg @ref RCC_IT_MSIRDY  MSI ready interrupt
+  *            @arg @ref RCC_IT_HSIRDY  HSI ready interrupt
+  *            @arg @ref RCC_IT_HSERDY  HSE ready interrupt
+  *            @arg @ref RCC_IT_PLLRDY  Main PLL ready interrupt
+  *            @arg @ref RCC_IT_PLLSAI1RDY  PLLSAI1 ready interrupt
+  *            @arg @ref RCC_IT_PLLSAI2RDY  PLLSAI2 ready interrupt
+  *            @arg @ref RCC_IT_CSS  HSE Clock security system interrupt
+  *            @arg @ref RCC_IT_LSECSS  LSE Clock security system interrupt
+  * @retval The new state of __INTERRUPT__ (TRUE or FALSE).
+  */
+#define __HAL_RCC_GET_IT(__INTERRUPT__) ((RCC->CIFR & (__INTERRUPT__)) == (__INTERRUPT__))
+
+/** @brief Set RMVF bit to clear the reset flags.
+  *        The reset flags are: RCC_FLAG_FWRRST, RCC_FLAG_OBLRST, RCC_FLAG_PINRST, RCC_FLAG_BORRST,
+  *        RCC_FLAG_SFTRST, RCC_FLAG_IWDGRST, RCC_FLAG_WWDGRST and RCC_FLAG_LPWRRST.
+  * @retval None
+ */
+#define __HAL_RCC_CLEAR_RESET_FLAGS() (RCC->CSR |= RCC_CSR_RMVF)
+
+/** @brief  Check whether the selected RCC flag is set or not.
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_FLAG_MSIRDY  MSI oscillator clock ready
+  *            @arg @ref RCC_FLAG_HSIRDY  HSI oscillator clock ready
+  *            @arg @ref RCC_FLAG_HSERDY  HSE oscillator clock ready
+  *            @arg @ref RCC_FLAG_PLLRDY  Main PLL clock ready
+  *            @arg @ref RCC_FLAG_PLLSAI1RDY  PLLSAI1 clock ready
+  *            @arg @ref RCC_FLAG_PLLSAI2RDY  PLLSAI2 clock ready
+  *            @arg @ref RCC_FLAG_LSERDY  LSE oscillator clock ready
+  *            @arg @ref RCC_FLAG_LSECSSD  Clock security system failure on LSE oscillator detection
+  *            @arg @ref RCC_FLAG_LSIRDY  LSI oscillator clock ready
+  *            @arg @ref RCC_FLAG_BORRST  BOR reset
+  *            @arg @ref RCC_FLAG_OBLRST  OBLRST reset
+  *            @arg @ref RCC_FLAG_PINRST  Pin reset
+  *            @arg @ref RCC_FLAG_FWRST  FIREWALL reset
+  *            @arg @ref RCC_FLAG_RMVF  Remove reset Flag
+  *            @arg @ref RCC_FLAG_SFTRST  Software reset
+  *            @arg @ref RCC_FLAG_IWDGRST  Independent Watchdog reset
+  *            @arg @ref RCC_FLAG_WWDGRST  Window Watchdog reset
+  *            @arg @ref RCC_FLAG_LPWRRST  Low Power reset
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_RCC_GET_FLAG(__FLAG__) (((((((__FLAG__) >> 5U) == 1U) ? RCC->CR :                    \
+                                        ((((__FLAG__) >> 5U) == 2U) ? RCC->BDCR :                  \
+                                        ((((__FLAG__) >> 5U) == 3U) ? RCC->CSR : RCC->CIFR))) &    \
+                                          ((uint32_t)1 << ((__FLAG__) & RCC_FLAG_MASK))) != RESET) \
+                                            ? 1U : 0U)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup RCC_Private_Constants RCC Private Constants
+  * @{
+  */
+/* Defines used for Flags */
+#define CR_REG_INDEX              ((uint32_t)1U)
+#define BDCR_REG_INDEX            ((uint32_t)2U)
+#define CSR_REG_INDEX             ((uint32_t)3U)
+
+#define RCC_FLAG_MASK             ((uint32_t)0x1FU)
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @addtogroup RCC_Private_Macros
+  * @{
+  */
+
+#define IS_RCC_OSCILLATORTYPE(__OSCILLATOR__) (((__OSCILLATOR__) == RCC_OSCILLATORTYPE_NONE)                           || \
+                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSE) == RCC_OSCILLATORTYPE_HSE) || \
+                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSI) == RCC_OSCILLATORTYPE_HSI) || \
+                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_MSI) == RCC_OSCILLATORTYPE_MSI) || \
+                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSI) == RCC_OSCILLATORTYPE_LSI) || \
+                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSE) == RCC_OSCILLATORTYPE_LSE))
+
+#define IS_RCC_HSE(__HSE__)  (((__HSE__) == RCC_HSE_OFF) || ((__HSE__) == RCC_HSE_ON) || \
+                              ((__HSE__) == RCC_HSE_BYPASS))
+
+#define IS_RCC_LSE(__LSE__)  (((__LSE__) == RCC_LSE_OFF) || ((__LSE__) == RCC_LSE_ON) || \
+                              ((__LSE__) == RCC_LSE_BYPASS))
+
+#define IS_RCC_HSI(__HSI__)  (((__HSI__) == RCC_HSI_OFF) || ((__HSI__) == RCC_HSI_ON))
+
+#define IS_RCC_HSI_CALIBRATION_VALUE(__VALUE__) ((__VALUE__) <= (uint32_t)31U)
+
+#define IS_RCC_LSI(__LSI__)  (((__LSI__) == RCC_LSI_OFF) || ((__LSI__) == RCC_LSI_ON))
+
+#define IS_RCC_MSI(__MSI__)  (((__MSI__) == RCC_MSI_OFF) || ((__MSI__) == RCC_MSI_ON))
+
+#define IS_RCC_MSICALIBRATION_VALUE(__VALUE__) ((__VALUE__) <= (uint32_t)255U)
+
+#define IS_RCC_PLL(__PLL__) (((__PLL__) == RCC_PLL_NONE) ||((__PLL__) == RCC_PLL_OFF) || \
+                             ((__PLL__) == RCC_PLL_ON))
+
+#define IS_RCC_PLLSOURCE(__SOURCE__) (((__SOURCE__) == RCC_PLLSOURCE_NONE) || \
+                                      ((__SOURCE__) == RCC_PLLSOURCE_MSI)  || \
+                                      ((__SOURCE__) == RCC_PLLSOURCE_HSI)  || \
+                                      ((__SOURCE__) == RCC_PLLSOURCE_HSE))
+
+#define IS_RCC_PLLM_VALUE(__VALUE__) ((__VALUE__) <= 8U)
+
+#define IS_RCC_PLLN_VALUE(__VALUE__) ((8U <= (__VALUE__)) && ((__VALUE__) <= 86U))
+
+#define IS_RCC_PLLP_VALUE(__VALUE__) (((__VALUE__) == 7U) || ((__VALUE__) == 17U))
+
+#define IS_RCC_PLLQ_VALUE(__VALUE__) (((__VALUE__) == 2U) || ((__VALUE__) == 4U) || \
+                                      ((__VALUE__) == 6U) || ((__VALUE__) == 8U))
+
+#define IS_RCC_PLLR_VALUE(__VALUE__) (((__VALUE__) == 2U) || ((__VALUE__) == 4U) || \
+                                      ((__VALUE__) == 6U) || ((__VALUE__) == 8U))
+
+#define IS_RCC_PLLSAI1CLOCKOUT_VALUE(__VALUE__) (((((__VALUE__) & RCC_PLLSAI1_SAI1CLK) == RCC_PLLSAI1_SAI1CLK)  || \
+                                                  (((__VALUE__) & RCC_PLLSAI1_48M2CLK) == RCC_PLLSAI1_48M2CLK)  || \
+                                                  (((__VALUE__) & RCC_PLLSAI1_ADC1CLK) == RCC_PLLSAI1_ADC1CLK)) && \
+                                                 (((__VALUE__) & ~(RCC_PLLSAI1_SAI1CLK|RCC_PLLSAI1_48M2CLK|RCC_PLLSAI1_ADC1CLK)) == 0U))
+
+#define IS_RCC_PLLSAI2CLOCKOUT_VALUE(__VALUE__) (((((__VALUE__) & RCC_PLLSAI2_SAI2CLK) == RCC_PLLSAI2_SAI2CLK ) || \
+                                                  (((__VALUE__) & RCC_PLLSAI2_ADC2CLK) == RCC_PLLSAI2_ADC2CLK)) && \
+                                                 (((__VALUE__) & ~(RCC_PLLSAI2_SAI2CLK|RCC_PLLSAI2_ADC2CLK)) == 0U))   
+
+#define IS_RCC_MSI_CLOCK_RANGE(__RANGE__) (((__RANGE__) == RCC_MSIRANGE_0)  || \
+                                           ((__RANGE__) == RCC_MSIRANGE_1)  || \
+                                           ((__RANGE__) == RCC_MSIRANGE_2)  || \
+                                           ((__RANGE__) == RCC_MSIRANGE_3)  || \
+                                           ((__RANGE__) == RCC_MSIRANGE_4)  || \
+                                           ((__RANGE__) == RCC_MSIRANGE_5)  || \
+                                           ((__RANGE__) == RCC_MSIRANGE_6)  || \
+                                           ((__RANGE__) == RCC_MSIRANGE_7)  || \
+                                           ((__RANGE__) == RCC_MSIRANGE_8)  || \
+                                           ((__RANGE__) == RCC_MSIRANGE_9)  || \
+                                           ((__RANGE__) == RCC_MSIRANGE_10) || \
+                                           ((__RANGE__) == RCC_MSIRANGE_11))
+
+#define IS_RCC_MSI_STANDBY_CLOCK_RANGE(__RANGE__) (((__RANGE__) == RCC_MSIRANGE_4)  || \
+                                                   ((__RANGE__) == RCC_MSIRANGE_5)  || \
+                                                   ((__RANGE__) == RCC_MSIRANGE_6)  || \
+                                                   ((__RANGE__) == RCC_MSIRANGE_7))
+
+#define IS_RCC_CLOCKTYPE(__CLK__)  ((1U <= (__CLK__)) && ((__CLK__) <= 15U))
+
+#define IS_RCC_SYSCLKSOURCE(__SOURCE__) (((__SOURCE__) == RCC_SYSCLKSOURCE_MSI) || \
+                                         ((__SOURCE__) == RCC_SYSCLKSOURCE_HSI) || \
+                                         ((__SOURCE__) == RCC_SYSCLKSOURCE_HSE) || \
+                                         ((__SOURCE__) == RCC_SYSCLKSOURCE_PLLCLK))
+
+#define IS_RCC_HCLK(__HCLK__) (((__HCLK__) == RCC_SYSCLK_DIV1)   || ((__HCLK__) == RCC_SYSCLK_DIV2)   || \
+                               ((__HCLK__) == RCC_SYSCLK_DIV4)   || ((__HCLK__) == RCC_SYSCLK_DIV8)   || \
+                               ((__HCLK__) == RCC_SYSCLK_DIV16)  || ((__HCLK__) == RCC_SYSCLK_DIV64)  || \
+                               ((__HCLK__) == RCC_SYSCLK_DIV128) || ((__HCLK__) == RCC_SYSCLK_DIV256) || \
+                               ((__HCLK__) == RCC_SYSCLK_DIV512))
+
+#define IS_RCC_PCLK(__PCLK__) (((__PCLK__) == RCC_HCLK_DIV1) || ((__PCLK__) == RCC_HCLK_DIV2) || \
+                               ((__PCLK__) == RCC_HCLK_DIV4) || ((__PCLK__) == RCC_HCLK_DIV8) || \
+                               ((__PCLK__) == RCC_HCLK_DIV16))
+
+#define IS_RCC_RTCCLKSOURCE(__SOURCE__) (((__SOURCE__) == RCC_RTCCLKSOURCE_LSE) || \
+                                         ((__SOURCE__) == RCC_RTCCLKSOURCE_LSI) || \
+                                         ((__SOURCE__) == RCC_RTCCLKSOURCE_HSE_DIV32))
+
+#define IS_RCC_MCO(__MCOX__) ((__MCOX__) == RCC_MCO1)
+
+#define IS_RCC_MCO1SOURCE(__SOURCE__) (((__SOURCE__) == RCC_MCO1SOURCE_NOCLOCK) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_SYSCLK) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_MSI) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_HSI) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_HSE) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_PLLCLK) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_LSI) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_LSE))
+
+#define IS_RCC_MCODIV(__DIV__) (((__DIV__) == RCC_MCODIV_1) || ((__DIV__) == RCC_MCODIV_2) || \
+                                ((__DIV__) == RCC_MCODIV_4) || ((__DIV__) == RCC_MCODIV_8) || \
+                                ((__DIV__) == RCC_MCODIV_16))
+
+#define IS_RCC_LSE_DRIVE(__DRIVE__) (((__DRIVE__) == RCC_LSEDRIVE_LOW)        || \
+                                     ((__DRIVE__) == RCC_LSEDRIVE_MEDIUMLOW)  || \
+                                     ((__DRIVE__) == RCC_LSEDRIVE_MEDIUMHIGH) || \
+                                     ((__DRIVE__) == RCC_LSEDRIVE_HIGH))
+
+#define IS_RCC_STOP_WAKEUPCLOCK(__SOURCE__) (((__SOURCE__) == RCC_STOP_WAKEUPCLOCK_MSI) || \
+                                             ((__SOURCE__) == RCC_STOP_WAKEUPCLOCK_HSI))
+/**
+  * @}
+  */
+
+/* Include RCC HAL Extended module */
+#include "stm32l4xx_hal_rcc_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup RCC_Exported_Functions
+  * @{
+  */
+
+
+/** @addtogroup RCC_Exported_Functions_Group1
+  * @{
+  */
+
+/* Initialization and de-initialization functions  ******************************/
+void              HAL_RCC_DeInit(void);
+HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef *RCC_OscInitStruct);
+HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef *RCC_ClkInitStruct, uint32_t FLatency);
+
+/**
+  * @}
+  */
+
+/** @addtogroup RCC_Exported_Functions_Group2
+  * @{
+  */
+
+/* Peripheral Control functions  ************************************************/
+void              HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_MCODiv);
+void              HAL_RCC_EnableCSS(void);
+uint32_t          HAL_RCC_GetSysClockFreq(void);
+uint32_t          HAL_RCC_GetHCLKFreq(void);
+uint32_t          HAL_RCC_GetPCLK1Freq(void);
+uint32_t          HAL_RCC_GetPCLK2Freq(void);
+void              HAL_RCC_GetOscConfig(RCC_OscInitTypeDef *RCC_OscInitStruct);
+void              HAL_RCC_GetClockConfig(RCC_ClkInitTypeDef *RCC_ClkInitStruct, uint32_t *pFLatency);
+/* CSS NMI IRQ handler */
+void              HAL_RCC_NMI_IRQHandler(void);
+/* User Callbacks in non blocking mode (IT mode) */
+void              HAL_RCC_CSSCallback(void);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_RCC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_rcc_ex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_rcc_ex.h
@@ -1,0 +1,1518 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_rcc_ex.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of RCC HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_RCC_EX_H
+#define __STM32L4xx_HAL_RCC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RCCEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** @defgroup RCCEx_Exported_Types RCCEx Exported Types
+  * @{
+  */
+
+/**
+  * @brief  PLLSAI1 Clock structure definition
+  */
+typedef struct
+{
+
+  uint32_t PLLSAI1N;         /*!< PLLSAI1N: specifies the multiplication factor for PLLSAI1 VCO output clock.
+                                  This parameter must be a number between 8 and 86. */
+
+  uint32_t PLLSAI1P;         /*!< PLLSAI1P: specifies the division factor for SAI clock.
+                                  This parameter must be a value of @ref RCC_PLLP_Clock_Divider */
+
+  uint32_t PLLSAI1Q;         /*!< PLLSAI1Q: specifies the division factor for USB/RNG/SDMMC1 clock.
+                                  This parameter must be a value of @ref RCC_PLLQ_Clock_Divider */
+
+  uint32_t PLLSAI1R;         /*!< PLLSAI1R: specifies the division factor for ADC clock.
+                                  This parameter must be a value of @ref RCC_PLLR_Clock_Divider */
+
+  uint32_t PLLSAI1ClockOut;  /*!< PLLSAIClockOut: specifies PLLSAI1 output clock to be enabled.
+                                  This parameter must be a value of @ref RCC_PLLSAI1_Clock_Output */
+}RCC_PLLSAI1InitTypeDef;
+
+/**
+  * @brief  PLLSAI2 Clock structure definition
+  */
+typedef struct
+{
+
+  uint32_t PLLSAI2N;         /*!< PLLSAI2N: specifies the multiplication factor for PLLSAI2 VCO output clock.
+                                  This parameter must be a number between 8 and 86. */
+
+  uint32_t PLLSAI2P;         /*!< PLLSAI2P: specifies the division factor for SAI clock.
+                                  This parameter must be a value of @ref RCC_PLLP_Clock_Divider */
+
+  uint32_t PLLSAI2R;         /*!< PLLSAI2R: specifies the division factor for ADC clock.
+                                  This parameter must be a value of @ref RCC_PLLR_Clock_Divider */
+
+  uint32_t PLLSAI2ClockOut;  /*!< PLLSAIClockOut: specifies PLLSAI2 output clock to be enabled.
+                                  This parameter must be a value of @ref RCC_PLLSAI2_Clock_Output */
+}RCC_PLLSAI2InitTypeDef;
+
+/**
+  * @brief  RCC extended clocks structure definition
+  */
+typedef struct
+{
+  uint32_t PeriphClockSelection;   /*!< The Extended Clock to be configured.
+                                        This parameter can be a value of @ref RCCEx_Periph_Clock_Selection */
+
+  RCC_PLLSAI1InitTypeDef PLLSAI1;  /*!< PLLSAI1 structure parameters.
+                                        This parameter will be used only when PLLSAI1 is selected as Clock Source for SAI1, USB/RNG/SDMMC1 or ADC */
+
+  RCC_PLLSAI2InitTypeDef PLLSAI2;  /*!< PLLSAI2 structure parameters.
+                                        This parameter will be used only when PLLSAI2 is selected as Clock Source for SAI2 or ADC */
+
+  uint32_t Usart1ClockSelection;   /*!< Specifies USART1 clock source.
+                                        This parameter can be a value of @ref RCCEx_USART1_Clock_Source */
+
+  uint32_t Usart2ClockSelection;   /*!< Specifies USART2 clock source.
+                                        This parameter can be a value of @ref RCCEx_USART2_Clock_Source */
+
+  uint32_t Usart3ClockSelection;   /*!< Specifies USART3 clock source.
+                                        This parameter can be a value of @ref RCCEx_USART3_Clock_Source */
+
+  uint32_t Uart4ClockSelection;    /*!< Specifies UART4 clock source.
+                                        This parameter can be a value of @ref RCCEx_UART4_Clock_Source */
+
+  uint32_t Uart5ClockSelection;    /*!< Specifies UART5 clock source.
+                                        This parameter can be a value of @ref RCCEx_UART5_Clock_Source */
+
+  uint32_t Lpuart1ClockSelection;  /*!< Specifies LPUART1 clock source.
+                                        This parameter can be a value of @ref RCCEx_LPUART1_Clock_Source */
+
+  uint32_t I2c1ClockSelection;     /*!< Specifies I2C1 clock source.
+                                        This parameter can be a value of @ref RCCEx_I2C1_Clock_Source */
+
+  uint32_t I2c2ClockSelection;     /*!< Specifies I2C2 clock source.
+                                        This parameter can be a value of @ref RCCEx_I2C2_Clock_Source */
+
+  uint32_t I2c3ClockSelection;     /*!< Specifies I2C3 clock source.
+                                        This parameter can be a value of @ref RCCEx_I2C3_Clock_Source */
+
+  uint32_t Lptim1ClockSelection;   /*!< Specifies LPTIM1 clock source.
+                                        This parameter can be a value of @ref RCCEx_LPTIM1_Clock_Source */
+
+  uint32_t Lptim2ClockSelection;   /*!< Specifies LPTIM2 clock source.
+                                        This parameter can be a value of @ref RCCEx_LPTIM2_Clock_Source */
+
+  uint32_t Sai1ClockSelection;     /*!< Specifies SAI1 clock source.
+                                        This parameter can be a value of @ref RCCEx_SAI1_Clock_Source */
+
+  uint32_t Sai2ClockSelection;     /*!< Specifies SAI2 clock source.
+                                        This parameter can be a value of @ref RCCEx_SAI2_Clock_Source */
+
+#if defined(USB_OTG_FS)
+
+  uint32_t UsbClockSelection;      /*!< Specifies USB clock source (warning: same source for SDMMC1 and RNG).
+                                        This parameter can be a value of @ref RCCEx_USB_Clock_Source */
+
+#endif /* USB_OTG_FS */
+
+  uint32_t Sdmmc1ClockSelection;   /*!< Specifies SDMMC1 clock source (warning: same source for USB and RNG).
+                                        This parameter can be a value of @ref RCCEx_SDMMC1_Clock_Source */
+
+  uint32_t RngClockSelection;      /*!< Specifies RNG clock source (warning: same source for USB and SDMMC1).
+                                        This parameter can be a value of @ref RCCEx_RNG_Clock_Source */
+
+  uint32_t AdcClockSelection;      /*!< Specifies ADC interface clock source.
+                                        This parameter can be a value of @ref RCCEx_ADC_Clock_Source */
+
+  uint32_t Swpmi1ClockSelection;   /*!< Specifies SWPMI1 clock source.
+                                        This parameter can be a value of @ref RCCEx_SWPMI1_Clock_Source */
+
+  uint32_t DfsdmClockSelection;    /*!< Specifies DFSDM clock source.
+                                        This parameter can be a value of @ref RCCEx_DFSDM_Clock_Source */
+
+  uint32_t RTCClockSelection;      /*!< Specifies RTC clock source.
+                                        This parameter can be a value of @ref RCC_RTC_Clock_Source */
+}RCC_PeriphCLKInitTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RCCEx_Exported_Constants RCCEx Exported Constants
+  * @{
+  */
+
+/** @defgroup RCCEx_LSCO_Clock_Source Low Speed Clock Source
+  * @{
+  */
+#define RCC_LSCOSOURCE_LSI             (uint32_t)0x00000000U /*!< LSI selection for low speed clock output */
+#define RCC_LSCOSOURCE_LSE             RCC_BDCR_LSCOSEL      /*!< LSE selection for low speed clock output */
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_Periph_Clock_Selection Periph Clock Selection
+  * @{
+  */
+#define RCC_PERIPHCLK_USART1           ((uint32_t)0x00000001U)
+#define RCC_PERIPHCLK_USART2           ((uint32_t)0x00000002U)
+#define RCC_PERIPHCLK_USART3           ((uint32_t)0x00000004U)
+#define RCC_PERIPHCLK_UART4            ((uint32_t)0x00000008U)
+#define RCC_PERIPHCLK_UART5            ((uint32_t)0x00000010U)
+#define RCC_PERIPHCLK_LPUART1          ((uint32_t)0x00000020U)
+#define RCC_PERIPHCLK_I2C1             ((uint32_t)0x00000040U)
+#define RCC_PERIPHCLK_I2C2             ((uint32_t)0x00000080U)
+#define RCC_PERIPHCLK_I2C3             ((uint32_t)0x00000100U)
+#define RCC_PERIPHCLK_LPTIM1           ((uint32_t)0x00000200U)
+#define RCC_PERIPHCLK_LPTIM2           ((uint32_t)0x00000400U)
+#define RCC_PERIPHCLK_SAI1             ((uint32_t)0x00000800U)
+#define RCC_PERIPHCLK_SAI2             ((uint32_t)0x00001000U)
+#if defined(USB_OTG_FS)
+#define RCC_PERIPHCLK_USB              ((uint32_t)0x00002000U)
+#endif
+#define RCC_PERIPHCLK_ADC              ((uint32_t)0x00004000U)
+#define RCC_PERIPHCLK_SWPMI1           ((uint32_t)0x00008000U)
+#define RCC_PERIPHCLK_DFSDM            ((uint32_t)0x00010000U)
+#define RCC_PERIPHCLK_RTC              ((uint32_t)0x00020000U)
+#define RCC_PERIPHCLK_RNG              ((uint32_t)0x00040000U)
+#define RCC_PERIPHCLK_SDMMC1           ((uint32_t)0x00080000U)
+/**
+  * @}
+  */
+
+
+/** @defgroup RCCEx_USART1_Clock_Source USART1 Clock Source
+  * @{
+  */
+#define RCC_USART1CLKSOURCE_PCLK2      ((uint32_t)0x00000000U)
+#define RCC_USART1CLKSOURCE_SYSCLK     RCC_CCIPR_USART1SEL_0
+#define RCC_USART1CLKSOURCE_HSI        RCC_CCIPR_USART1SEL_1
+#define RCC_USART1CLKSOURCE_LSE        (RCC_CCIPR_USART1SEL_0 | RCC_CCIPR_USART1SEL_1)
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_USART2_Clock_Source USART2 Clock Source
+  * @{
+  */
+#define RCC_USART2CLKSOURCE_PCLK1      ((uint32_t)0x00000000U)
+#define RCC_USART2CLKSOURCE_SYSCLK     RCC_CCIPR_USART2SEL_0
+#define RCC_USART2CLKSOURCE_HSI        RCC_CCIPR_USART2SEL_1
+#define RCC_USART2CLKSOURCE_LSE        (RCC_CCIPR_USART2SEL_0 | RCC_CCIPR_USART2SEL_1)
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_USART3_Clock_Source USART3 Clock Source
+  * @{
+  */
+#define RCC_USART3CLKSOURCE_PCLK1      ((uint32_t)0x00000000U)
+#define RCC_USART3CLKSOURCE_SYSCLK     RCC_CCIPR_USART3SEL_0
+#define RCC_USART3CLKSOURCE_HSI        RCC_CCIPR_USART3SEL_1
+#define RCC_USART3CLKSOURCE_LSE        (RCC_CCIPR_USART3SEL_0 | RCC_CCIPR_USART3SEL_1)
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_UART4_Clock_Source UART4 Clock Source
+  * @{
+  */
+#define RCC_UART4CLKSOURCE_PCLK1       ((uint32_t)0x00000000U)
+#define RCC_UART4CLKSOURCE_SYSCLK      RCC_CCIPR_UART4SEL_0
+#define RCC_UART4CLKSOURCE_HSI         RCC_CCIPR_UART4SEL_1
+#define RCC_UART4CLKSOURCE_LSE         (RCC_CCIPR_UART4SEL_0 | RCC_CCIPR_UART4SEL_1)
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_UART5_Clock_Source UART5 Clock Source
+  * @{
+  */
+#define RCC_UART5CLKSOURCE_PCLK1       ((uint32_t)0x00000000U)
+#define RCC_UART5CLKSOURCE_SYSCLK      RCC_CCIPR_UART5SEL_0
+#define RCC_UART5CLKSOURCE_HSI         RCC_CCIPR_UART5SEL_1
+#define RCC_UART5CLKSOURCE_LSE         (RCC_CCIPR_UART5SEL_0 | RCC_CCIPR_UART5SEL_1)
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_LPUART1_Clock_Source LPUART1 Clock Source
+  * @{
+  */
+#define RCC_LPUART1CLKSOURCE_PCLK1     ((uint32_t)0x00000000U)
+#define RCC_LPUART1CLKSOURCE_SYSCLK    RCC_CCIPR_LPUART1SEL_0
+#define RCC_LPUART1CLKSOURCE_HSI       RCC_CCIPR_LPUART1SEL_1
+#define RCC_LPUART1CLKSOURCE_LSE       (RCC_CCIPR_LPUART1SEL_0 | RCC_CCIPR_LPUART1SEL_1)
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2C1_Clock_Source I2C1 Clock Source
+  * @{
+  */
+#define RCC_I2C1CLKSOURCE_PCLK1        ((uint32_t)0x00000000U)
+#define RCC_I2C1CLKSOURCE_SYSCLK       RCC_CCIPR_I2C1SEL_0
+#define RCC_I2C1CLKSOURCE_HSI          RCC_CCIPR_I2C1SEL_1
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2C2_Clock_Source I2C2 Clock Source
+  * @{
+  */
+#define RCC_I2C2CLKSOURCE_PCLK1        ((uint32_t)0x00000000U)
+#define RCC_I2C2CLKSOURCE_SYSCLK       RCC_CCIPR_I2C2SEL_0
+#define RCC_I2C2CLKSOURCE_HSI          RCC_CCIPR_I2C2SEL_1
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2C3_Clock_Source I2C3 Clock Source
+  * @{
+  */
+#define RCC_I2C3CLKSOURCE_PCLK1        ((uint32_t)0x00000000U)
+#define RCC_I2C3CLKSOURCE_SYSCLK       RCC_CCIPR_I2C3SEL_0
+#define RCC_I2C3CLKSOURCE_HSI          RCC_CCIPR_I2C3SEL_1
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_SAI1_Clock_Source SAI1 Clock Source
+  * @{
+  */
+#define RCC_SAI1CLKSOURCE_PLLSAI1      ((uint32_t)0x00000000U)
+#define RCC_SAI1CLKSOURCE_PLLSAI2      RCC_CCIPR_SAI1SEL_0
+#define RCC_SAI1CLKSOURCE_PLL          RCC_CCIPR_SAI1SEL_1
+#define RCC_SAI1CLKSOURCE_PIN          RCC_CCIPR_SAI1SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_SAI2_Clock_Source SAI2 Clock Source
+  * @{
+  */
+#define RCC_SAI2CLKSOURCE_PLLSAI1      ((uint32_t)0x00000000U)
+#define RCC_SAI2CLKSOURCE_PLLSAI2      RCC_CCIPR_SAI2SEL_0
+#define RCC_SAI2CLKSOURCE_PLL          RCC_CCIPR_SAI2SEL_1
+#define RCC_SAI2CLKSOURCE_PIN          RCC_CCIPR_SAI2SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_LPTIM1_Clock_Source LPTIM1 Clock Source
+  * @{
+  */
+#define RCC_LPTIM1CLKSOURCE_PCLK       ((uint32_t)0x00000000U)
+#define RCC_LPTIM1CLKSOURCE_LSI        RCC_CCIPR_LPTIM1SEL_0
+#define RCC_LPTIM1CLKSOURCE_HSI        RCC_CCIPR_LPTIM1SEL_1
+#define RCC_LPTIM1CLKSOURCE_LSE        RCC_CCIPR_LPTIM1SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_LPTIM2_Clock_Source LPTIM2 Clock Source
+  * @{
+  */
+#define RCC_LPTIM2CLKSOURCE_PCLK       ((uint32_t)0x00000000U)
+#define RCC_LPTIM2CLKSOURCE_LSI        RCC_CCIPR_LPTIM2SEL_0
+#define RCC_LPTIM2CLKSOURCE_HSI        RCC_CCIPR_LPTIM2SEL_1
+#define RCC_LPTIM2CLKSOURCE_LSE        RCC_CCIPR_LPTIM2SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_SDMMC1_Clock_Source SDMMC1 Clock Source
+  * @{
+  */
+#define RCC_SDMMC1CLKSOURCE_NONE       ((uint32_t)0x00000000U)
+#define RCC_SDMMC1CLKSOURCE_PLLSAI1    RCC_CCIPR_CLK48SEL_0
+#define RCC_SDMMC1CLKSOURCE_PLL        RCC_CCIPR_CLK48SEL_1
+#define RCC_SDMMC1CLKSOURCE_MSI        RCC_CCIPR_CLK48SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_RNG_Clock_Source RNG Clock Source
+  * @{
+  */
+#define RCC_RNGCLKSOURCE_NONE          ((uint32_t)0x00000000U)
+#define RCC_RNGCLKSOURCE_PLLSAI1       RCC_CCIPR_CLK48SEL_0
+#define RCC_RNGCLKSOURCE_PLL           RCC_CCIPR_CLK48SEL_1
+#define RCC_RNGCLKSOURCE_MSI           RCC_CCIPR_CLK48SEL
+/**
+  * @}
+  */
+
+#if defined(USB_OTG_FS)
+/** @defgroup RCCEx_USB_Clock_Source USB Clock Source
+  * @{
+  */
+#define RCC_USBCLKSOURCE_NONE          ((uint32_t)0x00000000U)
+#define RCC_USBCLKSOURCE_PLLSAI1       RCC_CCIPR_CLK48SEL_0
+#define RCC_USBCLKSOURCE_PLL           RCC_CCIPR_CLK48SEL_1
+#define RCC_USBCLKSOURCE_MSI           RCC_CCIPR_CLK48SEL
+/**
+  * @}
+  */
+#endif /* USB_OTG_FS */
+
+/** @defgroup RCCEx_ADC_Clock_Source ADC Clock Source
+  * @{
+  */
+#define RCC_ADCCLKSOURCE_NONE        ((uint32_t)0x00000000U)
+#define RCC_ADCCLKSOURCE_PLLSAI1      RCC_CCIPR_ADCSEL_0
+#define RCC_ADCCLKSOURCE_PLLSAI2      RCC_CCIPR_ADCSEL_1
+#define RCC_ADCCLKSOURCE_SYSCLK       RCC_CCIPR_ADCSEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_SWPMI1_Clock_Source SWPMI1 Clock Source
+  * @{
+  */
+#define RCC_SWPMI1CLKSOURCE_PCLK       ((uint32_t)0x00000000U)
+#define RCC_SWPMI1CLKSOURCE_HSI        RCC_CCIPR_SWPMI1SEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_DFSDM_Clock_Source DFSDM Clock Source
+  * @{
+  */
+#define RCC_DFSDMCLKSOURCE_PCLK        ((uint32_t)0x00000000U)
+#define RCC_DFSDMCLKSOURCE_SYSCLK      RCC_CCIPR_DFSDMSEL
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_EXTI_LINE_LSECSS  RCC LSE CSS external interrupt line
+  * @{
+  */
+#define RCC_EXTI_LINE_LSECSS           EXTI_IMR1_IM19        /*!< External interrupt line 19 connected to the LSE CSS EXTI Line */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup RCCEx_Exported_Macros RCCEx Exported Macros
+ * @{
+ */
+
+
+/**
+  * @brief  Macro to configure the PLLSAI1 clock multiplication and division factors.
+  *
+  * @note   This function must be used only when the PLLSAI1 is disabled.
+  * @note   PLLSAI1 clock source is common with the main PLL (configured through
+  *         __HAL_RCC_PLL_CONFIG() macro)
+  *
+  * @param  __PLLSAI1N__ specifies the multiplication factor for PLLSAI1 VCO output clock.
+  *         This parameter must be a number between 8 and 86.
+  * @note   You have to set the PLLSAI1N parameter correctly to ensure that the VCO
+  *         output frequency is between 64 and 344 MHz.
+  *         PLLSAI1 clock frequency = f(PLLSAI1) multiplied by PLLSAI1N
+  *
+  * @param  __PLLSAI1P__ specifies the division factor for SAI clock.
+  *         This parameter must be a number in the range (7 or 17).
+  *         SAI1 clock frequency = f(PLLSAI1) / PLLSAI1P
+  *
+  * @param  __PLLSAI1Q__ specifies the division factor for USB/RNG/SDMMC1 clock.
+  *         This parameter must be in the range (2, 4, 6 or 8).
+  *         USB/RNG/SDMMC1 clock frequency = f(PLLSAI1) / PLLSAI1Q
+  *
+  * @param  __PLLSAI1R__ specifies the division factor for SAR ADC clock.
+  *         This parameter must be in the range (2, 4, 6 or 8).
+  *         ADC clock frequency = f(PLLSAI1) / PLLSAI1R
+  *
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI1_CONFIG(__PLLSAI1N__, __PLLSAI1P__, __PLLSAI1Q__, __PLLSAI1R__) \
+                  WRITE_REG(RCC->PLLSAI1CFGR, ((__PLLSAI1N__) << POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1N)) | \
+                    (((__PLLSAI1P__) >> 4U) << POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1P)) | \
+                    ((((__PLLSAI1Q__) >> 1U) - 1U) << POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1Q)) | \
+                    ((((__PLLSAI1R__) >> 1U) - 1U) << POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1R)))
+
+/**
+  * @brief  Macro to configure the PLLSAI1 clock multiplication factor N.
+  *
+  * @note   This function must be used only when the PLLSAI1 is disabled.
+  * @note   PLLSAI1 clock source is common with the main PLL (configured through
+  *         __HAL_RCC_PLL_CONFIG() macro)
+  *
+  * @param  __PLLSAI1N__ specifies the multiplication factor for PLLSAI1 VCO output clock.
+  *          This parameter must be a number between 8 and 86.
+  * @note   You have to set the PLLSAI1N parameter correctly to ensure that the VCO
+  *         output frequency is between 64 and 344 MHz.
+  *         Use to set PLLSAI1 clock frequency = f(PLLSAI1) multiplied by PLLSAI1N
+  *
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI1_MULN_CONFIG(__PLLSAI1N__) \
+                  MODIFY_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLSAI1N, (__PLLSAI1N__) << POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1N))
+
+/** @brief  Macro to configure the PLLSAI1 clock division factor P.
+  *
+  * @note   This function must be used only when the PLLSAI1 is disabled.
+  * @note   PLLSAI1 clock source is common with the main PLL (configured through
+  *         __HAL_RCC_PLL_CONFIG() macro)
+  *
+  * @param  __PLLSAI1P__ specifies the division factor for SAI clock.
+  *         This parameter must be a number in the range (7 or 17).
+  *         Use to set SAI1 clock frequency = f(PLLSAI1) / PLLSAI1P
+  *
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI1_DIVP_CONFIG(__PLLSAI1P__) \
+                  MODIFY_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLSAI1P, ((__PLLSAI1P__) >> 4U) << POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1P))
+
+/** @brief  Macro to configure the PLLSAI1 clock division factor Q.
+  *
+  * @note   This function must be used only when the PLLSAI1 is disabled.
+  * @note   PLLSAI1 clock source is common with the main PLL (configured through
+  *         __HAL_RCC_PLL_CONFIG() macro)
+  *
+  * @param  __PLLSAI1Q__ specifies the division factor for USB/RNG/SDMMC1 clock.
+  *         This parameter must be in the range (2, 4, 6 or 8).
+  *         Use to set USB/RNG/SDMMC1 clock frequency = f(PLLSAI1) / PLLSAI1Q
+  *
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI1_DIVQ_CONFIG(__PLLSAI1Q__) \
+                  MODIFY_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLSAI1Q, (((__PLLSAI1Q__) >> 1U) - 1U) << POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1Q))
+
+/** @brief  Macro to configure the PLLSAI1 clock division factor R.
+  *
+  * @note   This function must be used only when the PLLSAI1 is disabled.
+  * @note   PLLSAI1 clock source is common with the main PLL (configured through
+  *         __HAL_RCC_PLL_CONFIG() macro)
+  *
+  * @param  __PLLSAI1R__ specifies the division factor for ADC clock.
+  *         This parameter must be in the range (2, 4, 6 or 8)
+  *         Use to set ADC clock frequency = f(PLLSAI1) / PLLSAI1R
+  *
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI1_DIVR_CONFIG(__PLLSAI1R__) \
+                  MODIFY_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLSAI1R, (((__PLLSAI1R__) >> 1U) - 1U) << POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1R))
+
+/**
+  * @brief  Macros to enable or disable the PLLSAI1.
+  * @note   The PLLSAI1 is disabled by hardware when entering STOP and STANDBY modes.
+  * @retval None
+  */
+
+#define __HAL_RCC_PLLSAI1_ENABLE()  SET_BIT(RCC->CR, RCC_CR_PLLSAI1ON)
+
+#define __HAL_RCC_PLLSAI1_DISABLE() CLEAR_BIT(RCC->CR, RCC_CR_PLLSAI1ON)
+
+/**
+  * @brief  Macros to enable or disable each clock output (PLLSAI1_SAI1, PLLSAI1_USB2 and PLLSAI1_ADC1).
+  * @note   Enabling and disabling those clocks can be done without the need to stop the PLL.
+  *         This is mainly used to save Power.
+  * @param  __PLLSAI1_CLOCKOUT__ specifies the PLLSAI1 clock to be output.
+  *         This parameter can be one or a combination of the following values:
+  *            @arg @ref RCC_PLLSAI1_SAI1CLK  This clock is used to generate an accurate clock to achieve
+  *                                   high-quality audio performance on SAI interface in case.
+  *            @arg @ref RCC_PLLSAI1_48M2CLK  This clock is used to generate the clock for the USB OTG FS (48 MHz),
+  *                                   the random number generator (<=48 MHz) and the SDIO (<= 48 MHz).
+  *            @arg @ref RCC_PLLSAI1_ADC1CLK  Clock used to clock ADC peripheral.
+  * @retval None
+  */
+
+#define __HAL_RCC_PLLSAI1CLKOUT_ENABLE(__PLLSAI1_CLOCKOUT__)   SET_BIT(RCC->PLLSAI1CFGR, (__PLLSAI1_CLOCKOUT__))
+
+#define __HAL_RCC_PLLSAI1CLKOUT_DISABLE(__PLLSAI1_CLOCKOUT__)  CLEAR_BIT(RCC->PLLSAI1CFGR, (__PLLSAI1_CLOCKOUT__))
+
+/**
+  * @brief  Macro to get clock output enable status (PLLSAI1_SAI1, PLLSAI1_USB2 and PLLSAI1_ADC1).
+  * @param  __PLLSAI1_CLOCKOUT__ specifies the PLLSAI1 clock to be output.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_PLLSAI1_SAI1CLK  This clock is used to generate an accurate clock to achieve
+  *                                   high-quality audio performance on SAI interface in case.
+  *            @arg @ref RCC_PLLSAI1_48M2CLK  This clock is used to generate the clock for the USB OTG FS (48 MHz),
+  *                                   the random number generator (<=48 MHz) and the SDIO (<= 48 MHz).
+  *            @arg @ref RCC_PLLSAI1_ADC1CLK  Clock used to clock ADC peripheral.
+  * @retval SET / RESET
+  */
+#define __HAL_RCC_GET_PLLSAI1CLKOUT_CONFIG(__PLLSAI1_CLOCKOUT__)  READ_BIT(RCC->PLLSAI1CFGR, (__PLLSAI1_CLOCKOUT__))
+
+/**
+  * @brief  Macro to configure the PLLSAI2 clock multiplication and division factors.
+  *
+  * @note   This function must be used only when the PLLSAI2 is disabled.
+  * @note   PLLSAI2 clock source is common with the main PLL (configured through
+  *         __HAL_RCC_PLL_CONFIG() macro)
+  *
+  * @param  __PLLSAI2N__ specifies the multiplication factor for PLLSAI2 VCO output clock.
+  *          This parameter must be a number between 8 and 86.
+  * @note   You have to set the PLLSAI2N parameter correctly to ensure that the VCO
+  *         output frequency is between 64 and 344 MHz.
+  *
+  * @param  __PLLSAI2P__ specifies the division factor for SAI clock.
+  *          This parameter must be a number in the range (7 or 17).
+  *
+  *
+  * @param  __PLLSAI2R__ specifies the division factor for SAR ADC clock.
+  *          This parameter must be in the range (2, 4, 6 or 8)
+  *
+  * @retval None
+  */
+
+#define __HAL_RCC_PLLSAI2_CONFIG(__PLLSAI2N__, __PLLSAI2P__, __PLLSAI2R__) \
+                  WRITE_REG(RCC->PLLSAI2CFGR, ((__PLLSAI2N__) << POSITION_VAL(RCC_PLLSAI2CFGR_PLLSAI2N)) | \
+                    (((__PLLSAI2P__) >> 4U) << POSITION_VAL(RCC_PLLSAI2CFGR_PLLSAI2P)) | \
+                    ((((__PLLSAI2R__) >> 1U) - 1U) << POSITION_VAL(RCC_PLLSAI2CFGR_PLLSAI2R)))
+
+/**
+  * @brief  Macro to configure the PLLSAI2 clock multiplication factor N.
+  *
+  * @note   This function must be used only when the PLLSAI2 is disabled.
+  * @note   PLLSAI2 clock source is common with the main PLL (configured through
+  *         __HAL_RCC_PLL_CONFIG() macro)
+  *
+  * @param  __PLLSAI2N__ specifies the multiplication factor for PLLSAI2 VCO output clock.
+  *          This parameter must be a number between 8 and 86.
+  * @note   You have to set the PLLSAI2N parameter correctly to ensure that the VCO
+  *         output frequency is between 64 and 344 MHz.
+  *         PLLSAI1 clock frequency = f(PLLSAI1) multiplied by PLLSAI2N
+  *
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI2_MULN_CONFIG(__PLLSAI2N__) \
+                  MODIFY_REG(RCC->PLLSAI2CFGR, RCC_PLLSAI2CFGR_PLLSAI2N, (__PLLSAI2N__) << POSITION_VAL(RCC_PLLSAI2CFGR_PLLSAI2N))
+
+/** @brief  Macro to configure the PLLSAI2 clock division factor P.
+  *
+  * @note   This function must be used only when the PLLSAI2 is disabled.
+  * @note   PLLSAI2 clock source is common with the main PLL (configured through
+  *         __HAL_RCC_PLL_CONFIG() macro)
+  *
+  * @param  __PLLSAI2P__ specifies the division factor.
+  *         This parameter must be a number in the range (7 or 17).
+  *         Use to set SAI2 clock frequency = f(PLLSAI2) / __PLLSAI2P__
+  *
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI2_DIVP_CONFIG(__PLLSAI2P__) \
+                  MODIFY_REG(RCC->PLLSAI2CFGR, RCC_PLLSAI2CFGR_PLLSAI2P, ((__PLLSAI2P__) >> 4U) << POSITION_VAL(RCC_PLLSAI2CFGR_PLLSAI2P))
+
+/** @brief  Macro to configure the PLLSAI2 clock division factor R.
+  *
+  * @note   This function must be used only when the PLLSAI2 is disabled.
+  * @note   PLLSAI1 clock source is common with the main PLL (configured through
+  *         __HAL_RCC_PLL_CONFIG() macro)
+  *
+  * @param  __PLLSAI2R__ specifies the division factor.
+  *         This parameter must be in the range (2, 4, 6 or 8).
+  *         Use to set ADC clock frequency = f(PLLSAI2) / __PLLSAI2Q__
+  *
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI2_DIVR_CONFIG(__PLLSAI2R__) \
+                  MODIFY_REG(RCC->PLLSAI2CFGR, RCC_PLLSAI2CFGR_PLLSAI2R, (((__PLLSAI2R__) >> 1U) - 1U) << POSITION_VAL(RCC_PLLSAI2CFGR_PLLSAI2R))
+
+/**
+  * @brief  Macros to enable or disable the PLLSAI2.
+  * @note   The PLLSAI2 is disabled by hardware when entering STOP and STANDBY modes.
+  * @retval None
+  */
+
+#define __HAL_RCC_PLLSAI2_ENABLE()  SET_BIT(RCC->CR, RCC_CR_PLLSAI2ON)
+
+#define __HAL_RCC_PLLSAI2_DISABLE() CLEAR_BIT(RCC->CR, RCC_CR_PLLSAI2ON)
+
+/**
+  * @brief  Macros to enable or disable each clock output (PLLSAI2_SAI2 and PLLSAI2_ADC2).
+  * @note   Enabling and disabling those clocks can be done without the need to stop the PLL.
+  *         This is mainly used to save Power.
+  * @param  __PLLSAI2_CLOCKOUT__ specifies the PLLSAI2 clock to be output.
+  *         This parameter can be one or a combination of the following values:
+  *            @arg @ref RCC_PLLSAI2_SAI2CLK  This clock is used to generate an accurate clock to achieve
+  *                                   high-quality audio performance on SAI interface in case.
+  *            @arg @ref RCC_PLLSAI2_ADC2CLK  Clock used to clock ADC peripheral.
+  * @retval None
+  */
+
+#define __HAL_RCC_PLLSAI2CLKOUT_ENABLE(__PLLSAI2_CLOCKOUT__)  SET_BIT(RCC->PLLSAI2CFGR, (__PLLSAI2_CLOCKOUT__))
+
+#define __HAL_RCC_PLLSAI2CLKOUT_DISABLE(__PLLSAI2_CLOCKOUT__) CLEAR_BIT(RCC->PLLSAI2CFGR, (__PLLSAI2_CLOCKOUT__))
+
+/**
+  * @brief  Macro to get clock output enable status (PLLSAI2_SAI2 and PLLSAI2_ADC2).
+  * @param  __PLLSAI2_CLOCKOUT__ specifies the PLLSAI2 clock to be output.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_PLLSAI2_SAI2CLK  This clock is used to generate an accurate clock to achieve
+  *                                   high-quality audio performance on SAI interface in case.
+  *            @arg @ref RCC_PLLSAI2_ADC2CLK  Clock used to clock ADC peripheral.
+  * @retval SET / RESET
+  */
+#define __HAL_RCC_GET_PLLSAI2CLKOUT_CONFIG(__PLLSAI2_CLOCKOUT__)  READ_BIT(RCC->PLLSAI2CFGR, (__PLLSAI2_CLOCKOUT__))
+
+/**
+  * @brief  Macro to configure the SAI1 clock source.
+  * @param  __SAI1_CLKSOURCE__ defines the SAI1 clock source. This clock is derived
+  *         from the PLLSAI1, system PLL or external clock (through a dedicated pin).
+  *          This parameter can be one of the following values:
+  *             @arg @ref RCC_SAI1CLKSOURCE_PLLSAI1  SAI1 clock = PLLSAI1 "P" clock (PLLSAI1CLK)
+  *             @arg @ref RCC_SAI1CLKSOURCE_PLLSAI2  SAI1 clock = PLLSAI2 "P" clock (PLLSAI2CLK)
+  *             @arg @ref RCC_SAI1CLKSOURCE_PLL  SAI1 clock  = PLL "P" clock (PLLSAI3CLK)
+  *             @arg @ref RCC_SAI1CLKSOURCE_PIN  SAI1 clock = External Clock (SAI1_EXTCLK)
+  *
+  * @retval None
+  */
+#define __HAL_RCC_SAI1_CONFIG(__SAI1_CLKSOURCE__)\
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_SAI1SEL, (uint32_t)(__SAI1_CLKSOURCE__))
+
+/** @brief  Macro to get the SAI1 clock source.
+  * @retval The clock source can be one of the following values:
+  *             @arg @ref RCC_SAI1CLKSOURCE_PLLSAI1  SAI1 clock = PLLSAI1 "P" clock (PLLSAI1CLK)
+  *             @arg @ref RCC_SAI1CLKSOURCE_PLLSAI2  SAI1 clock = PLLSAI2 "P" clock (PLLSAI2CLK)
+  *             @arg @ref RCC_SAI1CLKSOURCE_PLL  SAI1 clock  = PLL "P" clock (PLLSAI3CLK)
+  *             @arg @ref RCC_SAI1CLKSOURCE_PIN  SAI1 clock = External Clock (SAI1_EXTCLK)
+  */
+#define __HAL_RCC_GET_SAI1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_SAI1SEL)))
+
+/**
+  * @brief  Macro to configure the SAI2 clock source.
+  * @param  __SAI2_CLKSOURCE__ defines the SAI2 clock source. This clock is derived
+  *         from the PLLSAI2, system PLL or external clock (through a dedicated pin).
+  *          This parameter can be one of the following values:
+  *             @arg @ref RCC_SAI2CLKSOURCE_PLLSAI1  SAI2 clock = PLLSAI1 "P" clock (PLLSAI1CLK)
+  *             @arg @ref RCC_SAI2CLKSOURCE_PLLSAI2  SAI2 clock = PLLSAI2 "P" clock (PLLSAI2CLK)
+  *             @arg @ref RCC_SAI2CLKSOURCE_PLL  SAI2 clock  = PLL "P" clock (PLLSAI3CLK)
+  *             @arg @ref RCC_SAI2CLKSOURCE_PIN  SAI2 clock = External Clock (SAI2_EXTCLK)
+  * @retval None
+  */
+#define __HAL_RCC_SAI2_CONFIG(__SAI2_CLKSOURCE__ )\
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_SAI2SEL, (uint32_t)(__SAI2_CLKSOURCE__))
+
+/** @brief  Macro to get the SAI2 clock source.
+  * @retval The clock source can be one of the following values:
+  *             @arg @ref RCC_SAI2CLKSOURCE_PLLSAI1  SAI2 clock = PLLSAI1 "P" clock (PLLSAI1CLK)
+  *             @arg @ref RCC_SAI2CLKSOURCE_PLLSAI2  SAI2 clock = PLLSAI2 "P" clock (PLLSAI2CLK)
+  *             @arg @ref RCC_SAI2CLKSOURCE_PLL  SAI2 clock  = PLL "P" clock (PLLSAI3CLK)
+  *             @arg @ref RCC_SAI2CLKSOURCE_PIN  SAI2 clock = External Clock (SAI2_EXTCLK)
+  */
+#define __HAL_RCC_GET_SAI2_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_SAI2SEL)))
+
+/** @brief  Macro to configure the I2C1 clock (I2C1CLK).
+  *
+  * @param  __I2C1_CLKSOURCE__ specifies the I2C1 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_I2C1CLKSOURCE_PCLK1  PCLK1 selected as I2C1 clock
+  *            @arg @ref RCC_I2C1CLKSOURCE_HSI  HSI selected as I2C1 clock
+  *            @arg @ref RCC_I2C1CLKSOURCE_SYSCLK  System Clock selected as I2C1 clock
+  * @retval None
+  */
+#define __HAL_RCC_I2C1_CONFIG(__I2C1_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_I2C1SEL, (uint32_t)(__I2C1_CLKSOURCE__))
+
+/** @brief  Macro to get the I2C1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_I2C1CLKSOURCE_PCLK1  PCLK1 selected as I2C1 clock
+  *            @arg @ref RCC_I2C1CLKSOURCE_HSI  HSI selected as I2C1 clock
+  *            @arg @ref RCC_I2C1CLKSOURCE_SYSCLK  System Clock selected as I2C1 clock
+  */
+#define __HAL_RCC_GET_I2C1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_I2C1SEL)))
+
+/** @brief  Macro to configure the I2C2 clock (I2C2CLK).
+  *
+  * @param  __I2C2_CLKSOURCE__ specifies the I2C2 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_I2C2CLKSOURCE_PCLK1  PCLK1 selected as I2C2 clock
+  *            @arg @ref RCC_I2C2CLKSOURCE_HSI  HSI selected as I2C2 clock
+  *            @arg @ref RCC_I2C2CLKSOURCE_SYSCLK  System Clock selected as I2C2 clock
+  * @retval None
+  */
+#define __HAL_RCC_I2C2_CONFIG(__I2C2_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_I2C2SEL, (uint32_t)(__I2C2_CLKSOURCE__))
+
+/** @brief  Macro to get the I2C2 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_I2C2CLKSOURCE_PCLK1  PCLK1 selected as I2C2 clock
+  *            @arg @ref RCC_I2C2CLKSOURCE_HSI  HSI selected as I2C2 clock
+  *            @arg @ref RCC_I2C2CLKSOURCE_SYSCLK  System Clock selected as I2C2 clock
+  */
+#define __HAL_RCC_GET_I2C2_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_I2C2SEL)))
+
+/** @brief  Macro to configure the I2C3 clock (I2C3CLK).
+  *
+  * @param  __I2C3_CLKSOURCE__ specifies the I2C3 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_I2C3CLKSOURCE_PCLK1  PCLK1 selected as I2C3 clock
+  *            @arg @ref RCC_I2C3CLKSOURCE_HSI  HSI selected as I2C3 clock
+  *            @arg @ref RCC_I2C3CLKSOURCE_SYSCLK  System Clock selected as I2C3 clock
+  * @retval None
+  */
+#define __HAL_RCC_I2C3_CONFIG(__I2C3_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_I2C3SEL, (uint32_t)(__I2C3_CLKSOURCE__))
+
+/** @brief  Macro to get the I2C3 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_I2C3CLKSOURCE_PCLK1  PCLK1 selected as I2C3 clock
+  *            @arg @ref RCC_I2C3CLKSOURCE_HSI  HSI selected as I2C3 clock
+  *            @arg @ref RCC_I2C3CLKSOURCE_SYSCLK  System Clock selected as I2C3 clock
+  */
+#define __HAL_RCC_GET_I2C3_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_I2C3SEL)))
+
+/** @brief  Macro to configure the USART1 clock (USART1CLK).
+  *
+  * @param  __USART1_CLKSOURCE__ specifies the USART1 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_USART1CLKSOURCE_PCLK2  PCLK2 selected as USART1 clock
+  *            @arg @ref RCC_USART1CLKSOURCE_HSI  HSI selected as USART1 clock
+  *            @arg @ref RCC_USART1CLKSOURCE_SYSCLK  System Clock selected as USART1 clock
+  *            @arg @ref RCC_USART1CLKSOURCE_LSE  SE selected as USART1 clock
+  * @retval None
+  */
+#define __HAL_RCC_USART1_CONFIG(__USART1_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_USART1SEL, (uint32_t)(__USART1_CLKSOURCE__))
+
+/** @brief  Macro to get the USART1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_USART1CLKSOURCE_PCLK2  PCLK2 selected as USART1 clock
+  *            @arg @ref RCC_USART1CLKSOURCE_HSI  HSI selected as USART1 clock
+  *            @arg @ref RCC_USART1CLKSOURCE_SYSCLK  System Clock selected as USART1 clock
+  *            @arg @ref RCC_USART1CLKSOURCE_LSE  LSE selected as USART1 clock
+  */
+#define __HAL_RCC_GET_USART1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_USART1SEL)))
+
+/** @brief  Macro to configure the USART2 clock (USART2CLK).
+  *
+  * @param  __USART2_CLKSOURCE__ specifies the USART2 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_USART2CLKSOURCE_PCLK1  PCLK1 selected as USART2 clock
+  *            @arg @ref RCC_USART2CLKSOURCE_HSI  HSI selected as USART2 clock
+  *            @arg @ref RCC_USART2CLKSOURCE_SYSCLK  System Clock selected as USART2 clock
+  *            @arg @ref RCC_USART2CLKSOURCE_LSE  LSE selected as USART2 clock
+  * @retval None
+  */
+#define __HAL_RCC_USART2_CONFIG(__USART2_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_USART2SEL, (uint32_t)(__USART2_CLKSOURCE__))
+
+/** @brief  Macro to get the USART2 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_USART2CLKSOURCE_PCLK1  PCLK1 selected as USART2 clock
+  *            @arg @ref RCC_USART2CLKSOURCE_HSI  HSI selected as USART2 clock
+  *            @arg @ref RCC_USART2CLKSOURCE_SYSCLK  System Clock selected as USART2 clock
+  *            @arg @ref RCC_USART2CLKSOURCE_LSE  LSE selected as USART2 clock
+  */
+#define __HAL_RCC_GET_USART2_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_USART2SEL)))
+
+/** @brief  Macro to configure the USART3 clock (USART3CLK).
+  *
+  * @param  __USART3_CLKSOURCE__ specifies the USART3 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_USART3CLKSOURCE_PCLK1  PCLK1 selected as USART3 clock
+  *            @arg @ref RCC_USART3CLKSOURCE_HSI  HSI selected as USART3 clock
+  *            @arg @ref RCC_USART3CLKSOURCE_SYSCLK  System Clock selected as USART3 clock
+  *            @arg @ref RCC_USART3CLKSOURCE_LSE  LSE selected as USART3 clock
+  * @retval None
+  */
+#define __HAL_RCC_USART3_CONFIG(__USART3_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_USART3SEL, (uint32_t)(__USART3_CLKSOURCE__))
+
+/** @brief  Macro to get the USART3 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_USART3CLKSOURCE_PCLK1  PCLK1 selected as USART3 clock
+  *            @arg @ref RCC_USART3CLKSOURCE_HSI  HSI selected as USART3 clock
+  *            @arg @ref RCC_USART3CLKSOURCE_SYSCLK  System Clock selected as USART3 clock
+  *            @arg @ref RCC_USART3CLKSOURCE_LSE  LSE selected as USART3 clock
+  */
+#define __HAL_RCC_GET_USART3_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_USART3SEL)))
+
+/** @brief  Macro to configure the UART4 clock (UART4CLK).
+  *
+  * @param  __UART4_CLKSOURCE__ specifies the UART4 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_UART4CLKSOURCE_PCLK1  PCLK1 selected as UART4 clock
+  *            @arg @ref RCC_UART4CLKSOURCE_HSI  HSI selected as UART4 clock
+  *            @arg @ref RCC_UART4CLKSOURCE_SYSCLK  System Clock selected as UART4 clock
+  *            @arg @ref RCC_UART4CLKSOURCE_LSE  LSE selected as UART4 clock
+  * @retval None
+  */
+#define __HAL_RCC_UART4_CONFIG(__UART4_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_UART4SEL, (uint32_t)(__UART4_CLKSOURCE__))
+
+/** @brief  Macro to get the UART4 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_UART4CLKSOURCE_PCLK1  PCLK1 selected as UART4 clock
+  *            @arg @ref RCC_UART4CLKSOURCE_HSI  HSI selected as UART4 clock
+  *            @arg @ref RCC_UART4CLKSOURCE_SYSCLK  System Clock selected as UART4 clock
+  *            @arg @ref RCC_UART4CLKSOURCE_LSE  LSE selected as UART4 clock
+  */
+#define __HAL_RCC_GET_UART4_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_UART4SEL)))
+
+ /** @brief  Macro to configure the UART5 clock (UART5CLK).
+  *
+  * @param  __UART5_CLKSOURCE__ specifies the UART5 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_UART5CLKSOURCE_PCLK1  PCLK1 selected as UART5 clock
+  *            @arg @ref RCC_UART5CLKSOURCE_HSI  HSI selected as UART5 clock
+  *            @arg @ref RCC_UART5CLKSOURCE_SYSCLK  System Clock selected as UART5 clock
+  *            @arg @ref RCC_UART5CLKSOURCE_LSE  LSE selected as UART5 clock
+  * @retval None
+  */
+#define __HAL_RCC_UART5_CONFIG(__UART5_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_UART5SEL, (uint32_t)(__UART5_CLKSOURCE__))
+
+/** @brief  Macro to get the UART5 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_UART5CLKSOURCE_PCLK1  PCLK1 selected as UART5 clock
+  *            @arg @ref RCC_UART5CLKSOURCE_HSI  HSI selected as UART5 clock
+  *            @arg @ref RCC_UART5CLKSOURCE_SYSCLK  System Clock selected as UART5 clock
+  *            @arg @ref RCC_UART5CLKSOURCE_LSE  LSE selected as UART5 clock
+  */
+#define __HAL_RCC_GET_UART5_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_UART5SEL)))
+
+/** @brief  Macro to configure the LPUART1 clock (LPUART1CLK).
+  *
+  * @param  __LPUART1_CLKSOURCE__ specifies the LPUART1 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_LPUART1CLKSOURCE_PCLK1  PCLK1 selected as LPUART1 clock
+  *            @arg @ref RCC_LPUART1CLKSOURCE_HSI  HSI selected as LPUART1 clock
+  *            @arg @ref RCC_LPUART1CLKSOURCE_SYSCLK  System Clock selected as LPUART1 clock
+  *            @arg @ref RCC_LPUART1CLKSOURCE_LSE  LSE selected as LPUART1 clock
+  * @retval None
+  */
+#define __HAL_RCC_LPUART1_CONFIG(__LPUART1_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_LPUART1SEL, (uint32_t)(__LPUART1_CLKSOURCE__))
+
+/** @brief  Macro to get the LPUART1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_LPUART1CLKSOURCE_PCLK1  PCLK1 selected as LPUART1 clock
+  *            @arg @ref RCC_LPUART1CLKSOURCE_HSI  HSI selected as LPUART1 clock
+  *            @arg @ref RCC_LPUART1CLKSOURCE_SYSCLK  System Clock selected as LPUART1 clock
+  *            @arg @ref RCC_LPUART1CLKSOURCE_LSE  LSE selected as LPUART1 clock
+  */
+#define __HAL_RCC_GET_LPUART1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_LPUART1SEL)))
+
+/** @brief  Macro to configure the LPTIM1 clock (LPTIM1CLK).
+  *
+  * @param  __LPTIM1_CLKSOURCE__ specifies the LPTIM1 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_LPTIM1CLKSOURCE_PCLK  PCLK selected as LPTIM1 clock
+  *            @arg @ref RCC_LPTIM1CLKSOURCE_LSI  HSI selected as LPTIM1 clock
+  *            @arg @ref RCC_LPTIM1CLKSOURCE_HSI  LSI selected as LPTIM1 clock
+  *            @arg @ref RCC_LPTIM1CLKSOURCE_LSE  LSE selected as LPTIM1 clock
+  * @retval None
+  */
+#define __HAL_RCC_LPTIM1_CONFIG(__LPTIM1_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_LPTIM1SEL, (uint32_t)(__LPTIM1_CLKSOURCE__))
+
+/** @brief  Macro to get the LPTIM1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_LPTIM1CLKSOURCE_PCLK  PCLK selected as LPUART1 clock
+  *            @arg @ref RCC_LPTIM1CLKSOURCE_LSI  HSI selected as LPUART1 clock
+  *            @arg @ref RCC_LPTIM1CLKSOURCE_HSI  System Clock selected as LPUART1 clock
+  *            @arg @ref RCC_LPTIM1CLKSOURCE_LSE  LSE selected as LPUART1 clock
+  */
+#define __HAL_RCC_GET_LPTIM1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_LPTIM1SEL)))
+
+/** @brief  Macro to configure the LPTIM2 clock (LPTIM2CLK).
+  *
+  * @param  __LPTIM2_CLKSOURCE__ specifies the LPTIM2 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_LPTIM2CLKSOURCE_PCLK  PCLK selected as LPTIM2 clock
+  *            @arg @ref RCC_LPTIM2CLKSOURCE_LSI  HSI selected as LPTIM2 clock
+  *            @arg @ref RCC_LPTIM2CLKSOURCE_HSI  LSI selected as LPTIM2 clock
+  *            @arg @ref RCC_LPTIM2CLKSOURCE_LSE  LSE selected as LPTIM2 clock
+  * @retval None
+  */
+#define __HAL_RCC_LPTIM2_CONFIG(__LPTIM2_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_LPTIM2SEL, (uint32_t)(__LPTIM2_CLKSOURCE__))
+
+/** @brief  Macro to get the LPTIM2 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_LPTIM2CLKSOURCE_PCLK  PCLK selected as LPUART1 clock
+  *            @arg @ref RCC_LPTIM2CLKSOURCE_LSI  HSI selected as LPUART1 clock
+  *            @arg @ref RCC_LPTIM2CLKSOURCE_HSI  System Clock selected as LPUART1 clock
+  *            @arg @ref RCC_LPTIM2CLKSOURCE_LSE  LSE selected as LPUART1 clock
+  */
+#define __HAL_RCC_GET_LPTIM2_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_LPTIM2SEL)))
+
+/** @brief  Macro to configure the SDMMC1 clock.
+  *
+  * @note  USB, RNG and SDMMC1 peripherals share the same 48MHz clock source.
+  *
+  * @param  __SDMMC1_CLKSOURCE__ specifies the SDMMC1 clock source.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_SDMMC1CLKSOURCE_NONE  No clock selected as SDMMC1 clock
+  *            @arg @ref RCC_SDMMC1CLKSOURCE_MSI  MSI selected as SDMMC1 clock
+  *            @arg @ref RCC_SDMMC1CLKSOURCE_PLLSAI1  PLLSAI1 Clock selected as SDMMC1 clock
+  *            @arg @ref RCC_SDMMC1CLKSOURCE_PLL  PLL Clock selected as SDMMC1 clock
+  * @retval None
+  */
+#define __HAL_RCC_SDMMC1_CONFIG(__SDMMC1_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_CLK48SEL, (uint32_t)(__SDMMC1_CLKSOURCE__))
+
+/** @brief  Macro to get the SDMMC1 clock.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_SDMMC1CLKSOURCE_NONE  No clock selected as SDMMC1 clock
+  *            @arg @ref RCC_SDMMC1CLKSOURCE_MSI  MSI selected as SDMMC1 clock
+  *            @arg @ref RCC_SDMMC1CLKSOURCE_PLLSAI1  PLLSAI1 "Q" clock (PLL48M2CLK) selected as SDMMC1 clock
+  *            @arg @ref RCC_SDMMC1CLKSOURCE_PLL  PLL "Q" clock (PLL48M1CLK) selected as SDMMC1 clock
+  */
+#define __HAL_RCC_GET_SDMMC1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_CLK48SEL)))
+
+/** @brief  Macro to configure the RNG clock.
+  *
+  * @note  USB, RNG and SDMMC1 peripherals share the same 48MHz clock source.
+  *
+  * @param  __RNG_CLKSOURCE__ specifies the RNG clock source.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_RNGCLKSOURCE_NONE  No clock selected as RNG clock
+  *            @arg @ref RCC_RNGCLKSOURCE_MSI  MSI selected as RNG clock
+  *            @arg @ref RCC_RNGCLKSOURCE_PLLSAI1  PLLSAI1 Clock selected as RNG clock
+  *            @arg @ref RCC_RNGCLKSOURCE_PLL  PLL Clock selected as RNG clock
+  * @retval None
+  */
+#define __HAL_RCC_RNG_CONFIG(__RNG_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_CLK48SEL, (uint32_t)(__RNG_CLKSOURCE__))
+
+/** @brief  Macro to get the RNG clock.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_RNGCLKSOURCE_NONE  No clock selected as RNG clock
+  *            @arg @ref RCC_RNGCLKSOURCE_MSI  MSI selected as RNG clock
+  *            @arg @ref RCC_RNGCLKSOURCE_PLLSAI1  PLLSAI1 "Q" clock (PLL48M2CLK) selected as RNG clock
+  *            @arg @ref RCC_RNGCLKSOURCE_PLL  PLL "Q" clock (PLL48M1CLK) selected as RNG clock
+  */
+#define __HAL_RCC_GET_RNG_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_CLK48SEL)))
+
+#if defined(USB_OTG_FS)
+
+/** @brief  Macro to configure the USB clock (USBCLK).
+  *
+  * @note  USB, RNG and SDMMC1 peripherals share the same 48MHz clock source.
+  *
+  * @param  __USB_CLKSOURCE__ specifies the USB clock source.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_USBCLKSOURCE_NONE  No clock selected as 48MHz clock
+  *            @arg @ref RCC_USBCLKSOURCE_MSI  MSI selected as USB clock
+  *            @arg @ref RCC_USBCLKSOURCE_PLLSAI1  PLLSAI1 "Q" clock (PLL48M2CLK) selected as USB clock
+  *            @arg @ref RCC_USBCLKSOURCE_PLL  PLL "Q" clock (PLL48M1CLK) selected as USB clock
+  * @retval None
+  */
+#define __HAL_RCC_USB_CONFIG(__USB_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_CLK48SEL, (uint32_t)(__USB_CLKSOURCE__))
+
+/** @brief  Macro to get the USB clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_USBCLKSOURCE_NONE  No clock selected as 48MHz clock
+  *            @arg @ref RCC_USBCLKSOURCE_MSI  MSI selected as USB clock
+  *            @arg @ref RCC_USBCLKSOURCE_PLLSAI1  PLLSAI1 "Q" clock (PLL48M2CLK) selected as USB clock
+  *            @arg @ref RCC_USBCLKSOURCE_PLL  PLL "Q" clock (PLL48M1CLK) selected as USB clock
+  */
+#define __HAL_RCC_GET_USB_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_CLK48SEL)))
+
+#endif /* USB_OTG_FS */
+
+/** @brief  Macro to configure the ADC interface clock.
+  * @param  __ADC_CLKSOURCE__ specifies the ADC digital interface clock source.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_ADCCLKSOURCE_NONE  No clock selected as ADC clock
+  *            @arg @ref RCC_ADCCLKSOURCE_PLLSAI1  PLLSAI1 Clock selected as ADC clock
+  *            @arg @ref RCC_ADCCLKSOURCE_PLLSAI2  PLLSAI2 Clock selected as ADC clock
+  *            @arg @ref RCC_ADCCLKSOURCE_SYSCLK  System Clock selected as ADC clock
+  * @retval None
+  */
+#define __HAL_RCC_ADC_CONFIG(__ADC_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_ADCSEL, (uint32_t)(__ADC_CLKSOURCE__))
+
+/** @brief  Macro to get the ADC clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_ADCCLKSOURCE_NONE  No clock selected as ADC clock
+  *            @arg @ref RCC_ADCCLKSOURCE_PLLSAI1  PLLSAI1 Clock selected as ADC clock
+  *            @arg @ref RCC_ADCCLKSOURCE_PLLSAI2  PLLSAI2 Clock selected as ADC clock
+  *            @arg @ref RCC_ADCCLKSOURCE_SYSCLK  System Clock selected as ADC clock
+  */
+#define __HAL_RCC_GET_ADC_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_ADCSEL)))
+
+/** @brief  Macro to configure the SWPMI1 clock.
+  * @param  __SWPMI1_CLKSOURCE__ specifies the SWPMI1 clock source.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_SWPMI1CLKSOURCE_PCLK  PCLK Clock selected as SWPMI1 clock
+  *            @arg @ref RCC_SWPMI1CLKSOURCE_HSI  HSI Clock selected as SWPMI1 clock
+  * @retval None
+  */
+#define __HAL_RCC_SWPMI1_CONFIG(__SWPMI1_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_SWPMI1SEL, (uint32_t)(__SWPMI1_CLKSOURCE__))
+
+/** @brief  Macro to get the SWPMI1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_SWPMI1CLKSOURCE_PCLK  PCLK Clock selected as SWPMI1 clock
+  *            @arg @ref RCC_SWPMI1CLKSOURCE_HSI  HSI Clock selected as SWPMI1 clock
+  */
+#define __HAL_RCC_GET_SWPMI1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_SWPMI1SEL)))
+
+/** @brief  Macro to configure the DFSDM clock.
+  * @param  __DFSDM_CLKSOURCE__ specifies the DFSDM clock source.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_DFSDMCLKSOURCE_PCLK  PCLK Clock selected as DFSDM clock
+  *            @arg @ref RCC_DFSDMCLKSOURCE_SYSCLK  System Clock selected as DFSDM clock
+  * @retval None
+  */
+#define __HAL_RCC_DFSDM_CONFIG(__DFSDM_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_DFSDMSEL, (uint32_t)(__DFSDM_CLKSOURCE__))
+
+/** @brief  Macro to get the DFSDM clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_DFSDMCLKSOURCE_PCLK  PCLK Clock selected as DFSDM clock
+  *            @arg @ref RCC_DFSDMCLKSOURCE_SYSCLK  System Clock selected as DFSDM clock
+  */
+#define __HAL_RCC_GET_DFSDM_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_DFSDMSEL)))
+
+/** @defgroup RCCEx_Flags_Interrupts_Management Flags Interrupts Management
+  * @brief macros to manage the specified RCC Flags and interrupts.
+  * @{
+  */
+
+/** @brief Enable PLLSAI1RDY interrupt.
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI1_ENABLE_IT()  SET_BIT(RCC->CIER, RCC_CIER_PLLSAI1RDYIE)
+
+/** @brief Disable PLLSAI1RDY interrupt.
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI1_DISABLE_IT() CLEAR_BIT(RCC->CIER, RCC_CIER_PLLSAI1RDYIE)
+
+/** @brief Clear the PLLSAI1RDY interrupt pending bit.
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI1_CLEAR_IT()   WRITE_REG(RCC->CICR, RCC_CICR_PLLSAI1RDYC)
+
+/** @brief Check whether PLLSAI1RDY interrupt has occurred or not.
+  * @retval TRUE or FALSE.
+  */
+#define __HAL_RCC_PLLSAI1_GET_IT_SOURCE()     (READ_BIT(RCC->CIFR, RCC_CIFR_PLLSAI1RDYF) == RCC_CIFR_PLLSAI1RDYF)
+
+/** @brief  Check whether the PLLSAI1RDY flag is set or not.
+  * @retval TRUE or FALSE.
+  */
+#define __HAL_RCC_PLLSAI1_GET_FLAG()   (READ_BIT(RCC->CR, RCC_CR_PLLSAI1RDY) == (RCC_CR_PLLSAI1RDY))
+
+/** @brief Enable PLLSAI2RDY interrupt.
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI2_ENABLE_IT()  SET_BIT(RCC->CIER, RCC_CIER_PLLSAI2RDYIE)
+
+/** @brief Disable PLLSAI2RDY interrupt.
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI2_DISABLE_IT() CLEAR_BIT(RCC->CIER, RCC_CIER_PLLSAI2RDYIE)
+
+/** @brief Clear the PLLSAI2RDY interrupt pending bit.
+  * @retval None
+  */
+#define __HAL_RCC_PLLSAI2_CLEAR_IT()   WRITE_REG(RCC->CICR, RCC_CICR_PLLSAI2RDYC)
+
+/** @brief Check whether the PLLSAI2RDY interrupt has occurred or not.
+  * @retval TRUE or FALSE.
+  */
+#define __HAL_RCC_PLLSAI2_GET_IT_SOURCE()     (READ_BIT(RCC->CIFR, RCC_CIFR_PLLSAI2RDYF) == RCC_CIFR_PLLSAI2RDYF)
+
+/** @brief  Check whether the PLLSAI2RDY flag is set or not.
+  * @retval TRUE or FALSE.
+  */
+#define __HAL_RCC_PLLSAI2_GET_FLAG()   (READ_BIT(RCC->CR, RCC_CR_PLLSAI2RDY) == (RCC_CR_PLLSAI2RDY))
+
+/**
+  * @brief Enable the RCC LSE CSS Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_RCC_LSECSS_EXTI_ENABLE_IT()      SET_BIT(EXTI->IMR1, RCC_EXTI_LINE_LSECSS)
+
+/**
+  * @brief Disable the RCC LSE CSS Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_RCC_LSECSS_EXTI_DISABLE_IT()     CLEAR_BIT(EXTI->IMR1, RCC_EXTI_LINE_LSECSS)
+
+/**
+  * @brief Enable the RCC LSE CSS Event Line.
+  * @retval None.
+  */
+#define __HAL_RCC_LSECSS_EXTI_ENABLE_EVENT()   SET_BIT(EXTI->EMR1, RCC_EXTI_LINE_LSECSS)
+
+/**
+  * @brief Disable the RCC LSE CSS Event Line.
+  * @retval None.
+  */
+#define __HAL_RCC_LSECSS_EXTI_DISABLE_EVENT()  CLEAR_BIT(EXTI->EMR1, RCC_EXTI_LINE_LSECSS)
+
+
+/**
+  * @brief  Enable the RCC LSE CSS Extended Interrupt Falling Trigger.
+  * @retval None.
+  */
+#define __HAL_RCC_LSECSS_EXTI_ENABLE_FALLING_EDGE()  SET_BIT(EXTI->FTSR1, RCC_EXTI_LINE_LSECSS)
+
+
+/**
+  * @brief Disable the RCC LSE CSS Extended Interrupt Falling Trigger.
+  * @retval None.
+  */
+#define __HAL_RCC_LSECSS_EXTI_DISABLE_FALLING_EDGE()  CLEAR_BIT(EXTI->FTSR1, RCC_EXTI_LINE_LSECSS)
+
+
+/**
+  * @brief  Enable the RCC LSE CSS Extended Interrupt Rising Trigger.
+  * @retval None.
+  */
+#define __HAL_RCC_LSECSS_EXTI_ENABLE_RISING_EDGE()   SET_BIT(EXTI->RTSR1, RCC_EXTI_LINE_LSECSS)
+
+/**
+  * @brief Disable the RCC LSE CSS Extended Interrupt Rising Trigger.
+  * @retval None.
+  */
+#define __HAL_RCC_LSECSS_EXTI_DISABLE_RISING_EDGE()  CLEAR_BIT(EXTI->RTSR1, RCC_EXTI_LINE_LSECSS)
+
+/**
+  * @brief Enable the RCC LSE CSS Extended Interrupt Rising & Falling Trigger.
+  * @retval None.
+  */
+#define __HAL_RCC_LSECSS_EXTI_ENABLE_RISING_FALLING_EDGE()  \
+  do {                                                      \
+    __HAL_RCC_LSECSS_EXTI_ENABLE_RISING_EDGE();             \
+    __HAL_RCC_LSECSS_EXTI_ENABLE_FALLING_EDGE();            \
+  } while(0)  
+  
+/**
+  * @brief Disable the RCC LSE CSS Extended Interrupt Rising & Falling Trigger.
+  * @retval None.
+  */
+#define __HAL_RCC_LSECSS_EXTI_DISABLE_RISING_FALLING_EDGE()  \
+  do {                                                       \
+    __HAL_RCC_LSECSS_EXTI_DISABLE_RISING_EDGE();             \
+    __HAL_RCC_LSECSS_EXTI_DISABLE_FALLING_EDGE();            \
+  } while(0)  
+
+/**
+  * @brief Check whether the specified RCC LSE CSS EXTI interrupt flag is set or not.
+  * @retval EXTI RCC LSE CSS Line Status.
+  */
+#define __HAL_RCC_LSECSS_EXTI_GET_FLAG()       (READ_BIT(EXTI->PR1, RCC_EXTI_LINE_LSECSS) == RCC_EXTI_LINE_LSECSS)
+
+/**
+  * @brief Clear the RCC LSE CSS EXTI flag.
+  * @retval None.
+  */
+#define __HAL_RCC_LSECSS_EXTI_CLEAR_FLAG()     WRITE_REG(EXTI->PR1, RCC_EXTI_LINE_LSECSS)
+
+/**
+  * @brief Generate a Software interrupt on the RCC LSE CSS EXTI line.
+  * @retval None.
+  */
+#define __HAL_RCC_LSECSS_EXTI_GENERATE_SWIT()  SET_BIT(EXTI->SWIER1, RCC_EXTI_LINE_LSECSS)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup RCCEx_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup RCCEx_Exported_Functions_Group1
+  * @{
+  */
+
+HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit);
+void              HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit);
+uint32_t          HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk);
+
+/**
+  * @}
+  */
+
+/** @addtogroup RCCEx_Exported_Functions_Group2
+  * @{
+  */
+
+HAL_StatusTypeDef HAL_RCCEx_EnablePLLSAI1(RCC_PLLSAI1InitTypeDef  *PLLSAI1Init);
+HAL_StatusTypeDef HAL_RCCEx_DisablePLLSAI1(void);
+
+HAL_StatusTypeDef HAL_RCCEx_EnablePLLSAI2(RCC_PLLSAI2InitTypeDef  *PLLSAI2Init);
+HAL_StatusTypeDef HAL_RCCEx_DisablePLLSAI2(void);
+
+void              HAL_RCCEx_WakeUpStopCLKConfig(uint32_t WakeUpClk);
+void              HAL_RCCEx_StandbyMSIRangeConfig(uint32_t MSIRange);
+void              HAL_RCCEx_EnableLSECSS(void);
+void              HAL_RCCEx_DisableLSECSS(void);
+void              HAL_RCCEx_EnableLSECSS_IT(void);
+void              HAL_RCCEx_LSECSS_IRQHandler(void);
+void              HAL_RCCEx_LSECSS_Callback(void);
+void              HAL_RCCEx_EnableLSCO(uint32_t LSCOSource);
+void              HAL_RCCEx_DisableLSCO(void);
+void              HAL_RCCEx_EnableMSIPLLMode(void);
+void              HAL_RCCEx_DisableMSIPLLMode(void);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @addtogroup RCCEx_Private_Macros
+  * @{
+  */
+
+#define IS_RCC_LSCOSOURCE(__SOURCE__) (((__SOURCE__) == RCC_LSCOSOURCE_LSI) || \
+                                       ((__SOURCE__) == RCC_LSCOSOURCE_LSE))
+
+#if defined(STM32L471xx)
+
+#define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
+               ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USART2)  == RCC_PERIPHCLK_USART2)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USART3)  == RCC_PERIPHCLK_USART3)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_UART4)   == RCC_PERIPHCLK_UART4)   || \
+                (((__SELECTION__) & RCC_PERIPHCLK_UART5)   == RCC_PERIPHCLK_UART5)   || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPUART1) == RCC_PERIPHCLK_LPUART1) || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C1)    == RCC_PERIPHCLK_I2C1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C2)    == RCC_PERIPHCLK_I2C2)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C3)    == RCC_PERIPHCLK_I2C3)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM1)  == RCC_PERIPHCLK_LPTIM1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM2)  == RCC_PERIPHCLK_LPTIM2)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_SAI1)    == RCC_PERIPHCLK_SAI1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_SAI2)    == RCC_PERIPHCLK_SAI2)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_ADC)     == RCC_PERIPHCLK_ADC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_SWPMI1)  == RCC_PERIPHCLK_SWPMI1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_DFSDM)   == RCC_PERIPHCLK_DFSDM)   || \
+                (((__SELECTION__) & RCC_PERIPHCLK_RTC)     == RCC_PERIPHCLK_RTC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_RNG)     == RCC_PERIPHCLK_RNG)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_SDMMC1)  == RCC_PERIPHCLK_SDMMC1))
+
+#else
+
+#define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
+               ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USART2)  == RCC_PERIPHCLK_USART2)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USART3)  == RCC_PERIPHCLK_USART3)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_UART4)   == RCC_PERIPHCLK_UART4)   || \
+                (((__SELECTION__) & RCC_PERIPHCLK_UART5)   == RCC_PERIPHCLK_UART5)   || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPUART1) == RCC_PERIPHCLK_LPUART1) || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C1)    == RCC_PERIPHCLK_I2C1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C2)    == RCC_PERIPHCLK_I2C2)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C3)    == RCC_PERIPHCLK_I2C3)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM1)  == RCC_PERIPHCLK_LPTIM1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM2)  == RCC_PERIPHCLK_LPTIM2)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_SAI1)    == RCC_PERIPHCLK_SAI1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_SAI2)    == RCC_PERIPHCLK_SAI2)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USB)     == RCC_PERIPHCLK_USB)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_ADC)     == RCC_PERIPHCLK_ADC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_SWPMI1)  == RCC_PERIPHCLK_SWPMI1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_DFSDM)   == RCC_PERIPHCLK_DFSDM)   || \
+                (((__SELECTION__) & RCC_PERIPHCLK_RTC)     == RCC_PERIPHCLK_RTC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_RNG)     == RCC_PERIPHCLK_RNG)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_SDMMC1)  == RCC_PERIPHCLK_SDMMC1))
+
+#endif /* STM32L471xx */
+
+#define IS_RCC_USART1CLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_USART1CLKSOURCE_PCLK2)  || \
+                ((__SOURCE__) == RCC_USART1CLKSOURCE_SYSCLK) || \
+                ((__SOURCE__) == RCC_USART1CLKSOURCE_LSE)    || \
+                ((__SOURCE__) == RCC_USART1CLKSOURCE_HSI))
+
+#define IS_RCC_USART2CLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_USART2CLKSOURCE_PCLK1)  || \
+                ((__SOURCE__) == RCC_USART2CLKSOURCE_SYSCLK) || \
+                ((__SOURCE__) == RCC_USART2CLKSOURCE_LSE)    || \
+                ((__SOURCE__) == RCC_USART2CLKSOURCE_HSI))
+
+#define IS_RCC_USART3CLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_USART3CLKSOURCE_PCLK1)  || \
+                ((__SOURCE__) == RCC_USART3CLKSOURCE_SYSCLK) || \
+                ((__SOURCE__) == RCC_USART3CLKSOURCE_LSE)    || \
+                ((__SOURCE__) == RCC_USART3CLKSOURCE_HSI))
+
+#define IS_RCC_UART4CLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_UART4CLKSOURCE_PCLK1)  || \
+                ((__SOURCE__) == RCC_UART4CLKSOURCE_SYSCLK) || \
+                ((__SOURCE__) == RCC_UART4CLKSOURCE_LSE)    || \
+                ((__SOURCE__) == RCC_UART4CLKSOURCE_HSI))
+
+#define IS_RCC_UART5CLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_UART5CLKSOURCE_PCLK1)  || \
+                ((__SOURCE__) == RCC_UART5CLKSOURCE_SYSCLK) || \
+                ((__SOURCE__) == RCC_UART5CLKSOURCE_LSE)    || \
+                ((__SOURCE__) == RCC_UART5CLKSOURCE_HSI))
+
+#define IS_RCC_LPUART1CLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_LPUART1CLKSOURCE_PCLK1)  || \
+                ((__SOURCE__) == RCC_LPUART1CLKSOURCE_SYSCLK) || \
+                ((__SOURCE__) == RCC_LPUART1CLKSOURCE_LSE)    || \
+                ((__SOURCE__) == RCC_LPUART1CLKSOURCE_HSI))
+
+#define IS_RCC_I2C1CLKSOURCE(__SOURCE__)   \
+               (((__SOURCE__) == RCC_I2C1CLKSOURCE_PCLK1) || \
+                ((__SOURCE__) == RCC_I2C1CLKSOURCE_SYSCLK)|| \
+                ((__SOURCE__) == RCC_I2C1CLKSOURCE_HSI))
+
+#define IS_RCC_I2C2CLKSOURCE(__SOURCE__)   \
+               (((__SOURCE__) == RCC_I2C2CLKSOURCE_PCLK1) || \
+                ((__SOURCE__) == RCC_I2C2CLKSOURCE_SYSCLK)|| \
+                ((__SOURCE__) == RCC_I2C2CLKSOURCE_HSI))
+
+#define IS_RCC_I2C3CLKSOURCE(__SOURCE__)   \
+               (((__SOURCE__) == RCC_I2C3CLKSOURCE_PCLK1) || \
+                ((__SOURCE__) == RCC_I2C3CLKSOURCE_SYSCLK)|| \
+                ((__SOURCE__) == RCC_I2C3CLKSOURCE_HSI))
+
+#define IS_RCC_SAI1CLK(__SOURCE__)   \
+               (((__SOURCE__) == RCC_SAI1CLKSOURCE_PLLSAI1) || \
+                ((__SOURCE__) == RCC_SAI1CLKSOURCE_PLLSAI2) || \
+                ((__SOURCE__) == RCC_SAI1CLKSOURCE_PLL)     || \
+                ((__SOURCE__) == RCC_SAI1CLKSOURCE_PIN))
+
+#define IS_RCC_SAI2CLK(__SOURCE__)   \
+               (((__SOURCE__) == RCC_SAI2CLKSOURCE_PLLSAI1) || \
+                ((__SOURCE__) == RCC_SAI2CLKSOURCE_PLLSAI2) || \
+                ((__SOURCE__) == RCC_SAI2CLKSOURCE_PLL)     || \
+                ((__SOURCE__) == RCC_SAI2CLKSOURCE_PIN))
+
+#define IS_RCC_LPTIM1CLK(__SOURCE__)  \
+               (((__SOURCE__) == RCC_LPTIM1CLKSOURCE_PCLK) || \
+                ((__SOURCE__) == RCC_LPTIM1CLKSOURCE_LSI)  || \
+                ((__SOURCE__) == RCC_LPTIM1CLKSOURCE_HSI)  || \
+                ((__SOURCE__) == RCC_LPTIM1CLKSOURCE_LSE))
+
+#define IS_RCC_LPTIM2CLK(__SOURCE__)  \
+               (((__SOURCE__) == RCC_LPTIM2CLKSOURCE_PCLK) || \
+                ((__SOURCE__) == RCC_LPTIM2CLKSOURCE_LSI)  || \
+                ((__SOURCE__) == RCC_LPTIM2CLKSOURCE_HSI)  || \
+                ((__SOURCE__) == RCC_LPTIM2CLKSOURCE_LSE))
+
+#define IS_RCC_SDMMC1CLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_SDMMC1CLKSOURCE_NONE)    || \
+                ((__SOURCE__) == RCC_SDMMC1CLKSOURCE_PLLSAI1) || \
+                ((__SOURCE__) == RCC_SDMMC1CLKSOURCE_PLL)     || \
+                ((__SOURCE__) == RCC_SDMMC1CLKSOURCE_MSI))
+
+#define IS_RCC_RNGCLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_RNGCLKSOURCE_NONE)    || \
+                ((__SOURCE__) == RCC_RNGCLKSOURCE_PLLSAI1) || \
+                ((__SOURCE__) == RCC_RNGCLKSOURCE_PLL)     || \
+                ((__SOURCE__) == RCC_RNGCLKSOURCE_MSI))
+
+#if defined(USB_OTG_FS)
+
+#define IS_RCC_USBCLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_USBCLKSOURCE_NONE)    || \
+                ((__SOURCE__) == RCC_USBCLKSOURCE_PLLSAI1) || \
+                ((__SOURCE__) == RCC_USBCLKSOURCE_PLL)     || \
+                ((__SOURCE__) == RCC_USBCLKSOURCE_MSI))
+
+#endif /* USB_OTG_FS */
+
+#define IS_RCC_ADCCLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_ADCCLKSOURCE_NONE)    || \
+                ((__SOURCE__) == RCC_ADCCLKSOURCE_PLLSAI1) || \
+                ((__SOURCE__) == RCC_ADCCLKSOURCE_PLLSAI2) || \
+                ((__SOURCE__) == RCC_ADCCLKSOURCE_SYSCLK))
+
+#define IS_RCC_SWPMI1CLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_SWPMI1CLKSOURCE_PCLK) || \
+                ((__SOURCE__) == RCC_SWPMI1CLKSOURCE_HSI))
+
+#define IS_RCC_DFSDMCLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_DFSDMCLKSOURCE_PCLK) || \
+                ((__SOURCE__) == RCC_DFSDMCLKSOURCE_SYSCLK))
+
+#define IS_RCC_PLLSAI1N_VALUE(__VALUE__)   ((8U <= (__VALUE__)) && ((__VALUE__) <= 86U))
+
+#define IS_RCC_PLLSAI1P_VALUE(__VALUE__)   (((__VALUE__) == 7U) || ((__VALUE__) == 17U))
+
+#define IS_RCC_PLLSAI1Q_VALUE(__VALUE__)   (((__VALUE__) == 2U) || ((__VALUE__) == 4U) || \
+                                            ((__VALUE__) == 6U) || ((__VALUE__) == 8U))
+
+#define IS_RCC_PLLSAI1R_VALUE(__VALUE__)   (((__VALUE__) == 2U) || ((__VALUE__) == 4U) || \
+                                            ((__VALUE__) == 6U) || ((__VALUE__) == 8U))
+
+#define IS_RCC_PLLSAI2N_VALUE(__VALUE__)   ((8U <= (__VALUE__)) && ((__VALUE__) <= 86U))
+
+#define IS_RCC_PLLSAI2P_VALUE(__VALUE__)   (((__VALUE__) == 7U) || ((__VALUE__) == 17U))
+
+#define IS_RCC_PLLSAI2R_VALUE(__VALUE__)   (((__VALUE__) == 2U) || ((__VALUE__) == 4U) || \
+                                            ((__VALUE__) == 6U) || ((__VALUE__) == 8U))
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_RCC_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_rng.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_rng.h
@@ -1,0 +1,285 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_rng.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of RNG HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_RNG_H
+#define __STM32L4xx_HAL_RNG_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RNG
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/** @defgroup RNG_Exported_Types RNG Exported Types
+  * @{
+  */
+
+/** 
+  * @brief  RNG HAL State Structure definition  
+  */ 
+typedef enum
+{
+  HAL_RNG_STATE_RESET     = 0x00,  /*!< RNG not yet initialized or disabled */
+  HAL_RNG_STATE_READY     = 0x01,  /*!< RNG initialized and ready for use   */
+  HAL_RNG_STATE_BUSY      = 0x02,  /*!< RNG internal process is ongoing     */ 
+  HAL_RNG_STATE_TIMEOUT   = 0x03,  /*!< RNG timeout state                   */
+  HAL_RNG_STATE_ERROR     = 0x04   /*!< RNG error state                     */
+    
+}HAL_RNG_StateTypeDef;
+
+/** 
+  * @brief  RNG Handle Structure definition  
+  */ 
+typedef struct
+{
+  RNG_TypeDef                 *Instance;  /*!< Register base address   */ 
+  
+  HAL_LockTypeDef             Lock;       /*!< RNG locking object      */
+  
+  __IO HAL_RNG_StateTypeDef   State;      /*!< RNG communication state */
+  
+  uint32_t               RandomNumber;    /*!< Last Generated RNG Data */
+  
+}RNG_HandleTypeDef;
+
+/** 
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RNG_Exported_Constants RNG Exported Constants
+  * @{
+  */
+
+/** @defgroup RNG_Interrupt_definition  RNG Interrupts Definition
+  * @{
+  */
+#define RNG_IT_DRDY  RNG_SR_DRDY  /*!< Data Ready interrupt  */
+#define RNG_IT_CEI   RNG_SR_CEIS  /*!< Clock error interrupt */
+#define RNG_IT_SEI   RNG_SR_SEIS  /*!< Seed error interrupt  */
+/**
+  * @}
+  */
+
+/** @defgroup RNG_Flag_definition  RNG Flags Definition
+  * @{
+  */ 
+#define RNG_FLAG_DRDY   RNG_SR_DRDY  /*!< Data ready                 */
+#define RNG_FLAG_CECS   RNG_SR_CECS  /*!< Clock error current status */
+#define RNG_FLAG_SECS   RNG_SR_SECS  /*!< Seed error current status  */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+  
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup RNG_Exported_Macros RNG Exported Macros
+  * @{
+  */
+
+/** @brief Reset RNG handle state.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_RNG_STATE_RESET)
+
+/**
+  * @brief  Enable the RNG peripheral.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR |=  RNG_CR_RNGEN)
+
+/**
+  * @brief  Disable the RNG peripheral.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR &= ~RNG_CR_RNGEN)
+
+/**
+  * @brief  Check whether the specified RNG flag is set or not.
+  * @param  __HANDLE__: RNG Handle
+  * @param  __FLAG__: RNG flag
+  *          This parameter can be one of the following values:
+  *            @arg RNG_FLAG_DRDY:  Data ready                
+  *            @arg RNG_FLAG_CECS:  Clock error current status
+  *            @arg RNG_FLAG_SECS:  Seed error current status 
+  * @retval The new state of __FLAG__ (SET or RESET).
+  */
+#define __HAL_RNG_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR & (__FLAG__)) == (__FLAG__))
+
+
+/**
+  * @brief  Clear the selected RNG flag status.
+  * @param  __HANDLE__: RNG handle
+  * @param  __FLAG__: RNG flag to clear  
+  * @note   WARNING: This is a dummy macro for HAL code alignment,
+  *         flags RNG_FLAG_DRDY, RNG_FLAG_CECS and RNG_FLAG_SECS are read-only.
+  * @retval None
+  */
+#define __HAL_RNG_CLEAR_FLAG(__HANDLE__, __FLAG__)                      /* dummy  macro */
+
+
+
+/**
+  * @brief  Enable the RNG interrupt.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_ENABLE_IT(__HANDLE__) ((__HANDLE__)->Instance->CR |=  RNG_CR_IE)
+    
+/**
+  * @brief  Disable the RNG interrupt.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_DISABLE_IT(__HANDLE__) ((__HANDLE__)->Instance->CR &= ~RNG_CR_IE)
+
+/**
+  * @brief  Check whether the specified RNG interrupt has occurred or not.
+  * @param  __HANDLE__: RNG Handle
+  * @param  __INTERRUPT__: specifies the RNG interrupt status flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg RNG_IT_DRDY: Data ready interrupt              
+  *            @arg RNG_IT_CEI: Clock error interrupt
+  *            @arg RNG_IT_SEI: Seed error interrupt
+  * @retval The new state of __INTERRUPT__ (SET or RESET).
+  */
+#define __HAL_RNG_GET_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->SR & (__INTERRUPT__)) == (__INTERRUPT__))   
+
+/**
+  * @brief  Clear the RNG interrupt status flags.
+  * @param  __HANDLE__: RNG Handle
+  * @param  __INTERRUPT__: specifies the RNG interrupt status flag to clear.
+  *          This parameter can be one of the following values:            
+  *            @arg RNG_IT_CEI: Clock error interrupt
+  *            @arg RNG_IT_SEI: Seed error interrupt
+  * @note   RNG_IT_DRDY flag is read-only, reading RNG_DR register automatically clears RNG_IT_DRDY.          
+  * @retval None
+  */
+#define __HAL_RNG_CLEAR_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->SR) = ~(__INTERRUPT__))
+
+/**
+  * @}
+  */ 
+
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup RNG_Exported_Functions RNG Exported Functions
+  * @{
+  */
+
+/* Initialization and de-initialization functions  ******************************/
+/** @defgroup RNG_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */  
+HAL_StatusTypeDef HAL_RNG_Init(RNG_HandleTypeDef *hrng);
+HAL_StatusTypeDef HAL_RNG_DeInit (RNG_HandleTypeDef *hrng);
+void HAL_RNG_MspInit(RNG_HandleTypeDef *hrng);
+void HAL_RNG_MspDeInit(RNG_HandleTypeDef *hrng);
+/**
+  * @}
+  */ 
+
+/* Peripheral Control functions  ************************************************/
+/** @defgroup RNG_Exported_Functions_Group2 Peripheral Control functions
+  * @{
+  */
+uint32_t HAL_RNG_GetRandomNumber(RNG_HandleTypeDef *hrng);    /* Obsolete, use HAL_RNG_GenerateRandomNumber() instead    */
+uint32_t HAL_RNG_GetRandomNumber_IT(RNG_HandleTypeDef *hrng); /* Obsolete, use HAL_RNG_GenerateRandomNumber_IT() instead */
+
+HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber(RNG_HandleTypeDef *hrng, uint32_t *random32bit);
+HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber_IT(RNG_HandleTypeDef *hrng);
+uint32_t HAL_RNG_ReadLastRandomNumber(RNG_HandleTypeDef *hrng);
+
+void HAL_RNG_IRQHandler(RNG_HandleTypeDef *hrng);
+void HAL_RNG_ErrorCallback(RNG_HandleTypeDef *hrng);
+void HAL_RNG_ReadyDataCallback(RNG_HandleTypeDef* hrng, uint32_t random32bit);
+/**
+  * @}
+  */ 
+
+/* Peripheral State functions  **************************************************/
+/** @defgroup RNG_Exported_Functions_Group3 Peripheral State functions
+  * @{
+  */
+HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng);
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/* Private functions prototypes ----------------------------------------------*/
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_RNG_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_rtc.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_rtc.h
@@ -1,0 +1,863 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_rtc.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of RTC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_RTC_H
+#define __STM32L4xx_HAL_RTC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RTC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup RTC_Exported_Types RTC Exported Types
+  * @{
+  */
+/** 
+  * @brief  HAL State structures definition  
+  */
+typedef enum
+{
+  HAL_RTC_STATE_RESET             = 0x00,  /*!< RTC not yet initialized or disabled */
+  HAL_RTC_STATE_READY             = 0x01,  /*!< RTC initialized and ready for use   */
+  HAL_RTC_STATE_BUSY              = 0x02,  /*!< RTC process is ongoing              */
+  HAL_RTC_STATE_TIMEOUT           = 0x03,  /*!< RTC timeout state                   */
+  HAL_RTC_STATE_ERROR             = 0x04   /*!< RTC error state                     */
+
+}HAL_RTCStateTypeDef;
+
+/** 
+  * @brief  RTC Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t HourFormat;      /*!< Specifies the RTC Hour Format.
+                                 This parameter can be a value of @ref RTC_Hour_Formats */
+
+  uint32_t AsynchPrediv;    /*!< Specifies the RTC Asynchronous Predivider value.
+                                 This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7F */
+                               
+  uint32_t SynchPrediv;     /*!< Specifies the RTC Synchronous Predivider value.
+                                 This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7FFF */
+
+  uint32_t OutPut;          /*!< Specifies which signal will be routed to the RTC output.
+                                 This parameter can be a value of @ref RTCEx_Output_selection_Definitions */
+
+  uint32_t OutPutRemap;    /*!< Specifies the remap for RTC output.
+                                 This parameter can be a value of @ref  RTC_Output_ALARM_OUT_Remap */
+
+  uint32_t OutPutPolarity;  /*!< Specifies the polarity of the output signal.  
+                                 This parameter can be a value of @ref RTC_Output_Polarity_Definitions */
+
+  uint32_t OutPutType;      /*!< Specifies the RTC Output Pin mode.
+                                 This parameter can be a value of @ref RTC_Output_Type_ALARM_OUT */
+}RTC_InitTypeDef;
+
+/** 
+  * @brief  RTC Time structure definition  
+  */
+typedef struct
+{
+  uint8_t Hours;            /*!< Specifies the RTC Time Hour.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 12 if the RTC_HourFormat_12 is selected.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 23 if the RTC_HourFormat_24 is selected */
+
+  uint8_t Minutes;          /*!< Specifies the RTC Time Minutes.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 59 */
+
+  uint8_t Seconds;          /*!< Specifies the RTC Time Seconds.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 59 */
+
+  uint8_t TimeFormat;       /*!< Specifies the RTC AM/PM Time.
+                                 This parameter can be a value of @ref RTC_AM_PM_Definitions */
+  
+  uint32_t SubSeconds;     /*!< Specifies the RTC_SSR RTC Sub Second register content.
+                                 This parameter corresponds to a time unit range between [0-1] Second
+                                 with [1 Sec / SecondFraction +1] granularity */
+ 
+  uint32_t SecondFraction;  /*!< Specifies the range or granularity of Sub Second register content
+                                 corresponding to Synchronous pre-scaler factor value (PREDIV_S)
+                                 This parameter corresponds to a time unit range between [0-1] Second
+                                 with [1 Sec / SecondFraction +1] granularity.
+                                 This field will be used only by HAL_RTC_GetTime function */
+  
+  uint32_t DayLightSaving;  /*!< Specifies RTC_DayLightSaveOperation: the value of hour adjustment.
+                                 This parameter can be a value of @ref RTC_DayLightSaving_Definitions */
+
+  uint32_t StoreOperation;  /*!< Specifies RTC_StoreOperation value to be written in the BCK bit 
+                                 in CR register to store the operation.
+                                 This parameter can be a value of @ref RTC_StoreOperation_Definitions */
+}RTC_TimeTypeDef;
+
+/** 
+  * @brief  RTC Date structure definition
+  */
+typedef struct
+{
+  uint8_t WeekDay;  /*!< Specifies the RTC Date WeekDay.
+                         This parameter can be a value of @ref RTC_WeekDay_Definitions */
+
+  uint8_t Month;    /*!< Specifies the RTC Date Month (in BCD format).
+                         This parameter can be a value of @ref RTC_Month_Date_Definitions */
+
+  uint8_t Date;     /*!< Specifies the RTC Date.
+                         This parameter must be a number between Min_Data = 1 and Max_Data = 31 */
+
+  uint8_t Year;     /*!< Specifies the RTC Date Year.
+                         This parameter must be a number between Min_Data = 0 and Max_Data = 99 */
+
+}RTC_DateTypeDef;
+
+/** 
+  * @brief  RTC Alarm structure definition
+  */
+typedef struct
+{
+  RTC_TimeTypeDef AlarmTime;     /*!< Specifies the RTC Alarm Time members */
+
+  uint32_t AlarmMask;            /*!< Specifies the RTC Alarm Masks.
+                                      This parameter can be a value of @ref RTC_AlarmMask_Definitions */
+  
+  uint32_t AlarmSubSecondMask;   /*!< Specifies the RTC Alarm SubSeconds Masks.
+                                      This parameter can be a value of @ref RTC_Alarm_Sub_Seconds_Masks_Definitions */
+
+  uint32_t AlarmDateWeekDaySel;  /*!< Specifies the RTC Alarm is on Date or WeekDay.
+                                     This parameter can be a value of @ref RTC_AlarmDateWeekDay_Definitions */
+
+  uint8_t AlarmDateWeekDay;      /*!< Specifies the RTC Alarm Date/WeekDay.
+                                      If the Alarm Date is selected, this parameter must be set to a value in the 1-31 range.
+                                      If the Alarm WeekDay is selected, this parameter can be a value of @ref RTC_WeekDay_Definitions */
+
+  uint32_t Alarm;                /*!< Specifies the alarm .
+                                      This parameter can be a value of @ref RTC_Alarms_Definitions */
+}RTC_AlarmTypeDef;
+
+/** 
+  * @brief  Time Handle Structure definition
+  */
+typedef struct
+{
+  RTC_TypeDef               *Instance;  /*!< Register base address    */
+
+  RTC_InitTypeDef           Init;       /*!< RTC required parameters  */
+
+  HAL_LockTypeDef           Lock;       /*!< RTC locking object       */
+
+  __IO HAL_RTCStateTypeDef  State;      /*!< Time communication state */
+
+}RTC_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RTC_Exported_Constants RTC Exported Constants
+  * @{
+  */
+
+/** @defgroup RTC_Hour_Formats RTC Hour Formats
+  * @{
+  */
+#define RTC_HOURFORMAT_24              ((uint32_t)0x00000000)
+#define RTC_HOURFORMAT_12              ((uint32_t)0x00000040)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_Polarity_Definitions RTC Output Polarity Definitions
+  * @{
+  */
+#define RTC_OUTPUT_POLARITY_HIGH       ((uint32_t)0x00000000)
+#define RTC_OUTPUT_POLARITY_LOW        ((uint32_t)0x00100000)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_Type_ALARM_OUT RTC Output Type ALARM OUT
+  * @{
+  */
+#define RTC_OUTPUT_TYPE_OPENDRAIN      ((uint32_t)0x00000000)
+#define RTC_OUTPUT_TYPE_PUSHPULL       ((uint32_t)RTC_OR_ALARMOUTTYPE)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_ALARM_OUT_Remap RTC Output ALARM OUT Remap
+  * @{
+  */
+#define RTC_OUTPUT_REMAP_NONE          ((uint32_t)0x00000000)
+#define RTC_OUTPUT_REMAP_POS1          ((uint32_t)RTC_OR_OUT_RMP)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_AM_PM_Definitions RTC AM PM Definitions
+  * @{
+  */
+#define RTC_HOURFORMAT12_AM            ((uint8_t)0x00)
+#define RTC_HOURFORMAT12_PM            ((uint8_t)0x40)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_DayLightSaving_Definitions RTC DayLight Saving Definitions
+  * @{
+  */
+#define RTC_DAYLIGHTSAVING_SUB1H       ((uint32_t)0x00020000)
+#define RTC_DAYLIGHTSAVING_ADD1H       ((uint32_t)0x00010000)
+#define RTC_DAYLIGHTSAVING_NONE        ((uint32_t)0x00000000)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_StoreOperation_Definitions RTC Store Operation Definitions
+  * @{
+  */
+#define RTC_STOREOPERATION_RESET        ((uint32_t)0x00000000)
+#define RTC_STOREOPERATION_SET          ((uint32_t)0x00040000)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Input_parameter_format_definitions RTC Input Parameter Format Definitions
+  * @{
+  */
+#define RTC_FORMAT_BIN                  ((uint32_t)0x000000000)
+#define RTC_FORMAT_BCD                  ((uint32_t)0x000000001)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Month_Date_Definitions RTC Month Date Definitions
+  * @{
+  */
+
+/* Coded in BCD format */
+#define RTC_MONTH_JANUARY              ((uint8_t)0x01)
+#define RTC_MONTH_FEBRUARY             ((uint8_t)0x02)
+#define RTC_MONTH_MARCH                ((uint8_t)0x03)
+#define RTC_MONTH_APRIL                ((uint8_t)0x04)
+#define RTC_MONTH_MAY                  ((uint8_t)0x05)
+#define RTC_MONTH_JUNE                 ((uint8_t)0x06)
+#define RTC_MONTH_JULY                 ((uint8_t)0x07)
+#define RTC_MONTH_AUGUST               ((uint8_t)0x08)
+#define RTC_MONTH_SEPTEMBER            ((uint8_t)0x09)
+#define RTC_MONTH_OCTOBER              ((uint8_t)0x10)
+#define RTC_MONTH_NOVEMBER             ((uint8_t)0x11)
+#define RTC_MONTH_DECEMBER             ((uint8_t)0x12)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_WeekDay_Definitions RTC WeekDay Definitions
+  * @{
+  */
+#define RTC_WEEKDAY_MONDAY             ((uint8_t)0x01)
+#define RTC_WEEKDAY_TUESDAY            ((uint8_t)0x02)
+#define RTC_WEEKDAY_WEDNESDAY          ((uint8_t)0x03)
+#define RTC_WEEKDAY_THURSDAY           ((uint8_t)0x04)
+#define RTC_WEEKDAY_FRIDAY             ((uint8_t)0x05)
+#define RTC_WEEKDAY_SATURDAY           ((uint8_t)0x06)
+#define RTC_WEEKDAY_SUNDAY             ((uint8_t)0x07)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_AlarmDateWeekDay_Definitions RTC Alarm Date WeekDay Definitions
+  * @{
+  */
+#define RTC_ALARMDATEWEEKDAYSEL_DATE      ((uint32_t)0x00000000)
+#define RTC_ALARMDATEWEEKDAYSEL_WEEKDAY   ((uint32_t)0x40000000)
+/**
+  * @}
+  */
+
+
+/** @defgroup RTC_AlarmMask_Definitions RTC Alarm Mask Definitions
+  * @{
+  */
+#define RTC_ALARMMASK_NONE                ((uint32_t)0x00000000)
+#define RTC_ALARMMASK_DATEWEEKDAY         RTC_ALRMAR_MSK4
+#define RTC_ALARMMASK_HOURS               RTC_ALRMAR_MSK3
+#define RTC_ALARMMASK_MINUTES             RTC_ALRMAR_MSK2
+#define RTC_ALARMMASK_SECONDS             RTC_ALRMAR_MSK1
+#define RTC_ALARMMASK_ALL                 ((uint32_t)0x80808080)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Alarms_Definitions RTC Alarms Definitions
+  * @{
+  */
+#define RTC_ALARM_A                       RTC_CR_ALRAE
+#define RTC_ALARM_B                       RTC_CR_ALRBE
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Alarm_Sub_Seconds_Masks_Definitions RTC Alarm Sub Seconds Masks Definitions
+  * @{
+  */
+#define RTC_ALARMSUBSECONDMASK_ALL         ((uint32_t)0x00000000)  /*!< All Alarm SS fields are masked.
+                                                                        There is no comparison on sub seconds
+                                                                        for Alarm */
+#define RTC_ALARMSUBSECONDMASK_SS14_1      ((uint32_t)0x01000000)  /*!< SS[14:1] are don't care in Alarm
+                                                                        comparison. Only SS[0] is compared.    */
+#define RTC_ALARMSUBSECONDMASK_SS14_2      ((uint32_t)0x02000000)  /*!< SS[14:2] are don't care in Alarm
+                                                                        comparison. Only SS[1:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_3      ((uint32_t)0x03000000)  /*!< SS[14:3] are don't care in Alarm
+                                                                        comparison. Only SS[2:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_4      ((uint32_t)0x04000000)  /*!< SS[14:4] are don't care in Alarm
+                                                                        comparison. Only SS[3:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_5      ((uint32_t)0x05000000)  /*!< SS[14:5] are don't care in Alarm
+                                                                        comparison. Only SS[4:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_6      ((uint32_t)0x06000000)  /*!< SS[14:6] are don't care in Alarm
+                                                                        comparison. Only SS[5:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_7      ((uint32_t)0x07000000)  /*!< SS[14:7] are don't care in Alarm
+                                                                        comparison. Only SS[6:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_8      ((uint32_t)0x08000000)  /*!< SS[14:8] are don't care in Alarm
+                                                                        comparison. Only SS[7:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_9      ((uint32_t)0x09000000)  /*!< SS[14:9] are don't care in Alarm
+                                                                        comparison. Only SS[8:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_10     ((uint32_t)0x0A000000)  /*!< SS[14:10] are don't care in Alarm
+                                                                        comparison. Only SS[9:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_11     ((uint32_t)0x0B000000)  /*!< SS[14:11] are don't care in Alarm
+                                                                        comparison. Only SS[10:0] are compared */
+#define RTC_ALARMSUBSECONDMASK_SS14_12     ((uint32_t)0x0C000000)  /*!< SS[14:12] are don't care in Alarm
+                                                                        comparison. Only SS[11:0] are compared */
+#define RTC_ALARMSUBSECONDMASK_SS14_13     ((uint32_t)0x0D000000)  /*!< SS[14:13] are don't care in Alarm
+                                                                        comparison. Only SS[12:0] are compared */
+#define RTC_ALARMSUBSECONDMASK_SS14        ((uint32_t)0x0E000000)  /*!< SS[14] is don't care in Alarm
+                                                                        comparison. Only SS[13:0] are compared */
+#define RTC_ALARMSUBSECONDMASK_NONE        ((uint32_t)0x0F000000)  /*!< SS[14:0] are compared and must match
+                                                                        to activate alarm. */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Interrupts_Definitions RTC Interrupts Definitions
+  * @{
+  */
+#define RTC_IT_TS                         ((uint32_t)RTC_CR_TSIE)        /*!< Enable Timestamp Interrupt    */
+#define RTC_IT_WUT                        ((uint32_t)RTC_CR_WUTIE)       /*!< Enable Wakeup timer Interrupt */
+#define RTC_IT_ALRA                       ((uint32_t)RTC_CR_ALRAIE)      /*!< Enable Alarm A Interrupt      */
+#define RTC_IT_ALRB                       ((uint32_t)RTC_CR_ALRBIE)      /*!< Enable Alarm B Interrupt      */
+#define RTC_IT_TAMP                       ((uint32_t)RTC_TAMPCR_TAMPIE)  /*!< Enable all Tamper Interrupt   */
+#define RTC_IT_TAMP1                      ((uint32_t)RTC_TAMPCR_TAMP1IE) /*!< Enable Tamper 1 Interrupt     */
+#define RTC_IT_TAMP2                      ((uint32_t)RTC_TAMPCR_TAMP2IE) /*!< Enable Tamper 2 Interrupt     */
+#define RTC_IT_TAMP3                      ((uint32_t)RTC_TAMPCR_TAMP3IE) /*!< Enable Tamper 3 Interrupt     */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Flags_Definitions RTC Flags Definitions
+  * @{
+  */
+#define RTC_FLAG_RECALPF                  ((uint32_t)RTC_ISR_RECALPF)
+#define RTC_FLAG_TAMP3F                   ((uint32_t)RTC_ISR_TAMP3F)
+#define RTC_FLAG_TAMP2F                   ((uint32_t)RTC_ISR_TAMP2F)
+#define RTC_FLAG_TAMP1F                   ((uint32_t)RTC_ISR_TAMP1F)
+#define RTC_FLAG_TSOVF                    ((uint32_t)RTC_ISR_TSOVF)
+#define RTC_FLAG_TSF                      ((uint32_t)RTC_ISR_TSF)
+#define RTC_FLAG_ITSF                     ((uint32_t)RTC_ISR_ITSF)
+#define RTC_FLAG_WUTF                     ((uint32_t)RTC_ISR_WUTF)
+#define RTC_FLAG_ALRBF                    ((uint32_t)RTC_ISR_ALRBF)
+#define RTC_FLAG_ALRAF                    ((uint32_t)RTC_ISR_ALRAF)
+#define RTC_FLAG_INITF                    ((uint32_t)RTC_ISR_INITF)
+#define RTC_FLAG_RSF                      ((uint32_t)RTC_ISR_RSF)
+#define RTC_FLAG_INITS                    ((uint32_t)RTC_ISR_INITS)
+#define RTC_FLAG_SHPF                     ((uint32_t)RTC_ISR_SHPF)
+#define RTC_FLAG_WUTWF                    ((uint32_t)RTC_ISR_WUTWF)
+#define RTC_FLAG_ALRBWF                   ((uint32_t)RTC_ISR_ALRBWF)
+#define RTC_FLAG_ALRAWF                   ((uint32_t)RTC_ISR_ALRAWF)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup RTC_Exported_Macros RTC Exported Macros
+  * @{
+  */
+
+/** @brief Reset RTC handle state.
+  * @param  __HANDLE__: RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_RTC_STATE_RESET)
+
+/**
+  * @brief  Disable the write protection for RTC registers.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WRITEPROTECTION_DISABLE(__HANDLE__)             \
+                        do{                                       \
+                            (__HANDLE__)->Instance->WPR = 0xCA;   \
+                            (__HANDLE__)->Instance->WPR = 0x53;   \
+                          } while(0)
+
+/**
+  * @brief  Enable the write protection for RTC registers.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WRITEPROTECTION_ENABLE(__HANDLE__)              \
+                        do{                                       \
+                            (__HANDLE__)->Instance->WPR = 0xFF;   \
+                          } while(0)
+
+
+/**
+  * @brief  Enable the RTC ALARMA peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMA_ENABLE(__HANDLE__)                          ((__HANDLE__)->Instance->CR |= (RTC_CR_ALRAE))
+
+/**
+  * @brief  Disable the RTC ALARMA peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMA_DISABLE(__HANDLE__)                         ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ALRAE))
+
+/**
+  * @brief  Enable the RTC ALARMB peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMB_ENABLE(__HANDLE__)                          ((__HANDLE__)->Instance->CR |= (RTC_CR_ALRBE))
+
+/**
+  * @brief  Disable the RTC ALARMB peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMB_DISABLE(__HANDLE__)                         ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ALRBE))
+
+/**
+  * @brief  Enable the RTC Alarm interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Alarm interrupt sources to be enabled or disabled.
+  *          This parameter can be any combination of the following values:
+  *             @arg RTC_IT_ALRA: Alarm A interrupt
+  *             @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_ENABLE_IT(__HANDLE__, __INTERRUPT__)         ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC Alarm interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Alarm interrupt sources to be enabled or disabled.
+  *         This parameter can be any combination of the following values:
+  *            @arg RTC_IT_ALRA: Alarm A interrupt
+  *            @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_DISABLE_IT(__HANDLE__, __INTERRUPT__)        ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC Alarm interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Alarm interrupt sources to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_ALRA: Alarm A interrupt
+  *            @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_GET_IT(__HANDLE__, __INTERRUPT__)            (((((__HANDLE__)->Instance->ISR)& ((__INTERRUPT__)>> 4)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC Alarm's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Alarm Flag sources to check.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_ALRAF
+  *            @arg RTC_FLAG_ALRBF
+  *            @arg RTC_FLAG_ALRAWF
+  *            @arg RTC_FLAG_ALRBWF
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_GET_FLAG(__HANDLE__, __FLAG__)               (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Clear the RTC Alarm's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Alarm Flag sources to clear.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_ALRAF
+  *             @arg RTC_FLAG_ALRBF
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_CLEAR_FLAG(__HANDLE__, __FLAG__)             ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Check whether the specified RTC Alarm interrupt is enabled or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Alarm interrupt sources to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_ALRA: Alarm A interrupt
+  *            @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)     (((((__HANDLE__)->Instance->CR) & (__INTERRUPT__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Enable interrupt on the RTC Alarm associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_IT()            (EXTI->IMR1 |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Disable interrupt on the RTC Alarm associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_IT()           (EXTI->IMR1 &= ~(RTC_EXTI_LINE_ALARM_EVENT))
+
+/**
+  * @brief  Enable event on the RTC Alarm associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_EVENT()         (EXTI->EMR1 |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Disable event on the RTC Alarm associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_EVENT()         (EXTI->EMR1 &= ~(RTC_EXTI_LINE_ALARM_EVENT))
+
+/**
+  * @brief  Enable falling edge trigger on the RTC Alarm associated Exti line.  
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR1 |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Disable falling edge trigger on the RTC Alarm associated Exti line.  
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR1 &= ~(RTC_EXTI_LINE_ALARM_EVENT))
+
+/**
+  * @brief  Enable rising edge trigger on the RTC Alarm associated Exti line.  
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR1 |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Disable rising edge trigger on the RTC Alarm associated Exti line.  
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR1 &= ~(RTC_EXTI_LINE_ALARM_EVENT))
+
+/**
+  * @brief  Enable rising & falling edge trigger on the RTC Alarm associated Exti line.  
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_RISING_FALLING_EDGE()  do { \
+                                                             __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE();  \
+                                                             __HAL_RTC_ALARM_EXTI_ENABLE_FALLING_EDGE(); \
+                                                           } while(0)
+
+/**
+  * @brief  Disable rising & falling edge trigger on the RTC Alarm associated Exti line.  
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_RISING_FALLING_EDGE() do { \
+                                                             __HAL_RTC_ALARM_EXTI_DISABLE_RISING_EDGE();  \
+                                                             __HAL_RTC_ALARM_EXTI_DISABLE_FALLING_EDGE(); \
+                                                           } while(0)
+
+/**
+  * @brief Check whether the RTC Alarm associated Exti line interrupt flag is set or not.
+  * @retval Line Status.
+  */
+#define __HAL_RTC_ALARM_EXTI_GET_FLAG()              (EXTI->PR1 & RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief Clear the RTC Alarm associated Exti line flag.
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_CLEAR_FLAG()            (EXTI->PR1 = RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief Generate a Software interrupt on RTC Alarm associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_GENERATE_SWIT()         (EXTI->SWIER1 |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @}
+  */
+
+/* Include RTC HAL Extended module */
+#include "stm32l4xx_hal_rtc_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup RTC_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group1
+  * @{
+  */
+/* Initialization and de-initialization functions  ****************************/
+HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc);
+void              HAL_RTC_MspInit(RTC_HandleTypeDef *hrtc);
+void              HAL_RTC_MspDeInit(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group2
+  * @{
+  */
+/* RTC Time and Date functions ************************************************/
+HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format);
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group3
+  * @{
+  */
+/* RTC Alarm functions ********************************************************/
+HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alarm);
+HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Alarm, uint32_t Format);
+void              HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+void              HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group4
+  * @{
+  */
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc);
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group5
+  * @{
+  */
+/* Peripheral State functions *************************************************/
+HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/ 
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup RTC_Private_Constants RTC Private Constants
+  * @{
+  */
+/* Masks Definition */
+#define RTC_TR_RESERVED_MASK    ((uint32_t)0x007F7F7F)
+#define RTC_DR_RESERVED_MASK    ((uint32_t)0x00FFFF3F) 
+#define RTC_INIT_MASK           ((uint32_t)0xFFFFFFFFU)  
+#define RTC_RSF_MASK            ((uint32_t)0xFFFFFF5FU)
+
+#define RTC_TIMEOUT_VALUE  1000
+  
+#define RTC_EXTI_LINE_ALARM_EVENT             ((uint32_t)0x00040000)  /*!< External interrupt line 18 Connected to the RTC Alarm event */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup RTC_Private_Macros RTC Private Macros
+  * @{
+  */
+
+/** @defgroup RTC_IS_RTC_Definitions RTC Private macros to check input parameters
+  * @{
+  */ 
+
+#define IS_RTC_HOUR_FORMAT(FORMAT)     (((FORMAT) == RTC_HOURFORMAT_12) || \
+                                        ((FORMAT) == RTC_HOURFORMAT_24))
+
+#define IS_RTC_OUTPUT_POL(POL) (((POL) == RTC_OUTPUT_POLARITY_HIGH) || \
+                                ((POL) == RTC_OUTPUT_POLARITY_LOW))
+
+#define IS_RTC_OUTPUT_TYPE(TYPE) (((TYPE) == RTC_OUTPUT_TYPE_OPENDRAIN) || \
+                                  ((TYPE) == RTC_OUTPUT_TYPE_PUSHPULL))
+
+#define IS_RTC_OUTPUT_REMAP(REMAP)   (((REMAP) == RTC_OUTPUT_REMAP_NONE) || \
+                                      ((REMAP) == RTC_OUTPUT_REMAP_POS1))
+
+#define IS_RTC_HOURFORMAT12(PM)  (((PM) == RTC_HOURFORMAT12_AM) || ((PM) == RTC_HOURFORMAT12_PM))
+
+#define IS_RTC_DAYLIGHT_SAVING(SAVE) (((SAVE) == RTC_DAYLIGHTSAVING_SUB1H) || \
+                                      ((SAVE) == RTC_DAYLIGHTSAVING_ADD1H) || \
+                                      ((SAVE) == RTC_DAYLIGHTSAVING_NONE))
+
+#define IS_RTC_STORE_OPERATION(OPERATION) (((OPERATION) == RTC_STOREOPERATION_RESET) || \
+                                           ((OPERATION) == RTC_STOREOPERATION_SET))
+
+#define IS_RTC_FORMAT(FORMAT) (((FORMAT) == RTC_FORMAT_BIN) || ((FORMAT) == RTC_FORMAT_BCD))
+
+#define IS_RTC_YEAR(YEAR)              ((YEAR) <= (uint32_t)99)
+
+#define IS_RTC_MONTH(MONTH)            (((MONTH) >= (uint32_t)1) && ((MONTH) <= (uint32_t)12))
+
+#define IS_RTC_DATE(DATE)              (((DATE) >= (uint32_t)1) && ((DATE) <= (uint32_t)31))
+
+#define IS_RTC_WEEKDAY(WEEKDAY) (((WEEKDAY) == RTC_WEEKDAY_MONDAY)    || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_TUESDAY)   || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_WEDNESDAY) || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_THURSDAY)  || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_FRIDAY)    || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_SATURDAY)  || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_SUNDAY))
+
+#define IS_RTC_ALARM_DATE_WEEKDAY_DATE(DATE) (((DATE) >(uint32_t) 0) && ((DATE) <= (uint32_t)31))
+
+#define IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(WEEKDAY) (((WEEKDAY) == RTC_WEEKDAY_MONDAY)    || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_TUESDAY)   || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_WEDNESDAY) || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_THURSDAY)  || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_FRIDAY)    || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_SATURDAY)  || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_SUNDAY))
+
+#define IS_RTC_ALARM_DATE_WEEKDAY_SEL(SEL) (((SEL) == RTC_ALARMDATEWEEKDAYSEL_DATE) || \
+                                            ((SEL) == RTC_ALARMDATEWEEKDAYSEL_WEEKDAY))
+
+#define IS_RTC_ALARM_MASK(MASK)  (((MASK) & 0x7F7F7F7F) == (uint32_t)RESET)
+
+#define IS_RTC_ALARM(ALARM)      (((ALARM) == RTC_ALARM_A) || ((ALARM) == RTC_ALARM_B))
+
+#define IS_RTC_ALARM_SUB_SECOND_VALUE(VALUE) ((VALUE) <= (uint32_t)0x00007FFF)
+
+#define IS_RTC_ALARM_SUB_SECOND_MASK(MASK)   (((MASK) == RTC_ALARMSUBSECONDMASK_ALL) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_1) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_2) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_3) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_4) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_5) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_6) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_7) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_8) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_9) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_10) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_11) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_12) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_13) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_NONE))
+
+#define IS_RTC_ASYNCH_PREDIV(PREDIV)   ((PREDIV) <= (uint32_t)0x7F)
+
+#define IS_RTC_SYNCH_PREDIV(PREDIV)    ((PREDIV) <= (uint32_t)0x7FFF)
+
+#define IS_RTC_HOUR12(HOUR)            (((HOUR) > (uint32_t)0) && ((HOUR) <= (uint32_t)12))
+
+#define IS_RTC_HOUR24(HOUR)            ((HOUR) <= (uint32_t)23)
+
+#define IS_RTC_MINUTES(MINUTES)        ((MINUTES) <= (uint32_t)59)
+
+#define IS_RTC_SECONDS(SECONDS)        ((SECONDS) <= (uint32_t)59)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @addtogroup RTC_Private_Functions
+  * @{
+  */
+
+HAL_StatusTypeDef  RTC_EnterInitMode(RTC_HandleTypeDef* hrtc);
+uint8_t            RTC_ByteToBcd2(uint8_t Value);
+uint8_t            RTC_Bcd2ToByte(uint8_t Value);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_RTC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_rtc_ex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_rtc_ex.h
@@ -1,0 +1,1094 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_rtc_ex.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of RTC HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_RTC_EX_H
+#define __STM32L4xx_HAL_RTC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RTCEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup RTCEx_Exported_Types RTCEx Exported Types
+  * @{
+  */
+/**
+  * @brief  RTC Tamper structure definition
+  */
+typedef struct
+{
+  uint32_t Tamper;                      /*!< Specifies the Tamper Pin.
+                                             This parameter can be a value of @ref  RTCEx_Tamper_Pins_Definitions */
+
+  uint32_t Interrupt;                   /*!< Specifies the Tamper Interrupt.
+                                             This parameter can be a value of @ref  RTCEx_Tamper_Interrupt_Definitions */
+
+  uint32_t Trigger;                     /*!< Specifies the Tamper Trigger.
+                                             This parameter can be a value of @ref  RTCEx_Tamper_Trigger_Definitions */
+
+  uint32_t NoErase;                     /*!< Specifies the Tamper no erase mode.
+                                             This parameter can be a value of @ref  RTCEx_Tamper_EraseBackUp_Definitions */
+
+  uint32_t MaskFlag;                     /*!< Specifies the Tamper Flag masking.
+                                             This parameter can be a value of @ref RTCEx_Tamper_MaskFlag_Definitions   */
+
+  uint32_t Filter;                      /*!< Specifies the RTC Filter Tamper.
+                                             This parameter can be a value of @ref RTCEx_Tamper_Filter_Definitions */
+
+  uint32_t SamplingFrequency;           /*!< Specifies the sampling frequency.
+                                             This parameter can be a value of @ref RTCEx_Tamper_Sampling_Frequencies_Definitions */
+
+  uint32_t PrechargeDuration;           /*!< Specifies the Precharge Duration .
+                                             This parameter can be a value of @ref RTCEx_Tamper_Pin_Precharge_Duration_Definitions */
+
+  uint32_t TamperPullUp;                /*!< Specifies the Tamper PullUp .
+                                             This parameter can be a value of @ref RTCEx_Tamper_Pull_UP_Definitions */
+
+  uint32_t TimeStampOnTamperDetection;  /*!< Specifies the TimeStampOnTamperDetection.
+                                             This parameter can be a value of @ref RTCEx_Tamper_TimeStampOnTamperDetection_Definitions */
+}RTC_TamperTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RTCEx_Exported_Constants RTCEx Exported Constants
+  * @{
+  */
+
+/** @defgroup RTCEx_Output_selection_Definitions RTC Output Selection Definitions
+  * @{
+  */
+#define RTC_OUTPUT_DISABLE             ((uint32_t)0x00000000)
+#define RTC_OUTPUT_ALARMA              ((uint32_t)0x00200000)
+#define RTC_OUTPUT_ALARMB              ((uint32_t)0x00400000)
+#define RTC_OUTPUT_WAKEUP              ((uint32_t)0x00600000)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Backup_Registers_Definitions RTC Backup Registers Definitions
+  * @{
+  */
+#define RTC_BKP_DR0                       ((uint32_t)0x00000000)
+#define RTC_BKP_DR1                       ((uint32_t)0x00000001)
+#define RTC_BKP_DR2                       ((uint32_t)0x00000002)
+#define RTC_BKP_DR3                       ((uint32_t)0x00000003)
+#define RTC_BKP_DR4                       ((uint32_t)0x00000004)
+#define RTC_BKP_DR5                       ((uint32_t)0x00000005)
+#define RTC_BKP_DR6                       ((uint32_t)0x00000006)
+#define RTC_BKP_DR7                       ((uint32_t)0x00000007)
+#define RTC_BKP_DR8                       ((uint32_t)0x00000008)
+#define RTC_BKP_DR9                       ((uint32_t)0x00000009)
+#define RTC_BKP_DR10                      ((uint32_t)0x0000000A)
+#define RTC_BKP_DR11                      ((uint32_t)0x0000000B)
+#define RTC_BKP_DR12                      ((uint32_t)0x0000000C)
+#define RTC_BKP_DR13                      ((uint32_t)0x0000000D)
+#define RTC_BKP_DR14                      ((uint32_t)0x0000000E)
+#define RTC_BKP_DR15                      ((uint32_t)0x0000000F)
+#define RTC_BKP_DR16                      ((uint32_t)0x00000010)
+#define RTC_BKP_DR17                      ((uint32_t)0x00000011)
+#define RTC_BKP_DR18                      ((uint32_t)0x00000012)
+#define RTC_BKP_DR19                      ((uint32_t)0x00000013)
+#define RTC_BKP_DR20                      ((uint32_t)0x00000014)
+#define RTC_BKP_DR21                      ((uint32_t)0x00000015)
+#define RTC_BKP_DR22                      ((uint32_t)0x00000016)
+#define RTC_BKP_DR23                      ((uint32_t)0x00000017)
+#define RTC_BKP_DR24                      ((uint32_t)0x00000018)
+#define RTC_BKP_DR25                      ((uint32_t)0x00000019)
+#define RTC_BKP_DR26                      ((uint32_t)0x0000001A)
+#define RTC_BKP_DR27                      ((uint32_t)0x0000001B)
+#define RTC_BKP_DR28                      ((uint32_t)0x0000001C)
+#define RTC_BKP_DR29                      ((uint32_t)0x0000001D)
+#define RTC_BKP_DR30                      ((uint32_t)0x0000001E)
+#define RTC_BKP_DR31                      ((uint32_t)0x0000001F)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_TimeStamp_Edges_definitions RTC TimeStamp Edges Definitions
+  * @{
+  */ 
+#define RTC_TIMESTAMPEDGE_RISING          ((uint32_t)0x00000000)
+#define RTC_TIMESTAMPEDGE_FALLING         ((uint32_t)0x00000008)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_TimeStamp_Pin_Selection RTC TimeStamp Pins Selection
+  * @{
+  */
+#define RTC_TIMESTAMPPIN_DEFAULT          ((uint32_t)0x00000000)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Pins_Definitions RTC Tamper Pins Definitions
+  * @{
+  */
+#if defined(RTC_TAMPER1_SUPPORT)
+#define RTC_TAMPER_1                       RTC_TAMPCR_TAMP1E
+#endif /* RTC_TAMPER1_SUPPORT */
+#define RTC_TAMPER_2                       RTC_TAMPCR_TAMP2E
+#if defined(RTC_TAMPER3_SUPPORT)
+#define RTC_TAMPER_3                       RTC_TAMPCR_TAMP3E
+#endif /* RTC_TAMPER3_SUPPORT */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Interrupt_Definitions RTC Tamper Interrupts Definitions
+  * @{
+  */
+#if defined(RTC_TAMPER1_SUPPORT)
+#define RTC_TAMPER1_INTERRUPT              RTC_TAMPCR_TAMP1IE
+#endif /* RTC_TAMPER1_SUPPORT */
+#define RTC_TAMPER2_INTERRUPT              RTC_TAMPCR_TAMP2IE
+#if defined(RTC_TAMPER3_SUPPORT)
+#define RTC_TAMPER3_INTERRUPT              RTC_TAMPCR_TAMP3IE
+#endif /* RTC_TAMPER3_SUPPORT */
+#define RTC_ALL_TAMPER_INTERRUPT           RTC_TAMPCR_TAMPIE
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Trigger_Definitions RTC Tamper Triggers Definitions
+  * @{
+  */
+#define RTC_TAMPERTRIGGER_RISINGEDGE       ((uint32_t)0x00000000)
+#define RTC_TAMPERTRIGGER_FALLINGEDGE      ((uint32_t)0x00000002)
+#define RTC_TAMPERTRIGGER_LOWLEVEL         RTC_TAMPERTRIGGER_RISINGEDGE
+#define RTC_TAMPERTRIGGER_HIGHLEVEL        RTC_TAMPERTRIGGER_FALLINGEDGE
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_EraseBackUp_Definitions RTC Tamper EraseBackUp Definitions
+* @{
+*/
+#define RTC_TAMPER_ERASE_BACKUP_ENABLE     ((uint32_t)0x00000000)
+#define RTC_TAMPER_ERASE_BACKUP_DISABLE    ((uint32_t)0x00020000)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_MaskFlag_Definitions RTC Tamper Mask Flag Definitions
+* @{
+*/
+#define RTC_TAMPERMASK_FLAG_DISABLE        ((uint32_t)0x00000000)
+#define RTC_TAMPERMASK_FLAG_ENABLE         ((uint32_t)0x00040000)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Filter_Definitions RTC Tamper Filter Definitions
+  * @{
+  */
+#define RTC_TAMPERFILTER_DISABLE   ((uint32_t)0x00000000)  /*!< Tamper filter is disabled */
+
+#define RTC_TAMPERFILTER_2SAMPLE   ((uint32_t)0x00000800)  /*!< Tamper is activated after 2
+                                                                consecutive samples at the active level */
+#define RTC_TAMPERFILTER_4SAMPLE   ((uint32_t)0x00001000)  /*!< Tamper is activated after 4
+                                                                consecutive samples at the active level */
+#define RTC_TAMPERFILTER_8SAMPLE   ((uint32_t)0x00001800)  /*!< Tamper is activated after 8
+                                                                consecutive samples at the active level. */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Sampling_Frequencies_Definitions RTC Tamper Sampling Frequencies Definitions
+  * @{
+  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV32768  ((uint32_t)0x00000000)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 32768 */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV16384  ((uint32_t)0x00000100)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 16384 */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV8192   ((uint32_t)0x00000200)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 8192  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV4096   ((uint32_t)0x00000300)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 4096  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV2048   ((uint32_t)0x00000400)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 2048  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV1024   ((uint32_t)0x00000500)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 1024  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV512    ((uint32_t)0x00000600)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 512   */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV256    ((uint32_t)0x00000700)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 256   */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Pin_Precharge_Duration_Definitions RTC Tamper Pin Precharge Duration Definitions
+  * @{
+  */
+#define RTC_TAMPERPRECHARGEDURATION_1RTCCLK ((uint32_t)0x00000000)  /*!< Tamper pins are pre-charged before
+                                                                         sampling during 1 RTCCLK cycle  */
+#define RTC_TAMPERPRECHARGEDURATION_2RTCCLK ((uint32_t)0x00002000)  /*!< Tamper pins are pre-charged before
+                                                                         sampling during 2 RTCCLK cycles */
+#define RTC_TAMPERPRECHARGEDURATION_4RTCCLK ((uint32_t)0x00004000)  /*!< Tamper pins are pre-charged before
+                                                                         sampling during 4 RTCCLK cycles */
+#define RTC_TAMPERPRECHARGEDURATION_8RTCCLK ((uint32_t)0x00006000)  /*!< Tamper pins are pre-charged before
+                                                                         sampling during 8 RTCCLK cycles */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_TimeStampOnTamperDetection_Definitions RTC Tamper TimeStamp On Tamper Detection Definitions
+  * @{
+  */
+#define RTC_TIMESTAMPONTAMPERDETECTION_ENABLE  ((uint32_t)RTC_TAMPCR_TAMPTS)  /*!< TimeStamp on Tamper Detection event saved        */
+#define RTC_TIMESTAMPONTAMPERDETECTION_DISABLE ((uint32_t)0x00000000)         /*!< TimeStamp on Tamper Detection event is not saved */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Pull_UP_Definitions RTC Tamper Pull Up Definitions
+  * @{
+  */
+#define RTC_TAMPER_PULLUP_ENABLE  ((uint32_t)0x00000000)              /*!< TimeStamp on Tamper Detection event saved        */
+#define RTC_TAMPER_PULLUP_DISABLE ((uint32_t)RTC_TAMPCR_TAMPPUDIS)    /*!< TimeStamp on Tamper Detection event is not saved */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Wakeup_Timer_Definitions RTC Wakeup Timer Definitions
+  * @{
+  */
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV16        ((uint32_t)0x00000000)
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV8         ((uint32_t)0x00000001)
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV4         ((uint32_t)0x00000002)
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV2         ((uint32_t)0x00000003)
+#define RTC_WAKEUPCLOCK_CK_SPRE_16BITS      ((uint32_t)0x00000004)
+#define RTC_WAKEUPCLOCK_CK_SPRE_17BITS      ((uint32_t)0x00000006)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Smooth_calib_period_Definitions RTC Smooth Calib Period Definitions
+  * @{
+  */
+#define RTC_SMOOTHCALIB_PERIOD_32SEC   ((uint32_t)0x00000000)  /*!< If RTCCLK = 32768 Hz, Smooth calibration
+                                                                    period is 32s,  else 2exp20 RTCCLK seconds */
+#define RTC_SMOOTHCALIB_PERIOD_16SEC   ((uint32_t)0x00002000)  /*!< If RTCCLK = 32768 Hz, Smooth calibration 
+                                                                    period is 16s, else 2exp19 RTCCLK seconds */
+#define RTC_SMOOTHCALIB_PERIOD_8SEC    ((uint32_t)0x00004000)  /*!< If RTCCLK = 32768 Hz, Smooth calibration 
+                                                                    period is 8s, else 2exp18 RTCCLK seconds */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Smooth_calib_Plus_pulses_Definitions RTC Smooth Calib Plus Pulses Definitions
+  * @{
+  */
+#define RTC_SMOOTHCALIB_PLUSPULSES_SET    ((uint32_t)0x00008000)  /*!< The number of RTCCLK pulses added
+                                                                       during a X -second window = Y - CALM[8:0]
+                                                                       with Y = 512, 256, 128 when X = 32, 16, 8 */
+#define RTC_SMOOTHCALIB_PLUSPULSES_RESET  ((uint32_t)0x00000000)  /*!< The number of RTCCLK pulses subbstited
+                                                                       during a 32-second window = CALM[8:0] */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Calib_Output_selection_Definitions RTC Calib Output Selection Definitions
+  * @{
+  */
+#define RTC_CALIBOUTPUT_512HZ            ((uint32_t)0x00000000)
+#define RTC_CALIBOUTPUT_1HZ              ((uint32_t)0x00080000)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Add_1_Second_Parameter_Definitions RTC Add 1 Second Parameter Definitions
+  * @{
+  */
+#define RTC_SHIFTADD1S_RESET      ((uint32_t)0x00000000)
+#define RTC_SHIFTADD1S_SET        ((uint32_t)0x80000000)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup RTCEx_Exported_Macros RTCEx Exported Macros
+  * @{
+  */
+
+/**
+  * @brief  Enable the RTC WakeUp Timer peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_ENABLE(__HANDLE__)                     ((__HANDLE__)->Instance->CR |= (RTC_CR_WUTE))
+
+/**
+  * @brief  Disable the RTC WakeUp Timer peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_DISABLE(__HANDLE__)                    ((__HANDLE__)->Instance->CR &= ~(RTC_CR_WUTE))
+
+/**
+  * @brief  Enable the RTC WakeUpTimer interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC WakeUpTimer interrupt sources to be enabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT: WakeUpTimer interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_ENABLE_IT(__HANDLE__, __INTERRUPT__)    ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC WakeUpTimer interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC WakeUpTimer interrupt sources to be disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT: WakeUpTimer interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_DISABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC WakeUpTimer interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC WakeUpTimer interrupt sources to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT:  WakeUpTimer interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_GET_IT(__HANDLE__, __INTERRUPT__)       (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 4)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Check whether the specified RTC Wake Up timer interrupt is enabled or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Wake Up timer interrupt sources to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT:  WakeUpTimer interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)   (((((__HANDLE__)->Instance->CR) & (__INTERRUPT__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC WakeUpTimer's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC WakeUpTimer Flag is pending or not.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_WUTF
+  *             @arg RTC_FLAG_WUTWF
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_GET_FLAG(__HANDLE__, __FLAG__)   (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Clear the RTC Wake Up timer's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC WakeUpTimer Flag to clear.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_WUTF
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT)) 
+
+/**
+  * @brief  Enable the RTC Tamper1 input detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER1_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->TAMPCR |= (RTC_TAMPCR_TAMP1E))
+
+/**
+  * @brief  Disable the RTC Tamper1 input detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER1_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->TAMPCR &= ~(RTC_TAMPCR_TAMP1E))
+
+/**
+  * @brief  Enable the RTC Tamper2 input detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER2_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->TAMPCR |= (RTC_TAMPCR_TAMP2E))
+
+/**
+  * @brief  Disable the RTC Tamper2 input detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER2_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->TAMPCR &= ~(RTC_TAMPCR_TAMP2E))
+
+/**
+  * @brief  Enable the RTC Tamper3 input detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER3_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->TAMPCR |= (RTC_TAMPCR_TAMP3E))
+
+/**
+  * @brief  Disable the RTC Tamper3 input detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER3_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->TAMPCR &= ~(RTC_TAMPCR_TAMP3E))
+
+/**
+  * @brief  Enable the RTC Tamper interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Tamper interrupt sources to be enabled.
+  *          This parameter can be any combination of the following values:
+  *             @arg  RTC_IT_TAMP: All tampers interrupts
+  *             @arg  RTC_IT_TAMP1: Tamper1 interrupt
+  *             @arg  RTC_IT_TAMP2: Tamper2 interrupt
+  *             @arg  RTC_IT_TAMP3: Tamper3 interrupt
+  * @retval None
+  */   
+#define __HAL_RTC_TAMPER_ENABLE_IT(__HANDLE__, __INTERRUPT__)        ((__HANDLE__)->Instance->TAMPCR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC Tamper interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Tamper interrupt sources to be disabled. 
+  *         This parameter can be any combination of the following values:
+  *            @arg  RTC_IT_TAMP: All tampers interrupts
+  *            @arg  RTC_IT_TAMP1: Tamper1 interrupt
+  *            @arg  RTC_IT_TAMP2: Tamper2 interrupt
+  *            @arg  RTC_IT_TAMP3: Tamper3 interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_DISABLE_IT(__HANDLE__, __INTERRUPT__)       ((__HANDLE__)->Instance->TAMPCR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC Tamper interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Tamper interrupt to check.
+  *         This parameter can be:
+  *            @arg  RTC_IT_TAMP1: Tamper1 interrupt
+  *            @arg  RTC_IT_TAMP2: Tamper2 interrupt
+  *            @arg  RTC_IT_TAMP3: Tamper3 interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_GET_IT(__HANDLE__, __INTERRUPT__)           (((__INTERRUPT__) == RTC_IT_TAMP1) ? (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 3)) != RESET) ? SET : RESET) : \
+                                                                      ((__INTERRUPT__) == RTC_IT_TAMP2) ? (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 5)) != RESET) ? SET : RESET) : \
+                                                                      (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 7)) != RESET) ? SET : RESET))
+
+/**
+  * @brief  Check whether the specified RTC Tamper interrupt is enabled or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Tamper interrupt source to check.
+  *         This parameter can be:
+  *            @arg  RTC_IT_TAMP: All tampers interrupts
+  *            @arg  RTC_IT_TAMP1: Tamper1 interrupt
+  *            @arg  RTC_IT_TAMP2: Tamper2 interrupt
+  *            @arg  RTC_IT_TAMP3: Tamper3 interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)    (((((__HANDLE__)->Instance->TAMPCR) & (__INTERRUPT__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC Tamper's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Tamper Flag is pending or not.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_TAMP1F: Tamper1 flag
+  *             @arg RTC_FLAG_TAMP2F: Tamper2 flag
+  *             @arg RTC_FLAG_TAMP3F: Tamper3 flag
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_GET_FLAG(__HANDLE__, __FLAG__)        (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Clear the RTC Tamper's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Tamper Flag sources to clear.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_TAMP1F: Tamper1 flag
+  *             @arg RTC_FLAG_TAMP2F: Tamper2 flag
+  *             @arg RTC_FLAG_TAMP3F: Tamper3 flag
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_CLEAR_FLAG(__HANDLE__, __FLAG__)      ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Enable the RTC TimeStamp peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_ENABLE(__HANDLE__)                       ((__HANDLE__)->Instance->CR |= (RTC_CR_TSE))
+
+/**
+  * @brief  Disable the RTC TimeStamp peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_DISABLE(__HANDLE__)                      ((__HANDLE__)->Instance->CR &= ~(RTC_CR_TSE))
+
+/**
+  * @brief  Enable the RTC TimeStamp interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC TimeStamp interrupt source to be enabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_ENABLE_IT(__HANDLE__, __INTERRUPT__)     ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC TimeStamp interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC TimeStamp interrupt source to be disabled. 
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_DISABLE_IT(__HANDLE__, __INTERRUPT__)    ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC TimeStamp interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC TimeStamp interrupt source to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_GET_IT(__HANDLE__, __INTERRUPT__)        (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 4)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Check whether the specified RTC Time Stamp interrupt is enabled or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Time Stamp interrupt source to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)     (((((__HANDLE__)->Instance->CR) & (__INTERRUPT__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC TimeStamp's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC TimeStamp Flag is pending or not.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_TSF
+  *            @arg RTC_FLAG_TSOVF
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)     (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Clear the RTC Time Stamp's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Alarm Flag sources to clear.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_TSF
+  *             @arg RTC_FLAG_TSOVF
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)   ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Enable the RTC internal TimeStamp peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_ENABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR |= (RTC_CR_ITSE))
+
+/**
+  * @brief  Disable the RTC internal TimeStamp peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_DISABLE(__HANDLE__)               ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ITSE))
+
+/**
+  * @brief  Get the selected RTC Internal Time Stamp's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Internal Time Stamp Flag is pending or not.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_ITSF
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)    (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Clear the RTC Internal Time Stamp's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Internal Time Stamp Flag source to clear.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_ITSF
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)  ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Enable the RTC calibration output.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CALIBRATION_OUTPUT_ENABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR |= (RTC_CR_COE))
+
+/**
+  * @brief  Disable the calibration output.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CALIBRATION_OUTPUT_DISABLE(__HANDLE__)               ((__HANDLE__)->Instance->CR &= ~(RTC_CR_COE))
+
+/**
+  * @brief  Enable the clock reference detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CLOCKREF_DETECTION_ENABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR |= (RTC_CR_REFCKON))
+
+/**
+  * @brief  Disable the clock reference detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CLOCKREF_DETECTION_DISABLE(__HANDLE__)               ((__HANDLE__)->Instance->CR &= ~(RTC_CR_REFCKON))
+
+/**
+  * @brief  Get the selected RTC shift operation's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC shift operation Flag is pending or not.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_SHPF
+  * @retval None
+  */
+#define __HAL_RTC_SHIFT_GET_FLAG(__HANDLE__, __FLAG__)         (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET) ? SET : RESET)
+
+/**
+  * @brief  Enable interrupt on the RTC WakeUp Timer associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT()       (EXTI->IMR1 |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Disable interrupt on the RTC WakeUp Timer associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_IT()      (EXTI->IMR1 &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
+
+/**
+  * @brief  Enable event on the RTC WakeUp Timer associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_EVENT()    (EXTI->EMR1 |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Disable event on the RTC WakeUp Timer associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_EVENT()   (EXTI->EMR1 &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
+
+/**
+  * @brief  Enable falling edge trigger on the RTC WakeUp Timer associated Exti line. 
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR1 |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Disable falling edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR1 &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
+
+/**
+  * @brief  Enable rising edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR1 |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Disable rising edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR1 &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
+
+/**
+  * @brief  Enable rising & falling edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_FALLING_EDGE()  do { \
+                                                                   __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE();  \
+                                                                   __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_FALLING_EDGE(); \
+                                                                 } while(0)
+
+/**
+  * @brief  Disable rising & falling edge trigger on the RTC WakeUp Timer associated Exti line.
+  * This parameter can be:
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_FALLING_EDGE()  do { \
+                                                                   __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_EDGE();  \
+                                                                   __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_FALLING_EDGE(); \
+                                                                  } while(0)
+
+/**
+  * @brief Check whether the RTC WakeUp Timer associated Exti line interrupt flag is set or not.
+  * @retval Line Status.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_GET_FLAG()              (EXTI->PR1 & RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief Clear the RTC WakeUp Timer associated Exti line flag.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_CLEAR_FLAG()            (EXTI->PR1 = RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief Generate a Software interrupt on the RTC WakeUp Timer associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_GENERATE_SWIT()         (EXTI->SWIER1 |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Enable interrupt on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT()        (EXTI->IMR1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Disable interrupt on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_IT()       (EXTI->IMR1 &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
+
+/**
+  * @brief  Enable event on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_EVENT()    (EXTI->EMR1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Disable event on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_EVENT()   (EXTI->EMR1 &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
+
+/**
+  * @brief  Enable falling edge trigger on the RTC Tamper and Timestamp associated Exti line. 
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Disable falling edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR1 &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
+
+/**
+  * @brief  Enable rising edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Disable rising edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR1 &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
+
+/**
+  * @brief  Enable rising & falling edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_FALLING_EDGE()  do { \
+                                                                        __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE();  \
+                                                                        __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_FALLING_EDGE(); \
+                                                                      } while(0)
+
+/**
+  * @brief  Disable rising & falling edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * This parameter can be:
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_FALLING_EDGE()  do { \
+                                                                        __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_EDGE();  \
+                                                                        __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_FALLING_EDGE(); \
+                                                                       } while(0)
+
+/**
+  * @brief Check whether the RTC Tamper and Timestamp associated Exti line interrupt flag is set or not.
+  * @retval Line Status.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GET_FLAG()         (EXTI->PR1 & RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief Clear the RTC Tamper and Timestamp associated Exti line flag.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG()       (EXTI->PR1 = RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief Generate a Software interrupt on the RTC Tamper and Timestamp associated Exti line
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GENERATE_SWIT()    (EXTI->SWIER1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup RTCEx_Exported_Functions
+  * @{
+  */
+
+/* RTC TimeStamp and Tamper functions *****************************************/
+/** @addtogroup RTCEx_Exported_Functions_Group1
+  * @{
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin);
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_SetInternalTimeStamp(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateInternalTimeStamp(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_GetTimeStamp(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTimeStamp, RTC_DateTypeDef *sTimeStampDate, uint32_t Format);
+
+HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper);
+HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t Tamper);
+void              HAL_RTCEx_TamperTimeStampIRQHandler(RTC_HandleTypeDef *hrtc);
+
+#if defined(RTC_TAMPER1_SUPPORT)
+void              HAL_RTCEx_Tamper1EventCallback(RTC_HandleTypeDef *hrtc);
+#endif /* RTC_TAMPER1_SUPPORT */
+void              HAL_RTCEx_Tamper2EventCallback(RTC_HandleTypeDef *hrtc);
+#if defined(RTC_TAMPER3_SUPPORT)
+void              HAL_RTCEx_Tamper3EventCallback(RTC_HandleTypeDef *hrtc);
+#endif /* RTC_TAMPER3_SUPPORT */
+void              HAL_RTCEx_TimeStampEventCallback(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_PollForTimeStampEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+#if defined(RTC_TAMPER1_SUPPORT)
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper1Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+#endif /* RTC_TAMPER1_SUPPORT */
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper2Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+#if defined(RTC_TAMPER3_SUPPORT)
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+#endif /* RTC_TAMPER3_SUPPORT */
+/**
+  * @}
+  */
+
+/* RTC Wake-up functions ******************************************************/
+/** @addtogroup RTCEx_Exported_Functions_Group2
+  * @{
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock);
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock);
+uint32_t          HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc);
+uint32_t          HAL_RTCEx_GetWakeUpTimer(RTC_HandleTypeDef *hrtc);
+void              HAL_RTCEx_WakeUpTimerIRQHandler(RTC_HandleTypeDef *hrtc);
+void              HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/* Extended Control functions ************************************************/
+/** @addtogroup RTCEx_Exported_Functions_Group3
+  * @{
+  */
+void HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data);
+uint32_t HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister);
+
+HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef *hrtc, uint32_t SmoothCalibPeriod, uint32_t SmoothCalibPlusPulses, uint32_t SmoothCalibMinusPulsesValue);
+HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef *hrtc, uint32_t ShiftAdd1S, uint32_t ShiftSubFS);
+HAL_StatusTypeDef HAL_RTCEx_SetCalibrationOutPut(RTC_HandleTypeDef *hrtc, uint32_t CalibOutput);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateCalibrationOutPut(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_SetRefClock(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateRefClock(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
+
+/* Extended RTC features functions *******************************************/
+/** @addtogroup RTCEx_Exported_Functions_Group4
+  * @{
+  */
+void              HAL_RTCEx_AlarmBEventCallback(RTC_HandleTypeDef *hrtc); 
+HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/ 
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup RTCEx_Private_Constants RTCEx Private Constants
+  * @{
+  */
+#define RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT  ((uint32_t)0x00080000)  /*!< External interrupt line 19 Connected to the RTC Tamper and Time Stamp events */
+#define RTC_EXTI_LINE_WAKEUPTIMER_EVENT       ((uint32_t)0x00100000)  /*!< External interrupt line 20 Connected to the RTC Wakeup event */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup RTCEx_Private_Macros RTCEx Private Macros
+  * @{
+  */
+
+/** @defgroup RTCEx_IS_RTC_Definitions Private macros to check input parameters
+  * @{
+  */ 
+
+#define IS_RTC_OUTPUT(OUTPUT) (((OUTPUT) == RTC_OUTPUT_DISABLE) || \
+                               ((OUTPUT) == RTC_OUTPUT_ALARMA)  || \
+                               ((OUTPUT) == RTC_OUTPUT_ALARMB)  || \
+                               ((OUTPUT) == RTC_OUTPUT_WAKEUP))
+
+#define IS_RTC_BKP(BKP)                   ((BKP) < (uint32_t) RTC_BKP_NUMBER)
+
+#define IS_TIMESTAMP_EDGE(EDGE) (((EDGE) == RTC_TIMESTAMPEDGE_RISING) || \
+                                 ((EDGE) == RTC_TIMESTAMPEDGE_FALLING))
+
+#define IS_RTC_TAMPER(TAMPER) ((((TAMPER) & (uint32_t)0xFFFFFFD6) == 0x00) && ((TAMPER) != (uint32_t)RESET))
+
+#define IS_RTC_TAMPER_INTERRUPT(INTERRUPT) ((((INTERRUPT) & (uint32_t)0xFFB6FFFB) == 0x00) && ((INTERRUPT) != (uint32_t)RESET))
+
+#define IS_RTC_TIMESTAMP_PIN(PIN)  (((PIN) == RTC_TIMESTAMPPIN_DEFAULT))
+
+#define IS_RTC_TAMPER_TRIGGER(TRIGGER) (((TRIGGER) == RTC_TAMPERTRIGGER_RISINGEDGE) || \
+                                        ((TRIGGER) == RTC_TAMPERTRIGGER_FALLINGEDGE) || \
+                                        ((TRIGGER) == RTC_TAMPERTRIGGER_LOWLEVEL) || \
+                                        ((TRIGGER) == RTC_TAMPERTRIGGER_HIGHLEVEL)) 
+
+#define IS_RTC_TAMPER_ERASE_MODE(MODE)             (((MODE) == RTC_TAMPER_ERASE_BACKUP_ENABLE) || \
+                                                    ((MODE) == RTC_TAMPER_ERASE_BACKUP_DISABLE))
+
+#define IS_RTC_TAMPER_MASKFLAG_STATE(STATE)        (((STATE) == RTC_TAMPERMASK_FLAG_ENABLE) || \
+                                                    ((STATE) == RTC_TAMPERMASK_FLAG_DISABLE))
+
+#define IS_RTC_TAMPER_FILTER(FILTER)  (((FILTER) == RTC_TAMPERFILTER_DISABLE) || \
+                                       ((FILTER) == RTC_TAMPERFILTER_2SAMPLE) || \
+                                       ((FILTER) == RTC_TAMPERFILTER_4SAMPLE) || \
+                                       ((FILTER) == RTC_TAMPERFILTER_8SAMPLE))
+
+#define IS_RTC_TAMPER_SAMPLING_FREQ(FREQ) (((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV32768)|| \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV16384)|| \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV8192) || \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV4096) || \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV2048) || \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV1024) || \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV512)  || \
+                                          ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV256))
+
+#define IS_RTC_TAMPER_PRECHARGE_DURATION(DURATION) (((DURATION) == RTC_TAMPERPRECHARGEDURATION_1RTCCLK) || \
+                                                    ((DURATION) == RTC_TAMPERPRECHARGEDURATION_2RTCCLK) || \
+                                                    ((DURATION) == RTC_TAMPERPRECHARGEDURATION_4RTCCLK) || \
+                                                   ((DURATION) == RTC_TAMPERPRECHARGEDURATION_8RTCCLK))
+
+#define IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION(DETECTION) (((DETECTION) == RTC_TIMESTAMPONTAMPERDETECTION_ENABLE) || \
+                                                              ((DETECTION) == RTC_TIMESTAMPONTAMPERDETECTION_DISABLE))
+
+#define IS_RTC_TAMPER_PULLUP_STATE(STATE) (((STATE) == RTC_TAMPER_PULLUP_ENABLE) || \
+                                           ((STATE) == RTC_TAMPER_PULLUP_DISABLE))
+
+#define IS_RTC_WAKEUP_CLOCK(CLOCK) (((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV16)       || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV8)    || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV4)    || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV2)    || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_CK_SPRE_16BITS) || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_CK_SPRE_17BITS))
+
+#define IS_RTC_WAKEUP_COUNTER(COUNTER)  ((COUNTER) <= 0xFFFF)
+
+#define IS_RTC_SMOOTH_CALIB_PERIOD(PERIOD) (((PERIOD) == RTC_SMOOTHCALIB_PERIOD_32SEC) || \
+                                            ((PERIOD) == RTC_SMOOTHCALIB_PERIOD_16SEC) || \
+                                            ((PERIOD) == RTC_SMOOTHCALIB_PERIOD_8SEC))
+
+#define IS_RTC_SMOOTH_CALIB_PLUS(PLUS) (((PLUS) == RTC_SMOOTHCALIB_PLUSPULSES_SET) || \
+                                        ((PLUS) == RTC_SMOOTHCALIB_PLUSPULSES_RESET))
+
+#define  IS_RTC_SMOOTH_CALIB_MINUS(VALUE) ((VALUE) <= 0x000001FF)
+
+#define IS_RTC_SHIFT_ADD1S(SEL) (((SEL) == RTC_SHIFTADD1S_RESET) || \
+                                 ((SEL) == RTC_SHIFTADD1S_SET))
+
+#define IS_RTC_SHIFT_SUBFS(FS) ((FS) <= 0x00007FFF)
+
+#define IS_RTC_CALIB_OUTPUT(OUTPUT)  (((OUTPUT) == RTC_CALIBOUTPUT_512HZ) || \
+                                      ((OUTPUT) == RTC_CALIBOUTPUT_1HZ))
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_RTC_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_sd.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_sd.h
@@ -1,0 +1,774 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_sd.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of SD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_SD_H
+#define __STM32L4xx_HAL_SD_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_ll_sdmmc.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SD SD
+  * @brief SD HAL module driver
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/** @defgroup SD_Exported_Types SD Exported Types
+  * @{
+  */
+
+/** @defgroup SD_Exported_Types_Group1 SD Handle Structure definition   
+  * @{
+  */
+#define SD_InitTypeDef      SDMMC_InitTypeDef 
+#define SD_TypeDef          SDMMC_TypeDef
+
+typedef struct
+{
+  SD_TypeDef                   *Instance;        /*!< SDMMC register base address                     */
+  
+  SD_InitTypeDef               Init;             /*!< SD required parameters                         */
+  
+  HAL_LockTypeDef              Lock;             /*!< SD locking object                              */
+  
+  uint32_t                     CardType;         /*!< SD card type                                   */
+  
+  uint32_t                     RCA;              /*!< SD relative card address                       */
+  
+  uint32_t                     CSD[4];           /*!< SD card specific data table                    */
+  
+  uint32_t                     CID[4];           /*!< SD card identification number table            */
+  
+  __IO uint32_t                SdTransferCplt;   /*!< SD transfer complete flag in non blocking mode */
+  
+  __IO uint32_t                SdTransferErr;    /*!< SD transfer error flag in non blocking mode    */
+  
+  __IO uint32_t                DmaTransferCplt;  /*!< SD DMA transfer complete flag                  */
+  
+  __IO uint32_t                SdOperation;      /*!< SD transfer operation (read/write)             */
+  
+  DMA_HandleTypeDef            *hdmarx;          /*!< SD Rx DMA handle parameters                    */
+  
+  DMA_HandleTypeDef            *hdmatx;          /*!< SD Tx DMA handle parameters                    */
+  
+}SD_HandleTypeDef;
+/** 
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group2 Card Specific Data: CSD Register 
+  * @{
+  */ 
+typedef struct
+{
+  __IO uint8_t  CSDStruct;            /*!< CSD structure                         */
+  __IO uint8_t  SysSpecVersion;       /*!< System specification version          */
+  __IO uint8_t  Reserved1;            /*!< Reserved                              */
+  __IO uint8_t  TAAC;                 /*!< Data read access time 1               */
+  __IO uint8_t  NSAC;                 /*!< Data read access time 2 in CLK cycles */
+  __IO uint8_t  MaxBusClkFrec;        /*!< Max. bus clock frequency              */
+  __IO uint16_t CardComdClasses;      /*!< Card command classes                  */
+  __IO uint8_t  RdBlockLen;           /*!< Max. read data block length           */
+  __IO uint8_t  PartBlockRead;        /*!< Partial blocks for read allowed       */
+  __IO uint8_t  WrBlockMisalign;      /*!< Write block misalignment              */
+  __IO uint8_t  RdBlockMisalign;      /*!< Read block misalignment               */
+  __IO uint8_t  DSRImpl;              /*!< DSR implemented                       */
+  __IO uint8_t  Reserved2;            /*!< Reserved                              */
+  __IO uint32_t DeviceSize;           /*!< Device Size                           */
+  __IO uint8_t  MaxRdCurrentVDDMin;   /*!< Max. read current @ VDD min           */
+  __IO uint8_t  MaxRdCurrentVDDMax;   /*!< Max. read current @ VDD max           */
+  __IO uint8_t  MaxWrCurrentVDDMin;   /*!< Max. write current @ VDD min          */
+  __IO uint8_t  MaxWrCurrentVDDMax;   /*!< Max. write current @ VDD max          */
+  __IO uint8_t  DeviceSizeMul;        /*!< Device size multiplier                */
+  __IO uint8_t  EraseGrSize;          /*!< Erase group size                      */
+  __IO uint8_t  EraseGrMul;           /*!< Erase group size multiplier           */
+  __IO uint8_t  WrProtectGrSize;      /*!< Write protect group size              */
+  __IO uint8_t  WrProtectGrEnable;    /*!< Write protect group enable            */
+  __IO uint8_t  ManDeflECC;           /*!< Manufacturer default ECC              */
+  __IO uint8_t  WrSpeedFact;          /*!< Write speed factor                    */
+  __IO uint8_t  MaxWrBlockLen;        /*!< Max. write data block length          */
+  __IO uint8_t  WriteBlockPaPartial;  /*!< Partial blocks for write allowed      */
+  __IO uint8_t  Reserved3;            /*!< Reserved                              */
+  __IO uint8_t  ContentProtectAppli;  /*!< Content protection application        */
+  __IO uint8_t  FileFormatGrouop;     /*!< File format group                     */
+  __IO uint8_t  CopyFlag;             /*!< Copy flag (OTP)                       */
+  __IO uint8_t  PermWrProtect;        /*!< Permanent write protection            */
+  __IO uint8_t  TempWrProtect;        /*!< Temporary write protection            */
+  __IO uint8_t  FileFormat;           /*!< File format                           */
+  __IO uint8_t  ECC;                  /*!< ECC code                              */
+  __IO uint8_t  CSD_CRC;              /*!< CSD CRC                               */
+  __IO uint8_t  Reserved4;            /*!< Always 1                              */
+
+}HAL_SD_CSDTypedef;
+/** 
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group3 Card Identification Data: CID Register
+  * @{
+  */
+typedef struct
+{
+  __IO uint8_t  ManufacturerID;  /*!< Manufacturer ID       */
+  __IO uint16_t OEM_AppliID;     /*!< OEM/Application ID    */
+  __IO uint32_t ProdName1;       /*!< Product Name part1    */
+  __IO uint8_t  ProdName2;       /*!< Product Name part2    */
+  __IO uint8_t  ProdRev;         /*!< Product Revision      */
+  __IO uint32_t ProdSN;          /*!< Product Serial Number */
+  __IO uint8_t  Reserved1;       /*!< Reserved1             */
+  __IO uint16_t ManufactDate;    /*!< Manufacturing Date    */
+  __IO uint8_t  CID_CRC;         /*!< CID CRC               */
+  __IO uint8_t  Reserved2;       /*!< Always 1              */
+
+}HAL_SD_CIDTypedef;
+/** 
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group4 SD Card Status returned by ACMD13 
+  * @{
+  */
+typedef struct
+{
+  __IO uint8_t  DAT_BUS_WIDTH;           /*!< Shows the currently defined data bus width                 */
+  __IO uint8_t  SECURED_MODE;            /*!< Card is in secured mode of operation                       */
+  __IO uint16_t SD_CARD_TYPE;            /*!< Carries information about card type                        */
+  __IO uint32_t SIZE_OF_PROTECTED_AREA;  /*!< Carries information about the capacity of protected area   */
+  __IO uint8_t  SPEED_CLASS;             /*!< Carries information about the speed class of the card      */
+  __IO uint8_t  PERFORMANCE_MOVE;        /*!< Carries information about the card's performance move      */
+  __IO uint8_t  AU_SIZE;                 /*!< Carries information about the card's allocation unit size  */
+  __IO uint16_t ERASE_SIZE;              /*!< Determines the number of AUs to be erased in one operation */
+  __IO uint8_t  ERASE_TIMEOUT;           /*!< Determines the timeout for any number of AU erase          */
+  __IO uint8_t  ERASE_OFFSET;            /*!< Carries information about the erase offset                 */
+
+}HAL_SD_CardStatusTypedef;
+/** 
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group5 SD Card information structure 
+  * @{
+  */
+typedef struct
+{
+  HAL_SD_CSDTypedef   SD_csd;         /*!< SD card specific data register         */
+  HAL_SD_CIDTypedef   SD_cid;         /*!< SD card identification number register */
+  uint64_t            CardCapacity;   /*!< Card capacity                          */
+  uint32_t            CardBlockSize;  /*!< Card block size                        */
+  uint16_t            RCA;            /*!< SD relative card address               */
+  uint8_t             CardType;       /*!< SD card type                           */
+
+}HAL_SD_CardInfoTypedef;
+/** 
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group6 SD Error status enumeration Structure definition 
+  * @{
+  */
+typedef enum
+{
+/** 
+  * @brief  SD specific error defines  
+  */   
+  SD_CMD_CRC_FAIL                    = (1),   /*!< Command response received (but CRC check failed)              */
+  SD_DATA_CRC_FAIL                   = (2),   /*!< Data block sent/received (CRC check failed)                   */
+  SD_CMD_RSP_TIMEOUT                 = (3),   /*!< Command response timeout                                      */
+  SD_DATA_TIMEOUT                    = (4),   /*!< Data timeout                                                  */
+  SD_TX_UNDERRUN                     = (5),   /*!< Transmit FIFO underrun                                        */
+  SD_RX_OVERRUN                      = (6),   /*!< Receive FIFO overrun                                          */
+  SD_START_BIT_ERR                   = (7),   /*!< Start bit not detected on all data signals in wide bus mode   */
+  SD_CMD_OUT_OF_RANGE                = (8),   /*!< Command's argument was out of range.                          */
+  SD_ADDR_MISALIGNED                 = (9),   /*!< Misaligned address                                            */
+  SD_BLOCK_LEN_ERR                   = (10),  /*!< Transferred block length is not allowed for the card or the number of transferred bytes does not match the block length */
+  SD_ERASE_SEQ_ERR                   = (11),  /*!< An error in the sequence of erase command occurs.            */
+  SD_BAD_ERASE_PARAM                 = (12),  /*!< An invalid selection for erase groups                        */
+  SD_WRITE_PROT_VIOLATION            = (13),  /*!< Attempt to program a write protect block                     */
+  SD_LOCK_UNLOCK_FAILED              = (14),  /*!< Sequence or password error has been detected in unlock command or if there was an attempt to access a locked card */
+  SD_COM_CRC_FAILED                  = (15),  /*!< CRC check of the previous command failed                     */
+  SD_ILLEGAL_CMD                     = (16),  /*!< Command is not legal for the card state                      */
+  SD_CARD_ECC_FAILED                 = (17),  /*!< Card internal ECC was applied but failed to correct the data */
+  SD_CC_ERROR                        = (18),  /*!< Internal card controller error                               */
+  SD_GENERAL_UNKNOWN_ERROR           = (19),  /*!< General or unknown error                                     */
+  SD_STREAM_READ_UNDERRUN            = (20),  /*!< The card could not sustain data transfer in stream read operation. */
+  SD_STREAM_WRITE_OVERRUN            = (21),  /*!< The card could not sustain data programming in stream mode   */
+  SD_CID_CSD_OVERWRITE               = (22),  /*!< CID/CSD overwrite error                                      */
+  SD_WP_ERASE_SKIP                   = (23),  /*!< Only partial address space was erased                        */
+  SD_CARD_ECC_DISABLED               = (24),  /*!< Command has been executed without using internal ECC         */
+  SD_ERASE_RESET                     = (25),  /*!< Erase sequence was cleared before executing because an out of erase sequence command was received */
+  SD_AKE_SEQ_ERROR                   = (26),  /*!< Error in sequence of authentication.                         */
+  SD_INVALID_VOLTRANGE               = (27),
+  SD_ADDR_OUT_OF_RANGE               = (28),
+  SD_SWITCH_ERROR                    = (29),
+  SD_SDMMC_DISABLED                  = (30),
+  SD_SDMMC_FUNCTION_BUSY             = (31),
+  SD_SDMMC_FUNCTION_FAILED           = (32),
+  SD_SDMMC_UNKNOWN_FUNCTION          = (33),
+
+/** 
+  * @brief  Standard error defines   
+  */ 
+  SD_INTERNAL_ERROR                  = (34),
+  SD_NOT_CONFIGURED                  = (35),
+  SD_REQUEST_PENDING                 = (36),
+  SD_REQUEST_NOT_APPLICABLE          = (37),
+  SD_INVALID_PARAMETER               = (38),
+  SD_UNSUPPORTED_FEATURE             = (39),
+  SD_UNSUPPORTED_HW                  = (40),
+  SD_ERROR                           = (41),
+  SD_OK                              = (0) 
+
+}HAL_SD_ErrorTypedef;
+/** 
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group7 SD Transfer state enumeration structure
+  * @{
+  */   
+typedef enum
+{
+  SD_TRANSFER_OK    = 0,  /*!< Transfer success      */
+  SD_TRANSFER_BUSY  = 1,  /*!< Transfer is occurring */
+  SD_TRANSFER_ERROR = 2   /*!< Transfer failed       */
+
+}HAL_SD_TransferStateTypedef;
+/** 
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group8 SD Card State enumeration structure
+  * @{
+  */   
+typedef enum
+{
+  SD_CARD_READY                  = ((uint32_t)0x00000001),  /*!< Card state is ready                     */
+  SD_CARD_IDENTIFICATION         = ((uint32_t)0x00000002),  /*!< Card is in identification state         */
+  SD_CARD_STANDBY                = ((uint32_t)0x00000003),  /*!< Card is in standby state                */
+  SD_CARD_TRANSFER               = ((uint32_t)0x00000004),  /*!< Card is in transfer state               */  
+  SD_CARD_SENDING                = ((uint32_t)0x00000005),  /*!< Card is sending an operation            */
+  SD_CARD_RECEIVING              = ((uint32_t)0x00000006),  /*!< Card is receiving operation information */
+  SD_CARD_PROGRAMMING            = ((uint32_t)0x00000007),  /*!< Card is in programming state            */
+  SD_CARD_DISCONNECTED           = ((uint32_t)0x00000008),  /*!< Card is disconnected                    */
+  SD_CARD_ERROR                  = ((uint32_t)0x000000FF)   /*!< Card is in error state                  */
+
+}HAL_SD_CardStateTypedef;
+/** 
+  * @}
+  */
+
+/** @defgroup SD_Exported_Types_Group9 SD Operation enumeration structure
+  * @{
+  */   
+typedef enum
+{
+  SD_READ_SINGLE_BLOCK    = 0,  /*!< Read single block operation      */
+  SD_READ_MULTIPLE_BLOCK  = 1,  /*!< Read multiple blocks operation   */
+  SD_WRITE_SINGLE_BLOCK   = 2,  /*!< Write single block operation     */
+  SD_WRITE_MULTIPLE_BLOCK = 3   /*!< Write multiple blocks operation  */
+
+}HAL_SD_OperationTypedef;
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup SD_Exported_Constants SD Exported Constants
+  * @{
+  */
+
+/** 
+  * @brief SD Commands Index 
+  */
+#define SD_CMD_GO_IDLE_STATE                       ((uint8_t)0)   /*!< Resets the SD memory card.                                                               */
+#define SD_CMD_SEND_OP_COND                        ((uint8_t)1)   /*!< Sends host capacity support information and activates the card's initialization process. */
+#define SD_CMD_ALL_SEND_CID                        ((uint8_t)2)   /*!< Asks any card connected to the host to send the CID numbers on the CMD line.             */
+#define SD_CMD_SET_REL_ADDR                        ((uint8_t)3)   /*!< Asks the card to publish a new relative address (RCA).                                   */
+#define SD_CMD_SET_DSR                             ((uint8_t)4)   /*!< Programs the DSR of all cards.                                                           */
+#define SD_CMD_SDMMC_SEN_OP_COND                   ((uint8_t)5)   /*!< Sends host capacity support information (HCS) and asks the accessed card to send its 
+                                                                       operating condition register (OCR) content in the response on the CMD line.              */
+#define SD_CMD_HS_SWITCH                           ((uint8_t)6)   /*!< Checks switchable function (mode 0) and switch card function (mode 1).                   */
+#define SD_CMD_SEL_DESEL_CARD                      ((uint8_t)7)   /*!< Selects the card by its own relative address and gets deselected by any other address    */
+#define SD_CMD_HS_SEND_EXT_CSD                     ((uint8_t)8)   /*!< Sends SD Memory Card interface condition, which includes host supply voltage information 
+                                                                       and asks the card whether card supports voltage.                                         */
+#define SD_CMD_SEND_CSD                            ((uint8_t)9)   /*!< Addressed card sends its card specific data (CSD) on the CMD line.                       */
+#define SD_CMD_SEND_CID                            ((uint8_t)10)  /*!< Addressed card sends its card identification (CID) on the CMD line.                      */
+#define SD_CMD_READ_DAT_UNTIL_STOP                 ((uint8_t)11)  /*!< SD card doesn't support it.                                                              */
+#define SD_CMD_STOP_TRANSMISSION                   ((uint8_t)12)  /*!< Forces the card to stop transmission.                                                    */
+#define SD_CMD_SEND_STATUS                         ((uint8_t)13)  /*!< Addressed card sends its status register.                                                */
+#define SD_CMD_HS_BUSTEST_READ                     ((uint8_t)14) 
+#define SD_CMD_GO_INACTIVE_STATE                   ((uint8_t)15)  /*!< Sends an addressed card into the inactive state.                                         */
+#define SD_CMD_SET_BLOCKLEN                        ((uint8_t)16)  /*!< Sets the block length (in bytes for SDSC) for all following block commands 
+                                                                       (read, write, lock). Default block length is fixed to 512 Bytes. Not effective 
+                                                                       for SDHS and SDXC.                                                                       */
+#define SD_CMD_READ_SINGLE_BLOCK                   ((uint8_t)17)  /*!< Reads single block of size selected by SET_BLOCKLEN in case of SDSC, and a block of 
+                                                                       fixed 512 bytes in case of SDHC and SDXC.                                                */
+#define SD_CMD_READ_MULT_BLOCK                     ((uint8_t)18)  /*!< Continuously transfers data blocks from card to host until interrupted by 
+                                                                       STOP_TRANSMISSION command.                                                               */
+#define SD_CMD_HS_BUSTEST_WRITE                    ((uint8_t)19)  /*!< 64 bytes tuning pattern is sent for SDR50 and SDR104.                                    */
+#define SD_CMD_WRITE_DAT_UNTIL_STOP                ((uint8_t)20)  /*!< Speed class control command.                                                             */
+#define SD_CMD_SET_BLOCK_COUNT                     ((uint8_t)23)  /*!< Specify block count for CMD18 and CMD25.                                                 */
+#define SD_CMD_WRITE_SINGLE_BLOCK                  ((uint8_t)24)  /*!< Writes single block of size selected by SET_BLOCKLEN in case of SDSC, and a block of 
+                                                                       fixed 512 bytes in case of SDHC and SDXC.                                                */
+#define SD_CMD_WRITE_MULT_BLOCK                    ((uint8_t)25)  /*!< Continuously writes blocks of data until a STOP_TRANSMISSION follows.                    */
+#define SD_CMD_PROG_CID                            ((uint8_t)26)  /*!< Reserved for manufacturers.                                                              */
+#define SD_CMD_PROG_CSD                            ((uint8_t)27)  /*!< Programming of the programmable bits of the CSD.                                         */
+#define SD_CMD_SET_WRITE_PROT                      ((uint8_t)28)  /*!< Sets the write protection bit of the addressed group.                                    */
+#define SD_CMD_CLR_WRITE_PROT                      ((uint8_t)29)  /*!< Clears the write protection bit of the addressed group.                                  */
+#define SD_CMD_SEND_WRITE_PROT                     ((uint8_t)30)  /*!< Asks the card to send the status of the write protection bits.                           */
+#define SD_CMD_SD_ERASE_GRP_START                  ((uint8_t)32)  /*!< Sets the address of the first write block to be erased. (For SD card only).              */
+#define SD_CMD_SD_ERASE_GRP_END                    ((uint8_t)33)  /*!< Sets the address of the last write block of the continuous range to be erased.           */
+#define SD_CMD_ERASE_GRP_START                     ((uint8_t)35)  /*!< Sets the address of the first write block to be erased. Reserved for each command 
+                                                                       system set by switch function command (CMD6).                                            */
+#define SD_CMD_ERASE_GRP_END                       ((uint8_t)36)  /*!< Sets the address of the last write block of the continuous range to be erased. 
+                                                                       Reserved for each command system set by switch function command (CMD6).                  */
+#define SD_CMD_ERASE                               ((uint8_t)38)  /*!< Reserved for SD security applications.                                                   */
+#define SD_CMD_FAST_IO                             ((uint8_t)39)  /*!< SD card doesn't support it (Reserved).                                                   */
+#define SD_CMD_GO_IRQ_STATE                        ((uint8_t)40)  /*!< SD card doesn't support it (Reserved).                                                   */
+#define SD_CMD_LOCK_UNLOCK                         ((uint8_t)42)  /*!< Sets/resets the password or lock/unlock the card. The size of the data block is set by 
+                                                                       the SET_BLOCK_LEN command.                                                               */
+#define SD_CMD_APP_CMD                             ((uint8_t)55)  /*!< Indicates to the card that the next command is an application specific command rather 
+                                                                       than a standard command.                                                                 */
+#define SD_CMD_GEN_CMD                             ((uint8_t)56)  /*!< Used either to transfer a data block to the card or to get a data block from the card 
+                                                                       for general purpose/application specific commands.                                       */
+#define SD_CMD_NO_CMD                              ((uint8_t)64) 
+
+/** 
+  * @brief Following commands are SD Card Specific commands.
+  *        SDMMC_APP_CMD should be sent before sending these commands. 
+  */
+#define SD_CMD_APP_SD_SET_BUSWIDTH                 ((uint8_t)6)   /*!< (ACMD6) Defines the data bus width to be used for data transfer. The allowed data bus 
+                                                                       widths are given in SCR register.                                                          */
+#define SD_CMD_SD_APP_STATUS                       ((uint8_t)13)  /*!< (ACMD13) Sends the SD status.                                                              */
+#define SD_CMD_SD_APP_SEND_NUM_WRITE_BLOCKS        ((uint8_t)22)  /*!< (ACMD22) Sends the number of the written (without errors) write blocks. Responds with 
+                                                                       32bit+CRC data block.                                                                      */
+#define SD_CMD_SD_APP_OP_COND                      ((uint8_t)41)  /*!< (ACMD41) Sends host capacity support information (HCS) and asks the accessed card to 
+                                                                       send its operating condition register (OCR) content in the response on the CMD line.       */
+#define SD_CMD_SD_APP_SET_CLR_CARD_DETECT          ((uint8_t)42)  /*!< (ACMD42) Connects/Disconnects the 50 KOhm pull-up resistor on CD/DAT3 (pin 1) of the card. */
+#define SD_CMD_SD_APP_SEND_SCR                     ((uint8_t)51)  /*!< Reads the SD Configuration Register (SCR).                                                 */
+#define SD_CMD_SDMMC_RW_DIRECT                     ((uint8_t)52)  /*!< For SD I/O card only, reserved for security specification.                                 */
+#define SD_CMD_SDMMC_RW_EXTENDED                   ((uint8_t)53)  /*!< For SD I/O card only, reserved for security specification.                                 */
+
+/** 
+  * @brief Following commands are SD Card Specific security commands.
+  *        SD_CMD_APP_CMD should be sent before sending these commands. 
+  */
+#define SD_CMD_SD_APP_GET_MKB                      ((uint8_t)43)  /*!< For SD card only */
+#define SD_CMD_SD_APP_GET_MID                      ((uint8_t)44)  /*!< For SD card only */
+#define SD_CMD_SD_APP_SET_CER_RN1                  ((uint8_t)45)  /*!< For SD card only */
+#define SD_CMD_SD_APP_GET_CER_RN2                  ((uint8_t)46)  /*!< For SD card only */
+#define SD_CMD_SD_APP_SET_CER_RES2                 ((uint8_t)47)  /*!< For SD card only */
+#define SD_CMD_SD_APP_GET_CER_RES1                 ((uint8_t)48)  /*!< For SD card only */
+#define SD_CMD_SD_APP_SECURE_READ_MULTIPLE_BLOCK   ((uint8_t)18)  /*!< For SD card only */
+#define SD_CMD_SD_APP_SECURE_WRITE_MULTIPLE_BLOCK  ((uint8_t)25)  /*!< For SD card only */
+#define SD_CMD_SD_APP_SECURE_ERASE                 ((uint8_t)38)  /*!< For SD card only */
+#define SD_CMD_SD_APP_CHANGE_SECURE_AREA           ((uint8_t)49)  /*!< For SD card only */
+#define SD_CMD_SD_APP_SECURE_WRITE_MKB             ((uint8_t)48)  /*!< For SD card only */
+
+/** 
+  * @brief Supported SD Memory Cards 
+  */
+#define STD_CAPACITY_SD_CARD_V1_1             ((uint32_t)0x00000000)
+#define STD_CAPACITY_SD_CARD_V2_0             ((uint32_t)0x00000001)
+#define HIGH_CAPACITY_SD_CARD                 ((uint32_t)0x00000002)
+#define MULTIMEDIA_CARD                       ((uint32_t)0x00000003)
+#define SECURE_DIGITAL_IO_CARD                ((uint32_t)0x00000004)
+#define HIGH_SPEED_MULTIMEDIA_CARD            ((uint32_t)0x00000005)
+#define SECURE_DIGITAL_IO_COMBO_CARD          ((uint32_t)0x00000006)
+#define HIGH_CAPACITY_MMC_CARD                ((uint32_t)0x00000007)
+/**
+  * @}
+  */
+  
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup SD_Exported_macros SD Exported Macros
+ *  @brief macros to handle interrupts and specific clock configurations
+ * @{
+ */
+ 
+/**
+  * @brief  Enable the SD device.
+  * @retval None
+  */ 
+#define __HAL_SD_SDMMC_ENABLE(__HANDLE__) __SDMMC_ENABLE((__HANDLE__)->Instance)
+
+/**
+  * @brief  Disable the SD device.
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_DISABLE(__HANDLE__) __SDMMC_DISABLE((__HANDLE__)->Instance)
+
+/**
+  * @brief  Enable the SDMMC DMA transfer.
+  * @retval None
+  */ 
+#define __HAL_SD_SDMMC_DMA_ENABLE(__HANDLE__) __SDMMC_DMA_ENABLE((__HANDLE__)->Instance)
+
+/**
+  * @brief  Disable the SDMMC DMA transfer.
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_DMA_DISABLE(__HANDLE__)  __SDMMC_DMA_DISABLE((__HANDLE__)->Instance)
+ 
+/**
+  * @brief  Enable the SD device interrupt.
+  * @param  __HANDLE__: SD Handle  
+  * @param  __INTERRUPT__: specifies the SDMMC interrupt sources to be enabled.
+  *         This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDACT:   Command transfer in progress interrupt
+  *            @arg SDMMC_IT_TXACT:    Data transmit in progress interrupt
+  *            @arg SDMMC_IT_RXACT:    Data receive in progress interrupt
+  *            @arg SDMMC_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+  *            @arg SDMMC_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+  *            @arg SDMMC_IT_TXFIFOF:  Transmit FIFO full interrupt
+  *            @arg SDMMC_IT_RXFIFOF:  Receive FIFO full interrupt
+  *            @arg SDMMC_IT_TXFIFOE:  Transmit FIFO empty interrupt
+  *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
+  *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
+  *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_ENABLE_IT(__HANDLE__, __INTERRUPT__) __SDMMC_ENABLE_IT((__HANDLE__)->Instance, (__INTERRUPT__))
+
+/**
+  * @brief  Disable the SD device interrupt.
+  * @param  __HANDLE__: SD Handle   
+  * @param  __INTERRUPT__: specifies the SDMMC interrupt sources to be disabled.
+  *          This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDACT:   Command transfer in progress interrupt
+  *            @arg SDMMC_IT_TXACT:    Data transmit in progress interrupt
+  *            @arg SDMMC_IT_RXACT:    Data receive in progress interrupt
+  *            @arg SDMMC_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+  *            @arg SDMMC_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+  *            @arg SDMMC_IT_TXFIFOF:  Transmit FIFO full interrupt
+  *            @arg SDMMC_IT_RXFIFOF:  Receive FIFO full interrupt
+  *            @arg SDMMC_IT_TXFIFOE:  Transmit FIFO empty interrupt
+  *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
+  *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
+  *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt   
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_DISABLE_IT(__HANDLE__, __INTERRUPT__) __SDMMC_DISABLE_IT((__HANDLE__)->Instance, (__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified SD flag is set or not. 
+  * @param  __HANDLE__: SD Handle   
+  * @param  __FLAG__: specifies the flag to check. 
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_FLAG_CCRCFAIL: Command response received (CRC check failed)
+  *            @arg SDMMC_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
+  *            @arg SDMMC_FLAG_CTIMEOUT: Command response timeout
+  *            @arg SDMMC_FLAG_DTIMEOUT: Data timeout
+  *            @arg SDMMC_FLAG_TXUNDERR: Transmit FIFO underrun error
+  *            @arg SDMMC_FLAG_RXOVERR:  Received FIFO overrun error
+  *            @arg SDMMC_FLAG_CMDREND:  Command response received (CRC check passed)
+  *            @arg SDMMC_FLAG_CMDSENT:  Command sent (no response required)
+  *            @arg SDMMC_FLAG_DATAEND:  Data end (data counter, SDIDCOUNT, is zero)
+  *            @arg SDMMC_FLAG_DBCKEND:  Data block sent/received (CRC check passed)
+  *            @arg SDMMC_FLAG_CMDACT:   Command transfer in progress
+  *            @arg SDMMC_FLAG_TXACT:    Data transmit in progress
+  *            @arg SDMMC_FLAG_RXACT:    Data receive in progress
+  *            @arg SDMMC_FLAG_TXFIFOHE: Transmit FIFO Half Empty
+  *            @arg SDMMC_FLAG_RXFIFOHF: Receive FIFO Half Full
+  *            @arg SDMMC_FLAG_TXFIFOF:  Transmit FIFO full
+  *            @arg SDMMC_FLAG_RXFIFOF:  Receive FIFO full
+  *            @arg SDMMC_FLAG_TXFIFOE:  Transmit FIFO empty
+  *            @arg SDMMC_FLAG_RXFIFOE:  Receive FIFO empty
+  *            @arg SDMMC_FLAG_TXDAVL:   Data available in transmit FIFO
+  *            @arg SDMMC_FLAG_RXDAVL:   Data available in receive FIFO
+  *            @arg SDMMC_FLAG_SDIOIT:   SD I/O interrupt received
+  * @retval The new state of SD FLAG (SET or RESET).
+  */
+#define __HAL_SD_SDMMC_GET_FLAG(__HANDLE__, __FLAG__) __SDMMC_GET_FLAG((__HANDLE__)->Instance, (__FLAG__))
+
+/**
+  * @brief  Clear the SD's pending flags.
+  * @param  __HANDLE__: SD Handle  
+  * @param  __FLAG__: specifies the flag to clear.  
+  *          This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_FLAG_CCRCFAIL: Command response received (CRC check failed)
+  *            @arg SDMMC_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
+  *            @arg SDMMC_FLAG_CTIMEOUT: Command response timeout
+  *            @arg SDMMC_FLAG_DTIMEOUT: Data timeout
+  *            @arg SDMMC_FLAG_TXUNDERR: Transmit FIFO underrun error
+  *            @arg SDMMC_FLAG_RXOVERR:  Received FIFO overrun error
+  *            @arg SDMMC_FLAG_CMDREND:  Command response received (CRC check passed)
+  *            @arg SDMMC_FLAG_CMDSENT:  Command sent (no response required)
+  *            @arg SDMMC_FLAG_DATAEND:  Data end (data counter, SDIDCOUNT, is zero)
+  *            @arg SDMMC_FLAG_DBCKEND:  Data block sent/received (CRC check passed)
+  *            @arg SDMMC_FLAG_SDIOIT:   SD I/O interrupt received
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_CLEAR_FLAG(__HANDLE__, __FLAG__) __SDMMC_CLEAR_FLAG((__HANDLE__)->Instance, (__FLAG__))
+
+/**
+  * @brief  Check whether the specified SD interrupt has occurred or not.
+  * @param  __HANDLE__: SD Handle   
+  * @param  __INTERRUPT__: specifies the SDMMC interrupt source to check. 
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDACT:   Command transfer in progress interrupt
+  *            @arg SDMMC_IT_TXACT:    Data transmit in progress interrupt
+  *            @arg SDMMC_IT_RXACT:    Data receive in progress interrupt
+  *            @arg SDMMC_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+  *            @arg SDMMC_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+  *            @arg SDMMC_IT_TXFIFOF:  Transmit FIFO full interrupt
+  *            @arg SDMMC_IT_RXFIFOF:  Receive FIFO full interrupt
+  *            @arg SDMMC_IT_TXFIFOE:  Transmit FIFO empty interrupt
+  *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
+  *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
+  *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval The new state of SD IT (SET or RESET).
+  */
+#define __HAL_SD_SDMMC_GET_IT(__HANDLE__, __INTERRUPT__) __SDMMC_GET_IT((__HANDLE__)->Instance, (__INTERRUPT__))
+
+/**
+  * @brief  Clear the SD's interrupt pending bits.
+  * @param  __HANDLE__: SD Handle
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. 
+  *          This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDMMC_DCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval None
+  */
+#define __HAL_SD_SDMMC_CLEAR_IT(__HANDLE__, __INTERRUPT__) __SDMMC_CLEAR_IT((__HANDLE__)->Instance, (__INTERRUPT__))
+/**
+  * @}
+  */
+  
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup SD_Exported_Functions SD Exported Functions
+  * @{
+  */
+  
+/** @defgroup SD_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+HAL_SD_ErrorTypedef HAL_SD_Init(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTypedef *SDCardInfo);
+HAL_StatusTypeDef   HAL_SD_DeInit (SD_HandleTypeDef *hsd);
+void HAL_SD_MspInit(SD_HandleTypeDef *hsd);
+void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd);
+/**
+  * @}
+  */
+  
+/** @defgroup SD_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
+/* Blocking mode: Polling */
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
+HAL_SD_ErrorTypedef HAL_SD_Erase(SD_HandleTypeDef *hsd, uint64_t startaddr, uint64_t endaddr);
+
+/* Non-Blocking mode: Interrupt */
+void HAL_SD_IRQHandler(SD_HandleTypeDef *hsd);
+
+/* Callback in non blocking modes (DMA) */
+void HAL_SD_DMA_RxCpltCallback(DMA_HandleTypeDef *hdma);
+void HAL_SD_DMA_RxErrorCallback(DMA_HandleTypeDef *hdma);
+void HAL_SD_DMA_TxCpltCallback(DMA_HandleTypeDef *hdma);
+void HAL_SD_DMA_TxErrorCallback(DMA_HandleTypeDef *hdma);
+void HAL_SD_XferCpltCallback(SD_HandleTypeDef *hsd);
+void HAL_SD_XferErrorCallback(SD_HandleTypeDef *hsd);
+
+/* Non-Blocking mode: DMA */
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
+HAL_SD_ErrorTypedef HAL_SD_CheckWriteOperation(SD_HandleTypeDef *hsd, uint32_t Timeout);
+HAL_SD_ErrorTypedef HAL_SD_CheckReadOperation(SD_HandleTypeDef *hsd, uint32_t Timeout);
+/**
+  * @}
+  */
+  
+/** @defgroup SD_Exported_Functions_Group3 Peripheral Control functions
+  * @{
+  */
+HAL_SD_ErrorTypedef HAL_SD_Get_CardInfo(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTypedef *pCardInfo);
+HAL_SD_ErrorTypedef HAL_SD_WideBusOperation_Config(SD_HandleTypeDef *hsd, uint32_t WideMode);
+HAL_SD_ErrorTypedef HAL_SD_StopTransfer(SD_HandleTypeDef *hsd);
+HAL_SD_ErrorTypedef HAL_SD_HighSpeed (SD_HandleTypeDef *hsd);
+/**
+  * @}
+  */
+  
+/* Peripheral State functions  ************************************************/
+/** @defgroup SD_Exported_Functions_Group4 Peripheral State functions
+  * @{
+  */
+HAL_SD_ErrorTypedef HAL_SD_SendSDStatus(SD_HandleTypeDef *hsd, uint32_t *pSDstatus);
+HAL_SD_ErrorTypedef HAL_SD_GetCardStatus(SD_HandleTypeDef *hsd, HAL_SD_CardStatusTypedef *pCardStatus);
+HAL_SD_TransferStateTypedef HAL_SD_GetStatus(SD_HandleTypeDef *hsd);
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */
+    
+/* Private types -------------------------------------------------------------*/
+/** @defgroup SD_Private_Types SD Private Types
+  * @{
+  */
+
+/**
+  * @}
+  */ 
+
+/* Private defines -----------------------------------------------------------*/
+/** @defgroup SD_Private_Defines SD Private Defines
+  * @{
+  */
+
+/**
+  * @}
+  */ 
+          
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup SD_Private_Variables SD Private Variables
+  * @{
+  */
+
+/**
+  * @}
+  */ 
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup SD_Private_Constants SD Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */ 
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup SD_Private_Macros SD Private Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions prototypes ----------------------------------------------*/
+/** @defgroup SD_Private_Functions_Prototypes SD Private Functions Prototypes
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup SD_Private_Functions SD Private Functions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L4xx_HAL_SD_H */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_spi.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_spi.h
@@ -1,0 +1,696 @@
+ /**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_spi.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of SPI HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_SPI_H
+#define __STM32L4xx_HAL_SPI_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup SPI
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup SPI_Exported_Types SPI Exported Types
+  * @{
+  */
+
+/**
+  * @brief  SPI Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t Mode;                /*!< Specifies the SPI operating mode.
+                                     This parameter can be a value of @ref SPI_Mode */
+
+  uint32_t Direction;           /*!< Specifies the SPI bidirectional mode state.
+                                     This parameter can be a value of @ref SPI_Direction */
+
+  uint32_t DataSize;            /*!< Specifies the SPI data size.
+                                     This parameter can be a value of @ref SPI_Data_Size */
+
+  uint32_t CLKPolarity;         /*!< Specifies the serial clock steady state.
+                                     This parameter can be a value of @ref SPI_Clock_Polarity */
+
+  uint32_t CLKPhase;            /*!< Specifies the clock active edge for the bit capture.
+                                     This parameter can be a value of @ref SPI_Clock_Phase */
+
+  uint32_t NSS;                 /*!< Specifies whether the NSS signal is managed by
+                                     hardware (NSS pin) or by software using the SSI bit.
+                                     This parameter can be a value of @ref SPI_Slave_Select_management */
+
+  uint32_t BaudRatePrescaler;   /*!< Specifies the Baud Rate prescaler value which will be
+                                     used to configure the transmit and receive SCK clock.
+                                     This parameter can be a value of @ref SPI_BaudRate_Prescaler
+                                     @note The communication clock is derived from the master
+                                     clock. The slave clock does not need to be set. */
+
+  uint32_t FirstBit;            /*!< Specifies whether data transfers start from MSB or LSB bit.
+                                     This parameter can be a value of @ref SPI_MSB_LSB_transmission */
+
+  uint32_t TIMode;              /*!< Specifies if the TI mode is enabled or not .
+                                     This parameter can be a value of @ref SPI_TI_mode */
+
+  uint32_t CRCCalculation;      /*!< Specifies if the CRC calculation is enabled or not.
+                                     This parameter can be a value of @ref SPI_CRC_Calculation */
+
+  uint32_t CRCPolynomial;       /*!< Specifies the polynomial used for the CRC calculation.
+                                     This parameter must be a number between Min_Data = 0 and Max_Data = 65535 */
+
+  uint32_t CRCLength;           /*!< Specifies the CRC Length used for the CRC calculation.
+                                     CRC Length is only used with Data8 and Data16, not other data size
+                                     This parameter can be a value of @ref SPI_CRC_length */
+
+  uint32_t NSSPMode;            /*!< Specifies whether the NSSP signal is enabled or not .
+                                     This parameter can be a value of @ref SPI_NSSP_Mode
+                                     This mode is activated by the NSSP bit in the SPIx_CR2 register and
+                                     it takes effect only if the SPI interface is configured as Motorola SPI
+                                     master (FRF=0) with capture on the first edge (SPIx_CR1 CPHA = 0,
+                                     CPOL setting is ignored).. */
+} SPI_InitTypeDef;
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef enum
+{
+  HAL_SPI_STATE_RESET      = 0x00,    /*!< Peripheral not Initialized                         */
+  HAL_SPI_STATE_READY      = 0x01,    /*!< Peripheral Initialized and ready for use           */
+  HAL_SPI_STATE_BUSY       = 0x02,    /*!< an internal process is ongoing                     */
+  HAL_SPI_STATE_BUSY_TX    = 0x03,    /*!< Data Transmission process is ongoing               */
+  HAL_SPI_STATE_BUSY_RX    = 0x04,    /*!< Data Reception process is ongoing                  */
+  HAL_SPI_STATE_BUSY_TX_RX = 0x05,    /*!< Data Transmission and Reception process is ongoing*/
+  HAL_SPI_STATE_ERROR      = 0x06     /*!< SPI error state                                   */
+}HAL_SPI_StateTypeDef;
+
+/**
+  * @brief  SPI handle Structure definition
+  */
+typedef struct __SPI_HandleTypeDef
+{
+  SPI_TypeDef             *Instance;      /* SPI registers base address     */
+
+  SPI_InitTypeDef         Init;           /* SPI communication parameters   */
+
+  uint8_t                 *pTxBuffPtr;    /* Pointer to SPI Tx transfer Buffer */
+
+  uint16_t                TxXferSize;     /* SPI Tx Transfer size */
+
+  uint16_t                TxXferCount;    /* SPI Tx Transfer Counter */
+
+  uint8_t                 *pRxBuffPtr;    /* Pointer to SPI Rx transfer Buffer */
+
+  uint16_t                RxXferSize;     /* SPI Rx Transfer size */
+
+  uint16_t                RxXferCount;    /* SPI Rx Transfer Counter */
+
+  uint32_t                CRCSize;        /* SPI CRC size used for the transfer */
+
+  void (*RxISR)(struct __SPI_HandleTypeDef *hspi); /* function pointer on Rx IRQ handler   */
+
+  void (*TxISR)(struct __SPI_HandleTypeDef *hspi); /* function pointer on Tx IRQ handler   */
+
+  DMA_HandleTypeDef       *hdmatx;        /* SPI Tx DMA Handle parameters   */
+
+  DMA_HandleTypeDef       *hdmarx;        /* SPI Rx DMA Handle parameters   */
+
+  HAL_LockTypeDef         Lock;           /* Locking object                 */
+
+  HAL_SPI_StateTypeDef    State;          /* SPI communication state        */
+
+  uint32_t                ErrorCode;      /* SPI Error code                 */
+
+}SPI_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup SPI_Exported_Constants SPI Exported Constants
+  * @{
+  */
+
+/** @defgroup SPI_Error_Code SPI Error Code
+  * @{
+  */
+#define HAL_SPI_ERROR_NONE   (uint32_t)0x00000000  /*!< No error                          */
+#define HAL_SPI_ERROR_MODF   (uint32_t)0x00000001  /*!< MODF error                        */
+#define HAL_SPI_ERROR_CRC    (uint32_t)0x00000002  /*!< CRC error                         */
+#define HAL_SPI_ERROR_OVR    (uint32_t)0x00000004  /*!< OVR error                         */
+#define HAL_SPI_ERROR_FRE    (uint32_t)0x00000008  /*!< FRE error                         */
+#define HAL_SPI_ERROR_DMA    (uint32_t)0x00000010  /*!< DMA transfer error                */
+#define HAL_SPI_ERROR_FLAG   (uint32_t)0x00000020  /*!< Error on BSY/TXE/FTLVL/FRLVL Flag */
+#define HAL_SPI_ERROR_UNKNOW (uint32_t)0x00000040  /*!< Unknown error                     */
+/**
+  * @}
+  */
+
+
+/** @defgroup SPI_Mode SPI Mode
+  * @{
+  */
+#define SPI_MODE_SLAVE                  ((uint32_t)0x00000000)
+#define SPI_MODE_MASTER                 (SPI_CR1_MSTR | SPI_CR1_SSI)
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Direction SPI Direction Mode
+  * @{
+  */
+#define SPI_DIRECTION_2LINES            ((uint32_t)0x00000000)
+#define SPI_DIRECTION_2LINES_RXONLY     SPI_CR1_RXONLY
+#define SPI_DIRECTION_1LINE             SPI_CR1_BIDIMODE
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Data_Size SPI Data Size
+  * @{
+  */
+#define SPI_DATASIZE_4BIT               ((uint32_t)0x0300)
+#define SPI_DATASIZE_5BIT               ((uint32_t)0x0400)
+#define SPI_DATASIZE_6BIT               ((uint32_t)0x0500)
+#define SPI_DATASIZE_7BIT               ((uint32_t)0x0600)
+#define SPI_DATASIZE_8BIT               ((uint32_t)0x0700)
+#define SPI_DATASIZE_9BIT               ((uint32_t)0x0800)
+#define SPI_DATASIZE_10BIT              ((uint32_t)0x0900)
+#define SPI_DATASIZE_11BIT              ((uint32_t)0x0A00)
+#define SPI_DATASIZE_12BIT              ((uint32_t)0x0B00)
+#define SPI_DATASIZE_13BIT              ((uint32_t)0x0C00)
+#define SPI_DATASIZE_14BIT              ((uint32_t)0x0D00)
+#define SPI_DATASIZE_15BIT              ((uint32_t)0x0E00)
+#define SPI_DATASIZE_16BIT              ((uint32_t)0x0F00)
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Clock_Polarity SPI Clock Polarity
+  * @{
+  */
+#define SPI_POLARITY_LOW                ((uint32_t)0x00000000)
+#define SPI_POLARITY_HIGH               SPI_CR1_CPOL
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Clock_Phase SPI Clock Phase
+  * @{
+  */
+#define SPI_PHASE_1EDGE                 ((uint32_t)0x00000000)
+#define SPI_PHASE_2EDGE                 SPI_CR1_CPHA
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Slave_Select_management SPI Slave Select management
+  * @{
+  */
+#define SPI_NSS_SOFT                    SPI_CR1_SSM
+#define SPI_NSS_HARD_INPUT              ((uint32_t)0x00000000)
+#define SPI_NSS_HARD_OUTPUT             ((uint32_t)0x00040000)
+/**
+  * @}
+  */
+
+/** @defgroup SPI_NSSP_Mode SPI NSS Pulse Mode
+  * @{
+  */
+#define SPI_NSS_PULSE_ENABLE            SPI_CR2_NSSP
+#define SPI_NSS_PULSE_DISABLE           ((uint32_t)0x00000000)
+/**
+  * @}
+  */
+
+/** @defgroup SPI_BaudRate_Prescaler SPI BaudRate Prescaler
+  * @{
+  */
+#define SPI_BAUDRATEPRESCALER_2         ((uint32_t)0x00000000)
+#define SPI_BAUDRATEPRESCALER_4         ((uint32_t)0x00000008)
+#define SPI_BAUDRATEPRESCALER_8         ((uint32_t)0x00000010)
+#define SPI_BAUDRATEPRESCALER_16        ((uint32_t)0x00000018)
+#define SPI_BAUDRATEPRESCALER_32        ((uint32_t)0x00000020)
+#define SPI_BAUDRATEPRESCALER_64        ((uint32_t)0x00000028)
+#define SPI_BAUDRATEPRESCALER_128       ((uint32_t)0x00000030)
+#define SPI_BAUDRATEPRESCALER_256       ((uint32_t)0x00000038)
+/**
+  * @}
+  */
+
+/** @defgroup SPI_MSB_LSB_transmission SPI MSB LSB transmission
+  * @{
+  */
+#define SPI_FIRSTBIT_MSB                ((uint32_t)0x00000000)
+#define SPI_FIRSTBIT_LSB                SPI_CR1_LSBFIRST
+/**
+  * @}
+  */
+
+/** @defgroup SPI_TI_mode SPI TI mode
+  * @{
+  */
+#define SPI_TIMODE_DISABLE              ((uint32_t)0x00000000)
+#define SPI_TIMODE_ENABLE               SPI_CR2_FRF
+/**
+  * @}
+  */
+
+/** @defgroup SPI_CRC_Calculation SPI CRC Calculation
+  * @{
+  */
+#define SPI_CRCCALCULATION_DISABLE      ((uint32_t)0x00000000)
+#define SPI_CRCCALCULATION_ENABLE       SPI_CR1_CRCEN
+/**
+  * @}
+  */
+
+/** @defgroup SPI_CRC_length SPI CRC Length
+  * @{
+  * This parameter can be one of the following values:
+  *     SPI_CRC_LENGTH_DATASIZE: aligned with the data size
+  *     SPI_CRC_LENGTH_8BIT    : CRC 8bit
+  *     SPI_CRC_LENGTH_16BIT   : CRC 16bit
+  */
+#define SPI_CRC_LENGTH_DATASIZE         ((uint32_t)0x00000000)
+#define SPI_CRC_LENGTH_8BIT             ((uint32_t)0x00000001)
+#define SPI_CRC_LENGTH_16BIT            ((uint32_t)0x00000002)
+/**
+  * @}
+  */
+
+/** @defgroup SPI_FIFO_reception_threshold SPI FIFO Reception Threshold
+  * @{
+  * This parameter can be one of the following values:
+  *     SPI_RXFIFO_THRESHOLD or SPI_RXFIFO_THRESHOLD_QF :
+  *          RXNE event is generated if the FIFO
+  *          level is greater or equal to 1/2(16-bits).
+  *     SPI_RXFIFO_THRESHOLD_HF: RXNE event is generated if the FIFO
+  *          level is greater or equal to 1/4(8 bits). */
+#define SPI_RXFIFO_THRESHOLD            SPI_CR2_FRXTH
+#define SPI_RXFIFO_THRESHOLD_QF         SPI_CR2_FRXTH
+#define SPI_RXFIFO_THRESHOLD_HF         ((uint32_t)0x00000000)
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Interrupt_configuration_definition SPI Interrupt configuration definition
+  * @brief SPI Interrupt definition
+  *        Elements values convention: 0xXXXXXXXX
+  *           - XXXXXXXX  : Interrupt control mask
+  * @{
+  */
+#define SPI_IT_TXE                      SPI_CR2_TXEIE
+#define SPI_IT_RXNE                     SPI_CR2_RXNEIE
+#define SPI_IT_ERR                      SPI_CR2_ERRIE
+/**
+  * @}
+  */
+
+
+/** @defgroup SPI_Flag_definition SPI Flag definition
+  * @brief Flag definition
+  *        Elements values convention: 0xXXXXYYYY
+  *           - XXXX  : Flag register Index
+  *           - YYYY  : Flag mask
+  * @{
+  */
+#define SPI_FLAG_RXNE                   SPI_SR_RXNE   /* SPI status flag: Rx buffer not empty flag */
+#define SPI_FLAG_TXE                    SPI_SR_TXE    /* SPI status flag: Tx buffer empty flag */
+#define SPI_FLAG_BSY                    SPI_SR_BSY    /* SPI status flag: Busy flag */
+#define SPI_FLAG_CRCERR                 SPI_SR_CRCERR /* SPI Error flag: CRC error flag */
+#define SPI_FLAG_MODF                   SPI_SR_MODF   /* SPI Error flag: Mode fault flag */
+#define SPI_FLAG_OVR                    SPI_SR_OVR    /* SPI Error flag: Overrun flag */
+#define SPI_FLAG_FRE                    SPI_SR_FRE    /* SPI Error flag: TI mode frame format error flag */
+#define SPI_FLAG_FTLVL                  SPI_SR_FTLVL  /* SPI fifo transmission level */
+#define SPI_FLAG_FRLVL                  SPI_SR_FRLVL  /* SPI fifo reception level */
+/**
+  * @}
+  */
+
+/** @defgroup SPI_transmission_fifo_status_level SPI Transmission FIFO Status Level
+  * @{
+  */
+#define SPI_FTLVL_EMPTY           ((uint32_t)0x0000)
+#define SPI_FTLVL_QUARTER_FULL    ((uint32_t)0x0800)
+#define SPI_FTLVL_HALF_FULL       ((uint32_t)0x1000)
+#define SPI_FTLVL_FULL            ((uint32_t)0x1800)
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_reception_fifo_status_level SPI Reception FIFO Status Level
+  * @{
+  */
+#define SPI_FRLVL_EMPTY           ((uint32_t)0x0000)
+#define SPI_FRLVL_QUARTER_FULL    ((uint32_t)0x0200)
+#define SPI_FRLVL_HALF_FULL       ((uint32_t)0x0400)
+#define SPI_FRLVL_FULL            ((uint32_t)0x0600)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros ------------------------------------------------------------*/
+/** @defgroup SPI_Exported_Macros SPI Exported Macros
+  * @{
+  */
+
+/** @brief  Reset SPI handle state.
+  * @param  __HANDLE__: SPI handle.
+  * @retval None
+  */
+#define __HAL_SPI_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_SPI_STATE_RESET)
+
+/** @brief  Enable or disable the specified SPI interrupts.
+  * @param  __HANDLE__: specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @param  __INTERRUPT__: specifies the interrupt source to enable or disable.
+  *        This parameter can be one of the following values:
+  *            @arg SPI_IT_TXE: Tx buffer empty interrupt enable
+  *            @arg SPI_IT_RXNE: RX buffer not empty interrupt enable
+  *            @arg SPI_IT_ERR: Error interrupt enable
+  * @retval None
+  */
+#define __HAL_SPI_ENABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CR2 |= (__INTERRUPT__))
+#define __HAL_SPI_DISABLE_IT(__HANDLE__, __INTERRUPT__)  ((__HANDLE__)->Instance->CR2 &= (~(__INTERRUPT__)))
+
+/** @brief  Check whether the specified SPI interrupt source is enabled or not.
+  * @param  __HANDLE__: specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @param  __INTERRUPT__: specifies the SPI interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg SPI_IT_TXE: Tx buffer empty interrupt enable
+  *            @arg SPI_IT_RXNE: RX buffer not empty interrupt enable
+  *            @arg SPI_IT_ERR: Error interrupt enable
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_SPI_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR2 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/** @brief  Check whether the specified SPI flag is set or not.
+  * @param  __HANDLE__: specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg SPI_FLAG_RXNE: Receive buffer not empty flag
+  *            @arg SPI_FLAG_TXE: Transmit buffer empty flag
+  *            @arg SPI_FLAG_CRCERR: CRC error flag
+  *            @arg SPI_FLAG_MODF: Mode fault flag
+  *            @arg SPI_FLAG_OVR: Overrun flag
+  *            @arg SPI_FLAG_BSY: Busy flag
+  *            @arg SPI_FLAG_FRE: Frame format error flag
+  *            @arg SPI_FLAG_FTLVL: SPI fifo transmission level
+  *            @arg SPI_FLAG_FRLVL: SPI fifo reception level
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_SPI_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->SR) & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Clear the SPI CRCERR pending flag.
+  * @param  __HANDLE__: specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define __HAL_SPI_CLEAR_CRCERRFLAG(__HANDLE__) ((__HANDLE__)->Instance->SR = (uint16_t)(~SPI_FLAG_CRCERR))
+
+/** @brief  Clear the SPI MODF pending flag.
+  * @param  __HANDLE__: specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  *
+  * @retval None
+  */
+#define __HAL_SPI_CLEAR_MODFFLAG(__HANDLE__)        \
+   do{                                              \
+     __IO uint32_t tmpreg;                          \
+     tmpreg = (__HANDLE__)->Instance->SR;           \
+     (__HANDLE__)->Instance->CR1 &= (~SPI_CR1_SPE); \
+     UNUSED(tmpreg);                                \
+   } while(0)
+
+/** @brief  Clear the SPI OVR pending flag.
+  * @param  __HANDLE__: specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  *
+  * @retval None
+  */
+#define __HAL_SPI_CLEAR_OVRFLAG(__HANDLE__)         \
+   do{                                              \
+     __IO uint32_t tmpreg;                          \
+     tmpreg = (__HANDLE__)->Instance->DR;           \
+     tmpreg = (__HANDLE__)->Instance->SR;           \
+     UNUSED(tmpreg);                                \
+   } while(0)
+
+/** @brief  Clear the SPI FRE pending flag.
+  * @param  __HANDLE__: specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  *
+  * @retval None
+  */
+#define __HAL_SPI_CLEAR_FREFLAG(__HANDLE__)         \
+   do{                                              \
+     __IO uint32_t tmpreg;                          \
+     tmpreg = (__HANDLE__)->Instance->SR;           \
+     UNUSED(tmpreg);                                \
+   } while(0)
+
+/** @brief  Enable the SPI peripheral.
+  * @param  __HANDLE__: specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define __HAL_SPI_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR1 |=  SPI_CR1_SPE)
+
+/** @brief  Disable the SPI peripheral.
+  * @param  __HANDLE__: specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define __HAL_SPI_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR1 &= (~SPI_CR1_SPE))
+
+/**
+  * @}
+  */
+
+/* Private macros --------------------------------------------------------*/
+/** @defgroup SPI_Private_Macros   SPI Private Macros
+  * @{
+  */
+
+/** @brief  Set the SPI transmit-only mode.
+  * @param  __HANDLE__: specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define SPI_1LINE_TX(__HANDLE__) ((__HANDLE__)->Instance->CR1 |= SPI_CR1_BIDIOE)
+
+/** @brief  Set the SPI receive-only mode.
+  * @param  __HANDLE__: specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define SPI_1LINE_RX(__HANDLE__) ((__HANDLE__)->Instance->CR1 &= (~SPI_CR1_BIDIOE))
+
+/** @brief  Reset the CRC calculation of the SPI.
+  * @param  __HANDLE__: specifies the SPI Handle.
+  *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define SPI_RESET_CRC(__HANDLE__) do{(__HANDLE__)->Instance->CR1 &= (uint16_t)(~SPI_CR1_CRCEN);\
+                                     (__HANDLE__)->Instance->CR1 |= SPI_CR1_CRCEN;}while(0)
+
+#define IS_SPI_MODE(MODE) (((MODE) == SPI_MODE_SLAVE) || \
+                           ((MODE) == SPI_MODE_MASTER))
+
+#define IS_SPI_DIRECTION(MODE)   (((MODE) == SPI_DIRECTION_2LINES) || \
+                                  ((MODE) == SPI_DIRECTION_2LINES_RXONLY) ||\
+                                  ((MODE) == SPI_DIRECTION_1LINE))
+
+#define IS_SPI_DIRECTION_2LINES(MODE) ((MODE) == SPI_DIRECTION_2LINES)
+
+#define IS_SPI_DIRECTION_2LINES_OR_1LINE(MODE) (((MODE) == SPI_DIRECTION_2LINES)|| \
+                                                 ((MODE) == SPI_DIRECTION_1LINE))
+
+#define IS_SPI_DATASIZE(DATASIZE) (((DATASIZE) == SPI_DATASIZE_16BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_15BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_14BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_13BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_12BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_11BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_10BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_9BIT)  || \
+                                   ((DATASIZE) == SPI_DATASIZE_8BIT)  || \
+                                   ((DATASIZE) == SPI_DATASIZE_7BIT)  || \
+                                   ((DATASIZE) == SPI_DATASIZE_6BIT)  || \
+                                   ((DATASIZE) == SPI_DATASIZE_5BIT)  || \
+                                   ((DATASIZE) == SPI_DATASIZE_4BIT))
+
+#define IS_SPI_CPOL(CPOL) (((CPOL) == SPI_POLARITY_LOW) || \
+                           ((CPOL) == SPI_POLARITY_HIGH))
+
+#define IS_SPI_CPHA(CPHA) (((CPHA) == SPI_PHASE_1EDGE) || \
+                           ((CPHA) == SPI_PHASE_2EDGE))
+
+#define IS_SPI_NSS(NSS) (((NSS) == SPI_NSS_SOFT) || \
+                         ((NSS) == SPI_NSS_HARD_INPUT) || \
+                         ((NSS) == SPI_NSS_HARD_OUTPUT))
+
+#define IS_SPI_NSSP(NSSP) (((NSSP) == SPI_NSS_PULSE_ENABLE) || \
+                           ((NSSP) == SPI_NSS_PULSE_DISABLE))
+
+#define IS_SPI_BAUDRATE_PRESCALER(PRESCALER) (((PRESCALER) == SPI_BAUDRATEPRESCALER_2) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_4) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_8) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_16) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_32) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_64) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_128) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_256))
+
+#define IS_SPI_FIRST_BIT(BIT) (((BIT) == SPI_FIRSTBIT_MSB) || \
+                               ((BIT) == SPI_FIRSTBIT_LSB))
+
+#define IS_SPI_TIMODE(MODE) (((MODE) == SPI_TIMODE_DISABLE) || \
+                             ((MODE) == SPI_TIMODE_ENABLE))
+
+#define IS_SPI_CRC_CALCULATION(CALCULATION) (((CALCULATION) == SPI_CRCCALCULATION_DISABLE) || \
+                                             ((CALCULATION) == SPI_CRCCALCULATION_ENABLE))
+
+#define IS_SPI_CRC_LENGTH(LENGTH) (((LENGTH) == SPI_CRC_LENGTH_DATASIZE) ||\
+                                   ((LENGTH) == SPI_CRC_LENGTH_8BIT)  ||   \
+                                   ((LENGTH) == SPI_CRC_LENGTH_16BIT))
+
+#define IS_SPI_CRC_POLYNOMIAL(POLYNOMIAL) (((POLYNOMIAL) >= 0x1) && ((POLYNOMIAL) <= 0xFFFF))
+
+
+/**
+  * @}
+  */
+
+/* Include SPI HAL Extended module */
+#include "stm32l4xx_hal_spi_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup SPI_Exported_Functions
+  * @{
+  */
+
+/* Initialization and de-initialization functions  ****************************/
+/** @addtogroup SPI_Exported_Functions_Group1
+  * @{
+  */
+HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPI_DeInit (SPI_HandleTypeDef *hspi);
+void HAL_SPI_MspInit(SPI_HandleTypeDef *hspi);
+void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi);
+/**
+  * @}
+  */
+
+/* IO operation functions *****************************************************/
+/** @addtogroup SPI_Exported_Functions_Group2
+  * @{
+  */
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_DMAPause(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPI_DMAResume(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPI_DMAStop(SPI_HandleTypeDef *hspi);
+
+void HAL_SPI_IRQHandler(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxHalfCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_RxHalfCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxRxHalfCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi);
+/**
+  * @}
+  */
+
+/* Peripheral State and Error functions ***************************************/
+/** @addtogroup SPI_Exported_Functions_Group3
+  * @{
+  */
+HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi);
+uint32_t             HAL_SPI_GetError(SPI_HandleTypeDef *hspi);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_SPI_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_spi_ex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_spi_ex.h
@@ -1,0 +1,93 @@
+ /**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_spi_ex.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of SPI HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_SPI_EX_H
+#define __STM32L4xx_HAL_SPI_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup SPIEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/* Exported macros ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup SPIEx_Exported_Functions
+  * @{
+  */
+
+/* Initialization and de-initialization functions  ****************************/
+/* IO operation functions *****************************************************/
+/** @addtogroup SPIEx_Exported_Functions_Group1
+  * @{
+  */
+HAL_StatusTypeDef HAL_SPIEx_FlushRxFifo(SPI_HandleTypeDef *hspi);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_SPI_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_tim.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_tim.h
@@ -1,0 +1,1978 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_tim.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of TIM HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_TIM_H
+#define __STM32L4xx_HAL_TIM_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup TIM
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup TIM_Exported_Types TIM Exported Types
+  * @{
+  */
+
+/**
+  * @brief  TIM Time base Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t Prescaler;         /*!< Specifies the prescaler value used to divide the TIM clock.
+                                   This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t CounterMode;       /*!< Specifies the counter mode.
+                                   This parameter can be a value of @ref TIM_Counter_Mode */
+
+  uint32_t Period;            /*!< Specifies the period value to be loaded into the active
+                                   Auto-Reload Register at the next update event.
+                                   This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF.  */
+
+  uint32_t ClockDivision;     /*!< Specifies the clock division.
+                                   This parameter can be a value of @ref TIM_ClockDivision */
+
+  uint32_t RepetitionCounter;  /*!< Specifies the repetition counter value. Each time the RCR downcounter
+                                    reaches zero, an update event is generated and counting restarts
+                                    from the RCR value (N).
+                                    This means in PWM mode that (N+1) corresponds to:
+                                        - the number of PWM periods in edge-aligned mode
+                                        - the number of half PWM period in center-aligned mode
+                                     This parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFF.
+                                     @note This parameter is valid only for TIM1 and TIM8. */
+} TIM_Base_InitTypeDef;
+
+/**
+  * @brief  TIM Output Compare Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t OCMode;        /*!< Specifies the TIM mode.
+                               This parameter can be a value of @ref TIM_Output_Compare_and_PWM_modes */
+
+  uint32_t Pulse;         /*!< Specifies the pulse value to be loaded into the Capture Compare Register.
+                               This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t OCPolarity;    /*!< Specifies the output polarity.
+                               This parameter can be a value of @ref TIM_Output_Compare_Polarity */
+
+  uint32_t OCNPolarity;   /*!< Specifies the complementary output polarity.
+                               This parameter can be a value of @ref TIM_Output_Compare_N_Polarity
+                               @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint32_t OCFastMode;   /*!< Specifies the Fast mode state.
+                               This parameter can be a value of @ref TIM_Output_Fast_State
+                               @note This parameter is valid only in PWM1 and PWM2 mode. */
+
+
+  uint32_t OCIdleState;   /*!< Specifies the TIM Output Compare pin state during Idle state.
+                               This parameter can be a value of @ref TIM_Output_Compare_Idle_State
+                               @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint32_t OCNIdleState;  /*!< Specifies the TIM Output Compare pin state during Idle state.
+                               This parameter can be a value of @ref TIM_Output_Compare_N_Idle_State
+                               @note This parameter is valid only for TIM1 and TIM8. */
+} TIM_OC_InitTypeDef;
+
+/**
+  * @brief  TIM One Pulse Mode Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t OCMode;        /*!< Specifies the TIM mode.
+                               This parameter can be a value of @ref TIM_Output_Compare_and_PWM_modes */
+
+  uint32_t Pulse;         /*!< Specifies the pulse value to be loaded into the Capture Compare Register.
+                               This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t OCPolarity;    /*!< Specifies the output polarity.
+                               This parameter can be a value of @ref TIM_Output_Compare_Polarity */
+
+  uint32_t OCNPolarity;   /*!< Specifies the complementary output polarity.
+                               This parameter can be a value of @ref TIM_Output_Compare_N_Polarity
+                               @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint32_t OCIdleState;   /*!< Specifies the TIM Output Compare pin state during Idle state.
+                               This parameter can be a value of @ref TIM_Output_Compare_Idle_State
+                               @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint32_t OCNIdleState;  /*!< Specifies the TIM Output Compare pin state during Idle state.
+                               This parameter can be a value of @ref TIM_Output_Compare_N_Idle_State
+                               @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint32_t ICPolarity;    /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t ICSelection;   /*!< Specifies the input.
+                              This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint32_t ICFilter;      /*!< Specifies the input capture filter.
+                              This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+} TIM_OnePulse_InitTypeDef;
+
+
+/**
+  * @brief  TIM Input Capture Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t  ICPolarity;   /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t ICSelection;  /*!< Specifies the input.
+                              This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint32_t ICPrescaler;  /*!< Specifies the Input Capture Prescaler.
+                              This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+  uint32_t ICFilter;     /*!< Specifies the input capture filter.
+                              This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+} TIM_IC_InitTypeDef;
+
+/**
+  * @brief  TIM Encoder Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t EncoderMode;   /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Encoder_Mode */
+
+  uint32_t IC1Polarity;   /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t IC1Selection;  /*!< Specifies the input.
+                               This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint32_t IC1Prescaler;  /*!< Specifies the Input Capture Prescaler.
+                               This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+  uint32_t IC1Filter;     /*!< Specifies the input capture filter.
+                               This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+
+  uint32_t IC2Polarity;   /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t IC2Selection;  /*!< Specifies the input.
+                              This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint32_t IC2Prescaler;  /*!< Specifies the Input Capture Prescaler.
+                               This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+  uint32_t IC2Filter;     /*!< Specifies the input capture filter.
+                               This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+} TIM_Encoder_InitTypeDef;
+
+
+/**
+  * @brief  Clock Configuration Handle Structure definition
+  */
+typedef struct
+{
+  uint32_t ClockSource;     /*!< TIM clock sources
+                                 This parameter can be a value of @ref TIM_Clock_Source */
+  uint32_t ClockPolarity;   /*!< TIM clock polarity
+                                 This parameter can be a value of @ref TIM_Clock_Polarity */
+  uint32_t ClockPrescaler;  /*!< TIM clock prescaler
+                                 This parameter can be a value of @ref TIM_Clock_Prescaler */
+  uint32_t ClockFilter;    /*!< TIM clock filter
+                                This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+}TIM_ClockConfigTypeDef;
+
+/**
+  * @brief  Clear Input Configuration Handle Structure definition
+  */
+typedef struct
+{
+  uint32_t ClearInputState;      /*!< TIM clear Input state
+                                      This parameter can be ENABLE or DISABLE */
+  uint32_t ClearInputSource;     /*!< TIM clear Input sources
+                                      This parameter can be a value of @ref TIM_ClearInput_Source */
+  uint32_t ClearInputPolarity;   /*!< TIM Clear Input polarity
+                                      This parameter can be a value of @ref TIM_ClearInput_Polarity */
+  uint32_t ClearInputPrescaler;  /*!< TIM Clear Input prescaler
+                                      This parameter can be a value of @ref TIM_ClearInput_Prescaler */
+  uint32_t ClearInputFilter;    /*!< TIM Clear Input filter
+                                     This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+}TIM_ClearInputConfigTypeDef;
+
+/**
+  * @brief  TIM Master configuration Structure definition
+  * @note   Advanced timers provide TRGO2 internal line which is redirected
+  *         to the ADC
+  */
+typedef struct {
+  uint32_t  MasterOutputTrigger;   /*!< Trigger output (TRGO) selection
+                                      This parameter can be a value of @ref TIM_Master_Mode_Selection */
+  uint32_t  MasterOutputTrigger2;  /*!< Trigger output2 (TRGO2) selection
+                                      This parameter can be a value of @ref TIM_Master_Mode_Selection_2 */
+  uint32_t  MasterSlaveMode;       /*!< Master/slave mode selection
+                                      This parameter can be a value of @ref TIM_Master_Slave_Mode */
+}TIM_MasterConfigTypeDef;
+
+/**
+  * @brief  TIM Slave configuration Structure definition
+  */
+typedef struct {
+  uint32_t  SlaveMode;      /*!< Slave mode selection
+                               This parameter can be a value of @ref TIM_Slave_Mode */
+  uint32_t  InputTrigger;      /*!< Input Trigger source
+                                  This parameter can be a value of @ref TIM_Trigger_Selection */
+  uint32_t  TriggerPolarity;   /*!< Input Trigger polarity
+                                  This parameter can be a value of @ref TIM_Trigger_Polarity */
+  uint32_t  TriggerPrescaler;  /*!< Input trigger prescaler
+                                  This parameter can be a value of @ref TIM_Trigger_Prescaler */
+  uint32_t  TriggerFilter;     /*!< Input trigger filter
+                                  This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF  */
+
+}TIM_SlaveConfigTypeDef;
+
+/**
+  * @brief  TIM Break input(s) and Dead time configuration Structure definition
+  * @note   2 break inputs can be configured (BKIN and BKIN2) with configurable
+  *        filter and polarity.
+  */
+typedef struct
+{
+  uint32_t OffStateRunMode;	      /*!< TIM off state in run mode
+                                         This parameter can be a value of @ref TIM_OSSR_Off_State_Selection_for_Run_mode_state */
+  uint32_t OffStateIDLEMode;	      /*!< TIM off state in IDLE mode
+                                         This parameter can be a value of @ref TIM_OSSI_Off_State_Selection_for_Idle_mode_state */
+  uint32_t LockLevel;	 	      /*!< TIM Lock level
+                                         This parameter can be a value of @ref TIM_Lock_level */
+  uint32_t DeadTime;	 	      /*!< TIM dead Time
+                                         This parameter can be a number between Min_Data = 0x00 and Max_Data = 0xFF */
+  uint32_t BreakState;	 	      /*!< TIM Break State
+                                         This parameter can be a value of @ref TIM_Break_Input_enable_disable */
+  uint32_t BreakPolarity;             /*!< TIM Break input polarity
+                                         This parameter can be a value of @ref TIM_Break_Polarity */
+  uint32_t BreakFilter;               /*!< Specifies the break input filter.
+                                         This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+  uint32_t Break2State;	 	      /*!< TIM Break2 State
+                                         This parameter can be a value of @ref TIM_Break2_Input_enable_disable */
+  uint32_t Break2Polarity;            /*!< TIM Break2 input polarity
+                                         This parameter can be a value of @ref TIM_Break2_Polarity */
+  uint32_t Break2Filter;              /*!< TIM break2 input filter.
+                                         This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+  uint32_t AutomaticOutput;           /*!< TIM Automatic Output Enable state
+                                         This parameter can be a value of @ref TIM_AOE_Bit_Set_Reset */
+} TIM_BreakDeadTimeConfigTypeDef;
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef enum
+{
+  HAL_TIM_STATE_RESET             = 0x00,    /*!< Peripheral not yet initialized or disabled  */
+  HAL_TIM_STATE_READY             = 0x01,    /*!< Peripheral Initialized and ready for use    */
+  HAL_TIM_STATE_BUSY              = 0x02,    /*!< An internal process is ongoing              */
+  HAL_TIM_STATE_TIMEOUT           = 0x03,    /*!< Timeout state                               */
+  HAL_TIM_STATE_ERROR             = 0x04     /*!< Reception process is ongoing                */
+}HAL_TIM_StateTypeDef;
+
+/**
+  * @brief  HAL Active channel structures definition
+  */
+typedef enum
+{
+  HAL_TIM_ACTIVE_CHANNEL_1        = 0x01,    /*!< The active channel is 1     */
+  HAL_TIM_ACTIVE_CHANNEL_2        = 0x02,    /*!< The active channel is 2     */
+  HAL_TIM_ACTIVE_CHANNEL_3        = 0x04,    /*!< The active channel is 3     */
+  HAL_TIM_ACTIVE_CHANNEL_4        = 0x08,    /*!< The active channel is 4     */
+  HAL_TIM_ACTIVE_CHANNEL_5        = 0x10,    /*!< The active channel is 5     */
+  HAL_TIM_ACTIVE_CHANNEL_6        = 0x20,    /*!< The active channel is 6     */
+  HAL_TIM_ACTIVE_CHANNEL_CLEARED  = 0x00    /*!< All active channels cleared */
+}HAL_TIM_ActiveChannel;
+
+/**
+  * @brief  TIM Time Base Handle Structure definition
+  */
+typedef struct
+{
+  TIM_TypeDef              *Instance;     /*!< Register base address             */
+  TIM_Base_InitTypeDef     Init;          /*!< TIM Time Base required parameters */
+  HAL_TIM_ActiveChannel    Channel;       /*!< Active channel                    */
+  DMA_HandleTypeDef        *hdma[7];      /*!< DMA Handlers array
+                                             This array is accessed by a @ref DMA_Handle_index */
+  HAL_LockTypeDef          Lock;          /*!< Locking object                    */
+  __IO HAL_TIM_StateTypeDef   State;         /*!< TIM operation state               */
+}TIM_HandleTypeDef;
+
+/**
+  * @}
+  */
+/* End of exported types -----------------------------------------------------*/
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup TIM_Exported_Constants TIM Exported Constants
+  * @{
+  */
+
+/** @defgroup TIM_ClearInput_Source TIM Clear Input Source
+  * @{
+  */
+#define TIM_CLEARINPUTSOURCE_ETR            ((uint32_t)0x0001)
+#define TIM_CLEARINPUTSOURCE_OCREFCLR       ((uint32_t)0x0002)
+#define TIM_CLEARINPUTSOURCE_NONE           ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_DMA_Base_address TIM DMA Base Address
+  * @{
+  */
+#define TIM_DMABASE_CR1                    (0x00000000)
+#define TIM_DMABASE_CR2                    (0x00000001)
+#define TIM_DMABASE_SMCR                   (0x00000002)
+#define TIM_DMABASE_DIER                   (0x00000003)
+#define TIM_DMABASE_SR                     (0x00000004)
+#define TIM_DMABASE_EGR                    (0x00000005)
+#define TIM_DMABASE_CCMR1                  (0x00000006)
+#define TIM_DMABASE_CCMR2                  (0x00000007)
+#define TIM_DMABASE_CCER                   (0x00000008)
+#define TIM_DMABASE_CNT                    (0x00000009)
+#define TIM_DMABASE_PSC                    (0x0000000A)
+#define TIM_DMABASE_ARR                    (0x0000000B)
+#define TIM_DMABASE_RCR                    (0x0000000C)
+#define TIM_DMABASE_CCR1                   (0x0000000D)
+#define TIM_DMABASE_CCR2                   (0x0000000E)
+#define TIM_DMABASE_CCR3                   (0x0000000F)
+#define TIM_DMABASE_CCR4                   (0x00000010)
+#define TIM_DMABASE_BDTR                   (0x00000011)
+#define TIM_DMABASE_DCR                    (0x00000012)
+#define TIM_DMABASE_DMAR                   (0x00000013)
+#define TIM_DMABASE_OR1                    (0x00000014)
+#define TIM_DMABASE_CCMR3                  (0x00000015)
+#define TIM_DMABASE_CCR5                   (0x00000016)
+#define TIM_DMABASE_CCR6                   (0x00000017)
+#define TIM_DMABASE_OR2                    (0x00000018)
+#define TIM_DMABASE_OR3                    (0x00000019)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Event_Source TIM  Extended Event Source
+  * @{
+  */
+#define TIM_EVENTSOURCE_UPDATE              TIM_EGR_UG     /*!< Reinitialize the counter and generates an update of the registers */
+#define TIM_EVENTSOURCE_CC1                 TIM_EGR_CC1G   /*!< A capture/compare event is generated on channel 1 */
+#define TIM_EVENTSOURCE_CC2                 TIM_EGR_CC2G   /*!< A capture/compare event is generated on channel 2 */
+#define TIM_EVENTSOURCE_CC3                 TIM_EGR_CC3G   /*!< A capture/compare event is generated on channel 3 */
+#define TIM_EVENTSOURCE_CC4                 TIM_EGR_CC4G   /*!< A capture/compare event is generated on channel 4 */
+#define TIM_EVENTSOURCE_COM                 TIM_EGR_COMG   /*!< A commutation event is generated */
+#define TIM_EVENTSOURCE_TRIGGER             TIM_EGR_TG     /*!< A trigger event is generated */
+#define TIM_EVENTSOURCE_BREAK               TIM_EGR_BG     /*!< A break event is generated */
+#define TIM_EVENTSOURCE_BREAK2              TIM_EGR_B2G    /*!< A break 2 event is generated */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Input_Channel_Polarity TIM Input Channel polarity
+  * @{
+  */
+#define  TIM_INPUTCHANNELPOLARITY_RISING      ((uint32_t)0x00000000)            /*!< Polarity for TIx source */
+#define  TIM_INPUTCHANNELPOLARITY_FALLING     (TIM_CCER_CC1P)                   /*!< Polarity for TIx source */
+#define  TIM_INPUTCHANNELPOLARITY_BOTHEDGE    (TIM_CCER_CC1P | TIM_CCER_CC1NP)  /*!< Polarity for TIx source */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ETR_Polarity TIM ETR Polarity
+  * @{
+  */
+#define TIM_ETRPOLARITY_INVERTED              (TIM_SMCR_ETP)                    /*!< Polarity for ETR source */
+#define TIM_ETRPOLARITY_NONINVERTED           ((uint32_t)0x0000)                /*!< Polarity for ETR source */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ETR_Prescaler TIM ETR Prescaler
+  * @{
+  */
+#define TIM_ETRPRESCALER_DIV1                 ((uint32_t)0x0000)                /*!< No prescaler is used */
+#define TIM_ETRPRESCALER_DIV2                 (TIM_SMCR_ETPS_0)                 /*!< ETR input source is divided by 2 */
+#define TIM_ETRPRESCALER_DIV4                 (TIM_SMCR_ETPS_1)                 /*!< ETR input source is divided by 4 */
+#define TIM_ETRPRESCALER_DIV8                 (TIM_SMCR_ETPS)                   /*!< ETR input source is divided by 8 */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Counter_Mode TIM Counter Mode
+  * @{
+  */
+#define TIM_COUNTERMODE_UP                 ((uint32_t)0x0000)
+#define TIM_COUNTERMODE_DOWN               TIM_CR1_DIR
+#define TIM_COUNTERMODE_CENTERALIGNED1     TIM_CR1_CMS_0
+#define TIM_COUNTERMODE_CENTERALIGNED2     TIM_CR1_CMS_1
+#define TIM_COUNTERMODE_CENTERALIGNED3     TIM_CR1_CMS
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ClockDivision TIM Clock Division
+  * @{
+  */
+#define TIM_CLOCKDIVISION_DIV1             ((uint32_t)0x0000)
+#define TIM_CLOCKDIVISION_DIV2             (TIM_CR1_CKD_0)
+#define TIM_CLOCKDIVISION_DIV4             (TIM_CR1_CKD_1)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_State TIM Output Compare State
+  * @{
+  */
+#define TIM_OUTPUTSTATE_DISABLE            ((uint32_t)0x0000)
+#define TIM_OUTPUTSTATE_ENABLE             (TIM_CCER_CC1E)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Fast_State TIM Output Fast State
+  * @{
+  */
+#define TIM_OCFAST_DISABLE                 ((uint32_t)0x0000)
+#define TIM_OCFAST_ENABLE                  (TIM_CCMR1_OC1FE)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_N_State TIM Complementary Output Compare State
+  * @{
+  */
+#define TIM_OUTPUTNSTATE_DISABLE           ((uint32_t)0x0000)
+#define TIM_OUTPUTNSTATE_ENABLE            (TIM_CCER_CC1NE)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_Polarity TIM Output Compare Polarity
+  * @{
+  */
+#define TIM_OCPOLARITY_HIGH                ((uint32_t)0x0000)
+#define TIM_OCPOLARITY_LOW                 (TIM_CCER_CC1P)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_N_Polarity TIM Complementary Output Compare Polarity
+  * @{
+  */
+#define TIM_OCNPOLARITY_HIGH               ((uint32_t)0x0000)
+#define TIM_OCNPOLARITY_LOW                (TIM_CCER_CC1NP)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_Idle_State TIM Output Compare Idle State
+  * @{
+  */
+#define TIM_OCIDLESTATE_SET                (TIM_CR2_OIS1)
+#define TIM_OCIDLESTATE_RESET              ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_N_Idle_State TIM Complementary Output Compare Idle State
+  * @{
+  */
+#define TIM_OCNIDLESTATE_SET               (TIM_CR2_OIS1N)
+#define TIM_OCNIDLESTATE_RESET             ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Input_Capture_Polarity TIM Input Capture Polarity
+  * @{
+  */
+#define  TIM_ICPOLARITY_RISING             TIM_INPUTCHANNELPOLARITY_RISING
+#define  TIM_ICPOLARITY_FALLING            TIM_INPUTCHANNELPOLARITY_FALLING
+#define  TIM_ICPOLARITY_BOTHEDGE           TIM_INPUTCHANNELPOLARITY_BOTHEDGE
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Input_Capture_Selection TIM Input Capture Selection
+  * @{
+  */
+#define TIM_ICSELECTION_DIRECTTI           (TIM_CCMR1_CC1S_0)   /*!< TIM Input 1, 2, 3 or 4 is selected to be
+                                                                               connected to IC1, IC2, IC3 or IC4, respectively */
+#define TIM_ICSELECTION_INDIRECTTI         (TIM_CCMR1_CC1S_1)   /*!< TIM Input 1, 2, 3 or 4 is selected to be
+                                                                               connected to IC2, IC1, IC4 or IC3, respectively */
+#define TIM_ICSELECTION_TRC                (TIM_CCMR1_CC1S)     /*!< TIM Input 1, 2, 3 or 4 is selected to be connected to TRC */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Input_Capture_Prescaler TIM Input Capture Prescaler
+  * @{
+  */
+#define TIM_ICPSC_DIV1                     ((uint32_t)0x0000)                 /*!< Capture performed each time an edge is detected on the capture input */
+#define TIM_ICPSC_DIV2                     (TIM_CCMR1_IC1PSC_0)     /*!< Capture performed once every 2 events */
+#define TIM_ICPSC_DIV4                     (TIM_CCMR1_IC1PSC_1)     /*!< Capture performed once every 4 events */
+#define TIM_ICPSC_DIV8                     (TIM_CCMR1_IC1PSC)       /*!< Capture performed once every 8 events */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_One_Pulse_Mode TIM One Pulse Mode
+  * @{
+  */
+#define TIM_OPMODE_SINGLE                  (TIM_CR1_OPM)
+#define TIM_OPMODE_REPETITIVE              ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Encoder_Mode TIM Encoder Mode
+  * @{
+  */
+#define TIM_ENCODERMODE_TI1                (TIM_SMCR_SMS_0)
+#define TIM_ENCODERMODE_TI2                (TIM_SMCR_SMS_1)
+#define TIM_ENCODERMODE_TI12               (TIM_SMCR_SMS_1 | TIM_SMCR_SMS_0)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Interrupt_definition TIM interrupt Definition
+  * @{
+  */
+#define TIM_IT_UPDATE                      (TIM_DIER_UIE)
+#define TIM_IT_CC1                         (TIM_DIER_CC1IE)
+#define TIM_IT_CC2                         (TIM_DIER_CC2IE)
+#define TIM_IT_CC3                         (TIM_DIER_CC3IE)
+#define TIM_IT_CC4                         (TIM_DIER_CC4IE)
+#define TIM_IT_COM                         (TIM_DIER_COMIE)
+#define TIM_IT_TRIGGER                     (TIM_DIER_TIE)
+#define TIM_IT_BREAK                       (TIM_DIER_BIE)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Commutation_Source  TIM Commutation Source 
+  * @{
+  */  
+#define TIM_COMMUTATION_TRGI              (TIM_CR2_CCUS)
+#define TIM_COMMUTATION_SOFTWARE          ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_DMA_sources TIM DMA Sources
+  * @{
+  */
+#define TIM_DMA_UPDATE                     (TIM_DIER_UDE)
+#define TIM_DMA_CC1                        (TIM_DIER_CC1DE)
+#define TIM_DMA_CC2                        (TIM_DIER_CC2DE)
+#define TIM_DMA_CC3                        (TIM_DIER_CC3DE)
+#define TIM_DMA_CC4                        (TIM_DIER_CC4DE)
+#define TIM_DMA_COM                        (TIM_DIER_COMDE)
+#define TIM_DMA_TRIGGER                    (TIM_DIER_TDE)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Flag_definition TIM Flag Definition
+  * @{
+  */
+#define TIM_FLAG_UPDATE                    (TIM_SR_UIF)
+#define TIM_FLAG_CC1                       (TIM_SR_CC1IF)
+#define TIM_FLAG_CC2                       (TIM_SR_CC2IF)
+#define TIM_FLAG_CC3                       (TIM_SR_CC3IF)
+#define TIM_FLAG_CC4                       (TIM_SR_CC4IF)
+#define TIM_FLAG_CC5                       (TIM_SR_CC5IF)
+#define TIM_FLAG_CC6                       (TIM_SR_CC6IF)
+#define TIM_FLAG_COM                       (TIM_SR_COMIF)
+#define TIM_FLAG_TRIGGER                   (TIM_SR_TIF)
+#define TIM_FLAG_BREAK                     (TIM_SR_BIF)
+#define TIM_FLAG_BREAK2                    (TIM_SR_B2IF)
+#define TIM_FLAG_SYSTEM_BREAK              (TIM_SR_SBIF)
+#define TIM_FLAG_CC1OF                     (TIM_SR_CC1OF)
+#define TIM_FLAG_CC2OF                     (TIM_SR_CC2OF)
+#define TIM_FLAG_CC3OF                     (TIM_SR_CC3OF)
+#define TIM_FLAG_CC4OF                     (TIM_SR_CC4OF)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Channel TIM Channel
+  * @{
+  */
+#define TIM_CHANNEL_1                      ((uint32_t)0x0000)
+#define TIM_CHANNEL_2                      ((uint32_t)0x0004)
+#define TIM_CHANNEL_3                      ((uint32_t)0x0008)
+#define TIM_CHANNEL_4                      ((uint32_t)0x000C)
+#define TIM_CHANNEL_5                      ((uint32_t)0x0010)
+#define TIM_CHANNEL_6                      ((uint32_t)0x0014)
+#define TIM_CHANNEL_ALL                    ((uint32_t)0x003C)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Clock_Source TIM Clock Source
+  * @{
+  */
+#define	TIM_CLOCKSOURCE_ETRMODE2    (TIM_SMCR_ETPS_1)
+#define	TIM_CLOCKSOURCE_INTERNAL    (TIM_SMCR_ETPS_0)
+#define	TIM_CLOCKSOURCE_ITR0        ((uint32_t)0x0000)
+#define	TIM_CLOCKSOURCE_ITR1        (TIM_SMCR_TS_0)
+#define	TIM_CLOCKSOURCE_ITR2        (TIM_SMCR_TS_1)
+#define	TIM_CLOCKSOURCE_ITR3        (TIM_SMCR_TS_0 | TIM_SMCR_TS_1)
+#define	TIM_CLOCKSOURCE_TI1ED       (TIM_SMCR_TS_2)
+#define	TIM_CLOCKSOURCE_TI1         (TIM_SMCR_TS_0 | TIM_SMCR_TS_2)
+#define	TIM_CLOCKSOURCE_TI2         (TIM_SMCR_TS_1 | TIM_SMCR_TS_2)
+#define	TIM_CLOCKSOURCE_ETRMODE1    (TIM_SMCR_TS)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Clock_Polarity TIM Clock Polarity
+  * @{
+  */
+#define TIM_CLOCKPOLARITY_INVERTED           TIM_ETRPOLARITY_INVERTED          /*!< Polarity for ETRx clock sources */
+#define TIM_CLOCKPOLARITY_NONINVERTED        TIM_ETRPOLARITY_NONINVERTED       /*!< Polarity for ETRx clock sources */
+#define TIM_CLOCKPOLARITY_RISING             TIM_INPUTCHANNELPOLARITY_RISING   /*!< Polarity for TIx clock sources */
+#define TIM_CLOCKPOLARITY_FALLING            TIM_INPUTCHANNELPOLARITY_FALLING   /*!< Polarity for TIx clock sources */
+#define TIM_CLOCKPOLARITY_BOTHEDGE           TIM_INPUTCHANNELPOLARITY_BOTHEDGE  /*!< Polarity for TIx clock sources */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Clock_Prescaler TIM Clock Prescaler
+  * @{
+  */
+#define TIM_CLOCKPRESCALER_DIV1                 TIM_ETRPRESCALER_DIV1     /*!< No prescaler is used */
+#define TIM_CLOCKPRESCALER_DIV2                 TIM_ETRPRESCALER_DIV2     /*!< Prescaler for External ETR Clock: Capture performed once every 2 events. */
+#define TIM_CLOCKPRESCALER_DIV4                 TIM_ETRPRESCALER_DIV4     /*!< Prescaler for External ETR Clock: Capture performed once every 4 events. */
+#define TIM_CLOCKPRESCALER_DIV8                 TIM_ETRPRESCALER_DIV8     /*!< Prescaler for External ETR Clock: Capture performed once every 8 events. */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ClearInput_Polarity TIM Clear Input Polarity
+  * @{
+  */
+#define TIM_CLEARINPUTPOLARITY_INVERTED           TIM_ETRPOLARITY_INVERTED                    /*!< Polarity for ETRx pin */
+#define TIM_CLEARINPUTPOLARITY_NONINVERTED        TIM_ETRPOLARITY_NONINVERTED                          /*!< Polarity for ETRx pin */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ClearInput_Prescaler TIM Clear Input Prescaler
+  * @{
+  */
+#define TIM_CLEARINPUTPRESCALER_DIV1              TIM_ETRPRESCALER_DIV1      /*!< No prescaler is used */
+#define TIM_CLEARINPUTPRESCALER_DIV2              TIM_ETRPRESCALER_DIV2      /*!< Prescaler for External ETR pin: Capture performed once every 2 events. */
+#define TIM_CLEARINPUTPRESCALER_DIV4              TIM_ETRPRESCALER_DIV4      /*!< Prescaler for External ETR pin: Capture performed once every 4 events. */
+#define TIM_CLEARINPUTPRESCALER_DIV8              TIM_ETRPRESCALER_DIV8        /*!< Prescaler for External ETR pin: Capture performed once every 8 events. */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_OSSR_Off_State_Selection_for_Run_mode_state TIM OSSR OffState Selection for Run mode state
+  * @{
+  */
+#define TIM_OSSR_ENABLE 	                 (TIM_BDTR_OSSR)
+#define TIM_OSSR_DISABLE                   ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_OSSI_Off_State_Selection_for_Idle_mode_state TIM OSSI OffState Selection for Idle mode state
+  * @{
+  */
+#define TIM_OSSI_ENABLE	 	                 (TIM_BDTR_OSSI)
+#define TIM_OSSI_DISABLE                   ((uint32_t)0x0000)
+/**
+  * @}
+  */
+/** @defgroup TIM_Lock_level  TIM Lock level
+  * @{
+  */
+#define TIM_LOCKLEVEL_OFF	                 ((uint32_t)0x0000)
+#define TIM_LOCKLEVEL_1                    (TIM_BDTR_LOCK_0)
+#define TIM_LOCKLEVEL_2                    (TIM_BDTR_LOCK_1)
+#define TIM_LOCKLEVEL_3                    (TIM_BDTR_LOCK)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Break_Input_enable_disable TIM Break Input Enable
+  * @{
+  */
+#define TIM_BREAK_ENABLE                   (TIM_BDTR_BKE)
+#define TIM_BREAK_DISABLE                  ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Break_Polarity TIM Break Input Polarity
+  * @{
+  */
+#define TIM_BREAKPOLARITY_LOW              ((uint32_t)0x0000)
+#define TIM_BREAKPOLARITY_HIGH             (TIM_BDTR_BKP)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Break2_Input_enable_disable TIM Break input 2 Enable
+  * @{
+  */
+#define TIM_BREAK2_DISABLE                 ((uint32_t)0x00000000)
+#define TIM_BREAK2_ENABLE                  ((uint32_t)TIM_BDTR_BK2E)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Break2_Polarity TIM Break Input 2 Polarity
+  * @{
+  */
+#define TIM_BREAK2POLARITY_LOW             ((uint32_t)0x00000000)
+#define TIM_BREAK2POLARITY_HIGH            ((uint32_t)TIM_BDTR_BK2P)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_AOE_Bit_Set_Reset TIM Automatic Output Enable
+  * @{
+  */
+#define TIM_AUTOMATICOUTPUT_ENABLE         (TIM_BDTR_AOE)
+#define	TIM_AUTOMATICOUTPUT_DISABLE        ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group_Channel5 Group Channel 5 and Channel 1, 2 or 3
+  * @{
+  */
+#define TIM_GROUPCH5_NONE       (uint32_t)0x00000000  /* !< No effect of OC5REF on OC1REFC, OC2REFC and OC3REFC */
+#define TIM_GROUPCH5_OC1REFC    (TIM_CCR5_GC5C1)      /* !< OC1REFC is the logical AND of OC1REFC and OC5REF */
+#define TIM_GROUPCH5_OC2REFC    (TIM_CCR5_GC5C2)      /* !< OC2REFC is the logical AND of OC2REFC and OC5REF */
+#define TIM_GROUPCH5_OC3REFC    (TIM_CCR5_GC5C3)      /* !< OC3REFC is the logical AND of OC3REFC and OC5REF */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Master_Mode_Selection TIM Master Mode Selection
+  * @{
+  */
+#define	TIM_TRGO_RESET            ((uint32_t)0x0000)
+#define	TIM_TRGO_ENABLE           (TIM_CR2_MMS_0)
+#define	TIM_TRGO_UPDATE           (TIM_CR2_MMS_1)
+#define	TIM_TRGO_OC1              ((TIM_CR2_MMS_1 | TIM_CR2_MMS_0))
+#define	TIM_TRGO_OC1REF           (TIM_CR2_MMS_2)
+#define	TIM_TRGO_OC2REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_0))
+#define	TIM_TRGO_OC3REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_1))
+#define	TIM_TRGO_OC4REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_1 | TIM_CR2_MMS_0))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Master_Mode_Selection_2 TIM Master Mode Selection 2 (TRGO2)
+  * @{
+  */
+#define	TIM_TRGO2_RESET                          ((uint32_t)0x00000000)
+#define	TIM_TRGO2_ENABLE                         ((uint32_t)(TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_UPDATE                         ((uint32_t)(TIM_CR2_MMS2_1))
+#define	TIM_TRGO2_OC1                            ((uint32_t)(TIM_CR2_MMS2_1 | TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_OC1REF                         ((uint32_t)(TIM_CR2_MMS2_2))
+#define	TIM_TRGO2_OC2REF                         ((uint32_t)(TIM_CR2_MMS2_2 | TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_OC3REF                         ((uint32_t)(TIM_CR2_MMS2_2 | TIM_CR2_MMS2_1))
+#define	TIM_TRGO2_OC4REF                         ((uint32_t)(TIM_CR2_MMS2_2 | TIM_CR2_MMS2_1 | TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_OC5REF                         ((uint32_t)(TIM_CR2_MMS2_3))
+#define	TIM_TRGO2_OC6REF                         ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_OC4REF_RISINGFALLING           ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_1))
+#define	TIM_TRGO2_OC6REF_RISINGFALLING           ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_1 | TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_OC4REF_RISING_OC6REF_RISING    ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_2))
+#define	TIM_TRGO2_OC4REF_RISING_OC6REF_FALLING   ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_2 | TIM_CR2_MMS2_0))
+#define	TIM_TRGO2_OC5REF_RISING_OC6REF_RISING    ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_2 |TIM_CR2_MMS2_1))
+#define	TIM_TRGO2_OC5REF_RISING_OC6REF_FALLING   ((uint32_t)(TIM_CR2_MMS2_3 | TIM_CR2_MMS2_2 | TIM_CR2_MMS2_1 | TIM_CR2_MMS2_0))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Master_Slave_Mode TIM Master/Slave Mode
+  * @{
+  */
+#define TIM_MASTERSLAVEMODE_ENABLE         ((uint32_t)0x0080)
+#define TIM_MASTERSLAVEMODE_DISABLE        ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Slave_Mode TIM Slave mode
+  * @{
+  */
+#define TIM_SLAVEMODE_DISABLE                ((uint32_t)0x0000)
+#define TIM_SLAVEMODE_RESET                  ((uint32_t)(TIM_SMCR_SMS_2))
+#define TIM_SLAVEMODE_GATED                  ((uint32_t)(TIM_SMCR_SMS_2 | TIM_SMCR_SMS_0))
+#define TIM_SLAVEMODE_TRIGGER                ((uint32_t)(TIM_SMCR_SMS_2 | TIM_SMCR_SMS_1))
+#define TIM_SLAVEMODE_EXTERNAL1              ((uint32_t)(TIM_SMCR_SMS_2 | TIM_SMCR_SMS_1 | TIM_SMCR_SMS_0))
+#define TIM_SLAVEMODE_COMBINED_RESETTRIGGER  ((uint32_t)(TIM_SMCR_SMS_3))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_and_PWM_modes TIM Output Compare and PWM Modes
+  * @{
+  */
+#define TIM_OCMODE_TIMING                   ((uint32_t)0x0000)
+#define TIM_OCMODE_ACTIVE                   ((uint32_t)TIM_CCMR1_OC1M_0)
+#define TIM_OCMODE_INACTIVE                 ((uint32_t)TIM_CCMR1_OC1M_1)
+#define TIM_OCMODE_TOGGLE                   ((uint32_t)TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0)
+#define TIM_OCMODE_PWM1                     ((uint32_t)TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1)
+#define TIM_OCMODE_PWM2                     ((uint32_t)TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0)
+#define TIM_OCMODE_FORCED_ACTIVE            ((uint32_t)TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_0)
+#define TIM_OCMODE_FORCED_INACTIVE          ((uint32_t)TIM_CCMR1_OC1M_2)
+
+#define TIM_OCMODE_RETRIGERRABLE_OPM1      ((uint32_t)TIM_CCMR1_OC1M_3)
+#define TIM_OCMODE_RETRIGERRABLE_OPM2      ((uint32_t)TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0)
+#define TIM_OCMODE_COMBINED_PWM1           ((uint32_t)TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_2)
+#define TIM_OCMODE_COMBINED_PWM2           ((uint32_t)TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_2)
+#define TIM_OCMODE_ASSYMETRIC_PWM1         ((uint32_t)TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2)
+#define TIM_OCMODE_ASSYMETRIC_PWM2         ((uint32_t)TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Trigger_Selection TIM Trigger Selection
+  * @{
+  */
+#define TIM_TS_ITR0                        ((uint32_t)0x0000)
+#define TIM_TS_ITR1                        ((uint32_t)0x0010)
+#define TIM_TS_ITR2                        ((uint32_t)0x0020)
+#define TIM_TS_ITR3                        ((uint32_t)0x0030)
+#define TIM_TS_TI1F_ED                     ((uint32_t)0x0040)
+#define TIM_TS_TI1FP1                      ((uint32_t)0x0050)
+#define TIM_TS_TI2FP2                      ((uint32_t)0x0060)
+#define TIM_TS_ETRF                        ((uint32_t)0x0070)
+#define TIM_TS_NONE                        ((uint32_t)0xFFFF)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Trigger_Polarity TIM Trigger Polarity
+  * @{
+  */
+#define TIM_TRIGGERPOLARITY_INVERTED           TIM_ETRPOLARITY_INVERTED      /*!< Polarity for ETRx trigger sources */
+#define TIM_TRIGGERPOLARITY_NONINVERTED        TIM_ETRPOLARITY_NONINVERTED   /*!< Polarity for ETRx trigger sources */
+#define TIM_TRIGGERPOLARITY_RISING             TIM_INPUTCHANNELPOLARITY_RISING        /*!< Polarity for TIxFPx or TI1_ED trigger sources */
+#define TIM_TRIGGERPOLARITY_FALLING            TIM_INPUTCHANNELPOLARITY_FALLING       /*!< Polarity for TIxFPx or TI1_ED trigger sources */
+#define TIM_TRIGGERPOLARITY_BOTHEDGE           TIM_INPUTCHANNELPOLARITY_BOTHEDGE      /*!< Polarity for TIxFPx or TI1_ED trigger sources */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Trigger_Prescaler TIM Trigger Prescaler
+  * @{
+  */
+#define TIM_TRIGGERPRESCALER_DIV1             TIM_ETRPRESCALER_DIV1     /*!< No prescaler is used */
+#define TIM_TRIGGERPRESCALER_DIV2             TIM_ETRPRESCALER_DIV2     /*!< Prescaler for External ETR Trigger: Capture performed once every 2 events. */
+#define TIM_TRIGGERPRESCALER_DIV4             TIM_ETRPRESCALER_DIV4     /*!< Prescaler for External ETR Trigger: Capture performed once every 4 events. */
+#define TIM_TRIGGERPRESCALER_DIV8             TIM_ETRPRESCALER_DIV8     /*!< Prescaler for External ETR Trigger: Capture performed once every 8 events. */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_TI1_Selection TIM TI1 Input Selection
+  * @{
+  */
+#define TIM_TI1SELECTION_CH1               ((uint32_t)0x0000)
+#define TIM_TI1SELECTION_XORCOMBINATION    (TIM_CR2_TI1S)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_DMA_Burst_Length TIM DMA Burst Length
+  * @{
+  */
+#define TIM_DMABURSTLENGTH_1TRANSFER       (0x00000000)
+#define TIM_DMABURSTLENGTH_2TRANSFERS      (0x00000100)
+#define TIM_DMABURSTLENGTH_3TRANSFERS      (0x00000200)
+#define TIM_DMABURSTLENGTH_4TRANSFERS      (0x00000300)
+#define TIM_DMABURSTLENGTH_5TRANSFERS      (0x00000400)
+#define TIM_DMABURSTLENGTH_6TRANSFERS      (0x00000500)
+#define TIM_DMABURSTLENGTH_7TRANSFERS      (0x00000600)
+#define TIM_DMABURSTLENGTH_8TRANSFERS      (0x00000700)
+#define TIM_DMABURSTLENGTH_9TRANSFERS      (0x00000800)
+#define TIM_DMABURSTLENGTH_10TRANSFERS     (0x00000900)
+#define TIM_DMABURSTLENGTH_11TRANSFERS     (0x00000A00)
+#define TIM_DMABURSTLENGTH_12TRANSFERS     (0x00000B00)
+#define TIM_DMABURSTLENGTH_13TRANSFERS     (0x00000C00)
+#define TIM_DMABURSTLENGTH_14TRANSFERS     (0x00000D00)
+#define TIM_DMABURSTLENGTH_15TRANSFERS     (0x00000E00)
+#define TIM_DMABURSTLENGTH_16TRANSFERS     (0x00000F00)
+#define TIM_DMABURSTLENGTH_17TRANSFERS     (0x00001000)
+#define TIM_DMABURSTLENGTH_18TRANSFERS     (0x00001100)
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Handle_index TIM DMA Handle Index
+  * @{
+  */
+#define TIM_DMA_ID_UPDATE                ((uint16_t) 0x0)       /*!< Index of the DMA handle used for Update DMA requests */
+#define TIM_DMA_ID_CC1                   ((uint16_t) 0x1)       /*!< Index of the DMA handle used for Capture/Compare 1 DMA requests */
+#define TIM_DMA_ID_CC2                   ((uint16_t) 0x2)       /*!< Index of the DMA handle used for Capture/Compare 2 DMA requests */
+#define TIM_DMA_ID_CC3                   ((uint16_t) 0x3)       /*!< Index of the DMA handle used for Capture/Compare 3 DMA requests */
+#define TIM_DMA_ID_CC4                   ((uint16_t) 0x4)       /*!< Index of the DMA handle used for Capture/Compare 4 DMA requests */
+#define TIM_DMA_ID_COMMUTATION           ((uint16_t) 0x5)       /*!< Index of the DMA handle used for Commutation DMA requests */
+#define TIM_DMA_ID_TRIGGER               ((uint16_t) 0x6)       /*!< Index of the DMA handle used for Trigger DMA requests */
+/**
+  * @}
+  */
+
+/** @defgroup Channel_CC_State TIM Capture/Compare Channel State
+  * @{
+  */
+#define TIM_CCx_ENABLE                   ((uint32_t)0x0001)
+#define TIM_CCx_DISABLE                  ((uint32_t)0x0000)
+#define TIM_CCxN_ENABLE                  ((uint32_t)0x0004)
+#define TIM_CCxN_DISABLE                 ((uint32_t)0x0000)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Break_System TIM Break System
+  * @{
+  */
+#define TIM_BREAK_SYSTEM_ECC                 SYSCFG_CFGR2_ECCL  /*!< Enables and locks the ECC error signal with Break Input of TIM1/8/15/16/17 */
+#define TIM_BREAK_SYSTEM_PVD                 SYSCFG_CFGR2_PVDL  /*!< Enables and locks the PVD connection with TIM1/8/15/16/17 Break Input and also the PVDE and PLS bits of the Power Control Interface */
+#define TIM_BREAK_SYSTEM_SRAM2_PARITY_ERROR  SYSCFG_CFGR2_SPL   /*!< Enables and locks the SRAM2_PARITY error signal with Break Input of TIM1/8/15/16/17 */
+#define TIM_BREAK_SYSTEM_LOCKUP              SYSCFG_CFGR2_CLL   /*!< Enables and locks the LOCKUP output of CortexM4 with Break Input of TIM1/15/16/17 */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* End of exported constants -------------------------------------------------*/
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup TIM_Exported_Macros TIM Exported Macros
+  * @{
+  */
+
+/** @brief  Reset TIM handle state.
+  * @param  __HANDLE__: TIM handle.
+  * @retval None
+  */
+#define __HAL_TIM_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_TIM_STATE_RESET)
+
+/**
+  * @brief  Enable the TIM peripheral.
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+ */
+#define __HAL_TIM_ENABLE(__HANDLE__)                 ((__HANDLE__)->Instance->CR1|=(TIM_CR1_CEN))
+
+/**
+  * @brief  Enable the TIM main Output.
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+  */
+#define __HAL_TIM_MOE_ENABLE(__HANDLE__)             ((__HANDLE__)->Instance->BDTR|=(TIM_BDTR_MOE))
+
+/**
+  * @brief  Disable the TIM peripheral.
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+  */
+#define __HAL_TIM_DISABLE(__HANDLE__) \
+                        do { \
+                          if (((__HANDLE__)->Instance->CCER & TIM_CCER_CCxE_MASK) == 0) \
+                            { \
+                            if(((__HANDLE__)->Instance->CCER & TIM_CCER_CCxNE_MASK) == 0) \
+                            { \
+                              (__HANDLE__)->Instance->CR1 &= ~(TIM_CR1_CEN); \
+                            } \
+                          } \
+                        } while(0)
+
+/**
+  * @brief  Disable the TIM main Output.
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+  * @note The Main Output Enable of a timer instance is disabled only if all the CCx and CCxN channels have been disabled
+  */
+#define __HAL_TIM_MOE_DISABLE(__HANDLE__) \
+                        do { \
+                          if (((__HANDLE__)->Instance->CCER & TIM_CCER_CCxE_MASK) == 0) \
+                          { \
+                            if(((__HANDLE__)->Instance->CCER & TIM_CCER_CCxNE_MASK) == 0) \
+                            { \
+                              (__HANDLE__)->Instance->BDTR &= ~(TIM_BDTR_MOE); \
+                            } \
+                            } \
+                        } while(0)
+
+/** @brief  Enable the specified TIM interrupt.
+  * @param  __HANDLE__: specifies the TIM Handle.
+  * @param  __INTERRUPT__: specifies the TIM interrupt source to enable.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_IT_UPDATE: Update interrupt
+  *            @arg TIM_IT_CC1:   Capture/Compare 1 interrupt
+  *            @arg TIM_IT_CC2:  Capture/Compare 2 interrupt
+  *            @arg TIM_IT_CC3:  Capture/Compare 3 interrupt
+  *            @arg TIM_IT_CC4:  Capture/Compare 4 interrupt
+  *            @arg TIM_IT_COM:   Commutation interrupt
+  *            @arg TIM_IT_TRIGGER: Trigger interrupt
+  *            @arg TIM_IT_BREAK: Break interrupt
+  * @retval None
+  */
+#define __HAL_TIM_ENABLE_IT(__HANDLE__, __INTERRUPT__)    ((__HANDLE__)->Instance->DIER |= (__INTERRUPT__))
+
+
+/** @brief  Disable the specified TIM interrupt.
+  * @param  __HANDLE__: specifies the TIM Handle.
+  * @param  __INTERRUPT__: specifies the TIM interrupt source to disable.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_IT_UPDATE: Update interrupt
+  *            @arg TIM_IT_CC1:   Capture/Compare 1 interrupt
+  *            @arg TIM_IT_CC2:  Capture/Compare 2 interrupt
+  *            @arg TIM_IT_CC3:  Capture/Compare 3 interrupt
+  *            @arg TIM_IT_CC4:  Capture/Compare 4 interrupt
+  *            @arg TIM_IT_COM:   Commutation interrupt
+  *            @arg TIM_IT_TRIGGER: Trigger interrupt
+  *            @arg TIM_IT_BREAK: Break interrupt
+  * @retval None
+  */
+#define __HAL_TIM_DISABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->DIER &= ~(__INTERRUPT__))
+
+/** @brief  Enable the specified DMA request.
+  * @param  __HANDLE__: specifies the TIM Handle.
+  * @param  __DMA__: specifies the TIM DMA request to enable.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_DMA_UPDATE: Update DMA request
+  *            @arg TIM_DMA_CC1:   Capture/Compare 1 DMA request
+  *            @arg TIM_DMA_CC2:  Capture/Compare 2 DMA request
+  *            @arg TIM_DMA_CC3:  Capture/Compare 3 DMA request
+  *            @arg TIM_DMA_CC4:  Capture/Compare 4 DMA request
+  *            @arg TIM_DMA_COM:   Commutation DMA request
+  *            @arg TIM_DMA_TRIGGER: Trigger DMA request
+  *            @arg TIM_DMA_BREAK: Break DMA request
+  * @retval None
+  */
+#define __HAL_TIM_ENABLE_DMA(__HANDLE__, __DMA__)         ((__HANDLE__)->Instance->DIER |= (__DMA__))
+
+/** @brief  Disable the specified DMA request.
+  * @param  __HANDLE__: specifies the TIM Handle.
+  * @param  __DMA__: specifies the TIM DMA request to disable.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_DMA_UPDATE: Update DMA request
+  *            @arg TIM_DMA_CC1:   Capture/Compare 1 DMA request
+  *            @arg TIM_DMA_CC2:  Capture/Compare 2 DMA request
+  *            @arg TIM_DMA_CC3:  Capture/Compare 3 DMA request
+  *            @arg TIM_DMA_CC4:  Capture/Compare 4 DMA request
+  *            @arg TIM_DMA_COM:   Commutation DMA request
+  *            @arg TIM_DMA_TRIGGER: Trigger DMA request
+  *            @arg TIM_DMA_BREAK: Break DMA request
+  * @retval None
+  */
+#define __HAL_TIM_DISABLE_DMA(__HANDLE__, __DMA__)        ((__HANDLE__)->Instance->DIER &= ~(__DMA__))
+
+/** @brief  Check whether the specified TIM interrupt flag is set or not.
+  * @param  __HANDLE__: specifies the TIM Handle.
+  * @param  __FLAG__: specifies the TIM interrupt flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg TIM_FLAG_UPDATE: Update interrupt flag
+  *            @arg TIM_FLAG_CC1: Capture/Compare 1 interrupt flag
+  *            @arg TIM_FLAG_CC2: Capture/Compare 2 interrupt flag
+  *            @arg TIM_FLAG_CC3: Capture/Compare 3 interrupt flag
+  *            @arg TIM_FLAG_CC4: Capture/Compare 4 interrupt flag
+  *            @arg TIM_FLAG_CC5: Compare 5 interrupt flag
+  *            @arg TIM_FLAG_CC6: Compare 5 interrupt flag
+  *            @arg TIM_FLAG_COM:  Commutation interrupt flag
+  *            @arg TIM_FLAG_TRIGGER: Trigger interrupt flag
+  *            @arg TIM_FLAG_BREAK: Break interrupt flag   
+  *            @arg TIM_FLAG_BREAK2: Break 2 interrupt flag                     
+  *            @arg TIM_FLAG_SYSTEM_BREAK: System Break interrupt flag
+  *            @arg TIM_FLAG_CC1OF: Capture/Compare 1 overcapture flag
+  *            @arg TIM_FLAG_CC2OF: Capture/Compare 2 overcapture flag
+  *            @arg TIM_FLAG_CC3OF: Capture/Compare 3 overcapture flag
+  *            @arg TIM_FLAG_CC4OF: Capture/Compare 4 overcapture flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_TIM_GET_FLAG(__HANDLE__, __FLAG__)          (((__HANDLE__)->Instance->SR &(__FLAG__)) == (__FLAG__))
+
+/** @brief  Clear the specified TIM interrupt flag.
+  * @param  __HANDLE__: specifies the TIM Handle.
+  * @param  __FLAG__: specifies the TIM interrupt flag to clear.
+  *        This parameter can be one of the following values:
+  *            @arg TIM_FLAG_UPDATE: Update interrupt flag
+  *            @arg TIM_FLAG_CC1: Capture/Compare 1 interrupt flag
+  *            @arg TIM_FLAG_CC2: Capture/Compare 2 interrupt flag
+  *            @arg TIM_FLAG_CC3: Capture/Compare 3 interrupt flag
+  *            @arg TIM_FLAG_CC4: Capture/Compare 4 interrupt flag
+  *            @arg TIM_FLAG_CC5: Compare 5 interrupt flag
+  *            @arg TIM_FLAG_CC6: Compare 5 interrupt flag
+  *            @arg TIM_FLAG_COM:  Commutation interrupt flag
+  *            @arg TIM_FLAG_TRIGGER: Trigger interrupt flag
+  *            @arg TIM_FLAG_BREAK: Break interrupt flag   
+  *            @arg TIM_FLAG_BREAK2: Break 2 interrupt flag                     
+  *            @arg TIM_FLAG_SYSTEM_BREAK: System Break interrupt flag
+  *            @arg TIM_FLAG_CC1OF: Capture/Compare 1 overcapture flag
+  *            @arg TIM_FLAG_CC2OF: Capture/Compare 2 overcapture flag
+  *            @arg TIM_FLAG_CC3OF: Capture/Compare 3 overcapture flag
+  *            @arg TIM_FLAG_CC4OF: Capture/Compare 4 overcapture flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_TIM_CLEAR_FLAG(__HANDLE__, __FLAG__)        ((__HANDLE__)->Instance->SR = ~(__FLAG__))
+
+/**
+  * @brief  Check whether the specified TIM interrupt source is enabled or not.
+  * @param  __HANDLE__: TIM handle
+  * @param  __INTERRUPT__: specifies the TIM interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_IT_UPDATE: Update interrupt
+  *            @arg TIM_IT_CC1:   Capture/Compare 1 interrupt
+  *            @arg TIM_IT_CC2:  Capture/Compare 2 interrupt
+  *            @arg TIM_IT_CC3:  Capture/Compare 3 interrupt
+  *            @arg TIM_IT_CC4:  Capture/Compare 4 interrupt
+  *            @arg TIM_IT_COM:   Commutation interrupt
+  *            @arg TIM_IT_TRIGGER: Trigger interrupt
+  *            @arg TIM_IT_BREAK: Break interrupt
+  * @retval The state of TIM_IT (SET or RESET).
+  */
+#define __HAL_TIM_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->DIER & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/** @brief Clear the TIM interrupt pending bits.
+  * @param  __HANDLE__: TIM handle
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_IT_UPDATE: Update interrupt
+  *            @arg TIM_IT_CC1:   Capture/Compare 1 interrupt
+  *            @arg TIM_IT_CC2:  Capture/Compare 2 interrupt
+  *            @arg TIM_IT_CC3:  Capture/Compare 3 interrupt
+  *            @arg TIM_IT_CC4:  Capture/Compare 4 interrupt
+  *            @arg TIM_IT_COM:   Commutation interrupt
+  *            @arg TIM_IT_TRIGGER: Trigger interrupt
+  *            @arg TIM_IT_BREAK: Break interrupt
+  * @retval None
+  */
+#define __HAL_TIM_CLEAR_IT(__HANDLE__, __INTERRUPT__)      ((__HANDLE__)->Instance->SR = ~(__INTERRUPT__))
+
+/**
+  * @brief  Indicates whether or not the TIM Counter is used as downcounter.
+  * @param  __HANDLE__: TIM handle.
+  * @retval False (Counter used as upcounter) or True (Counter used as downcounter)
+  * @note This macro is particularly useful to get the counting mode when the timer operates in Center-aligned mode or Encoder
+mode.
+  */
+#define __HAL_TIM_IS_TIM_COUNTING_DOWN(__HANDLE__)    (((__HANDLE__)->Instance->CR1 &(TIM_CR1_DIR)) == (TIM_CR1_DIR))
+
+
+/**
+  * @brief  Set the TIM Prescaler on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __PRESC__: specifies the Prescaler new value.
+  * @retval None
+  */
+#define __HAL_TIM_SET_PRESCALER(__HANDLE__, __PRESC__)       ((__HANDLE__)->Instance->PSC = (__PRESC__))
+
+/**
+  * @brief  Set the TIM Counter Register value on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __COUNTER__: specifies the Counter register new value.
+  * @retval None
+  */
+#define __HAL_TIM_SET_COUNTER(__HANDLE__, __COUNTER__)  ((__HANDLE__)->Instance->CNT = (__COUNTER__))
+
+/**
+  * @brief  Get the TIM Counter Register value on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @retval None
+  */
+#define __HAL_TIM_GET_COUNTER(__HANDLE__) \
+   ((__HANDLE__)->Instance->CNT)
+
+/**
+  * @brief  Set the TIM Autoreload Register value on runtime without calling another time any Init function.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __AUTORELOAD__: specifies the Counter register new value.
+  * @retval None
+  */
+#define __HAL_TIM_SET_AUTORELOAD(__HANDLE__, __AUTORELOAD__) \
+                        do{                                                    \
+                              (__HANDLE__)->Instance->ARR = (__AUTORELOAD__);  \
+                              (__HANDLE__)->Init.Period = (__AUTORELOAD__);    \
+                          } while(0)
+
+/**
+  * @brief  Get the TIM Autoreload Register value on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @retval None
+  */
+#define __HAL_TIM_GET_AUTORELOAD(__HANDLE__) \
+   ((__HANDLE__)->Instance->ARR)
+
+/**
+  * @brief  Set the TIM Clock Division value on runtime without calling another time any Init function.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CKD__: specifies the clock division value.
+  *          This parameter can be one of the following value:
+  *            @arg TIM_CLOCKDIVISION_DIV1
+  *            @arg TIM_CLOCKDIVISION_DIV2
+  *            @arg TIM_CLOCKDIVISION_DIV4
+  * @retval None
+  */
+#define __HAL_TIM_SET_CLOCKDIVISION(__HANDLE__, __CKD__) \
+                        do{                                                    \
+                              (__HANDLE__)->Instance->CR1 &= (uint16_t)(~TIM_CR1_CKD);  \
+                              (__HANDLE__)->Instance->CR1 |= (__CKD__);                   \
+                              (__HANDLE__)->Init.ClockDivision = (__CKD__);             \
+                          } while(0)
+
+/**
+  * @brief  Get the TIM Clock Division value on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @retval None
+  */
+#define __HAL_TIM_GET_CLOCKDIVISION(__HANDLE__)  \
+   ((__HANDLE__)->Instance->CR1 & TIM_CR1_CKD)
+
+/**
+  * @brief  Set the TIM Input Capture prescaler on runtime without calling another time HAL_TIM_IC_ConfigChannel() function.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__: TIM Channels to be configured.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  __ICPSC__: specifies the Input Capture4 prescaler new value.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPSC_DIV1: no prescaler
+  *            @arg TIM_ICPSC_DIV2: capture is done once every 2 events
+  *            @arg TIM_ICPSC_DIV4: capture is done once every 4 events
+  *            @arg TIM_ICPSC_DIV8: capture is done once every 8 events
+  * @retval None
+  */
+#define __HAL_TIM_SET_ICPRESCALER(__HANDLE__, __CHANNEL__, __ICPSC__) \
+                        do{                                                    \
+                              TIM_RESET_ICPRESCALERVALUE((__HANDLE__), (__CHANNEL__));  \
+                              TIM_SET_ICPRESCALERVALUE((__HANDLE__), (__CHANNEL__), (__ICPSC__)); \
+                          } while(0)
+
+/**
+  * @brief  Get the TIM Input Capture prescaler on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__: TIM Channels to be configured.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: get input capture 1 prescaler value
+  *            @arg TIM_CHANNEL_2: get input capture 2 prescaler value
+  *            @arg TIM_CHANNEL_3: get input capture 3 prescaler value
+  *            @arg TIM_CHANNEL_4: get input capture 4 prescaler value
+  * @retval None
+  */
+#define __HAL_TIM_GET_ICPRESCALER(__HANDLE__, __CHANNEL__)  \
+  (((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCMR1 & TIM_CCMR1_IC1PSC) :\
+   ((__CHANNEL__) == TIM_CHANNEL_2) ? (((__HANDLE__)->Instance->CCMR1 & TIM_CCMR1_IC2PSC) >> 8) :\
+   ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCMR2 & TIM_CCMR2_IC3PSC) :\
+   (((__HANDLE__)->Instance->CCMR2 & TIM_CCMR2_IC4PSC)) >> 8)
+
+/**
+  * @brief  Set the TIM Capture Compare Register value on runtime without calling another time ConfigChannel function.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__: TIM Channels to be configured.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  * @param  __COMPARE__: specifies the Capture Compare register new value.
+  * @retval None
+  */
+#define __HAL_TIM_SET_COMPARE(__HANDLE__, __CHANNEL__, __COMPARE__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCR1 = (__COMPARE__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCR2 = (__COMPARE__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCR3 = (__COMPARE__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_4) ? ((__HANDLE__)->Instance->CCR4 = (__COMPARE__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_5) ? ((__HANDLE__)->Instance->CCR5 = (__COMPARE__)) :\
+ ((__HANDLE__)->Instance->CCR6 = (__COMPARE__)))
+
+/**
+  * @brief  Get the TIM Capture Compare Register value on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__: TIM Channel associated with the capture compare register
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: get capture/compare 1 register value
+  *            @arg TIM_CHANNEL_2: get capture/compare 2 register value
+  *            @arg TIM_CHANNEL_3: get capture/compare 3 register value
+  *            @arg TIM_CHANNEL_4: get capture/compare 4 register value
+  *            @arg TIM_CHANNEL_5: get capture/compare 5 register value
+  *            @arg TIM_CHANNEL_6: get capture/compare 6 register value
+  * @retval None
+  */
+#define __HAL_TIM_GET_COMPARE(__HANDLE__, __CHANNEL__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCR1) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCR2) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCR3) :\
+ ((__CHANNEL__) == TIM_CHANNEL_4) ? ((__HANDLE__)->Instance->CCR4) :\
+ ((__CHANNEL__) == TIM_CHANNEL_5) ? ((__HANDLE__)->Instance->CCR5) :\
+ ((__HANDLE__)->Instance->CCR6))
+
+/**
+  * @brief  Set the Update Request Source (URS) bit of the TIMx_CR1 register.
+  * @param  __HANDLE__: TIM handle.
+  * @note  When the USR bit of the TIMx_CR1 register is set, only counter 
+  *        overflow/underflow generates an update interrupt or DMA request (if
+  *        enabled)
+  * @retval None
+  */
+#define __HAL_TIM_URS_ENABLE(__HANDLE__) \
+    ((__HANDLE__)->Instance->CR1|= (TIM_CR1_URS))
+
+/**
+  * @brief  Reset the Update Request Source (URS) bit of the TIMx_CR1 register.
+  * @param  __HANDLE__: TIM handle.
+  * @note  When the USR bit of the TIMx_CR1 register is reset, any of the 
+  *        following events generate an update interrupt or DMA request (if 
+  *        enabled):
+  *           _ Counter overflow underflow
+  *           _ Setting the UG bit
+  *           _ Update generation through the slave mode controller
+  * @retval None
+  */
+#define __HAL_TIM_URS_DISABLE(__HANDLE__) \
+      ((__HANDLE__)->Instance->CR1&=~(TIM_CR1_URS))
+        
+/**
+  * @brief  Set the TIM Capture x input polarity on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__: TIM Channels to be configured.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  __POLARITY__: Polarity for TIx source   
+  *            @arg TIM_INPUTCHANNELPOLARITY_RISING: Rising Edge
+  *            @arg TIM_INPUTCHANNELPOLARITY_FALLING: Falling Edge
+  *            @arg TIM_INPUTCHANNELPOLARITY_BOTHEDGE: Rising and Falling Edge
+  * @retval None
+  */
+#define __HAL_TIM_SET_CAPTUREPOLARITY(__HANDLE__, __CHANNEL__, __POLARITY__)    \
+        do{                                                                     \
+          TIM_RESET_CAPTUREPOLARITY((__HANDLE__), (__CHANNEL__));               \
+          TIM_SET_CAPTUREPOLARITY((__HANDLE__), (__CHANNEL__), (__POLARITY__)); \
+        }while(0)
+          
+/**
+  * @}
+  */
+/* End of exported macros ----------------------------------------------------*/
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup TIM_Private_Constants TIM Private Constants
+  * @{
+  */
+/* The counter of a timer instance is disabled only if all the CCx and CCxN
+   channels have been disabled */
+#define TIM_CCER_CCxE_MASK  ((uint32_t)(TIM_CCER_CC1E | TIM_CCER_CC2E | TIM_CCER_CC3E | TIM_CCER_CC4E))
+#define TIM_CCER_CCxNE_MASK ((uint32_t)(TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE))
+/**
+  * @}
+  */
+/* End of private constants --------------------------------------------------*/
+  
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup TIM_Private_Macros TIM Private Macros
+  * @{
+  */
+
+#define IS_TIM_CLEARINPUT_SOURCE(__MODE__)  (((__MODE__) == TIM_CLEARINPUTSOURCE_ETR)      || \
+                                             ((__MODE__) == TIM_CLEARINPUTSOURCE_OCREFCLR) || \
+                                             ((__MODE__) == TIM_CLEARINPUTSOURCE_NONE))
+
+#define IS_TIM_DMA_BASE(__BASE__) (((__BASE__) == TIM_DMABASE_CR1)   || \
+                                   ((__BASE__) == TIM_DMABASE_CR2)   || \
+                                   ((__BASE__) == TIM_DMABASE_SMCR)  || \
+                                   ((__BASE__) == TIM_DMABASE_DIER)  || \
+                                   ((__BASE__) == TIM_DMABASE_SR)    || \
+                                   ((__BASE__) == TIM_DMABASE_EGR)   || \
+                                   ((__BASE__) == TIM_DMABASE_CCMR1) || \
+                                   ((__BASE__) == TIM_DMABASE_CCMR2) || \
+                                   ((__BASE__) == TIM_DMABASE_CCER)  || \
+                                   ((__BASE__) == TIM_DMABASE_CNT)   || \
+                                   ((__BASE__) == TIM_DMABASE_PSC)   || \
+                                   ((__BASE__) == TIM_DMABASE_ARR)   || \
+                                   ((__BASE__) == TIM_DMABASE_RCR)   || \
+                                   ((__BASE__) == TIM_DMABASE_CCR1)  || \
+                                   ((__BASE__) == TIM_DMABASE_CCR2)  || \
+                                   ((__BASE__) == TIM_DMABASE_CCR3)  || \
+                                   ((__BASE__) == TIM_DMABASE_CCR4)  || \
+                                   ((__BASE__) == TIM_DMABASE_BDTR)  || \
+                                   ((__BASE__) == TIM_DMABASE_CCMR3) || \
+                                   ((__BASE__) == TIM_DMABASE_CCR5)  || \
+                                   ((__BASE__) == TIM_DMABASE_CCR6)  || \
+                                   ((__BASE__) == TIM_DMABASE_OR1)   || \
+                                   ((__BASE__) == TIM_DMABASE_OR2)   || \
+                                   ((__BASE__) == TIM_DMABASE_OR3))
+
+
+#define IS_TIM_EVENT_SOURCE(__SOURCE__) ((((__SOURCE__) & 0xFFFFFE00) == 0x00000000) && ((__SOURCE__) != 0x00000000))
+
+
+#define IS_TIM_COUNTER_MODE(__MODE__)      (((__MODE__) == TIM_COUNTERMODE_UP)              || \
+                                            ((__MODE__) == TIM_COUNTERMODE_DOWN)            || \
+                                            ((__MODE__) == TIM_COUNTERMODE_CENTERALIGNED1)  || \
+                                            ((__MODE__) == TIM_COUNTERMODE_CENTERALIGNED2)  || \
+                                            ((__MODE__) == TIM_COUNTERMODE_CENTERALIGNED3))
+
+#define IS_TIM_CLOCKDIVISION_DIV(__DIV__)  (((__DIV__) == TIM_CLOCKDIVISION_DIV1) || \
+                                            ((__DIV__) == TIM_CLOCKDIVISION_DIV2) || \
+                                            ((__DIV__) == TIM_CLOCKDIVISION_DIV4))
+
+#define IS_TIM_FAST_STATE(__STATE__)       (((__STATE__) == TIM_OCFAST_DISABLE) || \
+                                            ((__STATE__) == TIM_OCFAST_ENABLE))
+
+#define IS_TIM_OC_POLARITY(__POLARITY__)   (((__POLARITY__) == TIM_OCPOLARITY_HIGH) || \
+                                            ((__POLARITY__) == TIM_OCPOLARITY_LOW))
+
+#define IS_TIM_OCN_POLARITY(__POLARITY__)  (((__POLARITY__) == TIM_OCNPOLARITY_HIGH) || \
+                                            ((__POLARITY__) == TIM_OCNPOLARITY_LOW))
+
+#define IS_TIM_OCIDLE_STATE(__STATE__)     (((__STATE__) == TIM_OCIDLESTATE_SET) || \
+                                            ((__STATE__) == TIM_OCIDLESTATE_RESET))
+
+#define IS_TIM_OCNIDLE_STATE(__STATE__)    (((__STATE__) == TIM_OCNIDLESTATE_SET) || \
+                                            ((__STATE__) == TIM_OCNIDLESTATE_RESET))
+
+#define IS_TIM_IC_POLARITY(__POLARITY__)   (((__POLARITY__) == TIM_ICPOLARITY_RISING)   || \
+                                            ((__POLARITY__) == TIM_ICPOLARITY_FALLING)  || \
+                                            ((__POLARITY__) == TIM_ICPOLARITY_BOTHEDGE))
+
+#define IS_TIM_IC_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_ICSELECTION_DIRECTTI) || \
+                                            ((__SELECTION__) == TIM_ICSELECTION_INDIRECTTI) || \
+                                            ((__SELECTION__) == TIM_ICSELECTION_TRC))
+
+#define IS_TIM_IC_PRESCALER(__PRESCALER__) (((__PRESCALER__) == TIM_ICPSC_DIV1) || \
+                                            ((__PRESCALER__) == TIM_ICPSC_DIV2) || \
+                                            ((__PRESCALER__) == TIM_ICPSC_DIV4) || \
+                                            ((__PRESCALER__) == TIM_ICPSC_DIV8))
+
+#define IS_TIM_OPM_MODE(__MODE__)          (((__MODE__) == TIM_OPMODE_SINGLE) || \
+                                            ((__MODE__) == TIM_OPMODE_REPETITIVE))
+
+#define IS_TIM_ENCODER_MODE(__MODE__)      (((__MODE__) == TIM_ENCODERMODE_TI1) || \
+                                            ((__MODE__) == TIM_ENCODERMODE_TI2) || \
+                                            ((__MODE__) == TIM_ENCODERMODE_TI12))
+
+#define IS_TIM_DMA_SOURCE(__SOURCE__) ((((__SOURCE__) & 0xFFFF80FF) == 0x00000000) && ((__SOURCE__) != 0x00000000))
+
+#define IS_TIM_CHANNELS(__CHANNEL__)       (((__CHANNEL__) == TIM_CHANNEL_1) || \
+                                            ((__CHANNEL__) == TIM_CHANNEL_2) || \
+                                            ((__CHANNEL__) == TIM_CHANNEL_3) || \
+                                            ((__CHANNEL__) == TIM_CHANNEL_4) || \
+                                            ((__CHANNEL__) == TIM_CHANNEL_5) || \
+                                            ((__CHANNEL__) == TIM_CHANNEL_6) || \
+                                            ((__CHANNEL__) == TIM_CHANNEL_ALL))
+
+#define IS_TIM_OPM_CHANNELS(__CHANNEL__)   (((__CHANNEL__) == TIM_CHANNEL_1) || \
+                                            ((__CHANNEL__) == TIM_CHANNEL_2))
+
+#define IS_TIM_COMPLEMENTARY_CHANNELS(__CHANNEL__) (((__CHANNEL__) == TIM_CHANNEL_1) || \
+                                                    ((__CHANNEL__) == TIM_CHANNEL_2) || \
+                                                    ((__CHANNEL__) == TIM_CHANNEL_3))
+
+#define IS_TIM_CLOCKSOURCE(__CLOCK__) (((__CLOCK__) == TIM_CLOCKSOURCE_INTERNAL) || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ETRMODE2) || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR0)     || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR1)     || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR2)     || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR3)     || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_TI1ED)    || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_TI1)      || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_TI2)      || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ETRMODE1))
+
+#define IS_TIM_CLOCKPOLARITY(__POLARITY__) (((__POLARITY__) == TIM_CLOCKPOLARITY_INVERTED)    || \
+                                            ((__POLARITY__) == TIM_CLOCKPOLARITY_NONINVERTED) || \
+                                            ((__POLARITY__) == TIM_CLOCKPOLARITY_RISING)      || \
+                                            ((__POLARITY__) == TIM_CLOCKPOLARITY_FALLING)     || \
+                                            ((__POLARITY__) == TIM_CLOCKPOLARITY_BOTHEDGE))
+
+#define IS_TIM_CLOCKPRESCALER(__PRESCALER__) (((__PRESCALER__) == TIM_CLOCKPRESCALER_DIV1) || \
+                                              ((__PRESCALER__) == TIM_CLOCKPRESCALER_DIV2) || \
+                                              ((__PRESCALER__) == TIM_CLOCKPRESCALER_DIV4) || \
+                                              ((__PRESCALER__) == TIM_CLOCKPRESCALER_DIV8))
+
+#define IS_TIM_CLOCKFILTER(ICFILTER)      ((ICFILTER) <= 0xF)
+
+#define IS_TIM_CLEARINPUT_POLARITY(__POLARITY__) (((__POLARITY__) == TIM_CLEARINPUTPOLARITY_INVERTED) || \
+                                                  ((__POLARITY__) == TIM_CLEARINPUTPOLARITY_NONINVERTED))
+
+#define IS_TIM_CLEARINPUT_PRESCALER(__PRESCALER__) (((__PRESCALER__) == TIM_CLEARINPUTPRESCALER_DIV1) || \
+                                                    ((__PRESCALER__) == TIM_CLEARINPUTPRESCALER_DIV2) || \
+                                                    ((__PRESCALER__) == TIM_CLEARINPUTPRESCALER_DIV4) || \
+                                                    ((__PRESCALER__) == TIM_CLEARINPUTPRESCALER_DIV8))
+
+#define IS_TIM_CLEARINPUT_FILTER(__ICFILTER__) ((__ICFILTER__) <= 0xF)
+
+
+#define IS_TIM_OSSR_STATE(__STATE__)       (((__STATE__) == TIM_OSSR_ENABLE) || \
+                                            ((__STATE__) == TIM_OSSR_DISABLE))
+
+#define IS_TIM_OSSI_STATE(__STATE__)       (((__STATE__) == TIM_OSSI_ENABLE) || \
+                                            ((__STATE__) == TIM_OSSI_DISABLE))
+
+#define IS_TIM_LOCK_LEVEL(__LEVEL__)       (((__LEVEL__) == TIM_LOCKLEVEL_OFF) || \
+                                            ((__LEVEL__) == TIM_LOCKLEVEL_1)   || \
+                                            ((__LEVEL__) == TIM_LOCKLEVEL_2)   || \
+                                            ((__LEVEL__) == TIM_LOCKLEVEL_3))
+
+#define IS_TIM_BREAK_FILTER(__BRKFILTER__) ((__BRKFILTER__) <= 0xF)
+
+
+#define IS_TIM_BREAK_STATE(__STATE__)      (((__STATE__) == TIM_BREAK_ENABLE) || \
+                                            ((__STATE__) == TIM_BREAK_DISABLE))
+
+#define IS_TIM_BREAK_POLARITY(__POLARITY__) (((__POLARITY__) == TIM_BREAKPOLARITY_LOW) || \
+                                             ((__POLARITY__) == TIM_BREAKPOLARITY_HIGH))
+
+#define IS_TIM_BREAK2_STATE(__STATE__)     (((__STATE__) == TIM_BREAK2_ENABLE) || \
+                                            ((__STATE__) == TIM_BREAK2_DISABLE))
+
+#define IS_TIM_BREAK2_POLARITY(__POLARITY__) (((__POLARITY__) == TIM_BREAK2POLARITY_LOW) || \
+                                              ((__POLARITY__) == TIM_BREAK2POLARITY_HIGH))
+
+#define IS_TIM_AUTOMATIC_OUTPUT_STATE(__STATE__) (((__STATE__) == TIM_AUTOMATICOUTPUT_ENABLE) || \
+                                                  ((__STATE__) == TIM_AUTOMATICOUTPUT_DISABLE))
+
+#define IS_TIM_GROUPCH5(__OCREF__) ((((__OCREF__) & 0x1FFFFFFF) == 0x00000000))
+
+#define IS_TIM_TRGO_SOURCE(__SOURCE__) (((__SOURCE__) == TIM_TRGO_RESET)  || \
+                                        ((__SOURCE__) == TIM_TRGO_ENABLE) || \
+                                        ((__SOURCE__) == TIM_TRGO_UPDATE) || \
+                                        ((__SOURCE__) == TIM_TRGO_OC1)    || \
+                                        ((__SOURCE__) == TIM_TRGO_OC1REF) || \
+                                        ((__SOURCE__) == TIM_TRGO_OC2REF) || \
+                                        ((__SOURCE__) == TIM_TRGO_OC3REF) || \
+                                        ((__SOURCE__) == TIM_TRGO_OC4REF))
+
+#define IS_TIM_TRGO2_SOURCE(__SOURCE__) (((__SOURCE__) == TIM_TRGO2_RESET)                        || \
+                                         ((__SOURCE__) == TIM_TRGO2_ENABLE)                       || \
+                                         ((__SOURCE__) == TIM_TRGO2_UPDATE)                       || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC1)                          || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC1REF)                       || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC2REF)                       || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC3REF)                       || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC3REF)                       || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC4REF)                       || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC5REF)                       || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC6REF)                       || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC4REF_RISINGFALLING)         || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC6REF_RISINGFALLING)         || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC4REF_RISING_OC6REF_RISING)  || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC4REF_RISING_OC6REF_FALLING) || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC5REF_RISING_OC6REF_RISING)  || \
+                                         ((__SOURCE__) == TIM_TRGO2_OC5REF_RISING_OC6REF_FALLING))
+
+#define IS_TIM_MSM_STATE(__STATE__)      (((__STATE__) == TIM_MASTERSLAVEMODE_ENABLE) || \
+                                          ((__STATE__) == TIM_MASTERSLAVEMODE_DISABLE))
+
+#define IS_TIM_SLAVE_MODE(__MODE__) (((__MODE__) == TIM_SLAVEMODE_DISABLE)   || \
+                                     ((__MODE__) == TIM_SLAVEMODE_RESET)     || \
+                                     ((__MODE__) == TIM_SLAVEMODE_GATED)     || \
+                                     ((__MODE__) == TIM_SLAVEMODE_TRIGGER)   || \
+                                     ((__MODE__) == TIM_SLAVEMODE_EXTERNAL1) || \
+                                     ((__MODE__) == TIM_SLAVEMODE_COMBINED_RESETTRIGGER))
+
+#define IS_TIM_PWM_MODE(__MODE__) (((__MODE__) == TIM_OCMODE_PWM1)               || \
+	                                 ((__MODE__) == TIM_OCMODE_PWM2)               || \
+                                   ((__MODE__) == TIM_OCMODE_COMBINED_PWM1)      || \
+                                   ((__MODE__) == TIM_OCMODE_COMBINED_PWM2)      || \
+                                   ((__MODE__) == TIM_OCMODE_ASSYMETRIC_PWM1)    || \
+                                   ((__MODE__) == TIM_OCMODE_ASSYMETRIC_PWM2))
+
+#define IS_TIM_OC_MODE(__MODE__)  (((__MODE__) == TIM_OCMODE_TIMING)             || \
+                                   ((__MODE__) == TIM_OCMODE_ACTIVE)             || \
+                                   ((__MODE__) == TIM_OCMODE_INACTIVE)           || \
+                                   ((__MODE__) == TIM_OCMODE_TOGGLE)             || \
+                                   ((__MODE__) == TIM_OCMODE_FORCED_ACTIVE)      || \
+                                   ((__MODE__) == TIM_OCMODE_FORCED_INACTIVE)    || \
+                                   ((__MODE__) == TIM_OCMODE_RETRIGERRABLE_OPM1) || \
+                                   ((__MODE__) == TIM_OCMODE_RETRIGERRABLE_OPM2))
+
+#define IS_TIM_TRIGGER_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_TS_ITR0) || \
+                                                 ((__SELECTION__) == TIM_TS_ITR1) || \
+                                                 ((__SELECTION__) == TIM_TS_ITR2) || \
+                                                 ((__SELECTION__) == TIM_TS_ITR3) || \
+                                                 ((__SELECTION__) == TIM_TS_TI1F_ED) || \
+                                                 ((__SELECTION__) == TIM_TS_TI1FP1) || \
+                                                 ((__SELECTION__) == TIM_TS_TI2FP2) || \
+                                                 ((__SELECTION__) == TIM_TS_ETRF))
+
+#define IS_TIM_INTERNAL_TRIGGEREVENT_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_TS_ITR0) || \
+                                                               ((__SELECTION__) == TIM_TS_ITR1) || \
+                                                               ((__SELECTION__) == TIM_TS_ITR2) || \
+                                                               ((__SELECTION__) == TIM_TS_ITR3) || \
+                                                               ((__SELECTION__) == TIM_TS_NONE))
+
+
+#define IS_TIM_TRIGGERPOLARITY(__POLARITY__)   (((__POLARITY__) == TIM_TRIGGERPOLARITY_INVERTED   ) || \
+                                                ((__POLARITY__) == TIM_TRIGGERPOLARITY_NONINVERTED) || \
+                                                ((__POLARITY__) == TIM_TRIGGERPOLARITY_RISING     ) || \
+                                                ((__POLARITY__) == TIM_TRIGGERPOLARITY_FALLING    ) || \
+                                                ((__POLARITY__) == TIM_TRIGGERPOLARITY_BOTHEDGE   ))
+
+#define IS_TIM_TRIGGERPRESCALER(__PRESCALER__) (((__PRESCALER__) == TIM_TRIGGERPRESCALER_DIV1) || \
+                                                ((__PRESCALER__) == TIM_TRIGGERPRESCALER_DIV2) || \
+                                                ((__PRESCALER__) == TIM_TRIGGERPRESCALER_DIV4) || \
+                                                ((__PRESCALER__) == TIM_TRIGGERPRESCALER_DIV8))
+
+#define IS_TIM_TRIGGERFILTER(__ICFILTER__) ((__ICFILTER__) <= 0xF)
+
+#define IS_TIM_TI1SELECTION(__TI1SELECTION__)  (((__TI1SELECTION__) == TIM_TI1SELECTION_CH1) || \
+                                                ((__TI1SELECTION__) == TIM_TI1SELECTION_XORCOMBINATION))
+
+#define IS_TIM_DMA_LENGTH(__LENGTH__)      (((__LENGTH__) == TIM_DMABURSTLENGTH_1TRANSFER) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_2TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_3TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_4TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_5TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_6TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_7TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_8TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_9TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_10TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_11TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_12TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_13TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_14TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_15TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_16TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_17TRANSFERS) || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_18TRANSFERS))
+
+#define IS_TIM_IC_FILTER(__ICFILTER__)   ((__ICFILTER__) <= 0xF)
+
+#define IS_TIM_DEADTIME(__DEADTIME__)    ((__DEADTIME__) <= 0xFF)
+
+#define IS_TIM_BREAK_SYSTEM(__CONFIG__)    (((__CONFIG__) == TIM_BREAK_SYSTEM_ECC)                 || \
+                                            ((__CONFIG__) == TIM_BREAK_SYSTEM_PVD)                 || \
+                                            ((__CONFIG__) == TIM_BREAK_SYSTEM_SRAM2_PARITY_ERROR)  || \
+                                            ((__CONFIG__) == TIM_BREAK_SYSTEM_LOCKUP))
+
+#define TIM_SET_ICPRESCALERVALUE(__HANDLE__, __CHANNEL__, __ICPSC__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCMR1 |= (__ICPSC__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCMR1 |= ((__ICPSC__) << 8)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCMR2 |= (__ICPSC__)) :\
+ ((__HANDLE__)->Instance->CCMR2 |= ((__ICPSC__) << 8)))
+
+#define TIM_RESET_ICPRESCALERVALUE(__HANDLE__, __CHANNEL__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCMR1 &= (uint16_t)~TIM_CCMR1_IC1PSC) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCMR1 &= (uint16_t)~TIM_CCMR1_IC2PSC) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCMR2 &= (uint16_t)~TIM_CCMR2_IC3PSC) :\
+ ((__HANDLE__)->Instance->CCMR2 &= (uint16_t)~TIM_CCMR2_IC4PSC))
+
+#define TIM_SET_CAPTUREPOLARITY(__HANDLE__, __CHANNEL__, __POLARITY__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCER |= (__POLARITY__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCER |= ((__POLARITY__) << 4)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCER |= ((__POLARITY__) << 8)) :\
+ ((__HANDLE__)->Instance->CCER |= (((__POLARITY__) << 12))))
+
+#define TIM_RESET_CAPTUREPOLARITY(__HANDLE__, __CHANNEL__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCER &= (uint16_t)~(TIM_CCER_CC1P | TIM_CCER_CC1NP)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCER &= (uint16_t)~(TIM_CCER_CC2P | TIM_CCER_CC2NP)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCER &= (uint16_t)~(TIM_CCER_CC3P | TIM_CCER_CC3NP)) :\
+ ((__HANDLE__)->Instance->CCER &= (uint16_t)~(TIM_CCER_CC4P | TIM_CCER_CC4NP)))
+
+/**
+  * @}
+  */
+/* End of private macros -----------------------------------------------------*/
+
+/* Include TIM HAL Extended module */
+#include "stm32l4xx_hal_tim_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup TIM_Exported_Functions TIM Exported Functions
+  * @{
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group1 Time Base functions
+ *  @brief    Time Base functions
+ * @{
+ */
+/* Time Base functions ********************************************************/
+HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_Base_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_Base_Start(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_Base_Stop(TIM_HandleTypeDef *htim);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_Base_Start_IT(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_Base_Stop_IT(TIM_HandleTypeDef *htim);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_Base_Stop_DMA(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group2 Time Output Compare functions
+ *  @brief    Time Output Compare functions
+ * @{
+ */
+/* Timer Output Compare functions *********************************************/
+HAL_StatusTypeDef HAL_TIM_OC_Init(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_OC_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_OC_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_OC_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_OC_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_OC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group3 Time PWM functions
+ *  @brief    Time PWM functions
+ * @{
+ */
+/* Timer PWM functions ********************************************************/
+HAL_StatusTypeDef HAL_TIM_PWM_Init(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_PWM_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_PWM_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_PWM_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group4 Time Input Capture functions
+ *  @brief    Time Input Capture functions
+ * @{
+ */
+/* Timer Input Capture functions **********************************************/
+HAL_StatusTypeDef HAL_TIM_IC_Init(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_IC_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_IC_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_IC_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_IC_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_IC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_IC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group5 Time One Pulse functions
+ *  @brief    Time One Pulse functions
+ * @{
+ */
+/* Timer One Pulse functions **************************************************/
+HAL_StatusTypeDef HAL_TIM_OnePulse_Init(TIM_HandleTypeDef *htim, uint32_t OnePulseMode);
+HAL_StatusTypeDef HAL_TIM_OnePulse_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_OnePulse_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_OnePulse_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+HAL_StatusTypeDef HAL_TIM_OnePulse_Stop(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group6 Time Encoder functions
+ *  @brief    Time Encoder functions
+ * @{
+ */
+/* Timer Encoder functions ****************************************************/
+HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_InitTypeDef* sConfig);
+HAL_StatusTypeDef HAL_TIM_Encoder_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim);
+ /* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData1, uint32_t *pData2, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+/**
+  * @}
+  */
+
+/** @addtogroup TIM_Exported_Functions_Group7 TIM IRQ handler management
+ *  @brief    IRQ handler management
+  * @{
+  */
+/* Interrupt Handler functions  ***********************************************/
+void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group8 Peripheral Control functions
+ *  @brief   	Peripheral Control functions
+  * @{
+  */
+/* Control functions  *********************************************************/
+HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitTypeDef* sConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OnePulse_InitTypeDef* sConfig, uint32_t OutputChannel,  uint32_t InputChannel);
+HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim, TIM_ClearInputConfigTypeDef * sClearInputConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_ConfigClockSource(TIM_HandleTypeDef *htim, TIM_ClockConfigTypeDef * sClockSourceConfig);
+HAL_StatusTypeDef HAL_TIM_ConfigTI1Input(TIM_HandleTypeDef *htim, uint32_t TI1_Selection);
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchronization(TIM_HandleTypeDef *htim, TIM_SlaveConfigTypeDef * sSlaveConfig);
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchronization_IT(TIM_HandleTypeDef *htim, TIM_SlaveConfigTypeDef * sSlaveConfig);
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc, \
+                                              uint32_t  *BurstBuffer, uint32_t  BurstLength);
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc);
+HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc, \
+                                              uint32_t  *BurstBuffer, uint32_t  BurstLength);
+HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc);
+HAL_StatusTypeDef HAL_TIM_GenerateEvent(TIM_HandleTypeDef *htim, uint32_t EventSource);
+uint32_t HAL_TIM_ReadCapturedValue(TIM_HandleTypeDef *htim, uint32_t Channel);
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group9 TIM Callbacks functions
+ *  @brief    TIM Callbacks functions
+  * @{
+  */
+/* Callback in non blocking modes (Interrupt and DMA) *************************/
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_TriggerCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_ErrorCallback(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group10 Peripheral State functions
+ *  @brief   Peripheral State functions
+ * @{
+ */
+/* Peripheral State functions  ************************************************/
+HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_OC_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* End of exported functions -------------------------------------------------*/
+
+/* Private functions----------------------------------------------------------*/
+/** @defgroup TIM_Private_Functions TIM Private Functions
+* @{
+*/
+void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure);
+void TIM_TI1_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection, uint32_t TIM_ICFilter);
+void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+void TIM_ETR_SetConfig(TIM_TypeDef* TIMx, uint32_t TIM_ExtTRGPrescaler,
+                       uint32_t TIM_ExtTRGPolarity, uint32_t ExtTRGFilter);
+
+void TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma);
+void TIM_DMAError(DMA_HandleTypeDef *hdma);
+void TIM_DMACaptureCplt(DMA_HandleTypeDef *hdma);
+void TIM_CCxChannelCmd(TIM_TypeDef* TIMx, uint32_t Channel, uint32_t ChannelState);
+/**
+* @}
+*/ 
+/* End of private functions --------------------------------------------------*/
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_TIM_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_tim_ex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_tim_ex.h
@@ -1,0 +1,396 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_tim_ex.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of TIM HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_TIM_EX_H
+#define __STM32L4xx_HAL_TIM_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup TIMEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/** @defgroup TIMEx_Exported_Types TIM Extended Exported Types
+  * @{
+  */
+
+/** 
+  * @brief  TIM Hall sensor Configuration Structure definition  
+  */
+
+typedef struct
+{
+                                  
+  uint32_t IC1Polarity;         /*!< Specifies the active edge of the input signal.
+                                     This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+                                                                   
+  uint32_t IC1Prescaler;        /*!< Specifies the Input Capture Prescaler.
+                                     This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+                                  
+  uint32_t IC1Filter;           /*!< Specifies the input capture filter.
+                                     This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */  
+
+  uint32_t Commutation_Delay;   /*!< Specifies the pulse value to be loaded into the Capture Compare Register. 
+                                     This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */                              
+} TIM_HallSensor_InitTypeDef;
+
+/** 
+  * @brief  TIM Break/Break2 input configuration   
+  */
+typedef struct {
+  uint32_t Source;         /*!< Specifies the source of the timer break input.
+                                This parameter can be a value of @ref TIMEx_Break_Input_Source */
+  uint32_t Enable;         /*!< Specifies whether or not the break input source is enabled.
+                                This parameter can be a value of @ref TIMEx_Break_Input_Source_Enable */
+  uint32_t Polarity;       /*!< Specifies the break input source polarity.
+                                This parameter can be a value of @ref TIMEx_Break_Input_Source_Polarity
+                                Not relevant when analog watchdog output of the DFSDM used as break input source */
+} TIMEx_BreakInputConfigTypeDef;
+
+/**
+  * @}
+  */
+/* End of exported types -----------------------------------------------------*/ 
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup TIMEx_Exported_Constants TIM Extended Exported Constants
+  * @{
+  */
+
+/** @defgroup TIMEx_Remap TIM  Extended Remapping
+  * @{
+  */
+#define TIM_TIM1_ETR_ADC1_NONE      ((uint32_t)(0x00000000))                              /* !< TIM1_ETR is not connected to any AWD (analog watchdog)*/
+#define TIM_TIM1_ETR_ADC1_AWD1      (TIM1_OR1_ETR_ADC1_RMP_0)                             /* !< TIM1_ETR is connected to ADC1 AWD1 */
+#define TIM_TIM1_ETR_ADC1_AWD2      (TIM1_OR1_ETR_ADC1_RMP_1)                             /* !< TIM1_ETR is connected to ADC1 AWD2 */
+#define TIM_TIM1_ETR_ADC1_AWD3      (TIM1_OR1_ETR_ADC1_RMP_1 | TIM1_OR1_ETR_ADC1_RMP_0)   /* !< TIM1_ETR is connected to ADC1 AWD3 */
+#define TIM_TIM1_ETR_ADC3_NONE      ((uint32_t)(0x00000000))                              /* !< TIM1_ETR is not connected to any AWD (analog watchdog)*/
+#define TIM_TIM1_ETR_ADC3_AWD1      (TIM1_OR1_ETR_ADC3_RMP_0)                             /* !< TIM1_ETR is connected to ADC3 AWD1 */
+#define TIM_TIM1_ETR_ADC3_AWD2      (TIM1_OR1_ETR_ADC3_RMP_1)                             /* !< TIM1_ETR is connected to ADC3 AWD2 */
+#define TIM_TIM1_ETR_ADC3_AWD3      (TIM1_OR1_ETR_ADC3_RMP_1 | TIM1_OR1_ETR_ADC3_RMP_0)   /* !< TIM1_ETR is connected to ADC3 AWD3 */
+#define TIM_TIM1_TI1_GPIO           ((uint32_t)(0x00000000))                              /* !< TIM1 TI1 is connected to GPIO */
+#define TIM_TIM1_TI1_COMP1          (TIM1_OR1_TI1_RMP)                                    /* !< TIM1 TI1 is connected to COMP1 */
+#define TIM_TIM1_ETR_COMP1          (TIM1_OR2_ETRSEL_0)                                   /* !< TIM1_ETR is connected to COMP1 output */
+#define TIM_TIM1_ETR_COMP2          (TIM1_OR2_ETRSEL_1)                                   /* !< TIM1_ETR is connected to COMP2 output */
+#define TIM_TIM2_ITR1_TIM8_TRGO     ((uint32_t)(0x00000000))                              /* !< TIM2_ITR1 is connected to TIM8_TRGO */
+#define TIM_TIM2_ITR1_OTG_FS_SOF    (TIM2_OR1_ITR1_RMP)                                   /* !< TIM2_ITR1 is connected to OTG_FS SOF */
+#define TIM_TIM2_ETR_GPIO           ((uint32_t)(0x00000000))                              /* !< TIM2_ETR is connected to GPIO */
+#define TIM_TIM2_ETR_LSE            (TIM2_OR1_ETR1_RMP)                                   /* !< TIM2_ETR is connected to LSE */
+#define TIM_TIM2_ETR_COMP1          (TIM2_OR2_ETRSEL_0)                                   /* !< TIM2_ETR is connected to COMP1 output */
+#define TIM_TIM2_ETR_COMP2          (TIM2_OR2_ETRSEL_1)                                   /* !< TIM2_ETR is connected to COMP2 output */
+#define TIM_TIM2_TI4_GPIO           ((uint32_t)(0x00000000))                              /* !< TIM2 TI4 is connected to GPIO */
+#define TIM_TIM2_TI4_COMP1          (TIM2_OR1_TI4_RMP_0)                                  /* !< TIM2 TI4 is connected to COMP1 output */
+#define TIM_TIM2_TI4_COMP2          (TIM2_OR1_TI4_RMP_1)                                  /* !< TIM2 TI4 is connected to COMP2 output */
+#define TIM_TIM2_TI4_COMP1_COMP2    (TIM2_OR1_TI4_RMP_1| TIM2_OR1_TI4_RMP_0)              /* !< TIM2 TI4 is connected to logical OR between COMP1 and COMP2 output2 */
+#define TIM_TIM3_TI1_GPIO           ((uint32_t)(0x00000000))                              /* !< TIM3 TI1 is connected to GPIO */
+#define TIM_TIM3_TI1_COMP1          (TIM3_OR1_TI1_RMP_0)                                  /* !< TIM3 TI1 is connected to COMP1 output */
+#define TIM_TIM3_TI1_COMP2          (TIM3_OR1_TI1_RMP_1)                                  /* !< TIM3 TI1 is connected to COMP2 output */
+#define TIM_TIM3_TI1_COMP1_COMP2    (TIM3_OR1_TI1_RMP_1 | TIM3_OR1_TI1_RMP_0)             /* !< TIM3 TI1 is connected to logical OR between COMP1 and COMP2 output2 */
+#define TIM_TIM3_ETR_GPIO           ((uint32_t)(0x00000000))                              /* !< TIM3_ETR is connected to GPIO */
+#define TIM_TIM3_ETR_COMP1          (TIM3_OR2_ETRSEL_0)                                   /* !< TIM3_ETR is connected to COMP1 output */
+#define TIM_TIM8_ETR_ADC2_NONE      ((uint32_t)(0x00000000))                              /* !< TIM8_ETR is not connected to any AWD (analog watchdog)*/
+#define TIM_TIM8_ETR_ADC2_AWD1      (TIM8_OR1_ETR_ADC2_RMP_0)                             /* !< TIM8_ETR is connected to ADC2 AWD1 */
+#define TIM_TIM8_ETR_ADC2_AWD2      (TIM8_OR1_ETR_ADC2_RMP_1)                             /* !< TIM8_ETR is connected to ADC2 AWD2 */
+#define TIM_TIM8_ETR_ADC2_AWD3      (TIM8_OR1_ETR_ADC2_RMP_1 | TIM8_OR1_ETR_ADC2_RMP_0)   /* !< TIM8_ETR is connected to ADC2 AWD3 */
+#define TIM_TIM8_ETR_ADC3_NONE      ((uint32_t)(0x00000000))                              /* !< TIM8_ETR is not connected to any AWD (analog watchdog)*/
+#define TIM_TIM8_ETR_ADC3_AWD1      (TIM8_OR1_ETR_ADC3_RMP_0)                             /* !< TIM8_ETR is connected to ADC3 AWD1 */
+#define TIM_TIM8_ETR_ADC3_AWD2      (TIM8_OR1_ETR_ADC3_RMP_1)                             /* !< TIM8_ETR is connected to ADC3 AWD2 */
+#define TIM_TIM8_ETR_ADC3_AWD3      (TIM8_OR1_ETR_ADC3_RMP_1 | TIM8_OR1_ETR_ADC3_RMP_0)   /* !< TIM8_ETR is connected to ADC3 AWD3 */
+#define TIM_TIM8_TI1_GPIO           ((uint32_t)(0x00000000))                              /* !< TIM8 TI1 is connected to GPIO */
+#define TIM_TIM8_TI1_COMP2          (TIM8_OR1_TI1_RMP)                                    /* !< TIM8 TI1 is connected to COMP1 */
+#define TIM_TIM8_ETR_COMP1          (TIM8_OR2_ETRSEL_0)                                   /* !< TIM8_ETR is connected to COMP1 output */
+#define TIM_TIM8_ETR_COMP2          (TIM8_OR2_ETRSEL_1)                                   /* !< TIM8_ETR is connected to COMP2 output */
+#define TIM_TIM15_TI1_GPIO          ((uint32_t)(0x00000000))                              /* !< TIM15 TI1 is connected to GPIO */
+#define TIM_TIM15_TI1_LSE           (TIM15_OR1_TI1_RMP)                                   /* !< TIM15 TI1 is connected to LSE */
+#define TIM_TIM15_ENCODERMODE_NONE  ((uint32_t)(0x00000000))                              /* !< No redirection */
+#define TIM_TIM15_ENCODERMODE_TIM2  (TIM15_OR1_ENCODER_MODE_0)                            /* !< TIM2 IC1 and TIM2 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively */
+#define TIM_TIM15_ENCODERMODE_TIM3  (TIM15_OR1_ENCODER_MODE_1)                            /* !< TIM3 IC1 and TIM3 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively */
+#define TIM_TIM15_ENCODERMODE_TIM4  (TIM15_OR1_ENCODER_MODE_1 | TIM15_OR1_ENCODER_MODE_0) /* !< TIM4 IC1 and TIM4 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively */
+#define TIM_TIM16_TI1_GPIO          ((uint32_t)(0x00000000))                              /* !< TIM16 TI1 is connected to GPIO */
+#define TIM_TIM16_TI1_LSI           (TIM16_OR1_TI1_RMP_0)                                 /* !< TIM16 TI1 is connected to LSI */
+#define TIM_TIM16_TI1_LSE           (TIM16_OR1_TI1_RMP_1)                                 /* !< TIM16 TI1 is connected to LSE */
+#define TIM_TIM16_TI1_RTC           (TIM16_OR1_TI1_RMP_1 | TIM16_OR1_TI1_RMP_0)           /* !< TIM16 TI1 is connected to RTC wakeup interrupt */
+#define TIM_TIM17_TI1_GPIO          ((uint32_t)(0x00000000))                              /* !< TIM17 TI1 is connected to GPIO */
+#define TIM_TIM17_TI1_MSI           (TIM17_OR1_TI1_RMP_0)                                 /* !< TIM17 TI1 is connected to MSI */
+#define TIM_TIM17_TI1_HSE_32        (TIM17_OR1_TI1_RMP_1)                                 /* !< TIM17 TI1 is connected to HSE div 32 */
+#define TIM_TIM17_TI1_MCO           (TIM17_OR1_TI1_RMP_1 | TIM17_OR1_TI1_RMP_0)           /* !< TIM17 TI1 is connected to MCO */
+/**
+  * @}
+  */ 
+
+/** @defgroup TIMEx_Break_Input TIM  Extended Break input
+  * @{
+  */
+#define TIM_BREAKINPUT_BRK     ((uint32_t)(0x00000001)) /* !< Timer break input  */
+#define TIM_BREAKINPUT_BRK2    ((uint32_t)(0x00000002)) /* !< Timer break2 input */
+/**
+  * @}
+  */ 
+
+/** @defgroup TIMEx_Break_Input_Source TIM  Extended Break input source
+  * @{
+  */
+#define TIM_BREAKINPUTSOURCE_BKIN     ((uint32_t)(0x00000001)) /* !< An external source (GPIO) is connected to the BKIN pin  */
+#define TIM_BREAKINPUTSOURCE_COMP1    ((uint32_t)(0x00000002)) /* !< The COMP1 output is connected to the break input */
+#define TIM_BREAKINPUTSOURCE_COMP2    ((uint32_t)(0x00000004)) /* !< The COMP2 output is connected to the break input */
+#define TIM_BREAKINPUTSOURCE_DFSDM    ((uint32_t)(0x00000008)) /* !< The analog watchdog output of the DFSDM peripheral is connected to the break input */
+/**
+  * @}
+  */ 
+
+/** @defgroup TIMEx_Break_Input_Source_Enable TIM Extended Break input source enabling
+  * @{
+  */
+#define TIM_BREAKINPUTSOURCE_DISABLE     ((uint32_t)(0x00000000)) /* !< Break input source is disabled */
+#define TIM_BREAKINPUTSOURCE_ENABLE      ((uint32_t)(0x00000001)) /* !< Break input source is enabled */
+/**
+  * @}
+  */ 
+
+/** @defgroup TIMEx_Break_Input_Source_Polarity TIM  Extended Break input polarity
+  * @{
+  */
+#define TIM_BREAKINPUTSOURCE_POLARITY_LOW     ((uint32_t)(0x00000001)) /* !< Break input source is active low */
+#define TIM_BREAKINPUTSOURCE_POLARITY_HIGH    ((uint32_t)(0x00000000)) /* !< Break input source is active_high */
+/**
+  * @}
+  */ 
+   
+/**
+  * @}
+  */ 
+/* End of exported constants -------------------------------------------------*/
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup TIMEx_Exported_Macros TIM Extended Exported Macros
+  * @{
+  */  
+
+/**
+  * @}
+  */ 
+/* End of exported macro -----------------------------------------------------*/
+
+/* Private macro -------------------------------------------------------------*/
+/** @defgroup TIMEx_Private_Macros TIM Extended Private Macros
+  * @{
+  */  
+#define IS_TIM_REMAP(__REMAP__)    (((__REMAP__) <= (uint32_t)0x0001C01F))
+
+#define IS_TIM_BREAKINPUT(__BREAKINPUT__)  (((__BREAKINPUT__) == TIM_BREAKINPUT_BRK)  || \
+                                            ((__BREAKINPUT__) == TIM_BREAKINPUT_BRK2))
+
+#define IS_TIM_BREAKINPUTSOURCE(__SOURCE__)  (((__SOURCE__) == TIM_BREAKINPUTSOURCE_BKIN)  || \
+                                              ((__SOURCE__) == TIM_BREAKINPUTSOURCE_COMP1) || \
+                                              ((__SOURCE__) == TIM_BREAKINPUTSOURCE_COMP2) || \
+                                              ((__SOURCE__) == TIM_BREAKINPUTSOURCE_DFSDM))
+
+#define IS_TIM_BREAKINPUTSOURCE_STATE(__STATE__)  (((__STATE__) == TIM_BREAKINPUTSOURCE_DISABLE)  || \
+                                                   ((__STATE__) == TIM_BREAKINPUTSOURCE_ENABLE))
+
+#define IS_TIM_BREAKINPUTSOURCE_POLARITY(__POLARITY__)  (((__POLARITY__) == TIM_BREAKINPUTSOURCE_POLARITY_LOW)  || \
+                                                         ((__POLARITY__) == TIM_BREAKINPUTSOURCE_POLARITY_HIGH))
+/**
+  * @}
+  */ 
+/* End of private macro ------------------------------------------------------*/
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup TIMEx_Exported_Functions TIM Extended Exported Functions
+  * @{
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group1 Extended Timer Hall Sensor functions 
+ *  @brief    Timer Hall Sensor functions
+ * @{
+ */
+/*  Timer Hall Sensor functions  **********************************************/
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef *htim, TIM_HallSensor_InitTypeDef* sConfig);
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_DeInit(TIM_HandleTypeDef *htim);
+
+void HAL_TIMEx_HallSensor_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIMEx_HallSensor_MspDeInit(TIM_HandleTypeDef *htim);
+
+ /* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop(TIM_HandleTypeDef *htim);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_IT(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_IT(TIM_HandleTypeDef *htim);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_DMA(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group2 Extended Timer Complementary Output Compare functions
+ *  @brief   Timer Complementary Output Compare functions
+ * @{
+ */
+/*  Timer Complementary Output Compare functions  *****************************/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIMEx_OCN_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+/**
+  * @}
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group3 Extended Timer Complementary PWM functions
+ *  @brief    Timer Complementary PWM functions
+ * @{
+ */
+/*  Timer Complementary PWM functions  ****************************************/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+/**
+  * @}
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group4 Extended Timer Complementary One Pulse functions
+ *  @brief    Timer Complementary One Pulse functions
+ * @{
+ */
+/*  Timer Complementary One Pulse functions  **********************************/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+/**
+  * @}
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group5 Extended Peripheral Control functions
+ *  @brief    Peripheral Control functions
+ * @{
+ */
+/* Extended Control functions  ************************************************/
+HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent(TIM_HandleTypeDef *htim, uint32_t  InputTrigger, uint32_t  CommutationSource);
+HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent_IT(TIM_HandleTypeDef *htim, uint32_t  InputTrigger, uint32_t  CommutationSource);
+HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent_DMA(TIM_HandleTypeDef *htim, uint32_t  InputTrigger, uint32_t  CommutationSource);
+HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim, TIM_MasterConfigTypeDef * sMasterConfig);
+HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim, TIM_BreakDeadTimeConfigTypeDef *sBreakDeadTimeConfig);
+HAL_StatusTypeDef HAL_TIMEx_ConfigBreakInput(TIM_HandleTypeDef *htim, uint32_t BreakInput, TIMEx_BreakInputConfigTypeDef *sBreakInputConfig);
+HAL_StatusTypeDef HAL_TIMEx_GroupChannel5(TIM_HandleTypeDef *htim, uint32_t Channels);
+HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap);
+
+/**
+  * @}
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group6 Extended Callbacks functions 
+  * @brief    Extended Callbacks functions
+  * @{
+  */
+/* Extended Callback **********************************************************/
+void HAL_TIMEx_CommutationCallback(TIM_HandleTypeDef *htim);
+void HAL_TIMEx_BreakCallback(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
+
+/** @addtogroup TIMEx_Exported_Functions_Group7 Extended Peripheral State functions 
+  * @brief    Extended Peripheral State functions
+  * @{
+  */
+/* Extended Peripheral State functions  ***************************************/
+HAL_TIM_StateTypeDef HAL_TIMEx_HallSensor_GetState(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+/* End of exported functions -------------------------------------------------*/
+
+/* Private functions----------------------------------------------------------*/
+/** @defgroup TIMEx_Private_Functions TIMEx Private Functions
+* @{
+*/
+void TIMEx_DMACommutationCplt(DMA_HandleTypeDef *hdma);
+/**
+* @}
+*/ 
+/* End of private functions --------------------------------------------------*/
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L4xx_HAL_TIM_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_uart.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_uart.h
@@ -1,0 +1,1379 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_uart.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of UART HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_UART_H
+#define __STM32L4xx_HAL_UART_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup UART
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup UART_Exported_Types UART Exported Types
+  * @{
+  */
+
+/**
+  * @brief UART Init Structure definition
+  */
+typedef struct
+{
+  uint32_t BaudRate;                  /*!< This member configures the UART communication baud rate.
+                                           The baud rate register is computed using the following formula:
+                                           - If oversampling is 16 or in LIN mode,
+                                              Baud Rate Register = ((PCLKx) / ((huart->Init.BaudRate)))
+                                           - If oversampling is 8,
+                                           - -  Baud Rate Register[15:4] = ((2 * PCLKx) / ((huart->Init.BaudRate)))[15:4]
+                                           - -  Baud Rate Register[3] =  0
+                                           - -  Baud Rate Register[2:0] =  (((2 * PCLKx) / ((huart->Init.BaudRate)))[3:0]) >> 1      */
+
+  uint32_t WordLength;                /*!< Specifies the number of data bits transmitted or received in a frame.
+                                           This parameter can be a value of @ref UARTEx_Word_Length. */
+
+  uint32_t StopBits;                  /*!< Specifies the number of stop bits transmitted.
+                                           This parameter can be a value of @ref UART_Stop_Bits. */
+
+  uint32_t Parity;                    /*!< Specifies the parity mode.
+                                           This parameter can be a value of @ref UART_Parity
+                                           @note When parity is enabled, the computed parity is inserted
+                                                 at the MSB position of the transmitted data (9th bit when
+                                                 the word length is set to 9 data bits; 8th bit when the
+                                                 word length is set to 8 data bits). */
+
+  uint32_t Mode;                      /*!< Specifies whether the Receive or Transmit mode is enabled or disabled.
+                                           This parameter can be a value of @ref UART_Mode. */
+
+  uint32_t HwFlowCtl;                 /*!< Specifies whether the hardware flow control mode is enabled
+                                           or disabled.
+                                           This parameter can be a value of @ref UART_Hardware_Flow_Control. */
+
+  uint32_t OverSampling;              /*!< Specifies whether the Over sampling 8 is enabled or disabled, to achieve higher speed (up to f_PCLK/8).
+                                           This parameter can be a value of @ref UART_Over_Sampling. */
+
+  uint32_t OneBitSampling;            /*!< Specifies whether a single sample or three samples' majority vote is selected.
+                                           Selecting the single sample method increases the receiver tolerance to clock
+                                           deviations. This parameter can be a value of @ref UART_OneBit_Sampling. */
+}UART_InitTypeDef;
+
+/**
+  * @brief  UART Advanced Features initalization structure definition
+  */
+typedef struct
+{
+  uint32_t AdvFeatureInit;        /*!< Specifies which advanced UART features is initialized. Several
+                                       Advanced Features may be initialized at the same time .
+                                       This parameter can be a value of @ref UART_Advanced_Features_Initialization_Type. */
+
+  uint32_t TxPinLevelInvert;      /*!< Specifies whether the TX pin active level is inverted.
+                                       This parameter can be a value of @ref UART_Tx_Inv.  */
+
+  uint32_t RxPinLevelInvert;      /*!< Specifies whether the RX pin active level is inverted.
+                                       This parameter can be a value of @ref UART_Rx_Inv.  */
+
+  uint32_t DataInvert;            /*!< Specifies whether data are inverted (positive/direct logic
+                                       vs negative/inverted logic).
+                                       This parameter can be a value of @ref UART_Data_Inv. */
+
+  uint32_t Swap;                  /*!< Specifies whether TX and RX pins are swapped.
+                                       This parameter can be a value of @ref UART_Rx_Tx_Swap. */
+
+  uint32_t OverrunDisable;        /*!< Specifies whether the reception overrun detection is disabled.
+                                       This parameter can be a value of @ref UART_Overrun_Disable. */
+
+  uint32_t DMADisableonRxError;   /*!< Specifies whether the DMA is disabled in case of reception error.
+                                       This parameter can be a value of @ref UART_DMA_Disable_on_Rx_Error. */
+
+  uint32_t AutoBaudRateEnable;    /*!< Specifies whether auto Baud rate detection is enabled.
+                                       This parameter can be a value of @ref UART_AutoBaudRate_Enable */
+
+  uint32_t AutoBaudRateMode;      /*!< If auto Baud rate detection is enabled, specifies how the rate
+                                       detection is carried out.
+                                       This parameter can be a value of @ref UART_AutoBaud_Rate_Mode. */
+
+  uint32_t MSBFirst;              /*!< Specifies whether MSB is sent first on UART line.
+                                       This parameter can be a value of @ref UART_MSB_First. */
+} UART_AdvFeatureInitTypeDef;
+
+
+
+/**
+  * @brief HAL UART State structures definition
+  */
+typedef enum
+{
+  HAL_UART_STATE_RESET             = 0x00,    /*!< Peripheral is not initialized                      */
+  HAL_UART_STATE_READY             = 0x01,    /*!< Peripheral Initialized and ready for use           */
+  HAL_UART_STATE_BUSY              = 0x02,    /*!< an internal process is ongoing                     */
+  HAL_UART_STATE_BUSY_TX           = 0x12,    /*!< Data Transmission process is ongoing               */
+  HAL_UART_STATE_BUSY_RX           = 0x22,    /*!< Data Reception process is ongoing                  */
+  HAL_UART_STATE_BUSY_TX_RX        = 0x32,    /*!< Data Transmission and Reception process is ongoing */
+  HAL_UART_STATE_TIMEOUT           = 0x03,    /*!< Timeout state                                      */
+  HAL_UART_STATE_ERROR             = 0x04     /*!< Error                                              */
+}HAL_UART_StateTypeDef;
+
+/**
+  * @brief  HAL UART Error Code structure definition
+  */
+typedef enum
+{
+  HAL_UART_ERROR_NONE      = 0x00,    /*!< No error            */
+  HAL_UART_ERROR_PE        = 0x01,    /*!< Parity error        */
+  HAL_UART_ERROR_NE        = 0x02,    /*!< Noise error         */
+  HAL_UART_ERROR_FE        = 0x04,    /*!< frame error         */
+  HAL_UART_ERROR_ORE       = 0x08,    /*!< Overrun error       */
+  HAL_UART_ERROR_DMA       = 0x10     /*!< DMA transfer error  */
+}HAL_UART_ErrorTypeDef;
+
+/**
+  * @brief UART clock sources definition
+  */
+typedef enum
+{
+  UART_CLOCKSOURCE_PCLK1      = 0x00,    /*!< PCLK1 clock source  */
+  UART_CLOCKSOURCE_PCLK2      = 0x01,    /*!< PCLK2 clock source  */
+  UART_CLOCKSOURCE_HSI        = 0x02,    /*!< HSI clock source    */
+  UART_CLOCKSOURCE_SYSCLK     = 0x04,    /*!< SYSCLK clock source */
+  UART_CLOCKSOURCE_LSE        = 0x08,    /*!< LSE clock source       */
+  UART_CLOCKSOURCE_UNDEFINED  = 0x10     /*!< Undefined clock source */
+}UART_ClockSourceTypeDef;
+
+/**
+  * @brief  UART handle Structure definition
+  */
+typedef struct
+{
+  USART_TypeDef            *Instance;        /*!< UART registers base address        */
+
+  UART_InitTypeDef         Init;             /*!< UART communication parameters      */
+
+  UART_AdvFeatureInitTypeDef AdvancedInit;   /*!< UART Advanced Features initialization parameters */
+
+  uint8_t                  *pTxBuffPtr;      /*!< Pointer to UART Tx transfer Buffer */
+
+  uint16_t                 TxXferSize;       /*!< UART Tx Transfer size              */
+
+  uint16_t                 TxXferCount;      /*!< UART Tx Transfer Counter           */
+
+  uint8_t                  *pRxBuffPtr;      /*!< Pointer to UART Rx transfer Buffer */
+
+  uint16_t                 RxXferSize;       /*!< UART Rx Transfer size              */
+
+  uint16_t                 RxXferCount;      /*!< UART Rx Transfer Counter           */
+
+  uint16_t                 Mask;             /*!< UART Rx RDR register mask          */
+
+  DMA_HandleTypeDef        *hdmatx;          /*!< UART Tx DMA Handle parameters      */
+
+  DMA_HandleTypeDef        *hdmarx;          /*!< UART Rx DMA Handle parameters      */
+
+  HAL_LockTypeDef           Lock;            /*!< Locking object                     */
+
+  __IO HAL_UART_StateTypeDef    State;       /*!< UART communication state           */
+
+  __IO uint32_t             ErrorCode;       /*!< UART Error code                    */
+
+}UART_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup UART_Exported_Constants UART Exported Constants
+  * @{
+  */
+
+/** @defgroup UART_Stop_Bits   UART Number of Stop Bits
+  * @{
+  */
+#define UART_STOPBITS_0_5                    USART_CR2_STOP_0                     /*!< UART frame with 0.5 stop bit  */
+#define UART_STOPBITS_1                     ((uint32_t)0x00000000)                /*!< UART frame with 1 stop bit    */
+#define UART_STOPBITS_1_5                   (USART_CR2_STOP_0 | USART_CR2_STOP_1) /*!< UART frame with 1.5 stop bits */
+#define UART_STOPBITS_2                      USART_CR2_STOP_1                     /*!< UART frame with 2 stop bits   */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Parity  UART Parity
+  * @{
+  */
+#define UART_PARITY_NONE                    ((uint32_t)0x00000000)                         /*!< No parity   */
+#define UART_PARITY_EVEN                    ((uint32_t)USART_CR1_PCE)                      /*!< Even parity */
+#define UART_PARITY_ODD                     ((uint32_t)(USART_CR1_PCE | USART_CR1_PS))     /*!< Odd parity  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Hardware_Flow_Control UART Hardware Flow Control
+  * @{
+  */
+#define UART_HWCONTROL_NONE                  ((uint32_t)0x00000000)                           /*!< No hardware control       */
+#define UART_HWCONTROL_RTS                   ((uint32_t)USART_CR3_RTSE)                       /*!< Request To Send           */
+#define UART_HWCONTROL_CTS                   ((uint32_t)USART_CR3_CTSE)                       /*!< Clear To Send             */
+#define UART_HWCONTROL_RTS_CTS               ((uint32_t)(USART_CR3_RTSE | USART_CR3_CTSE))    /*!< Request and Clear To Send */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Mode UART Transfer Mode
+  * @{
+  */
+#define UART_MODE_RX                        ((uint32_t)USART_CR1_RE)                    /*!< RX mode        */ 
+#define UART_MODE_TX                        ((uint32_t)USART_CR1_TE)                    /*!< TX mode        */ 
+#define UART_MODE_TX_RX                     ((uint32_t)(USART_CR1_TE |USART_CR1_RE))    /*!< RX and TX mode */ 
+/**
+  * @}
+  */
+
+ /** @defgroup UART_State  UART State
+  * @{
+  */
+#define UART_STATE_DISABLE                  ((uint32_t)0x00000000)          /*!< UART disabled  */
+#define UART_STATE_ENABLE                   ((uint32_t)USART_CR1_UE)        /*!< UART enabled   */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Over_Sampling UART Over Sampling
+  * @{
+  */
+#define UART_OVERSAMPLING_16                ((uint32_t)0x00000000)          /*!< Oversampling by 16 */
+#define UART_OVERSAMPLING_8                 ((uint32_t)USART_CR1_OVER8)     /*!< Oversampling by 8  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_OneBit_Sampling UART One Bit Sampling Method
+  * @{
+  */
+#define UART_ONE_BIT_SAMPLE_DISABLE         ((uint32_t)0x00000000)          /*!< One-bit sampling disable */
+#define UART_ONE_BIT_SAMPLE_ENABLE          ((uint32_t)USART_CR3_ONEBIT)    /*!< One-bit sampling enable  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_AutoBaud_Rate_Mode    UART Advanced Feature AutoBaud Rate Mode
+  * @{
+  */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ONSTARTBIT    ((uint32_t)0x0000)                /*!< Auto Baud rate detection on start bit            */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ONFALLINGEDGE ((uint32_t)USART_CR2_ABRMODE_0)   /*!< Auto Baud rate detection on falling edge         */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X7FFRAME   ((uint32_t)USART_CR2_ABRMODE_1)   /*!< Auto Baud rate detection on 0x7F frame detection */    
+#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X55FRAME   ((uint32_t)USART_CR2_ABRMODE)     /*!< Auto Baud rate detection on 0x55 frame detection */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Receiver_TimeOut UART Receiver TimeOut
+  * @{
+  */
+#define UART_RECEIVER_TIMEOUT_DISABLE       ((uint32_t)0x00000000)                  /*!< UART receiver timeout disable */
+#define UART_RECEIVER_TIMEOUT_ENABLE        ((uint32_t)USART_CR2_RTOEN)             /*!< UART receiver timeout enable  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_LIN    UART Local Interconnection Network mode
+  * @{
+  */
+#define UART_LIN_DISABLE                    ((uint32_t)0x00000000)                 /*!< Local Interconnect Network disable */
+#define UART_LIN_ENABLE                     ((uint32_t)USART_CR2_LINEN)            /*!< Local Interconnect Network enable  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_LIN_Break_Detection  UART LIN Break Detection
+  * @{
+  */
+#define UART_LINBREAKDETECTLENGTH_10B       ((uint32_t)0x00000000)                /*!< LIN 10-bit break detection length */
+#define UART_LINBREAKDETECTLENGTH_11B       ((uint32_t)USART_CR2_LBDL)            /*!< LIN 11-bit break detection length  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_DMA_Tx    UART DMA Tx
+  * @{
+  */
+#define UART_DMA_TX_DISABLE                 ((uint32_t)0x00000000)                /*!< UART DMA TX disabled */
+#define UART_DMA_TX_ENABLE                  ((uint32_t)USART_CR3_DMAT)            /*!< UART DMA TX enabled  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_DMA_Rx   UART DMA Rx
+  * @{
+  */
+#define UART_DMA_RX_DISABLE                 ((uint32_t)0x0000)                      /*!< UART DMA RX disabled */
+#define UART_DMA_RX_ENABLE                  ((uint32_t)USART_CR3_DMAR)              /*!< UART DMA RX enabled  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Half_Duplex_Selection  UART Half Duplex Selection
+  * @{
+  */
+#define UART_HALF_DUPLEX_DISABLE            ((uint32_t)0x0000)                      /*!< UART half-duplex disabled */
+#define UART_HALF_DUPLEX_ENABLE             ((uint32_t)USART_CR3_HDSEL)             /*!< UART half-duplex enabled  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_WakeUp_Methods   UART WakeUp Methods
+  * @{
+  */
+#define UART_WAKEUPMETHOD_IDLELINE          ((uint32_t)0x00000000)                  /*!< UART wake-up on idle line    */
+#define UART_WAKEUPMETHOD_ADDRESSMARK       ((uint32_t)USART_CR1_WAKE)              /*!< UART wake-up on address mark */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Request_Parameters UART Request Parameters
+  * @{
+  */
+#define UART_AUTOBAUD_REQUEST               ((uint32_t)USART_RQR_ABRRQ)        /*!< Auto-Baud Rate Request      */
+#define UART_SENDBREAK_REQUEST              ((uint32_t)USART_RQR_SBKRQ)        /*!< Send Break Request          */
+#define UART_MUTE_MODE_REQUEST              ((uint32_t)USART_RQR_MMRQ)         /*!< Mute Mode Request           */
+#define UART_RXDATA_FLUSH_REQUEST           ((uint32_t)USART_RQR_RXFRQ)        /*!< Receive Data flush Request  */
+#define UART_TXDATA_FLUSH_REQUEST           ((uint32_t)USART_RQR_TXFRQ)        /*!< Transmit data flush Request */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Advanced_Features_Initialization_Type  UART Advanced Feature Initialization Type
+  * @{
+  */
+#define UART_ADVFEATURE_NO_INIT                 ((uint32_t)0x00000000)          /*!< No advanced feature initialization       */
+#define UART_ADVFEATURE_TXINVERT_INIT           ((uint32_t)0x00000001)          /*!< TX pin active level inversion            */
+#define UART_ADVFEATURE_RXINVERT_INIT           ((uint32_t)0x00000002)          /*!< RX pin active level inversion            */
+#define UART_ADVFEATURE_DATAINVERT_INIT         ((uint32_t)0x00000004)          /*!< Binary data inversion                    */
+#define UART_ADVFEATURE_SWAP_INIT               ((uint32_t)0x00000008)          /*!< TX/RX pins swap                          */
+#define UART_ADVFEATURE_RXOVERRUNDISABLE_INIT   ((uint32_t)0x00000010)          /*!< RX overrun disable                       */
+#define UART_ADVFEATURE_DMADISABLEONERROR_INIT  ((uint32_t)0x00000020)          /*!< DMA disable on Reception Error           */
+#define UART_ADVFEATURE_AUTOBAUDRATE_INIT       ((uint32_t)0x00000040)          /*!< Auto Baud rate detection initialization  */
+#define UART_ADVFEATURE_MSBFIRST_INIT           ((uint32_t)0x00000080)          /*!< Most significant bit sent/received first */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Tx_Inv UART Advanced Feature TX Pin Active Level Inversion
+  * @{
+  */
+#define UART_ADVFEATURE_TXINV_DISABLE       ((uint32_t)0x00000000)              /*!< TX pin active level inversion disable */
+#define UART_ADVFEATURE_TXINV_ENABLE        ((uint32_t)USART_CR2_TXINV)         /*!< TX pin active level inversion enable  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Rx_Inv UART Advanced Feature RX Pin Active Level Inversion
+  * @{
+  */
+#define UART_ADVFEATURE_RXINV_DISABLE       ((uint32_t)0x00000000)              /*!< RX pin active level inversion disable */ 
+#define UART_ADVFEATURE_RXINV_ENABLE        ((uint32_t)USART_CR2_RXINV)         /*!< RX pin active level inversion enable  */ 
+/**
+  * @}
+  */
+
+/** @defgroup UART_Data_Inv  UART Advanced Feature Binary Data Inversion
+  * @{
+  */
+#define UART_ADVFEATURE_DATAINV_DISABLE     ((uint32_t)0x00000000)              /*!< Binary data inversion disable */
+#define UART_ADVFEATURE_DATAINV_ENABLE      ((uint32_t)USART_CR2_DATAINV)       /*!< Binary data inversion enable  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Rx_Tx_Swap UART Advanced Feature RX TX Pins Swap
+  * @{
+  */
+#define UART_ADVFEATURE_SWAP_DISABLE        ((uint32_t)0x00000000)              /*!< TX/RX pins swap disable */
+#define UART_ADVFEATURE_SWAP_ENABLE         ((uint32_t)USART_CR2_SWAP)          /*!< TX/RX pins swap enable  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Overrun_Disable  UART Advanced Feature Overrun Disable
+  * @{
+  */
+#define UART_ADVFEATURE_OVERRUN_ENABLE      ((uint32_t)0x00000000)              /*!< RX overrun enable  */ 
+#define UART_ADVFEATURE_OVERRUN_DISABLE     ((uint32_t)USART_CR3_OVRDIS)        /*!< RX overrun disable */ 
+/**
+  * @}
+  */
+
+/** @defgroup UART_AutoBaudRate_Enable  UART Advanced Feature Auto BaudRate Enable
+  * @{
+  */
+#define UART_ADVFEATURE_AUTOBAUDRATE_DISABLE   ((uint32_t)0x00000000)           /*!< RX Auto Baud rate detection enable  */ 
+#define UART_ADVFEATURE_AUTOBAUDRATE_ENABLE    ((uint32_t)USART_CR2_ABREN)      /*!< RX Auto Baud rate detection disable */ 
+/**
+  * @}
+  */
+
+/** @defgroup UART_DMA_Disable_on_Rx_Error   UART Advanced Feature DMA Disable On Rx Error
+  * @{
+  */
+#define UART_ADVFEATURE_DMA_ENABLEONRXERROR    ((uint32_t)0x00000000)           /*!< DMA enable on Reception Error  */
+#define UART_ADVFEATURE_DMA_DISABLEONRXERROR   ((uint32_t)USART_CR3_DDRE)       /*!< DMA disable on Reception Error */
+/**
+  * @}
+  */
+
+/** @defgroup UART_MSB_First   UART Advanced Feature MSB First
+  * @{
+  */
+#define UART_ADVFEATURE_MSBFIRST_DISABLE    ((uint32_t)0x00000000)              /*!< Most significant bit sent/received first disable */
+#define UART_ADVFEATURE_MSBFIRST_ENABLE     ((uint32_t)USART_CR2_MSBFIRST)      /*!< Most significant bit sent/received first enable  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Stop_Mode_Enable   UART Advanced Feature Stop Mode Enable
+  * @{
+  */
+#define UART_ADVFEATURE_STOPMODE_DISABLE    ((uint32_t)0x00000000)              /*!< UART stop mode disable */
+#define UART_ADVFEATURE_STOPMODE_ENABLE     ((uint32_t)USART_CR1_UESM)          /*!< UART stop mode enable  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Mute_Mode   UART Advanced Feature Mute Mode Enable
+  * @{
+  */
+#define UART_ADVFEATURE_MUTEMODE_DISABLE    ((uint32_t)0x00000000)              /*!< UART mute mode disable */
+#define UART_ADVFEATURE_MUTEMODE_ENABLE     ((uint32_t)USART_CR1_MME)           /*!< UART mute mode enable  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_CR2_ADDRESS_LSB_POS    UART Address-matching LSB Position In CR2 Register
+  * @{
+  */
+#define UART_CR2_ADDRESS_LSB_POS            ((uint32_t) 24)                     /*!< UART address-matching LSB position in CR2 register */
+/**
+  * @}
+  */
+
+/** @defgroup UART_WakeUp_from_Stop_Selection   UART WakeUp From Stop Selection
+  * @{
+  */
+#define UART_WAKEUP_ON_ADDRESS              ((uint32_t)0x00000000)              /*!< UART wake-up on address                         */
+#define UART_WAKEUP_ON_STARTBIT             ((uint32_t)USART_CR3_WUS_1)         /*!< UART wake-up on start bit                       */
+#define UART_WAKEUP_ON_READDATA_NONEMPTY    ((uint32_t)USART_CR3_WUS)           /*!< UART wake-up on receive data register not empty */
+/**
+  * @}
+  */
+
+/** @defgroup UART_DriverEnable_Polarity      UART DriverEnable Polarity
+  * @{
+  */
+#define UART_DE_POLARITY_HIGH               ((uint32_t)0x00000000)              /*!< Driver enable signal is active high */
+#define UART_DE_POLARITY_LOW                ((uint32_t)USART_CR3_DEP)           /*!< Driver enable signal is active low  */
+/**
+  * @}
+  */
+
+/** @defgroup UART_CR1_DEAT_ADDRESS_LSB_POS    UART Driver Enable Assertion Time LSB Position In CR1 Register
+  * @{
+  */
+#define UART_CR1_DEAT_ADDRESS_LSB_POS       ((uint32_t) 21)                     /*!< UART Driver Enable assertion time LSB position in CR1 register */
+/**
+  * @}
+  */
+
+/** @defgroup UART_CR1_DEDT_ADDRESS_LSB_POS    UART Driver Enable DeAssertion Time LSB Position In CR1 Register
+  * @{
+  */
+#define UART_CR1_DEDT_ADDRESS_LSB_POS       ((uint32_t) 16)                     /*!< UART Driver Enable de-assertion time LSB position in CR1 register */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Interruption_Mask    UART Interruptions Flag Mask
+  * @{
+  */
+#define UART_IT_MASK                        ((uint32_t)0x001F)                  /*!< UART interruptions flags mask */
+/**
+  * @}
+  */
+
+/** @defgroup UART_TimeOut_Value    UART polling-based communications time-out value
+  * @{
+  */
+#define HAL_UART_TIMEOUT_VALUE              0x1FFFFFF                           /*!< UART polling-based communications time-out value */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Flags     UART Status Flags
+  *        Elements values convention: 0xXXXX
+  *           - 0xXXXX  : Flag mask in the ISR register
+  * @{
+  */
+#define UART_FLAG_REACK                     ((uint32_t)0x00400000)              /*!< UART receive enable acknowledge flag      */
+#define UART_FLAG_TEACK                     ((uint32_t)0x00200000)              /*!< UART transmit enable acknowledge flag     */
+#define UART_FLAG_WUF                       ((uint32_t)0x00100000)              /*!< UART wake-up from stop mode flag          */
+#define UART_FLAG_RWU                       ((uint32_t)0x00080000)              /*!< UART receiver wake-up from mute mode flag */
+#define UART_FLAG_SBKF                      ((uint32_t)0x00040000)              /*!< UART send break flag                      */
+#define UART_FLAG_CMF                       ((uint32_t)0x00020000)              /*!< UART character match flag                 */
+#define UART_FLAG_BUSY                      ((uint32_t)0x00010000)              /*!< UART busy flag                            */
+#define UART_FLAG_ABRF                      ((uint32_t)0x00008000)              /*!< UART auto Baud rate flag                  */
+#define UART_FLAG_ABRE                      ((uint32_t)0x00004000)              /*!< UART uto Baud rate error                  */
+#define UART_FLAG_EOBF                      ((uint32_t)0x00001000)              /*!< UART end of block flag                    */
+#define UART_FLAG_RTOF                      ((uint32_t)0x00000800)              /*!< UART receiver timeout flag                */
+#define UART_FLAG_CTS                       ((uint32_t)0x00000400)              /*!< UART clear to send flag                   */
+#define UART_FLAG_CTSIF                     ((uint32_t)0x00000200)              /*!< UART clear to send interrupt flag         */
+#define UART_FLAG_LBDF                      ((uint32_t)0x00000100)              /*!< UART LIN break detection flag             */
+#define UART_FLAG_TXE                       ((uint32_t)0x00000080)              /*!< UART transmit data register empty         */
+#define UART_FLAG_TC                        ((uint32_t)0x00000040)              /*!< UART transmission complete                */
+#define UART_FLAG_RXNE                      ((uint32_t)0x00000020)              /*!< UART read data register not empty         */
+#define UART_FLAG_IDLE                      ((uint32_t)0x00000010)              /*!< UART idle flag                            */
+#define UART_FLAG_ORE                       ((uint32_t)0x00000008)              /*!< UART overrun error                        */
+#define UART_FLAG_NE                        ((uint32_t)0x00000004)              /*!< UART noise error                          */
+#define UART_FLAG_FE                        ((uint32_t)0x00000002)              /*!< UART frame error                          */
+#define UART_FLAG_PE                        ((uint32_t)0x00000001)              /*!< UART parity error                         */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Interrupt_definition   UART Interrupts Definition
+  *        Elements values convention: 000ZZZZZ0XXYYYYYb
+  *           - YYYYY  : Interrupt source position in the XX register (5bits)
+  *           - XX  : Interrupt source register (2bits)
+  *                 - 01: CR1 register
+  *                 - 10: CR2 register
+  *                 - 11: CR3 register
+  *           - ZZZZZ  : Flag position in the ISR register(5bits)
+  * @{
+  */
+#define UART_IT_PE                          ((uint32_t)0x0028)                  /*!< UART parity error interruption                 */    
+#define UART_IT_TXE                         ((uint32_t)0x0727)                  /*!< UART transmit data register empty interruption */    
+#define UART_IT_TC                          ((uint32_t)0x0626)                  /*!< UART transmission complete interruption        */    
+#define UART_IT_RXNE                        ((uint32_t)0x0525)                  /*!< UART read data register not empty interruption */    
+#define UART_IT_IDLE                        ((uint32_t)0x0424)                  /*!< UART idle interruption                         */                                                               
+#define UART_IT_LBD                         ((uint32_t)0x0846)                  /*!< UART LIN break detection interruption          */                
+#define UART_IT_CTS                         ((uint32_t)0x096A)                  /*!< UART CTS interruption                          */                
+#define UART_IT_CM                          ((uint32_t)0x112E)                  /*!< UART character match interruption              */                
+#define UART_IT_WUF                         ((uint32_t)0x1476)                  /*!< UART wake-up from stop mode interruption       */                
+                                                                                                     
+/*        Elements values convention: 000000000XXYYYYYb                                         
+              - YYYYY  : Interrupt source position in the XX register (5bits)                   
+              - XX  : Interrupt source register (2bits)
+                    - 01: CR1 register
+                    - 10: CR2 register
+                    - 11: CR3 register */
+#define UART_IT_ERR                         ((uint32_t)0x0060)                  /*!< UART error interruption         */   
+                                                                                  
+/*       Elements values convention: 0000ZZZZ00000000b                            
+             - ZZZZ  : Flag position in the ISR register(4bits) */                
+#define UART_IT_ORE                         ((uint32_t)0x0300)                  /*!< UART overrun error interruption */ 
+#define UART_IT_NE                          ((uint32_t)0x0200)                  /*!< UART noise error interruption   */ 
+#define UART_IT_FE                          ((uint32_t)0x0100)                  /*!< UART frame error interruption   */ 
+/**
+  * @}
+  */
+
+/** @defgroup UART_IT_CLEAR_Flags  UART Interruption Clear Flags
+  * @{
+  */
+#define UART_CLEAR_PEF                       USART_ICR_PECF            /*!< Parity Error Clear Flag           */
+#define UART_CLEAR_FEF                       USART_ICR_FECF            /*!< Framing Error Clear Flag          */
+#define UART_CLEAR_NEF                       USART_ICR_NCF             /*!< Noise detected Clear Flag         */
+#define UART_CLEAR_OREF                      USART_ICR_ORECF           /*!< Overrun Error Clear Flag          */
+#define UART_CLEAR_IDLEF                     USART_ICR_IDLECF          /*!< IDLE line detected Clear Flag     */
+#define UART_CLEAR_TCF                       USART_ICR_TCCF            /*!< Transmission Complete Clear Flag  */
+#define UART_CLEAR_LBDF                      USART_ICR_LBDCF           /*!< LIN Break Detection Clear Flag    */
+#define UART_CLEAR_CTSF                      USART_ICR_CTSCF           /*!< CTS Interrupt Clear Flag          */
+#define UART_CLEAR_RTOF                      USART_ICR_RTOCF           /*!< Receiver Time Out Clear Flag      */
+#define UART_CLEAR_EOBF                      USART_ICR_EOBCF           /*!< End Of Block Clear Flag           */
+#define UART_CLEAR_CMF                       USART_ICR_CMCF            /*!< Character Match Clear Flag        */
+#define UART_CLEAR_WUF                       USART_ICR_WUCF            /*!< Wake Up from stop mode Clear Flag */
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup UART_Exported_Macros UART Exported Macros
+  * @{
+  */
+
+/** @brief Reset UART handle state.
+  * @param  __HANDLE__: UART handle.
+  * @retval None
+  */
+#define __HAL_UART_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_UART_STATE_RESET)
+
+/** @brief  Flush the UART Data registers.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None  
+  */
+#define __HAL_UART_FLUSH_DRREGISTER(__HANDLE__)  \
+  do{                \
+      SET_BIT((__HANDLE__)->Instance->RQR, UART_RXDATA_FLUSH_REQUEST); \
+      SET_BIT((__HANDLE__)->Instance->RQR, UART_TXDATA_FLUSH_REQUEST); \
+    }  while(0)
+
+/** @brief  Clear the specified UART pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *          This parameter can be any combination of the following values:
+  *            @arg @ref UART_CLEAR_PEF      Parity Error Clear Flag           
+  *            @arg @ref UART_CLEAR_FEF      Framing Error Clear Flag          
+  *            @arg @ref UART_CLEAR_NEF      Noise detected Clear Flag         
+  *            @arg @ref UART_CLEAR_OREF     Overrun Error Clear Flag          
+  *            @arg @ref UART_CLEAR_IDLEF    IDLE line detected Clear Flag     
+  *            @arg @ref UART_CLEAR_TCF      Transmission Complete Clear Flag  
+  *            @arg @ref UART_CLEAR_LBDF     LIN Break Detection Clear Flag    
+  *            @arg @ref UART_CLEAR_CTSF     CTS Interrupt Clear Flag          
+  *            @arg @ref UART_CLEAR_RTOF     Receiver Time Out Clear Flag      
+  *            @arg @ref UART_CLEAR_EOBF     End Of Block Clear Flag           
+  *            @arg @ref UART_CLEAR_CMF      Character Match Clear Flag        
+  *            @arg @ref UART_CLEAR_WUF      Wake Up from stop mode Clear Flag 
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ICR = (__FLAG__))
+
+/** @brief  Clear the UART PE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_PEFLAG(__HANDLE__)   __HAL_UART_CLEAR_FLAG((__HANDLE__), UART_CLEAR_PEF)
+
+/** @brief  Clear the UART FE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_FEFLAG(__HANDLE__)   __HAL_UART_CLEAR_FLAG((__HANDLE__), UART_CLEAR_FEF)
+
+/** @brief  Clear the UART NE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_NEFLAG(__HANDLE__)  __HAL_UART_CLEAR_FLAG((__HANDLE__), UART_CLEAR_NEF)
+
+/** @brief  Clear the UART ORE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_OREFLAG(__HANDLE__)   __HAL_UART_CLEAR_FLAG((__HANDLE__), UART_CLEAR_OREF)
+
+/** @brief  Clear the UART IDLE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_IDLEFLAG(__HANDLE__)   __HAL_UART_CLEAR_FLAG((__HANDLE__), UART_CLEAR_IDLEF)
+
+/** @brief  Check whether the specified UART flag is set or not.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg @ref UART_FLAG_REACK Receive enable acknowledge flag
+  *            @arg @ref UART_FLAG_TEACK Transmit enable acknowledge flag
+  *            @arg @ref UART_FLAG_WUF   Wake up from stop mode flag
+  *            @arg @ref UART_FLAG_RWU   Receiver wake up flag (if the UART in mute mode)
+  *            @arg @ref UART_FLAG_SBKF  Send Break flag
+  *            @arg @ref UART_FLAG_CMF   Character match flag
+  *            @arg @ref UART_FLAG_BUSY  Busy flag
+  *            @arg @ref UART_FLAG_ABRF  Auto Baud rate detection flag
+  *            @arg @ref UART_FLAG_ABRE  Auto Baud rate detection error flag
+  *            @arg @ref UART_FLAG_EOBF  End of block flag
+  *            @arg @ref UART_FLAG_RTOF  Receiver timeout flag
+  *            @arg @ref UART_FLAG_CTS   CTS Change flag
+  *            @arg @ref UART_FLAG_LBDF  LIN Break detection flag
+  *            @arg @ref UART_FLAG_TXE   Transmit data register empty flag
+  *            @arg @ref UART_FLAG_TC    Transmission Complete flag
+  *            @arg @ref UART_FLAG_RXNE  Receive data register not empty flag
+  *            @arg @ref UART_FLAG_IDLE  Idle Line detection flag
+  *            @arg @ref UART_FLAG_ORE   Overrun Error flag
+  *            @arg @ref UART_FLAG_NE    Noise Error flag
+  *            @arg @ref UART_FLAG_FE    Framing Error flag
+  *            @arg @ref UART_FLAG_PE    Parity Error flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_UART_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->ISR & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Enable the specified UART interrupt.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __INTERRUPT__: specifies the UART interrupt source to enable.
+  *          This parameter can be one of the following values:
+  *            @arg @ref UART_IT_WUF  Wakeup from stop mode interrupt
+  *            @arg @ref UART_IT_CM   Character match interrupt
+  *            @arg @ref UART_IT_CTS  CTS change interrupt
+  *            @arg @ref UART_IT_LBD  LIN Break detection interrupt
+  *            @arg @ref UART_IT_TXE  Transmit Data Register empty interrupt
+  *            @arg @ref UART_IT_TC   Transmission complete interrupt
+  *            @arg @ref UART_IT_RXNE Receive Data register not empty interrupt
+  *            @arg @ref UART_IT_IDLE Idle line detection interrupt
+  *            @arg @ref UART_IT_PE   Parity Error interrupt
+  *            @arg @ref UART_IT_ERR  Error interrupt (Frame error, noise error, overrun error)
+  * @retval None
+  */
+#define __HAL_UART_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (((((uint8_t)(__INTERRUPT__)) >> 5U) == 1)? ((__HANDLE__)->Instance->CR1 |= (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 2)? ((__HANDLE__)->Instance->CR2 |= (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((__HANDLE__)->Instance->CR3 |= (1U << ((__INTERRUPT__) & UART_IT_MASK))))
+
+
+/** @brief  Disable the specified UART interrupt.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __INTERRUPT__: specifies the UART interrupt source to disable.
+  *          This parameter can be one of the following values:
+  *            @arg @ref UART_IT_WUF  Wakeup from stop mode interrupt
+  *            @arg @ref UART_IT_CM   Character match interrupt
+  *            @arg @ref UART_IT_CTS  CTS change interrupt
+  *            @arg @ref UART_IT_LBD  LIN Break detection interrupt
+  *            @arg @ref UART_IT_TXE  Transmit Data Register empty interrupt
+  *            @arg @ref UART_IT_TC   Transmission complete interrupt
+  *            @arg @ref UART_IT_RXNE Receive Data register not empty interrupt
+  *            @arg @ref UART_IT_IDLE Idle line detection interrupt
+  *            @arg @ref UART_IT_PE   Parity Error interrupt
+  *            @arg @ref UART_IT_ERR  Error interrupt (Frame error, noise error, overrun error)
+  * @retval None
+  */
+#define __HAL_UART_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((((uint8_t)(__INTERRUPT__)) >> 5U) == 1)? ((__HANDLE__)->Instance->CR1 &= ~ (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 2)? ((__HANDLE__)->Instance->CR2 &= ~ (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((__HANDLE__)->Instance->CR3 &= ~ (1U << ((__INTERRUPT__) & UART_IT_MASK))))
+
+/** @brief  Check whether the specified UART interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __IT__: specifies the UART interrupt to check.
+  *          This parameter can be one of the following values:
+  *            @arg @ref UART_IT_WUF  Wakeup from stop mode interrupt
+  *            @arg @ref UART_IT_CM   Character match interrupt
+  *            @arg @ref UART_IT_CTS  CTS change interrupt
+  *            @arg @ref UART_IT_LBD  LIN Break detection interrupt
+  *            @arg @ref UART_IT_TXE  Transmit Data Register empty interrupt
+  *            @arg @ref UART_IT_TC   Transmission complete interrupt
+  *            @arg @ref UART_IT_RXNE Receive Data register not empty interrupt
+  *            @arg @ref UART_IT_IDLE Idle line detection interrupt
+  *            @arg @ref UART_IT_ORE  Overrun Error interrupt
+  *            @arg @ref UART_IT_NE   Noise Error interrupt   
+  *            @arg @ref UART_IT_FE   Framing Error interrupt   
+  *            @arg @ref UART_IT_PE   Parity Error interrupt
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_UART_GET_IT(__HANDLE__, __IT__) ((__HANDLE__)->Instance->ISR & ((uint32_t)1 << ((__IT__)>> 0x08)))
+
+/** @brief  Check whether the specified UART interrupt source is enabled or not.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __IT__: specifies the UART interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg @ref UART_IT_WUF  Wakeup from stop mode interrupt
+  *            @arg @ref UART_IT_CM   Character match interrupt  
+  *            @arg @ref UART_IT_CTS  CTS change interrupt
+  *            @arg @ref UART_IT_LBD  LIN Break detection interrupt
+  *            @arg @ref UART_IT_TXE  Transmit Data Register empty interrupt
+  *            @arg @ref UART_IT_TC   Transmission complete interrupt
+  *            @arg @ref UART_IT_RXNE Receive Data register not empty interrupt
+  *            @arg @ref UART_IT_IDLE Idle line detection interrupt
+  *            @arg @ref UART_IT_ERR  Error interrupt (Frame error, noise error, overrun error)
+  *            @arg @ref UART_IT_PE   Parity Error interrupt
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_UART_GET_IT_SOURCE(__HANDLE__, __IT__) ((((((uint8_t)(__IT__)) >> 5U) == 1)? (__HANDLE__)->Instance->CR1:(((((uint8_t)(__IT__)) >> 5U) == 2)? \
+                                                       (__HANDLE__)->Instance->CR2 : (__HANDLE__)->Instance->CR3)) & ((uint32_t)1 << (((uint16_t)(__IT__)) & UART_IT_MASK)))
+
+/** @brief  Clear the specified UART ISR flag, in setting the proper ICR register flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __IT_CLEAR__: specifies the interrupt clear register flag that needs to be set
+  *                       to clear the corresponding interrupt
+  *          This parameter can be one of the following values:
+  *            @arg @ref UART_CLEAR_PEF Parity Error Clear Flag
+  *            @arg @ref UART_CLEAR_FEF Framing Error Clear Flag
+  *            @arg @ref UART_CLEAR_NEF Noise detected Clear Flag
+  *            @arg @ref UART_CLEAR_OREF Overrun Error Clear Flag
+  *            @arg @ref UART_CLEAR_IDLEF IDLE line detected Clear Flag
+  *            @arg @ref UART_CLEAR_TCF Transmission Complete Clear Flag
+  *            @arg @ref UART_CLEAR_LBDF LIN Break Detection Clear Flag
+  *            @arg @ref UART_CLEAR_CTSF CTS Interrupt Clear Flag
+  *            @arg @ref UART_CLEAR_CMF Character Match Clear Flag
+  *            @arg @ref UART_CLEAR_WUF  Wake Up from stop mode Clear Flag
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_IT(__HANDLE__, __IT_CLEAR__) ((__HANDLE__)->Instance->ICR = (uint32_t)(__IT_CLEAR__))
+
+/** @brief  Set a specific UART request flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __REQ__: specifies the request flag to set
+  *          This parameter can be one of the following values:
+  *            @arg @ref UART_AUTOBAUD_REQUEST Auto-Baud Rate Request
+  *            @arg @ref UART_SENDBREAK_REQUEST Send Break Request
+  *            @arg @ref UART_MUTE_MODE_REQUEST Mute Mode Request
+  *            @arg @ref UART_RXDATA_FLUSH_REQUEST Receive Data flush Request
+  *            @arg @ref UART_TXDATA_FLUSH_REQUEST Transmit data flush Request
+  * @retval None
+  */
+#define __HAL_UART_SEND_REQ(__HANDLE__, __REQ__) ((__HANDLE__)->Instance->RQR |= (uint32_t)(__REQ__))
+
+/** @brief  Enable the UART one bit sample method.
+  * @param  __HANDLE__: specifies the UART Handle.  
+  * @retval None
+  */     
+#define __HAL_UART_ONE_BIT_SAMPLE_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR3|= USART_CR3_ONEBIT)
+
+/** @brief  Disable the UART one bit sample method.
+  * @param  __HANDLE__: specifies the UART Handle.  
+  * @retval None
+  */      
+#define __HAL_UART_ONE_BIT_SAMPLE_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_ONEBIT))
+
+/** @brief  Enable UART.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_ENABLE(__HANDLE__)                   ((__HANDLE__)->Instance->CR1 |=  USART_CR1_UE)
+
+/** @brief  Disable UART.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_DISABLE(__HANDLE__)                  ((__HANDLE__)->Instance->CR1 &=  ~USART_CR1_UE)
+
+/** @brief  Enable CTS flow control.
+  * @note   This macro allows to enable CTS hardware flow control for a given UART instance, 
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying CTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e. __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).                                                                                                                  
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_CTS_ENABLE(__HANDLE__)        \
+  do{                                                      \
+    SET_BIT((__HANDLE__)->Instance->CR3, USART_CR3_CTSE);  \
+    (__HANDLE__)->Init.HwFlowCtl |= USART_CR3_CTSE;        \
+  } while(0)
+
+/** @brief  Disable CTS flow control.
+  * @note   This macro allows to disable CTS hardware flow control for a given UART instance, 
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying CTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e. __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e. __HAL_UART_ENABLE(__HANDLE__)). 
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_CTS_DISABLE(__HANDLE__)        \
+  do{                                                       \
+    CLEAR_BIT((__HANDLE__)->Instance->CR3, USART_CR3_CTSE); \
+    (__HANDLE__)->Init.HwFlowCtl &= ~(USART_CR3_CTSE);      \
+  } while(0)
+
+/** @brief  Enable RTS flow control.
+  * @note   This macro allows to enable RTS hardware flow control for a given UART instance, 
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying RTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e. __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e. __HAL_UART_ENABLE(__HANDLE__)). 
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_RTS_ENABLE(__HANDLE__)       \
+  do{                                                     \
+    SET_BIT((__HANDLE__)->Instance->CR3, USART_CR3_RTSE); \
+    (__HANDLE__)->Init.HwFlowCtl |= USART_CR3_RTSE;       \
+  } while(0)
+
+/** @brief  Disable RTS flow control.
+  * @note   This macro allows to disable RTS hardware flow control for a given UART instance, 
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying RTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e. __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e. __HAL_UART_ENABLE(__HANDLE__)). 
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_RTS_DISABLE(__HANDLE__)       \
+  do{                                                      \
+    CLEAR_BIT((__HANDLE__)->Instance->CR3, USART_CR3_RTSE);\
+    (__HANDLE__)->Init.HwFlowCtl &= ~(USART_CR3_RTSE);     \
+  } while(0)
+
+/**
+  * @}
+  */
+
+/* Private macros --------------------------------------------------------*/
+/** @defgroup UART_Private_Macros   UART Private Macros
+  * @{
+  */
+/** @brief  BRR division operation to set BRR register with LPUART.
+  * @param  __PCLK__: LPUART clock.
+  * @param  __BAUD__: Baud rate set by the user.
+  * @retval Division result
+  */
+#define UART_DIV_LPUART(__PCLK__, __BAUD__)                (((uint64_t)(__PCLK__)*256)/((__BAUD__)))
+
+/** @brief  BRR division operation to set BRR register in 8-bit oversampling mode.
+  * @param  __PCLK__: UART clock.
+  * @param  __BAUD__: Baud rate set by the user.
+  * @retval Division result
+  */
+#define UART_DIV_SAMPLING8(__PCLK__, __BAUD__)             (((__PCLK__)*2)/((__BAUD__)))
+
+/** @brief  BRR division operation to set BRR register in 16-bit oversampling mode.
+  * @param  __PCLK__: UART clock.
+  * @param  __BAUD__: Baud rate set by the user.
+  * @retval Division result
+  */
+#define UART_DIV_SAMPLING16(__PCLK__, __BAUD__)             (((__PCLK__))/((__BAUD__)))
+
+/** @brief  Check whether or not UART instance is Low Power UART.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval SET (instance is LPUART) or RESET (instance isn't LPUART)
+  */
+#define UART_INSTANCE_LOWPOWER(__HANDLE__) (((__HANDLE__)->Instance == LPUART1) ? SET : RESET )
+
+/** @brief  Check UART Baud rate.
+  * @param  __BAUDRATE__: Baudrate specified by the user.
+  *         The maximum Baud Rate is derived from the maximum clock on L4 (i.e. 80 MHz)
+  *         divided by the smallest oversampling used on the USART (i.e. 8)
+  * @retval SET (__BAUDRATE__ is valid) or RESET (__BAUDRATE__ is invalid)
+  */
+#define IS_UART_BAUDRATE(__BAUDRATE__) ((__BAUDRATE__) < 10000001)
+
+/** @brief  Check UART assertion time.
+  * @param  __TIME__: 5-bit value assertion time.
+  * @retval Test result (TRUE or FALSE).
+  */
+#define IS_UART_ASSERTIONTIME(__TIME__)    ((__TIME__) <= 0x1F)
+
+/** @brief  Check UART deassertion time.
+  * @param  __TIME__: 5-bit value deassertion time.
+  * @retval Test result (TRUE or FALSE).
+  */
+#define IS_UART_DEASSERTIONTIME(__TIME__) ((__TIME__) <= 0x1F)
+
+/**
+  * @brief Ensure that UART frame number of stop bits is valid.
+  * @param __STOPBITS__: UART frame number of stop bits. 
+  * @retval SET (__STOPBITS__ is valid) or RESET (__STOPBITS__ is invalid)  UART_STOPBITS_1_5
+  */
+#define IS_UART_STOPBITS(__STOPBITS__) (((__STOPBITS__) == UART_STOPBITS_0_5) || \
+                                        ((__STOPBITS__) == UART_STOPBITS_1)   || \
+                                        ((__STOPBITS__) == UART_STOPBITS_1_5) || \
+                                        ((__STOPBITS__) == UART_STOPBITS_2))
+
+/**
+  * @brief Ensure that LPUART frame number of stop bits is valid.
+  * @param __STOPBITS__: LPUART frame number of stop bits. 
+  * @retval SET (__STOPBITS__ is valid) or RESET (__STOPBITS__ is invalid)
+  */ 
+#define IS_LPUART_STOPBITS(__STOPBITS__) (((__STOPBITS__) == UART_STOPBITS_1) || \
+                                          ((__STOPBITS__) == UART_STOPBITS_2))
+
+/**
+  * @brief Ensure that UART frame parity is valid.
+  * @param __PARITY__: UART frame parity. 
+  * @retval SET (__PARITY__ is valid) or RESET (__PARITY__ is invalid)
+  */ 
+#define IS_UART_PARITY(__PARITY__) (((__PARITY__) == UART_PARITY_NONE) || \
+                                    ((__PARITY__) == UART_PARITY_EVEN) || \
+                                    ((__PARITY__) == UART_PARITY_ODD))
+
+/**
+  * @brief Ensure that UART hardware flow control is valid.
+  * @param __CONTROL__: UART hardware flow control. 
+  * @retval SET (__CONTROL__ is valid) or RESET (__CONTROL__ is invalid)
+  */ 
+#define IS_UART_HARDWARE_FLOW_CONTROL(__CONTROL__)\
+                                   (((__CONTROL__) == UART_HWCONTROL_NONE) || \
+                                    ((__CONTROL__) == UART_HWCONTROL_RTS)  || \
+                                    ((__CONTROL__) == UART_HWCONTROL_CTS)  || \
+                                    ((__CONTROL__) == UART_HWCONTROL_RTS_CTS))
+
+/**
+  * @brief Ensure that UART communication mode is valid.
+  * @param __MODE__: UART communication mode. 
+  * @retval SET (__MODE__ is valid) or RESET (__MODE__ is invalid)
+  */ 
+#define IS_UART_MODE(__MODE__) ((((__MODE__) & (~((uint32_t)(UART_MODE_TX_RX)))) == (uint32_t)0x00) && ((__MODE__) != (uint32_t)0x00))
+
+/**
+  * @brief Ensure that UART state is valid.
+  * @param __STATE__: UART state. 
+  * @retval SET (__STATE__ is valid) or RESET (__STATE__ is invalid)
+  */ 
+#define IS_UART_STATE(__STATE__) (((__STATE__) == UART_STATE_DISABLE) || \
+                                  ((__STATE__) == UART_STATE_ENABLE))
+
+/**
+  * @brief Ensure that UART oversampling is valid.
+  * @param __SAMPLING__: UART oversampling. 
+  * @retval SET (__SAMPLING__ is valid) or RESET (__SAMPLING__ is invalid)
+  */ 
+#define IS_UART_OVERSAMPLING(__SAMPLING__) (((__SAMPLING__) == UART_OVERSAMPLING_16) || \
+                                            ((__SAMPLING__) == UART_OVERSAMPLING_8))
+
+/**
+  * @brief Ensure that UART frame sampling is valid.
+  * @param __ONEBIT__: UART frame sampling. 
+  * @retval SET (__ONEBIT__ is valid) or RESET (__ONEBIT__ is invalid)
+  */
+#define IS_UART_ONE_BIT_SAMPLE(__ONEBIT__) (((__ONEBIT__) == UART_ONE_BIT_SAMPLE_DISABLE) || \
+                                            ((__ONEBIT__) == UART_ONE_BIT_SAMPLE_ENABLE))
+
+/**
+  * @brief Ensure that UART auto Baud rate detection mode is valid.
+  * @param __MODE__: UART auto Baud rate detection mode. 
+  * @retval SET (__MODE__ is valid) or RESET (__MODE__ is invalid)
+  */
+#define IS_UART_ADVFEATURE_AUTOBAUDRATEMODE(__MODE__)  (((__MODE__) == UART_ADVFEATURE_AUTOBAUDRATE_ONSTARTBIT)    || \
+                                                        ((__MODE__) == UART_ADVFEATURE_AUTOBAUDRATE_ONFALLINGEDGE) || \
+                                                        ((__MODE__) == UART_ADVFEATURE_AUTOBAUDRATE_ON0X7FFRAME)   || \
+                                                        ((__MODE__) == UART_ADVFEATURE_AUTOBAUDRATE_ON0X55FRAME))
+
+/**
+  * @brief Ensure that UART receiver timeout setting is valid.
+  * @param __TIMEOUT__: UART receiver timeout setting. 
+  * @retval SET (__TIMEOUT__ is valid) or RESET (__TIMEOUT__ is invalid)
+  */
+#define IS_UART_RECEIVER_TIMEOUT(__TIMEOUT__) (((__TIMEOUT__) == UART_RECEIVER_TIMEOUT_DISABLE) || \
+                                               ((__TIMEOUT__) == UART_RECEIVER_TIMEOUT_ENABLE))
+
+/**
+  * @brief Ensure that UART LIN state is valid.
+  * @param __LIN__: UART LIN state. 
+  * @retval SET (__LIN__ is valid) or RESET (__LIN__ is invalid)
+  */
+#define IS_UART_LIN(__LIN__)        (((__LIN__) == UART_LIN_DISABLE) || \
+                                     ((__LIN__) == UART_LIN_ENABLE))
+
+/**
+  * @brief Ensure that UART LIN break detection length is valid.
+  * @param __LENGTH__: UART LIN break detection length. 
+  * @retval SET (__LENGTH__ is valid) or RESET (__LENGTH__ is invalid)
+  */
+#define IS_UART_LIN_BREAK_DETECT_LENGTH(__LENGTH__) (((__LENGTH__) == UART_LINBREAKDETECTLENGTH_10B) || \
+                                                     ((__LENGTH__) == UART_LINBREAKDETECTLENGTH_11B))
+
+/**
+  * @brief Ensure that UART DMA TX state is valid.
+  * @param __DMATX__: UART DMA TX state. 
+  * @retval SET (__DMATX__ is valid) or RESET (__DMATX__ is invalid)
+  */
+#define IS_UART_DMA_TX(__DMATX__)     (((__DMATX__) == UART_DMA_TX_DISABLE) || \
+                                       ((__DMATX__) == UART_DMA_TX_ENABLE))
+
+/**
+  * @brief Ensure that UART DMA RX state is valid.
+  * @param __DMARX__: UART DMA RX state. 
+  * @retval SET (__DMARX__ is valid) or RESET (__DMARX__ is invalid)
+  */
+#define IS_UART_DMA_RX(__DMARX__)     (((__DMARX__) == UART_DMA_RX_DISABLE) || \
+                                       ((__DMARX__) == UART_DMA_RX_ENABLE))
+
+/**
+  * @brief Ensure that UART half-duplex state is valid.
+  * @param __HDSEL__: UART half-duplex state. 
+  * @retval SET (__HDSEL__ is valid) or RESET (__HDSEL__ is invalid)
+  */
+#define IS_UART_HALF_DUPLEX(__HDSEL__)     (((__HDSEL__) == UART_HALF_DUPLEX_DISABLE) || \
+                                            ((__HDSEL__) == UART_HALF_DUPLEX_ENABLE))
+
+/**
+  * @brief Ensure that UART wake-up method is valid.
+  * @param __WAKEUP__: UART wake-up method . 
+  * @retval SET (__WAKEUP__ is valid) or RESET (__WAKEUP__ is invalid)
+  */
+#define IS_UART_WAKEUPMETHOD(__WAKEUP__) (((__WAKEUP__) == UART_WAKEUPMETHOD_IDLELINE) || \
+                                          ((__WAKEUP__) == UART_WAKEUPMETHOD_ADDRESSMARK))
+
+/**
+  * @brief Ensure that UART request parameter is valid.
+  * @param __PARAM__: UART request parameter. 
+  * @retval SET (__PARAM__ is valid) or RESET (__PARAM__ is invalid)
+  */
+#define IS_UART_REQUEST_PARAMETER(__PARAM__) (((__PARAM__) == UART_AUTOBAUD_REQUEST)     || \
+                                              ((__PARAM__) == UART_SENDBREAK_REQUEST)    || \
+                                              ((__PARAM__) == UART_MUTE_MODE_REQUEST)    || \
+                                              ((__PARAM__) == UART_RXDATA_FLUSH_REQUEST) || \
+                                              ((__PARAM__) == UART_TXDATA_FLUSH_REQUEST))
+
+/**
+  * @brief Ensure that UART advanced features initialization is valid.
+  * @param __INIT__: UART advanced features initialization. 
+  * @retval SET (__INIT__ is valid) or RESET (__INIT__ is invalid)
+  */
+#define IS_UART_ADVFEATURE_INIT(__INIT__)   ((__INIT__) <= (UART_ADVFEATURE_NO_INIT                | \
+                                                            UART_ADVFEATURE_TXINVERT_INIT          | \
+                                                            UART_ADVFEATURE_RXINVERT_INIT          | \
+                                                            UART_ADVFEATURE_DATAINVERT_INIT        | \
+                                                            UART_ADVFEATURE_SWAP_INIT              | \
+                                                            UART_ADVFEATURE_RXOVERRUNDISABLE_INIT  | \
+                                                            UART_ADVFEATURE_DMADISABLEONERROR_INIT | \
+                                                            UART_ADVFEATURE_AUTOBAUDRATE_INIT      | \
+                                                            UART_ADVFEATURE_MSBFIRST_INIT))
+
+/**
+  * @brief Ensure that UART frame TX inversion setting is valid.
+  * @param __TXINV__: UART frame TX inversion setting. 
+  * @retval SET (__TXINV__ is valid) or RESET (__TXINV__ is invalid)
+  */
+#define IS_UART_ADVFEATURE_TXINV(__TXINV__) (((__TXINV__) == UART_ADVFEATURE_TXINV_DISABLE) || \
+                                             ((__TXINV__) == UART_ADVFEATURE_TXINV_ENABLE))
+
+/**
+  * @brief Ensure that UART frame RX inversion setting is valid.
+  * @param __RXINV__: UART frame RX inversion setting. 
+  * @retval SET (__RXINV__ is valid) or RESET (__RXINV__ is invalid)
+  */
+#define IS_UART_ADVFEATURE_RXINV(__RXINV__) (((__RXINV__) == UART_ADVFEATURE_RXINV_DISABLE) || \
+                                             ((__RXINV__) == UART_ADVFEATURE_RXINV_ENABLE))
+
+/**
+  * @brief Ensure that UART frame data inversion setting is valid.
+  * @param __DATAINV__: UART frame data inversion setting. 
+  * @retval SET (__DATAINV__ is valid) or RESET (__DATAINV__ is invalid)
+  */
+#define IS_UART_ADVFEATURE_DATAINV(__DATAINV__) (((__DATAINV__) == UART_ADVFEATURE_DATAINV_DISABLE) || \
+                                                 ((__DATAINV__) == UART_ADVFEATURE_DATAINV_ENABLE))
+
+/**
+  * @brief Ensure that UART frame RX/TX pins swap setting is valid.
+  * @param __SWAP__: UART frame RX/TX pins swap setting. 
+  * @retval SET (__SWAP__ is valid) or RESET (__SWAP__ is invalid)
+  */
+#define IS_UART_ADVFEATURE_SWAP(__SWAP__) (((__SWAP__) == UART_ADVFEATURE_SWAP_DISABLE) || \
+                                           ((__SWAP__) == UART_ADVFEATURE_SWAP_ENABLE))
+
+/**
+  * @brief Ensure that UART frame overrun setting is valid.
+  * @param __OVERRUN__: UART frame overrun setting. 
+  * @retval SET (__OVERRUN__ is valid) or RESET (__OVERRUN__ is invalid)
+  */
+#define IS_UART_OVERRUN(__OVERRUN__)     (((__OVERRUN__) == UART_ADVFEATURE_OVERRUN_ENABLE) || \
+                                          ((__OVERRUN__) == UART_ADVFEATURE_OVERRUN_DISABLE))
+
+/**
+  * @brief Ensure that UART auto Baud rate state is valid.
+  * @param __AUTOBAUDRATE__: UART auto Baud rate state. 
+  * @retval SET (__AUTOBAUDRATE__ is valid) or RESET (__AUTOBAUDRATE__ is invalid)
+  */
+#define IS_UART_ADVFEATURE_AUTOBAUDRATE(__AUTOBAUDRATE__)  (((__AUTOBAUDRATE__) == UART_ADVFEATURE_AUTOBAUDRATE_DISABLE) || \
+                                                            ((__AUTOBAUDRATE__) == UART_ADVFEATURE_AUTOBAUDRATE_ENABLE))
+
+/**
+  * @brief Ensure that UART DMA enabling or disabling on error setting is valid.
+  * @param __DMA__: UART DMA enabling or disabling on error setting. 
+  * @retval SET (__DMA__ is valid) or RESET (__DMA__ is invalid)
+  */
+#define IS_UART_ADVFEATURE_DMAONRXERROR(__DMA__)  (((__DMA__) == UART_ADVFEATURE_DMA_ENABLEONRXERROR) || \
+                                                   ((__DMA__) == UART_ADVFEATURE_DMA_DISABLEONRXERROR))
+
+/**
+  * @brief Ensure that UART frame MSB first setting is valid.
+  * @param __MSBFIRST__: UART frame MSB first setting. 
+  * @retval SET (__MSBFIRST__ is valid) or RESET (__MSBFIRST__ is invalid)
+  */
+#define IS_UART_ADVFEATURE_MSBFIRST(__MSBFIRST__) (((__MSBFIRST__) == UART_ADVFEATURE_MSBFIRST_DISABLE) || \
+                                                   ((__MSBFIRST__) == UART_ADVFEATURE_MSBFIRST_ENABLE))
+
+/**
+  * @brief Ensure that UART stop mode state is valid.
+  * @param __STOPMODE__: UART stop mode state. 
+  * @retval SET (__STOPMODE__ is valid) or RESET (__STOPMODE__ is invalid)
+  */
+#define IS_UART_ADVFEATURE_STOPMODE(__STOPMODE__) (((__STOPMODE__) == UART_ADVFEATURE_STOPMODE_DISABLE) || \
+                                                   ((__STOPMODE__) == UART_ADVFEATURE_STOPMODE_ENABLE))
+
+/**
+  * @brief Ensure that UART mute mode state is valid.
+  * @param __MUTE__: UART mute mode state. 
+  * @retval SET (__MUTE__ is valid) or RESET (__MUTE__ is invalid)
+  */
+#define IS_UART_MUTE_MODE(__MUTE__)       (((__MUTE__) == UART_ADVFEATURE_MUTEMODE_DISABLE) || \
+                                           ((__MUTE__) == UART_ADVFEATURE_MUTEMODE_ENABLE))
+
+/**
+  * @brief Ensure that UART wake-up selection is valid.
+  * @param __WAKE__: UART wake-up selection. 
+  * @retval SET (__WAKE__ is valid) or RESET (__WAKE__ is invalid)
+  */
+#define IS_UART_WAKEUP_SELECTION(__WAKE__) (((__WAKE__) == UART_WAKEUP_ON_ADDRESS) || \
+                                            ((__WAKE__) == UART_WAKEUP_ON_STARTBIT) || \
+                                            ((__WAKE__) == UART_WAKEUP_ON_READDATA_NONEMPTY))
+
+/**
+  * @brief Ensure that UART driver enable polarity is valid.
+  * @param __POLARITY__: UART driver enable polarity. 
+  * @retval SET (__POLARITY__ is valid) or RESET (__POLARITY__ is invalid)
+  */
+#define IS_UART_DE_POLARITY(__POLARITY__)    (((__POLARITY__) == UART_DE_POLARITY_HIGH) || \
+                                              ((__POLARITY__) == UART_DE_POLARITY_LOW))
+
+/**
+  * @}
+  */
+
+/* Include UART HAL Extended module */
+#include "stm32l4xx_hal_uart_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup UART_Exported_Functions UART Exported Functions
+  * @{
+  */
+
+/** @addtogroup UART_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+
+/* Initialization and de-initialization functions  ****************************/
+HAL_StatusTypeDef HAL_UART_Init(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_HalfDuplex_Init(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_LIN_Init(UART_HandleTypeDef *huart, uint32_t BreakDetectLength);
+HAL_StatusTypeDef HAL_MultiProcessor_Init(UART_HandleTypeDef *huart, uint8_t Address, uint32_t WakeUpMethod);
+HAL_StatusTypeDef HAL_UART_DeInit (UART_HandleTypeDef *huart);
+void HAL_UART_MspInit(UART_HandleTypeDef *huart);
+void HAL_UART_MspDeInit(UART_HandleTypeDef *huart);
+
+/**
+  * @}
+  */
+
+/** @addtogroup UART_Exported_Functions_Group2 IO operation functions
+  * @{
+  */
+
+/* IO operation functions *****************************************************/
+HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_DMAPause(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_UART_DMAResume(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_UART_DMAStop(UART_HandleTypeDef *huart);
+void HAL_UART_IRQHandler(UART_HandleTypeDef *huart);
+void HAL_UART_TxHalfCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart);
+
+/**
+  * @}
+  */
+
+/** @addtogroup UART_Exported_Functions_Group3 Peripheral Control functions
+  * @{
+  */
+
+/* Peripheral Control functions  ************************************************/
+HAL_StatusTypeDef HAL_LIN_SendBreak(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_MultiProcessor_EnableMuteMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_MultiProcessor_DisableMuteMode(UART_HandleTypeDef *huart);
+void HAL_MultiProcessor_EnterMuteMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_HalfDuplex_EnableTransmitter(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_HalfDuplex_EnableReceiver(UART_HandleTypeDef *huart);
+
+/**
+  * @}
+  */
+
+/** @addtogroup UART_Exported_Functions_Group4 Peripheral State and Error functions
+  * @{
+  */
+
+/* Peripheral State and Errors functions  **************************************************/
+HAL_UART_StateTypeDef HAL_UART_GetState(UART_HandleTypeDef *huart);
+uint32_t              HAL_UART_GetError(UART_HandleTypeDef *huart);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions -----------------------------------------------------------*/
+/** @addtogroup UART_Private_Functions UART Private Functions
+  * @{
+  */
+
+HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+void UART_AdvFeatureConfig(UART_HandleTypeDef *huart);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_UART_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_uart.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_uart.h
@@ -962,7 +962,8 @@ typedef struct
   * @param  __BAUD__: Baud rate set by the user.
   * @retval Division result
   */
-#define UART_DIV_LPUART(__PCLK__, __BAUD__)                (((uint64_t)(__PCLK__)*256)/((__BAUD__)))
+/* FIXME tobbad Adapted to avoid 64 bit division. */
+#define UART_DIV_LPUART(__PCLK__, __BAUD__)                HAL_UART_CalcBrr((__PCLK__), (__BAUD__))
 
 /** @brief  BRR division operation to set BRR register in 8-bit oversampling mode.
   * @param  __PCLK__: UART clock.
@@ -1369,6 +1370,8 @@ void UART_AdvFeatureConfig(UART_HandleTypeDef *huart);
 /**
   * @}
   */
+/* Functions added by micropython */
+uint32_t HAL_UART_CalcBrr(uint32_t fck, uint32_t baud);
 
 #ifdef __cplusplus
 }

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_uart_ex.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_uart_ex.h
@@ -1,0 +1,372 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_uart_ex.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of UART HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_HAL_UART_EX_H
+#define __STM32L4xx_HAL_UART_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup UARTEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup UARTEx_Exported_Types UARTEx Exported Types
+  * @{
+  */
+
+/**
+  * @brief  UART wake up from stop mode parameters
+  */
+typedef struct
+{
+  uint32_t WakeUpEvent;        /*!< Specifies which event will activat the Wakeup from Stop mode flag (WUF).
+                                    This parameter can be a value of @ref UART_WakeUp_from_Stop_Selection.
+                                    If set to UART_WAKEUP_ON_ADDRESS, the two other fields below must
+                                    be filled up. */
+
+  uint16_t AddressLength;      /*!< Specifies whether the address is 4 or 7-bit long.
+                                    This parameter can be a value of @ref UARTEx_WakeUp_Address_Length.  */
+
+  uint8_t Address;             /*!< UART/USART node address (7-bit long max). */
+} UART_WakeUpTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup UARTEx_Exported_Constants UARTEx Exported Constants
+  * @{
+  */
+
+/** @defgroup UARTEx_Word_Length UART Word Length
+  * @{
+  */
+#define UART_WORDLENGTH_7B                  ((uint32_t)USART_CR1_M1)   /*!< 7-bit long UART frame */
+#define UART_WORDLENGTH_8B                  ((uint32_t)0x00000000)     /*!< 8-bit long UART frame */
+#define UART_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M0)   /*!< 9-bit long UART frame */
+/**
+  * @}
+  */
+
+/** @defgroup UARTEx_WakeUp_Address_Length UART Extended WakeUp Address Length
+  * @{
+  */
+#define UART_ADDRESS_DETECT_4B              ((uint32_t)0x00000000)       /*!< 4-bit long wake-up address */
+#define UART_ADDRESS_DETECT_7B              ((uint32_t)USART_CR2_ADDM7)  /*!< 7-bit long wake-up address */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup UARTEx_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup UARTEx_Exported_Functions_Group1
+  * @{
+  */
+
+/* Initialization and de-initialization functions  ****************************/
+HAL_StatusTypeDef HAL_RS485Ex_Init(UART_HandleTypeDef *huart, uint32_t Polarity, uint32_t AssertionTime, uint32_t DeassertionTime);
+
+/**
+  * @}
+  */
+
+/* IO operation functions *****************************************************/
+
+/** @addtogroup UARTEx_Exported_Functions_Group3
+  * @{
+  */
+
+/* Peripheral Control functions  **********************************************/
+HAL_StatusTypeDef HAL_UARTEx_StopModeWakeUpSourceConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection);
+HAL_StatusTypeDef HAL_UARTEx_EnableStopMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_UARTEx_DisableStopMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_MultiProcessorEx_AddressLength_Set(UART_HandleTypeDef *huart, uint32_t AddressLength);
+void HAL_UARTEx_WakeupCallback(UART_HandleTypeDef *huart);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup UARTEx_Private_Macros UARTEx Private Macros
+  * @{
+  */
+
+/** @brief  Report the UART clock source.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @param  __CLOCKSOURCE__: output variable.
+  * @retval UART clocking source, written in __CLOCKSOURCE__.
+  */
+#define UART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)       \
+  do {                                                        \
+    if((__HANDLE__)->Instance == USART1)                      \
+    {                                                         \
+       switch(__HAL_RCC_GET_USART1_SOURCE())                  \
+       {                                                      \
+        case RCC_USART1CLKSOURCE_PCLK2:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK2;         \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART2)                 \
+    {                                                         \
+       switch(__HAL_RCC_GET_USART2_SOURCE())                  \
+       {                                                      \
+        case RCC_USART2CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART3)                 \
+    {                                                         \
+       switch(__HAL_RCC_GET_USART3_SOURCE())                  \
+       {                                                      \
+        case RCC_USART3CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if((__HANDLE__)->Instance == UART4)                  \
+    {                                                         \
+       switch(__HAL_RCC_GET_UART4_SOURCE())                   \
+       {                                                      \
+        case RCC_UART4CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_UART4CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_UART4CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_UART4CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if ((__HANDLE__)->Instance == UART5)                 \
+    {                                                         \
+       switch(__HAL_RCC_GET_UART5_SOURCE())                   \
+       {                                                      \
+        case RCC_UART5CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_UART5CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_UART5CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_UART5CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if((__HANDLE__)->Instance == LPUART1)                \
+    {                                                         \
+       switch(__HAL_RCC_GET_LPUART1_SOURCE())                 \
+       {                                                      \
+        case RCC_LPUART1CLKSOURCE_PCLK1:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_LPUART1CLKSOURCE_HSI:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_LPUART1CLKSOURCE_SYSCLK:                     \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_LPUART1CLKSOURCE_LSE:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+  } while(0)
+
+/** @brief  Report the UART mask to apply to retrieve the received data
+  *         according to the word length and to the parity bits activation.
+  * @note   If PCE = 1, the parity bit is not included in the data extracted
+  *         by the reception API().
+  *         This masking operation is not carried out in the case of
+  *         DMA transfers.
+  * @param  __HANDLE__: specifies the UART Handle.
+  * @retval None, the mask to apply to UART RDR register is stored in (__HANDLE__)->Mask field.
+  */
+#define UART_MASK_COMPUTATION(__HANDLE__)                             \
+  do {                                                                \
+  if ((__HANDLE__)->Init.WordLength == UART_WORDLENGTH_9B)            \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == UART_PARITY_NONE)               \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x01FF ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x00FF ;                                 \
+     }                                                                \
+  }                                                                   \
+  else if ((__HANDLE__)->Init.WordLength == UART_WORDLENGTH_8B)       \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == UART_PARITY_NONE)               \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x00FF ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x007F ;                                 \
+     }                                                                \
+  }                                                                   \
+  else if ((__HANDLE__)->Init.WordLength == UART_WORDLENGTH_7B)       \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == UART_PARITY_NONE)               \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x007F ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x003F ;                                 \
+     }                                                                \
+  }                                                                   \
+} while(0)
+
+
+/**
+  * @brief Ensure that UART frame length is valid.
+  * @param __LENGTH__: UART frame length. 
+  * @retval SET (__LENGTH__ is valid) or RESET (__LENGTH__ is invalid)
+  */
+#define IS_UART_WORD_LENGTH(__LENGTH__) (((__LENGTH__) == UART_WORDLENGTH_7B) || \
+                                         ((__LENGTH__) == UART_WORDLENGTH_8B) || \
+                                         ((__LENGTH__) == UART_WORDLENGTH_9B))
+
+/**
+  * @brief Ensure that UART wake-up address length is valid.
+  * @param __ADDRESS__: UART wake-up address length. 
+  * @retval SET (__ADDRESS__ is valid) or RESET (__ADDRESS__ is invalid)
+  */
+#define IS_UART_ADDRESSLENGTH_DETECT(__ADDRESS__) (((__ADDRESS__) == UART_ADDRESS_DETECT_4B) || \
+                                                   ((__ADDRESS__) == UART_ADDRESS_DETECT_7B))
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_HAL_UART_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_ll_sdmmc.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_ll_sdmmc.h
@@ -1,0 +1,804 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_ll_sdmmc.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of low layer SDMMC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_LL_SDMMC_H
+#define __STM32L4xx_LL_SDMMC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_Driver
+  * @{
+  */
+
+/** @addtogroup SDMMC_LL
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/** @defgroup SDMMC_LL_Exported_Types SDMMC_LL Exported Types
+  * @{
+  */
+  
+/** 
+  * @brief  SDMMC Configuration Structure definition  
+  */
+typedef struct
+{
+  uint32_t ClockEdge;            /*!< Specifies the clock transition on which the bit capture is made.
+                                      This parameter can be a value of @ref SDMMC_LL_Clock_Edge                 */
+
+  uint32_t ClockBypass;          /*!< Specifies whether the SDMMC Clock divider bypass is
+                                      enabled or disabled.
+                                      This parameter can be a value of @ref SDMMC_LL_Clock_Bypass               */
+
+  uint32_t ClockPowerSave;       /*!< Specifies whether SDMMC Clock output is enabled or
+                                      disabled when the bus is idle.
+                                      This parameter can be a value of @ref SDMMC_LL_Clock_Power_Save           */
+
+  uint32_t BusWide;              /*!< Specifies the SDMMC bus width.
+                                      This parameter can be a value of @ref SDMMC_LL_Bus_Wide                   */
+
+  uint32_t HardwareFlowControl;  /*!< Specifies whether the SDMMC hardware flow control is enabled or disabled.
+                                      This parameter can be a value of @ref SDMMC_LL_Hardware_Flow_Control      */
+
+  uint32_t ClockDiv;             /*!< Specifies the clock frequency of the SDMMC controller.
+                                      This parameter can be a value between Min_Data = 0 and Max_Data = 255 */  
+  
+}SDMMC_InitTypeDef;
+  
+
+/** 
+  * @brief  SDMMC Command Control structure 
+  */
+typedef struct                                                                                            
+{
+  uint32_t Argument;            /*!< Specifies the SDMMC command argument which is sent
+                                     to a card as part of a command message. If a command
+                                     contains an argument, it must be loaded into this register
+                                     before writing the command to the command register.              */
+
+  uint32_t CmdIndex;            /*!< Specifies the SDMMC command index. It must be Min_Data = 0 and 
+                                     Max_Data = 64                                                    */
+
+  uint32_t Response;            /*!< Specifies the SDMMC response type.
+                                     This parameter can be a value of @ref SDMMC_LL_Response_Type         */
+
+  uint32_t WaitForInterrupt;    /*!< Specifies whether SDMMC wait for interrupt request is 
+                                     enabled or disabled.
+                                     This parameter can be a value of @ref SDMMC_LL_Wait_Interrupt_State  */
+
+  uint32_t CPSM;                /*!< Specifies whether SDMMC Command path state machine (CPSM)
+                                     is enabled or disabled.
+                                     This parameter can be a value of @ref SDMMC_LL_CPSM_State            */
+}SDMMC_CmdInitTypeDef;
+
+
+/** 
+  * @brief  SDMMC Data Control structure 
+  */
+typedef struct
+{
+  uint32_t DataTimeOut;         /*!< Specifies the data timeout period in card bus clock periods.  */
+
+  uint32_t DataLength;          /*!< Specifies the number of data bytes to be transferred.         */
+ 
+  uint32_t DataBlockSize;       /*!< Specifies the data block size for block transfer.
+                                     This parameter can be a value of @ref SDMMC_LL_Data_Block_Size    */
+ 
+  uint32_t TransferDir;         /*!< Specifies the data transfer direction, whether the transfer
+                                     is a read or write.
+                                     This parameter can be a value of @ref SDMMC_LL_Transfer_Direction */
+ 
+  uint32_t TransferMode;        /*!< Specifies whether data transfer is in stream or block mode.
+                                     This parameter can be a value of @ref SDMMC_LL_Transfer_Type      */
+ 
+  uint32_t DPSM;                /*!< Specifies whether SDMMC Data path state machine (DPSM)
+                                     is enabled or disabled.
+                                     This parameter can be a value of @ref SDMMC_LL_DPSM_State         */
+}SDMMC_DataInitTypeDef;
+
+/**
+  * @}
+  */
+  
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup SDMMC_LL_Exported_Constants SDMMC_LL Exported Constants
+  * @{
+  */
+
+/** @defgroup SDMMC_LL_Clock_Edge Clock Edge
+  * @{
+  */
+#define SDMMC_CLOCK_EDGE_RISING               ((uint32_t)0x00000000)
+#define SDMMC_CLOCK_EDGE_FALLING              SDMMC_CLKCR_NEGEDGE
+
+#define IS_SDMMC_CLOCK_EDGE(EDGE) (((EDGE) == SDMMC_CLOCK_EDGE_RISING) || \
+                                  ((EDGE) == SDMMC_CLOCK_EDGE_FALLING))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Clock_Bypass Clock Bypass
+  * @{
+  */
+#define SDMMC_CLOCK_BYPASS_DISABLE             ((uint32_t)0x00000000)
+#define SDMMC_CLOCK_BYPASS_ENABLE              SDMMC_CLKCR_BYPASS   
+
+#define IS_SDMMC_CLOCK_BYPASS(BYPASS) (((BYPASS) == SDMMC_CLOCK_BYPASS_DISABLE) || \
+                                      ((BYPASS) == SDMMC_CLOCK_BYPASS_ENABLE))
+/**
+  * @}
+  */ 
+
+/** @defgroup SDMMC_LL_Clock_Power_Save Clock Power Saving
+  * @{
+  */
+#define SDMMC_CLOCK_POWER_SAVE_DISABLE         ((uint32_t)0x00000000)
+#define SDMMC_CLOCK_POWER_SAVE_ENABLE          SDMMC_CLKCR_PWRSAV
+
+#define IS_SDMMC_CLOCK_POWER_SAVE(SAVE) (((SAVE) == SDMMC_CLOCK_POWER_SAVE_DISABLE) || \
+                                        ((SAVE) == SDMMC_CLOCK_POWER_SAVE_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Bus_Wide Bus Width
+  * @{
+  */
+#define SDMMC_BUS_WIDE_1B                      ((uint32_t)0x00000000)
+#define SDMMC_BUS_WIDE_4B                      SDMMC_CLKCR_WIDBUS_0
+#define SDMMC_BUS_WIDE_8B                      SDMMC_CLKCR_WIDBUS_1
+
+#define IS_SDMMC_BUS_WIDE(WIDE) (((WIDE) == SDMMC_BUS_WIDE_1B) || \
+                                ((WIDE) == SDMMC_BUS_WIDE_4B) || \
+                                ((WIDE) == SDMMC_BUS_WIDE_8B))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Hardware_Flow_Control Hardware Flow Control
+  * @{
+  */
+#define SDMMC_HARDWARE_FLOW_CONTROL_DISABLE    ((uint32_t)0x00000000)
+#define SDMMC_HARDWARE_FLOW_CONTROL_ENABLE     SDMMC_CLKCR_HWFC_EN
+
+#define IS_SDMMC_HARDWARE_FLOW_CONTROL(CONTROL) (((CONTROL) == SDMMC_HARDWARE_FLOW_CONTROL_DISABLE) || \
+                                                ((CONTROL) == SDMMC_HARDWARE_FLOW_CONTROL_ENABLE))
+/**
+  * @}
+  */
+  
+/** @defgroup SDMMC_LL_Clock_Division Clock Division
+  * @{
+  */
+#define IS_SDMMC_CLKDIV(DIV)   ((DIV) <= 0xFF)
+/**
+  * @}
+  */  
+    
+/** @defgroup SDMMC_LL_Command_Index Command Index
+  * @{
+  */
+#define IS_SDMMC_CMD_INDEX(INDEX)            ((INDEX) < 0x40)
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Response_Type Response Type
+  * @{
+  */
+#define SDMMC_RESPONSE_NO                    ((uint32_t)0x00000000)
+#define SDMMC_RESPONSE_SHORT                 SDMMC_CMD_WAITRESP_0
+#define SDMMC_RESPONSE_LONG                  SDMMC_CMD_WAITRESP
+
+#define IS_SDMMC_RESPONSE(RESPONSE) (((RESPONSE) == SDMMC_RESPONSE_NO)    || \
+                                    ((RESPONSE) == SDMMC_RESPONSE_SHORT) || \
+                                    ((RESPONSE) == SDMMC_RESPONSE_LONG))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Wait_Interrupt_State Wait Interrupt
+  * @{
+  */
+#define SDMMC_WAIT_NO                        ((uint32_t)0x00000000)
+#define SDMMC_WAIT_IT                        SDMMC_CMD_WAITINT 
+#define SDMMC_WAIT_PEND                      SDMMC_CMD_WAITPEND
+
+#define IS_SDMMC_WAIT(WAIT) (((WAIT) == SDMMC_WAIT_NO) || \
+                            ((WAIT) == SDMMC_WAIT_IT) || \
+                            ((WAIT) == SDMMC_WAIT_PEND))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_CPSM_State CPSM State
+  * @{
+  */
+#define SDMMC_CPSM_DISABLE                   ((uint32_t)0x00000000)
+#define SDMMC_CPSM_ENABLE                    SDMMC_CMD_CPSMEN
+
+#define IS_SDMMC_CPSM(CPSM) (((CPSM) == SDMMC_CPSM_DISABLE) || \
+                            ((CPSM) == SDMMC_CPSM_ENABLE))
+/**
+  * @}
+  */  
+
+/** @defgroup SDMMC_LL_Response_Registers Response Register
+  * @{
+  */
+#define SDMMC_RESP1                          ((uint32_t)0x00000000)
+#define SDMMC_RESP2                          ((uint32_t)0x00000004)
+#define SDMMC_RESP3                          ((uint32_t)0x00000008)
+#define SDMMC_RESP4                          ((uint32_t)0x0000000C)
+
+#define IS_SDMMC_RESP(RESP) (((RESP) == SDMMC_RESP1) || \
+                            ((RESP) == SDMMC_RESP2) || \
+                            ((RESP) == SDMMC_RESP3) || \
+                            ((RESP) == SDMMC_RESP4))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Data_Length Data Lenght
+  * @{
+  */
+#define IS_SDMMC_DATA_LENGTH(LENGTH) ((LENGTH) <= 0x01FFFFFF)
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Data_Block_Size  Data Block Size
+  * @{
+  */
+#define SDMMC_DATABLOCK_SIZE_1B               ((uint32_t)0x00000000)
+#define SDMMC_DATABLOCK_SIZE_2B               SDMMC_DCTRL_DBLOCKSIZE_0
+#define SDMMC_DATABLOCK_SIZE_4B               SDMMC_DCTRL_DBLOCKSIZE_1
+#define SDMMC_DATABLOCK_SIZE_8B               (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_1)
+#define SDMMC_DATABLOCK_SIZE_16B              SDMMC_DCTRL_DBLOCKSIZE_2
+#define SDMMC_DATABLOCK_SIZE_32B              (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_2)
+#define SDMMC_DATABLOCK_SIZE_64B              (SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_2)
+#define SDMMC_DATABLOCK_SIZE_128B             (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_2)
+#define SDMMC_DATABLOCK_SIZE_256B             SDMMC_DCTRL_DBLOCKSIZE_3
+#define SDMMC_DATABLOCK_SIZE_512B             (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_3)
+#define SDMMC_DATABLOCK_SIZE_1024B            (SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_3)
+#define SDMMC_DATABLOCK_SIZE_2048B            (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_3) 
+#define SDMMC_DATABLOCK_SIZE_4096B            (SDMMC_DCTRL_DBLOCKSIZE_2|SDMMC_DCTRL_DBLOCKSIZE_3)
+#define SDMMC_DATABLOCK_SIZE_8192B            (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_2|SDMMC_DCTRL_DBLOCKSIZE_3)
+#define SDMMC_DATABLOCK_SIZE_16384B           (SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_2|SDMMC_DCTRL_DBLOCKSIZE_3)
+
+#define IS_SDMMC_BLOCK_SIZE(SIZE) (((SIZE) == SDMMC_DATABLOCK_SIZE_1B)    || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_2B)    || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_4B)    || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_8B)    || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_16B)   || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_32B)   || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_64B)   || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_128B)  || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_256B)  || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_512B)  || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_1024B) || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_2048B) || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_4096B) || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_8192B) || \
+                                  ((SIZE) == SDMMC_DATABLOCK_SIZE_16384B)) 
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Transfer_Direction Transfer Direction
+  * @{
+  */
+#define SDMMC_TRANSFER_DIR_TO_CARD            ((uint32_t)0x00000000)
+#define SDMMC_TRANSFER_DIR_TO_SDMMC            SDMMC_DCTRL_DTDIR
+
+#define IS_SDMMC_TRANSFER_DIR(DIR) (((DIR) == SDMMC_TRANSFER_DIR_TO_CARD) || \
+                                   ((DIR) == SDMMC_TRANSFER_DIR_TO_SDMMC))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Transfer_Type Transfer Type
+  * @{
+  */
+#define SDMMC_TRANSFER_MODE_BLOCK             ((uint32_t)0x00000000)
+#define SDMMC_TRANSFER_MODE_STREAM            SDMMC_DCTRL_DTMODE
+
+#define IS_SDMMC_TRANSFER_MODE(MODE) (((MODE) == SDMMC_TRANSFER_MODE_BLOCK) || \
+                                     ((MODE) == SDMMC_TRANSFER_MODE_STREAM))
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_DPSM_State DPSM State
+  * @{
+  */
+#define SDMMC_DPSM_DISABLE                    ((uint32_t)0x00000000)
+#define SDMMC_DPSM_ENABLE                     SDMMC_DCTRL_DTEN
+
+#define IS_SDMMC_DPSM(DPSM) (((DPSM) == SDMMC_DPSM_DISABLE) ||\
+                            ((DPSM) == SDMMC_DPSM_ENABLE))
+/**
+  * @}
+  */
+  
+/** @defgroup SDMMC_LL_Read_Wait_Mode Read Wait Mode
+  * @{
+  */
+#define SDMMC_READ_WAIT_MODE_DATA2                ((uint32_t)0x00000000)
+#define SDMMC_READ_WAIT_MODE_CLK                  (SDMMC_DCTRL_RWMOD)
+
+#define IS_SDMMC_READWAIT_MODE(MODE) (((MODE) == SDMMC_READ_WAIT_MODE_CLK) || \
+                                     ((MODE) == SDMMC_READ_WAIT_MODE_DATA2))
+/**
+  * @}
+  */  
+
+/** @defgroup SDMMC_LL_Interrupt_sources Interrupt Sources
+  * @{
+  */
+#define SDMMC_IT_CCRCFAIL                    SDMMC_STA_CCRCFAIL
+#define SDMMC_IT_DCRCFAIL                    SDMMC_STA_DCRCFAIL
+#define SDMMC_IT_CTIMEOUT                    SDMMC_STA_CTIMEOUT
+#define SDMMC_IT_DTIMEOUT                    SDMMC_STA_DTIMEOUT
+#define SDMMC_IT_TXUNDERR                    SDMMC_STA_TXUNDERR
+#define SDMMC_IT_RXOVERR                     SDMMC_STA_RXOVERR
+#define SDMMC_IT_CMDREND                     SDMMC_STA_CMDREND
+#define SDMMC_IT_CMDSENT                     SDMMC_STA_CMDSENT
+#define SDMMC_IT_DATAEND                     SDMMC_STA_DATAEND
+#define SDMMC_IT_DBCKEND                     SDMMC_STA_DBCKEND
+#define SDMMC_IT_CMDACT                      SDMMC_STA_CMDACT
+#define SDMMC_IT_TXACT                       SDMMC_STA_TXACT
+#define SDMMC_IT_RXACT                       SDMMC_STA_RXACT
+#define SDMMC_IT_TXFIFOHE                    SDMMC_STA_TXFIFOHE
+#define SDMMC_IT_RXFIFOHF                    SDMMC_STA_RXFIFOHF
+#define SDMMC_IT_TXFIFOF                     SDMMC_STA_TXFIFOF
+#define SDMMC_IT_RXFIFOF                     SDMMC_STA_RXFIFOF
+#define SDMMC_IT_TXFIFOE                     SDMMC_STA_TXFIFOE
+#define SDMMC_IT_RXFIFOE                     SDMMC_STA_RXFIFOE
+#define SDMMC_IT_TXDAVL                      SDMMC_STA_TXDAVL
+#define SDMMC_IT_RXDAVL                      SDMMC_STA_RXDAVL
+#define SDMMC_IT_SDIOIT                      SDMMC_STA_SDIOIT
+/**
+  * @}
+  */ 
+
+/** @defgroup SDMMC_LL_Flags Flags
+  * @{
+  */
+#define SDMMC_FLAG_CCRCFAIL                  SDMMC_STA_CCRCFAIL
+#define SDMMC_FLAG_DCRCFAIL                  SDMMC_STA_DCRCFAIL
+#define SDMMC_FLAG_CTIMEOUT                  SDMMC_STA_CTIMEOUT
+#define SDMMC_FLAG_DTIMEOUT                  SDMMC_STA_DTIMEOUT
+#define SDMMC_FLAG_TXUNDERR                  SDMMC_STA_TXUNDERR
+#define SDMMC_FLAG_RXOVERR                   SDMMC_STA_RXOVERR
+#define SDMMC_FLAG_CMDREND                   SDMMC_STA_CMDREND
+#define SDMMC_FLAG_CMDSENT                   SDMMC_STA_CMDSENT
+#define SDMMC_FLAG_DATAEND                   SDMMC_STA_DATAEND
+#define SDMMC_FLAG_DBCKEND                   SDMMC_STA_DBCKEND
+#define SDMMC_FLAG_CMDACT                    SDMMC_STA_CMDACT
+#define SDMMC_FLAG_TXACT                     SDMMC_STA_TXACT
+#define SDMMC_FLAG_RXACT                     SDMMC_STA_RXACT
+#define SDMMC_FLAG_TXFIFOHE                  SDMMC_STA_TXFIFOHE
+#define SDMMC_FLAG_RXFIFOHF                  SDMMC_STA_RXFIFOHF
+#define SDMMC_FLAG_TXFIFOF                   SDMMC_STA_TXFIFOF
+#define SDMMC_FLAG_RXFIFOF                   SDMMC_STA_RXFIFOF
+#define SDMMC_FLAG_TXFIFOE                   SDMMC_STA_TXFIFOE
+#define SDMMC_FLAG_RXFIFOE                   SDMMC_STA_RXFIFOE
+#define SDMMC_FLAG_TXDAVL                    SDMMC_STA_TXDAVL
+#define SDMMC_FLAG_RXDAVL                    SDMMC_STA_RXDAVL
+#define SDMMC_FLAG_SDIOIT                    SDMMC_STA_SDIOIT
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup SDMMC_LL_Exported_macros SDMMC_LL Exported Macros
+  * @{
+  */
+  
+/** @defgroup SDMMC_LL_Register Bits And Addresses Definitions
+  * @brief SDMMC_LL registers bit address in the alias region
+  * @{
+  */
+/* ---------------------- SDMMC registers bit mask --------------------------- */
+/* --- CLKCR Register ---*/
+/* CLKCR register clear mask */ 
+#define CLKCR_CLEAR_MASK         ((uint32_t)(SDMMC_CLKCR_CLKDIV  | SDMMC_CLKCR_PWRSAV |\
+                                             SDMMC_CLKCR_BYPASS  | SDMMC_CLKCR_WIDBUS |\
+                                             SDMMC_CLKCR_NEGEDGE | SDMMC_CLKCR_HWFC_EN))
+
+/* --- DCTRL Register ---*/
+/* SDMMC DCTRL Clear Mask */
+#define DCTRL_CLEAR_MASK         ((uint32_t)(SDMMC_DCTRL_DTEN    | SDMMC_DCTRL_DTDIR |\
+                                             SDMMC_DCTRL_DTMODE  | SDMMC_DCTRL_DBLOCKSIZE))
+
+/* --- CMD Register ---*/
+/* CMD Register clear mask */
+#define CMD_CLEAR_MASK           ((uint32_t)(SDMMC_CMD_CMDINDEX | SDMMC_CMD_WAITRESP |\
+                                             SDMMC_CMD_WAITINT  | SDMMC_CMD_WAITPEND |\
+                                             SDMMC_CMD_CPSMEN   | SDMMC_CMD_SDIOSUSPEND))
+
+/* SDMMC Intialization Frequency (400KHz max) */
+#define SDMMC_INIT_CLK_DIV ((uint8_t)0x76)
+
+/* SDMMC Data Transfer Frequency (25MHz max) */
+#define SDMMC_TRANSFER_CLK_DIV ((uint8_t)0x0)
+
+/**
+  * @}
+  */
+
+/** @defgroup SDMMC_LL_Interrupt_Clock Interrupt And Clock Configuration
+ *  @brief macros to handle interrupts and specific clock configurations
+ * @{
+ */
+ 
+/**
+  * @brief  Enable the SDMMC device.
+  * @param  __INSTANCE__: SDMMC Instance  
+  * @retval None
+  */ 
+#define __SDMMC_ENABLE(__INSTANCE__)  ((__INSTANCE__)->CLKCR |= SDMMC_CLKCR_CLKEN)
+
+/**
+  * @brief  Disable the SDMMC device.
+  * @param  __INSTANCE__: SDMMC Instance  
+  * @retval None
+  */
+#define __SDMMC_DISABLE(__INSTANCE__)  ((__INSTANCE__)->CLKCR &= ~SDMMC_CLKCR_CLKEN)
+
+/**
+  * @brief  Enable the SDMMC DMA transfer.
+  * @param  None  
+  * @retval None
+  */ 
+#define __SDMMC_DMA_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_DMAEN)
+/**
+  * @brief  Disable the SDMMC DMA transfer.
+  * @param  None   
+  * @retval None
+  */
+#define __SDMMC_DMA_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_DMAEN)
+ 
+/**
+  * @brief  Enable the SDMMC device interrupt.
+  * @param  __INSTANCE__: Pointer to SDMMC register base  
+  * @param  __INTERRUPT__: specifies the SDMMC interrupt sources to be enabled.
+  *         This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDACT:   Command transfer in progress interrupt
+  *            @arg SDMMC_IT_TXACT:    Data transmit in progress interrupt
+  *            @arg SDMMC_IT_RXACT:    Data receive in progress interrupt
+  *            @arg SDMMC_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+  *            @arg SDMMC_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+  *            @arg SDMMC_IT_TXFIFOF:  Transmit FIFO full interrupt
+  *            @arg SDMMC_IT_RXFIFOF:  Receive FIFO full interrupt
+  *            @arg SDMMC_IT_TXFIFOE:  Transmit FIFO empty interrupt
+  *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
+  *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
+  *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt   
+  * @retval None
+  */
+#define __SDMMC_ENABLE_IT(__INSTANCE__, __INTERRUPT__)  ((__INSTANCE__)->MASK |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the SDMMC device interrupt.
+  * @param  __INSTANCE__: Pointer to SDMMC register base   
+  * @param  __INTERRUPT__: specifies the SDMMC interrupt sources to be disabled.
+  *          This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDACT:   Command transfer in progress interrupt
+  *            @arg SDMMC_IT_TXACT:    Data transmit in progress interrupt
+  *            @arg SDMMC_IT_RXACT:    Data receive in progress interrupt
+  *            @arg SDMMC_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+  *            @arg SDMMC_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+  *            @arg SDMMC_IT_TXFIFOF:  Transmit FIFO full interrupt
+  *            @arg SDMMC_IT_RXFIFOF:  Receive FIFO full interrupt
+  *            @arg SDMMC_IT_TXFIFOE:  Transmit FIFO empty interrupt
+  *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
+  *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
+  *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt   
+  * @retval None
+  */
+#define __SDMMC_DISABLE_IT(__INSTANCE__, __INTERRUPT__)  ((__INSTANCE__)->MASK &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Checks whether the specified SDMMC flag is set or not. 
+  * @param  __INSTANCE__: Pointer to SDMMC register base   
+  * @param  __FLAG__: specifies the flag to check. 
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_FLAG_CCRCFAIL: Command response received (CRC check failed)
+  *            @arg SDMMC_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
+  *            @arg SDMMC_FLAG_CTIMEOUT: Command response timeout
+  *            @arg SDMMC_FLAG_DTIMEOUT: Data timeout
+  *            @arg SDMMC_FLAG_TXUNDERR: Transmit FIFO underrun error
+  *            @arg SDMMC_FLAG_RXOVERR:  Received FIFO overrun error
+  *            @arg SDMMC_FLAG_CMDREND:  Command response received (CRC check passed)
+  *            @arg SDMMC_FLAG_CMDSENT:  Command sent (no response required)
+  *            @arg SDMMC_FLAG_DATAEND:  Data end (data counter, SDIDCOUNT, is zero)
+  *            @arg SDMMC_FLAG_DBCKEND:  Data block sent/received (CRC check passed)
+  *            @arg SDMMC_FLAG_CMDACT:   Command transfer in progress
+  *            @arg SDMMC_FLAG_TXACT:    Data transmit in progress
+  *            @arg SDMMC_FLAG_RXACT:    Data receive in progress
+  *            @arg SDMMC_FLAG_TXFIFOHE: Transmit FIFO Half Empty
+  *            @arg SDMMC_FLAG_RXFIFOHF: Receive FIFO Half Full
+  *            @arg SDMMC_FLAG_TXFIFOF:  Transmit FIFO full
+  *            @arg SDMMC_FLAG_RXFIFOF:  Receive FIFO full
+  *            @arg SDMMC_FLAG_TXFIFOE:  Transmit FIFO empty
+  *            @arg SDMMC_FLAG_RXFIFOE:  Receive FIFO empty
+  *            @arg SDMMC_FLAG_TXDAVL:   Data available in transmit FIFO
+  *            @arg SDMMC_FLAG_RXDAVL:   Data available in receive FIFO
+  *            @arg SDMMC_FLAG_SDMMCIT:   SD I/O interrupt received
+  * @retval The new state of SDMMC_FLAG (SET or RESET).
+  */
+#define __SDMMC_GET_FLAG(__INSTANCE__, __FLAG__)  (((__INSTANCE__)->STA &(__FLAG__)) != RESET)
+
+
+/**
+  * @brief  Clears the SDMMC pending flags.
+  * @param  __INSTANCE__: Pointer to SDMMC register base  
+  * @param  __FLAG__: specifies the flag to clear.  
+  *          This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_FLAG_CCRCFAIL: Command response received (CRC check failed)
+  *            @arg SDMMC_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
+  *            @arg SDMMC_FLAG_CTIMEOUT: Command response timeout
+  *            @arg SDMMC_FLAG_DTIMEOUT: Data timeout
+  *            @arg SDMMC_FLAG_TXUNDERR: Transmit FIFO underrun error
+  *            @arg SDMMC_FLAG_RXOVERR:  Received FIFO overrun error
+  *            @arg SDMMC_FLAG_CMDREND:  Command response received (CRC check passed)
+  *            @arg SDMMC_FLAG_CMDSENT:  Command sent (no response required)
+  *            @arg SDMMC_FLAG_DATAEND:  Data end (data counter, SDIDCOUNT, is zero)
+  *            @arg SDMMC_FLAG_DBCKEND:  Data block sent/received (CRC check passed)
+  *            @arg SDMMC_FLAG_SDMMCIT:   SD I/O interrupt received
+  * @retval None
+  */
+#define __SDMMC_CLEAR_FLAG(__INSTANCE__, __FLAG__)  ((__INSTANCE__)->ICR = (__FLAG__))
+
+/**
+  * @brief  Checks whether the specified SDMMC interrupt has occurred or not.
+  * @param  __INSTANCE__: Pointer to SDMMC register base   
+  * @param  __INTERRUPT__: specifies the SDMMC interrupt source to check. 
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDACT:   Command transfer in progress interrupt
+  *            @arg SDMMC_IT_TXACT:    Data transmit in progress interrupt
+  *            @arg SDMMC_IT_RXACT:    Data receive in progress interrupt
+  *            @arg SDMMC_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+  *            @arg SDMMC_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+  *            @arg SDMMC_IT_TXFIFOF:  Transmit FIFO full interrupt
+  *            @arg SDMMC_IT_RXFIFOF:  Receive FIFO full interrupt
+  *            @arg SDMMC_IT_TXFIFOE:  Transmit FIFO empty interrupt
+  *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
+  *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
+  *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval The new state of SDMMC_IT (SET or RESET).
+  */
+#define __SDMMC_GET_IT(__INSTANCE__, __INTERRUPT__)  (((__INSTANCE__)->STA &(__INTERRUPT__)) == (__INTERRUPT__))
+
+/**
+  * @brief  Clears the SDMMC's interrupt pending bits.
+  * @param  __INSTANCE__: Pointer to SDMMC register base 
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. 
+  *          This parameter can be one or a combination of the following values:
+  *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+  *            @arg SDMMC_IT_CTIMEOUT: Command response timeout interrupt
+  *            @arg SDMMC_IT_DTIMEOUT: Data timeout interrupt
+  *            @arg SDMMC_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+  *            @arg SDMMC_IT_RXOVERR:  Received FIFO overrun error interrupt
+  *            @arg SDMMC_IT_CMDREND:  Command response received (CRC check passed) interrupt
+  *            @arg SDMMC_IT_CMDSENT:  Command sent (no response required) interrupt
+  *            @arg SDMMC_IT_DATAEND:  Data end (data counter, SDMMC_DCOUNT, is zero) interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SD I/O interrupt received interrupt
+  * @retval None
+  */
+#define __SDMMC_CLEAR_IT(__INSTANCE__, __INTERRUPT__)  ((__INSTANCE__)->ICR = (__INTERRUPT__))
+
+/**
+  * @brief  Enable Start the SD I/O Read Wait operation.
+  * @param  __INSTANCE__: Pointer to SDMMC register base  
+  * @retval None
+  */  
+#define __SDMMC_START_READWAIT_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_RWSTART)
+
+/**
+  * @brief  Disable Start the SD I/O Read Wait operations.
+  * @param  __INSTANCE__: Pointer to SDMMC register base   
+  * @retval None
+  */  
+#define __SDMMC_START_READWAIT_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_RWSTART)
+
+/**
+  * @brief  Enable Start the SD I/O Read Wait operation.
+  * @param  __INSTANCE__: Pointer to SDMMC register base   
+  * @retval None
+  */  
+#define __SDMMC_STOP_READWAIT_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_RWSTOP)
+
+/**
+  * @brief  Disable Stop the SD I/O Read Wait operations.
+  * @param  __INSTANCE__: Pointer to SDMMC register base  
+  * @retval None
+  */  
+#define __SDMMC_STOP_READWAIT_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_RWSTOP)
+
+/**
+  * @brief  Enable the SD I/O Mode Operation.
+  * @param  __INSTANCE__: Pointer to SDMMC register base   
+  * @retval None
+  */  
+#define __SDMMC_OPERATION_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_SDIOEN) 
+
+/**
+  * @brief  Disable the SD I/O Mode Operation.
+  * @param  __INSTANCE__: Pointer to SDMMC register base 
+  * @retval None
+  */  
+#define __SDMMC_OPERATION_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_SDIOEN) 
+
+/**
+  * @brief  Enable the SD I/O Suspend command sending.
+  * @param  __INSTANCE__: Pointer to SDMMC register base  
+  * @retval None
+  */  
+#define __SDMMC_SUSPEND_CMD_ENABLE(__INSTANCE__)  ((__INSTANCE__)->CMD |= SDMMC_CMD_SDIOSUSPEND) 
+
+/**
+  * @brief  Disable the SD I/O Suspend command sending.
+  * @param  __INSTANCE__: Pointer to SDMMC register base  
+  * @retval None
+  */  
+#define __SDMMC_SUSPEND_CMD_DISABLE(__INSTANCE__)  ((__INSTANCE__)->CMD &= ~SDMMC_CMD_SDIOSUSPEND) 
+      
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */  
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup SDMMC_LL_Exported_Functions
+  * @{
+  */
+  
+/* Initialization/de-initialization functions  **********************************/
+/** @addtogroup HAL_SDMMC_LL_Group1
+  * @{
+  */
+HAL_StatusTypeDef SDMMC_Init(SDMMC_TypeDef *SDMMCx, SDMMC_InitTypeDef Init);
+/**
+  * @}
+  */
+  
+/* I/O operation functions  *****************************************************/
+/** @addtogroup HAL_SDMMC_LL_Group2
+  * @{
+  */
+/* Blocking mode: Polling */
+uint32_t          SDMMC_ReadFIFO(SDMMC_TypeDef *SDMMCx);
+HAL_StatusTypeDef SDMMC_WriteFIFO(SDMMC_TypeDef *SDMMCx, uint32_t *pWriteData);
+/**
+  * @}
+  */
+  
+/* Peripheral Control functions  ************************************************/
+/** @addtogroup HAL_SDMMC_LL_Group3
+  * @{
+  */
+HAL_StatusTypeDef SDMMC_PowerState_ON(SDMMC_TypeDef *SDMMCx);
+HAL_StatusTypeDef SDMMC_PowerState_OFF(SDMMC_TypeDef *SDMMCx);
+uint32_t          SDMMC_GetPowerState(SDMMC_TypeDef *SDMMCx);
+
+/* Command path state machine (CPSM) management functions */
+HAL_StatusTypeDef SDMMC_SendCommand(SDMMC_TypeDef *SDMMCx, SDMMC_CmdInitTypeDef *Command);
+uint8_t           SDMMC_GetCommandResponse(SDMMC_TypeDef *SDMMCx);
+uint32_t          SDMMC_GetResponse(SDMMC_TypeDef *SDMMCx, uint32_t Response);
+
+/* Data path state machine (DPSM) management functions */
+HAL_StatusTypeDef SDMMC_DataConfig(SDMMC_TypeDef *SDMMCx, SDMMC_DataInitTypeDef* Data);
+uint32_t          SDMMC_GetDataCounter(SDMMC_TypeDef *SDMMCx);
+uint32_t          SDMMC_GetFIFOCount(SDMMC_TypeDef *SDMMCx);
+
+/* SDMMC Cards mode management functions */
+HAL_StatusTypeDef SDMMC_SetSDMMCReadWaitMode(SDMMC_TypeDef *SDMMCx, uint32_t SDMMC_ReadWaitMode);
+
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_LL_SDMMC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/inc/stm32l4xx_ll_usb.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_ll_usb.h
@@ -1,0 +1,468 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_ll_usb.h
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Header file of USB Core HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_LL_USB_H
+#define __STM32L4xx_LL_USB_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined(STM32L475xx) || defined(STM32L476xx) || defined(STM32L485xx) || defined(STM32L486xx)
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal_def.h"
+
+/** @addtogroup STM32L4xx_HAL
+  * @{
+  */
+
+/** @addtogroup USB_Core
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** 
+  * @brief  USB Mode definition  
+  */  
+typedef enum 
+{
+   USB_OTG_DEVICE_MODE  = 0,
+   USB_OTG_HOST_MODE    = 1,
+   USB_OTG_DRD_MODE     = 2
+   
+}USB_OTG_ModeTypeDef;
+
+/** 
+  * @brief  URB States definition  
+  */ 
+typedef enum {
+  URB_IDLE = 0,
+  URB_DONE,
+  URB_NOTREADY,
+  URB_NYET,
+  URB_ERROR,
+  URB_STALL
+    
+}USB_OTG_URBStateTypeDef;
+
+/** 
+  * @brief  Host channel States  definition  
+  */ 
+typedef enum {
+  HC_IDLE = 0,
+  HC_XFRC,
+  HC_HALTED,
+  HC_NAK,
+  HC_NYET,
+  HC_STALL,
+  HC_XACTERR,  
+  HC_BBLERR,   
+  HC_DATATGLERR
+    
+}USB_OTG_HCStateTypeDef;
+
+/** 
+  * @brief  PCD Initialization Structure definition  
+  */
+typedef struct
+{
+  uint32_t dev_endpoints;        /*!< Device Endpoints number.
+                                      This parameter depends on the used USB core.   
+                                      This parameter must be a number between Min_Data = 1 and Max_Data = 15 */    
+  
+  uint32_t Host_channels;        /*!< Host Channels number.
+                                      This parameter Depends on the used USB core.   
+                                      This parameter must be a number between Min_Data = 1 and Max_Data = 15 */       
+
+  uint32_t speed;                /*!< USB Core speed.
+                                      This parameter can be any value of @ref USB_Core_Speed_                */        
+                               
+  uint32_t dma_enable;           /*!< Enable or disable of the USB embedded DMA.                             */            
+
+  uint32_t ep0_mps;              /*!< Set the Endpoint 0 Max Packet size. 
+                                      This parameter can be any value of @ref USB_EP0_MPS_                   */              
+                       
+  uint32_t phy_itface;           /*!< Select the used PHY interface.
+                                      This parameter can be any value of @ref USB_Core_PHY_                  */ 
+                                
+  uint32_t Sof_enable;           /*!< Enable or disable the output of the SOF signal.                        */     
+                               
+  uint32_t low_power_enable;     /*!< Enable or disable the low power mode.                                  */     
+                          
+  uint32_t lpm_enable;           /*!< Enable or disable Battery charging.                                    */    
+
+  uint32_t battery_charging_enable; /*!< Enable or disable Battery charging.                                 */   
+  
+  uint32_t vbus_sensing_enable;  /*!< Enable or disable the VBUS Sensing feature.                            */ 
+
+  uint32_t use_dedicated_ep1;    /*!< Enable or disable the use of the dedicated EP1 interrupt.              */      
+  
+  uint32_t use_external_vbus;    /*!< Enable or disable the use of the external VBUS.                        */   
+  
+}USB_OTG_CfgTypeDef;
+
+typedef struct
+{
+  uint8_t   num;            /*!< Endpoint number
+                                This parameter must be a number between Min_Data = 1 and Max_Data = 15    */ 
+                                
+  uint8_t   is_in;          /*!< Endpoint direction
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1     */ 
+  
+  uint8_t   is_stall;       /*!< Endpoint stall condition
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1     */ 
+  
+  uint8_t   type;           /*!< Endpoint type
+                                 This parameter can be any value of @ref USB_EP_Type_                     */ 
+                                
+  uint8_t   data_pid_start; /*!< Initial data PID
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1     */
+                                
+  uint8_t   even_odd_frame; /*!< IFrame parity
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 1    */
+                                
+  uint16_t  tx_fifo_num;    /*!< Transmission FIFO number
+                                 This parameter must be a number between Min_Data = 1 and Max_Data = 15   */
+                                
+  uint32_t  maxpacket;      /*!< Endpoint Max packet size
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 64KB */
+
+  uint8_t   *xfer_buff;     /*!< Pointer to transfer buffer                                               */
+                                
+  uint32_t  dma_addr;       /*!< 32 bits aligned transfer buffer address                                  */
+  
+  uint32_t  xfer_len;       /*!< Current transfer length                                                  */
+  
+  uint32_t  xfer_count;     /*!< Partial transfer length in case of multi packet transfer                 */
+
+}USB_OTG_EPTypeDef;
+
+typedef struct
+{
+  uint8_t   dev_addr ;     /*!< USB device address.
+                                This parameter must be a number between Min_Data = 1 and Max_Data = 255    */ 
+
+  uint8_t   ch_num;        /*!< Host channel number.
+                                This parameter must be a number between Min_Data = 1 and Max_Data = 15     */ 
+                                
+  uint8_t   ep_num;        /*!< Endpoint number.
+                                This parameter must be a number between Min_Data = 1 and Max_Data = 15     */ 
+                                
+  uint8_t   ep_is_in;      /*!< Endpoint direction
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1      */ 
+                                
+  uint8_t   speed;         /*!< USB Host speed.
+                                This parameter can be any value of @ref USB_Core_Speed_                    */
+                                
+  uint8_t   do_ping;       /*!< Enable or disable the use of the PING protocol for HS mode.                */
+  
+  uint8_t   process_ping;  /*!< Execute the PING protocol for HS mode.                                     */
+
+  uint8_t   ep_type;       /*!< Endpoint Type.
+                                This parameter can be any value of @ref USB_EP_Type_                       */
+                                
+  uint16_t  max_packet;    /*!< Endpoint Max packet size.
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 64KB   */
+                                
+  uint8_t   data_pid;      /*!< Initial data PID.
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1      */
+                                
+  uint8_t   *xfer_buff;    /*!< Pointer to transfer buffer.                                                */
+  
+  uint32_t  xfer_len;      /*!< Current transfer length.                                                   */
+  
+  uint32_t  xfer_count;    /*!< Partial transfer length in case of multi packet transfer.                  */
+  
+  uint8_t   toggle_in;     /*!< IN transfer current toggle flag.
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1      */
+                                
+  uint8_t   toggle_out;    /*!< OUT transfer current toggle flag
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1      */
+  
+  uint32_t  dma_addr;      /*!< 32 bits aligned transfer buffer address.                                   */
+  
+  uint32_t  ErrCnt;        /*!< Host channel error count.*/
+  
+  USB_OTG_URBStateTypeDef  urb_state;  /*!< URB state. 
+                                           This parameter can be any value of @ref USB_OTG_URBStateTypeDef */ 
+  
+  USB_OTG_HCStateTypeDef   state;     /*!< Host Channel state. 
+                                           This parameter can be any value of @ref USB_OTG_HCStateTypeDef  */ 
+                                             
+}USB_OTG_HCTypeDef;
+  
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup PCD_Exported_Constants PCD Exported Constants
+  * @{
+  */
+
+/** @defgroup USB_Core_Mode_ USB Core Mode
+  * @{
+  */
+#define USB_OTG_MODE_DEVICE                    0
+#define USB_OTG_MODE_HOST                      1
+#define USB_OTG_MODE_DRD                       2
+/**
+  * @}
+  */
+
+/** @defgroup USB_Core_Speed_   USB Core Speed
+  * @{
+  */  
+#define USB_OTG_SPEED_HIGH                     0
+#define USB_OTG_SPEED_HIGH_IN_FULL             1
+#define USB_OTG_SPEED_LOW                      2  
+#define USB_OTG_SPEED_FULL                     3
+/**
+  * @}
+  */
+  
+/** @defgroup USB_Core_PHY_   USB Core PHY
+  * @{
+  */   
+#define USB_OTG_EMBEDDED_PHY                   1
+/**
+  * @}
+  */
+  
+/** @defgroup USB_Core_MPS_   USB Core MPS
+  * @{
+  */
+#define USB_OTG_FS_MAX_PACKET_SIZE           64
+#define USB_OTG_MAX_EP0_SIZE                 64
+/**
+  * @}
+  */
+
+/** @defgroup USB_Core_Phy_Frequency_   USB Core Phy Frequency
+  * @{
+  */
+#define DSTS_ENUMSPD_HS_PHY_30MHZ_OR_60MHZ     (0 << 1)
+#define DSTS_ENUMSPD_FS_PHY_30MHZ_OR_60MHZ     (1 << 1)
+#define DSTS_ENUMSPD_LS_PHY_6MHZ               (2 << 1)
+#define DSTS_ENUMSPD_FS_PHY_48MHZ              (3 << 1)
+/**
+  * @}
+  */
+  
+/** @defgroup USB_CORE_Frame_Interval_   USB CORE Frame Interval
+  * @{
+  */  
+#define DCFG_FRAME_INTERVAL_80                 0
+#define DCFG_FRAME_INTERVAL_85                 1
+#define DCFG_FRAME_INTERVAL_90                 2
+#define DCFG_FRAME_INTERVAL_95                 3
+/**
+  * @}
+  */
+
+/** @defgroup USB_EP0_MPS_  USB EP0 MPS
+  * @{
+  */
+#define DEP0CTL_MPS_64                         0
+#define DEP0CTL_MPS_32                         1
+#define DEP0CTL_MPS_16                         2
+#define DEP0CTL_MPS_8                          3
+/**
+  * @}
+  */
+
+/** @defgroup USB_EP_Speed_  USB EP Speed
+  * @{
+  */
+#define EP_SPEED_LOW                           0
+#define EP_SPEED_FULL                          1
+#define EP_SPEED_HIGH                          2
+/**
+  * @}
+  */
+
+/** @defgroup USB_EP_Type_  USB EP Type
+  * @{
+  */
+#define EP_TYPE_CTRL                           0
+#define EP_TYPE_ISOC                           1
+#define EP_TYPE_BULK                           2
+#define EP_TYPE_INTR                           3
+#define EP_TYPE_MSK                            3
+/**
+  * @}
+  */
+
+/** @defgroup USB_STS_Defines_   USB STS Defines
+  * @{
+  */
+#define STS_GOUT_NAK                           1
+#define STS_DATA_UPDT                          2
+#define STS_XFER_COMP                          3
+#define STS_SETUP_COMP                         4
+#define STS_SETUP_UPDT                         6
+/**
+  * @}
+  */
+
+/** @defgroup HCFG_SPEED_Defines_   HCFG SPEED Defines
+  * @{
+  */  
+#define HCFG_30_60_MHZ                         0
+#define HCFG_48_MHZ                            1
+#define HCFG_6_MHZ                             2
+/**
+  * @}
+  */
+    
+/** @defgroup HPRT0_PRTSPD_SPEED_Defines_  HPRT0 PRTSPD SPEED Defines
+  * @{
+  */    
+#define HPRT0_PRTSPD_HIGH_SPEED                0
+#define HPRT0_PRTSPD_FULL_SPEED                1
+#define HPRT0_PRTSPD_LOW_SPEED                 2
+/**
+  * @}
+  */  
+   
+#define HCCHAR_CTRL                            0
+#define HCCHAR_ISOC                            1
+#define HCCHAR_BULK                            2
+#define HCCHAR_INTR                            3
+       
+#define HC_PID_DATA0                           0
+#define HC_PID_DATA2                           1
+#define HC_PID_DATA1                           2
+#define HC_PID_SETUP                           3
+
+#define GRXSTS_PKTSTS_IN                       2
+#define GRXSTS_PKTSTS_IN_XFER_COMP             3
+#define GRXSTS_PKTSTS_DATA_TOGGLE_ERR          5
+#define GRXSTS_PKTSTS_CH_HALTED                7
+    
+#define USBx_PCGCCTL    *(__IO uint32_t *)((uint32_t)USBx + USB_OTG_PCGCCTL_BASE)
+#define USBx_HPRT0      *(__IO uint32_t *)((uint32_t)USBx + USB_OTG_HOST_PORT_BASE)
+
+#define USBx_DEVICE     ((USB_OTG_DeviceTypeDef *)((uint32_t )USBx + USB_OTG_DEVICE_BASE)) 
+#define USBx_INEP(i)    ((USB_OTG_INEndpointTypeDef *)((uint32_t)USBx + USB_OTG_IN_ENDPOINT_BASE + (i)*USB_OTG_EP_REG_SIZE))        
+#define USBx_OUTEP(i)   ((USB_OTG_OUTEndpointTypeDef *)((uint32_t)USBx + USB_OTG_OUT_ENDPOINT_BASE + (i)*USB_OTG_EP_REG_SIZE))        
+#define USBx_DFIFO(i)   *(__IO uint32_t *)((uint32_t)USBx + USB_OTG_FIFO_BASE + (i) * USB_OTG_FIFO_SIZE)
+
+#define USBx_HOST       ((USB_OTG_HostTypeDef *)((uint32_t )USBx + USB_OTG_HOST_BASE))  
+#define USBx_HC(i)      ((USB_OTG_HostChannelTypeDef *)((uint32_t)USBx + USB_OTG_HOST_CHANNEL_BASE + (i)*USB_OTG_HOST_CHANNEL_SIZE))
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+#define USB_MASK_INTERRUPT(__INSTANCE__, __INTERRUPT__)     ((__INSTANCE__)->GINTMSK &= ~(__INTERRUPT__))
+#define USB_UNMASK_INTERRUPT(__INSTANCE__, __INTERRUPT__)   ((__INSTANCE__)->GINTMSK |= (__INTERRUPT__))
+    
+#define CLEAR_IN_EP_INTR(__EPNUM__, __INTERRUPT__)          (USBx_INEP(__EPNUM__)->DIEPINT = (__INTERRUPT__))
+#define CLEAR_OUT_EP_INTR(__EPNUM__, __INTERRUPT__)         (USBx_OUTEP(__EPNUM__)->DOEPINT = (__INTERRUPT__))  
+
+/* Exported functions --------------------------------------------------------*/
+HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef Init);
+HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef Init);
+HAL_StatusTypeDef USB_EnableGlobalInt(USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_DisableGlobalInt(USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_SetCurrentMode(USB_OTG_GlobalTypeDef *USBx , USB_OTG_ModeTypeDef mode);
+HAL_StatusTypeDef USB_SetDevSpeed(USB_OTG_GlobalTypeDef *USBx , uint8_t speed);
+HAL_StatusTypeDef USB_FlushRxFifo (USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_FlushTxFifo (USB_OTG_GlobalTypeDef *USBx, uint32_t num );
+HAL_StatusTypeDef USB_ActivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep);
+HAL_StatusTypeDef USB_DeactivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep);
+HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep);
+HAL_StatusTypeDef USB_DeactivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep);
+HAL_StatusTypeDef USB_EPStartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma);
+HAL_StatusTypeDef USB_EP0StartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma);
+HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uint8_t ch_ep_num, uint16_t len, uint8_t dma);
+void *            USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len);
+HAL_StatusTypeDef USB_EPSetStall(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep);
+HAL_StatusTypeDef USB_EPClearStall(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep);
+HAL_StatusTypeDef USB_SetDevAddress (USB_OTG_GlobalTypeDef *USBx, uint8_t address);
+HAL_StatusTypeDef USB_DevConnect (USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_DevDisconnect (USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_StopDevice(USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_ActivateSetup (USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_EP0_OutStart(USB_OTG_GlobalTypeDef *USBx, uint8_t dma, uint8_t *psetup);
+uint8_t           USB_GetDevSpeed(USB_OTG_GlobalTypeDef *USBx);
+uint32_t          USB_GetMode(USB_OTG_GlobalTypeDef *USBx);
+uint32_t          USB_ReadInterrupts (USB_OTG_GlobalTypeDef *USBx);
+uint32_t          USB_ReadDevAllOutEpInterrupt (USB_OTG_GlobalTypeDef *USBx);
+uint32_t          USB_ReadDevOutEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum);
+uint32_t          USB_ReadDevAllInEpInterrupt (USB_OTG_GlobalTypeDef *USBx);
+uint32_t          USB_ReadDevInEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum);
+void              USB_ClearInterrupts (USB_OTG_GlobalTypeDef *USBx, uint32_t interrupt);
+
+HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_InitFSLSPClkSel(USB_OTG_GlobalTypeDef *USBx , uint8_t freq);
+HAL_StatusTypeDef USB_ResetPort(USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_DriveVbus (USB_OTG_GlobalTypeDef *USBx, uint8_t state);
+uint32_t          USB_GetHostSpeed (USB_OTG_GlobalTypeDef *USBx);
+uint32_t          USB_GetCurrentFrame (USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_HC_Init(USB_OTG_GlobalTypeDef *USBx,  
+                                  uint8_t ch_num,
+                                  uint8_t epnum,
+                                  uint8_t dev_address,
+                                  uint8_t speed,
+                                  uint8_t ep_type,
+                                  uint16_t mps);
+HAL_StatusTypeDef USB_HC_StartXfer(USB_OTG_GlobalTypeDef *USBx, USB_OTG_HCTypeDef *hc, uint8_t dma);
+uint32_t          USB_HC_ReadInterrupt (USB_OTG_GlobalTypeDef *USBx);
+HAL_StatusTypeDef USB_HC_Halt(USB_OTG_GlobalTypeDef *USBx , uint8_t hc_num);
+HAL_StatusTypeDef USB_DoPing(USB_OTG_GlobalTypeDef *USBx , uint8_t ch_num);
+HAL_StatusTypeDef USB_StopHost(USB_OTG_GlobalTypeDef *USBx);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#endif /* STM32L475xx || STM32L476xx || STM32L485xx || STM32L486xx */
+  
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L4xx_LL_USB_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal.c
@@ -1,0 +1,660 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   HAL module driver.
+  *          This is the common part of the HAL initialization
+  *
+  @verbatim
+  ==============================================================================
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+    The common HAL driver contains a set of generic and common APIs that can be
+    used by the PPP peripheral drivers and the user to start using the HAL.
+    [..]
+    The HAL contains two APIs' categories:
+         (+) Common HAL APIs
+         (+) Services HAL APIs
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup HAL HAL
+  * @brief HAL module driver
+  * @{
+  */
+
+#ifdef HAL_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/**
+ * @brief STM32L4xx HAL Driver version number V1.3.0
+   */
+#define __STM32L4xx_HAL_VERSION_MAIN   (0x01) /*!< [31:24] main version */
+#define __STM32L4xx_HAL_VERSION_SUB1   (0x03) /*!< [23:16] sub1 version */
+#define __STM32L4xx_HAL_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
+#define __STM32L4xx_HAL_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
+#define __STM32L4xx_HAL_VERSION         ((__STM32L4xx_HAL_VERSION_MAIN << 24)\
+                                        |(__STM32L4xx_HAL_VERSION_SUB1 << 16)\
+                                        |(__STM32L4xx_HAL_VERSION_SUB2 << 8 )\
+                                        |(__STM32L4xx_HAL_VERSION_RC))
+
+#if defined(VREFBUF)
+#define VREFBUF_TIMEOUT_VALUE     (uint32_t)10   /* 10 ms (to be confirmed) */
+#endif /* VREFBUF */
+
+/* ------------ SYSCFG registers bit address in the alias region ------------ */
+#define SYSCFG_OFFSET             (SYSCFG_BASE - PERIPH_BASE)
+/* ---  MEMRMP Register ---*/
+/* Alias word address of FB_MODE bit */
+#define MEMRMP_OFFSET             SYSCFG_OFFSET
+#define FB_MODE_BitNumber         ((uint8_t)0x8)
+#define FB_MODE_BB                (PERIPH_BB_BASE + (MEMRMP_OFFSET * 32) + (FB_MODE_BitNumber * 4))
+
+/* --- SCSR Register ---*/
+/* Alias word address of SRAM2ER bit */
+#define SCSR_OFFSET              (SYSCFG_OFFSET + 0x18)
+#define BRER_BitNumber           ((uint8_t)0x0)
+#define SCSR_SRAM2ER_BB          (PERIPH_BB_BASE + (SCSR_OFFSET * 32) + (BRER_BitNumber * 4))
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+__IO uint32_t uwTick;
+
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup HAL_Exported_Functions HAL Exported Functions
+  * @{
+  */
+
+/** @defgroup HAL_Exported_Functions_Group1 Initialization and de-initialization Functions
+ *  @brief    Initialization and de-initialization functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize the Flash interface the NVIC allocation and initial time base
+          clock configuration.
+      (+) De-initialize common part of the HAL.
+      (+) Configure the time base source to have 1ms time base with a dedicated
+          Tick interrupt priority.
+        (++) SysTick timer is used by default as source of time base, but user
+             can eventually implement his proper time base source (a general purpose
+             timer for example or other time source), keeping in mind that Time base
+             duration should be kept 1ms since PPP_TIMEOUT_VALUEs are defined and
+             handled in milliseconds basis.
+        (++) Time base configuration function (HAL_InitTick ()) is called automatically
+             at the beginning of the program after reset by HAL_Init() or at any time
+             when clock is configured, by HAL_RCC_ClockConfig().
+        (++) Source of time base is configured  to generate interrupts at regular
+             time intervals. Care must be taken if HAL_Delay() is called from a
+             peripheral ISR process, the Tick interrupt line must have higher priority
+            (numerically lower) than the peripheral interrupt. Otherwise the caller
+            ISR process will be blocked.
+       (++) functions affecting time base configurations are declared as __weak
+             to make  override possible  in case of other  implementations in user file.
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configure the Flash prefetch, the Instruction and Data caches,
+  *         the time base source, NVIC and any required global low level hardware 
+  *         by calling the HAL_MspInit() callback function to be optionally defined in user file 
+  *         stm32l4xx_hal_msp.c.
+  *
+  * @note   HAL_Init() function is called at the beginning of program after reset and before 
+  *         the clock configuration.
+  *             
+  * @note   In the default implementation the System Timer (Systick) is used as source of time base.
+  *         The Systick configuration is based on MSI clock, as MSI is the clock
+  *         used after a system Reset and the NVIC configuration is set to Priority group 4.
+  *         Once done, time base tick starts incrementing: the tick variable counter is incremented 
+  *         each 1ms in the SysTick_Handler() interrupt handler.
+  *
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_Init(void)
+{
+  /* Configure Flash prefetch, Instruction cache, Data cache */
+  /* Default configuration at reset is:                      */
+  /* - Prefetch disabled                                     */
+  /* - Instruction cache enabled                             */
+  /* - Data cache enabled                                    */
+#if (INSTRUCTION_CACHE_ENABLE == 0)
+   __HAL_FLASH_INSTRUCTION_CACHE_DISABLE();
+#endif /* INSTRUCTION_CACHE_ENABLE */
+
+#if (DATA_CACHE_ENABLE == 0)
+   __HAL_FLASH_DATA_CACHE_DISABLE();
+#endif /* DATA_CACHE_ENABLE */
+
+#if (PREFETCH_ENABLE != 0)
+  __HAL_FLASH_PREFETCH_BUFFER_ENABLE();
+#endif /* PREFETCH_ENABLE */
+
+  /* Set Interrupt Group Priority */
+  HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
+
+  /* Use SysTick as time base source and configure 1ms tick (default clock after Reset is MSI) */
+  HAL_InitTick(TICK_INT_PRIORITY);
+
+  /* Init the low level hardware */
+  HAL_MspInit();
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief De-initialize common part of the HAL and stop the source of time base.
+  * @note This function is optional.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DeInit(void)
+{
+  /* Reset of all peripherals */
+  __HAL_RCC_APB1_FORCE_RESET();
+  __HAL_RCC_APB1_RELEASE_RESET();
+
+  __HAL_RCC_APB2_FORCE_RESET();
+  __HAL_RCC_APB2_RELEASE_RESET();
+
+  __HAL_RCC_AHB1_FORCE_RESET();
+  __HAL_RCC_AHB1_RELEASE_RESET();
+
+  __HAL_RCC_AHB2_FORCE_RESET();
+  __HAL_RCC_AHB2_RELEASE_RESET();
+
+  __HAL_RCC_AHB3_FORCE_RESET();
+  __HAL_RCC_AHB3_RELEASE_RESET();
+
+  /* De-Init the low level hardware */
+  HAL_MspDeInit();
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initialize the MSP.
+  * @retval None
+  */
+__weak void HAL_MspInit(void)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitialize the MSP.
+  * @retval None
+  */
+__weak void HAL_MspDeInit(void)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief This function configures the source of the time base:
+  *        The time source is configured to have 1ms time base with a dedicated
+  *        Tick interrupt priority.
+  * @note This function is called  automatically at the beginning of program after
+  *       reset by HAL_Init() or at any time when clock is reconfigured  by HAL_RCC_ClockConfig().
+  * @note In the default implementation, SysTick timer is the source of time base.
+  *       It is used to generate interrupts at regular time intervals.
+  *       Care must be taken if HAL_Delay() is called from a peripheral ISR process,
+  *       The SysTick interrupt must have higher priority (numerically lower)
+  *       than the peripheral interrupt. Otherwise the caller ISR process will be blocked.
+  *       The function is declared as __weak  to be overwritten  in case of other
+  *       implementation  in user file.
+  * @param TickPriority: Tick interrupt priority.
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
+{
+  /*Configure the SysTick to have interrupt in 1ms time basis*/
+  HAL_SYSTICK_Config(SystemCoreClock/1000);
+
+  /*Configure the SysTick IRQ priority */
+  HAL_NVIC_SetPriority(SysTick_IRQn, TickPriority ,0);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_Exported_Functions_Group2 HAL Control functions
+ *  @brief    HAL Control functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### HAL Control functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Provide a tick value in millisecond
+      (+) Provide a blocking delay in millisecond
+      (+) Suspend the time base source interrupt
+      (+) Resume the time base source interrupt
+      (+) Get the HAL API driver version
+      (+) Get the device identifier
+      (+) Get the device revision identifier
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief This function is called to increment a global variable "uwTick"
+  *        used as application time base.
+  * @note In the default implementation, this variable is incremented each 1ms
+  *       in SysTick ISR.
+ * @note This function is declared as __weak to be overwritten in case of other
+  *      implementations in user file.
+  * @retval None
+  */
+__weak void HAL_IncTick(void)
+{
+  uwTick++;
+}
+
+/**
+  * @brief Provide a tick value in millisecond.
+  * @note This function is declared as __weak to be overwritten in case of other
+  *       implementations in user file.
+  * @retval tick value
+  */
+__weak uint32_t HAL_GetTick(void)
+{
+  return uwTick;
+}
+
+/**
+  * @brief Provide accurate delay (in milliseconds) based on variable incremented.
+  * @note In the default implementation , SysTick timer is the source of time base.
+  *       It is used to generate interrupts at regular time intervals where uwTick
+  *       is incremented.
+  * @note This function is declared as __weak to be overwritten in case of other
+  *       implementations in user file.
+  * @param Delay: specifies the delay time length, in milliseconds.
+  * @retval None
+  */
+__weak void HAL_Delay(uint32_t Delay)
+{
+  uint32_t tickstart = 0;
+  tickstart = HAL_GetTick();
+  while((HAL_GetTick() - tickstart) < Delay)
+  {
+  }
+}
+
+/**
+  * @brief Suspend Tick increment.
+  * @note In the default implementation , SysTick timer is the source of time base. It is
+  *       used to generate interrupts at regular time intervals. Once HAL_SuspendTick()
+  *       is called, the SysTick interrupt will be disabled and so Tick increment
+  *       is suspended.
+  * @note This function is declared as __weak to be overwritten in case of other
+  *       implementations in user file.
+  * @retval None
+  */
+__weak void HAL_SuspendTick(void)
+{
+  /* Disable SysTick Interrupt */
+  SysTick->CTRL &= ~SysTick_CTRL_TICKINT_Msk;
+}
+
+/**
+  * @brief Resume Tick increment.
+  * @note In the default implementation , SysTick timer is the source of time base. It is
+  *       used to generate interrupts at regular time intervals. Once HAL_ResumeTick()
+  *       is called, the SysTick interrupt will be enabled and so Tick increment
+  *       is resumed.
+  * @note This function is declared as __weak to be overwritten in case of other
+  *       implementations in user file.
+  * @retval None
+  */
+__weak void HAL_ResumeTick(void)
+{
+  /* Enable SysTick Interrupt */
+  SysTick->CTRL  |= SysTick_CTRL_TICKINT_Msk;
+}
+
+/**
+  * @brief  Return the HAL revision.
+  * @retval version : 0xXYZR (8bits for each decimal, R for RC)
+  */
+uint32_t HAL_GetHalVersion(void)
+{
+ return __STM32L4xx_HAL_VERSION;
+}
+
+/**
+  * @brief  Return the device revision identifier.
+  * @retval Device revision identifier
+  */
+uint32_t HAL_GetREVID(void)
+{
+   return((DBGMCU->IDCODE & DBGMCU_IDCODE_REV_ID) >> 16);
+}
+
+/**
+  * @brief  Return the device identifier.
+  * @retval Device identifier
+  */
+uint32_t HAL_GetDEVID(void)
+{
+   return(DBGMCU->IDCODE & DBGMCU_IDCODE_DEV_ID);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_Exported_Functions_Group3 HAL Debug functions
+ *  @brief    HAL Debug functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### HAL Debug functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Enable/Disable Debug module during SLEEP mode
+      (+) Enable/Disable Debug module during STOP0/STOP1/STOP2 modes
+      (+) Enable/Disable Debug module during STANDBY mode
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enable the Debug Module during SLEEP mode.
+  * @retval None
+  */
+void HAL_DBGMCU_EnableDBGSleepMode(void)
+{
+  SET_BIT(DBGMCU->CR, DBGMCU_CR_DBG_SLEEP);
+}
+
+/**
+  * @brief  Disable the Debug Module during SLEEP mode.
+  * @retval None
+  */
+void HAL_DBGMCU_DisableDBGSleepMode(void)
+{
+  CLEAR_BIT(DBGMCU->CR, DBGMCU_CR_DBG_SLEEP);
+}
+
+/**
+  * @brief  Enable the Debug Module during STOP0/STOP1/STOP2 modes.
+  * @retval None
+  */
+void HAL_DBGMCU_EnableDBGStopMode(void)
+{
+  SET_BIT(DBGMCU->CR, DBGMCU_CR_DBG_STOP);
+}
+
+/**
+  * @brief  Disable the Debug Module during STOP0/STOP1/STOP2 modes.
+  * @retval None
+  */
+void HAL_DBGMCU_DisableDBGStopMode(void)
+{
+  CLEAR_BIT(DBGMCU->CR, DBGMCU_CR_DBG_STOP);
+}
+
+/**
+  * @brief  Enable the Debug Module during STANDBY mode.
+  * @retval None
+  */
+void HAL_DBGMCU_EnableDBGStandbyMode(void)
+{
+  SET_BIT(DBGMCU->CR, DBGMCU_CR_DBG_STANDBY);
+}
+
+/**
+  * @brief  Disable the Debug Module during STANDBY mode.
+  * @retval None
+  */
+void HAL_DBGMCU_DisableDBGStandbyMode(void)
+{
+  CLEAR_BIT(DBGMCU->CR, DBGMCU_CR_DBG_STANDBY);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_Exported_Functions_Group4 HAL SYSCFG configuration functions
+ *  @brief    HAL SYSCFG configuration functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### HAL SYSCFG configuration functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Start a hardware SRAM2 erase operation
+      (+) Enable/Disable the Internal FLASH Bank Swapping
+      (+) Configure the Voltage reference buffer
+      (+) Enable/Disable the Voltage reference buffer
+      (+) Enable/Disable the I/O analog switch voltage booster
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Start a hardware SRAM2 erase operation.
+  * @note   As long as SRAM2 is not erased the SRAM2ER bit will be set.
+  *         This bit is automatically reset at the end of the SRAM2 erase operation.
+  * @retval None
+  */
+void HAL_SYSCFG_SRAM2Erase(void)
+{
+  /* unlock the write protection of the SRAM2ER bit */
+  SYSCFG->SKR = 0xCA;
+  SYSCFG->SKR = 0x53;
+  /* Starts a hardware SRAM2 erase operation*/
+  *(__IO uint32_t *) SCSR_SRAM2ER_BB = (uint8_t)0x00000001;
+}
+
+/**
+  * @brief  Enable the Internal FLASH Bank Swapping.
+  *
+  * @note   This function can be used only for STM32L4xx devices.
+  *
+  * @note   Flash Bank2 mapped at 0x08000000 (and aliased @0x00000000)
+  *         and Flash Bank1 mapped at 0x08100000 (and aliased at 0x00100000)
+  *
+  * @retval None
+  */
+void HAL_SYSCFG_EnableMemorySwappingBank(void)
+{
+  *(__IO uint32_t *)FB_MODE_BB = (uint32_t)ENABLE;
+}
+
+/**
+  * @brief  Disable the Internal FLASH Bank Swapping.
+  *
+  * @note   This function can be used only for STM32L4xx devices.
+  *
+  * @note   The default state : Flash Bank1 mapped at 0x08000000 (and aliased @0x0000 0000)
+  *         and Flash Bank2 mapped at 0x08100000 (and aliased at 0x00100000)
+  *
+  * @retval None
+  */
+void HAL_SYSCFG_DisableMemorySwappingBank(void)
+{
+
+  *(__IO uint32_t *)FB_MODE_BB = (uint32_t)DISABLE;
+}
+
+#if defined(VREFBUF)
+/**
+  * @brief Configure the internal voltage reference buffer voltage scale.
+  * @param  VoltageScaling: specifies the output voltage to achieve
+  *          This parameter can be one of the following values:
+  *            @arg SYSCFG_VREFBUF_VOLTAGE_SCALE0: VREF_OUT1 around 2.048 V. 
+  *                                                This requires VDDA equal to or higher than 2.4 V.
+  *            @arg SYSCFG_VREFBUF_VOLTAGE_SCALE1: VREF_OUT1 around 2.5 V. 
+  *                                                This requires VDDA equal to or higher than 2.8 V.
+  * @retval None
+  */
+void HAL_SYSCFG_VREFBUF_VoltageScalingConfig(uint32_t VoltageScaling)
+{
+  /* Check the parameters */
+  assert_param(IS_SYSCFG_VREFBUF_VOLTAGE_SCALE(VoltageScaling));
+  
+  MODIFY_REG(VREFBUF->CSR, VREFBUF_CSR_VRS, VoltageScaling);
+}
+
+/**
+  * @brief Configure the internal voltage reference buffer high impedance mode.
+  * @param  Mode: specifies the high impedance mode
+  *          This parameter can be one of the following values:
+  *            @arg SYSCFG_VREFBUF_HIGH_IMPEDANCE_DISABLE: VREF+ pin is internally connect to VREFINT output.
+  *            @arg SYSCFG_VREFBUF_HIGH_IMPEDANCE_ENABLE: VREF+ pin is high impedance.
+  * @retval None
+  */
+void HAL_SYSCFG_VREFBUF_HighImpedanceConfig(uint32_t Mode)
+{
+  /* Check the parameters */
+  assert_param(IS_SYSCFG_VREFBUF_HIGH_IMPEDANCE(Mode));
+  
+  MODIFY_REG(VREFBUF->CSR, VREFBUF_CSR_HIZ, Mode);
+}
+
+/**
+  * @brief  Tune the Internal Voltage Reference buffer (VREFBUF).
+  * @retval None
+  */
+void HAL_SYSCFG_VREFBUF_TrimmingConfig(uint32_t TrimmingValue)
+{
+  /* Check the parameters */
+  assert_param(IS_SYSCFG_VREFBUF_TRIMMING(TrimmingValue));
+  
+  MODIFY_REG(VREFBUF->CCR, VREFBUF_CCR_TRIM, TrimmingValue);
+}
+
+/**
+  * @brief  Enable the Internal Voltage Reference buffer (VREFBUF).
+  * @retval HAL_OK/HAL_TIMEOUT
+  */
+HAL_StatusTypeDef HAL_SYSCFG_EnableVREFBUF(void)
+{
+  uint32_t  tickstart = 0;
+  
+  SET_BIT(VREFBUF->CSR, VREFBUF_CSR_ENVR);
+  
+  /* Get Start Tick*/
+  tickstart = HAL_GetTick();
+
+  /* Wait for VRR bit  */
+  while(READ_BIT(VREFBUF->CSR, VREFBUF_CSR_VRR) == RESET)
+  {
+    if((HAL_GetTick() - tickstart) > VREFBUF_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disable the Internal Voltage Reference buffer (VREFBUF).
+  *
+  * @retval None
+  */
+void HAL_SYSCFG_DisableVREFBUF(void)
+{
+  CLEAR_BIT(VREFBUF->CSR, VREFBUF_CSR_ENVR);
+}
+#endif /* VREFBUF */
+
+/**
+  * @brief  Enable the I/O analog switch voltage booster
+  *
+  * @retval None
+  */
+void HAL_SYSCFG_EnableIOAnalogSwitchBooster(void)
+{
+  SET_BIT(SYSCFG->CFGR1, SYSCFG_CFGR1_BOOSTEN);
+}
+
+/**
+  * @brief  Disable the I/O analog switch voltage booster
+  *
+  * @retval None
+  */
+void HAL_SYSCFG_DisableIOAnalogSwitchBooster(void)
+{
+  CLEAR_BIT(SYSCFG->CFGR1, SYSCFG_CFGR1_BOOSTEN);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_adc.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_adc.c
@@ -1,0 +1,2992 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_adc.c
+  * @author  MCD Application conversion
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the Analog to Digital Convertor (ADC)
+  *          peripheral:
+  *           + Initialization and de-initialization functions
+  *             ++ Configuration of ADC
+  *           + Operation functions
+  *             ++ Start, stop, get result of regular conversions of regular 
+  *                using 3 possible modes: polling, interruption or DMA.
+  *           + Control functions
+  *             ++ Analog Watchdog configuration
+  *             ++ Channels configuration on regular group
+  *           + State functions
+  *             ++ ADC state machine management
+  *             ++ Interrupts and flags management
+  *     
+   @verbatim      
+  ==============================================================================
+                    ##### ADC specific features #####
+  ==============================================================================
+  [..] 
+  (#) 12-bit, 10-bit, 8-bit or 6-bit configurable resolution.
+
+  (#) Interrupt generation at the end of regular conversion and in case of 
+      analog watchdog and overrun events.
+  
+  (#) Single and continuous conversion modes.
+  
+  (#) Scan mode for automatic conversion of channel 0 to channel 'n'.
+  
+  (#) Data alignment with in-built data coherency.
+  
+  (#) Channel-wise programmable sampling time.
+
+  (#) External trigger (timer or EXTI) with configurable polarity for  
+      regular groups.
+
+  (#) DMA request generation for transfer of regular group converted data.
+  
+  (#) Configurable delay between conversions in Dual interleaved mode.
+
+  (#) ADC channels selectable single/differential input.
+
+  (#) ADC offset on regular groups.
+
+  (#) ADC supply requirements: 1.62 V to 3.6 V.
+  
+  (#) ADC input range: from Vref_ (connected to Vssa) to Vref+ (connected to 
+      Vdda or to an external voltage reference).
+      
+
+
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+
+    (#) Enable the ADC interface 
+        As prerequisite, in HAL_ADC_MspInit(), ADC clock source must be  
+        configured at RCC top level.
+
+        Two different clock sources are available:
+        (++) - the ADC clock can be a specific clock source, coming from the system 
+        clock, the PLLSAI1 or the PLLSAI2 running up to 80MHz.
+        (++) - or the ADC clock can be derived from the AHB clock of the ADC bus 
+       interface, divided by a programmable factor
+
+
+        (++) For example, in case of PLLSAI2:
+            (+++) __HAL_RCC_ADC_CLK_ENABLE();
+            (+++) HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
+            (+++) where
+              (+++) PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC
+              (+++) PeriphClkInit.AdcClockSelection    = RCC_ADCCLKSOURCE_PLLSAI2
+
+                      
+    (#) ADC pins configuration
+         (++) Enable the clock for the ADC GPIOs using the following function:
+             __HAL_RCC_GPIOx_CLK_ENABLE();   
+         (++) Configure these ADC pins in analog mode using HAL_GPIO_Init();  
+  
+    (#) Configure the ADC parameters (conversion resolution, data alignment,  
+         continuous mode, ...) using the HAL_ADC_Init() function.
+         
+    (#) Optionally, perform an automatic ADC calibration to improve the
+        conversion accuracy using function HAL_ADCEx_Calibration_Start().
+
+    (#) Activate the ADC peripheral using one of the start functions: 
+        HAL_ADC_Start(), HAL_ADC_Start_IT(), HAL_ADC_Start_DMA(),
+        HAL_ADCEx_InjectedStart(), HAL_ADCEx_InjectedStart_IT() or 
+        HAL_ADCEx_MultiModeStart_DMA() when multimode feature is available.
+  
+   *** Channels to regular group configuration ***
+     ============================================
+     [..]    
+       (+) To configure the ADC regular group features, use 
+           HAL_ADC_Init() and HAL_ADC_ConfigChannel() functions.
+       (+) To activate the continuous mode, use the HAL_ADC_Init() function.   
+       (+) To read the ADC converted values, use the HAL_ADC_GetValue() function.
+  
+     *** DMA for regular configuration ***
+     ============================================================= 
+     [..]
+       (+) To enable the DMA mode for regular group, use the  
+           HAL_ADC_Start_DMA() function.
+       (+) To enable the generation of DMA requests continuously at the end of 
+           the last DMA transfer, resort to DMAContinuousRequests parameter of 
+           ADC handle initialization structure.
+  
+
+  
+    @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup ADC ADC
+  * @brief ADC HAL module driver
+  * @{
+  */ 
+
+#ifdef HAL_ADC_MODULE_ENABLED
+    
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+
+/** @defgroup ADC_Private_Constants ADC Private Constants
+  * @{                                                         
+  */
+  
+#define ADC_CFGR_FIELDS_1  ((uint32_t)(ADC_CFGR_RES    | ADC_CFGR_ALIGN   |\
+                                       ADC_CFGR_CONT   | ADC_CFGR_OVRMOD  |\
+                                       ADC_CFGR_DISCEN | ADC_CFGR_DISCNUM |\
+                                       ADC_CFGR_EXTEN  | ADC_CFGR_EXTSEL))   /*!< ADC_CFGR fields of parameters that can be updated 
+                                                                                  when no regular conversion is on-going */
+                                      
+#define ADC_CFGR2_FIELDS  ((uint32_t)(ADC_CFGR2_ROVSE | ADC_CFGR2_OVSR  |\
+                                       ADC_CFGR2_OVSS | ADC_CFGR2_TROVS |\
+                                       ADC_CFGR2_ROVSM))                     /*!< ADC_CFGR2 fields of parameters that can be updated when no conversion
+                                                                                 (neither regular nor injected) is on-going  */
+
+#define ADC_CFGR_WD_FIELDS  ((uint32_t)(ADC_CFGR_AWD1SGL | ADC_CFGR_JAWD1EN | \
+                                        ADC_CFGR_AWD1EN | ADC_CFGR_AWD1CH))  /*!< ADC_CFGR fields of Analog Watchdog parameters that can be updated when no
+                                                                                  conversion (neither regular nor injected) is on-going  */
+  
+#define ADC_OFR_FIELDS  ((uint32_t)(ADC_OFR1_OFFSET1 | ADC_OFR1_OFFSET1_CH | ADC_OFR1_OFFSET1_EN)) /*!< ADC_OFR fields of parameters that can be updated when no conversion
+                                                                                                        (neither regular nor injected) is on-going */
+
+
+  
+/* Delay to wait before setting ADEN once ADCAL has been reset
+   must be at least 4 ADC clock cycles.
+   Assuming lowest ADC clock (140 KHz according to DS), this
+   4 ADC clock cycles duration is equal to
+   4 / 140,000 = 0.028 ms.
+   ADC_ENABLE_TIMEOUT set to 2 is a margin large enough to ensure
+   the 4 ADC clock cycles have elapsed while waiting for ADRDY
+   to become 1 */        
+  #define ADC_ENABLE_TIMEOUT              ((uint32_t)  2)    /*!< ADC enable time-out value  */
+  #define ADC_DISABLE_TIMEOUT             ((uint32_t)  2)    /*!< ADC disable time-out value */
+   
+    
+                                                                            
+/* Delay for ADC voltage regulator startup time                               */
+/*  Maximum delay is 10 microseconds                                          */
+/* (refer device RM, parameter Tadcvreg_stup).                                */
+#define ADC_STAB_DELAY_US               ((uint32_t) 10)     /*!< ADC voltage regulator startup time */
+  
+  
+/* Timeout to wait for current conversion on going to be completed.           */
+/* Timeout fixed to worst case, for 1 channel.                                */
+/*   - maximum sampling time (640.5 adc_clk)                                  */
+/*   - ADC resolution (Tsar 12 bits= 12.5 adc_clk)                            */
+/*   - ADC clock with prescaler 256                                           */
+/*     653 * 256 = 167168 clock cycles max                                    */
+/* Unit: cycles of CPU clock.                                                 */
+#define ADC_CONVERSION_TIME_MAX_CPU_CYCLES ((uint32_t) 167168)  /*!< ADC conversion completion time-out value */
+  
+  
+
+  
+/**
+  * @}
+  */  
+  
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup ADC_Exported_Functions ADC Exported Functions
+  * @{
+  */ 
+
+/** @defgroup ADC_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the ADC. 
+      (+) De-initialize the ADC. 
+         
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initialize the ADC peripheral and regular group according to  
+  *         parameters specified in structure "ADC_InitTypeDef".
+  * @note   As prerequisite, ADC clock must be configured at RCC top level
+  *         depending on possible clock sources: System/PLLSAI1/PLLSAI2 clocks 
+  *         or AHB clock.
+  * @note   Possibility to update parameters on the fly:
+  *         this function initializes the ADC MSP (HAL_ADC_MspInit()) only when
+  *         coming from ADC state reset. Following calls to this function can
+  *         be used to reconfigure some parameters of ADC_InitTypeDef  
+  *         structure on the fly, without modifying MSP configuration. If ADC  
+  *         MSP has to be modified again, HAL_ADC_DeInit() must be called
+  *         before HAL_ADC_Init().
+  *         The setting of these parameters is conditioned by ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_InitTypeDef".
+  * @note   This function configures the ADC within 2 scopes: scope of entire 
+  *         ADC and scope of regular group. For parameters details, see comments 
+  *         of structure "ADC_InitTypeDef".
+  * @note   Parameters related to common ADC registers (ADC clock mode) are set 
+  *         only if all ADCs are disabled.
+  *         If this is not the case, these common parameters setting are  
+  *         bypassed without error reporting: it can be the intended behaviour in
+  *         case of update of a parameter of ADC_InitTypeDef on the fly,
+  *         without  disabling the other ADCs.
+  * @param  hadc: ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+
+  ADC_Common_TypeDef *tmpADC_Common;
+  uint32_t tmpCFGR = 0;
+  uint32_t wait_loop_index = 0;
+  
+  /* Check ADC handle */
+  if(hadc == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_CLOCKPRESCALER(hadc->Init.ClockPrescaler)); 
+  assert_param(IS_ADC_RESOLUTION(hadc->Init.Resolution));
+  assert_param(IS_ADC_DATA_ALIGN(hadc->Init.DataAlign)); 
+  assert_param(IS_ADC_SCAN_MODE(hadc->Init.ScanConvMode));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EXTTRIG_EDGE(hadc->Init.ExternalTrigConvEdge));
+  assert_param(IS_ADC_EXTTRIG(hadc->Init.ExternalTrigConv));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DMAContinuousRequests));
+  assert_param(IS_ADC_EOC_SELECTION(hadc->Init.EOCSelection));
+  assert_param(IS_ADC_OVERRUN(hadc->Init.Overrun));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.LowPowerAutoWait));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.OversamplingMode));
+  
+  if(hadc->Init.ScanConvMode != ADC_SCAN_DISABLE)
+  {
+    assert_param(IS_ADC_REGULAR_NB_CONV(hadc->Init.NbrOfConversion));
+    assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DiscontinuousConvMode));
+    
+    if (hadc->Init.DiscontinuousConvMode == ENABLE)
+    { 
+      assert_param(IS_ADC_REGULAR_DISCONT_NUMBER(hadc->Init.NbrOfDiscConversion));
+    }
+  }
+
+  
+  /* DISCEN and CONT bits can't be set at the same time */
+  assert_param(!((hadc->Init.DiscontinuousConvMode == ENABLE) && (hadc->Init.ContinuousConvMode == ENABLE)));
+ 
+  
+  /* Actions performed only if ADC is coming from state reset:                */
+  /* - Initialization of ADC MSP                                              */
+  if (hadc->State == HAL_ADC_STATE_RESET)
+  {
+    /* Init the low level hardware */
+    HAL_ADC_MspInit(hadc);
+    
+    /* Set ADC error code to none */
+    ADC_CLEAR_ERRORCODE(hadc);
+    
+    /* Initialize Lock */
+    hadc->Lock = HAL_UNLOCKED;
+  }
+    
+    
+  /* - Exit from deep-power-down mode and ADC voltage regulator enable        */    
+  /*  Exit deep power down mode if still in that state */
+  if (HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_DEEPPWD))
+  {
+    /* Exit deep power down mode */ 
+    CLEAR_BIT(hadc->Instance->CR, ADC_CR_DEEPPWD);
+    
+    /* System was in deep power down mode, calibration must
+     be relaunched or a previously saved calibration factor 
+     re-applied once the ADC voltage regulator is enabled */    
+  }
+  
+
+  if  (HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADVREGEN))
+  {  
+    /* Enable ADC internal voltage regulator  then 
+     wait for start-up time */
+    SET_BIT(hadc->Instance->CR, ADC_CR_ADVREGEN);
+    wait_loop_index = (ADC_STAB_DELAY_US * (SystemCoreClock / 1000000));
+    while(wait_loop_index != 0)
+    {
+      wait_loop_index--;
+    }    
+  }
+
+
+ 
+  
+  /* Verification that ADC voltage regulator is correctly enabled, whether    */
+  /* or not ADC is coming from state reset (if any potential problem of       */
+  /* clocking, voltage regulator would not be enabled).                       */
+  if (HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADVREGEN))  
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+    
+    /* Set ADC error code to ADC IP internal error */
+    SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+    
+    tmp_status = HAL_ERROR;
+  }
+ 
+
+  /* Configuration of ADC parameters if previous preliminary actions are      */ 
+  /* correctly completed and if there is no conversion on going on regular    */
+  /* group (ADC may already be enabled at this point if HAL_ADC_Init() is     */
+  /* called to update a parameter on the fly).                                */
+  if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL) &&
+      (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)  )
+  {
+    
+    /* Initialize the ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_BUSY_INTERNAL);
+    
+    /* Configuration of common ADC parameters                                 */
+    
+    /* Pointer to the common control register                                 */
+    tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+    
+  
+    /* Parameters update conditioned to ADC state:                            */
+    /* Parameters that can be updated only when ADC is disabled:              */
+    /*  - clock configuration                                                 */
+    if ((ADC_IS_ENABLE(hadc) == RESET)   &&
+         (ADC_ANY_OTHER_ENABLED(hadc) == RESET) )         
+    {
+      /* Reset configuration of ADC common register CCR:                      */
+      /*                                                                      */
+      /*   - ADC clock mode and ACC prescaler (CKMODE and PRESC bits)are set  */
+      /*     according to adc->Init.ClockPrescaler. It selects the clock      */
+      /*    source and sets the clock division factor.                        */
+      /*                                                                      */
+      /* Some parameters of this register are not reset, since they are set   */
+      /* by other functions and must be kept in case of usage of this         */
+      /* function on the fly (update of a parameter of ADC_InitTypeDef        */
+      /* without needing to reconfigure all other ADC groups/channels         */
+      /* parameters):                                                         */
+      /*   - when multimode feature is available, multimode-related           */
+      /*     parameters: MDMA, DMACFG, DELAY, DUAL (set by API                */
+      /*     HAL_ADCEx_MultiModeConfigChannel() )                             */
+      /*   - internal measurement paths: Vbat, temperature sensor, Vref       */
+      /*     (set into HAL_ADC_ConfigChannel() or                             */
+      /*     HAL_ADCEx_InjectedConfigChannel() )                              */
+           
+      MODIFY_REG(tmpADC_Common->CCR, ADC_CCR_PRESC|ADC_CCR_CKMODE, hadc->Init.ClockPrescaler);
+    }
+      
+      
+    /* Configuration of ADC:                                                  */
+    /*  - resolution                               Init.Resolution            */
+    /*  - data alignment                           Init.DataAlign             */
+    /*  - external trigger to start conversion     Init.ExternalTrigConv      */
+    /*  - external trigger polarity                Init.ExternalTrigConvEdge  */
+    /*  - continuous conversion mode               Init.ContinuousConvMode    */
+    /*  - overrun                                  Init.Overrun               */
+    /*  - discontinuous mode                       Init.DiscontinuousConvMode */
+    /*  - discontinuous mode channel count         Init.NbrOfDiscConversion   */    
+    tmpCFGR  = ( ADC_CFGR_CONTINUOUS(hadc->Init.ContinuousConvMode)          |
+                 hadc->Init.Overrun                                          |
+                 hadc->Init.DataAlign                                        |
+                 hadc->Init.Resolution                                       |
+                ADC_CFGR_REG_DISCONTINUOUS(hadc->Init.DiscontinuousConvMode) |
+                ADC_CFGR_DISCONTINUOUS_NUM(hadc->Init.NbrOfDiscConversion) );
+      
+    /* Enable external trigger if trigger selection is different of software  */
+    /* start.                                                                 */
+    /*  - external trigger to start conversion     Init.ExternalTrigConv      */
+    /*  - external trigger polarity                Init.ExternalTrigConvEdge  */    
+    /* Note:  parameter ExternalTrigConvEdge set to "trigger edge none" is    */
+    /*        equivalent to software start.                                   */
+    if ((hadc->Init.ExternalTrigConv != ADC_SOFTWARE_START)
+    &&  (hadc->Init.ExternalTrigConvEdge != ADC_EXTERNALTRIGCONVEDGE_NONE))
+    {
+      tmpCFGR |= ( hadc->Init.ExternalTrigConv |  hadc->Init.ExternalTrigConvEdge);
+    }
+    
+     /* Update Configuration Register CFGR */
+     MODIFY_REG(hadc->Instance->CFGR, ADC_CFGR_FIELDS_1, tmpCFGR); 
+     
+
+    /* Parameters update conditioned to ADC state:                            */
+    /* Parameters that can be updated when ADC is disabled or enabled without */
+    /* conversion on going on regular and injected groups:                    */
+    /*  - DMA continuous request          Init.DMAContinuousRequests          */
+    /*  - LowPowerAutoWait feature        Init.LowPowerAutoWait               */
+    /*  - Oversampling parameters         Init.Oversampling                     */    
+    if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET)
+    {
+      tmpCFGR = ( ADC_CFGR_AUTOWAIT(hadc->Init.LowPowerAutoWait)       |
+                  ADC_CFGR_DMACONTREQ(hadc->Init.DMAContinuousRequests) );
+               
+      MODIFY_REG(hadc->Instance->CFGR, ADC_CFGR_FIELDS_2, tmpCFGR);                    
+    
+ 
+      if (hadc->Init.OversamplingMode == ENABLE)
+      {
+        assert_param(IS_ADC_OVERSAMPLING_RATIO(hadc->Init.Oversampling.Ratio));
+        assert_param(IS_ADC_RIGHT_BIT_SHIFT(hadc->Init.Oversampling.RightBitShift));
+        assert_param(IS_ADC_TRIGGERED_OVERSAMPLING_MODE(hadc->Init.Oversampling.TriggeredMode));
+        assert_param(IS_ADC_REGOVERSAMPLING_MODE(hadc->Init.Oversampling.OversamplingStopReset));
+        
+        if ((hadc->Init.ExternalTrigConv == ADC_SOFTWARE_START)
+        ||  (hadc->Init.ExternalTrigConvEdge == ADC_EXTERNALTRIGCONVEDGE_NONE))
+        {
+            /* Multi trigger is not applicable to software-triggered conversions */
+            assert_param((hadc->Init.Oversampling.TriggeredMode == ADC_TRIGGEREDMODE_SINGLE_TRIGGER));
+        }    
+    
+    
+       /* Configuration of Oversampler:                                       */
+       /*  - Oversampling Ratio                                               */
+       /*  - Right bit shift                                                  */
+       /*  - Triggered mode                                                   */
+       /*  - Oversampling mode (continued/resumed)                            */    
+       MODIFY_REG(hadc->Instance->CFGR2, ADC_CFGR2_FIELDS, 
+                               ADC_CFGR2_ROVSE                     | 
+                               hadc->Init.Oversampling.Ratio         |
+                               hadc->Init.Oversampling.RightBitShift |
+                               hadc->Init.Oversampling.TriggeredMode |
+                               hadc->Init.Oversampling.OversamplingStopReset);
+      }  
+      else
+      {
+        /* Disable Regular OverSampling */
+        CLEAR_BIT( hadc->Instance->CFGR2, ADC_CFGR2_ROVSE);
+      }    
+ 
+    
+    }   /*  if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET) */
+    
+
+    
+    
+    /* Configuration of regular group sequencer:                              */
+    /* - if scan mode is disabled, regular channels sequence length is set to */
+    /*   0x00: 1 channel converted (channel on regular rank 1)                */
+    /*   Parameter "NbrOfConversion" is discarded.                            */
+    /*   Note: Scan mode is not present by hardware on this device, but       */
+    /*   emulated by software for alignment over all STM32 devices.           */
+    /* - if scan mode is enabled, regular channels sequence length is set to  */
+    /*   parameter "NbrOfConversion"                                          */
+
+    if (hadc->Init.ScanConvMode == ADC_SCAN_ENABLE)
+    {
+      /* Set number of ranks in regular group sequencer */     
+      MODIFY_REG(hadc->Instance->SQR1, ADC_SQR1_L, (hadc->Init.NbrOfConversion - (uint8_t)1));  
+    } 
+    else
+    {
+      CLEAR_BIT(hadc->Instance->SQR1, ADC_SQR1_L);
+    }
+    
+    
+    /* Initialize the ADC state */
+    /* Clear HAL_ADC_STATE_BUSY_INTERNAL bit, set HAL_ADC_STATE_READY bit */
+    ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_BUSY_INTERNAL, HAL_ADC_STATE_READY);
+  }
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+    tmp_status = HAL_ERROR;
+  }  /*  if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL)  && (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)  ) */
+  
+  
+  /* Return function status */
+  return tmp_status;
+
+}
+
+/**
+  * @brief  Deinitialize the ADC peripheral registers to their default reset
+  *         values, with deinitialization of the ADC MSP.           
+  * @note   Keep in mind that all ADCs use the same clock: disabling
+  *         the clock will reset all ADCs.
+  * @note   By default, HAL_ADC_DeInit() sets DEEPPWD: this saves more power by
+  *         reducing the leakage currents and is particularly interesting before
+  *         entering STOP 1 or STOP 2 modes.         
+  * @param  hadc: ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
+{  
+  /* Check ADC handle */
+  if(hadc == NULL)
+  {
+     return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Change ADC state */
+  SET_BIT(hadc->State, HAL_ADC_STATE_BUSY_INTERNAL);
+  
+  /* Stop potential conversion on going, on regular and injected groups */
+  /* No check on ADC_ConversionStop() return status, if the conversion
+    stop failed, it is up to HAL_ADC_MspDeInit() to reset the ADC IP */
+  ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+
+  
+  /* Disable ADC peripheral if conversions are effectively stopped            */
+  /* Flush register JSQR: reset the queue sequencer when injected             */
+  /* queue sequencer is enabled and ADC disabled.                             */
+  /* The software and hardware triggers of the injected sequence are both     */
+  /* internally disabled just after the completion of the last valid          */
+  /* injected sequence.                                                       */
+  SET_BIT(hadc->Instance->CFGR, ADC_CFGR_JQM);
+    
+  /* Disable the ADC peripheral */
+  /* No check on ADC_Disable() return status, if the ADC disabling process
+    failed, it is up to HAL_ADC_MspDeInit() to reset the ADC IP */  
+  ADC_Disable(hadc);
+
+
+  /* ========== Reset ADC registers ========== */
+  /* Reset register IER */
+  __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_AWD3  | ADC_IT_AWD2 | ADC_IT_AWD1 |
+                              ADC_IT_JQOVF | ADC_IT_OVR  |
+                              ADC_IT_JEOS  | ADC_IT_JEOC |
+                              ADC_IT_EOS   | ADC_IT_EOC  |
+                              ADC_IT_EOSMP | ADC_IT_RDY                 ) );
+      
+  /* Reset register ISR */
+  __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_AWD3  | ADC_FLAG_AWD2 | ADC_FLAG_AWD1 |
+                              ADC_FLAG_JQOVF | ADC_FLAG_OVR  |
+                              ADC_FLAG_JEOS  | ADC_FLAG_JEOC |
+                              ADC_FLAG_EOS   | ADC_FLAG_EOC  |
+                              ADC_FLAG_EOSMP | ADC_FLAG_RDY                   ) );
+  
+  /* Reset register CR */
+ /* Bits ADC_CR_JADSTP, ADC_CR_ADSTP, ADC_CR_JADSTART, ADC_CR_ADSTART, 
+    ADC_CR_ADCAL, ADC_CR_ADDIS and ADC_CR_ADEN are in access mode "read-set": 
+    no direct reset applicable. 
+    Update CR register to reset value where doable by software */
+  CLEAR_BIT(hadc->Instance->CR, ADC_CR_ADVREGEN | ADC_CR_ADCALDIF);
+  SET_BIT(hadc->Instance->CR, ADC_CR_DEEPPWD);    
+      
+  /* Reset register CFGR */
+  CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_FIELDS);
+  SET_BIT(hadc->Instance->CFGR, ADC_CFGR_JQDIS);  
+  
+  /* Reset register CFGR2 */
+  CLEAR_BIT(hadc->Instance->CFGR2, ADC_CFGR2_ROVSM  | ADC_CFGR2_TROVS   | ADC_CFGR2_OVSS |   
+                                  ADC_CFGR2_OVSR  | ADC_CFGR2_JOVSE | ADC_CFGR2_ROVSE    );                                 
+  
+  /* Reset register SMPR1 */
+  CLEAR_BIT(hadc->Instance->SMPR1, ADC_SMPR1_FIELDS);                                 
+  
+  /* Reset register SMPR2 */
+  CLEAR_BIT(hadc->Instance->SMPR2, ADC_SMPR2_SMP18 | ADC_SMPR2_SMP17 | ADC_SMPR2_SMP16 | 
+                             ADC_SMPR2_SMP15 | ADC_SMPR2_SMP14 | ADC_SMPR2_SMP13 | 
+                             ADC_SMPR2_SMP12 | ADC_SMPR2_SMP11 | ADC_SMPR2_SMP10    );                                 
+  
+  /* Reset register TR1 */
+  CLEAR_BIT(hadc->Instance->TR1, ADC_TR1_HT1 | ADC_TR1_LT1);
+  
+  /* Reset register TR2 */
+  CLEAR_BIT(hadc->Instance->TR2, ADC_TR2_HT2 | ADC_TR2_LT2);    
+  
+  /* Reset register TR3 */
+  CLEAR_BIT(hadc->Instance->TR3, ADC_TR3_HT3 | ADC_TR3_LT3);      
+  
+  /* Reset register SQR1 */
+  CLEAR_BIT(hadc->Instance->SQR1, ADC_SQR1_SQ4 | ADC_SQR1_SQ3 | ADC_SQR1_SQ2 | 
+                            ADC_SQR1_SQ1 | ADC_SQR1_L);                              
+  
+  /* Reset register SQR2 */
+  CLEAR_BIT(hadc->Instance->SQR2, ADC_SQR2_SQ9 | ADC_SQR2_SQ8 | ADC_SQR2_SQ7 | 
+                            ADC_SQR2_SQ6 | ADC_SQR2_SQ5);                                
+  
+  /* Reset register SQR3 */
+  CLEAR_BIT(hadc->Instance->SQR3, ADC_SQR3_SQ14 | ADC_SQR3_SQ13 | ADC_SQR3_SQ12 | 
+                            ADC_SQR3_SQ11 | ADC_SQR3_SQ10);                                 
+  
+  /* Reset register SQR4 */
+  CLEAR_BIT(hadc->Instance->SQR4, ADC_SQR4_SQ16 | ADC_SQR4_SQ15); 
+  
+  /* Register JSQR was reset when the ADC was disabled */
+  
+  /* Reset register DR */
+  /* bits in access mode read only, no direct reset applicable*/
+    
+  /* Reset register OFR1 */
+  CLEAR_BIT(hadc->Instance->OFR1, ADC_OFR1_OFFSET1_EN | ADC_OFR1_OFFSET1_CH | ADC_OFR1_OFFSET1); 
+  /* Reset register OFR2 */
+  CLEAR_BIT(hadc->Instance->OFR2, ADC_OFR2_OFFSET2_EN | ADC_OFR2_OFFSET2_CH | ADC_OFR2_OFFSET2); 
+  /* Reset register OFR3 */
+  CLEAR_BIT(hadc->Instance->OFR3, ADC_OFR3_OFFSET3_EN | ADC_OFR3_OFFSET3_CH | ADC_OFR3_OFFSET3); 
+  /* Reset register OFR4 */
+  CLEAR_BIT(hadc->Instance->OFR4, ADC_OFR4_OFFSET4_EN | ADC_OFR4_OFFSET4_CH | ADC_OFR4_OFFSET4);
+  
+  /* Reset registers JDR1, JDR2, JDR3, JDR4 */
+  /* bits in access mode read only, no direct reset applicable*/
+  
+  /* Reset register AWD2CR */
+  CLEAR_BIT(hadc->Instance->AWD2CR, ADC_AWD2CR_AWD2CH);
+  
+  /* Reset register AWD3CR */
+  CLEAR_BIT(hadc->Instance->AWD3CR, ADC_AWD3CR_AWD3CH);
+  
+  /* Reset register DIFSEL */
+  CLEAR_BIT(hadc->Instance->DIFSEL, ADC_DIFSEL_DIFSEL);
+  
+  /* Reset register CALFACT */
+  CLEAR_BIT(hadc->Instance->CALFACT, ADC_CALFACT_CALFACT_D | ADC_CALFACT_CALFACT_S);
+
+  
+  
+  
+  
+  
+  /* ========== Reset common ADC registers ========== */
+        
+  /* Software is allowed to change common parameters only when all the other
+     ADCs are disabled.   */
+  if ((ADC_IS_ENABLE(hadc) == RESET)   &&
+       (ADC_ANY_OTHER_ENABLED(hadc) == RESET) )
+  {
+    /* Reset configuration of ADC common register CCR:
+      - clock mode: CKMODE, PRESCEN
+      - multimode related parameters (when this feature is available): MDMA, 
+        DMACFG, DELAY, DUAL (set by HAL_ADCEx_MultiModeConfigChannel() API)
+      - internal measurement paths: Vbat, temperature sensor, Vref (set into
+        HAL_ADC_ConfigChannel() or HAL_ADCEx_InjectedConfigChannel() )
+    */
+    ADC_CLEAR_COMMON_CONTROL_REGISTER(hadc);
+  }
+
+  /* DeInit the low level hardware. 
+  
+     For example:
+    __HAL_RCC_ADC_FORCE_RESET();
+    __HAL_RCC_ADC_RELEASE_RESET();
+    __HAL_RCC_ADC_CLK_DISABLE();
+    
+    Keep in mind that all ADCs use the same clock: disabling
+    the clock will reset all ADCs. 
+    
+  */ 
+  HAL_ADC_MspDeInit(hadc);
+    
+  /* Set ADC error code to none */
+  ADC_CLEAR_ERRORCODE(hadc);
+    
+  /* Reset injected channel configuration parameters */
+  hadc->InjectionConfig.ContextQueue = 0;
+  hadc->InjectionConfig.ChannelCount = 0; 
+    
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_RESET;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  
+  /* Return function status */
+  return HAL_OK;
+
+}
+    
+/**
+  * @brief  Initialize the ADC MSP.
+  * @param  hadc: ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_MspInit must be implemented in the user file.
+   */ 
+}
+
+/**
+  * @brief  DeInitialize the ADC MSP.
+  * @param  hadc: ADC handle
+  * @note   All ADCs use the same clock: disabling the clock will reset all ADCs.  
+  * @retval None
+  */
+__weak void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_MspDeInit must be implemented in the user file.
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group2 Input and Output operation functions
+ *  @brief    IO operation functions 
+ *
+@verbatim   
+ ===============================================================================
+             ##### IO operation functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Start conversion of regular group.
+      (+) Stop conversion of regular group.
+      (+) Poll for conversion complete on regular group.
+      (+) Poll for conversion event.
+      (+) Get result of regular channel conversion.
+      (+) Start conversion of regular group and enable interruptions.
+      (+) Stop conversion of regular group and disable interruptions.
+      (+) Handle ADC interrupt request
+      (+) Start conversion of regular group and enable DMA transfer.
+      (+) Stop conversion of regular group and disable ADC DMA transfer.
+               
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Enable ADC, start conversion of regular group.
+  * @note   Interruptions enabled in this function: None.
+  * @note   Case of multimode enabled (when multimode feature is available): 
+  *           if ADC is Slave, ADC is enabled but conversion is not started, 
+  *           if ADC is master, ADC is enabled and multimode conversion is started.
+  * @param  hadc: ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef* hadc)
+{
+  ADC_TypeDef        *tmpADC_Master;
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+   
+  
+  /* if a regular conversion is already on-going (i.e. ADSTART is set),
+     don't restart the conversion. */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc))
+  {
+    return HAL_BUSY;
+  }
+  else
+  {
+    /* Process locked */
+    __HAL_LOCK(hadc);
+    
+    /* Enable the ADC peripheral */
+    tmp_status = ADC_Enable(hadc);
+  
+    /* Start conversion if ADC is effectively enabled */
+    if (tmp_status == HAL_OK)
+    {
+      /* State machine update: Check if an injected conversion is ongoing */
+      if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+      {
+        /* Reset ADC error code fields related to regular conversions only */
+        CLEAR_BIT(hadc->ErrorCode, (HAL_ADC_ERROR_OVR|HAL_ADC_ERROR_DMA));         
+      }
+      else
+      {  
+        /* Set ADC error code to none */
+        ADC_CLEAR_ERRORCODE(hadc); 
+      }
+      /* Clear HAL_ADC_STATE_READY and regular conversion results bits, set HAL_ADC_STATE_REG_BUSY bit */
+      ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_READY|HAL_ADC_STATE_REG_EOC|HAL_ADC_STATE_REG_OVR|HAL_ADC_STATE_REG_EOSMP), HAL_ADC_STATE_REG_BUSY);
+
+      /* Reset HAL_ADC_STATE_MULTIMODE_SLAVE bit
+        - by default if ADC is Master or Independent or if multimode feature is not available
+        - if multimode setting is set to independent mode (no dual regular or injected conversions are configured) */
+      if (ADC_NONMULTIMODE_OR_MULTIMODEMASTER(hadc))
+      {
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }
+    
+      /* Clear regular group conversion flag and overrun flag                   */
+      /* (To ensure of no unknown state from potential previous ADC operations) */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_OVR));
+    
+      /* Enable conversion of regular group.                                  */
+      /* If software start has been selected, conversion starts immediately.  */
+      /* If external trigger has been selected, conversion starts at next     */
+      /* trigger event.                                                       */
+      /* Case of multimode enabled (when multimode feature is available):     */ 
+      /*  - if ADC is slave and dual regular conversions are enabled, ADC is  */
+      /*    enabled only (conversion is not started),                         */
+      /*  - if ADC is master, ADC is enabled and conversion is started.       */
+      if (ADC_INDEPENDENT_OR_NONMULTIMODEREGULAR_SLAVE(hadc))
+      {
+        /* Multimode feature is not available or ADC Instance is Independent or Master, 
+           or is not Slave ADC with dual regular conversions enabled. 
+           Then, set HAL_ADC_STATE_INJ_BUSY bit and reset HAL_ADC_STATE_INJ_EOC bit if JAUTO is set. */
+        if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO) != RESET)
+        {
+          ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);  
+        }
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        /* Start ADC */
+        SET_BIT(hadc->Instance->CR, ADC_CR_ADSTART);
+      }
+      else
+      {
+        SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+        /* if Master ADC JAUTO bit is set, update Slave State in setting 
+           HAL_ADC_STATE_INJ_BUSY bit and in resetting HAL_ADC_STATE_INJ_EOC bit */
+        tmpADC_Master = ADC_MASTER_REGISTER(hadc); 
+        if (READ_BIT(tmpADC_Master->CFGR, ADC_CFGR_JAUTO) != RESET)
+        {
+          ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);
+           
+        }  /* if (READ_BIT(tmpADC_Master->CFGR, ADC_CFGR_JAUTO) != RESET) */
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);      
+      } /* if (ADC_INDEPENDENT_OR_NONMULTIMODEREGULAR_SLAVE(hadc)) */
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);    
+    }    
+  
+  /* Return function status */
+  return tmp_status;
+  }
+}
+
+/**  
+  * @brief  Stop ADC conversion of regular and injected groups, disable ADC peripheral.
+  * @param  hadc: ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc)
+{ 
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential regular and injected on-going conversions */
+  tmp_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+  
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_status == HAL_OK)
+  {
+    /* 2. Disable the ADC peripheral */
+    tmp_status = ADC_Disable(hadc);
+    
+    /* Check if ADC is effectively disabled */
+    if (tmp_status == HAL_OK)
+    {
+      /* Change ADC state */
+      /* Clear HAL_ADC_STATE_REG_BUSY and HAL_ADC_STATE_INJ_BUSY bits, set HAL_ADC_STATE_READY bit */
+      ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_REG_BUSY|HAL_ADC_STATE_INJ_BUSY), HAL_ADC_STATE_READY);
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+}
+
+
+
+/**
+  * @brief  Wait for regular group conversion to be completed.
+  * @param  hadc: ADC handle
+  * @param  Timeout: Timeout value in millisecond.
+  * @note   Depending on hadc->Init.EOCSelection, EOS or EOC is 
+  *         checked and cleared depending on AUTDLY bit status. 
+  * @note   HAL_ADC_PollForConversion() returns HAL_ERROR if EOC is polled in a
+  *         DMA-managed conversions configuration: indeed, EOC is immediately 
+  *         reset by the DMA reading the DR register when the converted data is
+  *         available. Therefore, EOC is set for a too short period to be 
+  *         reliably polled.                    
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
+{
+  uint32_t           tickstart;
+  uint32_t           tmp_Flag_End   = 0x00;
+  ADC_TypeDef        *tmpADC_Master;
+  uint32_t           tmp_cfgr       = 0x00;
+  uint32_t           tmp_eos_raised = 0x01; /* by default, assume that EOS is set, 
+                                               tmp_eos_raised will be corrected
+                                               accordingly during API execution */ 
+ 
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* If end of sequence selected */
+  if (hadc->Init.EOCSelection == ADC_EOC_SEQ_CONV)
+  {
+    tmp_Flag_End = ADC_FLAG_EOS;
+  }
+  else /* end of conversion selected */
+  {
+    /* Check that the ADC is not in a DMA-based configuration. Otherwise,
+       returns an error.  */
+       
+    /* Check whether dual regular conversions are disabled or unavailable. */
+    if (ADC_IS_DUAL_REGULAR_CONVERSION_ENABLE(hadc) == RESET)  
+    {
+      /* Check DMAEN bit in handle ADC CFGR register */
+      if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_DMAEN) != RESET)
+      {
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        return HAL_ERROR;
+      } 
+    }
+    else
+    {
+      /* Else need to check Common register CCR MDMA bit field. */
+      if (ADC_MULTIMODE_DMA_ENABLED())
+      {
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG); 
+        return HAL_ERROR;          
+      }
+    }  
+    
+    /* no DMA transfer detected, polling ADC_FLAG_EOC is possible */         
+    tmp_Flag_End = ADC_FLAG_EOC;
+  }
+    
+  /* Get timeout */
+  tickstart = HAL_GetTick();  
+     
+  /* Wait until End of Conversion or Sequence flag is raised */
+  while (HAL_IS_BIT_CLR(hadc->Instance->ISR, tmp_Flag_End))
+  {
+    /* Check if timeout is disabled (set to infinite wait) */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
+      { 
+        SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);       
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  
+  /* Next, to clear the polled flag as well as to update the handle State,
+     EOS is checked and the relevant configuration register is retrieved. */
+  /*   1. Check whether or not EOS is set */
+  if (HAL_IS_BIT_CLR(hadc->Instance->ISR, ADC_FLAG_EOS))
+  {
+    tmp_eos_raised = 0;   
+  }
+  /*  2. Check whether or not hadc is the handle of a Slave ADC with dual
+   regular conversions enabled. */
+   if (ADC_INDEPENDENT_OR_NONMULTIMODEREGULAR_SLAVE(hadc)) 
+  {
+    /* Retrieve handle ADC CFGR register */
+    tmp_cfgr = READ_REG(hadc->Instance->CFGR);  
+  }
+  else
+  {
+    /* Retrieve Master ADC CFGR register */
+    tmpADC_Master = ADC_MASTER_REGISTER(hadc);
+    tmp_cfgr = READ_REG(tmpADC_Master->CFGR);
+  }        
+
+  /* Clear polled flag */                         
+  if (tmp_Flag_End == ADC_FLAG_EOS)
+  {
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOS);  
+  }
+  else
+  {               
+
+    /* Clear end of conversion EOC flag of regular group if low power feature */
+    /* "LowPowerAutoWait " is disabled, to not interfere with this feature    */
+    /* until data register is read using function HAL_ADC_GetValue().         */
+    /* For regular groups, no new conversion will start before EOC is cleared.*/
+    /* Note that 1. reading DR clears EOC.                                    */ 
+    /*           2. in multimode with dual regular conversions enabled (when  */
+    /*              multimode feature is available), Master AUTDLY bit is     */
+    /*              checked.                                                  */
+    if (READ_BIT (tmp_cfgr, ADC_CFGR_AUTDLY) == RESET)
+    {
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOC);
+    }
+  }
+
+  
+  /* Update ADC state machine */
+  SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOC);
+  /* If 1. EOS is set
+        2. conversions are software-triggered
+        3. CONT bit is reset (that of handle ADC or Master ADC if applicable)          
+     Then regular conversions are over and HAL_ADC_STATE_REG_BUSY can be reset.
+        4. additionally, if no injected conversions are on-going, HAL_ADC_STATE_READY
+          can be set */
+  if ((tmp_eos_raised)
+   && (ADC_IS_SOFTWARE_START_REGULAR(hadc))
+   && (READ_BIT (tmp_cfgr, ADC_CFGR_CONT) == RESET))
+   {
+     CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);   
+     /* If no injected conversion on-going, set HAL_ADC_STATE_READY bit */
+     if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+     { 
+       SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+     }
+   }                       
+
+  
+  /* Return API HAL status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Poll for ADC event.
+  * @param  hadc: ADC handle
+  * @param  EventType: the ADC event type.
+  *          This parameter can be one of the following values:
+  *            @arg @ref ADC_EOSMP_EVENT  ADC End of Sampling event            
+  *            @arg @ref ADC_AWD_EVENT    ADC Analog watchdog 1 event
+  *            @arg @ref ADC_AWD2_EVENT   ADC Analog watchdog 2 event
+  *            @arg @ref ADC_AWD3_EVENT   ADC Analog watchdog 3 event
+  *            @arg @ref ADC_OVR_EVENT    ADC Overrun event
+  *            @arg @ref ADC_JQOVF_EVENT  ADC Injected context queue overflow event
+  * @param  Timeout: Timeout value in millisecond.
+  * @note   The relevant flag is cleared if found to be set, except for ADC_FLAG_OVR.
+  *         Indeed, the latter is reset only if hadc->Init.Overrun field is set  
+  *         to ADC_OVR_DATA_OVERWRITTEN. Otherwise, DR may be potentially overwritten 
+  *         by a new converted data as soon as OVR is cleared.
+  *         To reset OVR flag once the preserved data is retrieved, the user can resort
+  *         to macro __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR); 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout)
+{
+  uint32_t tickstart; 
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_EVENT_TYPE(EventType));
+  
+  tickstart = HAL_GetTick();   
+      
+  /* Check selected event flag */
+  while(__HAL_ADC_GET_FLAG(hadc, EventType) == RESET)
+  {
+    /* Check if timeout is disabled (set to infinite wait) */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
+      {
+        /* Update ADC state machine to timeout */
+        SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  
+  switch(EventType)
+  {
+  /* End Of Sampling event */
+  case ADC_EOSMP_EVENT:
+    /* Change ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOSMP);
+     
+    /* Clear the End Of Sampling flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOSMP);
+       
+    break;  
+  
+  /* Analog watchdog (level out of window) event                              */
+  /* Note: In case of several analog watchdog enabled, if needed to know      */
+  /* which one triggered and on which ADCx, test ADC state of Analog Watchdog */
+  /* flags HAL_ADC_STATE_AWD/2/3 function.                                    */
+  /* For example: "if (HAL_ADC_GetState(hadc1) == HAL_ADC_STATE_AWD) "        */
+  /*              "if (HAL_ADC_GetState(hadc1) == HAL_ADC_STATE_AWD2)"        */
+  /*              "if (HAL_ADC_GetState(hadc1) == HAL_ADC_STATE_AWD3)"        */
+  case ADC_AWD_EVENT:
+    /* Change ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD1);
+     
+    /* Clear ADC analog watchdog flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD1);
+       
+    break;
+  
+  /* Check analog watchdog 2 flag */
+  case ADC_AWD2_EVENT:
+    /* Change ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD2);
+      
+    /* Clear ADC analog watchdog flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD2);
+      
+    break;
+  
+  /* Check analog watchdog 3 flag */
+  case ADC_AWD3_EVENT:
+    /* Change ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD3);
+      
+    /* Clear ADC analog watchdog flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD3);
+      
+    break;
+  
+  /* Injected context queue overflow event */
+  case ADC_JQOVF_EVENT:
+    /* Change ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_INJ_JQOVF);
+      
+    /* Set ADC error code to Injected context queue overflow */
+    SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_JQOVF);
+    
+    /* Clear ADC Injected context queue overflow flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JQOVF);
+    
+    break;
+     
+  /* Overrun event */
+  default: /* Case ADC_OVR_EVENT */
+    /* If overrun is set to overwrite previous data, overrun event is not     */
+    /* considered as an error.                                                */
+    /* (cf ref manual "Managing conversions without using the DMA and without */
+    /* overrun ")                                                             */
+    if (hadc->Init.Overrun == ADC_OVR_DATA_PRESERVED)
+    {
+      /* Change ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_REG_OVR);
+        
+      /* Set ADC error code to overrun */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_OVR);
+    }
+    else
+    {
+      /* Clear ADC Overrun flag only if Overrun is set to ADC_OVR_DATA_OVERWRITTEN
+         otherwise, DR is potentially overwritten by new converted data as soon
+         as OVR is cleared. */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);
+    }
+    break;
+  }
+  
+  /* Return API HAL status */
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Enable ADC, start conversion of regular group with interruption.
+  * @note   Interruptions enabled in this function according to initialization
+  *         setting : EOC (end of conversion), EOS (end of sequence), 
+  *         OVR overrun.
+  *         Each of these interruptions has its dedicated callback function.
+  * @note   Case of multimode enabled (when multimode feature is available): 
+  *         HAL_ADC_Start_IT() must be called for ADC Slave first, then for
+  *         ADC Master. 
+  *         For ADC Slave, ADC is enabled only (conversion is not started).  
+  *         For ADC Master, ADC is enabled and multimode conversion is started.
+  * @note   To guarantee a proper reset of all interruptions once all the needed
+  *         conversions are obtained, HAL_ADC_Stop_IT() must be called to ensure 
+  *         a correct stop of the IT-based conversions.  
+  * @note   By default, HAL_ADC_Start_IT() doesn't enable the End Of Sampling 
+  *         interruption. If required (e.g. in case of oversampling with trigger
+  *         mode), the user must    
+  *          1. first clear the EOSMP flag if set with macro __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOSMP)             
+  *          2. then enable the EOSMP interrupt with macro __HAL_ADC_ENABLE_IT(hadc, ADC_IT_EOSMP)     
+  *          before calling HAL_ADC_Start_IT().    
+  * @param  hadc: ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  ADC_TypeDef        *tmpADC_Master;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* if a regular conversion is already on-going (i.e. ADSTART is set),
+     don't restart the conversion. */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc))
+  {
+    return HAL_BUSY;
+  }
+  else
+  {  
+    /* Process locked */
+    __HAL_LOCK(hadc);
+ 
+    /* Enable the ADC peripheral */
+    tmp_status = ADC_Enable(hadc);
+ 
+    /* Start conversion if ADC is effectively enabled */
+    if (tmp_status == HAL_OK)
+    {
+      /* State machine update: Check if an injected conversion is ongoing */
+      if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+      {
+        /* Reset ADC error code fields related to regular conversions only */
+        CLEAR_BIT(hadc->ErrorCode, (HAL_ADC_ERROR_OVR|HAL_ADC_ERROR_DMA));         
+      }
+      else
+      {
+        /* Set ADC error code to none */
+        ADC_CLEAR_ERRORCODE(hadc); 
+      } 
+      /* Clear HAL_ADC_STATE_READY and regular conversion results bits, set HAL_ADC_STATE_REG_BUSY bit */
+      ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_READY|HAL_ADC_STATE_REG_EOC|HAL_ADC_STATE_REG_OVR|HAL_ADC_STATE_REG_EOSMP), HAL_ADC_STATE_REG_BUSY);
+      
+      /* Reset HAL_ADC_STATE_MULTIMODE_SLAVE bit
+        - by default if ADC is Master or Independent or if multimode feature is not available
+        - if MultiMode setting is set to independent mode (no dual regular or injected conversions are configured) */
+      if (ADC_NONMULTIMODE_OR_MULTIMODEMASTER(hadc))
+      {
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }      
+  
+      /* Clear regular group conversion flag and overrun flag */
+      /* (To ensure of no unknown state from potential previous ADC operations) */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_OVR));
+   
+      /* By default, disable all interruptions before enabling the desired ones */
+      __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_EOC | ADC_IT_EOS | ADC_IT_OVR));
+  
+      /* Enable required interruptions */  
+      switch(hadc->Init.EOCSelection)
+      {
+        case ADC_EOC_SEQ_CONV: 
+          __HAL_ADC_ENABLE_IT(hadc, ADC_IT_EOS);
+         break;
+        /* case ADC_EOC_SINGLE_CONV */
+        default:
+         __HAL_ADC_ENABLE_IT(hadc, ADC_IT_EOC);
+         break;
+      }
+   
+      /* If hadc->Init.Overrun is set to ADC_OVR_DATA_PRESERVED, only then is
+         ADC_IT_OVR enabled; otherwise data overwrite is considered as normal
+         behavior and no CPU time is lost for a non-processed interruption */
+      if (hadc->Init.Overrun == ADC_OVR_DATA_PRESERVED)
+      {
+        __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);  
+      }   
+      
+      /* Enable conversion of regular group.                                  */
+      /* If software start has been selected, conversion starts immediately.  */
+      /* If external trigger has been selected, conversion starts at next     */
+      /* trigger event.                                                       */
+      /* Case of multimode enabled (when multimode feature is available):     */ 
+      /*  - if ADC is slave and dual regular conversions are enabled, ADC is  */
+      /*    enabled only (conversion is not started),                         */
+      /*  - if ADC is master, ADC is enabled and conversion is started.       */
+      if (ADC_INDEPENDENT_OR_NONMULTIMODEREGULAR_SLAVE(hadc)   )
+      {
+        /* Multimode feature is not available or ADC Instance is Independent or Master, 
+           or is not Slave ADC with dual regular conversions enabled.         
+           Then set HAL_ADC_STATE_INJ_BUSY and reset HAL_ADC_STATE_INJ_EOC if JAUTO is set. */
+        if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO) != RESET)
+        {
+          ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);
+          
+          /* Enable as well injected interruptions in case 
+           HAL_ADCEx_InjectedStart_IT() has not been called beforehand. This
+           allows to start regular and injected conversions when JAUTO is
+           set with a single call to HAL_ADC_Start_IT() */
+          switch(hadc->Init.EOCSelection)
+          {
+            case ADC_EOC_SEQ_CONV: 
+              __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC);
+              __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOS);
+            break;
+            /* case ADC_EOC_SINGLE_CONV */
+            default:
+              __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOS);      
+              __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOC);
+            break;
+          }  
+        } /*  if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO) != RESET) */
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);           
+        /* Start ADC */     
+        SET_BIT(hadc->Instance->CR, ADC_CR_ADSTART);
+      }
+      else
+      {
+        /* hadc is the handle of a Slave ADC with dual regular conversions
+           enabled. Therefore, ADC_CR_ADSTART is NOT set */
+        SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+        /* if Master ADC JAUTO bit is set, Slave injected interruptions
+           are enabled nevertheless (for same reason as above) */
+        tmpADC_Master = ADC_MASTER_REGISTER(hadc); 
+        if (READ_BIT(tmpADC_Master->CFGR, ADC_CFGR_JAUTO) != RESET)
+        {
+          /* First, update Slave State in setting HAL_ADC_STATE_INJ_BUSY bit 
+             and in resetting HAL_ADC_STATE_INJ_EOC bit */
+          ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);
+          /* Next, set Slave injected interruptions */
+          switch(hadc->Init.EOCSelection)
+          {
+            case ADC_EOC_SEQ_CONV: 
+              __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC);
+              __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOS);
+            break;
+            /* case ADC_EOC_SINGLE_CONV */
+            default:
+              __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOS);      
+              __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOC);
+            break;
+          }         
+        }  /* if (READ_BIT(tmpADC_Master->CFGR, ADC_CFGR_JAUTO) != RESET) */
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);         
+      } /*  if (ADC_INDEPENDENT_OR_NONMULTIMODEREGULAR_SLAVE(hadc)   ) */     
+    }  /*  if (tmp_status == HAL_OK) */
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);    
+    }
+ 
+    /* Return function status */
+    return tmp_status;
+ 
+  }  
+}
+
+
+
+/**  
+  * @brief  Stop ADC conversion of regular groups when interruptions are enabled.
+  * @note   Stop as well injected conversions and disable ADC peripheral.
+  * @param  hadc: ADC handle
+  * @retval HAL status.
+  */  
+HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential regular and injected on-going conversions */
+  tmp_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+  
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_status == HAL_OK)
+  {
+    /* Disable all interrupts */
+    __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_EOC | ADC_IT_EOS | ADC_IT_OVR));
+    
+    /* 2. Disable the ADC peripheral */
+    tmp_status = ADC_Disable(hadc);
+    
+    /* Check if ADC is effectively disabled */
+    if (tmp_status == HAL_OK)
+    {
+      /* Change ADC state */
+      /* Clear HAL_ADC_STATE_REG_BUSY and HAL_ADC_STATE_INJ_BUSY bits, set HAL_ADC_STATE_READY bit */
+      ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_REG_BUSY|HAL_ADC_STATE_INJ_BUSY), HAL_ADC_STATE_READY); 
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+}
+
+
+/**
+  * @brief  Enable ADC, start conversion of regular group and transfer result through DMA.
+  * @note   Interruptions enabled in this function:
+  *         overrun (if applicable), DMA half transfer, DMA transfer complete. 
+  *         Each of these interruptions has its dedicated callback function.
+  * @note   Case of multimode enabled (when multimode feature is available): HAL_ADC_Start_DMA() 
+  *         is designed for single-ADC mode only. For multimode, the dedicated 
+  *         HAL_ADCEx_MultiModeStart_DMA() function must be used.
+  * @param  hadc: ADC handle
+  * @param  pData: Destination Buffer address.
+  * @param  Length: Length of data to be transferred from ADC peripheral to memory (in bytes)
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc))
+  {
+    return HAL_BUSY;
+  }
+  else
+  {
+    
+    /* Process locked */
+    __HAL_LOCK(hadc);
+  
+    /* Ensure that dual regular conversions are not enabled or unavailable.   */
+    /* Otherwise, dedicated API HAL_ADCEx_MultiModeStart_DMA() must be used.  */
+    if (ADC_IS_DUAL_REGULAR_CONVERSION_ENABLE(hadc) == RESET)
+    {
+      /* Enable the ADC peripheral */
+      tmp_status = ADC_Enable(hadc);
+    
+      /* Start conversion if ADC is effectively enabled */
+      if (tmp_status == HAL_OK)
+      {
+        /* State machine update: Check if an injected conversion is ongoing */
+        if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+        {
+          /* Reset ADC error code fields related to regular conversions only */
+          CLEAR_BIT(hadc->ErrorCode, (HAL_ADC_ERROR_OVR|HAL_ADC_ERROR_DMA));             
+        }
+        else
+        {
+          /* Set ADC error code to none */
+          ADC_CLEAR_ERRORCODE(hadc);          
+        }
+        /* Clear HAL_ADC_STATE_READY and regular conversion results bits, set HAL_ADC_STATE_REG_BUSY bit */
+        ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_READY|HAL_ADC_STATE_REG_EOC|HAL_ADC_STATE_REG_OVR|HAL_ADC_STATE_REG_EOSMP), HAL_ADC_STATE_REG_BUSY);
+
+       /* Reset HAL_ADC_STATE_MULTIMODE_SLAVE bit
+        - by default if ADC is Master or Independent or if multimode feature is not available
+        - if multimode setting is set to independent mode (no dual regular or injected conversions are configured) */
+        if (ADC_NONMULTIMODE_OR_MULTIMODEMASTER(hadc))
+        {
+          CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+        }
+      
+        /* Set the DMA transfer complete callback */
+        hadc->DMA_Handle->XferCpltCallback = ADC_DMAConvCplt;
+
+        /* Set the DMA half transfer complete callback */
+        hadc->DMA_Handle->XferHalfCpltCallback = ADC_DMAHalfConvCplt;
+      
+        /* Set the DMA error callback */
+        hadc->DMA_Handle->XferErrorCallback = ADC_DMAError;
+
+            
+        /* Manage ADC and DMA start: ADC overrun interruption, DMA start,     */
+        /* ADC start (in case of SW start):                                   */
+      
+        /* Clear regular group conversion flag and overrun flag               */
+        /* (To ensure of no unknown state from potential previous ADC         */
+        /* operations)                                                        */
+        __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_OVR));
+      
+        /* With DMA, overrun event is always considered as an error even if 
+           hadc->Init.Overrun is set to ADC_OVR_DATA_OVERWRITTEN. Therefore,  
+           ADC_IT_OVR is enabled.  */         
+        __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);  
+     
+      
+        /* Enable ADC DMA mode */
+        SET_BIT(hadc->Instance->CFGR, ADC_CFGR_DMAEN);
+      
+        /* Start the DMA channel */
+        HAL_DMA_Start_IT(hadc->DMA_Handle, (uint32_t)&hadc->Instance->DR, (uint32_t)pData, Length);
+               
+        /* Enable conversion of regular group.                                  */
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);          
+        /* If software start has been selected, conversion starts immediately.  */
+        /* If external trigger has been selected, conversion will start at next */
+        /* trigger event.                                                       */
+        SET_BIT(hadc->Instance->CR, ADC_CR_ADSTART);
+      
+      }  
+      else
+      {
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);      
+      }  /* if (tmp_status == HAL_OK) */
+    }
+    else
+    {
+      tmp_status = HAL_ERROR;
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);      
+    } /* if (ADC_IS_DUAL_REGULAR_CONVERSION_ENABLE(hadc) == RESET) */
+  
+
+  
+  /* Return function status */
+  return tmp_status;
+  } /* if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc)) */
+}
+
+
+/**
+  * @brief  Stop ADC conversion of regular groups and disable ADC DMA transfer. 
+  * @note   Stop as well injected conversions and disable ADC peripheral.
+  * @note   Case of multimode enabled (when multimode feature is available): 
+  *         HAL_ADC_Stop_DMA() function is dedicated to single-ADC mode only. 
+  *         For multimode, the dedicated HAL_ADCEx_MultiModeStop_DMA() API must be used.
+  * @param  hadc: ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
+{  
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential regular conversion on going */
+  tmp_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+  
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_status == HAL_OK)
+  {
+    /* Disable ADC DMA (ADC DMA configuration ADC_CFGR_DMACFG is kept) */
+    CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_DMAEN); 
+    
+    /* Disable the DMA channel (in case of DMA in circular mode or stop while */
+    /* while DMA transfer is on going)                                        */
+    tmp_status = HAL_DMA_Abort(hadc->DMA_Handle);   
+    
+    /* Check if DMA channel effectively disabled */
+    if (tmp_status != HAL_OK)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);  
+    }
+    
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+    
+    /* 2. Disable the ADC peripheral */
+    /* Update "tmp_status" only if DMA channel disabling passed, to keep in */
+    /* memory a potential failing status.                                     */
+    if (tmp_status == HAL_OK)
+    {
+      tmp_status = ADC_Disable(hadc);
+    }
+    else
+    {
+      ADC_Disable(hadc);
+    }
+
+    /* Check if ADC is effectively disabled */
+    if (tmp_status == HAL_OK)
+    {
+      /* Change ADC state */
+      /* Clear HAL_ADC_STATE_REG_BUSY and HAL_ADC_STATE_INJ_BUSY bits, set HAL_ADC_STATE_READY bit */
+      ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_REG_BUSY|HAL_ADC_STATE_INJ_BUSY), HAL_ADC_STATE_READY);     
+    }
+    
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+}
+
+
+/**
+  * @brief  Get ADC regular group conversion result.
+  * @param  hadc: ADC handle
+  * @note   Reading DR register automatically clears EOC flag. To reset EOS flag, 
+  *         the user must resort to the macro 
+  *         __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOS)  
+  * @retval Converted value
+  */
+uint32_t HAL_ADC_GetValue(ADC_HandleTypeDef* hadc)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Return ADC converted value */ 
+  return hadc->Instance->DR;
+}
+
+
+/**
+  * @brief  Handle ADC interrupt request.  
+  * @param  hadc: ADC handle
+  * @retval None
+  */
+void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
+{
+  uint32_t overrun_error = 0; /* flag set if overrun occurrence has to be considered as an error */
+  ADC_TypeDef        *tmpADC_Master;  
+  uint32_t tmp_isr      = hadc->Instance->ISR;
+  uint32_t tmp_ier      = hadc->Instance->IER;
+  uint32_t tmp_cfgr     = 0x0;
+  uint32_t tmp_cfgr_jqm = 0x0;       
+  
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_EOC_SELECTION(hadc->Init.EOCSelection));
+  
+  
+  /* ====== Check End of Sampling flag for regular group ===== */
+  if (((tmp_isr & ADC_FLAG_EOSMP) == ADC_FLAG_EOSMP) && ((tmp_ier & ADC_IT_EOSMP) == ADC_IT_EOSMP))
+  {
+    /* Update state machine on end of sampling status if not in error state */
+    if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL))
+    {
+      /* Change ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOSMP);
+    }
+        
+    /* End Of Sampling callback */
+      HAL_ADCEx_EndOfSamplingCallback(hadc);
+    
+    /* Clear regular group conversion flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOSMP );
+  }  
+  
+  /* ====== Check End of Conversion or Sequence flags for regular group ===== */
+  if( (((tmp_isr & ADC_FLAG_EOC) == ADC_FLAG_EOC) && ((tmp_ier & ADC_IT_EOC) == ADC_IT_EOC)) ||
+      (((tmp_isr & ADC_FLAG_EOS) == ADC_FLAG_EOS) && ((tmp_ier & ADC_IT_EOS) == ADC_IT_EOS))  )
+  {
+    /* Update state machine on conversion status if not in error state */
+    if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL))
+    {
+      /* Change ADC state */    
+      SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOC); 
+    }
+    
+    /* Disable interruption if no further conversion upcoming by regular      */
+    /* external trigger or by continuous mode,                                */
+    /* and if scan sequence if completed.                                     */
+    if(ADC_IS_SOFTWARE_START_REGULAR(hadc))
+    {
+      if (ADC_INDEPENDENT_OR_NONMULTIMODEREGULAR_SLAVE(hadc))
+      {
+        /* check CONT bit directly in handle ADC CFGR register */
+        tmp_cfgr = READ_REG(hadc->Instance->CFGR); 
+      }
+      else
+      {
+        /* else need to check Master ADC CONT bit */
+        tmpADC_Master = ADC_MASTER_REGISTER(hadc);
+        tmp_cfgr = READ_REG(tmpADC_Master->CFGR); 
+      }
+      
+      /* Carry on if continuous mode is disabled */
+      if (READ_BIT (tmp_cfgr, ADC_CFGR_CONT) != ADC_CFGR_CONT)
+      {
+        /* If End of Sequence is reached, disable interrupts */
+        if( __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS) )
+        {
+          /* Allowed to modify bits ADC_IT_EOC/ADC_IT_EOS only if bit           */
+          /* ADSTART==0 (no conversion on going)                                */
+          if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)
+          {
+            /* Disable ADC end of sequence conversion interrupt */
+            /* Note: if Overrun interrupt was enabled with EOC or EOS interrupt */
+            /* in HAL_Start_IT(), it isn't disabled here because it can be used */
+            /* by overrun IRQ process below.                                    */
+            __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC | ADC_IT_EOS);
+            /* Clear HAL_ADC_STATE_REG_BUSY bit */
+             CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY); 
+             /* If no injected conversion on-going, set HAL_ADC_STATE_READY bit */
+             if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+             { 
+               SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+             }           
+          }
+          else
+          {
+            /* Change ADC state to error state */
+            SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+            
+            /* Set ADC error code to ADC IP internal error */
+            SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+          }
+        }
+      } /* if (READ_BIT (tmp_cfgr, ADC_CFGR_CONT) != ADC_CFGR_CONT) */
+    }   /* if(ADC_IS_SOFTWARE_START_REGULAR(hadc)                   */
+    
+    /* Conversion complete callback */
+    /* Note:  HAL_ADC_ConvCpltCallback can resort to 
+              if( __HAL_ADC_GET_FLAG(&hadc, ADC_FLAG_EOS)) or
+              if( __HAL_ADC_GET_FLAG(&hadc, ADC_FLAG_EOC)) to determine whether 
+              interruption has been triggered by end of conversion or end of 
+              sequence.    */
+      HAL_ADC_ConvCpltCallback(hadc);
+
+    
+    /* Clear regular group conversion flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS) );
+  }
+  
+  
+  /* ========== Check End of Conversion flag for injected group ========== */
+  if( (((tmp_isr & ADC_FLAG_JEOC) == ADC_FLAG_JEOC) && ((tmp_ier & ADC_IT_JEOC) == ADC_IT_JEOC)) ||
+      (((tmp_isr & ADC_FLAG_JEOS) == ADC_FLAG_JEOS) && ((tmp_ier & ADC_IT_JEOS) == ADC_IT_JEOS))  )      
+  {
+    /* Update state machine on conversion status if not in error state */
+    if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL))
+    {
+      /* Change ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_INJ_EOC);
+    }
+    
+
+    /* Check whether interruptions can be disabled only if
+        - injected conversions are software-triggered when injected queue management is disabled
+        OR
+        - auto-injection is enabled, continuous mode is disabled (CONT = 0)
+          and regular conversions are software-triggered */
+          /* If End of Sequence is reached, disable interrupts */
+    if( __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOS))
+    {
+          
+      /* First, retrieve proper registers to check */
+      /* 1a. Are injected conversions that of a dual Slave ? */      
+      if (ADC_INDEPENDENT_OR_NONMULTIMODEINJECTED_SLAVE(hadc))
+      {
+        /* hadc is not the handle of a Slave ADC with dual injected conversions enabled:
+           check JQM bit directly in ADC CFGR register */
+        tmp_cfgr_jqm = READ_REG(hadc->Instance->CFGR); 
+      }
+      else
+      {
+        /* hadc is the handle of a Slave ADC with dual injected conversions enabled:
+           need to check JQM bit of Master ADC CFGR register */
+          tmpADC_Master = ADC_MASTER_REGISTER(hadc);
+          tmp_cfgr_jqm = READ_REG(tmpADC_Master->CFGR); 
+      }
+      /* 1b. Is hadc the handle of a Slave ADC with regular conversions enabled? */ 
+      if (ADC_INDEPENDENT_OR_NONMULTIMODEREGULAR_SLAVE(hadc))
+      {
+        /* hadc is not the handle of a Slave ADC with dual regular conversions enabled:
+           check JAUTO and CONT bits directly in ADC CFGR register */        
+          tmp_cfgr = READ_REG(hadc->Instance->CFGR); 
+      }
+      else
+      {
+        /* hadc is not the handle of a Slave ADC with dual regular conversions enabled:
+           check JAUTO and CONT bits of Master ADC CFGR register */  
+        tmpADC_Master = ADC_MASTER_REGISTER(hadc);
+        tmp_cfgr = READ_REG(tmpADC_Master->CFGR); 
+      }
+      
+      /* Secondly, check whether JEOC and JEOS interruptions can be disabled */                                                 
+      if ((ADC_IS_SOFTWARE_START_INJECTED(hadc) && (READ_BIT(tmp_cfgr_jqm, ADC_CFGR_JQM) != ADC_CFGR_JQM))  
+         && (!((READ_BIT(tmp_cfgr, (ADC_CFGR_JAUTO|ADC_CFGR_CONT)) == (ADC_CFGR_JAUTO|ADC_CFGR_CONT)) &&    
+             (ADC_IS_SOFTWARE_START_REGULAR(hadc))))    )
+      {
+        /* Allowed to modify bits ADC_IT_JEOC/ADC_IT_JEOS only if bit         */
+        /* JADSTART==0 (no conversion on going)                               */
+        if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET)
+        {
+          /* Disable ADC end of sequence conversion interrupt  */
+          __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC | ADC_IT_JEOS);
+          /* Clear HAL_ADC_STATE_INJ_BUSY bit */
+           CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);   
+           /* If no regular conversion on-going, set HAL_ADC_STATE_READY bit */                   
+          if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_REG_BUSY))
+          { 
+            SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+          }           
+        }
+        else
+        {
+          /* Change ADC state to error state */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+          
+          /* Set ADC error code to ADC IP internal error */
+          SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+        }
+      }
+    } /* if( __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOS)) */
+    
+    /* Injected Conversion complete callback */
+    /* Note:  HAL_ADCEx_InjectedConvCpltCallback can resort to 
+              if( __HAL_ADC_GET_FLAG(&hadc, ADC_FLAG_JEOS)) or
+              if( __HAL_ADC_GET_FLAG(&hadc, ADC_FLAG_JEOC)) to determine whether 
+              interruption has been triggered by end of conversion or end of 
+              sequence.    */    
+    HAL_ADCEx_InjectedConvCpltCallback(hadc);
+    
+    /* Clear injected group conversion flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JEOC | ADC_FLAG_JEOS);
+  }
+  
+   
+  /* ========== Check Analog watchdog flags =================================================== */
+  
+  /* ========== Check Analog watchdog 1 flags ========== */
+  if (((tmp_isr & ADC_FLAG_AWD1) == ADC_FLAG_AWD1) && ((tmp_ier & ADC_IT_AWD1) == ADC_IT_AWD1))      
+  {
+    /* Change ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD1);
+    
+    /* Level out of window 1 callback */
+    HAL_ADC_LevelOutOfWindowCallback(hadc);
+    /* Clear ADC Analog watchdog flag */ 
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD1);
+  }
+  
+  /* ========== Check Analog watchdog 2 flags ========== */
+  if (((tmp_isr & ADC_FLAG_AWD2) == ADC_FLAG_AWD2) && ((tmp_ier & ADC_IT_AWD2) == ADC_IT_AWD2))      
+  {
+    /* Change ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD2);
+    
+    /* Level out of window 2 callback */
+    HAL_ADCEx_LevelOutOfWindow2Callback(hadc);
+    /* Clear ADC Analog watchdog flag */ 
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD2);
+  } 
+  
+  /* ========== Check Analog watchdog 3 flags ========== */
+  if (((tmp_isr & ADC_FLAG_AWD3) == ADC_FLAG_AWD3) && ((tmp_ier & ADC_IT_AWD3) == ADC_IT_AWD3))      
+  {
+    /* Change ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD3);
+    
+    /* Level out of window 3 callback */
+    HAL_ADCEx_LevelOutOfWindow3Callback(hadc);
+    /* Clear ADC Analog watchdog flag */ 
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD3);
+  } 
+  
+  
+  /* ========== Check Overrun flag ========== */
+  if (((tmp_isr & ADC_FLAG_OVR) == ADC_FLAG_OVR) && ((tmp_ier & ADC_IT_OVR) == ADC_IT_OVR)) 
+  {
+    /* If overrun is set to overwrite previous data (default setting),        */
+    /* overrun event is not considered as an error.                           */
+    /* (cf ref manual "Managing conversions without using the DMA and without */
+    /* overrun ")                                                             */
+    /* Exception for usage with DMA overrun event always considered as an     */
+    /* error.                                                                 */
+    
+    if (hadc->Init.Overrun == ADC_OVR_DATA_PRESERVED)
+    {
+      overrun_error = 1;
+    }
+    else
+    {
+      /* check DMA configuration, depending on multimode set or not,
+        or whether or not multimode feature is available */
+      if (ADC_IS_DUAL_CONVERSION_ENABLE(hadc) == RESET)
+      {
+        /* Multimode not set or feature not available or ADC independent */
+        if (HAL_IS_BIT_SET(hadc->Instance->CFGR, ADC_CFGR_DMAEN))
+        {
+          overrun_error = 1;  
+        }      
+      }
+      else
+      {
+        /* Multimode (when feature is available) is enabled, 
+           Common Control Register MDMA bits must be checked. */
+        if (ADC_MULTIMODE_DMA_ENABLED())
+        {
+          overrun_error = 1;  
+        }
+      }
+    }
+        
+    if (overrun_error == 1)
+    {
+      /* Change ADC state to error state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_REG_OVR);
+      
+      /* Set ADC error code to overrun */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_OVR);
+      
+      /* Error callback */ 
+      HAL_ADC_ErrorCallback(hadc);
+    }
+
+    /* Clear the Overrun flag, to be done AFTER HAL_ADC_ErrorCallback() since
+       old data is preserved until OVR is reset */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);  
+
+  }
+  
+  
+  /* ========== Check Injected context queue overflow flag ========== */
+  if (((tmp_isr & ADC_FLAG_JQOVF) == ADC_FLAG_JQOVF) && ((tmp_ier & ADC_IT_JQOVF) == ADC_IT_JQOVF)) 
+  {
+    /* Change ADC state to overrun state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_INJ_JQOVF);
+        
+    /* Set ADC error code to Injected context queue overflow */
+    SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_JQOVF);
+    
+    /* Clear the Injected context queue overflow flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JQOVF);
+    
+    /* Error callback */ 
+    HAL_ADCEx_InjectedQueueOverflowCallback(hadc);
+  }
+  
+}
+
+/**
+  * @brief  Conversion complete callback in non-blocking mode.
+  * @param  hadc: ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_ConvCpltCallback must be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  Conversion DMA half-transfer callback in non-blocking mode.
+  * @param  hadc: ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_ConvHalfCpltCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  Analog watchdog 1 callback in non-blocking mode.        
+  * @param  hadc: ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_LevelOutOfWindowCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  ADC error callback in non-blocking mode
+  *        (ADC conversion with interruption or transfer by DMA).
+  * @param  hadc: ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_ErrorCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group3 Peripheral Control functions
+ *  @brief    Peripheral Control functions 
+ *
+@verbatim   
+ ===============================================================================
+             ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Configure channels on regular group
+      (+) Configure the analog watchdog
+      
+@endverbatim
+  * @{
+  */
+
+
+/**
+  * @brief  Configure the selected channel to be linked to the regular group.
+  * @note   In case of usage of internal measurement channels (Vbat / VrefInt /
+  *         TempSensor), the recommended sampling time is provided by the
+  *         datasheet.  
+  *         These internal paths can be disabled using function 
+  *         HAL_ADC_DeInit().
+  * @note   Possibility to update parameters on the fly:
+  *         HAL_ADC_ConfigChannel() initializes channel into regular group, 
+  *         consecutive calls to this function can be used to reconfigure some 
+  *         parameters of structure "ADC_ChannelConfTypeDef" on the fly, without 
+  *         resetting the ADC.
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_ChannelConfTypeDef".
+  * @param  hadc: ADC handle
+  * @param  sConfig: Structure ADC channel for regular group.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+                                                                                                                     
+  ADC_Common_TypeDef *tmpADC_Common;
+  uint32_t tmpOffsetShifted;
+  __IO uint32_t wait_loop_index = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_REGULAR_RANK(sConfig->Rank));
+  assert_param(IS_ADC_SAMPLE_TIME(sConfig->SamplingTime));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(sConfig->SingleDiff));
+  assert_param(IS_ADC_OFFSET_NUMBER(sConfig->OffsetNumber));
+  assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), sConfig->Offset));
+
+  /* if ROVSE is set, the value of the OFFSETy_EN bit in ADCx_OFRy register is  
+     ignored (considered as reset) */
+  assert_param(!((sConfig->OffsetNumber != ADC_OFFSET_NONE) && (hadc->Init.OversamplingMode == ENABLE)));  
+  
+  /* Verification of channel number */
+  if (sConfig->SingleDiff != ADC_DIFFERENTIAL_ENDED)
+  {
+     assert_param(IS_ADC_CHANNEL(hadc, sConfig->Channel));
+  }
+  else
+  {
+    assert_param(IS_ADC_DIFF_CHANNEL(hadc, sConfig->Channel));
+  }
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on regular group:                                    */
+  /*  - Channel number                                                        */
+  /*  - Channel rank                                                          */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)
+  {
+    
+      /* Regular sequence configuration */
+      /* Clear the old SQx bits then set the new ones for the selected rank */
+      /* For Rank 1 to 4 */
+      if (sConfig->Rank < 5)
+      {      
+        MODIFY_REG(hadc->Instance->SQR1, 
+                  ADC_SQR1_RK(ADC_SQR2_SQ5, sConfig->Rank), 
+                  ADC_SQR1_RK(sConfig->Channel, sConfig->Rank));      
+      }
+      /* For Rank 5 to 9 */
+      else if (sConfig->Rank < 10)
+      {
+        MODIFY_REG(hadc->Instance->SQR2, 
+                  ADC_SQR2_RK(ADC_SQR2_SQ5, sConfig->Rank), 
+                  ADC_SQR2_RK(sConfig->Channel, sConfig->Rank));       
+      }
+      /* For Rank 10 to 14 */
+      else if (sConfig->Rank < 15)
+      {
+        MODIFY_REG(hadc->Instance->SQR3, 
+                  ADC_SQR3_RK(ADC_SQR3_SQ10, sConfig->Rank), 
+                  ADC_SQR3_RK(sConfig->Channel, sConfig->Rank));        
+      }
+      /* For Rank 15 to 16 */
+      else
+      {   
+        MODIFY_REG(hadc->Instance->SQR4, 
+                  ADC_SQR4_RK(ADC_SQR4_SQ15, sConfig->Rank), 
+                  ADC_SQR4_RK(sConfig->Channel, sConfig->Rank));         
+      }
+      
+      
+      /* Parameters update conditioned to ADC state:                              */
+      /* Parameters that can be updated when ADC is disabled or enabled without   */
+      /* conversion on going on regular group:                                    */
+      /*  - Channel sampling time                                                 */
+      /*  - Channel offset                                                        */
+      if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET)
+      {
+       
+        /* Channel sampling time configuration */
+        /* Clear the old sample time then set the new one for the selected channel */    
+        /* For channels 10 to 18 */
+        if (sConfig->Channel >= ADC_CHANNEL_10)
+        {
+          ADC_SMPR2_SETTING(hadc, sConfig->SamplingTime, sConfig->Channel);                
+        }
+        else /* For channels 0 to 9 */
+        {
+          ADC_SMPR1_SETTING(hadc, sConfig->SamplingTime, sConfig->Channel);                       
+        }
+      
+  
+       /* Configure the offset: offset enable/disable, channel, offset value */
+  
+       /* Shift the offset with respect to the selected ADC resolution. */
+       /* Offset has to be left-aligned on bit 11, the LSB (right bits) are set to 0 */
+       tmpOffsetShifted = ADC_OFFSET_SHIFT_RESOLUTION(hadc, sConfig->Offset);
+      
+       switch (sConfig->OffsetNumber)
+       {
+        /* Configure offset register i when applicable:                         */
+        /* - Enable offset                                                      */
+        /* - Set channel number                                                 */
+        /* - Set offset value                                                   */    
+       case ADC_OFFSET_1:                                
+          MODIFY_REG(hadc->Instance->OFR1, 
+                  ADC_OFR_FIELDS, 
+                  ADC_OFR1_OFFSET1_EN | ADC_OFR_CHANNEL(sConfig->Channel) | tmpOffsetShifted);                                   
+         break;
+      
+       case ADC_OFFSET_2:
+         MODIFY_REG(hadc->Instance->OFR2, 
+                  ADC_OFR_FIELDS, 
+                  ADC_OFR2_OFFSET2_EN | ADC_OFR_CHANNEL(sConfig->Channel) | tmpOffsetShifted);                                  
+         break;
+          
+       case ADC_OFFSET_3:
+         MODIFY_REG(hadc->Instance->OFR3, 
+                  ADC_OFR_FIELDS, 
+                  ADC_OFR3_OFFSET3_EN | ADC_OFR_CHANNEL(sConfig->Channel) | tmpOffsetShifted);                                  
+         break;
+      
+       case ADC_OFFSET_4:
+         MODIFY_REG(hadc->Instance->OFR4, 
+                  ADC_OFR_FIELDS, 
+                  ADC_OFR4_OFFSET4_EN | ADC_OFR_CHANNEL(sConfig->Channel) | tmpOffsetShifted);                                  
+         break;
+      
+       /* Case ADC_OFFSET_NONE */
+       default :
+       /* Scan OFR1, OFR2, OFR3, OFR4 to check if the selected channel is enabled. 
+          If this is the case, offset OFRx is disabled since 
+          sConfig->OffsetNumber = ADC_OFFSET_NONE. */
+         if (((hadc->Instance->OFR1) & ADC_OFR1_OFFSET1_CH) == ADC_OFR_CHANNEL(sConfig->Channel))
+         {
+           CLEAR_BIT(hadc->Instance->OFR1, ADC_OFR1_OFFSET1_EN);
+         }
+         if (((hadc->Instance->OFR2) & ADC_OFR2_OFFSET2_CH) == ADC_OFR_CHANNEL(sConfig->Channel))
+         {
+           CLEAR_BIT(hadc->Instance->OFR2, ADC_OFR2_OFFSET2_EN); 
+         }
+         if (((hadc->Instance->OFR3) & ADC_OFR3_OFFSET3_CH) == ADC_OFR_CHANNEL(sConfig->Channel))
+         {
+           CLEAR_BIT(hadc->Instance->OFR3, ADC_OFR3_OFFSET3_EN); 
+         }
+         if (((hadc->Instance->OFR4) & ADC_OFR4_OFFSET4_CH) == ADC_OFR_CHANNEL(sConfig->Channel))
+         {
+           CLEAR_BIT(hadc->Instance->OFR4, ADC_OFR4_OFFSET4_EN);
+         }
+         break;
+      }  /*  switch (sConfig->OffsetNumber) */
+  
+    }  /* if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET) */
+   
+  
+  
+    /* Parameters update conditioned to ADC state:                              */
+    /* Parameters that can be updated only when ADC is disabled:                */
+    /*  - Single or differential mode                                           */
+    /*  - Internal measurement channels: Vbat/VrefInt/TempSensor                */
+    if (ADC_IS_ENABLE(hadc) == RESET)
+    {
+      /* Configuration of differential mode */
+      if (sConfig->SingleDiff != ADC_DIFFERENTIAL_ENDED)
+      {
+        /* Disable differential mode (default mode: single-ended) */
+        CLEAR_BIT(hadc->Instance->DIFSEL, ADC_DIFSEL_CHANNEL(sConfig->Channel));
+      }
+      else
+      {
+        /* Enable differential mode */
+        SET_BIT(hadc->Instance->DIFSEL, ADC_DIFSEL_CHANNEL(sConfig->Channel));
+        
+        /* Sampling time configuration of channel ADC_IN+1 (negative input)     */
+        /* Clear the old sample time then set the new one for the selected      */
+        /* channel.                                                             */        
+        /* Starting from channel 9, SMPR2 register must be configured           */
+        if (sConfig->Channel >= ADC_CHANNEL_9)
+        {
+          ADC_SMPR2_SETTING(hadc, sConfig->SamplingTime, sConfig->Channel+1);                                
+        }
+        else /* For channels 0 to 8, SMPR1 must be configured */
+        {
+          ADC_SMPR1_SETTING(hadc, sConfig->SamplingTime, sConfig->Channel+1);      
+        }
+      }
+    
+    
+      
+      /* Management of internal measurement channels: Vbat/VrefInt/TempSensor.  */
+      /* If internal channel selected, enable dedicated internal buffers and    */
+      /*  paths.                                                                */
+      /* Note: these internal measurement paths can be disabled using           */
+      /* HAL_ADC_DeInit().                                                      */
+         
+      /* Configuration of common ADC parameters                                 */
+      tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+    
+  
+      /* If the requested internal measurement path has already been enabled,   */
+      /* bypass the configuration processing.                                   */
+      if (( (sConfig->Channel == ADC_CHANNEL_TEMPSENSOR) &&
+            (HAL_IS_BIT_CLR(tmpADC_Common->CCR, ADC_CCR_TSEN))            ) ||
+          ( (sConfig->Channel == ADC_CHANNEL_VBAT)       &&
+            (HAL_IS_BIT_CLR(tmpADC_Common->CCR, ADC_CCR_VBATEN))          ) ||
+          ( (sConfig->Channel == ADC_CHANNEL_VREFINT)    &&
+            (HAL_IS_BIT_CLR(tmpADC_Common->CCR, ADC_CCR_VREFEN)))
+         )
+      {
+        /* Configuration of common ADC parameters (continuation)                */
+  
+        /* Software is allowed to change common parameters only when all ADCs   */
+        /* of the common group are disabled.                                    */
+        if ((ADC_IS_ENABLE(hadc) == RESET)   &&
+           (ADC_ANY_OTHER_ENABLED(hadc) == RESET) )              
+        {
+          if (sConfig->Channel == ADC_CHANNEL_TEMPSENSOR)
+          {
+            if (ADC_TEMPERATURE_SENSOR_INSTANCE(hadc)) 
+            {
+              SET_BIT(tmpADC_Common->CCR, ADC_CCR_TSEN);
+            
+              /* Delay for temperature sensor stabilization time */
+              /* Compute number of CPU cycles to wait for */
+              wait_loop_index = (ADC_TEMPSENSOR_DELAY_US * (SystemCoreClock / 1000000));
+              while(wait_loop_index != 0)
+              {
+                wait_loop_index--;
+              }
+            }
+          }
+          else if (sConfig->Channel == ADC_CHANNEL_VBAT)
+          {
+            if (ADC_BATTERY_VOLTAGE_INSTANCE(hadc))
+            {
+              SET_BIT(tmpADC_Common->CCR, ADC_CCR_VBATEN);
+            }
+          }
+          else if (sConfig->Channel == ADC_CHANNEL_VREFINT)
+          { 
+            if (ADC_VREFINT_INSTANCE(hadc))
+            {
+              SET_BIT(tmpADC_Common->CCR, ADC_CCR_VREFEN);
+            }        
+          }
+        }
+        /* If the requested internal measurement path has already been          */
+        /* enabled and other ADC of the common group are enabled, internal      */
+        /* measurement paths cannot be enabled.                                 */
+        else  
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+          
+          tmp_status = HAL_ERROR;
+        }
+      }
+  
+    } /* if (ADC_IS_ENABLE(hadc) == RESET) */
+
+  } /* if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET) */
+  
+  /* If a conversion is on going on regular group, no update on regular       */
+  /* channel could be done on neither of the channel configuration structure  */
+  /* parameters.                                                              */
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+    
+    tmp_status = HAL_ERROR;
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_status;
+}
+  
+
+
+/**
+  * @brief  Configure the analog watchdog.
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes the selected analog watchdog, successive  
+  *         calls to this function can be used to reconfigure some parameters 
+  *         of structure "ADC_AnalogWDGConfTypeDef" on the fly, without resetting 
+  *         the ADC, e.g. to set several channels to monitor simultaneously. 
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_AnalogWDGConfTypeDef".
+  * @param  hadc: ADC handle
+  * @param  AnalogWDGConfig: Structure of ADC analog watchdog configuration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+
+  
+  uint32_t tmpAWDHighThresholdShifted;
+  uint32_t tmpAWDLowThresholdShifted;
+  
+  uint32_t tmpADCFlagAWD2orAWD3;
+  uint32_t tmpADCITAWD2orAWD3;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_ANALOG_WATCHDOG_NUMBER(AnalogWDGConfig->WatchdogNumber));
+  assert_param(IS_ADC_ANALOG_WATCHDOG_MODE(AnalogWDGConfig->WatchdogMode));
+  assert_param(IS_FUNCTIONAL_STATE(AnalogWDGConfig->ITMode));
+  
+  if((AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REG)     ||
+     (AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_INJEC)   ||
+     (AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REGINJEC)  )
+  {
+    assert_param(IS_ADC_CHANNEL(hadc, AnalogWDGConfig->Channel));
+  }
+  
+
+  /* Verify if threshold is within the selected ADC resolution */
+  assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->HighThreshold));
+  assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->LowThreshold));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on regular and injected groups:                      */
+  /*  - Analog watchdog channels                                              */
+  /*  - Analog watchdog thresholds                                            */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET)
+  {
+  
+    /* Analog watchdogs configuration */
+    if(AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_1)
+    {
+      /* Configuration of analog watchdog:                                    */
+      /*  - Set the analog watchdog enable mode: regular and/or injected      */
+      /*    groups, one or overall group of channels.                         */
+      /*  - Set the Analog watchdog channel (is not used if watchdog          */
+      /*    mode "all channels": ADC_CFGR_AWD1SGL=0).                         */
+                                
+        MODIFY_REG(hadc->Instance->CFGR,  ADC_CFGR_WD_FIELDS, 
+              AnalogWDGConfig->WatchdogMode | ADC_CFGR_SET_AWD1CH(AnalogWDGConfig->Channel) );                                  
+
+      /* Shift the offset with respect to the selected ADC resolution:         */
+      /* Thresholds have to be left-aligned on bit 11, the LSB (right bits)   */
+      /* are set to 0                                                         */ 
+      tmpAWDHighThresholdShifted = ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->HighThreshold);
+      tmpAWDLowThresholdShifted  = ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->LowThreshold);
+      
+      /* Set the high and low thresholds */                                
+      MODIFY_REG(hadc->Instance->TR1,  ADC_TR1_HT1 | ADC_TR1_LT1, 
+              ADC_TRX_HIGHTHRESHOLD (tmpAWDHighThresholdShifted) | tmpAWDLowThresholdShifted );                                  
+      
+      /* Clear the ADC Analog watchdog flag (in case left enabled by          */
+      /* previous ADC operations) to be ready to use for HAL_ADC_IRQHandler() */
+      /* or HAL_ADC_PollForEvent().                                           */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_IT_AWD1);
+      
+      /* Configure ADC Analog watchdog interrupt */
+      if(AnalogWDGConfig->ITMode == ENABLE)
+      {
+        /* Enable the ADC Analog watchdog interrupt */
+        __HAL_ADC_ENABLE_IT(hadc, ADC_IT_AWD1);
+      }
+      else
+      {
+        /* Disable the ADC Analog watchdog interrupt */
+        __HAL_ADC_DISABLE_IT(hadc, ADC_IT_AWD1);
+      }
+      
+      /* Update state, clear previous result related to AWD1 */
+      CLEAR_BIT(hadc->State, HAL_ADC_STATE_AWD1);
+    }
+    /* Case of ADC_ANALOGWATCHDOG_2 and ADC_ANALOGWATCHDOG_3 */
+    else
+    {
+    /* Shift the threshold with respect to the selected ADC resolution         */
+    /* have to be left-aligned on bit 7, the LSB (right bits) are set to 0    */
+      tmpAWDHighThresholdShifted = ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->HighThreshold);
+      tmpAWDLowThresholdShifted  = ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->LowThreshold);
+
+      if (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_2)
+      {
+        /* Set the Analog watchdog channel or group of channels. This also    */
+        /* enables the watchdog.                                              */
+        /* Note: Conditional register reset, because several channels can be */
+        /*       set by successive calls of this function.                    */
+        if (AnalogWDGConfig->WatchdogMode != ADC_ANALOGWATCHDOG_NONE) 
+        {
+          SET_BIT(hadc->Instance->AWD2CR, ADC_CFGR_SET_AWD23CR(AnalogWDGConfig->Channel));
+        }
+        else
+        {
+          CLEAR_BIT(hadc->Instance->AWD2CR,  ADC_AWD2CR_AWD2CH);
+        }
+        
+        /* Set the high and low thresholds */
+        MODIFY_REG(hadc->Instance->TR2,  ADC_TR2_HT2 | ADC_TR2_LT2, 
+              ADC_TRX_HIGHTHRESHOLD (tmpAWDHighThresholdShifted) | tmpAWDLowThresholdShifted );                                      
+        
+        /* Set temporary variable to flag and IT of AWD2 or AWD3 for further  */
+        /* settings.                                                          */
+        tmpADCFlagAWD2orAWD3 = ADC_FLAG_AWD2;
+        tmpADCITAWD2orAWD3 = ADC_IT_AWD2;
+        
+        /* Update state, clear previous result related to AWD2 */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_AWD2);
+      }
+      /* (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_3) */
+      else
+      {
+        /* Set the Analog watchdog channel or group of channels. This also    */
+        /* enables the watchdog.                                              */
+        /* Note: Conditional register reset, because several channels can be */
+        /*       set by successive calls of this function.                    */
+        if (AnalogWDGConfig->WatchdogMode != ADC_ANALOGWATCHDOG_NONE) 
+        {
+          SET_BIT(hadc->Instance->AWD3CR, ADC_CFGR_SET_AWD23CR(AnalogWDGConfig->Channel));
+        }
+        else
+        {
+          CLEAR_BIT(hadc->Instance->AWD3CR,  ADC_AWD3CR_AWD3CH);
+        }
+        
+        /* Set the high and low thresholds */
+        MODIFY_REG(hadc->Instance->TR3,  ADC_TR3_HT3 | ADC_TR3_LT3, 
+              ADC_TRX_HIGHTHRESHOLD (tmpAWDHighThresholdShifted) | tmpAWDLowThresholdShifted );                                    
+        
+        /* Set temporary variable to flag and IT of AWD2 or AWD3 for further  */
+        /* settings.                                                          */
+        tmpADCFlagAWD2orAWD3 = ADC_FLAG_AWD3;
+        tmpADCITAWD2orAWD3 = ADC_IT_AWD3;
+        
+        /* Update state, clear previous result related to AWD3 */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_AWD3);
+      }
+
+      /* Clear the ADC Analog watchdog flag (in case left enabled by          */
+      /* previous ADC operations) to be ready to use for HAL_ADC_IRQHandler() */
+      /* or HAL_ADC_PollForEvent().                                           */
+      __HAL_ADC_CLEAR_FLAG(hadc, tmpADCFlagAWD2orAWD3);
+
+      /* Configure ADC Analog watchdog interrupt */
+      if(AnalogWDGConfig->ITMode == ENABLE)
+      {
+        __HAL_ADC_ENABLE_IT(hadc, tmpADCITAWD2orAWD3);
+      }
+      else
+      {
+        __HAL_ADC_DISABLE_IT(hadc, tmpADCITAWD2orAWD3);
+      }
+    }
+  
+  }
+  /* If a conversion is on going on regular or injected groups, no update     */
+  /* could be done on neither of the AWD configuration structure parameters.  */
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+    
+    tmp_status = HAL_ERROR;
+  }
+  
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+
+  /* Return function status */
+  return tmp_status;
+}
+
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group4 Peripheral State functions
+ *  @brief   ADC Peripheral State functions 
+ *
+@verbatim   
+ ===============================================================================
+            ##### Peripheral state and errors functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions to get in run-time the status of the  
+    peripheral.
+      (+) Check the ADC state
+      (+) Check the ADC error code
+         
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Return the ADC handle state.
+  * @param  hadc: ADC handle
+  * @retval HAL state  (uint32_t bit-map)
+  */
+uint32_t HAL_ADC_GetState(ADC_HandleTypeDef* hadc)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Return ADC handle state */
+  return hadc->State;
+}
+
+
+/**
+  * @brief  Return the ADC error code.
+  * @param  hadc: ADC handle
+  * @retval ADC Error Code (uint32_t bit-map)
+  */
+uint32_t HAL_ADC_GetError(ADC_HandleTypeDef *hadc)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  return hadc->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+
+/** @defgroup ADC_Private_Functions ADC Private Functions
+  * @{
+  */
+
+/**
+  * @brief  Stop ADC conversion.
+  * @param  hadc: ADC handle
+  * @param  ConversionGroup: ADC group regular and/or injected.
+  *          This parameter can be one of the following values:
+  *            @arg @ref ADC_REGULAR_GROUP           ADC regular conversion type.
+  *            @arg @ref ADC_INJECTED_GROUP          ADC injected conversion type.
+  *            @arg @ref ADC_REGULAR_INJECTED_GROUP  ADC regular and injected conversion type.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef* hadc, uint32_t ConversionGroup)
+{
+  uint32_t tmp_ADC_CR_ADSTART_JADSTART = 0;
+  uint32_t tickstart = 0;
+  uint32_t Conversion_Timeout_CPU_cycles = 0;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_CONVERSION_GROUP(ConversionGroup));
+    
+  /* Verification if ADC is not already stopped (on regular and injected      */
+  /* groups) to bypass this function if not needed.                           */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc))
+  {
+    /* Particular case of continuous auto-injection mode combined with        */
+    /* auto-delay mode.                                                       */
+    /* In auto-injection mode, regular group stop ADC_CR_ADSTP is used (not   */
+    /* injected group stop ADC_CR_JADSTP).                                    */
+    /* Procedure to be followed: Wait until JEOS=1, clear JEOS, set ADSTP=1   */
+    /* (see reference manual).                                                */
+    if ((HAL_IS_BIT_SET(hadc->Instance->CFGR, ADC_CFGR_JAUTO)) 
+         && (hadc->Init.ContinuousConvMode==ENABLE) 
+         && (hadc->Init.LowPowerAutoWait==ENABLE))
+    {
+      /* Use stop of regular group */
+      ConversionGroup = ADC_REGULAR_GROUP;
+      
+      /* Wait until JEOS=1 (maximum Timeout: 4 injected conversions) */
+      while(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOS) == RESET)
+      {
+        if (Conversion_Timeout_CPU_cycles >= (ADC_CONVERSION_TIME_MAX_CPU_CYCLES *4))
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+          
+          /* Set ADC error code to ADC IP internal error */
+          SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+          
+          return HAL_ERROR;
+        }
+        Conversion_Timeout_CPU_cycles ++;
+      }
+
+      /* Clear JEOS */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JEOS);
+    }
+    
+    /* Stop potential conversion on going on regular group */
+    if (ConversionGroup != ADC_INJECTED_GROUP)
+    {
+      /* Software is allowed to set ADSTP only when ADSTART=1 and ADDIS=0 */
+      if (HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADSTART) && 
+          HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADDIS)     )
+      {
+        /* Stop conversions on regular group */
+        SET_BIT(hadc->Instance->CR, ADC_CR_ADSTP);
+      }
+    }
+
+    /* Stop potential conversion on going on injected group */
+    if (ConversionGroup != ADC_REGULAR_GROUP)
+    {
+      /* Software is allowed to set JADSTP only when JADSTART=1 and ADDIS=0 */
+      if (HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_JADSTART) && 
+          HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADDIS)      )
+      {
+        /* Stop conversions on injected group */
+        SET_BIT(hadc->Instance->CR, ADC_CR_JADSTP);
+      }   
+    }
+
+    /* Selection of start and stop bits with respect to the regular or injected group */
+    switch(ConversionGroup)
+    {
+    case ADC_REGULAR_INJECTED_GROUP:
+        tmp_ADC_CR_ADSTART_JADSTART = (ADC_CR_ADSTART | ADC_CR_JADSTART);
+        break;
+    case ADC_INJECTED_GROUP:
+        tmp_ADC_CR_ADSTART_JADSTART = ADC_CR_JADSTART;
+        break;
+    /* Case ADC_REGULAR_GROUP only*/
+    default:
+        tmp_ADC_CR_ADSTART_JADSTART = ADC_CR_ADSTART;
+        break;
+    }
+    
+    /* Wait for conversion effectively stopped */
+
+    
+    tickstart = HAL_GetTick();
+      
+    while((hadc->Instance->CR & tmp_ADC_CR_ADSTART_JADSTART) != RESET)
+    {
+      if((HAL_GetTick()-tickstart) > ADC_STOP_CONVERSION_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Set ADC error code to ADC IP internal error */
+        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+        
+        return HAL_ERROR;
+      }
+    }
+    
+  } /* if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc)) */
+   
+  /* Return HAL status */
+  return HAL_OK;
+}
+
+
+
+/**
+  * @brief  Enable the selected ADC.
+  * @note   Prerequisite condition to use this function: ADC must be disabled
+  *         and voltage regulator must be enabled (done into HAL_ADC_Init()).
+  * @param  hadc: ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc)
+{
+  uint32_t tickstart = 0;
+  
+  /* ADC enable and wait for ADC ready (in case of ADC is disabled or         */
+  /* enabling phase not yet completed: flag ADC ready not set yet).           */
+  /* Timeout implemented not to be stuck if ADC cannot be enabled (possible   */
+  /* causes: ADC clock not running, ...).                                     */
+  if (ADC_IS_ENABLE(hadc) == RESET)
+  {
+    /* Check if conditions to enable the ADC are fulfilled */
+    if (ADC_ENABLING_CONDITIONS(hadc) == RESET)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+      
+      /* Set ADC error code to ADC IP internal error */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+      
+      return HAL_ERROR;
+    }
+    
+    /* Enable the ADC peripheral */
+    ADC_ENABLE(hadc);
+    
+    
+    /* Wait for ADC effectively enabled */
+    tickstart = HAL_GetTick();  
+    
+    while(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_RDY) == RESET)
+    {
+      /*  If ADEN bit is set less than 4 ADC clock cycles after the ADCAL bit 
+          has been cleared (after a calibration), ADEN bit is reset by the 
+          calibration logic.
+			    The workaround is to continue setting ADEN until ADRDY is becomes 1.
+          Additionally, ADC_ENABLE_TIMEOUT is defined to encompass this
+          4 ADC clock cycle duration */
+      ADC_ENABLE(hadc);
+
+      if((HAL_GetTick()-tickstart) > ADC_ENABLE_TIMEOUT)
+      {  
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Set ADC error code to ADC IP internal error */
+       SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+      
+        return HAL_ERROR;
+      }
+    } 
+  }
+   
+  /* Return HAL status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disable the selected ADC.
+  * @note   Prerequisite condition to use this function: ADC conversions must be
+  *         stopped.
+  * @param  hadc: ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef* hadc)
+{
+  uint32_t tickstart = 0;
+  
+  /* Verification if ADC is not already disabled:                             */
+  /* Note: forbidden to disable ADC (set bit ADC_CR_ADDIS) if ADC is already  */
+  /* disabled.                                                                */
+  if (ADC_IS_ENABLE(hadc) != RESET )
+  {
+    /* Check if conditions to disable the ADC are fulfilled */
+    if (ADC_DISABLING_CONDITIONS(hadc) != RESET)
+    {
+      /* Disable the ADC peripheral */
+      ADC_DISABLE(hadc);
+    }
+    else
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+      
+      /* Set ADC error code to ADC IP internal error */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+      
+      return HAL_ERROR;
+    }
+     
+    /* Wait for ADC effectively disabled */
+    tickstart = HAL_GetTick();
+    
+    while(HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADEN))
+    {
+      if((HAL_GetTick()-tickstart) > ADC_DISABLE_TIMEOUT)
+      { 
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Set ADC error code to ADC IP internal error */
+        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+        
+        return HAL_ERROR;
+      }
+    }
+  }
+  
+  /* Return HAL status */
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  DMA transfer complete callback. 
+  * @param  hdma: pointer to DMA handle.
+  * @retval None
+  */
+void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma)
+{
+  /* Retrieve ADC handle corresponding to current DMA handle */
+  ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+ 
+  /* Update state machine on conversion status if not in error state */
+  if (HAL_IS_BIT_CLR(hadc->State, (HAL_ADC_STATE_ERROR_INTERNAL|HAL_ADC_STATE_ERROR_DMA)))
+  {
+    /* Update ADC state machine */
+    SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOC);
+    /* Is it the end of the regular sequence ? */
+    if (HAL_IS_BIT_SET(hadc->Instance->ISR, ADC_FLAG_EOS))
+    {
+      /* Are conversions software-triggered ? */
+      if(ADC_IS_SOFTWARE_START_REGULAR(hadc))
+      {
+        /* Is CONT bit set ? */
+        if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_CONT) == RESET)
+        {
+          /* CONT bit is not set, no more conversions expected */
+          CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+          if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+          { 
+            SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+          }
+        }
+      }
+    }
+    else
+    {
+      /* DMA End of Transfer interrupt was triggered but conversions sequence
+         is not over. If DMACFG is set to 0, conversions are stopped. */
+      if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_DMACFG) == RESET)
+      {
+        /* DMACFG bit is not set, conversions are stopped. */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+        if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+        { 
+          SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+        }
+      }
+    }
+    
+    /* Conversion complete callback */
+    HAL_ADC_ConvCpltCallback(hadc);   
+  }
+  else /* DMA or internal error occurred (or both) */
+  {
+    /* In case of internal error, */
+    if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL))
+    {
+      /* call Error Callback function */
+      HAL_ADC_ErrorCallback(hadc);
+    }
+  
+  }
+  
+
+}
+
+/**
+  * @brief  DMA half transfer complete callback. 
+  * @param  hdma: pointer to DMA handle.
+  * @retval None
+  */
+void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma)   
+{
+  /* Retrieve ADC handle corresponding to current DMA handle */
+  ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  /* Half conversion callback */
+  HAL_ADC_ConvHalfCpltCallback(hadc); 
+}
+
+/**
+  * @brief  DMA error callback.
+  * @param  hdma: pointer to DMA handle.
+  * @retval None
+  */
+void ADC_DMAError(DMA_HandleTypeDef *hdma)   
+{
+  /* Retrieve ADC handle corresponding to current DMA handle */
+  ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  /* Change ADC state */
+  SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
+  
+  /* Set ADC error code to DMA error */
+  SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_DMA);
+  
+  /* Error callback */
+  HAL_ADC_ErrorCallback(hadc); 
+}
+
+
+/**
+  * @}
+  */
+
+
+#endif /* HAL_ADC_MODULE_ENABLED */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_adc_ex.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_adc_ex.c
@@ -1,0 +1,2382 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_adc_ex.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the Analog to Digital Convertor (ADC)
+  *          peripheral:
+  *           + Calibration functions
+  *             ++ Calibration start-up
+  *             ++ Calibration value reading or setting 
+  *           + Operation functions
+  *             ++ Start, stop, get result of conversions of injected
+  *             groups, using 3 possible modes: polling or interruption.
+  *             ++ Multimode feature when available
+  *           + Control functions
+  *             ++ Configure channels on injected group
+  *           + State functions
+  *             ++ Injected group queues management
+  *  
+   @verbatim           
+  ==============================================================================
+                    ##### ADC specific features #####
+  ==============================================================================
+  [..] 
+  (#) Interrupt generation at the end of injected conversion and in case of 
+      injected queues overflow.
+  
+  (#) External trigger (timer or EXTI) with configurable polarity for  
+      injected groups.
+
+  (#) Multimode Dual mode when multimode feature is available.
+  
+  (#) Configurable DMA data storage in Multimode Dual mode.
+  
+  (#) Configurable delay between conversions in Dual interleaved mode.
+  
+  (#) ADC calibration.
+
+  (#) ADC channels selectable single/differential input.
+
+  (#) ADC Injected sequencer&channels configuration context queue.
+
+  (#) ADC offset on injected groups.
+  
+  (#) ADC oversampling.
+
+
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+  
+     (#) Configure the ADC parameters (conversion resolution, data alignment,  
+         continuous mode, ...) using the HAL_ADC_Init() function.
+
+     (#) Activate the ADC peripheral using one of the start functions: 
+         HAL_ADCEx_InjectedStart(), HAL_ADCEx_InjectedStart_IT() for injected conversions
+         or 
+         HAL_ADC_MultiModeStart_DMA() for multimode conversions when multimode
+         feature is available.
+  
+  
+     *** Channels to injected group configuration ***
+     =============================================    
+     [..]
+       (+) To configure the ADC Injected channels group features, use 
+           HAL_ADCEx_InjectedConfigChannel() functions.
+       (+) To read the ADC converted values, use the HAL_ADCEx_InjectedGetValue() 
+           function.  
+            
+            
+     *** Multimode ADCs configuration (when  multimode feature is available) ***
+     ========================================================================
+     [..]
+       (+) Multimode feature is available and applicable to Master and
+           Slave ADCs.
+       (+) Refer to "Channels to regular group configuration" description to  
+           configure the Master and Slave regular groups.        
+       (+) Select the Multi mode ADC  features (dual mode
+           simultaneous, interleaved, ...) and configure the DMA mode using 
+           HAL_ADCEx_MultiModeConfigChannel() functions. 
+       (+) Read the ADCs converted values using the HAL_ADCEx_MultiModeGetValue()
+           function.
+
+  
+    @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup ADCEx ADCEx
+  * @brief ADC Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+    
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+
+/** @defgroup ADCEx_Private_Constants ADC Extended Private Constants
+  * @{
+  */
+
+#define ADC_JSQR_FIELDS  ((uint32_t)(ADC_JSQR_JL | ADC_JSQR_JEXTSEL | ADC_JSQR_JEXTEN |\
+                                     ADC_JSQR_JSQ1  | ADC_JSQR_JSQ2 |\
+                                      ADC_JSQR_JSQ3 | ADC_JSQR_JSQ4 ))  /*!< ADC_JSQR fields of parameters that can be updated anytime
+                                                                             once the ADC is enabled */
+                                      
+#define ADC_CFGR2_INJ_FIELDS  ((uint32_t)(ADC_CFGR2_JOVSE | ADC_CFGR2_OVSR  |\
+                                       ADC_CFGR2_OVSS ))     /*!< ADC_CFGR2 injected oversampling parameters that can be updated
+                                                                  when no conversion is on-going (neither regular nor injected) */
+                                       
+/* Fixed timeout value for ADC calibration.                                   */
+/* Values defined to be higher than worst cases: low clock frequency,         */
+/* maximum prescalers.                                                        */
+/* Ex of profile low frequency : f_ADC at 0.14 MHz (minimum value             */
+/* according to Data sheet), calibration_time MAX = 112 / f_ADC               */
+/*           112 / 140,000 = 0.8 ms                                           */
+/* At maximum CPU speed (80 MHz), this means                                  */
+/*    0.8 ms * 80 MHz = 64000 CPU cycles                                      */  
+#define ADC_CALIBRATION_TIMEOUT         ((uint32_t) 64000)    /*!< ADC calibration time-out value */ 
+                                    
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup ADCEx_Exported_Functions ADC Extended Exported Functions
+  * @{
+  */ 
+
+
+
+/** @defgroup ADCEx_Exported_Functions_Group1 Extended Input and Output operation functions
+  * @brief    Extended IO operation functions
+  *
+@verbatim   
+ ===============================================================================
+             ##### IO operation functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+    
+      (+) Perform the ADC self-calibration for single or differential ending.
+      (+) Get calibration factors for single or differential ending.
+      (+) Set calibration factors for single or differential ending.
+          
+      (+) Start conversion of injected group.
+      (+) Stop conversion of injected group.
+      (+) Poll for conversion complete on injected group.
+      (+) Get result of injected channel conversion.
+      (+) Start conversion of injected group and enable interruptions.
+      (+) Stop conversion of injected group and disable interruptions.
+
+      (+) When multimode feature is available, start multimode and enable DMA transfer.
+      (+) Stop multimode and disable ADC DMA transfer.
+      (+) Get result of multimode conversion.
+
+
+
+@endverbatim
+  * @{
+  */
+  
+
+
+/**
+  * @brief  Perform an ADC automatic self-calibration
+  *         Calibration prerequisite: ADC must be disabled (execute this
+  *         function before HAL_ADC_Start() or after HAL_ADC_Stop() ).
+  * @param  hadc: ADC handle.
+  * @param  SingleDiff: Selection of single-ended or differential input
+  *          This parameter can be one of the following values:
+  *            @arg @ref ADC_SINGLE_ENDED       Channel in mode input single ended
+  *            @arg @ref ADC_DIFFERENTIAL_ENDED Channel in mode input differential ended
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc, uint32_t SingleDiff)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  uint32_t WaitLoopIndex = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+   
+  /* Calibration prerequisite: ADC must be disabled. */
+   
+  /* Disable the ADC (if not already disabled) */
+  tmp_status = ADC_Disable(hadc);
+  
+  /* Check if ADC is effectively disabled */
+  if (tmp_status == HAL_OK)
+  {
+    /* Change ADC state */
+    /* Clear HAL_ADC_STATE_REG_BUSY and HAL_ADC_STATE_INJ_BUSY bits, set HAL_ADC_STATE_BUSY_INTERNAL bit */
+    ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_REG_BUSY|HAL_ADC_STATE_INJ_BUSY), HAL_ADC_STATE_BUSY_INTERNAL);
+    
+    /* Select calibration mode single ended or differential ended */
+    MODIFY_REG(hadc->Instance->CR, ADC_CR_ADCALDIF, SingleDiff);
+
+    /* Start ADC calibration */
+    SET_BIT(hadc->Instance->CR, ADC_CR_ADCAL);
+
+
+    /* Wait for calibration completion */
+    while(HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADCAL))
+    {
+      WaitLoopIndex++;
+      if (WaitLoopIndex >= ADC_CALIBRATION_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        /* Clear HAL_ADC_STATE_BUSY_INTERNAL bit, set HAL_ADC_STATE_ERROR_INTERNAL bit */
+        ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_BUSY_INTERNAL, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_ERROR;
+      }
+    }
+    
+    /* Clear HAL_ADC_STATE_BUSY_INTERNAL bit, set HAL_ADC_STATE_READY bit */
+    ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_BUSY_INTERNAL, HAL_ADC_STATE_READY);
+  }
+  else
+  {
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+    
+    /* Update ADC state machine to error */
+    tmp_status = HAL_ERROR; 
+  }
+  
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+}
+
+
+
+
+/**
+  * @brief  Get the calibration factor from automatic conversion result.
+  * @param  hadc: ADC handle.
+  * @param  SingleDiff: Selection of single-ended or differential input
+  *          This parameter can be one of the following values:
+  *            @arg @ref ADC_SINGLE_ENDED       Channel in mode input single ended
+  *            @arg @ref ADC_DIFFERENTIAL_ENDED Channel in mode input differential ended
+  * @retval Converted value
+  */
+uint32_t HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef* hadc, uint32_t SingleDiff)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff)); 
+  
+  /* Return the selected ADC calibration value */ 
+  if (SingleDiff == ADC_DIFFERENTIAL_ENDED)
+  {
+    return ADC_CALFACT_DIFF_GET(hadc->Instance->CALFACT);
+  }
+  else
+  {
+    return ((hadc->Instance->CALFACT) & ADC_CALFACT_CALFACT_S);
+  }
+}
+
+
+
+/**
+  * @brief  Set the calibration factor to overwrite automatic conversion result. ADC must be enabled and no conversion on going.
+  * @param  hadc: ADC handle.
+  * @param  SingleDiff: Selection of single-ended or differential input.
+  *          This parameter can be one of the following values:
+  *            @arg @ref ADC_SINGLE_ENDED       Channel in mode input single ended
+  *            @arg @ref ADC_DIFFERENTIAL_ENDED Channel in mode input differential ended
+  * @param  CalibrationFactor: Calibration factor (coded on 7 bits maximum)
+  * @retval HAL state
+  */
+HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef* hadc, uint32_t SingleDiff, uint32_t CalibrationFactor)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff)); 
+  assert_param(IS_ADC_CALFACT(CalibrationFactor)); 
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Verification of hardware constraints before modifying the calibration    */
+  /* factors register: ADC must be enabled, no conversion on going.           */
+  if ( (ADC_IS_ENABLE(hadc) != RESET)                            &&
+       (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET)  )
+  {
+    /* Set the selected ADC calibration value */ 
+    if (SingleDiff == ADC_DIFFERENTIAL_ENDED)
+    {
+      MODIFY_REG(hadc->Instance->CALFACT, ADC_CALFACT_CALFACT_D, ADC_CALFACT_DIFF_SET(CalibrationFactor));
+    }
+    else
+    {
+      MODIFY_REG(hadc->Instance->CALFACT, ADC_CALFACT_CALFACT_S, CalibrationFactor);
+    }
+  }
+  else
+  {
+    /* Update ADC state machine */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+    
+    /* Update ADC state machine to error */
+    tmp_status = HAL_ERROR;
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+}
+
+
+
+/**
+  * @brief  Enable ADC, start conversion of injected group.
+  * @note   Interruptions enabled in this function: None.
+  * @note   Case of multimode enabled when multimode feature is available: 
+  *         HAL_ADCEx_InjectedStart() API must be called for ADC slave first, 
+  *         then for ADC master. 
+  *         For ADC slave, ADC is enabled only (conversion is not started).  
+  *         For ADC master, ADC is enabled and multimode conversion is started.
+  * @param  hadc: ADC handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStart(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;  
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc))
+  {
+    return HAL_BUSY;
+  }
+  else
+  {
+  
+    /* In case of software trigger detection enabled, JQDIS must be set 
+      (which can be done only if ADSTART and JADSTART are both cleared).
+       If JQDIS is not set at that point, returns an error
+       - since software trigger detection is disabled. User needs to
+       resort to HAL_ADCEx_DisableInjectedQueue() API to set JQDIS.  
+       - or (if JQDIS is intentionally reset) since JEXTEN = 0 which means 
+         the queue is empty */
+    if ((READ_BIT(hadc->Instance->JSQR, ADC_JSQR_JEXTEN) == RESET)   
+    && (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JQDIS) == RESET))  
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG); 
+      return HAL_ERROR;
+    }
+
+      
+    /* Process locked */
+    __HAL_LOCK(hadc);
+      
+    /* Enable the ADC peripheral */
+    tmp_status = ADC_Enable(hadc);
+    
+    /* Start conversion if ADC is effectively enabled */
+    if (tmp_status == HAL_OK)
+    {
+      /* Check if a regular conversion is ongoing */
+      if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_REG_BUSY)) 
+      {
+        /* Reset ADC error code field related to injected conversions only */
+        CLEAR_BIT(hadc->ErrorCode, HAL_ADC_ERROR_JQOVF);             
+      }
+      else
+      {
+        /* Set ADC error code to none */
+        ADC_CLEAR_ERRORCODE(hadc);        
+      }
+      /* Update ADC state */
+      /* Clear HAL_ADC_STATE_READY and HAL_ADC_STATE_INJ_EOC bits, set HAL_ADC_STATE_INJ_BUSY bit */
+      ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_READY|HAL_ADC_STATE_INJ_EOC), HAL_ADC_STATE_INJ_BUSY);
+      
+      /* Reset HAL_ADC_STATE_MULTIMODE_SLAVE bit
+        - by default if ADC is Master or Independent or if multimode feature is not available
+        - if multimode setting is set to independent mode (no dual regular or injected conversions are configured) */
+      if (ADC_NONMULTIMODE_OR_MULTIMODEMASTER(hadc))
+      {
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }      
+
+      
+      /* Clear injected group conversion flag */
+      /* (To ensure of no unknown state from potential previous ADC operations) */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_JEOC | ADC_FLAG_JEOS));
+      
+      /* Enable conversion of injected group, if automatic injected conversion  */
+      /* is disabled.                                                           */
+      /* If software start has been selected, conversion starts immediately.    */
+      /* If external trigger has been selected, conversion will start at next   */
+      /* trigger event.                                                         */
+      /* Case of multimode enabled (when multimode feature is available):       */
+      /* if ADC is slave,                                                       */
+      /*    - ADC is enabled only (conversion is not started).                  */
+      /*    - if multimode only concerns regular conversion, ADC is enabled     */
+      /*     and conversion is started.                                         */
+      /* If ADC is master or independent,                                       */
+      /*    - ADC is enabled and conversion is started.                         */
+
+      /* Are injected conversions that of a dual Slave ? */      
+      if (ADC_INDEPENDENT_OR_NONMULTIMODEINJECTED_SLAVE(hadc))
+      {
+        /* hadc is not the handle of a Slave ADC with dual injected conversions enabled:
+           set ADSTART only if JAUTO is cleared */
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);            
+        if (HAL_IS_BIT_CLR(hadc->Instance->CFGR, ADC_CFGR_JAUTO))
+        {
+          SET_BIT(hadc->Instance->CR, ADC_CR_JADSTART) ;
+        }
+      }
+      else
+      {
+        /* hadc is the handle of a Slave ADC with dual injected conversions enabled:
+           ADSTART is not set */
+          SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);            
+      }
+    } 
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);    
+    } /* if (tmp_status == HAL_OK) */
+  
+  
+    /* Return function status */
+    return tmp_status;
+  } /*  if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc)) */
+}
+
+
+
+/**
+  * @brief  Stop conversion of injected channels, disable ADC peripheral if no regular conversion is on going.
+  * @note   If ADC must be disabled and if regular conversion
+  *         is on going, function HAL_ADC_Stop() must be used.
+  * @note   In case of auto-injection mode, HAL_ADC_Stop() must be used.
+  * @note   In case of multimode enabled (when multimode feature is available), 
+  *         HAL_ADCEx_InjectedStop() must be called for ADC master first, then for ADC slave.
+  *         For ADC master, conversion is stopped and ADC is disabled. 
+  *         For ADC slave, ADC is disabled only (conversion stop of ADC master
+  *         has already stopped conversion of ADC slave).
+  * @param  hadc: ADC handle.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStop(ADC_HandleTypeDef* hadc)
+{  
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential conversion on going on injected group only. */
+  tmp_status = ADC_ConversionStop(hadc, ADC_INJECTED_GROUP);
+  
+  /* Disable ADC peripheral if injected conversions are effectively stopped   */
+  /* and if no conversion on regular group is on-going                       */
+  if (tmp_status == HAL_OK)
+  {
+    if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET)
+    {
+      /* 2. Disable the ADC peripheral */
+      tmp_status = ADC_Disable(hadc);
+      
+      /* Check if ADC is effectively disabled */
+      if (tmp_status == HAL_OK)
+      {
+        /* Change ADC state */
+      /* Clear HAL_ADC_STATE_REG_BUSY and HAL_ADC_STATE_INJ_BUSY bits, set HAL_ADC_STATE_READY bit */
+      ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_REG_BUSY|HAL_ADC_STATE_INJ_BUSY), HAL_ADC_STATE_READY);
+      }
+    }
+    /* Conversion on injected group is stopped, but ADC not disabled since    */
+    /* conversion on regular group is still running.                          */
+    else
+    {
+      /* Clear HAL_ADC_STATE_INJ_BUSY bit */
+      CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY); 
+    }
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+}
+
+
+
+/**
+  * @brief  Wait for injected group conversion to be completed.
+  * @param  hadc: ADC handle
+  * @param  Timeout: Timeout value in millisecond.
+  * @note   Depending on hadc->Init.EOCSelection, JEOS or JEOC is 
+  *         checked and cleared depending on AUTDLY bit status.    
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedPollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
+{
+  uint32_t           tickstart;
+  uint32_t           tmp_Flag_End        = 0x00;
+  ADC_TypeDef        *tmpADC_Master;
+  uint32_t           tmp_cfgr            = 0x00;
+  uint32_t           tmp_cfgr_jqm_autdly = 0x00;   
+  uint32_t           tmp_jeos_raised     = 0x01; /* by default, assume that JEOS is set, 
+                                                    tmp_jeos_raised will be corrected
+                                                    accordingly during API execution */       
+ 
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* If end of sequence selected */
+  if (hadc->Init.EOCSelection == ADC_EOC_SEQ_CONV)
+  {
+    tmp_Flag_End = ADC_FLAG_JEOS;
+  }
+  else /* end of conversion selected */
+  {
+    tmp_Flag_End = ADC_FLAG_JEOC;
+  }
+  
+  /* Get timeout */
+  tickstart = HAL_GetTick();  
+     
+   /* Wait until End of Conversion or Sequence flag is raised */
+  while(HAL_IS_BIT_CLR(hadc->Instance->ISR, tmp_Flag_End))
+  {
+    /* Check if timeout is disabled (set to infinite wait) */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
+      {
+        /* Update ADC state machine to timeout */
+        SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  
+  /* Next, to clear the polled flag as well as to update the handle State,
+     JEOS is checked and the relevant configuration registers are retrieved. 
+     JQM, JAUTO and CONT bits will have to be read for the State update,
+     AUTDLY for JEOS clearing. */
+  /*   1. Check whether or not JEOS is set */
+  if (HAL_IS_BIT_CLR(hadc->Instance->ISR, ADC_FLAG_JEOS))
+  {
+    tmp_jeos_raised = 0;   
+  }
+  /*  2. Check whether or not hadc is the handle of a Slave ADC with dual
+        injected conversions enabled. */
+  if (ADC_INDEPENDENT_OR_NONMULTIMODEINJECTED_SLAVE(hadc) == RESET)  
+  {
+    /* hadc is not the handle of a Slave ADC with dual injected conversions enabled:
+        check JQM and AUTDLY bits directly in ADC CFGR register */     
+    tmp_cfgr_jqm_autdly = READ_REG(hadc->Instance->CFGR);  
+  }
+  else
+  {
+    /* hadc is the handle of a Slave ADC with dual injected conversions enabled:
+        need to check JQM and AUTDLY bits of Master ADC CFGR register */    
+    tmpADC_Master = ADC_MASTER_REGISTER(hadc);
+    tmp_cfgr_jqm_autdly = READ_REG(tmpADC_Master->CFGR);
+  }  
+  /* 3. Check whether or not hadc is the handle of a Slave ADC with dual
+        regular conversions enabled. */ 
+  if (ADC_INDEPENDENT_OR_NONMULTIMODEREGULAR_SLAVE(hadc))
+  {
+    /* hadc is not the handle of a Slave ADC with dual regular conversions enabled:
+       check JAUTO and CONT bits directly in ADC CFGR register */        
+    tmp_cfgr = READ_REG(hadc->Instance->CFGR); 
+  }
+  else
+  {
+    /* hadc is not the handle of a Slave ADC with dual regular conversions enabled:
+      check JAUTO and CONT bits of Master ADC CFGR register */  
+    tmpADC_Master = ADC_MASTER_REGISTER(hadc);
+    tmp_cfgr = READ_REG(tmpADC_Master->CFGR); 
+  }        
+  
+  
+  
+  /* Clear polled flag */                         
+  if (tmp_Flag_End == ADC_FLAG_JEOS)
+  {
+    /* Clear end of sequence JEOS flag of injected group if low power feature */
+    /* "LowPowerAutoWait " is disabled, to not interfere with this feature.   */
+    /* For injected groups, no new conversion will start before JEOS is       */
+    /* cleared.                                                               */
+    /* Note that 1. reading ADCx_JDRy clears JEOC.                            */ 
+    /*           2. in multimode with dual injected conversions enabled (when */
+    /*              multimode feature is available), Master AUTDLY bit is     */
+    /*              checked.                                                  */        
+    if (READ_BIT (tmp_cfgr_jqm_autdly, ADC_CFGR_AUTDLY) == RESET)
+    {
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOC);
+    }
+  }
+  else
+  {
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JEOC);    
+  }  
+  
+  
+  /* Update ADC state machine */
+  SET_BIT(hadc->State, HAL_ADC_STATE_INJ_EOC); 
+  /* Are injected conversions over ? This is the case if JEOS is set AND
+        - injected conversions are software-triggered when injected queue management is disabled
+        OR
+        - auto-injection is enabled, continuous mode is disabled,
+          and regular conversions are software-triggered */
+          
+  if (tmp_jeos_raised)
+  {  
+    if ((ADC_IS_SOFTWARE_START_INJECTED(hadc) && (READ_BIT(tmp_cfgr_jqm_autdly, ADC_CFGR_JQM) != ADC_CFGR_JQM))  
+       && (!((READ_BIT(tmp_cfgr, (ADC_CFGR_JAUTO|ADC_CFGR_CONT)) == (ADC_CFGR_JAUTO|ADC_CFGR_CONT)) &&    
+           (ADC_IS_SOFTWARE_START_REGULAR(hadc)))    ))           
+    {
+      /* Clear HAL_ADC_STATE_INJ_BUSY bit */
+      CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY); 
+      /* If no regular conversion on-going, set HAL_ADC_STATE_READY bit */                   
+      if (HAL_IS_BIT_CLR(hadc->State, HAL_ADC_STATE_REG_BUSY))
+      { 
+        SET_BIT(hadc->State, HAL_ADC_STATE_READY); 
+      }           
+    }      
+  }
+
+
+    
+  /* Return API HAL status */
+  return HAL_OK;
+}
+
+
+
+/**
+  * @brief  Enable ADC, start conversion of injected group with interruption.
+  * @note   Interruptions enabled in this function according to initialization
+  *         setting : JEOC (end of conversion) or JEOS (end of sequence) 
+  * @note   Case of multimode enabled (when multimode feature is enabled): 
+  *         HAL_ADCEx_InjectedStart_IT() API must be called for ADC slave first, 
+  *         then for ADC master. 
+  *         For ADC slave, ADC is enabled only (conversion is not started).  
+  *         For ADC master, ADC is enabled and multimode conversion is started.
+  * @param  hadc: ADC handle.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStart_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;  
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc))
+  {
+    return HAL_BUSY;
+  }
+  else
+  {
+
+    /* In case of software trigger detection enabled, JQDIS must be set 
+      (which can be done only if ADSTART and JADSTART are both cleared).
+       If JQDIS is not set at that point, returns an error
+       - since software trigger detection is disabled. User needs to
+       resort to HAL_ADCEx_DisableInjectedQueue() API to set JQDIS.  
+       - or (if JQDIS is intentionally reset) since JEXTEN = 0 which means 
+         the queue is empty */
+    if ((READ_BIT(hadc->Instance->JSQR, ADC_JSQR_JEXTEN) == RESET)   
+    && (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JQDIS) == RESET))  
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG); 
+      return HAL_ERROR;
+    }
+
+    /* Process locked */
+    __HAL_LOCK(hadc);
+      
+    /* Enable the ADC peripheral */
+    tmp_status = ADC_Enable(hadc);
+    
+    /* Start conversion if ADC is effectively enabled */
+    if (tmp_status == HAL_OK)
+    {
+      /* Check if a regular conversion is ongoing */
+      if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_REG_BUSY))
+      {
+        /* Reset ADC error code field related to injected conversions only */
+        CLEAR_BIT(hadc->ErrorCode, HAL_ADC_ERROR_JQOVF);            
+      }
+      else
+      {
+        /* Set ADC error code to none */
+        ADC_CLEAR_ERRORCODE(hadc);
+      }
+      /* Clear HAL_ADC_STATE_READY and HAL_ADC_STATE_INJ_EOC bits, set HAL_ADC_STATE_INJ_BUSY bit */
+      ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_READY|HAL_ADC_STATE_INJ_EOC), HAL_ADC_STATE_INJ_BUSY);
+      
+      /* Reset HAL_ADC_STATE_MULTIMODE_SLAVE bit
+        - by default if ADC is Master or Independent or if multimode feature is not available
+        - if multimode setting is set to independent mode (no dual regular or injected conversions are configured) */
+      if (ADC_NONMULTIMODE_OR_MULTIMODEMASTER(hadc))
+      {
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }      
+    
+      /* Clear injected group conversion flag */
+      /* (To ensure of no unknown state from potential previous ADC operations) */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_JEOC | ADC_FLAG_JEOS));
+      
+      /* Enable ADC Injected context queue overflow interrupt if this feature   */
+      /* is enabled.                                                            */
+      if ((hadc->Instance->CFGR & ADC_CFGR_JQM) != RESET)
+      {
+        __HAL_ADC_ENABLE_IT(hadc, ADC_FLAG_JQOVF);
+      }
+      
+      /* Enable ADC end of conversion interrupt */
+      switch(hadc->Init.EOCSelection)
+      {
+        case ADC_EOC_SEQ_CONV: 
+          __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC);
+          __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOS);
+          break;
+        /* case ADC_EOC_SINGLE_CONV */
+        default:
+          __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOS);      
+          __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOC);
+          break;
+      }
+      
+      /* Enable conversion of injected group, if automatic injected conversion  */
+      /* is disabled.                                                           */
+      /* If software start has been selected, conversion starts immediately.    */
+      /* If external trigger has been selected, conversion will start at next   */
+      /* trigger event.                                                         */
+      /* Case of multimode enabled (when multimode feature is available):       */
+      /* if ADC is slave,                                                       */
+      /*    - ADC is enabled only (conversion is not started),                  */
+      /*    - if multimode only concerns regular conversion, ADC is enabled     */
+      /*     and conversion is started.                                         */
+      /* If ADC is master or independent,                                       */
+      /*    - ADC is enabled and conversion is started.                         */
+
+      /* Are injected conversions that of a dual Slave ? */      
+      if (ADC_INDEPENDENT_OR_NONMULTIMODEINJECTED_SLAVE(hadc))
+      {
+        /* hadc is not the handle of a Slave ADC with dual injected conversions enabled:
+           set ADSTART only if JAUTO is cleared */
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);            
+        if (HAL_IS_BIT_CLR(hadc->Instance->CFGR, ADC_CFGR_JAUTO))
+        {
+          SET_BIT(hadc->Instance->CR, ADC_CR_JADSTART) ;
+        }
+      }
+      else
+      {
+        /* hadc is the handle of a Slave ADC with dual injected conversions enabled:
+           ADSTART is not set */
+          SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);          
+      }
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+    
+    /* Return function status */
+    return tmp_status;
+}
+}
+
+
+
+/**
+  * @brief  Stop conversion of injected channels, disable interruption of end-of-conversion. 
+  * @note   Disable ADC peripheral if no regular conversion
+  *         is on going.
+  * @note   If ADC must be disabled and if regular conversion
+  *         is on going, function HAL_ADC_Stop must be used first.
+  * @note   Case of multimode enabled (when multimode feature is available): 
+  *         HAL_ADCEx_InjectedStop_IT() API must be called for ADC master first, 
+  *         then for ADC slave.
+  *         For ADC master, conversion is stopped and ADC is disabled. 
+  *         For ADC slave, ADC is disabled only (conversion stop of ADC master
+  *         has already stopped conversion of ADC slave).
+  * @note   In case of auto-injection mode, HAL_ADC_Stop() must be used.
+  * @param  hadc: ADC handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStop_IT(ADC_HandleTypeDef* hadc)
+{ 
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential conversion on going on injected group only. */
+  tmp_status = ADC_ConversionStop(hadc, ADC_INJECTED_GROUP);
+  
+  /* Disable ADC peripheral if injected conversions are effectively stopped   */
+  /* and if no conversion on the other group (regular group) is intended to   */
+  /* continue.                                                                */
+  if (tmp_status == HAL_OK)
+  {
+    /* Disable ADC end of conversion interrupt for injected channels */
+    __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_JEOC | ADC_IT_JEOS | ADC_FLAG_JQOVF));
+    
+    if ((ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET))
+    {
+      /* 2. Disable the ADC peripheral */
+      tmp_status = ADC_Disable(hadc);
+      
+      /* Check if ADC is effectively disabled */
+      if (tmp_status == HAL_OK)
+      {
+        /* Change ADC state */
+        /* Clear HAL_ADC_STATE_REG_BUSY and HAL_ADC_STATE_INJ_BUSY bits, set HAL_ADC_STATE_READY bit */
+        ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_REG_BUSY|HAL_ADC_STATE_INJ_BUSY), HAL_ADC_STATE_READY);
+      }
+    }
+    /* Conversion on injected group is stopped, but ADC not disabled since    */
+    /* conversion on regular group is still running.                          */
+    else
+    {
+      /* Clear HAL_ADC_STATE_INJ_BUSY bit */
+      CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY); 
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+}
+
+
+/**
+  * @brief  Enable ADC, start MultiMode conversion and transfer regular results through DMA.
+  * @note   Multimode must have been previously configured using 
+  *         HAL_ADCEx_MultiModeConfigChannel() function.
+  *         Interruptions enabled in this function:
+  *          overrun, DMA half transfer, DMA transfer complete. 
+  *         Each of these interruptions has its dedicated callback function.
+  * @note   State field of Slave ADC handle is not updated in this configuration: 
+  *          user should not rely on it for information related to Slave regular 
+  *         conversions.                                                                          
+  * @param  hadc: ADC handle of ADC master (handle of ADC slave must not be used)
+  * @param  pData: Destination Buffer address.
+  * @param  Length: Length of data to be transferred from ADC peripheral to memory (in bytes).
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_MultiModeStart_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  ADC_HandleTypeDef tmphadcSlave;
+  ADC_Common_TypeDef *tmpADC_Common;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EXTTRIG_EDGE(hadc->Init.ExternalTrigConvEdge));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DMAContinuousRequests));
+  
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc))
+  {
+    return HAL_BUSY;
+  }
+  else
+  {
+    /* Process locked */
+    __HAL_LOCK(hadc);
+
+    /* Set a temporary handle of the ADC slave associated to the ADC master   */
+    ADC_MULTI_SLAVE(hadc, &tmphadcSlave);
+  
+    if (tmphadcSlave.Instance == NULL)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+    
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    
+      return HAL_ERROR;
+    }
+    
+  
+    /* Enable the ADC peripherals: master and slave (in case if not already   */
+    /* enabled previously)                                                    */
+    tmp_status = ADC_Enable(hadc);
+    if (tmp_status == HAL_OK)
+    {
+      tmp_status = ADC_Enable(&tmphadcSlave);
+    }
+  
+    /* Start multimode conversion of ADCs pair */
+    if (tmp_status == HAL_OK)
+    {
+      /* Update Master State */
+      /* Clear HAL_ADC_STATE_READY and regular conversion results bits, set HAL_ADC_STATE_REG_BUSY bit */
+      ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_READY|HAL_ADC_STATE_REG_EOC|HAL_ADC_STATE_REG_OVR|HAL_ADC_STATE_REG_EOSMP), HAL_ADC_STATE_REG_BUSY);
+
+       
+      /* Set ADC error code to none */
+      ADC_CLEAR_ERRORCODE(hadc);
+      
+      
+      /* Set the DMA transfer complete callback */
+      hadc->DMA_Handle->XferCpltCallback = ADC_DMAConvCplt;
+         
+      /* Set the DMA half transfer complete callback */
+      hadc->DMA_Handle->XferHalfCpltCallback = ADC_DMAHalfConvCplt;
+      
+      /* Set the DMA error callback */
+      hadc->DMA_Handle->XferErrorCallback = ADC_DMAError ;
+      
+      /* Pointer to the common control register  */
+      tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+      
+      
+      /* Manage ADC and DMA start: ADC overrun interruption, DMA start, ADC     */
+      /* start (in case of SW start):                                           */
+  
+      /* Clear regular group conversion flag and overrun flag */
+      /* (To ensure of no unknown state from potential previous ADC operations) */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_OVR));
+      
+      /* Enable ADC overrun interrupt */
+      __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
+  
+      /* Start the DMA channel */
+      HAL_DMA_Start_IT(hadc->DMA_Handle, (uint32_t)&tmpADC_Common->CDR, (uint32_t)pData, Length);
+          
+      /* Enable conversion of regular group.                                    */
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);      
+      /* If software start has been selected, conversion starts immediately.    */
+      /* If external trigger has been selected, conversion will start at next   */
+      /* trigger event.                                                         */
+      SET_BIT(hadc->Instance->CR, ADC_CR_ADSTART);
+
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+  
+    /* Return function status */
+    return tmp_status;
+  }
+}
+
+/**
+  * @brief  Stop multimode ADC conversion, disable ADC DMA transfer, disable ADC peripheral.
+  * @note   Multimode is kept enabled after this function. MultiMode DMA bits
+  *         (MDMA and DMACFG bits of common CCR register) are maintained. To disable 
+  *         Multimode (set with HAL_ADCEx_MultiModeConfigChannel()), ADC must be 
+  *         reinitialized using HAL_ADC_Init() or HAL_ADC_DeInit(), or the user can
+  *         resort to HAL_ADCEx_DisableMultiMode() API.
+  * @note   In case of DMA configured in circular mode, function 
+  *         HAL_ADC_Stop_DMA() must be called after this function with handle of
+  *         ADC slave, to properly disable the DMA channel.
+  * @param  hadc: ADC handle of ADC master (handle of ADC slave must not be used)
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_MultiModeStop_DMA(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  uint32_t tickstart;
+  ADC_HandleTypeDef tmphadcSlave;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+ 
+  /* 1. Stop potential multimode conversion on going, on regular and injected groups */
+  tmp_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_status == HAL_OK)
+  {                                      
+    /* Set a temporary handle of the ADC slave associated to the ADC master   */
+    ADC_MULTI_SLAVE(hadc, &tmphadcSlave);
+    
+    if (tmphadcSlave.Instance == NULL)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+      
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+      
+      return HAL_ERROR;
+    }
+    
+    /* Procedure to disable the ADC peripheral: wait for conversions          */
+    /* effectively stopped (ADC master and ADC slave), then disable ADC       */
+    
+    /* 1. Wait until ADSTP=0 for ADC master and ADC slave*/
+    tickstart = HAL_GetTick();  
+
+    while(ADC_IS_CONVERSION_ONGOING_REGULAR(hadc)          || 
+          ADC_IS_CONVERSION_ONGOING_REGULAR(&tmphadcSlave)   )
+    {
+      if((HAL_GetTick()-tickstart) > ADC_STOP_CONVERSION_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_ERROR;
+      }
+    }
+    
+    /* Disable the DMA channel (in case of DMA in circular mode or stop       */
+    /* while DMA transfer is on going)                                        */
+    /* Note: DMA channel of ADC slave should be stopped after this function   */
+    /*       with HAL_ADC_Stop_DMA() API.                                     */
+    tmp_status = HAL_DMA_Abort(hadc->DMA_Handle);
+    
+    /* Check if DMA channel effectively disabled */
+    if (tmp_status == HAL_ERROR)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA); 
+    }
+    
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+    
+    
+    
+    /* 2. Disable the ADC peripherals: master and slave */
+    /* Update "tmp_status" only if DMA channel disabling passed, to keep in */
+    /* memory a potential failing status.                                     */
+    if (tmp_status == HAL_OK)
+    {
+      /* Check if ADC are effectively disabled */
+      if ((ADC_Disable(hadc) == HAL_OK)         &&
+          (ADC_Disable(&tmphadcSlave) == HAL_OK)   )
+      {
+        tmp_status = HAL_OK;
+      }
+    }
+    else
+    {
+      ADC_Disable(hadc);
+      ADC_Disable(&tmphadcSlave);
+    }
+    /* Change ADC state (ADC master) */
+    /* Clear HAL_ADC_STATE_REG_BUSY and HAL_ADC_STATE_INJ_BUSY bits, set HAL_ADC_STATE_READY bit */
+    ADC_STATE_CLR_SET(hadc->State, (HAL_ADC_STATE_REG_BUSY|HAL_ADC_STATE_INJ_BUSY), HAL_ADC_STATE_READY);
+    
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+}
+
+
+/**
+  * @brief  Return the last ADC Master and Slave regular conversions results when in multimode configuration.
+  * @param  hadc: ADC handle of ADC Master (handle of ADC Slave must not be used)
+  * @retval The converted data values.
+  */
+uint32_t HAL_ADCEx_MultiModeGetValue(ADC_HandleTypeDef* hadc)
+{
+  ADC_Common_TypeDef *tmpADC_Common;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+  
+  /* Pointer to the common control register  */
+  tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+  
+  /* Return the multi mode conversion value */
+  return tmpADC_Common->CDR;
+}
+
+
+/**
+  * @brief  Get ADC injected group conversion result.
+  * @param  hadc: ADC handle
+  * @param  InjectedRank: the converted ADC injected rank.
+  *          This parameter can be one of the following values:
+  *            @arg @ref ADC_INJECTED_RANK_1 Injected Channel1 selected
+  *            @arg @ref ADC_INJECTED_RANK_2 Injected Channel2 selected
+  *            @arg @ref ADC_INJECTED_RANK_3 Injected Channel3 selected
+  *            @arg @ref ADC_INJECTED_RANK_4 Injected Channel4 selected
+  * @note   Reading JDRy register automatically clears JEOC flag. To reset JEOS 
+  *         flag the user must resort to the macro 
+  *         __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JEOS).    
+  * @retval None
+  */
+uint32_t HAL_ADCEx_InjectedGetValue(ADC_HandleTypeDef* hadc, uint32_t InjectedRank)
+{
+  uint32_t tmp_jdr = 0;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_INJECTED_RANK(InjectedRank));
+  
+  
+  /* Get ADC converted value */ 
+  switch(InjectedRank)
+  {  
+    case ADC_INJECTED_RANK_4: 
+      tmp_jdr = hadc->Instance->JDR4;
+      break;
+    case ADC_INJECTED_RANK_3: 
+      tmp_jdr = hadc->Instance->JDR3;
+      break;
+    case ADC_INJECTED_RANK_2: 
+      tmp_jdr = hadc->Instance->JDR2;
+      break;
+    case ADC_INJECTED_RANK_1:
+    default:
+      tmp_jdr = hadc->Instance->JDR1;
+      break;
+  }
+  
+  /* Return ADC converted value */ 
+  return tmp_jdr;
+}
+
+/**
+  * @brief  Injected conversion complete callback in non-blocking mode. 
+  * @param  hadc: ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADCEx_InjectedConvCpltCallback must be implemented in the user file.
+  */
+}
+
+
+/**
+  * @brief  Injected context queue overflow callback. 
+  * @note   This callback is called if injected context queue is enabled
+            (parameter "QueueInjectedContext" in injected channel configuration)
+            and if a new injected context is set when queue is full (maximum 2
+            contexts).
+  * @param  hadc: ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_InjectedQueueOverflowCallback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADCEx_InjectedQueueOverflowCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  Analog watchdog 2 callback in non-blocking mode.        
+  * @param  hadc: ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_LevelOutOfWindow2Callback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADCEx_LevelOutOfWindow2Callback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  Analog watchdog 3 callback in non-blocking mode.        
+  * @param  hadc: ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_LevelOutOfWindow3Callback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADCEx_LevelOutOfWindow3Callback must be implemented in the user file.
+  */
+}
+
+
+/**
+  * @brief  End Of Sampling callback in non-blocking mode.        
+  * @param  hadc: ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_EndOfSamplingCallback(ADC_HandleTypeDef* hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADCEx_EndOfSamplingCallback must be implemented in the user file.
+  */
+}
+
+
+
+/**  
+  * @brief  Stop ADC conversion of regular groups, disable ADC peripheral if no injected conversion is on-going.
+  * @param  hadc: ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_RegularStop(ADC_HandleTypeDef* hadc)
+{ 
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential regular conversion on going */
+  tmp_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
+  
+  /* Disable ADC peripheral if regular conversions are effectively stopped 
+     and if no injected conversions are on-going */
+  if (tmp_status == HAL_OK)
+  {
+    /* Clear HAL_ADC_STATE_REG_BUSY bit */ 
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY); 
+     
+    if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET)
+    {
+      /* 2. Disable the ADC peripheral */
+      tmp_status = ADC_Disable(hadc);
+      
+      /* Check if ADC is effectively disabled */
+      if (tmp_status == HAL_OK)
+      {
+        /* Change ADC state */
+        /* Clear HAL_ADC_STATE_INJ_BUSY bit, set HAL_ADC_STATE_READY bit */
+        ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY, HAL_ADC_STATE_READY);
+      }
+    }
+    /* Conversion on injected group is stopped, but ADC not disabled since    */
+    /* conversion on regular group is still running.                          */
+    else
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+}
+
+
+/**  
+  * @brief  Stop ADC conversion of regular groups when interruptions are enabled, disable ADC peripheral if no injected conversion is on-going.
+  * @param  hadc: ADC handle
+  * @retval HAL status.
+  */  
+HAL_StatusTypeDef HAL_ADCEx_RegularStop_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential regular conversion on going */
+  tmp_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
+  
+  /* Disable ADC peripheral if conversions are effectively stopped
+    and if no injected conversion is on-going */
+  if (tmp_status == HAL_OK)
+  {
+    /* Clear HAL_ADC_STATE_REG_BUSY bit */ 
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);  
+     
+    /* Disable all regular-related interrupts */
+    __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_EOC | ADC_IT_EOS | ADC_IT_OVR));
+    
+    /* 2. Disable ADC peripheral if no injected conversions are on-going */
+    if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET)
+    {     
+      tmp_status = ADC_Disable(hadc);
+      /* if no issue reported */
+      if (tmp_status == HAL_OK)
+      {
+        /* Change ADC state */
+        /* Clear HAL_ADC_STATE_INJ_BUSY bit, set HAL_ADC_STATE_READY bit */
+        ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY, HAL_ADC_STATE_READY);
+      }
+    }
+    else
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+}
+
+
+/**
+  * @brief  Stop ADC conversion of regular groups and disable ADC DMA transfer, disable ADC peripheral if no injected conversion is on-going.
+  * @note   HAL_ADCEx_RegularStop_DMA() function is dedicated to single-ADC mode only. 
+  *         For multimode (when multimode feature is available), 
+  *         HAL_ADCEx_RegularMultiModeStop_DMA() API must be used.
+  * @param  hadc: ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_RegularStop_DMA(ADC_HandleTypeDef* hadc)
+{  
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential regular conversion on going */
+  tmp_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
+  
+  /* Disable ADC peripheral if conversions are effectively stopped 
+     and if no injected conversion is on-going */
+  if (tmp_status == HAL_OK)
+  {
+    /* Clear HAL_ADC_STATE_REG_BUSY bit */ 
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+    
+    /* Disable ADC DMA (ADC DMA configuration ADC_CFGR_DMACFG is kept) */
+    CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_DMAEN); 
+    
+    /* Disable the DMA channel (in case of DMA in circular mode or stop while */
+    /* while DMA transfer is on going)                                        */
+    tmp_status = HAL_DMA_Abort(hadc->DMA_Handle);   
+    
+    /* Check if DMA channel effectively disabled */
+    if (tmp_status != HAL_OK)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);   
+    }
+    
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+    
+    /* 2. Disable the ADC peripheral */
+    /* Update "tmp_status" only if DMA channel disabling passed, to keep in */
+    /* memory a potential failing status.                                     */
+    if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET)
+    {    
+      if (tmp_status == HAL_OK)
+      {
+        tmp_status = ADC_Disable(hadc);
+      }
+      else
+      {
+        ADC_Disable(hadc);
+      }
+
+      /* Check if ADC is effectively disabled */
+      if (tmp_status == HAL_OK)
+      {
+        /* Change ADC state */
+        /* Clear HAL_ADC_STATE_INJ_BUSY bit, set HAL_ADC_STATE_READY bit */
+        ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY, HAL_ADC_STATE_READY);      
+      }
+    }
+    else
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);  
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+}
+
+
+/**
+  * @brief  Stop DMA-based multimode ADC conversion, disable ADC DMA transfer, disable ADC peripheral if no injected conversion is on-going.
+  * @note   Multimode is kept enabled after this function. Multimode DMA bits
+  *         (MDMA and DMACFG bits of common CCR register) are maintained. To disable 
+  *         multimode (set with HAL_ADCEx_MultiModeConfigChannel()), ADC must be 
+  *         reinitialized using HAL_ADC_Init() or HAL_ADC_DeInit(), or the user can
+  *         resort to HAL_ADCEx_DisableMultiMode() API.  
+  * @note   In case of DMA configured in circular mode, function 
+  *         HAL_ADCEx_RegularStop_DMA() must be called after this function with handle of
+  *         ADC slave, to properly disable the DMA channel.
+  * @param  hadc: ADC handle of ADC master (handle of ADC slave must not be used)
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_RegularMultiModeStop_DMA(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  uint32_t tickstart;
+  ADC_HandleTypeDef tmphadcSlave;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+ 
+  /* 1. Stop potential multimode conversion on going, on regular groups */
+  tmp_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
+
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_status == HAL_OK)
+  { 
+    /* Clear HAL_ADC_STATE_REG_BUSY bit */                                     
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+    
+    /* Set a temporary handle of the ADC slave associated to the ADC master   */
+    ADC_MULTI_SLAVE(hadc, &tmphadcSlave);
+    
+    if (tmphadcSlave.Instance == NULL)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+      
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+      
+      return HAL_ERROR;
+    }
+    
+    /* Procedure to disable the ADC peripheral: wait for conversions          */
+    /* effectively stopped (ADC master and ADC slave), then disable ADC       */
+    
+    /* 1. Wait until ADSTP=0 for ADC master and ADC slave*/
+    tickstart = HAL_GetTick();  
+
+    while(ADC_IS_CONVERSION_ONGOING_REGULAR(hadc)          || 
+          ADC_IS_CONVERSION_ONGOING_REGULAR(&tmphadcSlave)   )
+    {
+      if((HAL_GetTick()-tickstart) > ADC_STOP_CONVERSION_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_ERROR;
+      }
+    }
+    
+    /* Disable the DMA channel (in case of DMA in circular mode or stop       */
+    /* while DMA transfer is on going)                                        */
+    /* Note: DMA channel of ADC slave should be stopped after this function   */
+    /* with HAL_ADCEx_RegularStop_DMA() API.                                  */
+    tmp_status = HAL_DMA_Abort(hadc->DMA_Handle);
+    
+    /* Check if DMA channel effectively disabled */
+    if (tmp_status != HAL_OK)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);  
+    }
+    
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+    
+    
+    
+    /* 2. Disable the ADC peripherals: master and slave if no injected        */
+    /*   conversion is on-going.                                              */
+    /* Update "tmp_status" only if DMA channel disabling passed, to keep in */
+    /* memory a potential failing status.                                     */
+    if (tmp_status == HAL_OK)
+    {
+       if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET)
+       {  
+         tmp_status =  ADC_Disable(hadc);
+         if (tmp_status == HAL_OK)
+         {
+           if (ADC_IS_CONVERSION_ONGOING_INJECTED(&tmphadcSlave) == RESET)
+           {
+             tmp_status =  ADC_Disable(&tmphadcSlave);
+           }
+         }
+       }
+       
+       if (tmp_status == HAL_OK)
+       {
+         /* Both Master and Slave ADC's could be disabled. Update Master State */
+         /* Clear HAL_ADC_STATE_INJ_BUSY bit, set HAL_ADC_STATE_READY bit */
+         ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY, HAL_ADC_STATE_READY);
+       }
+       else
+       {
+         /* injected (Master or Slave) conversions are still on-going,
+            no Master State change */
+       }
+          
+
+    }
+
+    
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+}
+
+
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Exported_Functions_Group2 Extended Peripheral Control functions
+  * @brief    Extended Peripheral Control functions
+  *
+@verbatim   
+ ===============================================================================
+             ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Configure channels on injected group
+      (+) Configure multimode when multimode feature is available
+      (+) Enable or Disable Injected Queue
+      (+) Disable ADC voltage regulator
+      (+) Enter ADC deep-power-down mode      
+      
+      
+@endverbatim
+  * @{
+  */
+
+/**  
+  * @brief  Configure the ADC injected group and the selected channel to be linked to the injected group.
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes injected group, consecutive calls to this 
+  *         function can be used to reconfigure some parameters of structure
+  *         "ADC_InjectionConfTypeDef" on the fly, without resetting the ADC.
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_InjectionConfTypeDef".
+  * @note   In case of usage of internal measurement channels (Vbat/VrefInt/TempSensor),
+  *         The internal paths can be disabled using function HAL_ADC_DeInit().
+  * @note   To reset injected sequencer, function HAL_ADCEx_InjectedStop() can
+  *         be used.
+  * @note   Caution: For Injected Context Queue use, a context must be fully 
+  *         defined before start of injected conversion. All channels are configured 
+  *         consecutively for the same ADC instance. Therefore, the number of calls to 
+  *         HAL_ADCEx_InjectedConfigChannel() must be equal to the value of parameter 
+  *         InjectedNbrOfConversion for each context.
+  *  - Example 1: If 1 context is intended to be used (or if there is no use of the 
+  *    Injected Queue Context feature) and if the context contains 3 injected ranks 
+  *    (InjectedNbrOfConversion = 3), HAL_ADCEx_InjectedConfigChannel() must be  
+  *    called once for each channel (i.e. 3 times) before starting a conversion.   
+  *    This function must not be called to configure a 4th injected channel:   
+  *    it would start a new context into context queue.
+  *  - Example 2: If 2 contexts are intended to be used and each of them contains 
+  *    3 injected ranks (InjectedNbrOfConversion = 3),  
+  *    HAL_ADCEx_InjectedConfigChannel() must be called once for each channel and  
+  *    for each context (3 channels x 2 contexts = 6 calls). Conversion can  
+  *    start once the 1st context is set, that is after the first three 
+  *    HAL_ADCEx_InjectedConfigChannel() calls. The 2nd context can be set on the fly.
+  * @param  hadc: ADC handle
+  * @param  sConfigInjected: Structure of ADC injected group and ADC channel for
+  *         injected group.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef* hadc, ADC_InjectionConfTypeDef* sConfigInjected)
+{
+  HAL_StatusTypeDef tmp_status = HAL_OK;
+  ADC_Common_TypeDef *tmpADC_Common;
+  uint32_t tmpOffsetShifted;
+  uint32_t wait_loop_index = 0;
+  
+
+  uint32_t tmp_JSQR_ContextQueueBeingBuilt = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SAMPLE_TIME(sConfigInjected->InjectedSamplingTime));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(sConfigInjected->InjectedSingleDiff));
+  assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->AutoInjectedConv));
+  assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->QueueInjectedContext));
+  assert_param(IS_ADC_EXTTRIGINJEC_EDGE(sConfigInjected->ExternalTrigInjecConvEdge));
+  assert_param(IS_ADC_EXTTRIGINJEC(sConfigInjected->ExternalTrigInjecConv));
+  assert_param(IS_ADC_OFFSET_NUMBER(sConfigInjected->InjectedOffsetNumber));
+  assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), sConfigInjected->InjectedOffset));
+  assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->InjecOversamplingMode));
+  
+  if(hadc->Init.ScanConvMode != ADC_SCAN_DISABLE)
+  {
+    assert_param(IS_ADC_INJECTED_RANK(sConfigInjected->InjectedRank));
+    assert_param(IS_ADC_INJECTED_NB_CONV(sConfigInjected->InjectedNbrOfConversion));
+    assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->InjectedDiscontinuousConvMode));
+  }
+  
+  
+  /* if JOVSE is set, the value of the OFFSETy_EN bit in ADCx_OFRy register is  
+     ignored (considered as reset) */
+  assert_param(!((sConfigInjected->InjectedOffsetNumber != ADC_OFFSET_NONE) && (sConfigInjected->InjecOversamplingMode == ENABLE))); 
+    
+  /* JDISCEN and JAUTO bits can't be set at the same time  */
+  assert_param(!((sConfigInjected->InjectedDiscontinuousConvMode == ENABLE) && (sConfigInjected->AutoInjectedConv == ENABLE))); 
+
+  /*  DISCEN and JAUTO bits can't be set at the same time */
+  assert_param(!((hadc->Init.DiscontinuousConvMode == ENABLE) && (sConfigInjected->AutoInjectedConv == ENABLE)));  
+
+  /* Verification of channel number */
+  if (sConfigInjected->InjectedSingleDiff != ADC_DIFFERENTIAL_ENDED)
+  {
+     assert_param(IS_ADC_CHANNEL(hadc, sConfigInjected->InjectedChannel));
+  }
+  else
+  {
+    assert_param(IS_ADC_DIFF_CHANNEL(hadc, sConfigInjected->InjectedChannel));
+  }                
+ 
+    
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+
+
+  /* Configuration of Injected group sequencer.                               */
+  /* Hardware constraint: Must fully define injected context register JSQR    */
+  /* before make it entering into injected sequencer queue.                   */
+  /*                                                                          */
+  /* - if scan mode is disabled:                                              */
+  /*    * Injected channels sequence length is set to 0x00: 1 channel         */
+  /*      converted (channel on injected rank 1)                              */
+  /*      Parameter "InjectedNbrOfConversion" is discarded.                   */
+  /*    * Injected context register JSQR setting is simple: register is fully */
+  /*      defined on one call of this function (for injected rank 1) and can  */
+  /*      be entered into queue directly.                                     */
+  /* - if scan mode is enabled:                                               */
+  /*    * Injected channels sequence length is set to parameter               */
+  /*      "InjectedNbrOfConversion".                                          */
+  /*    * Injected context register JSQR setting more complex: register is    */
+  /*      fully defined over successive calls of this function, for each      */
+  /*      injected channel rank. It is entered into queue only when all       */
+  /*      injected ranks have been set.                                       */
+  /*   Note: Scan mode is not present by hardware on this device, but used    */
+  /*   by software for alignment over all STM32 devices.                      */
+
+  if ((hadc->Init.ScanConvMode == ADC_SCAN_DISABLE)  ||
+      (sConfigInjected->InjectedNbrOfConversion == 1)  )
+  {
+    /* Configuration of context register JSQR:                                */
+    /*  - number of ranks in injected group sequencer: fixed to 1st rank      */
+    /*    (scan mode disabled, only rank 1 used)                              */
+    /*  - external trigger to start conversion                                */
+    /*  - external trigger polarity                                           */
+    /*  - channel set to rank 1 (scan mode disabled, only rank 1 can be used) */
+    
+    if (sConfigInjected->InjectedRank == ADC_INJECTED_RANK_1)
+    {
+      /* Enable external trigger if trigger selection is different of         */
+      /* software start.                                                      */
+      /* Note: This configuration keeps the hardware feature of parameter     */
+      /*       ExternalTrigInjecConvEdge "trigger edge none" equivalent to    */
+      /*       software start.                                                */
+      if ((sConfigInjected->ExternalTrigInjecConv != ADC_INJECTED_SOFTWARE_START)
+         && (sConfigInjected->ExternalTrigInjecConvEdge != ADC_EXTERNALTRIGINJECCONV_EDGE_NONE))
+      {
+        tmp_JSQR_ContextQueueBeingBuilt = ( ADC_JSQR_RK(sConfigInjected->InjectedChannel, ADC_INJECTED_RANK_1) |
+                                             sConfigInjected->ExternalTrigInjecConv     |
+                                             sConfigInjected->ExternalTrigInjecConvEdge                                );                                              
+      }
+      else
+      {
+        tmp_JSQR_ContextQueueBeingBuilt = ( ADC_JSQR_RK(sConfigInjected->InjectedChannel, ADC_INJECTED_RANK_1) );
+      }
+      
+
+      MODIFY_REG(hadc->Instance->JSQR, ADC_JSQR_FIELDS, tmp_JSQR_ContextQueueBeingBuilt); 
+      /* For debug and informative reasons, hadc handle saves JSQR setting */
+      hadc->InjectionConfig.ContextQueue = tmp_JSQR_ContextQueueBeingBuilt;
+    
+    }
+  }
+  else
+  {
+    /* Case of scan mode enabled, several channels to set into injected group */
+    /* sequencer.                                                             */
+    /*                                                                        */
+    /* Procedure to define injected context register JSQR over successive     */
+    /* calls of this function, for each injected channel rank:                */
+    /* 1. Start new context and set parameters related to all injected        */
+    /*    channels: injected sequence length and trigger.                     */
+    
+    /* if hadc->InjectionConfig.ChannelCount is equal to 0, this is the first */
+    /*   call of the context under setting                                    */
+    if (hadc->InjectionConfig.ChannelCount == 0) 
+    {
+      /* Initialize number of channels that will be configured on the context */
+      /*  being built                                                         */
+      hadc->InjectionConfig.ChannelCount = sConfigInjected->InjectedNbrOfConversion;
+      /* Handle hadc saves the context under build up over each HAL_ADCEx_InjectedConfigChannel()
+         call, this context will be written in JSQR register at the last call.
+         At this point, the context is merely reset  */
+       hadc->InjectionConfig.ContextQueue = (uint32_t)0x00000000;
+
+      /* Configuration of context register JSQR:                              */
+      /*  - number of ranks in injected group sequencer                       */
+      /*  - external trigger to start conversion                              */
+      /*  - external trigger polarity                                         */
+        
+      /* Enable external trigger if trigger selection is different of         */
+      /* software start.                                                      */
+      /* Note: This configuration keeps the hardware feature of parameter     */
+      /*       ExternalTrigInjecConvEdge "trigger edge none" equivalent to    */
+      /*       software start.                                                */
+      if ((sConfigInjected->ExternalTrigInjecConv != ADC_INJECTED_SOFTWARE_START)
+         && (sConfigInjected->ExternalTrigInjecConvEdge != ADC_EXTERNALTRIGINJECCONV_EDGE_NONE))
+      {      
+        tmp_JSQR_ContextQueueBeingBuilt = ((sConfigInjected->InjectedNbrOfConversion - (uint32_t)1)              |
+                                             sConfigInjected->ExternalTrigInjecConv |
+                                             sConfigInjected->ExternalTrigInjecConvEdge                            );        
+      }
+      else
+      {
+        tmp_JSQR_ContextQueueBeingBuilt = ((sConfigInjected->InjectedNbrOfConversion - (uint32_t)1) );
+      }
+     
+      
+    } /* if (hadc->InjectionConfig.ChannelCount == 0) */  
+    
+
+    /* 2. Continue setting of context under definition with parameter       */
+    /*    related to each channel: channel rank sequence                    */ 
+    /* Clear the old JSQx bits for the selected rank */
+    tmp_JSQR_ContextQueueBeingBuilt &= ~ADC_JSQR_RK(ADC_SQR3_SQ10, sConfigInjected->InjectedRank);
+    
+    /* Set the JSQx bits for the selected rank */
+    tmp_JSQR_ContextQueueBeingBuilt |= ADC_JSQR_RK(sConfigInjected->InjectedChannel, sConfigInjected->InjectedRank);
+
+    /* Decrease channel count  */
+    hadc->InjectionConfig.ChannelCount--;
+    
+    
+    /* 3. tmp_JSQR_ContextQueueBeingBuilt is fully built for this HAL_ADCEx_InjectedConfigChannel()
+          call, aggregate the setting to those already built during the previous  
+          HAL_ADCEx_InjectedConfigChannel() calls (for the same context of course)  */
+    hadc->InjectionConfig.ContextQueue |= tmp_JSQR_ContextQueueBeingBuilt;
+          
+    /* 4. End of context setting: if this is the last channel set, then write context
+        into register JSQR and make it enter into queue                   */
+    if (hadc->InjectionConfig.ChannelCount == 0)
+    {
+      MODIFY_REG(hadc->Instance->JSQR, ADC_JSQR_FIELDS, hadc->InjectionConfig.ContextQueue); 
+    }
+
+    
+  } 
+
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on injected group:                                   */
+  /*  - Injected context queue: Queue disable (active context is kept) or     */
+  /*    enable (context decremented, up to 2 contexts queued)                 */
+  /*  - Injected discontinuous mode: can be enabled only if auto-injected     */
+  /*    mode is disabled.                                                     */
+  if (ADC_IS_CONVERSION_ONGOING_INJECTED(hadc) == RESET)
+  {
+     
+    /* If auto-injected mode is disabled: no constraint                       */
+    if (sConfigInjected->AutoInjectedConv == DISABLE)
+    {                               
+      MODIFY_REG(hadc->Instance->CFGR, ADC_CFGR_JQM | ADC_CFGR_JDISCEN, 
+                               ADC_CFGR_INJECT_CONTEXT_QUEUE(sConfigInjected->QueueInjectedContext)          | 
+                               ADC_CFGR_INJECT_DISCCONTINUOUS(sConfigInjected->InjectedDiscontinuousConvMode) );                          
+    }
+    /* If auto-injected mode is enabled: Injected discontinuous setting is   */
+    /* discarded.                                                             */
+    else
+    {
+            MODIFY_REG(hadc->Instance->CFGR, ADC_CFGR_JQM | ADC_CFGR_JDISCEN, 
+                               ADC_CFGR_INJECT_CONTEXT_QUEUE(sConfigInjected->QueueInjectedContext) );  
+    }
+
+  }
+  
+  
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on regular and injected groups:                      */
+  /*  - Automatic injected conversion: can be enabled if injected group       */
+  /*    external triggers are disabled.                                       */
+  /*  - Channel sampling time                                                 */
+  /*  - Channel offset                                                        */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET)
+  {    
+    /* If injected group external triggers are disabled (set to injected      */
+    /* software start): no constraint                                         */
+    if ((sConfigInjected->ExternalTrigInjecConv == ADC_INJECTED_SOFTWARE_START)
+       || (sConfigInjected->ExternalTrigInjecConvEdge == ADC_EXTERNALTRIGINJECCONV_EDGE_NONE))
+    {
+         if (sConfigInjected->AutoInjectedConv == ENABLE)
+         {
+           SET_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO);    
+         }
+         else
+         {
+           CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO);    
+         }                                                                                  
+    }
+    /* If Automatic injected conversion was intended to be set and could not  */
+    /* due to injected group external triggers enabled, error is reported.    */
+    else
+    {
+      if (sConfigInjected->AutoInjectedConv == ENABLE)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        
+        tmp_status = HAL_ERROR;
+      }
+      else
+      {
+        CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO); 
+      }
+    }
+    
+    
+    
+    if (sConfigInjected->InjecOversamplingMode == ENABLE)
+    {
+      assert_param(IS_ADC_OVERSAMPLING_RATIO(sConfigInjected->InjecOversampling.Ratio));
+      assert_param(IS_ADC_RIGHT_BIT_SHIFT(sConfigInjected->InjecOversampling.RightBitShift));
+      
+      /*  JOVSE must be reset in case of triggered regular mode  */
+      assert_param(!(READ_BIT(hadc->Instance->CFGR2, ADC_CFGR2_ROVSE|ADC_CFGR2_TROVS) == (ADC_CFGR2_ROVSE|ADC_CFGR2_TROVS)));
+
+      /* Configuration of Injected Oversampler:                                 */
+      /*  - Oversampling Ratio                                                  */
+      /*  - Right bit shift                                                     */
+      
+      /* Enable OverSampling mode */
+  
+       MODIFY_REG(hadc->Instance->CFGR2, ADC_CFGR2_INJ_FIELDS, 
+                                 ADC_CFGR2_JOVSE                     | 
+                                 sConfigInjected->InjecOversampling.Ratio         |
+                                 sConfigInjected->InjecOversampling.RightBitShift );
+    }  
+    else
+    {
+      /* Disable Regular OverSampling */
+       CLEAR_BIT( hadc->Instance->CFGR2, ADC_CFGR2_JOVSE);
+    }    
+        
+  
+    /* Sampling time configuration of the selected channel */
+    /* if ADC_Channel_10 ... ADC_Channel_18 is selected */
+    if (sConfigInjected->InjectedChannel >= ADC_CHANNEL_10)
+    {
+      /* Clear the old sample time and set the new one */
+      ADC_SMPR2_SETTING(hadc, sConfigInjected->InjectedSamplingTime, sConfigInjected->InjectedChannel);                
+    }
+    else /* if ADC_Channel_0 ... ADC_Channel_9 is selected */
+    {
+     /* Clear the old sample time and set the new one */
+      ADC_SMPR1_SETTING(hadc, sConfigInjected->InjectedSamplingTime, sConfigInjected->InjectedChannel);             
+    }
+    
+        
+    /* Configure the offset: offset enable/disable, channel, offset value */
+  
+    /* Shift the offset with respect to the selected ADC resolution. */
+    /* Offset has to be left-aligned on bit 11, the LSB (right bits) are set to 0 */
+    tmpOffsetShifted = ADC_OFFSET_SHIFT_RESOLUTION(hadc, sConfigInjected->InjectedOffset);
+    
+    switch (sConfigInjected->InjectedOffsetNumber)
+    {
+    case ADC_OFFSET_1:
+      /* Configure offset register 1:                                         */
+      /* - Enable offset                                                      */
+      /* - Set channel number                                                 */
+      /* - Set offset value                                                   */
+      MODIFY_REG(hadc->Instance->OFR1, 
+                ADC_OFR1_OFFSET1 | ADC_OFR1_OFFSET1_CH | ADC_OFR1_OFFSET1_EN, 
+                ADC_OFR1_OFFSET1_EN | ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel) | tmpOffsetShifted);                                    
+      break;
+    
+    case ADC_OFFSET_2:
+      /* Configure offset register 2:                                         */
+      /* - Enable offset                                                      */
+      /* - Set channel number                                                 */
+      /* - Set offset value                                                   */
+      MODIFY_REG(hadc->Instance->OFR2, 
+                ADC_OFR2_OFFSET2 | ADC_OFR2_OFFSET2_CH | ADC_OFR2_OFFSET2_EN, 
+                ADC_OFR2_OFFSET2_EN | ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel) | tmpOffsetShifted);                                     
+      break;
+        
+    case ADC_OFFSET_3:
+      /* Configure offset register 3:                                         */
+      /* - Enable offset                                                      */
+      /* - Set channel number                                                 */
+      /* - Set offset value                                                   */
+      MODIFY_REG(hadc->Instance->OFR3, 
+                ADC_OFR3_OFFSET3 | ADC_OFR3_OFFSET3_CH | ADC_OFR3_OFFSET3_EN, 
+                ADC_OFR3_OFFSET3_EN | ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel) | tmpOffsetShifted);                                   
+      break;
+    
+    case ADC_OFFSET_4:
+      /* Configure offset register 1:                                         */
+      /* - Enable offset                                                      */
+      /* - Set channel number                                                 */
+      /* - Set offset value                                                   */
+      MODIFY_REG(hadc->Instance->OFR4, 
+                ADC_OFR4_OFFSET4 | ADC_OFR4_OFFSET4_CH | ADC_OFR4_OFFSET4_EN, 
+                ADC_OFR4_OFFSET4_EN | ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel) | tmpOffsetShifted);                                  
+      break;
+    
+    /* Case ADC_OFFSET_NONE */
+    default :
+    /* Scan OFR1, OFR2, OFR3, OFR4 to check if the selected channel is enabled. If this is the case, offset OFRx is disabled. */
+      if (((hadc->Instance->OFR1) & ADC_OFR1_OFFSET1_CH) == ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel))
+      {
+        /* Disable offset OFR1*/
+        CLEAR_BIT(hadc->Instance->OFR1, ADC_OFR1_OFFSET1_EN);
+      }
+      if (((hadc->Instance->OFR2) & ADC_OFR2_OFFSET2_CH) == ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel))
+      {
+        /* Disable offset OFR2*/
+        CLEAR_BIT(hadc->Instance->OFR2, ADC_OFR2_OFFSET2_EN); 
+      }
+      if (((hadc->Instance->OFR3) & ADC_OFR3_OFFSET3_CH) == ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel))
+      {
+        /* Disable offset OFR3*/
+        CLEAR_BIT(hadc->Instance->OFR3, ADC_OFR3_OFFSET3_EN); 
+      }
+      if (((hadc->Instance->OFR4) & ADC_OFR4_OFFSET4_CH) == ADC_OFR_CHANNEL(sConfigInjected->InjectedChannel))
+      {
+        /* Disable offset OFR4*/
+        CLEAR_BIT(hadc->Instance->OFR4, ADC_OFR4_OFFSET4_EN); 
+      }
+      break;
+    }
+
+  } /* if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET) */
+  
+  
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated only when ADC is disabled:                */
+  /*  - Single or differential mode                                           */
+  /*  - Internal measurement channels: Vbat/VrefInt/TempSensor                */
+  if (ADC_IS_ENABLE(hadc) == RESET)
+  {
+    /* Configuration of differential mode */
+    if (sConfigInjected->InjectedSingleDiff != ADC_DIFFERENTIAL_ENDED)
+    {
+      /* Disable differential mode (default mode: single-ended) */
+      CLEAR_BIT(hadc->Instance->DIFSEL, ADC_DIFSEL_CHANNEL(sConfigInjected->InjectedChannel));
+    }
+    else
+    {
+      /* Enable differential mode */
+      SET_BIT(hadc->Instance->DIFSEL, ADC_DIFSEL_CHANNEL(sConfigInjected->InjectedChannel));
+      
+      /* Sampling time configuration of channel ADC_IN+1 (negative input).
+         Starting from channel 9, SMPR2 register must be configured.      */
+      if (sConfigInjected->InjectedChannel >= ADC_CHANNEL_9)
+      {
+        /* Clear the old sample time and set the new one */
+        ADC_SMPR2_SETTING(hadc, sConfigInjected->InjectedSamplingTime, sConfigInjected->InjectedChannel+1);                     
+      }
+      else /* For channels 0 to 8 */
+      {
+         /* Clear the old sample time and set the new one */
+        ADC_SMPR1_SETTING(hadc, sConfigInjected->InjectedSamplingTime, sConfigInjected->InjectedChannel+1);                 
+      }
+    }
+    
+
+    /* Management of internal measurement channels: Vbat/VrefInt/TempSensor   */
+    /* internal measurement paths enable: If internal channel selected,       */
+    /* enable dedicated internal buffers and path.                            */
+    /* Note: these internal measurement paths can be disabled using           */
+    /* HAL_ADC_DeInit().                                                      */
+
+    /* Configuration of common ADC parameters                                 */
+
+    tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+  
+    /* If the requested internal measurement path has already been enabled,   */
+    /* bypass the configuration processing.                                   */
+    if (( (sConfigInjected->InjectedChannel == ADC_CHANNEL_TEMPSENSOR) &&
+          (HAL_IS_BIT_CLR(tmpADC_Common->CCR, ADC_CCR_TSEN))            ) ||
+        ( (sConfigInjected->InjectedChannel == ADC_CHANNEL_VBAT)       &&
+          (HAL_IS_BIT_CLR(tmpADC_Common->CCR, ADC_CCR_VBATEN))          ) ||
+        ( (sConfigInjected->InjectedChannel == ADC_CHANNEL_VREFINT)    &&
+          (HAL_IS_BIT_CLR(tmpADC_Common->CCR, ADC_CCR_VREFEN)))
+       )
+    {
+      /* Configuration of common ADC parameters (continuation)                */
+      /* Software is allowed to change common parameters only when all ADCs   */
+      /* of the common group are disabled.                                    */
+      if ((ADC_IS_ENABLE(hadc) == RESET)   &&
+         (ADC_ANY_OTHER_ENABLED(hadc) == RESET) )              
+      {
+        if (sConfigInjected->InjectedChannel == ADC_CHANNEL_TEMPSENSOR)
+        {
+          if (ADC_TEMPERATURE_SENSOR_INSTANCE(hadc)) 
+          {
+            SET_BIT(tmpADC_Common->CCR, ADC_CCR_TSEN);
+          
+            /* Delay for temperature sensor stabilization time */
+            /* Compute number of CPU cycles to wait for */
+            wait_loop_index = (ADC_TEMPSENSOR_DELAY_US * (SystemCoreClock / 1000000));
+            while(wait_loop_index != 0)
+            {
+              wait_loop_index--;
+            }
+          }
+        }
+        else if (sConfigInjected->InjectedChannel == ADC_CHANNEL_VBAT)
+        { 
+          if (ADC_BATTERY_VOLTAGE_INSTANCE(hadc))
+          {
+            SET_BIT(tmpADC_Common->CCR, ADC_CCR_VBATEN);
+          }
+        }
+        else if (sConfigInjected->InjectedChannel == ADC_CHANNEL_VREFINT)
+        { 
+          if (ADC_VREFINT_INSTANCE(hadc))
+          {
+            SET_BIT(tmpADC_Common->CCR, ADC_CCR_VREFEN);
+          }                       
+        }       
+      }
+      /* If the requested internal measurement path has already been enabled  */
+      /* and other ADC of the common group are enabled, internal              */
+      /* measurement paths cannot be enabled.                                 */
+      else  
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        
+        tmp_status = HAL_ERROR;
+      }
+    }
+    
+  } /* if (ADC_IS_ENABLE(hadc) == RESET) */
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_status;
+}
+
+
+
+
+/**
+  * @brief  Enable ADC multimode and configure multimode parameters
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes multimode parameters, following  
+  *         calls to this function can be used to reconfigure some parameters 
+  *         of structure "ADC_MultiModeTypeDef" on the fly, without resetting 
+  *         the ADCs.
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure 
+  *         "ADC_MultiModeTypeDef".
+  * @note   To move back configuration from multimode to single mode, ADC must
+  *         be reset (using function HAL_ADC_Init() ).
+  * @param  hadc: Master ADC handle
+  * @param  multimode : Structure of ADC multimode configuration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_MultiModeConfigChannel(ADC_HandleTypeDef* hadc, ADC_MultiModeTypeDef* multimode)
+{
+  HAL_StatusTypeDef  tmp_status = HAL_OK;
+  ADC_Common_TypeDef *tmpADC_Common;
+  ADC_HandleTypeDef  tmphadcSlave;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_MULTIMODE(multimode->Mode));
+  assert_param(IS_ADC_DMA_ACCESS_MULTIMODE(multimode->DMAAccessMode));
+  assert_param(IS_ADC_SAMPLING_DELAY(multimode->TwoSamplingDelay));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  ADC_MULTI_SLAVE(hadc, &tmphadcSlave);
+  
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on regular group:                                    */
+  /*  - Multimode DMA configuration                                           */
+  /*  - Multimode DMA mode                                                    */
+  if ( (ADC_IS_CONVERSION_ONGOING_REGULAR(hadc) == RESET) 
+    && (ADC_IS_CONVERSION_ONGOING_REGULAR(&tmphadcSlave) == RESET) )
+  {
+    
+    /* Pointer to the common control register */
+    tmpADC_Common = ADC_COMMON_REGISTER(hadc);
+    
+    MODIFY_REG(tmpADC_Common->CCR, ADC_CCR_MDMA | ADC_CCR_DMACFG, 
+               multimode->DMAAccessMode |
+               ADC_CCR_MULTI_DMACONTREQ(hadc->Init.DMAContinuousRequests));
+               
+    /* Parameters that can be updated only when ADC is disabled:                */
+    /*  - Multimode mode selection                                              */
+    /*  - Multimode delay                                                       */
+    if ((ADC_IS_ENABLE(hadc) == RESET)                             &&
+        (ADC_IS_ENABLE(&tmphadcSlave) == RESET)  )
+    {
+      /* Configuration of ADC common group ADC1&ADC2                            */
+      /*  - set the selected multimode                                          */
+      /*  - Set delay between two sampling phases                               */
+      /*    Note: Delay range depends on selected resolution:                   */
+      /*      from 1 to 12 clock cycles for 12 bits                             */
+      /*      from 1 to 10 clock cycles for 10 bits,                            */
+      /*      from 1 to 8 clock cycles for 8 bits                               */
+      /*      from 1 to 6 clock cycles for 6 bits                               */
+      /*    If a higher delay is selected, it will be clipped to maximum delay  */
+      /*    range                                                               */
+  
+        MODIFY_REG(tmpADC_Common->CCR, ADC_CCR_DUAL | ADC_CCR_DELAY, 
+               multimode->Mode | multimode->TwoSamplingDelay );
+    }                              
+                            
+                            
+  }
+  /* If one of the ADC sharing the same common group is enabled, no update    */
+  /* could be done on neither of the multimode structure parameters.          */
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+    
+    tmp_status = HAL_ERROR;
+  }
+    
+    
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmp_status;
+} 
+
+
+/**
+  * @brief  Enable Injected Queue
+  * @note   This function resets CFGR register JQDIS bit in order to enable the
+  *         Injected Queue. JQDIS can be written only when ADSTART and JDSTART
+  *         are both equal to 0 to ensure that no regular nor injected 
+  *         conversion is ongoing. 
+  * @param  hadc: ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_EnableInjectedQueue(ADC_HandleTypeDef* hadc)
+{
+
+  /* Parameter can be set only if no conversion is on-going                   */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET)
+  {
+    CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_JQDIS);
+    
+    /* Update state, clear previous result related to injected queue overflow */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_JQOVF);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+
+}
+
+/**
+  * @brief  Disable Injected Queue
+  * @note   This function sets CFGR register JQDIS bit in order to disable the
+  *         Injected Queue. JQDIS can be written only when ADSTART and JDSTART
+  *         are both equal to 0 to ensure that no regular nor injected 
+  *         conversion is ongoing. 
+  * @param  hadc: ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_DisableInjectedQueue(ADC_HandleTypeDef* hadc)
+{
+
+  /* Parameter can be set only if no conversion is on-going                   */
+  if (ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(hadc) == RESET)
+  {
+    SET_BIT(hadc->Instance->CFGR, ADC_CFGR_JQDIS);
+    return HAL_OK;    
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+
+}
+
+
+/**
+  * @brief  Disable ADC voltage regulator.
+  * @note   Disabling voltage regulator allows to save power. This operation can
+  *         be carried out only when ADC is disabled.
+  * @note   To enable again the voltage regulator, the user is expected to 
+  *         resort to HAL_ADC_Init() API.           
+  * @param  hadc: ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_DisableVoltageRegulator(ADC_HandleTypeDef* hadc)
+{
+
+  /* ADVREGEN can be written only when the ADC is disabled  */
+  if (ADC_IS_ENABLE(hadc) == RESET)
+  {
+    CLEAR_BIT(hadc->Instance->CR, ADC_CR_ADVREGEN);
+    return HAL_OK;    
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Enter ADC deep-power-down mode
+  * @note   This mode is achieved in setting DEEPPWD bit and allows to save power 
+  *         in reducing leakage currents. It is particularly interesting before 
+  *         entering stop modes.
+  * @note   Setting DEEPPWD automatically clears ADVREGEN bit and disables the
+  *         ADC voltage regulator. This means that this API encompasses
+  *         HAL_ADCEx_DisableVoltageRegulator(). Additionally, the internal
+  *         calibration is lost.    
+  * @note   To exit the ADC deep-power-down mode, the user is expected to 
+  *         resort to HAL_ADC_Init() API as well as to relaunch a calibration
+  *         with HAL_ADCEx_Calibration_Start() API or to re-apply a previously
+  *         saved calibration factor.
+  * @param  hadc: ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_EnterADCDeepPowerDownMode(ADC_HandleTypeDef* hadc)
+{
+
+  /* DEEPPWD can be written only when the ADC is disabled  */
+  if (ADC_IS_ENABLE(hadc) == RESET)
+  {
+    SET_BIT(hadc->Instance->CR, ADC_CR_DEEPPWD);
+    return HAL_OK;    
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+
+  
+#endif /* HAL_ADC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_can.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_can.c
@@ -1,0 +1,1404 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_can.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   CAN HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Controller Area Network (CAN) peripheral:           
+  *           + Initialization and de-initialization functions 
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State and Error functions
+  *
+  @verbatim
+  ==============================================================================    
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]            
+      (#) Enable the CAN controller interface clock using 
+          __HAL_RCC_CAN1_CLK_ENABLE() for CAN1.
+       
+      (#) CAN pins configuration
+        (++) Enable the clock for the CAN GPIOs using the following function:
+             __HAL_RCC_GPIOx_CLK_ENABLE();   
+        (++) Connect and configure the involved CAN pins using the 
+              following function HAL_GPIO_Init(); 
+              
+      (#) Initialize and configure the CAN using HAL_CAN_Init() function.   
+                 
+      (#) Transmit the desired CAN frame using HAL_CAN_Transmit() or 
+          HAL_CAN_Transmit_IT() function.
+           
+      (#) Receive a CAN frame using HAL_CAN_Receive() or HAL_CAN_Receive_IT() function.
+
+     *** Polling mode IO operation ***
+     =================================
+     [..]    
+       (+) Start the CAN peripheral transmission and wait the end of this operation 
+           using HAL_CAN_Transmit(), at this stage user can specify the value of timeout
+           according to his end application
+       (+) Start the CAN peripheral reception and wait the end of this operation 
+           using HAL_CAN_Receive(), at this stage user can specify the value of timeout
+           according to his end application 
+       
+     *** Interrupt mode IO operation ***    
+     ===================================
+     [..]    
+       (+) Start the CAN peripheral transmission using HAL_CAN_Transmit_IT()
+       (+) Start the CAN peripheral reception using HAL_CAN_Receive_IT()         
+       (+) Use HAL_CAN_IRQHandler() called under the used CAN Interrupt subroutine
+       (+) At CAN end of transmission HAL_CAN_TxCpltCallback() function is executed and user can 
+            add his own code by customization of function pointer HAL_CAN_TxCpltCallback 
+       (+) In case of CAN Error, HAL_CAN_ErrorCallback() function is executed and user can 
+            add his own code by customization of function pointer HAL_CAN_ErrorCallback
+ 
+     *** CAN HAL driver macros list ***
+     ============================================= 
+     [..]
+       Below the list of most used macros in CAN HAL driver.
+       
+      (+) __HAL_CAN_ENABLE_IT: Enable the specified CAN interrupts
+      (+) __HAL_CAN_DISABLE_IT: Disable the specified CAN interrupts
+      (+) __HAL_CAN_GET_IT_SOURCE: Check if the specified CAN interrupt source is enabled or disabled
+      (+) __HAL_CAN_CLEAR_FLAG: Clear the CAN's pending flags
+      (+) __HAL_CAN_GET_FLAG: Get the selected CAN's flag status
+      
+     [..] 
+      (@) You can refer to the CAN HAL driver header file for more useful macros 
+                
+  @endverbatim
+           
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup CAN CAN
+  * @brief CAN driver modules
+  * @{
+  */ 
+  
+#ifdef HAL_CAN_MODULE_ENABLED  
+  
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @defgroup CAN_Private_Constants CAN Private Constants
+  * @{
+  */
+#define CAN_TIMEOUT_VALUE  10
+/**
+  * @}
+  */
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @defgroup CAN_Private_Functions CAN Private Functions
+ * @{
+ */
+static HAL_StatusTypeDef CAN_Receive_IT(CAN_HandleTypeDef* hcan, uint8_t FIFONumber);
+static HAL_StatusTypeDef CAN_Transmit_IT(CAN_HandleTypeDef* hcan);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup CAN_Exported_Functions CAN Exported Functions
+  * @{
+  */
+
+/** @defgroup CAN_Exported_Functions_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+  ==============================================================================
+              ##### Initialization and de-initialization functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the CAN. 
+      (+) De-initialize the CAN. 
+         
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Initialize the CAN peripheral according to the specified parameters 
+  *         in the CAN_InitStruct structure and initialize the associated handle.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CAN_Init(CAN_HandleTypeDef* hcan)
+{
+  uint32_t status = CAN_INITSTATUS_FAILED;  /* Default init status */
+  uint32_t tickstart = 0;
+  
+  /* Check CAN handle */
+  if(hcan == NULL)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_CAN_ALL_INSTANCE(hcan->Instance));
+  assert_param(IS_FUNCTIONAL_STATE(hcan->Init.TTCM));
+  assert_param(IS_FUNCTIONAL_STATE(hcan->Init.ABOM));
+  assert_param(IS_FUNCTIONAL_STATE(hcan->Init.AWUM));
+  assert_param(IS_FUNCTIONAL_STATE(hcan->Init.NART));
+  assert_param(IS_FUNCTIONAL_STATE(hcan->Init.RFLM));
+  assert_param(IS_FUNCTIONAL_STATE(hcan->Init.TXFP));
+  assert_param(IS_CAN_MODE(hcan->Init.Mode));
+  assert_param(IS_CAN_SJW(hcan->Init.SJW));
+  assert_param(IS_CAN_BS1(hcan->Init.BS1));
+  assert_param(IS_CAN_BS2(hcan->Init.BS2));
+  assert_param(IS_CAN_PRESCALER(hcan->Init.Prescaler));
+  
+  if(hcan->State == HAL_CAN_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hcan->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware */
+    HAL_CAN_MspInit(hcan);
+  }
+  
+  /* Initialize the CAN state*/
+  hcan->State = HAL_CAN_STATE_BUSY;
+  
+  /* Exit from sleep mode */
+  hcan->Instance->MCR &= (~(uint32_t)CAN_MCR_SLEEP);
+
+  /* Request initialisation */
+  hcan->Instance->MCR |= CAN_MCR_INRQ ;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait the acknowledge */
+  while((hcan->Instance->MSR & CAN_MSR_INAK) != CAN_MSR_INAK)
+  {
+    if((HAL_GetTick()-tickstart) > CAN_TIMEOUT_VALUE)
+    {
+      hcan->State= HAL_CAN_STATE_TIMEOUT;
+      /* Process unlocked */
+      __HAL_UNLOCK(hcan);
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Check acknowledge */
+  if ((hcan->Instance->MSR & CAN_MSR_INAK) == CAN_MSR_INAK)
+  {
+    /* Set the time triggered communication mode */
+    if (hcan->Init.TTCM == ENABLE)
+    {
+      hcan->Instance->MCR |= CAN_MCR_TTCM;
+    }
+    else
+    {
+      hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_TTCM;
+    }
+
+    /* Set the automatic bus-off management */
+    if (hcan->Init.ABOM == ENABLE)
+    {
+      hcan->Instance->MCR |= CAN_MCR_ABOM;
+    }
+    else
+    {
+      hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_ABOM;
+    }
+
+    /* Set the automatic wake-up mode */
+    if (hcan->Init.AWUM == ENABLE)
+    {
+      hcan->Instance->MCR |= CAN_MCR_AWUM;
+    }
+    else
+    {
+      hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_AWUM;
+    }
+
+    /* Set the no automatic retransmission */
+    if (hcan->Init.NART == ENABLE)
+    {
+      hcan->Instance->MCR |= CAN_MCR_NART;
+    }
+    else
+    {
+      hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_NART;
+    }
+
+    /* Set the receive FIFO locked mode */
+    if (hcan->Init.RFLM == ENABLE)
+    {
+      hcan->Instance->MCR |= CAN_MCR_RFLM;
+    }
+    else
+    {
+      hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_RFLM;
+    }
+
+    /* Set the transmit FIFO priority */
+    if (hcan->Init.TXFP == ENABLE)
+    {
+      hcan->Instance->MCR |= CAN_MCR_TXFP;
+    }
+    else
+    {
+      hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_TXFP;
+    }
+
+    /* Set the bit timing register */
+    hcan->Instance->BTR = (uint32_t)((uint32_t)hcan->Init.Mode) | \
+                ((uint32_t)hcan->Init.SJW) | \
+                ((uint32_t)hcan->Init.BS1) | \
+                ((uint32_t)hcan->Init.BS2) | \
+               ((uint32_t)hcan->Init.Prescaler - 1);
+
+    /* Request leave initialisation */
+    hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_INRQ;
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+   
+    /* Wait the acknowledge */
+    while((hcan->Instance->MSR & CAN_MSR_INAK) == CAN_MSR_INAK)
+    {
+      if((HAL_GetTick()-tickstart) > CAN_TIMEOUT_VALUE)
+      {
+         hcan->State= HAL_CAN_STATE_TIMEOUT;
+         /* Process unlocked */
+         __HAL_UNLOCK(hcan);
+         return HAL_TIMEOUT;
+      }
+    }
+
+    /* Check acknowledged */
+    if ((hcan->Instance->MSR & CAN_MSR_INAK) != CAN_MSR_INAK)
+    {
+      status = CAN_INITSTATUS_SUCCESS;
+    }
+  }
+ 
+  if(status == CAN_INITSTATUS_SUCCESS)
+  {
+    /* Set CAN error code to none */
+    hcan->ErrorCode = HAL_CAN_ERROR_NONE;
+    
+    /* Initialize the CAN state */
+    hcan->State = HAL_CAN_STATE_READY;
+  
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Initialize the CAN state */
+    hcan->State = HAL_CAN_STATE_ERROR;
+
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Configure the CAN reception filter according to the specified
+  *         parameters in the CAN_FilterInitStruct.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @param  sFilterConfig: pointer to a CAN_FilterConfTypeDef structure that
+  *         contains the filter configuration information.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_CAN_ConfigFilter(CAN_HandleTypeDef* hcan, CAN_FilterConfTypeDef* sFilterConfig)
+{
+  uint32_t filternbrbitpos = 0;
+  
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hcan);
+
+  /* Check the parameters */
+  assert_param(IS_CAN_FILTER_NUMBER(sFilterConfig->FilterNumber));
+  assert_param(IS_CAN_FILTER_MODE(sFilterConfig->FilterMode));
+  assert_param(IS_CAN_FILTER_SCALE(sFilterConfig->FilterScale));
+  assert_param(IS_CAN_FILTER_FIFO(sFilterConfig->FilterFIFOAssignment));
+  assert_param(IS_FUNCTIONAL_STATE(sFilterConfig->FilterActivation));
+  assert_param(IS_CAN_BANKNUMBER(sFilterConfig->BankNumber));
+
+  filternbrbitpos = ((uint32_t)1) << sFilterConfig->FilterNumber;
+
+  /* Initialisation mode for the filter */
+  CAN1->FMR |= (uint32_t)CAN_FMR_FINIT;
+  
+  /* Filter Deactivation */
+  CAN1->FA1R &= ~(uint32_t)filternbrbitpos;
+
+  /* Filter Scale */
+  if (sFilterConfig->FilterScale == CAN_FILTERSCALE_16BIT)
+  {
+    /* 16-bit scale for the filter */
+    CAN1->FS1R &= ~(uint32_t)filternbrbitpos;
+
+    /* First 16-bit identifier and First 16-bit mask */
+    /* Or First 16-bit identifier and Second 16-bit identifier */
+    CAN1->sFilterRegister[sFilterConfig->FilterNumber].FR1 = 
+       ((0x0000FFFF & (uint32_t)sFilterConfig->FilterMaskIdLow) << 16) |
+        (0x0000FFFF & (uint32_t)sFilterConfig->FilterIdLow);
+
+    /* Second 16-bit identifier and Second 16-bit mask */
+    /* Or Third 16-bit identifier and Fourth 16-bit identifier */
+    CAN1->sFilterRegister[sFilterConfig->FilterNumber].FR2 = 
+       ((0x0000FFFF & (uint32_t)sFilterConfig->FilterMaskIdHigh) << 16) |
+        (0x0000FFFF & (uint32_t)sFilterConfig->FilterIdHigh);
+  }
+
+  if (sFilterConfig->FilterScale == CAN_FILTERSCALE_32BIT)
+  {
+    /* 32-bit scale for the filter */
+    CAN1->FS1R |= filternbrbitpos;
+    /* 32-bit identifier or First 32-bit identifier */
+    CAN1->sFilterRegister[sFilterConfig->FilterNumber].FR1 = 
+       ((0x0000FFFF & (uint32_t)sFilterConfig->FilterIdHigh) << 16) |
+        (0x0000FFFF & (uint32_t)sFilterConfig->FilterIdLow);
+    /* 32-bit mask or Second 32-bit identifier */
+    CAN1->sFilterRegister[sFilterConfig->FilterNumber].FR2 = 
+       ((0x0000FFFF & (uint32_t)sFilterConfig->FilterMaskIdHigh) << 16) |
+        (0x0000FFFF & (uint32_t)sFilterConfig->FilterMaskIdLow);
+  }
+
+  /* Filter Mode */
+  if (sFilterConfig->FilterMode == CAN_FILTERMODE_IDMASK)
+  {
+    /*Id/Mask mode for the filter*/
+    CAN1->FM1R &= ~(uint32_t)filternbrbitpos;
+  }
+  else /* CAN_FilterInitStruct->CAN_FilterMode == CAN_FilterMode_IdList */
+  {
+    /*Identifier list mode for the filter*/
+    CAN1->FM1R |= (uint32_t)filternbrbitpos;
+  }
+
+  /* Filter FIFO assignment */
+  if (sFilterConfig->FilterFIFOAssignment == CAN_FILTER_FIFO0)
+  {
+    /* FIFO 0 assignation for the filter */
+    CAN1->FFA1R &= ~(uint32_t)filternbrbitpos;
+  }
+
+  if (sFilterConfig->FilterFIFOAssignment == CAN_FILTER_FIFO1)
+  {
+    /* FIFO 1 assignation for the filter */
+    CAN1->FFA1R |= (uint32_t)filternbrbitpos;
+  }
+  
+  /* Filter activation */
+  if (sFilterConfig->FilterActivation == ENABLE)
+  {
+    CAN1->FA1R |= filternbrbitpos;
+  }
+
+  /* Leave the initialisation mode for the filter */
+  CAN1->FMR &= ~((uint32_t)CAN_FMR_FINIT);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitialize the CAN peripheral registers to their default reset values. 
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CAN_DeInit(CAN_HandleTypeDef* hcan)
+{
+  /* Check CAN handle */
+  if(hcan == NULL)
+  {
+     return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_CAN_ALL_INSTANCE(hcan->Instance));
+  
+  /* Change CAN state */
+  hcan->State = HAL_CAN_STATE_BUSY;
+  
+  /* DeInit the low level hardware */
+  HAL_CAN_MspDeInit(hcan);
+  
+  /* Change CAN state */
+  hcan->State = HAL_CAN_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hcan);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initialize the CAN MSP.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.  
+  * @retval None
+  */
+__weak void HAL_CAN_MspInit(CAN_HandleTypeDef* hcan)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hcan);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_CAN_MspInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  DeInitialize the CAN MSP.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.  
+  * @retval None
+  */
+__weak void HAL_CAN_MspDeInit(CAN_HandleTypeDef* hcan)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hcan);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_CAN_MspDeInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup CAN_Exported_Functions_Group2 Input and Output operation functions
+ *  @brief    I/O operation functions 
+ *
+@verbatim   
+  ==============================================================================
+                      ##### IO operation functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Transmit a CAN frame message.
+      (+) Receive a CAN frame message.
+      (+) Enter CAN peripheral in sleep mode. 
+      (+) Wake up the CAN peripheral from sleep mode.
+               
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initiate and transmit a CAN frame message.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.  
+  * @param  Timeout: Timeout duration.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CAN_Transmit(CAN_HandleTypeDef* hcan, uint32_t Timeout)
+{
+  uint32_t transmitmailbox = CAN_TXSTATUS_NOMAILBOX;
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_CAN_IDTYPE(hcan->pTxMsg->IDE));
+  assert_param(IS_CAN_RTR(hcan->pTxMsg->RTR));
+  assert_param(IS_CAN_DLC(hcan->pTxMsg->DLC));
+  
+  /* Process locked */
+  __HAL_LOCK(hcan);
+  
+  if(hcan->State == HAL_CAN_STATE_BUSY_RX) 
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_TX_RX;
+  }
+  else
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_TX;
+  }
+  
+  /* Select one empty transmit mailbox */
+  if ((hcan->Instance->TSR&CAN_TSR_TME0) == CAN_TSR_TME0)
+  {
+    transmitmailbox = 0;
+  }
+  else if ((hcan->Instance->TSR&CAN_TSR_TME1) == CAN_TSR_TME1)
+  {
+    transmitmailbox = 1;
+  }
+  else if ((hcan->Instance->TSR&CAN_TSR_TME2) == CAN_TSR_TME2)
+  {
+    transmitmailbox = 2;
+  }
+
+  if (transmitmailbox != CAN_TXSTATUS_NOMAILBOX)
+  {
+    /* Set up the Id */
+    hcan->Instance->sTxMailBox[transmitmailbox].TIR &= CAN_TI0R_TXRQ;
+    if (hcan->pTxMsg->IDE == CAN_ID_STD)
+    {
+      assert_param(IS_CAN_STDID(hcan->pTxMsg->StdId));  
+      hcan->Instance->sTxMailBox[transmitmailbox].TIR |= ((hcan->pTxMsg->StdId << 21) | \
+                                                  hcan->pTxMsg->RTR);
+    }
+    else
+    {
+      assert_param(IS_CAN_EXTID(hcan->pTxMsg->ExtId));
+      hcan->Instance->sTxMailBox[transmitmailbox].TIR |= ((hcan->pTxMsg->ExtId << 3) | \
+                                                  hcan->pTxMsg->IDE | \
+                                                  hcan->pTxMsg->RTR);
+    }
+    
+    /* Set up the DLC */
+    hcan->pTxMsg->DLC &= (uint8_t)0x0000000F;
+    hcan->Instance->sTxMailBox[transmitmailbox].TDTR &= (uint32_t)0xFFFFFFF0;
+    hcan->Instance->sTxMailBox[transmitmailbox].TDTR |= hcan->pTxMsg->DLC;
+
+    /* Set up the data field */
+    hcan->Instance->sTxMailBox[transmitmailbox].TDLR = (((uint32_t)hcan->pTxMsg->Data[3] << 24) | 
+                                             ((uint32_t)hcan->pTxMsg->Data[2] << 16) |
+                                             ((uint32_t)hcan->pTxMsg->Data[1] << 8) | 
+                                             ((uint32_t)hcan->pTxMsg->Data[0]));
+    hcan->Instance->sTxMailBox[transmitmailbox].TDHR = (((uint32_t)hcan->pTxMsg->Data[7] << 24) | 
+                                             ((uint32_t)hcan->pTxMsg->Data[6] << 16) |
+                                             ((uint32_t)hcan->pTxMsg->Data[5] << 8) |
+                                             ((uint32_t)hcan->pTxMsg->Data[4]));
+    /* Request transmission */
+    hcan->Instance->sTxMailBox[transmitmailbox].TIR |= CAN_TI0R_TXRQ;
+  
+    /* Get tick */
+    tickstart = HAL_GetTick();
+  
+    /* Check End of transmission flag */
+    while(!(__HAL_CAN_TRANSMIT_STATUS(hcan, transmitmailbox)))
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
+        {
+          hcan->State = HAL_CAN_STATE_TIMEOUT;
+          /* Process unlocked */
+          __HAL_UNLOCK(hcan);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    if(hcan->State == HAL_CAN_STATE_BUSY_TX_RX) 
+    {
+      /* Change CAN state */
+      hcan->State = HAL_CAN_STATE_BUSY_RX;
+    }
+    else
+    {
+      /* Change CAN state */
+      hcan->State = HAL_CAN_STATE_READY;
+    }
+    
+    /* Process unlocked */
+    __HAL_UNLOCK(hcan);
+    
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_ERROR; 
+    
+    /* Process unlocked */
+    __HAL_UNLOCK(hcan);
+
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Initiate and transmit a CAN frame message in Interrupt mode.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CAN_Transmit_IT(CAN_HandleTypeDef* hcan)
+{
+  uint32_t transmitmailbox = CAN_TXSTATUS_NOMAILBOX;
+
+  /* Check the parameters */
+  assert_param(IS_CAN_IDTYPE(hcan->pTxMsg->IDE));
+  assert_param(IS_CAN_RTR(hcan->pTxMsg->RTR));
+  assert_param(IS_CAN_DLC(hcan->pTxMsg->DLC));
+  
+  if((hcan->State == HAL_CAN_STATE_READY) || (hcan->State == HAL_CAN_STATE_BUSY_RX))
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcan);
+    
+    /* Select one empty transmit mailbox */
+    if((hcan->Instance->TSR&CAN_TSR_TME0) == CAN_TSR_TME0)
+    {
+      transmitmailbox = 0;
+    }
+    else if((hcan->Instance->TSR&CAN_TSR_TME1) == CAN_TSR_TME1)
+    {
+      transmitmailbox = 1;
+    }
+    else if((hcan->Instance->TSR&CAN_TSR_TME2) == CAN_TSR_TME2)
+    {
+      transmitmailbox = 2;
+    }
+
+    if(transmitmailbox != CAN_TXSTATUS_NOMAILBOX)
+    {
+      /* Set up the Id */
+      hcan->Instance->sTxMailBox[transmitmailbox].TIR &= CAN_TI0R_TXRQ;
+      if(hcan->pTxMsg->IDE == CAN_ID_STD)
+      {
+        assert_param(IS_CAN_STDID(hcan->pTxMsg->StdId));  
+        hcan->Instance->sTxMailBox[transmitmailbox].TIR |= ((hcan->pTxMsg->StdId << 21) | \
+                                                  hcan->pTxMsg->RTR);
+      }
+      else
+      {
+        assert_param(IS_CAN_EXTID(hcan->pTxMsg->ExtId));
+        hcan->Instance->sTxMailBox[transmitmailbox].TIR |= ((hcan->pTxMsg->ExtId << 3) | \
+                                                  hcan->pTxMsg->IDE | \
+                                                  hcan->pTxMsg->RTR);
+      }
+    
+      /* Set up the DLC */
+      hcan->pTxMsg->DLC &= (uint8_t)0x0000000F;
+      hcan->Instance->sTxMailBox[transmitmailbox].TDTR &= (uint32_t)0xFFFFFFF0;
+      hcan->Instance->sTxMailBox[transmitmailbox].TDTR |= hcan->pTxMsg->DLC;
+
+      /* Set up the data field */
+      hcan->Instance->sTxMailBox[transmitmailbox].TDLR = (((uint32_t)hcan->pTxMsg->Data[3] << 24) | 
+                                             ((uint32_t)hcan->pTxMsg->Data[2] << 16) |
+                                             ((uint32_t)hcan->pTxMsg->Data[1] << 8) | 
+                                             ((uint32_t)hcan->pTxMsg->Data[0]));
+      hcan->Instance->sTxMailBox[transmitmailbox].TDHR = (((uint32_t)hcan->pTxMsg->Data[7] << 24) | 
+                                             ((uint32_t)hcan->pTxMsg->Data[6] << 16) |
+                                             ((uint32_t)hcan->pTxMsg->Data[5] << 8) |
+                                             ((uint32_t)hcan->pTxMsg->Data[4]));
+    
+      if(hcan->State == HAL_CAN_STATE_BUSY_RX) 
+      {
+        /* Change CAN state */
+        hcan->State = HAL_CAN_STATE_BUSY_TX_RX;
+      }
+      else
+      {
+        /* Change CAN state */
+        hcan->State = HAL_CAN_STATE_BUSY_TX;
+      }
+      
+      /* Set CAN error code to none */
+      hcan->ErrorCode = HAL_CAN_ERROR_NONE;
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hcan);
+      
+      /* Enable interrupts: */
+      /*  - Enable Error warning Interrupt */
+      /*  - Enable Error passive Interrupt */
+      /*  - Enable Bus-off Interrupt */
+      /*  - Enable Last error code Interrupt */
+      /*  - Enable Error Interrupt */
+      /*  - Enable Transmit mailbox empty Interrupt */
+      __HAL_CAN_ENABLE_IT(hcan, CAN_IT_EWG |
+                                CAN_IT_EPV |
+                                CAN_IT_BOF |
+                                CAN_IT_LEC |
+                                CAN_IT_ERR |
+                                CAN_IT_TME  );
+      
+      /* Request transmission */
+      hcan->Instance->sTxMailBox[transmitmailbox].TIR |= CAN_TI0R_TXRQ;
+    }
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Receive a correct CAN frame.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.  
+  * @param  FIFONumber:    FIFO number.
+  * @param  Timeout:       Timeout duration.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CAN_Receive(CAN_HandleTypeDef* hcan, uint8_t FIFONumber, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+   
+  /* Check the parameters */
+  assert_param(IS_CAN_FIFO(FIFONumber));
+  
+  /* Process locked */
+  __HAL_LOCK(hcan);
+  
+  if(hcan->State == HAL_CAN_STATE_BUSY_TX) 
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_TX_RX;
+  }
+  else
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_RX;
+  }
+    
+  /* Get tick */
+  tickstart = HAL_GetTick();
+  
+  /* Check pending message */
+  while(__HAL_CAN_MSG_PENDING(hcan, FIFONumber) == 0)
+  {
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
+      {
+        hcan->State = HAL_CAN_STATE_TIMEOUT;
+        /* Process unlocked */
+        __HAL_UNLOCK(hcan);
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  
+  /* Get the Id */
+  hcan->pRxMsg->IDE = (uint8_t)0x04 & hcan->Instance->sFIFOMailBox[FIFONumber].RIR;
+  if (hcan->pRxMsg->IDE == CAN_ID_STD)
+  {
+    hcan->pRxMsg->StdId = (uint32_t)0x000007FF & (hcan->Instance->sFIFOMailBox[FIFONumber].RIR >> 21);
+  }
+  else
+  {
+    hcan->pRxMsg->ExtId = (uint32_t)0x1FFFFFFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RIR >> 3);
+  }
+  
+  hcan->pRxMsg->RTR = (uint8_t)0x02 & hcan->Instance->sFIFOMailBox[FIFONumber].RIR;
+  /* Get the DLC */
+  hcan->pRxMsg->DLC = (uint8_t)0x0F & hcan->Instance->sFIFOMailBox[FIFONumber].RDTR;
+  /* Get the FMI */
+  hcan->pRxMsg->FMI = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDTR >> 8);
+  /* Get the data field */
+  hcan->pRxMsg->Data[0] = (uint8_t)0xFF & hcan->Instance->sFIFOMailBox[FIFONumber].RDLR;
+  hcan->pRxMsg->Data[1] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDLR >> 8);
+  hcan->pRxMsg->Data[2] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDLR >> 16);
+  hcan->pRxMsg->Data[3] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDLR >> 24);
+  hcan->pRxMsg->Data[4] = (uint8_t)0xFF & hcan->Instance->sFIFOMailBox[FIFONumber].RDHR;
+  hcan->pRxMsg->Data[5] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDHR >> 8);
+  hcan->pRxMsg->Data[6] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDHR >> 16);
+  hcan->pRxMsg->Data[7] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDHR >> 24);
+  
+  /* Release the FIFO */
+  if(FIFONumber == CAN_FIFO0)
+  {
+    /* Release FIFO0 */
+    __HAL_CAN_FIFO_RELEASE(hcan, CAN_FIFO0);
+  }
+  else /* FIFONumber == CAN_FIFO1 */
+  {
+    /* Release FIFO1 */
+    __HAL_CAN_FIFO_RELEASE(hcan, CAN_FIFO1);
+  }
+  
+  if(hcan->State == HAL_CAN_STATE_BUSY_TX_RX) 
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_TX;
+  }
+  else
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_READY;
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hcan);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Receive a correct CAN frame in Interrupt mode.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.  
+  * @param  FIFONumber:    FIFO number.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CAN_Receive_IT(CAN_HandleTypeDef* hcan, uint8_t FIFONumber)
+{
+  /* Check the parameters */
+  assert_param(IS_CAN_FIFO(FIFONumber));
+  
+  if((hcan->State == HAL_CAN_STATE_READY) || (hcan->State == HAL_CAN_STATE_BUSY_TX))
+  {
+    /* Process locked */
+    __HAL_LOCK(hcan);
+  
+    if(hcan->State == HAL_CAN_STATE_BUSY_TX) 
+    {
+      /* Change CAN state */
+      hcan->State = HAL_CAN_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      /* Change CAN state */
+      hcan->State = HAL_CAN_STATE_BUSY_RX;
+    }
+    
+    /* Set CAN error code to none */
+    hcan->ErrorCode = HAL_CAN_ERROR_NONE;
+    
+    /* Enable interrupts: */
+    /*  - Enable Error warning Interrupt */
+    /*  - Enable Error passive Interrupt */
+    /*  - Enable Bus-off Interrupt */
+    /*  - Enable Last error code Interrupt */
+    /*  - Enable Error Interrupt */
+    __HAL_CAN_ENABLE_IT(hcan, CAN_IT_EWG |
+                              CAN_IT_EPV |
+                              CAN_IT_BOF |
+                              CAN_IT_LEC |
+                              CAN_IT_ERR );
+
+    /* Process unlocked */
+    __HAL_UNLOCK(hcan);
+
+    if(FIFONumber == CAN_FIFO0)
+    {
+      /* Enable FIFO 0 message pending Interrupt */
+      __HAL_CAN_ENABLE_IT(hcan, CAN_IT_FMP0);
+    }
+    else
+    {
+      /* Enable FIFO 1 message pending Interrupt */
+      __HAL_CAN_ENABLE_IT(hcan, CAN_IT_FMP1);
+    }
+    
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enter the Sleep (low power) mode.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_CAN_Sleep(CAN_HandleTypeDef* hcan)
+{
+  uint32_t tickstart = 0;
+   
+  /* Process locked */
+  __HAL_LOCK(hcan);
+  
+  /* Change CAN state */
+  hcan->State = HAL_CAN_STATE_BUSY; 
+    
+  /* Request Sleep mode */
+   hcan->Instance->MCR = (((hcan->Instance->MCR) & (uint32_t)(~(uint32_t)CAN_MCR_INRQ)) | CAN_MCR_SLEEP);
+   
+  /* Sleep mode status */
+  if ((hcan->Instance->MSR & (CAN_MSR_SLAK|CAN_MSR_INAK)) != CAN_MSR_SLAK)
+  {
+    /* Process unlocked */
+    __HAL_UNLOCK(hcan);
+
+    /* Return function status */
+    return HAL_ERROR;
+  }
+  
+  /* Get tick */
+  tickstart = HAL_GetTick();
+  
+  /* Wait the acknowledge */
+  while((hcan->Instance->MSR & (CAN_MSR_SLAK|CAN_MSR_INAK)) != CAN_MSR_SLAK)
+  {
+    if((HAL_GetTick()-tickstart) > CAN_TIMEOUT_VALUE)
+    {
+      hcan->State = HAL_CAN_STATE_TIMEOUT;
+      /* Process unlocked */
+      __HAL_UNLOCK(hcan);
+      return HAL_TIMEOUT;
+    }
+  }
+  
+  /* Change CAN state */
+  hcan->State = HAL_CAN_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hcan);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Wake up the CAN peripheral from sleep mode (after that the CAN peripheral
+  *         is in the normal mode).
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_CAN_WakeUp(CAN_HandleTypeDef* hcan)
+{
+  uint32_t tickstart = 0;
+    
+  /* Process locked */
+  __HAL_LOCK(hcan);
+  
+  /* Change CAN state */
+  hcan->State = HAL_CAN_STATE_BUSY;  
+ 
+  /* Wake up request */
+  hcan->Instance->MCR &= ~(uint32_t)CAN_MCR_SLEEP;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Sleep mode status */
+  while((hcan->Instance->MSR & CAN_MSR_SLAK) == CAN_MSR_SLAK)
+  {
+    if((HAL_GetTick()-tickstart) > CAN_TIMEOUT_VALUE)
+    {
+      hcan->State= HAL_CAN_STATE_TIMEOUT;
+      /* Process unlocked */
+      __HAL_UNLOCK(hcan);
+      return HAL_TIMEOUT;
+    }
+  }
+  if((hcan->Instance->MSR & CAN_MSR_SLAK) == CAN_MSR_SLAK)
+  {
+    /* Process unlocked */
+    __HAL_UNLOCK(hcan);
+
+    /* Return function status */
+    return HAL_ERROR;
+  }
+  
+  /* Change CAN state */
+  hcan->State = HAL_CAN_STATE_READY; 
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hcan);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handle CAN interrupt request.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval None
+  */
+void HAL_CAN_IRQHandler(CAN_HandleTypeDef* hcan)
+{
+  /* Check End of transmission flag */
+  if(__HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_TME))
+  {
+    if((__HAL_CAN_TRANSMIT_STATUS(hcan, CAN_TXMAILBOX_0)) ||
+       (__HAL_CAN_TRANSMIT_STATUS(hcan, CAN_TXMAILBOX_1)) ||
+       (__HAL_CAN_TRANSMIT_STATUS(hcan, CAN_TXMAILBOX_2)))
+    {
+      /* Call transmit function */
+      CAN_Transmit_IT(hcan);
+    }
+  }
+  
+  /* Check End of reception flag for FIFO0 */
+  if((__HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_FMP0)) &&
+     (__HAL_CAN_MSG_PENDING(hcan, CAN_FIFO0) != 0))
+  {
+    /* Call receive function */
+    CAN_Receive_IT(hcan, CAN_FIFO0);
+  }
+  
+  /* Check End of reception flag for FIFO1 */
+  if((__HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_FMP1)) &&
+     (__HAL_CAN_MSG_PENDING(hcan, CAN_FIFO1) != 0))
+  {
+    /* Call receive function */
+    CAN_Receive_IT(hcan, CAN_FIFO1);
+  }
+  
+  /* Check Error Warning Flag */
+  if((__HAL_CAN_GET_FLAG(hcan, CAN_FLAG_EWG))    &&
+     (__HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_EWG)) &&
+     (__HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_ERR)))
+  {
+    /* Set CAN error code to EWG error */
+    hcan->ErrorCode |= HAL_CAN_ERROR_EWG;
+    /* No need for clear of Error Warning Flag as read-only */
+  }
+  
+  /* Check Error Passive Flag */
+  if((__HAL_CAN_GET_FLAG(hcan, CAN_FLAG_EPV))    &&
+     (__HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_EPV)) &&
+     (__HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_ERR)))
+  {
+    /* Set CAN error code to EPV error */
+    hcan->ErrorCode |= HAL_CAN_ERROR_EPV;
+    /* No need for clear of Error Passive Flag as read-only */ 
+  }
+  
+  /* Check Bus-Off Flag */
+  if((__HAL_CAN_GET_FLAG(hcan, CAN_FLAG_BOF))    &&
+     (__HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_BOF)) &&
+     (__HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_ERR)))
+  {
+    /* Set CAN error code to BOF error */
+    hcan->ErrorCode |= HAL_CAN_ERROR_BOF;
+    /* No need for clear of Bus-Off Flag as read-only */
+  }
+  
+  /* Check Last error code Flag */
+  if((!HAL_IS_BIT_CLR(hcan->Instance->ESR, CAN_ESR_LEC)) &&
+     (__HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_LEC))         &&
+     (__HAL_CAN_GET_IT_SOURCE(hcan, CAN_IT_ERR)))
+  {
+    switch(hcan->Instance->ESR & CAN_ESR_LEC)
+    {
+      case(CAN_ESR_LEC_0):
+          /* Set CAN error code to STF error */
+          hcan->ErrorCode |= HAL_CAN_ERROR_STF;
+          break;
+      case(CAN_ESR_LEC_1):
+          /* Set CAN error code to FOR error */
+          hcan->ErrorCode |= HAL_CAN_ERROR_FOR;
+          break;
+      case(CAN_ESR_LEC_1 | CAN_ESR_LEC_0):
+          /* Set CAN error code to ACK error */
+          hcan->ErrorCode |= HAL_CAN_ERROR_ACK;
+          break;
+      case(CAN_ESR_LEC_2):
+          /* Set CAN error code to BR error */
+          hcan->ErrorCode |= HAL_CAN_ERROR_BR;
+          break;
+      case(CAN_ESR_LEC_2 | CAN_ESR_LEC_0):
+          /* Set CAN error code to BD error */
+          hcan->ErrorCode |= HAL_CAN_ERROR_BD;
+          break;
+      case(CAN_ESR_LEC_2 | CAN_ESR_LEC_1):
+          /* Set CAN error code to CRC error */
+          hcan->ErrorCode |= HAL_CAN_ERROR_CRC;
+          break;
+      default:
+          break;
+    }
+
+    /* Clear Last error code Flag */ 
+    hcan->Instance->ESR &= ~(CAN_ESR_LEC);
+  }
+
+  /* Call the Error call Back in case of Errors */
+  if(hcan->ErrorCode != HAL_CAN_ERROR_NONE)
+  {
+    /* Clear ERRI bit */
+    SET_BIT(hcan->Instance->MSR, CAN_MSR_ERRI);
+    /* Set the CAN state ready to be able to start again the process */
+    hcan->State = HAL_CAN_STATE_READY;
+    /* Call Error callback function */
+    HAL_CAN_ErrorCallback(hcan);
+  }  
+}
+
+/**
+  * @brief  Transmission complete callback in non-blocking mode.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval None
+  */
+__weak void HAL_CAN_TxCpltCallback(CAN_HandleTypeDef* hcan)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hcan);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_CAN_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Reception complete callback in non-blocking mode.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval None
+  */
+__weak void HAL_CAN_RxCpltCallback(CAN_HandleTypeDef* hcan)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hcan);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_CAN_RxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error CAN callback.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval None
+  */
+__weak void HAL_CAN_ErrorCallback(CAN_HandleTypeDef *hcan)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hcan);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_CAN_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup CAN_Exported_Functions_Group3 Peripheral State and Error functions
+ *  @brief   CAN Peripheral State functions 
+ *
+@verbatim   
+  ==============================================================================
+            ##### Peripheral State and Error functions #####
+  ==============================================================================
+    [..]
+    This subsection provides functions allowing to :
+      (+) Check the CAN state.
+      (+) Check CAN Errors detected during interrupt process.
+         
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the CAN handle state.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval HAL state
+  */
+HAL_CAN_StateTypeDef HAL_CAN_GetState(CAN_HandleTypeDef* hcan)
+{
+  /* Return CAN handle state */
+  return hcan->State;
+}
+
+/**
+  * @brief  Return the CAN error code.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.
+  * @retval CAN Error Code
+  */
+uint32_t HAL_CAN_GetError(CAN_HandleTypeDef *hcan)
+{
+  return hcan->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup CAN_Private_Functions CAN Private Functions
+ * @{
+ */
+/**
+  * @brief  Initiate and transmit a CAN frame message.
+  * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.  
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef CAN_Transmit_IT(CAN_HandleTypeDef* hcan)
+{
+  /* Disable Transmit mailbox empty Interrupt */
+  __HAL_CAN_DISABLE_IT(hcan, CAN_IT_TME);
+  
+  if(hcan->State == HAL_CAN_STATE_BUSY_TX)
+  {   
+    /* Disable interrupts: */
+    /*  - Disable Error warning Interrupt */
+    /*  - Disable Error passive Interrupt */
+    /*  - Disable Bus-off Interrupt */
+    /*  - Disable Last error code Interrupt */
+    /*  - Disable Error Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_EWG |
+                               CAN_IT_EPV |
+                               CAN_IT_BOF |
+                               CAN_IT_LEC |
+                               CAN_IT_ERR  );
+  }
+  
+  if(hcan->State == HAL_CAN_STATE_BUSY_TX_RX) 
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_RX;
+  }
+  else
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_READY;
+  }
+  
+  /* Transmission complete callback */ 
+  HAL_CAN_TxCpltCallback(hcan);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Receive a correct CAN frame.
+  * @param  hcan:       Pointer to a CAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified CAN.  
+  * @param  FIFONumber: Specify the FIFO number    
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef CAN_Receive_IT(CAN_HandleTypeDef* hcan, uint8_t FIFONumber)
+{
+  /* Get the Id */
+  hcan->pRxMsg->IDE = (uint8_t)0x04 & hcan->Instance->sFIFOMailBox[FIFONumber].RIR;
+  if (hcan->pRxMsg->IDE == CAN_ID_STD)
+  {
+    hcan->pRxMsg->StdId = (uint32_t)0x000007FF & (hcan->Instance->sFIFOMailBox[FIFONumber].RIR >> 21);
+  }
+  else
+  {
+    hcan->pRxMsg->ExtId = (uint32_t)0x1FFFFFFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RIR >> 3);
+  }
+  
+  hcan->pRxMsg->RTR = (uint8_t)0x02 & hcan->Instance->sFIFOMailBox[FIFONumber].RIR;
+  /* Get the DLC */
+  hcan->pRxMsg->DLC = (uint8_t)0x0F & hcan->Instance->sFIFOMailBox[FIFONumber].RDTR;
+  /* Get the FMI */
+  hcan->pRxMsg->FMI = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDTR >> 8);
+  /* Get the data field */
+  hcan->pRxMsg->Data[0] = (uint8_t)0xFF & hcan->Instance->sFIFOMailBox[FIFONumber].RDLR;
+  hcan->pRxMsg->Data[1] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDLR >> 8);
+  hcan->pRxMsg->Data[2] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDLR >> 16);
+  hcan->pRxMsg->Data[3] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDLR >> 24);
+  hcan->pRxMsg->Data[4] = (uint8_t)0xFF & hcan->Instance->sFIFOMailBox[FIFONumber].RDHR;
+  hcan->pRxMsg->Data[5] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDHR >> 8);
+  hcan->pRxMsg->Data[6] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDHR >> 16);
+  hcan->pRxMsg->Data[7] = (uint8_t)0xFF & (hcan->Instance->sFIFOMailBox[FIFONumber].RDHR >> 24);
+  /* Release the FIFO */
+  /* Release FIFO0 */
+  if (FIFONumber == CAN_FIFO0)
+  {
+    __HAL_CAN_FIFO_RELEASE(hcan, CAN_FIFO0);
+    
+    /* Disable FIFO 0 message pending Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_FMP0);
+  }
+  /* Release FIFO1 */
+  else /* FIFONumber == CAN_FIFO1 */
+  {
+    __HAL_CAN_FIFO_RELEASE(hcan, CAN_FIFO1);
+    
+    /* Disable FIFO 1 message pending Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_FMP1);
+  }
+  
+  if(hcan->State == HAL_CAN_STATE_BUSY_RX)
+  {
+    /* Disable interrupts: */
+    /*  - Disable Error warning Interrupt */
+    /*  - Disable Error passive Interrupt */
+    /*  - Disable Bus-off Interrupt */
+    /*  - Disable Last error code Interrupt */
+    /*  - Disable Error Interrupt */
+    __HAL_CAN_DISABLE_IT(hcan, CAN_IT_EWG |
+                               CAN_IT_EPV |
+                               CAN_IT_BOF |
+                               CAN_IT_LEC |
+                               CAN_IT_ERR  );
+  }
+  
+  if(hcan->State == HAL_CAN_STATE_BUSY_TX_RX) 
+  {
+    /* Disable CAN state */
+    hcan->State = HAL_CAN_STATE_BUSY_TX;
+  }
+  else
+  {
+    /* Change CAN state */
+    hcan->State = HAL_CAN_STATE_READY;
+  }
+
+  /* Receive complete callback */ 
+  HAL_CAN_RxCpltCallback(hcan);
+
+  /* Return function status */
+  return HAL_OK;
+}
+/**
+ * @}
+ */
+
+#endif /* HAL_CAN_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_cortex.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_cortex.c
@@ -1,0 +1,492 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_cortex.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   CORTEX HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the CORTEX:
+  *           + Initialization and Configuration functions
+  *           + Peripheral Control functions
+  *
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+
+    [..]
+    *** How to configure Interrupts using CORTEX HAL driver ***
+    ===========================================================
+    [..]
+    This section provides functions allowing to configure the NVIC interrupts (IRQ).
+    The Cortex-M4 exceptions are managed by CMSIS functions.
+
+    (#) Configure the NVIC Priority Grouping using HAL_NVIC_SetPriorityGrouping() function.
+    (#) Configure the priority of the selected IRQ Channels using HAL_NVIC_SetPriority().
+    (#) Enable the selected IRQ Channels using HAL_NVIC_EnableIRQ().
+
+     -@- When the NVIC_PRIORITYGROUP_0 is selected, IRQ pre-emption is no more possible.
+         The pending IRQ priority will be managed only by the sub priority.
+
+     -@- IRQ priority order (sorted by highest to lowest priority):
+        (+@) Lowest pre-emption priority
+        (+@) Lowest sub priority
+        (+@) Lowest hardware priority (IRQ number)
+
+    [..]
+    *** How to configure SysTick using CORTEX HAL driver ***
+    ========================================================
+    [..]
+    Setup SysTick Timer for time base.
+
+   (+) The HAL_SYSTICK_Config() function calls the SysTick_Config() function which
+       is a CMSIS function that:
+        (++) Configures the SysTick Reload register with value passed as function parameter.
+        (++) Configures the SysTick IRQ priority to the lowest value (0x0F).
+        (++) Resets the SysTick Counter register.
+        (++) Configures the SysTick Counter clock source to be Core Clock Source (HCLK).
+        (++) Enables the SysTick Interrupt.
+        (++) Starts the SysTick Counter.
+
+   (+) You can change the SysTick Clock source to be HCLK_Div8 by calling the macro
+       __HAL_CORTEX_SYSTICKCLK_CONFIG(SYSTICK_CLKSOURCE_HCLK_DIV8) just after the
+       HAL_SYSTICK_Config() function call. The __HAL_CORTEX_SYSTICKCLK_CONFIG() macro is defined
+       inside the stm32l4xx_hal_cortex.h file.
+
+   (+) You can change the SysTick IRQ priority by calling the
+       HAL_NVIC_SetPriority(SysTick_IRQn,...) function just after the HAL_SYSTICK_Config() function
+       call. The HAL_NVIC_SetPriority() call the NVIC_SetPriority() function which is a CMSIS function.
+
+   (+) To adjust the SysTick time base, use the following formula:
+
+       Reload Value = SysTick Counter Clock (Hz) x  Desired Time base (s)
+       (++) Reload Value is the parameter to be passed for HAL_SYSTICK_Config() function
+       (++) Reload Value should not exceed 0xFFFFFF
+
+  @endverbatim
+  ******************************************************************************
+
+  The table below gives the allowed values of the pre-emption priority and subpriority according
+  to the Priority Grouping configuration performed by HAL_NVIC_SetPriorityGrouping() function.
+  
+    ==========================================================================================================================
+      NVIC_PriorityGroup   | NVIC_IRQChannelPreemptionPriority | NVIC_IRQChannelSubPriority  |       Description
+    ==========================================================================================================================
+     NVIC_PRIORITYGROUP_0  |                0                  |            0-15             | 0 bit for pre-emption priority
+                           |                                   |                             | 4 bits for subpriority
+    --------------------------------------------------------------------------------------------------------------------------
+     NVIC_PRIORITYGROUP_1  |                0-1                |            0-7              | 1 bit for pre-emption priority
+                           |                                   |                             | 3 bits for subpriority
+    --------------------------------------------------------------------------------------------------------------------------    
+     NVIC_PRIORITYGROUP_2  |                0-3                |            0-3              | 2 bits for pre-emption priority
+                           |                                   |                             | 2 bits for subpriority
+    --------------------------------------------------------------------------------------------------------------------------    
+     NVIC_PRIORITYGROUP_3  |                0-7                |            0-1              | 3 bits for pre-emption priority
+                           |                                   |                             | 1 bit for subpriority
+    --------------------------------------------------------------------------------------------------------------------------    
+     NVIC_PRIORITYGROUP_4  |                0-15               |            0                | 4 bits for pre-emption priority
+                           |                                   |                             | 0 bit for subpriority                       
+    ==========================================================================================================================
+
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup CORTEX
+  * @{
+  */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup CORTEX_Exported_Functions
+  * @{
+  */
+
+
+/** @addtogroup CORTEX_Exported_Functions_Group1
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+  ==============================================================================
+              ##### Initialization and Configuration functions #####
+  ==============================================================================
+    [..]
+      This section provides the CORTEX HAL driver functions allowing to configure Interrupts
+      SysTick functionalities
+
+@endverbatim
+  * @{
+  */
+
+
+/**
+  * @brief  Set the priority grouping field (pre-emption priority and subpriority)
+  *         using the required unlock sequence.
+  * @param  PriorityGroup: The priority grouping bits length.
+  *         This parameter can be one of the following values:
+  *         @arg NVIC_PRIORITYGROUP_0: 0 bit  for pre-emption priority,
+  *                                    4 bits for subpriority
+  *         @arg NVIC_PRIORITYGROUP_1: 1 bit  for pre-emption priority,
+  *                                    3 bits for subpriority
+  *         @arg NVIC_PRIORITYGROUP_2: 2 bits for pre-emption priority,
+  *                                    2 bits for subpriority
+  *         @arg NVIC_PRIORITYGROUP_3: 3 bits for pre-emption priority,
+  *                                    1 bit  for subpriority
+  *         @arg NVIC_PRIORITYGROUP_4: 4 bits for pre-emption priority,
+  *                                    0 bit  for subpriority
+  * @note   When the NVIC_PriorityGroup_0 is selected, IRQ pre-emption is no more possible.
+  *         The pending IRQ priority will be managed only by the subpriority.
+  * @retval None
+  */
+void HAL_NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_PRIORITY_GROUP(PriorityGroup));
+
+  /* Set the PRIGROUP[10:8] bits according to the PriorityGroup parameter value */
+  NVIC_SetPriorityGrouping(PriorityGroup);
+}
+
+/**
+  * @brief  Set the priority of an interrupt.
+  * @param  IRQn: External interrupt number.
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32l4xxxx.h))
+  * @param  PreemptPriority: The pre-emption priority for the IRQn channel.
+  *         This parameter can be a value between 0 and 15
+  *         A lower priority value indicates a higher priority
+  * @param  SubPriority: the subpriority level for the IRQ channel.
+  *         This parameter can be a value between 0 and 15
+  *         A lower priority value indicates a higher priority.
+  * @retval None
+  */
+void HAL_NVIC_SetPriority(IRQn_Type IRQn, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t prioritygroup = 0x00;
+
+  /* Check the parameters */
+  assert_param(IS_NVIC_SUB_PRIORITY(SubPriority));
+  assert_param(IS_NVIC_PREEMPTION_PRIORITY(PreemptPriority));
+
+  prioritygroup = NVIC_GetPriorityGrouping();
+
+  NVIC_SetPriority(IRQn, NVIC_EncodePriority(prioritygroup, PreemptPriority, SubPriority));
+}
+
+/**
+  * @brief  Enable a device specific interrupt in the NVIC interrupt controller.
+  * @note   To configure interrupts priority correctly, the NVIC_PriorityGroupConfig()
+  *         function should be called before.
+  * @param  IRQn External interrupt number.
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32l4xxxx.h))
+  * @retval None
+  */
+void HAL_NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_DEVICE_IRQ(IRQn));
+  
+  /* Enable interrupt */
+  NVIC_EnableIRQ(IRQn);
+}
+
+/**
+  * @brief  Disable a device specific interrupt in the NVIC interrupt controller.
+  * @param  IRQn External interrupt number.
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32l4xxxx.h))
+  * @retval None
+  */
+void HAL_NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_DEVICE_IRQ(IRQn));
+  
+  /* Disable interrupt */
+  NVIC_DisableIRQ(IRQn);
+}
+
+/**
+  * @brief  Initiate a system reset request to reset the MCU.
+  * @retval None
+  */
+void HAL_NVIC_SystemReset(void)
+{
+  /* System Reset */
+  NVIC_SystemReset();
+}
+
+/**
+  * @brief  Initialize the System Timer with interrupt enabled and start the System Tick Timer (SysTick): 
+  *         Counter is in free running mode to generate periodic interrupts.
+  * @param  TicksNumb: Specifies the ticks Number of ticks between two interrupts.
+  * @retval status:  - 0  Function succeeded.
+  *                  - 1  Function failed.
+  */
+uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb)
+{
+   return SysTick_Config(TicksNumb);
+}
+/**
+  * @}
+  */
+
+/** @addtogroup CORTEX_Exported_Functions_Group2
+ *  @brief   Cortex control functions
+ *
+@verbatim
+  ==============================================================================
+                      ##### Peripheral Control functions #####
+  ==============================================================================
+    [..]
+      This subsection provides a set of functions allowing to control the CORTEX
+      (NVIC, SYSTICK, MPU) functionalities.
+
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Get the priority grouping field from the NVIC Interrupt Controller.
+  * @retval Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field)
+  */
+uint32_t HAL_NVIC_GetPriorityGrouping(void)
+{
+  /* Get the PRIGROUP[10:8] field value */
+  return NVIC_GetPriorityGrouping();
+}
+
+/**
+  * @brief  Get the priority of an interrupt.
+  * @param  IRQn: External interrupt number.
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32l4xxxx.h))
+  * @param   PriorityGroup: the priority grouping bits length.
+  *         This parameter can be one of the following values:
+  *           @arg NVIC_PRIORITYGROUP_0: 0 bit for pre-emption priority,
+  *                                      4 bits for subpriority
+  *           @arg NVIC_PRIORITYGROUP_1: 1 bit for pre-emption priority,
+  *                                      3 bits for subpriority
+  *           @arg NVIC_PRIORITYGROUP_2: 2 bits for pre-emption priority,
+  *                                      2 bits for subpriority
+  *           @arg NVIC_PRIORITYGROUP_3: 3 bits for pre-emption priority,
+  *                                      1 bit for subpriority
+  *           @arg NVIC_PRIORITYGROUP_4: 4 bits for pre-emption priority,
+  *                                      0 bit for subpriority
+  * @param  pPreemptPriority: Pointer on the Preemptive priority value (starting from 0).
+  * @param  pSubPriority: Pointer on the Subpriority value (starting from 0).
+  * @retval None
+  */
+void HAL_NVIC_GetPriority(IRQn_Type IRQn, uint32_t PriorityGroup, uint32_t *pPreemptPriority, uint32_t *pSubPriority)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_PRIORITY_GROUP(PriorityGroup));
+ /* Get priority for Cortex-M system or device specific interrupts */
+  NVIC_DecodePriority(NVIC_GetPriority(IRQn), PriorityGroup, pPreemptPriority, pSubPriority);
+}
+
+/**
+  * @brief  Set Pending bit of an external interrupt.
+  * @param  IRQn External interrupt number
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32l4xxxx.h))
+  * @retval None
+  */
+void HAL_NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  /* Set interrupt pending */
+  NVIC_SetPendingIRQ(IRQn);
+}
+
+/**
+  * @brief  Get Pending Interrupt (read the pending register in the NVIC
+  *         and return the pending bit for the specified interrupt).
+  * @param  IRQn External interrupt number.
+  *          This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32l4xxxx.h))
+  * @retval status: - 0  Interrupt status is not pending.
+  *                 - 1  Interrupt status is pending.
+  */
+uint32_t HAL_NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  /* Return 1 if pending else 0 */
+  return NVIC_GetPendingIRQ(IRQn);
+}
+
+/**
+  * @brief  Clear the pending bit of an external interrupt.
+  * @param  IRQn External interrupt number.
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32l4xxxx.h))
+  * @retval None
+  */
+void HAL_NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  /* Clear pending interrupt */
+  NVIC_ClearPendingIRQ(IRQn);
+}
+
+/**
+  * @brief Get active interrupt (read the active register in NVIC and return the active bit).
+  * @param IRQn External interrupt number
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to the appropriate CMSIS device file (stm32l4xxxx.h))
+  * @retval status: - 0  Interrupt status is not pending.
+  *                 - 1  Interrupt status is pending.
+  */
+uint32_t HAL_NVIC_GetActive(IRQn_Type IRQn)
+{
+  /* Return 1 if active else 0 */
+  return NVIC_GetActive(IRQn);
+}
+
+/**
+  * @brief  Configure the SysTick clock source.
+  * @param  CLKSource: specifies the SysTick clock source.
+  *          This parameter can be one of the following values:
+  *             @arg SYSTICK_CLKSOURCE_HCLK_DIV8: AHB clock divided by 8 selected as SysTick clock source.
+  *             @arg SYSTICK_CLKSOURCE_HCLK: AHB clock selected as SysTick clock source.
+  * @retval None
+  */
+void HAL_SYSTICK_CLKSourceConfig(uint32_t CLKSource)
+{
+  /* Check the parameters */
+  assert_param(IS_SYSTICK_CLK_SOURCE(CLKSource));
+  if (CLKSource == SYSTICK_CLKSOURCE_HCLK)
+  {
+    SysTick->CTRL |= SYSTICK_CLKSOURCE_HCLK;
+  }
+  else
+  {
+    SysTick->CTRL &= ~SYSTICK_CLKSOURCE_HCLK;
+  }
+}
+
+/**
+  * @brief  Handle SYSTICK interrupt request.
+  * @retval None
+  */
+void HAL_SYSTICK_IRQHandler(void)
+{
+  HAL_SYSTICK_Callback();
+}
+
+/**
+  * @brief  SYSTICK callback.
+  * @retval None
+  */
+__weak void HAL_SYSTICK_Callback(void)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SYSTICK_Callback could be implemented in the user file
+   */
+}
+
+#if (__MPU_PRESENT == 1)
+/**
+  * @brief  Initialize and configure the Region and the memory to be protected.
+  * @param  MPU_Init: Pointer to a MPU_Region_InitTypeDef structure that contains
+  *                the initialization and configuration information.
+  * @retval None
+  */
+void HAL_MPU_ConfigRegion(MPU_Region_InitTypeDef *MPU_Init)
+{
+  /* Check the parameters */
+  assert_param(IS_MPU_REGION_NUMBER(MPU_Init->Number));
+  assert_param(IS_MPU_REGION_ENABLE(MPU_Init->Enable));
+
+  /* Set the Region number */
+  MPU->RNR = MPU_Init->Number;
+
+  if ((MPU_Init->Enable) != RESET)
+  {
+    /* Check the parameters */
+    assert_param(IS_MPU_INSTRUCTION_ACCESS(MPU_Init->DisableExec));
+    assert_param(IS_MPU_REGION_PERMISSION_ATTRIBUTE(MPU_Init->AccessPermission));
+    assert_param(IS_MPU_TEX_LEVEL(MPU_Init->TypeExtField));
+    assert_param(IS_MPU_ACCESS_SHAREABLE(MPU_Init->IsShareable));
+    assert_param(IS_MPU_ACCESS_CACHEABLE(MPU_Init->IsCacheable));
+    assert_param(IS_MPU_ACCESS_BUFFERABLE(MPU_Init->IsBufferable));
+    assert_param(IS_MPU_SUB_REGION_DISABLE(MPU_Init->SubRegionDisable));
+    assert_param(IS_MPU_REGION_SIZE(MPU_Init->Size));
+
+    MPU->RBAR = MPU_Init->BaseAddress;
+    MPU->RASR = ((uint32_t)MPU_Init->DisableExec        << MPU_RASR_XN_Pos)   |
+                ((uint32_t)MPU_Init->AccessPermission   << MPU_RASR_AP_Pos)   |
+                ((uint32_t)MPU_Init->TypeExtField       << MPU_RASR_TEX_Pos)  |
+                ((uint32_t)MPU_Init->IsShareable        << MPU_RASR_S_Pos)    |
+                ((uint32_t)MPU_Init->IsCacheable        << MPU_RASR_C_Pos)    |
+                ((uint32_t)MPU_Init->IsBufferable       << MPU_RASR_B_Pos)    |
+                ((uint32_t)MPU_Init->SubRegionDisable   << MPU_RASR_SRD_Pos)  |
+                ((uint32_t)MPU_Init->Size               << MPU_RASR_SIZE_Pos) |
+                ((uint32_t)MPU_Init->Enable             << MPU_RASR_ENABLE_Pos);
+  }
+  else
+  {
+    MPU->RBAR = 0x00;
+    MPU->RASR = 0x00;
+  }
+}
+#endif /* __MPU_PRESENT */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_dac.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_dac.c
@@ -1,0 +1,1183 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_dac.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   DAC HAL module driver.
+  *         This file provides firmware functions to manage the following 
+  *         functionalities of the Digital to Analog Converter (DAC) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State and Errors functions      
+  *     
+  *
+  @verbatim      
+  ==============================================================================
+                      ##### DAC Peripheral features #####
+  ==============================================================================
+    [..]        
+      *** DAC Channels ***
+      ====================  
+    [..]  
+    STM32L4 devices integrate two 12-bit Digital Analog Converters
+
+    The 2 converters (i.e. channel1 & channel2)
+    can be used independently or simultaneously (dual mode):
+      (#) DAC channel1 with DAC_OUT1 (PA4) as output or connected to on-chip 
+          peripherals (ex. OPAMPs, comparators).
+      (#) DAC channel2 with DAC_OUT2 (PA5) as output or connected to on-chip 
+          peripherals (ex. OPAMPs, comparators).
+      
+      *** DAC Triggers ***
+      ====================
+    [..]
+    Digital to Analog conversion can be non-triggered using DAC_TRIGGER_NONE
+    and DAC_OUT1/DAC_OUT2 is available once writing to DHRx register. 
+    [..] 
+    Digital to Analog conversion can be triggered by:
+      (#) External event: EXTI Line 9 (any GPIOx_PIN_9) using DAC_TRIGGER_EXT_IT9.
+          The used pin (GPIOx_PIN_9) must be configured in input mode.
+  
+      (#) Timers TRGO: TIM2, TIM3, TIM4, TIM5, TIM6 and TIM7 
+          (DAC_TRIGGER_T2_TRGO, DAC_TRIGGER_T3_TRGO...)
+  
+      (#) Software using DAC_TRIGGER_SOFTWARE
+  
+      *** DAC Buffer mode feature ***
+      =============================== 
+      [..] 
+      Each DAC channel integrates an output buffer that can be used to 
+      reduce the output impedance, and to drive external loads directly
+      without having to add an external operational amplifier.
+      To enable, the output buffer use  
+      sConfig.DAC_OutputBuffer = DAC_OUTPUTBUFFER_ENABLE;
+      [..]           
+      (@) Refer to the device datasheet for more details about output 
+          impedance value with and without output buffer.
+
+      *** DAC connect feature ***
+      =============================== 
+      [..] 
+      Each DAC channel can be connected internally. 
+      To connect, use
+      sConfig.DAC_ConnectOnChipPeripheral = DAC_CHIPCONNECT_ENABLE;
+                                               
+      *** GPIO configurations guidelines ***
+      =====================
+      [..] 
+      When a DAC channel is used (ex channel1 on PA4) and the other is not 
+      (ex channel2 on PA5 is configured in Analog and disabled).
+      Channel1 may disturb channel2 as coupling effect.
+      Note that there is no coupling on channel2 as soon as channel2 is turned on.
+      Coupling on adjacent channel could be avoided as follows:
+      when unused PA5 is configured as INPUT PULL-UP or DOWN. 
+      PA5 is configured in ANALOG just before it is turned on.     
+                                               
+      *** DAC Sample and Hold feature ***
+      ========================
+      [..] 
+      For each converter, 2 modes are supported: normal mode and 
+      "sample and hold" mode (i.e. low power mode).
+      In the sample and hold mode, the DAC core converts data, then holds the 
+      converted voltage on a capacitor. When not converting, the DAC cores and 
+      buffer are completely turned off between samples and the DAC output is 
+      tri-stated, therefore  reducing the overall power consumption. A new 
+      stabilization period is needed before each new conversion.
+
+      The sample and hold allow setting internal or external voltage @
+      low power consumption cost (output value can be at any given rate either 
+      by CPU or DMA).
+
+      The Sample and hold block and registers uses either LSI & run in 
+      several power modes: run mode, sleep mode, low power run, low power sleep 
+      mode & stop1 mode.
+          
+      Low power stop1 mode allows only static conversion.
+          
+      To enable Sample and Hold mode 
+      Enable LSI using HAL_RCC_OscConfig with RCC_OSCILLATORTYPE_LSI &
+      RCC_LSI_ON parameters.
+
+      Use DAC_InitStructure.DAC_SampleAndHold = DAC_SAMPLEANDHOLD_ENABLE;
+         & DAC_ChannelConfTypeDef.DAC_SampleAndHoldConfig.DAC_SampleTime,
+           DAC_HoldTime & DAC_RefreshTime;
+    
+
+
+       *** DAC calibration feature ***
+       =================================== 
+      [..] 
+       (#)  The 2 converters (channel1 & channel2) provide calibration capabilities.  
+       (++) Calibration aims at correcting some offset of output buffer.
+       (++) The DAC uses either factory calibration settings OR user defined 
+           calibration (trimming) settings (i.e. trimming mode).
+       (++) The user defined settings can be figured out using self calibration 
+           handled by HAL_DACEx_SelfCalibrate.
+       (++) HAL_DACEx_SelfCalibrate:
+       (+++) Runs automatically the calibration.
+       (+++) Enables the user trimming mode
+       (+++) Updates a structure with trimming values with fresh calibration 
+            results. 
+            The user may store the calibration results for larger 
+            (ex monitoring the trimming as a function of temperature 
+            for instance)
+
+       *** DAC wave generation feature ***
+       =================================== 
+       [..]     
+       Both DAC channels can be used to generate
+         (#) Noise wave 
+         (#) Triangle wave
+            
+       *** DAC data format ***
+       =======================
+       [..]   
+       The DAC data format can be:
+         (#) 8-bit right alignment using DAC_ALIGN_8B_R
+         (#) 12-bit left alignment using DAC_ALIGN_12B_L
+         (#) 12-bit right alignment using DAC_ALIGN_12B_R
+  
+       *** DAC data value to voltage correspondence ***  
+       ================================================ 
+       [..] 
+       The analog output voltage on each DAC channel pin is determined
+       by the following equation:
+       [..]
+       DAC_OUTx = VREF+ * DOR / 4095
+       (+) with  DOR is the Data Output Register
+       [..]
+          VEF+ is the input voltage reference (refer to the device datasheet)
+       [..]
+        e.g. To set DAC_OUT1 to 0.7V, use
+       (+) Assuming that VREF+ = 3.3V, DAC_OUT1 = (3.3 * 868) / 4095 = 0.7V
+  
+       *** DMA requests ***
+       =====================
+       [..]
+       A DMA1 request can be generated when an external trigger (but not a software trigger) 
+       occurs if DMA1 requests are enabled using HAL_DAC_Start_DMA(). 
+       DMA requests are mapped as following:          
+      (#) DAC channel1: mapped either on
+      (++) DMA1 request 6 channel3 
+      (++) or DMA2 request channel4 which must be already configured
+      (#) DAC channel2: mapped either on
+      (++) DMA1 request 5 channel4 
+      (++) or DMA2 request 3 channel5 which must be already configured 
+     [..]
+    (@) For Dual mode and specific signal (Triangle and noise) generation please 
+        refer to Extended Features Driver description        
+      
+                      ##### How to use this driver #####
+  ==============================================================================
+    [..]          
+      (+) DAC APB clock must be enabled to get write access to DAC
+          registers using HAL_DAC_Init()
+      (+) Configure DAC_OUTx (DAC_OUT1: PA4, DAC_OUT2: PA5) in analog mode.
+      (+) Configure the DAC channel using HAL_DAC_ConfigChannel() function.
+      (+) Enable the DAC channel using HAL_DAC_Start() or HAL_DAC_Start_DMA() functions.
+
+     *** Calibration mode IO operation ***
+     ======================================
+     [..]    
+       (+) Retrieve the factory trimming (calibration settings) using HAL_DACEx_GetTrimOffset()
+       (+) Run the calibration using HAL_DACEx_SelfCalibrate() 
+       (+) Update the trimming while DAC running using HAL_DACEx_SetUserTrimming()
+
+     *** Polling mode IO operation ***
+     =================================
+     [..]    
+       (+) Start the DAC peripheral using HAL_DAC_Start() 
+       (+) To read the DAC last data output value, use the HAL_DAC_GetValue() function.
+       (+) Stop the DAC peripheral using HAL_DAC_Stop()
+       
+     *** DMA mode IO operation ***    
+     ==============================
+     [..]    
+       (+) Start the DAC peripheral using HAL_DAC_Start_DMA(), at this stage the user specify the length 
+           of data to be transferred at each end of conversion
+       (+) At the middle of data transfer HAL_DAC_ConvHalfCpltCallbackCh1() or HAL_DACEx_ConvHalfCpltCallbackCh2()  
+           function is executed and user can add his own code by customization of function pointer 
+           HAL_DAC_ConvHalfCpltCallbackCh1() or HAL_DACEx_ConvHalfCpltCallbackCh2()
+       (+) At The end of data transfer HAL_DAC_ConvCpltCallbackCh1() or HAL_DACEx_ConvHalfCpltCallbackCh2()  
+           function is executed and user can add his own code by customization of function pointer 
+           HAL_DAC_ConvCpltCallbackCh1() or HAL_DACEx_ConvHalfCpltCallbackCh2()
+       (+) In case of transfer Error, HAL_DAC_ErrorCallbackCh1() function is executed and user can 
+            add his own code by customization of function pointer HAL_DAC_ErrorCallbackCh1
+       (+) In case of DMA underrun, DAC interruption triggers and execute internal function HAL_DAC_IRQHandler.
+           HAL_DAC_DMAUnderrunCallbackCh1() or HAL_DACEx_DMAUnderrunCallbackCh2()  
+           function is executed and user can add his own code by customization of function pointer 
+           HAL_DAC_DMAUnderrunCallbackCh1() or HAL_DACEx_DMAUnderrunCallbackCh2() and
+           add his own code by customization of function pointer HAL_DAC_ErrorCallbackCh1()
+       (+) Stop the DAC peripheral using HAL_DAC_Stop_DMA()
+                    
+     *** DAC HAL driver macros list ***
+     ============================================= 
+     [..]
+       Below the list of most used macros in DAC HAL driver.
+       
+      (+) __HAL_DAC_ENABLE : Enable the DAC peripheral
+      (+) __HAL_DAC_DISABLE : Disable the DAC peripheral
+      (+) __HAL_DAC_CLEAR_FLAG: Clear the DAC's pending flags
+      (+) __HAL_DAC_GET_FLAG: Get the selected DAC's flag status
+      
+     [..]
+      (@) You can refer to the DAC HAL driver header file for more useful macros  
+   
+ @endverbatim    
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+  /** @defgroup DAC DAC
+  * @brief DAC driver modules  
+  * @{
+  */ 
+
+#ifdef HAL_DAC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @addtogroup DAC_Private_Constants DAC Private Constants
+  * @{
+  */
+#define TIMEOUT_DAC_CALIBCONFIG    ((uint32_t)1)  /* 1ms                  */
+/**
+  * @}
+  */ 
+
+/* Private macro -------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @defgroup DAC_Private_Functions DAC Private Functions
+  * @{
+  */
+static void DAC_DMAConvCpltCh1(DMA_HandleTypeDef *hdma);
+static void DAC_DMAErrorCh1(DMA_HandleTypeDef *hdma);
+static void DAC_DMAHalfConvCpltCh1(DMA_HandleTypeDef *hdma); 
+/**
+  * @}
+  */
+/* Exported functions -------------------------------------------------------*/
+
+/** @defgroup DAC_Exported_Functions DAC Exported Functions
+  * @{
+  */
+
+/** @defgroup DAC_Exported_Functions_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+  ==============================================================================
+              ##### Initialization and de-initialization functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the DAC. 
+      (+) De-initialize the DAC. 
+         
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initialize the DAC peripheral according to the specified parameters
+  *         in the DAC_InitStruct and initialize the associated handle.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Init(DAC_HandleTypeDef* hdac)
+{ 
+  /* Check DAC handle */
+  if(hdac == NULL)
+  {
+     return HAL_ERROR;
+  }
+  /* Check the parameters */
+  assert_param(IS_DAC_ALL_INSTANCE(hdac->Instance));
+  
+  if(hdac->State == HAL_DAC_STATE_RESET)
+  {  
+    /* Allocate lock resource and initialize it */
+    hdac->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware */
+    HAL_DAC_MspInit(hdac);
+  }
+  
+  /* Initialize the DAC state*/
+  hdac->State = HAL_DAC_STATE_BUSY;
+  
+  /* Set DAC error code to none */
+  hdac->ErrorCode = HAL_DAC_ERROR_NONE;
+  
+  /* Initialize the DAC state*/
+  hdac->State = HAL_DAC_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deinitialize the DAC peripheral registers to their default reset values.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_DeInit(DAC_HandleTypeDef* hdac)
+{
+  /* Check DAC handle */
+  if(hdac == NULL)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_DAC_ALL_INSTANCE(hdac->Instance));
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* DeInit the low level hardware */
+  HAL_DAC_MspDeInit(hdac);
+
+  /* Set DAC error code to none */
+  hdac->ErrorCode = HAL_DAC_ERROR_NONE;
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initialize the DAC MSP.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_MspInit(DAC_HandleTypeDef* hdac)
+{ 
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DAC_MspInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  DeInitialize the DAC MSP.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.  
+  * @retval None
+  */
+__weak void HAL_DAC_MspDeInit(DAC_HandleTypeDef* hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DAC_MspDeInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Exported_Functions_Group2 IO operation functions
+ *  @brief    IO operation functions 
+ *
+@verbatim   
+  ==============================================================================
+             ##### IO operation functions #####
+  ==============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Start conversion.
+      (+) Stop conversion.
+      (+) Start conversion and enable DMA transfer.
+      (+) Stop conversion and disable DMA transfer.
+      (+) Get result of conversion.
+                     
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enables DAC and starts conversion of channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef* hdac, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  
+  /* Process locked */
+  __HAL_LOCK(hdac);
+  
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+  
+  /* Enable the Peripheral */
+  __HAL_DAC_ENABLE(hdac, Channel);
+
+  if(Channel == DAC_CHANNEL_1)
+  {
+    /* Check if software trigger enabled */
+    if((hdac->Instance->CR & (DAC_CR_TEN1 | DAC_CR_TSEL1)) == (DAC_CR_TEN1 | DAC_CR_TSEL1))
+    {
+      /* Enable the selected DAC software conversion */
+      SET_BIT(hdac->Instance->SWTRIGR, DAC_SWTRIGR_SWTRIG1);
+    }
+  }
+  else
+  {
+    /* Check if software trigger enabled */
+    if((hdac->Instance->CR & (DAC_CR_TEN2 | DAC_CR_TSEL2)) == (DAC_CR_TEN2 | DAC_CR_TSEL2))
+    {
+      /* Enable the selected DAC software conversion*/
+      SET_BIT(hdac->Instance->SWTRIGR, DAC_SWTRIGR_SWTRIG2);
+    }
+  }
+  
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+    
+  /* Return function status */
+  return HAL_OK;
+}
+  
+/**
+  * @brief  Disables DAC and stop conversion of channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Stop(DAC_HandleTypeDef* hdac, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  
+  /* Disable the Peripheral */
+  __HAL_DAC_DISABLE(hdac, Channel);
+  
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables DAC and starts conversion of channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @param  pData: The destination peripheral Buffer address.
+  * @param  Length: The length of data to be transferred from memory to DAC peripheral
+  * @param  Alignment: Specifies the data alignment for DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_ALIGN_8B_R: 8bit right data alignment selected
+  *            @arg DAC_ALIGN_12B_L: 12bit left data alignment selected
+  *            @arg DAC_ALIGN_12B_R: 12bit right data alignment selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Start_DMA(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t* pData, uint32_t Length, uint32_t Alignment)
+{
+  uint32_t tmpreg = 0;
+    
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_ALIGN(Alignment));
+  
+  /* Process locked */
+  __HAL_LOCK(hdac);
+  
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+  
+  if(Channel == DAC_CHANNEL_1)
+  {
+    /* Set the DMA transfer complete callback for channel1 */
+    hdac->DMA_Handle1->XferCpltCallback = DAC_DMAConvCpltCh1;
+    
+    /* Set the DMA half transfer complete callback for channel1 */
+    hdac->DMA_Handle1->XferHalfCpltCallback = DAC_DMAHalfConvCpltCh1;
+       
+    /* Set the DMA error callback for channel1 */
+    hdac->DMA_Handle1->XferErrorCallback = DAC_DMAErrorCh1;
+    
+    /* Enable the selected DAC channel1 DMA request */
+    SET_BIT(hdac->Instance->CR, DAC_CR_DMAEN1);
+    
+    /* Case of use of channel 1 */
+    switch(Alignment)
+    {
+      case DAC_ALIGN_12B_R:
+        /* Get DHR12R1 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR12R1;
+        break;
+      case DAC_ALIGN_12B_L:
+        /* Get DHR12L1 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR12L1;
+        break;
+      case DAC_ALIGN_8B_R:
+        /* Get DHR8R1 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR8R1;
+        break;
+      default:
+        break;
+    }
+  }
+  else
+  {
+    /* Set the DMA transfer complete callback for channel2 */
+    hdac->DMA_Handle2->XferCpltCallback = DAC_DMAConvCpltCh2;
+    
+    /* Set the DMA half transfer complete callback for channel2 */
+    hdac->DMA_Handle2->XferHalfCpltCallback = DAC_DMAHalfConvCpltCh2;
+       
+    /* Set the DMA error callback for channel2 */
+    hdac->DMA_Handle2->XferErrorCallback = DAC_DMAErrorCh2;
+    
+    /* Enable the selected DAC channel2 DMA request */
+    SET_BIT(hdac->Instance->CR, DAC_CR_DMAEN2);
+    
+    /* Case of use of channel 2 */
+    switch(Alignment)
+    {
+      case DAC_ALIGN_12B_R:
+        /* Get DHR12R2 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR12R2;
+        break;
+      case DAC_ALIGN_12B_L:
+        /* Get DHR12L2 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR12L2;
+        break;
+      case DAC_ALIGN_8B_R:
+        /* Get DHR8R2 address */
+        tmpreg = (uint32_t)&hdac->Instance->DHR8R2;
+        break;
+      default:
+        break;
+    }
+  }
+  
+  /* Enable the DMA channel */
+  if(Channel == DAC_CHANNEL_1)
+  {
+    /* Enable the DAC DMA underrun interrupt */
+    __HAL_DAC_ENABLE_IT(hdac, DAC_IT_DMAUDR1);
+    
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hdac->DMA_Handle1, (uint32_t)pData, tmpreg, Length);
+  } 
+  else
+  {
+    /* Enable the DAC DMA underrun interrupt */
+    __HAL_DAC_ENABLE_IT(hdac, DAC_IT_DMAUDR2);
+    
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hdac->DMA_Handle2, (uint32_t)pData, tmpreg, Length);
+  }
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Enable the Peripheral */
+  __HAL_DAC_ENABLE(hdac, Channel);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+ 
+/**
+  * @brief  Disables DAC and stop conversion of channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Stop_DMA(DAC_HandleTypeDef* hdac, uint32_t Channel)
+{
+   HAL_StatusTypeDef status = HAL_OK;
+    
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  
+  /* Disable the selected DAC channel DMA request */
+    hdac->Instance->CR &= ~(DAC_CR_DMAEN1 << Channel);
+    
+  /* Disable the Peripheral */
+  __HAL_DAC_DISABLE(hdac, Channel);
+  
+  /* Disable the DMA channel */
+  /* Channel1 is used */
+  if (Channel == DAC_CHANNEL_1)
+  {
+    /* Disable the DMA channel */
+    status = HAL_DMA_Abort(hdac->DMA_Handle1);
+    
+    /* Disable the DAC DMA underrun interrupt */
+    __HAL_DAC_DISABLE_IT(hdac, DAC_IT_DMAUDR1);
+  }
+  else /* Channel2 is used for */
+  {
+    /* Disable the DMA channel */
+    status = HAL_DMA_Abort(hdac->DMA_Handle2);
+    
+    /* Disable the DAC DMA underrun interrupt */
+    __HAL_DAC_DISABLE_IT(hdac, DAC_IT_DMAUDR2);
+  }
+  
+  /* Check if DMA Channel effectively disabled */
+  if (status != HAL_OK)
+  {
+    /* Update DAC state machine to error */
+    hdac->State = HAL_DAC_STATE_ERROR;
+  }
+  else
+  {
+    /* Change DAC state */
+    hdac->State = HAL_DAC_STATE_READY;
+  }
+  
+  /* Return function status */
+  return status;
+}
+
+/* DAC channel 2 is available on top of DAC channel 1 */
+
+/**
+  * @brief  Handles DAC interrupt request
+  *         This function uses the interruption of DMA
+  *         underrun.  
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+void HAL_DAC_IRQHandler(DAC_HandleTypeDef* hdac)
+{
+  if(__HAL_DAC_GET_IT_SOURCE(hdac, DAC_IT_DMAUDR1))
+  { 
+    /* Check underrun flag of DAC channel 1 */
+    if(__HAL_DAC_GET_FLAG(hdac, DAC_FLAG_DMAUDR1))
+    {
+      /* Change DAC state to error state */
+      hdac->State = HAL_DAC_STATE_ERROR;
+      
+      /* Set DAC error code to chanel1 DMA underrun error */
+      SET_BIT(hdac->ErrorCode, HAL_DAC_ERROR_DMAUNDERRUNCH1);
+      
+      /* Clear the underrun flag */
+      __HAL_DAC_CLEAR_FLAG(hdac,DAC_FLAG_DMAUDR1);
+      
+      /* Disable the selected DAC channel1 DMA request */
+      CLEAR_BIT(hdac->Instance->CR, DAC_CR_DMAEN1);
+      
+      /* Error callback */ 
+      HAL_DAC_DMAUnderrunCallbackCh1(hdac);
+    }
+  }
+  if(__HAL_DAC_GET_IT_SOURCE(hdac, DAC_IT_DMAUDR2))
+  {
+    /* Check underrun flag of DAC channel 1 */
+    if(__HAL_DAC_GET_FLAG(hdac, DAC_FLAG_DMAUDR2))
+    {
+      /* Change DAC state to error state */
+      hdac->State = HAL_DAC_STATE_ERROR;
+      
+      /* Set DAC error code to channel2 DMA underrun error */
+      SET_BIT(hdac->ErrorCode, HAL_DAC_ERROR_DMAUNDERRUNCH2);
+      
+      /* Clear the underrun flag */
+      __HAL_DAC_CLEAR_FLAG(hdac,DAC_FLAG_DMAUDR2);
+      
+      /* Disable the selected DAC channel1 DMA request */
+      CLEAR_BIT(hdac->Instance->CR, DAC_CR_DMAEN2);
+      
+      /* Error callback */ 
+      HAL_DACEx_DMAUnderrunCallbackCh2(hdac);
+    }
+  }
+}
+
+/**
+  * @brief  Set the specified data holding register value for DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected  
+  * @param  Alignment: Specifies the data alignment.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_ALIGN_8B_R: 8bit right data alignment selected
+  *            @arg DAC_ALIGN_12B_L: 12bit left data alignment selected
+  *            @arg DAC_ALIGN_12B_R: 12bit right data alignment selected
+  * @param  Data: Data to be loaded in the selected data holding register.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t Alignment, uint32_t Data)
+{  
+  __IO uint32_t tmp = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_ALIGN(Alignment));
+  assert_param(IS_DAC_DATA(Data));
+  
+  tmp = (uint32_t)hdac->Instance; 
+  if(Channel == DAC_CHANNEL_1)
+  {
+    tmp += DAC_DHR12R1_ALIGNMENT(Alignment);
+  }
+  else
+  {
+    tmp += DAC_DHR12R2_ALIGNMENT(Alignment);
+  }
+
+  /* Set the DAC channel selected data holding register */
+  *(__IO uint32_t *) tmp = Data;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Conversion complete callback in non-blocking mode for Channel1 
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_ConvCpltCallbackCh1(DAC_HandleTypeDef* hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DAC_ConvCpltCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Conversion half DMA transfer callback in non-blocking mode for Channel1 
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_ConvHalfCpltCallbackCh1(DAC_HandleTypeDef* hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DAC_ConvHalfCpltCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error DAC callback for Channel1.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_ErrorCallbackCh1(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DAC_ErrorCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DMA underrun DAC callback for channel1.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_DMAUnderrunCallbackCh1(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DAC_DMAUnderrunCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+  
+/** @defgroup DAC_Exported_Functions_Group3 Peripheral Control functions
+ *  @brief    Peripheral Control functions 
+ *
+@verbatim   
+  ==============================================================================
+             ##### Peripheral Control functions #####
+  ==============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Configure channels. 
+      (+) Set the specified data holding register value for DAC channel.
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the last data output value of the selected DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval The selected DAC channel data output value.
+  */
+uint32_t HAL_DAC_GetValue(DAC_HandleTypeDef* hdac, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  
+  /* Returns the DAC channel data output register value */
+  if(Channel == DAC_CHANNEL_1)
+  {
+    return hdac->Instance->DOR1;
+  }
+  else
+  {
+    return hdac->Instance->DOR2;
+  }
+}
+
+/**
+  * @brief  Configures the selected DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  sConfig: DAC configuration structure.
+  * @param  Channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_ConfigChannel(DAC_HandleTypeDef* hdac, DAC_ChannelConfTypeDef* sConfig, uint32_t Channel)
+{
+  uint32_t tmpreg1 = 0, tmpreg2 = 0;
+  uint32_t tickstart = 0;
+   
+  /* Check the DAC parameters */
+  assert_param(IS_DAC_TRIGGER(sConfig->DAC_Trigger));
+  assert_param(IS_DAC_OUTPUT_BUFFER_STATE(sConfig->DAC_OutputBuffer));
+  assert_param(IS_DAC_CHIP_CONNECTION(sConfig->DAC_ConnectOnChipPeripheral));
+  assert_param(IS_DAC_TRIMMING(sConfig->DAC_UserTrimming));
+  if ((sConfig->DAC_UserTrimming) == DAC_TRIMMING_USER)
+  {
+    assert_param(IS_DAC_TRIMMINGVALUE(sConfig->DAC_TrimmingValue));               
+  }
+  assert_param(IS_DAC_SAMPLEANDHOLD(sConfig->DAC_SampleAndHold));
+  if ((sConfig->DAC_SampleAndHold) == DAC_SAMPLEANDHOLD_ENABLE)
+  {
+    assert_param(IS_DAC_SAMPLETIME(sConfig->DAC_SampleAndHoldConfig.DAC_SampleTime));
+    assert_param(IS_DAC_HOLDTIME(sConfig->DAC_SampleAndHoldConfig.DAC_HoldTime));
+    assert_param(IS_DAC_REFRESHTIME(sConfig->DAC_SampleAndHoldConfig.DAC_RefreshTime)); 
+  }
+  assert_param(IS_DAC_CHANNEL(Channel));
+ 
+  /* Process locked */
+  __HAL_LOCK(hdac);
+  
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+  
+  if(sConfig->DAC_SampleAndHold == DAC_SAMPLEANDHOLD_ENABLE)
+  /* Sample on old configuration */ 
+  {
+    /* SampleTime */
+    if (Channel == DAC_CHANNEL_1)
+    {
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /* SHSR1 can be written when BWST1  equals RESET */
+      while (((hdac->Instance->SR) & DAC_SR_BWST1)!= RESET)
+      {
+        /* Check for the Timeout */
+        if((HAL_GetTick() - tickstart) > TIMEOUT_DAC_CALIBCONFIG)
+        {
+          /* Update error code */
+          SET_BIT(hdac->ErrorCode, HAL_DAC_ERROR_TIMEOUT);
+
+          /* Change the DMA state */
+          hdac->State = HAL_DAC_STATE_TIMEOUT;
+
+          return HAL_TIMEOUT;
+        }
+      }
+      HAL_Delay(1);
+      hdac->Instance->SHSR1 = sConfig->DAC_SampleAndHoldConfig.DAC_SampleTime;
+    }
+    else /* Channel 2 */
+    {
+      /* SHSR2 can be written when BWST2 equals RESET */
+
+      while (((hdac->Instance->SR) & DAC_SR_BWST2)!= RESET)
+      {
+        /* Check for the Timeout */
+        if((HAL_GetTick() - tickstart) > TIMEOUT_DAC_CALIBCONFIG)
+        {
+          /* Update error code */
+          SET_BIT(hdac->ErrorCode, HAL_DAC_ERROR_TIMEOUT);
+
+          /* Change the DMA state */
+          hdac->State = HAL_DAC_STATE_TIMEOUT;
+
+          return HAL_TIMEOUT;
+        }
+      }
+      HAL_Delay(1);
+      hdac->Instance->SHSR2 = sConfig->DAC_SampleAndHoldConfig.DAC_SampleTime;
+    }
+    /* HoldTime */
+    hdac->Instance->SHHR = (sConfig->DAC_SampleAndHoldConfig.DAC_HoldTime)<<Channel;
+    /* RefreshTime */
+    hdac->Instance->SHRR = (sConfig->DAC_SampleAndHoldConfig.DAC_RefreshTime)<<Channel;
+  }
+    
+  if(sConfig->DAC_UserTrimming == DAC_TRIMMING_USER)
+  /* USER TRIMMING */
+  {
+  /* Get the DAC CCR value */
+  tmpreg1 = hdac->Instance->CCR;
+  /* Clear trimming value */
+  tmpreg1 &= ~(((uint32_t)(DAC_CCR_OTRIM1)) << Channel);
+  /* Configure for the selected trimming offset */
+  tmpreg2 = sConfig->DAC_TrimmingValue;
+  /* Calculate CCR register value depending on DAC_Channel */
+  tmpreg1 |= tmpreg2 << Channel;
+  /* Write to DAC CCR */
+  hdac->Instance->CCR = tmpreg1;
+  }
+  /* else factory trimming is used (factory setting are available at reset)*/
+  /* SW Nothing has nothing to do */
+  
+  /* Get the DAC MCR value */
+  tmpreg1 = hdac->Instance->MCR;
+  /* Clear DAC_MCR_MODE2_0, DAC_MCR_MODE2_1 and DAC_MCR_MODE2_2 bits */
+  tmpreg1 &= ~(((uint32_t)(DAC_MCR_MODE1)) << Channel); 
+  /* Configure for the selected DAC channel: mode, buffer output & on chip peripheral connect */
+  tmpreg2 = (sConfig->DAC_SampleAndHold | sConfig->DAC_OutputBuffer | sConfig->DAC_ConnectOnChipPeripheral);
+  /* Calculate MCR register value depending on DAC_Channel */
+  tmpreg1 |= tmpreg2 << Channel;
+  /* Write to DAC MCR */
+  hdac->Instance->MCR = tmpreg1;
+  
+  /* DAC in normal operating mode hence clear DAC_CR_CENx bit */
+  CLEAR_BIT (hdac->Instance->CR, DAC_CR_CEN1 << Channel);
+  
+  /* Get the DAC CR value */
+  tmpreg1 = hdac->Instance->CR;
+  /* Clear TENx, TSELx, WAVEx and MAMPx bits */
+  tmpreg1 &= ~(((uint32_t)(DAC_CR_MAMP1 | DAC_CR_WAVE1 | DAC_CR_TSEL1 | DAC_CR_TEN1)) << Channel); 
+  /* Configure for the selected DAC channel: trigger */
+  /* Set TSELx and TENx bits according to DAC_Trigger value */
+  tmpreg2 = (sConfig->DAC_Trigger);
+  /* Calculate CR register value depending on DAC_Channel */
+  tmpreg1 |= tmpreg2 << Channel;
+  /* Write to DAC CR */
+  hdac->Instance->CR = tmpreg1;
+      
+  /* Disable wave generation */
+  hdac->Instance->CR &= ~(DAC_CR_WAVE1 << Channel);
+  
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Exported_Functions_Group4 Peripheral State and Errors functions
+ *  @brief   Peripheral State and Errors functions 
+ *
+@verbatim   
+  ==============================================================================
+            ##### Peripheral State and Errors functions #####
+  ==============================================================================  
+    [..]
+    This subsection provides functions allowing to
+      (+) Check the DAC state.
+      (+) Check the DAC Errors.
+        
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  return the DAC handle state
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL state
+  */
+HAL_DAC_StateTypeDef HAL_DAC_GetState(DAC_HandleTypeDef* hdac)
+{
+  /* Return DAC handle state */
+  return hdac->State;
+}
+
+
+/**
+  * @brief  Return the DAC error code
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval DAC Error Code
+  */
+uint32_t HAL_DAC_GetError(DAC_HandleTypeDef *hdac)
+{
+  return hdac->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  DMA conversion complete callback. 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void DAC_DMAConvCpltCh1(DMA_HandleTypeDef *hdma)   
+{
+  DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  HAL_DAC_ConvCpltCallbackCh1(hdac); 
+  
+  hdac->State= HAL_DAC_STATE_READY;
+}
+
+/**
+  * @brief  DMA half transfer complete callback. 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void DAC_DMAHalfConvCpltCh1(DMA_HandleTypeDef *hdma)   
+{
+    DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+    /* Conversion complete callback */
+    HAL_DAC_ConvHalfCpltCallbackCh1(hdac); 
+}
+
+/**
+  * @brief  DMA error callback 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void DAC_DMAErrorCh1(DMA_HandleTypeDef *hdma)   
+{
+  DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+    
+  /* Set DAC error code to DMA error */
+  hdac->ErrorCode |= HAL_DAC_ERROR_DMA;
+    
+  HAL_DAC_ErrorCallbackCh1(hdac); 
+    
+  hdac->State= HAL_DAC_STATE_READY;
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_dac_ex.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_dac_ex.c
@@ -1,0 +1,620 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_dac_ex.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   DAC HAL module driver.
+  *          This file provides firmware functions to manage the extended 
+  *          functionalities of the DAC peripheral.  
+  *     
+  *
+  @verbatim      
+  ==============================================================================
+                      ##### How to use this driver #####
+  ==============================================================================
+    [..]          
+      (+) When Dual mode is enabled (i.e. DAC Channel1 and Channel2 are used simultaneously) :
+          Use HAL_DACEx_DualGetValue() to get digital data to be converted and use
+          HAL_DACEx_DualSetValue() to set digital value to converted simultaneously in Channel 1 and Channel 2.  
+      (+) Use HAL_DACEx_TriangleWaveGenerate() to generate Triangle signal.
+      (+) Use HAL_DACEx_NoiseWaveGenerate() to generate Noise signal.
+
+      (+) HAL_DACEx_SelfCalibrate to calibrate one DAC channel.
+      (+) HAL_DACEx_SetUserTrimming to set user trimming value.
+      (+) HAL_DACEx_GetTrimOffset to retrieve trimming value (factory setting 
+          after reset, user setting if HAL_DACEx_SetUserTrimming have been used 
+          at least one time after reset).
+
+ @endverbatim    
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup DACEx DACEx
+  * @brief DAC Extended HAL module driver
+  * @{
+  */ 
+
+#ifdef HAL_DAC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+  
+/** @defgroup DACEx_Exported_Functions DACEx Exported Functions
+  * @{
+  */
+
+/** @defgroup DACEx_Exported_Functions_Group2 IO operation functions
+ *  @brief    Extended IO operation functions 
+ *
+@verbatim   
+  ==============================================================================
+                 ##### Extended features functions #####
+  ==============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Start conversion.
+      (+) Stop conversion.
+      (+) Start conversion and enable DMA transfer.
+      (+) Stop conversion and disable DMA transfer.
+      (+) Get result of conversion.
+      (+) Get result of dual mode conversion.
+                     
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enable or disable the selected DAC channel wave generation.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  Channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            DAC_CHANNEL_1 / DAC_CHANNEL_2
+  * @param  Amplitude: Select max triangle amplitude. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_TRIANGLEAMPLITUDE_1: Select max triangle amplitude of 1
+  *            @arg DAC_TRIANGLEAMPLITUDE_3: Select max triangle amplitude of 3
+  *            @arg DAC_TRIANGLEAMPLITUDE_7: Select max triangle amplitude of 7
+  *            @arg DAC_TRIANGLEAMPLITUDE_15: Select max triangle amplitude of 15
+  *            @arg DAC_TRIANGLEAMPLITUDE_31: Select max triangle amplitude of 31
+  *            @arg DAC_TRIANGLEAMPLITUDE_63: Select max triangle amplitude of 63
+  *            @arg DAC_TRIANGLEAMPLITUDE_127: Select max triangle amplitude of 127
+  *            @arg DAC_TRIANGLEAMPLITUDE_255: Select max triangle amplitude of 255
+  *            @arg DAC_TRIANGLEAMPLITUDE_511: Select max triangle amplitude of 511
+  *            @arg DAC_TRIANGLEAMPLITUDE_1023: Select max triangle amplitude of 1023
+  *            @arg DAC_TRIANGLEAMPLITUDE_2047: Select max triangle amplitude of 2047
+  *            @arg DAC_TRIANGLEAMPLITUDE_4095: Select max triangle amplitude of 4095                               
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_TriangleWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t Amplitude)
+{  
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_LFSR_UNMASK_TRIANGLE_AMPLITUDE(Amplitude));
+  
+  /* Process locked */
+  __HAL_LOCK(hdac);
+  
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+  
+  /* Enable the triangle wave generation for the selected DAC channel */
+  MODIFY_REG(hdac->Instance->CR, ((DAC_CR_WAVE1)|(DAC_CR_MAMP1))<<Channel, (DAC_CR_WAVE1_1 | Amplitude) << Channel);
+  
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enable or disable the selected DAC channel wave generation.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC. 
+  * @param  Channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            DAC_CHANNEL_1 / DAC_CHANNEL_2
+  * @param  Amplitude: Unmask DAC channel LFSR for noise wave generation. 
+  *          This parameter can be one of the following values: 
+  *            @arg DAC_LFSRUNMASK_BIT0: Unmask DAC channel LFSR bit0 for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS1_0: Unmask DAC channel LFSR bit[1:0] for noise wave generation  
+  *            @arg DAC_LFSRUNMASK_BITS2_0: Unmask DAC channel LFSR bit[2:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS3_0: Unmask DAC channel LFSR bit[3:0] for noise wave generation 
+  *            @arg DAC_LFSRUNMASK_BITS4_0: Unmask DAC channel LFSR bit[4:0] for noise wave generation 
+  *            @arg DAC_LFSRUNMASK_BITS5_0: Unmask DAC channel LFSR bit[5:0] for noise wave generation 
+  *            @arg DAC_LFSRUNMASK_BITS6_0: Unmask DAC channel LFSR bit[6:0] for noise wave generation 
+  *            @arg DAC_LFSRUNMASK_BITS7_0: Unmask DAC channel LFSR bit[7:0] for noise wave generation 
+  *            @arg DAC_LFSRUNMASK_BITS8_0: Unmask DAC channel LFSR bit[8:0] for noise wave generation 
+  *            @arg DAC_LFSRUNMASK_BITS9_0: Unmask DAC channel LFSR bit[9:0] for noise wave generation 
+  *            @arg DAC_LFSRUNMASK_BITS10_0: Unmask DAC channel LFSR bit[10:0] for noise wave generation 
+  *            @arg DAC_LFSRUNMASK_BITS11_0: Unmask DAC channel LFSR bit[11:0] for noise wave generation 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_NoiseWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t Channel, uint32_t Amplitude)
+{   
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_LFSR_UNMASK_TRIANGLE_AMPLITUDE(Amplitude));
+  
+  /* Process locked */
+  __HAL_LOCK(hdac);
+  
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+     
+  /* Enable the noise wave generation for the selected DAC channel */
+  MODIFY_REG(hdac->Instance->CR, ((DAC_CR_WAVE1)|(DAC_CR_MAMP1))<<Channel, (DAC_CR_WAVE1_0 | Amplitude) << Channel);
+  
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+
+
+/**
+  * @brief  Set the specified data holding register value for dual DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *               the configuration information for the specified DAC.
+  * @param  Alignment: Specifies the data alignment for dual channel DAC.
+  *          This parameter can be one of the following values:
+  *            DAC_ALIGN_8B_R: 8bit right data alignment selected
+  *            DAC_ALIGN_12B_L: 12bit left data alignment selected
+  *            DAC_ALIGN_12B_R: 12bit right data alignment selected
+  * @param  Data1: Data for DAC Channel2 to be loaded in the selected data holding register.
+  * @param  Data2: Data for DAC Channel1 to be loaded in the selected data  holding register.
+  * @note   In dual mode, a unique register access is required to write in both
+  *          DAC channels at the same time.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_DualSetValue(DAC_HandleTypeDef* hdac, uint32_t Alignment, uint32_t Data1, uint32_t Data2)
+{  
+  uint32_t data = 0, tmp = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_DAC_ALIGN(Alignment));
+  assert_param(IS_DAC_DATA(Data1));
+  assert_param(IS_DAC_DATA(Data2));
+  
+  /* Calculate and set dual DAC data holding register value */
+  if (Alignment == DAC_ALIGN_8B_R)
+  {
+    data = ((uint32_t)Data2 << 8) | Data1; 
+  }
+  else
+  {
+    data = ((uint32_t)Data2 << 16) | Data1;
+  }
+  
+  tmp = (uint32_t)hdac->Instance;
+  tmp += DAC_DHR12RD_ALIGNMENT(Alignment);
+
+  /* Set the dual DAC selected data holding register */
+  *(__IO uint32_t *)tmp = data;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Conversion complete callback in non-blocking mode for Channel2.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DACEx_ConvCpltCallbackCh2(DAC_HandleTypeDef* hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DACEx_ConvCpltCallbackCh2 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Conversion half DMA transfer callback in non-blocking mode for Channel2. 
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DACEx_ConvHalfCpltCallbackCh2(DAC_HandleTypeDef* hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DACEx_ConvHalfCpltCallbackCh2 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error DAC callback for Channel2.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DACEx_ErrorCallbackCh2(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DACEx_ErrorCallbackCh2 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DMA underrun DAC callback for Channel2.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DACEx_DMAUnderrunCallbackCh2(DAC_HandleTypeDef *hdac)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdac);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_DACEx_DMAUnderrunCallbackCh2 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Run the self calibration of one DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  sConfig: DAC channel configuration structure.
+  * @param  Channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval Updates DAC_TrimmingValue. , DAC_UserTrimming set to DAC_UserTrimming
+  * @retval HAL status
+  * @note   Calibration runs about 7 ms.
+  */
+
+HAL_StatusTypeDef HAL_DACEx_SelfCalibrate (DAC_HandleTypeDef* hdac, DAC_ChannelConfTypeDef* sConfig, uint32_t Channel)
+{ 
+  HAL_StatusTypeDef status = HAL_OK;
+   
+  __IO uint32_t tmp = 0;
+  uint32_t trimmingvalue = 0;
+  uint32_t delta;
+  
+  /* store/restore channel configuration structure purpose */
+  uint32_t oldmodeconfiguration = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+    
+ /* Check the DAC handle allocation */
+ /* Check if DAC running */
+  if((hdac == NULL) || (hdac->State == HAL_DAC_STATE_BUSY))
+  {
+    status = HAL_ERROR;
+  }
+  
+  /* Process locked */
+  __HAL_LOCK(hdac);
+  
+  /* Store configuration */
+  oldmodeconfiguration = (hdac->Instance->MCR & (DAC_MCR_MODE1 << Channel));
+  
+  /* Disable the selected DAC channel */
+  CLEAR_BIT ((hdac->Instance->CR), (DAC_CR_EN1 << Channel));
+  
+  /* Set mode in MCR  for calibration */
+   MODIFY_REG(hdac->Instance->MCR, (DAC_MCR_MODE1 << Channel), 0);
+   
+  /* Set DAC Channel1 DHR register to the middle value */
+  /* HAL_DAC_SetValue(hdac, Channel, DAC_ALIGN_12B_R, 0x0800); */
+  tmp = (uint32_t)hdac->Instance; 
+  if(Channel == DAC_CHANNEL_1)
+  {
+    tmp += DAC_DHR12R1_ALIGNMENT(DAC_ALIGN_12B_R);
+  }
+  else
+  {
+    tmp += DAC_DHR12R2_ALIGNMENT(DAC_ALIGN_12B_R);
+  }
+  *(__IO uint32_t *) tmp = 0x0800;
+     
+  /* Enable the selected DAC channel calibration */
+  /* i.e. set DAC_CR_CENx bit */
+  SET_BIT ((hdac->Instance->CR), (DAC_CR_CEN1 << Channel));
+  
+  /* Init trimming counter */    
+  /* Medium value */
+  trimmingvalue = 16; 
+  delta = 8;
+  while (delta != 0) 
+    {
+    /* Set candidate trimming */
+    MODIFY_REG(hdac->Instance->CCR, (DAC_CCR_OTRIM1<<Channel), (trimmingvalue<<Channel));
+  
+    /* tOFFTRIMmax delay x ms as per datasheet (electrical characteristics */ 
+    /* i.e. minimum time needed between two calibration steps */
+    HAL_Delay(1);
+  
+    if ((hdac->Instance->SR & (DAC_SR_CAL_FLAG1<<Channel)) == RESET)
+      { 
+        /* DAC_SR_CAL_FLAGx is HIGH try higher trimming */
+        trimmingvalue += delta;
+      }
+      else
+      {
+        /* DAC_SR_CAL_FLAGx is LOW try lower trimming */
+        trimmingvalue -= delta;
+       }                   
+     delta >>= 1;
+    }
+  
+    /* Still need to check if right calibration is current value or one step below */
+    /* Indeed the first value that causes the DAC_SR_CAL_FLAGx bit to change from 0 to 1  */
+    /* Set candidate trimming */
+    MODIFY_REG(hdac->Instance->CCR, (DAC_CCR_OTRIM1<<Channel), (trimmingvalue<<Channel));
+  
+    /* tOFFTRIMmax delay x ms as per datasheet (electrical characteristics */ 
+    /* i.e. minimum time needed between two calibration steps */
+    HAL_Delay(1);
+    
+    if ((hdac->Instance->SR & (DAC_SR_CAL_FLAG1<<Channel)) == RESET)
+      { 
+      /* OPAMP_CSR_OUTCAL is actually one value more */
+      trimmingvalue++;
+      /* Set right trimming */
+        MODIFY_REG(hdac->Instance->CCR, (DAC_CCR_OTRIM1<<Channel), (trimmingvalue<<Channel));
+      }
+    
+  /* Disable the selected DAC channel calibration */
+  /* i.e. clear DAC_CR_CENx bit */
+  CLEAR_BIT ((hdac->Instance->CR), (DAC_CR_CEN1 << Channel));
+  
+  sConfig->DAC_TrimmingValue = trimmingvalue;
+  sConfig->DAC_UserTrimming = DAC_TRIMMING_USER;
+  
+  /* Restore configuration */
+  MODIFY_REG(hdac->Instance->MCR, (DAC_MCR_MODE1 << Channel), oldmodeconfiguration);
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+  
+  return status;
+}
+
+/**
+  * @brief  Set the trimming mode and trimming value (user trimming mode applied).
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  sConfig: DAC configuration structure updated with new DAC trimming value.
+  * @param  Channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @param  NewTrimmingValue: DAC new trimming value
+  * @retval HAL status
+  */
+
+HAL_StatusTypeDef HAL_DACEx_SetUserTrimming (DAC_HandleTypeDef* hdac, DAC_ChannelConfTypeDef* sConfig, uint32_t Channel, uint32_t NewTrimmingValue)
+{ 
+  HAL_StatusTypeDef status = HAL_OK;
+     
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(Channel));
+  assert_param(IS_DAC_NEWTRIMMINGVALUE(NewTrimmingValue));
+  
+ /* Check the DAC handle allocation */
+  if(hdac == NULL)
+  {
+    status = HAL_ERROR;
+  }
+  
+  /* Process locked */
+  __HAL_LOCK(hdac);
+  
+  /* Set new trimming */
+  MODIFY_REG(hdac->Instance->CCR, (DAC_CCR_OTRIM1<<Channel), (NewTrimmingValue<<Channel));
+  
+  /* Update trimming mode */
+  sConfig->DAC_UserTrimming = DAC_TRIMMING_USER;
+  sConfig->DAC_TrimmingValue = NewTrimmingValue;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+    
+  return status;
+}
+
+/**
+  * @brief  Return the DAC trimming value.
+  * @param  hdac : DAC handle
+  * @param  Channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  *            @arg DAC_CHANNEL_2: DAC Channel2 selected
+  * @retval Trimming value : range: 0->31
+  *         
+ */
+
+uint32_t HAL_DACEx_GetTrimOffset (DAC_HandleTypeDef *hdac, uint32_t Channel)
+{
+  uint32_t trimmingvalue = 0;
+  
+  /* Check the DAC handle allocation */
+  /* And not in Reset state */
+  if((hdac == NULL) || (hdac->State == HAL_DAC_STATE_RESET))
+  {
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Check the parameter */
+    assert_param(IS_DAC_CHANNEL(Channel));
+
+    /* Retrieve trimming  */
+    trimmingvalue = ((hdac->Instance->CCR & (DAC_CCR_OTRIM1 << Channel)) >> Channel);
+  }  
+  return trimmingvalue;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DACEx_Exported_Functions_Group3 Peripheral Control functions
+ *  @brief    Extended Peripheral Control functions 
+ *
+@verbatim   
+  ==============================================================================
+             ##### Peripheral Control functions #####
+  ==============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Configure channels. 
+      (+) Set the specified data holding register value for DAC channel.
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the last data output value of the selected DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval The selected DAC channel data output value.
+  */
+uint32_t HAL_DACEx_DualGetValue(DAC_HandleTypeDef* hdac)
+{
+  uint32_t tmp = 0;
+  
+  tmp |= hdac->Instance->DOR1;
+
+  tmp |= hdac->Instance->DOR2 << 16;
+  
+  /* Returns the DAC channel data output register value */
+  return tmp;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup DACEx_Private_Functions DACEx private functions
+ *  @brief    Extended private functions
+   * @{
+  */
+
+/**
+  * @brief  DMA conversion complete callback. 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void DAC_DMAConvCpltCh2(DMA_HandleTypeDef *hdma)   
+{
+  DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  HAL_DACEx_ConvCpltCallbackCh2(hdac); 
+  
+  hdac->State= HAL_DAC_STATE_READY;
+}
+
+/**
+  * @brief  DMA half transfer complete callback. 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void DAC_DMAHalfConvCpltCh2(DMA_HandleTypeDef *hdma)   
+{
+    DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+    /* Conversion complete callback */
+    HAL_DACEx_ConvHalfCpltCallbackCh2(hdac); 
+}
+
+/**
+  * @brief  DMA error callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void DAC_DMAErrorCh2(DMA_HandleTypeDef *hdma)   
+{
+  DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+    
+  /* Set DAC error code to DMA error */
+  hdac->ErrorCode |= HAL_DAC_ERROR_DMA;
+    
+  HAL_DACEx_ErrorCallbackCh2(hdac); 
+    
+  hdac->State= HAL_DAC_STATE_READY;
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_dma.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_dma.c
@@ -1,0 +1,899 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_dma.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   DMA HAL module driver.
+  *    
+  *         This file provides firmware functions to manage the following
+  *         functionalities of the Direct Memory Access (DMA) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral State and errors functions
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+  [..]
+   (#) Enable and configure the peripheral to be connected to the DMA Channel
+       (except for internal SRAM / FLASH memories: no initialization is 
+       necessary). Please refer to the Reference manual for connection between peripherals
+       and DMA requests.
+
+   (#) For a given Channel, program the required configuration through the following parameters:
+       Channel request, Transfer Direction, Source and Destination data formats,
+       Circular or Normal mode, Channel Priority level, Source and Destination Increment mode
+       using HAL_DMA_Init() function.
+
+   (#) Use HAL_DMA_GetState() function to return the DMA state and HAL_DMA_GetError() in case of error 
+       detection.
+                    
+   (#) Use HAL_DMA_Abort() function to abort the current transfer
+                   
+     -@-   In Memory-to-Memory transfer mode, Circular mode is not allowed.
+     *** Polling mode IO operation ***
+     =================================
+    [..]
+          (+) Use HAL_DMA_Start() to start DMA transfer after the configuration of Source
+              address and destination address and the Length of data to be transferred
+          (+) Use HAL_DMA_PollForTransfer() to poll for the end of current transfer, in this
+              case a fixed Timeout can be configured by User depending from his application.
+
+     *** Interrupt mode IO operation ***
+     ===================================
+    [..]
+          (+) Configure the DMA interrupt priority using HAL_NVIC_SetPriority()
+          (+) Enable the DMA IRQ handler using HAL_NVIC_EnableIRQ()
+          (+) Use HAL_DMA_Start_IT() to start DMA transfer after the configuration of
+              Source address and destination address and the Length of data to be transferred.
+              In this case the DMA interrupt is configured
+          (+) Use HAL_DMA_IRQHandler() called under DMA_IRQHandler() Interrupt subroutine
+          (+) At the end of data transfer HAL_DMA_IRQHandler() function is executed and user can
+              add his own function by customization of function pointer XferCpltCallback and
+              XferErrorCallback (i.e. a member of DMA handle structure).
+
+     *** DMA HAL driver macros list ***
+     ============================================= 
+      [..]
+       Below the list of most used macros in DMA HAL driver.
+
+       (+) __HAL_DMA_ENABLE: Enable the specified DMA Channel.
+       (+) __HAL_DMA_DISABLE: Disable the specified DMA Channel.
+       (+) __HAL_DMA_GET_FLAG: Get the DMA Channel pending flags.
+       (+) __HAL_DMA_CLEAR_FLAG: Clear the DMA Channel pending flags.
+       (+) __HAL_DMA_ENABLE_IT: Enable the specified DMA Channel interrupts.
+       (+) __HAL_DMA_DISABLE_IT: Disable the specified DMA Channel interrupts.
+       (+) __HAL_DMA_GET_IT_SOURCE: Check whether the specified DMA Channel interrupt has occurred or not. 
+
+     [..] 
+      (@) You can refer to the DMA HAL driver header file for more useful macros  
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup DMA DMA
+  * @brief DMA HAL module driver
+  * @{
+  */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @defgroup DMA_Private_Constants DMA Private Constants
+  * @{
+  */
+#define HAL_TIMEOUT_DMA_ABORT    ((uint32_t)1000)  /* 1s  */
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @defgroup DMA_Private_Functions DMA Private Functions
+  * @{
+  */
+static void DMA_SetConfig(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
+/**
+  * @}
+  */
+
+/* Exported functions ---------------------------------------------------------*/
+
+/** @defgroup DMA_Exported_Functions DMA Exported Functions
+  * @{
+  */
+
+/** @defgroup DMA_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief   Initialization and de-initialization functions 
+ *
+@verbatim
+ ===============================================================================
+             ##### Initialization and de-initialization functions  #####
+ ===============================================================================
+    [..]
+    This section provides functions allowing to initialize the DMA Channel source
+    and destination addresses, incrementation and data sizes, transfer direction, 
+    circular/normal mode selection, memory-to-memory mode selection and Channel priority value.
+    [..]
+    The HAL_DMA_Init() function follows the DMA configuration procedures as described in
+    reference manual.  
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initialize the DMA according to the specified
+  *         parameters in the DMA_InitTypeDef and initialize the associated handle.
+  * @param  hdma: Pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Channel.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
+{
+  uint32_t tmp = 0;
+
+  /* Check the DMA handle allocation */
+  if(hdma == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_DMA_ALL_INSTANCE(hdma->Instance));
+  assert_param(IS_DMA_DIRECTION(hdma->Init.Direction));
+  assert_param(IS_DMA_PERIPHERAL_INC_STATE(hdma->Init.PeriphInc));
+  assert_param(IS_DMA_MEMORY_INC_STATE(hdma->Init.MemInc));
+  assert_param(IS_DMA_PERIPHERAL_DATA_SIZE(hdma->Init.PeriphDataAlignment));
+  assert_param(IS_DMA_MEMORY_DATA_SIZE(hdma->Init.MemDataAlignment));
+  assert_param(IS_DMA_MODE(hdma->Init.Mode));
+  assert_param(IS_DMA_PRIORITY(hdma->Init.Priority));
+  if(hdma->Init.Direction != DMA_MEMORY_TO_MEMORY)
+  {
+    assert_param(IS_DMA_ALL_REQUEST(hdma->Init.Request));
+  }
+  
+  if(hdma->State == HAL_DMA_STATE_RESET)
+  {  
+    /* Allocate lock resource and initialize it */
+    hdma->Lock = HAL_UNLOCKED;
+  }
+
+  /* Change DMA peripheral state */
+  hdma->State = HAL_DMA_STATE_BUSY;
+
+  /* Get the CR register value */
+  tmp = hdma->Instance->CCR;
+
+  /* Clear PL, MSIZE, PSIZE, MINC, PINC, CIRC, DIR bits */
+  tmp &= ((uint32_t)~(DMA_CCR_PL    | DMA_CCR_MSIZE  | DMA_CCR_PSIZE  | \
+                      DMA_CCR_MINC  | DMA_CCR_PINC   | DMA_CCR_CIRC   | \
+                      DMA_CCR_DIR));
+
+  /* Prepare the DMA Channel configuration */
+  tmp |=  hdma->Init.Direction        |
+          hdma->Init.PeriphInc           | hdma->Init.MemInc           |
+          hdma->Init.PeriphDataAlignment | hdma->Init.MemDataAlignment |
+          hdma->Init.Mode                | hdma->Init.Priority;
+
+  /* Write to DMA Channel CR register */
+  hdma->Instance->CCR = tmp;
+
+  /* Set request selection */
+  if(hdma->Init.Direction != DMA_MEMORY_TO_MEMORY)
+  {
+    /* Write to DMA channel selection register */
+    if (hdma->Instance == DMA1_Channel1)
+    {
+      /*Reset request selection for DMA1 Channel1*/
+      DMA1_CSELR->CSELR &= ~DMA_CSELR_C1S;
+
+      /* Configure request selection for DMA1 Channel1 */
+      DMA1_CSELR->CSELR |= hdma->Init.Request;
+    }
+    else if (hdma->Instance == DMA1_Channel2)
+    {
+      /*Reset request selection for DMA1 Channel2*/
+      DMA1_CSELR->CSELR &= ~DMA_CSELR_C2S;
+
+      /* Configure request selection for DMA1 Channel2 */
+      DMA1_CSELR->CSELR |= (uint32_t)(hdma->Init.Request << 4);
+    }
+    else if (hdma->Instance == DMA1_Channel3)
+    {
+      /*Reset request selection for DMA1 Channel3*/
+      DMA1_CSELR->CSELR &= ~DMA_CSELR_C3S;
+
+      /* Configure request selection for DMA1 Channel3 */
+      DMA1_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 8);
+    }
+    else if (hdma->Instance == DMA1_Channel4)
+    {
+      /*Reset request selection for DMA1 Channel4*/
+      DMA1_CSELR->CSELR &= ~DMA_CSELR_C4S;
+
+      /* Configure request selection for DMA1 Channel4 */
+      DMA1_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 12);
+    }
+    else if (hdma->Instance == DMA1_Channel5)
+    {
+      /*Reset request selection for DMA1 Channel5*/
+      DMA1_CSELR->CSELR &= ~DMA_CSELR_C5S;
+
+      /* Configure request selection for DMA1 Channel5 */
+      DMA1_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 16);
+    }
+    else if (hdma->Instance == DMA1_Channel6)
+    {
+      /*Reset request selection for DMA1 Channel6*/
+      DMA1_CSELR->CSELR &= ~DMA_CSELR_C6S;
+
+      /* Configure request selection for DMA1 Channel6 */
+      DMA1_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 20);
+    }
+    else if (hdma->Instance == DMA1_Channel7)
+    {
+      /*Reset request selection for DMA1 Channel7*/
+      DMA1_CSELR->CSELR &= ~DMA_CSELR_C7S;
+
+      /* Configure request selection for DMA1 Channel7 */
+      DMA1_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 24);
+    }
+    else if (hdma->Instance == DMA2_Channel1)
+    {
+      /*Reset request selection for DMA2 Channel1*/
+      DMA2_CSELR->CSELR &= ~DMA_CSELR_C1S;
+
+      /* Configure request selection for DMA2 Channel1 */
+      DMA2_CSELR->CSELR |= hdma->Init.Request;
+    }
+    else if (hdma->Instance == DMA2_Channel2)
+    {
+      /*Reset request selection for DMA2 Channel2*/
+      DMA2_CSELR->CSELR &= ~DMA_CSELR_C2S;
+
+      /* Configure request selection for DMA2 Channel2 */
+      DMA2_CSELR->CSELR |= (uint32_t)(hdma->Init.Request << 4);
+    }
+    else if (hdma->Instance == DMA2_Channel3)
+    {
+      /*Reset request selection for DMA2 Channel3*/
+      DMA2_CSELR->CSELR &= ~DMA_CSELR_C3S;
+
+      /* Configure request selection for DMA2 Channel3 */
+      DMA2_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 8);
+    }
+    else if (hdma->Instance == DMA2_Channel4)
+    {
+      /*Reset request selection for DMA2 Channel4*/
+      DMA2_CSELR->CSELR &= ~DMA_CSELR_C4S;
+
+      /* Configure request selection for DMA2 Channel4 */
+      DMA2_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 12);
+    }
+    else if (hdma->Instance == DMA2_Channel5)
+    {
+      /*Reset request selection for DMA2 Channel5*/
+      DMA2_CSELR->CSELR &= ~DMA_CSELR_C5S;
+
+      /* Configure request selection for DMA2 Channel5 */
+      DMA2_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 16);
+    }
+    else if (hdma->Instance == DMA2_Channel6)
+    {
+      /*Reset request selection for DMA2 Channel6*/
+      DMA2_CSELR->CSELR &= ~DMA_CSELR_C6S;
+
+      /* Configure request selection for DMA2 Channel6 */
+      DMA2_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 20);
+    }
+    else if (hdma->Instance == DMA2_Channel7)
+    {
+      /*Reset request selection for DMA2 Channel7*/
+      DMA2_CSELR->CSELR &= ~DMA_CSELR_C7S;
+
+      /* Configure request selection for DMA2 Channel7 */
+      DMA2_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 24);
+    }
+  }
+
+  /* Initialize the error code */
+  hdma->ErrorCode = HAL_DMA_ERROR_NONE;
+
+  /* Initialize the DMA state*/
+  hdma->State  = HAL_DMA_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitialize the DMA peripheral.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Channel.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma)
+{
+  /* Check the DMA handle allocation */
+  if(hdma == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_DMA_ALL_INSTANCE(hdma->Instance));
+
+  /* Check the DMA peripheral state */
+  if(hdma->State == HAL_DMA_STATE_BUSY)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Disable the selected DMA Channelx */
+  __HAL_DMA_DISABLE(hdma);
+
+  /* Reset DMA Channel control register */
+  hdma->Instance->CCR  = 0;
+
+  /* Reset DMA Channel Number of Data to Transfer register */
+  hdma->Instance->CNDTR = 0;
+
+  /* Reset DMA Channel peripheral address register */
+  hdma->Instance->CPAR  = 0;
+
+  /* Reset DMA Channel memory address register */
+  hdma->Instance->CMAR = 0;
+
+  /* Clear all flags */
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_GI_FLAG_INDEX(hdma));
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma));
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+
+  /* Reset DMA channel selection register */
+  if (hdma->Instance == DMA1_Channel1)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C1S;
+  }
+  else if (hdma->Instance == DMA1_Channel2)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C2S;
+  }
+  else if (hdma->Instance == DMA1_Channel3)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C3S;
+  }
+  else if (hdma->Instance == DMA1_Channel4)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C4S;
+  }
+  else if (hdma->Instance == DMA1_Channel5)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C5S;
+  }
+  else if (hdma->Instance == DMA1_Channel6)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C6S;
+  }
+  else if (hdma->Instance == DMA1_Channel7)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C7S;
+  }
+  else if (hdma->Instance == DMA2_Channel1)
+  {
+    /*Reset DMA request*/
+    DMA2_CSELR->CSELR &= ~DMA_CSELR_C1S;
+  }
+  else if (hdma->Instance == DMA2_Channel2)
+  {
+    /*Reset DMA request*/
+    DMA2_CSELR->CSELR &= ~DMA_CSELR_C2S;
+  }
+  else if (hdma->Instance == DMA2_Channel3)
+  {
+    /*Reset DMA request*/
+    DMA2_CSELR->CSELR &= ~DMA_CSELR_C3S;
+  }
+  else if (hdma->Instance == DMA2_Channel4)
+  {
+    /*Reset DMA request*/
+    DMA2_CSELR->CSELR &= ~DMA_CSELR_C4S;
+  }
+  else if (hdma->Instance == DMA2_Channel5)
+  {
+    /*Reset DMA request*/
+    DMA2_CSELR->CSELR &= ~DMA_CSELR_C5S;
+  }
+  else if (hdma->Instance == DMA2_Channel6)
+  {
+    /*Reset DMA request*/
+    DMA2_CSELR->CSELR &= ~DMA_CSELR_C6S;
+  }
+  else if (hdma->Instance == DMA2_Channel7)
+  {
+    /*Reset DMA request*/
+    DMA2_CSELR->CSELR &= ~DMA_CSELR_C7S;
+  }
+
+  /* Initialize the error code */
+  hdma->ErrorCode = HAL_DMA_ERROR_NONE;
+
+  /* Initialize the DMA state */
+  hdma->State = HAL_DMA_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hdma);
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Exported_Functions_Group2 Input and Output operation functions
+ *  @brief   Input and Output operation functions
+ *
+@verbatim
+ ===============================================================================
+                      #####  IO operation functions  #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Configure the source, destination address and data length and Start DMA transfer
+      (+) Configure the source, destination address and data length and
+          Start DMA transfer with interrupt
+      (+) Abort DMA transfer
+      (+) Poll for transfer complete
+      (+) Handle DMA interrupt request
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Start the DMA Transfer.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Channel.
+  * @param  SrcAddress: The source memory Buffer address
+  * @param  DstAddress: The destination memory Buffer address
+  * @param  DataLength: The length of data to be transferred from source to destination
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_Start(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength)
+{
+  /* Process locked */
+  __HAL_LOCK(hdma);
+
+  /* Change DMA peripheral state */
+  hdma->State = HAL_DMA_STATE_BUSY;
+
+   /* Check the parameters */
+  assert_param(IS_DMA_BUFFER_SIZE(DataLength));
+
+  /* Disable the peripheral */
+  __HAL_DMA_DISABLE(hdma);
+
+  /* Configure the source, destination address and the data length */
+  DMA_SetConfig(hdma, SrcAddress, DstAddress, DataLength);
+
+  /* Enable the Peripheral */
+  __HAL_DMA_ENABLE(hdma);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Start the DMA Transfer with interrupt enabled.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Channel.
+  * @param  SrcAddress: The source memory Buffer address
+  * @param  DstAddress: The destination memory Buffer address
+  * @param  DataLength: The length of data to be transferred from source to destination
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength)
+{
+  /* Process locked */
+  __HAL_LOCK(hdma);
+
+  /* Change DMA peripheral state */
+  hdma->State = HAL_DMA_STATE_BUSY;
+
+   /* Check the parameters */
+  assert_param(IS_DMA_BUFFER_SIZE(DataLength));
+
+  /* Disable the peripheral */
+  __HAL_DMA_DISABLE(hdma);
+
+  /* Configure the source, destination address and the data length */
+  DMA_SetConfig(hdma, SrcAddress, DstAddress, DataLength);
+
+  /* Enable the transfer complete interrupt */
+  /* Enable the Half transfer complete interrupt */
+  /* Enable the transfer Error interrupt */
+  __HAL_DMA_ENABLE_IT(hdma, (DMA_IT_TC | DMA_IT_HT | DMA_IT_TE));
+
+   /* Enable the Peripheral */
+  __HAL_DMA_ENABLE(hdma);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Abort the DMA Transfer.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Channel.
+  *                   
+  * @note  After disabling a DMA Channel, a check for wait until the DMA Channel is 
+  *        effectively disabled is added. If a Channel is disabled 
+  *        while a data transfer is ongoing, the current data will be transferred
+  *        and the Channel will be effectively disabled only after the transfer of
+  *        this single data is finished.  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
+{
+  uint32_t tickstart = 0;
+
+  /* Disable the channel */
+  __HAL_DMA_DISABLE(hdma);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Check if the DMA Channel is effectively disabled */
+  while((hdma->Instance->CCR & DMA_CCR_EN) != 0)
+  {
+    /* Check for the Timeout */
+    if((HAL_GetTick() - tickstart) > HAL_TIMEOUT_DMA_ABORT)
+    {
+      /* Update error code */
+      hdma->ErrorCode |= HAL_DMA_ERROR_TIMEOUT;
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_TIMEOUT;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+
+      return HAL_TIMEOUT;
+    }
+  }
+  /* Change the DMA state */
+  hdma->State = HAL_DMA_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hdma);
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief  Polling for transfer complete.
+  * @param  hdma:    pointer to a DMA_HandleTypeDef structure that contains
+  *                  the configuration information for the specified DMA Channel.
+  * @param  CompleteLevel: Specifies the DMA level complete.
+  * @param  Timeout:       Timeout duration.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, uint32_t CompleteLevel, uint32_t Timeout)
+{
+  uint32_t temp;
+  uint32_t tickstart = 0;
+
+  /* Get the level transfer complete flag */
+  if(CompleteLevel == HAL_DMA_FULL_TRANSFER)
+  {
+    /* Transfer Complete flag */
+    temp = __HAL_DMA_GET_TC_FLAG_INDEX(hdma);
+  }
+  else
+  {
+    /* Half Transfer Complete flag */
+    temp = __HAL_DMA_GET_HT_FLAG_INDEX(hdma);
+  }
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while(__HAL_DMA_GET_FLAG(hdma, temp) == RESET)
+  {
+    if((__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma)) != RESET))
+    {
+      /* Clear the transfer error flags */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma));
+
+      /* Update error code */
+      SET_BIT(hdma->ErrorCode, HAL_DMA_ERROR_TE);
+
+      /* Change the DMA state */
+      hdma->State= HAL_DMA_STATE_ERROR;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+
+      return HAL_ERROR;
+    }
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0) || ((HAL_GetTick() - tickstart) > Timeout))
+      {
+        /* Update error code */
+        hdma->ErrorCode |= HAL_DMA_ERROR_TIMEOUT;
+
+        /* Change the DMA state */
+        hdma->State = HAL_DMA_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hdma);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  if(CompleteLevel == HAL_DMA_FULL_TRANSFER)
+  {
+    /* Clear the transfer complete flag */
+    __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
+
+    /* The selected Channelx EN bit is cleared (DMA is disabled and
+    all transfers are complete) */
+    hdma->State = HAL_DMA_STATE_READY;
+
+  }
+  else
+  {
+    /* Clear the half transfer complete flag */
+    __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+
+    hdma->State = HAL_DMA_STATE_READY_HALF;
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hdma);  
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handle DMA interrupt request.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Channel.
+  * @retval None
+  */
+void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
+{
+  /* Transfer Error Interrupt management ***************************************/
+  if(__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma)) != RESET)
+  {
+    if(__HAL_DMA_GET_IT_SOURCE(hdma, DMA_IT_TE) != RESET)
+    {
+      /* Disable the transfer error interrupt */
+      __HAL_DMA_DISABLE_IT(hdma, DMA_IT_TE);
+
+      /* Clear the transfer error flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma));
+
+      /* Update error code */
+      hdma->ErrorCode |= HAL_DMA_ERROR_TE;
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+
+      if (hdma->XferErrorCallback != NULL)
+      {
+        /* Transfer error callback */
+        hdma->XferErrorCallback(hdma);
+      }
+    }
+  }
+
+  /* Half Transfer Complete Interrupt management ******************************/
+  if(__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma)) != RESET)
+  {
+    if(__HAL_DMA_GET_IT_SOURCE(hdma, DMA_IT_HT) != RESET)
+    {
+      /* Disable the half transfer interrupt if the DMA mode is not CIRCULAR */
+      if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+      {
+        /* Disable the half transfer interrupt */
+        __HAL_DMA_DISABLE_IT(hdma, DMA_IT_HT);
+      }
+      /* Clear the half transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+
+      /* Change DMA peripheral state */
+      hdma->State = HAL_DMA_STATE_READY_HALF;
+
+      if(hdma->XferHalfCpltCallback != NULL)
+      {
+        /* Half transfer callback */
+        hdma->XferHalfCpltCallback(hdma);
+      }
+    }
+  }
+
+  /* Transfer Complete Interrupt management ***********************************/
+  if(__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma)) != RESET)
+  {
+    if(__HAL_DMA_GET_IT_SOURCE(hdma, DMA_IT_TC) != RESET)
+    {
+      if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+      {
+        /* Disable the transfer complete interrupt */
+        __HAL_DMA_DISABLE_IT(hdma, DMA_IT_TC);
+      }
+      /* Clear the transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
+
+      /* Update error code */
+      hdma->ErrorCode |= HAL_DMA_ERROR_NONE;
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+
+      if(hdma->XferCpltCallback != NULL)
+      {
+        /* Transfer complete callback */
+        hdma->XferCpltCallback(hdma);
+      }
+    }
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Exported_Functions_Group3 Peripheral State and Errors functions
+ *  @brief    Peripheral State and Errors functions
+ *
+@verbatim
+ ===============================================================================
+            ##### Peripheral State and Errors functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides functions allowing to
+      (+) Check the DMA state
+      (+) Get error code
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the DMA hande state.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Channel.
+  * @retval HAL state
+  */
+HAL_DMA_StateTypeDef HAL_DMA_GetState(DMA_HandleTypeDef *hdma)
+{
+  /* Return DMA handle state */
+  return hdma->State;
+}
+
+/**
+  * @brief  Return the DMA error code.
+  * @param  hdma : pointer to a DMA_HandleTypeDef structure that contains
+  *              the configuration information for the specified DMA Channel.
+  * @retval DMA Error Code
+  */
+uint32_t HAL_DMA_GetError(DMA_HandleTypeDef *hdma)
+{
+  return hdma->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup DMA_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Sets the DMA Transfer parameter.
+  * @param  hdma:       pointer to a DMA_HandleTypeDef structure that contains
+  *                     the configuration information for the specified DMA Channel.
+  * @param  SrcAddress: The source memory Buffer address
+  * @param  DstAddress: The destination memory Buffer address
+  * @param  DataLength: The length of data to be transferred from source to destination
+  * @retval HAL status
+  */
+static void DMA_SetConfig(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength)
+{
+  /* Configure DMA Channel data length */
+  hdma->Instance->CNDTR = DataLength;
+
+  /* Peripheral to Memory */
+  if((hdma->Init.Direction) == DMA_MEMORY_TO_PERIPH)
+  {
+    /* Configure DMA Channel destination address */
+    hdma->Instance->CPAR = DstAddress;
+
+    /* Configure DMA Channel source address */
+    hdma->Instance->CMAR = SrcAddress;
+  }
+  /* Memory to Peripheral */
+  else
+  {
+    /* Configure DMA Channel source address */
+    hdma->Instance->CPAR = SrcAddress;
+
+    /* Configure DMA Channel destination address */
+    hdma->Instance->CMAR = DstAddress;
+  }
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_DMA_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_flash.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_flash.c
@@ -1,0 +1,773 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_flash.c
+  * @author  MCD Application Team
+  * @version V1.3.0 
+  * @date    29-January-2016
+  * @brief   FLASH HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the internal FLASH memory:
+  *           + Program operations functions
+  *           + Memory Control functions 
+  *           + Peripheral Errors functions
+  *  
+ @verbatim    
+  ==============================================================================
+                        ##### FLASH peripheral features #####
+  ==============================================================================
+           
+  [..] The Flash memory interface manages CPU AHB I-Code and D-Code accesses 
+       to the Flash memory. It implements the erase and program Flash memory operations 
+       and the read and write protection mechanisms.
+      
+  [..] The Flash memory interface accelerates code execution with a system of instruction
+       prefetch and cache lines. 
+
+  [..] The FLASH main features are:
+      (+) Flash memory read operations
+      (+) Flash memory program/erase operations
+      (+) Read / write protections
+      (+) Option bytes programming
+      (+) Prefetch on I-Code
+      (+) 32 cache lines of 4*64 bits on I-Code
+      (+) 8 cache lines of 4*64 bits on D-Code
+      (+) Error code correction (ECC) : Data in flash are 72-bits word
+          (8 bits added per double word)
+      
+      
+                        ##### How to use this driver #####
+ ==============================================================================
+    [..]                             
+      This driver provides functions and macros to configure and program the FLASH  
+      memory of all STM32L4xx devices. 
+   
+      (#) Flash Memory IO Programming functions: 
+           (++) Lock and Unlock the FLASH interface using HAL_FLASH_Unlock() and 
+                HAL_FLASH_Lock() functions
+           (++) Program functions: double word and fast program (full row programming)
+           (++) There Two modes of programming :
+            (+++) Polling mode using HAL_FLASH_Program() function
+            (+++) Interrupt mode using HAL_FLASH_Program_IT() function
+    
+      (#) Interrupts and flags management functions : 
+           (++) Handle FLASH interrupts by calling HAL_FLASH_IRQHandler()
+           (++) Callback functions are called when the flash operations are finished :
+                HAL_FLASH_EndOfOperationCallback() when everything is ok, otherwise
+                HAL_FLASH_OperationErrorCallback()
+           (++) Get error flag status by calling HAL_GetError()    
+           
+      (#) Option bytes management functions :
+           (++) Lock and Unlock the option bytes using HAL_FLASH_OB_Unlock() and
+                HAL_FLASH_OB_Lock() functions
+           (++) Launch the reload of the option bytes using HAL_FLASH_Launch() function.
+                In this case, a reset is generated
+                         
+    [..] 
+      In addition to these functions, this driver includes a set of macros allowing
+      to handle the following operations:
+       (+) Set the latency
+       (+) Enable/Disable the prefetch buffer
+       (+) Enable/Disable the Instruction cache and the Data cache
+       (+) Reset the Instruction cache and the Data cache
+       (+) Enable/Disable the Flash power-down during low-power run and sleep modes
+       (+) Enable/Disable the Flash interrupts
+       (+) Monitor the Flash flags status
+    
+ @endverbatim                      
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup FLASH FLASH
+  * @brief FLASH HAL module driver
+  * @{
+  */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/ 
+/* Private macros ------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup FLASH_Private_Variables FLASH Private Variables
+ * @{
+ */
+/**
+  * @brief  Variable used for Program/Erase sectors under interruption 
+  */
+FLASH_ProcessTypeDef pFlash;
+/**
+  * @}
+  */
+
+/* Private function prototypes -----------------------------------------------*/
+/** @defgroup FLASH_Private_Functions FLASH Private Functions
+ * @{
+ */
+HAL_StatusTypeDef    FLASH_WaitForLastOperation(uint32_t Timeout);
+extern void          FLASH_PageErase(uint32_t Page, uint32_t Banks);
+extern void          FLASH_FlushCaches(void);
+static void          FLASH_SetErrorCode(void);
+static void          FLASH_Program_DoubleWord(uint32_t Address, uint64_t Data);
+static void          FLASH_Program_Fast(uint32_t Address, uint32_t DataAddress);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup FLASH_Exported_Functions FLASH Exported Functions
+  * @{
+  */
+
+/** @defgroup FLASH_Exported_Functions_Group1 Programming operation functions 
+ *  @brief   Programming operation functions 
+ *
+@verbatim   
+ ===============================================================================
+                  ##### Programming operation functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to manage the FLASH 
+    program operations.
+ 
+@endverbatim
+  * @{
+  */
+ 
+/**
+  * @brief  Program double word or fast program of a row at a specified address.
+  * @param  TypeProgram:  Indicate the way to program at a specified address.
+  *                           This parameter can be a value of @ref FLASH_Type_Program
+  * @param  Address:  specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed
+  *                This parameter is the data for the double word program and the address where 
+  *                are stored the data for the row fast program
+  * 
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint64_t Data)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  uint32_t prog_bit = 0;
+  
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_FLASH_TYPEPROGRAM(TypeProgram));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+  
+  if(status == HAL_OK)
+  {
+    pFlash.ErrorCode = HAL_FLASH_ERROR_NONE;
+
+    if(TypeProgram == FLASH_TYPEPROGRAM_DOUBLEWORD)
+    {
+      /* Program double-word (64-bit) at a specified address */
+      FLASH_Program_DoubleWord(Address, Data);
+      prog_bit = FLASH_CR_PG;
+    }
+    else if((TypeProgram == FLASH_TYPEPROGRAM_FAST) || (TypeProgram == FLASH_TYPEPROGRAM_FAST_AND_LAST))
+    {
+      /* Fast program a 32 row double-word (64-bit) at a specified address */
+      FLASH_Program_Fast(Address, (uint32_t)Data);
+      
+      /* If it is the last row, the bit will be cleared at the end of the operation */
+      if(TypeProgram == FLASH_TYPEPROGRAM_FAST_AND_LAST)
+      {
+        prog_bit = FLASH_CR_FSTPG;
+      }
+    }
+
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+    
+    /* If the program operation is completed, disable the PG or FSTPG Bit */
+    if (prog_bit != 0)
+    {
+      CLEAR_BIT(FLASH->CR, prog_bit);
+    }
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(&pFlash);
+
+  return status;  
+}
+
+/**
+  * @brief  Program double word or fast program of a row at a specified address with interrupt enabled.
+  * @param  TypeProgram:  Indicate the way to program at a specified address.
+  *                           This parameter can be a value of @ref FLASH_Type_Program
+  * @param  Address:  specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed
+  *                This parameter is the data for the double word program and the address where 
+  *                are stored the data for the row fast program
+  * 
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Program_IT(uint32_t TypeProgram, uint32_t Address, uint64_t Data)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_FLASH_TYPEPROGRAM(TypeProgram));
+
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  pFlash.ErrorCode = HAL_FLASH_ERROR_NONE;
+
+  /* Set internal variables used by the IRQ handler */
+  if(TypeProgram == FLASH_TYPEPROGRAM_FAST_AND_LAST)
+  {
+    pFlash.ProcedureOnGoing = FLASH_PROC_PROGRAM_LAST;
+  }
+  else
+  {
+    pFlash.ProcedureOnGoing = FLASH_PROC_PROGRAM;
+  }
+  pFlash.Address = Address;
+    
+  /* Enable End of Operation and Error interrupts */
+  __HAL_FLASH_ENABLE_IT(FLASH_IT_EOP | FLASH_IT_OPERR);
+
+  if(TypeProgram == FLASH_TYPEPROGRAM_DOUBLEWORD)
+  {
+    /* Program double-word (64-bit) at a specified address */
+    FLASH_Program_DoubleWord(Address, Data);
+  }
+    else if((TypeProgram == FLASH_TYPEPROGRAM_FAST) || (TypeProgram == FLASH_TYPEPROGRAM_FAST_AND_LAST))
+  {
+    /* Fast program a 32 row double-word (64-bit) at a specified address */
+    FLASH_Program_Fast(Address, (uint32_t)Data);
+  }
+
+  return status;  
+}
+
+/**
+  * @brief Handle FLASH interrupt request.
+  * @retval None
+  */
+void HAL_FLASH_IRQHandler(void)
+{
+  uint32_t tmp_page;
+
+  /* If the operation is completed, disable the PG, PNB, MER1, MER2 and PER Bit */
+  CLEAR_BIT(FLASH->CR, (FLASH_CR_PG | FLASH_CR_MER1 | FLASH_CR_PER | FLASH_CR_PNB));
+  CLEAR_BIT(FLASH->CR, FLASH_CR_MER2);
+  
+  /* Disable the FSTPG Bit only if it is the last row programmed */
+  if(pFlash.ProcedureOnGoing == FLASH_PROC_PROGRAM_LAST)
+  {
+    CLEAR_BIT(FLASH->CR, FLASH_CR_FSTPG);
+  }
+
+  /* Check FLASH operation error flags */
+  if((__HAL_FLASH_GET_FLAG(FLASH_FLAG_OPERR))  || (__HAL_FLASH_GET_FLAG(FLASH_FLAG_PROGERR)) || 
+     (__HAL_FLASH_GET_FLAG(FLASH_FLAG_WRPERR)) || (__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGAERR))  || 
+     (__HAL_FLASH_GET_FLAG(FLASH_FLAG_SIZERR)) || (__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGSERR))  ||
+     (__HAL_FLASH_GET_FLAG(FLASH_FLAG_MISERR)) || (__HAL_FLASH_GET_FLAG(FLASH_FLAG_FASTERR)) || 
+     (__HAL_FLASH_GET_FLAG(FLASH_FLAG_RDERR))  || (__HAL_FLASH_GET_FLAG(FLASH_FLAG_OPTVERR)) ||
+     (__HAL_FLASH_GET_FLAG(FLASH_FLAG_ECCD)))
+  {
+    /*Save the error code*/
+    FLASH_SetErrorCode();
+    
+    /* FLASH error interrupt user callback */
+    if(pFlash.ProcedureOnGoing == FLASH_PROC_PAGE_ERASE)
+    {
+       HAL_FLASH_EndOfOperationCallback(pFlash.Page);
+    }
+    else if(pFlash.ProcedureOnGoing == FLASH_PROC_MASS_ERASE)
+    {
+        HAL_FLASH_EndOfOperationCallback(pFlash.Bank);
+    }
+    else if((pFlash.ProcedureOnGoing == FLASH_PROC_PROGRAM) || 
+            (pFlash.ProcedureOnGoing == FLASH_PROC_PROGRAM_LAST))
+    {
+       HAL_FLASH_OperationErrorCallback(pFlash.Address);
+    }
+
+    HAL_FLASH_OperationErrorCallback(pFlash.Address);
+
+    /*Stop the procedure ongoing*/
+    pFlash.ProcedureOnGoing = FLASH_PROC_NONE;
+  }
+
+  /* Check FLASH End of Operation flag  */
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_EOP))
+  {
+    /* Clear FLASH End of Operation pending bit */
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP);
+
+    if(pFlash.ProcedureOnGoing == FLASH_PROC_PAGE_ERASE)
+    {
+      /* Nb of pages to erased can be decreased */
+      pFlash.NbPagesToErase--;
+
+      /* Check if there are still pages to erase*/
+      if(pFlash.NbPagesToErase != 0)
+      {
+        /* Indicate user which page has been erased*/
+        HAL_FLASH_EndOfOperationCallback(pFlash.Page);
+
+        /* Increment page number */
+        pFlash.Page++;
+        tmp_page = pFlash.Page;
+        FLASH_PageErase(tmp_page, pFlash.Bank);
+      }
+      else
+      {
+        /* No more pages to Erase */
+        /* Reset Address and stop Erase pages procedure */
+        pFlash.Page = 0xFFFFFFFF;
+        pFlash.ProcedureOnGoing = FLASH_PROC_NONE;
+
+        /* Flush the caches to be sure of the data consistency */
+        FLASH_FlushCaches() ;
+        
+        /* FLASH EOP interrupt user callback */
+        HAL_FLASH_EndOfOperationCallback(pFlash.Page);
+      }
+    }
+    else
+    {
+      if(pFlash.ProcedureOnGoing == FLASH_PROC_MASS_ERASE)
+      {
+        /* MassErase ended. Return the selected bank */
+        /* Flush the caches to be sure of the data consistency */
+        FLASH_FlushCaches() ;
+
+        /* FLASH EOP interrupt user callback */
+        HAL_FLASH_EndOfOperationCallback(pFlash.Bank);
+      }
+      else if((pFlash.ProcedureOnGoing == FLASH_PROC_PROGRAM) || 
+              (pFlash.ProcedureOnGoing == FLASH_PROC_PROGRAM_LAST))
+      {
+        /* Program ended. Return the selected address */
+        /* FLASH EOP interrupt user callback */
+        HAL_FLASH_EndOfOperationCallback(pFlash.Address);
+      }
+
+      /*Clear the procedure ongoing*/
+      pFlash.ProcedureOnGoing = FLASH_PROC_NONE;
+    }
+  }
+
+  if(pFlash.ProcedureOnGoing == FLASH_PROC_NONE)
+  {
+    /* Disable End of Operation and Error interrupts */
+    __HAL_FLASH_DISABLE_IT(FLASH_IT_EOP | FLASH_IT_OPERR);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(&pFlash);
+  }
+}
+
+/**
+  * @brief  FLASH end of operation interrupt callback.
+  * @param  ReturnValue: The value saved in this parameter depends on the ongoing procedure
+  *                  Mass Erase: Bank number which has been requested to erase
+  *                  Page Erase: Page which has been erased 
+  *                    (if 0xFFFFFFFF, it means that all the selected pages have been erased)
+  *                  Program: Address which was selected for data program
+  * @retval None
+  */
+__weak void HAL_FLASH_EndOfOperationCallback(uint32_t ReturnValue)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(ReturnValue);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_FLASH_EndOfOperationCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  FLASH operation error interrupt callback.
+  * @param  ReturnValue: The value saved in this parameter depends on the ongoing procedure
+  *                 Mass Erase: Bank number which has been requested to erase
+  *                 Page Erase: Page number which returned an error
+  *                 Program: Address which was selected for data program
+  * @retval None
+  */
+__weak void HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(ReturnValue);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_FLASH_OperationErrorCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_Exported_Functions_Group2 Peripheral Control functions 
+ *  @brief   Management functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the FLASH 
+    memory operations.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Unlock the FLASH control register access.
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Unlock(void)
+{
+  if(READ_BIT(FLASH->CR, FLASH_CR_LOCK) != RESET)
+  {
+    /* Authorize the FLASH Registers access */
+    WRITE_REG(FLASH->KEYR, FLASH_KEY1);
+    WRITE_REG(FLASH->KEYR, FLASH_KEY2);
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Lock the FLASH control register access.
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Lock(void)
+{
+  /* Set the LOCK Bit to lock the FLASH Registers access */
+  SET_BIT(FLASH->CR, FLASH_CR_LOCK);
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Unlock the FLASH Option Bytes Registers access.
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_OB_Unlock(void)
+{
+  if(READ_BIT(FLASH->CR, FLASH_CR_OPTLOCK) != RESET)
+  {
+    /* Authorizes the Option Byte register programming */
+    WRITE_REG(FLASH->OPTKEYR, FLASH_OPTKEY1);
+    WRITE_REG(FLASH->OPTKEYR, FLASH_OPTKEY2);
+  }
+  else
+  {
+    return HAL_ERROR;
+  }  
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Lock the FLASH Option Bytes Registers access.
+  * @retval HAL Status 
+  */
+HAL_StatusTypeDef HAL_FLASH_OB_Lock(void)
+{
+  /* Set the OPTLOCK Bit to lock the FLASH Option Byte Registers access */
+  SET_BIT(FLASH->CR, FLASH_CR_OPTLOCK);
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Launch the option byte loading.
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_OB_Launch(void)
+{
+  /* Set the bit to force the option byte reloading */
+  SET_BIT(FLASH->CR, FLASH_CR_OBL_LAUNCH); 
+
+  /* Wait for last operation to be completed */
+  return(FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE)); 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Exported_Functions_Group3 Peripheral State and Errors functions 
+ *  @brief   Peripheral Errors functions 
+ *
+@verbatim   
+ ===============================================================================
+                ##### Peripheral Errors functions #####
+ ===============================================================================  
+    [..]
+    This subsection permits to get in run-time Errors of the FLASH peripheral.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Get the specific FLASH error flag.
+  * @retval FLASH_ErrorCode: The returned value can be:
+  *            @arg HAL_FLASH_ERROR_RD: FLASH Read Protection error flag (PCROP)
+  *            @arg HAL_FLASH_ERROR_PGS: FLASH Programming Sequence error flag 
+  *            @arg HAL_FLASH_ERROR_PGP: FLASH Programming Parallelism error flag  
+  *            @arg HAL_FLASH_ERROR_PGA: FLASH Programming Alignment error flag
+  *            @arg HAL_FLASH_ERROR_WRP: FLASH Write protected error flag
+  *            @arg HAL_FLASH_ERROR_OPERATION: FLASH operation Error flag 
+  *            @arg HAL_FLASH_ERROR_NONE: No error set 
+  *            @arg HAL_FLASH_ERROR_OP: FLASH Operation error
+  *            @arg HAL_FLASH_ERROR_PROG: FLASH Programming error
+  *            @arg HAL_FLASH_ERROR_WRP: FLASH Write protection error
+  *            @arg HAL_FLASH_ERROR_PGA: FLASH Programming alignment error
+  *            @arg HAL_FLASH_ERROR_SIZ: FLASH Size error
+  *            @arg HAL_FLASH_ERROR_PGS: FLASH Programming sequence error
+  *            @arg HAL_FLASH_ERROR_MIS: FLASH Fast programming data miss error
+  *            @arg HAL_FLASH_ERROR_FAST: FLASH Fast programming error
+  *            @arg HAL_FLASH_ERROR_RD: FLASH PCROP read error
+  *            @arg HAL_FLASH_ERROR_OPTV: FLASH Option validity error
+  *            @arg HAL_FLASH_ERROR_ECCD: FLASH two ECC errors have been detected
+  */
+uint32_t HAL_FLASH_GetError(void)
+{ 
+   return pFlash.ErrorCode;
+}
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @addtogroup FLASH_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Wait for a FLASH operation to complete.
+  * @param  Timeout: maximum flash operation timeout
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout)
+{
+  /* Wait for the FLASH operation to complete by polling on BUSY flag to be reset.
+     Even if the FLASH operation fails, the BUSY flag will be reset and an error
+     flag will be set */
+    
+  uint32_t timeout = HAL_GetTick() + Timeout;
+     
+  while(__HAL_FLASH_GET_FLAG(FLASH_FLAG_BSY)) 
+  { 
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if(HAL_GetTick() >= timeout)
+      {
+        return HAL_TIMEOUT;
+      }
+    } 
+  }
+  
+  if((__HAL_FLASH_GET_FLAG(FLASH_FLAG_OPERR))  || (__HAL_FLASH_GET_FLAG(FLASH_FLAG_PROGERR)) || 
+     (__HAL_FLASH_GET_FLAG(FLASH_FLAG_WRPERR)) || (__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGAERR))  || 
+     (__HAL_FLASH_GET_FLAG(FLASH_FLAG_SIZERR)) || (__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGSERR))  ||
+     (__HAL_FLASH_GET_FLAG(FLASH_FLAG_MISERR)) || (__HAL_FLASH_GET_FLAG(FLASH_FLAG_FASTERR)) || 
+     (__HAL_FLASH_GET_FLAG(FLASH_FLAG_RDERR))  || (__HAL_FLASH_GET_FLAG(FLASH_FLAG_OPTVERR)) ||
+     (__HAL_FLASH_GET_FLAG(FLASH_FLAG_ECCD)))
+  {
+    /*Save the error code*/
+    FLASH_SetErrorCode();
+    
+    return HAL_ERROR;
+  }
+
+  /* Check FLASH End of Operation flag  */
+  if (__HAL_FLASH_GET_FLAG(FLASH_FLAG_EOP))
+  {
+    /* Clear FLASH End of Operation pending bit */
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP);
+  }
+  
+  /* If there is an error flag set */
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Set the specific FLASH error flag.
+  * @retval None
+  */
+static void FLASH_SetErrorCode(void)
+{  
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_OPERR))
+  {
+    pFlash.ErrorCode |= HAL_FLASH_ERROR_OP;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_PROGERR))
+  { 
+    pFlash.ErrorCode |= HAL_FLASH_ERROR_PROG;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_WRPERR))
+  { 
+    pFlash.ErrorCode |= HAL_FLASH_ERROR_WRP;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGAERR))
+  { 
+    pFlash.ErrorCode |= HAL_FLASH_ERROR_PGA;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_SIZERR))
+  { 
+    pFlash.ErrorCode |= HAL_FLASH_ERROR_SIZ;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGSERR))
+  { 
+    pFlash.ErrorCode |= HAL_FLASH_ERROR_PGS;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_MISERR))
+  { 
+   pFlash.ErrorCode |= HAL_FLASH_ERROR_MIS;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_FASTERR))
+  { 
+   pFlash.ErrorCode |= HAL_FLASH_ERROR_FAST;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_RDERR))
+  { 
+   pFlash.ErrorCode |= HAL_FLASH_ERROR_RD;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_OPTVERR))
+  { 
+   pFlash.ErrorCode |= HAL_FLASH_ERROR_OPTV;
+  }
+
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_ECCD))
+  { 
+   pFlash.ErrorCode |= HAL_FLASH_ERROR_ECCD;
+  }
+
+  /* Clear error programming flags */
+  __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
+} 
+
+/**
+  * @brief  Program double-word (64-bit) at a specified address.
+  * @param  Address: specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed.
+  * @retval None
+  */
+static void FLASH_Program_DoubleWord(uint32_t Address, uint64_t Data)
+{
+  /* Check the parameters */
+  assert_param(IS_FLASH_PROGRAM_ADDRESS(Address));
+
+  /* Set PG bit */
+  SET_BIT(FLASH->CR, FLASH_CR_PG);
+  
+  /* Program the double word */
+  *(__IO uint32_t*)Address = (uint32_t)Data;
+  *(__IO uint32_t*)(Address+4) = (uint32_t)(Data >> 32);
+}
+
+/**
+  * @brief  Fast program a 32 row double-word (64-bit) at a specified address.
+  * @param  Address: specifies the address to be programmed.
+  * @param  DataAddress: specifies the address where the data are stored.
+  * @retval None
+  */
+static void FLASH_Program_Fast(uint32_t Address, uint32_t DataAddress)
+{
+  uint8_t row_index = 32;
+  __IO uint64_t *dest_addr = (__IO uint64_t*)Address;
+  __IO uint64_t *src_addr = (__IO uint64_t*)DataAddress;
+
+  /* Check the parameters */
+  assert_param(IS_FLASH_MAIN_MEM_ADDRESS(Address));
+
+  /* Set FSTPG bit */
+  SET_BIT(FLASH->CR, FLASH_CR_FSTPG);
+  
+  /* Disable interrupts to avoid any interruption during the loop */
+  __disable_irq();
+  
+  /* Program the 32 double word */
+  do
+  {
+    *dest_addr++ = *src_addr++;
+  } while (--row_index != 0);
+
+  /* Re-enable the interrupts */
+  __enable_irq();
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_flash_ex.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_flash_ex.c
@@ -1,0 +1,980 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_flash_ex.c
+  * @author  MCD Application Team
+  * @version V1.3.0 
+  * @date    29-January-2016
+  * @brief   Extended FLASH HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the FLASH extended peripheral:
+  *           + Extended programming operations functions
+  *  
+ @verbatim    
+ ==============================================================================
+                   ##### Flash Extended features #####
+  ==============================================================================
+           
+  [..] Comparing to other previous devices, the FLASH interface for STM32L4xx 
+       devices contains the following additional features 
+       
+       (+) Capacity up to 2 Mbyte with dual bank architecture supporting read-while-write
+           capability (RWW)
+       (+) Dual bank memory organization       
+       (+) PCROP protection for all banks
+   
+                        ##### How to use this driver #####
+ ==============================================================================
+  [..] This driver provides functions to configure and program the FLASH memory 
+       of all STM32L4xx devices. It includes
+      (#) Flash Memory Erase functions: 
+           (++) Lock and Unlock the FLASH interface using HAL_FLASH_Unlock() and 
+                HAL_FLASH_Lock() functions
+           (++) Erase function: Erase page, erase all sectors
+           (++) There are two modes of erase :
+             (+++) Polling Mode using HAL_FLASHEx_Erase()
+             (+++) Interrupt Mode using HAL_FLASHEx_Erase_IT()
+                         
+      (#) Option Bytes Programming function: Use HAL_FLASHEx_OBProgram() to :
+        (++) Set/Reset the write protection
+        (++) Set the Read protection Level
+        (++) Program the user Option Bytes
+        (++) Configure the PCROP protection
+        
+      (#) Get Option Bytes Configuration function: Use HAL_FLASHEx_OBGetConfig() to :
+        (++) Get the value of a write protection area
+        (++) Know if the read protection is activated
+        (++) Get the value of the user Option Bytes
+        (++) Get the value of a PCROP area
+    
+ @endverbatim                      
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup FLASHEx FLASHEx
+  * @brief FALSH Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/ 
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup FLASHEx_Private_Variables FLASHEx Private Variables
+ * @{
+ */
+extern FLASH_ProcessTypeDef pFlash;
+/**
+  * @}
+  */
+
+/* Private function prototypes -----------------------------------------------*/
+/** @defgroup FLASHEx_Private_Functions FLASHEx Private Functions
+ * @{
+ */
+extern HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout);
+void                     FLASH_PageErase(uint32_t Page, uint32_t Banks);
+static void              FLASH_MassErase(uint32_t Banks);
+void                     FLASH_FlushCaches(void);
+static HAL_StatusTypeDef FLASH_OB_WRPConfig(uint32_t WRPArea, uint32_t WRPStartOffset, uint32_t WRDPEndOffset);
+static HAL_StatusTypeDef FLASH_OB_RDPConfig(uint32_t RDPLevel);
+static HAL_StatusTypeDef FLASH_OB_UserConfig(uint32_t UserType, uint32_t UserConfig);
+static HAL_StatusTypeDef FLASH_OB_PCROPConfig(uint32_t PCROPConfig, uint32_t PCROPStartAddr, uint32_t PCROPEndAddr);
+static void              FLASH_OB_GetWRP(uint32_t WRPArea, uint32_t * WRPStartOffset, uint32_t * WRDPEndOffset);
+static uint32_t          FLASH_OB_GetRDP(void);
+static uint32_t          FLASH_OB_GetUser(void);
+static void              FLASH_OB_GetPCROP(uint32_t * PCROPConfig, uint32_t * PCROPStartAddr, uint32_t * PCROPEndAddr);
+/**
+  * @}
+  */
+
+/* Exported functions -------------------------------------------------------*/
+/** @defgroup FLASHEx_Exported_Functions FLASH Extended Exported Functions
+  * @{
+  */ 
+
+/** @defgroup FLASHEx_Exported_Functions_Group1 Extended IO operation functions
+ *  @brief   Extended IO operation functions 
+ *
+@verbatim   
+ ===============================================================================
+                ##### Extended programming operation functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to manage the Extended FLASH 
+    programming operations Operations.
+ 
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Perform a mass erase or erase the specified FLASH memory pages.
+  * @param[in]  pEraseInit: pointer to an FLASH_EraseInitTypeDef structure that
+  *         contains the configuration information for the erasing.
+  * 
+  * @param[out]  PageError  : pointer to variable that contains the configuration 
+  *         information on faulty page in case of error (0xFFFFFFFF means that all 
+  *         the pages have been correctly erased)
+  * 
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t *PageError)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  uint32_t page_index = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_FLASH_TYPEERASE(pEraseInit->TypeErase));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+  if (status == HAL_OK)
+  {
+    pFlash.ErrorCode = HAL_FLASH_ERROR_NONE;
+
+    if (pEraseInit->TypeErase == FLASH_TYPEERASE_MASSERASE)
+    {
+      /* Mass erase to be done */
+      FLASH_MassErase(pEraseInit->Banks);
+
+      /* Wait for last operation to be completed */
+      status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+      /* If the erase operation is completed, disable the MER1 and MER2 Bits */
+      CLEAR_BIT(FLASH->CR, (FLASH_CR_MER1 | FLASH_CR_MER2));
+    }
+    else
+    {
+      /*Initialization of PageError variable*/
+      *PageError = 0xFFFFFFFF;
+      
+      for(page_index = pEraseInit->Page; page_index < (pEraseInit->Page + pEraseInit->NbPages); page_index++)
+      {
+        FLASH_PageErase(page_index, pEraseInit->Banks);
+
+        /* Wait for last operation to be completed */
+        status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+        /* If the erase operation is completed, disable the PER Bit */
+        CLEAR_BIT(FLASH->CR, (FLASH_CR_PER | FLASH_CR_PNB));
+
+        if (status != HAL_OK)
+        {
+          /* In case of error, stop erase procedure and return the faulty address */
+          *PageError = page_index;
+          break;
+        }
+      }
+    }
+    
+    /* Flush the caches to be sure of the data consistency */
+    FLASH_FlushCaches();
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(&pFlash);
+
+  return status;
+}
+
+/**
+  * @brief  Perform a mass erase or erase the specified FLASH memory pages with interrupt enabled.
+  * @param  pEraseInit: pointer to an FLASH_EraseInitTypeDef structure that
+  *         contains the configuration information for the erasing.
+  * 
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_FLASH_TYPEERASE(pEraseInit->TypeErase));
+
+  pFlash.ErrorCode = HAL_FLASH_ERROR_NONE;
+
+  /* Enable End of Operation and Error interrupts */
+  __HAL_FLASH_ENABLE_IT(FLASH_IT_EOP | FLASH_IT_OPERR);
+
+  pFlash.Bank = pEraseInit->Banks;
+
+  if (pEraseInit->TypeErase == FLASH_TYPEERASE_MASSERASE)
+  {
+    /* Mass erase to be done */
+    pFlash.ProcedureOnGoing = FLASH_PROC_MASS_ERASE;
+    FLASH_MassErase(pEraseInit->Banks);
+  }
+  else
+  {
+    /* Erase by page to be done */
+    pFlash.ProcedureOnGoing = FLASH_PROC_PAGE_ERASE;
+    pFlash.NbPagesToErase = pEraseInit->NbPages;
+    pFlash.Page = pEraseInit->Page;
+
+    /*Erase 1st page and wait for IT */
+    FLASH_PageErase(pEraseInit->Page, pEraseInit->Banks);
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Program Option bytes.
+  * @param  pOBInit: pointer to an FLASH_OBInitStruct structure that
+  *         contains the configuration information for the programming.
+  * 
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_OPTIONBYTE(pOBInit->OptionType));
+  
+  pFlash.ErrorCode = HAL_FLASH_ERROR_NONE;
+
+  /* Write protection configuration */
+  if((pOBInit->OptionType & OPTIONBYTE_WRP) != RESET)
+  {
+    /* Configure of Write protection on the selected area */
+    status = FLASH_OB_WRPConfig(pOBInit->WRPArea, pOBInit->WRPStartOffset, pOBInit->WRPEndOffset);
+  }
+  
+  /* Read protection configuration */
+  if((pOBInit->OptionType & OPTIONBYTE_RDP) != RESET)
+  {
+    /* Configure the Read protection level */
+    status = FLASH_OB_RDPConfig(pOBInit->RDPLevel);
+  }
+  
+  /* User Configuration */
+  if((pOBInit->OptionType & OPTIONBYTE_USER) != RESET)
+  {
+    /* Configure the user option bytes */
+    status = FLASH_OB_UserConfig(pOBInit->USERType, pOBInit->USERConfig);
+  }
+  
+  /* PCROP Configuration */
+  if((pOBInit->OptionType & OPTIONBYTE_PCROP) != RESET)
+  {
+    /* Configure the Proprietary code readout protection */
+    status = FLASH_OB_PCROPConfig(pOBInit->PCROPConfig, pOBInit->PCROPStartAddr, pOBInit->PCROPEndAddr);
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(&pFlash);
+
+  return status;
+}
+
+/**
+  * @brief  Get the Option bytes configuration.
+  * @param  pOBInit: pointer to an FLASH_OBInitStruct structure that contains the 
+  *                  configuration information. The fields pOBInit->WRPArea and 
+  *                  pOBInit->PCROPConfig should indicate which area is requested
+  *                  for the WRP and PCROP 
+  * 
+  * @retval None
+  */
+void HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit)
+{
+  pOBInit->OptionType = (OPTIONBYTE_WRP | OPTIONBYTE_RDP | OPTIONBYTE_USER | OPTIONBYTE_PCROP);
+
+  /* Get write protection on the selected area */
+  FLASH_OB_GetWRP(pOBInit->WRPArea, &(pOBInit->WRPStartOffset), &(pOBInit->WRPEndOffset));
+  
+  /* Get Read protection level */
+  pOBInit->RDPLevel = FLASH_OB_GetRDP();
+  
+  /* Get the user option bytes */
+  pOBInit->USERConfig = FLASH_OB_GetUser();
+  
+  /* Get the Proprietary code readout protection */
+  FLASH_OB_GetPCROP(&(pOBInit->PCROPConfig), &(pOBInit->PCROPStartAddr), &(pOBInit->PCROPEndAddr));
+  
+}
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @addtogroup FLASHEx_Private_Functions
+  * @{
+  */
+/**
+  * @brief  Mass erase of FLASH memory.
+  * @param  Banks: Banks to be erased
+  *          This parameter can be one of the following values:
+  *            @arg FLASH_BANK_1: Bank1 to be erased
+  *            @arg FLASH_BANK_2: Bank2 to be erased
+  *            @arg FLASH_BANK_BOTH: Bank1 and Bank2 to be erased
+  * @retval None
+  */
+static void FLASH_MassErase(uint32_t Banks)
+{
+  /* Check the parameters */
+  assert_param(IS_FLASH_BANK(Banks));
+
+  /* Set the Mass Erase Bit for the bank 1 if requested */
+  if((Banks & FLASH_BANK_1) != RESET)
+  {
+    SET_BIT(FLASH->CR, FLASH_CR_MER1);
+  }
+  
+  /* Set the Mass Erase Bit for the bank 2 if requested */
+  if((Banks & FLASH_BANK_2) != RESET)
+  {
+    SET_BIT(FLASH->CR, FLASH_CR_MER2);
+  }
+
+  /* Proceed to erase all sectors */
+  SET_BIT(FLASH->CR, FLASH_CR_STRT);
+}
+
+/**
+  * @brief  Erase the specified FLASH memory page.
+  * @param  Page: FLASH page to erase
+  *         This parameter must be a value between 0 and (max number of pages in the bank - 1)      
+  * @param  Banks: Bank(s) where the page will be erased
+  *          This parameter can be one or a combination of the following values:
+  *            @arg FLASH_BANK_1: Page in bank 1 to be erased
+  *            @arg FLASH_BANK_2: Page in bank 2 to be erased
+  * @retval None
+  */
+void FLASH_PageErase(uint32_t Page, uint32_t Banks)
+{
+  /* Check the parameters */
+  assert_param(IS_FLASH_PAGE(Page));
+  assert_param(IS_FLASH_BANK_EXCLUSIVE(Banks));
+
+  if((Banks & FLASH_BANK_1) != RESET)
+  {
+    CLEAR_BIT(FLASH->CR, FLASH_CR_BKER);
+  }
+  else
+  {
+    SET_BIT(FLASH->CR, FLASH_CR_BKER);
+  }
+
+  /* Proceed to erase the page */
+  MODIFY_REG(FLASH->CR, FLASH_CR_PNB, (Page << 3));
+  SET_BIT(FLASH->CR, FLASH_CR_PER);
+  SET_BIT(FLASH->CR, FLASH_CR_STRT);
+}
+
+/**
+  * @brief  Flush the instruction and data caches.
+  * @retval None
+  */
+void FLASH_FlushCaches(void)
+{
+  /* Flush instruction cache  */
+  if(READ_BIT(FLASH->ACR, FLASH_ACR_ICEN) != RESET)
+  {
+    /* Disable instruction cache  */
+    __HAL_FLASH_INSTRUCTION_CACHE_DISABLE();
+    /* Reset instruction cache */
+    __HAL_FLASH_INSTRUCTION_CACHE_RESET();
+    /* Enable instruction cache */
+    __HAL_FLASH_INSTRUCTION_CACHE_ENABLE();
+  }
+  
+  /* Flush data cache */
+  if(READ_BIT(FLASH->ACR, FLASH_ACR_DCEN) != RESET)
+  {
+    /* Disable data cache  */
+    __HAL_FLASH_DATA_CACHE_DISABLE();
+    /* Reset data cache */
+    __HAL_FLASH_DATA_CACHE_RESET();
+    /* Enable data cache */
+    __HAL_FLASH_DATA_CACHE_ENABLE();
+  }
+}
+
+/**
+  * @brief  Configure the write protection of the desired pages.
+  *
+  * @note   When the memory read protection level is selected (RDP level = 1), 
+  *         it is not possible to program or erase Flash memory if the CPU debug 
+  *         features are connected (JTAG or single wire) or boot code is being 
+  *         executed from RAM or System flash, even if WRP is not activated. 
+  * @note   To configure the WRP options, the option lock bit OPTLOCK must be 
+  *         cleared with the call of the HAL_FLASH_OB_Unlock() function.
+  * @note   To validate the WRP options, the option bytes must be reloaded 
+  *         through the call of the HAL_FLASH_OB_Launch() function.
+  *
+  * @param  WRPArea: specifies the area to be configured.
+  *          This parameter can be one of the following values:
+  *            @arg OB_WRPAREA_BANK1_AREAA: Flash Bank 1 Area A                      
+  *            @arg OB_WRPAREA_BANK1_AREAB: Flash Bank 1 Area B                      
+  *            @arg OB_WRPAREA_BANK2_AREAA: Flash Bank 2 Area A                      
+  *            @arg OB_WRPAREA_BANK2_AREAB: Flash Bank 2 Area B                      
+  *
+  * @param  WRPStartOffset: specifies the start page of the write protected area
+  *          This parameter can be page number between 0 and (max number of pages in the bank - 1) 
+  *
+  * @param  WRDPEndOffset: specifies the end page of the write protected area
+  *          This parameter can be page number between WRPStartOffset and (max number of pages in the bank - 1) 
+  *
+  * @retval HAL Status
+  */
+static HAL_StatusTypeDef FLASH_OB_WRPConfig(uint32_t WRPArea, uint32_t WRPStartOffset, uint32_t WRDPEndOffset)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_OB_WRPAREA(WRPArea));
+  assert_param(IS_FLASH_PAGE(WRPStartOffset));
+  assert_param(IS_FLASH_PAGE(WRDPEndOffset));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+  if(status == HAL_OK)
+  {
+    /* Configure the write protected area */
+    if(WRPArea == OB_WRPAREA_BANK1_AREAA)
+    {
+      MODIFY_REG(FLASH->WRP1AR, (FLASH_WRP1AR_WRP1A_STRT | FLASH_WRP1AR_WRP1A_END), 
+                 (WRPStartOffset | (WRDPEndOffset << 16)));
+    }
+    else if(WRPArea == OB_WRPAREA_BANK1_AREAB)
+    {
+      MODIFY_REG(FLASH->WRP1BR, (FLASH_WRP1BR_WRP1B_STRT | FLASH_WRP1BR_WRP1B_END), 
+                 (WRPStartOffset | (WRDPEndOffset << 16)));
+    }
+    else if(WRPArea == OB_WRPAREA_BANK2_AREAA)
+    {
+      MODIFY_REG(FLASH->WRP2AR, (FLASH_WRP2AR_WRP2A_STRT | FLASH_WRP2AR_WRP2A_END), 
+                 (WRPStartOffset | (WRDPEndOffset << 16)));
+    }
+    else if(WRPArea == OB_WRPAREA_BANK2_AREAB)
+    {
+      MODIFY_REG(FLASH->WRP2BR, (FLASH_WRP2BR_WRP2B_STRT | FLASH_WRP2BR_WRP2B_END), 
+                 (WRPStartOffset | (WRDPEndOffset << 16)));
+    }
+    
+    /* Set OPTSTRT Bit */
+    SET_BIT(FLASH->CR, FLASH_CR_OPTSTRT);
+    
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+    /* If the option byte program operation is completed, disable the OPTSTRT Bit */
+    CLEAR_BIT(FLASH->CR, FLASH_CR_OPTSTRT);
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Set the read protection level.
+  *    
+  * @note   To configure the RDP level, the option lock bit OPTLOCK must be 
+  *         cleared with the call of the HAL_FLASH_OB_Unlock() function.
+  * @note   To validate the RDP level, the option bytes must be reloaded 
+  *         through the call of the HAL_FLASH_OB_Launch() function.
+  * @note   !!! Warning : When enabling OB_RDP level 2 it's no more possible 
+  *         to go back to level 1 or 0 !!!
+  *    
+  * @param  RDPLevel: specifies the read protection level.
+  *         This parameter can be one of the following values:
+  *            @arg OB_RDP_LEVEL_0: No protection
+  *            @arg OB_RDP_LEVEL_1: Read protection of the memory
+  *            @arg OB_RDP_LEVEL_2: Full chip protection
+  *   
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef FLASH_OB_RDPConfig(uint32_t RDPLevel)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_OB_RDP_LEVEL(RDPLevel));
+    
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+  if(status == HAL_OK)
+  { 
+    /* Configure the RDP level in the option bytes register */
+    MODIFY_REG(FLASH->OPTR, FLASH_OPTR_RDP, RDPLevel);
+    
+    /* Set OPTSTRT Bit */
+    SET_BIT(FLASH->CR, FLASH_CR_OPTSTRT);
+    
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+    /* If the option byte program operation is completed, disable the OPTSTRT Bit */
+    CLEAR_BIT(FLASH->CR, FLASH_CR_OPTSTRT);
+  }
+
+  return status;            
+}
+
+/**
+  * @brief  Program the FLASH User Option Byte.    
+  *   
+  * @note   To configure the user option bytes, the option lock bit OPTLOCK must
+  *         be cleared with the call of the HAL_FLASH_OB_Unlock() function.
+  * @note   To validate the user option bytes, the option bytes must be reloaded 
+  *         through the call of the HAL_FLASH_OB_Launch() function.
+  *   
+  * @param  UserType: The FLASH User Option Bytes to be modified 
+  * @param  UserConfig: The FLASH User Option Bytes values: 
+  *         BOR_LEV(Bit8-10), nRST_STOP(Bit12), nRST_STDBY(Bit13), IWDG_SW(Bit16),
+  *         IWDG_STOP(Bit17), IWDG_STDBY(Bit18), WWDG_SW(Bit19), BFB2(Bit20), 
+  *         DUALBANK(Bit21), nBOOT1(Bit23), SRAM2_PE(Bit24) and SRAM2_RST(Bit25). 
+  *   
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef FLASH_OB_UserConfig(uint32_t UserType, uint32_t UserConfig)
+{
+  uint32_t optr_reg_val = 0;
+  uint32_t optr_reg_mask = 0;
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_OB_USER_TYPE(UserType));
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+  if(status == HAL_OK)
+  { 
+    if((UserType & OB_USER_BOR_LEV) != RESET)
+    {
+      /* BOR level option byte should be modified */
+      assert_param(IS_OB_USER_BOR_LEVEL(UserConfig & FLASH_OPTR_BOR_LEV));
+    
+      /* Set value and mask for BOR level option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_BOR_LEV);
+      optr_reg_mask |= FLASH_OPTR_BOR_LEV;
+    }
+
+    if((UserType & OB_USER_nRST_STOP) != RESET)
+    {
+      /* nRST_STOP option byte should be modified */
+      assert_param(IS_OB_USER_STOP(UserConfig & FLASH_OPTR_nRST_STOP));
+    
+      /* Set value and mask for nRST_STOP option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_nRST_STOP);
+      optr_reg_mask |= FLASH_OPTR_nRST_STOP;
+    }
+
+    if((UserType & OB_USER_nRST_STDBY) != RESET)
+    {
+      /* nRST_STDBY option byte should be modified */
+      assert_param(IS_OB_USER_STANDBY(UserConfig & FLASH_OPTR_nRST_STDBY));
+    
+      /* Set value and mask for nRST_STDBY option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_nRST_STDBY);
+      optr_reg_mask |= FLASH_OPTR_nRST_STDBY;
+    }
+
+    if((UserType & OB_USER_nRST_SHDW) != RESET)
+    {
+      /* nRST_SHDW option byte should be modified */
+      assert_param(IS_OB_USER_SHUTDOWN(UserConfig & FLASH_OPTR_nRST_SHDW));
+    
+      /* Set value and mask for nRST_SHDW option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_nRST_SHDW);
+      optr_reg_mask |= FLASH_OPTR_nRST_SHDW;
+    }
+
+    if((UserType & OB_USER_IWDG_SW) != RESET)
+    {
+      /* IWDG_SW option byte should be modified */
+      assert_param(IS_OB_USER_IWDG(UserConfig & FLASH_OPTR_IWDG_SW));
+    
+      /* Set value and mask for IWDG_SW option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_IWDG_SW);
+      optr_reg_mask |= FLASH_OPTR_IWDG_SW;
+    }
+
+    if((UserType & OB_USER_IWDG_STOP) != RESET)
+    {
+      /* IWDG_STOP option byte should be modified */
+      assert_param(IS_OB_USER_IWDG_STOP(UserConfig & FLASH_OPTR_IWDG_STOP));
+    
+      /* Set value and mask for IWDG_STOP option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_IWDG_STOP);
+      optr_reg_mask |= FLASH_OPTR_IWDG_STOP;
+    }
+
+    if((UserType & OB_USER_IWDG_STDBY) != RESET)
+    {
+      /* IWDG_STDBY option byte should be modified */
+      assert_param(IS_OB_USER_IWDG_STDBY(UserConfig & FLASH_OPTR_IWDG_STDBY));
+    
+      /* Set value and mask for IWDG_STDBY option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_IWDG_STDBY);
+      optr_reg_mask |= FLASH_OPTR_IWDG_STDBY;
+    }
+
+    if((UserType & OB_USER_WWDG_SW) != RESET)
+    {
+      /* WWDG_SW option byte should be modified */
+      assert_param(IS_OB_USER_WWDG(UserConfig & FLASH_OPTR_WWDG_SW));
+    
+      /* Set value and mask for WWDG_SW option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_WWDG_SW);
+      optr_reg_mask |= FLASH_OPTR_WWDG_SW;
+    }
+
+    if((UserType & OB_USER_BFB2) != RESET)
+    {
+      /* BFB2 option byte should be modified */
+      assert_param(IS_OB_USER_BFB2(UserConfig & FLASH_OPTR_BFB2));
+    
+      /* Set value and mask for BFB2 option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_BFB2);
+      optr_reg_mask |= FLASH_OPTR_BFB2;
+    }
+
+    if((UserType & OB_USER_DUALBANK) != RESET)
+    {
+      /* DUALBANK option byte should be modified */
+      assert_param(IS_OB_USER_DUALBANK(UserConfig & FLASH_OPTR_DUALBANK));
+    
+      /* Set value and mask for DUALBANK option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_DUALBANK);
+      optr_reg_mask |= FLASH_OPTR_DUALBANK;
+    }
+
+    if((UserType & OB_USER_nBOOT1) != RESET)
+    {
+      /* nBOOT1 option byte should be modified */
+      assert_param(IS_OB_USER_BOOT1(UserConfig & FLASH_OPTR_nBOOT1));
+    
+      /* Set value and mask for nBOOT1 option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_nBOOT1);
+      optr_reg_mask |= FLASH_OPTR_nBOOT1;
+    }
+
+    if((UserType & OB_USER_SRAM2_PE) != RESET)
+    {
+      /* SRAM2_PE option byte should be modified */
+      assert_param(IS_OB_USER_SRAM2_PARITY(UserConfig & FLASH_OPTR_SRAM2_PE));
+    
+      /* Set value and mask for SRAM2_PE option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_SRAM2_PE);
+      optr_reg_mask |= FLASH_OPTR_SRAM2_PE;
+    }
+
+    if((UserType & OB_USER_SRAM2_RST) != RESET)
+    {
+      /* SRAM2_RST option byte should be modified */
+      assert_param(IS_OB_USER_SRAM2_RST(UserConfig & FLASH_OPTR_SRAM2_RST));
+    
+      /* Set value and mask for SRAM2_RST option byte */
+      optr_reg_val |= (UserConfig & FLASH_OPTR_SRAM2_RST);
+      optr_reg_mask |= FLASH_OPTR_SRAM2_RST;
+    }
+
+    /* Configure the option bytes register */
+    MODIFY_REG(FLASH->OPTR, optr_reg_mask, optr_reg_val);
+    
+    /* Set OPTSTRT Bit */
+    SET_BIT(FLASH->CR, FLASH_CR_OPTSTRT);
+    
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+    /* If the option byte program operation is completed, disable the OPTSTRT Bit */
+    CLEAR_BIT(FLASH->CR, FLASH_CR_OPTSTRT);
+  }
+
+  return status;            
+}
+
+/**
+  * @brief  Configure the Proprietary code readout protection of the desired addresses.
+  *
+  * @note   To configure the PCROP options, the option lock bit OPTLOCK must be 
+  *         cleared with the call of the HAL_FLASH_OB_Unlock() function.
+  * @note   To validate the PCROP options, the option bytes must be reloaded 
+  *         through the call of the HAL_FLASH_OB_Launch() function.
+  *
+  * @param  PCROPConfig: specifies the configuration (Bank to be configured and PCROP_RDP option).
+  *          This parameter must be a combination of FLASH_BANK_1 or FLASH_BANK_2 
+  *          with OB_PCROP_RDP_NOT_ERASE or OB_PCROP_RDP_ERASE
+  *
+  * @param  PCROPStartAddr: specifies the start address of the Proprietary code readout protection
+  *          This parameter can be an address between begin and end of the bank 
+  *
+  * @param  PCROPEndAddr: specifies the end address of the Proprietary code readout protection
+  *          This parameter can be an address between PCROPStartAddr and end of the bank 
+  *
+  * @retval HAL Status
+  */
+static HAL_StatusTypeDef FLASH_OB_PCROPConfig(uint32_t PCROPConfig, uint32_t PCROPStartAddr, uint32_t PCROPEndAddr)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t reg_value = 0;
+  uint32_t bank1_addr, bank2_addr;
+
+  /* Check the parameters */
+  assert_param(IS_FLASH_BANK_EXCLUSIVE(PCROPConfig & FLASH_BANK_BOTH));
+  assert_param(IS_OB_PCROP_RDP(PCROPConfig & FLASH_PCROP1ER_PCROP_RDP));
+  assert_param(IS_FLASH_MAIN_MEM_ADDRESS(PCROPStartAddr));
+  assert_param(IS_FLASH_MAIN_MEM_ADDRESS(PCROPEndAddr));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+  if(status == HAL_OK)
+  {
+    /* Get the information about the bank swapping */
+    if (READ_BIT(SYSCFG->MEMRMP, SYSCFG_MEMRMP_FB_MODE) == 0)
+    {
+      bank1_addr = FLASH_BASE;
+      bank2_addr = FLASH_BASE + FLASH_BANK_SIZE;
+    }
+    else
+    {
+      bank1_addr = FLASH_BASE + FLASH_BANK_SIZE;
+      bank2_addr = FLASH_BASE;
+    }
+  
+    /* Configure the Proprietary code readout protection */
+    if((PCROPConfig & FLASH_BANK_BOTH) == FLASH_BANK_1)
+    {
+      reg_value = ((PCROPStartAddr - bank1_addr) >> 3);
+      MODIFY_REG(FLASH->PCROP1SR, FLASH_PCROP1SR_PCROP1_STRT, reg_value);
+
+      reg_value = ((PCROPEndAddr - bank1_addr) >> 3);
+      MODIFY_REG(FLASH->PCROP1ER, FLASH_PCROP1ER_PCROP1_END, reg_value);
+    }
+    else if((PCROPConfig & FLASH_BANK_BOTH) == FLASH_BANK_2)
+    {
+      reg_value = ((PCROPStartAddr - bank2_addr) >> 3);
+      MODIFY_REG(FLASH->PCROP2SR, FLASH_PCROP2SR_PCROP2_STRT, reg_value);
+
+      reg_value = ((PCROPEndAddr - bank2_addr) >> 3);
+      MODIFY_REG(FLASH->PCROP2ER, FLASH_PCROP2ER_PCROP2_END, reg_value);
+    }
+
+    MODIFY_REG(FLASH->PCROP1ER, FLASH_PCROP1ER_PCROP_RDP, (PCROPConfig & FLASH_PCROP1ER_PCROP_RDP));
+    
+    /* Set OPTSTRT Bit */
+    SET_BIT(FLASH->CR, FLASH_CR_OPTSTRT);
+    
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+
+    /* If the option byte program operation is completed, disable the OPTSTRT Bit */
+    CLEAR_BIT(FLASH->CR, FLASH_CR_OPTSTRT);
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Return the FLASH Write Protection Option Bytes value.
+  *
+  * @param[in]  WRPArea: specifies the area to be returned.
+  *          This parameter can be one of the following values:
+  *            @arg OB_WRPAREA_BANK1_AREAA: Flash Bank 1 Area A                      
+  *            @arg OB_WRPAREA_BANK1_AREAB: Flash Bank 1 Area B                      
+  *            @arg OB_WRPAREA_BANK2_AREAA: Flash Bank 2 Area A                      
+  *            @arg OB_WRPAREA_BANK2_AREAB: Flash Bank 2 Area B                      
+  *
+  * @param[out]  WRPStartOffset: specifies the address where to copied the start page 
+  *                         of the write protected area
+  *
+  * @param[out]  WRDPEndOffset: specifies the address where to copied the end page of 
+  *                        the write protected area
+  *
+  * @retval None
+  */
+static void FLASH_OB_GetWRP(uint32_t WRPArea, uint32_t * WRPStartOffset, uint32_t * WRDPEndOffset)
+{
+  /* Check the parameters */
+  assert_param(IS_OB_WRPAREA(WRPArea));
+
+  /* Get the configuration of the write protected area */
+  if(WRPArea == OB_WRPAREA_BANK1_AREAA)
+  {
+    *WRPStartOffset = READ_BIT(FLASH->WRP1AR, FLASH_WRP1AR_WRP1A_STRT);
+    *WRDPEndOffset = (READ_BIT(FLASH->WRP1AR, FLASH_WRP1AR_WRP1A_END) >> 16);
+  }
+  else if(WRPArea == OB_WRPAREA_BANK1_AREAB)
+  {
+    *WRPStartOffset = READ_BIT(FLASH->WRP1BR, FLASH_WRP1BR_WRP1B_STRT);
+    *WRDPEndOffset = (READ_BIT(FLASH->WRP1BR, FLASH_WRP1BR_WRP1B_END) >> 16);
+  }
+  else if(WRPArea == OB_WRPAREA_BANK2_AREAA)
+  {
+    *WRPStartOffset = READ_BIT(FLASH->WRP2AR, FLASH_WRP2AR_WRP2A_STRT);
+    *WRDPEndOffset = (READ_BIT(FLASH->WRP2AR, FLASH_WRP2AR_WRP2A_END) >> 16);
+  }
+  else if(WRPArea == OB_WRPAREA_BANK2_AREAB)
+  {
+    *WRPStartOffset = READ_BIT(FLASH->WRP2BR, FLASH_WRP2BR_WRP2B_STRT);
+    *WRDPEndOffset = (READ_BIT(FLASH->WRP2BR, FLASH_WRP2BR_WRP2B_END) >> 16);
+  }
+}
+
+/**
+  * @brief  Return the FLASH Read Protection level.
+  * @retval FLASH ReadOut Protection Status:
+  *         This return value can be one of the following values:
+  *            @arg OB_RDP_LEVEL_0: No protection
+  *            @arg OB_RDP_LEVEL_1: Read protection of the memory
+  *            @arg OB_RDP_LEVEL_2: Full chip protection
+  */
+static uint32_t FLASH_OB_GetRDP(void)
+{
+  if ((READ_BIT(FLASH->OPTR, FLASH_OPTR_RDP) != OB_RDP_LEVEL_0) && 
+      (READ_BIT(FLASH->OPTR, FLASH_OPTR_RDP) != OB_RDP_LEVEL_2))
+  {
+    return (OB_RDP_LEVEL_1);
+  }
+  else
+  {
+    return (READ_BIT(FLASH->OPTR, FLASH_OPTR_RDP));
+  }
+}
+
+/**
+  * @brief  Return the FLASH User Option Byte value.
+  * @retval The FLASH User Option Bytes values: 
+  *         BOR_LEV(Bit8-10), nRST_STOP(Bit12), nRST_STDBY(Bit13), nRST_SHDW(Bit14), 
+  *         IWDG_SW(Bit16), IWDG_STOP(Bit17), IWDG_STDBY(Bit18), WWDG_SW(Bit19),  
+  *         BFB2(Bit20), DUALBANK(Bit21), nBOOT1(Bit23), SRAM2_PE(Bit24) and SRAM2_RST(Bit25). 
+  */
+static uint32_t FLASH_OB_GetUser(void)
+{
+  uint32_t user_config = READ_REG(FLASH->OPTR);
+  CLEAR_BIT(user_config, FLASH_OPTR_RDP);
+  
+  return user_config;
+}
+
+/**
+  * @brief  Return the FLASH Write Protection Option Bytes value.
+  *
+  * @param PCROPConfig [inout]: specifies the configuration (Bank to be configured and PCROP_RDP option).
+  *          This parameter must be a combination of FLASH_BANK_1 or FLASH_BANK_2 
+  *          with OB_PCROP_RDP_NOT_ERASE or OB_PCROP_RDP_ERASE
+  *
+  * @param PCROPStartAddr [out]: specifies the address where to copied the start address 
+  *                         of the Proprietary code readout protection
+  *
+  * @param PCROPEndAddr [out]: specifies the address where to copied the end address of 
+  *                       the Proprietary code readout protection
+  *
+  * @retval None
+  */
+static void FLASH_OB_GetPCROP(uint32_t * PCROPConfig, uint32_t * PCROPStartAddr, uint32_t * PCROPEndAddr)
+{
+  uint32_t reg_value = 0;
+  uint32_t bank1_addr, bank2_addr;
+  
+  /* Check the parameters */
+  assert_param(IS_FLASH_BANK_EXCLUSIVE((*PCROPConfig) & FLASH_BANK_BOTH));
+
+  /* Get the information about the bank swapping */
+  if (READ_BIT(SYSCFG->MEMRMP, SYSCFG_MEMRMP_FB_MODE) == 0)
+  {
+    bank1_addr = FLASH_BASE;
+    bank2_addr = FLASH_BASE + FLASH_BANK_SIZE;
+  }
+  else
+  {
+    bank1_addr = FLASH_BASE + FLASH_BANK_SIZE;
+    bank2_addr = FLASH_BASE;
+  }
+
+  if(((*PCROPConfig) & FLASH_BANK_BOTH) == FLASH_BANK_1)
+  {
+    reg_value       = (READ_REG(FLASH->PCROP1SR) & FLASH_PCROP1SR_PCROP1_STRT);
+    *PCROPStartAddr = (reg_value << 3) + bank1_addr;
+    
+    reg_value     = (READ_REG(FLASH->PCROP1ER) & FLASH_PCROP1ER_PCROP1_END);
+    *PCROPEndAddr = (reg_value << 3) + bank1_addr;
+  }
+  else if(((*PCROPConfig) & FLASH_BANK_BOTH) == FLASH_BANK_2)
+  {
+    reg_value       = (READ_REG(FLASH->PCROP2SR) & FLASH_PCROP2SR_PCROP2_STRT);
+    *PCROPStartAddr = (reg_value << 3) + bank2_addr;
+
+    reg_value     = (READ_REG(FLASH->PCROP2ER) & FLASH_PCROP2ER_PCROP2_END);
+    *PCROPEndAddr = (reg_value << 3) + bank2_addr;
+  }
+
+  *PCROPConfig |= (READ_REG(FLASH->PCROP1ER) & FLASH_PCROP1ER_PCROP_RDP);
+}
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_flash_ramfunc.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_flash_ramfunc.c
@@ -1,0 +1,155 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_flash_ramfunc.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   FLASH RAMFUNC driver.
+  *          This file provides a Flash firmware functions which should be 
+  *          executed from internal SRAM
+  *            + FLASH HalfPage Programming
+  *            + FLASH Power Down in Run mode
+  *
+  *  @verbatim
+  ==============================================================================
+                   ##### Flash RAM functions #####
+  ==============================================================================    
+
+    *** ARM Compiler ***
+    --------------------
+    [..] RAM functions are defined using the toolchain options. 
+         Functions that are executed in RAM should reside in a separate
+         source module. Using the 'Options for File' dialog you can simply change
+         the 'Code / Const' area of a module to a memory space in physical RAM.
+         Available memory areas are declared in the 'Target' tab of the 
+         Options for Target' dialog.
+
+    *** ICCARM Compiler ***
+    -----------------------
+    [..] RAM functions are defined using a specific toolchain keyword "__ramfunc".
+
+    *** GNU Compiler ***
+    --------------------
+    [..] RAM functions are defined using a specific toolchain attribute
+         "__attribute__((section(".RamFunc")))".
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup FLASH_RAMFUNC FLASH_RAMFUNC
+  * @brief FLASH functions executed from RAM
+  * @{
+  */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions -------------------------------------------------------*/
+
+/** @defgroup FLASH_RAMFUNC_Exported_Functions FLASH in RAM function Exported Functions
+  * @{
+  */
+
+/** @defgroup FLASH_RAMFUNC_Exported_Functions_Group1 Peripheral features functions 
+ *  @brief   Data transfers functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### ramfunc functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions that should be executed from RAM.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief   Enable the Power down in Run Mode
+  * @note    This function should be called and executed from SRAM memory
+  * @retval None
+  */
+__RAM_FUNC HAL_FLASHEx_EnableRunPowerDown(void)
+{
+  /* Enable the Power Down in Run mode*/
+  __HAL_FLASH_POWER_DOWN_ENABLE();
+  
+  return HAL_OK;
+  
+}
+
+/**
+  * @brief   Disable the Power down in Run Mode
+  * @note    This function should be called and executed from SRAM memory
+  * @retval None
+  */
+__RAM_FUNC HAL_FLASHEx_DisableRunPowerDown(void)
+{
+  /* Disable the Power Down in Run mode*/
+  __HAL_FLASH_POWER_DOWN_DISABLE();
+
+  return HAL_OK;  
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */   
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+
+  
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+     
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+

--- a/stmhal/hal/l4/src/stm32l4xx_hal_gpio.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_gpio.c
@@ -1,0 +1,562 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_gpio.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   GPIO HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the General Purpose Input/Output (GPIO) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *
+  @verbatim
+  ==============================================================================
+                    ##### GPIO Peripheral features #####
+  ==============================================================================
+  [..]
+    (+) Each port bit of the general-purpose I/O (GPIO) ports can be individually
+        configured by software in several modes:
+        (++) Input mode
+        (++) Analog mode
+        (++) Output mode
+        (++) Alternate function mode
+        (++) External interrupt/event lines
+
+    (+) During and just after reset, the alternate functions and external interrupt
+        lines are not active and the I/O ports are configured in input floating mode.
+
+    (+) All GPIO pins have weak internal pull-up and pull-down resistors, which can be
+        activated or not.
+
+    (+) In Output or Alternate mode, each IO can be configured on open-drain or push-pull
+        type and the IO speed can be selected depending on the VDD value.
+
+    (+) The microcontroller IO pins are connected to onboard peripherals/modules through a
+        multiplexer that allows only one peripheral alternate function (AF) connected
+       to an IO pin at a time. In this way, there can be no conflict between peripherals
+       sharing the same IO pin.
+
+    (+) All ports have external interrupt/event capability. To use external interrupt
+        lines, the port must be configured in input mode. All available GPIO pins are
+        connected to the 16 external interrupt/event lines from EXTI0 to EXTI15.
+
+    (+) The external interrupt/event controller consists of up to 39 edge detectors
+        (16 lines are connected to GPIO) for generating event/interrupt requests (each
+        input line can be independently configured to select the type (interrupt or event)
+        and the corresponding trigger event (rising or falling or both). Each line can
+        also be masked independently.
+
+                     ##### How to use this driver #####
+  ==============================================================================
+  [..]
+    (#) Enable the GPIO AHB clock using the following function: __HAL_RCC_GPIOx_CLK_ENABLE().
+
+    (#) Configure the GPIO pin(s) using HAL_GPIO_Init().
+        (++) Configure the IO mode using "Mode" member from GPIO_InitTypeDef structure
+        (++) Activate Pull-up, Pull-down resistor using "Pull" member from GPIO_InitTypeDef
+             structure.
+        (++) In case of Output or alternate function mode selection: the speed is
+             configured through "Speed" member from GPIO_InitTypeDef structure.
+        (++) In alternate mode is selection, the alternate function connected to the IO
+             is configured through "Alternate" member from GPIO_InitTypeDef structure.
+        (++) Analog mode is required when a pin is to be used as ADC channel
+             or DAC output.
+        (++) In case of external interrupt/event selection the "Mode" member from
+             GPIO_InitTypeDef structure select the type (interrupt or event) and
+             the corresponding trigger event (rising or falling or both).
+
+    (#) In case of external interrupt/event mode selection, configure NVIC IRQ priority
+        mapped to the EXTI line using HAL_NVIC_SetPriority() and enable it using
+        HAL_NVIC_EnableIRQ().
+
+    (#) To get the level of a pin configured in input mode use HAL_GPIO_ReadPin().
+
+    (#) To set/reset the level of a pin configured in output mode use
+        HAL_GPIO_WritePin()/HAL_GPIO_TogglePin().
+
+   (#) To lock pin configuration until next reset use HAL_GPIO_LockPin().
+  
+    (#) During and just after reset, the alternate functions are not
+        active and the GPIO pins are configured in input floating mode (except JTAG
+        pins).
+
+    (#) The LSE oscillator pins OSC32_IN and OSC32_OUT can be used as general purpose
+        (PC14 and PC15, respectively) when the LSE oscillator is off. The LSE has
+        priority over the GPIO function.
+
+    (#) The HSE oscillator pins OSC_IN/OSC_OUT can be used as
+        general purpose PH0 and PH1, respectively, when the HSE oscillator is off.
+        The HSE has priority over the GPIO function.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup GPIO GPIO
+  * @brief GPIO HAL module driver
+  * @{
+  */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/
+/** @defgroup GPIO_Private_Defines GPIO Private Defines
+  * @{
+  */
+#define GPIO_MODE             ((uint32_t)0x00000003)
+#define ANALOG_MODE           ((uint32_t)0x00000008)
+#define EXTI_MODE             ((uint32_t)0x10000000)
+#define GPIO_MODE_IT          ((uint32_t)0x00010000)
+#define GPIO_MODE_EVT         ((uint32_t)0x00020000)
+#define RISING_EDGE           ((uint32_t)0x00100000)
+#define FALLING_EDGE          ((uint32_t)0x00200000)
+#define GPIO_OUTPUT_TYPE      ((uint32_t)0x00000010)
+
+#define GPIO_NUMBER           ((uint32_t)16)
+/**
+  * @}
+  */
+  
+/* Private macros ------------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup GPIO_Private_Macros GPIO Private Macros
+  * @{
+  */
+/**
+  * @}
+  */
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup GPIO_Exported_Functions GPIO Exported Functions
+  * @{
+  */
+
+/** @defgroup GPIO_Exported_Functions_Group1 Initialization/de-initialization functions 
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initialize the GPIOx peripheral according to the specified parameters in the GPIO_Init.
+  * @param  GPIOx: where x can be (A..H) to select the GPIO peripheral for STM32L4 family
+  * @param  GPIO_Init: pointer to a GPIO_InitTypeDef structure that contains
+  *         the configuration information for the specified GPIO peripheral.
+  * @retval None
+  */
+void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
+{
+  uint32_t position = 0x00;
+  uint32_t iocurrent = 0x00;
+  uint32_t temp = 0x00;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_INSTANCE(GPIOx));
+  assert_param(IS_GPIO_PIN(GPIO_Init->Pin));
+  assert_param(IS_GPIO_MODE(GPIO_Init->Mode));
+  assert_param(IS_GPIO_PULL(GPIO_Init->Pull));
+
+  /* Configure the port pins */
+  while (((GPIO_Init->Pin) >> position) != RESET)
+  {
+    /* Get current io position */
+    iocurrent = (GPIO_Init->Pin) & (1U << position);
+
+    if(iocurrent)
+    {
+      /*--------------------- GPIO Mode Configuration ------------------------*/
+      /* In case of Alternate function mode selection */
+      if((GPIO_Init->Mode == GPIO_MODE_AF_PP) || (GPIO_Init->Mode == GPIO_MODE_AF_OD))
+      {
+        /* Check the Alternate function parameters */
+        assert_param(IS_GPIO_AF_INSTANCE(GPIOx));
+        assert_param(IS_GPIO_AF(GPIO_Init->Alternate));
+        
+        /* Configure Alternate function mapped with the current IO */
+        temp = GPIOx->AFR[position >> 3];
+        temp &= ~((uint32_t)0xF << ((uint32_t)(position & (uint32_t)0x07) * 4)) ;
+        temp |= ((uint32_t)(GPIO_Init->Alternate) << (((uint32_t)position & (uint32_t)0x07) * 4));
+        GPIOx->AFR[position >> 3] = temp;
+      }
+
+      /* Configure IO Direction mode (Input, Output, Alternate or Analog) */
+      temp = GPIOx->MODER;
+      temp &= ~(GPIO_MODER_MODE0 << (position * 2));
+      temp |= ((GPIO_Init->Mode & GPIO_MODE) << (position * 2));
+      GPIOx->MODER = temp;
+
+      /* In case of Output or Alternate function mode selection */
+      if((GPIO_Init->Mode == GPIO_MODE_OUTPUT_PP) || (GPIO_Init->Mode == GPIO_MODE_AF_PP) ||
+         (GPIO_Init->Mode == GPIO_MODE_OUTPUT_OD) || (GPIO_Init->Mode == GPIO_MODE_AF_OD))
+      {
+        /* Check the Speed parameter */
+        assert_param(IS_GPIO_SPEED(GPIO_Init->Speed));
+        /* Configure the IO Speed */
+        temp = GPIOx->OSPEEDR;
+        temp &= ~(GPIO_OSPEEDR_OSPEED0 << (position * 2));
+        temp |= (GPIO_Init->Speed << (position * 2));
+        GPIOx->OSPEEDR = temp;
+
+        /* Configure the IO Output Type */
+        temp = GPIOx->OTYPER;
+        temp &= ~(GPIO_OTYPER_OT0 << position) ;
+        temp |= (((GPIO_Init->Mode & GPIO_OUTPUT_TYPE) >> 4) << position);
+        GPIOx->OTYPER = temp;
+      }
+
+      /* In case of Analog mode, check if ADC control mode is selected */
+      if((GPIO_Init->Mode & GPIO_MODE_ANALOG) == GPIO_MODE_ANALOG)
+      {
+        /* Configure the IO Output Type */
+        temp = GPIOx->ASCR;
+        temp &= ~(GPIO_ASCR_ASC0 << position) ;
+        temp |= (((GPIO_Init->Mode & ANALOG_MODE) >> 3) << position);
+        GPIOx->ASCR = temp;
+      }
+
+      /* Activate the Pull-up or Pull down resistor for the current IO */
+      temp = GPIOx->PUPDR;
+      temp &= ~(GPIO_PUPDR_PUPD0 << (position * 2));
+      temp |= ((GPIO_Init->Pull) << (position * 2));
+      GPIOx->PUPDR = temp;
+
+      /*--------------------- EXTI Mode Configuration ------------------------*/
+      /* Configure the External Interrupt or event for the current IO */
+      if((GPIO_Init->Mode & EXTI_MODE) == EXTI_MODE)
+      {
+        /* Enable SYSCFG Clock */
+        __HAL_RCC_SYSCFG_CLK_ENABLE();
+
+        temp = SYSCFG->EXTICR[position >> 2];
+        temp &= ~(((uint32_t)0x0F) << (4 * (position & 0x03)));
+        temp |= (GPIO_GET_INDEX(GPIOx) << (4 * (position & 0x03)));
+        SYSCFG->EXTICR[position >> 2] = temp;
+
+        /* Clear EXTI line configuration */
+        temp = EXTI->IMR1;
+        temp &= ~((uint32_t)iocurrent);
+        if((GPIO_Init->Mode & GPIO_MODE_IT) == GPIO_MODE_IT)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->IMR1 = temp;
+
+        temp = EXTI->EMR1;
+        temp &= ~((uint32_t)iocurrent);
+        if((GPIO_Init->Mode & GPIO_MODE_EVT) == GPIO_MODE_EVT)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->EMR1 = temp;
+
+        /* Clear Rising Falling edge configuration */
+        temp = EXTI->RTSR1;
+        temp &= ~((uint32_t)iocurrent);
+        if((GPIO_Init->Mode & RISING_EDGE) == RISING_EDGE)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->RTSR1 = temp;
+
+        temp = EXTI->FTSR1;
+        temp &= ~((uint32_t)iocurrent);
+        if((GPIO_Init->Mode & FALLING_EDGE) == FALLING_EDGE)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->FTSR1 = temp;
+      }
+    }
+    
+    position++;
+  }
+}
+
+/**
+  * @brief  De-initialize the GPIOx peripheral registers to their default reset values.
+  * @param  GPIOx: where x can be (A..H) to select the GPIO peripheral for STM32L4 family
+  * @param  GPIO_Pin: specifies the port bit to be written.
+  *         This parameter can be one of GPIO_PIN_x where x can be (0..15).
+  * @retval None
+  */
+void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
+{
+  uint32_t position = 0x00;
+  uint32_t iocurrent = 0x00;
+  uint32_t tmp = 0x00;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_INSTANCE(GPIOx));
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+
+  /* Configure the port pins */
+  while ((GPIO_Pin >> position) != RESET)
+  {
+    /* Get current io position */
+    iocurrent = (GPIO_Pin) & (1U << position);
+
+    if (iocurrent)
+    {
+      /*------------------------- GPIO Mode Configuration --------------------*/
+      /* Configure IO in Analog Mode */
+      GPIOx->MODER |= (GPIO_MODER_MODE0 << (position * 2));
+
+      /* Configure the default Alternate Function in current IO */
+      GPIOx->AFR[position >> 3] &= ~((uint32_t)0xF << ((uint32_t)(position & (uint32_t)0x07) * 4)) ;
+
+      /* Configure the default value for IO Speed */
+      GPIOx->OSPEEDR &= ~(GPIO_OSPEEDR_OSPEED0 << (position * 2));
+
+      /* Configure the default value IO Output Type */
+      GPIOx->OTYPER  &= ~(GPIO_OTYPER_OT0 << position) ;
+
+      /* Deactivate the Pull-up and Pull-down resistor for the current IO */
+      GPIOx->PUPDR &= ~(GPIO_PUPDR_PUPD0 << (position * 2));
+
+      /* Deactivate the Control bit of Analog mode for the current IO */
+      GPIOx->ASCR &= ~(GPIO_ASCR_ASC0<< position);
+
+      /*------------------------- EXTI Mode Configuration --------------------*/
+      /* Clear the External Interrupt or Event for the current IO */
+      
+      tmp = SYSCFG->EXTICR[position >> 2];
+      tmp &= (((uint32_t)0x0F) << (4 * (position & 0x03)));
+      if(tmp == (GPIO_GET_INDEX(GPIOx) << (4 * (position & 0x03))))
+      {
+        tmp = ((uint32_t)0x0F) << (4 * (position & 0x03));
+        SYSCFG->EXTICR[position >> 2] &= ~tmp;
+
+        /* Clear EXTI line configuration */
+        EXTI->IMR1 &= ~((uint32_t)iocurrent);
+        EXTI->EMR1 &= ~((uint32_t)iocurrent);
+
+        /* Clear Rising Falling edge configuration */
+        EXTI->RTSR1 &= ~((uint32_t)iocurrent);
+        EXTI->FTSR1 &= ~((uint32_t)iocurrent);
+      }
+    }
+    
+    position++;
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup GPIO_Exported_Functions_Group2 IO operation functions 
+ *  @brief GPIO Read, Write, Toggle, Lock and EXTI management functions.
+ *
+@verbatim
+ ===============================================================================
+                       ##### IO operation functions #####
+ ===============================================================================
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Read the specified input port pin.
+  * @param  GPIOx: where x can be (A..H) to select the GPIO peripheral for STM32L4 family
+  * @param  GPIO_Pin: specifies the port bit to read.
+  *         This parameter can be GPIO_PIN_x where x can be (0..15).
+  * @retval The input port pin value.
+  */
+GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  GPIO_PinState bitstatus;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+
+  if((GPIOx->IDR & GPIO_Pin) != (uint32_t)GPIO_PIN_RESET)
+  {
+    bitstatus = GPIO_PIN_SET;
+  }
+  else
+  {
+    bitstatus = GPIO_PIN_RESET;
+  }
+  return bitstatus;
+}
+
+/**
+  * @brief  Set or clear the selected data port bit.
+  *
+  * @note   This function uses GPIOx_BSRR and GPIOx_BRR registers to allow atomic read/modify
+  *         accesses. In this way, there is no risk of an IRQ occurring between
+  *         the read and the modify access.
+  *
+  * @param  GPIOx: where x can be (A..H) to select the GPIO peripheral for STM32L4 family
+  * @param  GPIO_Pin: specifies the port bit to be written.
+  *         This parameter can be one of GPIO_PIN_x where x can be (0..15).
+  * @param  PinState: specifies the value to be written to the selected bit.
+  *         This parameter can be one of the GPIO_PinState enum values:
+  *            @arg GPIO_PIN_RESET: to clear the port pin
+  *            @arg GPIO_PIN_SET: to set the port pin
+  * @retval None
+  */
+void HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+  assert_param(IS_GPIO_PIN_ACTION(PinState));
+
+  if(PinState != GPIO_PIN_RESET)
+  {
+    GPIOx->BSRR = (uint32_t)GPIO_Pin;
+  }
+  else
+  {
+    GPIOx->BRR = (uint32_t)GPIO_Pin;
+  }
+}
+
+/**
+  * @brief  Toggle the specified GPIO pin.
+  * @param  GPIOx: where x can be (A..H) to select the GPIO peripheral for STM32L4 family
+  * @param  GPIO_Pin: specifies the pin to be toggled.
+  * @retval None
+  */
+void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+
+  GPIOx->ODR ^= GPIO_Pin;
+}
+
+/**
+* @brief  Lock GPIO Pins configuration registers.
+  * @note   The locked registers are GPIOx_MODER, GPIOx_OTYPER, GPIOx_OSPEEDR,
+  *         GPIOx_PUPDR, GPIOx_AFRL and GPIOx_AFRH.
+  * @note   The configuration of the locked GPIO pins can no longer be modified
+  *         until the next reset.
+  * @param  GPIOx: where x can be (A..H) to select the GPIO peripheral for STM32L4 family
+  * @param  GPIO_Pin: specifies the port bits to be locked.
+  *         This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  __IO uint32_t tmp = GPIO_LCKR_LCKK;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_LOCK_INSTANCE(GPIOx));
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+
+  /* Apply lock key write sequence */
+  tmp |= GPIO_Pin;
+  /* Set LCKx bit(s): LCKK='1' + LCK[15-0] */
+  GPIOx->LCKR = tmp;
+  /* Reset LCKx bit(s): LCKK='0' + LCK[15-0] */
+  GPIOx->LCKR = GPIO_Pin;
+  /* Set LCKx bit(s): LCKK='1' + LCK[15-0] */
+  GPIOx->LCKR = tmp;
+  /* Read LCKK bit*/
+  tmp = GPIOx->LCKR;
+
+  if((GPIOx->LCKR & GPIO_LCKR_LCKK) != RESET)
+  {
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Handle EXTI interrupt request.
+  * @param  GPIO_Pin: Specifies the port pin connected to corresponding EXTI line.
+  * @retval None
+  */
+void HAL_GPIO_EXTI_IRQHandler(uint16_t GPIO_Pin)
+{
+  /* EXTI line interrupt detected */
+  if(__HAL_GPIO_EXTI_GET_IT(GPIO_Pin) != RESET)
+  {
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_Pin);
+    HAL_GPIO_EXTI_Callback(GPIO_Pin);
+  }
+}
+
+/**
+  * @brief  EXTI line detection callback.
+  * @param  GPIO_Pin: Specifies the port pin connected to corresponding EXTI line.
+  * @retval None
+  */
+__weak void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(GPIO_Pin);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_GPIO_EXTI_Callback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+#endif /* HAL_GPIO_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_i2c.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_i2c.c
@@ -1,0 +1,5227 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_i2c.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   I2C HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Inter Integrated Circuit (I2C) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral State and Errors functions
+  *
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]
+    The I2C HAL driver can be used as follows:
+
+    (#) Declare a I2C_HandleTypeDef handle structure, for example:
+        I2C_HandleTypeDef  hi2c;
+
+    (#)Initialize the I2C low level resources by implementing the HAL_I2C_MspInit() API:
+        (##) Enable the I2Cx interface clock
+        (##) I2C pins configuration
+            (+++) Enable the clock for the I2C GPIOs
+            (+++) Configure I2C pins as alternate function open-drain
+        (##) NVIC configuration if you need to use interrupt process
+            (+++) Configure the I2Cx interrupt priority
+            (+++) Enable the NVIC I2C IRQ Channel
+        (##) DMA Configuration if you need to use DMA process
+            (+++) Declare a DMA_HandleTypeDef handle structure for the transmit or receive channel
+            (+++) Enable the DMAx interface clock using
+            (+++) Configure the DMA handle parameters
+            (+++) Configure the DMA Tx or Rx channel
+            (+++) Associate the initialized DMA handle to the hi2c DMA Tx or Rx handle
+            (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on
+                  the DMA Tx or Rx channel
+
+    (#) Configure the Communication Clock Timing, Own Address1, Master Addressing mode, Dual Addressing mode,
+        Own Address2, Own Address2 Mask, General call and Nostretch mode in the hi2c Init structure.
+
+    (#) Initialize the I2C registers by calling the HAL_I2C_Init(), configures also the low level Hardware
+        (GPIO, CLOCK, NVIC...etc) by calling the customized HAL_I2C_MspInit(&hi2c) API.
+
+    (#) To check if target device is ready for communication, use the function HAL_I2C_IsDeviceReady()
+
+    (#) For I2C IO and IO MEM operations, three operation modes are available within this driver :
+
+    *** Polling mode IO operation ***
+    =================================
+    [..]
+      (+) Transmit in master mode an amount of data in blocking mode using HAL_I2C_Master_Transmit()
+      (+) Receive in master mode an amount of data in blocking mode using HAL_I2C_Master_Receive()
+      (+) Transmit in slave mode an amount of data in blocking mode using HAL_I2C_Slave_Transmit()
+      (+) Receive in slave mode an amount of data in blocking mode using HAL_I2C_Slave_Receive()
+
+    *** Polling mode IO MEM operation ***
+    =====================================
+    [..]
+      (+) Write an amount of data in blocking mode to a specific memory address using HAL_I2C_Mem_Write()
+      (+) Read an amount of data in blocking mode from a specific memory address using HAL_I2C_Mem_Read()
+
+
+    *** Interrupt mode IO operation ***
+    ===================================
+    [..]
+      (+) Transmit in master mode an amount of data in non-blocking mode using HAL_I2C_Master_Transmit_IT()
+      (+) At transmission end of transfer, HAL_I2C_MasterTxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterTxCpltCallback()
+      (+) Receive in master mode an amount of data in non-blocking mode using HAL_I2C_Master_Receive_IT()
+      (+) At reception end of transfer, HAL_I2C_MasterRxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterRxCpltCallback()
+      (+) Transmit in slave mode an amount of data in non-blocking mode using HAL_I2C_Slave_Transmit_IT()
+      (+) At transmission end of transfer, HAL_I2C_SlaveTxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveTxCpltCallback()
+      (+) Receive in slave mode an amount of data in non-blocking mode using HAL_I2C_Slave_Receive_IT()
+      (+) At reception end of transfer, HAL_I2C_SlaveRxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback()
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ErrorCallback()
+      (+) Transmit in master mode an amount of data in non-blocking mode using HAL_I2C_Master_Transmit_IT()
+
+    *** Interrupt mode IO sequential operation ***
+    ===================================
+    [..]
+      (@) These interfaces allow to manage a sequential transfer with a repeated start condition
+          when a direction change during transfer
+    [..]
+      (+) A specific option field manage the different steps of a sequential transfer
+      (+) Option field values are defined through I2C_XferOptions_definition and are listed below:
+      (++) I2C_FIRST_AND_LAST_FRAME: No sequential usage, functionnal is same as associated interfaces in no sequential mode
+      (++) I2C_FIRST_FRAME: Sequential usage, this option allow to manage a sequence with start condition, address
+                            and data to transfer without a final stop condition
+      (++) I2C_NEXT_FRAME: Sequential usage, this option allow to manage a sequence with a restart condition, address
+                            and with new data to transfer if the direction change or manage only the new data to transfer
+                            if no direction change and without a final stop condition in both cases
+      (++) I2C_LAST_FRAME: Sequential usage, this option allow to manage a sequance with a restart condition, address
+                            and with new data to transfer if the direction change or manage only the new data to transfer
+                            if no direction change and with a final stop condition in both cases
+
+      (+) Differents sequential I2C interfaces are listed below:
+      (++) Sequential transmit in master I2C mode an amount of data in non-blocking mode using HAL_I2C_Master_Sequential_Transmit_IT()
+      (+++) At transmission end of current frame transfer, HAL_I2C_MasterTxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterTxCpltCallback()
+      (++) Sequential receive in master I2C mode an amount of data in non-blocking mode using HAL_I2C_Master_Sequential_Receive_IT()
+      (+++) At reception end of current frame transfer, HAL_I2C_MasterRxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterRxCpltCallback()
+      (++) Abort a master I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
+      (+++) The associated previous transfer callback is called at the end of abort process
+      (+++) mean HAL_I2C_MasterTxCpltCallback() in case of previous state was master transmit
+      (+++) mean HAL_I2c_MasterRxCpltCallback() in case of previous state was master receive
+      (++) Enable/disable the Address listen mode in slave I2C mode using HAL_I2C_EnableListen_IT() HAL_I2C_DisableListen_IT()
+      (+++) When address slave I2C match, HAL_I2C_AddrCallback() is executed and user can
+           add his own code to check the Address Match Code and the transmission direction request by master (Write/Read).
+      (+++) At Listen mode end HAL_I2C_ListenCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ListenCpltCallback()
+      (++) Sequential transmit in slave I2C mode an amount of data in non-blocking mode using HAL_I2C_Slave_Sequential_Transmit_IT()
+      (+++) At transmission end of current frame transfer, HAL_I2C_SlaveTxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveTxCpltCallback()
+      (++) Sequential receive in slave I2C mode an amount of data in non-blocking mode using HAL_I2C_Slave_Sequential_Receive_IT()
+      (+++) At reception end of current frame transfer, HAL_I2C_SlaveRxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback()
+
+    *** Interrupt mode IO MEM operation ***
+    =======================================
+    [..]
+      (+) Write an amount of data in non-blocking mode with Interrupt to a specific memory address using
+          HAL_I2C_Mem_Write_IT()
+      (+) At Memory end of write transfer, HAL_I2C_MemTxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MemTxCpltCallback()
+      (+) Read an amount of data in non-blocking mode with Interrupt from a specific memory address using
+          HAL_I2C_Mem_Read_IT()
+      (+) At Memory end of read transfer, HAL_I2C_MemRxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MemRxCpltCallback()
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ErrorCallback()
+
+    *** DMA mode IO operation ***
+    ==============================
+    [..]
+      (+) Transmit in master mode an amount of data in non-blocking mode (DMA) using
+          HAL_I2C_Master_Transmit_DMA()
+      (+) At transmission end of transfer, HAL_I2C_MasterTxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterTxCpltCallback()
+      (+) Receive in master mode an amount of data in non-blocking mode (DMA) using
+          HAL_I2C_Master_Receive_DMA()
+      (+) At reception end of transfer, HAL_I2C_MasterRxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterRxCpltCallback()
+      (+) Transmit in slave mode an amount of data in non-blocking mode (DMA) using
+          HAL_I2C_Slave_Transmit_DMA()
+      (+) At transmission end of transfer, HAL_I2C_SlaveTxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveTxCpltCallback()
+      (+) Receive in slave mode an amount of data in non-blocking mode (DMA) using
+          HAL_I2C_Slave_Receive_DMA()
+      (+) At reception end of transfer, HAL_I2C_SlaveRxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback()
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ErrorCallback()
+
+    *** DMA mode IO MEM operation ***
+    =================================
+    [..]
+      (+) Write an amount of data in non-blocking mode with DMA to a specific memory address using
+          HAL_I2C_Mem_Write_DMA()
+      (+) At Memory end of write transfer, HAL_I2C_MemTxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MemTxCpltCallback()
+      (+) Read an amount of data in non-blocking mode with DMA from a specific memory address using
+          HAL_I2C_Mem_Read_DMA()
+      (+) At Memory end of read transfer, HAL_I2C_MemRxCpltCallback() is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MemRxCpltCallback()
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ErrorCallback()
+
+
+     *** I2C HAL driver macros list ***
+     ==================================
+     [..]
+       Below the list of most used macros in I2C HAL driver.
+
+      (+) __HAL_I2C_ENABLE: Enable the I2C peripheral
+      (+) __HAL_I2C_DISABLE: Disable the I2C peripheral
+      (+) __HAL_I2C_GET_FLAG:    Check whether the specified I2C flag is set or not
+      (+) __HAL_I2C_CLEAR_FLAG: Clear the specified I2C pending flag
+      (+) __HAL_I2C_ENABLE_IT: Enable the specified I2C interrupt
+      (+) __HAL_I2C_DISABLE_IT: Disable the specified I2C interrupt
+
+     [..]
+       (@) You can refer to the I2C HAL driver header file for more useful macros
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup I2C I2C
+  * @brief I2C HAL module driver
+  * @{
+  */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+
+/** @defgroup I2C_Private_Define I2C Private Define
+  * @{
+  */
+#define TIMING_CLEAR_MASK   ((uint32_t)0xF0FFFFFF)  /*!<  I2C TIMING clear register Mask */
+#define I2C_TIMEOUT_ADDR    ((uint32_t)10000)       /*!< 10 s  */
+#define I2C_TIMEOUT_BUSY    ((uint32_t)25)          /*!< 25 ms */
+#define I2C_TIMEOUT_DIR     ((uint32_t)25)          /*!< 25 ms */
+#define I2C_TIMEOUT_RXNE    ((uint32_t)25)          /*!< 25 ms */
+#define I2C_TIMEOUT_STOPF   ((uint32_t)25)          /*!< 25 ms */
+#define I2C_TIMEOUT_TC      ((uint32_t)25)          /*!< 25 ms */
+#define I2C_TIMEOUT_TCR     ((uint32_t)25)          /*!< 25 ms */
+#define I2C_TIMEOUT_TXIS    ((uint32_t)25)          /*!< 25 ms */
+#define I2C_TIMEOUT_FLAG    ((uint32_t)25)          /*!< 25 ms */
+
+#define SlaveAddr_SHIFT     7
+#define SlaveAddr_MSK       0x06
+
+/* Private define for @ref PreviousState usage */
+#define I2C_STATE_MSK             ((uint32_t)((HAL_I2C_STATE_BUSY_TX | HAL_I2C_STATE_BUSY_RX) & (~HAL_I2C_STATE_READY))) /*!< Mask State define, keep only RX and TX bits            */
+#define I2C_STATE_NONE            ((uint32_t)(HAL_I2C_MODE_NONE))                                                        /*!< Default Value                                          */
+#define I2C_STATE_MASTER_BUSY_TX  ((uint32_t)((HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | HAL_I2C_MODE_MASTER))            /*!< Master Busy TX, combinaison of State LSB and Mode enum */
+#define I2C_STATE_MASTER_BUSY_RX  ((uint32_t)((HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | HAL_I2C_MODE_MASTER))            /*!< Master Busy RX, combinaison of State LSB and Mode enum */
+#define I2C_STATE_SLAVE_BUSY_TX   ((uint32_t)((HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | HAL_I2C_MODE_SLAVE))             /*!< Slave Busy TX, combinaison of State LSB and Mode enum  */
+#define I2C_STATE_SLAVE_BUSY_RX   ((uint32_t)((HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | HAL_I2C_MODE_SLAVE))             /*!< Slave Busy RX, combinaison of State LSB and Mode enum  */
+#define I2C_STATE_MEM_BUSY_TX     ((uint32_t)((HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | HAL_I2C_MODE_MEM))               /*!< Memory Busy TX, combinaison of State LSB and Mode enum */
+#define I2C_STATE_MEM_BUSY_RX     ((uint32_t)((HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | HAL_I2C_MODE_MEM))               /*!< Memory Busy RX, combinaison of State LSB and Mode enum */
+
+
+/* Private define to centralize the enable/disable of Interrupts */
+#define I2C_XFER_TX_IT                       ((uint32_t)0x00000001)
+#define I2C_XFER_RX_IT                       ((uint32_t)0x00000002)
+#define I2C_XFER_LISTEN_IT                   ((uint32_t)0x00000004)
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+
+/** @defgroup I2C_Private_Functions I2C Private Functions
+  * @{
+  */
+static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMASlaveReceiveCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMAMemTransmitCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMAMemReceiveCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMAError(DMA_HandleTypeDef *hdma);
+
+static HAL_StatusTypeDef I2C_RequestMemoryWrite(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout, uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_RequestMemoryRead(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout, uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Flag, FlagStatus Status, uint32_t Timeout, uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_IsAcknowledgeFailed(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart);
+
+static HAL_StatusTypeDef I2C_Master_ISR(I2C_HandleTypeDef *hi2c);
+static HAL_StatusTypeDef I2C_Slave_ISR(I2C_HandleTypeDef *hi2c);
+
+static HAL_StatusTypeDef I2C_Enable_IRQ(I2C_HandleTypeDef *hi2c, uint16_t InterruptRequest);
+static HAL_StatusTypeDef I2C_Disable_IRQ(I2C_HandleTypeDef *hi2c, uint16_t InterruptRequest);
+
+static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup I2C_Exported_Functions I2C Exported Functions
+  * @{
+  */
+
+/** @defgroup I2C_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This subsection provides a set of functions allowing to initialize and
+          deinitialize the I2Cx peripheral:
+
+      (+) User must Implement HAL_I2C_MspInit() function in which he configures
+          all related peripherals resources (CLOCK, GPIO, DMA, IT and NVIC ).
+
+      (+) Call the function HAL_I2C_Init() to configure the selected device with
+          the selected configuration:
+        (++) Clock Timing
+        (++) Own Address 1
+        (++) Addressing mode (Master, Slave)
+        (++) Dual Addressing mode
+        (++) Own Address 2
+        (++) Own Address 2 Mask
+        (++) General call mode
+        (++) Nostretch mode
+
+      (+) Call the function HAL_I2C_DeInit() to restore the default configuration
+          of the selected I2Cx peripheral.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the I2C according to the specified parameters
+  *         in the I2C_InitTypeDef and initialize the associated handle.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c)
+{ 
+  /* Check the I2C handle allocation */
+  if(hi2c == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  assert_param(IS_I2C_OWN_ADDRESS1(hi2c->Init.OwnAddress1));
+  assert_param(IS_I2C_ADDRESSING_MODE(hi2c->Init.AddressingMode));
+  assert_param(IS_I2C_DUAL_ADDRESS(hi2c->Init.DualAddressMode));
+  assert_param(IS_I2C_OWN_ADDRESS2(hi2c->Init.OwnAddress2));
+  assert_param(IS_I2C_OWN_ADDRESS2_MASK(hi2c->Init.OwnAddress2Masks));
+  assert_param(IS_I2C_GENERAL_CALL(hi2c->Init.GeneralCallMode));
+  assert_param(IS_I2C_NO_STRETCH(hi2c->Init.NoStretchMode));
+
+  if(hi2c->State == HAL_I2C_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hi2c->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX...etc */
+    HAL_I2C_MspInit(hi2c);
+  }
+
+  hi2c->State = HAL_I2C_STATE_BUSY;
+
+  /* Disable the selected I2C peripheral */
+  __HAL_I2C_DISABLE(hi2c);
+
+  /*---------------------------- I2Cx TIMINGR Configuration ------------------*/
+  /* Configure I2Cx: Frequency range */
+  hi2c->Instance->TIMINGR = hi2c->Init.Timing & TIMING_CLEAR_MASK;
+
+  /*---------------------------- I2Cx OAR1 Configuration ---------------------*/
+  /* Configure I2Cx: Own Address1 and ack own address1 mode */
+  hi2c->Instance->OAR1 &= ~I2C_OAR1_OA1EN;
+  if(hi2c->Init.OwnAddress1 != 0)
+  {
+    if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_7BIT)
+    {
+      hi2c->Instance->OAR1 = (I2C_OAR1_OA1EN | hi2c->Init.OwnAddress1);
+    }
+    else /* I2C_ADDRESSINGMODE_10BIT */
+    {
+      hi2c->Instance->OAR1 = (I2C_OAR1_OA1EN | I2C_OAR1_OA1MODE | hi2c->Init.OwnAddress1);
+    }
+  }
+
+  /*---------------------------- I2Cx CR2 Configuration ----------------------*/
+  /* Configure I2Cx: Addressing Master mode */
+  if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
+  {
+    hi2c->Instance->CR2 = (I2C_CR2_ADD10);
+  }
+  /* Enable the AUTOEND by default, and enable NACK (should be disable only during Slave process */
+  hi2c->Instance->CR2 |= (I2C_CR2_AUTOEND | I2C_CR2_NACK);
+
+  /*---------------------------- I2Cx OAR2 Configuration ---------------------*/
+  /* Configure I2Cx: Dual mode and Own Address2 */
+  hi2c->Instance->OAR2 = (hi2c->Init.DualAddressMode | hi2c->Init.OwnAddress2 | (hi2c->Init.OwnAddress2Masks << 8));
+
+  /*---------------------------- I2Cx CR1 Configuration ----------------------*/
+  /* Configure I2Cx: Generalcall and NoStretch mode */
+  hi2c->Instance->CR1 = (hi2c->Init.GeneralCallMode | hi2c->Init.NoStretchMode);
+
+  /* Enable the selected I2C peripheral */
+  __HAL_I2C_ENABLE(hi2c);
+
+  hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+  hi2c->State = HAL_I2C_STATE_READY;
+  hi2c->PreviousState = I2C_STATE_NONE;
+  hi2c->Mode = HAL_I2C_MODE_NONE;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitialize the I2C peripheral.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_DeInit(I2C_HandleTypeDef *hi2c)
+{
+  /* Check the I2C handle allocation */
+  if(hi2c == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+
+  hi2c->State = HAL_I2C_STATE_BUSY;
+
+  /* Disable the I2C Peripheral Clock */
+  __HAL_I2C_DISABLE(hi2c);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_I2C_MspDeInit(hi2c);
+
+  hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+  hi2c->State = HAL_I2C_STATE_RESET;
+  hi2c->PreviousState = I2C_STATE_NONE;
+  hi2c->Mode = HAL_I2C_MODE_NONE;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Initialize the I2C MSP.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hi2c);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_I2C_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief DeInitialize the I2C MSP.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hi2c);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_I2C_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Exported_Functions_Group2 Input and Output operation functions
+ *  @brief   Data transfers functions 
+ *
+@verbatim
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to manage the I2C data
+    transfers.
+
+    (#) There are two modes of transfer:
+       (++) Blocking mode : The communication is performed in the polling mode.
+            The status of all data processing is returned by the same function 
+            after finishing transfer.
+       (++) No-Blocking mode : The communication is performed using Interrupts
+            or DMA. These functions return the status of the transfer startup.
+            The end of the data processing will be indicated through the
+            dedicated I2C IRQ when using Interrupt mode or the DMA IRQ when
+            using DMA mode.
+
+    (#) Blocking mode functions are :
+        (++) HAL_I2C_Master_Transmit()
+        (++) HAL_I2C_Master_Receive()
+        (++) HAL_I2C_Slave_Transmit()
+        (++) HAL_I2C_Slave_Receive()
+        (++) HAL_I2C_Mem_Write()
+        (++) HAL_I2C_Mem_Read()
+        (++) HAL_I2C_IsDeviceReady()
+
+    (#) No-Blocking mode functions with Interrupt are :
+        (++) HAL_I2C_Master_Transmit_IT()
+        (++) HAL_I2C_Master_Receive_IT()
+        (++) HAL_I2C_Slave_Transmit_IT()
+        (++) HAL_I2C_Slave_Receive_IT()
+        (++) HAL_I2C_Mem_Write_IT()
+        (++) HAL_I2C_Mem_Read_IT()
+
+    (#) No-Blocking mode functions with DMA are :
+        (++) HAL_I2C_Master_Transmit_DMA()
+        (++) HAL_I2C_Master_Receive_DMA()
+        (++) HAL_I2C_Slave_Transmit_DMA()
+        (++) HAL_I2C_Slave_Receive_DMA()
+        (++) HAL_I2C_Mem_Write_DMA()
+        (++) HAL_I2C_Mem_Read_DMA()
+
+    (#) A set of Transfer Complete Callbacks are provided in non Blocking mode:
+        (++) HAL_I2C_MemTxCpltCallback()
+        (++) HAL_I2C_MemRxCpltCallback()
+        (++) HAL_I2C_MasterTxCpltCallback()
+        (++) HAL_I2C_MasterRxCpltCallback()
+        (++) HAL_I2C_SlaveTxCpltCallback()
+        (++) HAL_I2C_SlaveRxCpltCallback()
+        (++) HAL_I2C_ErrorCallback()
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Transmits in master mode an amount of data in blocking mode.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+  uint32_t sizetmp = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {    
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_TX;
+    hi2c->Mode = HAL_I2C_MODE_MASTER;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    /* Size > 255, need to set RELOAD bit */
+    if(Size > 255)
+    {
+      I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+      sizetmp = 255;
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_GENERATE_START_WRITE);
+      sizetmp = Size;
+    }
+
+    do
+    {
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          return HAL_ERROR;
+        }
+        else
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = (*pData++);
+      sizetmp--;
+      Size--;
+
+      if((sizetmp == 0)&&(Size!=0))
+      {
+        /* Wait until TCR flag is set */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout, tickstart) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        if(Size > 255)
+        {
+          I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          sizetmp = 255;
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          sizetmp = Size;
+        }
+      }
+
+    }while(Size > 0);
+
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is set */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receives in master mode an amount of data in blocking mode.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+  uint32_t sizetmp = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {    
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_RX;
+    hi2c->Mode = HAL_I2C_MODE_MASTER;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    /* Size > 255, need to set RELOAD bit */
+    if(Size > 255)
+    {
+      I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+      sizetmp = 255;
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+      sizetmp = Size;
+    }
+
+    do
+    {
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnRXNEFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          return HAL_ERROR;
+        }
+        else
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+
+      /* Write data to RXDR */
+      (*pData++) =hi2c->Instance->RXDR;
+      sizetmp--;
+      Size--;
+
+      if((sizetmp == 0)&&(Size!=0))
+      {
+        /* Wait until TCR flag is set */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout, tickstart) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        if(Size > 255)
+        {
+          I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          sizetmp = 255;
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          sizetmp = Size;
+        }
+      }
+
+    }while(Size > 0);
+
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is set */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmits in slave mode an amount of data in blocking mode. 
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_TX;
+    hi2c->Mode = HAL_I2C_MODE_SLAVE;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Wait until ADDR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+
+    /* If 10bit addressing mode is selected */
+    if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
+    {
+      /* Wait until ADDR flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout, tickstart) != HAL_OK)
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+        return HAL_TIMEOUT;
+      }
+
+      /* Clear ADDR flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+    }
+
+    /* Wait until DIR flag is set Transmitter mode */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_DIR, RESET, Timeout, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    do
+    {
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          return HAL_ERROR;
+        }
+        else
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = (*pData++);
+      Size--;
+    }while(Size > 0);
+
+    /* Wait until STOP flag is set */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+	/* Normal use case for Transmitter mode */
+	/* A NACK is generated to confirm the end of transfer */
+	hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_STOPF);
+
+    /* Wait until BUSY flag is reset */ 
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, Timeout, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Disable Address Acknowledge */
+    hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive in slave mode an amount of data in blocking mode
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {  
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_RX;
+    hi2c->Mode = HAL_I2C_MODE_SLAVE;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Wait until ADDR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+
+    /* Wait until DIR flag is reset Receiver mode */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_DIR, SET, Timeout, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    while(Size > 0)
+    {
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnRXNEFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+        /* Store Last receive data if any */
+        if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET)
+        {
+          /* Read data from RXDR */
+          (*pData++) = hi2c->Instance->RXDR;
+        }
+
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_TIMEOUT)
+        {
+          return HAL_TIMEOUT;
+        }
+        else
+        {
+          return HAL_ERROR;
+        }
+      }
+
+      /* Read data from RXDR */
+      (*pData++) = hi2c->Instance->RXDR;
+      Size--;
+    }
+
+    /* Wait until STOP flag is set */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_STOPF);
+
+    /* Wait until BUSY flag is reset */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, Timeout, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Disable Address Acknowledge */
+    hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit in master mode an amount of data in non-blocking mode with Interrupt
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY_TX;
+    hi2c->Mode = HAL_I2C_MODE_MASTER;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    hi2c->XferOptions = I2C_NO_OPTION_FRAME;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_WRITE);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c); 
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive in master mode an amount of data in non-blocking mode with Interrupt
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY_RX;
+    hi2c->Mode = HAL_I2C_MODE_MASTER;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    hi2c->XferOptions = I2C_NO_OPTION_FRAME;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+    }
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+    /* Enable ERR, TC, STOP, NACK, RXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit in slave mode an amount of data in non-blocking mode with Interrupt
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY_TX;
+    hi2c->Mode = HAL_I2C_MODE_SLAVE;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    hi2c->XferOptions = I2C_NO_OPTION_FRAME;
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferSize = Size;
+    hi2c->XferCount = Size;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT | I2C_XFER_LISTEN_IT);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive in slave mode an amount of data in non-blocking mode with Interrupt 
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY_RX;
+    hi2c->Mode = HAL_I2C_MODE_SLAVE;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    hi2c->XferOptions = I2C_NO_OPTION_FRAME;
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferSize = Size;
+    hi2c->XferCount = Size;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+    /* Enable ERR, TC, STOP, NACK, RXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT | I2C_XFER_LISTEN_IT);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit in master mode an amount of data in non-blocking mode with DMA
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+{
+  uint32_t tickstart = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_TX;
+    hi2c->Mode = HAL_I2C_MODE_MASTER;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmatx->XferCpltCallback = I2C_DMAMasterTransmitCplt;
+
+    /* Set the DMA error callback */
+    hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if((hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount))
+    {
+      I2C_TransferConfig(hi2c, DevAddress, hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c, DevAddress, hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_WRITE);
+    }
+
+    /* Wait until TXIS flag is set */
+    if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, I2C_TIMEOUT_TXIS, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      /* Abort DMA */
+      HAL_DMA_Abort(hi2c->hdmatx);
+
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive in master mode an amount of data in non-blocking mode with DMA
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+{
+  uint32_t tickstart = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }  
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_RX;
+    hi2c->Mode = HAL_I2C_MODE_MASTER;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmarx->XferCpltCallback = I2C_DMAMasterReceiveCplt;
+
+    /* Set the DMA error callback */
+    hi2c->hdmarx->XferErrorCallback = I2C_DMAError;
+
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, hi2c->XferSize);
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+    }
+
+    /* Wait until RXNE flag is set */
+    if(I2C_WaitOnRXNEFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, tickstart) != HAL_OK)
+    {
+      /* Abort DMA */
+      HAL_DMA_Abort(hi2c->hdmarx);
+
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit in slave mode an amount of data in non-blocking mode with DMA
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size)
+{
+  uint32_t tickstart = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }   
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_TX;
+    hi2c->Mode = HAL_I2C_MODE_SLAVE;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    hi2c->XferSize = Size;
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmatx->XferCpltCallback = I2C_DMASlaveTransmitCplt;
+
+    /* Set the DMA error callback */
+    hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Wait until ADDR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, I2C_TIMEOUT_ADDR, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+    
+    /* If 10bits addressing mode is selected */
+    if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
+    {
+      /* Wait until ADDR flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, I2C_TIMEOUT_ADDR, tickstart) != HAL_OK)
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+        return HAL_TIMEOUT;
+      }
+
+      /* Clear ADDR flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+    }
+    
+    /* Wait until DIR flag is set Transmitter mode */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_DIR, RESET, I2C_TIMEOUT_BUSY, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN; 
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive in slave mode an amount of data in non-blocking mode with DMA
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size)
+{
+  uint32_t tickstart = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }   
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_RX;
+    hi2c->Mode = HAL_I2C_MODE_SLAVE;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferSize = Size;
+    hi2c->XferCount = Size;
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmarx->XferCpltCallback = I2C_DMASlaveReceiveCplt;
+
+    /* Set the DMA error callback */
+    hi2c->hdmarx->XferErrorCallback = I2C_DMAError;
+
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, Size);
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Wait until ADDR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, I2C_TIMEOUT_ADDR, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+
+    /* Wait until DIR flag is set Receiver mode */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_DIR, SET, I2C_TIMEOUT_DIR, tickstart) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+ 
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+/**
+  * @brief  Write an amount of data in blocking mode to a specific memory address
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  MemAddress Internal memory address
+  * @param  MemAddSize Size of internal memory address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+  uint32_t Sizetmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_TX;
+    hi2c->Mode = HAL_I2C_MODE_MEM;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryWrite(hi2c, DevAddress, MemAddress, MemAddSize, Timeout, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set NBYTES to write and reload if size > 255 */
+    /* Size > 255, need to set RELOAD bit */
+    if(Size > 255)
+    {
+      I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      Sizetmp = 255;
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      Sizetmp = Size;
+    }
+
+    do
+    {
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          return HAL_ERROR;
+        }
+        else
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+
+      /* Write data to DR */
+      hi2c->Instance->TXDR = (*pData++);
+      Sizetmp--;
+      Size--;
+
+      if((Sizetmp == 0)&&(Size!=0))
+      {
+        /* Wait until TCR flag is set */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout, tickstart) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        if(Size > 255)
+        {
+          I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          Sizetmp = 255;
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          Sizetmp = Size;
+        }
+      }
+
+    }while(Size > 0);
+
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */ 
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Read an amount of data in blocking mode from a specific memory address
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  MemAddress Internal memory address
+  * @param  MemAddSize Size of internal memory address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+  uint32_t Sizetmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_RX;
+    hi2c->Mode = HAL_I2C_MODE_MEM;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryRead(hi2c, DevAddress, MemAddress, MemAddSize, Timeout, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    /* Size > 255, need to set RELOAD bit */
+    if(Size > 255)
+    {
+      I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+      Sizetmp = 255;
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+      Sizetmp = Size;
+    }
+
+    do
+    {
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, Timeout, tickstart) != HAL_OK)
+      {
+        return HAL_TIMEOUT;
+      }
+
+      /* Read data from RXDR */
+      (*pData++) = hi2c->Instance->RXDR;
+
+      /* Decrement the Size counter */
+      Sizetmp--;
+      Size--;
+
+      if((Sizetmp == 0)&&(Size!=0))
+      {
+        /* Wait until TCR flag is set */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout, tickstart) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        if(Size > 255)
+        {
+          I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          Sizetmp = 255;
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          Sizetmp = Size;
+        }
+      }
+
+    }while(Size > 0);
+
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */ 
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+/**
+  * @brief  Write an amount of data in non-blocking mode with Interrupt to a specific memory address
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  MemAddress Internal memory address
+  * @param  MemAddSize Size of internal memory address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+    
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_TX;
+    hi2c->Mode = HAL_I2C_MODE_MEM;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+    hi2c->XferOptions = I2C_NO_OPTION_FRAME;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryWrite(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set NBYTES to write and reload if size > 255 */
+    /* Size > 255, need to set RELOAD bit */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+    }  
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c); 
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process 
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Read an amount of data in non-blocking mode with Interrupt from a specific memory address
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  MemAddress Internal memory address
+  * @param  MemAddSize Size of internal memory address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+    
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_RX;
+    hi2c->Mode = HAL_I2C_MODE_MEM;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+    hi2c->XferOptions = I2C_NO_OPTION_FRAME;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryRead(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    /* Size > 255, need to set RELOAD bit */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+    /* Enable ERR, TC, STOP, NACK, RXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }   
+}
+/**
+  * @brief  Write an amount of data in non-blocking mode with DMA to a specific memory address
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  MemAddress Internal memory address
+  * @param  MemAddSize Size of internal memory address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_TX;
+    hi2c->Mode = HAL_I2C_MODE_MEM;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmatx->XferCpltCallback = I2C_DMAMemTransmitCplt;
+
+    /* Set the DMA error callback */
+    hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryWrite(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+    }
+
+    /* Wait until TXIS flag is set */
+    if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, I2C_TIMEOUT_TXIS, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Reads an amount of data in non-blocking mode with DMA from a specific memory address.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  MemAddress Internal memory address
+  * @param  MemAddSize Size of internal memory address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be read
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+  
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Init tickstart for timeout management*/
+    tickstart = HAL_GetTick();
+
+    hi2c->State = HAL_I2C_STATE_BUSY_RX;
+    hi2c->Mode = HAL_I2C_MODE_MEM;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmarx->XferCpltCallback = I2C_DMAMemReceiveCplt;
+
+    /* Set the DMA error callback */
+    hi2c->hdmarx->XferErrorCallback = I2C_DMAError;
+
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, hi2c->XferSize);
+
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryRead(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+    }
+
+    /* Wait until RXNE flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, I2C_TIMEOUT_RXNE, tickstart) != HAL_OK)
+    {
+      return HAL_TIMEOUT;
+    }
+
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Checks if target device is ready for communication.
+  * @note   This function is used with Memory devices
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  Trials Number of trials
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout)
+{  
+  uint32_t tickstart = 0;
+
+  __IO uint32_t I2C_Trials = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    do
+    {
+      /* Generate Start */
+      hi2c->Instance->CR2 = I2C_GENERATE_START(hi2c->Init.AddressingMode,DevAddress);
+      
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is set or a NACK flag is set*/
+      tickstart = HAL_GetTick();
+      while((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET) && (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == RESET) && (hi2c->State != HAL_I2C_STATE_TIMEOUT))
+      {
+      	if(Timeout != HAL_MAX_DELAY)
+      	{
+          if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+          {
+            /* Device is ready */
+            hi2c->State = HAL_I2C_STATE_READY;
+            /* Process Unlocked */
+            __HAL_UNLOCK(hi2c);
+            return HAL_TIMEOUT;
+          }
+        } 
+      }
+
+      /* Check if the NACKF flag has not been set */
+      if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == RESET)
+      {
+        /* Wait until STOPF flag is reset */ 
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout, tickstart) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+        /* Device is ready */
+        hi2c->State = HAL_I2C_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        return HAL_OK;
+      }
+      else
+      {
+        /* Wait until STOPF flag is reset */ 
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout, tickstart) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+        /* Clear STOP Flag, auto generated with autoend*/
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+      }
+
+      /* Check if the maximum allowed number of trials has been reached */
+      if (I2C_Trials++ == Trials)
+      {
+        /* Generate Stop */
+        hi2c->Instance->CR2 |= I2C_CR2_STOP;
+        
+        /* Wait until STOPF flag is reset */ 
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout, tickstart) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+      }
+    }while(I2C_Trials < Trials);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_TIMEOUT;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Sequential transmit in master I2C mode an amount of data in non-blocking mode with Interrupt.
+  * @note   This interface allow to manage repeated start condition when a direction change during transfer
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @param  XferOptions Options of Transfer, value of @ref I2C_XferOptions_definition
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_TRANSFER_OPTIONS_REQUEST(XferOptions));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY_TX;
+    hi2c->Mode = HAL_I2C_MODE_MASTER;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    /* Prepare transfer parameters */
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    hi2c->XferOptions = XferOptions;
+
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if((hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount))
+    {
+      I2C_TransferConfig(hi2c, DevAddress, hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+    }
+    else
+    {
+      /* If transfer direction not change, do not generate Restart Condition */
+      /* Mean Previous state is same as current state */
+      if(hi2c->PreviousState == I2C_STATE_SLAVE_BUSY_TX)
+      {
+        I2C_TransferConfig(hi2c, DevAddress, hi2c->XferSize, hi2c->XferOptions, I2C_NO_STARTSTOP);
+      }
+      /* Else transfer direction change, so generate Restart with new transfer direction */
+      else
+      {
+        I2C_TransferConfig(hi2c, DevAddress, hi2c->XferSize, hi2c->XferOptions, I2C_GENERATE_START_WRITE);
+      }
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c); 
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Sequential receive in master I2C mode an amount of data in non-blocking mode with Interrupt
+  * @note   This interface allow to manage repeated start condition when a direction change during transfer
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @param  XferOptions Options of Transfer, value of @ref I2C_XferOptions_definition
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_TRANSFER_OPTIONS_REQUEST(XferOptions));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY_RX;
+    hi2c->Mode = HAL_I2C_MODE_MASTER;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    /* Prepare transfer parameters */
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    hi2c->XferOptions = XferOptions;
+
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress, hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      /* If transfer direction not change, do not generate Restart Condition */
+      /* Mean Previous state is same as current state */
+      if(hi2c->PreviousState == I2C_STATE_MASTER_BUSY_RX)
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, hi2c->XferOptions, I2C_NO_STARTSTOP);
+      }
+      /* Else transfer direction change, so generate Restart with new transfer direction */
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, hi2c->XferOptions, I2C_GENERATE_START_READ);
+      }
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c); 
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Sequential transmit in slave/device I2C mode an amount of data in non-blocking mode with Interrupt
+  * @note   This interface allow to manage repeated start condition when a direction change during transfer
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @param  XferOptions Options of Transfer, value of @ref I2C_XferOptions_definition
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_TRANSFER_OPTIONS_REQUEST(XferOptions));
+
+  if(hi2c->State == HAL_I2C_STATE_LISTEN)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Disable Interrupts, to prevent preemption during treatment in case of multicall */
+    I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT | I2C_XFER_TX_IT);
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY_TX_LISTEN;
+    hi2c->Mode = HAL_I2C_MODE_SLAVE;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Prepare transfer parameters */
+    hi2c->pBuffPtr = pData;
+    hi2c->XferSize = Size;
+    hi2c->XferCount = Size;
+    hi2c->XferOptions = XferOptions;
+
+    if(I2C_GET_DIR(hi2c) == I2C_DIRECTION_RECEIVE)
+    {
+      /* Clear ADDR flag after prepare the transfer parameters */
+      /* This action will generate an acknowledge to the Master */
+      __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c); 
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+    to avoid the risk of I2C interrupt handle execution before current
+    process unlock */
+    /* REnable ADDR interrupt */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT | I2C_XFER_LISTEN_IT);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Sequential receive in slave/device I2C mode an amount of data in non-blocking mode with Interrupt
+  * @note   This interface allow to manage repeated start condition when a direction change during transfer
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData Pointer to data buffer
+  * @param  Size Amount of data to be sent
+  * @param  XferOptions Options of Transfer, value of @ref I2C_XferOptions_definition
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_TRANSFER_OPTIONS_REQUEST(XferOptions));
+
+  if(hi2c->State == HAL_I2C_STATE_LISTEN)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Disable Interrupts, to prevent preemption during treatment in case of multicall */
+    I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT | I2C_XFER_RX_IT);
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY_RX_LISTEN;
+    hi2c->Mode = HAL_I2C_MODE_SLAVE;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Prepare transfer parameters */
+    hi2c->pBuffPtr = pData;
+    hi2c->XferSize = Size;
+    hi2c->XferCount = Size;
+    hi2c->XferOptions = XferOptions;
+
+    if(I2C_GET_DIR(hi2c) == I2C_DIRECTION_TRANSMIT)
+    {
+      /* Clear ADDR flag after prepare the transfer parameters */
+      /* This action will generate an acknowledge to the Master */
+      __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process
+    to avoid the risk of I2C interrupt handle execution before current
+    process unlock */
+    /* REnable ADDR interrupt */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT | I2C_XFER_LISTEN_IT);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Enable the Address listen mode with Interrupt.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_EnableListen_IT(I2C_HandleTypeDef *hi2c)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    hi2c->State = HAL_I2C_STATE_LISTEN;
+
+    /* Enable the Address Match interrupt */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_LISTEN_IT);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Disable the Address listen mode with Interrupt.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_DisableListen_IT(I2C_HandleTypeDef *hi2c)
+{
+  /* Declaration of tmp to prevent undefined behavior of volatile usage */
+  uint32_t tmp;
+
+  /* Disable Address listen mode only if a transfer is not ongoing */
+  if(hi2c->State == HAL_I2C_STATE_LISTEN)
+  {
+    tmp = (uint32_t)(hi2c->State) & I2C_STATE_MSK;
+    hi2c->PreviousState = tmp | (uint32_t)(hi2c->Mode);
+    hi2c->State = HAL_I2C_STATE_READY;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+    /* Disable the Address Match interrupt */
+    I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Abort a master/host I2C process communication with Interrupt.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Abort_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
+{
+  if((hi2c->Mode == HAL_I2C_MODE_MASTER) || \
+     ((hi2c->ErrorCode != HAL_I2C_ERROR_NONE) && (hi2c->Mode == HAL_I2C_MODE_MASTER)))
+  {
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    /* Keep the same state as previous */
+    /* to perform as well the call of the corresponding end of transfer callback */
+    if((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX) && (hi2c->ErrorCode != HAL_I2C_ERROR_NONE))
+    {
+      hi2c->State = HAL_I2C_STATE_BUSY_TX;
+      hi2c->Mode = HAL_I2C_MODE_MASTER;
+    }
+    else if((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_RX) && (hi2c->ErrorCode != HAL_I2C_ERROR_NONE))
+    {
+      hi2c->State = HAL_I2C_STATE_BUSY_RX;
+      hi2c->Mode = HAL_I2C_MODE_MASTER;
+    }
+
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+
+    /* Set NBYTES to 1 to generate a dummy read on I2C peripheral */
+    /* Set AUTOEND mode, this will generate a NACK then STOP condition to abort the current transfer */
+    I2C_TransferConfig(hi2c, DevAddress, 1, I2C_AUTOEND_MODE, I2C_GENERATE_STOP);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process 
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+    if((hi2c->State == HAL_I2C_STATE_BUSY_TX) && (hi2c->Mode == HAL_I2C_MODE_MASTER))
+    {
+      I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
+    }
+    if((hi2c->State == HAL_I2C_STATE_BUSY_RX) && (hi2c->Mode == HAL_I2C_MODE_MASTER))
+    {
+      I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT);
+    }
+    
+    return HAL_OK;
+  }
+  else
+  {
+    /* Wrong usage of abort function */
+    /* This function should be used only in case of abort monitored by master device */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup I2C_IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
+ * @{
+ */   
+
+/**
+  * @brief  This function handles I2C event interrupt request.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+void HAL_I2C_EV_IRQHandler(I2C_HandleTypeDef *hi2c)
+{
+  uint32_t tmpisrvalue = 0;
+  
+  /* Use a local variable to store the current ISR flags */
+  /* This action will avoid a wrong treatment due to ISR flags change during interrupt handler */
+  tmpisrvalue = I2C_GET_ISR_REG(hi2c);
+    
+  /* I2C in mode Transmitter ---------------------------------------------------*/
+  if (((I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_TXIS) != RESET) || (I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_TCR) != RESET) || (I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_TC) != RESET) || (I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_STOPF) != RESET) || (I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_AF) != RESET)) && (__HAL_I2C_GET_IT_SOURCE(hi2c, (I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_TXI)) != RESET))
+  {
+    /* Slave mode selected */
+    if (hi2c->Mode  == HAL_I2C_MODE_SLAVE)
+    {
+      I2C_Slave_ISR(hi2c);
+    }
+    /* Master or Memory mode selected */
+    else if ((hi2c->Mode == HAL_I2C_MODE_MASTER) || (hi2c->Mode == HAL_I2C_MODE_MEM))
+    {
+      I2C_Master_ISR(hi2c);
+    }
+  }
+
+  /* I2C in mode Receiver ----------------------------------------------------*/
+  if (((I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_RXNE) != RESET) || (I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_TCR) != RESET) || (I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_TC) != RESET) || (I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_STOPF) != RESET) || (I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_AF) != RESET)) && (__HAL_I2C_GET_IT_SOURCE(hi2c, (I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_RXI)) != RESET))
+  {
+    /* Slave mode selected */
+    if (hi2c->Mode  == HAL_I2C_MODE_SLAVE)
+    {
+      I2C_Slave_ISR(hi2c);
+    }
+    /* Master or Memory mode selected */
+    else if ((hi2c->Mode == HAL_I2C_MODE_MASTER) || (hi2c->Mode == HAL_I2C_MODE_MEM))
+    {
+      I2C_Master_ISR(hi2c);
+    }
+  } 
+
+  /* I2C in mode Listener Only --------------------------------------------------*/
+  if (((I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_ADDR) != RESET) || (I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_STOPF) != RESET) || (I2C_CHECK_FLAG(tmpisrvalue, I2C_FLAG_AF) != RESET)) && ((__HAL_I2C_GET_IT_SOURCE(hi2c, I2C_IT_ADDRI) != RESET) || (__HAL_I2C_GET_IT_SOURCE(hi2c, I2C_IT_STOPI) != RESET) || (__HAL_I2C_GET_IT_SOURCE(hi2c, I2C_IT_NACKI) != RESET)))
+  {
+    if(hi2c->XferOptions != I2C_NO_OPTION_FRAME)
+    {    
+      if((hi2c->State == HAL_I2C_STATE_LISTEN) || (hi2c->State == HAL_I2C_STATE_BUSY_TX_LISTEN) || (hi2c->State == HAL_I2C_STATE_BUSY_RX_LISTEN))
+      {
+        I2C_Slave_ISR(hi2c);
+      }
+    }
+    else
+    {
+      if(hi2c->Mode == HAL_I2C_MODE_SLAVE)
+      {
+        I2C_Slave_ISR(hi2c);
+      }
+    }
+  }
+}
+
+/**
+  * @brief  This function handles I2C error interrupt request.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+void HAL_I2C_ER_IRQHandler(I2C_HandleTypeDef *hi2c)
+{
+  /* I2C Bus error interrupt occurred ------------------------------------*/
+  if((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BERR) == SET) && (__HAL_I2C_GET_IT_SOURCE(hi2c, I2C_IT_ERRI) == SET))
+  {
+    hi2c->ErrorCode |= HAL_I2C_ERROR_BERR;
+
+    /* Clear BERR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_BERR);
+  }
+
+  /* I2C Over-Run/Under-Run interrupt occurred ----------------------------------------*/
+  if((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_OVR) == SET) && (__HAL_I2C_GET_IT_SOURCE(hi2c, I2C_IT_ERRI) == SET))
+  {
+    hi2c->ErrorCode |= HAL_I2C_ERROR_OVR;
+
+    /* Clear OVR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_OVR);
+  }
+
+  /* I2C Arbitration Loss error interrupt occurred -------------------------------------*/
+  if((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ARLO) == SET) && (__HAL_I2C_GET_IT_SOURCE(hi2c, I2C_IT_ERRI) == SET))
+  {
+    hi2c->ErrorCode |= HAL_I2C_ERROR_ARLO;
+
+    /* Clear ARLO flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_ARLO);
+  }
+
+  /* Call the Error Callback in case of Error detected */
+  if((hi2c->ErrorCode & (HAL_I2C_ERROR_BERR | HAL_I2C_ERROR_OVR | HAL_I2C_ERROR_ARLO)) !=  HAL_I2C_ERROR_NONE)
+  {
+    if(((hi2c->State == HAL_I2C_STATE_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_BUSY_RX)) && (hi2c->Mode == HAL_I2C_MODE_SLAVE))
+    {
+      /* Reset only HAL_I2C_STATE_SLAVE_BUSY_XX */
+      /* keep HAL_I2C_STATE_LISTEN if set */
+      hi2c->PreviousState = I2C_STATE_NONE;
+      hi2c->State = HAL_I2C_STATE_LISTEN;
+    }
+    else
+    {
+      hi2c->PreviousState = I2C_STATE_NONE;
+      hi2c->State = HAL_I2C_STATE_READY;
+    }
+
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+}
+
+/**
+  * @brief  Master Tx Transfer completed callback.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hi2c);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_I2C_MasterTxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Master Rx Transfer completed callback.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hi2c);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_I2C_MasterRxCpltCallback could be implemented in the user file
+   */
+}
+
+/** @brief  Slave Tx Transfer completed callback.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_SlaveTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hi2c);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_I2C_SlaveTxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Slave Rx Transfer completed callback.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hi2c);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_I2C_SlaveRxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Slave Address Match callback.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  TransferDirection: Master request Transfer Direction (Write/Read), value of @ref I2C_XferOptions_definition
+  * @param  AddrMatchCode: Address Match Code
+  * @retval None
+  */
+__weak void HAL_I2C_AddrCallback(I2C_HandleTypeDef *hi2c, uint8_t TransferDirection, uint16_t AddrMatchCode)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hi2c);
+  UNUSED(TransferDirection);
+  UNUSED(AddrMatchCode);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_I2C_AddrCallback() could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Listen Complete callback.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_ListenCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hi2c);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_I2C_ListenCpltCallback() could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Memory Tx Transfer completed callback.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hi2c);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_I2C_MemTxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Memory Rx Transfer completed callback.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hi2c);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_I2C_MemRxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  I2C error callback.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hi2c);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_I2C_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Exported_Functions_Group3 Peripheral State, Mode and Error functions
+ *  @brief   Peripheral State, Mode and Error functions
+ *
+@verbatim
+ ===============================================================================
+            ##### Peripheral State, Mode and Error functions #####
+ ===============================================================================
+    [..]
+    This subsection permit to get in run-time the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the I2C handle state.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL state
+  */
+HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c)
+{
+  /* Return I2C handle state */
+  return hi2c->State;
+}
+
+/**
+  * @brief  Returns the I2C Master, Slave, Memory or no mode.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *         the configuration information for I2C module
+  * @retval HAL mode
+  */
+HAL_I2C_ModeTypeDef HAL_I2C_GetMode(I2C_HandleTypeDef *hi2c)
+{
+  return hi2c->Mode;
+}
+
+/**
+* @brief  Return the I2C error code.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *              the configuration information for the specified I2C.
+* @retval I2C Error Code
+*/
+uint32_t HAL_I2C_GetError(I2C_HandleTypeDef *hi2c)
+{
+  return hi2c->ErrorCode;
+}
+
+/**
+  * @}
+  */  
+
+/**
+  * @}
+  */
+
+/** @addtogroup I2C_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Interrupt Sub-Routine which handle the Interrupt Flags Master Mode.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_Master_ISR(I2C_HandleTypeDef *hi2c) 
+{
+  uint16_t DevAddress;
+
+  /* Process Locked */
+  __HAL_LOCK(hi2c);
+
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) != RESET)
+  {
+    /* Clear NACK Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Set corresponding Error Code */
+    /* No need to generate STOP, it is automatically done */
+    /* Error callback will be send during stop flag treatment */
+    hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+
+    /* If a pending TXIS flag is set */
+    /* Write a dummy data in TXDR */
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) != RESET)
+    {
+       hi2c->Instance->TXDR = 0x00;
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) != RESET)
+  {
+    /* Read data from RXDR */
+    (*hi2c->pBuffPtr++) = hi2c->Instance->RXDR;
+    hi2c->XferSize--;
+    hi2c->XferCount--;
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) != RESET)
+  {
+    /* Write data to TXDR */
+    hi2c->Instance->TXDR = (*hi2c->pBuffPtr++);
+    hi2c->XferSize--;
+    hi2c->XferCount--;	
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) != RESET)
+  {
+    if((hi2c->XferSize == 0)&&(hi2c->XferCount!=0))
+    {
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+      
+      if(hi2c->XferCount > 255)
+      {
+        I2C_TransferConfig(hi2c, DevAddress, 255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+        if(hi2c->XferOptions != I2C_NO_OPTION_FRAME)
+        {
+          I2C_TransferConfig(hi2c, DevAddress, hi2c->XferSize, hi2c->XferOptions, I2C_NO_STARTSTOP);
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c, DevAddress, hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+        }
+      }
+    }
+    else
+    {
+      /* Call TxCpltCallback() if no stop mode is set */
+      if((I2C_GET_STOP_MODE(hi2c) != I2C_AUTOEND_MODE)&&(hi2c->Mode == HAL_I2C_MODE_MASTER))
+      {
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        if (hi2c->State == HAL_I2C_STATE_BUSY_TX)
+        {
+          hi2c->State = HAL_I2C_STATE_READY;
+          hi2c->PreviousState = I2C_STATE_MASTER_BUSY_TX;
+
+          /* Disable Interrupts */
+          I2C_Disable_IRQ(hi2c, I2C_XFER_TX_IT);
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+
+          /* Call the corresponding callback to inform upper layer of End of Transfer */
+            HAL_I2C_MasterTxCpltCallback(hi2c);
+        }
+        /* hi2c->State == HAL_I2C_STATE_BUSY_RX */
+        else
+        {
+          hi2c->State = HAL_I2C_STATE_READY;
+          hi2c->PreviousState = I2C_STATE_MASTER_BUSY_RX;
+
+          /* Disable Interrupts */
+          I2C_Disable_IRQ(hi2c, I2C_XFER_RX_IT);
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+
+          /* Call the corresponding callback to inform upper layer of End of Transfer */
+          HAL_I2C_MasterRxCpltCallback(hi2c);
+        }
+      }
+      else
+      {
+        hi2c->PreviousState = I2C_STATE_NONE;
+        hi2c->State = HAL_I2C_STATE_READY;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        /* Wrong size Status regarding TCR flag event */
+        hi2c->ErrorCode |= HAL_I2C_ERROR_SIZE;
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET)
+  {
+    if(hi2c->XferCount == 0)
+    {
+      if((I2C_GET_STOP_MODE(hi2c) != I2C_AUTOEND_MODE)&&(hi2c->Mode == HAL_I2C_MODE_MASTER))
+      {
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        /* No Generate Stop, to permit restart mode */
+        /* The stop will be done at the end of transfer, when I2C_AUTOEND_MODE enable */
+        if (hi2c->State == HAL_I2C_STATE_BUSY_TX)
+        {
+          hi2c->PreviousState = I2C_STATE_MASTER_BUSY_TX;
+          hi2c->State = HAL_I2C_STATE_READY;
+
+          /* Disable Interrupts */
+          I2C_Disable_IRQ(hi2c, I2C_XFER_TX_IT);
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+
+          /* Call the corresponding callback to inform upper layer of End of Transfer */
+          HAL_I2C_MasterTxCpltCallback(hi2c);
+        }
+        /* hi2c->State == HAL_I2C_STATE_BUSY_RX */
+        else
+        {
+          hi2c->PreviousState = I2C_STATE_MASTER_BUSY_RX;
+          hi2c->State = HAL_I2C_STATE_READY;
+
+          /* Disable Interrupts */
+          I2C_Disable_IRQ(hi2c, I2C_XFER_RX_IT);
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+
+          /* Call the corresponding callback to inform upper layer of End of Transfer */
+          HAL_I2C_MasterRxCpltCallback(hi2c);
+        }
+      }
+    }
+    else
+    {
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+      
+      /* Wrong size Status regarding TC flag event */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_SIZE;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      /* Call the corresponding callback to inform upper layer of End of Transfer */
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+  }
+
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) != RESET)
+  {
+    if(hi2c->State == HAL_I2C_STATE_BUSY_TX)
+    {
+      if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
+      {
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+
+        /* If a pending TXIS flag is set */
+        /* Write a dummy data in TXDR to clear it */
+        if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) != RESET)
+        {
+           hi2c->Instance->TXDR = 0x00;
+        }
+      }
+
+      /* Disable Interrupts */
+      I2C_Disable_IRQ(hi2c, I2C_XFER_TX_IT);
+
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c);
+
+      /* Flush TX register if not empty */
+      if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXE) == RESET)
+      {
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_TXE);
+      }
+
+      /* Call the corresponding callback to inform upper layer of End of Transfer */
+      if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+      {
+        hi2c->PreviousState = I2C_STATE_NONE;
+        hi2c->State = HAL_I2C_STATE_READY;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        /* Call the corresponding callback to inform upper layer of End of Transfer */
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        if (hi2c->Mode == HAL_I2C_MODE_MEM)
+        {
+          hi2c->PreviousState = I2C_STATE_NONE;
+          hi2c->State = HAL_I2C_STATE_READY;
+          hi2c->Mode = HAL_I2C_MODE_NONE;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+
+          /* Call the corresponding callback to inform upper layer of End of Transfer */
+          HAL_I2C_MemTxCpltCallback(hi2c);
+        }
+        else
+        {
+          hi2c->PreviousState = I2C_STATE_MASTER_BUSY_TX;
+          hi2c->State = HAL_I2C_STATE_READY;
+          hi2c->Mode = HAL_I2C_MODE_NONE;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+
+          /* Call the corresponding callback to inform upper layer of End of Transfer */
+          HAL_I2C_MasterTxCpltCallback(hi2c);
+        }
+      }
+    }
+    else if(hi2c->State == HAL_I2C_STATE_BUSY_RX)
+    {
+      if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
+      {
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+
+      /* Disable Interrupts */
+      I2C_Disable_IRQ(hi2c, I2C_XFER_RX_IT);
+
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c);
+
+      /* Call the corresponding callback to inform upper layer of End of Transfer */
+      if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+      {
+        hi2c->PreviousState = I2C_STATE_NONE;
+        hi2c->State = HAL_I2C_STATE_READY;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        if (hi2c->Mode == HAL_I2C_MODE_MEM)
+        {
+          hi2c->PreviousState = I2C_STATE_NONE;
+          hi2c->State = HAL_I2C_STATE_READY;
+          hi2c->Mode = HAL_I2C_MODE_NONE;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+      
+          HAL_I2C_MemRxCpltCallback(hi2c);
+        }
+        else
+        {
+          hi2c->PreviousState = I2C_STATE_MASTER_BUSY_RX;
+          hi2c->State = HAL_I2C_STATE_READY;
+          hi2c->Mode = HAL_I2C_MODE_NONE;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+
+          HAL_I2C_MasterRxCpltCallback(hi2c);
+        }
+      }
+    }
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Interrupt Sub-Routine which handle the Interrupt Flags Slave Mode.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_Slave_ISR(I2C_HandleTypeDef *hi2c) 
+{
+  uint8_t TransferDirection = 0;
+  uint16_t SlaveAddrCode = 0;
+  uint16_t OwnAdd1Code = 0;
+  uint16_t OwnAdd2Code = 0;
+
+  /* Process locked */
+  __HAL_LOCK(hi2c);
+  
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) != RESET)
+  {
+    /* Check that I2C transfer finished */
+    /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
+    /* Mean XferCount == 0*/
+    /* So clear Flag NACKF only */
+    if(hi2c->XferCount == 0)
+    {
+      if(((hi2c->XferOptions == I2C_FIRST_AND_LAST_FRAME) || (hi2c->XferOptions == I2C_LAST_FRAME)) && \
+        (hi2c->State == HAL_I2C_STATE_LISTEN))
+      {
+        hi2c->XferOptions = I2C_NO_OPTION_FRAME;
+
+        hi2c->PreviousState = I2C_STATE_NONE;
+        hi2c->State = HAL_I2C_STATE_READY;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        /* Store Last receive data if any */
+        if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET)
+        {
+          /* Read data from RXDR */
+          (*hi2c->pBuffPtr++) = hi2c->Instance->RXDR;
+          hi2c->XferSize--;
+          hi2c->XferCount--;
+        }
+
+        /* Disable all Interrupts*/
+        I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT | I2C_XFER_RX_IT | I2C_XFER_TX_IT);
+
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        /* Call the Listen Complete callback, to inform upper layer of the end of Listen usecase */
+        HAL_I2C_ListenCpltCallback(hi2c);
+      }
+      else if((hi2c->XferOptions != I2C_NO_OPTION_FRAME) && (hi2c->State == HAL_I2C_STATE_BUSY_TX_LISTEN))
+      {
+        /* Last Byte is Transmitted */
+        /* Remove HAL_I2C_STATE_SLAVE_BUSY_TX, keep only HAL_I2C_STATE_LISTEN */
+        hi2c->PreviousState = I2C_STATE_SLAVE_BUSY_TX;
+        hi2c->State = HAL_I2C_STATE_LISTEN;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        /* Disable all Interrupts*/
+        I2C_Disable_IRQ(hi2c, I2C_XFER_TX_IT);
+
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+        /* Check if TXIS flag is SET */
+        if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) != RESET)
+        {
+          /* Send a dummy data, to clear TXIS event */
+          hi2c->Instance->TXDR = 0x00;
+
+          /* Flush TX register if not empty */
+          if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXE) == RESET)
+          {
+            __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_TXE);
+          }
+        }
+        
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        /* Call the Tx complete callback to inform upper layer of the end of transmit process */
+        HAL_I2C_SlaveTxCpltCallback(hi2c);
+      }
+      else
+      {
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+      }
+    }
+    else
+    {
+      /* if no, error use case, a Non-Acknowledge of last Data is generated by the MASTER*/
+      /* Clear NACK Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+      if(hi2c->XferOptions != I2C_NO_OPTION_FRAME)
+      { 
+        /* Set HAL State to "Idle" State, mean to LISTEN state */
+        /* So reset Slave Busy state */
+        hi2c->PreviousState = I2C_STATE_NONE;
+        hi2c->State = HAL_I2C_STATE_LISTEN;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        /* Disable RX/TX Interrupts, keep only ADDR Interrupt */
+        I2C_Disable_IRQ(hi2c, I2C_XFER_RX_IT | I2C_XFER_TX_IT);
+      }
+
+      /* Set ErrorCode corresponding to a Non-Acknowledge */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      /* Call the Error callback to prevent upper layer */
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) != RESET)
+  {
+    /* Read data from RXDR */
+    (*hi2c->pBuffPtr++) = hi2c->Instance->RXDR;
+    hi2c->XferSize--;
+    hi2c->XferCount--;
+
+    if((hi2c->XferCount == 0)&&(hi2c->XferOptions != I2C_NO_OPTION_FRAME))
+    {
+        /* Last Byte is received, disable Interrupt */
+        I2C_Disable_IRQ(hi2c, I2C_XFER_RX_IT);
+
+        /* Remove HAL_I2C_STATE_SLAVE_BUSY_RX, keep only HAL_I2C_STATE_LISTEN */
+        hi2c->PreviousState = I2C_STATE_SLAVE_BUSY_RX;
+        hi2c->State = HAL_I2C_STATE_LISTEN;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+          
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        /* Call the Rx complete callback to inform upper layer of the end of receive process */
+        HAL_I2C_SlaveRxCpltCallback(hi2c);
+    }
+
+    if((hi2c->XferCount == 0)                     && \
+       (hi2c->XferOptions != I2C_NO_OPTION_FRAME) && \
+       (hi2c->State == HAL_I2C_STATE_BUSY_RX_LISTEN))
+    {
+      /* Last Byte is received, disable Interrupt */
+      I2C_Disable_IRQ(hi2c, I2C_XFER_RX_IT);
+
+      /* Remove HAL_I2C_STATE_SLAVE_BUSY_RX, keep only HAL_I2C_STATE_LISTEN */
+      hi2c->PreviousState = I2C_STATE_SLAVE_BUSY_RX;
+      hi2c->State = HAL_I2C_STATE_LISTEN;
+      hi2c->Mode = HAL_I2C_MODE_NONE;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR) != RESET)
+  {
+    /* Disable ADDR interrupt to prevent multiple ADDRInterrupt*/
+    /* Other ADDRInterrupt will be treat in next Listen usecase */
+    if(hi2c->XferOptions != I2C_NO_OPTION_FRAME)
+    {
+      TransferDirection = I2C_GET_DIR(hi2c);
+      SlaveAddrCode = I2C_GET_ADDR_MATCH(hi2c);
+      OwnAdd1Code = I2C_GET_OWN_ADDRESS1(hi2c);
+      OwnAdd2Code = I2C_GET_OWN_ADDRESS2(hi2c);
+
+      /* If 10bits addressing mode is selected */
+      if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
+      {
+        if((SlaveAddrCode & SlaveAddr_MSK) == ((OwnAdd1Code >> SlaveAddr_SHIFT) & SlaveAddr_MSK))
+        {
+          SlaveAddrCode = OwnAdd1Code;
+          hi2c->AddrEventCount++;
+          if(hi2c->AddrEventCount == 2)
+          {
+            /* Reset Address Event counter  */
+            hi2c->AddrEventCount = 0;
+
+            /* Clear ADDR flag */
+            __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+
+            /* Process Unlocked */
+            __HAL_UNLOCK(hi2c);
+
+            /* Call Slave Addr callback */
+            HAL_I2C_AddrCallback(hi2c, TransferDirection, SlaveAddrCode);
+          }
+        }
+        else
+        {
+          SlaveAddrCode = OwnAdd2Code;
+
+          /* Disable ADDR Interrupts */
+          I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT);
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+
+          /* Call Slave Addr callback */
+          HAL_I2C_AddrCallback(hi2c, TransferDirection, SlaveAddrCode);
+        }
+      }
+      /* else 7 bits addressing mode is selected */
+      else
+      {
+        /* Disable ADDR Interrupts */
+        I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT);
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        /* Call Slave Addr callback */
+        HAL_I2C_AddrCallback(hi2c, TransferDirection, SlaveAddrCode);
+      }
+    }
+    else
+    {
+      /* Clear ADDR flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_ADDR);
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) != RESET)
+  {
+    /* Write data to TXDR only if XferCount not reach "0" */
+    /* A TXIS flag can be set, during STOP treatment      */
+    /* Check if all Datas have already been sent */
+    /* If it is the case, this last write in TXDR is not sent, correspond to a dummy TXIS event */
+    if(hi2c->XferCount > 0)
+    {
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = (*hi2c->pBuffPtr++);
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+    }
+    else
+    {
+      if(((hi2c->XferOptions == I2C_NEXT_FRAME) || (hi2c->XferOptions == I2C_FIRST_FRAME)) && (hi2c->State == HAL_I2C_STATE_BUSY_TX_LISTEN))
+      {
+        /* Last Byte is Transmitted */
+        /* Remove HAL_I2C_STATE_SLAVE_BUSY_TX, keep only HAL_I2C_STATE_LISTEN */
+        I2C_Disable_IRQ(hi2c, I2C_XFER_TX_IT);
+        hi2c->PreviousState = I2C_STATE_SLAVE_BUSY_TX;
+        hi2c->State = HAL_I2C_STATE_LISTEN;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        /* Call the Tx complete callback to inform upper layer of the end of transmit process */
+        HAL_I2C_SlaveTxCpltCallback(hi2c);
+      }
+    }
+  }
+
+  /* Check if STOPF is set */
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) != RESET)
+  {
+    /* Disable all interrupts */
+    I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT | I2C_XFER_TX_IT | I2C_XFER_RX_IT);
+
+    /* Disable Address Acknowledge */
+    hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    /* Flush TX register if not empty */
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXE) == RESET)
+    {
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_TXE);
+    }
+
+    /* Store Last receive data if any */
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET)
+    {
+      /* Read data from RXDR */
+      (*hi2c->pBuffPtr++) = hi2c->Instance->RXDR;
+      hi2c->XferSize--;
+      hi2c->XferCount--;
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+
+    hi2c->PreviousState = I2C_STATE_NONE;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+    if(hi2c->XferOptions != I2C_NO_OPTION_FRAME)
+    {
+      hi2c->XferOptions = 0;
+      hi2c->State = HAL_I2C_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      /* Call the Listen Complete callback, to prevent upper layer of the end of Listen usecase */
+      HAL_I2C_ListenCpltCallback(hi2c);
+    }
+    else
+    {
+      if(hi2c->State == HAL_I2C_STATE_BUSY_RX)
+      {
+        hi2c->State = HAL_I2C_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        /* Call the Slave Rx Complete callback */
+        HAL_I2C_SlaveRxCpltCallback(hi2c);
+      }
+      else
+      {
+        hi2c->State = HAL_I2C_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        /* Call the Slave Tx Complete callback */
+        HAL_I2C_SlaveTxCpltCallback(hi2c);
+      }
+    }
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK;
+}  
+
+/**
+  * @brief  Master sends target device address followed by internal memory address for write request.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  MemAddress Internal memory address
+  * @param  MemAddSize Size of internal memory address
+  * @param  Timeout Timeout duration
+  * @param  Tickstart Tick start value
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_RequestMemoryWrite(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout, uint32_t Tickstart)
+{
+  I2C_TransferConfig(hi2c,DevAddress,MemAddSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+
+  /* Wait until TXIS flag is set */
+  if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout, Tickstart) != HAL_OK)
+  {
+    if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* If Memory address size is 8Bit */
+  if(MemAddSize == I2C_MEMADD_SIZE_8BIT)
+  {
+    /* Send Memory Address */
+    hi2c->Instance->TXDR = I2C_MEM_ADD_LSB(MemAddress);
+  }
+  /* If Memory address size is 16Bit */
+  else
+  {
+    /* Send MSB of Memory Address */
+    hi2c->Instance->TXDR = I2C_MEM_ADD_MSB(MemAddress);
+
+    /* Wait until TXIS flag is set */
+    if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout, Tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    
+    /* Send LSB of Memory Address */
+    hi2c->Instance->TXDR = I2C_MEM_ADD_LSB(MemAddress);
+  }
+
+  /* Wait until TCR flag is set */
+  if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout, Tickstart) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+
+return HAL_OK;
+}
+
+/**
+  * @brief  Master sends target device address followed by internal memory address for read request.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress Target device address
+  * @param  MemAddress Internal memory address
+  * @param  MemAddSize Size of internal memory address
+  * @param  Timeout Timeout duration
+  * @param  Tickstart Tick start value
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_RequestMemoryRead(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout, uint32_t Tickstart)
+{
+  I2C_TransferConfig(hi2c,DevAddress,MemAddSize, I2C_SOFTEND_MODE, I2C_GENERATE_START_WRITE);
+
+  /* Wait until TXIS flag is set */
+  if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout, Tickstart) != HAL_OK)
+  {
+    if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* If Memory address size is 8Bit */
+  if(MemAddSize == I2C_MEMADD_SIZE_8BIT)
+  {
+    /* Send Memory Address */
+    hi2c->Instance->TXDR = I2C_MEM_ADD_LSB(MemAddress);
+  }
+  /* If Memory address size is 16Bit */
+  else
+  {
+    /* Send MSB of Memory Address */
+    hi2c->Instance->TXDR = I2C_MEM_ADD_MSB(MemAddress);
+
+    /* Wait until TXIS flag is set */
+    if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout, Tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    
+    /* Send LSB of Memory Address */
+    hi2c->Instance->TXDR = I2C_MEM_ADD_LSB(MemAddress);
+  }
+
+  /* Wait until TC flag is set */
+  if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TC, RESET, Timeout, Tickstart) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  DMA I2C master transmit process complete callback.
+  * @param  hdma DMA handle
+  * @retval None
+  */
+static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  uint32_t tickstart = 0;
+  uint16_t DevAddress;
+  I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  /* Init tickstart for timeout managment*/
+  tickstart = HAL_GetTick();
+
+  /* Check if last DMA request was done with RELOAD */
+  /* Set NBYTES to write and reload if size > 255 */
+  if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+  {
+    /* Wait until TCR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, I2C_TIMEOUT_TCR, tickstart) != HAL_OK)
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is reset */
+      if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+        else
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        }
+      }
+
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+          
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c);
+
+      hi2c->XferCount = 0;
+
+      hi2c->State = HAL_I2C_STATE_READY;
+      hi2c->Mode = HAL_I2C_MODE_NONE;
+
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      hi2c->pBuffPtr += hi2c->XferSize;
+      hi2c->XferCount -= hi2c->XferSize;
+      if(hi2c->XferCount > 255)
+      {
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+      }
+
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)hi2c->pBuffPtr, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if size > 255 */
+      if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }
+
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, I2C_TIMEOUT_TXIS, tickstart) != HAL_OK)
+      {
+        /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+        /* Wait until STOPF flag is reset */ 
+        if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+        {
+          if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+          }
+          else
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          }
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+        /* Clear Configuration Register 2 */
+        I2C_RESET_CR2(hi2c);
+
+        hi2c->XferCount = 0;
+
+        hi2c->State = HAL_I2C_STATE_READY;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+      }
+    }
+  }
+  else
+  {
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */ 
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+      else
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN; 
+
+    hi2c->XferCount = 0;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+   /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MasterTxCpltCallback(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  DMA I2C slave transmit process complete callback.
+  * @param  hdma DMA handle
+  * @retval None
+  */
+static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  uint32_t tickstart = 0;
+  I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  /* Init tickstart for timeout managment*/
+  tickstart = HAL_GetTick();
+
+  /* Wait until STOP flag is set */
+  if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+  {
+    if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    {
+      /* Normal Use case, a AF is generated by master */
+      /* to inform slave the end of transfer */
+      hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+    }
+    else
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+  }
+
+  /* Clear STOP flag */
+  __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_STOPF);
+
+  /* Wait until BUSY flag is reset */
+  if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, I2C_TIMEOUT_BUSY, tickstart) != HAL_OK)
+  {
+    hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+  }
+
+  /* Disable DMA Request */
+  hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN;
+
+  hi2c->XferCount = 0;
+
+  hi2c->State = HAL_I2C_STATE_READY;
+  hi2c->Mode = HAL_I2C_MODE_NONE;
+
+  /* Check if Errors has been detected during transfer */
+  if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+  {
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+  else
+  {
+    HAL_I2C_SlaveTxCpltCallback(hi2c);
+  }
+}
+
+/**
+  * @brief DMA I2C master receive process complete callback.
+  * @param  hdma DMA handle
+  * @retval None
+  */
+static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  uint32_t tickstart = 0;
+  I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  uint16_t DevAddress;
+
+  /* Init tickstart for timeout managment*/
+  tickstart = HAL_GetTick();
+
+  /* Check if last DMA request was done with RELOAD */
+  /* Set NBYTES to write and reload if size > 255 */
+  if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+  {
+    /* Wait until TCR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, I2C_TIMEOUT_TCR, tickstart) != HAL_OK)
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is reset */
+      if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+        else
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        }
+      }
+
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c);
+
+      hi2c->XferCount = 0;
+
+      hi2c->State = HAL_I2C_STATE_READY;
+      hi2c->Mode = HAL_I2C_MODE_NONE;
+
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      hi2c->pBuffPtr += hi2c->XferSize;
+      hi2c->XferCount -= hi2c->XferSize;
+      if(hi2c->XferCount > 255)
+      {
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+      }
+
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)hi2c->pBuffPtr, hi2c->XferSize);
+
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if size > 255 */
+      if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }
+
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, I2C_TIMEOUT_RXNE, tickstart) != HAL_OK)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+
+      /* Check if Errors has been detected during transfer */
+      if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+      {
+        /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+        /* Wait until STOPF flag is reset */ 
+        if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+        {
+          if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+          }
+          else
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          }
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+        /* Clear Configuration Register 2 */
+        I2C_RESET_CR2(hi2c);
+
+        hi2c->XferCount = 0;
+
+        hi2c->State = HAL_I2C_STATE_READY;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+      }
+    }
+  }
+  else
+  {
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+      else
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN; 
+
+    hi2c->XferCount = 0;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MasterRxCpltCallback(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  DMA I2C slave receive process complete callback.
+  * @param  hdma DMA handle
+  * @retval None
+  */
+static void I2C_DMASlaveReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  uint32_t tickstart = 0;
+  I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  /* Init tickstart for timeout managment*/
+  tickstart = HAL_GetTick();
+
+  /* Wait until STOPF flag is reset */ 
+  if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+  {
+    if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+    }
+    else
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+  }
+
+  /* Clear STOPF flag */
+  __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+  /* Wait until BUSY flag is reset */
+  if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, I2C_TIMEOUT_BUSY, tickstart) != HAL_OK)
+  {
+    hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+  }
+
+  /* Disable DMA Request */
+  hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN;
+
+  /* Disable Address Acknowledge */
+  hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+  hi2c->XferCount = 0;
+
+  hi2c->State = HAL_I2C_STATE_READY;
+  hi2c->Mode = HAL_I2C_MODE_NONE;
+
+  /* Check if Errors has been detected during transfer */
+  if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+  {
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+  else
+  {
+    HAL_I2C_SlaveRxCpltCallback(hi2c);
+  }
+}
+
+/**
+  * @brief DMA I2C Memory Write process complete callback.
+  * @param hdma DMA handle
+  * @retval None
+  */
+static void I2C_DMAMemTransmitCplt(DMA_HandleTypeDef *hdma)   
+{
+  uint32_t tickstart = 0;
+  uint16_t DevAddress;
+  I2C_HandleTypeDef* hi2c = ( I2C_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Init tickstart for timeout managment*/
+  tickstart = HAL_GetTick();
+
+  /* Check if last DMA request was done with RELOAD */
+  /* Set NBYTES to write and reload if size > 255 */
+  if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+  {
+    /* Wait until TCR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, I2C_TIMEOUT_TCR, tickstart) != HAL_OK)
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN; 
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is reset */
+      if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+        else
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        }
+      }
+
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c);
+
+      hi2c->XferCount = 0;
+
+      hi2c->State = HAL_I2C_STATE_READY;
+      hi2c->Mode = HAL_I2C_MODE_NONE;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      hi2c->pBuffPtr += hi2c->XferSize;
+      hi2c->XferCount -= hi2c->XferSize;
+      if(hi2c->XferCount > 255)
+      {
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+      }
+
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)hi2c->pBuffPtr, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if size > 255 */
+      if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }
+
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, I2C_TIMEOUT_TXIS, tickstart) != HAL_OK)
+      {
+        /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+        /* Wait until STOPF flag is reset */
+        if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+        {
+          if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+          }
+          else
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          }
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+        /* Clear Configuration Register 2 */
+        I2C_RESET_CR2(hi2c);
+
+        hi2c->XferCount = 0;
+
+        hi2c->State = HAL_I2C_STATE_READY;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+      }
+    }
+  }
+  else
+  {
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+      else
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN;
+
+    hi2c->XferCount = 0;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MemTxCpltCallback(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  DMA I2C Memory Read process complete callback.
+  * @param  hdma DMA handle
+  * @retval None
+  */
+static void I2C_DMAMemReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  uint32_t tickstart = 0;
+  I2C_HandleTypeDef* hi2c = ( I2C_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  uint16_t DevAddress;
+
+  /* Init tickstart for timeout managment*/
+  tickstart = HAL_GetTick();
+
+  /* Check if last DMA request was done with RELOAD */
+  /* Set NBYTES to write and reload if size > 255 */
+  if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+  {
+    /* Wait until TCR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, I2C_TIMEOUT_TCR, tickstart) != HAL_OK)
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN; 
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is reset */ 
+      if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+        else
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        }
+      }
+
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c);
+
+      hi2c->XferCount = 0;
+
+      hi2c->State = HAL_I2C_STATE_READY;
+      hi2c->Mode = HAL_I2C_MODE_NONE;
+
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      hi2c->pBuffPtr += hi2c->XferSize;
+      hi2c->XferCount -= hi2c->XferSize;
+      if(hi2c->XferCount > 255)
+      {
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+      }
+
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)hi2c->pBuffPtr, hi2c->XferSize);
+
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if size > 255 */
+      if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }
+
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, I2C_TIMEOUT_RXNE, tickstart) != HAL_OK)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+
+      /* Check if Errors has been detected during transfer */
+      if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+      {
+        /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+        /* Wait until STOPF flag is reset */
+        if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+        {
+          if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+          }
+          else
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          }
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+        /* Clear Configuration Register 2 */
+        I2C_RESET_CR2(hi2c);
+
+        hi2c->XferCount = 0;
+
+        hi2c->State = HAL_I2C_STATE_READY;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+      }
+    }
+  }
+  else
+  {
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF, tickstart) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+      else
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+    }
+  
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN;
+
+    hi2c->XferCount = 0;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MemRxCpltCallback(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  DMA I2C communication error callback.
+  * @param hdma DMA handle
+  * @retval None
+  */
+static void I2C_DMAError(DMA_HandleTypeDef *hdma)
+{
+  I2C_HandleTypeDef* hi2c = ( I2C_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Disable Acknowledge */
+  hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+  hi2c->XferCount = 0;
+
+  hi2c->State = HAL_I2C_STATE_READY;
+  hi2c->Mode = HAL_I2C_MODE_NONE;
+
+  hi2c->ErrorCode |= HAL_I2C_ERROR_DMA;
+
+  HAL_I2C_ErrorCallback(hi2c);
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Flag Specifies the I2C flag to check.
+  * @param  Status The new Flag status (SET or RESET).
+  * @param  Timeout Timeout duration
+  * @param  Tickstart Tick start value
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Flag, FlagStatus Status, uint32_t Timeout, uint32_t Tickstart)
+{
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {
+    while(__HAL_I2C_GET_FLAG(hi2c, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - Tickstart ) > Timeout))
+        {
+          hi2c->State= HAL_I2C_STATE_READY;
+          hi2c->Mode = HAL_I2C_MODE_NONE;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_I2C_GET_FLAG(hi2c, Flag) != RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - Tickstart ) > Timeout))
+        {
+          hi2c->State= HAL_I2C_STATE_READY;
+          hi2c->Mode = HAL_I2C_MODE_NONE;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout for specific usage of TXIS flag.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout Timeout duration
+  * @param  Tickstart Tick start value
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart)
+{
+  while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == RESET)
+  {
+    /* Check if a NACK is detected */
+    if(I2C_IsAcknowledgeFailed(hi2c, Timeout, Tickstart) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - Tickstart) > Timeout))
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        hi2c->State= HAL_I2C_STATE_READY;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout for specific usage of STOP flag.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout Timeout duration
+  * @param  Tickstart Tick start value
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart)
+{
+  while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET)
+  {
+    /* Check if a NACK is detected */
+    if(I2C_IsAcknowledgeFailed(hi2c, Timeout, Tickstart) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+
+    /* Check for the Timeout */
+    if((Timeout == 0)||((HAL_GetTick() - Tickstart) > Timeout))
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      hi2c->State= HAL_I2C_STATE_READY;
+      hi2c->Mode = HAL_I2C_MODE_NONE;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout for specific usage of RXNE flag.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout Timeout duration
+  * @param  Tickstart Tick start value
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart)
+{
+  while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == RESET)
+  {
+    /* Check if a NACK is detected */
+    if(I2C_IsAcknowledgeFailed(hi2c, Timeout, Tickstart) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+
+    /* Check if a STOPF is detected */
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+    {
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c);
+
+      hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+      hi2c->State= HAL_I2C_STATE_READY;
+      hi2c->Mode = HAL_I2C_MODE_NONE;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      return HAL_ERROR;
+    }
+
+    /* Check for the Timeout */
+    if((Timeout == 0)||((HAL_GetTick() - Tickstart) > Timeout))
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      hi2c->State= HAL_I2C_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles Acknowledge failed detection during an I2C Communication.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout Timeout duration
+  * @param  Tickstart Tick start value
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_IsAcknowledgeFailed(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart)
+{
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
+  {
+    /* Wait until STOP Flag is reset */
+    /* AutoEnd should be initiate after AF */
+    while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+      if((Timeout == 0)||((HAL_GetTick() - Tickstart) > Timeout))
+        {
+          hi2c->State= HAL_I2C_STATE_READY;
+          hi2c->Mode = HAL_I2C_MODE_NONE;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+
+    /* Clear NACKF Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Flush TX register if not empty */
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXE) == RESET)
+    {
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_TXE);
+    }
+
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c);
+
+    hi2c->ErrorCode = HAL_I2C_ERROR_AF;
+    hi2c->State= HAL_I2C_STATE_READY;
+    hi2c->Mode = HAL_I2C_MODE_NONE;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_ERROR;
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles I2Cx communication when starting transfer or during transfer (TC or TCR flag are set).
+  * @param  hi2c I2C handle.
+  * @param  DevAddress Specifies the slave address to be programmed.
+  * @param  Size Specifies the number of bytes to be programmed.
+  *   This parameter must be a value between 0 and 255.
+  * @param  Mode New state of the I2C START condition generation.
+  *   This parameter can be one of the following values:
+  *     @arg @ref I2C_RELOAD_MODE Enable Reload mode .
+  *     @arg @ref I2C_AUTOEND_MODE Enable Automatic end mode.
+  *     @arg @ref I2C_SOFTEND_MODE Enable Software end mode.
+  * @param  Request New state of the I2C START condition generation.
+  *   This parameter can be one of the following values:
+  *     @arg @ref I2C_NO_STARTSTOP Don't Generate stop and start condition.
+  *     @arg @ref I2C_GENERATE_STOP Generate stop condition (Size should be set to 0).
+  *     @arg @ref I2C_GENERATE_START_READ Generate Restart for read request.
+  *     @arg @ref I2C_GENERATE_START_WRITE Generate Restart for write request.
+  * @retval None
+  */
+static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  assert_param(IS_TRANSFER_MODE(Mode));
+  assert_param(IS_TRANSFER_REQUEST(Request));
+
+  /* Get the CR2 register value */
+  tmpreg = hi2c->Instance->CR2;
+
+  /* clear tmpreg specific bits */
+  tmpreg &= (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_AUTOEND | I2C_CR2_RD_WRN | I2C_CR2_START | I2C_CR2_STOP));
+
+  /* update tmpreg */
+  tmpreg |= (uint32_t)(((uint32_t)DevAddress & I2C_CR2_SADD) | (((uint32_t)Size << 16 ) & I2C_CR2_NBYTES) | \
+            (uint32_t)Mode | (uint32_t)Request);
+
+  /* update CR2 register */
+  hi2c->Instance->CR2 = tmpreg;
+}
+
+/**
+  * @brief  Manage the enabling of Interrupts.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  InterruptRequest Value of @ref I2C_Interrupt_configuration_definition.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_Enable_IRQ(I2C_HandleTypeDef *hi2c, uint16_t InterruptRequest)
+{
+  uint32_t tmpisr = 0;
+
+  if((InterruptRequest & I2C_XFER_LISTEN_IT) == I2C_XFER_LISTEN_IT)
+  {
+    /* Enable ADDR and STOP interrupt */
+    tmpisr |= I2C_IT_ADDRI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ERRI;
+  }
+
+  if((InterruptRequest & I2C_XFER_TX_IT) == I2C_XFER_TX_IT)
+  {
+    /* Enable ERR, TC, STOP, NACK and RXI interrupt */
+    tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_TXI;
+  }
+
+  if((InterruptRequest & I2C_XFER_RX_IT) == I2C_XFER_RX_IT)
+  {
+    /* Enable ERR, TC, STOP, NACK and TXI interrupt */
+    tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_RXI;
+  }
+
+  /* Enable interrupts only at the end */
+  /* to avoid the risk of I2C interrupt handle execution before */
+  /* all interrupts requested done */
+  __HAL_I2C_ENABLE_IT(hi2c, tmpisr);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Manage the disabling of Interrupts.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  InterruptRequest Value of @ref I2C_Interrupt_configuration_definition.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_Disable_IRQ(I2C_HandleTypeDef *hi2c, uint16_t InterruptRequest)
+{
+  uint32_t tmpisr = 0;
+
+  if((InterruptRequest & I2C_XFER_TX_IT) == I2C_XFER_TX_IT)
+  {
+    /* Disable TC and TXI interrupts */
+    tmpisr |= I2C_IT_TCI | I2C_IT_TXI;
+
+    if((hi2c->State & HAL_I2C_STATE_LISTEN) != HAL_I2C_STATE_LISTEN)
+    {
+      /* Disable NACK and STOP interrupts */
+      tmpisr |= I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ERRI;
+    }
+  }
+
+  if((InterruptRequest & I2C_XFER_RX_IT) == I2C_XFER_RX_IT)
+  {
+    /* Disable TC and RXI interrupts */
+    tmpisr |= I2C_IT_TCI | I2C_IT_RXI;
+
+    if((hi2c->State & HAL_I2C_STATE_LISTEN) != HAL_I2C_STATE_LISTEN)
+    {
+      /* Disable NACK and STOP interrupts */
+      tmpisr |= I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ERRI;
+    }
+  }
+
+  if((InterruptRequest & I2C_XFER_LISTEN_IT) == I2C_XFER_LISTEN_IT)
+  {
+    /* Disable ADDR, NACK and STOP interrupts */
+    tmpisr |= I2C_IT_ADDRI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ERRI;
+  }
+
+  /* Disable interrupts only at the end */
+  /* to avoid a breaking situation like at "t" time */
+  /* all disable interrupts request are not done */
+  __HAL_I2C_DISABLE_IT(hi2c, tmpisr);
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_I2C_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_i2c_ex.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_i2c_ex.c
@@ -1,0 +1,350 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_i2c_ex.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   I2C Extended HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of I2C Extended peripheral:
+  *           + Extended features functions
+  *
+  @verbatim
+  ==============================================================================
+               ##### I2C peripheral Extended features  #####
+  ==============================================================================
+
+  [..] Comparing to other previous devices, the I2C interface for STM32L4xx
+       devices contains the following additional features
+
+       (+) Possibility to disable or enable Analog Noise Filter
+       (+) Use of a configured Digital Noise Filter
+       (+) Disable or enable wakeup from Stop modes
+
+                     ##### How to use this driver #####
+  ==============================================================================
+  [..] This driver provides functions to configure Noise Filter and Wake Up Feature
+    (#) Configure I2C Analog noise filter using the function HAL_I2CEx_ConfigAnalogFilter()
+    (#) Configure I2C Digital noise filter using the function HAL_I2CEx_ConfigDigitalFilter()
+    (#) Configure the enable or disable of I2C Wake Up Mode using the functions :
+          (++) HAL_I2CEx_EnableWakeUp()
+          (++) HAL_I2CEx_DisableWakeUp()
+    (#) Configure the enable or disable of fast mode plus driving capability using the functions :
+          (++) HAL_I2CEx_EnableFastModePlus()
+          (++) HAL_I2CEx_DisbleFastModePlus()
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup I2CEx I2CEx
+  * @brief I2C Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup I2CEx_Exported_Functions I2C Extended Exported Functions
+  * @{
+  */
+
+/** @defgroup I2CEx_Exported_Functions_Group1 Extended features functions
+  * @brief    Extended features functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### Extended features functions #####
+ ===============================================================================
+    [..] This section provides functions allowing to:
+      (+) Configure Noise Filters 
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configure I2C Analog noise filter.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2Cx peripheral.
+  * @param  AnalogFilter New state of the Analog filter.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2CEx_ConfigAnalogFilter(I2C_HandleTypeDef *hi2c, uint32_t AnalogFilter)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  assert_param(IS_I2C_ANALOG_FILTER(AnalogFilter));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY;
+
+    /* Disable the selected I2C peripheral */
+    __HAL_I2C_DISABLE(hi2c);
+
+    /* Reset I2Cx ANOFF bit */
+    hi2c->Instance->CR1 &= ~(I2C_CR1_ANFOFF);
+
+    /* Set analog filter bit*/
+    hi2c->Instance->CR1 |= AnalogFilter;
+
+    __HAL_I2C_ENABLE(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Configure I2C Digital noise filter.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2Cx peripheral.
+  * @param  DigitalFilter Coefficient of digital noise filter between 0x00 and 0x0F.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2CEx_ConfigDigitalFilter(I2C_HandleTypeDef *hi2c, uint32_t DigitalFilter)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  assert_param(IS_I2C_DIGITAL_FILTER(DigitalFilter));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY;
+
+    /* Disable the selected I2C peripheral */
+    __HAL_I2C_DISABLE(hi2c);
+
+    /* Get the old register value */
+    tmpreg = hi2c->Instance->CR1;
+
+    /* Reset I2Cx DNF bits [11:8] */
+    tmpreg &= ~(I2C_CR1_DNF);
+
+    /* Set I2Cx DNF coefficient */
+    tmpreg |= DigitalFilter << 8;
+
+    /* Store the new register value */
+    hi2c->Instance->CR1 = tmpreg;
+
+    __HAL_I2C_ENABLE(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+/**
+  * @brief  Enable I2C wakeup from stop mode.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2Cx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2CEx_EnableWakeUp (I2C_HandleTypeDef *hi2c)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY;
+
+    /* Disable the selected I2C peripheral */
+    __HAL_I2C_DISABLE(hi2c);
+
+    /* Enable wakeup from stop mode */
+    hi2c->Instance->CR1 |= I2C_CR1_WUPEN;
+
+    __HAL_I2C_ENABLE(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+
+/**
+  * @brief  Disable I2C wakeup from stop mode.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2Cx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2CEx_DisableWakeUp (I2C_HandleTypeDef *hi2c)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_BUSY;
+
+    /* Disable the selected I2C peripheral */
+    __HAL_I2C_DISABLE(hi2c);
+
+    /* Enable wakeup from stop mode */
+    hi2c->Instance->CR1 &= ~(I2C_CR1_WUPEN);
+
+    __HAL_I2C_ENABLE(hi2c); 
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Enable the I2C fast mode plus driving capability.
+  * @param ConfigFastModePlus Selects the pin.
+  *   This parameter can be one of the @ref I2CEx_FastModePlus values
+  * @note  For I2C1, fast mode plus driving capability can be enabled on all selected
+  *        I2C1 pins using I2C_FASTMODEPLUS_I2C1 parameter or independently
+  *        on each one of the following pins PB6, PB7, PB8 and PB9.
+  * @note  For remaining I2C1 pins (PA14, PA15...) fast mode plus driving capability
+  *        can be enabled only by using I2C_FASTMODEPLUS_I2C1 parameter.
+  * @note  For all I2C2 pins fast mode plus driving capability can be enabled
+  *        only by using I2C_FASTMODEPLUS_I2C2 parameter.
+  * @note  For all I2C3 pins fast mode plus driving capability can be enabled
+  *        only by using I2C_FASTMODEPLUS_I2C3 parameter.
+  * @retval None
+  */
+void HAL_I2CEx_EnableFastModePlus(uint32_t ConfigFastModePlus)
+{
+  /* Check the parameter */
+  assert_param(IS_I2C_FASTMODEPLUS(ConfigFastModePlus));
+
+  /* Enable SYSCFG clock */
+  __HAL_RCC_SYSCFG_CLK_ENABLE();
+
+  /* Enable fast mode plus driving capability for selected pin */
+  SET_BIT(SYSCFG->CFGR1, (uint32_t)ConfigFastModePlus);
+}
+
+/**
+  * @brief Disable the I2C fast mode plus driving capability.
+  * @param ConfigFastModePlus Selects the pin.
+  *   This parameter can be one of the @ref I2CEx_FastModePlus values
+  * @note  For I2C1, fast mode plus driving capability can be disabled on all selected
+  *        I2C1 pins using I2C_FASTMODEPLUS_I2C1 parameter or independently
+  *        on each one of the following pins PB6, PB7, PB8 and PB9.
+  * @note  For remaining I2C1 pins (PA14, PA15...) fast mode plus driving capability
+  *        can be disabled only by using I2C_FASTMODEPLUS_I2C1 parameter.
+  * @note  For all I2C2 pins fast mode plus driving capability can be disabled
+  *        only by using I2C_FASTMODEPLUS_I2C2 parameter.
+  * @note  For all I2C3 pins fast mode plus driving capability can be disabled
+  *        only by using I2C_FASTMODEPLUS_I2C3 parameter.
+  * @retval None
+  */
+void HAL_I2CEx_DisableFastModePlus(uint32_t ConfigFastModePlus)
+{
+  /* Check the parameter */
+  assert_param(IS_I2C_FASTMODEPLUS(ConfigFastModePlus));
+
+  /* Enable SYSCFG clock */
+  __HAL_RCC_SYSCFG_CLK_ENABLE();
+
+  /* Disable fast mode plus driving capability for selected pin */
+  CLEAR_BIT(SYSCFG->CFGR1, (uint32_t)ConfigFastModePlus);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_I2C_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_pcd.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_pcd.c
@@ -1,0 +1,1255 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_pcd.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   PCD HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the USB Peripheral Controller:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                    ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      The PCD HAL driver can be used as follows:
+
+     (#) Declare a PCD_HandleTypeDef handle structure, for example:
+         PCD_HandleTypeDef  hpcd;
+        
+     (#) Fill parameters of Init structure in HCD handle
+  
+     (#) Call HAL_PCD_Init() API to initialize the PCD peripheral (Core, Device core, ...) 
+
+     (#) Initialize the PCD low level resources through the HAL_PCD_MspInit() API:
+         (##) Enable the PCD/USB Low Level interface clock using 
+              (+++) __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
+         (##) Initialize the related GPIO clocks
+         (##) Configure PCD pin-out
+         (##) Configure PCD NVIC interrupt
+    
+     (#)Associate the Upper USB device stack to the HAL PCD Driver:
+         (##) hpcd.pData = pdev;
+
+     (#)Enable PCD transmission and reception:
+         (##) HAL_PCD_Start();
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+#if defined(STM32L475xx) || defined(STM32L476xx) || defined(STM32L485xx) || defined(STM32L486xx)
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PCD PCD
+  * @brief PCD HAL module driver
+  * @{
+  */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup PCD_Private_Macros PCD Private Macros
+  * @{
+  */
+#define PCD_MIN(a, b)  (((a) < (b)) ? (a) : (b))
+#define PCD_MAX(a, b)  (((a) > (b)) ? (a) : (b))
+/**
+  * @}
+  */
+
+/* Private functions prototypes ----------------------------------------------*/
+/** @defgroup PCD_Private_Functions PCD Private Functions
+  * @{
+  */
+static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t epnum);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup PCD_Exported_Functions PCD Exported Functions
+  * @{
+  */
+
+/** @defgroup PCD_Exported_Functions_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim
+ ===============================================================================
+            ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+     
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the PCD according to the specified
+  *         parameters in the PCD_InitTypeDef and initialize the associated handle.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
+{ 
+  uint32_t i = 0;
+  
+  /* Check the PCD handle allocation */
+  if(hpcd == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_PCD_ALL_INSTANCE(hpcd->Instance));
+  
+  if(hpcd->State == HAL_PCD_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hpcd->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK, NVIC... */
+    HAL_PCD_MspInit(hpcd);
+  }
+
+  hpcd->State = HAL_PCD_STATE_BUSY;
+
+  /* Disable the Interrupts */
+  __HAL_PCD_DISABLE(hpcd);
+
+  /*Init the Core (common init.) */
+  USB_CoreInit(hpcd->Instance, hpcd->Init);
+
+  /* Force Device Mode*/
+  USB_SetCurrentMode(hpcd->Instance , USB_OTG_DEVICE_MODE);
+
+  /* Init endpoints structures */
+  for (i = 0; i < hpcd->Init.dev_endpoints ; i++)
+  {
+    /* Init ep structure */
+    hpcd->IN_ep[i].is_in = 1;
+    hpcd->IN_ep[i].num = i;
+    hpcd->IN_ep[i].tx_fifo_num = i;
+    /* Control until ep is activated */
+    hpcd->IN_ep[i].type = EP_TYPE_CTRL;
+    hpcd->IN_ep[i].maxpacket =  0;
+    hpcd->IN_ep[i].xfer_buff = 0;
+    hpcd->IN_ep[i].xfer_len = 0;
+  }
+ 
+  for (i = 0; i < hpcd->Init.dev_endpoints ; i++)
+  {
+    hpcd->OUT_ep[i].is_in = 0;
+    hpcd->OUT_ep[i].num = i;
+    hpcd->IN_ep[i].tx_fifo_num = i;
+    /* Control until ep is activated */
+    hpcd->OUT_ep[i].type = EP_TYPE_CTRL;
+    hpcd->OUT_ep[i].maxpacket = 0;
+    hpcd->OUT_ep[i].xfer_buff = 0;
+    hpcd->OUT_ep[i].xfer_len = 0;
+
+    hpcd->Instance->DIEPTXF[i] = 0;
+  }
+
+  /* Init Device */
+  USB_DevInit(hpcd->Instance, hpcd->Init);
+
+  hpcd->State= HAL_PCD_STATE_READY;
+  
+   /* Activate LPM */
+  if (hpcd->Init.lpm_enable ==1)
+  {
+    HAL_PCDEx_ActivateLPM(hpcd);
+  }  
+  /* Activate Battery charging */
+  if (hpcd->Init.battery_charging_enable ==1)
+  {
+    HAL_PCDEx_ActivateBCD(hpcd);
+  }
+  USB_DevDisconnect (hpcd->Instance);  
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the PCD peripheral.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DeInit(PCD_HandleTypeDef *hpcd)
+{
+  /* Check the PCD handle allocation */
+  if(hpcd == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  hpcd->State = HAL_PCD_STATE_BUSY;
+  
+  /* Stop Device */
+  HAL_PCD_Stop(hpcd);
+    
+  /* DeInit the low level hardware */
+  HAL_PCD_MspDeInit(hpcd);
+  
+  hpcd->State = HAL_PCD_STATE_RESET; 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the PCD MSP.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes PCD MSP.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup PCD_Exported_Functions_Group2 Input and Output operation functions 
+ *  @brief   Data transfers functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to manage the PCD data 
+    transfers.
+
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Start The USB OTG Device.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_Start(PCD_HandleTypeDef *hpcd)
+{ 
+  __HAL_LOCK(hpcd); 
+  USB_DevConnect (hpcd->Instance);  
+  __HAL_PCD_ENABLE(hpcd);
+  __HAL_UNLOCK(hpcd); 
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop The USB OTG Device.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd)
+{ 
+  __HAL_LOCK(hpcd); 
+  __HAL_PCD_DISABLE(hpcd);
+  USB_StopDevice(hpcd->Instance);
+  USB_DevDisconnect (hpcd->Instance);
+  __HAL_UNLOCK(hpcd); 
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles PCD interrupt request.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+  uint32_t i = 0, ep_intr = 0, epint = 0, epnum = 0;
+  uint32_t fifoemptymsk = 0, temp = 0;
+  USB_OTG_EPTypeDef *ep;
+  
+  /* ensure that we are in device mode */
+  if (USB_GetMode(hpcd->Instance) == USB_OTG_MODE_DEVICE)
+  {
+    /* avoid spurious interrupt */
+    if(__HAL_PCD_IS_INVALID_INTERRUPT(hpcd)) 
+    {
+      return;
+    }
+    
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_MMIS))
+    {
+      /* incorrect mode, acknowledge the interrupt */
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_MMIS);
+    }
+    
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_OEPINT))
+    {
+      epnum = 0;
+      
+      /* Read in the device interrupt bits */
+      ep_intr = USB_ReadDevAllOutEpInterrupt(hpcd->Instance);
+      
+      while ( ep_intr )
+      {
+        if (ep_intr & 0x1)
+        {
+          epint = USB_ReadDevOutEPInterrupt(hpcd->Instance, epnum);
+          
+          if(( epint & USB_OTG_DOEPINT_XFRC) == USB_OTG_DOEPINT_XFRC)
+          {
+            CLEAR_OUT_EP_INTR(epnum, USB_OTG_DOEPINT_XFRC);
+            
+            if ((( (USBx_OUTEP(0)->DOEPINT & 0x8000) == 0)) )
+            {
+              
+              if(hpcd->Init.dma_enable == 1)
+              {
+                hpcd->OUT_ep[epnum].xfer_count = hpcd->OUT_ep[epnum].maxpacket- (USBx_OUTEP(epnum)->DOEPTSIZ & USB_OTG_DOEPTSIZ_XFRSIZ); 
+                hpcd->OUT_ep[epnum].xfer_buff += hpcd->OUT_ep[epnum].maxpacket;            
+              }
+              
+              HAL_PCD_DataOutStageCallback(hpcd, epnum);
+              
+              if(hpcd->Init.dma_enable == 1)
+              {
+                if((epnum == 0) && (hpcd->OUT_ep[epnum].xfer_len == 0))
+                {
+                  /* this is ZLP, so prepare EP0 for next setup */
+                  USB_EP0_OutStart(hpcd->Instance, 1, (uint8_t *)hpcd->Setup);
+                }              
+              }
+            }
+            /* Clear the SetPktRcvd flag*/ 
+            USBx_OUTEP(0)->DOEPINT |= 0x8020;
+          }
+          
+          if(( epint & USB_OTG_DOEPINT_STUP) == USB_OTG_DOEPINT_STUP)
+          {
+            /* Inform the upper layer that a setup packet is available */
+            HAL_PCD_SetupStageCallback(hpcd);
+            CLEAR_OUT_EP_INTR(epnum, USB_OTG_DOEPINT_STUP);
+          }
+          
+          if(( epint & USB_OTG_DOEPINT_OTEPDIS) == USB_OTG_DOEPINT_OTEPDIS)
+          {
+            CLEAR_OUT_EP_INTR(epnum, USB_OTG_DOEPINT_OTEPDIS);
+          }
+        }
+        epnum++;
+        ep_intr >>= 1;
+      }
+    }
+    
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_IEPINT))
+    {
+      /* Read in the device interrupt bits */
+      ep_intr = USB_ReadDevAllInEpInterrupt(hpcd->Instance);
+      
+      epnum = 0;
+      
+      while ( ep_intr )
+      {
+        if (ep_intr & 0x1) /* In ITR */
+        {
+          epint = USB_ReadDevInEPInterrupt(hpcd->Instance, epnum);
+          
+          if(( epint & USB_OTG_DIEPINT_XFRC) == USB_OTG_DIEPINT_XFRC)
+          {
+            fifoemptymsk = 0x1 << epnum;
+            USBx_DEVICE->DIEPEMPMSK &= ~fifoemptymsk;
+            
+            CLEAR_IN_EP_INTR(epnum, USB_OTG_DIEPINT_XFRC);
+            
+            if (hpcd->Init.dma_enable == 1)
+            {
+              hpcd->IN_ep[epnum].xfer_buff += hpcd->IN_ep[epnum].maxpacket; 
+            }
+            
+            HAL_PCD_DataInStageCallback(hpcd, epnum);
+            
+            if (hpcd->Init.dma_enable == 1)
+            {
+              /* this is ZLP, so prepare EP0 for next setup */
+              if((epnum == 0) && (hpcd->IN_ep[epnum].xfer_len == 0))
+              {
+                /* prepare to rx more setup packets */
+                USB_EP0_OutStart(hpcd->Instance, 1, (uint8_t *)hpcd->Setup);
+              }
+            }           
+          }
+          if(( epint & USB_OTG_DIEPINT_TOC) == USB_OTG_DIEPINT_TOC)
+          {
+            CLEAR_IN_EP_INTR(epnum, USB_OTG_DIEPINT_TOC);
+          }
+          if(( epint & USB_OTG_DIEPINT_ITTXFE) == USB_OTG_DIEPINT_ITTXFE)
+          {
+            CLEAR_IN_EP_INTR(epnum, USB_OTG_DIEPINT_ITTXFE);
+          }
+          if(( epint & USB_OTG_DIEPINT_INEPNE) == USB_OTG_DIEPINT_INEPNE)
+          {
+            CLEAR_IN_EP_INTR(epnum, USB_OTG_DIEPINT_INEPNE);
+          }
+          if(( epint & USB_OTG_DIEPINT_EPDISD) == USB_OTG_DIEPINT_EPDISD)
+          {
+            CLEAR_IN_EP_INTR(epnum, USB_OTG_DIEPINT_EPDISD);
+          }       
+          if(( epint & USB_OTG_DIEPINT_TXFE) == USB_OTG_DIEPINT_TXFE)
+          {
+            PCD_WriteEmptyTxFifo(hpcd , epnum);
+          }
+        }
+        epnum++;
+        ep_intr >>= 1;
+      }
+    }
+    
+    /* Handle Resume Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_WKUINT))
+    {    
+      /* Clear the Remote Wake-up Signaling */
+      USBx_DEVICE->DCTL &= ~USB_OTG_DCTL_RWUSIG;
+      
+      if(hpcd->LPM_State == LPM_L1)
+      {
+        hpcd->LPM_State = LPM_L0;
+        HAL_PCDEx_LPM_Callback(hpcd, PCD_LPM_L0_ACTIVE);
+      }
+      else
+      {
+        HAL_PCD_ResumeCallback(hpcd);
+      }
+      
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_WKUINT);
+    }
+    
+    /* Handle Suspend Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_USBSUSP))
+    {
+      if((USBx_DEVICE->DSTS & USB_OTG_DSTS_SUSPSTS) == USB_OTG_DSTS_SUSPSTS)
+      {
+        
+        HAL_PCD_SuspendCallback(hpcd);
+      }
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_USBSUSP);
+    }
+    
+    /* Handle LPM Interrupt */ 
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_LPMINT))
+    {
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_LPMINT);      
+      if( hpcd->LPM_State == LPM_L0)
+      {   
+        hpcd->LPM_State = LPM_L1;
+        hpcd->BESL = (hpcd->Instance->GLPMCFG & USB_OTG_GLPMCFG_BESL) >>2 ;  
+        HAL_PCDEx_LPM_Callback(hpcd, PCD_LPM_L1_ACTIVE);
+      }
+      else
+      {
+        HAL_PCD_SuspendCallback(hpcd);
+      }
+    }
+    
+    /* Handle Reset Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_USBRST))
+    {
+      USBx_DEVICE->DCTL &= ~USB_OTG_DCTL_RWUSIG; 
+      USB_FlushTxFifo(hpcd->Instance ,  0 );
+      
+      for (i = 0; i < hpcd->Init.dev_endpoints ; i++)
+      {
+        USBx_INEP(i)->DIEPINT = 0xFF;
+        USBx_OUTEP(i)->DOEPINT = 0xFF;
+      }
+      USBx_DEVICE->DAINT = 0xFFFFFFFF;
+      USBx_DEVICE->DAINTMSK |= 0x10001;
+      
+      if(hpcd->Init.use_dedicated_ep1)
+      {
+        USBx_DEVICE->DOUTEP1MSK |= (USB_OTG_DOEPMSK_STUPM | USB_OTG_DOEPMSK_XFRCM | USB_OTG_DOEPMSK_EPDM); 
+        USBx_DEVICE->DINEP1MSK |= (USB_OTG_DIEPMSK_TOM | USB_OTG_DIEPMSK_XFRCM | USB_OTG_DIEPMSK_EPDM);  
+      }
+      else
+      {
+        USBx_DEVICE->DOEPMSK |= (USB_OTG_DOEPMSK_STUPM | USB_OTG_DOEPMSK_XFRCM | USB_OTG_DOEPMSK_EPDM);
+        USBx_DEVICE->DIEPMSK |= (USB_OTG_DIEPMSK_TOM | USB_OTG_DIEPMSK_XFRCM | USB_OTG_DIEPMSK_EPDM);
+      }
+      
+      /* Set Default Address to 0 */
+      USBx_DEVICE->DCFG &= ~USB_OTG_DCFG_DAD;
+      
+      /* setup EP0 to receive SETUP packets */
+      USB_EP0_OutStart(hpcd->Instance, hpcd->Init.dma_enable, (uint8_t *)hpcd->Setup);
+      
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_USBRST);
+    }
+    
+    /* Handle Enumeration done Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_ENUMDNE))
+    {
+      USB_ActivateSetup(hpcd->Instance);
+      hpcd->Instance->GUSBCFG &= ~USB_OTG_GUSBCFG_TRDT;
+      
+      hpcd->Init.speed            = USB_OTG_SPEED_FULL;
+      hpcd->Init.ep0_mps          = USB_OTG_FS_MAX_PACKET_SIZE ;  
+      hpcd->Instance->GUSBCFG |= (uint32_t)((USBD_FS_TRDT_VALUE << 10) & USB_OTG_GUSBCFG_TRDT);
+      
+      HAL_PCD_ResetCallback(hpcd);
+      
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_ENUMDNE);
+    }
+    
+    /* Handle RxQLevel Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_RXFLVL))
+    {
+      USB_MASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
+      
+      temp = USBx->GRXSTSP;
+      
+      ep = &hpcd->OUT_ep[temp & USB_OTG_GRXSTSP_EPNUM];
+      
+      if(((temp & USB_OTG_GRXSTSP_PKTSTS) >> 17) ==  STS_DATA_UPDT)
+      {
+        if((temp & USB_OTG_GRXSTSP_BCNT) != 0)
+        {
+          USB_ReadPacket(USBx, ep->xfer_buff, (temp & USB_OTG_GRXSTSP_BCNT) >> 4);
+          ep->xfer_buff += (temp & USB_OTG_GRXSTSP_BCNT) >> 4;
+          ep->xfer_count += (temp & USB_OTG_GRXSTSP_BCNT) >> 4;
+        }
+      }
+      else if (((temp & USB_OTG_GRXSTSP_PKTSTS) >> 17) ==  STS_SETUP_UPDT)
+      {
+        USB_ReadPacket(USBx, (uint8_t *)hpcd->Setup, 8);
+        ep->xfer_count += (temp & USB_OTG_GRXSTSP_BCNT) >> 4;
+      }
+      USB_UNMASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
+    }
+    
+    /* Handle SOF Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_SOF))
+    {
+      HAL_PCD_SOFCallback(hpcd);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_SOF);
+    }
+    
+    /* Handle Incomplete ISO IN Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_IISOIXFR))
+    {
+      HAL_PCD_ISOINIncompleteCallback(hpcd, epnum);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_IISOIXFR);
+    } 
+    
+    /* Handle Incomplete ISO OUT Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_PXFR_INCOMPISOOUT))
+    {
+      HAL_PCD_ISOOUTIncompleteCallback(hpcd, epnum);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_PXFR_INCOMPISOOUT);
+    } 
+    
+    /* Handle Connection event Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_SRQINT))
+    {
+      HAL_PCD_ConnectCallback(hpcd);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_SRQINT);
+    } 
+    
+    /* Handle Disconnection event Interrupt */
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_OTGINT))
+    {
+      temp = hpcd->Instance->GOTGINT;
+      
+      if((temp & USB_OTG_GOTGINT_SEDET) == USB_OTG_GOTGINT_SEDET)
+      {
+        HAL_PCD_DisconnectCallback(hpcd);
+      }
+      hpcd->Instance->GOTGINT |= temp;
+    }
+  }
+}
+
+/**
+  * @brief  Data OUT stage callback.
+  * @param  hpcd: PCD handle
+  * @param  epnum: endpoint number
+  * @retval None
+  */
+__weak void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(epnum);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Data IN stage callback.
+  * @param  hpcd: PCD handle
+  * @param  epnum: endpoint number
+  * @retval None
+  */
+__weak void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(epnum);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_DataInStageCallback could be implemented in the user file
+   */ 
+}
+/**
+  * @brief  Setup stage callback.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_SetupStageCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  USB Start Of Frame callback.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_SOFCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  USB Reset callback.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_ResetCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Suspend event callback.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_SuspendCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Resume event callback.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_ResumeCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Incomplete ISO OUT callback.
+  * @param  hpcd: PCD handle
+  * @param  epnum: endpoint number
+  * @retval None
+  */
+__weak void HAL_PCD_ISOOUTIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(epnum);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_ISOOUTIncompleteCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Incomplete ISO IN callback.
+  * @param  hpcd: PCD handle
+  * @param  epnum: endpoint number
+  * @retval None
+  */
+__weak void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(epnum);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_ISOINIncompleteCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Connection event callback.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_ConnectCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Disconnection event callback.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_DisconnectCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+  
+/** @defgroup PCD_Exported_Functions_Group3 Peripheral Control functions 
+ *  @brief   management functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the PCD data 
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Connect the USB device.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DevConnect(PCD_HandleTypeDef *hpcd)
+{
+  __HAL_LOCK(hpcd); 
+  USB_DevConnect(hpcd->Instance);
+  __HAL_UNLOCK(hpcd); 
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disconnect the USB device.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DevDisconnect(PCD_HandleTypeDef *hpcd)
+{
+  __HAL_LOCK(hpcd); 
+  USB_DevDisconnect(hpcd->Instance);
+  __HAL_UNLOCK(hpcd); 
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the USB Device address.
+  * @param  hpcd: PCD handle
+  * @param  address: new device address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_SetAddress(PCD_HandleTypeDef *hpcd, uint8_t address)
+{
+  __HAL_LOCK(hpcd); 
+  USB_SetDevAddress(hpcd->Instance, address);
+  __HAL_UNLOCK(hpcd);   
+  return HAL_OK;
+}
+/**
+  * @brief  Open and configure an endpoint.
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @param  ep_mps: endpoint max packet size
+  * @param  ep_type: endpoint type   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint16_t ep_mps, uint8_t ep_type)
+{
+  HAL_StatusTypeDef  ret = HAL_OK;
+  USB_OTG_EPTypeDef *ep;
+  
+  if ((ep_addr & 0x80) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr & 0x7F];
+  }
+  ep->num   = ep_addr & 0x7F;
+  
+  ep->is_in = (0x80 & ep_addr) != 0;
+  ep->maxpacket = ep_mps;
+  ep->type = ep_type;
+  if (ep->is_in)
+  {
+    /* Assign a Tx FIFO */
+    ep->tx_fifo_num = ep->num;
+  }
+  /* Set initial data PID. */
+  if (ep_type == EP_TYPE_BULK )
+  {
+    ep->data_pid_start = 0;
+  }
+  
+  __HAL_LOCK(hpcd); 
+  USB_ActivateEndpoint(hpcd->Instance , ep);
+  __HAL_UNLOCK(hpcd);   
+  return ret;
+}
+
+
+/**
+  * @brief  Deactivate an endpoint.
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{  
+  USB_OTG_EPTypeDef *ep;
+  
+  if ((ep_addr & 0x80) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr & 0x7F];
+  }
+  ep->num   = ep_addr & 0x7F;
+  
+  ep->is_in = (0x80 & ep_addr) != 0;
+  
+  __HAL_LOCK(hpcd); 
+  USB_DeactivateEndpoint(hpcd->Instance , ep);
+  __HAL_UNLOCK(hpcd);   
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Receive an amount of data.
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @param  pBuf: pointer to the reception buffer   
+  * @param  len: amount of data to be received
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len)
+{
+  USB_OTG_EPTypeDef *ep;
+  
+  ep = &hpcd->OUT_ep[ep_addr & 0x7F];
+  
+  /*setup and start the Xfer */
+  ep->xfer_buff = pBuf;  
+  ep->xfer_len = len;
+  ep->xfer_count = 0;
+  ep->is_in = 0;
+  ep->num = ep_addr & 0x7F;
+  
+  if (hpcd->Init.dma_enable == 1)
+  {
+    ep->dma_addr = (uint32_t)pBuf;  
+  }
+  
+  __HAL_LOCK(hpcd); 
+  
+  if ((ep_addr & 0x7F) == 0 )
+  {
+    USB_EP0StartXfer(hpcd->Instance , ep, hpcd->Init.dma_enable);
+  }
+  else
+  {
+    USB_EPStartXfer(hpcd->Instance , ep, hpcd->Init.dma_enable);
+  }
+  __HAL_UNLOCK(hpcd); 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get Received Data Size.
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval Data Size
+  */
+uint16_t HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  return hpcd->OUT_ep[ep_addr & 0x7F].xfer_count;
+}
+/**
+  * @brief  Send an amount of data.
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @param  pBuf: pointer to the transmission buffer   
+  * @param  len: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len)
+{
+  USB_OTG_EPTypeDef *ep;
+  
+  ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  
+  /*setup and start the Xfer */
+  ep->xfer_buff = pBuf;  
+  ep->xfer_len = len;
+  ep->xfer_count = 0;
+  ep->is_in = 1;
+  ep->num = ep_addr & 0x7F;
+  
+  if (hpcd->Init.dma_enable == 1)
+  {
+    ep->dma_addr = (uint32_t)pBuf;  
+  }
+  
+  __HAL_LOCK(hpcd); 
+  
+  if ((ep_addr & 0x7F) == 0 )
+  {
+    USB_EP0StartXfer(hpcd->Instance , ep, hpcd->Init.dma_enable);
+  }
+  else
+  {
+    USB_EPStartXfer(hpcd->Instance , ep, hpcd->Init.dma_enable);
+  }
+  
+  __HAL_UNLOCK(hpcd);
+     
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set a STALL condition over an endpoint.
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  USB_OTG_EPTypeDef *ep;
+  
+  if ((0x80 & ep_addr) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr];
+  }
+  
+  ep->is_stall = 1;
+  ep->num   = ep_addr & 0x7F;
+  ep->is_in = ((ep_addr & 0x80) == 0x80);
+  
+  
+  __HAL_LOCK(hpcd); 
+  USB_EPSetStall(hpcd->Instance , ep);
+  if((ep_addr & 0x7F) == 0)
+  {
+    USB_EP0_OutStart(hpcd->Instance, hpcd->Init.dma_enable, (uint8_t *)hpcd->Setup);
+  }
+  __HAL_UNLOCK(hpcd); 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Clear a STALL condition over in an endpoint.
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  USB_OTG_EPTypeDef *ep;
+  
+  if ((0x80 & ep_addr) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr];
+  }
+  
+  ep->is_stall = 0;
+  ep->num   = ep_addr & 0x7F;
+  ep->is_in = ((ep_addr & 0x80) == 0x80);
+  
+  __HAL_LOCK(hpcd); 
+  USB_EPClearStall(hpcd->Instance , ep);
+  __HAL_UNLOCK(hpcd); 
+    
+  return HAL_OK;
+}
+
+/**
+  * @brief  Flush an endpoint.
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  __HAL_LOCK(hpcd); 
+  
+  if ((ep_addr & 0x80) == 0x80)
+  {
+    USB_FlushTxFifo(hpcd->Instance, ep_addr & 0x7F);
+  }
+  else
+  {
+    USB_FlushRxFifo(hpcd->Instance);
+  }
+  
+  __HAL_UNLOCK(hpcd); 
+    
+  return HAL_OK;
+}
+
+/**
+  * @brief  Activate remote wakeup signalling.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_ActivateRemoteWakeup(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;  
+    
+  if((USBx_DEVICE->DSTS & USB_OTG_DSTS_SUSPSTS) == USB_OTG_DSTS_SUSPSTS)
+  {
+    /* Activate Remote wakeup signaling */
+    USBx_DEVICE->DCTL |= USB_OTG_DCTL_RWUSIG;
+  }
+  return HAL_OK;  
+}
+
+/**
+  * @brief  De-activate remote wakeup signalling.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DeActivateRemoteWakeup(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;  
+  
+  /* De-activate Remote wakeup signaling */
+   USBx_DEVICE->DCTL &= ~(USB_OTG_DCTL_RWUSIG);
+  return HAL_OK;  
+}
+/**
+  * @}
+  */
+  
+/** @defgroup PCD_Exported_Functions_Group4 Peripheral State functions 
+ *  @brief   Peripheral State functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================  
+    [..]
+    This subsection permits to get in run-time the status of the peripheral 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the PCD handle state.
+  * @param  hpcd: PCD handle
+  * @retval HAL state
+  */
+PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd)
+{
+  return hpcd->State;
+}
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @addtogroup PCD_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Check FIFO for the next packet to be loaded.
+  * @param  hpcd: PCD handle
+  * @param  epnum: endpoint number
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t epnum)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;  
+  USB_OTG_EPTypeDef *ep;
+  int32_t len = 0;
+  uint32_t len32b;
+  uint32_t fifoemptymsk = 0;
+
+  ep = &hpcd->IN_ep[epnum];
+  len = ep->xfer_len - ep->xfer_count;
+  
+  if (len > ep->maxpacket)
+  {
+    len = ep->maxpacket;
+  }
+  
+  
+  len32b = (len + 3) / 4;
+ 
+  while  ( (USBx_INEP(epnum)->DTXFSTS & USB_OTG_DTXFSTS_INEPTFSAV) > len32b &&
+          ep->xfer_count < ep->xfer_len &&
+            ep->xfer_len != 0)
+  {
+    /* Write the FIFO */
+    len = ep->xfer_len - ep->xfer_count;
+    
+    if (len > ep->maxpacket)
+    {
+      len = ep->maxpacket;
+    }
+    len32b = (len + 3) / 4;
+    
+    USB_WritePacket(USBx, ep->xfer_buff, epnum, len, hpcd->Init.dma_enable); 
+    
+    ep->xfer_buff  += len;
+    ep->xfer_count += len;
+  }
+  
+  if(len <= 0)
+  {
+    fifoemptymsk = 0x1 << epnum;
+    USBx_DEVICE->DIEPEMPMSK &= ~fifoemptymsk;
+    
+  }
+  
+  return HAL_OK;  
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_PCD_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* STM32L475xx || STM32L476xx || STM32L485xx || STM32L486xx */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_pcd_ex.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_pcd_ex.c
@@ -1,0 +1,323 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_pcd_ex.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   PCD Extended HAL module driver.  
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the USB Peripheral Controller:
+  *           + Extended features functions
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+#if defined(STM32L475xx) || defined(STM32L476xx) || defined(STM32L485xx) || defined(STM32L486xx)
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PCDEx PCDEx
+  * @brief PCD Extended HAL module driver
+  * @{
+  */
+#ifdef HAL_PCD_MODULE_ENABLED
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup PCDEx_Exported_Functions PCDEx Exported Functions
+  * @{
+  */
+  
+/** @defgroup PCDEx_Exported_Functions_Group1 Peripheral Control functions
+  * @brief    PCDEx control functions 
+ *
+@verbatim   
+ ===============================================================================
+                 ##### Extended features functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Update FIFO configuration
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Set Tx FIFO
+  * @param  hpcd: PCD handle
+  * @param  fifo: The number of Tx fifo
+  * @param  size: Fifo size
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_SetTxFiFo(PCD_HandleTypeDef *hpcd, uint8_t fifo, uint16_t size)
+{
+  uint8_t i = 0;
+  uint32_t Tx_Offset = 0;
+
+  /*  TXn min size = 16 words. (n  : Transmit FIFO index)
+      When a TxFIFO is not used, the Configuration should be as follows: 
+          case 1 :  n > m    and Txn is not used    (n,m  : Transmit FIFO indexes)
+         --> Txm can use the space allocated for Txn.
+         case2  :  n < m    and Txn is not used    (n,m  : Transmit FIFO indexes)
+         --> Txn should be configured with the minimum space of 16 words
+     The FIFO is used optimally when used TxFIFOs are allocated in the top 
+         of the FIFO.Ex: use EP1 and EP2 as IN instead of EP1 and EP3 as IN ones.
+     When DMA is used 3n * FIFO locations should be reserved for internal DMA registers */
+  
+  Tx_Offset = hpcd->Instance->GRXFSIZ;
+  
+  if(fifo == 0)
+  {
+    hpcd->Instance->DIEPTXF0_HNPTXFSIZ = (size << 16) | Tx_Offset;
+  }
+  else
+  {
+    Tx_Offset += (hpcd->Instance->DIEPTXF0_HNPTXFSIZ) >> 16;
+    for (i = 0; i < (fifo - 1); i++)
+    {
+      Tx_Offset += (hpcd->Instance->DIEPTXF[i] >> 16);
+    }
+    
+    /* Multiply Tx_Size by 2 to get higher performance */
+    hpcd->Instance->DIEPTXF[fifo - 1] = (size << 16) | Tx_Offset;
+  }
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set Rx FIFO
+  * @param  hpcd: PCD handle
+  * @param  size: Size of Rx fifo
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_SetRxFiFo(PCD_HandleTypeDef *hpcd, uint16_t size)
+{
+  hpcd->Instance->GRXFSIZ = size;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Activate LPM feature.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_ActivateLPM(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;  
+  
+  hpcd->lpm_active = ENABLE;
+  hpcd->LPM_State = LPM_L0;
+  USBx->GINTMSK |= USB_OTG_GINTMSK_LPMINTM;
+  USBx->GLPMCFG |= (USB_OTG_GLPMCFG_LPMEN | USB_OTG_GLPMCFG_LPMACK | USB_OTG_GLPMCFG_ENBESL);
+
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Deactivate LPM feature.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_DeActivateLPM(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;  
+  
+  hpcd->lpm_active = DISABLE;
+  USBx->GINTMSK &= ~USB_OTG_GINTMSK_LPMINTM;
+  USBx->GLPMCFG &= ~(USB_OTG_GLPMCFG_LPMEN | USB_OTG_GLPMCFG_LPMACK | USB_OTG_GLPMCFG_ENBESL);
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Handle BatteryCharging Process.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+void HAL_PCDEx_BCD_VBUSDetect(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;  
+  uint32_t tickstart = HAL_GetTick();
+  
+  /* Start BCD When device is connected */
+  if (USBx_DEVICE->DCTL & USB_OTG_DCTL_SDIS)
+  { 
+    /* Enable DCD : Data Contact Detect */
+    USBx->GCCFG |= USB_OTG_GCCFG_DCDEN;
+    
+    /* Wait Detect flag or a timeout is happen*/
+    while ((USBx->GCCFG & USB_OTG_GCCFG_DCDET) == 0)
+    {
+      /* Check for the Timeout */
+      if((HAL_GetTick() - tickstart ) > 1000)
+      {
+        HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_ERROR);
+        return;
+      }
+    }
+    
+    /* Right response got */
+    HAL_Delay(100); 
+    
+    /* Check Detect flag*/
+    if (USBx->GCCFG & USB_OTG_GCCFG_DCDET)
+    {
+      HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_CONTACT_DETECTION);
+    }
+    
+    /*Primary detection: checks if connected to Standard Downstream Port  
+    (without charging capability) */
+    USBx->GCCFG &=~ USB_OTG_GCCFG_DCDEN;
+    USBx->GCCFG |=  USB_OTG_GCCFG_PDEN;
+    HAL_Delay(100); 
+    
+    if (!(USBx->GCCFG & USB_OTG_GCCFG_PDET))
+    {
+      /* Case of Standard Downstream Port */
+      HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_STD_DOWNSTREAM_PORT);
+    }
+    else  
+    {
+      /* start secondary detection to check connection to Charging Downstream 
+      Port or Dedicated Charging Port */
+      USBx->GCCFG &=~ USB_OTG_GCCFG_PDEN;
+      USBx->GCCFG |=  USB_OTG_GCCFG_SDEN;
+      HAL_Delay(100); 
+      
+      if ((USBx->GCCFG) & USB_OTG_GCCFG_SDET)
+      { 
+        /* case Dedicated Charging Port  */
+        HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_DEDICATED_CHARGING_PORT);
+      }
+      else
+      {
+        /* case Charging Downstream Port  */
+        HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_CHARGING_DOWNSTREAM_PORT);
+      }
+    }
+    /* Battery Charging capability discovery finished */
+    HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_DISCOVERY_COMPLETED);
+  }
+}
+
+/**
+  * @brief  Activate BatteryCharging feature.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_ActivateBCD(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;  
+
+  hpcd->battery_charging_active = ENABLE; 
+  USBx->GCCFG |= (USB_OTG_GCCFG_BCDEN);
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Deactivate BatteryCharging feature.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_DeActivateBCD(PCD_HandleTypeDef *hpcd)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;  
+  hpcd->battery_charging_active = DISABLE; 
+  USBx->GCCFG &= ~(USB_OTG_GCCFG_BCDEN);
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Send LPM message to user layer callback.
+  * @param  hpcd: PCD handle
+  * @param  msg: LPM message
+  * @retval HAL status
+  */
+__weak void HAL_PCDEx_LPM_Callback(PCD_HandleTypeDef *hpcd, PCD_LPM_MsgTypeDef msg)
+{ 
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(msg);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCDEx_LPM_Callback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Send BatteryCharging message to user layer callback.
+  * @param  hpcd: PCD handle
+  * @param  msg: LPM message
+  * @retval HAL status
+  */
+__weak void HAL_PCDEx_BCD_Callback(PCD_HandleTypeDef *hpcd, PCD_BCD_MsgTypeDef msg)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(msg);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCDEx_BCD_Callback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_PCD_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* STM32L475xx || STM32L476xx || STM32L485xx || STM32L486xx */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_pwr.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_pwr.c
@@ -1,0 +1,676 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_pwr.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   PWR HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Power Controller (PWR) peripheral:
+  *           + Initialization/de-initialization functions
+  *           + Peripheral Control functions
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PWR PWR
+  * @brief PWR HAL module driver
+  * @{
+  */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/ 
+
+/** @defgroup PWR_Private_Defines PWR Private Defines
+  * @{
+  */
+  
+/** @defgroup PWR_PVD_Mode_Mask PWR PVD Mode Mask
+  * @{
+  */ 
+#define PVD_MODE_IT               ((uint32_t)0x00010000)  /*!< Mask for interruption yielded by PVD threshold crossing */ 
+#define PVD_MODE_EVT              ((uint32_t)0x00020000)  /*!< Mask for event yielded by PVD threshold crossing        */ 
+#define PVD_RISING_EDGE           ((uint32_t)0x00000001)  /*!< Mask for rising edge set as PVD trigger                 */ 
+#define PVD_FALLING_EDGE          ((uint32_t)0x00000002)  /*!< Mask for falling edge set as PVD trigger                */ 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup PWR_Exported_Functions PWR Exported Functions
+  * @{
+  */
+
+/** @defgroup PWR_Exported_Functions_Group1 Initialization and de-initialization functions 
+  *  @brief    Initialization and de-initialization functions
+  *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Deinitialize the HAL PWR peripheral registers to their default reset values.
+  * @retval None
+  */
+void HAL_PWR_DeInit(void)
+{
+  __HAL_RCC_PWR_FORCE_RESET();
+  __HAL_RCC_PWR_RELEASE_RESET();
+}
+
+/**
+  * @brief Enable access to the backup domain 
+  *        (RTC registers, RTC backup data registers).
+  * @note  After reset, the backup domain is protected against 
+  *        possible unwanted write accesses.
+  * @note  RTCSEL that sets the RTC clock source selection is in the RTC back-up domain.
+  *        In order to set or modify the RTC clock, the backup domain access must be
+  *        disabled. 
+  * @note  LSEON bit that switches on and off the LSE crystal belongs as well to the
+  *        back-up domain.                
+  * @retval None
+  */
+void HAL_PWR_EnableBkUpAccess(void)
+{
+  SET_BIT(PWR->CR1, PWR_CR1_DBP);    
+}
+
+/**
+  * @brief Disable access to the backup domain
+  *        (RTC registers, RTC backup data registers).    
+  * @retval None
+  */
+void HAL_PWR_DisableBkUpAccess(void)
+{
+  CLEAR_BIT(PWR->CR1, PWR_CR1_DBP);   
+}
+
+
+
+
+/**
+  * @}
+  */
+
+
+
+/** @defgroup PWR_Exported_Functions_Group2 Peripheral Control functions
+  *  @brief Low Power modes configuration functions
+  *
+@verbatim
+
+ ===============================================================================
+                 ##### Peripheral Control functions #####
+ ===============================================================================
+ 
+     [..]
+     *** PVD configuration ***
+    =========================
+    [..]
+      (+) The PVD is used to monitor the VDD power supply by comparing it to a
+          threshold selected by the PVD Level (PLS[2:0] bits in PWR_CR2 register).
+
+      (+) PVDO flag is available to indicate if VDD/VDDA is higher or lower
+          than the PVD threshold. This event is internally connected to the EXTI
+          line16 and can generate an interrupt if enabled. This is done through
+          __HAL_PVD_EXTI_ENABLE_IT() macro.
+      (+) The PVD is stopped in Standby mode.
+ 
+    
+    *** WakeUp pin configuration ***
+    ================================
+    [..]
+      (+) WakeUp pins are used to wakeup the system from Standby mode or Shutdown mode. 
+          The polarity of these pins can be set to configure event detection on high 
+          level (rising edge) or low level (falling edge).
+
+
+   
+    *** Low Power modes configuration ***
+    =====================================
+    [..]
+      The devices feature 8 low-power modes:
+      (+) Low-power Run mode: core and peripherals are running, main regulator off, low power regulator on.
+      (+) Sleep mode: Cortex-M4 core stopped, peripherals kept running, main and low power regulators on.
+      (+) Low-power Sleep mode: Cortex-M4 core stopped, peripherals kept running, main regulator off, low power regulator on.
+      (+) Stop 0 mode: all clocks are stopped except LSI and LSE, main and low power regulators on.
+      (+) Stop 1 mode: all clocks are stopped except LSI and LSE, main regulator off, low power regulator on.
+      (+) Stop 2 mode: all clocks are stopped except LSI and LSE, main regulator off, low power regulator on, reduced set of waking up IPs compared to Stop 1 mode.      
+      (+) Standby mode with SRAM2: all clocks are stopped except LSI and LSE, SRAM2 content preserved, main regulator off, low power regulator on. 
+      (+) Standby mode without SRAM2: all clocks are stopped except LSI and LSE, main and low power regulators off.
+      (+) Shutdown mode: all clocks are stopped except LSE, main and low power regulators off.
+
+
+   *** Low-power run mode ***
+   ==========================
+    [..]
+      (+) Entry: (from main run mode)
+        (++) set LPR bit with HAL_PWREx_EnableLowPowerRunMode() API after having decreased the system clock below 2 MHz. 
+     
+      (+) Exit:
+        (++) clear LPR bit then wait for REGLP bit to be reset with HAL_PWREx_DisableLowPowerRunMode() API. Only
+             then can the system clock frequency be increased above 2 MHz.
+
+
+   *** Sleep mode / Low-power sleep mode ***
+   =========================================
+    [..]
+      (+) Entry:                                                         
+          The Sleep mode / Low-power Sleep mode is entered thru HAL_PWR_EnterSLEEPMode() API
+          in specifying whether or not the regulator is forced to low-power mode and if exit is interrupt or event-triggered. 
+          (++) PWR_MAINREGULATOR_ON: Sleep mode (regulator in main mode).              
+          (++) PWR_LOWPOWERREGULATOR_ON: Low-power sleep (regulator in low power mode).
+          In the latter case, the system clock frequency must have been decreased below 2 MHz beforehand.           
+          (++) PWR_SLEEPENTRY_WFI: enter SLEEP mode with WFI instruction
+          (++) PWR_SLEEPENTRY_WFE: enter SLEEP mode with WFE instruction
+     
+      (+) WFI Exit:
+        (++) Any peripheral interrupt acknowledged by the nested vectored interrupt
+             controller (NVIC) or any wake-up event.
+             
+      (+) WFE Exit:
+        (++) Any wake-up event such as an EXTI line configured in event mode.             
+             
+         [..] When exiting the Low-power sleep mode by issuing an interrupt or a wakeup event, 
+             the MCU is in Low-power Run mode. 
+
+   *** Stop 0, Stop 1 and Stop 2 modes ***
+   ===============================
+    [..]
+      (+) Entry:                                                 
+          The Stop 0, Stop 1 or Stop 2 modes are entered thru the following API's:
+          (++) HAL_PWREx_EnterSTOP0Mode() for mode 0 or HAL_PWREx_EnterSTOP1Mode() for mode 1 or for porting reasons HAL_PWR_EnterSTOPMode().
+          (++) HAL_PWREx_EnterSTOP2Mode() for mode 2.  
+      (+) Regulator setting (applicable to HAL_PWR_EnterSTOPMode() only):
+          (++) PWR_MAINREGULATOR_ON
+          (++) PWR_LOWPOWERREGULATOR_ON
+      (+) Exit (interrupt or event-triggered, specified when entering STOP mode):
+          (++) PWR_STOPENTRY_WFI: enter Stop mode with WFI instruction
+          (++) PWR_STOPENTRY_WFE: enter Stop mode with WFE instruction
+          
+      (+) WFI Exit:
+          (++) Any EXTI Line (Internal or External) configured in Interrupt mode.
+          (++) Some specific communication peripherals (USART, LPUART, I2C) interrupts 
+               when programmed in wakeup mode. 
+      (+) WFE Exit:  
+          (++) Any EXTI Line (Internal or External) configured in Event mode.
+       
+       [..]                      
+          When exiting Stop 0 and Stop 1 modes, the MCU is either in Run mode or in Low-power Run mode
+          depending on the LPR bit setting. 
+          When exiting Stop 2 mode, the MCU is in Run mode. 
+
+   *** Standby mode ***
+   ====================
+     [..]
+      The Standby mode offers two options: 
+      (+) option a) all clocks off except LSI and LSE, RRS bit set (keeps voltage regulator in low power mode).
+        SRAM and registers contents are lost except for the SRAM2 content, the RTC registers, RTC backup registers 
+        and Standby circuitry.      
+      (+) option b) all clocks off except LSI and LSE, RRS bit cleared (voltage regulator then disabled).
+        SRAM and register contents are lost except for the RTC registers, RTC backup registers 
+        and Standby circuitry.
+
+      (++) Entry:                                    
+          (+++) The Standby mode is entered thru HAL_PWR_EnterSTANDBYMode() API. 
+                SRAM1 and register contents are lost except for registers in the Backup domain and 
+                Standby circuitry. SRAM2 content can be preserved if the bit RRS is set in PWR_CR3 register. 
+                To enable this feature, the user can resort to HAL_PWREx_EnableSRAM2ContentRetention() API 
+                to set RRS bit.   
+          
+      (++) Exit:
+          (+++) WKUP pin rising edge, RTC alarm or wakeup, tamper event, time-stamp event, 
+                external reset in NRST pin, IWDG reset.
+                
+      [..]    After waking up from Standby mode, program execution restarts in the same way as after a Reset.
+          
+
+    *** Shutdown mode ***
+   ======================
+     [..]
+      In Shutdown mode, 
+        voltage regulator is disabled, all clocks are off except LSE, RRS bit is cleared.
+        SRAM and registers contents are lost except for backup domain registers.
+
+      (+) Entry:                                    
+          The Shutdown mode is entered thru HAL_PWREx_EnterSHUTDOWNMode() API.
+          
+      (+) Exit:
+          (++) WKUP pin rising edge, RTC alarm or wakeup, tamper event, time-stamp event, 
+               external reset in NRST pin.
+               
+         [..] After waking up from Shutdown mode, program execution restarts in the same way as after a Reset.
+
+
+   *** Auto-wakeup (AWU) from low-power mode ***
+   =============================================
+    [..]
+      The MCU can be woken up from low-power mode by an RTC Alarm event, an RTC
+      Wakeup event, a tamper event or a time-stamp event, without depending on
+      an external interrupt (Auto-wakeup mode).
+
+      (+) RTC auto-wakeup (AWU) from the Stop, Standby and Shutdown modes
+  
+
+        (++) To wake up from the Stop mode with an RTC alarm event, it is necessary to
+             configure the RTC to generate the RTC alarm using the HAL_RTC_SetAlarm_IT() function.
+
+        (++) To wake up from the Stop mode with an RTC Tamper or time stamp event, it
+             is necessary to configure the RTC to detect the tamper or time stamp event using the
+             HAL_RTCEx_SetTimeStamp_IT() or HAL_RTCEx_SetTamper_IT() functions.
+
+        (++) To wake up from the Stop mode with an RTC WakeUp event, it is necessary to
+              configure the RTC to generate the RTC WakeUp event using the HAL_RTCEx_SetWakeUpTimer_IT() function.
+
+@endverbatim
+  * @{
+  */
+
+
+
+/**
+  * @brief Configure the voltage threshold detected by the Power Voltage Detector (PVD).
+  * @param sConfigPVD: pointer to a PWR_PVDTypeDef structure that contains the PVD 
+  *        configuration information.
+  * @note Refer to the electrical characteristics of your device datasheet for
+  *         more details about the voltage thresholds corresponding to each
+  *         detection level.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_PWR_ConfigPVD(PWR_PVDTypeDef *sConfigPVD)
+{
+  /* Check the parameters */
+  assert_param(IS_PWR_PVD_LEVEL(sConfigPVD->PVDLevel));
+  assert_param(IS_PWR_PVD_MODE(sConfigPVD->Mode));
+
+  /* Set PLS bits according to PVDLevel value */
+  MODIFY_REG(PWR->CR2, PWR_CR2_PLS, sConfigPVD->PVDLevel);
+  
+  /* Clear any previous config. Keep it clear if no event or IT mode is selected */
+  __HAL_PWR_PVD_EXTI_DISABLE_EVENT();
+  __HAL_PWR_PVD_EXTI_DISABLE_IT();
+  __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE(); 
+  __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE();
+
+  /* Configure interrupt mode */
+  if((sConfigPVD->Mode & PVD_MODE_IT) == PVD_MODE_IT)
+  {
+    __HAL_PWR_PVD_EXTI_ENABLE_IT();
+  }
+  
+  /* Configure event mode */
+  if((sConfigPVD->Mode & PVD_MODE_EVT) == PVD_MODE_EVT)
+  {
+    __HAL_PWR_PVD_EXTI_ENABLE_EVENT();
+  }
+  
+  /* Configure the edge */
+  if((sConfigPVD->Mode & PVD_RISING_EDGE) == PVD_RISING_EDGE)
+  {
+    __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE();
+  }
+  
+  if((sConfigPVD->Mode & PVD_FALLING_EDGE) == PVD_FALLING_EDGE)
+  {
+    __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE();
+  }
+  
+  return HAL_OK;
+}
+
+
+/**
+  * @brief Enable the Power Voltage Detector (PVD).
+  * @retval None
+  */
+void HAL_PWR_EnablePVD(void)
+{
+  SET_BIT(PWR->CR2, PWR_CR2_PVDE);  
+}
+
+/**
+  * @brief Disable the Power Voltage Detector (PVD).
+  * @retval None
+  */
+void HAL_PWR_DisablePVD(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_CR2_PVDE);   
+}
+
+
+
+
+/**
+  * @brief Enable the WakeUp PINx functionality.
+  * @param WakeUpPinPolarity: Specifies which Wake-Up pin to enable.
+  *         This parameter can be one of the following legacy values which set the default polarity 
+  *         i.e. detection on high level (rising edge):
+  *           @arg @ref PWR_WAKEUP_PIN1, PWR_WAKEUP_PIN2, PWR_WAKEUP_PIN3, PWR_WAKEUP_PIN4, PWR_WAKEUP_PIN5
+  *             
+  *         or one of the following value where the user can explicitly specify the enabled pin and
+  *         the chosen polarity:  
+  *           @arg @ref PWR_WAKEUP_PIN1_HIGH or PWR_WAKEUP_PIN1_LOW 
+  *           @arg @ref PWR_WAKEUP_PIN2_HIGH or PWR_WAKEUP_PIN2_LOW 
+  *           @arg @ref PWR_WAKEUP_PIN3_HIGH or PWR_WAKEUP_PIN3_LOW 
+  *           @arg @ref PWR_WAKEUP_PIN4_HIGH or PWR_WAKEUP_PIN4_LOW
+  *           @arg @ref PWR_WAKEUP_PIN5_HIGH or PWR_WAKEUP_PIN5_LOW 
+  * @note  PWR_WAKEUP_PINx and PWR_WAKEUP_PINx_HIGH are equivalent.               
+  * @retval None
+  */
+void HAL_PWR_EnableWakeUpPin(uint32_t WakeUpPinPolarity)
+{
+  assert_param(IS_PWR_WAKEUP_PIN(WakeUpPinPolarity)); 
+  
+  /* Specifies the Wake-Up pin polarity for the event detection 
+    (rising or falling edge) */
+  MODIFY_REG(PWR->CR4, (PWR_CR3_EWUP & WakeUpPinPolarity), (WakeUpPinPolarity >> PWR_WUP_POLARITY_SHIFT)); 
+    
+  /* Enable wake-up pin */
+  SET_BIT(PWR->CR3, (PWR_CR3_EWUP & WakeUpPinPolarity));
+
+    
+}
+
+/**
+  * @brief Disable the WakeUp PINx functionality.
+  * @param WakeUpPinx: Specifies the Power Wake-Up pin to disable.
+  *         This parameter can be one of the following values:
+  *           @arg @ref PWR_WAKEUP_PIN1, PWR_WAKEUP_PIN2, PWR_WAKEUP_PIN3, PWR_WAKEUP_PIN4, PWR_WAKEUP_PIN5 
+  * @retval None
+  */
+void HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx)
+{
+  assert_param(IS_PWR_WAKEUP_PIN(WakeUpPinx));
+
+  CLEAR_BIT(PWR->CR3, (PWR_CR3_EWUP & WakeUpPinx)); 
+}
+
+
+/**
+  * @brief Enter Sleep or Low-power Sleep mode.
+  * @note  In Sleep/Low-power Sleep mode, all I/O pins keep the same state as in Run mode.
+  * @param Regulator: Specifies the regulator state in Sleep/Low-power Sleep mode.
+  *          This parameter can be one of the following values:
+  *            @arg @ref PWR_MAINREGULATOR_ON Sleep mode (regulator in main mode)
+  *            @arg @ref PWR_LOWPOWERREGULATOR_ON Low-power Sleep mode (regulator in low-power mode) 
+  * @note  Low-power Sleep mode is entered from Low-power Run mode. Therefore, if not yet 
+  *        in Low-power Run mode before calling HAL_PWR_EnterSLEEPMode() with Regulator set 
+  *        to PWR_LOWPOWERREGULATOR_ON, the user can optionally configure the    
+  *        Flash in power-down monde in setting the SLEEP_PD bit in FLASH_ACR register.
+  *        Additionally, the clock frequency must be reduced below 2 MHz.
+  *        Setting SLEEP_PD in FLASH_ACR then appropriately reducing the clock frequency must 
+  *        be done before calling HAL_PWR_EnterSLEEPMode() API. 
+  * @note  When exiting Low-power Sleep mode, the MCU is in Low-power Run mode. To move in 
+  *        Run mode, the user must resort to HAL_PWREx_DisableLowPowerRunMode() API.       
+  * @param SLEEPEntry: Specifies if Sleep mode is entered with WFI or WFE instruction.
+  *           This parameter can be one of the following values:
+  *            @arg @ref PWR_SLEEPENTRY_WFI enter Sleep or Low-power Sleep mode with WFI instruction
+  *            @arg @ref PWR_SLEEPENTRY_WFE enter Sleep or Low-power Sleep mode with WFE instruction
+  * @note  When WFI entry is used, tick interrupt have to be disabled if not desired as 
+  *        the interrupt wake up source.   
+  * @retval None
+  */
+void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry)
+{
+  /* Check the parameters */
+  assert_param(IS_PWR_REGULATOR(Regulator));
+  assert_param(IS_PWR_SLEEP_ENTRY(SLEEPEntry));
+
+  /* Set Regulator parameter */
+  if (Regulator == PWR_MAINREGULATOR_ON)
+  {
+    /* If in low-power run mode at this point, exit it */
+    if (HAL_IS_BIT_SET(PWR->SR2, PWR_SR2_REGLPF))
+    {
+      HAL_PWREx_DisableLowPowerRunMode();  
+    } 
+    /* Regulator now in main mode. */
+  }
+  else
+  {
+    /* If in run mode, first move to low-power run mode.
+       The system clock frequency must be below 2 MHz at this point. */
+    if (HAL_IS_BIT_SET(PWR->SR2, PWR_SR2_REGLPF) == RESET)
+    {
+      HAL_PWREx_EnableLowPowerRunMode();  
+    } 
+  } 
+    
+  /* Clear SLEEPDEEP bit of Cortex System Control Register */
+  CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
+  
+  /* Select SLEEP mode entry -------------------------------------------------*/
+  if(SLEEPEntry == PWR_SLEEPENTRY_WFI)
+  {
+    /* Request Wait For Interrupt */
+    __WFI();
+  }
+  else
+  {
+    /* Request Wait For Event */
+    __SEV();
+    __WFE();
+    __WFE();
+  }
+
+}
+
+
+/**
+  * @brief Enter Stop mode
+  * @note  This API is named HAL_PWR_EnterSTOPMode to ensure compatibility with legacy code running
+  *        on devices where only "Stop mode" is mentioned with main or low power regulator ON.
+  * @note  In Stop mode, all I/O pins keep the same state as in Run mode.          
+  * @note  All clocks in the VCORE domain are stopped; the PLL, the MSI, 
+  *        the HSI and the HSE oscillators are disabled. Some peripherals with the wakeup capability 
+  *        (I2Cx, USARTx and LPUART) can switch on the HSI to receive a frame, and switch off the HSI 
+  *        after receiving the frame if it is not a wakeup frame. In this case, the HSI clock is propagated 
+  *        only to the peripheral requesting it.
+  *        SRAM1, SRAM2 and register contents are preserved.
+  *        The BOR is available.
+  *        The voltage regulator can be configured either in normal (Stop 0) or low-power mode (Stop 1).  
+  * @note  When exiting Stop 0 or Stop 1 mode by issuing an interrupt or a wakeup event,
+  *         the HSI RC oscillator is selected as system clock if STOPWUCK bit in RCC_CFGR register
+  *         is set; the MSI oscillator is selected if STOPWUCK is cleared.  
+  * @note  When the voltage regulator operates in low power mode (Stop 1), an additional
+  *         startup delay is incurred when waking up.
+  *         By keeping the internal regulator ON during Stop mode (Stop 0), the consumption
+  *         is higher although the startup time is reduced.
+  * @param Regulator: Specifies the regulator state in Stop mode.
+  *          This parameter can be one of the following values:
+  *            @arg @ref PWR_MAINREGULATOR_ON  Stop 0 mode (main regulator ON)
+  *            @arg @ref PWR_LOWPOWERREGULATOR_ON  Stop 1 mode (low power regulator ON) 
+  * @param STOPEntry: Specifies Stop 0 or Stop 1 mode is entered with WFI or WFE instruction.
+  *          This parameter can be one of the following values:
+  *            @arg @ref PWR_STOPENTRY_WFI  Enter Stop 0 or Stop 1 mode with WFI instruction.
+  *            @arg @ref PWR_STOPENTRY_WFE  Enter Stop 0 or Stop 1 mode with WFE instruction.
+  * @retval None
+  */
+void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry)
+{
+  /* Check the parameters */
+  assert_param(IS_PWR_REGULATOR(Regulator));
+  
+  if(Regulator == PWR_LOWPOWERREGULATOR_ON)
+  {
+    HAL_PWREx_EnterSTOP1Mode(STOPEntry);
+  }
+  else
+  {
+    HAL_PWREx_EnterSTOP0Mode(STOPEntry);
+  }
+}
+
+/**
+  * @brief Enter Standby mode.
+  * @note  In Standby mode, the PLL, the HSI, the MSI and the HSE oscillators are switched 
+  *        off. The voltage regulator is disabled, except when SRAM2 content is preserved
+  *        in which case the regulator is in low-power mode. 
+  *        SRAM1 and register contents are lost except for registers in the Backup domain and 
+  *        Standby circuitry. SRAM2 content can be preserved if the bit RRS is set in PWR_CR3 register. 
+  *        To enable this feature, the user can resort to HAL_PWREx_EnableSRAM2ContentRetention() API 
+  *        to set RRS bit.   
+  *        The BOR is available.  
+  * @note  The I/Os can be configured either with a pull-up or pull-down or can be kept in analog state.
+  *        HAL_PWREx_EnableGPIOPullUp() and HAL_PWREx_EnableGPIOPullDown() respectively enable Pull Up and
+  *        Pull Down state, HAL_PWREx_DisableGPIOPullUp() and HAL_PWREx_DisableGPIOPullDown() disable the
+  *        same.
+  *        These states are effective in Standby mode only if APC bit is set through
+  *        HAL_PWREx_EnablePullUpPullDownConfig() API.        
+  * @retval None
+  */
+void HAL_PWR_EnterSTANDBYMode(void)
+{
+  /* Set Stand-by mode */
+  MODIFY_REG(PWR->CR1, PWR_CR1_LPMS, PWR_CR1_LPMS_STANDBY);
+
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+  SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
+
+/* This option is used to ensure that store operations are completed */
+#if defined ( __CC_ARM)
+  __force_stores();
+#endif
+  /* Request Wait For Interrupt */
+  __WFI();
+}
+
+
+
+/**
+  * @brief Indicate Sleep-On-Exit when returning from Handler mode to Thread mode. 
+  * @note Set SLEEPONEXIT bit of SCR register. When this bit is set, the processor 
+  *       re-enters SLEEP mode when an interruption handling is over.
+  *       Setting this bit is useful when the processor is expected to run only on
+  *       interruptions handling.         
+  * @retval None
+  */
+void HAL_PWR_EnableSleepOnExit(void)
+{
+  /* Set SLEEPONEXIT bit of Cortex System Control Register */
+  SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPONEXIT_Msk));
+}
+
+
+/**
+  * @brief Disable Sleep-On-Exit feature when returning from Handler mode to Thread mode. 
+  * @note Clear SLEEPONEXIT bit of SCR register. When this bit is set, the processor 
+  *       re-enters SLEEP mode when an interruption handling is over.          
+  * @retval None
+  */
+void HAL_PWR_DisableSleepOnExit(void)
+{
+  /* Clear SLEEPONEXIT bit of Cortex System Control Register */
+  CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPONEXIT_Msk));
+}
+
+
+
+/**
+  * @brief Enable CORTEX M4 SEVONPEND bit. 
+  * @note Set SEVONPEND bit of SCR register. When this bit is set, this causes 
+  *       WFE to wake up when an interrupt moves from inactive to pended.
+  * @retval None
+  */
+void HAL_PWR_EnableSEVOnPend(void)
+{
+  /* Set SEVONPEND bit of Cortex System Control Register */
+  SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SEVONPEND_Msk));
+}
+
+
+/**
+  * @brief Disable CORTEX M4 SEVONPEND bit. 
+  * @note Clear SEVONPEND bit of SCR register. When this bit is set, this causes 
+  *       WFE to wake up when an interrupt moves from inactive to pended.         
+  * @retval None
+  */
+void HAL_PWR_DisableSEVOnPend(void)
+{
+  /* Clear SEVONPEND bit of Cortex System Control Register */
+  CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SEVONPEND_Msk));
+}
+
+
+
+
+
+/**
+  * @brief PWR PVD interrupt callback
+  * @retval None
+  */
+__weak void HAL_PWR_PVDCallback(void)
+{
+  /* NOTE : This function should not be modified; when the callback is needed,
+            the HAL_PWR_PVDCallback can be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_PWR_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_pwr_ex.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_pwr_ex.c
@@ -1,0 +1,1176 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_pwr_ex.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Extended PWR HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Power Controller (PWR) peripheral:
+  *           + Extended Initialization and de-initialization functions
+  *           + Extended Peripheral Control functions
+  *         
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PWREx PWREx
+  * @brief PWR Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+
+#define PWR_PORTH_AVAILABLE_PINS   (PWR_GPIO_BIT_0|PWR_GPIO_BIT_1)    
+
+/** @defgroup PWR_Extended_Private_Defines PWR Extended Private Defines
+  * @{
+  */
+  
+/** @defgroup PWREx_PVM_Mode_Mask PWR PVM Mode Mask
+  * @{
+  */ 
+#define PVM_MODE_IT               ((uint32_t)0x00010000)  /*!< Mask for interruption yielded by PVM threshold crossing */
+#define PVM_MODE_EVT              ((uint32_t)0x00020000)  /*!< Mask for event yielded by PVM threshold crossing        */
+#define PVM_RISING_EDGE           ((uint32_t)0x00000001)  /*!< Mask for rising edge set as PVM trigger                 */
+#define PVM_FALLING_EDGE          ((uint32_t)0x00000002)  /*!< Mask for falling edge set as PVM trigger                */
+/**
+  * @}
+  */
+  
+/** @defgroup PWREx_TimeOut_Value PWR Extended Flag Setting Time Out Value
+  * @{
+  */ 
+#define PWR_FLAG_SETTING_DELAY_US                      50   /*!< Time out value for REGLPF and VOSF flags setting */
+/**
+  * @}
+  */
+    
+  
+
+/**
+  * @}
+  */
+
+
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+  
+/** @defgroup PWREx_Exported_Functions PWR Extended Exported Functions
+  * @{
+  */
+
+/** @defgroup PWREx_Exported_Functions_Group1 Extended Peripheral Control functions
+  *  @brief   Extended Peripheral Control functions
+  *
+@verbatim
+ ===============================================================================
+              ##### Extended Peripheral Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]
+
+@endverbatim
+  * @{
+  */
+  
+
+/**
+  * @brief Return Voltage Scaling Range.
+  * @retval VOS bit field (PWR_REGULATOR_VOLTAGE_RANGE1 or PWR_REGULATOR_VOLTAGE_RANGE2)
+  */  
+uint32_t HAL_PWREx_GetVoltageRange(void)
+{
+  return  (PWR->CR1 & PWR_CR1_VOS);
+}
+
+  
+
+/**
+  * @brief Configure the main internal regulator output voltage.
+  * @param  VoltageScaling: specifies the regulator output voltage to achieve
+  *         a tradeoff between performance and power consumption.
+  *          This parameter can be one of the following values:
+  *            @arg @ref PWR_REGULATOR_VOLTAGE_SCALE1 Regulator voltage output range 1 mode,
+  *                                                typical output voltage at 1.2 V,  
+  *                                                system frequency up to 80 MHz.
+  *            @arg @ref PWR_REGULATOR_VOLTAGE_SCALE2 Regulator voltage output range 2 mode,
+  *                                                typical output voltage at 1.0 V,                
+  *                                                system frequency up to 26 MHz.
+  * @note  When moving from Range 1 to Range 2, the system frequency must be decreased to
+  *        a value below 26 MHz before calling HAL_PWREx_ControlVoltageScaling() API.
+  *        When moving from Range 2 to Range 1, the system frequency can be increased to
+  *        a value up to 80 MHz after calling HAL_PWREx_ControlVoltageScaling() API.
+  * @note  When moving from Range 2 to Range 1, the API waits for VOSF flag to be
+  *        cleared before returning the status. If the flag is not cleared within
+  *        50 microseconds, HAL_TIMEOUT status is reported.                    
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_PWREx_ControlVoltageScaling(uint32_t VoltageScaling)
+{
+  uint32_t wait_loop_index = 0;  
+
+  assert_param(IS_PWR_VOLTAGE_SCALING_RANGE(VoltageScaling));
+  
+  /* If Set Range 1 */
+  if (VoltageScaling == PWR_REGULATOR_VOLTAGE_SCALE1)
+  {
+    if (READ_BIT(PWR->CR1, PWR_CR1_VOS) != PWR_REGULATOR_VOLTAGE_SCALE1)
+    {
+      /* Set Range 1 */
+      MODIFY_REG(PWR->CR1, PWR_CR1_VOS, PWR_REGULATOR_VOLTAGE_SCALE1);
+      
+      /* Wait until VOSF is cleared */      
+      wait_loop_index = (PWR_FLAG_SETTING_DELAY_US * (SystemCoreClock / 1000000));
+      while ((wait_loop_index != 0) && (HAL_IS_BIT_SET(PWR->SR2, PWR_SR2_VOSF)))
+      {
+        wait_loop_index--;
+      }
+      if (HAL_IS_BIT_SET(PWR->SR2, PWR_SR2_VOSF))
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  else
+  {
+    if (READ_BIT(PWR->CR1, PWR_CR1_VOS) != PWR_REGULATOR_VOLTAGE_SCALE2)
+    {
+      /* Set Range 2 */
+      MODIFY_REG(PWR->CR1, PWR_CR1_VOS, PWR_REGULATOR_VOLTAGE_SCALE2);
+      /* No need to wait for VOSF to be cleared for this transition */
+    }
+  }
+  
+  return HAL_OK;
+}  
+
+
+/**
+  * @brief Enable battery charging.
+  *        When VDD is present, charge the external battery on VBAT thru an internal resistor.  
+  * @param  ResistorSelection: specifies the resistor impedance.
+  *          This parameter can be one of the following values:
+  *            @arg @ref PWR_BATTERY_CHARGING_RESISTOR_5     5 kOhms resistor
+  *            @arg @ref PWR_BATTERY_CHARGING_RESISTOR_1_5 1.5 kOhms resistor 
+  * @retval None
+  */
+void HAL_PWREx_EnableBatteryCharging(uint32_t ResistorSelection)
+{
+  assert_param(IS_PWR_BATTERY_RESISTOR_SELECT(ResistorSelection));
+  
+  /* Specify resistor selection */
+  MODIFY_REG(PWR->CR4, PWR_CR4_VBRS, ResistorSelection);
+  
+  /* Enable battery charging */
+  SET_BIT(PWR->CR4, PWR_CR4_VBE);
+}
+
+
+/**
+  * @brief Disable battery charging.  
+  * @retval None
+  */
+void HAL_PWREx_DisableBatteryCharging(void)
+{
+  CLEAR_BIT(PWR->CR4, PWR_CR4_VBE); 
+}  
+
+
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+/**
+  * @brief Enable VDDUSB supply. 
+  * @note  Remove VDDUSB electrical and logical isolation, once VDDUSB supply is present.  
+  * @retval None
+  */
+void HAL_PWREx_EnableVddUSB(void)
+{
+  SET_BIT(PWR->CR2, PWR_CR2_USV);
+}
+
+
+/**
+  * @brief Disable VDDUSB supply. 
+  * @retval None
+  */
+void HAL_PWREx_DisableVddUSB(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_CR2_USV);
+}
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */
+
+/**
+  * @brief Enable VDDIO2 supply. 
+  * @note  Remove VDDIO2 electrical and logical isolation, once VDDIO2 supply is present. 
+  * @retval None
+  */
+void HAL_PWREx_EnableVddIO2(void)
+{
+  SET_BIT(PWR->CR2, PWR_CR2_IOSV);
+}
+
+
+/**
+  * @brief Disable VDDIO2 supply. 
+  * @retval None
+  */
+void HAL_PWREx_DisableVddIO2(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_CR2_IOSV);
+}
+
+
+/**
+  * @brief Enable Internal Wake-up Line. 
+  * @retval None
+  */
+void HAL_PWREx_EnableInternalWakeUpLine(void)
+{
+  SET_BIT(PWR->CR3, PWR_CR3_EIWF);
+}
+
+
+/**
+  * @brief Disable Internal Wake-up Line. 
+  * @retval None
+  */
+void HAL_PWREx_DisableInternalWakeUpLine(void)
+{
+  CLEAR_BIT(PWR->CR3, PWR_CR3_EIWF);
+}
+
+
+
+/**
+  * @brief Enable GPIO pull-up state in Standby and Shutdown modes.
+  * @note  Set the relevant PUy bits of PWR_PUCRx register to configure the I/O in 
+  *        pull-up state in Standby and Shutdown modes. 
+  * @note  This state is effective in Standby and Shutdown modes only if APC bit 
+  *        is set through HAL_PWREx_EnablePullUpPullDownConfig() API.
+  * @note  The configuration is lost when exiting the Shutdown mode due to the 
+  *        power-on reset, maintained when exiting the Standby mode. 
+  * @note  To avoid any conflict at Standby and Shutdown modes exits, the corresponding
+  *        PDy bit of PWR_PDCRx register is cleared unless it is reserved. 
+  * @note  Even if a PUy bit to set is reserved, the other PUy bits entered as input 
+  *        parameter at the same time are set.     
+  * @param  GPIO: Specify the IO port. This parameter can be PWR_GPIO_A, ..., PWR_GPIO_H 
+  *         to select the GPIO peripheral.
+  * @param  GPIONumber: Specify the I/O pins numbers.
+  *         This parameter can be one of the following values:
+  *         PWR_GPIO_BIT_0, ..., PWR_GPIO_BIT_15 (except for PORTH where less  
+  *         I/O pins are available) or the logical OR of several of them to set 
+  *         several bits for a given port in a single API call.    
+  * @retval HAL Status
+  */   
+HAL_StatusTypeDef HAL_PWREx_EnableGPIOPullUp(uint32_t GPIO, uint32_t GPIONumber)
+{  
+  assert_param(IS_PWR_GPIO(GPIO));
+  assert_param(IS_PWR_GPIO_BIT_NUMBER(GPIONumber));
+
+  switch (GPIO)
+  {
+    case PWR_GPIO_A:
+       SET_BIT(PWR->PUCRA, (GPIONumber & (~(PWR_GPIO_BIT_14))));
+       CLEAR_BIT(PWR->PDCRA, (GPIONumber & (~(PWR_GPIO_BIT_13|PWR_GPIO_BIT_15))));                       
+       break;
+    case PWR_GPIO_B:
+       SET_BIT(PWR->PUCRB, GPIONumber);
+       CLEAR_BIT(PWR->PDCRB, (GPIONumber & (~(PWR_GPIO_BIT_4))));                  
+       break; 
+    case PWR_GPIO_C:
+       SET_BIT(PWR->PUCRC, GPIONumber);
+       CLEAR_BIT(PWR->PDCRC, GPIONumber);         
+       break; 
+    case PWR_GPIO_D:
+       SET_BIT(PWR->PUCRD, GPIONumber);
+       CLEAR_BIT(PWR->PDCRD, GPIONumber);         
+       break;
+    case PWR_GPIO_E:
+       SET_BIT(PWR->PUCRE, GPIONumber);
+       CLEAR_BIT(PWR->PDCRE, GPIONumber);         
+       break;
+    case PWR_GPIO_F:
+       SET_BIT(PWR->PUCRF, GPIONumber);
+       CLEAR_BIT(PWR->PDCRF, GPIONumber);         
+       break;
+    case PWR_GPIO_G:
+       SET_BIT(PWR->PUCRG, GPIONumber);
+       CLEAR_BIT(PWR->PDCRG, GPIONumber);         
+       break;
+    case PWR_GPIO_H:
+       SET_BIT(PWR->PUCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
+       CLEAR_BIT(PWR->PDCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));           
+       break;                                                   
+    default:
+        return HAL_ERROR;
+  }
+       
+  return HAL_OK;
+}
+
+
+/**
+  * @brief Disable GPIO pull-up state in Standby mode and Shutdown modes.
+  * @note  Reset the relevant PUy bits of PWR_PUCRx register used to configure the I/O
+  *        in pull-up state in Standby and Shutdown modes.
+  * @note  Even if a PUy bit to reset is reserved, the other PUy bits entered as input 
+  *        parameter at the same time are reset.      
+  * @param  GPIO: Specifies the IO port. This parameter can be PWR_GPIO_A, ..., PWR_GPIO_H 
+  *         to select the GPIO peripheral.
+  * @param  GPIONumber: Specify the I/O pins numbers.
+  *         This parameter can be one of the following values:
+  *         PWR_GPIO_BIT_0, ..., PWR_GPIO_BIT_15 (except for PORTH where less  
+  *         I/O pins are available) or the logical OR of several of them to reset 
+  *         several bits for a given port in a single API call. 
+  * @retval HAL Status
+  */   
+HAL_StatusTypeDef HAL_PWREx_DisableGPIOPullUp(uint32_t GPIO, uint32_t GPIONumber)
+{  
+  assert_param(IS_PWR_GPIO(GPIO));
+  assert_param(IS_PWR_GPIO_BIT_NUMBER(GPIONumber));
+  
+  switch (GPIO)
+  {
+    case PWR_GPIO_A:
+       CLEAR_BIT(PWR->PUCRA, (GPIONumber & (~(PWR_GPIO_BIT_14))));         
+       break;
+    case PWR_GPIO_B:
+       CLEAR_BIT(PWR->PUCRB, GPIONumber);
+       break; 
+    case PWR_GPIO_C:
+       CLEAR_BIT(PWR->PUCRC, GPIONumber);
+       break; 
+    case PWR_GPIO_D:
+       CLEAR_BIT(PWR->PUCRD, GPIONumber);
+       break;
+    case PWR_GPIO_E:
+       CLEAR_BIT(PWR->PUCRE, GPIONumber);
+       break;
+    case PWR_GPIO_F:
+       CLEAR_BIT(PWR->PUCRF, GPIONumber);
+       break;
+    case PWR_GPIO_G:
+       CLEAR_BIT(PWR->PUCRG, GPIONumber);
+       break;
+    case PWR_GPIO_H:
+       CLEAR_BIT(PWR->PUCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
+       break;                                                   
+    default:
+        return HAL_ERROR;
+  }
+       
+  return HAL_OK;
+}
+
+
+
+/**
+  * @brief Enable GPIO pull-down state in Standby and Shutdown modes.
+  * @note  Set the relevant PDy bits of PWR_PDCRx register to configure the I/O in 
+  *        pull-down state in Standby and Shutdown modes. 
+  * @note  This state is effective in Standby and Shutdown modes only if APC bit
+  *        is set through HAL_PWREx_EnablePullUpPullDownConfig() API. 
+  * @note  The configuration is lost when exiting the Shutdown mode due to the 
+  *        power-on reset, maintained when exiting the Standby mode. 
+  * @note  To avoid any conflict at Standby and Shutdown modes exits, the corresponding
+  *        PUy bit of PWR_PUCRx register is cleared unless it is reserved. 
+  * @note  Even if a PDy bit to set is reserved, the other PDy bits entered as input 
+  *        parameter at the same time are set.         
+  * @param  GPIO: Specify the IO port. This parameter can be PWR_GPIO_A..PWR_GPIO_H 
+  *         to select the GPIO peripheral.
+  * @param  GPIONumber: Specify the I/O pins numbers.
+  *         This parameter can be one of the following values:
+  *         PWR_GPIO_BIT_0, ..., PWR_GPIO_BIT_15 (except for PORTH where less  
+  *         I/O pins are available) or the logical OR of several of them to set 
+  *         several bits for a given port in a single API call. 
+  * @retval HAL Status
+  */   
+HAL_StatusTypeDef HAL_PWREx_EnableGPIOPullDown(uint32_t GPIO, uint32_t GPIONumber)
+{
+  assert_param(IS_PWR_GPIO(GPIO));
+  assert_param(IS_PWR_GPIO_BIT_NUMBER(GPIONumber));
+  
+  switch (GPIO)
+  { 
+    case PWR_GPIO_A:
+       SET_BIT(PWR->PDCRA, (GPIONumber & (~(PWR_GPIO_BIT_13|PWR_GPIO_BIT_15))));        
+       CLEAR_BIT(PWR->PUCRA, (GPIONumber & (~(PWR_GPIO_BIT_14))));           
+       break;
+    case PWR_GPIO_B:
+       SET_BIT(PWR->PDCRB, (GPIONumber & (~(PWR_GPIO_BIT_4))));
+       CLEAR_BIT(PWR->PUCRB, GPIONumber);                    
+       break; 
+    case PWR_GPIO_C:
+       SET_BIT(PWR->PDCRC, GPIONumber);
+       CLEAR_BIT(PWR->PUCRC, GPIONumber);        
+       break; 
+    case PWR_GPIO_D:
+       SET_BIT(PWR->PDCRD, GPIONumber);
+       CLEAR_BIT(PWR->PUCRD, GPIONumber);        
+       break;
+    case PWR_GPIO_E:
+       SET_BIT(PWR->PDCRE, GPIONumber);
+       CLEAR_BIT(PWR->PUCRE, GPIONumber);        
+       break;
+    case PWR_GPIO_F:
+       SET_BIT(PWR->PDCRF, GPIONumber);
+       CLEAR_BIT(PWR->PUCRF, GPIONumber);        
+       break;
+    case PWR_GPIO_G:
+       SET_BIT(PWR->PDCRG, GPIONumber);
+       CLEAR_BIT(PWR->PUCRG, GPIONumber);        
+       break;
+    case PWR_GPIO_H:
+       SET_BIT(PWR->PDCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
+       CLEAR_BIT(PWR->PUCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));          
+       break;                                                   
+    default:
+        return HAL_ERROR;
+  }
+       
+  return HAL_OK;
+}
+
+
+/**
+  * @brief Disable GPIO pull-down state in Standby and Shutdown modes.
+  * @note  Reset the relevant PDy bits of PWR_PDCRx register used to configure the I/O
+  *        in pull-down state in Standby and Shutdown modes. 
+  * @note  Even if a PDy bit to reset is reserved, the other PDy bits entered as input 
+  *        parameter at the same time are reset.   
+  * @param  GPIO: Specifies the IO port. This parameter can be PWR_GPIO_A..PWR_GPIO_H 
+  *         to select the GPIO peripheral.
+  * @param  GPIONumber: Specify the I/O pins numbers.
+  *         This parameter can be one of the following values:
+  *         PWR_GPIO_BIT_0, ..., PWR_GPIO_BIT_15 (except for PORTH where less  
+  *         I/O pins are available) or the logical OR of several of them to reset 
+  *         several bits for a given port in a single API call. 
+  * @retval HAL Status
+  */   
+HAL_StatusTypeDef HAL_PWREx_DisableGPIOPullDown(uint32_t GPIO, uint32_t GPIONumber)
+{
+  assert_param(IS_PWR_GPIO(GPIO));
+  assert_param(IS_PWR_GPIO_BIT_NUMBER(GPIONumber));
+   
+  switch (GPIO)
+  {
+    case PWR_GPIO_A:
+       CLEAR_BIT(PWR->PDCRA, (GPIONumber & (~(PWR_GPIO_BIT_13|PWR_GPIO_BIT_15))));                        
+       break;
+    case PWR_GPIO_B:
+       CLEAR_BIT(PWR->PDCRB, (GPIONumber & (~(PWR_GPIO_BIT_4))));           
+       break; 
+    case PWR_GPIO_C:
+       CLEAR_BIT(PWR->PDCRC, GPIONumber);
+       break; 
+    case PWR_GPIO_D:
+       CLEAR_BIT(PWR->PDCRD, GPIONumber);
+       break;
+    case PWR_GPIO_E:
+       CLEAR_BIT(PWR->PDCRE, GPIONumber);
+       break;
+    case PWR_GPIO_F:
+       CLEAR_BIT(PWR->PDCRF, GPIONumber);
+       break;
+    case PWR_GPIO_G:
+       CLEAR_BIT(PWR->PDCRG, GPIONumber);
+       break;
+    case PWR_GPIO_H:
+      CLEAR_BIT(PWR->PDCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
+       break;                                                   
+    default:
+        return HAL_ERROR;
+  }
+       
+  return HAL_OK;
+}
+
+
+
+/**
+  * @brief Enable pull-up and pull-down configuration.
+  * @note  When APC bit is set, the I/O pull-up and pull-down configurations defined in 
+  *        PWR_PUCRx and PWR_PDCRx registers are applied in Standby and Shutdown modes.    
+  * @note  Pull-up set by PUy bit of PWR_PUCRx register is not activated if the corresponding
+  *        PDy bit of PWR_PDCRx register is also set (pull-down configuration priority is higher). 
+  *        HAL_PWREx_EnableGPIOPullUp() and HAL_PWREx_EnableGPIOPullDown() API's ensure there 
+  *        is no conflict when setting PUy or PDy bit.         
+  * @retval None
+  */
+void HAL_PWREx_EnablePullUpPullDownConfig(void)
+{
+  SET_BIT(PWR->CR3, PWR_CR3_APC);
+}
+
+
+/**
+  * @brief Disable pull-up and pull-down configuration.
+  * @note  When APC bit is cleared, the I/O pull-up and pull-down configurations defined in 
+  *        PWR_PUCRx and PWR_PDCRx registers are not applied in Standby and Shutdown modes.     
+  * @retval None
+  */
+void HAL_PWREx_DisablePullUpPullDownConfig(void)
+{
+  CLEAR_BIT(PWR->CR3, PWR_CR3_APC);
+}
+
+
+
+/**
+  * @brief Enable SRAM2 content retention in Standby mode.
+  * @note  When RRS bit is set, SRAM2 is powered by the low-power regulator in 
+  *         Standby mode and its content is kept.    
+  * @retval None
+  */
+void HAL_PWREx_EnableSRAM2ContentRetention(void)
+{
+  SET_BIT(PWR->CR3, PWR_CR3_RRS);
+}
+
+
+/**
+  * @brief Disable SRAM2 content retention in Standby mode.
+  * @note  When RRS bit is reset, SRAM2 is powered off in Standby mode 
+  *        and its content is lost.      
+  * @retval None
+  */
+void HAL_PWREx_DisableSRAM2ContentRetention(void)
+{
+  CLEAR_BIT(PWR->CR3, PWR_CR3_RRS);
+}
+
+
+
+
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+/**
+  * @brief Enable the Power Voltage Monitoring 1: VDDUSB versus 1.2V.
+  * @retval None
+  */
+void HAL_PWREx_EnablePVM1(void)
+{
+  SET_BIT(PWR->CR2, PWR_PVM_1);    
+}
+
+/**
+  * @brief Disable the Power Voltage Monitoring 1: VDDUSB versus 1.2V.
+  * @retval None
+  */
+void HAL_PWREx_DisablePVM1(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_PVM_1);    
+}
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */
+
+
+/**
+  * @brief Enable the Power Voltage Monitoring 2: VDDIO2 versus 0.9V.
+  * @retval None
+  */
+void HAL_PWREx_EnablePVM2(void)
+{
+  SET_BIT(PWR->CR2, PWR_PVM_2);    
+}
+
+/**
+  * @brief Disable the Power Voltage Monitoring 2: VDDIO2 versus 0.9V.
+  * @retval None
+  */
+void HAL_PWREx_DisablePVM2(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_PVM_2);    
+}
+
+
+/**
+  * @brief Enable the Power Voltage Monitoring 3: VDDA versus 1.62V.
+  * @retval None
+  */
+void HAL_PWREx_EnablePVM3(void)
+{
+  SET_BIT(PWR->CR2, PWR_PVM_3);    
+}
+
+/**
+  * @brief Disable the Power Voltage Monitoring 3: VDDA versus 1.62V.
+  * @retval None
+  */
+void HAL_PWREx_DisablePVM3(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_PVM_3);    
+}
+
+
+/**
+  * @brief Enable the Power Voltage Monitoring 4:  VDDA versus 2.2V.
+  * @retval None
+  */
+void HAL_PWREx_EnablePVM4(void)
+{
+  SET_BIT(PWR->CR2, PWR_PVM_4);    
+}
+
+/**
+  * @brief Disable the Power Voltage Monitoring 4:  VDDA versus 2.2V.
+  * @retval None
+  */
+void HAL_PWREx_DisablePVM4(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_PVM_4);    
+}
+
+
+
+
+/**
+  * @brief Configure the Peripheral Voltage Monitoring (PVM).
+  * @param sConfigPVM: pointer to a PWR_PVMTypeDef structure that contains the
+  *        PVM configuration information.
+  * @note The API configures a single PVM according to the information contained 
+  *       in the input structure. To configure several PVMs, the API must be singly 
+  *       called for each PVM used.
+  * @note Refer to the electrical characteristics of your device datasheet for
+  *         more details about the voltage thresholds corresponding to each
+  *         detection level and to each monitored supply.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PWREx_ConfigPVM(PWR_PVMTypeDef *sConfigPVM)
+{  
+  /* Check the parameters */
+  assert_param(IS_PWR_PVM_TYPE(sConfigPVM->PVMType));
+  assert_param(IS_PWR_PVM_MODE(sConfigPVM->Mode));
+
+
+  /* Configure EXTI 35 to 38 interrupts if so required:
+     scan thru PVMType to detect which PVMx is set and
+     configure the corresponding EXTI line accordingly. */
+  switch (sConfigPVM->PVMType)
+  {
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+    case PWR_PVM_1:
+      /* Clear any previous config. Keep it clear if no event or IT mode is selected */
+      __HAL_PWR_PVM1_EXTI_DISABLE_EVENT();
+      __HAL_PWR_PVM1_EXTI_DISABLE_IT();
+      __HAL_PWR_PVM1_EXTI_DISABLE_FALLING_EDGE(); 
+      __HAL_PWR_PVM1_EXTI_DISABLE_RISING_EDGE();
+
+      /* Configure interrupt mode */
+      if((sConfigPVM->Mode & PVM_MODE_IT) == PVM_MODE_IT)
+      {
+        __HAL_PWR_PVM1_EXTI_ENABLE_IT();
+      }
+  
+      /* Configure event mode */
+      if((sConfigPVM->Mode & PVM_MODE_EVT) == PVM_MODE_EVT)
+      {
+        __HAL_PWR_PVM1_EXTI_ENABLE_EVENT();
+      }
+  
+      /* Configure the edge */
+      if((sConfigPVM->Mode & PVM_RISING_EDGE) == PVM_RISING_EDGE)
+      {
+        __HAL_PWR_PVM1_EXTI_ENABLE_RISING_EDGE();
+      }
+  
+      if((sConfigPVM->Mode & PVM_FALLING_EDGE) == PVM_FALLING_EDGE)
+      {
+        __HAL_PWR_PVM1_EXTI_ENABLE_FALLING_EDGE();
+      }
+      break; 
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */        
+    
+    case PWR_PVM_2:
+      /* Clear any previous config. Keep it clear if no event or IT mode is selected */
+      __HAL_PWR_PVM2_EXTI_DISABLE_EVENT();
+      __HAL_PWR_PVM2_EXTI_DISABLE_IT();
+      __HAL_PWR_PVM2_EXTI_DISABLE_FALLING_EDGE(); 
+      __HAL_PWR_PVM2_EXTI_DISABLE_RISING_EDGE();
+
+      /* Configure interrupt mode */
+      if((sConfigPVM->Mode & PVM_MODE_IT) == PVM_MODE_IT)
+      {
+        __HAL_PWR_PVM2_EXTI_ENABLE_IT();
+      }
+  
+      /* Configure event mode */
+      if((sConfigPVM->Mode & PVM_MODE_EVT) == PVM_MODE_EVT)
+      {
+        __HAL_PWR_PVM2_EXTI_ENABLE_EVENT();
+      }
+  
+      /* Configure the edge */
+      if((sConfigPVM->Mode & PVM_RISING_EDGE) == PVM_RISING_EDGE)
+      {
+        __HAL_PWR_PVM2_EXTI_ENABLE_RISING_EDGE();
+      }
+  
+      if((sConfigPVM->Mode & PVM_FALLING_EDGE) == PVM_FALLING_EDGE)
+      {
+        __HAL_PWR_PVM2_EXTI_ENABLE_FALLING_EDGE();
+      }
+      break;
+      
+    case PWR_PVM_3:
+      /* Clear any previous config. Keep it clear if no event or IT mode is selected */
+      __HAL_PWR_PVM3_EXTI_DISABLE_EVENT();
+      __HAL_PWR_PVM3_EXTI_DISABLE_IT();
+      __HAL_PWR_PVM3_EXTI_DISABLE_FALLING_EDGE(); 
+      __HAL_PWR_PVM3_EXTI_DISABLE_RISING_EDGE();
+
+      /* Configure interrupt mode */
+      if((sConfigPVM->Mode & PVM_MODE_IT) == PVM_MODE_IT)
+      {
+        __HAL_PWR_PVM3_EXTI_ENABLE_IT();
+      }
+  
+      /* Configure event mode */
+      if((sConfigPVM->Mode & PVM_MODE_EVT) == PVM_MODE_EVT)
+      {
+        __HAL_PWR_PVM3_EXTI_ENABLE_EVENT();
+      }
+  
+      /* Configure the edge */
+      if((sConfigPVM->Mode & PVM_RISING_EDGE) == PVM_RISING_EDGE)
+      {
+        __HAL_PWR_PVM3_EXTI_ENABLE_RISING_EDGE();
+      }
+  
+      if((sConfigPVM->Mode & PVM_FALLING_EDGE) == PVM_FALLING_EDGE)
+      {
+        __HAL_PWR_PVM3_EXTI_ENABLE_FALLING_EDGE();
+      }
+      break;
+      
+    case PWR_PVM_4:
+      /* Clear any previous config. Keep it clear if no event or IT mode is selected */
+      __HAL_PWR_PVM4_EXTI_DISABLE_EVENT();
+      __HAL_PWR_PVM4_EXTI_DISABLE_IT();
+      __HAL_PWR_PVM4_EXTI_DISABLE_FALLING_EDGE(); 
+      __HAL_PWR_PVM4_EXTI_DISABLE_RISING_EDGE();
+
+      /* Configure interrupt mode */
+      if((sConfigPVM->Mode & PVM_MODE_IT) == PVM_MODE_IT)
+      {
+        __HAL_PWR_PVM4_EXTI_ENABLE_IT();
+      }
+  
+      /* Configure event mode */
+      if((sConfigPVM->Mode & PVM_MODE_EVT) == PVM_MODE_EVT)
+      {
+        __HAL_PWR_PVM4_EXTI_ENABLE_EVENT();
+      }
+  
+      /* Configure the edge */
+      if((sConfigPVM->Mode & PVM_RISING_EDGE) == PVM_RISING_EDGE)
+      {
+        __HAL_PWR_PVM4_EXTI_ENABLE_RISING_EDGE();
+      }
+  
+      if((sConfigPVM->Mode & PVM_FALLING_EDGE) == PVM_FALLING_EDGE)
+      {
+        __HAL_PWR_PVM4_EXTI_ENABLE_FALLING_EDGE();
+      }
+      break;  
+      
+    default:
+      return HAL_ERROR;                      
+    
+  }   
+
+  
+  return HAL_OK;
+}
+
+
+
+/**
+  * @brief Enter Low-power Run mode
+  * @note  In Low-power Run mode, all I/O pins keep the same state as in Run mode.  
+  * @note  When Regulator is set to PWR_LOWPOWERREGULATOR_ON, the user can optionally configure the 
+  *        Flash in power-down monde in setting the RUN_PD bit in FLASH_ACR register.
+  *        Additionally, the clock frequency must be reduced below 2 MHz.
+  *        Setting RUN_PD in FLASH_ACR then appropriately reducing the clock frequency must 
+  *        be done before calling HAL_PWREx_EnableLowPowerRunMode() API.     
+  * @retval None
+  */
+void HAL_PWREx_EnableLowPowerRunMode(void)
+{
+  /* Set Regulator parameter */
+  SET_BIT(PWR->CR1, PWR_CR1_LPR); 
+}
+
+
+/**
+  * @brief Exit Low-power Run mode.
+  * @note  Before HAL_PWREx_DisableLowPowerRunMode() completion, the function checks that 
+  *        REGLPF has been properly reset (otherwise, HAL_PWREx_DisableLowPowerRunMode 
+  *        returns HAL_TIMEOUT status). The system clock frequency can then be
+  *        increased above 2 MHz.   
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_PWREx_DisableLowPowerRunMode(void)
+{
+  uint32_t wait_loop_index = 0;
+  
+  /* Clear LPR bit */
+  CLEAR_BIT(PWR->CR1, PWR_CR1_LPR); 
+
+  /* Wait until REGLPF is reset */
+  wait_loop_index = (PWR_FLAG_SETTING_DELAY_US * (SystemCoreClock / 1000000));
+  while ((wait_loop_index != 0) && (HAL_IS_BIT_SET(PWR->SR2, PWR_SR2_REGLPF)))
+  {
+    wait_loop_index--;
+  }
+  if (HAL_IS_BIT_SET(PWR->SR2, PWR_SR2_REGLPF))
+  {
+    return HAL_TIMEOUT;
+  }
+  
+  return HAL_OK;
+}
+
+
+/**
+  * @brief Enter Stop 0 mode.
+  * @note  In Stop 0 mode, main and low voltage regulators are ON.
+  * @note  In Stop 0 mode, all I/O pins keep the same state as in Run mode.
+  * @note  All clocks in the VCORE domain are stopped; the PLL, the MSI, 
+  *        the HSI and the HSE oscillators are disabled. Some peripherals with the wakeup capability 
+  *        (I2Cx, USARTx and LPUART) can switch on the HSI to receive a frame, and switch off the HSI 
+  *        after receiving the frame if it is not a wakeup frame. In this case, the HSI clock is propagated 
+  *        only to the peripheral requesting it.
+  *        SRAM1, SRAM2 and register contents are preserved.
+  *        The BOR is available.
+  * @note  When exiting Stop 0 mode by issuing an interrupt or a wakeup event,
+  *         the HSI RC oscillator is selected as system clock if STOPWUCK bit in RCC_CFGR register
+  *         is set; the MSI oscillator is selected if STOPWUCK is cleared.  
+  * @note  By keeping the internal regulator ON during Stop 0 mode, the consumption
+  *         is higher although the startup time is reduced.
+  * @param STOPEntry  specifies if Stop mode in entered with WFI or WFE instruction.
+  *          This parameter can be one of the following values:
+  *            @arg @ref PWR_STOPENTRY_WFI  Enter Stop mode with WFI instruction
+  *            @arg @ref PWR_STOPENTRY_WFE  Enter Stop mode with WFE instruction
+  * @retval None
+  */
+void HAL_PWREx_EnterSTOP0Mode(uint8_t STOPEntry)
+{
+  /* Check the parameters */
+  assert_param(IS_PWR_STOP_ENTRY(STOPEntry));
+    
+  /* Stop 0 mode with Main Regulator */
+  MODIFY_REG(PWR->CR1, PWR_CR1_LPMS, PWR_CR1_LPMS_STOP0);
+
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+  SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
+
+  /* Select Stop mode entry --------------------------------------------------*/
+  if(STOPEntry == PWR_STOPENTRY_WFI)
+  {
+    /* Request Wait For Interrupt */
+    __WFI();
+  }
+  else
+  {
+    /* Request Wait For Event */
+    __SEV();
+    __WFE();
+    __WFE();
+  }
+
+  /* Reset SLEEPDEEP bit of Cortex System Control Register */
+  CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
+}
+
+
+/**
+  * @brief Enter Stop 1 mode.
+  * @note  In Stop 1 mode, only low power voltage regulator is ON.
+  * @note  In Stop 1 mode, all I/O pins keep the same state as in Run mode.
+  * @note  All clocks in the VCORE domain are stopped; the PLL, the MSI, 
+  *        the HSI and the HSE oscillators are disabled. Some peripherals with the wakeup capability 
+  *        (I2Cx, USARTx and LPUART) can switch on the HSI to receive a frame, and switch off the HSI 
+  *        after receiving the frame if it is not a wakeup frame. In this case, the HSI clock is propagated 
+  *        only to the peripheral requesting it.
+  *        SRAM1, SRAM2 and register contents are preserved.
+  *        The BOR is available.
+  * @note  When exiting Stop 1 mode by issuing an interrupt or a wakeup event,
+  *         the HSI RC oscillator is selected as system clock if STOPWUCK bit in RCC_CFGR register
+  *         is set; the MSI oscillator is selected if STOPWUCK is cleared.  
+  * @note  Due to low power mode, an additional startup delay is incurred when waking up from Stop 1 mode.
+  * @param STOPEntry  specifies if Stop mode in entered with WFI or WFE instruction.
+  *          This parameter can be one of the following values:
+  *            @arg @ref PWR_STOPENTRY_WFI  Enter Stop mode with WFI instruction
+  *            @arg @ref PWR_STOPENTRY_WFE  Enter Stop mode with WFE instruction
+  * @retval None
+  */
+void HAL_PWREx_EnterSTOP1Mode(uint8_t STOPEntry)
+{
+  /* Check the parameters */
+  assert_param(IS_PWR_STOP_ENTRY(STOPEntry));
+    
+  /* Stop 1 mode with Low-Power Regulator */
+  MODIFY_REG(PWR->CR1, PWR_CR1_LPMS, PWR_CR1_LPMS_STOP1);
+
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+  SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
+
+  /* Select Stop mode entry --------------------------------------------------*/
+  if(STOPEntry == PWR_STOPENTRY_WFI)
+  {
+    /* Request Wait For Interrupt */
+    __WFI();
+  }
+  else
+  {
+    /* Request Wait For Event */
+    __SEV();
+    __WFE();
+    __WFE();
+  }
+
+  /* Reset SLEEPDEEP bit of Cortex System Control Register */
+  CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
+}
+
+
+/**
+  * @brief Enter Stop 2 mode.
+  * @note  In Stop 2 mode, only low power voltage regulator is ON.
+  * @note  In Stop 2 mode, all I/O pins keep the same state as in Run mode.
+  * @note  All clocks in the VCORE domain are stopped, the PLL, the MSI, 
+  *        the HSI and the HSE oscillators are disabled. Some peripherals with wakeup capability 
+  *        (LCD, LPTIM1, I2C3 and LPUART) can switch on the HSI to receive a frame, and switch off the HSI after 
+  *        receiving the frame if it is not a wakeup frame. In this case the HSI clock is propagated only 
+  *        to the peripheral requesting it.
+  *        SRAM1, SRAM2 and register contents are preserved.
+  *        The BOR is available.   
+  *        The voltage regulator is set in low-power mode but LPR bit must be cleared to enter stop 2 mode.
+  *        Otherwise, Stop 1 mode is entered.  
+  * @note  When exiting Stop 2 mode by issuing an interrupt or a wakeup event,
+  *         the HSI RC oscillator is selected as system clock if STOPWUCK bit in RCC_CFGR register
+  *         is set; the MSI oscillator is selected if STOPWUCK is cleared.     
+  * @param STOPEntry  specifies if Stop mode in entered with WFI or WFE instruction.
+  *          This parameter can be one of the following values:
+  *            @arg @ref PWR_STOPENTRY_WFI  Enter Stop mode with WFI instruction
+  *            @arg @ref PWR_STOPENTRY_WFE  Enter Stop mode with WFE instruction
+  * @retval None
+  */
+void HAL_PWREx_EnterSTOP2Mode(uint8_t STOPEntry)
+{
+  /* Check the parameter */
+  assert_param(IS_PWR_STOP_ENTRY(STOPEntry));
+
+  /* Set Stop mode 2 */
+  MODIFY_REG(PWR->CR1, PWR_CR1_LPMS, PWR_CR1_LPMS_STOP2);
+
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+  SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
+
+  /* Select Stop mode entry --------------------------------------------------*/
+  if(STOPEntry == PWR_STOPENTRY_WFI)
+  {
+    /* Request Wait For Interrupt */
+    __WFI();
+  }
+  else
+  {
+    /* Request Wait For Event */
+    __SEV();
+    __WFE();
+    __WFE();
+  }
+
+  /* Reset SLEEPDEEP bit of Cortex System Control Register */
+  CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
+}
+
+
+
+
+
+/**
+  * @brief Enter Shutdown mode. 
+  * @note  In Shutdown mode, the PLL, the HSI, the MSI, the LSI and the HSE oscillators are switched 
+  *        off. The voltage regulator is disabled and Vcore domain is powered off. 
+  *        SRAM1, SRAM2 and registers contents are lost except for registers in the Backup domain.
+  *        The BOR is not available.  
+  * @note  The I/Os can be configured either with a pull-up or pull-down or can be kept in analog state.  
+  * @retval None
+  */
+void HAL_PWREx_EnterSHUTDOWNMode(void)
+{
+  
+  /* Set Shutdown mode */
+  MODIFY_REG(PWR->CR1, PWR_CR1_LPMS, PWR_CR1_LPMS_SHUTDOWN);
+  
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+  SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
+
+/* This option is used to ensure that store operations are completed */
+#if defined ( __CC_ARM)
+  __force_stores();
+#endif
+  /* Request Wait For Interrupt */
+  __WFI();
+}
+
+
+
+
+/**
+  * @brief This function handles the PWR PVD/PVMx interrupt request.
+  * @note This API should be called under the PVD_PVM_IRQHandler().  
+  * @retval None
+  */
+void HAL_PWREx_PVD_PVM_IRQHandler(void)
+{
+  /* Check PWR exti flag */
+  if(__HAL_PWR_PVD_EXTI_GET_FLAG() != RESET)
+  {
+    /* PWR PVD interrupt user callback */
+    HAL_PWR_PVDCallback();
+
+    /* Clear PVD exti pending bit */
+    __HAL_PWR_PVD_EXTI_CLEAR_FLAG();
+  }
+  /* Next, successively check PVMx exti flags */
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+  if(__HAL_PWR_PVM1_EXTI_GET_FLAG() != RESET) 
+  {
+    /* PWR PVM1 interrupt user callback */
+    HAL_PWREx_PVM1Callback();
+   
+    /* Clear PVM1 exti pending bit */
+    __HAL_PWR_PVM1_EXTI_CLEAR_FLAG();
+  }
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */
+  if(__HAL_PWR_PVM2_EXTI_GET_FLAG() != RESET) 
+  {
+    /* PWR PVM2 interrupt user callback */
+    HAL_PWREx_PVM2Callback();
+   
+    /* Clear PVM2 exti pending bit */
+    __HAL_PWR_PVM2_EXTI_CLEAR_FLAG();
+  }
+  if(__HAL_PWR_PVM3_EXTI_GET_FLAG() != RESET) 
+  {
+    /* PWR PVM3 interrupt user callback */
+    HAL_PWREx_PVM3Callback();
+   
+    /* Clear PVM3 exti pending bit */
+    __HAL_PWR_PVM3_EXTI_CLEAR_FLAG();
+  }
+  if(__HAL_PWR_PVM4_EXTI_GET_FLAG() != RESET) 
+  {
+    /* PWR PVM4 interrupt user callback */
+    HAL_PWREx_PVM4Callback();
+   
+    /* Clear PVM4 exti pending bit */
+    __HAL_PWR_PVM4_EXTI_CLEAR_FLAG();
+  }      
+}
+
+
+#if defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx)
+/**
+  * @brief PWR PVM1 interrupt callback
+  * @retval None
+  */
+__weak void HAL_PWREx_PVM1Callback(void)
+{
+  /* NOTE : This function should not be modified; when the callback is needed,
+            HAL_PWREx_PVM1Callback() API can be implemented in the user file
+   */
+}
+#endif /* defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) */
+
+/**
+  * @brief PWR PVM2 interrupt callback
+  * @retval None
+  */
+__weak void HAL_PWREx_PVM2Callback(void)
+{
+  /* NOTE : This function should not be modified; when the callback is needed,
+            HAL_PWREx_PVM2Callback() API can be implemented in the user file
+   */
+}
+
+/**
+  * @brief PWR PVM3 interrupt callback
+  * @retval None
+  */
+__weak void HAL_PWREx_PVM3Callback(void)
+{
+  /* NOTE : This function should not be modified; when the callback is needed,
+            HAL_PWREx_PVM3Callback() API can be implemented in the user file
+   */
+}
+
+/**
+  * @brief PWR PVM4 interrupt callback
+  * @retval None
+  */
+__weak void HAL_PWREx_PVM4Callback(void)
+{
+  /* NOTE : This function should not be modified; when the callback is needed,
+            HAL_PWREx_PVM4Callback() API can be implemented in the user file
+   */
+}
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_PWR_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_qspi.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_qspi.c
@@ -1,0 +1,1981 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_qspi.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   QSPI HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the QuadSPI interface (QSPI).
+  *           + Initialization and de-initialization functions
+  *           + Indirect functional mode management
+  *           + Memory-mapped functional mode management
+  *           + Auto-polling functional mode management
+  *           + Interrupts and flags management
+  *           + DMA channel configuration for indirect functional mode
+  *           + Errors management and abort functionality
+  *
+  *
+  @verbatim
+ ===============================================================================
+                        ##### How to use this driver #####
+ ===============================================================================
+  [..]
+    *** Initialization ***
+    ======================
+    [..]
+      (#) As prerequisite, fill in the HAL_QSPI_MspInit() :
+        (++) Enable QuadSPI clock interface with __HAL_RCC_QSPI_CLK_ENABLE().
+        (++) Reset QuadSPI IP with __HAL_RCC_QSPI_FORCE_RESET() and __HAL_RCC_QSPI_RELEASE_RESET().
+        (++) Enable the clocks for the QuadSPI GPIOS with __HAL_RCC_GPIOx_CLK_ENABLE().
+        (++) Configure these QuadSPI pins in alternate mode using HAL_GPIO_Init().
+        (++) If interrupt mode is used, enable and configure QuadSPI global
+            interrupt with HAL_NVIC_SetPriority() and HAL_NVIC_EnableIRQ().
+        (++) If DMA mode is used, enable the clocks for the QuadSPI DMA channel 
+            with __HAL_RCC_DMAx_CLK_ENABLE(), configure DMA with HAL_DMA_Init(), 
+            link it with QuadSPI handle using __HAL_LINKDMA(), enable and configure 
+            DMA channel global interrupt with HAL_NVIC_SetPriority() and HAL_NVIC_EnableIRQ().
+      (#) Configure the flash size, the clock prescaler, the fifo threshold, the
+          clock mode, the sample shifting and the CS high time using the HAL_QSPI_Init() function.
+
+    *** Indirect functional mode ***
+    ================================
+    [..]
+      (#) Configure the command sequence using the HAL_QSPI_Command() or HAL_QSPI_Command_IT() 
+          functions :
+         (++) Instruction phase : the mode used and if present the instruction opcode.
+         (++) Address phase : the mode used and if present the size and the address value.
+         (++) Alternate-bytes phase : the mode used and if present the size and the alternate 
+             bytes values.
+         (++) Dummy-cycles phase : the number of dummy cycles (mode used is same as data phase).
+         (++) Data phase : the mode used and if present the number of bytes.
+         (++) Double Data Rate (DDR) mode : the activation (or not) of this mode and the delay 
+             if activated.
+         (++) Sending Instruction Only Once (SIOO) mode : the activation (or not) of this mode.
+      (#) If no data is required for the command, it is sent directly to the memory :
+         (++) In polling mode, the output of the function is done when the transfer is complete.
+         (++) In interrupt mode, HAL_QSPI_CmdCpltCallback() will be called when the transfer is complete.
+      (#) For the indirect write mode, use HAL_QSPI_Transmit(), HAL_QSPI_Transmit_DMA() or 
+          HAL_QSPI_Transmit_IT() after the command configuration :
+         (++) In polling mode, the output of the function is done when the transfer is complete.
+         (++) In interrupt mode, HAL_QSPI_FifoThresholdCallback() will be called when the fifo threshold 
+             is reached and HAL_QSPI_TxCpltCallback() will be called when the transfer is complete.
+         (++) In DMA mode, HAL_QSPI_TxHalfCpltCallback() will be called at the half transfer and 
+             HAL_QSPI_TxCpltCallback() will be called when the transfer is complete.
+      (#) For the indirect read mode, use HAL_QSPI_Receive(), HAL_QSPI_Receive_DMA() or 
+          HAL_QSPI_Receive_IT() after the command configuration :
+         (++) In polling mode, the output of the function is done when the transfer is complete.
+         (++) In interrupt mode, HAL_QSPI_FifoThresholdCallback() will be called when the fifo threshold 
+             is reached and HAL_QSPI_RxCpltCallback() will be called when the transfer is complete.
+         (++) In DMA mode, HAL_QSPI_RxHalfCpltCallback() will be called at the half transfer and 
+             HAL_QSPI_RxCpltCallback() will be called when the transfer is complete.
+
+    *** Auto-polling functional mode ***
+    ====================================
+    [..]
+      (#) Configure the command sequence and the auto-polling functional mode using the 
+          HAL_QSPI_AutoPolling() or HAL_QSPI_AutoPolling_IT() functions :
+         (++) Instruction phase : the mode used and if present the instruction opcode.
+         (++) Address phase : the mode used and if present the size and the address value.
+         (++) Alternate-bytes phase : the mode used and if present the size and the alternate 
+             bytes values.
+         (++) Dummy-cycles phase : the number of dummy cycles (mode used is same as data phase).
+         (++) Data phase : the mode used.
+         (++) Double Data Rate (DDR) mode : the activation (or not) of this mode and the delay 
+             if activated.
+         (++) Sending Instruction Only Once (SIOO) mode : the activation (or not) of this mode.
+         (++) The size of the status bytes, the match value, the mask used, the match mode (OR/AND),
+             the polling interval and the automatic stop activation.
+      (#) After the configuration :
+         (++) In polling mode, the output of the function is done when the status match is reached. The
+             automatic stop is activated to avoid an infinite loop.
+         (++) In interrupt mode, HAL_QSPI_StatusMatchCallback() will be called each time the status match is reached.
+
+    *** Memory-mapped functional mode ***
+    =====================================
+    [..]
+      (#) Configure the command sequence and the memory-mapped functional mode using the 
+          HAL_QSPI_MemoryMapped() functions :
+         (++) Instruction phase : the mode used and if present the instruction opcode.
+         (++) Address phase : the mode used and the size.
+         (++) Alternate-bytes phase : the mode used and if present the size and the alternate 
+             bytes values.
+         (++) Dummy-cycles phase : the number of dummy cycles (mode used is same as data phase).
+         (++) Data phase : the mode used.
+         (++) Double Data Rate (DDR) mode : the activation (or not) of this mode and the delay 
+             if activated.
+         (++) Sending Instruction Only Once (SIOO) mode : the activation (or not) of this mode.
+         (++) The timeout activation and the timeout period.
+      (#) After the configuration, the QuadSPI will be used as soon as an access on the AHB is done on 
+          the address range. HAL_QSPI_TimeOutCallback() will be called when the timeout expires.
+
+    *** Errors management and abort functionality ***
+    ==================================================
+    [..]
+      (#) HAL_QSPI_GetError() function gives the error raised during the last operation.
+      (#) HAL_QSPI_Abort() function aborts any on-going operation and flushes the fifo.
+      (#) HAL_QSPI_GetState() function gives the current state of the HAL QuadSPI driver.
+
+    *** Workarounds linked to Silicon Limitation ***
+    ====================================================
+    [..]
+      (#) Workarounds Implemented inside HAL Driver
+         (++) Extra data written in the FIFO at the end of a read transfer
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup QSPI QSPI
+  * @brief QSPI HAL module driver
+  * @{
+  */
+#ifdef HAL_QSPI_MODULE_ENABLED
+    
+/* Private typedef -----------------------------------------------------------*/
+
+/* Private define ------------------------------------------------------------*/
+/** @defgroup QSPI_Private_Constants QSPI Private Constants
+  * @{
+  */
+#define QSPI_FUNCTIONAL_MODE_INDIRECT_WRITE ((uint32_t)0x00000000)          /*!<Indirect write mode*/
+#define QSPI_FUNCTIONAL_MODE_INDIRECT_READ  ((uint32_t)QUADSPI_CCR_FMODE_0) /*!<Indirect read mode*/
+#define QSPI_FUNCTIONAL_MODE_AUTO_POLLING   ((uint32_t)QUADSPI_CCR_FMODE_1) /*!<Automatic polling mode*/
+#define QSPI_FUNCTIONAL_MODE_MEMORY_MAPPED  ((uint32_t)QUADSPI_CCR_FMODE)   /*!<Memory-mapped mode*/
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/** @defgroup QSPI_Private_Macros QSPI Private Macros
+  * @{
+  */
+#define IS_QSPI_FUNCTIONAL_MODE(MODE) (((MODE) == QSPI_FUNCTIONAL_MODE_INDIRECT_WRITE) || \
+                                       ((MODE) == QSPI_FUNCTIONAL_MODE_INDIRECT_READ)  || \
+                                       ((MODE) == QSPI_FUNCTIONAL_MODE_AUTO_POLLING)   || \
+                                       ((MODE) == QSPI_FUNCTIONAL_MODE_MEMORY_MAPPED))
+/**
+  * @}
+  */
+
+/* Private variables ---------------------------------------------------------*/
+
+/* Private function prototypes -----------------------------------------------*/
+static void QSPI_DMARxCplt(DMA_HandleTypeDef *hdma);
+static void QSPI_DMATxCplt(DMA_HandleTypeDef *hdma);
+static void QSPI_DMARxHalfCplt(DMA_HandleTypeDef *hdma);
+static void QSPI_DMATxHalfCplt(DMA_HandleTypeDef *hdma);
+static void QSPI_DMAError(DMA_HandleTypeDef *hdma); 
+static HAL_StatusTypeDef QSPI_WaitFlagStateUntilTimeout(QSPI_HandleTypeDef *hqspi, uint32_t Flag, FlagStatus State, uint32_t Timeout);
+static void QSPI_Config(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, uint32_t FunctionalMode);
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup QSPI_Exported_Functions QSPI Exported Functions
+  * @{
+  */
+
+/** @defgroup QSPI_Exported_Functions_Group1 Initialization/de-initialization functions 
+  *  @brief    Initialization and Configuration functions 
+  *
+@verbatim    
+===============================================================================
+            ##### Initialization and Configuration functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to :
+      (+) Initialize the QuadSPI.
+      (+) De-initialize the QuadSPI.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Initialize the QSPI mode according to the specified parameters
+  *        in the QSPI_InitTypeDef and initialize the associated handle.
+  * @param hqspi: QSPI handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_Init(QSPI_HandleTypeDef *hqspi)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the QSPI handle allocation */
+  if(hqspi == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_QSPI_ALL_INSTANCE(hqspi->Instance));
+  assert_param(IS_QSPI_CLOCK_PRESCALER(hqspi->Init.ClockPrescaler));
+  assert_param(IS_QSPI_FIFO_THRESHOLD(hqspi->Init.FifoThreshold));
+  assert_param(IS_QSPI_SSHIFT(hqspi->Init.SampleShifting));
+  assert_param(IS_QSPI_FLASH_SIZE(hqspi->Init.FlashSize));
+  assert_param(IS_QSPI_CS_HIGH_TIME(hqspi->Init.ChipSelectHighTime));
+  assert_param(IS_QSPI_CLOCK_MODE(hqspi->Init.ClockMode));
+
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+  
+  if(hqspi->State == HAL_QSPI_STATE_RESET)
+  {  
+    /* Allocate lock resource and initialize it */
+    hqspi->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK */
+    HAL_QSPI_MspInit(hqspi);
+    
+    /* Configure the default timeout for the QSPI memory access */
+    HAL_QSPI_SetTimeout(hqspi, HAL_QPSI_TIMEOUT_DEFAULT_VALUE);
+  }
+  
+  /* Configure QSPI FIFO Threshold */
+  MODIFY_REG(hqspi->Instance->CR, QUADSPI_CR_FTHRES, 
+             ((hqspi->Init.FifoThreshold - 1) << POSITION_VAL(QUADSPI_CR_FTHRES)));
+
+  /* Wait till BUSY flag reset */
+  status = QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_BUSY, RESET, hqspi->Timeout);
+
+  if(status == HAL_OK)
+  {
+    /* Configure QSPI Clock Prescaler and Sample Shift */
+    MODIFY_REG(hqspi->Instance->CR, (QUADSPI_CR_PRESCALER | QUADSPI_CR_SSHIFT), 
+               ((hqspi->Init.ClockPrescaler << POSITION_VAL(QUADSPI_CR_PRESCALER)) | 
+                hqspi->Init.SampleShifting));
+
+    /* Configure QSPI Flash Size, CS High Time and Clock Mode */
+    MODIFY_REG(hqspi->Instance->DCR, (QUADSPI_DCR_FSIZE | QUADSPI_DCR_CSHT | QUADSPI_DCR_CKMODE), 
+               ((hqspi->Init.FlashSize << POSITION_VAL(QUADSPI_DCR_FSIZE)) | 
+                hqspi->Init.ChipSelectHighTime | hqspi->Init.ClockMode));
+
+    /* Enable the QSPI peripheral */
+    __HAL_QSPI_ENABLE(hqspi);
+  
+    /* Set QSPI error code to none */
+    hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;  
+
+    /* Initialize the QSPI state */
+    hqspi->State = HAL_QSPI_STATE_READY;
+  }
+  
+  /* Release Lock */
+  __HAL_UNLOCK(hqspi);
+
+  /* Return function status */
+  return status;
+}
+
+/**
+  * @brief De-Initialize the QSPI peripheral. 
+  * @param hqspi: QSPI handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_DeInit(QSPI_HandleTypeDef *hqspi)
+{
+  /* Check the QSPI handle allocation */
+  if(hqspi == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+
+  /* Disable the QSPI Peripheral Clock */
+  __HAL_QSPI_DISABLE(hqspi);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC... */
+  HAL_QSPI_MspDeInit(hqspi);
+
+  /* Set QSPI error code to none */
+  hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;
+
+  /* Initialize the QSPI state */
+  hqspi->State = HAL_QSPI_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hqspi);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Initialize the QSPI MSP.
+  * @param hqspi: QSPI handle
+  * @retval None
+  */
+__weak void HAL_QSPI_MspInit(QSPI_HandleTypeDef *hqspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hqspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_QSPI_MspInit can be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief DeInitialize the QSPI MSP.
+  * @param hqspi: QSPI handle
+  * @retval None
+  */
+__weak void HAL_QSPI_MspDeInit(QSPI_HandleTypeDef *hqspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hqspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_QSPI_MspDeInit can be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup QSPI_Exported_Functions_Group2 Input and Output operation functions 
+  *  @brief QSPI Transmit/Receive functions 
+  *
+@verbatim   
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to :
+      (+) Handle the interrupts.
+      (+) Handle the command sequence.
+      (+) Transmit data in blocking, interrupt or DMA mode.
+      (+) Receive data in blocking, interrupt or DMA mode.
+      (+) Manage the auto-polling functional mode.
+      (+) Manage the memory-mapped functional mode.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Handle QSPI interrupt request.
+  * @param hqspi: QSPI handle
+  * @retval None
+  */
+void HAL_QSPI_IRQHandler(QSPI_HandleTypeDef *hqspi)
+{
+  __IO uint32_t *data_reg;
+  uint32_t flag = 0, itsource = 0;
+
+  /* QSPI Fifo Threshold interrupt occurred ----------------------------------*/
+  flag     = __HAL_QSPI_GET_FLAG(hqspi, QSPI_FLAG_FT);
+  itsource = __HAL_QSPI_GET_IT_SOURCE(hqspi, QSPI_IT_FT);
+  
+  if((flag != RESET) && (itsource != RESET))
+  {
+    data_reg = &hqspi->Instance->DR;
+
+    if(hqspi->State == HAL_QSPI_STATE_BUSY_INDIRECT_TX)
+    {
+      /* Transmission process */
+      while(__HAL_QSPI_GET_FLAG(hqspi, QSPI_FLAG_FT) != 0)
+      {
+        if (hqspi->TxXferCount > 0)
+        {
+          /* Fill the FIFO until the threshold is reached */
+          *(__IO uint8_t *)data_reg = *hqspi->pTxBuffPtr++;
+          hqspi->TxXferCount--;
+        }
+        else
+        {
+          /* No more data available for the transfer */
+          /* Disable the QSPI FIFO Threshold Interrupt */
+          __HAL_QSPI_DISABLE_IT(hqspi, QSPI_IT_FT);
+          break;
+        }
+      }
+    }
+    else if(hqspi->State == HAL_QSPI_STATE_BUSY_INDIRECT_RX)
+    {
+      /* Receiving Process */
+      while(__HAL_QSPI_GET_FLAG(hqspi, QSPI_FLAG_FT) != 0)
+      {
+        if (hqspi->RxXferCount > 0)
+        {
+          /* Read the FIFO until the threshold is reached */
+          *hqspi->pRxBuffPtr++ = *(__IO uint8_t *)data_reg;
+          hqspi->RxXferCount--;
+        }
+        else
+        {
+          /* All data have been received for the transfer */
+          /* Disable the QSPI FIFO Threshold Interrupt */
+          __HAL_QSPI_DISABLE_IT(hqspi, QSPI_IT_FT);
+          break;
+        }
+      }
+    }
+    
+    /* FIFO Threshold callback */
+    HAL_QSPI_FifoThresholdCallback(hqspi);
+  }
+
+  /* QSPI Transfer Complete interrupt occurred -------------------------------*/
+  flag     = __HAL_QSPI_GET_FLAG(hqspi, QSPI_FLAG_TC);
+  itsource = __HAL_QSPI_GET_IT_SOURCE(hqspi, QSPI_IT_TC);
+  
+  if((flag != RESET) && (itsource != RESET))
+  {
+    /* Clear interrupt */
+    __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
+
+    /* Disable the QSPI FIFO Threshold, Transfer Error and Transfer complete Interrupts */
+    __HAL_QSPI_DISABLE_IT(hqspi, QSPI_IT_TC | QSPI_IT_TE | QSPI_IT_FT);
+    
+    /* Transfer complete callback */
+    if(hqspi->State == HAL_QSPI_STATE_BUSY_INDIRECT_TX)
+    {
+      /* Clear Busy bit */
+      HAL_QSPI_Abort(hqspi);
+      
+      /* TX Complete callback */
+      HAL_QSPI_TxCpltCallback(hqspi);
+    }
+    else if(hqspi->State == HAL_QSPI_STATE_BUSY_INDIRECT_RX)
+    {
+      data_reg = &hqspi->Instance->DR;
+      while(READ_BIT(hqspi->Instance->SR, QUADSPI_SR_FLEVEL) != 0)
+      {
+        if (hqspi->RxXferCount > 0)
+        {
+          /* Read the last data received in the FIFO until it is empty */
+          *hqspi->pRxBuffPtr++ = *(__IO uint8_t *)data_reg;
+          hqspi->RxXferCount--;
+        }
+        else
+        {
+          /* All data have been received for the transfer */
+          break;
+        }
+      }
+
+      /* Workaround - Extra data written in the FIFO at the end of a read transfer */
+      HAL_QSPI_Abort(hqspi);
+
+      /* RX Complete callback */
+      HAL_QSPI_RxCpltCallback(hqspi);
+    }
+    else if(hqspi->State == HAL_QSPI_STATE_BUSY)
+    {
+      /* Command Complete callback */
+      HAL_QSPI_CmdCpltCallback(hqspi);
+    }
+
+    /* Change state of QSPI */
+    hqspi->State = HAL_QSPI_STATE_READY;
+  }
+
+  /* QSPI Status Match interrupt occurred ------------------------------------*/
+  flag     = __HAL_QSPI_GET_FLAG(hqspi, QSPI_FLAG_SM);
+  itsource = __HAL_QSPI_GET_IT_SOURCE(hqspi, QSPI_IT_SM);
+  
+  if((flag != RESET) && (itsource != RESET))
+  {
+    /* Clear interrupt */
+    __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_SM);
+   
+    /* Check if the automatic poll mode stop is activated */
+    if(READ_BIT(hqspi->Instance->CR, QUADSPI_CR_APMS) != 0)
+    {
+      /* Disable the QSPI Transfer Error and Status Match Interrupts */
+      __HAL_QSPI_DISABLE_IT(hqspi, (QSPI_IT_SM | QSPI_IT_TE));
+
+      /* Change state of QSPI */
+      hqspi->State = HAL_QSPI_STATE_READY;
+    }
+
+    /* Status match callback */
+    HAL_QSPI_StatusMatchCallback(hqspi);
+  }
+
+  /* QSPI Transfer Error interrupt occurred ----------------------------------*/
+  flag     = __HAL_QSPI_GET_FLAG(hqspi, QSPI_FLAG_TE);
+  itsource = __HAL_QSPI_GET_IT_SOURCE(hqspi, QSPI_IT_TE);
+  
+  if((flag != RESET) && (itsource != RESET))
+  {
+    /* Clear interrupt */
+    __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TE);
+    
+    /* Disable all the QSPI Interrupts */
+    __HAL_QSPI_DISABLE_IT(hqspi, QSPI_IT_SM | QSPI_IT_TC | QSPI_IT_TE | QSPI_IT_FT);
+
+    /* Set error code */
+    hqspi->ErrorCode |= HAL_QSPI_ERROR_TRANSFER;
+    
+    /* Change state of QSPI */
+    hqspi->State = HAL_QSPI_STATE_ERROR;
+
+    /* Error callback */
+    HAL_QSPI_ErrorCallback(hqspi);
+  }
+
+  /* QSPI Timeout interrupt occurred -----------------------------------------*/
+  flag     = __HAL_QSPI_GET_FLAG(hqspi, QSPI_FLAG_TO);
+  itsource = __HAL_QSPI_GET_IT_SOURCE(hqspi, QSPI_IT_TO);
+  
+  if((flag != RESET) && (itsource != RESET))
+  {
+    /* Clear interrupt */
+    __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TO);
+    
+    /* Timeout callback */
+    HAL_QSPI_TimeOutCallback(hqspi);
+  }
+}
+
+/**
+  * @brief Set the command configuration. 
+  * @param hqspi: QSPI handle
+  * @param cmd : structure that contains the command configuration information
+  * @param Timeout : Timeout duration
+  * @note   This function is used only in Indirect Read or Write Modes
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_Command(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, uint32_t Timeout)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_QSPI_INSTRUCTION_MODE(cmd->InstructionMode));
+  if (cmd->InstructionMode != QSPI_INSTRUCTION_NONE)
+  {
+    assert_param(IS_QSPI_INSTRUCTION(cmd->Instruction));
+  }
+
+  assert_param(IS_QSPI_ADDRESS_MODE(cmd->AddressMode));
+  if (cmd->AddressMode != QSPI_ADDRESS_NONE)
+  {
+    assert_param(IS_QSPI_ADDRESS_SIZE(cmd->AddressSize));
+  }
+
+  assert_param(IS_QSPI_ALTERNATE_BYTES_MODE(cmd->AlternateByteMode));
+  if (cmd->AlternateByteMode != QSPI_ALTERNATE_BYTES_NONE)
+  {
+    assert_param(IS_QSPI_ALTERNATE_BYTES_SIZE(cmd->AlternateBytesSize));
+  }
+
+  assert_param(IS_QSPI_DUMMY_CYCLES(cmd->DummyCycles));
+  assert_param(IS_QSPI_DATA_MODE(cmd->DataMode));
+
+  assert_param(IS_QSPI_DDR_MODE(cmd->DdrMode));
+  assert_param(IS_QSPI_DDR_HHC(cmd->DdrHoldHalfCycle));
+  assert_param(IS_QSPI_SIOO_MODE(cmd->SIOOMode));
+  
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+
+  if(hqspi->State == HAL_QSPI_STATE_READY)
+  {
+    hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;
+    
+    /* Update QSPI state */
+    hqspi->State = HAL_QSPI_STATE_BUSY;   
+    
+    /* Wait till BUSY flag reset */
+    status = QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_BUSY, RESET, Timeout);
+    
+    if (status == HAL_OK)
+    {
+      /* Call the configuration function */
+      QSPI_Config(hqspi, cmd, QSPI_FUNCTIONAL_MODE_INDIRECT_WRITE);
+      
+      if (cmd->DataMode == QSPI_DATA_NONE)
+      {
+        /* When there is no data phase, the transfer start as soon as the configuration is done 
+        so wait until TC flag is set to go back in idle state */
+        if(QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_TC, SET, Timeout) != HAL_OK)
+        { 
+          status = HAL_TIMEOUT;
+        }
+        else
+        {
+          __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
+          
+          /* Update QSPI state */
+          hqspi->State = HAL_QSPI_STATE_READY;   
+        }
+        
+      }
+      else
+      {
+        /* Update QSPI state */
+        hqspi->State = HAL_QSPI_STATE_READY;   
+      }
+    }
+  }
+  else
+  {
+    status = HAL_BUSY;   
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hqspi);
+
+  /* Return function status */
+  return status;
+}
+
+/**
+  * @brief Set the command configuration in interrupt mode. 
+  * @param hqspi: QSPI handle
+  * @param cmd : structure that contains the command configuration information
+  * @note   This function is used only in Indirect Read or Write Modes
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_Command_IT(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_QSPI_INSTRUCTION_MODE(cmd->InstructionMode));
+  if (cmd->InstructionMode != QSPI_INSTRUCTION_NONE)
+  {
+    assert_param(IS_QSPI_INSTRUCTION(cmd->Instruction));
+  }
+
+  assert_param(IS_QSPI_ADDRESS_MODE(cmd->AddressMode));
+  if (cmd->AddressMode != QSPI_ADDRESS_NONE)
+  {
+    assert_param(IS_QSPI_ADDRESS_SIZE(cmd->AddressSize));
+  }
+
+  assert_param(IS_QSPI_ALTERNATE_BYTES_MODE(cmd->AlternateByteMode));
+  if (cmd->AlternateByteMode != QSPI_ALTERNATE_BYTES_NONE)
+  {
+    assert_param(IS_QSPI_ALTERNATE_BYTES_SIZE(cmd->AlternateBytesSize));
+  }
+
+  assert_param(IS_QSPI_DUMMY_CYCLES(cmd->DummyCycles));
+  assert_param(IS_QSPI_DATA_MODE(cmd->DataMode));
+
+  assert_param(IS_QSPI_DDR_MODE(cmd->DdrMode));
+  assert_param(IS_QSPI_DDR_HHC(cmd->DdrHoldHalfCycle));
+  assert_param(IS_QSPI_SIOO_MODE(cmd->SIOOMode));
+  
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+
+  if(hqspi->State == HAL_QSPI_STATE_READY)
+  {
+    hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;
+    
+    /* Update QSPI state */
+    hqspi->State = HAL_QSPI_STATE_BUSY;   
+    
+    /* Wait till BUSY flag reset */
+    status = QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_BUSY, RESET, hqspi->Timeout);
+    
+    if (status == HAL_OK)
+    {
+      if (cmd->DataMode == QSPI_DATA_NONE)
+      {
+        /* When there is no data phase, the transfer start as soon as the configuration is done 
+        so activate TC and TE interrupts */
+        /* Clear interrupt */
+        __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TE | QSPI_FLAG_TC);
+
+        /* Enable the QSPI Transfer Error Interrupt */
+        __HAL_QSPI_ENABLE_IT(hqspi, QSPI_IT_TE | QSPI_IT_TC);
+      }
+      
+      /* Call the configuration function */
+      QSPI_Config(hqspi, cmd, QSPI_FUNCTIONAL_MODE_INDIRECT_WRITE);
+      
+      if (cmd->DataMode != QSPI_DATA_NONE)
+      {
+        /* Update QSPI state */
+        hqspi->State = HAL_QSPI_STATE_READY;   
+      }
+    }
+  }
+  else
+  {
+    status = HAL_BUSY;   
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hqspi);
+
+  /* Return function status */
+  return status;
+}
+
+/**
+  * @brief Transmit an amount of data in blocking mode. 
+  * @param hqspi: QSPI handle
+  * @param pData: pointer to data buffer
+  * @param Timeout : Timeout duration
+  * @note   This function is used only in Indirect Write Mode
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_Transmit(QSPI_HandleTypeDef *hqspi, uint8_t *pData, uint32_t Timeout)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  __IO uint32_t *data_reg = &hqspi->Instance->DR;
+
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+
+  if(hqspi->State == HAL_QSPI_STATE_READY)
+  {
+    if(pData != NULL )
+    {
+      hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;
+    
+      /* Update state */
+      hqspi->State = HAL_QSPI_STATE_BUSY_INDIRECT_TX;
+      
+      /* Configure counters and size of the handle */
+      hqspi->TxXferCount = READ_REG(hqspi->Instance->DLR) + 1;
+      hqspi->TxXferSize = READ_REG(hqspi->Instance->DLR) + 1;
+      hqspi->pTxBuffPtr = pData;
+    
+      /* Configure QSPI: CCR register with functional as indirect write */
+      MODIFY_REG(hqspi->Instance->CCR, QUADSPI_CCR_FMODE, QSPI_FUNCTIONAL_MODE_INDIRECT_WRITE);
+
+      while(hqspi->TxXferCount > 0)
+      {
+        /* Wait until FT flag is set to send data */
+        if(QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_FT, SET, Timeout) != HAL_OK)
+        { 
+          status = HAL_TIMEOUT;
+          break;
+        }
+
+        *(__IO uint8_t *)data_reg = *hqspi->pTxBuffPtr++;
+        hqspi->TxXferCount--;
+      }
+    
+      if (status == HAL_OK)
+      {
+        /* Wait until TC flag is set to go back in idle state */
+        if(QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_TC, SET, Timeout) != HAL_OK)
+        { 
+          status = HAL_TIMEOUT;
+        }
+        else
+        {
+          /* Clear Transfer Complete bit */
+          __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
+          
+          /* Clear Busy bit */
+          status = HAL_QSPI_Abort(hqspi);
+        }
+      }
+    
+      /* Update QSPI state */
+      hqspi->State = HAL_QSPI_STATE_READY;    
+    }
+    else
+    {
+      status = HAL_ERROR;
+    }
+  }
+  else
+  {
+    status = HAL_BUSY;
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hqspi);
+
+  return status;
+}
+
+
+/**
+  * @brief Receive an amount of data in blocking mode.
+  * @param hqspi: QSPI handle
+  * @param pData: pointer to data buffer
+  * @param Timeout : Timeout duration
+  * @note   This function is used only in Indirect Read Mode
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_Receive(QSPI_HandleTypeDef *hqspi, uint8_t *pData, uint32_t Timeout)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t addr_reg = READ_REG(hqspi->Instance->AR);
+  __IO uint32_t *data_reg = &hqspi->Instance->DR;
+
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+
+  if(hqspi->State == HAL_QSPI_STATE_READY)
+  {
+    if(pData != NULL )
+    {
+      hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;
+    
+      /* Update state */
+      hqspi->State = HAL_QSPI_STATE_BUSY_INDIRECT_RX;
+    
+      /* Configure counters and size of the handle */
+      hqspi->RxXferCount = READ_REG(hqspi->Instance->DLR) + 1;
+      hqspi->RxXferSize = READ_REG(hqspi->Instance->DLR) + 1;
+      hqspi->pRxBuffPtr = pData;
+
+      /* Configure QSPI: CCR register with functional as indirect read */
+      MODIFY_REG(hqspi->Instance->CCR, QUADSPI_CCR_FMODE, QSPI_FUNCTIONAL_MODE_INDIRECT_READ);
+
+      /* Start the transfer by re-writing the address in AR register */
+      WRITE_REG(hqspi->Instance->AR, addr_reg);
+      
+      while(hqspi->RxXferCount > 0)
+      {
+        /* Wait until FT or TC flag is set to read received data */
+        if(QSPI_WaitFlagStateUntilTimeout(hqspi, (QSPI_FLAG_FT | QSPI_FLAG_TC), SET, Timeout) != HAL_OK)
+        { 
+          status = HAL_TIMEOUT;
+          break;
+        }
+
+        *hqspi->pRxBuffPtr++ = *(__IO uint8_t *)data_reg;
+        hqspi->RxXferCount--;
+      }
+    
+      if (status == HAL_OK)
+      {
+        /* Wait until TC flag is set to go back in idle state */
+        if(QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_TC, SET, Timeout) != HAL_OK)
+        { 
+          status = HAL_TIMEOUT;
+        }
+        else
+        {
+          /* Clear Transfer Complete bit */
+          __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
+
+          /* Workaround - Extra data written in the FIFO at the end of a read transfer */
+          status = HAL_QSPI_Abort(hqspi);
+        }
+      }
+
+      /* Update QSPI state */
+      hqspi->State = HAL_QSPI_STATE_READY;    
+    }
+    else
+    {
+      status = HAL_ERROR;
+    }
+  }
+  else
+  {
+    status = HAL_BUSY;
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hqspi);
+
+  return status;
+}
+
+/**
+  * @brief  Send an amount of data in non-blocking mode with interrupt.
+  * @param  hqspi: QSPI handle
+  * @param  pData: pointer to data buffer
+  * @note   This function is used only in Indirect Write Mode
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_Transmit_IT(QSPI_HandleTypeDef *hqspi, uint8_t *pData)
+{  
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+
+  if(hqspi->State == HAL_QSPI_STATE_READY)
+  {
+    if(pData != NULL )
+    {
+      hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;
+
+      /* Update state */
+      hqspi->State = HAL_QSPI_STATE_BUSY_INDIRECT_TX;
+
+      /* Configure counters and size of the handle */
+      hqspi->TxXferCount = READ_REG(hqspi->Instance->DLR) + 1;
+      hqspi->TxXferSize = READ_REG(hqspi->Instance->DLR) + 1;
+      hqspi->pTxBuffPtr = pData;
+    
+      /* Configure QSPI: CCR register with functional as indirect write */
+      MODIFY_REG(hqspi->Instance->CCR, QUADSPI_CCR_FMODE, QSPI_FUNCTIONAL_MODE_INDIRECT_WRITE);
+    
+      /* Clear interrupt */
+      __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TE | QSPI_FLAG_TC);
+
+      /* Enable the QSPI transfer error, FIFO threshold and transfer complete Interrupts */
+      __HAL_QSPI_ENABLE_IT(hqspi, QSPI_IT_TE | QSPI_IT_FT | QSPI_IT_TC);
+    }
+    else
+    {
+      status = HAL_ERROR;
+    }
+  }
+  else
+  {
+    status = HAL_BUSY;
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hqspi);
+
+  return status;
+}
+
+/**
+  * @brief  Receive an amount of data in non-blocking mode with interrupt.
+  * @param  hqspi: QSPI handle
+  * @param  pData: pointer to data buffer
+  * @note   This function is used only in Indirect Read Mode
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_Receive_IT(QSPI_HandleTypeDef *hqspi, uint8_t *pData)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t addr_reg = READ_REG(hqspi->Instance->AR);
+
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+
+  if(hqspi->State == HAL_QSPI_STATE_READY)
+  {
+    if(pData != NULL )
+    {
+      hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;
+    
+      /* Update state */
+      hqspi->State = HAL_QSPI_STATE_BUSY_INDIRECT_RX;
+    
+      /* Configure counters and size of the handle */
+      hqspi->RxXferCount = READ_REG(hqspi->Instance->DLR) + 1;
+      hqspi->RxXferSize = READ_REG(hqspi->Instance->DLR) + 1;
+      hqspi->pRxBuffPtr = pData;
+
+      /* Configure QSPI: CCR register with functional as indirect read */
+      MODIFY_REG(hqspi->Instance->CCR, QUADSPI_CCR_FMODE, QSPI_FUNCTIONAL_MODE_INDIRECT_READ);
+
+      /* Start the transfer by re-writing the address in AR register */
+      WRITE_REG(hqspi->Instance->AR, addr_reg);
+
+      /* Clear interrupt */
+      __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TE | QSPI_FLAG_TC);
+
+      /* Enable the QSPI transfer error, FIFO threshold and transfer complete Interrupts */
+      __HAL_QSPI_ENABLE_IT(hqspi, QSPI_IT_TE | QSPI_IT_FT | QSPI_IT_TC);
+    }
+    else
+    {
+      status = HAL_ERROR;
+    }
+  }
+  else
+  {
+    status = HAL_BUSY;   
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hqspi);
+
+  return status;
+}
+
+/**
+  * @brief  Send an amount of data in non-blocking mode with DMA. 
+  * @param  hqspi: QSPI handle
+  * @param  pData: pointer to data buffer
+  * @note   This function is used only in Indirect Write Mode
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_Transmit_DMA(QSPI_HandleTypeDef *hqspi, uint8_t *pData)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t *tmp;
+  
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+
+  if(hqspi->State == HAL_QSPI_STATE_READY)
+  {
+    if(pData != NULL ) 
+    {
+      hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;
+
+      /* Update state */
+      hqspi->State = HAL_QSPI_STATE_BUSY_INDIRECT_TX;
+
+      /* Configure counters and size of the handle */
+      hqspi->TxXferCount = READ_REG(hqspi->Instance->DLR) + 1;
+      hqspi->TxXferSize = READ_REG(hqspi->Instance->DLR) + 1;
+      hqspi->pTxBuffPtr = pData;
+    
+      /* Configure QSPI: CCR register with functional mode as indirect write */
+      MODIFY_REG(hqspi->Instance->CCR, QUADSPI_CCR_FMODE, QSPI_FUNCTIONAL_MODE_INDIRECT_WRITE);
+    
+      /* Set the QSPI DMA transfer complete callback */
+      hqspi->hdma->XferCpltCallback = QSPI_DMATxCplt;
+    
+      /* Set the QSPI DMA Half transfer complete callback */
+      hqspi->hdma->XferHalfCpltCallback = QSPI_DMATxHalfCplt;
+    
+      /* Set the DMA error callback */
+      hqspi->hdma->XferErrorCallback = QSPI_DMAError;
+      
+      /* Configure the direction of the DMA */
+      hqspi->hdma->Init.Direction = DMA_MEMORY_TO_PERIPH;
+      MODIFY_REG(hqspi->hdma->Instance->CCR, DMA_CCR_DIR, hqspi->hdma->Init.Direction);
+
+      /* Enable the QSPI transmit DMA Channel */
+      tmp = (uint32_t*)&pData;
+      HAL_DMA_Start_IT(hqspi->hdma, *(uint32_t*)tmp, (uint32_t)&hqspi->Instance->DR, hqspi->TxXferSize);
+    
+      /* Enable the DMA transfer by setting the DMAEN bit in the QSPI CR register */
+      SET_BIT(hqspi->Instance->CR, QUADSPI_CR_DMAEN);
+    }
+    else
+    {
+      status = HAL_ERROR;
+    }
+  }
+  else
+  {
+    status = HAL_BUSY;   
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hqspi);
+
+  return status;
+}
+
+/**
+  * @brief  Receive an amount of data in non-blocking mode with DMA. 
+  * @param  hqspi: QSPI handle
+  * @param  pData: pointer to data buffer.
+  * @note   This function is used only in Indirect Read Mode
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_Receive_DMA(QSPI_HandleTypeDef *hqspi, uint8_t *pData)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t *tmp;
+  uint32_t addr_reg = READ_REG(hqspi->Instance->AR);
+  
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+
+  if(hqspi->State == HAL_QSPI_STATE_READY)
+  {
+    if(pData != NULL ) 
+    {
+      hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;
+    
+      /* Update state */
+      hqspi->State = HAL_QSPI_STATE_BUSY_INDIRECT_RX;
+    
+      /* Configure counters and size of the handle */
+      hqspi->RxXferCount = READ_REG(hqspi->Instance->DLR) + 1;
+      hqspi->RxXferSize = READ_REG(hqspi->Instance->DLR) + 1;
+      hqspi->pRxBuffPtr = pData;
+
+      /* Set the QSPI DMA transfer complete callback */
+      hqspi->hdma->XferCpltCallback = QSPI_DMARxCplt;
+    
+      /* Set the QSPI DMA Half transfer complete callback */
+      hqspi->hdma->XferHalfCpltCallback = QSPI_DMARxHalfCplt;
+    
+      /* Set the DMA error callback */
+      hqspi->hdma->XferErrorCallback = QSPI_DMAError;
+      
+      /* Configure the direction of the DMA */
+      hqspi->hdma->Init.Direction = DMA_PERIPH_TO_MEMORY;
+      MODIFY_REG(hqspi->hdma->Instance->CCR, DMA_CCR_DIR, hqspi->hdma->Init.Direction);
+
+      /* Enable the DMA Channel */
+      tmp = (uint32_t*)&pData;
+      HAL_DMA_Start_IT(hqspi->hdma, (uint32_t)&hqspi->Instance->DR, *(uint32_t*)tmp, hqspi->RxXferSize);
+    
+      /* Configure QSPI: CCR register with functional as indirect read */
+      MODIFY_REG(hqspi->Instance->CCR, QUADSPI_CCR_FMODE, QSPI_FUNCTIONAL_MODE_INDIRECT_READ);
+
+      /* Start the transfer by re-writing the address in AR register */
+      WRITE_REG(hqspi->Instance->AR, addr_reg);
+
+      /* Enable the DMA transfer by setting the DMAEN bit in the QSPI CR register */
+      SET_BIT(hqspi->Instance->CR, QUADSPI_CR_DMAEN);
+    }
+    else
+    {
+      status = HAL_ERROR;
+    }
+  }
+  else
+  {
+    status = HAL_BUSY; 
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hqspi);
+
+  return status;
+}
+
+/**
+  * @brief  Configure the QSPI Automatic Polling Mode in blocking mode. 
+  * @param  hqspi: QSPI handle
+  * @param  cmd: structure that contains the command configuration information.
+  * @param  cfg: structure that contains the polling configuration information.
+  * @param  Timeout : Timeout duration
+  * @note   This function is used only in Automatic Polling Mode
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_AutoPolling(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, QSPI_AutoPollingTypeDef *cfg, uint32_t Timeout)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_QSPI_INSTRUCTION_MODE(cmd->InstructionMode));
+  if (cmd->InstructionMode != QSPI_INSTRUCTION_NONE)
+  {
+    assert_param(IS_QSPI_INSTRUCTION(cmd->Instruction));
+  }
+
+  assert_param(IS_QSPI_ADDRESS_MODE(cmd->AddressMode));
+  if (cmd->AddressMode != QSPI_ADDRESS_NONE)
+  {
+    assert_param(IS_QSPI_ADDRESS_SIZE(cmd->AddressSize));
+  }
+
+  assert_param(IS_QSPI_ALTERNATE_BYTES_MODE(cmd->AlternateByteMode));
+  if (cmd->AlternateByteMode != QSPI_ALTERNATE_BYTES_NONE)
+  {
+    assert_param(IS_QSPI_ALTERNATE_BYTES_SIZE(cmd->AlternateBytesSize));
+  }
+
+  assert_param(IS_QSPI_DUMMY_CYCLES(cmd->DummyCycles));
+  assert_param(IS_QSPI_DATA_MODE(cmd->DataMode));
+
+  assert_param(IS_QSPI_DDR_MODE(cmd->DdrMode));
+  assert_param(IS_QSPI_DDR_HHC(cmd->DdrHoldHalfCycle));
+  assert_param(IS_QSPI_SIOO_MODE(cmd->SIOOMode));
+
+  assert_param(IS_QSPI_INTERVAL(cfg->Interval));
+  assert_param(IS_QSPI_STATUS_BYTES_SIZE(cfg->StatusBytesSize));
+  assert_param(IS_QSPI_MATCH_MODE(cfg->MatchMode));
+  
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+  
+  if(hqspi->State == HAL_QSPI_STATE_READY)
+  {
+    hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;
+    
+    /* Update state */
+    hqspi->State = HAL_QSPI_STATE_BUSY_AUTO_POLLING;
+    
+    /* Wait till BUSY flag reset */
+    status = QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_BUSY, RESET, Timeout);
+    
+    if (status == HAL_OK)
+    {
+      /* Configure QSPI: PSMAR register with the status match value */
+      WRITE_REG(hqspi->Instance->PSMAR, cfg->Match);
+      
+      /* Configure QSPI: PSMKR register with the status mask value */
+      WRITE_REG(hqspi->Instance->PSMKR, cfg->Mask);
+      
+      /* Configure QSPI: PIR register with the interval value */
+      WRITE_REG(hqspi->Instance->PIR, cfg->Interval);
+      
+      /* Configure QSPI: CR register with Match mode and Automatic stop enabled 
+      (otherwise there will be an infinite loop in blocking mode) */
+      MODIFY_REG(hqspi->Instance->CR, (QUADSPI_CR_PMM | QUADSPI_CR_APMS), 
+               (cfg->MatchMode | QSPI_AUTOMATIC_STOP_ENABLE));
+      
+      /* Call the configuration function */
+      cmd->NbData = cfg->StatusBytesSize;
+      QSPI_Config(hqspi, cmd, QSPI_FUNCTIONAL_MODE_AUTO_POLLING);
+      
+      /* Wait until SM flag is set to go back in idle state */
+      if(QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_SM, SET, Timeout) != HAL_OK)
+      { 
+        status = HAL_TIMEOUT;
+      }
+      else
+      {
+        __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_SM);
+        
+        /* Update state */
+        hqspi->State = HAL_QSPI_STATE_READY;
+      }
+    }
+  }
+  else
+  {
+    status = HAL_BUSY;   
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hqspi);
+  
+  /* Return function status */
+  return status;  
+}
+
+/**
+  * @brief  Configure the QSPI Automatic Polling Mode in non-blocking mode. 
+  * @param  hqspi: QSPI handle
+  * @param  cmd: structure that contains the command configuration information.
+  * @param  cfg: structure that contains the polling configuration information.
+  * @note   This function is used only in Automatic Polling Mode
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_AutoPolling_IT(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, QSPI_AutoPollingTypeDef *cfg)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_QSPI_INSTRUCTION_MODE(cmd->InstructionMode));
+  if (cmd->InstructionMode != QSPI_INSTRUCTION_NONE)
+  {
+    assert_param(IS_QSPI_INSTRUCTION(cmd->Instruction));
+  }
+
+  assert_param(IS_QSPI_ADDRESS_MODE(cmd->AddressMode));
+  if (cmd->AddressMode != QSPI_ADDRESS_NONE)
+  {
+    assert_param(IS_QSPI_ADDRESS_SIZE(cmd->AddressSize));
+  }
+
+  assert_param(IS_QSPI_ALTERNATE_BYTES_MODE(cmd->AlternateByteMode));
+  if (cmd->AlternateByteMode != QSPI_ALTERNATE_BYTES_NONE)
+  {
+    assert_param(IS_QSPI_ALTERNATE_BYTES_SIZE(cmd->AlternateBytesSize));
+  }
+
+  assert_param(IS_QSPI_DUMMY_CYCLES(cmd->DummyCycles));
+  assert_param(IS_QSPI_DATA_MODE(cmd->DataMode));
+
+  assert_param(IS_QSPI_DDR_MODE(cmd->DdrMode));
+  assert_param(IS_QSPI_DDR_HHC(cmd->DdrHoldHalfCycle));
+  assert_param(IS_QSPI_SIOO_MODE(cmd->SIOOMode));
+
+  assert_param(IS_QSPI_INTERVAL(cfg->Interval));
+  assert_param(IS_QSPI_STATUS_BYTES_SIZE(cfg->StatusBytesSize));
+  assert_param(IS_QSPI_MATCH_MODE(cfg->MatchMode));
+  assert_param(IS_QSPI_AUTOMATIC_STOP(cfg->AutomaticStop));
+  
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+  
+  if(hqspi->State == HAL_QSPI_STATE_READY)
+  {
+    hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;
+    
+    /* Update state */
+    hqspi->State = HAL_QSPI_STATE_BUSY_AUTO_POLLING;
+    
+    /* Wait till BUSY flag reset */
+    status = QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_BUSY, RESET, hqspi->Timeout);
+    
+    if (status == HAL_OK)
+    {
+      /* Configure QSPI: PSMAR register with the status match value */
+      WRITE_REG(hqspi->Instance->PSMAR, cfg->Match);
+      
+      /* Configure QSPI: PSMKR register with the status mask value */
+      WRITE_REG(hqspi->Instance->PSMKR, cfg->Mask);
+      
+      /* Configure QSPI: PIR register with the interval value */
+      WRITE_REG(hqspi->Instance->PIR, cfg->Interval);
+      
+      /* Configure QSPI: CR register with Match mode and Automatic stop mode */
+      MODIFY_REG(hqspi->Instance->CR, (QUADSPI_CR_PMM | QUADSPI_CR_APMS), 
+               (cfg->MatchMode | cfg->AutomaticStop));
+      
+      /* Clear interrupt */
+      __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TE | QSPI_FLAG_SM);
+
+      /* Enable the QSPI Transfer Error and status match Interrupt */
+      __HAL_QSPI_ENABLE_IT(hqspi, (QSPI_IT_SM | QSPI_IT_TE));
+
+      /* Call the configuration function */
+      cmd->NbData = cfg->StatusBytesSize;
+      QSPI_Config(hqspi, cmd, QSPI_FUNCTIONAL_MODE_AUTO_POLLING);
+    }
+  }
+  else
+  {
+    status = HAL_BUSY;   
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hqspi);
+  
+  /* Return function status */
+  return status;  
+}
+
+/**
+  * @brief  Configure the Memory Mapped mode. 
+  * @param  hqspi: QSPI handle
+  * @param  cmd: structure that contains the command configuration information.
+  * @param  cfg: structure that contains the memory mapped configuration information.
+  * @note   This function is used only in Memory mapped Mode
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_QSPI_MemoryMapped(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, QSPI_MemoryMappedTypeDef *cfg)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_QSPI_INSTRUCTION_MODE(cmd->InstructionMode));
+  if (cmd->InstructionMode != QSPI_INSTRUCTION_NONE)
+  {
+  assert_param(IS_QSPI_INSTRUCTION(cmd->Instruction));
+  }
+
+  assert_param(IS_QSPI_ADDRESS_MODE(cmd->AddressMode));
+  if (cmd->AddressMode != QSPI_ADDRESS_NONE)
+  {
+    assert_param(IS_QSPI_ADDRESS_SIZE(cmd->AddressSize));
+  }
+
+  assert_param(IS_QSPI_ALTERNATE_BYTES_MODE(cmd->AlternateByteMode));
+  if (cmd->AlternateByteMode != QSPI_ALTERNATE_BYTES_NONE)
+  {
+    assert_param(IS_QSPI_ALTERNATE_BYTES_SIZE(cmd->AlternateBytesSize));
+  }
+
+  assert_param(IS_QSPI_DUMMY_CYCLES(cmd->DummyCycles));
+  assert_param(IS_QSPI_DATA_MODE(cmd->DataMode));
+
+  assert_param(IS_QSPI_DDR_MODE(cmd->DdrMode));
+  assert_param(IS_QSPI_DDR_HHC(cmd->DdrHoldHalfCycle));
+  assert_param(IS_QSPI_SIOO_MODE(cmd->SIOOMode));
+
+  assert_param(IS_QSPI_TIMEOUT_ACTIVATION(cfg->TimeOutActivation));
+  
+  /* Process locked */
+  __HAL_LOCK(hqspi);
+  
+  if(hqspi->State == HAL_QSPI_STATE_READY)
+  {
+    hqspi->ErrorCode = HAL_QSPI_ERROR_NONE;
+    
+    /* Update state */
+    hqspi->State = HAL_QSPI_STATE_BUSY_MEM_MAPPED;
+    
+    /* Wait till BUSY flag reset */
+    status = QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_BUSY, RESET, hqspi->Timeout);
+    
+    if (status == HAL_OK)
+    {
+      /* Configure QSPI: CR register with timeout counter enable */
+    MODIFY_REG(hqspi->Instance->CR, QUADSPI_CR_TCEN, cfg->TimeOutActivation);
+      
+    if (cfg->TimeOutActivation == QSPI_TIMEOUT_COUNTER_ENABLE)
+      {
+        assert_param(IS_QSPI_TIMEOUT_PERIOD(cfg->TimeOutPeriod));
+        
+        /* Configure QSPI: LPTR register with the low-power timeout value */
+        WRITE_REG(hqspi->Instance->LPTR, cfg->TimeOutPeriod);
+        
+        /* Clear interrupt */
+        __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TO);
+
+        /* Enable the QSPI TimeOut Interrupt */
+        __HAL_QSPI_ENABLE_IT(hqspi, QSPI_IT_TO);
+      }
+      
+      /* Call the configuration function */
+      QSPI_Config(hqspi, cmd, QSPI_FUNCTIONAL_MODE_MEMORY_MAPPED);
+    }
+  }
+  else
+  {
+    status = HAL_BUSY;   
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hqspi);
+  
+  /* Return function status */
+  return status;  
+}
+
+/**
+  * @brief  Transfer Error callback.
+  * @param  hqspi: QSPI handle
+  * @retval None
+  */
+__weak void HAL_QSPI_ErrorCallback(QSPI_HandleTypeDef *hqspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hqspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_QSPI_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Command completed callback.
+  * @param  hqspi: QSPI handle
+  * @retval None
+  */
+__weak void HAL_QSPI_CmdCpltCallback(QSPI_HandleTypeDef *hqspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hqspi);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_QSPI_CmdCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Rx Transfer completed callback.
+  * @param  hqspi: QSPI handle
+  * @retval None
+  */
+__weak void HAL_QSPI_RxCpltCallback(QSPI_HandleTypeDef *hqspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hqspi);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_QSPI_RxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Tx Transfer completed callback.
+  * @param  hqspi: QSPI handle
+  * @retval None
+  */
+ __weak void HAL_QSPI_TxCpltCallback(QSPI_HandleTypeDef *hqspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hqspi);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_QSPI_TxCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Rx Half Transfer completed callback.
+  * @param  hqspi: QSPI handle
+  * @retval None
+  */
+__weak void HAL_QSPI_RxHalfCpltCallback(QSPI_HandleTypeDef *hqspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hqspi);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_QSPI_RxHalfCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Tx Half Transfer completed callback.
+  * @param  hqspi: QSPI handle
+  * @retval None
+  */
+__weak void HAL_QSPI_TxHalfCpltCallback(QSPI_HandleTypeDef *hqspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hqspi);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_QSPI_TxHalfCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  FIFO Threshold callback.
+  * @param  hqspi: QSPI handle
+  * @retval None
+  */
+__weak void HAL_QSPI_FifoThresholdCallback(QSPI_HandleTypeDef *hqspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hqspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_QSPI_FIFOThresholdCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Status Match callback.
+  * @param  hqspi: QSPI handle
+  * @retval None
+  */
+__weak void HAL_QSPI_StatusMatchCallback(QSPI_HandleTypeDef *hqspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hqspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_QSPI_StatusMatchCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Timeout callback.
+  * @param  hqspi: QSPI handle
+  * @retval None
+  */
+__weak void HAL_QSPI_TimeOutCallback(QSPI_HandleTypeDef *hqspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hqspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_QSPI_TimeOutCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup QSPI_Exported_Functions_Group3 Peripheral Control and State functions 
+  *  @brief   QSPI control and State functions 
+  *
+@verbatim   
+ ===============================================================================
+                  ##### Peripheral Control and State functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to :
+      (+) Check in run-time the state of the driver. 
+      (+) Check the error code set during last operation.
+      (+) Abort any operation.
+
+  
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the QSPI handle state.
+  * @param  hqspi: QSPI handle
+  * @retval HAL state
+  */
+HAL_QSPI_StateTypeDef HAL_QSPI_GetState(QSPI_HandleTypeDef *hqspi)
+{
+  /* Return QSPI handle state */
+  return hqspi->State;
+}
+
+/**
+* @brief  Return the QSPI error code.
+* @param  hqspi: QSPI handle
+* @retval QSPI Error Code
+*/
+uint32_t HAL_QSPI_GetError(QSPI_HandleTypeDef *hqspi)
+{
+  return hqspi->ErrorCode;
+}
+
+/**
+* @brief  Abort the current transmission.
+* @param  hqspi: QSPI handle
+* @retval HAL status
+*/
+HAL_StatusTypeDef HAL_QSPI_Abort(QSPI_HandleTypeDef *hqspi)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Configure QSPI: CR register with Abort request */
+  SET_BIT(hqspi->Instance->CR, QUADSPI_CR_ABORT);
+
+  /* Wait until TC flag is set to go back in idle state */
+  if(QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_TC, SET, hqspi->Timeout) != HAL_OK)
+  { 
+    status = HAL_TIMEOUT;
+  }
+  else
+  {
+    __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
+    
+    /* Wait until BUSY flag is reset */
+    status = QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_BUSY, RESET, hqspi->Timeout);
+
+    /* Update state */
+    hqspi->State = HAL_QSPI_STATE_READY;
+  }
+
+  return status;
+}
+
+/** @brief Set QSPI timeout.
+  * @param  hqspi: QSPI handle.
+  * @param  Timeout: Timeout for the QSPI memory access.
+  * @retval None
+  */
+void HAL_QSPI_SetTimeout(QSPI_HandleTypeDef *hqspi, uint32_t Timeout)
+{
+  hqspi->Timeout = Timeout;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  DMA QSPI receive process complete callback. 
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void QSPI_DMARxCplt(DMA_HandleTypeDef *hdma)  
+{
+  QSPI_HandleTypeDef* hqspi = ( QSPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  hqspi->RxXferCount = 0;
+  
+  /* Wait for QSPI TC Flag */
+  if(QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_TC, SET, hqspi->Timeout) != HAL_OK)
+  {
+    /* Timeout occurred */ 
+    HAL_QSPI_ErrorCallback(hqspi);
+  }
+  else
+  {
+    /* Disable the DMA transfer by clearing the DMAEN bit in the QSPI CR register */
+    CLEAR_BIT(hqspi->Instance->CR, QUADSPI_CR_DMAEN);
+
+    /* Disable the DMA channel */
+    HAL_DMA_Abort(hdma);
+
+    /* Clear Transfer Complete bit */
+    __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
+
+    /* Workaround - Extra data written in the FIFO at the end of a read transfer */
+    HAL_QSPI_Abort(hqspi);
+
+    /* Update state */
+    hqspi->State = HAL_QSPI_STATE_READY;
+    
+    HAL_QSPI_RxCpltCallback(hqspi);
+  }
+}
+
+/**
+  * @brief  DMA QSPI transmit process complete callback. 
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void QSPI_DMATxCplt(DMA_HandleTypeDef *hdma)     
+{
+  QSPI_HandleTypeDef* hqspi = ( QSPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  hqspi->TxXferCount = 0;
+  
+  /* Wait for QSPI TC Flag */
+  if(QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_TC, SET, hqspi->Timeout) != HAL_OK)
+  {
+    /* Timeout occurred */ 
+    HAL_QSPI_ErrorCallback(hqspi);
+  }
+  else
+  {
+    /* Disable the DMA transfer by clearing the DMAEN bit in the QSPI CR register */
+    CLEAR_BIT(hqspi->Instance->CR, QUADSPI_CR_DMAEN);
+  
+    /* Disable the DMA channel */
+    HAL_DMA_Abort(hdma);
+
+    /* Clear Transfer Complete bit */
+    __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
+
+    /* Clear Busy bit */
+    HAL_QSPI_Abort(hqspi);
+
+    /* Update state */
+    hqspi->State = HAL_QSPI_STATE_READY;
+    
+    HAL_QSPI_TxCpltCallback(hqspi);
+  }
+}
+
+/**
+  * @brief  DMA QSPI receive process half complete callback. 
+  * @param  hdma : DMA handle
+  * @retval None
+  */
+static void QSPI_DMARxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  QSPI_HandleTypeDef* hqspi = (QSPI_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_QSPI_RxHalfCpltCallback(hqspi); 
+}
+
+/**
+  * @brief  DMA QSPI transmit process half complete callback.
+  * @param  hdma : DMA handle
+  * @retval None
+  */
+static void QSPI_DMATxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  QSPI_HandleTypeDef* hqspi = (QSPI_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_QSPI_TxHalfCpltCallback(hqspi);
+}
+
+/**
+  * @brief  DMA QSPI communication error callback.
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void QSPI_DMAError(DMA_HandleTypeDef *hdma)   
+{
+  QSPI_HandleTypeDef* hqspi = ( QSPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  hqspi->RxXferCount = 0;
+  hqspi->TxXferCount = 0;
+  hqspi->State       = HAL_QSPI_STATE_ERROR;
+  hqspi->ErrorCode   |= HAL_QSPI_ERROR_DMA;
+
+  HAL_QSPI_ErrorCallback(hqspi);
+}
+
+/**
+  * @brief  Wait for a flag state until timeout.
+  * @param  hqspi: QSPI handle
+  * @param  Flag: Flag checked
+  * @param  State: Value of the flag expected
+  * @param  Timeout: Duration of the timeout
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef QSPI_WaitFlagStateUntilTimeout(QSPI_HandleTypeDef *hqspi, uint32_t Flag,
+                                                        FlagStatus State, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+  
+  /* Wait until flag is in expected state */    
+  while((FlagStatus)(__HAL_QSPI_GET_FLAG(hqspi, Flag)) != State)
+  {
+    /* Check for the Timeout */
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0) || ((HAL_GetTick() - tickstart) > Timeout))
+      {
+        hqspi->State     = HAL_QSPI_STATE_ERROR;
+        hqspi->ErrorCode |= HAL_QSPI_ERROR_TIMEOUT;
+        
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configure the communication registers.
+  * @param  hqspi: QSPI handle
+  * @param  cmd: structure that contains the command configuration information
+  * @param  FunctionalMode: functional mode to configured
+  *           This parameter can be one of the following values:
+  *            @arg QSPI_FUNCTIONAL_MODE_INDIRECT_WRITE: Indirect write mode
+  *            @arg QSPI_FUNCTIONAL_MODE_INDIRECT_READ: Indirect read mode
+  *            @arg QSPI_FUNCTIONAL_MODE_AUTO_POLLING: Automatic polling mode
+  *            @arg QSPI_FUNCTIONAL_MODE_MEMORY_MAPPED: Memory-mapped mode
+  * @retval None
+  */
+static void QSPI_Config(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, uint32_t FunctionalMode)
+{
+  assert_param(IS_QSPI_FUNCTIONAL_MODE(FunctionalMode));
+
+  if ((cmd->DataMode != QSPI_DATA_NONE) && (FunctionalMode != QSPI_FUNCTIONAL_MODE_MEMORY_MAPPED))
+  {
+    /* Configure QSPI: DLR register with the number of data to read or write */
+    WRITE_REG(hqspi->Instance->DLR, (cmd->NbData - 1));
+  }
+
+  if (cmd->InstructionMode != QSPI_INSTRUCTION_NONE)
+  {
+    if (cmd->AlternateByteMode != QSPI_ALTERNATE_BYTES_NONE)
+    {
+      /* Configure QSPI: ABR register with alternate bytes value */
+      WRITE_REG(hqspi->Instance->ABR, cmd->AlternateBytes);
+
+      if (cmd->AddressMode != QSPI_ADDRESS_NONE)
+      {
+        /*---- Command with instruction, address and alternate bytes ----*/
+        /* Configure QSPI: CCR register with all communications parameters */
+        WRITE_REG(hqspi->Instance->CCR, (cmd->DdrMode | cmd->DdrHoldHalfCycle | cmd->SIOOMode | 
+                                         cmd->DataMode | (cmd->DummyCycles << POSITION_VAL(QUADSPI_CCR_DCYC)) | 
+                                         cmd->AlternateBytesSize | cmd->AlternateByteMode | 
+                                         cmd->AddressSize | cmd->AddressMode | cmd->InstructionMode | 
+                                         cmd->Instruction | FunctionalMode));
+
+        if (FunctionalMode != QSPI_FUNCTIONAL_MODE_MEMORY_MAPPED)
+        {
+          /* Configure QSPI: AR register with address value */
+          WRITE_REG(hqspi->Instance->AR, cmd->Address);
+        }
+      }
+      else
+      {
+        /*---- Command with instruction and alternate bytes ----*/
+        /* Configure QSPI: CCR register with all communications parameters */
+        WRITE_REG(hqspi->Instance->CCR, (cmd->DdrMode | cmd->DdrHoldHalfCycle | cmd->SIOOMode | 
+                                         cmd->DataMode | (cmd->DummyCycles << POSITION_VAL(QUADSPI_CCR_DCYC)) | 
+                                         cmd->AlternateBytesSize | cmd->AlternateByteMode | 
+                                         cmd->AddressMode | cmd->InstructionMode | 
+                                         cmd->Instruction | FunctionalMode));
+      }
+    }
+    else
+    {
+      if (cmd->AddressMode != QSPI_ADDRESS_NONE)
+      {
+        /*---- Command with instruction and address ----*/
+        /* Configure QSPI: CCR register with all communications parameters */
+        WRITE_REG(hqspi->Instance->CCR, (cmd->DdrMode | cmd->DdrHoldHalfCycle | cmd->SIOOMode | 
+                                         cmd->DataMode | (cmd->DummyCycles << POSITION_VAL(QUADSPI_CCR_DCYC)) | 
+                                         cmd->AlternateByteMode | cmd->AddressSize | cmd->AddressMode | 
+                                         cmd->InstructionMode | cmd->Instruction | FunctionalMode));
+
+        if (FunctionalMode != QSPI_FUNCTIONAL_MODE_MEMORY_MAPPED)
+        {
+          /* Configure QSPI: AR register with address value */
+          WRITE_REG(hqspi->Instance->AR, cmd->Address);
+        }
+      }
+      else
+      {
+        /*---- Command with only instruction ----*/
+        /* Configure QSPI: CCR register with all communications parameters */
+        WRITE_REG(hqspi->Instance->CCR, (cmd->DdrMode | cmd->DdrHoldHalfCycle | cmd->SIOOMode | 
+                                         cmd->DataMode | (cmd->DummyCycles << POSITION_VAL(QUADSPI_CCR_DCYC)) | 
+                                         cmd->AlternateByteMode | cmd->AddressMode | 
+                                         cmd->InstructionMode | cmd->Instruction | FunctionalMode));
+      }
+    }
+  }
+  else
+  {
+    if (cmd->AlternateByteMode != QSPI_ALTERNATE_BYTES_NONE)
+    {
+      /* Configure QSPI: ABR register with alternate bytes value */
+      WRITE_REG(hqspi->Instance->ABR, cmd->AlternateBytes);
+
+      if (cmd->AddressMode != QSPI_ADDRESS_NONE)
+      {
+        /*---- Command with address and alternate bytes ----*/
+        /* Configure QSPI: CCR register with all communications parameters */
+        WRITE_REG(hqspi->Instance->CCR, (cmd->DdrMode | cmd->DdrHoldHalfCycle | cmd->SIOOMode | 
+                                         cmd->DataMode | (cmd->DummyCycles << POSITION_VAL(QUADSPI_CCR_DCYC)) | 
+                                         cmd->AlternateBytesSize | cmd->AlternateByteMode | 
+                                         cmd->AddressSize | cmd->AddressMode | 
+                                         cmd->InstructionMode | FunctionalMode));
+
+        if (FunctionalMode != QSPI_FUNCTIONAL_MODE_MEMORY_MAPPED)
+        {
+          /* Configure QSPI: AR register with address value */
+          WRITE_REG(hqspi->Instance->AR, cmd->Address);
+        }
+      }
+      else
+      {
+        /*---- Command with only alternate bytes ----*/
+        /* Configure QSPI: CCR register with all communications parameters */
+        WRITE_REG(hqspi->Instance->CCR, (cmd->DdrMode | cmd->DdrHoldHalfCycle | cmd->SIOOMode | 
+                                         cmd->DataMode | (cmd->DummyCycles << POSITION_VAL(QUADSPI_CCR_DCYC)) | 
+                                         cmd->AlternateBytesSize | cmd->AlternateByteMode | 
+                                         cmd->AddressMode | cmd->InstructionMode | FunctionalMode));
+      }
+    }
+    else
+    {
+      if (cmd->AddressMode != QSPI_ADDRESS_NONE)
+      {
+        /*---- Command with only address ----*/
+        /* Configure QSPI: CCR register with all communications parameters */
+        WRITE_REG(hqspi->Instance->CCR, (cmd->DdrMode | cmd->DdrHoldHalfCycle | cmd->SIOOMode | 
+                                         cmd->DataMode | (cmd->DummyCycles << POSITION_VAL(QUADSPI_CCR_DCYC)) | 
+                                         cmd->AlternateByteMode | cmd->AddressSize | 
+                                         cmd->AddressMode | cmd->InstructionMode | FunctionalMode));
+
+        if (FunctionalMode != QSPI_FUNCTIONAL_MODE_MEMORY_MAPPED)
+        {
+          /* Configure QSPI: AR register with address value */
+          WRITE_REG(hqspi->Instance->AR, cmd->Address);
+        }
+      }
+      else
+      {
+        /*---- Command with only data phase ----*/
+        if (cmd->DataMode != QSPI_DATA_NONE)
+        {
+          /* Configure QSPI: CCR register with all communications parameters */
+          WRITE_REG(hqspi->Instance->CCR, (cmd->DdrMode | cmd->DdrHoldHalfCycle | cmd->SIOOMode | 
+                                           cmd->DataMode | (cmd->DummyCycles << POSITION_VAL(QUADSPI_CCR_DCYC)) | 
+                                           cmd->AlternateByteMode | cmd->AddressMode | 
+                                           cmd->InstructionMode | FunctionalMode));
+        }
+      }
+    }
+  }
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_QSPI_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_rcc.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_rcc.c
@@ -1,0 +1,1439 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_rcc.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   RCC HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Reset and Clock Control (RCC) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + Peripheral Control functions
+  *
+  @verbatim
+  ==============================================================================
+                      ##### RCC specific features #####
+  ==============================================================================
+    [..]
+      After reset the device is running from Multiple Speed Internal oscillator
+      (4 MHz) with Flash 0 wait state. Flash prefetch buffer, D-Cache
+      and I-Cache are disabled, and all peripherals are off except internal
+      SRAM, Flash and JTAG.
+
+      (+) There is no prescaler on High speed (AHBs) and Low speed (APBs) busses:
+          all peripherals mapped on these busses are running at MSI speed.
+      (+) The clock for all peripherals is switched off, except the SRAM and FLASH.
+      (+) All GPIOs are in analog mode, except the JTAG pins which
+          are assigned to be used for debug purpose.
+
+    [..]
+      Once the device started from reset, the user application has to:
+      (+) Configure the clock source to be used to drive the System clock
+          (if the application needs higher frequency/performance)
+      (+) Configure the System clock frequency and Flash settings
+      (+) Configure the AHB and APB busses prescalers
+      (+) Enable the clock for the peripheral(s) to be used
+      (+) Configure the clock source(s) for peripherals which clocks are not
+          derived from the System clock (SAIx, RTC, ADC, USB OTG FS/SDMMC1/RNG)
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RCC RCC
+  * @brief RCC HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @defgroup RCC_Private_Constants RCC Private Constants
+ * @{
+ */
+#define HSE_TIMEOUT_VALUE          HSE_STARTUP_TIMEOUT
+#define HSI_TIMEOUT_VALUE          ((uint32_t)2U)    /* 2 ms (minimum Tick + 1) */
+#define MSI_TIMEOUT_VALUE          ((uint32_t)2U)    /* 2 ms (minimum Tick + 1) */  
+#define LSI_TIMEOUT_VALUE          ((uint32_t)2U)    /* 2 ms (minimum Tick + 1) */
+#define PLL_TIMEOUT_VALUE          ((uint32_t)2U)    /* 2 ms (minimum Tick + 1) */
+#define CLOCKSWITCH_TIMEOUT_VALUE  ((uint32_t)5000U) /* 5 s    */
+
+#define PLLSOURCE_NONE             ((uint32_t)0U)
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/** @defgroup RCC_Private_Macros RCC Private Macros
+  * @{
+  */
+#define __MCO1_CLK_ENABLE()   __HAL_RCC_GPIOA_CLK_ENABLE()
+#define MCO1_GPIO_PORT        GPIOA
+#define MCO1_PIN              GPIO_PIN_8
+
+#define RCC_PLL_OSCSOURCE_CONFIG(__HAL_RCC_PLLSOURCE__) \
+            (MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC, (uint32_t)(__HAL_RCC_PLLSOURCE__)))
+/**
+  * @}
+  */
+
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup RCC_Private_Variables RCC Private Variables
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private function prototypes -----------------------------------------------*/
+/** @defgroup RCC_Private_Functions RCC Private Functions
+  * @{
+  */
+static HAL_StatusTypeDef RCC_SetFlashLatencyFromMSIRange(uint32_t msirange);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup RCC_Exported_Functions RCC Exported Functions
+  * @{
+  */
+
+/** @defgroup RCC_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and Configuration functions
+  *
+  @verbatim
+ ===============================================================================
+           ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]
+      This section provides functions allowing to configure the internal and external oscillators
+      (HSE, HSI, LSE, MSI, LSI, PLL, CSS and MCO) and the System busses clocks (SYSCLK, AHB, APB1
+       and APB2).
+
+    [..] Internal/external clock and PLL configuration
+         (+) HSI (high-speed internal): 16 MHz factory-trimmed RC used directly or through
+             the PLL as System clock source.
+             
+         (+) MSI (Mutiple Speed Internal): Its frequency is software trimmable from 100KHZ to 48MHZ.
+             It can be used to generate the clock for the USB OTG FS (48 MHz).
+             The number of flash wait states is automatically adjusted when MSI range is updated with 
+             HAL_RCC_OscConfig() and the MSI is used as System clock source. 
+
+         (+) LSI (low-speed internal): 32 KHz low consumption RC used as IWDG and/or RTC
+             clock source.
+
+         (+) HSE (high-speed external): 4 to 48 MHz crystal oscillator used directly or
+             through the PLL as System clock source. Can be used also optionally as RTC clock source.
+
+         (+) LSE (low-speed external): 32.768 KHz oscillator used optionally as RTC clock source.
+
+         (+) PLL (clocked by HSI, HSE or MSI) providing up to three independent output clocks:
+           (++) The first output is used to generate the high speed system clock (up to 80MHz).
+           (++) The second output is used to generate the clock for the USB OTG FS (48 MHz),
+                the random analog generator (<=48 MHz) and the SDMMC1 (<= 48 MHz).
+           (++) The third output is used to generate an accurate clock to achieve
+                high-quality audio performance on SAI interface.
+
+         (+) PLLSAI1 (clocked by HSI, HSE or MSI) providing up to three independent output clocks:
+           (++) The first output is used to generate SAR ADC1 clock.
+           (++) The second output is used to generate the clock for the USB OTG FS (48 MHz),
+                the random analog generator (<=48 MHz) and the SDMMC1 (<= 48 MHz).
+           (++) The Third output is used to generate an accurate clock to achieve
+                high-quality audio performance on SAI interface.
+
+         (+) PLLSAI2 (clocked by HSI , HSE or MSI) providing up to two independent output clocks:
+           (++) The first output is used to generate SAR ADC2 clock.
+           (++) The second  output is used to generate an accurate clock to achieve
+                high-quality audio performance on SAI interface.
+
+         (+) CSS (Clock security system): once enabled, if a HSE clock failure occurs
+            (HSE used directly or through PLL as System clock source), the System clock
+             is automatically switched to HSI and an interrupt is generated if enabled.
+             The interrupt is linked to the Cortex-M4 NMI (Non-Maskable Interrupt)
+             exception vector.
+
+         (+) MCO (microcontroller clock output): used to output MSI, LSI, HSI, LSE, HSE or
+             main PLL clock (through a configurable prescaler) on PA8 pin.
+
+    [..] System, AHB and APB busses clocks configuration
+         (+) Several clock sources can be used to drive the System clock (SYSCLK): MSI, HSI,
+             HSE and main PLL.
+             The AHB clock (HCLK) is derived from System clock through configurable
+             prescaler and used to clock the CPU, memory and peripherals mapped
+             on AHB bus (DMA, GPIO...). APB1 (PCLK1) and APB2 (PCLK2) clocks are derived
+             from AHB clock through configurable prescalers and used to clock
+             the peripherals mapped on these busses. You can use
+             "HAL_RCC_GetSysClockFreq()" function to retrieve the frequencies of these clocks.
+
+         -@- All the peripheral clocks are derived from the System clock (SYSCLK) except:
+
+           (+@) SAI: the SAI clock can be derived either from a specific PLL (PLLSAI1) or (PLLSAI2) or
+                from an external clock mapped on the SAI_CKIN pin.
+                You have to use HAL_RCCEx_PeriphCLKConfig() function to configure this clock.
+           (+@) RTC: the RTC clock can be derived either from the LSI, LSE or HSE clock
+                divided by 2 to 31.
+                You have to use __HAL_RCC_RTC_ENABLE() and HAL_RCCEx_PeriphCLKConfig() function
+                to configure this clock.
+           (+@) USB OTG FS, SDMMC1 and RNG: USB OTG FS requires a frequency equal to 48 MHz
+                to work correctly, while the SDMMC1 and RNG peripherals require a frequency 
+                equal or lower than to 48 MHz. This clock is derived of the main PLL or PLLSAI1
+                through PLLQ divider. You have to enable the peripheral clock and use 
+                HAL_RCCEx_PeriphCLKConfig() function to configure this clock.
+           (+@) IWDG clock which is always the LSI clock.
+
+
+         (+) The maximum frequency of the SYSCLK, HCLK, PCLK1 and PCLK2 is 80 MHz. 
+             The clock source frequency should be adapted depending on the device voltage range
+             as listed in the Reference Manual "Clock source frequency versus voltage scaling" chapter.
+
+  @endverbatim
+             
+           Table 1. HCLK clock frequency.             
+           +-------------------------------------------------------+     
+           | Latency         |    HCLK clock frequency (MHz)       |
+           |                 |-------------------------------------|     
+           |                 | voltage range 1  | voltage range 2  |
+           |                 |      1.2 V       |     1.0 V        |
+           |-----------------|------------------|------------------|          
+           |0WS(1 CPU cycles)|  0 < HCLK <= 16  |  0 < HCLK <= 6   |
+           |-----------------|------------------|------------------|
+           |1WS(2 CPU cycles)| 16 < HCLK <= 32  |  6 < HCLK <= 12  |
+           |-----------------|------------------|------------------|
+           |2WS(3 CPU cycles)| 32 < HCLK <= 48  | 12 < HCLK <= 18  |
+           |-----------------|------------------|------------------|
+           |3WS(4 CPU cycles)| 48 < HCLK <= 64  | 18 < HCLK <= 26  |
+           |-----------------|------------------|------------------|
+           |4WS(5 CPU cycles)| 64 < HCLK <= 80  | 18 < HCLK <= 26  |
+           +-------------------------------------------------------+   
+  * @{
+  */
+
+/**
+  * @brief  Reset the RCC clock configuration to the default reset state.
+  * @note   The default reset state of the clock configuration is given below:
+  *            - MSI ON and used as system clock source
+  *            - HSE, HSI, PLL, PLLSAI1 and PLLISAI2 OFF
+  *            - AHB, APB1 and APB2 prescaler set to 1.
+  *            - CSS, MCO1 OFF
+  *            - All interrupts disabled
+  * @note   This function doesn't modify the configuration of the
+  *            - Peripheral clocks
+  *            - LSI, LSE and RTC clocks
+  * @retval None
+  */
+void HAL_RCC_DeInit(void)
+{
+  /* Set MSION bit */
+  SET_BIT(RCC->CR, RCC_CR_MSION);
+
+  /* Insure MSIRDY bit is set before writing default MSIRANGE value */
+  while(READ_BIT(RCC->CR, RCC_CR_MSIRDY) == RESET) { __NOP(); }
+  
+  /* Set MSIRANGE default value */
+  MODIFY_REG(RCC->CR, RCC_CR_MSIRANGE, RCC_MSIRANGE_6);
+  
+  /* Reset CFGR register (MSI is selected as system clock source) */
+  CLEAR_REG(RCC->CFGR);
+
+  /* Reset HSION, HSIKERON, HSIASFS, HSEON, HSECSSON, PLLON, PLLSAIxON bits */
+  CLEAR_BIT(RCC->CR, RCC_CR_HSEON | RCC_CR_HSION | RCC_CR_HSIKERON| RCC_CR_HSIASFS | RCC_CR_PLLON | RCC_CR_PLLSAI1ON | RCC_CR_PLLSAI2ON);
+  
+  /* Reset PLLCFGR register */
+  CLEAR_REG(RCC->PLLCFGR);
+  SET_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLN_4 );
+
+  /* Reset PLLSAI1CFGR register */
+  CLEAR_REG(RCC->PLLSAI1CFGR);
+  SET_BIT(RCC->PLLSAI1CFGR,  RCC_PLLSAI1CFGR_PLLSAI1N_4 );
+
+  /* Reset PLLSAI2CFGR register */
+  CLEAR_REG(RCC->PLLSAI2CFGR);
+  SET_BIT(RCC->PLLSAI2CFGR,  RCC_PLLSAI2CFGR_PLLSAI2N_4 );
+
+  /* Reset HSEBYP bit */
+  CLEAR_BIT(RCC->CR, RCC_CR_HSEBYP);
+
+  /* Disable all interrupts */
+  CLEAR_REG(RCC->CIER);
+
+  /* Update the SystemCoreClock global variable */
+  SystemCoreClock = MSI_VALUE;
+}
+
+/**
+  * @brief  Initialize the RCC Oscillators according to the specified parameters in the
+  *         RCC_OscInitTypeDef.
+  * @param  RCC_OscInitStruct  pointer to an RCC_OscInitTypeDef structure that
+  *         contains the configuration information for the RCC Oscillators.
+  * @note   The PLL is not disabled when used as system clock.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(RCC_OscInitStruct != NULL);
+  assert_param(IS_RCC_OSCILLATORTYPE(RCC_OscInitStruct->OscillatorType));
+
+  /*----------------------------- MSI Configuration --------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_MSI) == RCC_OSCILLATORTYPE_MSI)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_MSI(RCC_OscInitStruct->MSIState));
+    assert_param(IS_RCC_MSICALIBRATION_VALUE(RCC_OscInitStruct->MSICalibrationValue));
+    assert_param(IS_RCC_MSI_CLOCK_RANGE(RCC_OscInitStruct->MSIClockRange));
+
+    /* When the MSI is used as system clock it will not be disabled */
+    if((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_MSI) )
+    {
+      if((READ_BIT(RCC->CR, RCC_CR_MSIRDY) != RESET) && (RCC_OscInitStruct->MSIState == RCC_MSI_OFF))
+      {
+        return HAL_ERROR;
+      }
+
+       /* Otherwise, just the calibration and MSI range change are allowed */
+      else
+      {
+        /* To correctly read data from FLASH memory, the number of wait states (LATENCY)
+           must be correctly programmed according to the frequency of the CPU clock
+           (HCLK) and the supply voltage of the device. */
+        if(RCC_OscInitStruct->MSIClockRange > __HAL_RCC_GET_MSI_RANGE())
+        {
+          /* First increase number of wait states update if necessary */
+          if(RCC_SetFlashLatencyFromMSIRange(RCC_OscInitStruct->MSIClockRange) != HAL_OK)
+          {
+            return HAL_ERROR;
+          }
+
+          /* Selects the Multiple Speed oscillator (MSI) clock range .*/
+          __HAL_RCC_MSI_RANGE_CONFIG(RCC_OscInitStruct->MSIClockRange);
+          /* Adjusts the Multiple Speed oscillator (MSI) calibration value.*/
+          __HAL_RCC_MSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->MSICalibrationValue);
+        }
+        else
+        {
+          /* Else, keep current flash latency while decreasing applies */
+          /* Selects the Multiple Speed oscillator (MSI) clock range .*/
+          __HAL_RCC_MSI_RANGE_CONFIG(RCC_OscInitStruct->MSIClockRange);
+          /* Adjusts the Multiple Speed oscillator (MSI) calibration value.*/
+          __HAL_RCC_MSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->MSICalibrationValue);
+
+          /* Decrease number of wait states update if necessary */
+          if(RCC_SetFlashLatencyFromMSIRange(RCC_OscInitStruct->MSIClockRange) != HAL_OK)
+          {
+            return HAL_ERROR;
+          }          
+        }
+
+        /* Update the SystemCoreClock global variable */
+        SystemCoreClock = HAL_RCC_GetSysClockFreq() >> AHBPrescTable[(RCC->CFGR & RCC_CFGR_HPRE)>> POSITION_VAL(RCC_CFGR_HPRE)];
+        
+        /* Configure the source of time base considering new system clocks settings*/
+        HAL_InitTick (TICK_INT_PRIORITY);
+      }
+    }
+    else
+    {
+      /* Check the MSI State */
+      if(RCC_OscInitStruct->MSIState != RCC_MSI_OFF)
+      {
+        /* Enable the Internal High Speed oscillator (MSI). */
+        __HAL_RCC_MSI_ENABLE();
+
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+
+        /* Wait till MSI is ready */
+        while(READ_BIT(RCC->CR, RCC_CR_MSIRDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart) > MSI_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+         /* Selects the Multiple Speed oscillator (MSI) clock range .*/
+        __HAL_RCC_MSI_RANGE_CONFIG(RCC_OscInitStruct->MSIClockRange);
+         /* Adjusts the Multiple Speed oscillator (MSI) calibration value.*/
+        __HAL_RCC_MSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->MSICalibrationValue);
+
+      }
+      else
+      {
+        /* Disable the Internal High Speed oscillator (MSI). */
+        __HAL_RCC_MSI_DISABLE();
+
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+
+        /* Wait till MSI is ready */
+        while(READ_BIT(RCC->CR, RCC_CR_MSIRDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart) > MSI_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }
+  }
+  /*------------------------------- HSE Configuration ------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_HSE) == RCC_OSCILLATORTYPE_HSE)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_HSE(RCC_OscInitStruct->HSEState));
+
+    /* When the HSE is used as system clock or clock source for PLL in these cases it is not allowed to be disabled */
+    if((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_HSE) || 
+       ((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_PLL) && (__HAL_RCC_GET_PLL_OSCSOURCE() == RCC_PLLSOURCE_HSE)))
+    {
+      if((READ_BIT(RCC->CR, RCC_CR_HSERDY) != RESET) && (RCC_OscInitStruct->HSEState == RCC_HSE_OFF))
+      {
+        return HAL_ERROR;
+      }
+    }
+    else
+    {
+      /* Reset HSEON and HSEBYP bits before configuring the HSE --------------*/
+      __HAL_RCC_HSE_CONFIG(RCC_HSE_OFF);
+
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait till HSE is disabled */
+      while(READ_BIT(RCC->CR, RCC_CR_HSERDY) != RESET)
+      {
+        if((HAL_GetTick() - tickstart) > HSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+
+      /* Set the new HSE configuration ---------------------------------------*/
+      __HAL_RCC_HSE_CONFIG(RCC_OscInitStruct->HSEState);
+
+      /* Check the HSE State */
+      if(RCC_OscInitStruct->HSEState != RCC_HSE_OFF)
+      {
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till HSE is ready */
+        while(READ_BIT(RCC->CR, RCC_CR_HSERDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart) > HSE_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+      else
+      {
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till HSE is disabled */
+        while(READ_BIT(RCC->CR, RCC_CR_HSERDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart) > HSE_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }
+  }
+  /*----------------------------- HSI Configuration --------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_HSI) == RCC_OSCILLATORTYPE_HSI)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_HSI(RCC_OscInitStruct->HSIState));
+    assert_param(IS_RCC_HSI_CALIBRATION_VALUE(RCC_OscInitStruct->HSICalibrationValue));
+
+    /* Check if HSI is used as system clock or as PLL source when PLL is selected as system clock */ 
+    if((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_HSI) ||
+       ((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_PLL) && (__HAL_RCC_GET_PLL_OSCSOURCE() == RCC_PLLSOURCE_HSI)))
+    {
+      /* When HSI is used as system clock it will not be disabled */
+      if((READ_BIT(RCC->CR, RCC_CR_HSIRDY) != RESET) && (RCC_OscInitStruct->HSIState == RCC_HSI_OFF))
+      {
+        return HAL_ERROR;
+      }
+      /* Otherwise, just the calibration is allowed */
+      else
+      {
+        /* Adjusts the Internal High Speed oscillator (HSI) calibration value.*/
+        __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->HSICalibrationValue);
+      }
+    }
+    else
+    {
+      /* Check the HSI State */
+      if(RCC_OscInitStruct->HSIState != RCC_HSI_OFF)
+      {
+        /* Enable the Internal High Speed oscillator (HSI). */
+        __HAL_RCC_HSI_ENABLE();
+
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till HSI is ready */
+        while(READ_BIT(RCC->CR, RCC_CR_HSIRDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart) > HSI_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+
+        /* Adjusts the Internal High Speed oscillator (HSI) calibration value.*/
+        __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->HSICalibrationValue);
+      }
+      else
+      {
+        /* Disable the Internal High Speed oscillator (HSI). */
+        __HAL_RCC_HSI_DISABLE();
+
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till HSI is disabled */
+        while(READ_BIT(RCC->CR, RCC_CR_HSIRDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart) > HSI_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }
+  }
+  /*------------------------------ LSI Configuration -------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_LSI) == RCC_OSCILLATORTYPE_LSI)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_LSI(RCC_OscInitStruct->LSIState));
+
+    /* Check the LSI State */
+    if(RCC_OscInitStruct->LSIState != RCC_LSI_OFF)
+    {
+      /* Enable the Internal Low Speed oscillator (LSI). */
+      __HAL_RCC_LSI_ENABLE();
+
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait till LSI is ready */
+      while(READ_BIT(RCC->CSR, RCC_CSR_LSIRDY) == RESET)
+      {
+        if((HAL_GetTick() - tickstart) > LSI_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    else
+    {
+      /* Disable the Internal Low Speed oscillator (LSI). */
+      __HAL_RCC_LSI_DISABLE();
+
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait till LSI is disabled */
+      while(READ_BIT(RCC->CSR, RCC_CSR_LSIRDY) != RESET)
+      {
+        if((HAL_GetTick() - tickstart) > LSI_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  /*------------------------------ LSE Configuration -------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_LSE) == RCC_OSCILLATORTYPE_LSE)
+  {
+    FlagStatus       pwrclkchanged = RESET;
+    
+    /* Check the parameters */
+    assert_param(IS_RCC_LSE(RCC_OscInitStruct->LSEState));
+
+    /* Update LSE configuration in Backup Domain control register    */
+    /* Requires to enable write access to Backup Domain of necessary */
+    if(HAL_IS_BIT_CLR(RCC->APB1ENR1, RCC_APB1ENR1_PWREN))
+    {
+      __HAL_RCC_PWR_CLK_ENABLE();
+      pwrclkchanged = SET;
+    }
+    
+    if(HAL_IS_BIT_CLR(PWR->CR1, PWR_CR1_DBP))
+    {
+      /* Enable write access to Backup domain */
+      SET_BIT(PWR->CR1, PWR_CR1_DBP);
+      
+      /* Wait for Backup domain Write protection disable */
+      tickstart = HAL_GetTick();
+
+      while(HAL_IS_BIT_CLR(PWR->CR1, PWR_CR1_DBP))
+      {
+        if((HAL_GetTick() - tickstart) > RCC_DBP_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+
+    /* Set the new LSE configuration -----------------------------------------*/
+    __HAL_RCC_LSE_CONFIG(RCC_OscInitStruct->LSEState);
+
+    /* Check the LSE State */
+    if(RCC_OscInitStruct->LSEState != RCC_LSE_OFF)
+    {
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait till LSE is ready */
+      while(READ_BIT(RCC->BDCR, RCC_BDCR_LSERDY) == RESET)
+      {
+        if((HAL_GetTick() - tickstart) > RCC_LSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    else
+    {
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait till LSE is disabled */
+      while(READ_BIT(RCC->BDCR, RCC_BDCR_LSERDY) != RESET)
+      {
+        if((HAL_GetTick() - tickstart) > RCC_LSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+
+    /* Restore clock configuration if changed */
+    if(pwrclkchanged == SET)
+    {
+      __HAL_RCC_PWR_CLK_DISABLE();
+    }
+  }
+  /*-------------------------------- PLL Configuration -----------------------*/
+  /* Check the parameters */
+  assert_param(IS_RCC_PLL(RCC_OscInitStruct->PLL.PLLState));
+
+  if(RCC_OscInitStruct->PLL.PLLState != RCC_PLL_NONE)
+  {
+    /* Check if the PLL is used as system clock or not */
+    if(__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_PLL)
+    {
+      if(RCC_OscInitStruct->PLL.PLLState == RCC_PLL_ON)
+      {
+        /* Check the parameters */
+        assert_param(IS_RCC_PLLSOURCE(RCC_OscInitStruct->PLL.PLLSource));
+        assert_param(IS_RCC_PLLM_VALUE(RCC_OscInitStruct->PLL.PLLM));
+        assert_param(IS_RCC_PLLN_VALUE(RCC_OscInitStruct->PLL.PLLN));
+        assert_param(IS_RCC_PLLP_VALUE(RCC_OscInitStruct->PLL.PLLP));
+        assert_param(IS_RCC_PLLQ_VALUE(RCC_OscInitStruct->PLL.PLLQ));
+        assert_param(IS_RCC_PLLR_VALUE(RCC_OscInitStruct->PLL.PLLR));
+
+        /* Disable the main PLL. */
+        __HAL_RCC_PLL_DISABLE();
+
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till PLL is ready */
+        while(READ_BIT(RCC->CR, RCC_CR_PLLRDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart) > PLL_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+
+        /* Configure the main PLL clock source, multiplication and division factors. */
+        __HAL_RCC_PLL_CONFIG(RCC_OscInitStruct->PLL.PLLSource,
+                             RCC_OscInitStruct->PLL.PLLM,
+                             RCC_OscInitStruct->PLL.PLLN,
+                             RCC_OscInitStruct->PLL.PLLP,
+                             RCC_OscInitStruct->PLL.PLLQ,
+                             RCC_OscInitStruct->PLL.PLLR);
+
+        /* Enable the main PLL. */
+        __HAL_RCC_PLL_ENABLE();
+
+        /* Enable PLL System Clock output. */
+         __HAL_RCC_PLLCLKOUT_ENABLE(RCC_PLL_SYSCLK);
+
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till PLL is ready */
+        while(READ_BIT(RCC->CR, RCC_CR_PLLRDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart) > PLL_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+      else
+      {
+        /* Disable the main PLL. */
+        __HAL_RCC_PLL_DISABLE();
+
+        /* Disable all PLL outputs to save power */
+        MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC, PLLSOURCE_NONE);
+        __HAL_RCC_PLLCLKOUT_DISABLE(RCC_PLL_SYSCLK | RCC_PLL_48M1CLK | RCC_PLL_SAI3CLK);
+
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till PLL is disabled */
+        while(READ_BIT(RCC->CR, RCC_CR_PLLRDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart) > PLL_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }
+    else
+    {
+      return HAL_ERROR;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initialize the CPU, AHB and APB busses clocks according to the specified
+  *         parameters in the RCC_ClkInitStruct.
+  * @param  RCC_ClkInitStruct  pointer to an RCC_OscInitTypeDef structure that
+  *         contains the configuration information for the RCC peripheral.
+  * @param  FLatency  FLASH Latency
+  *          This parameter can be one of the following values:
+  *            @arg FLASH_LATENCY_0   FLASH 0 Latency cycle
+  *            @arg FLASH_LATENCY_1   FLASH 1 Latency cycle
+  *            @arg FLASH_LATENCY_2   FLASH 2 Latency cycle
+  *            @arg FLASH_LATENCY_3   FLASH 3 Latency cycle
+  *            @arg FLASH_LATENCY_4   FLASH 4 Latency cycle
+  *
+  * @note   The SystemCoreClock CMSIS variable is used to store System Clock Frequency
+  *         and updated by HAL_RCC_GetHCLKFreq() function called within this function
+  *
+  * @note   The MSI is used by default as system clock source after
+  *         startup from Reset, wake-up from STANDBY mode. After restart from Reset,
+  *         the MSI frequency is set to its default value 4 MHz.
+  *
+  * @note   The HSI can be selected as system clock source after
+  *         from STOP modes or in case of failure of the HSE used directly or indirectly 
+  *         as system clock (if the Clock Security System CSS is enabled).
+  *
+  * @note   A switch from one clock source to another occurs only if the target
+  *         clock source is ready (clock stable after startup delay or PLL locked).
+  *         If a clock source which is not yet ready is selected, the switch will
+  *         occur when the clock source is ready.
+  *
+  * @note   You can use HAL_RCC_GetClockConfig() function to know which clock is
+  *         currently used as system clock source.
+  *
+  * @note   Depending on the device voltage range, the software has to set correctly
+  *         HPRE[3:0] bits to ensure that HCLK not exceed the maximum allowed frequency
+  *         (for more details refer to section above "Initialization/de-initialization functions")
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, uint32_t FLatency)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(RCC_ClkInitStruct != NULL);
+  assert_param(IS_RCC_CLOCKTYPE(RCC_ClkInitStruct->ClockType));
+  assert_param(IS_FLASH_LATENCY(FLatency));
+
+  /* To correctly read data from FLASH memory, the number of wait states (LATENCY)
+    must be correctly programmed according to the frequency of the CPU clock
+    (HCLK) and the supply voltage of the device. */
+
+  /* Increasing the number of wait states because of higher CPU frequency */
+  if(FLatency > (FLASH->ACR & FLASH_ACR_LATENCY))
+  {
+    /* Program the new number of wait states to the LATENCY bits in the FLASH_ACR register */
+    __HAL_FLASH_SET_LATENCY(FLatency);
+
+    /* Check that the new number of wait states is taken into account to access the Flash
+    memory by reading the FLASH_ACR register */
+    if((FLASH->ACR & FLASH_ACR_LATENCY) != FLatency)
+    {
+      return HAL_ERROR;
+    }
+  }
+
+  /*-------------------------- HCLK Configuration --------------------------*/
+  if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_HCLK) == RCC_CLOCKTYPE_HCLK)
+  {
+    assert_param(IS_RCC_HCLK(RCC_ClkInitStruct->AHBCLKDivider));
+    MODIFY_REG(RCC->CFGR, RCC_CFGR_HPRE, RCC_ClkInitStruct->AHBCLKDivider);
+  }
+
+  /*------------------------- SYSCLK Configuration ---------------------------*/
+  if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_SYSCLK) == RCC_CLOCKTYPE_SYSCLK)
+  {
+    assert_param(IS_RCC_SYSCLKSOURCE(RCC_ClkInitStruct->SYSCLKSource));
+
+    /* HSE is selected as System Clock Source */
+    if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_HSE)
+    {
+      /* Check the HSE ready flag */
+      if(READ_BIT(RCC->CR, RCC_CR_HSERDY) == RESET)
+      {
+        return HAL_ERROR;
+      }
+    }
+    /* PLL is selected as System Clock Source */
+    else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_PLLCLK)
+    {
+      /* Check the PLL ready flag */
+      if(READ_BIT(RCC->CR, RCC_CR_PLLRDY) == RESET)
+      {
+        return HAL_ERROR;
+      }
+    }
+    /* MSI is selected as System Clock Source */
+    else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_MSI)
+    {
+      /* Check the MSI ready flag */
+      if(READ_BIT(RCC->CR, RCC_CR_MSIRDY) == RESET)
+      {
+        return HAL_ERROR;
+      }
+    }
+    /* HSI is selected as System Clock Source */
+    else
+    {
+      /* Check the HSI ready flag */
+      if(READ_BIT(RCC->CR, RCC_CR_HSIRDY) == RESET)
+      {
+        return HAL_ERROR;
+      }
+    }
+    MODIFY_REG(RCC->CFGR, RCC_CFGR_SW, RCC_ClkInitStruct->SYSCLKSource);
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_HSE)
+    {
+      while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_HSE)
+      {
+        if((HAL_GetTick() - tickstart) > CLOCKSWITCH_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_PLLCLK)
+    {
+      while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_PLL)
+      {
+        if((HAL_GetTick() - tickstart) > CLOCKSWITCH_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_MSI)
+    {
+      while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_MSI)
+      {
+        if((HAL_GetTick() - tickstart) > CLOCKSWITCH_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    else
+    {
+      while(__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_HSI)
+      {
+        if((HAL_GetTick() - tickstart) > CLOCKSWITCH_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  
+  /* Decreasing the number of wait states because of lower CPU frequency */
+  if(FLatency < (FLASH->ACR & FLASH_ACR_LATENCY))
+  {
+    /* Program the new number of wait states to the LATENCY bits in the FLASH_ACR register */
+    __HAL_FLASH_SET_LATENCY(FLatency);
+
+    /* Check that the new number of wait states is taken into account to access the Flash
+    memory by reading the FLASH_ACR register */
+    if((FLASH->ACR & FLASH_ACR_LATENCY) != FLatency)
+    {
+      return HAL_ERROR;
+    }
+  }
+  
+  /*-------------------------- PCLK1 Configuration ---------------------------*/
+  if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_PCLK1) == RCC_CLOCKTYPE_PCLK1)
+  {
+    assert_param(IS_RCC_PCLK(RCC_ClkInitStruct->APB1CLKDivider));
+    MODIFY_REG(RCC->CFGR, RCC_CFGR_PPRE1, RCC_ClkInitStruct->APB1CLKDivider);
+  }
+
+  /*-------------------------- PCLK2 Configuration ---------------------------*/
+  if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_PCLK2) == RCC_CLOCKTYPE_PCLK2)
+  {
+    assert_param(IS_RCC_PCLK(RCC_ClkInitStruct->APB2CLKDivider));
+    MODIFY_REG(RCC->CFGR, RCC_CFGR_PPRE2, ((RCC_ClkInitStruct->APB2CLKDivider) << 3U));
+  }
+
+  /* Update the SystemCoreClock global variable */
+  SystemCoreClock = HAL_RCC_GetSysClockFreq() >> AHBPrescTable[(RCC->CFGR & RCC_CFGR_HPRE)>> POSITION_VAL(RCC_CFGR_HPRE)];
+
+  /* Configure the source of time base considering new system clocks settings*/
+  HAL_InitTick (TICK_INT_PRIORITY);
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Exported_Functions_Group2 Peripheral Control functions 
+ *  @brief   RCC clocks control functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to:
+    
+    (+) Ouput clock to MCO pin.
+    (+) Retrieve current clock frequencies.
+    (+) Enable the Clock Security System.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Select the clock source to output on MCO pin(PA8).
+  * @note   PA8 should be configured in alternate function mode.
+  * @param  RCC_MCOx  specifies the output direction for the clock source.
+  *          For STM32L4xx family this parameter can have only one value:
+  *            @arg @ref RCC_MCO1  Clock source to output on MCO1 pin(PA8).
+  * @param  RCC_MCOSource  specifies the clock source to output.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_MCO1SOURCE_NOCLOCK  MCO output disabled, no clock on MCO
+  *            @arg @ref RCC_MCO1SOURCE_SYSCLK  system  clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_MSI  MSI clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_HSI  HSI clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_HSE  HSE clock selected as MCO sourcee
+  *            @arg @ref RCC_MCO1SOURCE_PLLCLK  main PLL clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_LSI  LSI clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_LSE  LSE clock selected as MCO source
+  * @param  RCC_MCODiv  specifies the MCO prescaler.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_MCODIV_1  no division applied to MCO clock
+  *            @arg @ref RCC_MCODIV_2  division by 2 applied to MCO clock
+  *            @arg @ref RCC_MCODIV_4  division by 4 applied to MCO clock
+  *            @arg @ref RCC_MCODIV_8  division by 8 applied to MCO clock
+  *            @arg @ref RCC_MCODIV_16  division by 16 applied to MCO clock
+  * @retval None
+  */
+void HAL_RCC_MCOConfig( uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_MCODiv)
+{
+  GPIO_InitTypeDef GPIO_InitStruct;
+  /* Check the parameters */
+  assert_param(IS_RCC_MCO(RCC_MCOx));
+  assert_param(IS_RCC_MCODIV(RCC_MCODiv));
+  assert_param(IS_RCC_MCO1SOURCE(RCC_MCOSource));
+
+  /* MCO Clock Enable */
+  __MCO1_CLK_ENABLE();
+
+  /* Configue the MCO1 pin in alternate function mode */
+  GPIO_InitStruct.Pin = MCO1_PIN;
+  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  GPIO_InitStruct.Alternate = GPIO_AF0_MCO;
+  HAL_GPIO_Init(MCO1_GPIO_PORT, &GPIO_InitStruct);
+
+  /* Mask MCOSEL[] and MCOPRE[] bits then set MCO1 clock source and prescaler */
+  MODIFY_REG(RCC->CFGR, (RCC_CFGR_MCOSEL | RCC_CFGR_MCOPRE), (RCC_MCOSource | RCC_MCODiv ));
+}
+
+/**
+  * @brief  Return the SYSCLK frequency.
+  *
+  * @note   The system frequency computed by this function is not the real
+  *         frequency in the chip. It is calculated based on the predefined
+  *         constant and the selected clock source:
+  * @note     If SYSCLK source is MSI, function returns values based on MSI
+  *             Value as defined by the MSI range.
+  * @note     If SYSCLK source is HSI, function returns values based on HSI_VALUE(*)
+  * @note     If SYSCLK source is HSE, function returns values based on HSE_VALUE(**)
+  * @note     If SYSCLK source is PLL, function returns values based on HSE_VALUE(**),
+  *           HSI_VALUE(*) or MSI Value multiplied/divided by the PLL factors.
+  * @note     (*) HSI_VALUE is a constant defined in stm32l4xx_hal_conf.h file (default value
+  *               16 MHz) but the real value may vary depending on the variations
+  *               in voltage and temperature.
+  * @note     (**) HSE_VALUE is a constant defined in stm32l4xx_hal_conf.h file (default value
+  *                8 MHz), user has to ensure that HSE_VALUE is same as the real
+  *                frequency of the crystal used. Otherwise, this function may
+  *                have wrong result.
+  *
+  * @note   The result of this function could be not correct when using fractional
+  *         value for HSE crystal.
+  *
+  * @note   This function can be used by the user application to compute the
+  *         baudrate for the communication peripherals or configure other parameters.
+  *
+  * @note   Each time SYSCLK changes, this function must be called to update the
+  *         right SYSCLK value. Otherwise, any configuration based on this function will be incorrect.
+  *
+  *
+  * @retval SYSCLK frequency
+  */
+uint32_t HAL_RCC_GetSysClockFreq(void)
+{
+  uint32_t msirange = 0U, pllvco = 0U, pllsource = 0U, pllr = 2U, pllm = 2U;
+  uint32_t sysclockfreq = 0U;
+
+  if((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_MSI) ||
+     ((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_PLL) && (__HAL_RCC_GET_PLL_OSCSOURCE() == RCC_PLLSOURCE_MSI)))
+  {
+    /* MSI or PLL with MSI source used as system clock source */
+
+    /* Get SYSCLK source */
+    if(READ_BIT(RCC->CR, RCC_CR_MSIRGSEL) == RESET)
+    { /* MSISRANGE from RCC_CSR applies */
+      msirange = (RCC->CSR & RCC_CSR_MSISRANGE) >> POSITION_VAL(RCC_CSR_MSISRANGE);
+    }
+    else
+    { /* MSIRANGE from RCC_CR applies */
+      msirange = (RCC->CR & RCC_CR_MSIRANGE) >> POSITION_VAL(RCC_CR_MSIRANGE);
+    }
+    /*MSI frequency range in HZ*/
+    msirange = MSIRangeTable[msirange];
+
+    if(__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_MSI)
+    {
+      /* MSI used as system clock source */
+      sysclockfreq = msirange;
+    }
+  }
+  else if(__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_HSI)
+  {
+    /* HSI used as system clock source */
+    sysclockfreq = HSI_VALUE;
+  }
+  else if(__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_HSE)
+  {
+    /* HSE used as system clock source */
+    sysclockfreq = HSE_VALUE;
+  }
+
+  if(__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_PLL)
+  {
+    /* PLL used as system clock  source */
+
+    /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI_VALUE/ PLLM) * PLLN
+    SYSCLK = PLL_VCO / PLLR
+    */
+    pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC);
+    pllm = ((RCC->PLLCFGR & RCC_PLLCFGR_PLLM) >> POSITION_VAL(RCC_PLLCFGR_PLLM)) + 1U ;
+
+    switch (pllsource)
+    {
+    case RCC_PLLSOURCE_HSI:  /* HSI used as PLL clock source */
+      pllvco = (HSI_VALUE / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> POSITION_VAL(RCC_PLLCFGR_PLLN));
+      break;
+
+    case RCC_PLLSOURCE_HSE:  /* HSE used as PLL clock source */
+      pllvco = (HSE_VALUE / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> POSITION_VAL(RCC_PLLCFGR_PLLN));
+      break;
+
+    case RCC_PLLSOURCE_MSI:  /* MSI used as PLL clock source */
+    default:
+      pllvco = (msirange / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> POSITION_VAL(RCC_PLLCFGR_PLLN));
+      break;
+    }
+    pllr = (((RCC->PLLCFGR & RCC_PLLCFGR_PLLR) >> POSITION_VAL(RCC_PLLCFGR_PLLR)) + 1U ) * 2U;
+    sysclockfreq = pllvco/pllr;
+  }
+
+  return sysclockfreq;
+}
+
+/**
+  * @brief  Return the HCLK frequency.
+  * @note   Each time HCLK changes, this function must be called to update the
+  *         right HCLK value. Otherwise, any configuration based on this function will be incorrect.
+  *
+  * @note   The SystemCoreClock CMSIS variable is used to store System Clock Frequency.
+  * @retval HCLK frequency in Hz
+  */
+uint32_t HAL_RCC_GetHCLKFreq(void)
+{
+  return SystemCoreClock;
+}
+
+/**
+  * @brief  Return the PCLK1 frequency.
+  * @note   Each time PCLK1 changes, this function must be called to update the
+  *         right PCLK1 value. Otherwise, any configuration based on this function will be incorrect.
+  * @retval PCLK1 frequency in Hz
+  */
+uint32_t HAL_RCC_GetPCLK1Freq(void)
+{
+  /* Get HCLK source and Compute PCLK1 frequency ---------------------------*/
+  return (HAL_RCC_GetHCLKFreq() >> APBPrescTable[(RCC->CFGR & RCC_CFGR_PPRE1)>> POSITION_VAL(RCC_CFGR_PPRE1)]);
+}
+
+/**
+  * @brief  Return the PCLK2 frequency.
+  * @note   Each time PCLK2 changes, this function must be called to update the
+  *         right PCLK2 value. Otherwise, any configuration based on this function will be incorrect.
+  * @retval PCLK2 frequency in Hz
+  */
+uint32_t HAL_RCC_GetPCLK2Freq(void)
+{
+  /* Get HCLK source and Compute PCLK2 frequency ---------------------------*/
+  return (HAL_RCC_GetHCLKFreq()>> APBPrescTable[(RCC->CFGR & RCC_CFGR_PPRE2)>> POSITION_VAL(RCC_CFGR_PPRE2)]);
+}
+
+/**
+  * @brief  Configure the RCC_OscInitStruct according to the internal
+  *         RCC configuration registers.
+  * @param  RCC_OscInitStruct  pointer to an RCC_OscInitTypeDef structure that
+  *         will be configured.
+  * @retval None
+  */
+void HAL_RCC_GetOscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
+{
+  /* Check the parameters */
+  assert_param(RCC_OscInitStruct != NULL);
+
+  /* Set all possible values for the Oscillator type parameter ---------------*/
+  RCC_OscInitStruct->OscillatorType = RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_MSI | \
+                                      RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_LSI;
+
+  /* Get the HSE configuration -----------------------------------------------*/
+  if((RCC->CR & RCC_CR_HSEBYP) == RCC_CR_HSEBYP)
+  {
+    RCC_OscInitStruct->HSEState = RCC_HSE_BYPASS;
+  }
+  else if((RCC->CR & RCC_CR_HSEON) == RCC_CR_HSEON)
+  {
+    RCC_OscInitStruct->HSEState = RCC_HSE_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->HSEState = RCC_HSE_OFF;
+  }
+
+   /* Get the MSI configuration -----------------------------------------------*/
+  if((RCC->CR & RCC_CR_MSION) == RCC_CR_MSION)
+  {
+    RCC_OscInitStruct->MSIState = RCC_MSI_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->MSIState = RCC_MSI_OFF;
+  }
+
+  RCC_OscInitStruct->MSICalibrationValue = (uint32_t)((RCC->CR & RCC_ICSCR_MSITRIM) >> POSITION_VAL(RCC_ICSCR_MSITRIM));
+  RCC_OscInitStruct->MSIClockRange = (uint32_t)((RCC->CR & RCC_CR_MSIRANGE) );
+
+  /* Get the HSI configuration -----------------------------------------------*/
+  if((RCC->CR & RCC_CR_HSION) == RCC_CR_HSION)
+  {
+    RCC_OscInitStruct->HSIState = RCC_HSI_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->HSIState = RCC_HSI_OFF;
+  }
+
+  RCC_OscInitStruct->HSICalibrationValue = (uint32_t)((RCC->ICSCR & RCC_ICSCR_HSITRIM) >> POSITION_VAL(RCC_ICSCR_HSITRIM));
+
+  /* Get the LSE configuration -----------------------------------------------*/
+  if((RCC->BDCR & RCC_BDCR_LSEBYP) == RCC_BDCR_LSEBYP)
+  {
+    RCC_OscInitStruct->LSEState = RCC_LSE_BYPASS;
+  }
+  else if((RCC->BDCR & RCC_BDCR_LSEON) == RCC_BDCR_LSEON)
+  {
+    RCC_OscInitStruct->LSEState = RCC_LSE_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->LSEState = RCC_LSE_OFF;
+  }
+
+  /* Get the LSI configuration -----------------------------------------------*/
+  if((RCC->CSR & RCC_CSR_LSION) == RCC_CSR_LSION)
+  {
+    RCC_OscInitStruct->LSIState = RCC_LSI_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->LSIState = RCC_LSI_OFF;
+  }
+
+  /* Get the PLL configuration -----------------------------------------------*/
+  if((RCC->CR & RCC_CR_PLLON) == RCC_CR_PLLON)
+  {
+    RCC_OscInitStruct->PLL.PLLState = RCC_PLL_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->PLL.PLLState = RCC_PLL_OFF;
+  }
+  RCC_OscInitStruct->PLL.PLLSource = (uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC);
+  RCC_OscInitStruct->PLL.PLLM = (uint32_t)(((RCC->PLLCFGR & RCC_PLLCFGR_PLLM) >> POSITION_VAL(RCC_PLLCFGR_PLLM)) + 1U);
+  RCC_OscInitStruct->PLL.PLLN = (uint32_t)((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> POSITION_VAL(RCC_PLLCFGR_PLLN));
+  RCC_OscInitStruct->PLL.PLLQ = (uint32_t)((((RCC->PLLCFGR & RCC_PLLCFGR_PLLQ) >> POSITION_VAL(RCC_PLLCFGR_PLLQ)) + 1U) << 1U);
+  RCC_OscInitStruct->PLL.PLLR = (uint32_t)((((RCC->PLLCFGR & RCC_PLLCFGR_PLLR) >> POSITION_VAL(RCC_PLLCFGR_PLLR)) + 1U) << 1U);
+  if((RCC->PLLCFGR & RCC_PLLCFGR_PLLP) != RESET)
+  {
+    RCC_OscInitStruct->PLL.PLLP = RCC_PLLP_DIV17;
+  }
+  else
+  {
+    RCC_OscInitStruct->PLL.PLLP = RCC_PLLP_DIV7;
+  }
+}
+
+/**
+  * @brief  Configure the RCC_ClkInitStruct according to the internal
+  *         RCC configuration registers.
+  * @param  RCC_ClkInitStruct  pointer to an RCC_ClkInitTypeDef structure that
+  *         will be configured.
+  * @param  pFLatency  Pointer on the Flash Latency.
+  * @retval None
+  */
+void HAL_RCC_GetClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, uint32_t *pFLatency)
+{
+  /* Check the parameters */
+  assert_param(RCC_ClkInitStruct != NULL);
+  assert_param(pFLatency != NULL);
+
+  /* Set all possible values for the Clock type parameter --------------------*/
+  RCC_ClkInitStruct->ClockType = RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+
+  /* Get the SYSCLK configuration --------------------------------------------*/
+  RCC_ClkInitStruct->SYSCLKSource = (uint32_t)(RCC->CFGR & RCC_CFGR_SW);
+
+  /* Get the HCLK configuration ----------------------------------------------*/
+  RCC_ClkInitStruct->AHBCLKDivider = (uint32_t)(RCC->CFGR & RCC_CFGR_HPRE);
+
+  /* Get the APB1 configuration ----------------------------------------------*/
+  RCC_ClkInitStruct->APB1CLKDivider = (uint32_t)(RCC->CFGR & RCC_CFGR_PPRE1);
+
+  /* Get the APB2 configuration ----------------------------------------------*/
+  RCC_ClkInitStruct->APB2CLKDivider = (uint32_t)((RCC->CFGR & RCC_CFGR_PPRE2) >> 3U);
+
+  /* Get the Flash Wait State (Latency) configuration ------------------------*/
+  *pFLatency = (uint32_t)(FLASH->ACR & FLASH_ACR_LATENCY);
+}
+
+/**
+  * @brief  Enable the Clock Security System.
+  * @note   If a failure is detected on the HSE oscillator clock, this oscillator
+  *         is automatically disabled and an interrupt is generated to inform the
+  *         software about the failure (Clock Security System Interrupt, CSSI),
+  *         allowing the MCU to perform rescue operations. The CSSI is linked to
+  *         the Cortex-M4 NMI (Non-Maskable Interrupt) exception vector.
+  * @note   The Clock Security System can only be cleared by reset.
+  * @retval None
+  */
+void HAL_RCC_EnableCSS(void)
+{
+  SET_BIT(RCC->CR, RCC_CR_CSSON) ;
+}
+
+/**
+  * @brief Handle the RCC Clock Security System interrupt request.
+  * @note This API should be called under the NMI_Handler().
+  * @retval None
+  */
+void HAL_RCC_NMI_IRQHandler(void)
+{
+  /* Check RCC CSSF interrupt flag  */
+  if(__HAL_RCC_GET_IT(RCC_IT_CSS))
+  {
+    /* RCC Clock Security System interrupt user callback */
+    HAL_RCC_CSSCallback();
+
+    /* Clear RCC CSS pending bit */
+    __HAL_RCC_CLEAR_IT(RCC_IT_CSS);
+  }
+}
+
+/**
+  * @brief  RCC Clock Security System interrupt callback.
+  * @retval none
+  */
+__weak void HAL_RCC_CSSCallback(void)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_RCC_CSSCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private function prototypes -----------------------------------------------*/
+/** @addtogroup RCC_Private_Functions
+  * @{
+  */
+/**
+  * @brief  Update number of Flash wait states in line with MSI range and current 
+            voltage range.
+  * @param  msirange  MSI range value from RCC_MSIRANGE_0 to RCC_MSIRANGE_11
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef RCC_SetFlashLatencyFromMSIRange(uint32_t msirange)
+{
+  uint32_t vos = 0;
+  uint32_t latency = FLASH_LATENCY_0;  /* default value 0WS */
+  
+  if(__HAL_RCC_PWR_IS_CLK_ENABLED())
+  {
+    vos = HAL_PWREx_GetVoltageRange();
+  }
+  else
+  {
+    __HAL_RCC_PWR_CLK_ENABLE();
+    vos = HAL_PWREx_GetVoltageRange();
+    __HAL_RCC_PWR_CLK_DISABLE();
+  }
+  
+  if(vos == PWR_REGULATOR_VOLTAGE_SCALE1)
+  {
+    if(msirange > RCC_MSIRANGE_8)
+    {
+      /* MSI > 16Mhz */
+      if(msirange > RCC_MSIRANGE_10)
+      {
+        /* MSI 48Mhz */
+        latency = FLASH_LATENCY_2; /* 2WS */
+      }
+      else
+      {
+        /* MSI 24Mhz or 32Mhz */
+        latency = FLASH_LATENCY_1; /* 1WS */
+      }
+    }
+    /* else MSI <= 16Mhz default FLASH_LATENCY_0 0WS */
+  }
+  else
+  {
+    if(msirange > RCC_MSIRANGE_8)
+    {
+      /* MSI > 16Mhz */
+      latency = FLASH_LATENCY_3; /* 3WS */
+    }
+    else
+    {
+      if(msirange == RCC_MSIRANGE_8)
+      {
+        /* MSI 16Mhz */
+        latency = FLASH_LATENCY_2; /* 2WS */
+      }
+      else if(msirange == RCC_MSIRANGE_7) 
+      {
+        /* MSI 8Mhz */
+        latency = FLASH_LATENCY_1; /* 1WS */
+      }
+      /* else MSI < 8Mhz default FLASH_LATENCY_0 0WS */
+    }
+  }
+       
+  __HAL_FLASH_SET_LATENCY(latency);
+  
+  /* Check that the new number of wait states is taken into account to access the Flash
+     memory by reading the FLASH_ACR register */
+  if((FLASH->ACR & FLASH_ACR_LATENCY) != latency)
+  {
+    return HAL_ERROR;
+  }
+  
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RCC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_rcc_ex.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_rcc_ex.c
@@ -1,0 +1,2009 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_rcc_ex.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Extended RCC HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities RCC extended peripheral:
+  *           + Extended Peripheral Control functions
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RCCEx RCCEx
+  * @brief RCC Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/
+/** @defgroup RCCEx_Private_Constants RCCEx Private Constants
+ * @{
+ */
+#define PLLSAI1_TIMEOUT_VALUE    ((uint32_t)2U)    /* 2 ms (minimum Tick + 1) */
+#define PLLSAI2_TIMEOUT_VALUE    ((uint32_t)2U)    /* 2 ms (minimum Tick + 1) */
+#define PLL_TIMEOUT_VALUE        ((uint32_t)2U)    /* 2 ms (minimum Tick + 1) */
+
+#define __LSCO_CLK_ENABLE()   __HAL_RCC_GPIOA_CLK_ENABLE()
+#define LSCO_GPIO_PORT        GPIOA
+#define LSCO_PIN              GPIO_PIN_2
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @defgroup RCCEx_Private_Functions RCCEx Private Functions
+ * @{
+ */
+static HAL_StatusTypeDef RCCEx_PLLSAI1_ConfigNP(RCC_PLLSAI1InitTypeDef *PllSai1);
+static HAL_StatusTypeDef RCCEx_PLLSAI1_ConfigNQ(RCC_PLLSAI1InitTypeDef *PllSai1);
+static HAL_StatusTypeDef RCCEx_PLLSAI1_ConfigNR(RCC_PLLSAI1InitTypeDef *PllSai1);
+static HAL_StatusTypeDef RCCEx_PLLSAI2_ConfigNP(RCC_PLLSAI2InitTypeDef *PllSai2);
+static HAL_StatusTypeDef RCCEx_PLLSAI2_ConfigNR(RCC_PLLSAI2InitTypeDef *PllSai2);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup RCCEx_Exported_Functions RCCEx Exported Functions
+  * @{
+  */
+
+/** @defgroup RCCEx_Exported_Functions_Group1 Extended Peripheral Control functions 
+ *  @brief  Extended Peripheral Control functions
+ *
+@verbatim
+ ===============================================================================
+                ##### Extended Peripheral Control functions  #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the RCC Clocks
+    frequencies.
+    [..]
+    (@) Important note: Care must be taken when HAL_RCCEx_PeriphCLKConfig() is used to
+        select the RTC clock source; in this case the Backup domain will be reset in
+        order to modify the RTC Clock source, as consequence RTC registers (including
+        the backup registers) and RCC_BDCR register are set to their reset values.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initialize the RCC extended peripherals clocks according to the specified
+  *         parameters in the RCC_PeriphCLKInitTypeDef.
+  * @param  PeriphClkInit  pointer to an RCC_PeriphCLKInitTypeDef structure that
+  *         contains a field PeriphClockSelection which can be a combination of the following values:
+  *            @arg @ref RCC_PERIPHCLK_RTC  RTC peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_ADC  ADC peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_DFSDM  DFSDM peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_I2C1  I2C1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_I2C2  I2C2 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_I2C3  I2C3 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_LPTIM1  LPTIM1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_LPTIM2  LPTIM2 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_LPUART1  LPUART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_RNG  RNG peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_SAI1  SAI1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_SAI2  SAI2 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_SDMMC1  SDMMC1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_SWPMI1  SWPMI1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_USART1  USART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_USART2  USART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_USART3  USART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_UART4  USART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_UART5  USART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_USB  USB peripheral clock (only for devices with USB)
+  *
+  * @note   Care must be taken when HAL_RCCEx_PeriphCLKConfig() is used to select
+  *         the RTC clock source: in this case the access to Backup domain is enabled.
+  *
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
+{
+  uint32_t tmpregister = 0;
+  uint32_t tickstart = 0U;
+  HAL_StatusTypeDef ret = HAL_OK;      /* Intermediate status */
+  HAL_StatusTypeDef status = HAL_OK;   /* Final status */
+
+  /* Check the parameters */
+  assert_param(IS_RCC_PERIPHCLOCK(PeriphClkInit->PeriphClockSelection));
+
+  /*-------------------------- SAI1 clock source configuration ---------------------*/
+  if((((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SAI1) == RCC_PERIPHCLK_SAI1))
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_SAI1CLK(PeriphClkInit->Sai1ClockSelection));
+
+    switch(PeriphClkInit->Sai1ClockSelection)
+    {
+    case RCC_SAI1CLKSOURCE_PLL:      /* PLL is used as clock source for SAI1*/
+      /* Enable SAI Clock output generated form System PLL . */
+      __HAL_RCC_PLLCLKOUT_ENABLE(RCC_PLL_SAI3CLK);
+      /* SAI1 clock source config set later after clock selection check */
+      break;
+
+    case RCC_SAI1CLKSOURCE_PLLSAI1: /* PLLSAI1 is used as clock source for SAI1*/
+      /* PLLSAI1 parameters N & P configuration and clock output (PLLSAI1ClockOut) */
+      ret = RCCEx_PLLSAI1_ConfigNP(&(PeriphClkInit->PLLSAI1));
+      /* SAI1 clock source config set later after clock selection check */
+      break;
+
+    case RCC_SAI1CLKSOURCE_PLLSAI2:  /* PLLSAI2 is used as clock source for SAI1*/
+      /* PLLSAI2 parameters N & P configuration and clock output (PLLSAI2ClockOut) */
+      ret = RCCEx_PLLSAI2_ConfigNP(&(PeriphClkInit->PLLSAI2));
+      /* SAI1 clock source config set later after clock selection check */
+      break;
+
+    case RCC_SAI1CLKSOURCE_PIN:      /* External clock is used as source of SAI1 clock*/
+      /* SAI1 clock source config set later after clock selection check */
+      break;
+
+    default:
+      ret = HAL_ERROR;
+      break;
+    }
+
+    if(ret == HAL_OK)
+    {
+      /* Set the source of SAI1 clock*/
+      __HAL_RCC_SAI1_CONFIG(PeriphClkInit->Sai1ClockSelection);
+    }
+    else
+    {
+      /* set overall return value */
+      status = ret;
+    }
+  }
+
+  /*-------------------------- SAI2 clock source configuration ---------------------*/
+  if((((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SAI2) == RCC_PERIPHCLK_SAI2))
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_SAI2CLK(PeriphClkInit->Sai2ClockSelection));
+
+    switch(PeriphClkInit->Sai2ClockSelection)
+    {
+    case RCC_SAI2CLKSOURCE_PLL:      /* PLL is used as clock source for SAI2*/
+      /* Enable SAI Clock output generated form System PLL . */
+      __HAL_RCC_PLLCLKOUT_ENABLE(RCC_PLL_SAI3CLK);
+      /* SAI2 clock source config set later after clock selection check */
+      break;
+
+    case RCC_SAI2CLKSOURCE_PLLSAI1: /* PLLSAI1 is used as clock source for SAI2*/
+      /* PLLSAI1 parameters N & P configuration and clock output (PLLSAI1ClockOut) */
+      ret = RCCEx_PLLSAI1_ConfigNP(&(PeriphClkInit->PLLSAI1));
+      /* SAI2 clock source config set later after clock selection check */
+      break;
+
+    case RCC_SAI2CLKSOURCE_PLLSAI2:  /* PLLSAI2 is used as clock source for SAI2*/
+      /* PLLSAI2 parameters N & P configuration and clock output (PLLSAI2ClockOut) */
+      ret = RCCEx_PLLSAI2_ConfigNP(&(PeriphClkInit->PLLSAI2));
+      /* SAI2 clock source config set later after clock selection check */
+      break;
+
+    case RCC_SAI2CLKSOURCE_PIN:      /* External clock is used as source of SAI2 clock*/
+      /* SAI2 clock source config set later after clock selection check */
+      break;
+
+    default:
+      ret = HAL_ERROR;
+      break;
+    }
+
+    if(ret == HAL_OK)
+    {
+      /* Set the source of SAI2 clock*/
+      __HAL_RCC_SAI2_CONFIG(PeriphClkInit->Sai2ClockSelection);
+    }
+    else
+    {
+      /* set overall return value */
+      status = ret;
+    }
+  }
+
+  /*-------------------------- RTC clock source configuration ----------------------*/
+  if((PeriphClkInit->PeriphClockSelection & RCC_PERIPHCLK_RTC) == RCC_PERIPHCLK_RTC)
+  {
+    FlagStatus       pwrclkchanged = RESET;
+    
+    /* Check for RTC Parameters used to output RTCCLK */
+    assert_param(IS_RCC_RTCCLKSOURCE(PeriphClkInit->RTCClockSelection));
+
+    /* Enable Power Clock */
+    if(__HAL_RCC_PWR_IS_CLK_DISABLED())
+    {
+      __HAL_RCC_PWR_CLK_ENABLE();
+      pwrclkchanged = SET;
+    }
+      
+    /* Enable write access to Backup domain */
+    SET_BIT(PWR->CR1, PWR_CR1_DBP);
+
+    /* Wait for Backup domain Write protection disable */
+    tickstart = HAL_GetTick();
+
+    while((PWR->CR1 & PWR_CR1_DBP) == RESET)
+    {
+      if((HAL_GetTick() - tickstart) > RCC_DBP_TIMEOUT_VALUE)
+      {
+        ret = HAL_TIMEOUT;
+        break;
+      }
+    }
+
+    if(ret == HAL_OK)
+    { 
+      /* Reset the Backup domain only if the RTC Clock source selection is modified */
+      if(READ_BIT(RCC->BDCR, RCC_BDCR_RTCSEL) != PeriphClkInit->RTCClockSelection)
+      {
+        /* Store the content of BDCR register before the reset of Backup Domain */
+        tmpregister = READ_BIT(RCC->BDCR, ~(RCC_BDCR_RTCSEL));
+        /* RTC Clock selection can be changed only if the Backup Domain is reset */
+        __HAL_RCC_BACKUPRESET_FORCE();
+        __HAL_RCC_BACKUPRESET_RELEASE();
+        /* Restore the Content of BDCR register */
+        RCC->BDCR = tmpregister;
+      }
+
+      /* Wait for LSE reactivation if LSE was enable prior to Backup Domain reset */
+      if (HAL_IS_BIT_SET(tmpregister, RCC_BDCR_LSERDY))
+      {
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+
+        /* Wait till LSE is ready */
+        while(READ_BIT(RCC->BDCR, RCC_BDCR_LSERDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart) > RCC_LSE_TIMEOUT_VALUE)
+          {
+            ret = HAL_TIMEOUT;
+            break;
+          }
+        }
+      }
+      
+      if(ret == HAL_OK)
+      {
+        /* Apply new RTC clock source selection */
+        __HAL_RCC_RTC_CONFIG(PeriphClkInit->RTCClockSelection);
+      }
+      else
+      {
+        /* set overall return value */
+        status = ret;
+      }
+    }
+    else
+    {
+      /* set overall return value */
+      status = ret;
+    }
+
+    /* Restore clock configuration if changed */
+    if(pwrclkchanged == SET)
+    {
+      __HAL_RCC_PWR_CLK_DISABLE();
+    }
+  }
+
+  /*-------------------------- USART1 clock source configuration -------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USART1) == RCC_PERIPHCLK_USART1)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_USART1CLKSOURCE(PeriphClkInit->Usart1ClockSelection));
+
+    /* Configure the USART1 clock source */
+    __HAL_RCC_USART1_CONFIG(PeriphClkInit->Usart1ClockSelection);
+  }
+
+  /*-------------------------- USART2 clock source configuration -------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USART2) == RCC_PERIPHCLK_USART2)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_USART2CLKSOURCE(PeriphClkInit->Usart2ClockSelection));
+
+    /* Configure the USART2 clock source */
+    __HAL_RCC_USART2_CONFIG(PeriphClkInit->Usart2ClockSelection);
+  }
+
+  /*-------------------------- USART3 clock source configuration -------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USART3) == RCC_PERIPHCLK_USART3)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_USART3CLKSOURCE(PeriphClkInit->Usart3ClockSelection));
+
+    /* Configure the USART3 clock source */
+    __HAL_RCC_USART3_CONFIG(PeriphClkInit->Usart3ClockSelection);
+  }
+
+  /*-------------------------- UART4 clock source configuration --------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_UART4) == RCC_PERIPHCLK_UART4)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_UART4CLKSOURCE(PeriphClkInit->Uart4ClockSelection));
+
+    /* Configure the UART4 clock source */
+    __HAL_RCC_UART4_CONFIG(PeriphClkInit->Uart4ClockSelection);
+  }
+
+  /*-------------------------- UART5 clock source configuration --------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_UART5) == RCC_PERIPHCLK_UART5)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_UART5CLKSOURCE(PeriphClkInit->Uart5ClockSelection));
+
+    /* Configure the UART5 clock source */
+    __HAL_RCC_UART5_CONFIG(PeriphClkInit->Uart5ClockSelection);
+  }
+
+  /*-------------------------- LPUART1 clock source configuration ------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LPUART1) == RCC_PERIPHCLK_LPUART1)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_LPUART1CLKSOURCE(PeriphClkInit->Lpuart1ClockSelection));
+
+    /* Configure the LPUAR1 clock source */
+    __HAL_RCC_LPUART1_CONFIG(PeriphClkInit->Lpuart1ClockSelection);
+  }
+
+  /*-------------------------- LPTIM1 clock source configuration -------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LPTIM1) == (RCC_PERIPHCLK_LPTIM1))
+  {
+    assert_param(IS_RCC_LPTIM1CLK(PeriphClkInit->Lptim1ClockSelection));
+    __HAL_RCC_LPTIM1_CONFIG(PeriphClkInit->Lptim1ClockSelection);
+  }
+
+  /*-------------------------- LPTIM2 clock source configuration -------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LPTIM2) == (RCC_PERIPHCLK_LPTIM2))
+  {
+    assert_param(IS_RCC_LPTIM2CLK(PeriphClkInit->Lptim2ClockSelection));
+    __HAL_RCC_LPTIM2_CONFIG(PeriphClkInit->Lptim2ClockSelection);
+  }
+
+  /*-------------------------- I2C1 clock source configuration ---------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2C1) == RCC_PERIPHCLK_I2C1)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_I2C1CLKSOURCE(PeriphClkInit->I2c1ClockSelection));
+
+    /* Configure the I2C1 clock source */
+    __HAL_RCC_I2C1_CONFIG(PeriphClkInit->I2c1ClockSelection);
+  }
+
+  /*-------------------------- I2C2 clock source configuration ---------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2C2) == RCC_PERIPHCLK_I2C2)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_I2C2CLKSOURCE(PeriphClkInit->I2c2ClockSelection));
+
+    /* Configure the I2C2 clock source */
+    __HAL_RCC_I2C2_CONFIG(PeriphClkInit->I2c2ClockSelection);
+  }
+
+  /*-------------------------- I2C3 clock source configuration ---------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2C3) == RCC_PERIPHCLK_I2C3)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_I2C3CLKSOURCE(PeriphClkInit->I2c3ClockSelection));
+
+    /* Configure the I2C3 clock source */
+    __HAL_RCC_I2C3_CONFIG(PeriphClkInit->I2c3ClockSelection);
+  }
+
+#if defined(USB_OTG_FS)
+
+  /*-------------------------- USB clock source configuration ----------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USB) == (RCC_PERIPHCLK_USB))
+  {
+    assert_param(IS_RCC_USBCLKSOURCE(PeriphClkInit->UsbClockSelection));
+    __HAL_RCC_USB_CONFIG(PeriphClkInit->UsbClockSelection);
+
+    if(PeriphClkInit->UsbClockSelection == RCC_USBCLKSOURCE_PLL)
+    {
+      /* Enable PLL48M1CLK output */
+      __HAL_RCC_PLLCLKOUT_ENABLE(RCC_PLL_48M1CLK);
+    }
+    else if(PeriphClkInit->UsbClockSelection == RCC_USBCLKSOURCE_PLLSAI1)
+    {
+      /* PLLSAI1 parameters N & Q configuration and clock output (PLLSAI1ClockOut) */
+      ret = RCCEx_PLLSAI1_ConfigNQ(&(PeriphClkInit->PLLSAI1));
+      
+      if(ret != HAL_OK)
+      {
+        /* set overall return value */
+        status = ret;
+      }
+    }
+  }
+
+#endif /* USB_OTG_FS */
+
+  /*-------------------------- SDMMC1 clock source configuration -------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SDMMC1) == (RCC_PERIPHCLK_SDMMC1))
+  {
+    assert_param(IS_RCC_SDMMC1CLKSOURCE(PeriphClkInit->Sdmmc1ClockSelection));
+    __HAL_RCC_SDMMC1_CONFIG(PeriphClkInit->Sdmmc1ClockSelection);
+    
+    if(PeriphClkInit->Sdmmc1ClockSelection == RCC_SDMMC1CLKSOURCE_PLL)
+    {
+      /* Enable PLL48M1CLK output */
+      __HAL_RCC_PLLCLKOUT_ENABLE(RCC_PLL_48M1CLK);
+    }
+    else if(PeriphClkInit->Sdmmc1ClockSelection == RCC_SDMMC1CLKSOURCE_PLLSAI1)
+    {
+      /* PLLSAI1 parameters N & Q configuration and clock output (PLLSAI1ClockOut) */
+      ret = RCCEx_PLLSAI1_ConfigNQ(&(PeriphClkInit->PLLSAI1));
+      
+      if(ret != HAL_OK)
+      {
+        /* set overall return value */
+        status = ret;
+      }
+    }
+  }
+
+  /*-------------------------- RNG clock source configuration ----------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_RNG) == (RCC_PERIPHCLK_RNG))
+  {
+    assert_param(IS_RCC_RNGCLKSOURCE(PeriphClkInit->RngClockSelection));
+    __HAL_RCC_RNG_CONFIG(PeriphClkInit->RngClockSelection);
+
+    if(PeriphClkInit->RngClockSelection == RCC_RNGCLKSOURCE_PLL)
+    {
+      /* Enable PLL48M1CLK output */
+      __HAL_RCC_PLLCLKOUT_ENABLE(RCC_PLL_48M1CLK);
+    }
+    else if(PeriphClkInit->RngClockSelection == RCC_RNGCLKSOURCE_PLLSAI1)
+    {
+      /* PLLSAI1 parameters N & Q configuration and clock output (PLLSAI1ClockOut) */
+      ret = RCCEx_PLLSAI1_ConfigNQ(&(PeriphClkInit->PLLSAI1));
+      
+      if(ret != HAL_OK)
+      {
+        /* set overall return value */
+        status = ret;
+      }
+    }
+  }
+
+  /*-------------------------- ADC clock source configuration ----------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_ADC) == RCC_PERIPHCLK_ADC)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_ADCCLKSOURCE(PeriphClkInit->AdcClockSelection));
+
+    /* Configure the ADC interface clock source */
+    __HAL_RCC_ADC_CONFIG(PeriphClkInit->AdcClockSelection);
+    
+    if(PeriphClkInit->AdcClockSelection == RCC_ADCCLKSOURCE_PLLSAI1)
+    {
+      /* PLLSAI1 parameters N & R configuration and clock output (PLLSAI1ClockOut) */
+      ret = RCCEx_PLLSAI1_ConfigNR(&(PeriphClkInit->PLLSAI1));
+
+      if(ret != HAL_OK)
+      {
+        /* set overall return value */
+        status = ret;
+      }
+    }
+    else if(PeriphClkInit->AdcClockSelection == RCC_ADCCLKSOURCE_PLLSAI2)
+    {
+      /* PLLSAI2 parameters N & R configuration and clock output (PLLSAI2ClockOut) */
+      ret = RCCEx_PLLSAI2_ConfigNR(&(PeriphClkInit->PLLSAI2));
+      
+      if(ret != HAL_OK)
+      {
+        /* set overall return value */
+        status = ret;
+      }
+    }
+  }
+
+  /*-------------------------- SWPMI1 clock source configuration -------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SWPMI1) == RCC_PERIPHCLK_SWPMI1)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_SWPMI1CLKSOURCE(PeriphClkInit->Swpmi1ClockSelection));
+
+    /* Configure the SWPMI1 clock source */
+    __HAL_RCC_SWPMI1_CONFIG(PeriphClkInit->Swpmi1ClockSelection);
+  }
+
+  /*-------------------------- DFSDM clock source configuration --------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_DFSDM) == RCC_PERIPHCLK_DFSDM)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_DFSDMCLKSOURCE(PeriphClkInit->DfsdmClockSelection));
+
+    /* Configure the DFSDM interface clock source */
+    __HAL_RCC_DFSDM_CONFIG(PeriphClkInit->DfsdmClockSelection);
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Get the RCC_ClkInitStruct according to the internal RCC configuration registers.
+  * @param  PeriphClkInit  pointer to an RCC_PeriphCLKInitTypeDef structure that
+  *         returns the configuration information for the Extended Peripherals
+  *         clocks(SAI1, SAI2, LPTIM1, LPTIM2, I2C1, I2C2, I2C3, LPUART,
+  *         USART1, USART2, USART3, UART4, UART5, RTC, ADCx, DFSDMx, SWPMI1, USB, SDMMC1 and RNG).
+  * @retval None
+  */
+void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
+{
+  /* Set all possible values for the extended clock type parameter------------*/
+
+#if defined(STM32L471xx)
+
+  PeriphClkInit->PeriphClockSelection = RCC_PERIPHCLK_USART1  | RCC_PERIPHCLK_USART2 | RCC_PERIPHCLK_USART3 | RCC_PERIPHCLK_UART4  | RCC_PERIPHCLK_UART5  | \
+                                        RCC_PERIPHCLK_LPUART1 | RCC_PERIPHCLK_I2C1   | RCC_PERIPHCLK_I2C2   | RCC_PERIPHCLK_I2C3                          | \
+                                        RCC_PERIPHCLK_LPTIM1  | RCC_PERIPHCLK_LPTIM2 | RCC_PERIPHCLK_SAI1   | RCC_PERIPHCLK_SAI2                          | \
+                                        RCC_PERIPHCLK_SDMMC1  | RCC_PERIPHCLK_RNG    | RCC_PERIPHCLK_ADC    | RCC_PERIPHCLK_SWPMI1 | RCC_PERIPHCLK_DFSDM  | \
+                                        RCC_PERIPHCLK_RTC ;
+  
+#else
+
+  PeriphClkInit->PeriphClockSelection = RCC_PERIPHCLK_USART1  | RCC_PERIPHCLK_USART2 | RCC_PERIPHCLK_USART3 | RCC_PERIPHCLK_UART4  | RCC_PERIPHCLK_UART5  | \
+                                        RCC_PERIPHCLK_LPUART1 | RCC_PERIPHCLK_I2C1   | RCC_PERIPHCLK_I2C2   | RCC_PERIPHCLK_I2C3   |                        \
+                                        RCC_PERIPHCLK_LPTIM1  | RCC_PERIPHCLK_LPTIM2 | RCC_PERIPHCLK_SAI1   | RCC_PERIPHCLK_SAI2   | RCC_PERIPHCLK_USB    | \
+                                        RCC_PERIPHCLK_SDMMC1  | RCC_PERIPHCLK_RNG    | RCC_PERIPHCLK_ADC    | RCC_PERIPHCLK_SWPMI1 | RCC_PERIPHCLK_DFSDM  | \
+                                        RCC_PERIPHCLK_RTC ;
+
+#endif /* STM32L471xx */
+
+  /* Get the PLLSAI1 Clock configuration -----------------------------------------------*/
+  PeriphClkInit->PLLSAI1.PLLSAI1N = (uint32_t)((RCC->PLLSAI1CFGR & RCC_PLLSAI1CFGR_PLLSAI1N) >> POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1N));
+  PeriphClkInit->PLLSAI1.PLLSAI1P = (uint32_t)(((RCC->PLLSAI1CFGR & RCC_PLLSAI1CFGR_PLLSAI1P) >> POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1P)) << 4U) + 7U;
+  PeriphClkInit->PLLSAI1.PLLSAI1R = (uint32_t)(((RCC->PLLSAI1CFGR & RCC_PLLSAI1CFGR_PLLSAI1R) >> POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1R))+1U) * 2U;
+  PeriphClkInit->PLLSAI1.PLLSAI1Q = (uint32_t)(((RCC->PLLSAI1CFGR & RCC_PLLSAI1CFGR_PLLSAI1Q) >> POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1Q))+1U) * 2U;
+
+  /* Get the PLLSAI2 Clock configuration -----------------------------------------------*/
+  PeriphClkInit->PLLSAI2.PLLSAI2N = (uint32_t)((RCC->PLLSAI2CFGR & RCC_PLLSAI2CFGR_PLLSAI2N) >> POSITION_VAL(RCC_PLLSAI2CFGR_PLLSAI2N));
+  PeriphClkInit->PLLSAI2.PLLSAI2P = (uint32_t)(((RCC->PLLSAI2CFGR & RCC_PLLSAI2CFGR_PLLSAI2P) >> POSITION_VAL(RCC_PLLSAI2CFGR_PLLSAI2P)) << 4U) + 7U;
+  PeriphClkInit->PLLSAI2.PLLSAI2R = (uint32_t)(((RCC->PLLSAI2CFGR & RCC_PLLSAI2CFGR_PLLSAI2R)>> POSITION_VAL(RCC_PLLSAI2CFGR_PLLSAI2R))+1U) * 2U;
+
+  /* Get the USART1 clock source ---------------------------------------------*/
+  PeriphClkInit->Usart1ClockSelection  = __HAL_RCC_GET_USART1_SOURCE();
+  /* Get the USART2 clock source ---------------------------------------------*/
+  PeriphClkInit->Usart2ClockSelection  = __HAL_RCC_GET_USART2_SOURCE();
+  /* Get the USART3 clock source ---------------------------------------------*/
+  PeriphClkInit->Usart3ClockSelection  = __HAL_RCC_GET_USART3_SOURCE();
+  /* Get the UART4 clock source ----------------------------------------------*/
+  PeriphClkInit->Uart4ClockSelection   = __HAL_RCC_GET_UART4_SOURCE();
+  /* Get the UART5 clock source ----------------------------------------------*/
+  PeriphClkInit->Uart5ClockSelection   = __HAL_RCC_GET_UART5_SOURCE();
+  /* Get the LPUART1 clock source --------------------------------------------*/
+  PeriphClkInit->Lpuart1ClockSelection = __HAL_RCC_GET_LPUART1_SOURCE();
+  /* Get the I2C1 clock source -----------------------------------------------*/
+  PeriphClkInit->I2c1ClockSelection    = __HAL_RCC_GET_I2C1_SOURCE();
+   /* Get the I2C2 clock source ----------------------------------------------*/
+  PeriphClkInit->I2c2ClockSelection    = __HAL_RCC_GET_I2C2_SOURCE();
+  /* Get the I2C3 clock source -----------------------------------------------*/
+  PeriphClkInit->I2c3ClockSelection    = __HAL_RCC_GET_I2C3_SOURCE();
+  /* Get the LPTIM1 clock source ---------------------------------------------*/
+  PeriphClkInit->Lptim1ClockSelection  = __HAL_RCC_GET_LPTIM1_SOURCE();
+  /* Get the LPTIM2 clock source ---------------------------------------------*/
+  PeriphClkInit->Lptim2ClockSelection  = __HAL_RCC_GET_LPTIM2_SOURCE();
+  /* Get the SAI1 clock source -----------------------------------------------*/
+  PeriphClkInit->Sai1ClockSelection    = __HAL_RCC_GET_SAI1_SOURCE();
+  /* Get the SAI2 clock source -----------------------------------------------*/
+  PeriphClkInit->Sai2ClockSelection    = __HAL_RCC_GET_SAI2_SOURCE();
+  /* Get the RTC clock source ------------------------------------------------*/
+  PeriphClkInit->RTCClockSelection     = __HAL_RCC_GET_RTC_SOURCE();
+
+#if defined(USB_OTG_FS)
+  /* Get the USB clock source ------------------------------------------------*/
+  PeriphClkInit->UsbClockSelection   = __HAL_RCC_GET_USB_SOURCE();
+#endif /* USB_OTG_FS */
+
+  /* Get the SDMMC1 clock source ---------------------------------------------*/
+  PeriphClkInit->Sdmmc1ClockSelection   = __HAL_RCC_GET_SDMMC1_SOURCE();
+  /* Get the RNG clock source ------------------------------------------------*/
+  PeriphClkInit->RngClockSelection   = __HAL_RCC_GET_RNG_SOURCE();
+  /* Get the ADC clock source -----------------------------------------------*/
+  PeriphClkInit->AdcClockSelection     = __HAL_RCC_GET_ADC_SOURCE();
+  /* Get the SWPMI1 clock source ----------------------------------------------*/
+  PeriphClkInit->Swpmi1ClockSelection  = __HAL_RCC_GET_SWPMI1_SOURCE();
+  /* Get the DFSDM clock source -------------------------------------------*/
+  PeriphClkInit->DfsdmClockSelection   = __HAL_RCC_GET_DFSDM_SOURCE();
+}
+
+/**
+  * @brief  Return the peripheral clock frequency for peripherals with clock source from PLLSAIs 
+  * @note   Return 0 if peripheral clock identifier not managed by this API
+  * @param  PeriphClk  Peripheral clock identifier
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_PERIPHCLK_RTC  RTC peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_ADC  ADC peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_DFSDM  DFSDM peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_I2C1  I2C1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_I2C2  I2C2 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_I2C3  I2C3 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_LPTIM1  LPTIM1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_LPTIM2  LPTIM2 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_LPUART1  LPUART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_RNG  RNG peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_SAI1  SAI1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_SAI2  SAI2 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_SDMMC1  SDMMC1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_SWPMI1  SWPMI1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_USART1  USART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_USART2  USART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_USART3  USART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_UART4  USART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_UART5  USART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_USB  USB peripheral clock (only for devices with USB)
+  * @retval Frequency in Hz
+  */
+uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
+{
+  uint32_t frequency = 0U;
+  uint32_t srcclk = 0;
+  uint32_t pllvco = 0, plln = 0, pllp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RCC_PERIPHCLOCK(PeriphClk));
+
+  if(PeriphClk == RCC_PERIPHCLK_RTC)
+  {
+    /* Get the current RTC source */
+    srcclk = __HAL_RCC_GET_RTC_SOURCE();
+
+    /* Check if LSE is ready and if RTC clock selection is LSE */
+    if ((srcclk == RCC_RTCCLKSOURCE_LSE) && (HAL_IS_BIT_SET(RCC->BDCR, RCC_BDCR_LSERDY)))
+    {
+      frequency = LSE_VALUE;
+    }
+    /* Check if LSI is ready and if RTC clock selection is LSI */
+    else if ((srcclk == RCC_RTCCLKSOURCE_LSI) && (HAL_IS_BIT_SET(RCC->CSR, RCC_CSR_LSIRDY)))
+    {
+      frequency = LSI_VALUE;
+    }
+    /* Check if HSE is ready  and if RTC clock selection is HSI_DIV32*/
+    else if ((srcclk == RCC_RTCCLKSOURCE_HSE_DIV32) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSERDY)))
+    {
+      frequency = HSE_VALUE / 32;
+    }
+    /* Clock not enabled for RTC*/
+    else
+    {
+      frequency = 0U;
+    }
+  }
+  else
+  {
+    /* Other external peripheral clock source than RTC */
+    
+    /* Compute PLL clock input */
+    if(__HAL_RCC_GET_PLL_OSCSOURCE() == RCC_PLLSOURCE_MSI)        /* MSI ? */
+    {
+      pllvco = (1U << ((__HAL_RCC_GET_MSI_RANGE() >> 4U) - 4U)) * 1000000U;
+    }
+    else if(__HAL_RCC_GET_PLL_OSCSOURCE() == RCC_PLLSOURCE_HSI)   /* HSI ? */
+    {
+      pllvco = HSI_VALUE;
+    }
+    else if(__HAL_RCC_GET_PLL_OSCSOURCE() == RCC_PLLSOURCE_HSE)   /* HSE ? */
+    {
+      pllvco = HSE_VALUE;
+    }
+    else /* No source */
+    {
+      pllvco = 0;
+    }
+
+    /* f(PLL Source) / PLLM */
+    pllvco = (pllvco / ((READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLM) >> POSITION_VAL(RCC_PLLCFGR_PLLM)) + 1U));
+
+    switch(PeriphClk)
+    {
+    case RCC_PERIPHCLK_SAI1:
+    case RCC_PERIPHCLK_SAI2:
+
+      if(PeriphClk == RCC_PERIPHCLK_SAI1)
+      {
+        srcclk = READ_BIT(RCC->CCIPR, RCC_CCIPR_SAI1SEL);
+          
+        if(srcclk == RCC_SAI1CLKSOURCE_PIN)
+        {
+          frequency = EXTERNAL_SAI1_CLOCK_VALUE;
+        }
+        /* Else, PLL clock output to check below */
+      }
+      else /* RCC_PERIPHCLK_SAI2 */
+      {
+        srcclk = READ_BIT(RCC->CCIPR, RCC_CCIPR_SAI2SEL);
+          
+        if(srcclk == RCC_SAI2CLKSOURCE_PIN)
+        {
+          frequency = EXTERNAL_SAI2_CLOCK_VALUE;
+        }
+        /* Else, PLL clock output to check below */
+      }
+
+      if(frequency == 0U)
+      {
+        if((srcclk == RCC_SAI1CLKSOURCE_PLL) || (srcclk == RCC_SAI2CLKSOURCE_PLL))
+        {
+          if(__HAL_RCC_GET_PLLCLKOUT_CONFIG(RCC_PLL_SAI3CLK) != RESET)
+          {
+            /* f(PLLSAI3CLK) = f(VCO input) * PLLN / PLLP */
+            plln = READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLN) >> POSITION_VAL(RCC_PLLCFGR_PLLN);
+            if(READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLP) != RESET)
+            {
+              pllp = 17U;
+            }
+            else
+            {
+              pllp = 7U;
+            }
+            frequency = (pllvco * plln) / pllp;
+          }
+        }
+        else if(srcclk == 0U)  /* RCC_SAI1CLKSOURCE_PLLSAI1 || RCC_SAI2CLKSOURCE_PLLSAI1 */
+        {
+          if(__HAL_RCC_GET_PLLSAI1CLKOUT_CONFIG(RCC_PLLSAI1_SAI1CLK) != RESET)
+          {
+            /* f(PLLSAI1CLK) = f(VCOSAI1 input) * PLLSAI1N / PLLSAI1P */
+            plln = READ_BIT(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLSAI1N) >> POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1N);
+            if(READ_BIT(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLSAI1P) != RESET)
+            {
+              pllp = 17U;
+            }
+            else
+            {
+              pllp = 7U;
+            }
+            frequency = (pllvco * plln) / pllp;
+          }
+        }
+        else if((srcclk == RCC_SAI1CLKSOURCE_PLLSAI2) || (srcclk == RCC_SAI2CLKSOURCE_PLLSAI2))
+        {
+          if(__HAL_RCC_GET_PLLSAI2CLKOUT_CONFIG(RCC_PLLSAI2_SAI2CLK) != RESET)
+          {
+            /* f(PLLSAI2CLK) = f(VCOSAI2 input) * PLLSAI2N / PLLSAI2P */
+            plln = READ_BIT(RCC->PLLSAI2CFGR, RCC_PLLSAI2CFGR_PLLSAI2N) >> POSITION_VAL(RCC_PLLSAI2CFGR_PLLSAI2N);
+            if(READ_BIT(RCC->PLLSAI2CFGR, RCC_PLLSAI2CFGR_PLLSAI2P) != RESET)
+            {
+              pllp = 17U;
+            }
+            else
+            {
+              pllp = 7U;
+            }
+            frequency = (pllvco * plln) / pllp;
+          }
+        }
+        else
+        {
+          /* No clock source */
+          frequency = 0U;
+        }
+      }
+      break;
+    
+#if defined(USB_OTG_FS)
+    
+    case RCC_PERIPHCLK_USB:
+
+#endif /* USB_OTG_FS */
+
+    case RCC_PERIPHCLK_RNG:
+    case RCC_PERIPHCLK_SDMMC1:
+
+      srcclk = READ_BIT(RCC->CCIPR, RCC_CCIPR_CLK48SEL);
+      
+      if(srcclk == RCC_CCIPR_CLK48SEL)   /* MSI ? */
+      {
+        frequency = (1U << ((__HAL_RCC_GET_MSI_RANGE() >> 4U) - 4U)) * 1000000U;
+      }
+      else if(srcclk == RCC_CCIPR_CLK48SEL_1)  /* PLL ? */
+      {
+        /* f(PLL48M1CLK) = f(VCO input) * PLLN / PLLQ */
+        plln = READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLN) >> POSITION_VAL(RCC_PLLCFGR_PLLN);
+        frequency = (pllvco * plln) / (((READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLQ) >> POSITION_VAL(RCC_PLLCFGR_PLLQ)) + 1U) << 1U);
+      }
+      else if(srcclk == RCC_CCIPR_CLK48SEL_0)  /* PLLSAI1 ? */
+      {
+        /* f(PLL48M2CLK) = f(VCOSAI1 input) * PLLSAI1N / PLLSAI1Q */
+        plln = READ_BIT(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLSAI1N) >> POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1N);
+        frequency = (pllvco * plln) / (((READ_BIT(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLSAI1Q) >> POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1Q)) + 1U) << 1U);
+      }
+      else /* No clock source */
+      {
+        frequency = 0U;
+      }
+      break;
+      
+    case RCC_PERIPHCLK_USART1:
+      /* Get the current USART1 source */
+      srcclk = __HAL_RCC_GET_USART1_SOURCE();
+      
+      if(srcclk == RCC_USART1CLKSOURCE_PCLK2)
+      {
+        frequency = HAL_RCC_GetPCLK2Freq();
+      }
+      else if(srcclk == RCC_USART1CLKSOURCE_SYSCLK)
+      {
+        frequency = HAL_RCC_GetSysClockFreq();
+      }
+      else if((srcclk == RCC_USART1CLKSOURCE_HSI) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)))
+      {
+        frequency = HSI_VALUE;
+      }
+      else if((srcclk == RCC_USART1CLKSOURCE_LSE) && (HAL_IS_BIT_SET(RCC->BDCR, RCC_BDCR_LSERDY)))
+      {
+        frequency = LSE_VALUE;
+      }
+      /* Clock not enabled for USART1 */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    case RCC_PERIPHCLK_USART2:
+      /* Get the current USART2 source */
+      srcclk = __HAL_RCC_GET_USART2_SOURCE();
+      
+      if(srcclk == RCC_USART2CLKSOURCE_PCLK1)
+      {
+        frequency = HAL_RCC_GetPCLK1Freq();
+      }
+      else if(srcclk == RCC_USART2CLKSOURCE_SYSCLK)
+      {
+        frequency = HAL_RCC_GetSysClockFreq();
+      }
+      else if((srcclk == RCC_USART2CLKSOURCE_HSI) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)))
+      {
+        frequency = HSI_VALUE;
+      }
+      else if((srcclk == RCC_USART2CLKSOURCE_LSE) && (HAL_IS_BIT_SET(RCC->BDCR, RCC_BDCR_LSERDY)))
+      {
+        frequency = LSE_VALUE;
+      }
+      /* Clock not enabled for USART2 */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    case RCC_PERIPHCLK_USART3:
+      /* Get the current USART3 source */
+      srcclk = __HAL_RCC_GET_USART3_SOURCE();
+      
+      if(srcclk == RCC_USART3CLKSOURCE_PCLK1)
+      {
+        frequency = HAL_RCC_GetPCLK1Freq();
+      }
+      else if(srcclk == RCC_USART3CLKSOURCE_SYSCLK)
+      {
+        frequency = HAL_RCC_GetSysClockFreq();
+      }
+      else if((srcclk == RCC_USART3CLKSOURCE_HSI) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)))
+      {
+        frequency = HSI_VALUE;
+      }
+      else if((srcclk == RCC_USART3CLKSOURCE_LSE) && (HAL_IS_BIT_SET(RCC->BDCR, RCC_BDCR_LSERDY)))
+      {
+        frequency = LSE_VALUE;
+      }
+      /* Clock not enabled for USART3 */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    case RCC_PERIPHCLK_UART4:
+      /* Get the current UART4 source */
+      srcclk = __HAL_RCC_GET_UART4_SOURCE();
+      
+      if(srcclk == RCC_UART4CLKSOURCE_PCLK1)
+      {
+        frequency = HAL_RCC_GetPCLK1Freq();
+      }
+      else if(srcclk == RCC_UART4CLKSOURCE_SYSCLK)
+      {
+        frequency = HAL_RCC_GetSysClockFreq();
+      }
+      else if((srcclk == RCC_UART4CLKSOURCE_HSI) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)))
+      {
+        frequency = HSI_VALUE;
+      }
+      else if((srcclk == RCC_UART4CLKSOURCE_LSE) && (HAL_IS_BIT_SET(RCC->BDCR, RCC_BDCR_LSERDY)))
+      {
+        frequency = LSE_VALUE;
+      }
+      /* Clock not enabled for UART4 */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    case RCC_PERIPHCLK_UART5:
+      /* Get the current UART5 source */
+      srcclk = __HAL_RCC_GET_UART5_SOURCE();
+      
+      if(srcclk == RCC_UART5CLKSOURCE_PCLK1)
+      {
+        frequency = HAL_RCC_GetPCLK1Freq();
+      }
+      else if(srcclk == RCC_UART5CLKSOURCE_SYSCLK)
+      {
+        frequency = HAL_RCC_GetSysClockFreq();
+      }
+      else if((srcclk == RCC_UART5CLKSOURCE_HSI) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)))
+      {
+        frequency = HSI_VALUE;
+      }
+      else if((srcclk == RCC_UART5CLKSOURCE_LSE) && (HAL_IS_BIT_SET(RCC->BDCR, RCC_BDCR_LSERDY)))
+      {
+        frequency = LSE_VALUE;
+      }
+      /* Clock not enabled for UART5 */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    case RCC_PERIPHCLK_LPUART1:
+      /* Get the current LPUART1 source */
+      srcclk = __HAL_RCC_GET_LPUART1_SOURCE();
+      
+      if(srcclk == RCC_LPUART1CLKSOURCE_PCLK1)
+      {
+        frequency = HAL_RCC_GetPCLK1Freq();
+      }
+      else if(srcclk == RCC_LPUART1CLKSOURCE_SYSCLK)
+      {
+        frequency = HAL_RCC_GetSysClockFreq();
+      }
+      else if((srcclk == RCC_LPUART1CLKSOURCE_HSI) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)))
+      {
+        frequency = HSI_VALUE;
+      }
+      else if((srcclk == RCC_LPUART1CLKSOURCE_LSE) && (HAL_IS_BIT_SET(RCC->BDCR, RCC_BDCR_LSERDY)))
+      {
+        frequency = LSE_VALUE;
+      }
+      /* Clock not enabled for LPUART1 */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    case RCC_PERIPHCLK_ADC:
+    
+      srcclk = __HAL_RCC_GET_ADC_SOURCE();
+      
+      if(srcclk == RCC_ADCCLKSOURCE_SYSCLK)
+      {
+        frequency = HAL_RCC_GetSysClockFreq();
+      }
+      else if(srcclk == RCC_ADCCLKSOURCE_PLLSAI1)
+      {
+        if(__HAL_RCC_GET_PLLSAI1CLKOUT_CONFIG(RCC_PLLSAI1_ADC1CLK) != RESET)
+        {
+          /* f(PLLADC1CLK) = f(VCOSAI1 input) * PLLSAI1N / PLLSAI1R */
+          plln = READ_BIT(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLSAI1N) >> POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1N);
+          frequency = (pllvco * plln) / (((READ_BIT(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLSAI1R) >> POSITION_VAL(RCC_PLLSAI1CFGR_PLLSAI1R)) + 1U) << 1U);
+        }
+      }
+      else if(srcclk == RCC_ADCCLKSOURCE_PLLSAI2)
+      {
+        if(__HAL_RCC_GET_PLLSAI2CLKOUT_CONFIG(RCC_PLLSAI2_ADC2CLK) != RESET)
+        {
+          /* f(PLLADC2CLK) = f(VCOSAI2 input) * PLLSAI2N / PLLSAI2R */
+          plln = READ_BIT(RCC->PLLSAI2CFGR, RCC_PLLSAI2CFGR_PLLSAI2N) >> POSITION_VAL(RCC_PLLSAI2CFGR_PLLSAI2N);
+          frequency = (pllvco * plln) / (((READ_BIT(RCC->PLLSAI2CFGR, RCC_PLLSAI2CFGR_PLLSAI2R) >> POSITION_VAL(RCC_PLLSAI2CFGR_PLLSAI2R)) + 1U) << 1U);
+        }
+      }
+      /* Clock not enabled for ADC */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    case RCC_PERIPHCLK_DFSDM:
+      /* Get the current DFSDM source */
+      srcclk = __HAL_RCC_GET_DFSDM_SOURCE();
+      
+      if(srcclk == RCC_DFSDMCLKSOURCE_PCLK)
+      {
+        frequency = HAL_RCC_GetPCLK1Freq();
+      }
+      else
+      {
+        frequency = HAL_RCC_GetSysClockFreq();
+      }
+      break;
+
+    case RCC_PERIPHCLK_I2C1:
+      /* Get the current I2C1 source */
+      srcclk = __HAL_RCC_GET_I2C1_SOURCE();
+      
+      if(srcclk == RCC_I2C1CLKSOURCE_PCLK1)
+      {
+        frequency = HAL_RCC_GetPCLK1Freq();
+      }
+      else if(srcclk == RCC_I2C1CLKSOURCE_SYSCLK)
+      {
+        frequency = HAL_RCC_GetSysClockFreq();
+      }
+      else if((srcclk == RCC_I2C1CLKSOURCE_HSI) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)))
+      {
+        frequency = HSI_VALUE;
+      }
+      /* Clock not enabled for I2C1 */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    case RCC_PERIPHCLK_I2C2:
+      /* Get the current I2C2 source */
+      srcclk = __HAL_RCC_GET_I2C2_SOURCE();
+      
+      if(srcclk == RCC_I2C2CLKSOURCE_PCLK1)
+      {
+        frequency = HAL_RCC_GetPCLK1Freq();
+      }
+      else if(srcclk == RCC_I2C2CLKSOURCE_SYSCLK)
+      {
+        frequency = HAL_RCC_GetSysClockFreq();
+      }
+      else if((srcclk == RCC_I2C2CLKSOURCE_HSI) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)))
+      {
+        frequency = HSI_VALUE;
+      }
+      /* Clock not enabled for I2C2 */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    case RCC_PERIPHCLK_I2C3:
+      /* Get the current I2C3 source */
+      srcclk = __HAL_RCC_GET_I2C3_SOURCE();
+      
+      if(srcclk == RCC_I2C3CLKSOURCE_PCLK1)
+      {
+        frequency = HAL_RCC_GetPCLK1Freq();
+      }
+      else if(srcclk == RCC_I2C3CLKSOURCE_SYSCLK)
+      {
+        frequency = HAL_RCC_GetSysClockFreq();
+      }
+      else if((srcclk == RCC_I2C3CLKSOURCE_HSI) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)))
+      {
+        frequency = HSI_VALUE;
+      }
+      /* Clock not enabled for I2C3 */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    case RCC_PERIPHCLK_LPTIM1:
+      /* Get the current LPTIM1 source */
+      srcclk = __HAL_RCC_GET_LPTIM1_SOURCE();
+      
+      if(srcclk == RCC_LPTIM1CLKSOURCE_PCLK)
+      {
+        frequency = HAL_RCC_GetPCLK1Freq();
+      }
+      else if((srcclk == RCC_LPTIM1CLKSOURCE_LSI) && (HAL_IS_BIT_SET(RCC->CSR, RCC_CSR_LSIRDY)))
+      {
+        frequency = LSI_VALUE;
+      }
+      else if((srcclk == RCC_LPTIM1CLKSOURCE_HSI) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)))
+      {
+        frequency = HSI_VALUE;
+      }
+      else if ((srcclk == RCC_LPTIM1CLKSOURCE_LSE) && (HAL_IS_BIT_SET(RCC->BDCR, RCC_BDCR_LSERDY)))
+      {
+        frequency = LSE_VALUE;
+      }
+      /* Clock not enabled for LPTIM1 */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    case RCC_PERIPHCLK_LPTIM2:
+      /* Get the current LPTIM2 source */
+      srcclk = __HAL_RCC_GET_LPTIM2_SOURCE();
+      
+      if(srcclk == RCC_LPTIM2CLKSOURCE_PCLK)
+      {
+        frequency = HAL_RCC_GetPCLK1Freq();
+      }
+      else if((srcclk == RCC_LPTIM2CLKSOURCE_LSI) && (HAL_IS_BIT_SET(RCC->CSR, RCC_CSR_LSIRDY)))
+      {
+        frequency = LSI_VALUE;
+      }
+      else if((srcclk == RCC_LPTIM2CLKSOURCE_HSI) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)))
+      {
+        frequency = HSI_VALUE;
+      }
+      else if ((srcclk == RCC_LPTIM2CLKSOURCE_LSE) && (HAL_IS_BIT_SET(RCC->BDCR, RCC_BDCR_LSERDY)))
+      {
+        frequency = LSE_VALUE;
+      }
+      /* Clock not enabled for LPTIM2 */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    case RCC_PERIPHCLK_SWPMI1:
+      /* Get the current SWPMI1 source */
+      srcclk = __HAL_RCC_GET_SWPMI1_SOURCE();
+      
+      if(srcclk == RCC_SWPMI1CLKSOURCE_PCLK)
+      {
+        frequency = HAL_RCC_GetPCLK1Freq();
+      }
+      else if((srcclk == RCC_SWPMI1CLKSOURCE_HSI) && (HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)))
+      {
+        frequency = HSI_VALUE;
+      }
+      /* Clock not enabled for SWPMI1 */
+      else
+      {
+        frequency = 0U;
+      }
+      break;
+
+    default:
+      break;
+    }
+  }
+
+  return(frequency);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_Exported_Functions_Group2 Extended clock management functions
+ *  @brief  Extended clock management functions
+ *
+@verbatim   
+ ===============================================================================
+                ##### Extended clock management functions  #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the 
+    activation or deactivation of MSI PLL-mode, PLLSAI1, PLLSAI2, LSE CSS,
+    Low speed clock output and clock after wake-up from STOP mode.
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enable PLLSAI1.
+  * @param  PLLSAI1Init  pointer to an RCC_PLLSAI1InitTypeDef structure that
+  *         contains the configuration information for the PLLSAI1
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RCCEx_EnablePLLSAI1(RCC_PLLSAI1InitTypeDef  *PLLSAI1Init)
+{
+  uint32_t tickstart = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* check for PLLSAI1 Parameters used to output PLLSAI1CLK */
+  assert_param(IS_RCC_PLLSAI1N_VALUE(PLLSAI1Init->PLLSAI1N));
+  assert_param(IS_RCC_PLLSAI1P_VALUE(PLLSAI1Init->PLLSAI1P));
+  assert_param(IS_RCC_PLLSAI1Q_VALUE(PLLSAI1Init->PLLSAI1Q));
+  assert_param(IS_RCC_PLLSAI1R_VALUE(PLLSAI1Init->PLLSAI1R));
+  assert_param(IS_RCC_PLLSAI1CLOCKOUT_VALUE(PLLSAI1Init->PLLSAI1ClockOut));
+
+  /* Disable the PLLSAI1 */
+  __HAL_RCC_PLLSAI1_DISABLE();
+
+  /* Get Start Tick*/
+  tickstart = HAL_GetTick();
+
+  /* Wait till PLLSAI1 is ready to be updated */
+  while(READ_BIT(RCC->CR, RCC_CR_PLLSAI1RDY) != RESET)
+  {
+    if((HAL_GetTick() - tickstart) > PLLSAI1_TIMEOUT_VALUE)
+    {
+      status = HAL_TIMEOUT;
+      break;
+    }
+  }
+
+  if(status == HAL_OK)    
+  {
+    /* Configure the PLLSAI1 Multiplication factor N */
+    /* Configure the PLLSAI1 Division factors P, Q and R */
+    __HAL_RCC_PLLSAI1_CONFIG(PLLSAI1Init->PLLSAI1N, PLLSAI1Init->PLLSAI1P, PLLSAI1Init->PLLSAI1Q, PLLSAI1Init->PLLSAI1R);
+    /* Configure the PLLSAI1 Clock output(s) */    
+    __HAL_RCC_PLLSAI1CLKOUT_ENABLE(PLLSAI1Init->PLLSAI1ClockOut);
+
+    /* Enable the PLLSAI1 again by setting PLLSAI1ON to 1*/
+    __HAL_RCC_PLLSAI1_ENABLE();
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    /* Wait till PLLSAI1 is ready */
+    while(READ_BIT(RCC->CR, RCC_CR_PLLSAI1RDY) == RESET)
+    {
+      if((HAL_GetTick() - tickstart) > PLLSAI1_TIMEOUT_VALUE)
+      {
+        status = HAL_TIMEOUT;
+        break;
+      }
+    }
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Disable PLLSAI1.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RCCEx_DisablePLLSAI1(void)
+{
+  uint32_t tickstart = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Disable the PLLSAI1 */
+  __HAL_RCC_PLLSAI1_DISABLE();
+
+  /* Get Start Tick*/
+  tickstart = HAL_GetTick();
+
+  /* Wait till PLLSAI1 is ready */
+  while(READ_BIT(RCC->CR, RCC_CR_PLLSAI1RDY) != RESET)
+  {
+    if((HAL_GetTick() - tickstart) > PLLSAI1_TIMEOUT_VALUE)
+    {
+      status = HAL_TIMEOUT;
+      break;
+    }
+  }
+  
+  /* Disable the PLLSAI1 Clock outputs */    
+  __HAL_RCC_PLLSAI1CLKOUT_DISABLE(RCC_PLLSAI1_SAI1CLK|RCC_PLLSAI1_48M2CLK|RCC_PLLSAI1_ADC1CLK);
+
+  return status;
+}
+
+/**
+  * @brief  Enable PLLSAI2.
+  * @param  PLLSAI2Init  pointer to an RCC_PLLSAI2InitTypeDef structure that
+  *         contains the configuration information for the PLLSAI2
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RCCEx_EnablePLLSAI2(RCC_PLLSAI2InitTypeDef  *PLLSAI2Init)
+{
+  uint32_t tickstart = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* check for PLLSAI2 Parameters used to output PLLSAI2CLK */
+  assert_param(IS_RCC_PLLSAI2N_VALUE(PLLSAI2Init->PLLSAI2N));
+  assert_param(IS_RCC_PLLSAI2P_VALUE(PLLSAI2Init->PLLSAI2P));
+  assert_param(IS_RCC_PLLSAI2R_VALUE(PLLSAI2Init->PLLSAI2R));
+  assert_param(IS_RCC_PLLSAI2CLOCKOUT_VALUE(PLLSAI2Init->PLLSAI2ClockOut));
+
+  /* Disable the PLLSAI2 */
+  __HAL_RCC_PLLSAI2_DISABLE();
+
+  /* Get Start Tick*/
+  tickstart = HAL_GetTick();
+
+  /* Wait till PLLSAI2 is ready to be updated */
+  while(READ_BIT(RCC->CR, RCC_CR_PLLSAI2RDY) != RESET)
+  {
+    if((HAL_GetTick() - tickstart) > PLLSAI2_TIMEOUT_VALUE)
+    {
+      status = HAL_TIMEOUT;
+      break;
+    }
+  }
+
+  if(status == HAL_OK)    
+  {
+    /* Configure the PLLSAI2 Multiplication factor N */
+    /* Configure the PLLSAI2 Division factors P and R */
+    __HAL_RCC_PLLSAI2_CONFIG(PLLSAI2Init->PLLSAI2N, PLLSAI2Init->PLLSAI2P, PLLSAI2Init->PLLSAI2R);
+    /* Configure the PLLSAI2 Clock output(s) */    
+    __HAL_RCC_PLLSAI2CLKOUT_ENABLE(PLLSAI2Init->PLLSAI2ClockOut);
+
+    /* Enable the PLLSAI2 again by setting PLLSAI2ON to 1*/
+    __HAL_RCC_PLLSAI2_ENABLE();
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    /* Wait till PLLSAI2 is ready */
+    while(READ_BIT(RCC->CR, RCC_CR_PLLSAI2RDY) == RESET)
+    {
+      if((HAL_GetTick() - tickstart) > PLLSAI2_TIMEOUT_VALUE)
+      {
+        status = HAL_TIMEOUT;
+        break;
+      }
+    }
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Disable PLLISAI2.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RCCEx_DisablePLLSAI2(void)
+{
+  uint32_t tickstart = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Disable the PLLSAI2 */
+  __HAL_RCC_PLLSAI2_DISABLE();
+
+  /* Get Start Tick*/
+  tickstart = HAL_GetTick();
+
+  /* Wait till PLLSAI2 is ready */
+  while(READ_BIT(RCC->CR, RCC_CR_PLLSAI2RDY) != RESET)
+  {
+    if((HAL_GetTick() - tickstart) > PLLSAI2_TIMEOUT_VALUE)
+    {
+      status = HAL_TIMEOUT;
+      break;
+    }
+  }
+  
+  /* Disable the PLLSAI2 Clock outputs */    
+  __HAL_RCC_PLLSAI2CLKOUT_DISABLE(RCC_PLLSAI2_SAI2CLK|RCC_PLLSAI2_ADC2CLK);
+
+  return status;
+}
+
+/**
+  * @brief  Configure the oscillator clock source for wakeup from Stop and CSS backup clock.
+  * @param  WakeUpClk  Wakeup clock 
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_STOP_WAKEUPCLOCK_MSI  MSI oscillator selection
+  *            @arg @ref RCC_STOP_WAKEUPCLOCK_HSI  HSI oscillator selection
+  * @note   This function shall not be called after the Clock Security System on HSE has been
+  *         enabled.
+  * @retval None
+  */
+void HAL_RCCEx_WakeUpStopCLKConfig(uint32_t WakeUpClk)
+{
+  assert_param(IS_RCC_STOP_WAKEUPCLOCK(WakeUpClk));
+  
+  __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(WakeUpClk);
+}
+
+/**
+  * @brief  Configure the MSI range after standby mode.
+  * @note   After Standby its frequency can be selected between 4 possible values (1, 2, 4 or 8 MHz).
+  * @param  MSIRange  MSI range 
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_MSIRANGE_4  Range 4 around 1 MHz
+  *            @arg @ref RCC_MSIRANGE_5  Range 5 around 2 MHz
+  *            @arg @ref RCC_MSIRANGE_6  Range 6 around 4 MHz (reset value)
+  *            @arg @ref RCC_MSIRANGE_7  Range 7 around 8 MHz
+  * @retval None
+  */
+void HAL_RCCEx_StandbyMSIRangeConfig(uint32_t MSIRange)
+{
+  assert_param(IS_RCC_MSI_STANDBY_CLOCK_RANGE(MSIRange));
+  
+  __HAL_RCC_MSI_STANDBY_RANGE_CONFIG(MSIRange);
+}
+
+/**
+  * @brief  Enable the LSE Clock Security System.
+  * @note   Prior to enable the LSE Clock Security System, LSE oscillator is to be enabled
+  *         with HAL_RCC_OscConfig() and the LSE oscillator clock is to be selected as RTC
+  *         clock with HAL_RCCEx_PeriphCLKConfig().
+  * @retval None
+  */
+void HAL_RCCEx_EnableLSECSS(void)
+{
+  SET_BIT(RCC->BDCR, RCC_BDCR_LSECSSON) ;
+}
+
+/**
+  * @brief  Disable the LSE Clock Security System.
+  * @note   LSE Clock Security System can only be disabled after a LSE failure detection.
+  * @retval None
+  */
+void HAL_RCCEx_DisableLSECSS(void)
+{
+  CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSECSSON) ;
+  
+  /* Disable LSE CSS IT if any */
+  __HAL_RCC_DISABLE_IT(RCC_IT_LSECSS);
+}
+
+/**
+  * @brief  Enable the LSE Clock Security System Interrupt & corresponding EXTI line.
+  * @note   LSE Clock Security System Interrupt is mapped on RTC EXTI line 19
+  * @retval None
+  */
+void HAL_RCCEx_EnableLSECSS_IT(void)
+{
+  /* Enable LSE CSS */
+  SET_BIT(RCC->BDCR, RCC_BDCR_LSECSSON) ;
+
+  /* Enable LSE CSS IT */
+  __HAL_RCC_ENABLE_IT(RCC_IT_LSECSS);
+  
+  /* Enable IT on EXTI Line 19 */
+  __HAL_RCC_LSECSS_EXTI_ENABLE_IT();
+  __HAL_RCC_LSECSS_EXTI_ENABLE_RISING_EDGE();
+}
+
+/**
+  * @brief Handle the RCC LSE Clock Security System interrupt request.
+  * @retval None
+  */
+void HAL_RCCEx_LSECSS_IRQHandler(void)
+{
+  /* Check RCC LSE CSSF flag  */
+  if(__HAL_RCC_GET_IT(RCC_IT_LSECSS))
+  {
+    /* RCC LSE Clock Security System interrupt user callback */
+    HAL_RCCEx_LSECSS_Callback();
+
+    /* Clear RCC LSE CSS pending bit */
+    __HAL_RCC_CLEAR_IT(RCC_IT_LSECSS);
+  }
+}                                                                            
+
+/**
+  * @brief  RCCEx LSE Clock Security System interrupt callback.
+  * @retval none
+  */
+__weak void HAL_RCCEx_LSECSS_Callback(void)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the @ref HAL_RCCEx_LSECSS_Callback should be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Select the Low Speed clock source to output on LSCO pin (PA2).
+  * @param  LSCOSource  specifies the Low Speed clock source to output.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_LSCOSOURCE_LSI  LSI clock selected as LSCO source
+  *            @arg @ref RCC_LSCOSOURCE_LSE  LSE clock selected as LSCO source
+  * @retval None
+  */
+void HAL_RCCEx_EnableLSCO(uint32_t LSCOSource)
+{
+  GPIO_InitTypeDef GPIO_InitStruct;
+  FlagStatus       pwrclkchanged = RESET;
+  FlagStatus       backupchanged = RESET;
+  
+  /* Check the parameters */
+  assert_param(IS_RCC_LSCOSOURCE(LSCOSource));
+
+  /* LSCO Pin Clock Enable */
+  __LSCO_CLK_ENABLE();
+
+  /* Configue the LSCO pin in analog mode */
+  GPIO_InitStruct.Pin = LSCO_PIN;
+  GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  HAL_GPIO_Init(LSCO_GPIO_PORT, &GPIO_InitStruct);
+
+  /* Update LSCOSEL clock source in Backup Domain control register */
+  if(__HAL_RCC_PWR_IS_CLK_DISABLED())
+  {
+    __HAL_RCC_PWR_CLK_ENABLE();
+    pwrclkchanged = SET;
+  }
+  if(HAL_IS_BIT_CLR(PWR->CR1, PWR_CR1_DBP))
+  {
+    HAL_PWR_EnableBkUpAccess();
+    backupchanged = SET;
+  }
+  
+  MODIFY_REG(RCC->BDCR, RCC_BDCR_LSCOSEL | RCC_BDCR_LSCOEN, LSCOSource | RCC_BDCR_LSCOEN);
+  
+  if(backupchanged == SET)
+  {
+    HAL_PWR_DisableBkUpAccess();
+  }
+  if(pwrclkchanged == SET)
+  {
+    __HAL_RCC_PWR_CLK_DISABLE();
+  }
+}
+
+/**
+  * @brief  Disable the Low Speed clock output.
+  * @retval None
+  */
+void HAL_RCCEx_DisableLSCO(void)
+{
+  FlagStatus       pwrclkchanged = RESET;
+  FlagStatus       backupchanged = RESET;
+  
+  /* Update LSCOEN bit in Backup Domain control register */
+  if(__HAL_RCC_PWR_IS_CLK_DISABLED())
+  {
+    __HAL_RCC_PWR_CLK_ENABLE();
+    pwrclkchanged = SET;
+  }
+  if(HAL_IS_BIT_CLR(PWR->CR1, PWR_CR1_DBP))
+  {
+    /* Enable access to the backup domain */
+    HAL_PWR_EnableBkUpAccess();
+    backupchanged = SET;
+  }
+  
+  CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSCOEN);
+  
+  /* Restore previous configuration */
+  if(backupchanged == SET)
+  {
+    /* Disable access to the backup domain */
+    HAL_PWR_DisableBkUpAccess();
+  }
+  if(pwrclkchanged == SET)
+  {
+    __HAL_RCC_PWR_CLK_DISABLE();
+  }
+}
+
+/**
+  * @brief  Enable the PLL-mode of the MSI.
+  * @note   Prior to enable the PLL-mode of the MSI for automatic hardware
+  *         calibration LSE oscillator is to be enabled with HAL_RCC_OscConfig().
+  * @retval None
+  */
+void HAL_RCCEx_EnableMSIPLLMode(void)
+{
+  SET_BIT(RCC->CR, RCC_CR_MSIPLLEN) ;
+}
+
+/**
+  * @brief  Disable the PLL-mode of the MSI.
+  * @note   PLL-mode of the MSI is automatically reset when LSE oscillator is disabled.
+  * @retval None
+  */
+void HAL_RCCEx_DisableMSIPLLMode(void)
+{
+  CLEAR_BIT(RCC->CR, RCC_CR_MSIPLLEN) ;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup RCCEx_Private_Functions
+ * @{
+ */
+
+/**
+  * @brief  Configure the parameters N & P of PLLSAI1 and enable PLLSAI1 output clock(s).
+  * @param  PllSai1  pointer to an RCC_PLLSAI1InitTypeDef structure that
+  *         contains the configuration parameters N & P as well as PLLSAI1 output clock(s)
+  *
+  * @note   PLLSAI1 is temporary disable to apply new parameters
+  *
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef RCCEx_PLLSAI1_ConfigNP(RCC_PLLSAI1InitTypeDef *PllSai1)
+{
+  uint32_t tickstart = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* check for PLLSAI1 Parameters used to output PLLSAI1CLK */
+  assert_param(IS_RCC_PLLSAI1N_VALUE(PllSai1->PLLSAI1N));
+  assert_param(IS_RCC_PLLSAI1P_VALUE(PllSai1->PLLSAI1P));
+  assert_param(IS_RCC_PLLSAI1CLOCKOUT_VALUE(PllSai1->PLLSAI1ClockOut));
+
+  /* Disable the PLLSAI1 */
+  __HAL_RCC_PLLSAI1_DISABLE();
+
+  /* Get Start Tick*/
+  tickstart = HAL_GetTick();
+
+  /* Wait till PLLSAI1 is ready to be updated */
+  while(READ_BIT(RCC->CR, RCC_CR_PLLSAI1RDY) != RESET)
+  {
+    if((HAL_GetTick() - tickstart) > PLLSAI1_TIMEOUT_VALUE)
+    {
+      status = HAL_TIMEOUT;
+      break;
+    }
+  }
+
+  if(status == HAL_OK)    
+  {
+    /* Configure the PLLSAI1 Multiplication factor N */
+    __HAL_RCC_PLLSAI1_MULN_CONFIG(PllSai1->PLLSAI1N);
+    /* Configure the PLLSAI1 Division factor P */
+    __HAL_RCC_PLLSAI1_DIVP_CONFIG(PllSai1->PLLSAI1P);
+
+    /* Enable the PLLSAI1 again by setting PLLSAI1ON to 1*/
+    __HAL_RCC_PLLSAI1_ENABLE();
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    /* Wait till PLLSAI1 is ready */
+    while(READ_BIT(RCC->CR, RCC_CR_PLLSAI1RDY) == RESET)
+    {
+      if((HAL_GetTick() - tickstart) > PLLSAI1_TIMEOUT_VALUE)
+      {
+        status = HAL_TIMEOUT;
+        break;
+      }
+    }
+
+    if(status == HAL_OK)    
+    {
+      /* Configure the PLLSAI1 Clock output(s) */
+      __HAL_RCC_PLLSAI1CLKOUT_ENABLE(PllSai1->PLLSAI1ClockOut);
+    }
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Configure the parameters N & Q of PLLSAI1 and enable PLLSAI1 output clock(s).
+  * @param  PllSai1  pointer to an RCC_PLLSAI1InitTypeDef structure that
+  *         contains the configuration parameters N & Q as well as PLLSAI1 output clock(s)
+  *
+  * @note   PLLSAI1 is temporary disable to apply new parameters
+  *
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef RCCEx_PLLSAI1_ConfigNQ(RCC_PLLSAI1InitTypeDef *PllSai1)
+{
+  uint32_t tickstart = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* check for PLLSAI1 Parameters used to output PLLSAI1CLK */
+  assert_param(IS_RCC_PLLSAI1N_VALUE(PllSai1->PLLSAI1N));
+  assert_param(IS_RCC_PLLSAI1Q_VALUE(PllSai1->PLLSAI1Q));
+  assert_param(IS_RCC_PLLSAI1CLOCKOUT_VALUE(PllSai1->PLLSAI1ClockOut));
+
+  /* Disable the PLLSAI1 */
+  __HAL_RCC_PLLSAI1_DISABLE();
+
+  /* Get Start Tick*/
+  tickstart = HAL_GetTick();
+
+  /* Wait till PLLSAI1 is ready to be updated */
+  while(READ_BIT(RCC->CR, RCC_CR_PLLSAI1RDY) != RESET)
+  {
+    if((HAL_GetTick() - tickstart) > PLLSAI1_TIMEOUT_VALUE)
+    {
+      status = HAL_TIMEOUT;
+      break;
+    }
+  }
+
+  if(status == HAL_OK)    
+  {
+    /* Configure the PLLSAI1 Multiplication factor N */
+    __HAL_RCC_PLLSAI1_MULN_CONFIG(PllSai1->PLLSAI1N);
+    /* Configure the PLLSAI1 Division factor Q */
+    __HAL_RCC_PLLSAI1_DIVQ_CONFIG(PllSai1->PLLSAI1Q);
+
+    /* Enable the PLLSAI1 again by setting PLLSAI1ON to 1*/
+    __HAL_RCC_PLLSAI1_ENABLE();
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    /* Wait till PLLSAI1 is ready */
+    while(READ_BIT(RCC->CR, RCC_CR_PLLSAI1RDY) == RESET)
+    {
+      if((HAL_GetTick() - tickstart) > PLLSAI1_TIMEOUT_VALUE)
+      {
+        status = HAL_TIMEOUT;
+        break;
+      }
+    }
+
+    if(status == HAL_OK)
+    {
+      /* Configure the PLLSAI1 Clock output(s) */
+      __HAL_RCC_PLLSAI1CLKOUT_ENABLE(PllSai1->PLLSAI1ClockOut);
+    }
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Configure the parameters N & R of PLLSAI1 and enable PLLSAI1 output clock(s).
+  * @param  PllSai1  pointer to an RCC_PLLSAI1InitTypeDef structure that
+  *         contains the configuration parameters N & R as well as PLLSAI1 output clock(s)
+  *
+  * @note   PLLSAI1 is temporary disable to apply new parameters
+  *
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef RCCEx_PLLSAI1_ConfigNR(RCC_PLLSAI1InitTypeDef *PllSai1)
+{
+  uint32_t tickstart = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* check for PLLSAI1 Parameters used to output PLLSAI1CLK */
+  assert_param(IS_RCC_PLLSAI1N_VALUE(PllSai1->PLLSAI1N));
+  assert_param(IS_RCC_PLLSAI1R_VALUE(PllSai1->PLLSAI1R));
+  assert_param(IS_RCC_PLLSAI1CLOCKOUT_VALUE(PllSai1->PLLSAI1ClockOut));
+
+  /* Disable the PLLSAI1 */
+  __HAL_RCC_PLLSAI1_DISABLE();
+
+  /* Get Start Tick*/
+  tickstart = HAL_GetTick();
+
+  /* Wait till PLLSAI1 is ready to be updated */
+  while(READ_BIT(RCC->CR, RCC_CR_PLLSAI1RDY) != RESET)
+  {
+    if((HAL_GetTick() - tickstart) > PLLSAI1_TIMEOUT_VALUE)
+    {
+      status = HAL_TIMEOUT;
+      break;
+    }
+  }
+
+  if(status == HAL_OK)    
+  {
+    /* Configure the PLLSAI1 Multiplication factor N */
+    __HAL_RCC_PLLSAI1_MULN_CONFIG(PllSai1->PLLSAI1N);
+    /* Configure the PLLSAI1 Division factor R */
+    __HAL_RCC_PLLSAI1_DIVR_CONFIG(PllSai1->PLLSAI1R);
+
+    /* Enable the PLLSAI1 again by setting PLLSAI1ON to 1*/
+    __HAL_RCC_PLLSAI1_ENABLE();
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    /* Wait till PLLSAI1 is ready */
+    while(READ_BIT(RCC->CR, RCC_CR_PLLSAI1RDY) == RESET)
+    {
+      if((HAL_GetTick() - tickstart) > PLLSAI1_TIMEOUT_VALUE)
+      {
+        status = HAL_TIMEOUT;
+        break;
+      }
+    }
+    
+    if(status == HAL_OK)
+    {
+      /* Configure the PLLSAI1 Clock output(s) */
+      __HAL_RCC_PLLSAI1CLKOUT_ENABLE(PllSai1->PLLSAI1ClockOut);
+    }
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Configure the parameters N & P of PLLSAI2 and enable PLLSAI2 output clock(s).
+  * @param  PllSai2  pointer to an RCC_PLLSAI2InitTypeDef structure that
+  *         contains the configuration parameters N & P as well as PLLSAI2 output clock(s)
+  *
+  * @note   PLLSAI2 is temporary disable to apply new parameters
+  *
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef RCCEx_PLLSAI2_ConfigNP(RCC_PLLSAI2InitTypeDef *PllSai2)
+{
+  uint32_t tickstart = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* check for PLLSAI2 Parameters */
+  assert_param(IS_RCC_PLLSAI2N_VALUE(PllSai2->PLLSAI2N));
+  assert_param(IS_RCC_PLLSAI2P_VALUE(PllSai2->PLLSAI2P));
+  assert_param(IS_RCC_PLLSAI2CLOCKOUT_VALUE(PllSai2->PLLSAI2ClockOut));
+
+  /* Disable the PLLSAI2 */
+  __HAL_RCC_PLLSAI2_DISABLE();
+
+  /* Get Start Tick*/
+  tickstart = HAL_GetTick();
+
+  /* Wait till PLLSAI2 is ready */
+  while(READ_BIT(RCC->CR, RCC_CR_PLLSAI2RDY) != RESET)
+  {
+    if((HAL_GetTick() - tickstart) > PLLSAI2_TIMEOUT_VALUE)
+    {
+      status = HAL_TIMEOUT;
+      break;
+    }
+  }
+
+  if(status == HAL_OK)    
+  {
+    /* Configure the PLLSAI2 Multiplication factor N */
+    __HAL_RCC_PLLSAI2_MULN_CONFIG(PllSai2->PLLSAI2N);
+    /* Configure the PLLSAI2 Division factor P */
+    __HAL_RCC_PLLSAI2_DIVP_CONFIG(PllSai2->PLLSAI2P);
+
+    /* Enable the PLLSAI2 again by setting PLLSAI2ON to 1*/
+    __HAL_RCC_PLLSAI2_ENABLE();
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    /* Wait till PLLSAI2 is ready */
+    while(READ_BIT(RCC->CR, RCC_CR_PLLSAI2RDY) == RESET)
+    {
+      if((HAL_GetTick() - tickstart) > PLLSAI2_TIMEOUT_VALUE)
+      {
+        status = HAL_TIMEOUT;
+        break;
+      }
+    }
+    
+    if(status == HAL_OK)
+    {
+      /* Configure the PLLSAI2 Clock output(s) */
+      __HAL_RCC_PLLSAI2CLKOUT_ENABLE(PllSai2->PLLSAI2ClockOut);
+    }
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Configure the parameters N & R of PLLSAI2 and enable PLLSAI2 output clock(s).
+  * @param  PllSai2  pointer to an RCC_PLLSAI2InitTypeDef structure that
+  *         contains the configuration parameters N & R as well as PLLSAI2 output clock(s)
+  *
+  * @note   PLLSAI2 is temporary disable to apply new parameters
+  *
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef RCCEx_PLLSAI2_ConfigNR(RCC_PLLSAI2InitTypeDef *PllSai2)
+{
+  uint32_t tickstart = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* check for PLLSAI2 Parameters */
+  assert_param(IS_RCC_PLLSAI2N_VALUE(PllSai2->PLLSAI2N));
+  assert_param(IS_RCC_PLLSAI2R_VALUE(PllSai2->PLLSAI2R));
+  assert_param(IS_RCC_PLLSAI2CLOCKOUT_VALUE(PllSai2->PLLSAI2ClockOut));
+
+  /* Disable the PLLSAI2 */
+  __HAL_RCC_PLLSAI2_DISABLE();
+
+  /* Get Start Tick*/
+  tickstart = HAL_GetTick();
+
+  /* Wait till PLLSAI2 is ready */
+  while(READ_BIT(RCC->CR, RCC_CR_PLLSAI2RDY) != RESET)
+  {
+    if((HAL_GetTick() - tickstart) > PLLSAI2_TIMEOUT_VALUE)
+    {
+      status = HAL_TIMEOUT;
+      break;
+    }
+  }
+
+  if(status == HAL_OK)    
+  {
+    /* Configure the PLLSAI2 Multiplication factor N */
+    __HAL_RCC_PLLSAI2_MULN_CONFIG(PllSai2->PLLSAI2N);
+    /* Configure the PLLSAI2 Division factor R */
+    __HAL_RCC_PLLSAI2_DIVR_CONFIG(PllSai2->PLLSAI2R);
+
+    /* Enable the PLLSAI2 again by setting PLLSAI2ON to 1*/
+    __HAL_RCC_PLLSAI2_ENABLE();
+
+    /* Get Start Tick*/
+    tickstart = HAL_GetTick();
+
+    /* Wait till PLLSAI2 is ready */
+    while(READ_BIT(RCC->CR, RCC_CR_PLLSAI2RDY) == RESET)
+    {
+      if((HAL_GetTick() - tickstart) > PLLSAI2_TIMEOUT_VALUE)
+      {
+        status = HAL_TIMEOUT;
+        break;
+      }
+    }
+    
+    if(status == HAL_OK)
+    {
+      /* Configure the PLLSAI2 Clock output(s) */
+      __HAL_RCC_PLLSAI2CLKOUT_ENABLE(PllSai2->PLLSAI2ClockOut);
+    }
+  }
+  
+  return status;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RCC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/stmhal/hal/l4/src/stm32l4xx_hal_rng.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_rng.c
@@ -1,0 +1,519 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_rng.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   RNG HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Random Number Generator (RNG) peripheral:
+  *           + Initialization/de-initialization functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                     ##### How to use this driver #####
+  ==============================================================================
+  [..]
+      The RNG HAL driver can be used as follows:
+
+      (#) Enable the RNG controller clock using __HAL_RCC_RNG_CLK_ENABLE() macro 
+          in HAL_RNG_MspInit().
+      (#) Activate the RNG peripheral using HAL_RNG_Init() function.
+      (#) Wait until the 32-bit Random Number Generator contains a valid 
+          random data using (polling/interrupt) mode.   
+      (#) Get the 32 bit random number using HAL_RNG_GenerateRandomNumber() function.
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RNG RNG
+  * @brief RNG HAL module driver.
+  * @{
+  */
+
+#ifdef HAL_RNG_MODULE_ENABLED
+
+
+
+/* Private types -------------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/
+/** @defgroup RNG_Private_Constants RNG_Private_Constants
+  * @{
+  */
+#define RNG_TIMEOUT_VALUE     2
+/**
+  * @}
+  */ 
+
+/* Private macros ------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup RNG_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup RNG_Exported_Functions_Group1
+ *  @brief   Initialization and de-initialization functions
+ *
+@verbatim
+ ===============================================================================
+          ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize the RNG according to the specified parameters 
+          in the RNG_InitTypeDef and create the associated handle
+      (+) DeInitialize the RNG peripheral
+      (+) Initialize the RNG MSP (MCU Specific Package)
+      (+) DeInitialize the RNG MSP 
+ 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initialize the RNG peripheral and initialize the associated handle.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RNG_Init(RNG_HandleTypeDef *hrng)
+{ 
+  /* Check the RNG handle allocation */
+  if(hrng == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  assert_param(IS_RNG_ALL_INSTANCE(hrng->Instance)); 
+  
+  __HAL_LOCK(hrng);
+  
+  if(hrng->State == HAL_RNG_STATE_RESET)
+  {  
+    /* Allocate lock resource and initialize it */
+    hrng->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware */
+    HAL_RNG_MspInit(hrng);
+  }
+  
+  /* Change RNG peripheral state */
+  hrng->State = HAL_RNG_STATE_BUSY;
+
+  /* Enable the RNG Peripheral */
+  __HAL_RNG_ENABLE(hrng);
+
+  /* Initialize the RNG state */
+  hrng->State = HAL_RNG_STATE_READY;
+  
+  __HAL_UNLOCK(hrng);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitialize the RNG peripheral. 
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RNG_DeInit(RNG_HandleTypeDef *hrng)
+{ 
+  /* Check the RNG handle allocation */
+  if(hrng == NULL)
+  {
+    return HAL_ERROR;
+  }
+  /* Disable the RNG Peripheral */
+  CLEAR_BIT(hrng->Instance->CR, RNG_CR_IE | RNG_CR_RNGEN);
+  
+  /* Clear RNG interrupt status flags */
+  CLEAR_BIT(hrng->Instance->SR, RNG_SR_CEIS | RNG_SR_SEIS);
+  
+  /* DeInit the low level hardware */
+  HAL_RNG_MspDeInit(hrng);
+  
+  /* Update the RNG state */
+  hrng->State = HAL_RNG_STATE_RESET; 
+
+  /* Release Lock */
+  __HAL_UNLOCK(hrng);
+  
+  /* Return the function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initialize the RNG MSP.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure.
+  * @retval None
+  */
+__weak void HAL_RNG_MspInit(RNG_HandleTypeDef *hrng)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrng);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_RNG_MspInit must be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  DeInitialize the RNG MSP.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure.
+  * @retval None
+  */
+__weak void HAL_RNG_MspDeInit(RNG_HandleTypeDef *hrng)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrng);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_RNG_MspDeInit must be implemented in the user file.
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @addtogroup RNG_Exported_Functions_Group2
+ *  @brief    Management functions. 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Get the 32 bit Random number
+      (+) Get the 32 bit Random number with interrupt enabled
+      (+) Handle RNG interrupt request 
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Generate a 32-bit random number.
+  * @note   Each time the random number data is read the RNG_FLAG_DRDY flag 
+  *         is automatically cleared.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure.
+  * @param  random32bit: pointer to generated random number variable if successful.
+  * @retval HAL status
+  */
+
+HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber(RNG_HandleTypeDef *hrng, uint32_t *random32bit)
+{
+  uint32_t tickstart = 0;    
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process Locked */
+  __HAL_LOCK(hrng); 
+  
+  /* Check RNS peripheral state */
+  if(hrng->State == HAL_RNG_STATE_READY)
+  {
+    /* Change RNG peripheral state */  
+    hrng->State = HAL_RNG_STATE_BUSY;  
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+  
+    /* Check if data register contains valid random data */
+    while(__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_DRDY) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RNG_TIMEOUT_VALUE)
+      {    
+        hrng->State = HAL_RNG_STATE_ERROR;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrng);
+      
+        return HAL_TIMEOUT;
+      } 
+    }
+  
+    /* Get a 32bit Random number */
+    hrng->RandomNumber = hrng->Instance->DR;
+    *random32bit = hrng->RandomNumber;
+  
+    hrng->State = HAL_RNG_STATE_READY;
+  }
+  else
+  {
+    status = HAL_ERROR;
+  }
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrng);
+
+  return status;
+}
+
+/**
+  * @brief  Generate a 32-bit random number in interrupt mode.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber_IT(RNG_HandleTypeDef *hrng)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  
+  /* Process Locked */
+  __HAL_LOCK(hrng);
+  
+  /* Check RNG peripheral state */
+  if(hrng->State == HAL_RNG_STATE_READY)
+  {
+    /* Change RNG peripheral state */  
+    hrng->State = HAL_RNG_STATE_BUSY;  
+  
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrng);
+    
+    /* Enable the RNG Interrupts: Data Ready, Clock error, Seed error */ 
+    __HAL_RNG_ENABLE_IT(hrng);
+  }
+  else
+  {
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrng);
+    
+    status = HAL_ERROR;
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Handle RNG interrupt request.
+  * @note   In the case of a clock error, the RNG is no more able to generate 
+  *         random numbers because the PLL48CLK clock is not correct. User has 
+  *         to check that the clock controller is correctly configured to provide
+  *         the RNG clock and clear the CEIS bit using __HAL_RNG_CLEAR_IT(). 
+  *         The clock error has no impact on the previously generated 
+  *         random numbers, and the RNG_DR register contents can be used.
+  * @note   In the case of a seed error, the generation of random numbers is 
+  *         interrupted as long as the SECS bit is '1'. If a number is 
+  *         available in the RNG_DR register, it must not be used because it may 
+  *         not have enough entropy. In this case, it is recommended to clear the 
+  *         SEIS bit using __HAL_RNG_CLEAR_IT(), then disable and enable 
+  *         the RNG peripheral to reinitialize and restart the RNG.
+  * @note   User-written HAL_RNG_ErrorCallback() API is called once whether SEIS
+  *         or CEIS are set.  
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure.
+  * @retval None
+
+  */
+void HAL_RNG_IRQHandler(RNG_HandleTypeDef *hrng)
+{
+  /* RNG clock error interrupt occurred */
+  if((__HAL_RNG_GET_IT(hrng, RNG_IT_CEI) != RESET) ||  (__HAL_RNG_GET_IT(hrng, RNG_IT_SEI) != RESET))
+  { 
+    /* Change RNG peripheral state */
+    hrng->State = HAL_RNG_STATE_ERROR;
+  
+    HAL_RNG_ErrorCallback(hrng);
+    
+    /* Clear the clock error flag */
+    __HAL_RNG_CLEAR_IT(hrng, RNG_IT_CEI|RNG_IT_SEI);
+    
+  }
+  
+  /* Check RNG data ready interrupt occurred */    
+  if(__HAL_RNG_GET_IT(hrng, RNG_IT_DRDY) != RESET)
+  {
+    /* Generate random number once, so disable the IT */
+    __HAL_RNG_DISABLE_IT(hrng);
+    
+    /* Get the 32bit Random number (DRDY flag automatically cleared) */ 
+    hrng->RandomNumber = hrng->Instance->DR;
+    
+    if(hrng->State != HAL_RNG_STATE_ERROR)
+    {
+      /* Change RNG peripheral state */
+      hrng->State = HAL_RNG_STATE_READY; 
+      
+      /* Data Ready callback */ 
+      HAL_RNG_ReadyDataCallback(hrng, hrng->RandomNumber);
+    } 
+  }
+} 
+
+/**
+  * @brief  Return generated random number in polling mode (Obsolete).
+  * @note   Use HAL_RNG_GenerateRandomNumber() API instead.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval random value
+  */
+uint32_t HAL_RNG_GetRandomNumber(RNG_HandleTypeDef *hrng)
+{
+  if(HAL_RNG_GenerateRandomNumber(hrng, &(hrng->RandomNumber)) == HAL_OK)
+  {
+    return hrng->RandomNumber; 
+  }
+  else
+  {
+    return 0;
+  }
+}
+
+
+/**
+  * @brief  Return a 32-bit random number with interrupt enabled (Obsolete).
+  * @note   Use HAL_RNG_GenerateRandomNumber_IT() API instead.
+  * @param  hrng: RNG handle
+  * @retval 32-bit random number
+  */
+uint32_t HAL_RNG_GetRandomNumber_IT(RNG_HandleTypeDef *hrng)
+{
+  uint32_t random32bit = 0;
+  
+  /* Process locked */
+  __HAL_LOCK(hrng);
+  
+  /* Change RNG peripheral state */  
+  hrng->State = HAL_RNG_STATE_BUSY;  
+  
+  /* Get a 32bit Random number */ 
+  random32bit = hrng->Instance->DR;
+  
+  /* Enable the RNG Interrupts: Data Ready, Clock error, Seed error */ 
+  __HAL_RNG_ENABLE_IT(hrng); 
+  
+  /* Return the 32 bit random number */   
+  return random32bit;
+}
+
+
+
+/**
+  * @brief  Read latest generated random number. 
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure.
+  * @retval random value
+  */
+uint32_t HAL_RNG_ReadLastRandomNumber(RNG_HandleTypeDef *hrng)
+{
+  return(hrng->RandomNumber);
+}
+
+/**
+  * @brief  Data Ready callback in non-blocking mode. 
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure.
+  * @param  random32bit: generated random value
+  * @retval None
+  */
+__weak void HAL_RNG_ReadyDataCallback(RNG_HandleTypeDef *hrng, uint32_t random32bit)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrng);
+  UNUSED(random32bit);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_RNG_ReadyDataCallback must be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  RNG error callback.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure.
+  * @retval None
+  */
+__weak void HAL_RNG_ErrorCallback(RNG_HandleTypeDef *hrng)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrng);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_RNG_ErrorCallback must be implemented in the user file.
+   */
+}
+ 
+/**
+  * @}
+  */
+
+/** @addtogroup RNG_Exported_Functions_Group3
+ *  @brief    Peripheral State functions. 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================  
+    [..]
+    This subsection permits to get in run-time the status of the peripheral.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the RNG handle state.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure.
+  * @retval HAL state
+  */
+HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng)
+{
+  /* Return RNG handle state */
+  return hrng->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+#endif /* HAL_RNG_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_rtc.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_rtc.c
@@ -1,0 +1,1530 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_rtc.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   RTC HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Real-Time Clock (RTC) peripheral:
+  *           + Initialization
+  *           + Calendar (Time and Date) configuration
+  *           + Alarms (Alarm A and Alarm B) configuration
+  *           + WakeUp Timer configuration
+  *           + TimeStamp configuration
+  *           + Tampers configuration
+  *           + Backup Data Registers configuration  
+  *           + RTC Tamper and TimeStamp Pins Selection 
+  *           + Interrupts and flags management
+  *         
+  @verbatim
+ ===============================================================================   
+                          ##### RTC Operating Condition #####
+ ===============================================================================
+  [..] The real-time clock (RTC) and the RTC backup registers can be powered
+       from the VBAT voltage when the main VDD supply is powered off.
+       To retain the content of the RTC backup registers and supply the RTC 
+       when VDD is turned off, VBAT pin can be connected to an optional
+       standby voltage supplied by a battery or by another source.
+
+                   ##### Backup Domain Reset #####
+ ===============================================================================
+  [..] The backup domain reset sets all RTC registers and the RCC_BDCR register
+       to their reset values. 
+       A backup domain reset is generated when one of the following events occurs:
+    (#) Software reset, triggered by setting the BDRST bit in the 
+        RCC Backup domain control register (RCC_BDCR).
+    (#) VDD or VBAT power on, if both supplies have previously been powered off.
+    (#) Tamper detection event resets all data backup registers.
+
+                   ##### Backup Domain Access #####
+ ===================================================================
+  [..] After reset, the backup domain (RTC registers, RTC backup data 
+       registers and backup SRAM) is protected against possible unwanted write 
+       accesses.
+
+  [..] To enable access to the RTC Domain and RTC registers, proceed as follows:
+    (#) Call the function HAL_RCCEx_PeriphCLKConfig with RCC_PERIPHCLK_RTC for
+        PeriphClockSelection and select RTCClockSelection (LSE, LSI or HSEdiv32)
+    (#) Enable RTC Clock using the __HAL_RCC_RTC_ENABLE() macro.
+
+                  ##### How to use RTC Driver #####
+ ===================================================================
+  [..]
+    (#) Enable the RTC domain access (see description in the section above).
+    (#) Configure the RTC Prescaler (Asynchronous and Synchronous) and RTC hour
+        format using the HAL_RTC_Init() function.
+
+  *** Time and Date configuration ***
+  ===================================
+  [..] 
+    (#) To configure the RTC Calendar (Time and Date) use the HAL_RTC_SetTime()
+        and HAL_RTC_SetDate() functions.
+    (#) To read the RTC Calendar, use the HAL_RTC_GetTime() and HAL_RTC_GetDate() functions.
+
+  *** Alarm configuration ***
+  ===========================
+  [..]
+    (#) To configure the RTC Alarm use the HAL_RTC_SetAlarm() function.
+            You can also configure the RTC Alarm with interrupt mode using the 
+            HAL_RTC_SetAlarm_IT() function.
+    (#) To read the RTC Alarm, use the HAL_RTC_GetAlarm() function.
+
+                  ##### RTC and low power modes #####
+ ===================================================================
+  [..] The MCU can be woken up from a low power mode by an RTC alternate
+       function.
+  [..] The RTC alternate functions are the RTC alarms (Alarm A and Alarm B),
+       RTC wakeup, RTC tamper event detection and RTC time stamp event detection.
+       These RTC alternate functions can wake up the system from the Stop and 
+       Standby low power modes.
+  [..] The system can also wake up from low power modes without depending
+       on an external interrupt (Auto-wakeup mode), by using the RTC alarm
+       or the RTC wakeup events.
+  [..] The RTC provides a programmable time base for waking up from the
+       Stop or Standby mode at regular intervals.
+       Wakeup from STOP and Standby modes is possible only when the RTC clock source
+       is LSE or LSI.
+
+   @endverbatim
+
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RTC RTC
+  * @brief RTC HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup RTC_Exported_Functions RTC Exported Functions
+  * @{
+  */
+
+/** @defgroup RTC_Exported_Functions_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+   [..] This section provide functions allowing to initialize and configure the 
+         RTC Prescaler (Synchronous and Asynchronous), RTC Hour format, disable 
+         RTC registers Write protection, enter and exit the RTC initialization mode,
+         RTC registers synchronization check and reference clock detection enable.
+         (#) The RTC Prescaler is programmed to generate the RTC 1Hz time base.
+             It is split into 2 programmable prescalers to minimize power consumption.
+             (++) A 7-bit asynchronous prescaler and a 15-bit synchronous prescaler.
+             (++) When both prescalers are used, it is recommended to configure the 
+                 asynchronous prescaler to a high value to minimize power consumption.
+         (#) All RTC registers are Write protected. Writing to the RTC registers
+             is enabled by writing a key into the Write Protection register, RTC_WPR.
+         (#) To configure the RTC Calendar, user application should enter 
+             initialization mode. In this mode, the calendar counter is stopped
+             and its value can be updated. When the initialization sequence is 
+             complete, the calendar restarts counting after 4 RTCCLK cycles.
+         (#) To read the calendar through the shadow registers after Calendar 
+             initialization, calendar update or after wakeup from low power modes
+             the software must first clear the RSF flag. The software must then
+             wait until it is set again before reading the calendar, which means
+             that the calendar registers have been correctly copied into the
+             RTC_TR and RTC_DR shadow registers. The HAL_RTC_WaitForSynchro() function 
+             implements the above software sequence (RSF clear and RSF check).
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initialize the RTC according to the specified parameters 
+  *         in the RTC_InitTypeDef structure and initialize the associated handle.
+  * @param  hrtc: RTC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
+{
+  /* Check the RTC peripheral state */
+  if(hrtc == NULL)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_RTC_ALL_INSTANCE(hrtc->Instance));
+  assert_param(IS_RTC_HOUR_FORMAT(hrtc->Init.HourFormat));
+  assert_param(IS_RTC_ASYNCH_PREDIV(hrtc->Init.AsynchPrediv));
+  assert_param(IS_RTC_SYNCH_PREDIV(hrtc->Init.SynchPrediv));
+  assert_param(IS_RTC_OUTPUT(hrtc->Init.OutPut));
+  assert_param(IS_RTC_OUTPUT_REMAP(hrtc->Init.OutPutRemap));
+  assert_param(IS_RTC_OUTPUT_POL(hrtc->Init.OutPutPolarity));
+  assert_param(IS_RTC_OUTPUT_TYPE(hrtc->Init.OutPutType));
+  
+  if(hrtc->State == HAL_RTC_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hrtc->Lock = HAL_UNLOCKED;
+
+    /* Initialize RTC MSP */
+    HAL_RTC_MspInit(hrtc);
+  }
+
+  /* Set RTC state */
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state */
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Clear RTC_CR FMT, OSEL and POL Bits */
+    hrtc->Instance->CR &= ((uint32_t)~(RTC_CR_FMT | RTC_CR_OSEL | RTC_CR_POL));
+    /* Set RTC_CR register */
+    hrtc->Instance->CR |= (uint32_t)(hrtc->Init.HourFormat | hrtc->Init.OutPut | hrtc->Init.OutPutPolarity);
+
+    /* Configure the RTC PRER */
+    hrtc->Instance->PRER = (uint32_t)(hrtc->Init.SynchPrediv);
+    hrtc->Instance->PRER |= (uint32_t)(hrtc->Init.AsynchPrediv << 16);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= ((uint32_t)~RTC_ISR_INIT);
+
+    hrtc->Instance->OR &= (uint32_t)~(RTC_OR_ALARMOUTTYPE | RTC_OR_OUT_RMP);
+    hrtc->Instance->OR |= (uint32_t)(hrtc->Init.OutPutType | hrtc->Init.OutPutRemap);
+
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state */
+    hrtc->State = HAL_RTC_STATE_READY;
+
+    return HAL_OK;
+  }
+}
+
+/**
+  * @brief  DeInitialize the RTC peripheral.
+  * @param  hrtc: RTC handle
+  * @note   This function doesn't reset the RTC Backup Data registers.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_ALL_INSTANCE(hrtc->Instance));
+
+  /* Set RTC state */
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state */
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Reset TR, DR and CR registers */
+    hrtc->Instance->TR = (uint32_t)0x00000000;
+    hrtc->Instance->DR = ((uint32_t)(RTC_DR_WDU_0 | RTC_DR_MU_0 | RTC_DR_DU_0));
+    /* Reset All CR bits except CR[2:0] */
+    hrtc->Instance->CR &= RTC_CR_WUCKSEL;
+
+    tickstart = HAL_GetTick();
+
+    /* Wait till WUTWF flag is set and if Time out is reached exit */
+    while(((hrtc->Instance->ISR) & RTC_ISR_WUTWF) == (uint32_t)RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        /* Set RTC state */
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Reset all RTC CR register bits */
+    hrtc->Instance->CR &= (uint32_t)0x00000000;
+    hrtc->Instance->WUTR = RTC_WUTR_WUT;
+    hrtc->Instance->PRER = ((uint32_t)(RTC_PRER_PREDIV_A | 0x000000FF));
+    hrtc->Instance->ALRMAR = (uint32_t)0x00000000;
+    hrtc->Instance->ALRMBR = (uint32_t)0x00000000;
+    hrtc->Instance->SHIFTR = (uint32_t)0x00000000;
+    hrtc->Instance->CALR = (uint32_t)0x00000000;
+    hrtc->Instance->ALRMASSR = (uint32_t)0x00000000;
+    hrtc->Instance->ALRMBSSR = (uint32_t)0x00000000;
+
+    /* Reset ISR register and exit initialization mode */
+    hrtc->Instance->ISR = (uint32_t)0x00000000;
+
+    /* Reset Tamper configuration register */
+    hrtc->Instance->TAMPCR = 0x00000000;
+
+    /* Reset Option register */
+    hrtc->Instance->OR = 0x00000000;
+
+    /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == RESET)
+    {
+      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);  
+
+        hrtc->State = HAL_RTC_STATE_ERROR;
+
+        return HAL_ERROR;
+      }
+    }
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* De-Initialize RTC MSP */
+  HAL_RTC_MspDeInit(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initialize the RTC MSP.
+  * @param  hrtc: RTC handle  
+  * @retval None
+  */
+__weak void HAL_RTC_MspInit(RTC_HandleTypeDef* hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_RTC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitialize the RTC MSP.
+  * @param  hrtc: RTC handle 
+  * @retval None
+  */
+__weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_RTC_MspDeInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Exported_Functions_Group2 RTC Time and Date functions
+ *  @brief   RTC Time and Date functions
+ *
+@verbatim
+ ===============================================================================
+                 ##### RTC Time and Date functions #####
+ ===============================================================================
+ 
+ [..] This section provides functions allowing to configure Time and Date features
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Set RTC current time.
+  * @param  hrtc: RTC handle
+  * @param  sTime: Pointer to Time structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_FORMAT_BIN: Binary data format 
+  *            @arg RTC_FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format)
+{
+  uint32_t tmpreg = 0;
+
+ /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_DAYLIGHT_SAVING(sTime->DayLightSaving));
+  assert_param(IS_RTC_STORE_OPERATION(sTime->StoreOperation));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if(Format == RTC_FORMAT_BIN)
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      assert_param(IS_RTC_HOUR12(sTime->Hours));
+      assert_param(IS_RTC_HOURFORMAT12(sTime->TimeFormat));
+    }
+    else
+    {
+      sTime->TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(sTime->Hours));
+    }
+    assert_param(IS_RTC_MINUTES(sTime->Minutes));
+    assert_param(IS_RTC_SECONDS(sTime->Seconds));
+
+    tmpreg = (uint32_t)(((uint32_t)RTC_ByteToBcd2(sTime->Hours) << 16) | \
+                        ((uint32_t)RTC_ByteToBcd2(sTime->Minutes) << 8) | \
+                        ((uint32_t)RTC_ByteToBcd2(sTime->Seconds)) | \
+                        (((uint32_t)sTime->TimeFormat) << 16));
+  }
+  else
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      tmpreg = RTC_Bcd2ToByte(sTime->Hours);
+      assert_param(IS_RTC_HOUR12(tmpreg));
+      assert_param(IS_RTC_HOURFORMAT12(sTime->TimeFormat));
+    }
+    else
+    {
+      sTime->TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(RTC_Bcd2ToByte(sTime->Hours)));
+    }
+    assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sTime->Minutes)));
+    assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sTime->Seconds)));
+    tmpreg = (((uint32_t)(sTime->Hours) << 16) | \
+              ((uint32_t)(sTime->Minutes) << 8) | \
+              ((uint32_t)sTime->Seconds) | \
+              ((uint32_t)(sTime->TimeFormat) << 16));
+  }
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state */
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */ 
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Set the RTC_TR register */
+    hrtc->Instance->TR = (uint32_t)(tmpreg & RTC_TR_RESERVED_MASK);
+
+    /* Clear the bits to be configured */
+    hrtc->Instance->CR &= ((uint32_t)~RTC_CR_BCK);
+
+    /* Configure the RTC_CR register */
+    hrtc->Instance->CR |= (uint32_t)(sTime->DayLightSaving | sTime->StoreOperation);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= ((uint32_t)~RTC_ISR_INIT);
+
+    /* If  CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == RESET)
+    {
+      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_ERROR;
+
+        /* Process Unlocked */ 
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_ERROR;
+      }
+    }
+
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+    
+   hrtc->State = HAL_RTC_STATE_READY;
+
+   __HAL_UNLOCK(hrtc); 
+
+   return HAL_OK;
+  }
+}
+
+/**
+  * @brief  Get RTC current time.
+  * @param  hrtc: RTC handle
+  * @param  sTime: Pointer to Time structure with Hours, Minutes and Seconds fields returned 
+  *                with input format (BIN or BCD), also SubSeconds field returning the
+  *                RTC_SSR register content and SecondFraction field the Synchronous pre-scaler
+  *                factor to be used for second fraction ratio computation.
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_FORMAT_BIN: Binary data format 
+  *            @arg RTC_FORMAT_BCD: BCD data format
+  * @note  You can use SubSeconds and SecondFraction (sTime structure fields returned) to convert SubSeconds
+  *        value in second fraction ratio with time unit following generic formula:
+  *        Second fraction ratio * time_unit= [(SecondFraction-SubSeconds)/(SecondFraction+1)] * time_unit
+  *        This conversion can be performed only if no shift operation is pending (ie. SHFP=0) when PREDIV_S >= SS
+  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the values 
+  *        in the higher-order calendar shadow registers to ensure consistency between the time and date values.
+  *        Reading RTC current time locks the values in calendar shadow registers until Current date is read
+  *        to ensure consistency between the time and date values.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Get subseconds structure field from the corresponding register*/
+  sTime->SubSeconds = (uint32_t)(hrtc->Instance->SSR);
+
+  /* Get SecondFraction structure field from the corresponding register field*/
+  sTime->SecondFraction = (uint32_t)(hrtc->Instance->PRER & RTC_PRER_PREDIV_S);
+  
+  /* Get the TR register */
+  tmpreg = (uint32_t)(hrtc->Instance->TR & RTC_TR_RESERVED_MASK);
+
+  /* Fill the structure fields with the read parameters */
+  sTime->Hours = (uint8_t)((tmpreg & (RTC_TR_HT | RTC_TR_HU)) >> 16);
+  sTime->Minutes = (uint8_t)((tmpreg & (RTC_TR_MNT | RTC_TR_MNU)) >>8);
+  sTime->Seconds = (uint8_t)(tmpreg & (RTC_TR_ST | RTC_TR_SU));
+  sTime->TimeFormat = (uint8_t)((tmpreg & (RTC_TR_PM)) >> 16);
+
+  /* Check the input parameters format */
+  if(Format == RTC_FORMAT_BIN)
+  {
+    /* Convert the time structure parameters to Binary format */
+    sTime->Hours = (uint8_t)RTC_Bcd2ToByte(sTime->Hours);
+    sTime->Minutes = (uint8_t)RTC_Bcd2ToByte(sTime->Minutes);
+    sTime->Seconds = (uint8_t)RTC_Bcd2ToByte(sTime->Seconds);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set RTC current date.
+  * @param  hrtc: RTC handle
+  * @param  sDate: Pointer to date structure
+  * @param  Format: specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_FORMAT_BIN: Binary data format 
+  *            @arg RTC_FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format)
+{
+  uint32_t datetmpreg = 0;
+
+ /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+ /* Process Locked */
+ __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if((Format == RTC_FORMAT_BIN) && ((sDate->Month & 0x10) == 0x10))
+  {
+    sDate->Month = (uint8_t)((sDate->Month & (uint8_t)~(0x10)) + (uint8_t)0x0A);
+  }
+
+  assert_param(IS_RTC_WEEKDAY(sDate->WeekDay));
+
+  if(Format == RTC_FORMAT_BIN)
+  {
+    assert_param(IS_RTC_YEAR(sDate->Year));
+    assert_param(IS_RTC_MONTH(sDate->Month));
+    assert_param(IS_RTC_DATE(sDate->Date));
+
+   datetmpreg = (((uint32_t)RTC_ByteToBcd2(sDate->Year) << 16) | \
+                 ((uint32_t)RTC_ByteToBcd2(sDate->Month) << 8) | \
+                 ((uint32_t)RTC_ByteToBcd2(sDate->Date)) | \
+                 ((uint32_t)sDate->WeekDay << 13));
+  }
+  else
+  {
+    assert_param(IS_RTC_YEAR(RTC_Bcd2ToByte(sDate->Year)));
+    datetmpreg = RTC_Bcd2ToByte(sDate->Month);
+    assert_param(IS_RTC_MONTH(datetmpreg));
+    datetmpreg = RTC_Bcd2ToByte(sDate->Date);
+    assert_param(IS_RTC_DATE(datetmpreg));
+
+    datetmpreg = ((((uint32_t)sDate->Year) << 16) | \
+                  (((uint32_t)sDate->Month) << 8) | \
+                  ((uint32_t)sDate->Date) | \
+                  (((uint32_t)sDate->WeekDay) << 13));
+  }
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state*/
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */ 
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Set the RTC_DR register */
+    hrtc->Instance->DR = (uint32_t)(datetmpreg & RTC_DR_RESERVED_MASK);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= ((uint32_t)~RTC_ISR_INIT);
+
+    /* If  CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == RESET)
+    {
+      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);  
+
+        hrtc->State = HAL_RTC_STATE_ERROR;
+
+        /* Process Unlocked */ 
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_ERROR;
+      }
+    }
+
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    hrtc->State = HAL_RTC_STATE_READY ;
+
+    /* Process Unlocked */ 
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_OK;
+  }
+}
+
+/**
+  * @brief  Get RTC current date.
+  * @param  hrtc: RTC handle
+  * @param  sDate: Pointer to Date structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_FORMAT_BIN:  Binary data format 
+  *            @arg RTC_FORMAT_BCD:  BCD data format
+  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the values 
+  *        in the higher-order calendar shadow registers to ensure consistency between the time and date values.
+  *        Reading RTC current time locks the values in calendar shadow registers until Current date is read.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format)
+{
+  uint32_t datetmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Get the DR register */
+  datetmpreg = (uint32_t)(hrtc->Instance->DR & RTC_DR_RESERVED_MASK);
+
+  /* Fill the structure fields with the read parameters */
+  sDate->Year = (uint8_t)((datetmpreg & (RTC_DR_YT | RTC_DR_YU)) >> 16);
+  sDate->Month = (uint8_t)((datetmpreg & (RTC_DR_MT | RTC_DR_MU)) >> 8);
+  sDate->Date = (uint8_t)(datetmpreg & (RTC_DR_DT | RTC_DR_DU));
+  sDate->WeekDay = (uint8_t)((datetmpreg & (RTC_DR_WDU)) >> 13); 
+
+  /* Check the input parameters format */
+  if(Format == RTC_FORMAT_BIN)
+  {
+    /* Convert the date structure parameters to Binary format */
+    sDate->Year = (uint8_t)RTC_Bcd2ToByte(sDate->Year);
+    sDate->Month = (uint8_t)RTC_Bcd2ToByte(sDate->Month);
+    sDate->Date = (uint8_t)RTC_Bcd2ToByte(sDate->Date);
+  }
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Exported_Functions_Group3 RTC Alarm functions
+ *  @brief   RTC Alarm functions
+ *
+@verbatim   
+ ===============================================================================
+                 ##### RTC Alarm functions #####
+ ===============================================================================  
+ 
+ [..] This section provides functions allowing to configure Alarm feature
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Set the specified RTC Alarm.
+  * @param  hrtc: RTC handle
+  * @param  sAlarm: Pointer to Alarm structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_FORMAT_BIN: Binary data format 
+  *             @arg RTC_FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
+{
+  uint32_t tickstart = 0;
+  uint32_t tmpreg = 0, subsecondtmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_ALARM(sAlarm->Alarm));
+  assert_param(IS_RTC_ALARM_MASK(sAlarm->AlarmMask));
+  assert_param(IS_RTC_ALARM_DATE_WEEKDAY_SEL(sAlarm->AlarmDateWeekDaySel));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_VALUE(sAlarm->AlarmTime.SubSeconds));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_MASK(sAlarm->AlarmSubSecondMask));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if(Format == RTC_FORMAT_BIN)
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      assert_param(IS_RTC_HOUR12(sAlarm->AlarmTime.Hours));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(sAlarm->AlarmTime.Hours));
+    }
+    assert_param(IS_RTC_MINUTES(sAlarm->AlarmTime.Minutes));
+    assert_param(IS_RTC_SECONDS(sAlarm->AlarmTime.Seconds));
+
+    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(sAlarm->AlarmDateWeekDay));
+    }
+    else
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(sAlarm->AlarmDateWeekDay));
+    }
+
+    tmpreg = (((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Hours) << 16) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Minutes) << 8) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Seconds)) | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmDateWeekDay) << 24) | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+              ((uint32_t)sAlarm->AlarmMask));
+  }
+  else
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
+      assert_param(IS_RTC_HOUR12(tmpreg));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours)));
+    }
+
+    assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes)));
+    assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds)));
+
+    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(tmpreg));
+    }
+    else
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(tmpreg));
+    }
+
+    tmpreg = (((uint32_t)(sAlarm->AlarmTime.Hours) << 16) | \
+              ((uint32_t)(sAlarm->AlarmTime.Minutes) << 8) | \
+              ((uint32_t) sAlarm->AlarmTime.Seconds) | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16) | \
+              ((uint32_t)(sAlarm->AlarmDateWeekDay) << 24) | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+              ((uint32_t)sAlarm->AlarmMask));   
+  }
+
+  /* Configure the Alarm A or Alarm B Sub Second registers */
+  subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | (uint32_t)(sAlarm->AlarmSubSecondMask));
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Alarm register */
+  if(sAlarm->Alarm == RTC_ALARM_A)
+  {
+    /* Disable the Alarm A interrupt */
+    __HAL_RTC_ALARMA_DISABLE(hrtc);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRA);
+
+    tickstart = HAL_GetTick();
+    /* Wait till RTC ALRAWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+        
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */ 
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMAR = (uint32_t)tmpreg;
+    /* Configure the Alarm A Sub Second register */
+    hrtc->Instance->ALRMASSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMA_ENABLE(hrtc);
+  }
+  else
+  {
+    /* Disable the Alarm B interrupt */
+    __HAL_RTC_ALARMB_DISABLE(hrtc);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRB);
+
+    tickstart = HAL_GetTick();
+    /* Wait till RTC ALRBWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMBR = (uint32_t)tmpreg;
+    /* Configure the Alarm B Sub Second register */
+    hrtc->Instance->ALRMBSSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMB_ENABLE(hrtc);
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the specified RTC Alarm with Interrupt.
+  * @param  hrtc: RTC handle
+  * @param  sAlarm: Pointer to Alarm structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_FORMAT_BIN: Binary data format 
+  *             @arg RTC_FORMAT_BCD: BCD data format
+  * @note   The Alarm register can only be written when the corresponding Alarm
+  *         is disabled (Use the HAL_RTC_DeactivateAlarm()).   
+  * @note   The HAL_RTC_SetTime() must be called before enabling the Alarm feature.   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
+{
+  uint32_t tickstart = 0;
+  uint32_t tmpreg = 0, subsecondtmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_ALARM(sAlarm->Alarm));
+  assert_param(IS_RTC_ALARM_MASK(sAlarm->AlarmMask));
+  assert_param(IS_RTC_ALARM_DATE_WEEKDAY_SEL(sAlarm->AlarmDateWeekDaySel));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_VALUE(sAlarm->AlarmTime.SubSeconds));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_MASK(sAlarm->AlarmSubSecondMask));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if(Format == RTC_FORMAT_BIN)
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      assert_param(IS_RTC_HOUR12(sAlarm->AlarmTime.Hours));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(sAlarm->AlarmTime.Hours));
+    }
+    assert_param(IS_RTC_MINUTES(sAlarm->AlarmTime.Minutes));
+    assert_param(IS_RTC_SECONDS(sAlarm->AlarmTime.Seconds));
+
+    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(sAlarm->AlarmDateWeekDay));
+    }
+    else
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(sAlarm->AlarmDateWeekDay));
+    }
+    tmpreg = (((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Hours) << 16) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Minutes) << 8) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Seconds)) | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmDateWeekDay) << 24) | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+              ((uint32_t)sAlarm->AlarmMask));
+  }
+  else
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
+      assert_param(IS_RTC_HOUR12(tmpreg));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    } 
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours)));
+    }
+
+    assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes)));
+    assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds)));
+    
+    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(tmpreg));
+    }
+    else
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(tmpreg));
+    }
+    tmpreg = (((uint32_t)(sAlarm->AlarmTime.Hours) << 16) | \
+              ((uint32_t)(sAlarm->AlarmTime.Minutes) << 8) | \
+              ((uint32_t) sAlarm->AlarmTime.Seconds) | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16) | \
+              ((uint32_t)(sAlarm->AlarmDateWeekDay) << 24) | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+              ((uint32_t)sAlarm->AlarmMask));     
+  }
+  /* Configure the Alarm A or Alarm B Sub Second registers */
+  subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | (uint32_t)(sAlarm->AlarmSubSecondMask));
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Alarm register */
+  if(sAlarm->Alarm == RTC_ALARM_A)
+  {
+    /* Disable the Alarm A interrupt */
+    __HAL_RTC_ALARMA_DISABLE(hrtc);
+    
+    /* Clear flag alarm A */
+    __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+
+    tickstart = HAL_GetTick();
+    /* Wait till RTC ALRAWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT; 
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMAR = (uint32_t)tmpreg;
+    /* Configure the Alarm A Sub Second register */
+    hrtc->Instance->ALRMASSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMA_ENABLE(hrtc);
+    /* Configure the Alarm interrupt */
+    __HAL_RTC_ALARM_ENABLE_IT(hrtc,RTC_IT_ALRA);
+  }
+  else
+  {
+    /* Disable the Alarm B interrupt */
+    __HAL_RTC_ALARMB_DISABLE(hrtc);
+    
+    /* Clear flag alarm B */
+    __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+
+    tickstart = HAL_GetTick();
+    /* Wait till RTC ALRBWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMBR = (uint32_t)tmpreg;
+    /* Configure the Alarm B Sub Second register */
+    hrtc->Instance->ALRMBSSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMB_ENABLE(hrtc);
+    /* Configure the Alarm interrupt */
+    __HAL_RTC_ALARM_ENABLE_IT(hrtc, RTC_IT_ALRB);
+  }
+
+  /* RTC Alarm Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_ALARM_EXTI_ENABLE_IT();
+
+  __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE();
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY; 
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivate the specified RTC Alarm.
+  * @param  hrtc: RTC handle
+  * @param  Alarm: Specifies the Alarm.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_ALARM_A:  AlarmA
+  *            @arg RTC_ALARM_B:  AlarmB
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alarm)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_ALARM(Alarm));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  if(Alarm == RTC_ALARM_A)
+  {
+    /* AlarmA */
+    __HAL_RTC_ALARMA_DISABLE(hrtc);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRA);
+
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRxWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == RESET)
+    {
+      if( (HAL_GetTick()  - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  else
+  {
+    /* AlarmB */
+    __HAL_RTC_ALARMB_DISABLE(hrtc);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc,RTC_IT_ALRB);
+
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRxWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK; 
+}
+
+/**
+  * @brief  Get the RTC Alarm value and masks.
+  * @param  hrtc: RTC handle
+  * @param  sAlarm: Pointer to Date structure
+  * @param  Alarm: Specifies the Alarm.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_ALARM_A: AlarmA
+  *             @arg RTC_ALARM_B: AlarmB  
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_FORMAT_BIN: Binary data format 
+  *             @arg RTC_FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Alarm, uint32_t Format)
+{
+  uint32_t tmpreg = 0, subsecondtmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_ALARM(Alarm));
+
+  if(Alarm == RTC_ALARM_A)
+  {
+    /* AlarmA */
+    sAlarm->Alarm = RTC_ALARM_A;
+
+    tmpreg = (uint32_t)(hrtc->Instance->ALRMAR);
+    subsecondtmpreg = (uint32_t)((hrtc->Instance->ALRMASSR ) & RTC_ALRMASSR_SS);
+  }
+  else
+  {
+    sAlarm->Alarm = RTC_ALARM_B;
+
+    tmpreg = (uint32_t)(hrtc->Instance->ALRMBR);
+    subsecondtmpreg = (uint32_t)((hrtc->Instance->ALRMBSSR) & RTC_ALRMBSSR_SS);
+  }
+
+  /* Fill the structure with the read parameters */
+  /* ALRMAR/ALRMBR registers have same mapping)  */
+  sAlarm->AlarmTime.Hours = (uint32_t)((tmpreg & (RTC_ALRMAR_HT | RTC_ALRMAR_HU)) >> 16);
+  sAlarm->AlarmTime.Minutes = (uint32_t)((tmpreg & (RTC_ALRMAR_MNT | RTC_ALRMAR_MNU)) >> 8);
+  sAlarm->AlarmTime.Seconds = (uint32_t)(tmpreg & (RTC_ALRMAR_ST | RTC_ALRMAR_SU));
+  sAlarm->AlarmTime.TimeFormat = (uint32_t)((tmpreg & RTC_ALRMAR_PM) >> 16);
+  sAlarm->AlarmTime.SubSeconds = (uint32_t) subsecondtmpreg;
+  sAlarm->AlarmDateWeekDay = (uint32_t)((tmpreg & (RTC_ALRMAR_DT | RTC_ALRMAR_DU)) >> 24);
+  sAlarm->AlarmDateWeekDaySel = (uint32_t)(tmpreg & RTC_ALRMAR_WDSEL);
+  sAlarm->AlarmMask = (uint32_t)(tmpreg & RTC_ALARMMASK_ALL);
+
+  if(Format == RTC_FORMAT_BIN)
+  {
+    sAlarm->AlarmTime.Hours = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
+    sAlarm->AlarmTime.Minutes = RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes);
+    sAlarm->AlarmTime.Seconds = RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds);
+    sAlarm->AlarmDateWeekDay = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handle Alarm interrupt request.
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+void HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef* hrtc)
+{
+  /* Get the AlarmA interrupt source enable status */
+  if(__HAL_RTC_ALARM_GET_IT_SOURCE(hrtc, RTC_IT_ALRA) != RESET)
+  {
+    /* Get the pending status of the AlarmA Interrupt */
+    if(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAF) != RESET)
+    {
+      /* AlarmA callback */
+      HAL_RTC_AlarmAEventCallback(hrtc);
+
+      /* Clear the AlarmA interrupt pending bit */
+      __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+    }
+  }
+
+  /* Get the AlarmB interrupt source enable status */
+  if(__HAL_RTC_ALARM_GET_IT_SOURCE(hrtc, RTC_IT_ALRB) != RESET)
+  {
+    /* Get the pending status of the AlarmB Interrupt */
+    if(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBF) != RESET)
+    {
+      /* AlarmB callback */
+      HAL_RTCEx_AlarmBEventCallback(hrtc);
+
+      /* Clear the AlarmB interrupt pending bit */
+      __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+    }
+  }
+
+  /* Clear the EXTI's line Flag for RTC Alarm */
+  __HAL_RTC_ALARM_EXTI_CLEAR_FLAG();
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+}
+
+/**
+  * @brief  Alarm A callback.
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+__weak void HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_RTC_AlarmAEventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Handle AlarmA Polling request.
+  * @param  hrtc: RTC handle
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+
+  uint32_t tickstart = HAL_GetTick();   
+  
+  while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAF) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Alarm interrupt pending bit */
+  __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Exported_Functions_Group4 Peripheral Control functions 
+ *  @brief   Peripheral Control functions 
+ *
+@verbatim
+ ===============================================================================
+                     ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) Wait for RTC Time and Date Synchronization
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Wait until the RTC Time and Date registers (RTC_TR and RTC_DR) are
+  *         synchronized with RTC APB clock.
+  * @note   The RTC Resynchronization mode is write protected, use the 
+  *         __HAL_RTC_WRITEPROTECTION_DISABLE() before calling this function.
+  * @note   To read the calendar through the shadow registers after Calendar 
+  *         initialization, calendar update or after wakeup from low power modes
+  *         the software must first clear the RSF flag.
+  *         The software must then wait until it is set again before reading
+  *         the calendar, which means that the calendar registers have been
+  *         correctly copied into the RTC_TR and RTC_DR shadow registers.
+  * @param  hrtc: RTC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc)
+{
+  uint32_t tickstart = 0;
+
+  /* Clear RSF flag */
+  hrtc->Instance->ISR &= (uint32_t)RTC_RSF_MASK;
+
+  tickstart = HAL_GetTick();
+
+  /* Wait the registers to be synchronised */
+  while((hrtc->Instance->ISR & RTC_ISR_RSF) == (uint32_t)RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Exported_Functions_Group5 Peripheral State functions 
+ *  @brief   Peripheral State functions 
+ *
+@verbatim   
+ ===============================================================================
+                     ##### Peripheral State functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides functions allowing to
+      (+) Get RTC state
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Return the RTC handle state.
+  * @param  hrtc: RTC handle
+  * @retval HAL state
+  */
+HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef* hrtc)
+{
+  /* Return RTC handle state */
+  return hrtc->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Private_Functions RTC Private functions
+  * @{
+  */
+/**
+  * @brief  Enter the RTC Initialization mode.
+  * @note   The RTC Initialization mode is write protected, use the
+  *         __HAL_RTC_WRITEPROTECTION_DISABLE() before calling this function.
+  * @param  hrtc: RTC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef RTC_EnterInitMode(RTC_HandleTypeDef* hrtc)
+{
+  uint32_t tickstart = 0;
+
+  /* Check if the Initialization mode is set */
+  if((hrtc->Instance->ISR & RTC_ISR_INITF) == (uint32_t)RESET)
+  {
+    /* Set the Initialization mode */
+    hrtc->Instance->ISR = (uint32_t)RTC_INIT_MASK;
+
+    tickstart = HAL_GetTick();
+    /* Wait till RTC is in INIT state and if Time out is reached exit */
+    while((hrtc->Instance->ISR & RTC_ISR_INITF) == (uint32_t)RESET)
+    {
+      if((HAL_GetTick()  - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Convert a 2 digit decimal to BCD format.
+  * @param  Value: Byte to be converted
+  * @retval Converted byte
+  */
+uint8_t RTC_ByteToBcd2(uint8_t Value)
+{
+  uint32_t bcdhigh = 0;
+
+  while(Value >= 10)
+  {
+    bcdhigh++;
+    Value -= 10;
+  }
+
+  return  ((uint8_t)(bcdhigh << 4) | Value);
+}
+
+/**
+  * @brief  Convert from 2 digit BCD to Binary.
+  * @param  Value: BCD value to be converted
+  * @retval Converted word
+  */
+uint8_t RTC_Bcd2ToByte(uint8_t Value)
+{
+  uint32_t tmp = 0;
+  tmp = ((uint8_t)(Value & (uint8_t)0xF0) >> (uint8_t)0x4) * 10;
+  return (tmp + (Value & (uint8_t)0x0F));
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RTC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_rtc_ex.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_rtc_ex.c
@@ -1,0 +1,1876 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_rtc_ex.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Extended RTC HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Real Time Clock (RTC) Extended peripheral:
+  *           + RTC Time Stamp functions
+  *           + RTC Tamper functions 
+  *           + RTC Wake-up functions
+  *           + Extended Control functions
+  *           + Extended RTC features functions    
+  *
+  @verbatim
+  ==============================================================================
+                  ##### How to use this driver #####
+  ==============================================================================
+  [..]
+    (+) Enable the RTC domain access.
+    (+) Configure the RTC Prescaler (Asynchronous and Synchronous) and RTC hour
+        format using the HAL_RTC_Init() function.
+
+  *** RTC Wakeup configuration ***
+  ================================
+  [..] 
+    (+) To configure the RTC Wakeup Clock source and Counter use the HAL_RTCEx_SetWakeUpTimer()
+        function. You can also configure the RTC Wakeup timer with interrupt mode 
+        using the HAL_RTCEx_SetWakeUpTimer_IT() function.
+    (+) To read the RTC WakeUp Counter register, use the HAL_RTCEx_GetWakeUpTimer()
+        function.
+        
+  *** Outputs configuration ***
+  =============================
+  [..]  The RTC has 2 different outputs:
+    (+) RTC_ALARM: this output is used to manage the RTC Alarm A, Alarm B
+        and WaKeUp signals.
+        To output the selected RTC signal, use the HAL_RTC_Init() function.             
+    (+) RTC_CALIB: this output is 512Hz signal or 1Hz.
+        To enable the RTC_CALIB, use the HAL_RTCEx_SetCalibrationOutPut() function.
+    (+) Two pins can be used as RTC_ALARM or RTC_CALIB (PC13, PB2) managed on 
+        the RTC_OR register.
+    (+) When the RTC_CALIB or RTC_ALARM output is selected, the RTC_OUT pin is
+        automatically configured in output alternate function. 
+
+  *** Smooth digital Calibration configuration ***
+  ================================================
+  [..]
+    (+) Configure the RTC Original Digital Calibration Value and the corresponding
+        calibration cycle period (32s,16s and 8s) using the HAL_RTCEx_SetSmoothCalib() 
+        function.
+
+  *** TimeStamp configuration ***
+  ===============================
+  [..]
+    (+) Enable the RTC TimeStamp using the HAL_RTCEx_SetTimeStamp() function.
+        You can also configure the RTC TimeStamp with interrupt mode using the
+        HAL_RTCEx_SetTimeStamp_IT() function.
+    (+) To read the RTC TimeStamp Time and Date register, use the HAL_RTCEx_GetTimeStamp()
+        function.
+
+  *** Internal TimeStamp configuration ***
+  ===============================
+  [..]
+    (+) Enable the RTC internal TimeStamp using the HAL_RTCEx_SetInternalTimeStamp() function.
+        User has to check internal timestamp occurrence using __HAL_RTC_INTERNAL_TIMESTAMP_GET_FLAG.
+    (+) To read the RTC TimeStamp Time and Date register, use the HAL_RTCEx_GetTimeStamp()
+        function.
+
+  *** Tamper configuration ***
+  ============================
+  [..]
+    (+) Enable the RTC Tamper and configure the Tamper filter count, trigger Edge 
+        or Level according to the Tamper filter (if equal to 0 Edge else Level) 
+        value, sampling frequency, NoErase, MaskFlag,  precharge or discharge and
+        Pull-UP using the HAL_RTCEx_SetTamper() function. You can configure RTC Tamper
+        with interrupt mode using HAL_RTCEx_SetTamper_IT() function.
+    (+) The default configuration of the Tamper erases the backup registers. To avoid
+        erase, enable the NoErase field on the RTC_TAMPCR register.
+
+  *** Backup Data Registers configuration ***
+  ===========================================
+  [..]
+    (+) To write to the RTC Backup Data registers, use the HAL_RTCEx_BKUPWrite()
+        function.
+    (+) To read the RTC Backup Data registers, use the HAL_RTCEx_BKUPRead()
+        function.
+
+   @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RTCEx RTCEx
+  * @brief RTC Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#if defined(RTC_TAMPER1_SUPPORT) && defined(RTC_TAMPER3_SUPPORT)
+#define RTC_TAMPCR_MASK               ((uint32_t)RTC_TAMPCR_TAMPTS    |\
+                                       (uint32_t)RTC_TAMPCR_TAMPFREQ  | (uint32_t)RTC_TAMPCR_TAMPFLT      | (uint32_t)RTC_TAMPCR_TAMPPRCH |\
+                                       (uint32_t)RTC_TAMPCR_TAMPPUDIS | (uint32_t)RTC_TAMPCR_TAMPIE                                       |\
+                                       (uint32_t)RTC_TAMPCR_TAMP1IE   | (uint32_t)RTC_TAMPCR_TAMP1NOERASE | (uint32_t)RTC_TAMPCR_TAMP1MF  |\
+                                       (uint32_t)RTC_TAMPCR_TAMP2IE   | (uint32_t)RTC_TAMPCR_TAMP2NOERASE | (uint32_t)RTC_TAMPCR_TAMP2MF  |\
+                                       (uint32_t)RTC_TAMPCR_TAMP3IE   | (uint32_t)RTC_TAMPCR_TAMP3NOERASE | (uint32_t)RTC_TAMPCR_TAMP3MF)
+#elif defined(RTC_TAMPER1_SUPPORT)
+#define RTC_TAMPCR_MASK               ((uint32_t)RTC_TAMPCR_TAMPTS    |\
+                                       (uint32_t)RTC_TAMPCR_TAMPFREQ  | (uint32_t)RTC_TAMPCR_TAMPFLT      | (uint32_t)RTC_TAMPCR_TAMPPRCH |\
+                                       (uint32_t)RTC_TAMPCR_TAMPPUDIS | (uint32_t)RTC_TAMPCR_TAMPIE                                       |\
+                                       (uint32_t)RTC_TAMPCR_TAMP1IE   | (uint32_t)RTC_TAMPCR_TAMP1NOERASE | (uint32_t)RTC_TAMPCR_TAMP1MF  |\
+                                       (uint32_t)RTC_TAMPCR_TAMP2IE   | (uint32_t)RTC_TAMPCR_TAMP2NOERASE | (uint32_t)RTC_TAMPCR_TAMP2MF)
+#elif defined(RTC_TAMPER3_SUPPORT)
+#define RTC_TAMPCR_MASK               ((uint32_t)RTC_TAMPCR_TAMPTS    |\
+                                       (uint32_t)RTC_TAMPCR_TAMPFREQ  | (uint32_t)RTC_TAMPCR_TAMPFLT      | (uint32_t)RTC_TAMPCR_TAMPPRCH |\
+                                       (uint32_t)RTC_TAMPCR_TAMPPUDIS | (uint32_t)RTC_TAMPCR_TAMPIE                                       |\
+                                       (uint32_t)RTC_TAMPCR_TAMP2IE   | (uint32_t)RTC_TAMPCR_TAMP2NOERASE | (uint32_t)RTC_TAMPCR_TAMP2MF  |\
+                                       (uint32_t)RTC_TAMPCR_TAMP3IE   | (uint32_t)RTC_TAMPCR_TAMP3NOERASE | (uint32_t)RTC_TAMPCR_TAMP3MF)
+#else
+#define RTC_TAMPCR_MASK               ((uint32_t)RTC_TAMPCR_TAMPTS    |\
+                                       (uint32_t)RTC_TAMPCR_TAMPFREQ  | (uint32_t)RTC_TAMPCR_TAMPFLT      | (uint32_t)RTC_TAMPCR_TAMPPRCH |\
+                                       (uint32_t)RTC_TAMPCR_TAMPPUDIS | (uint32_t)RTC_TAMPCR_TAMPIE                                       |\
+                                       (uint32_t)RTC_TAMPCR_TAMP2IE   | (uint32_t)RTC_TAMPCR_TAMP2NOERASE | (uint32_t)RTC_TAMPCR_TAMP2MF)
+#endif /* RTC_TAMPER1_SUPPORT && RTC_TAMPER3_SUPPORT */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup RTCEx_Exported_Functions RTCEx Exported Functions
+  * @{
+  */
+
+
+/** @defgroup RTCEx_Exported_Functions_Group1 RTC TimeStamp and Tamper functions
+ *  @brief   RTC TimeStamp and Tamper functions
+  *
+@verbatim
+ ===============================================================================
+                 ##### RTC TimeStamp and Tamper functions #####
+ ===============================================================================
+ 
+ [..] This section provide functions allowing to configure TimeStamp feature
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Set TimeStamp.
+  * @note   This API must be called before enabling the TimeStamp feature.
+  * @param  hrtc: RTC handle
+  * @param  TimeStampEdge: Specifies the pin edge on which the TimeStamp is
+  *         activated.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPEDGE_RISING: the Time stamp event occurs on the  
+  *                                        rising edge of the related pin.
+  *             @arg RTC_TIMESTAMPEDGE_FALLING: the Time stamp event occurs on the 
+  *                                         falling edge of the related pin.
+  * @param  RTC_TimeStampPin: specifies the RTC TimeStamp Pin.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPPIN_DEFAULT: PC13 is selected as RTC TimeStamp Pin.
+  *               The RTC TimeStamp Pin is per default PC13, but for reasons of
+  *               compatibility, this parameter is required.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIMESTAMP_EDGE(TimeStampEdge));
+  assert_param(IS_RTC_TIMESTAMP_PIN(RTC_TimeStampPin));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Get the RTC_CR register and clear the bits to be configured */
+  tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
+
+  tmpreg|= TimeStampEdge;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Time Stamp TSEDGE and Enable bits */
+  hrtc->Instance->CR = (uint32_t)tmpreg;
+
+  __HAL_RTC_TIMESTAMP_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY; 
+
+  /* Process Unlocked */ 
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set TimeStamp with Interrupt.
+  * @param  hrtc: RTC handle
+  * @note   This API must be called before enabling the TimeStamp feature.
+  * @param  TimeStampEdge: Specifies the pin edge on which the TimeStamp is
+  *         activated.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPEDGE_RISING: the Time stamp event occurs on the  
+  *                                        rising edge of the related pin.
+  *             @arg RTC_TIMESTAMPEDGE_FALLING: the Time stamp event occurs on the 
+  *                                         falling edge of the related pin.
+  * @param  RTC_TimeStampPin: Specifies the RTC TimeStamp Pin.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPPIN_DEFAULT: PC13 is selected as RTC TimeStamp Pin.
+  *               The RTC TimeStamp Pin is per default PC13, but for reasons of
+  *               compatibility, this parameter is required.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIMESTAMP_EDGE(TimeStampEdge));
+  assert_param(IS_RTC_TIMESTAMP_PIN(RTC_TimeStampPin));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Get the RTC_CR register and clear the bits to be configured */
+  tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
+
+  tmpreg |= TimeStampEdge;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Time Stamp TSEDGE and Enable bits */
+  hrtc->Instance->CR = (uint32_t)tmpreg;
+
+  __HAL_RTC_TIMESTAMP_ENABLE(hrtc);
+
+  /* Enable IT timestamp */
+  __HAL_RTC_TIMESTAMP_ENABLE_IT(hrtc,RTC_IT_TS);
+
+  /* RTC timestamp Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT();
+
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE();
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivate TimeStamp.
+  * @param  hrtc: RTC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tmpreg = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* In case of interrupt mode is used, the interrupt source must disabled */
+  __HAL_RTC_TIMESTAMP_DISABLE_IT(hrtc, RTC_IT_TS);
+
+  /* Get the RTC_CR register and clear the bits to be configured */
+  tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
+
+  /* Configure the Time Stamp TSEDGE and Enable bits */
+  hrtc->Instance->CR = (uint32_t)tmpreg;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set Internal TimeStamp.
+  * @note   This API must be called before enabling the internal TimeStamp feature.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetInternalTimeStamp(RTC_HandleTypeDef *hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the internal Time Stamp Enable bits */
+  __HAL_RTC_INTERNAL_TIMESTAMP_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */ 
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivate Internal TimeStamp.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateInternalTimeStamp(RTC_HandleTypeDef *hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the internal Time Stamp Enable bits */
+  __HAL_RTC_INTERNAL_TIMESTAMP_DISABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get the RTC TimeStamp value.
+  * @param  hrtc: RTC handle
+  * @param  sTimeStamp: Pointer to Time structure
+  * @param  sTimeStampDate: Pointer to Date structure
+  * @param  Format: specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_FORMAT_BIN: Binary data format 
+  *             @arg RTC_FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_GetTimeStamp(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef* sTimeStamp, RTC_DateTypeDef* sTimeStampDate, uint32_t Format)
+{
+  uint32_t tmptime = 0, tmpdate = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Get the TimeStamp time and date registers values */
+  tmptime = (uint32_t)(hrtc->Instance->TSTR & RTC_TR_RESERVED_MASK);
+  tmpdate = (uint32_t)(hrtc->Instance->TSDR & RTC_DR_RESERVED_MASK);
+
+  /* Fill the Time structure fields with the read parameters */
+  sTimeStamp->Hours = (uint8_t)((tmptime & (RTC_TR_HT | RTC_TR_HU)) >> 16);
+  sTimeStamp->Minutes = (uint8_t)((tmptime & (RTC_TR_MNT | RTC_TR_MNU)) >> 8);
+  sTimeStamp->Seconds = (uint8_t)(tmptime & (RTC_TR_ST | RTC_TR_SU));
+  sTimeStamp->TimeFormat = (uint8_t)((tmptime & (RTC_TR_PM)) >> 16);
+  sTimeStamp->SubSeconds = (uint32_t) hrtc->Instance->TSSSR;
+
+  /* Fill the Date structure fields with the read parameters */
+  sTimeStampDate->Year = 0;
+  sTimeStampDate->Month = (uint8_t)((tmpdate & (RTC_DR_MT | RTC_DR_MU)) >> 8);
+  sTimeStampDate->Date = (uint8_t)(tmpdate & (RTC_DR_DT | RTC_DR_DU));
+  sTimeStampDate->WeekDay = (uint8_t)((tmpdate & (RTC_DR_WDU)) >> 13);
+
+  /* Check the input parameters format */
+  if(Format == RTC_FORMAT_BIN)
+  {
+    /* Convert the TimeStamp structure parameters to Binary format */
+    sTimeStamp->Hours = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Hours);
+    sTimeStamp->Minutes = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Minutes);
+    sTimeStamp->Seconds = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Seconds);
+
+    /* Convert the DateTimeStamp structure parameters to Binary format */
+    sTimeStampDate->Month = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->Month);
+    sTimeStampDate->Date = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->Date);
+    sTimeStampDate->WeekDay = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->WeekDay);
+  }
+
+  /* Clear the TIMESTAMP Flags */
+  __HAL_RTC_INTERNAL_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_ITSF);
+  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set Tamper.
+  * @note   By calling this API we disable the tamper interrupt for all tampers.
+  * @param  hrtc: RTC handle
+  * @param  sTamper: Pointer to Tamper Structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_TAMPER(sTamper->Tamper));
+  assert_param(IS_RTC_TAMPER_TRIGGER(sTamper->Trigger));
+  assert_param(IS_RTC_TAMPER_ERASE_MODE(sTamper->NoErase));
+  assert_param(IS_RTC_TAMPER_MASKFLAG_STATE(sTamper->MaskFlag));
+  assert_param(IS_RTC_TAMPER_FILTER(sTamper->Filter));
+  assert_param(IS_RTC_TAMPER_SAMPLING_FREQ(sTamper->SamplingFrequency));
+  assert_param(IS_RTC_TAMPER_PRECHARGE_DURATION(sTamper->PrechargeDuration));
+  assert_param(IS_RTC_TAMPER_PULLUP_STATE(sTamper->TamperPullUp));
+  assert_param(IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION(sTamper->TimeStampOnTamperDetection));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Configure the tamper trigger */
+  if(sTamper->Trigger != RTC_TAMPERTRIGGER_RISINGEDGE)
+  { 
+    sTamper->Trigger = (uint32_t)(sTamper->Tamper << 1); 
+  }
+
+  if(sTamper->NoErase != RTC_TAMPER_ERASE_BACKUP_ENABLE)
+  { 
+    sTamper->NoErase = 0;
+#if defined(RTC_TAMPER1_SUPPORT)
+    if((sTamper->Tamper & RTC_TAMPER_1) != 0)
+    {
+      sTamper->NoErase |= RTC_TAMPCR_TAMP1NOERASE;
+    }
+#endif /* RTC_TAMPER1_SUPPORT */
+    if((sTamper->Tamper & RTC_TAMPER_2) != 0)
+    {
+      sTamper->NoErase |= RTC_TAMPCR_TAMP2NOERASE;
+    }
+#if defined(RTC_TAMPER3_SUPPORT)
+    if((sTamper->Tamper & RTC_TAMPER_3) != 0)
+    {
+      sTamper->NoErase |= RTC_TAMPCR_TAMP3NOERASE;
+    }
+#endif /* RTC_TAMPER3_SUPPORT */
+  }
+
+  if(sTamper->MaskFlag != RTC_TAMPERMASK_FLAG_DISABLE)
+  {
+    sTamper->MaskFlag = 0;
+#if defined(RTC_TAMPER1_SUPPORT)
+    if((sTamper->Tamper & RTC_TAMPER_1) != 0)
+    {
+      sTamper->MaskFlag |= RTC_TAMPCR_TAMP1MF;
+    }
+#endif /* RTC_TAMPER1_SUPPORT */
+    if((sTamper->Tamper & RTC_TAMPER_2) != 0)
+    {
+      sTamper->MaskFlag |= RTC_TAMPCR_TAMP2MF;
+    }
+#if defined(RTC_TAMPER3_SUPPORT)
+    if((sTamper->Tamper & RTC_TAMPER_3) != 0)
+    {
+      sTamper->MaskFlag |= RTC_TAMPCR_TAMP3MF;
+    }
+#endif /* RTC_TAMPER3_SUPPORT */
+  }
+
+  tmpreg = ((uint32_t)sTamper->Tamper | (uint32_t)sTamper->Trigger  | (uint32_t)sTamper->NoErase |\
+            (uint32_t)sTamper->MaskFlag | (uint32_t)sTamper->Filter | (uint32_t)sTamper->SamplingFrequency |\
+            (uint32_t)sTamper->PrechargeDuration | (uint32_t)sTamper->TamperPullUp | sTamper->TimeStampOnTamperDetection);
+
+  hrtc->Instance->TAMPCR &= (uint32_t)~((uint32_t)sTamper->Tamper | (uint32_t)(sTamper->Tamper << 1) | RTC_TAMPCR_MASK);
+
+  hrtc->Instance->TAMPCR |= tmpreg;
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set Tamper with interrupt.
+  * @note   By calling this API we force the tamper interrupt for all tampers.
+  * @param  hrtc: RTC handle
+  * @param  sTamper: Pointer to RTC Tamper.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_TAMPER(sTamper->Tamper));
+  assert_param(IS_RTC_TAMPER_INTERRUPT(sTamper->Interrupt));
+  assert_param(IS_RTC_TAMPER_TRIGGER(sTamper->Trigger));
+  assert_param(IS_RTC_TAMPER_ERASE_MODE(sTamper->NoErase));
+  assert_param(IS_RTC_TAMPER_MASKFLAG_STATE(sTamper->MaskFlag));
+  assert_param(IS_RTC_TAMPER_FILTER(sTamper->Filter));
+  assert_param(IS_RTC_TAMPER_SAMPLING_FREQ(sTamper->SamplingFrequency));
+  assert_param(IS_RTC_TAMPER_PRECHARGE_DURATION(sTamper->PrechargeDuration));
+  assert_param(IS_RTC_TAMPER_PULLUP_STATE(sTamper->TamperPullUp));
+  assert_param(IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION(sTamper->TimeStampOnTamperDetection));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Configure the tamper trigger */
+  if(sTamper->Trigger != RTC_TAMPERTRIGGER_RISINGEDGE)
+  {
+    sTamper->Trigger = (uint32_t)(sTamper->Tamper << 1);
+  }
+
+  if(sTamper->NoErase != RTC_TAMPER_ERASE_BACKUP_ENABLE)
+  { 
+    sTamper->NoErase = 0;
+#if defined(RTC_TAMPER1_SUPPORT)
+    if((sTamper->Tamper & RTC_TAMPER_1) != 0)
+    {
+      sTamper->NoErase |= RTC_TAMPCR_TAMP1NOERASE;
+    }
+#endif /* RTC_TAMPER1_SUPPORT */
+    if((sTamper->Tamper & RTC_TAMPER_2) != 0)
+    {
+      sTamper->NoErase |= RTC_TAMPCR_TAMP2NOERASE;
+    }
+#if defined(RTC_TAMPER3_SUPPORT)
+    if((sTamper->Tamper & RTC_TAMPER_3) != 0)
+    {
+      sTamper->NoErase |= RTC_TAMPCR_TAMP3NOERASE;
+    }
+#endif /* RTC_TAMPER3_SUPPORT */
+  }
+
+  if(sTamper->MaskFlag != RTC_TAMPERMASK_FLAG_DISABLE)
+  {
+    sTamper->MaskFlag = 0;
+#if defined(RTC_TAMPER1_SUPPORT)
+    if((sTamper->Tamper & RTC_TAMPER_1) != 0)
+    {
+      sTamper->MaskFlag |= RTC_TAMPCR_TAMP1MF;
+    }
+#endif /* RTC_TAMPER1_SUPPORT */
+    if((sTamper->Tamper & RTC_TAMPER_2) != 0)
+    {
+      sTamper->MaskFlag |= RTC_TAMPCR_TAMP2MF;
+    }
+#if defined(RTC_TAMPER3_SUPPORT)
+    if((sTamper->Tamper & RTC_TAMPER_3) != 0)
+    {
+      sTamper->MaskFlag |= RTC_TAMPCR_TAMP3MF;
+    }
+#endif /* RTC_TAMPER3_SUPPORT */
+  }
+
+  tmpreg = ((uint32_t)sTamper->Tamper | (uint32_t)sTamper->Interrupt | (uint32_t)sTamper->Trigger  | (uint32_t)sTamper->NoErase |\
+            (uint32_t)sTamper->MaskFlag | (uint32_t)sTamper->Filter | (uint32_t)sTamper->SamplingFrequency |\
+            (uint32_t)sTamper->PrechargeDuration | (uint32_t)sTamper->TamperPullUp | sTamper->TimeStampOnTamperDetection);
+
+  hrtc->Instance->TAMPCR &= (uint32_t)~((uint32_t)sTamper->Tamper | (uint32_t)(sTamper->Tamper << 1) | RTC_TAMPCR_MASK);
+  
+  hrtc->Instance->TAMPCR |= tmpreg;
+
+  /* RTC Tamper Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT();
+
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE();
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivate Tamper.
+  * @param  hrtc: RTC handle
+  * @param  Tamper: Selected tamper pin.
+  *          This parameter can be any combination of RTC_TAMPER_1, RTC_TAMPER_2 and RTC_TAMPER_3.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t Tamper)
+{
+  assert_param(IS_RTC_TAMPER(Tamper));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the selected Tamper pin */
+  hrtc->Instance->TAMPCR &= ((uint32_t)~Tamper);
+
+#if defined(RTC_TAMPER1_SUPPORT)
+  if ((Tamper & RTC_TAMPER_1) != 0)
+  {
+    /* Disable the Tamper1 interrupt */
+    hrtc->Instance->TAMPCR &= ((uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP1));
+  }
+#endif /* RTC_TAMPER1_SUPPORT */
+  if ((Tamper & RTC_TAMPER_2) != 0)
+  {
+    /* Disable the Tamper2 interrupt */
+    hrtc->Instance->TAMPCR &= ((uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP2));
+  }
+#if defined(RTC_TAMPER3_SUPPORT)
+  if ((Tamper & RTC_TAMPER_3) != 0)
+  {
+    /* Disable the Tamper3 interrupt */
+    hrtc->Instance->TAMPCR &= ((uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP3));
+  }
+#endif /* RTC_TAMPER3_SUPPORT */
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handle TimeStamp interrupt request.
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+void HAL_RTCEx_TamperTimeStampIRQHandler(RTC_HandleTypeDef *hrtc)
+{ 
+  /* Get the TimeStamp interrupt source enable status */
+  if(__HAL_RTC_TIMESTAMP_GET_IT_SOURCE(hrtc, RTC_IT_TS) != RESET)
+  {
+    /* Get the pending status of the TIMESTAMP Interrupt */
+    if(__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSF) != RESET)
+    {
+      /* TIMESTAMP callback */ 
+      HAL_RTCEx_TimeStampEventCallback(hrtc);
+      
+      /* Clear the TIMESTAMP interrupt pending bit */
+      __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
+    }
+  }
+
+#if defined(RTC_TAMPER1_SUPPORT)
+  /* Get the Tamper1 interrupts source enable status */
+  if(__HAL_RTC_TAMPER_GET_IT_SOURCE(hrtc, RTC_IT_TAMP | RTC_IT_TAMP1) != RESET)
+  {
+    /* Get the pending status of the Tamper1 Interrupt */
+    if(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP1F) != RESET)
+    {
+      /* Tamper1 callback */
+      HAL_RTCEx_Tamper1EventCallback(hrtc);
+
+      /* Clear the Tamper1 interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP1F);
+    }
+  }
+#endif /* RTC_TAMPER1_SUPPORT */
+    
+  /* Get the Tamper2 interrupts source enable status */
+  if(__HAL_RTC_TAMPER_GET_IT_SOURCE(hrtc, RTC_IT_TAMP | RTC_IT_TAMP2) != RESET)
+  {
+    /* Get the pending status of the Tamper2 Interrupt */
+    if(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP2F) != RESET)
+    {
+      /* Tamper2 callback */
+      HAL_RTCEx_Tamper2EventCallback(hrtc);
+
+      /* Clear the Tamper2 interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP2F);
+    }
+  }
+
+#if defined(RTC_TAMPER3_SUPPORT)
+  /* Get the Tamper3 interrupts source enable status */
+  if(__HAL_RTC_TAMPER_GET_IT_SOURCE(hrtc, RTC_IT_TAMP | RTC_IT_TAMP3) != RESET)
+  {
+    /* Get the pending status of the Tamper3 Interrupt */
+    if(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP3F) != RESET)
+    {
+      /* Tamper3 callback */
+      HAL_RTCEx_Tamper3EventCallback(hrtc);
+
+      /* Clear the Tamper3 interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP3F);
+    }
+  }
+#endif /* RTC_TAMPER3_SUPPORT */
+  
+  /* Clear the EXTI's Flag for RTC TimeStamp and Tamper */
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG();
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+}
+
+/**
+  * @brief  TimeStamp callback. 
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+__weak void HAL_RTCEx_TimeStampEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_RTCEx_TimeStampEventCallback could be implemented in the user file
+  */
+}
+
+#if defined(RTC_TAMPER1_SUPPORT)
+/**
+  * @brief  Tamper 1 callback.
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+__weak void HAL_RTCEx_Tamper1EventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_RTCEx_Tamper1EventCallback could be implemented in the user file
+   */
+}
+#endif /* RTC_TAMPER1_SUPPORT */
+
+/**
+  * @brief  Tamper 2 callback. 
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+__weak void HAL_RTCEx_Tamper2EventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_RTCEx_Tamper2EventCallback could be implemented in the user file
+   */
+}
+
+#if defined(RTC_TAMPER3_SUPPORT)
+/**
+  * @brief  Tamper 3 callback. 
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+__weak void HAL_RTCEx_Tamper3EventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_RTCEx_Tamper3EventCallback could be implemented in the user file
+   */
+}
+#endif /* RTC_TAMPER3_SUPPORT */
+
+/**
+  * @brief  Handle TimeStamp polling request.
+  * @param  hrtc: RTC handle
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTimeStampEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{ 
+  uint32_t tickstart = HAL_GetTick();
+
+  while(__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSF) == RESET)
+  {
+    if(__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSOVF) != RESET)
+    {
+      /* Clear the TIMESTAMP OverRun Flag */
+      __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSOVF);
+
+      /* Change TIMESTAMP state */
+      hrtc->State = HAL_RTC_STATE_ERROR; 
+
+      return HAL_ERROR; 
+    }
+
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+  
+  return HAL_OK;
+}
+
+#if defined(RTC_TAMPER1_SUPPORT)
+/**
+  * @brief  Handle Tamper 1 Polling.
+  * @param  hrtc: RTC handle
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper1Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+
+  /* Get the status of the Interrupt */
+  while(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP1F)== RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Tamper Flag */
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP1F);
+  
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+  
+  return HAL_OK; 
+}
+#endif /* RTC_TAMPER1_SUPPORT */
+
+/**
+  * @brief  Handle Tamper 2 Polling.
+  * @param  hrtc: RTC handle
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper2Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+
+  /* Get the status of the Interrupt */
+  while(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP2F) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Tamper Flag */
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP2F);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+#if defined(RTC_TAMPER3_SUPPORT)
+/**
+  * @brief  Handle Tamper 3 Polling.
+  * @param  hrtc: RTC handle
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+
+  /* Get the status of the Interrupt */
+  while(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP3F) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Tamper Flag */
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP3F);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+#endif /* RTC_TAMPER3_SUPPORT */
+
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Exported_Functions_Group2 RTC Wake-up functions
+  * @brief    RTC Wake-up functions
+  *
+@verbatim   
+ ===============================================================================
+                        ##### RTC Wake-up functions #####
+ ===============================================================================  
+
+ [..] This section provide functions allowing to configure Wake-up feature
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Set wake up timer.
+  * @param  hrtc: RTC handle
+  * @param  WakeUpCounter: Wake up counter
+  * @param  WakeUpClock: Wake up clock
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_WAKEUP_CLOCK(WakeUpClock));
+  assert_param(IS_RTC_WAKEUP_COUNTER(WakeUpCounter));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /*Check RTC WUTWF flag is reset only when wake up timer enabled*/
+  if((hrtc->Instance->CR & RTC_CR_WUTE) != RESET)
+  {
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC WUTWF flag is reset and if Time out is reached exit */
+    while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == SET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */ 
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  tickstart = HAL_GetTick();
+
+  /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
+  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+      /* Process Unlocked */ 
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Clear the Wakeup Timer clock source bits in CR register */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
+
+  /* Configure the clock source */
+  hrtc->Instance->CR |= (uint32_t)WakeUpClock;
+
+  /* Configure the Wakeup Timer counter */
+  hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
+
+   /* Enable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set wake up timer with interrupt.
+  * @param  hrtc: RTC handle
+  * @param  WakeUpCounter: Wake up counter
+  * @param  WakeUpClock: Wake up clock  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_WAKEUP_CLOCK(WakeUpClock));
+  assert_param(IS_RTC_WAKEUP_COUNTER(WakeUpCounter));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /*Check RTC WUTWF flag is reset only when wake up timer enabled*/
+  if((hrtc->Instance->CR & RTC_CR_WUTE) != RESET)
+  {
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC WUTWF flag is reset and if Time out is reached exit */
+    while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == SET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */ 
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  tickstart = HAL_GetTick();
+
+  /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
+  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT; 
+
+      /* Process Unlocked */ 
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Configure the Wakeup Timer counter */
+  hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
+
+  /* Clear the Wakeup Timer clock source bits in CR register */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
+
+  /* Configure the clock source */
+  hrtc->Instance->CR |= (uint32_t)WakeUpClock;
+
+  /* RTC WakeUpTimer Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT();
+
+  __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE();
+
+  /* Configure the Interrupt in the RTC_CR register */
+  __HAL_RTC_WAKEUPTIMER_ENABLE_IT(hrtc,RTC_IT_WUT);
+  
+  /* Enable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY; 
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivate wake up timer counter.
+  * @param  hrtc: RTC handle 
+  * @retval HAL status
+  */
+uint32_t HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tickstart = 0;
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Disable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  /* In case of interrupt mode is used, the interrupt source must disabled */
+  __HAL_RTC_WAKEUPTIMER_DISABLE_IT(hrtc,RTC_IT_WUT);
+
+  tickstart = HAL_GetTick();
+  /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
+  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get wake up timer counter.
+  * @param  hrtc: RTC handle 
+  * @retval Counter value
+  */
+uint32_t HAL_RTCEx_GetWakeUpTimer(RTC_HandleTypeDef *hrtc)
+{
+  /* Get the counter value */
+  return ((uint32_t)(hrtc->Instance->WUTR & RTC_WUTR_WUT));
+}
+
+/**
+  * @brief  Handle Wake Up Timer interrupt request.
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+void HAL_RTCEx_WakeUpTimerIRQHandler(RTC_HandleTypeDef *hrtc)
+{
+  /* Get the pending status of the WAKEUPTIMER Interrupt */
+  if(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTF) != RESET)
+  {
+    /* WAKEUPTIMER callback */ 
+    HAL_RTCEx_WakeUpTimerEventCallback(hrtc);
+      
+    /* Clear the WAKEUPTIMER interrupt pending bit */
+    __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+  }
+
+
+  /* Clear the EXTI's line Flag for RTC WakeUpTimer */
+  __HAL_RTC_WAKEUPTIMER_EXTI_CLEAR_FLAG();
+  
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+}
+
+/**
+  * @brief  Wake Up Timer callback.
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+__weak void HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_RTCEx_WakeUpTimerEventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Handle Wake Up Timer Polling.
+  * @param  hrtc: RTC handle
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+
+  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTF) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+      
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the WAKEUPTIMER Flag */
+  __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+  
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+
+/** @defgroup RTCEx_Exported_Functions_Group3 Extended Peripheral Control functions
+  * @brief    Extended Peripheral Control functions
+  *
+@verbatim   
+ ===============================================================================
+              ##### Extended Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides functions allowing to
+      (+) Write a data in a specified RTC Backup data register
+      (+) Read a data in a specified RTC Backup data register
+      (+) Set the Coarse calibration parameters.
+      (+) Deactivate the Coarse calibration parameters
+      (+) Set the Smooth calibration parameters.
+      (+) Configure the Synchronization Shift Control Settings.
+      (+) Configure the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+      (+) Deactivate the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+      (+) Enable the RTC reference clock detection.
+      (+) Disable the RTC reference clock detection.
+      (+) Enable the Bypass Shadow feature.
+      (+) Disable the Bypass Shadow feature.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Write a data in a specified RTC Backup data register.
+  * @param  hrtc: RTC handle 
+  * @param  BackupRegister: RTC Backup data Register number.
+  *          This parameter can be: RTC_BKP_DRx where x can be from 0 to 19 to 
+  *                                 specify the register.
+  * @param  Data: Data to be written in the specified RTC Backup data register.
+  * @retval None
+  */
+void HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data)
+{
+  uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_BKP(BackupRegister));
+
+  tmp = (uint32_t)&(hrtc->Instance->BKP0R);
+  tmp += (BackupRegister * 4);
+
+  /* Write the specified register */
+  *(__IO uint32_t *)tmp = (uint32_t)Data;
+}
+
+/**
+  * @brief  Read data from the specified RTC Backup data Register.
+  * @param  hrtc: RTC handle 
+  * @param  BackupRegister: RTC Backup data Register number.
+  *          This parameter can be: RTC_BKP_DRx where x can be from 0 to 19 to 
+  *                                 specify the register.
+  * @retval Read value
+  */
+uint32_t HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister)
+{
+  uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_BKP(BackupRegister));
+
+  tmp = (uint32_t)&(hrtc->Instance->BKP0R);
+  tmp += (BackupRegister * 4);
+  
+  /* Read the specified register */
+  return (*(__IO uint32_t *)tmp);
+}
+
+/**
+  * @brief  Set the Smooth calibration parameters.
+  * @param  hrtc: RTC handle  
+  * @param  SmoothCalibPeriod: Select the Smooth Calibration Period.
+  *          This parameter can be can be one of the following values :
+  *             @arg RTC_SMOOTHCALIB_PERIOD_32SEC: The smooth calibration period is 32s.
+  *             @arg RTC_SMOOTHCALIB_PERIOD_16SEC: The smooth calibration period is 16s.
+  *             @arg RTC_SMOOTHCALIB_PERIOD_8SEC: The smooth calibration period is 8s.
+  * @param  SmoothCalibPlusPulses: Select to Set or reset the CALP bit.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_SMOOTHCALIB_PLUSPULSES_SET: Add one RTCCLK pulse every 2*11 pulses.
+  *             @arg RTC_SMOOTHCALIB_PLUSPULSES_RESET: No RTCCLK pulses are added.
+  * @param  SmoothCalibMinusPulsesValue: Select the value of CALM[8:0] bits.
+  *          This parameter can be one any value from 0 to 0x000001FF.
+  * @note   To deactivate the smooth calibration, the field SmoothCalibPlusPulses 
+  *         must be equal to SMOOTHCALIB_PLUSPULSES_RESET and the field
+  *         SmoothCalibMinusPulsesValue must be equal to 0.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef* hrtc, uint32_t SmoothCalibPeriod, uint32_t SmoothCalibPlusPulses, uint32_t SmoothCalibMinusPulsesValue)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_SMOOTH_CALIB_PERIOD(SmoothCalibPeriod));
+  assert_param(IS_RTC_SMOOTH_CALIB_PLUS(SmoothCalibPlusPulses));
+  assert_param(IS_RTC_SMOOTH_CALIB_MINUS(SmoothCalibMinusPulsesValue));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* check if a calibration is pending*/
+  if((hrtc->Instance->ISR & RTC_ISR_RECALPF) != RESET)
+  {
+    tickstart = HAL_GetTick();
+
+    /* check if a calibration is pending*/
+    while((hrtc->Instance->ISR & RTC_ISR_RECALPF) != RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        /* Change RTC state */
+        hrtc->State = HAL_RTC_STATE_TIMEOUT; 
+        
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Configure the Smooth calibration settings */
+  hrtc->Instance->CALR = (uint32_t)((uint32_t)SmoothCalibPeriod | (uint32_t)SmoothCalibPlusPulses | (uint32_t)SmoothCalibMinusPulsesValue);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY; 
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configure the Synchronization Shift Control Settings.
+  * @note   When REFCKON is set, firmware must not write to Shift control register. 
+  * @param  hrtc: RTC handle    
+  * @param  ShiftAdd1S: Select to add or not 1 second to the time calendar.
+  *          This parameter can be one of the following values :
+  *             @arg RTC_SHIFTADD1S_SET: Add one second to the clock calendar. 
+  *             @arg RTC_SHIFTADD1S_RESET: No effect.
+  * @param  ShiftSubFS: Select the number of Second Fractions to substitute.
+  *          This parameter can be one any value from 0 to 0x7FFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef* hrtc, uint32_t ShiftAdd1S, uint32_t ShiftSubFS)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_SHIFT_ADD1S(ShiftAdd1S));
+  assert_param(IS_RTC_SHIFT_SUBFS(ShiftSubFS));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+    tickstart = HAL_GetTick();
+
+    /* Wait until the shift is completed*/
+    while((hrtc->Instance->ISR & RTC_ISR_SHPF) != RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */ 
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Check if the reference clock detection is disabled */
+    if((hrtc->Instance->CR & RTC_CR_REFCKON) == RESET)
+    {
+      /* Configure the Shift settings */
+      hrtc->Instance->SHIFTR = (uint32_t)(uint32_t)(ShiftSubFS) | (uint32_t)(ShiftAdd1S);
+
+      /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+      if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == RESET)
+      {
+        if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+        {
+          /* Enable the write protection for RTC registers */
+          __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+          hrtc->State = HAL_RTC_STATE_ERROR;
+
+          /* Process Unlocked */ 
+          __HAL_UNLOCK(hrtc);
+
+          return HAL_ERROR;
+        }
+      }
+    }
+    else
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+      
+      /* Change RTC state */
+      hrtc->State = HAL_RTC_STATE_ERROR;
+      
+      /* Process Unlocked */ 
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_ERROR;
+    }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configure the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+  * @param  hrtc: RTC handle
+  * @param  CalibOutput : Select the Calibration output Selection .
+  *          This parameter can be one of the following values:
+  *             @arg RTC_CALIBOUTPUT_512HZ: A signal has a regular waveform at 512Hz.
+  *             @arg RTC_CALIBOUTPUT_1HZ: A signal has a regular waveform at 1Hz.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetCalibrationOutPut(RTC_HandleTypeDef* hrtc, uint32_t CalibOutput)
+{
+  /* Check the parameters */
+  assert_param(IS_RTC_CALIB_OUTPUT(CalibOutput));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Clear flags before config */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_COSEL;
+
+  /* Configure the RTC_CR register */
+  hrtc->Instance->CR |= (uint32_t)CalibOutput;
+
+  __HAL_RTC_CALIBRATION_OUTPUT_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivate the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+  * @param  hrtc: RTC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateCalibrationOutPut(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  __HAL_RTC_CALIBRATION_OUTPUT_DISABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enable the RTC reference clock detection.
+  * @param  hrtc: RTC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetRefClock(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state*/
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    __HAL_RTC_CLOCKREF_DETECTION_ENABLE(hrtc);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+   /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disable the RTC reference clock detection.
+  * @param  hrtc: RTC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateRefClock(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+  
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state*/
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    __HAL_RTC_CLOCKREF_DETECTION_DISABLE(hrtc);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enable the Bypass Shadow feature.
+  * @param  hrtc: RTC handle
+  * @note   When the Bypass Shadow is enabled the calendar value are taken
+  *         directly from the Calendar counter.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set the BYPSHAD bit */
+  hrtc->Instance->CR |= (uint8_t)RTC_CR_BYPSHAD;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disable the Bypass Shadow feature.
+  * @param  hrtc: RTC handle
+  * @note   When the Bypass Shadow is enabled the calendar value are taken
+  *         directly from the Calendar counter.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Reset the BYPSHAD bit */
+  hrtc->Instance->CR &= ((uint8_t)~RTC_CR_BYPSHAD);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Exported_Functions_Group4 Extended features functions
+  * @brief    Extended features functions
+  *
+@verbatim   
+ ===============================================================================
+                 ##### Extended features functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) RTC Alarm B callback
+      (+) RTC Poll for Alarm B request
+               
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Alarm B callback.
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+__weak void HAL_RTCEx_AlarmBEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_RTCEx_AlarmBEventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Handle Alarm B Polling request.
+  * @param  hrtc: RTC handle
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{ 
+  uint32_t tickstart = HAL_GetTick();
+  
+  while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBF) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Alarm Flag */
+  __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RTC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_sd.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_sd.c
@@ -1,0 +1,3412 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_sd.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   SD card HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Secure Digital (SD) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+  [..]
+    This driver implements a high level communication layer for read and write from/to 
+    this memory. The needed STM32 hardware resources (SDMMC1 and GPIO) are performed by 
+    the user in HAL_SD_MspInit() function (MSP layer).                             
+    Basically, the MSP layer configuration should be the same as we provide in the 
+    examples.
+    You can easily tailor this configuration according to hardware resources.
+
+  [..]
+    This driver is a generic layered driver for SDMMC memories which uses the HAL 
+    SDMMC driver functions to interface with SD and uSD cards devices. 
+    It is used as follows:
+ 
+    (#)Initialize the SDMMC1 low level resources by implementing the HAL_SD_MspInit() API:
+        (##) Call the function HAL_RCCEx_PeriphCLKConfig with RCC_PERIPHCLK_SDMMC1 for
+        PeriphClockSelection and select SDMMC1 clock source (MSI, main PLL or PLLSAI1)
+        (##) Enable the SDMMC1 interface clock using __HAL_RCC_SDMMC1_CLK_ENABLE(); 
+        (##) SDMMC pins configuration for SD card
+            (+++) Enable the clock for the SDMMC GPIOs using the functions __HAL_RCC_GPIOx_CLK_ENABLE();   
+            (+++) Configure these SDMMC pins as alternate function pull-up using HAL_GPIO_Init()
+                  and according to your pin assignment;
+        (##) DMA Configuration if you need to use DMA process (HAL_SD_ReadBlocks_DMA()
+             and HAL_SD_WriteBlocks_DMA() APIs).
+            (+++) Enable the DMAx interface clock using __HAL_RCC_DMAx_CLK_ENABLE(); 
+            (+++) Configure the DMA using the function HAL_DMA_Init() with predeclared and filled. 
+        (##) NVIC configuration if you need to use interrupt process when using DMA transfer.
+            (+++) Configure the SDMMC and DMA interrupt priorities using functions
+                  HAL_NVIC_SetPriority(); DMA priority is superior to SDMMC's priority
+            (+++) Enable the NVIC DMA and SDMMC IRQs using function HAL_NVIC_EnableIRQ()
+            (+++) SDMMC interrupts are managed using the macros __HAL_SD_SDMMC_ENABLE_IT() 
+                  and __HAL_SD_SDMMC_DISABLE_IT() inside the communication process.
+            (+++) SDMMC interrupts pending bits are managed using the macros __HAL_SD_SDMMC_GET_IT()
+                  and __HAL_SD_SDMMC_CLEAR_IT()
+    (#) At this stage, you can perform SD read/write/erase operations after SD card initialization  
+
+         
+  *** SD Card Initialization and configuration ***
+  ================================================    
+  [..]
+    To initialize the SD Card, use the HAL_SD_Init() function.  It Initializes 
+    the SD Card and put it into StandBy State (Ready for data transfer). 
+    This function provide the following operations:
+  
+    (#) Apply the SD Card initialization process at 400KHz and check the SD Card 
+        type (Standard Capacity or High Capacity). You can change or adapt this 
+        frequency by adjusting the "ClockDiv" field. 
+        The SD Card frequency (SDMMC_CK) is computed as follows:
+     (++)
+
+           SDMMC_CK = SDMMCCLK / (ClockDiv + 2)
+
+     -@@-  In initialization mode and according to the SD Card standard, 
+          make sure that the SDMMC_CK frequency doesn't exceed 400KHz.
+  
+    (#) Get the SD CID and CSD data. All these information are managed by the SDCardInfo 
+        structure. This structure provide also ready computed SD Card capacity 
+        and Block size.
+        
+        -@- These information are stored in SD handle structure in case of future use.  
+  
+    (#) Configure the SD Card Data transfer frequency. By Default, the card transfer 
+        frequency is set to 24MHz. You can change or adapt this frequency by adjusting 
+        the "ClockDiv" field.
+        In transfer mode and according to the SD Card standard, make sure that the 
+        SDMMC_CK frequency doesn't exceed 25MHz and 50MHz in High-speed mode switch.
+        To be able to use a frequency higher than 24MHz, you should use the SDMMC 
+        peripheral in bypass mode. Refer to the corresponding reference manual 
+        for more details.
+  
+    (#) Select the corresponding SD Card according to the address read with the step 2.
+    
+    (#) Configure the SD Card in wide bus mode: 4-bits data.
+  
+  *** SD Card Read operation ***
+  ==============================
+  [..] 
+    (+) You can read from SD card in polling mode by using function HAL_SD_ReadBlocks(). 
+        This function support only 512-bytes block length (the block size should be 
+        chosen as 512 bytes).
+        You can choose either one block read operation or multiple block read operation 
+        by adjusting the "NumberOfBlocks" parameter.
+
+    (+) You can read from SD card in DMA mode by using function HAL_SD_ReadBlocks_DMA().
+        This function support only 512-bytes block length (the block size should be 
+        chosen as 512 bytes).
+        You can choose either one block read operation or multiple block read operation 
+        by adjusting the "NumberOfBlocks" parameter.
+        After this, you have to call the function HAL_SD_CheckReadOperation(), to insure
+        that the read transfer is done correctly in both DMA and SD sides.
+  
+  *** SD Card Write operation ***
+  =============================== 
+  [..] 
+    (+) You can write to SD card in polling mode by using function HAL_SD_WriteBlocks(). 
+        This function support only 512-bytes block length (the block size should be 
+        chosen as 512 bytes).
+        You can choose either one block read operation or multiple block read operation 
+        by adjusting the "NumberOfBlocks" parameter.
+
+    (+) You can write to SD card in DMA mode by using function HAL_SD_WriteBlocks_DMA().
+        This function support only 512-bytes block length (the block size should be 
+        chosen as 512 byte).
+        You can choose either one block read operation or multiple block read operation 
+        by adjusting the "NumberOfBlocks" parameter.
+        After this, you have to call the function HAL_SD_CheckWriteOperation(), to insure
+        that the write transfer is done correctly in both DMA and SD sides.  
+  
+  *** SD card status ***
+  ====================== 
+  [..]
+    (+) At any time, you can check the SD Card status and get the SD card state 
+        by using the HAL_SD_GetStatus() function. This function checks first if the 
+        SD card is still connected and then get the internal SD Card transfer state.     
+    (+) You can also get the SD card SD Status register by using the HAL_SD_SendSDStatus() 
+        function.    
+
+  *** SD HAL driver macros list ***
+  ==================================
+  [..]
+    Below the list of most used macros in SD HAL driver.
+       
+    (+) __HAL_SD_SDMMC_ENABLE : Enable the SD device
+    (+) __HAL_SD_SDMMC_DISABLE : Disable the SD device
+    (+) __HAL_SD_SDMMC_DMA_ENABLE: Enable the SDMMC DMA transfer
+    (+) __HAL_SD_SDMMC_DMA_DISABLE: Disable the SDMMC DMA transfer
+    (+) __HAL_SD_SDMMC_ENABLE_IT: Enable the SD device interrupt
+    (+) __HAL_SD_SDMMC_DISABLE_IT: Disable the SD device interrupt
+    (+) __HAL_SD_SDMMC_GET_FLAG:Check whether the specified SD flag is set or not
+    (+) __HAL_SD_SDMMC_CLEAR_FLAG: Clear the SD's pending flags
+    [..]  
+    (@) You can refer to the SD HAL driver header file for more useful macros 
+      
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup SD 
+  * @{
+  */
+
+#ifdef HAL_SD_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @addtogroup SD_Private_Defines
+  * @{
+  */
+/** 
+  * @brief  SDMMC Data block size 
+  */ 
+#define DATA_BLOCK_SIZE                  ((uint32_t)(9 << 4))
+/** 
+  * @brief  SDMMC Static flags, Timeout, FIFO Address  
+  */
+#define SDMMC_STATIC_FLAGS               ((uint32_t)(SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_CTIMEOUT |\
+                                                    SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_TXUNDERR | SDMMC_FLAG_RXOVERR  |\
+                                                    SDMMC_FLAG_CMDREND  | SDMMC_FLAG_CMDSENT  | SDMMC_FLAG_DATAEND  |\
+                                                    SDMMC_FLAG_DBCKEND))  
+
+#define SDMMC_CMD0TIMEOUT                ((uint32_t)0x00010000)
+
+/** 
+  * @brief  Mask for errors Card Status R1 (OCR Register) 
+  */
+#define SD_OCR_ADDR_OUT_OF_RANGE        ((uint32_t)0x80000000)
+#define SD_OCR_ADDR_MISALIGNED          ((uint32_t)0x40000000)
+#define SD_OCR_BLOCK_LEN_ERR            ((uint32_t)0x20000000)
+#define SD_OCR_ERASE_SEQ_ERR            ((uint32_t)0x10000000)
+#define SD_OCR_BAD_ERASE_PARAM          ((uint32_t)0x08000000)
+#define SD_OCR_WRITE_PROT_VIOLATION     ((uint32_t)0x04000000)
+#define SD_OCR_LOCK_UNLOCK_FAILED       ((uint32_t)0x01000000)
+#define SD_OCR_COM_CRC_FAILED           ((uint32_t)0x00800000)
+#define SD_OCR_ILLEGAL_CMD              ((uint32_t)0x00400000)
+#define SD_OCR_CARD_ECC_FAILED          ((uint32_t)0x00200000)
+#define SD_OCR_CC_ERROR                 ((uint32_t)0x00100000)
+#define SD_OCR_GENERAL_UNKNOWN_ERROR    ((uint32_t)0x00080000)
+#define SD_OCR_STREAM_READ_UNDERRUN     ((uint32_t)0x00040000)
+#define SD_OCR_STREAM_WRITE_OVERRUN     ((uint32_t)0x00020000)
+#define SD_OCR_CID_CSD_OVERWRITE        ((uint32_t)0x00010000)
+#define SD_OCR_WP_ERASE_SKIP            ((uint32_t)0x00008000)
+#define SD_OCR_CARD_ECC_DISABLED        ((uint32_t)0x00004000)
+#define SD_OCR_ERASE_RESET              ((uint32_t)0x00002000)
+#define SD_OCR_AKE_SEQ_ERROR            ((uint32_t)0x00000008)
+#define SD_OCR_ERRORBITS                ((uint32_t)0xFDFFE008)
+
+/** 
+  * @brief  Masks for R6 Response 
+  */
+#define SD_R6_GENERAL_UNKNOWN_ERROR     ((uint32_t)0x00002000)
+#define SD_R6_ILLEGAL_CMD               ((uint32_t)0x00004000)
+#define SD_R6_COM_CRC_FAILED            ((uint32_t)0x00008000)
+
+#define SD_VOLTAGE_WINDOW_SD            ((uint32_t)0x80100000)
+#define SD_HIGH_CAPACITY                ((uint32_t)0x40000000)
+#define SD_STD_CAPACITY                 ((uint32_t)0x00000000)
+#define SD_CHECK_PATTERN                ((uint32_t)0x000001AA)
+
+#define SD_MAX_VOLT_TRIAL               ((uint32_t)0x0000FFFF)
+#define SD_ALLZERO                      ((uint32_t)0x00000000)
+
+#define SD_WIDE_BUS_SUPPORT             ((uint32_t)0x00040000)
+#define SD_SINGLE_BUS_SUPPORT           ((uint32_t)0x00010000)
+#define SD_CARD_LOCKED                  ((uint32_t)0x02000000)
+
+#define SD_DATATIMEOUT                  ((uint32_t)0xFFFFFFFF)
+#define SD_0TO7BITS                     ((uint32_t)0x000000FF)
+#define SD_8TO15BITS                    ((uint32_t)0x0000FF00)
+#define SD_16TO23BITS                   ((uint32_t)0x00FF0000)
+#define SD_24TO31BITS                   ((uint32_t)0xFF000000)
+#define SD_MAX_DATA_LENGTH              ((uint32_t)0x01FFFFFF)
+
+#define SD_HALFFIFO                     ((uint32_t)0x00000008)
+#define SD_HALFFIFOBYTES                ((uint32_t)0x00000020)
+
+/** 
+  * @brief  Command Class Supported 
+  */
+#define SD_CCCC_LOCK_UNLOCK             ((uint32_t)0x00000080)
+#define SD_CCCC_WRITE_PROT              ((uint32_t)0x00000040)
+#define SD_CCCC_ERASE                   ((uint32_t)0x00000020)
+
+/** 
+  * @brief  Following commands are SD Card Specific commands.
+  *         SDMMC_APP_CMD should be sent before sending these commands. 
+  */
+#define SD_SDMMC_SEND_IF_COND            ((uint32_t)SD_CMD_HS_SEND_EXT_CSD)
+/**
+  * @}
+  */
+  
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @addtogroup SD_Private_Functions_Prototypes
+  * @{
+  */
+static HAL_SD_ErrorTypedef SD_Initialize_Cards(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_Select_Deselect(SD_HandleTypeDef *hsd, uint64_t addr);
+static HAL_SD_ErrorTypedef SD_PowerON(SD_HandleTypeDef *hsd); 
+static HAL_SD_ErrorTypedef SD_PowerOFF(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_SendStatus(SD_HandleTypeDef *hsd, uint32_t *pCardStatus);
+static HAL_SD_CardStateTypedef SD_GetState(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_IsCardProgramming(SD_HandleTypeDef *hsd, uint8_t *pStatus);
+static HAL_SD_ErrorTypedef SD_CmdError(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_CmdResp1Error(SD_HandleTypeDef *hsd, uint8_t SD_CMD);
+static HAL_SD_ErrorTypedef SD_CmdResp7Error(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_CmdResp3Error(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_CmdResp2Error(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_CmdResp6Error(SD_HandleTypeDef *hsd, uint8_t SD_CMD, uint16_t *pRCA);
+static HAL_SD_ErrorTypedef SD_WideBus_Enable(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_WideBus_Disable(SD_HandleTypeDef *hsd);
+static HAL_SD_ErrorTypedef SD_FindSCR(SD_HandleTypeDef *hsd, uint32_t *pSCR);  
+static void SD_DMA_RxCplt(DMA_HandleTypeDef *hdma);
+static void SD_DMA_RxError(DMA_HandleTypeDef *hdma);
+static void SD_DMA_TxCplt(DMA_HandleTypeDef *hdma);
+static void SD_DMA_TxError(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup SD_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup SD_Exported_Functions_Group1
+ *  @brief   Initialization and de-initialization functions 
+ *
+@verbatim    
+  ==============================================================================
+          ##### Initialization and de-initialization functions #####
+  ==============================================================================
+  [..]  
+    This section provides functions allowing to initialize/de-initialize the SD
+    card device to be ready for use.
+      
+ 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the SD card according to the specified parameters in the 
+            SD_HandleTypeDef and initialize the associated handle.
+  * @param  hsd: SD handle
+  * @param  SDCardInfo: HAL_SD_CardInfoTypedef structure for SD card information   
+  * @retval HAL SD error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_Init(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTypedef *SDCardInfo)
+{ 
+  __IO HAL_SD_ErrorTypedef errorstate = SD_OK;
+  SD_InitTypeDef tmpinit;
+  
+  /* Initialize the low level hardware (MSP) */
+  HAL_SD_MspInit(hsd);
+  
+  /* Default SDMMC peripheral configuration for SD card initialization */
+  tmpinit.ClockEdge           = SDMMC_CLOCK_EDGE_RISING;
+  tmpinit.ClockBypass         = SDMMC_CLOCK_BYPASS_DISABLE;
+  tmpinit.ClockPowerSave      = SDMMC_CLOCK_POWER_SAVE_DISABLE;
+  tmpinit.BusWide             = SDMMC_BUS_WIDE_1B;
+  tmpinit.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_DISABLE;
+  tmpinit.ClockDiv            = SDMMC_INIT_CLK_DIV;
+  
+  /* Initialize SDMMC peripheral interface with default configuration */
+  SDMMC_Init(hsd->Instance, tmpinit);
+  
+  /* Identify card operating voltage */
+  errorstate = SD_PowerON(hsd); 
+  
+  if(errorstate != SD_OK)     
+  {
+    return errorstate;
+  }
+  
+  /* Initialize the present SDMMC card(s) and put them in idle state */
+  errorstate = SD_Initialize_Cards(hsd);
+  
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Read CSD/CID MSD registers */
+  errorstate = HAL_SD_Get_CardInfo(hsd, SDCardInfo);
+  
+  if (errorstate == SD_OK)
+  {
+    /* Select the Card */
+    errorstate = SD_Select_Deselect(hsd, (uint32_t)(((uint32_t)SDCardInfo->RCA) << 16));
+  }
+  
+  /* Configure SDMMC peripheral interface */
+  SDMMC_Init(hsd->Instance, hsd->Init);   
+  
+  return errorstate;
+}
+
+/**
+  * @brief  De-Initializes the SD card.
+  * @param  hsd: SD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SD_DeInit(SD_HandleTypeDef *hsd)
+{
+  
+  /* Set SD power state to off */ 
+  SD_PowerOFF(hsd);
+  
+  /* De-Initialize the MSP layer */
+  HAL_SD_MspDeInit(hsd);
+  
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Initializes the SD MSP.
+  * @param  hsd: SD handle
+  * @retval None
+  */
+__weak void HAL_SD_MspInit(SD_HandleTypeDef *hsd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hsd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SD_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  De-Initialize SD MSP.
+  * @param  hsd: SD handle
+  * @retval None
+  */
+__weak void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hsd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SD_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @addtogroup SD_Exported_Functions_Group2
+ *  @brief   Data transfer functions 
+ *
+@verbatim   
+  ==============================================================================
+                        ##### IO operation functions #####
+  ==============================================================================  
+  [..]
+    This subsection provides a set of functions allowing to manage the data 
+    transfer from/to SD card.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Reads block(s) from a specified address in a card. The Data transfer 
+  *         is managed by polling mode.  
+  * @param  hsd: SD handle
+  * @param  pReadBuffer: pointer to the buffer that will contain the received data
+  * @param  ReadAddr: Address from where data is to be read  
+  * @param  BlockSize: SD card Data block size 
+  *   @note BlockSize must be 512 bytes.
+  * @param  NumberOfBlocks: Number of SD blocks to read   
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
+{
+  SDMMC_CmdInitTypeDef  sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t count = 0, *tempbuff = (uint32_t *)pReadBuffer;
+  
+  /* Initialize data control register */
+  hsd->Instance->DCTRL = 0;
+  
+  if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
+  {
+    BlockSize = 512;
+    ReadAddr /= 512;
+  }
+  
+  /* Set Block Size for Card */ 
+  sdmmc_cmdinitstructure.Argument         = (uint32_t) BlockSize;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+  
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Configure the SD DPSM (Data Path State Machine) */
+  sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdmmc_datainitstructure.DataLength    = NumberOfBlocks * BlockSize;
+  sdmmc_datainitstructure.DataBlockSize = DATA_BLOCK_SIZE;
+  sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+  sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+  SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+  
+  if(NumberOfBlocks > 1)
+  {
+    /* Send CMD18 READ_MULT_BLOCK with argument data address */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_READ_MULT_BLOCK;
+  }
+  else
+  {
+    /* Send CMD17 READ_SINGLE_BLOCK */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_READ_SINGLE_BLOCK;    
+  }
+  
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)ReadAddr;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Read block(s) in polling mode */
+  if(NumberOfBlocks > 1)
+  {
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_READ_MULT_BLOCK);
+    
+    if (errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+    
+    /* Poll on SDMMC flags */
+    while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
+    {
+      if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXFIFOHF))
+      {
+        /* Read data from SDMMC Rx FIFO */
+        for (count = 0; count < 8; count++)
+        {
+          *(tempbuff + count) = SDMMC_ReadFIFO(hsd->Instance);
+        }
+        
+        tempbuff += 8;
+      }
+    }      
+  }
+  else
+  {
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_READ_SINGLE_BLOCK); 
+    
+    if (errorstate != SD_OK)
+    {
+      return errorstate;
+    }    
+    
+    /* In case of single block transfer, no need of stop transfer at all */
+    while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DBCKEND))
+    {
+      if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXFIFOHF))
+      {
+        /* Read data from SDMMC Rx FIFO */
+        for (count = 0; count < 8; count++)
+        {
+          *(tempbuff + count) = SDMMC_ReadFIFO(hsd->Instance);
+        }
+        
+        tempbuff += 8;
+      }
+    }   
+  }
+  
+  /* Send stop transmission command in case of multiblock read */
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DATAEND) && (NumberOfBlocks > 1))
+  {    
+    if ((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1) ||\
+      (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0) ||\
+        (hsd->CardType == HIGH_CAPACITY_SD_CARD))
+    {
+      /* Send stop transmission command */
+      errorstate = HAL_SD_StopTransfer(hsd);
+    }
+  }
+  
+  /* Get error state */
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DTIMEOUT))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DTIMEOUT);
+    
+    errorstate = SD_DATA_TIMEOUT;
+    
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DCRCFAIL))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DCRCFAIL);
+    
+    errorstate = SD_DATA_CRC_FAIL;
+    
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_RXOVERR);
+    
+    errorstate = SD_RX_OVERRUN;
+    
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }
+  
+  count = SD_DATATIMEOUT;
+  
+  /* Empty FIFO if there is still any data */
+  while ((__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXDAVL)) && (count > 0))
+  {
+    *tempbuff = SDMMC_ReadFIFO(hsd->Instance);
+    tempbuff++;
+    count--;
+  }
+  
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Allows to write block(s) to a specified address in a card. The Data
+  *         transfer is managed by polling mode.  
+  * @param  hsd: SD handle
+  * @param  pWriteBuffer: pointer to the buffer that will contain the data to transmit
+  * @param  WriteAddr: Address from where data is to be written 
+  * @param  BlockSize: SD card Data block size 
+  * @note   BlockSize must be 512 bytes.
+  * @param  NumberOfBlocks: Number of SD blocks to write 
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t totalnumberofbytes = 0, bytestransferred = 0, count = 0, restwords = 0;
+  uint32_t *tempbuff = (uint32_t *)pWriteBuffer;
+  uint8_t cardstate  = 0;
+  
+  /* Initialize data control register */
+  hsd->Instance->DCTRL = 0;
+  
+  if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
+  {
+    BlockSize = 512;
+    WriteAddr /= 512;
+  }
+  
+  /* Set Block Size for Card */ 
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)BlockSize;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+  
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  if(NumberOfBlocks > 1)
+  {
+    /* Send CMD25 WRITE_MULT_BLOCK with argument data address */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_WRITE_MULT_BLOCK;
+  }
+  else
+  {
+    /* Send CMD24 WRITE_SINGLE_BLOCK */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_WRITE_SINGLE_BLOCK;
+  }
+  
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)WriteAddr;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  if(NumberOfBlocks > 1)
+  {
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_WRITE_MULT_BLOCK);
+  }
+  else
+  {
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_WRITE_SINGLE_BLOCK);
+  }  
+  
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Set total number of bytes to write */
+  totalnumberofbytes = NumberOfBlocks * BlockSize;
+  
+  /* Configure the SD DPSM (Data Path State Machine) */ 
+  sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdmmc_datainitstructure.DataLength    = NumberOfBlocks * BlockSize;
+  sdmmc_datainitstructure.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
+  sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_CARD;
+  sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+  SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+  
+  /* Write block(s) in polling mode */
+  if(NumberOfBlocks > 1)
+  {
+    while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_TXUNDERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
+    {
+      if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_TXFIFOHE))
+      {
+        if ((totalnumberofbytes - bytestransferred) < 32)
+        {
+          restwords = ((totalnumberofbytes - bytestransferred) % 4 == 0) ? ((totalnumberofbytes - bytestransferred) / 4) : (( totalnumberofbytes -  bytestransferred) / 4 + 1);
+          
+          /* Write data to SDMMC Tx FIFO */
+          for (count = 0; count < restwords; count++)
+          {
+            SDMMC_WriteFIFO(hsd->Instance, tempbuff);
+            tempbuff++;
+            bytestransferred += 4;
+          }
+        }
+        else
+        {
+          /* Write data to SDMMC Tx FIFO */
+          for (count = 0; count < 8; count++)
+          {
+            SDMMC_WriteFIFO(hsd->Instance, (tempbuff + count));
+          }
+          
+          tempbuff += 8;
+          bytestransferred += 32;
+        }
+      }
+    }   
+  }
+  else
+  {
+    /* In case of single data block transfer no need of stop command at all */ 
+    while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_TXUNDERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DBCKEND))
+    {
+      if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_TXFIFOHE))
+      {
+        if ((totalnumberofbytes - bytestransferred) < 32)
+        {
+          restwords = ((totalnumberofbytes - bytestransferred) % 4 == 0) ? ((totalnumberofbytes - bytestransferred) / 4) : (( totalnumberofbytes -  bytestransferred) / 4 + 1);
+          
+          /* Write data to SDMMC Tx FIFO */
+          for (count = 0; count < restwords; count++)
+          {
+            SDMMC_WriteFIFO(hsd->Instance, tempbuff);
+            tempbuff++; 
+            bytestransferred += 4;
+          }
+        }
+        else
+        {
+          /* Write data to SDMMC Tx FIFO */
+          for (count = 0; count < 8; count++)
+          {
+            SDMMC_WriteFIFO(hsd->Instance, (tempbuff + count));
+          }
+          
+          tempbuff += 8;
+          bytestransferred += 32;
+        }
+      }
+    }  
+  }
+  
+  /* Send stop transmission command in case of multiblock write */
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DATAEND) && (NumberOfBlocks > 1))
+  {    
+    if ((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1) || (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0) ||\
+      (hsd->CardType == HIGH_CAPACITY_SD_CARD))
+    {
+      /* Send stop transmission command */
+      errorstate = HAL_SD_StopTransfer(hsd);
+    }
+  }
+  
+  /* Get error state */
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DTIMEOUT))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DTIMEOUT);
+    
+    errorstate = SD_DATA_TIMEOUT;
+    
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DCRCFAIL))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DCRCFAIL);
+    
+    errorstate = SD_DATA_CRC_FAIL;
+    
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_TXUNDERR))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_TXUNDERR);
+    
+    errorstate = SD_TX_UNDERRUN;
+    
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }
+  
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+  
+  /* Wait till the card is in programming state */
+  errorstate = SD_IsCardProgramming(hsd, &cardstate);
+  
+  while ((errorstate == SD_OK) && ((cardstate == SD_CARD_PROGRAMMING) || (cardstate == SD_CARD_RECEIVING)))
+  {
+    errorstate = SD_IsCardProgramming(hsd, &cardstate);
+  }
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Reads block(s) from a specified address in a card. The Data transfer 
+  *         is managed by DMA mode. 
+  * @note   This API should be followed by the function HAL_SD_CheckReadOperation()
+  *         to check the completion of the read process   
+  * @param  hsd: SD handle                 
+  * @param  pReadBuffer: Pointer to the buffer that will contain the received data
+  * @param  ReadAddr: Address from where data is to be read  
+  * @param  BlockSize: SD card Data block size 
+  * @note   BlockSize must be 512 bytes.
+  * @param  NumberOfBlocks: Number of blocks to read.
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  
+  /* Initialize data control register */
+  hsd->Instance->DCTRL = 0;
+  
+  /* Initialize handle flags */
+  hsd->SdTransferCplt  = 0;
+  hsd->DmaTransferCplt = 0;
+  hsd->SdTransferErr   = SD_OK; 
+  
+  /* Initialize SD Read operation */
+  if(NumberOfBlocks > 1)
+  {
+    hsd->SdOperation = SD_READ_MULTIPLE_BLOCK;
+  }
+  else
+  {
+    hsd->SdOperation = SD_READ_SINGLE_BLOCK;
+  }
+  
+  /* Enable transfer interrupts */
+  __HAL_SD_SDMMC_ENABLE_IT(hsd, (SDMMC_IT_DCRCFAIL |\
+                                 SDMMC_IT_DTIMEOUT |\
+                                 SDMMC_IT_DATAEND  |\
+                                 SDMMC_IT_RXOVERR));
+  
+  /* Enable SDMMC DMA transfer */
+  __HAL_SD_SDMMC_DMA_ENABLE(hsd);
+  
+  /* Configure DMA user callbacks */
+  hsd->hdmarx->XferCpltCallback  = SD_DMA_RxCplt;
+  hsd->hdmarx->XferErrorCallback = SD_DMA_RxError;
+
+  /* Change DMA direction Periph to Memory */
+  hsd->hdmarx->Init.Direction = DMA_PERIPH_TO_MEMORY;
+  hsd->hdmarx->Instance->CCR &= ~DMA_MEMORY_TO_PERIPH;
+  
+  /* Enable the DMA Channel */
+  HAL_DMA_Start_IT(hsd->hdmarx, (uint32_t)&hsd->Instance->FIFO, (uint32_t)pReadBuffer, (uint32_t)(BlockSize * NumberOfBlocks)/4);
+  
+  if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
+  {
+    BlockSize = 512;
+    ReadAddr /= 512;
+  }
+  
+  /* Set Block Size for Card */ 
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)BlockSize;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+  
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Configure the SD DPSM (Data Path State Machine) */ 
+  sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdmmc_datainitstructure.DataLength    = BlockSize * NumberOfBlocks;
+  sdmmc_datainitstructure.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
+  sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+  sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+  SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+  
+  /* Check number of blocks command */
+  if(NumberOfBlocks > 1)
+  {
+    /* Send CMD18 READ_MULT_BLOCK with argument data address */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_READ_MULT_BLOCK;
+  }
+  else
+  {
+    /* Send CMD17 READ_SINGLE_BLOCK */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_READ_SINGLE_BLOCK;
+  }
+  
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)ReadAddr;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  if(NumberOfBlocks > 1)
+  {
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_READ_MULT_BLOCK);
+  }
+  else
+  {
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_READ_SINGLE_BLOCK);
+  }
+  
+  /* Update the SD transfer error in SD handle */
+  hsd->SdTransferErr = errorstate;
+  
+  return errorstate;
+}
+
+
+/**
+  * @brief  Writes block(s) to a specified address in a card. The Data transfer 
+  *         is managed by DMA mode. 
+  * @note   This API should be followed by the function HAL_SD_CheckWriteOperation()
+  *         to check the completion of the write process (by SD current status polling).  
+  * @param  hsd: SD handle
+  * @param  pWriteBuffer: pointer to the buffer that will contain the data to transmit
+  * @param  WriteAddr: Address from where data is to be read   
+  * @param  BlockSize: the SD card Data block size 
+  * @note   BlockSize must be 512 bytes.
+  * @param  NumberOfBlocks: Number of blocks to write
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  
+  /* Initialize data control register */
+  hsd->Instance->DCTRL = 0;
+  
+  /* Initialize handle flags */
+  hsd->SdTransferCplt  = 0;
+  hsd->DmaTransferCplt = 0;
+  hsd->SdTransferErr   = SD_OK;
+  
+  /* Initialize SD Write operation */
+  if(NumberOfBlocks > 1)
+  {
+    hsd->SdOperation = SD_WRITE_MULTIPLE_BLOCK;
+  }
+  else
+  {
+    hsd->SdOperation = SD_WRITE_SINGLE_BLOCK;
+  }  
+  
+  /* Enable transfer interrupts */
+  __HAL_SD_SDMMC_ENABLE_IT(hsd, (SDMMC_IT_DCRCFAIL |\
+                                 SDMMC_IT_DTIMEOUT |\
+                                 SDMMC_IT_DATAEND  |\
+                                 SDMMC_IT_TXUNDERR)); 
+  
+  /* Configure DMA user callbacks */
+  hsd->hdmatx->XferCpltCallback  = SD_DMA_TxCplt;
+  hsd->hdmatx->XferErrorCallback = SD_DMA_TxError;
+
+  /* Change DMA direction Memory to Periph */
+  hsd->hdmatx->Init.Direction = DMA_MEMORY_TO_PERIPH;
+  hsd->hdmatx->Instance->CCR |= DMA_MEMORY_TO_PERIPH;
+  
+  /* Enable the DMA Channel */
+  HAL_DMA_Start_IT(hsd->hdmatx, (uint32_t)pWriteBuffer, (uint32_t)&hsd->Instance->FIFO, (uint32_t)(BlockSize * NumberOfBlocks)/4);
+
+  /* Enable SDMMC DMA transfer */
+  __HAL_SD_SDMMC_DMA_ENABLE(hsd);
+  
+  if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
+  {
+    BlockSize = 512;
+    WriteAddr /= 512;
+  }
+
+  /* Set Block Size for Card */ 
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)BlockSize;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Check number of blocks command */
+  if(NumberOfBlocks <= 1)
+  {
+    /* Send CMD24 WRITE_SINGLE_BLOCK */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_WRITE_SINGLE_BLOCK;
+  }
+  else
+  {
+    /* Send CMD25 WRITE_MULT_BLOCK with argument data address */
+    sdmmc_cmdinitstructure.CmdIndex = SD_CMD_WRITE_MULT_BLOCK;
+  }
+  
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)WriteAddr;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+
+  /* Check for error conditions */
+  if(NumberOfBlocks > 1)
+  {
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_WRITE_MULT_BLOCK);
+  }
+  else
+  {
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_WRITE_SINGLE_BLOCK);
+  }
+  
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Configure the SD DPSM (Data Path State Machine) */ 
+  sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdmmc_datainitstructure.DataLength    = BlockSize * NumberOfBlocks;
+  sdmmc_datainitstructure.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
+  sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_CARD;
+  sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+  SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+  
+  hsd->SdTransferErr = errorstate;
+  
+  return errorstate;
+}
+
+/**
+  * @brief  This function waits until the SD DMA data read transfer is finished. 
+  *         This API should be called after HAL_SD_ReadBlocks_DMA() function
+  *         to insure that all data sent by the card is already transferred by the 
+  *         DMA controller.
+  * @param  hsd: SD handle
+  * @param  Timeout: Timeout duration  
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_CheckReadOperation(SD_HandleTypeDef *hsd, uint32_t Timeout)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t timeout = Timeout;
+  uint32_t tmp1, tmp2;
+  HAL_SD_ErrorTypedef tmp3;
+  
+  /* Wait for DMA/SD transfer end or SD error variables to be in SD handle */
+  tmp1 = hsd->DmaTransferCplt; 
+  tmp2 = hsd->SdTransferCplt;
+  tmp3 = (HAL_SD_ErrorTypedef)hsd->SdTransferErr;
+    
+  while (((tmp1 & tmp2) == 0) && (tmp3 == SD_OK) && (timeout > 0))
+  {
+    tmp1 = hsd->DmaTransferCplt; 
+    tmp2 = hsd->SdTransferCplt;
+    tmp3 = (HAL_SD_ErrorTypedef)hsd->SdTransferErr;    
+    timeout--;
+  }
+
+  timeout = Timeout;
+  
+  /* Wait until the Rx transfer is no longer active */
+  while((__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXACT)) && (timeout > 0))
+  {
+    timeout--;  
+  }
+  
+  /* Send stop command in multiblock read */
+  if (hsd->SdOperation == SD_READ_MULTIPLE_BLOCK)
+  {
+    errorstate = HAL_SD_StopTransfer(hsd);
+  }
+  
+  if ((timeout == 0) && (errorstate == SD_OK))
+  {
+    errorstate = SD_DATA_TIMEOUT;
+  }
+  
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+  
+  /* Return error state */
+  if (hsd->SdTransferErr != SD_OK)
+  {
+    return (HAL_SD_ErrorTypedef)(hsd->SdTransferErr);
+  }
+  
+  return errorstate;
+}
+
+/**
+  * @brief  This function waits until the SD DMA data write transfer is finished. 
+  *         This API should be called after HAL_SD_WriteBlocks_DMA() function
+  *         to insure that all data sent by the card is already transferred by the 
+  *         DMA controller.
+  * @param  hsd: SD handle
+  * @param  Timeout: Timeout duration  
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_CheckWriteOperation(SD_HandleTypeDef *hsd, uint32_t Timeout)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t timeout = Timeout;
+  uint32_t tmp1, tmp2;
+  HAL_SD_ErrorTypedef tmp3;
+
+  /* Wait for DMA/SD transfer end or SD error variables to be in SD handle */
+  tmp1 = hsd->DmaTransferCplt; 
+  tmp2 = hsd->SdTransferCplt;
+  tmp3 = (HAL_SD_ErrorTypedef)hsd->SdTransferErr;
+    
+  while (((tmp1 & tmp2) == 0) && (tmp3 == SD_OK) && (timeout > 0))
+  {
+    tmp1 = hsd->DmaTransferCplt; 
+    tmp2 = hsd->SdTransferCplt;
+    tmp3 = (HAL_SD_ErrorTypedef)hsd->SdTransferErr;
+    timeout--;
+  }
+  
+  timeout = Timeout;
+  
+  /* Wait until the Tx transfer is no longer active */
+  while((__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_TXACT))  && (timeout > 0))
+  {
+    timeout--;  
+  }
+
+  /* Send stop command in multiblock write */
+  if (hsd->SdOperation == SD_WRITE_MULTIPLE_BLOCK)
+  {
+    errorstate = HAL_SD_StopTransfer(hsd);
+  }
+  
+  if ((timeout == 0) && (errorstate == SD_OK))
+  {
+    errorstate = SD_DATA_TIMEOUT;
+  }
+  
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+  
+  /* Return error state */
+  if (hsd->SdTransferErr != SD_OK)
+  {
+    return (HAL_SD_ErrorTypedef)(hsd->SdTransferErr);
+  }
+  
+  /* Wait until write is complete */
+  while(HAL_SD_GetStatus(hsd) != SD_TRANSFER_OK)
+  {    
+  }
+
+  return errorstate; 
+}
+
+/**
+  * @brief  Erases the specified memory area of the given SD card.
+  * @param  hsd: SD handle 
+  * @param  startaddr: Start byte address
+  * @param  endaddr: End byte address
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_Erase(SD_HandleTypeDef *hsd, uint64_t startaddr, uint64_t endaddr)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  
+  uint32_t delay         = 0;
+  __IO uint32_t maxdelay = 0;
+  uint8_t cardstate      = 0;
+  
+  /* Check if the card command class supports erase command */
+  if (((hsd->CSD[1] >> 20) & SD_CCCC_ERASE) == 0)
+  {
+    errorstate = SD_REQUEST_NOT_APPLICABLE;
+    
+    return errorstate;
+  }
+  
+  /* Get max delay value */
+  maxdelay = 120000 / (((hsd->Instance->CLKCR) & 0xFF) + 2);
+  
+  if((SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1) & SD_CARD_LOCKED) == SD_CARD_LOCKED)
+  {
+    errorstate = SD_LOCK_UNLOCK_FAILED;
+    
+    return errorstate;
+  }
+  
+  /* Get start and end block for high capacity cards */
+  if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
+  {
+    startaddr /= 512;
+    endaddr   /= 512;
+  }
+  
+  /* According to sd-card spec 1.0 ERASE_GROUP_START (CMD32) and erase_group_end(CMD33) */
+  if ((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1) || (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0) ||\
+    (hsd->CardType == HIGH_CAPACITY_SD_CARD))
+  {
+    /* Send CMD32 SD_ERASE_GRP_START with argument as addr  */
+    sdmmc_cmdinitstructure.Argument         =(uint32_t)startaddr;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SD_ERASE_GRP_START;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+    sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+    sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+    
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_SD_ERASE_GRP_START);
+    
+    if (errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+    
+    /* Send CMD33 SD_ERASE_GRP_END with argument as addr  */
+    sdmmc_cmdinitstructure.Argument         = (uint32_t)endaddr;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SD_ERASE_GRP_END;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+    
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_SD_ERASE_GRP_END);
+    
+    if (errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+  }
+  
+  /* Send CMD38 ERASE */
+  sdmmc_cmdinitstructure.Argument         = 0;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_ERASE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_ERASE);
+  
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  for (; delay < maxdelay; delay++)
+  {
+  }
+  
+  /* Wait until the card is in programming state */
+  errorstate = SD_IsCardProgramming(hsd, &cardstate);
+  
+  delay = SD_DATATIMEOUT;
+  
+  while ((delay > 0) && (errorstate == SD_OK) && ((cardstate == SD_CARD_PROGRAMMING) || (cardstate == SD_CARD_RECEIVING)))
+  {
+    errorstate = SD_IsCardProgramming(hsd, &cardstate);
+    delay--;
+  }
+  
+  return errorstate;
+}
+
+/**
+  * @brief  This function handles SD card interrupt request.
+  * @param  hsd: SD handle
+  * @retval None
+  */
+void HAL_SD_IRQHandler(SD_HandleTypeDef *hsd)
+{  
+  /* Check for SDMMC interrupt flags */
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_IT_DATAEND))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_IT_DATAEND);  
+      
+    /* SD transfer is complete */
+    hsd->SdTransferCplt = 1;
+
+    /* No transfer error */ 
+    hsd->SdTransferErr  = SD_OK;
+
+    HAL_SD_XferCpltCallback(hsd);  
+  }  
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_IT_DCRCFAIL))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DCRCFAIL);
+    
+    hsd->SdTransferErr = SD_DATA_CRC_FAIL;
+    
+    HAL_SD_XferErrorCallback(hsd);
+    
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_IT_DTIMEOUT))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DTIMEOUT);
+    
+    hsd->SdTransferErr = SD_DATA_TIMEOUT;
+    
+    HAL_SD_XferErrorCallback(hsd);
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_IT_RXOVERR))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_RXOVERR);
+    
+    hsd->SdTransferErr = SD_RX_OVERRUN;
+    
+    HAL_SD_XferErrorCallback(hsd);
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_IT_TXUNDERR))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_TXUNDERR);
+    
+    hsd->SdTransferErr = SD_TX_UNDERRUN;
+    
+    HAL_SD_XferErrorCallback(hsd);
+  }
+  else
+  {
+    /* No error flag set */
+  }  
+
+  /* Disable all SDMMC peripheral interrupt sources */
+  __HAL_SD_SDMMC_DISABLE_IT(hsd, SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT | SDMMC_IT_DATAEND  |\
+                                 SDMMC_IT_TXFIFOHE | SDMMC_IT_RXFIFOHF | SDMMC_IT_TXUNDERR |\
+                                 SDMMC_IT_RXOVERR);                               
+}
+
+
+/**
+  * @brief  SD end of transfer callback.
+  * @param  hsd: SD handle 
+  * @retval None
+  */
+__weak void HAL_SD_XferCpltCallback(SD_HandleTypeDef *hsd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hsd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SD_XferCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  SD Transfer Error callback.
+  * @param  hsd: SD handle
+  * @retval None
+  */
+__weak void HAL_SD_XferErrorCallback(SD_HandleTypeDef *hsd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hsd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SD_XferErrorCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  SD Transfer complete Rx callback in non-blocking mode.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+__weak void HAL_SD_DMA_RxCpltCallback(DMA_HandleTypeDef *hdma)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdma);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SD_DMA_RxCpltCallback could be implemented in the user file
+   */ 
+}  
+
+/**
+  * @brief  SD DMA transfer complete Rx error callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+__weak void HAL_SD_DMA_RxErrorCallback(DMA_HandleTypeDef *hdma)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdma);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SD_DMA_RxErrorCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  SD Transfer complete Tx callback in non-blocking mode.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+__weak void HAL_SD_DMA_TxCpltCallback(DMA_HandleTypeDef *hdma)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdma);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SD_DMA_TxCpltCallback could be implemented in the user file
+   */ 
+}  
+
+/**
+  * @brief  SD DMA transfer complete error Tx callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+__weak void HAL_SD_DMA_TxErrorCallback(DMA_HandleTypeDef *hdma)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hdma);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SD_DMA_TxErrorCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @addtogroup SD_Exported_Functions_Group3
+ *  @brief   management functions 
+ *
+@verbatim   
+  ==============================================================================
+                      ##### Peripheral Control functions #####
+  ==============================================================================  
+  [..]
+    This subsection provides a set of functions allowing to control the SD card 
+    operations.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns information about specific card.
+  * @param  hsd: SD handle
+  * @param  pCardInfo: Pointer to a HAL_SD_CardInfoTypedef structure that  
+  *         contains all SD cardinformation  
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_Get_CardInfo(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTypedef *pCardInfo)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t tmp = 0;
+  
+  pCardInfo->CardType = (uint8_t)(hsd->CardType);
+  pCardInfo->RCA      = (uint16_t)(hsd->RCA);
+  
+  /* Byte 0 */
+  tmp = (hsd->CSD[0] & 0xFF000000) >> 24;
+  pCardInfo->SD_csd.CSDStruct      = (uint8_t)((tmp & 0xC0) >> 6);
+  pCardInfo->SD_csd.SysSpecVersion = (uint8_t)((tmp & 0x3C) >> 2);
+  pCardInfo->SD_csd.Reserved1      = tmp & 0x03;
+  
+  /* Byte 1 */
+  tmp = (hsd->CSD[0] & 0x00FF0000) >> 16;
+  pCardInfo->SD_csd.TAAC = (uint8_t)tmp;
+  
+  /* Byte 2 */
+  tmp = (hsd->CSD[0] & 0x0000FF00) >> 8;
+  pCardInfo->SD_csd.NSAC = (uint8_t)tmp;
+  
+  /* Byte 3 */
+  tmp = hsd->CSD[0] & 0x000000FF;
+  pCardInfo->SD_csd.MaxBusClkFrec = (uint8_t)tmp;
+  
+  /* Byte 4 */
+  tmp = (hsd->CSD[1] & 0xFF000000) >> 24;
+  pCardInfo->SD_csd.CardComdClasses = (uint16_t)(tmp << 4);
+  
+  /* Byte 5 */
+  tmp = (hsd->CSD[1] & 0x00FF0000) >> 16;
+  pCardInfo->SD_csd.CardComdClasses |= (uint16_t)((tmp & 0xF0) >> 4);
+  pCardInfo->SD_csd.RdBlockLen       = (uint8_t)(tmp & 0x0F);
+  
+  /* Byte 6 */
+  tmp = (hsd->CSD[1] & 0x0000FF00) >> 8;
+  pCardInfo->SD_csd.PartBlockRead   = (uint8_t)((tmp & 0x80) >> 7);
+  pCardInfo->SD_csd.WrBlockMisalign = (uint8_t)((tmp & 0x40) >> 6);
+  pCardInfo->SD_csd.RdBlockMisalign = (uint8_t)((tmp & 0x20) >> 5);
+  pCardInfo->SD_csd.DSRImpl         = (uint8_t)((tmp & 0x10) >> 4);
+  pCardInfo->SD_csd.Reserved2       = 0; /*!< Reserved */
+  
+  if ((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1) || (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0))
+  {
+    pCardInfo->SD_csd.DeviceSize = (tmp & 0x03) << 10;
+    
+    /* Byte 7 */
+    tmp = (uint8_t)(hsd->CSD[1] & 0x000000FF);
+    pCardInfo->SD_csd.DeviceSize |= (tmp) << 2;
+    
+    /* Byte 8 */
+    tmp = (uint8_t)((hsd->CSD[2] & 0xFF000000) >> 24);
+    pCardInfo->SD_csd.DeviceSize |= (tmp & 0xC0) >> 6;
+    
+    pCardInfo->SD_csd.MaxRdCurrentVDDMin = (tmp & 0x38) >> 3;
+    pCardInfo->SD_csd.MaxRdCurrentVDDMax = (tmp & 0x07);
+    
+    /* Byte 9 */
+    tmp = (uint8_t)((hsd->CSD[2] & 0x00FF0000) >> 16);
+    pCardInfo->SD_csd.MaxWrCurrentVDDMin = (tmp & 0xE0) >> 5;
+    pCardInfo->SD_csd.MaxWrCurrentVDDMax = (tmp & 0x1C) >> 2;
+    pCardInfo->SD_csd.DeviceSizeMul      = (tmp & 0x03) << 1;
+    /* Byte 10 */
+    tmp = (uint8_t)((hsd->CSD[2] & 0x0000FF00) >> 8);
+    pCardInfo->SD_csd.DeviceSizeMul |= (tmp & 0x80) >> 7;
+    
+    pCardInfo->CardCapacity  = (pCardInfo->SD_csd.DeviceSize + 1) ;
+    pCardInfo->CardCapacity *= (1 << (pCardInfo->SD_csd.DeviceSizeMul + 2));
+    pCardInfo->CardBlockSize = 1 << (pCardInfo->SD_csd.RdBlockLen);
+    pCardInfo->CardCapacity *= pCardInfo->CardBlockSize;
+  }
+  else if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
+  {
+    /* Byte 7 */
+    tmp = (uint8_t)(hsd->CSD[1] & 0x000000FF);
+    pCardInfo->SD_csd.DeviceSize = (tmp & 0x3F) << 16;
+    
+    /* Byte 8 */
+    tmp = (uint8_t)((hsd->CSD[2] & 0xFF000000) >> 24);
+    
+    pCardInfo->SD_csd.DeviceSize |= (tmp << 8);
+    
+    /* Byte 9 */
+    tmp = (uint8_t)((hsd->CSD[2] & 0x00FF0000) >> 16);
+    
+    pCardInfo->SD_csd.DeviceSize |= (tmp);
+    
+    /* Byte 10 */
+    tmp = (uint8_t)((hsd->CSD[2] & 0x0000FF00) >> 8);
+    
+    pCardInfo->CardCapacity = (uint64_t)(((uint64_t)pCardInfo->SD_csd.DeviceSize + 1) * 512 * 1024);
+    pCardInfo->CardBlockSize = 512;    
+  }
+  else
+  {
+    /* Not supported card type */
+    errorstate = SD_ERROR;
+  }
+      
+  pCardInfo->SD_csd.EraseGrSize = (tmp & 0x40) >> 6;
+  pCardInfo->SD_csd.EraseGrMul  = (tmp & 0x3F) << 1;
+  
+  /* Byte 11 */
+  tmp = (uint8_t)(hsd->CSD[2] & 0x000000FF);
+  pCardInfo->SD_csd.EraseGrMul     |= (tmp & 0x80) >> 7;
+  pCardInfo->SD_csd.WrProtectGrSize = (tmp & 0x7F);
+  
+  /* Byte 12 */
+  tmp = (uint8_t)((hsd->CSD[3] & 0xFF000000) >> 24);
+  pCardInfo->SD_csd.WrProtectGrEnable = (tmp & 0x80) >> 7;
+  pCardInfo->SD_csd.ManDeflECC        = (tmp & 0x60) >> 5;
+  pCardInfo->SD_csd.WrSpeedFact       = (tmp & 0x1C) >> 2;
+  pCardInfo->SD_csd.MaxWrBlockLen     = (tmp & 0x03) << 2;
+  
+  /* Byte 13 */
+  tmp = (uint8_t)((hsd->CSD[3] & 0x00FF0000) >> 16);
+  pCardInfo->SD_csd.MaxWrBlockLen      |= (tmp & 0xC0) >> 6;
+  pCardInfo->SD_csd.WriteBlockPaPartial = (tmp & 0x20) >> 5;
+  pCardInfo->SD_csd.Reserved3           = 0;
+  pCardInfo->SD_csd.ContentProtectAppli = (tmp & 0x01);
+  
+  /* Byte 14 */
+  tmp = (uint8_t)((hsd->CSD[3] & 0x0000FF00) >> 8);
+  pCardInfo->SD_csd.FileFormatGrouop = (tmp & 0x80) >> 7;
+  pCardInfo->SD_csd.CopyFlag         = (tmp & 0x40) >> 6;
+  pCardInfo->SD_csd.PermWrProtect    = (tmp & 0x20) >> 5;
+  pCardInfo->SD_csd.TempWrProtect    = (tmp & 0x10) >> 4;
+  pCardInfo->SD_csd.FileFormat       = (tmp & 0x0C) >> 2;
+  pCardInfo->SD_csd.ECC              = (tmp & 0x03);
+  
+  /* Byte 15 */
+  tmp = (uint8_t)(hsd->CSD[3] & 0x000000FF);
+  pCardInfo->SD_csd.CSD_CRC   = (tmp & 0xFE) >> 1;
+  pCardInfo->SD_csd.Reserved4 = 1;
+  
+  /* Byte 0 */
+  tmp = (uint8_t)((hsd->CID[0] & 0xFF000000) >> 24);
+  pCardInfo->SD_cid.ManufacturerID = tmp;
+  
+  /* Byte 1 */
+  tmp = (uint8_t)((hsd->CID[0] & 0x00FF0000) >> 16);
+  pCardInfo->SD_cid.OEM_AppliID = tmp << 8;
+  
+  /* Byte 2 */
+  tmp = (uint8_t)((hsd->CID[0] & 0x000000FF00) >> 8);
+  pCardInfo->SD_cid.OEM_AppliID |= tmp;
+  
+  /* Byte 3 */
+  tmp = (uint8_t)(hsd->CID[0] & 0x000000FF);
+  pCardInfo->SD_cid.ProdName1 = tmp << 24;
+  
+  /* Byte 4 */
+  tmp = (uint8_t)((hsd->CID[1] & 0xFF000000) >> 24);
+  pCardInfo->SD_cid.ProdName1 |= tmp << 16;
+  
+  /* Byte 5 */
+  tmp = (uint8_t)((hsd->CID[1] & 0x00FF0000) >> 16);
+  pCardInfo->SD_cid.ProdName1 |= tmp << 8;
+  
+  /* Byte 6 */
+  tmp = (uint8_t)((hsd->CID[1] & 0x0000FF00) >> 8);
+  pCardInfo->SD_cid.ProdName1 |= tmp;
+  
+  /* Byte 7 */
+  tmp = (uint8_t)(hsd->CID[1] & 0x000000FF);
+  pCardInfo->SD_cid.ProdName2 = tmp;
+  
+  /* Byte 8 */
+  tmp = (uint8_t)((hsd->CID[2] & 0xFF000000) >> 24);
+  pCardInfo->SD_cid.ProdRev = tmp;
+  
+  /* Byte 9 */
+  tmp = (uint8_t)((hsd->CID[2] & 0x00FF0000) >> 16);
+  pCardInfo->SD_cid.ProdSN = tmp << 24;
+  
+  /* Byte 10 */
+  tmp = (uint8_t)((hsd->CID[2] & 0x0000FF00) >> 8);
+  pCardInfo->SD_cid.ProdSN |= tmp << 16;
+  
+  /* Byte 11 */
+  tmp = (uint8_t)(hsd->CID[2] & 0x000000FF);
+  pCardInfo->SD_cid.ProdSN |= tmp << 8;
+  
+  /* Byte 12 */
+  tmp = (uint8_t)((hsd->CID[3] & 0xFF000000) >> 24);
+  pCardInfo->SD_cid.ProdSN |= tmp;
+  
+  /* Byte 13 */
+  tmp = (uint8_t)((hsd->CID[3] & 0x00FF0000) >> 16);
+  pCardInfo->SD_cid.Reserved1   |= (tmp & 0xF0) >> 4;
+  pCardInfo->SD_cid.ManufactDate = (tmp & 0x0F) << 8;
+  
+  /* Byte 14 */
+  tmp = (uint8_t)((hsd->CID[3] & 0x0000FF00) >> 8);
+  pCardInfo->SD_cid.ManufactDate |= tmp;
+  
+  /* Byte 15 */
+  tmp = (uint8_t)(hsd->CID[3] & 0x000000FF);
+  pCardInfo->SD_cid.CID_CRC   = (tmp & 0xFE) >> 1;
+  pCardInfo->SD_cid.Reserved2 = 1;
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Enables wide bus operation for the requested card if supported by 
+  *         card.
+  * @param  hsd: SD handle       
+  * @param  WideMode: Specifies the SD card wide bus mode 
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_BUS_WIDE_8B: 8-bit data transfer (Only for MMC)
+  *            @arg SDMMC_BUS_WIDE_4B: 4-bit data transfer
+  *            @arg SDMMC_BUS_WIDE_1B: 1-bit data transfer
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_WideBusOperation_Config(SD_HandleTypeDef *hsd, uint32_t WideMode)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  SDMMC_InitTypeDef tmpinit;
+  
+  /* MMC Card does not support this feature */
+  if (hsd->CardType == MULTIMEDIA_CARD)
+  {
+    errorstate = SD_UNSUPPORTED_FEATURE;
+    
+    return errorstate;
+  }
+  else if ((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1) || (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0) ||\
+    (hsd->CardType == HIGH_CAPACITY_SD_CARD))
+  {
+    if (WideMode == SDMMC_BUS_WIDE_8B)
+    {
+      errorstate = SD_UNSUPPORTED_FEATURE;
+    }
+    else if (WideMode == SDMMC_BUS_WIDE_4B)
+    {
+      errorstate = SD_WideBus_Enable(hsd);
+    }
+    else if (WideMode == SDMMC_BUS_WIDE_1B)
+    {
+      errorstate = SD_WideBus_Disable(hsd);
+    }
+    else
+    {
+      /* WideMode is not a valid argument*/
+      errorstate = SD_INVALID_PARAMETER;
+    }
+      
+    if (errorstate == SD_OK)
+    {
+      /* Configure the SDMMC peripheral */
+      tmpinit.ClockEdge           = hsd->Init.ClockEdge;
+      tmpinit.ClockBypass         = hsd->Init.ClockBypass;
+      tmpinit.ClockPowerSave      = hsd->Init.ClockPowerSave;
+      tmpinit.BusWide             = WideMode;
+      tmpinit.HardwareFlowControl = hsd->Init.HardwareFlowControl;
+      tmpinit.ClockDiv            = hsd->Init.ClockDiv;
+      SDMMC_Init(hsd->Instance, tmpinit);
+    }
+  }
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Aborts an ongoing data transfer.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_StopTransfer(SD_HandleTypeDef *hsd)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  
+  /* Send CMD12 STOP_TRANSMISSION  */
+  sdmmc_cmdinitstructure.Argument         = 0;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_STOP_TRANSMISSION;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_STOP_TRANSMISSION);
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Switches the SD card to High Speed mode.
+  *         This API must be used after "Transfer State"
+  * @note   This operation should be followed by the configuration 
+  *         of PLL to have SDMMCCK clock between 67 and 75 MHz
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_HighSpeed (SD_HandleTypeDef *hsd)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  
+  uint8_t SD_hs[64]  = {0};
+  uint32_t SD_scr[2] = {0, 0};
+  uint32_t SD_SPEC   = 0 ;
+  uint32_t count = 0, *tempbuff = (uint32_t *)SD_hs;
+  
+  /* Initialize the Data control register */
+  hsd->Instance->DCTRL = 0;
+  
+  /* Get SCR Register */
+  errorstate = SD_FindSCR(hsd, SD_scr);
+  
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Test the Version supported by the card*/ 
+  SD_SPEC = (SD_scr[1]  & 0x01000000) | (SD_scr[1]  & 0x02000000);
+  
+  if (SD_SPEC != SD_ALLZERO)
+  {
+    /* Set Block Size for Card */
+    sdmmc_cmdinitstructure.Argument         = (uint32_t)64;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+    sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+    sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+    
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+    
+    if (errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+    
+    /* Configure the SD DPSM (Data Path State Machine) */
+    sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+    sdmmc_datainitstructure.DataLength    = 64;
+    sdmmc_datainitstructure.DataBlockSize = SDMMC_DATABLOCK_SIZE_64B ;
+    sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+    sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+    sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+    SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+    
+    /* Send CMD6 switch mode */
+    sdmmc_cmdinitstructure.Argument         = 0x80FFFF01;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_HS_SWITCH;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure); 
+    
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_HS_SWITCH);
+    
+    if (errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+        
+    while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DBCKEND))
+    {
+      if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXFIFOHF))
+      {
+        for (count = 0; count < 8; count++)
+        {
+          *(tempbuff + count) = SDMMC_ReadFIFO(hsd->Instance);
+        }
+        
+        tempbuff += 8;
+      }
+    }
+    
+    if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DTIMEOUT))
+    {
+      __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DTIMEOUT);
+      
+      errorstate = SD_DATA_TIMEOUT;
+      
+      return errorstate;
+    }
+    else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DCRCFAIL))
+    {
+      __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DCRCFAIL);
+      
+      errorstate = SD_DATA_CRC_FAIL;
+      
+      return errorstate;
+    }
+    else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR))
+    {
+      __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_RXOVERR);
+      
+      errorstate = SD_RX_OVERRUN;
+      
+      return errorstate;
+    }
+    else
+    {
+      /* No error flag set */
+    }
+        
+    count = SD_DATATIMEOUT;
+    
+    while ((__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXDAVL)) && (count > 0))
+    {
+      *tempbuff = SDMMC_ReadFIFO(hsd->Instance);
+      tempbuff++;
+      count--;
+    }
+    
+    /* Clear all the static flags */
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+    
+    /* Test if the switch mode HS is ok */
+    if ((SD_hs[13]& 2) != 2)
+    {
+      errorstate = SD_UNSUPPORTED_FEATURE;
+    } 
+  }
+  
+  return errorstate;
+}
+
+/**
+  * @}
+  */
+
+/** @addtogroup SD_Exported_Functions_Group4
+ *  @brief   Peripheral State functions 
+ *
+@verbatim   
+  ==============================================================================
+                      ##### Peripheral State functions #####
+  ==============================================================================  
+  [..]
+    This subsection permits to get in runtime the status of the peripheral 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the current SD card's status.
+  * @param  hsd: SD handle
+  * @param  pSDstatus: Pointer to the buffer that will contain the SD card status 
+  *         SD Status register)
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_SendSDStatus(SD_HandleTypeDef *hsd, uint32_t *pSDstatus)
+{
+  SDMMC_CmdInitTypeDef  sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t count = 0;
+  
+  /* Check SD response */
+  if ((SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1) & SD_CARD_LOCKED) == SD_CARD_LOCKED)
+  {
+    errorstate = SD_LOCK_UNLOCK_FAILED;
+    
+    return errorstate;
+  }
+  
+  /* Set block size for card if it is not equal to current block size for card */
+  sdmmc_cmdinitstructure.Argument         = 64;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+  
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Send CMD55 */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+  
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Configure the SD DPSM (Data Path State Machine) */ 
+  sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdmmc_datainitstructure.DataLength    = 64;
+  sdmmc_datainitstructure.DataBlockSize = SDMMC_DATABLOCK_SIZE_64B;
+  sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+  sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+  SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+  
+  /* Send ACMD13 (SD_APP_STAUS)  with argument as card's RCA */
+  sdmmc_cmdinitstructure.Argument         = 0;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SD_APP_STATUS;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SD_APP_STATUS);
+  
+  if (errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Get status data */
+  while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DBCKEND))
+  {
+    if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXFIFOHF))
+    {
+      for (count = 0; count < 8; count++)
+      {
+        *(pSDstatus + count) = SDMMC_ReadFIFO(hsd->Instance);
+      }
+      
+      pSDstatus += 8;
+    }
+  }
+  
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DTIMEOUT))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DTIMEOUT);
+    
+    errorstate = SD_DATA_TIMEOUT;
+    
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DCRCFAIL))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DCRCFAIL);
+    
+    errorstate = SD_DATA_CRC_FAIL;
+    
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_RXOVERR);
+    
+    errorstate = SD_RX_OVERRUN;
+    
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }  
+  
+  count = SD_DATATIMEOUT;
+  while ((__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXDAVL)) && (count > 0))
+  {
+    *pSDstatus = SDMMC_ReadFIFO(hsd->Instance);
+    pSDstatus++;
+    count--;
+  }
+  
+  /* Clear all the static status flags*/
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Gets the current sd card data status.
+  * @param  hsd: SD handle
+  * @retval Data Transfer state
+  */
+HAL_SD_TransferStateTypedef HAL_SD_GetStatus(SD_HandleTypeDef *hsd)
+{
+  HAL_SD_CardStateTypedef cardstate =  SD_CARD_TRANSFER;
+
+  /* Get SD card state */
+  cardstate = SD_GetState(hsd);
+  
+  /* Find SD status according to card state*/
+  if (cardstate == SD_CARD_TRANSFER)
+  {
+    return SD_TRANSFER_OK;
+  }
+  else if(cardstate == SD_CARD_ERROR)
+  {
+    return SD_TRANSFER_ERROR;
+  }
+  else
+  {
+    return SD_TRANSFER_BUSY;
+  }
+}
+
+/**
+  * @brief  Gets the SD card status.
+  * @param  hsd: SD handle      
+  * @param  pCardStatus: Pointer to the HAL_SD_CardStatusTypedef structure that 
+  *         will contain the SD card status information 
+  * @retval SD Card error state
+  */
+HAL_SD_ErrorTypedef HAL_SD_GetCardStatus(SD_HandleTypeDef *hsd, HAL_SD_CardStatusTypedef *pCardStatus)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t tmp = 0;
+  uint32_t sd_status[16];
+  
+  errorstate = HAL_SD_SendSDStatus(hsd, sd_status);
+  
+  if (errorstate  != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Byte 0 */
+  tmp = (sd_status[0] & 0xC0) >> 6;
+  pCardStatus->DAT_BUS_WIDTH = (uint8_t)tmp;
+  
+  /* Byte 0 */
+  tmp = (sd_status[0] & 0x20) >> 5;
+  pCardStatus->SECURED_MODE = (uint8_t)tmp;
+  
+  /* Byte 2 */
+  tmp = (sd_status[2] & 0xFF);
+  pCardStatus->SD_CARD_TYPE = (uint8_t)(tmp << 8);
+  
+  /* Byte 3 */
+  tmp = (sd_status[3] & 0xFF);
+  pCardStatus->SD_CARD_TYPE |= (uint8_t)tmp;
+  
+  /* Byte 4 */
+  tmp = (sd_status[4] & 0xFF);
+  pCardStatus->SIZE_OF_PROTECTED_AREA = (uint8_t)(tmp << 24);
+  
+  /* Byte 5 */
+  tmp = (sd_status[5] & 0xFF);
+  pCardStatus->SIZE_OF_PROTECTED_AREA |= (uint8_t)(tmp << 16);
+  
+  /* Byte 6 */
+  tmp = (sd_status[6] & 0xFF);
+  pCardStatus->SIZE_OF_PROTECTED_AREA |= (uint8_t)(tmp << 8);
+  
+  /* Byte 7 */
+  tmp = (sd_status[7] & 0xFF);
+  pCardStatus->SIZE_OF_PROTECTED_AREA |= (uint8_t)tmp;
+  
+  /* Byte 8 */
+  tmp = (sd_status[8] & 0xFF);
+  pCardStatus->SPEED_CLASS = (uint8_t)tmp;
+  
+  /* Byte 9 */
+  tmp = (sd_status[9] & 0xFF);
+  pCardStatus->PERFORMANCE_MOVE = (uint8_t)tmp;
+  
+  /* Byte 10 */
+  tmp = (sd_status[10] & 0xF0) >> 4;
+  pCardStatus->AU_SIZE = (uint8_t)tmp;
+  
+  /* Byte 11 */
+  tmp = (sd_status[11] & 0xFF);
+  pCardStatus->ERASE_SIZE = (uint8_t)(tmp << 8);
+  
+  /* Byte 12 */
+  tmp = (sd_status[12] & 0xFF);
+  pCardStatus->ERASE_SIZE |= (uint8_t)tmp;
+  
+  /* Byte 13 */
+  tmp = (sd_status[13] & 0xFC) >> 2;
+  pCardStatus->ERASE_TIMEOUT = (uint8_t)tmp;
+  
+  /* Byte 13 */
+  tmp = (sd_status[13] & 0x3);
+  pCardStatus->ERASE_OFFSET = (uint8_t)tmp;
+  
+  return errorstate;
+}
+         
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */
+  
+/* Private function ----------------------------------------------------------*/  
+/** @addtogroup SD_Private_Functions
+  * @{
+  */
+  
+/**
+  * @brief  SD DMA transfer complete Rx callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SD_DMA_RxCplt(DMA_HandleTypeDef *hdma)
+{
+  SD_HandleTypeDef *hsd = (SD_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  
+  /* DMA transfer is complete */
+  hsd->DmaTransferCplt = 1;
+  
+  /* Wait until SD transfer is complete */
+  while(hsd->SdTransferCplt == 0)
+  {
+  }
+  
+  /* Disable the DMA channel */
+  HAL_DMA_Abort(hdma);
+
+  /* Transfer complete user callback */
+  HAL_SD_DMA_RxCpltCallback(hsd->hdmarx);   
+}
+
+/**
+  * @brief  SD DMA transfer Error Rx callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SD_DMA_RxError(DMA_HandleTypeDef *hdma)
+{
+  SD_HandleTypeDef *hsd = (SD_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  
+  /* Transfer complete user callback */
+  HAL_SD_DMA_RxErrorCallback(hsd->hdmarx);
+}
+
+/**
+  * @brief  SD DMA transfer complete Tx callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SD_DMA_TxCplt(DMA_HandleTypeDef *hdma)
+{
+  SD_HandleTypeDef *hsd = (SD_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  
+  /* DMA transfer is complete */
+  hsd->DmaTransferCplt = 1;
+  
+  /* Wait until SD transfer is complete */
+  while(hsd->SdTransferCplt == 0)
+  {
+  }
+  
+  /* Disable the DMA channel */
+  HAL_DMA_Abort(hdma);
+
+  /* Transfer complete user callback */
+  HAL_SD_DMA_TxCpltCallback(hsd->hdmatx);  
+}
+
+/**
+  * @brief  SD DMA transfer Error Tx callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SD_DMA_TxError(DMA_HandleTypeDef *hdma)
+{
+  SD_HandleTypeDef *hsd = ( SD_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  /* Transfer complete user callback */
+  HAL_SD_DMA_TxErrorCallback(hsd->hdmatx);
+}
+
+/**
+  * @brief  Returns the SD current state.
+  * @param  hsd: SD handle
+  * @retval SD card current state
+  */
+static HAL_SD_CardStateTypedef SD_GetState(SD_HandleTypeDef *hsd)
+{
+  uint32_t resp1 = 0;
+  
+  if (SD_SendStatus(hsd, &resp1) != SD_OK)
+  {
+    return SD_CARD_ERROR;
+  }
+  else
+  {
+    return (HAL_SD_CardStateTypedef)((resp1 >> 9) & 0x0F);
+  }
+}
+
+/**
+  * @brief  Initializes all cards or single card as the case may be Card(s) come 
+  *         into standby state.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_Initialize_Cards(SD_HandleTypeDef *hsd)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure; 
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint16_t sd_rca = 1;
+  
+  if(SDMMC_GetPowerState(hsd->Instance) == 0) /* Power off */
+  {
+    errorstate = SD_REQUEST_NOT_APPLICABLE;
+    
+    return errorstate;
+  }
+  
+  if(hsd->CardType != SECURE_DIGITAL_IO_CARD)
+  {
+    /* Send CMD2 ALL_SEND_CID */
+    sdmmc_cmdinitstructure.Argument         = 0;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_ALL_SEND_CID;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_LONG;
+    sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+    sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+    
+    /* Check for error conditions */
+    errorstate = SD_CmdResp2Error(hsd);
+    
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+    
+    /* Get Card identification number data */
+    hsd->CID[0] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+    hsd->CID[1] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP2);
+    hsd->CID[2] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP3);
+    hsd->CID[3] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP4);
+  }
+  
+  if((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1)    || (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0) ||\
+     (hsd->CardType == SECURE_DIGITAL_IO_COMBO_CARD) || (hsd->CardType == HIGH_CAPACITY_SD_CARD))
+  {
+    /* Send CMD3 SET_REL_ADDR with argument 0 */
+    /* SD Card publishes its RCA. */
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_REL_ADDR;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+    
+    /* Check for error conditions */
+    errorstate = SD_CmdResp6Error(hsd, SD_CMD_SET_REL_ADDR, &sd_rca);
+    
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+  }
+  
+  if (hsd->CardType != SECURE_DIGITAL_IO_CARD)
+  {
+    /* Get the SD card RCA */
+    hsd->RCA = sd_rca;
+    
+    /* Send CMD9 SEND_CSD with argument as card's RCA */
+    sdmmc_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SEND_CSD;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_LONG;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+    
+    /* Check for error conditions */
+    errorstate = SD_CmdResp2Error(hsd);
+    
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+    
+    /* Get Card Specific Data */
+    hsd->CSD[0] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+    hsd->CSD[1] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP2);
+    hsd->CSD[2] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP3);
+    hsd->CSD[3] = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP4);
+  }
+  
+  /* All cards are initialized */
+  return errorstate;
+}
+
+/**
+  * @brief  Selects or Deselects the corresponding card.
+  * @param  hsd: SD handle
+  * @param  addr: Address of the card to be selected  
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_Select_Deselect(SD_HandleTypeDef *hsd, uint64_t addr)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  
+  /* Send CMD7 SDMMC_SEL_DESEL_CARD */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)addr;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SEL_DESEL_CARD;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SEL_DESEL_CARD);
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Enquires cards about their operating voltage and configures clock
+  *         controls and stores SD information that will be needed in future
+  *         in the SD handle.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_PowerON(SD_HandleTypeDef *hsd)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure; 
+  __IO HAL_SD_ErrorTypedef errorstate = SD_OK; 
+  uint32_t response = 0, count = 0, validvoltage = 0;
+  uint32_t sdtype = SD_STD_CAPACITY;
+  
+  /* Power ON Sequence -------------------------------------------------------*/
+  /* Disable SDMMC Clock */
+  __HAL_SD_SDMMC_DISABLE(hsd); 
+  
+  /* Set Power State to ON */
+  SDMMC_PowerState_ON(hsd->Instance);
+  
+  /* 1ms: required power up waiting time before starting the SD initialization 
+     sequence */
+  HAL_Delay(1);
+  
+  /* Enable SDMMC Clock */
+  __HAL_SD_SDMMC_ENABLE(hsd);
+  
+  /* CMD0: GO_IDLE_STATE -----------------------------------------------------*/
+  /* No CMD response required */
+  sdmmc_cmdinitstructure.Argument         = 0;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_GO_IDLE_STATE;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_NO;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdError(hsd);
+  
+  if(errorstate != SD_OK)
+  {
+    /* CMD Response Timeout (wait for CMDSENT flag) */
+    return errorstate;
+  }
+  
+  /* CMD8: SEND_IF_COND ------------------------------------------------------*/
+  /* Send CMD8 to verify SD card interface operating condition */
+  /* Argument: - [31:12]: Reserved (shall be set to '0')
+  - [11:8]: Supply Voltage (VHS) 0x1 (Range: 2.7-3.6 V)
+  - [7:0]: Check Pattern (recommended 0xAA) */
+  /* CMD Response: R7 */
+  sdmmc_cmdinitstructure.Argument         = SD_CHECK_PATTERN;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_SDMMC_SEND_IF_COND;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */ 
+  errorstate = SD_CmdResp7Error(hsd);
+  
+  if (errorstate == SD_OK)
+  {
+    /* SD Card 2.0 */
+    hsd->CardType = STD_CAPACITY_SD_CARD_V2_0; 
+    sdtype        = SD_HIGH_CAPACITY;
+  }
+  
+  /* Send CMD55 */
+  sdmmc_cmdinitstructure.Argument         = 0;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+  
+  /* If errorstate is Command Timeout, it is a MMC card */
+  /* If errorstate is SD_OK it is a SD card: SD card 2.0 (voltage range mismatch)
+     or SD card 1.x */
+  if(errorstate == SD_OK)
+  {
+    /* SD CARD */
+    /* Send ACMD41 SD_APP_OP_COND with Argument 0x80100000 */
+    while((!validvoltage) && (count < SD_MAX_VOLT_TRIAL))
+    {
+      
+      /* SEND CMD55 APP_CMD with RCA as 0 */
+      sdmmc_cmdinitstructure.Argument         = 0;
+      sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+      sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+      sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+      sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+      SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+      
+      /* Check for error conditions */
+      errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+      
+      if(errorstate != SD_OK)
+      {
+        return errorstate;
+      }
+      
+      /* Send CMD41 */
+      sdmmc_cmdinitstructure.Argument         = SD_VOLTAGE_WINDOW_SD | sdtype;
+      sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SD_APP_OP_COND;
+      sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+      sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+      sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+      SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+      
+      /* Check for error conditions */
+      errorstate = SD_CmdResp3Error(hsd);
+      
+      if(errorstate != SD_OK)
+      {
+        return errorstate;
+      }
+      
+      /* Get command response */
+      response = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+      
+      /* Get operating voltage*/
+      validvoltage = (((response >> 31) == 1) ? 1 : 0);
+      
+      count++;
+    }
+    
+    if(count >= SD_MAX_VOLT_TRIAL)
+    {
+      errorstate = SD_INVALID_VOLTRANGE;
+      
+      return errorstate;
+    }
+    
+    if((response & SD_HIGH_CAPACITY) == SD_HIGH_CAPACITY) /* (response &= SD_HIGH_CAPACITY) */
+    {
+      hsd->CardType = HIGH_CAPACITY_SD_CARD;
+    }
+    
+  } /* else MMC Card */
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Turns the SDMMC output signals off.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_PowerOFF(SD_HandleTypeDef *hsd)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  
+  /* Set Power State to OFF */
+  SDMMC_PowerState_OFF(hsd->Instance);
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Returns the current card's status.
+  * @param  hsd: SD handle
+  * @param  pCardStatus: pointer to the buffer that will contain the SD card 
+  *         status (Card Status register)  
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_SendStatus(SD_HandleTypeDef *hsd, uint32_t *pCardStatus)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  
+  if(pCardStatus == NULL)
+  {
+    errorstate = SD_INVALID_PARAMETER;
+    
+    return errorstate;
+  }
+  
+  /* Send Status command */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SEND_STATUS;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SEND_STATUS);
+  
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Get SD card status */
+  *pCardStatus = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Checks for error conditions for CMD0.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_CmdError(SD_HandleTypeDef *hsd)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t timeout, tmp;
+  
+  timeout = SDMMC_CMD0TIMEOUT;
+  
+  tmp = __HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CMDSENT);
+    
+  while((timeout > 0) && (!tmp))
+  {
+    tmp = __HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CMDSENT);
+    timeout--;
+  }
+  
+  if(timeout == 0)
+  {
+    errorstate = SD_CMD_RSP_TIMEOUT;
+    return errorstate;
+  }
+  
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Checks for error conditions for R7 response.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_CmdResp7Error(SD_HandleTypeDef *hsd)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_ERROR;
+  uint32_t timeout = SDMMC_CMD0TIMEOUT, tmp;
+  
+  tmp = __HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT); 
+  
+  while((!tmp) && (timeout > 0))
+  {
+    tmp = __HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT);
+    timeout--;
+  }
+  
+  tmp = __HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CTIMEOUT); 
+  
+  if((timeout == 0) || tmp)
+  {
+    /* Card is not V2.0 compliant or card does not support the set voltage range */
+    errorstate = SD_CMD_RSP_TIMEOUT;
+    
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+    
+    return errorstate;
+  }
+  
+  if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CMDREND))
+  {
+    /* Card is SD V2.0 compliant */
+    errorstate = SD_OK;
+    
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CMDREND);
+    
+    return errorstate;
+  }
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Checks for error conditions for R1 response.
+  * @param  hsd: SD handle
+  * @param  SD_CMD: The sent command index  
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_CmdResp1Error(SD_HandleTypeDef *hsd, uint8_t SD_CMD)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t response_r1;
+  
+  while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT))
+  {
+  }
+  
+  if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CTIMEOUT))
+  {
+    errorstate = SD_CMD_RSP_TIMEOUT;
+    
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+    
+    return errorstate;
+  }
+  else if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL))
+  {
+    errorstate = SD_CMD_CRC_FAIL;
+    
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CCRCFAIL);
+    
+    return errorstate;
+  }
+  
+  /* Check response received is of desired command */
+  if(SDMMC_GetCommandResponse(hsd->Instance) != SD_CMD)
+  {
+    errorstate = SD_ILLEGAL_CMD;
+    
+    return errorstate;
+  }
+  
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+  
+  /* We have received response, retrieve it for analysis  */
+  response_r1 = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+  
+  if((response_r1 & SD_OCR_ERRORBITS) == SD_ALLZERO)
+  {
+    return errorstate;
+  }
+  
+  if((response_r1 & SD_OCR_ADDR_OUT_OF_RANGE) == SD_OCR_ADDR_OUT_OF_RANGE)
+  {
+    return(SD_ADDR_OUT_OF_RANGE);
+  }
+  
+  if((response_r1 & SD_OCR_ADDR_MISALIGNED) == SD_OCR_ADDR_MISALIGNED)
+  {
+    return(SD_ADDR_MISALIGNED);
+  }
+  
+  if((response_r1 & SD_OCR_BLOCK_LEN_ERR) == SD_OCR_BLOCK_LEN_ERR)
+  {
+    return(SD_BLOCK_LEN_ERR);
+  }
+  
+  if((response_r1 & SD_OCR_ERASE_SEQ_ERR) == SD_OCR_ERASE_SEQ_ERR)
+  {
+    return(SD_ERASE_SEQ_ERR);
+  }
+  
+  if((response_r1 & SD_OCR_BAD_ERASE_PARAM) == SD_OCR_BAD_ERASE_PARAM)
+  {
+    return(SD_BAD_ERASE_PARAM);
+  }
+  
+  if((response_r1 & SD_OCR_WRITE_PROT_VIOLATION) == SD_OCR_WRITE_PROT_VIOLATION)
+  {
+    return(SD_WRITE_PROT_VIOLATION);
+  }
+  
+  if((response_r1 & SD_OCR_LOCK_UNLOCK_FAILED) == SD_OCR_LOCK_UNLOCK_FAILED)
+  {
+    return(SD_LOCK_UNLOCK_FAILED);
+  }
+  
+  if((response_r1 & SD_OCR_COM_CRC_FAILED) == SD_OCR_COM_CRC_FAILED)
+  {
+    return(SD_COM_CRC_FAILED);
+  }
+  
+  if((response_r1 & SD_OCR_ILLEGAL_CMD) == SD_OCR_ILLEGAL_CMD)
+  {
+    return(SD_ILLEGAL_CMD);
+  }
+  
+  if((response_r1 & SD_OCR_CARD_ECC_FAILED) == SD_OCR_CARD_ECC_FAILED)
+  {
+    return(SD_CARD_ECC_FAILED);
+  }
+  
+  if((response_r1 & SD_OCR_CC_ERROR) == SD_OCR_CC_ERROR)
+  {
+    return(SD_CC_ERROR);
+  }
+  
+  if((response_r1 & SD_OCR_GENERAL_UNKNOWN_ERROR) == SD_OCR_GENERAL_UNKNOWN_ERROR)
+  {
+    return(SD_GENERAL_UNKNOWN_ERROR);
+  }
+  
+  if((response_r1 & SD_OCR_STREAM_READ_UNDERRUN) == SD_OCR_STREAM_READ_UNDERRUN)
+  {
+    return(SD_STREAM_READ_UNDERRUN);
+  }
+  
+  if((response_r1 & SD_OCR_STREAM_WRITE_OVERRUN) == SD_OCR_STREAM_WRITE_OVERRUN)
+  {
+    return(SD_STREAM_WRITE_OVERRUN);
+  }
+  
+  if((response_r1 & SD_OCR_CID_CSD_OVERWRITE) == SD_OCR_CID_CSD_OVERWRITE)
+  {
+    return(SD_CID_CSD_OVERWRITE);
+  }
+  
+  if((response_r1 & SD_OCR_WP_ERASE_SKIP) == SD_OCR_WP_ERASE_SKIP)
+  {
+    return(SD_WP_ERASE_SKIP);
+  }
+  
+  if((response_r1 & SD_OCR_CARD_ECC_DISABLED) == SD_OCR_CARD_ECC_DISABLED)
+  {
+    return(SD_CARD_ECC_DISABLED);
+  }
+  
+  if((response_r1 & SD_OCR_ERASE_RESET) == SD_OCR_ERASE_RESET)
+  {
+    return(SD_ERASE_RESET);
+  }
+  
+  if((response_r1 & SD_OCR_AKE_SEQ_ERROR) == SD_OCR_AKE_SEQ_ERROR)
+  {
+    return(SD_AKE_SEQ_ERROR);
+  }
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Checks for error conditions for R3 (OCR) response.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_CmdResp3Error(SD_HandleTypeDef *hsd)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  
+  while (!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT))
+  {
+  }
+  
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CTIMEOUT))
+  {
+    errorstate = SD_CMD_RSP_TIMEOUT;
+    
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+    
+    return errorstate;
+  }
+  
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Checks for error conditions for R2 (CID or CSD) response.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_CmdResp2Error(SD_HandleTypeDef *hsd)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  
+  while (!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT))
+  {
+  }
+    
+  if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CTIMEOUT))
+  {
+    errorstate = SD_CMD_RSP_TIMEOUT;
+    
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+    
+    return errorstate;
+  }
+  else if (__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL))
+  {
+    errorstate = SD_CMD_CRC_FAIL;
+    
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CCRCFAIL);
+    
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }  
+  
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Checks for error conditions for R6 (RCA) response.
+  * @param  hsd: SD handle
+  * @param  SD_CMD: The sent command index
+  * @param  pRCA: Pointer to the variable that will contain the SD card relative 
+  *         address RCA   
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_CmdResp6Error(SD_HandleTypeDef *hsd, uint8_t SD_CMD, uint16_t *pRCA)
+{
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t response_r1;
+  
+  while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT))
+  {
+  }
+  
+  if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CTIMEOUT))
+  {
+    errorstate = SD_CMD_RSP_TIMEOUT;
+    
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+    
+    return errorstate;
+  }
+  else if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL))
+  {
+    errorstate = SD_CMD_CRC_FAIL;
+    
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CCRCFAIL);
+    
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }  
+  
+  /* Check response received is of desired command */
+  if(SDMMC_GetCommandResponse(hsd->Instance) != SD_CMD)
+  {
+    errorstate = SD_ILLEGAL_CMD;
+    
+    return errorstate;
+  }
+  
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+  
+  /* We have received response, retrieve it.  */
+  response_r1 = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+  
+  if((response_r1 & (SD_R6_GENERAL_UNKNOWN_ERROR | SD_R6_ILLEGAL_CMD | SD_R6_COM_CRC_FAILED)) == SD_ALLZERO)
+  {
+    *pRCA = (uint16_t) (response_r1 >> 16);
+    
+    return errorstate;
+  }
+  
+  if((response_r1 & SD_R6_GENERAL_UNKNOWN_ERROR) == SD_R6_GENERAL_UNKNOWN_ERROR)
+  {
+    return(SD_GENERAL_UNKNOWN_ERROR);
+  }
+  
+  if((response_r1 & SD_R6_ILLEGAL_CMD) == SD_R6_ILLEGAL_CMD)
+  {
+    return(SD_ILLEGAL_CMD);
+  }
+  
+  if((response_r1 & SD_R6_COM_CRC_FAILED) == SD_R6_COM_CRC_FAILED)
+  {
+    return(SD_COM_CRC_FAILED);
+  }
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Enables the SDMMC wide bus mode.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_WideBus_Enable(SD_HandleTypeDef *hsd)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  
+  uint32_t scr[2] = {0, 0};
+  
+  if((SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1) & SD_CARD_LOCKED) == SD_CARD_LOCKED)
+  {
+    errorstate = SD_LOCK_UNLOCK_FAILED;
+    
+    return errorstate;
+  }
+  
+  /* Get SCR Register */
+  errorstate = SD_FindSCR(hsd, scr);
+  
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* If requested card supports wide bus operation */
+  if((scr[1] & SD_WIDE_BUS_SUPPORT) != SD_ALLZERO)
+  {
+    /* Send CMD55 APP_CMD with argument as card's RCA.*/
+    sdmmc_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+    sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+    sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+    
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+    
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+    
+    /* Send ACMD6 APP_CMD with argument as 2 for wide bus mode */
+    sdmmc_cmdinitstructure.Argument         = 2;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_SD_SET_BUSWIDTH;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+    
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_SD_SET_BUSWIDTH);
+    
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+    
+    return errorstate;
+  }
+  else
+  {
+    errorstate = SD_REQUEST_NOT_APPLICABLE;
+    
+    return errorstate;
+  }
+}   
+
+/**
+  * @brief  Disables the SDMMC wide bus mode.
+  * @param  hsd: SD handle
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_WideBus_Disable(SD_HandleTypeDef *hsd)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  
+  uint32_t scr[2] = {0, 0};
+  
+  if((SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1) & SD_CARD_LOCKED) == SD_CARD_LOCKED)
+  {
+    errorstate = SD_LOCK_UNLOCK_FAILED;
+    
+    return errorstate;
+  }
+  
+  /* Get SCR Register */
+  errorstate = SD_FindSCR(hsd, scr);
+  
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* If requested card supports 1 bit mode operation */
+  if((scr[1] & SD_SINGLE_BUS_SUPPORT) != SD_ALLZERO)
+  {
+    /* Send CMD55 APP_CMD with argument as card's RCA */
+    sdmmc_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+    sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+    sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+    sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+    
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+    
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+    
+    /* Send ACMD6 APP_CMD with argument as 0 for single bus mode */
+    sdmmc_cmdinitstructure.Argument         = 0;
+    sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_SD_SET_BUSWIDTH;
+    SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+    
+    /* Check for error conditions */
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_SD_SET_BUSWIDTH);
+    
+    if(errorstate != SD_OK)
+    {
+      return errorstate;
+    }
+    
+    return errorstate;
+  }
+  else
+  {
+    errorstate = SD_REQUEST_NOT_APPLICABLE;
+    
+    return errorstate;
+  }
+}
+  
+  
+/**
+  * @brief  Finds the SD card SCR register value.
+  * @param  hsd: SD handle
+  * @param  pSCR: pointer to the buffer that will contain the SCR value  
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_FindSCR(SD_HandleTypeDef *hsd, uint32_t *pSCR)
+{
+  SDMMC_CmdInitTypeDef  sdmmc_cmdinitstructure;
+  SDMMC_DataInitTypeDef sdmmc_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t index = 0;
+  uint32_t tempscr[2] = {0, 0};
+  
+  /* Set Block Size To 8 Bytes */
+  /* Send CMD55 APP_CMD with argument as card's RCA */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)8;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+  
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  /* Send CMD55 APP_CMD with argument as card's RCA */
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)((hsd->RCA) << 16);
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+  
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  sdmmc_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdmmc_datainitstructure.DataLength    = 8;
+  sdmmc_datainitstructure.DataBlockSize = SDMMC_DATABLOCK_SIZE_8B;
+  sdmmc_datainitstructure.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+  sdmmc_datainitstructure.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  sdmmc_datainitstructure.DPSM          = SDMMC_DPSM_ENABLE;
+  SDMMC_DataConfig(hsd->Instance, &sdmmc_datainitstructure);
+  
+  /* Send ACMD51 SD_APP_SEND_SCR with argument as 0 */
+  sdmmc_cmdinitstructure.Argument         = 0;
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SD_APP_SEND_SCR;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  /* Check for error conditions */
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SD_APP_SEND_SCR);
+  
+  if(errorstate != SD_OK)
+  {
+    return errorstate;
+  }
+  
+  while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DBCKEND))
+  {
+    if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXDAVL))
+    {
+      *(tempscr + index) = SDMMC_ReadFIFO(hsd->Instance);
+      index++;
+    }
+  }
+  
+  if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DTIMEOUT))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DTIMEOUT);
+    
+    errorstate = SD_DATA_TIMEOUT;
+    
+    return errorstate;
+  }
+  else if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_DCRCFAIL))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_DCRCFAIL);
+    
+    errorstate = SD_DATA_CRC_FAIL;
+    
+    return errorstate;
+  }
+  else if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_RXOVERR))
+  {
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_RXOVERR);
+    
+    errorstate = SD_RX_OVERRUN;
+    
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }
+  
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+  
+  *(pSCR + 1) = ((tempscr[0] & SD_0TO7BITS) << 24)  | ((tempscr[0] & SD_8TO15BITS) << 8) |\
+    ((tempscr[0] & SD_16TO23BITS) >> 8) | ((tempscr[0] & SD_24TO31BITS) >> 24);
+  
+  *(pSCR) = ((tempscr[1] & SD_0TO7BITS) << 24)  | ((tempscr[1] & SD_8TO15BITS) << 8) |\
+    ((tempscr[1] & SD_16TO23BITS) >> 8) | ((tempscr[1] & SD_24TO31BITS) >> 24);
+  
+  return errorstate;
+}
+
+/**
+  * @brief  Checks if the SD card is in programming state.
+  * @param  hsd: SD handle
+  * @param  pStatus: pointer to the variable that will contain the SD card state  
+  * @retval SD Card error state
+  */
+static HAL_SD_ErrorTypedef SD_IsCardProgramming(SD_HandleTypeDef *hsd, uint8_t *pStatus)
+{
+  SDMMC_CmdInitTypeDef sdmmc_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  __IO uint32_t responseR1 = 0;
+  
+  sdmmc_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+  sdmmc_cmdinitstructure.CmdIndex         = SD_CMD_SEND_STATUS;
+  sdmmc_cmdinitstructure.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinitstructure.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinitstructure.CPSM             = SDMMC_CPSM_ENABLE;
+  SDMMC_SendCommand(hsd->Instance, &sdmmc_cmdinitstructure);
+  
+  while(!__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CMDREND | SDMMC_FLAG_CTIMEOUT))
+  {
+  }
+  
+  if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CTIMEOUT))
+  {
+    errorstate = SD_CMD_RSP_TIMEOUT;
+    
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CTIMEOUT);
+    
+    return errorstate;
+  }
+  else if(__HAL_SD_SDMMC_GET_FLAG(hsd, SDMMC_FLAG_CCRCFAIL))
+  {
+    errorstate = SD_CMD_CRC_FAIL;
+    
+    __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_FLAG_CCRCFAIL);
+    
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
+  }
+  
+  /* Check response received is of desired command */
+  if((uint32_t)SDMMC_GetCommandResponse(hsd->Instance) != SD_CMD_SEND_STATUS)
+  {
+    errorstate = SD_ILLEGAL_CMD;
+    
+    return errorstate;
+  }
+  
+  /* Clear all the static flags */
+  __HAL_SD_SDMMC_CLEAR_FLAG(hsd, SDMMC_STATIC_FLAGS);
+  
+  
+  /* We have received response, retrieve it for analysis */
+  responseR1 = SDMMC_GetResponse(hsd->Instance, SDMMC_RESP1);
+  
+  /* Find out card status */
+  *pStatus = (uint8_t)((responseR1 >> 9) & 0x0000000F);
+  
+  if((responseR1 & SD_OCR_ERRORBITS) == SD_ALLZERO)
+  {
+    return errorstate;
+  }
+  
+  if((responseR1 & SD_OCR_ADDR_OUT_OF_RANGE) == SD_OCR_ADDR_OUT_OF_RANGE)
+  {
+    return(SD_ADDR_OUT_OF_RANGE);
+  }
+  
+  if((responseR1 & SD_OCR_ADDR_MISALIGNED) == SD_OCR_ADDR_MISALIGNED)
+  {
+    return(SD_ADDR_MISALIGNED);
+  }
+  
+  if((responseR1 & SD_OCR_BLOCK_LEN_ERR) == SD_OCR_BLOCK_LEN_ERR)
+  {
+    return(SD_BLOCK_LEN_ERR);
+  }
+  
+  if((responseR1 & SD_OCR_ERASE_SEQ_ERR) == SD_OCR_ERASE_SEQ_ERR)
+  {
+    return(SD_ERASE_SEQ_ERR);
+  }
+  
+  if((responseR1 & SD_OCR_BAD_ERASE_PARAM) == SD_OCR_BAD_ERASE_PARAM)
+  {
+    return(SD_BAD_ERASE_PARAM);
+  }
+  
+  if((responseR1 & SD_OCR_WRITE_PROT_VIOLATION) == SD_OCR_WRITE_PROT_VIOLATION)
+  {
+    return(SD_WRITE_PROT_VIOLATION);
+  }
+  
+  if((responseR1 & SD_OCR_LOCK_UNLOCK_FAILED) == SD_OCR_LOCK_UNLOCK_FAILED)
+  {
+    return(SD_LOCK_UNLOCK_FAILED);
+  }
+  
+  if((responseR1 & SD_OCR_COM_CRC_FAILED) == SD_OCR_COM_CRC_FAILED)
+  {
+    return(SD_COM_CRC_FAILED);
+  }
+  
+  if((responseR1 & SD_OCR_ILLEGAL_CMD) == SD_OCR_ILLEGAL_CMD)
+  {
+    return(SD_ILLEGAL_CMD);
+  }
+  
+  if((responseR1 & SD_OCR_CARD_ECC_FAILED) == SD_OCR_CARD_ECC_FAILED)
+  {
+    return(SD_CARD_ECC_FAILED);
+  }
+  
+  if((responseR1 & SD_OCR_CC_ERROR) == SD_OCR_CC_ERROR)
+  {
+    return(SD_CC_ERROR);
+  }
+  
+  if((responseR1 & SD_OCR_GENERAL_UNKNOWN_ERROR) == SD_OCR_GENERAL_UNKNOWN_ERROR)
+  {
+    return(SD_GENERAL_UNKNOWN_ERROR);
+  }
+  
+  if((responseR1 & SD_OCR_STREAM_READ_UNDERRUN) == SD_OCR_STREAM_READ_UNDERRUN)
+  {
+    return(SD_STREAM_READ_UNDERRUN);
+  }
+  
+  if((responseR1 & SD_OCR_STREAM_WRITE_OVERRUN) == SD_OCR_STREAM_WRITE_OVERRUN)
+  {
+    return(SD_STREAM_WRITE_OVERRUN);
+  }
+  
+  if((responseR1 & SD_OCR_CID_CSD_OVERWRITE) == SD_OCR_CID_CSD_OVERWRITE)
+  {
+    return(SD_CID_CSD_OVERWRITE);
+  }
+  
+  if((responseR1 & SD_OCR_WP_ERASE_SKIP) == SD_OCR_WP_ERASE_SKIP)
+  {
+    return(SD_WP_ERASE_SKIP);
+  }
+  
+  if((responseR1 & SD_OCR_CARD_ECC_DISABLED) == SD_OCR_CARD_ECC_DISABLED)
+  {
+    return(SD_CARD_ECC_DISABLED);
+  }
+  
+  if((responseR1 & SD_OCR_ERASE_RESET) == SD_OCR_ERASE_RESET)
+  {
+    return(SD_ERASE_RESET);
+  }
+  
+  if((responseR1 & SD_OCR_AKE_SEQ_ERROR) == SD_OCR_AKE_SEQ_ERROR)
+  {
+    return(SD_AKE_SEQ_ERROR);
+  }
+  
+  return errorstate;
+}   
+
+/**
+  * @}
+  */
+
+#endif /* HAL_SD_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_spi.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_spi.c
@@ -1,0 +1,2769 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_spi.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   SPI HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Serial Peripheral Interface (SPI) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      The SPI HAL driver can be used as follows:
+
+      (#) Declare a SPI_HandleTypeDef handle structure, for example:
+          SPI_HandleTypeDef  hspi;
+
+      (#)Initialize the SPI low level resources by implementing the HAL_SPI_MspInit() API:
+          (##) Enable the SPIx interface clock
+          (##) SPI pins configuration
+              (+++) Enable the clock for the SPI GPIOs
+              (+++) Configure these SPI pins as alternate function push-pull
+          (##) NVIC configuration if you need to use interrupt process
+              (+++) Configure the SPIx interrupt priority
+              (+++) Enable the NVIC SPI IRQ handle
+          (##) DMA Configuration if you need to use DMA process
+              (+++) Declare a DMA_HandleTypeDef handle structure for the transmit or receive channel
+              (+++) Enable the DMAx clock
+              (+++) Configure the DMA handle parameters
+              (+++) Configure the DMA Tx or Rx channel
+              (+++) Associate the initialized hdma_tx handle to the hspi DMA Tx or Rx handle
+              (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx or Rx channel
+
+      (#) Program the Mode, BidirectionalMode , Data size, Baudrate Prescaler, NSS
+          management, Clock polarity and phase, FirstBit and CRC configuration in the hspi Init structure.
+
+      (#) Initialize the SPI registers by calling the HAL_SPI_Init() API:
+          (++) This API configures also the low level Hardware GPIO, CLOCK, CORTEX...etc)
+              by calling the customized HAL_SPI_MspInit() API.
+     [..]
+       Circular mode restriction:
+      (#) The DMA circular mode cannot be used when the SPI is configured in these modes:
+          (##) Master 2Lines RxOnly
+          (##) Master 1Line Rx
+      (#) The CRC feature is not managed when the DMA circular mode is enabled
+      (#) When the SPI DMA Pause/Stop features are used, we must use the following APIs
+          the HAL_SPI_DMAPause()/ HAL_SPI_DMAStop() only under the SPI callbacks
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SPI SPI
+  * @brief SPI HAL module driver
+  * @{
+  */
+#ifdef HAL_SPI_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/
+/** @defgroup SPI_Private_Constants SPI Private Constants
+  * @{
+  */
+#define SPI_DEFAULT_TIMEOUT 50
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @defgroup SPI_Private_Functions SPI Private Functions
+  * @{
+  */
+static void SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAHalfTransmitCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAHalfReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAHalfTransmitReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAError(DMA_HandleTypeDef *hdma);
+static HAL_StatusTypeDef SPI_WaitFlagStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Flag, uint32_t State, uint32_t Timeout);
+static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Fifo, uint32_t State, uint32_t Timeout);
+static void SPI_TxISR_8BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_TxISR_16BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_RxISR_8BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_RxISR_8BITCRC(struct __SPI_HandleTypeDef *hspi);
+static void SPI_RxISR_16BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_RxISR_16BITCRC(struct __SPI_HandleTypeDef *hspi);
+static void SPI_2linesRxISR_8BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_2linesRxISR_8BITCRC(struct __SPI_HandleTypeDef *hspi);
+static void SPI_2linesTxISR_8BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_2linesTxISR_16BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_2linesRxISR_16BIT(struct __SPI_HandleTypeDef *hspi);
+static void SPI_2linesRxISR_16BITCRC(struct __SPI_HandleTypeDef *hspi);
+static void SPI_CloseRxTx_ISR(SPI_HandleTypeDef *hspi);
+static void SPI_CloseRx_ISR(SPI_HandleTypeDef *hspi);
+static void SPI_CloseTx_ISR(SPI_HandleTypeDef *hspi);
+static HAL_StatusTypeDef SPI_EndRxTransaction(SPI_HandleTypeDef *hspi, uint32_t Timeout);
+static HAL_StatusTypeDef SPI_EndRxTxTransaction(SPI_HandleTypeDef *hspi, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/* Exported functions ---------------------------------------------------------*/
+
+/** @defgroup SPI_Exported_Functions SPI Exported Functions
+  * @{
+  */
+
+/** @defgroup SPI_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This subsection provides a set of functions allowing to initialize and
+          de-initialize the SPIx peripheral:
+
+      (+) User must implement HAL_SPI_MspInit() function in which he configures
+          all related peripherals resources (CLOCK, GPIO, DMA, IT and NVIC ).
+
+      (+) Call the function HAL_SPI_Init() to configure the selected device with
+          the selected configuration:
+        (++) Mode
+        (++) Direction
+        (++) Data Size
+        (++) Clock Polarity and Phase
+        (++) NSS Management
+        (++) BaudRate Prescaler
+        (++) FirstBit
+        (++) TIMode
+        (++) CRC Calculation
+        (++) CRC Polynomial if CRC enabled
+        (++) CRC Length, used only with Data8 and Data16
+        (++) FIFO reception threshold
+
+      (+) Call the function HAL_SPI_DeInit() to restore the default configuration
+          of the selected SPIx peripheral.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initialize the SPI according to the specified parameters
+  *         in the SPI_InitTypeDef and initialize the associated handle.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
+{
+  uint32_t frxth;
+
+  /* Check the SPI handle allocation */
+  if(hspi == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_SPI_ALL_INSTANCE(hspi->Instance));
+  assert_param(IS_SPI_MODE(hspi->Init.Mode));
+  assert_param(IS_SPI_DIRECTION(hspi->Init.Direction));
+  assert_param(IS_SPI_DATASIZE(hspi->Init.DataSize));
+  assert_param(IS_SPI_CPOL(hspi->Init.CLKPolarity));
+  assert_param(IS_SPI_CPHA(hspi->Init.CLKPhase));
+  assert_param(IS_SPI_NSS(hspi->Init.NSS));
+  assert_param(IS_SPI_NSSP(hspi->Init.NSSPMode));
+  assert_param(IS_SPI_BAUDRATE_PRESCALER(hspi->Init.BaudRatePrescaler));
+  assert_param(IS_SPI_FIRST_BIT(hspi->Init.FirstBit));
+  assert_param(IS_SPI_TIMODE(hspi->Init.TIMode));
+  assert_param(IS_SPI_CRC_CALCULATION(hspi->Init.CRCCalculation));
+  assert_param(IS_SPI_CRC_POLYNOMIAL(hspi->Init.CRCPolynomial));
+  assert_param(IS_SPI_CRC_LENGTH(hspi->Init.CRCLength));
+
+  if(hspi->State == HAL_SPI_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hspi->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK, NVIC... */
+    HAL_SPI_MspInit(hspi);
+  }
+
+  hspi->State = HAL_SPI_STATE_BUSY;
+
+  /* Disable the selected SPI peripheral */
+  __HAL_SPI_DISABLE(hspi);
+
+  /* Align by default the rs fifo threshold on the data size */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+  {
+    frxth = SPI_RXFIFO_THRESHOLD_HF;
+  }
+  else
+  {
+    frxth = SPI_RXFIFO_THRESHOLD_QF;
+  }
+
+  /* CRC calculation is valid only for 16Bit and 8 Bit */
+  if(( hspi->Init.DataSize != SPI_DATASIZE_16BIT ) && ( hspi->Init.DataSize != SPI_DATASIZE_8BIT ))
+  {
+    /* CRC must be disabled */
+    hspi->Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
+  }
+
+  /* Align the CRC Length on the data size */
+  if( hspi->Init.CRCLength == SPI_CRC_LENGTH_DATASIZE)
+  {
+    /* CRC Length aligned on the data size : value set by default */
+    if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+    {
+      hspi->Init.CRCLength = SPI_CRC_LENGTH_16BIT;
+    }
+    else
+    {
+      hspi->Init.CRCLength = SPI_CRC_LENGTH_8BIT;
+    }
+  }
+
+  /*---------------------------- SPIx CR1 & CR2 Configuration ------------------------*/
+  /* Configure : SPI Mode, Communication Mode, Clock polarity and phase, NSS management,
+  Communication speed, First bit, CRC calculation state, CRC Length */
+  hspi->Instance->CR1 = (hspi->Init.Mode | hspi->Init.Direction |
+                         hspi->Init.CLKPolarity | hspi->Init.CLKPhase | (hspi->Init.NSS & SPI_CR1_SSM) |
+                         hspi->Init.BaudRatePrescaler | hspi->Init.FirstBit  | hspi->Init.CRCCalculation);
+
+  if( hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT)
+  {
+    hspi->Instance->CR1|= SPI_CR1_CRCL;
+  }
+
+  /* Configure : NSS management */
+  /* Configure : Rx Fifo Threshold */
+  hspi->Instance->CR2 = (((hspi->Init.NSS >> 16) & SPI_CR2_SSOE) | hspi->Init.TIMode | hspi->Init.NSSPMode |
+                         hspi->Init.DataSize ) | frxth;
+
+  /*---------------------------- SPIx CRCPOLY Configuration --------------------*/
+  /* Configure : CRC Polynomial */
+  hspi->Instance->CRCPR = hspi->Init.CRCPolynomial;
+
+  hspi->ErrorCode = HAL_SPI_ERROR_NONE;
+  hspi->State= HAL_SPI_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitialize the SPI peripheral.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_DeInit(SPI_HandleTypeDef *hspi)
+{
+  /* Check the SPI handle allocation */
+  if(hspi == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_SPI_ALL_INSTANCE(hspi->Instance));
+  hspi->State = HAL_SPI_STATE_BUSY;
+
+  /* Disable the SPI Peripheral Clock */
+  __HAL_SPI_DISABLE(hspi);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC... */
+  HAL_SPI_MspDeInit(hspi);
+
+  hspi->ErrorCode = HAL_SPI_ERROR_NONE;
+  hspi->State = HAL_SPI_STATE_RESET;
+
+  __HAL_UNLOCK(hspi);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Initialize the SPI MSP.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_MspInit(SPI_HandleTypeDef *hspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_MspInit should be implemented in the user file
+   */
+}
+
+/**
+  * @brief DeInitialize the SPI MSP.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_MspDeInit should be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Exported_Functions_Group2 IO operation functions
+ *  @brief   Data transfers functions
+ *
+@verbatim
+  ==============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+ [..]
+    This subsection provides a set of functions allowing to manage the SPI
+    data transfers.
+
+    [..] The SPI supports master and slave mode :
+
+    (#) There are two modes of transfer:
+       (++) Blocking mode: The communication is performed in polling mode.
+            The HAL status of all data processing is returned by the same function
+            after finishing transfer.
+       (++) No-Blocking mode: The communication is performed using Interrupts
+           or DMA, These APIs return the HAL status.
+           The end of the data processing will be indicated through the
+           dedicated SPI IRQ when using Interrupt mode or the DMA IRQ when
+           using DMA mode.
+           The HAL_SPI_TxCpltCallback(), HAL_SPI_RxCpltCallback() and HAL_SPI_TxRxCpltCallback() user callbacks
+           will be executed respectively at the end of the transmit or Receive process
+           The HAL_SPI_ErrorCallback()user callback will be executed when a communication error is detected
+
+    (#) APIs provided for these 2 transfer modes (Blocking mode or Non blocking mode using either Interrupt or DMA)
+        exist for 1Line (simplex) and 2Lines (full duplex) modes.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Transmit an amount of data in blocking mode.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+  HAL_StatusTypeDef errorcode = HAL_OK;
+
+  assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  if(hspi->State != HAL_SPI_STATE_READY)
+  {
+    errorcode = HAL_BUSY;
+    goto error;
+  }
+
+  if((pData == NULL ) || (Size == 0))
+  {
+    errorcode = HAL_ERROR;
+    goto error;
+  }
+
+  /* Set the transaction information */
+  hspi->State       = HAL_SPI_STATE_BUSY_TX;
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pTxBuffPtr  = pData;
+  hspi->TxXferSize  = Size;
+  hspi->TxXferCount = Size;
+  hspi->pRxBuffPtr  = (uint8_t *)NULL;
+  hspi->RxXferSize  = 0;
+  hspi->RxXferCount = 0;
+
+  /* Configure communication direction : 1Line */
+  if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+  {
+    SPI_1LINE_TX(hspi);
+  }
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+  }
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+  /* Transmit data in 16 Bit mode */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+  {
+    /* Transmit data in 16 Bit mode */
+    while (hspi->TxXferCount > 0)
+    {
+      /* Wait until TXE flag is set to send data */
+      if((hspi->Instance->SR & SPI_FLAG_TXE) == SPI_FLAG_TXE)
+      {
+          hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+          hspi->pTxBuffPtr += sizeof(uint16_t);
+          hspi->TxXferCount--;
+      }
+      else
+      {
+        /* Timeout management */
+        if((Timeout == 0) || ((Timeout != HAL_MAX_DELAY) && ((HAL_GetTick()-tickstart) >=  Timeout)))
+        {
+          errorcode = HAL_TIMEOUT;
+          goto error;
+        }
+      }
+    }
+  }
+  /* Transmit data in 8 Bit mode */
+  else
+  {
+    while (hspi->TxXferCount > 0)
+    {
+      /* Wait until TXE flag is set to send data */
+      if((hspi->Instance->SR & SPI_FLAG_TXE) == SPI_FLAG_TXE)
+      {
+        if(hspi->TxXferCount > 1)
+        {
+          /* write on the data register in packing mode */
+          hspi->Instance->DR = *((uint16_t*)hspi->pTxBuffPtr);
+          hspi->pTxBuffPtr += sizeof(uint16_t);
+          hspi->TxXferCount -= 2;
+        }
+        else
+        {
+          *((__IO uint8_t*)&hspi->Instance->DR) = (*hspi->pTxBuffPtr++);
+          hspi->TxXferCount--;
+        }
+      }
+      else
+      {
+        /* Timeout management */
+        if((Timeout == 0) || ((Timeout != HAL_MAX_DELAY) && ((HAL_GetTick()-tickstart) >=  Timeout)))
+        {
+          errorcode = HAL_TIMEOUT;
+          goto error;
+        }
+      }
+    }
+  }
+
+  /* Enable CRC Transmission */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+     hspi->Instance->CR1|= SPI_CR1_CRCNEXT;
+  }
+
+  /* Check the end of the transaction */
+  if(SPI_EndRxTxTransaction(hspi,Timeout) != HAL_OK)
+  {
+    hspi->ErrorCode = HAL_SPI_ERROR_FLAG;
+  }
+  
+  /* Clear overrun flag in 2 Lines communication mode because received is not read */
+  if(hspi->Init.Direction == SPI_DIRECTION_2LINES)
+  {
+    __HAL_SPI_CLEAR_OVRFLAG(hspi);
+  }
+
+  if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+  {
+    errorcode = HAL_ERROR;
+  }
+
+error:
+  hspi->State = HAL_SPI_STATE_READY;
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+  return errorcode;
+}
+
+/**
+  * @brief  Receive an amount of data in blocking mode.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be received
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  __IO uint16_t tmpreg;
+  uint32_t tickstart = HAL_GetTick();
+  HAL_StatusTypeDef errorcode = HAL_OK;
+
+  if((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES))
+  {
+    /* the receive process is not supported in 2Lines direction master mode */
+    /* in this case we call the TransmitReceive process                     */
+    /* Process Locked */
+    return HAL_SPI_TransmitReceive(hspi,pData,pData,Size,Timeout);
+  }
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  if(hspi->State != HAL_SPI_STATE_READY)
+  {
+    errorcode = HAL_BUSY;
+    goto error;
+  }
+
+  if((pData == NULL ) || (Size == 0))
+  {
+    errorcode = HAL_ERROR;
+    goto error;
+  }
+
+  hspi->State       = HAL_SPI_STATE_BUSY_RX;
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pRxBuffPtr  = pData;
+  hspi->RxXferSize  = Size;
+  hspi->RxXferCount = Size;
+  hspi->pTxBuffPtr  = (uint8_t *)NULL;
+  hspi->TxXferSize  = 0;
+  hspi->TxXferCount = 0;
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+    /* this is done to handle the CRCNEXT before the latest data */
+    hspi->RxXferCount--;
+  }
+
+  /* Set the Rx Fido threshold */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+  {
+    /* set fiforxthresold according the reception data length: 16bit */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+  else
+  {
+    /* set fiforxthresold according the reception data length: 8bit */
+    SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+
+  /* Configure communication direction 1Line and enabled SPI if needed */
+  if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+  {
+    SPI_1LINE_RX(hspi);
+  }
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+  if(hspi->Init.DataSize <= SPI_DATASIZE_8BIT)
+  {
+    /* Transfer loop */
+    while(hspi->RxXferCount > 0)
+    {
+      /* Check the RXNE flag */
+      if((hspi->Instance->SR & SPI_FLAG_RXNE) == SPI_FLAG_RXNE)
+      {
+        /* read the received data */
+        (*hspi->pRxBuffPtr++)= *(__IO uint8_t *)&hspi->Instance->DR;
+        hspi->RxXferCount--;
+      }
+      else
+      {
+        /* Timeout management */
+        if((Timeout == 0) || ((Timeout != HAL_MAX_DELAY) && ((HAL_GetTick()-tickstart) >=  Timeout)))
+        {
+          errorcode = HAL_TIMEOUT;
+          goto error;
+        }
+      }
+    }
+  }
+  else
+  {
+    /* Transfer loop */
+    while(hspi->RxXferCount > 0)
+    {
+      /* Check the RXNE flag */
+      if((hspi->Instance->SR & SPI_FLAG_RXNE) == SPI_FLAG_RXNE)
+      {
+        *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+        hspi->pRxBuffPtr += sizeof(uint16_t);
+        hspi->RxXferCount--;
+      }
+      else
+      {
+        /* Timeout management */
+        if((Timeout == 0) || ((Timeout != HAL_MAX_DELAY) && ((HAL_GetTick()-tickstart) >=  Timeout)))
+        {
+          errorcode = HAL_TIMEOUT;
+          goto error;
+        }
+      }
+    }
+  }
+
+  /* Handle the CRC Transmission */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    /* freeze the CRC before the latest data */
+    hspi->Instance->CR1|= SPI_CR1_CRCNEXT;
+
+    /* Read the latest data */
+    if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
+    {
+      /* the latest data has not been received */
+      errorcode = HAL_TIMEOUT;
+      goto error;
+    }
+
+    /* Receive last data in 16 Bit mode */
+    if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+    {
+      *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+    }
+    /* Receive last data in 8 Bit mode */
+    else
+    {
+      *hspi->pRxBuffPtr = *(__IO uint8_t *)&hspi->Instance->DR;
+    }
+
+    /* Wait until TXE flag */
+    if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
+    {
+      /* Flag Error*/
+      hspi->ErrorCode = HAL_SPI_ERROR_CRC;
+      errorcode = HAL_TIMEOUT;
+      goto error;
+    }
+
+    if(hspi->Init.DataSize == SPI_DATASIZE_16BIT)
+    {
+      tmpreg = hspi->Instance->DR;
+      UNUSED(tmpreg); /* To avoid GCC warning */
+    }
+    else
+    {
+      tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+      UNUSED(tmpreg); /* To avoid GCC warning */
+
+      if((hspi->Init.DataSize == SPI_DATASIZE_8BIT) && (hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT))
+      {
+        if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
+        {
+          /* Error on the CRC reception */
+          hspi->ErrorCode = HAL_SPI_ERROR_CRC;
+          errorcode = HAL_TIMEOUT;
+          goto error;
+        }
+        tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+        UNUSED(tmpreg); /* To avoid GCC warning */
+      }
+    }
+  }
+  
+  /* Check the end of the transaction */
+  if(SPI_EndRxTransaction(hspi,Timeout) != HAL_OK)
+  {
+    hspi->ErrorCode = HAL_SPI_ERROR_FLAG;
+  }
+
+  /* Check if CRC error occurred */
+  if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+  {
+    hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+    __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+  }
+
+  if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+  {
+    errorcode = HAL_ERROR;
+  }
+
+error :
+  hspi->State = HAL_SPI_STATE_READY;
+  __HAL_UNLOCK(hspi);
+  return errorcode;
+}
+
+/**
+  * @brief  Transmit and Receive an amount of data in blocking mode.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pTxData: pointer to transmission data buffer
+  * @param  pRxData: pointer to reception data buffer
+  * @param  Size: amount of data to be sent and received
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout)
+{
+__IO uint16_t tmpreg;
+  uint32_t tickstart = HAL_GetTick();
+  HAL_StatusTypeDef errorcode = HAL_OK;
+
+  assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  if(hspi->State != HAL_SPI_STATE_READY)
+  {
+    errorcode = HAL_BUSY;
+    goto error;
+  }
+
+  if((pTxData == NULL) || (pRxData == NULL) || (Size == 0))
+  {
+    errorcode = HAL_ERROR;
+    goto error;
+  }
+
+  hspi->State       = HAL_SPI_STATE_BUSY_TX_RX;
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pRxBuffPtr  = pRxData;
+  hspi->RxXferCount = Size;
+  hspi->RxXferSize  = Size;
+  hspi->pTxBuffPtr  = pTxData;
+  hspi->TxXferCount = Size;
+  hspi->TxXferSize  = Size;
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+  }
+
+  /* Set the Rx Fido threshold */
+  if((hspi->Init.DataSize > SPI_DATASIZE_8BIT) || (hspi->RxXferCount > 1))
+  {
+    /* set fiforxthreshold according the reception data length: 16bit */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+  else
+  {
+    /* set fiforxthreshold according the reception data length: 8bit */
+    SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+  /* Transmit and Receive data in 16 Bit mode */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+  {
+    while ((hspi->TxXferCount > 0 ) || (hspi->RxXferCount > 0))
+    {
+      /* Check TXE flag */
+      if((hspi->TxXferCount > 0) && ((hspi->Instance->SR & SPI_FLAG_TXE) == SPI_FLAG_TXE))
+      {
+        hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+        hspi->pTxBuffPtr += sizeof(uint16_t);
+        hspi->TxXferCount--;
+
+        /* Enable CRC Transmission */
+        if((hspi->TxXferCount == 0) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE))
+        {
+          hspi->Instance->CR1|= SPI_CR1_CRCNEXT;
+        }
+      }
+
+      /* Check RXNE flag */
+      if((hspi->RxXferCount > 0) && ((hspi->Instance->SR & SPI_FLAG_RXNE) == SPI_FLAG_RXNE))
+      {
+        *((uint16_t *)hspi->pRxBuffPtr) = hspi->Instance->DR;
+        hspi->pRxBuffPtr += sizeof(uint16_t);
+        hspi->RxXferCount--;
+      }
+      if((Timeout != HAL_MAX_DELAY) && ((HAL_GetTick()-tickstart) >=  Timeout))
+      {
+        errorcode = HAL_TIMEOUT;
+        goto error;
+      }
+    }
+  }
+  /* Transmit and Receive data in 8 Bit mode */
+  else
+  {
+    while((hspi->TxXferCount > 0) || (hspi->RxXferCount > 0))
+    {
+      /* check TXE flag */
+      if((hspi->TxXferCount > 0) && ((hspi->Instance->SR & SPI_FLAG_TXE) == SPI_FLAG_TXE))
+      {
+        if(hspi->TxXferCount > 1)
+        {
+          hspi->Instance->DR = *((uint16_t*)hspi->pTxBuffPtr);
+          hspi->pTxBuffPtr += sizeof(uint16_t);
+          hspi->TxXferCount -= 2;
+        }
+        else
+        {
+          *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+          hspi->TxXferCount--;
+        }
+
+        /* Enable CRC Transmission */
+        if((hspi->TxXferCount == 0) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE))
+        {
+          hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+        }
+      }
+
+      /* Wait until RXNE flag is reset */
+      if((hspi->RxXferCount > 0) && ((hspi->Instance->SR & SPI_FLAG_RXNE) == SPI_FLAG_RXNE))
+      {
+        if(hspi->RxXferCount > 1)
+        {
+          *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+          hspi->pRxBuffPtr += sizeof(uint16_t);
+          hspi->RxXferCount -= 2;
+          if(hspi->RxXferCount <= 1)
+          {
+            /* set fiforxthresold before to switch on 8 bit data size */
+            SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+          }
+        }
+        else
+        {
+          (*hspi->pRxBuffPtr++) =  *(__IO uint8_t *)&hspi->Instance->DR;
+          hspi->RxXferCount--;
+        }
+      }
+      if((Timeout != HAL_MAX_DELAY) && ((HAL_GetTick()-tickstart) >=  Timeout))
+      {
+        errorcode = HAL_TIMEOUT;
+        goto error;
+      }
+    }
+  }
+
+  /* Read CRC from DR to close CRC calculation process */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    /* Wait until TXE flag */
+    if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
+    {
+      /* Error on the CRC reception */
+      hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+      errorcode = HAL_TIMEOUT;
+      goto error;
+    }
+
+    if(hspi->Init.DataSize == SPI_DATASIZE_16BIT)
+    {
+      tmpreg = hspi->Instance->DR;
+      UNUSED(tmpreg); /* To avoid GCC warning */
+    }
+    else
+    {
+      tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+      UNUSED(tmpreg); /* To avoid GCC warning */
+
+      if(hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT)
+      {
+        if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
+        {
+          /* Error on the CRC reception */
+          hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+          errorcode = HAL_TIMEOUT;
+          goto error;
+        }
+        tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+        UNUSED(tmpreg); /* To avoid GCC warning */
+      }
+    }
+  }
+
+  /* Check if CRC error occurred */
+  if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+  {
+    hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+    /* Clear CRC Flag */
+    __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+
+    errorcode = HAL_ERROR;
+  }
+
+  /* Check the end of the transaction */
+  if(SPI_EndRxTxTransaction(hspi,Timeout) != HAL_OK)
+  {
+    hspi->ErrorCode = HAL_SPI_ERROR_FLAG;
+  }
+
+  if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+  {
+    errorcode = HAL_ERROR;
+  }
+
+error :
+  hspi->State = HAL_SPI_STATE_READY;
+  __HAL_UNLOCK(hspi);
+  return errorcode;
+}
+
+/**
+  * @brief  Transmit an amount of data in non-blocking mode with Interrupt.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+{
+  HAL_StatusTypeDef errorcode = HAL_OK;
+  assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  if((pData == NULL) || (Size == 0))
+  {
+    errorcode = HAL_ERROR;
+    goto error;
+  }
+
+  if(hspi->State != HAL_SPI_STATE_READY)
+  {
+    errorcode = HAL_BUSY;
+    goto error;
+  }
+
+  /* prepare the transfer */
+  hspi->State       = HAL_SPI_STATE_BUSY_TX;
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pTxBuffPtr  = pData;
+  hspi->TxXferSize  = Size;
+  hspi->TxXferCount = Size;
+  hspi->pRxBuffPtr  = (uint8_t *)NULL;
+  hspi->RxXferSize  = 0;
+  hspi->RxXferCount = 0;
+  hspi->RxISR = NULL;
+
+  /* Set the function for IT treatment */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT )
+  {
+    hspi->TxISR = SPI_TxISR_16BIT;
+  }
+  else
+  {
+    hspi->TxISR = SPI_TxISR_8BIT;
+  }
+
+  /* Configure communication direction : 1Line */
+  if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+  {
+    SPI_1LINE_TX(hspi);
+  }
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+  }
+
+  /* Enable TXE and ERR interrupt */
+  __HAL_SPI_ENABLE_IT(hspi,(SPI_IT_TXE));
+
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+error :
+  __HAL_UNLOCK(hspi);
+  return errorcode;
+}
+
+/**
+  * @brief  Receive an amount of data in non-blocking mode with Interrupt.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+{
+  HAL_StatusTypeDef errorcode = HAL_OK;
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  if(hspi->State != HAL_SPI_STATE_READY)
+  {
+    errorcode = HAL_BUSY;
+    goto error;
+  }
+  if((pData == NULL) || (Size == 0))
+  {
+    errorcode = HAL_ERROR;
+    goto error;
+  }
+
+  /* Configure communication */
+  hspi->State       = HAL_SPI_STATE_BUSY_RX;
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pRxBuffPtr  = pData;
+  hspi->RxXferSize  = Size;
+  hspi->RxXferCount = Size;
+  hspi->pTxBuffPtr  = (uint8_t *)NULL;
+  hspi->TxXferSize  = 0;
+  hspi->TxXferCount = 0;
+
+  if((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES))
+  {
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+    /* the receive process is not supported in 2Lines direction master mode */
+    /* in this we call the TransmitReceive process          */
+    return HAL_SPI_TransmitReceive_IT(hspi,pData,pData,Size);
+  }
+
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    hspi->CRCSize = 1;
+    if((hspi->Init.DataSize <= SPI_DATASIZE_8BIT) && (hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT))
+    {
+      hspi->CRCSize = 2;
+    }
+  }
+  else
+  {
+    hspi->CRCSize = 0;
+  }
+
+  hspi->TxISR = NULL;
+  /* check the data size to adapt Rx threshold and the set the function for IT treatment */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT )
+  {
+    /* set fiforxthresold according the reception data length: 16 bit */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+    hspi->RxISR = SPI_RxISR_16BIT;
+  }
+  else
+  {
+    /* set fiforxthresold according the reception data length: 8 bit */
+    SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+    hspi->RxISR = SPI_RxISR_8BIT;
+  }
+
+  /* Configure communication direction : 1Line */
+  if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+  {
+    SPI_1LINE_RX(hspi);
+  }
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+  }
+
+  /* Enable TXE and ERR interrupt */
+  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_RXNE | SPI_IT_ERR));
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+error :
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+  return errorcode;
+}
+
+/**
+  * @brief  Transmit and Receive an amount of data in non-blocking mode with Interrupt.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pTxData: pointer to transmission data buffer
+  * @param  pRxData: pointer to reception data buffer
+  * @param  Size: amount of data to be sent and received
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size)
+{
+  HAL_StatusTypeDef errorcode = HAL_OK;
+  assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
+
+  /* Process locked */
+  __HAL_LOCK(hspi);
+
+  if(!((hspi->State == HAL_SPI_STATE_READY) || \
+    ((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->State == HAL_SPI_STATE_BUSY_RX))))
+  {
+    errorcode = HAL_BUSY;
+    goto error;
+  }
+
+  if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0))
+  {
+    errorcode = HAL_ERROR;
+    goto error;
+  }
+
+  hspi->CRCSize = 0;
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    hspi->CRCSize = 1;
+    if((hspi->Init.DataSize <= SPI_DATASIZE_8BIT) && (hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT))
+    {
+      hspi->CRCSize = 2;
+    }
+  }
+
+  if(hspi->State != HAL_SPI_STATE_BUSY_RX)
+  {
+    hspi->State = HAL_SPI_STATE_BUSY_TX_RX;
+  }
+
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pTxBuffPtr  = pTxData;
+  hspi->TxXferSize  = Size;
+  hspi->TxXferCount = Size;
+  hspi->pRxBuffPtr  = pRxData;
+  hspi->RxXferSize  = Size;
+  hspi->RxXferCount = Size;
+
+  /* Set the function for IT treatment */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT )
+  {
+    hspi->RxISR = SPI_2linesRxISR_16BIT;
+    hspi->TxISR = SPI_2linesTxISR_16BIT;
+  }
+  else
+  {
+    hspi->RxISR = SPI_2linesRxISR_8BIT;
+    hspi->TxISR = SPI_2linesTxISR_8BIT;
+  }
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+  }
+
+  /* check if packing mode is enabled and if there is more than 2 data to receive */
+  if((hspi->Init.DataSize > SPI_DATASIZE_8BIT) || (hspi->RxXferCount >= 2))
+  {
+    /* set fiforxthresold according the reception data length: 16 bit */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+  else
+  {
+    /* set fiforxthresold according the reception data length: 8 bit */
+    SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+
+  /* Enable TXE, RXNE and ERR interrupt */
+  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+error :
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+  return errorcode;
+}
+
+/**
+  * @brief  Transmit an amount of data in non-blocking mode with DMA.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+{
+  HAL_StatusTypeDef errorcode = HAL_OK;
+  assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  if(hspi->State != HAL_SPI_STATE_READY)
+  {
+    errorcode = HAL_BUSY;
+    goto error;
+  }
+
+  if((pData == NULL) || (Size == 0))
+  {
+    errorcode = HAL_ERROR;
+    goto error;
+  }
+
+  hspi->State       = HAL_SPI_STATE_BUSY_TX;
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pTxBuffPtr  = pData;
+  hspi->TxXferSize  = Size;
+  hspi->TxXferCount = Size;
+  hspi->pRxBuffPtr  = (uint8_t *)NULL;
+  hspi->RxXferSize  = 0;
+  hspi->RxXferCount = 0;
+
+  /* Configure communication direction : 1Line */
+  if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+  {
+    SPI_1LINE_TX(hspi);
+  }
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+  }
+
+  /* Set the SPI TxDMA Half transfer complete callback */
+  hspi->hdmatx->XferHalfCpltCallback = SPI_DMAHalfTransmitCplt;
+
+  /* Set the SPI TxDMA transfer complete callback */
+  hspi->hdmatx->XferCpltCallback = SPI_DMATransmitCplt;
+
+  /* Set the DMA error callback */
+  hspi->hdmatx->XferErrorCallback = SPI_DMAError;
+
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX);
+  /* packing mode is enabled only if the DMA setting is HALWORD */
+  if((hspi->Init.DataSize <= SPI_DATASIZE_8BIT) && (hspi->hdmatx->Init.MemDataAlignment == DMA_MDATAALIGN_HALFWORD))
+  {
+    /* Check the even/odd of the data size + crc if enabled */
+    if((hspi->TxXferCount & 0x1) == 0)
+    {
+      CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX);
+      hspi->TxXferCount = (hspi->TxXferCount >> 1);
+    }
+    else
+    {
+      SET_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX);
+      hspi->TxXferCount = (hspi->TxXferCount >> 1) + 1;
+    }
+  }
+
+  /* Enable the Tx DMA channel */
+  HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->DR, hspi->TxXferCount);
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+  /* Enable Tx DMA Request */
+  SET_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN);
+
+error :
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+  return errorcode;
+}
+
+/**
+  * @brief  Receive an amount of data in non-blocking mode with DMA.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @note  When the CRC feature is enabled the pData Length must be Size + 1.
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+{
+  HAL_StatusTypeDef errorcode = HAL_OK;
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  if(hspi->State != HAL_SPI_STATE_READY)
+  {
+    errorcode = HAL_BUSY;
+    goto error;
+  }
+
+  if((pData == NULL) || (Size == 0))
+  {
+    errorcode = HAL_ERROR;
+    goto error;
+  }
+
+  hspi->State       = HAL_SPI_STATE_BUSY_RX;
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pRxBuffPtr  = pData;
+  hspi->RxXferSize  = Size;
+  hspi->RxXferCount = Size;
+  hspi->pTxBuffPtr  = (uint8_t *)NULL;
+  hspi->TxXferSize  = 0;
+  hspi->TxXferCount = 0;
+
+  if((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES))
+  {
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+    /* the receive process is not supported in 2Lines direction master mode */
+    /* in this case we call the TransmitReceive process                     */
+    return HAL_SPI_TransmitReceive_DMA(hspi,pData,pData,Size);
+  }
+
+  /* Configure communication direction : 1Line */
+  if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+  {
+    SPI_1LINE_RX(hspi);
+  }
+
+  /* Reset CRC Calculation */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+  }
+
+  /* packing mode management is enabled by the DMA settings */
+  if((hspi->Init.DataSize <= SPI_DATASIZE_8BIT) && (hspi->hdmarx->Init.MemDataAlignment == DMA_MDATAALIGN_HALFWORD))
+  {
+    /* Restriction the DMA data received is not allowed in this mode */
+    errorcode = HAL_ERROR;
+    goto error;
+  }
+
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMARX);
+  if( hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+  {
+    /* set fiforxthresold according the reception data length: 16bit */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+  else
+  {
+    /* set fiforxthresold according the reception data length: 8bit */
+    SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+
+  /* Set the SPI RxDMA Half transfer complete callback */
+  hspi->hdmarx->XferHalfCpltCallback = SPI_DMAHalfReceiveCplt;
+
+  /* Set the SPI Rx DMA transfer complete callback */
+  hspi->hdmarx->XferCpltCallback = SPI_DMAReceiveCplt;
+
+  /* Set the DMA error callback */
+  hspi->hdmarx->XferErrorCallback = SPI_DMAError;
+
+  /* Enable Rx DMA Request */
+  SET_BIT(hspi->Instance->CR2, SPI_CR2_RXDMAEN);
+
+  /* Enable the Rx DMA channel */
+  HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t)hspi->pRxBuffPtr, hspi->RxXferCount);
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+error:
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+  return errorcode;
+}
+
+/**
+  * @brief  Transmit and Receive an amount of data in non-blocking mode with DMA.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param  pTxData: pointer to transmission data buffer
+  * @param  pRxData: pointer to reception data buffer
+  * @note  When the CRC feature is enabled the pRxData Length must be Size + 1
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size)
+{
+  HAL_StatusTypeDef errorcode = HAL_OK;
+  assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
+
+  /* Process locked */
+  __HAL_LOCK(hspi);
+
+  if(!((hspi->State == HAL_SPI_STATE_READY) ||
+      ((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->State == HAL_SPI_STATE_BUSY_RX))))
+  {
+    errorcode = HAL_BUSY;
+    goto error;
+  }
+
+  if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0))
+  {
+    errorcode = HAL_ERROR;
+    goto error;
+  }
+
+  /* check if the transmit Receive function is not called by a receive master */
+  if(hspi->State != HAL_SPI_STATE_BUSY_RX)
+  {
+    hspi->State = HAL_SPI_STATE_BUSY_TX_RX;
+  }
+
+  hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+  hspi->pTxBuffPtr  = (uint8_t *)pTxData;
+  hspi->TxXferSize  = Size;
+  hspi->TxXferCount = Size;
+  hspi->pRxBuffPtr  = (uint8_t *)pRxData;
+  hspi->RxXferSize  = Size;
+  hspi->RxXferCount = Size;
+
+  /* Reset CRC Calculation + increase the rxsize */
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+  {
+    SPI_RESET_CRC(hspi);
+  }
+
+  /* Reset the threshold bit */
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX | SPI_CR2_LDMARX);
+
+  /* the packing mode management is enabled by the DMA settings according the spi data size */
+  if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+  {
+    /* set fiforxthreshold according the reception data length: 16bit */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+  }
+  else
+  {
+    /* set fiforxthresold according the reception data length: 8bit */
+    SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+
+    if(hspi->hdmatx->Init.MemDataAlignment == DMA_MDATAALIGN_HALFWORD)
+    {
+      if((hspi->TxXferSize & 0x1) == 0x0)
+      {
+        CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX);
+        hspi->TxXferCount = hspi->TxXferCount >> 1;
+      }
+      else
+      {
+        SET_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX);
+        hspi->TxXferCount = (hspi->TxXferCount >> 1) + 1;
+      }
+    }
+
+    if(hspi->hdmarx->Init.MemDataAlignment == DMA_MDATAALIGN_HALFWORD)
+    {
+      /* set fiforxthresold according the reception data length: 16bit */
+      CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+
+      if((hspi->RxXferCount & 0x1) == 0x0 )
+      {
+        CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMARX);
+        hspi->RxXferCount = hspi->RxXferCount >> 1;
+      }
+      else
+      {
+        SET_BIT(hspi->Instance->CR2, SPI_CR2_LDMARX);
+        hspi->RxXferCount = (hspi->RxXferCount >> 1) + 1;
+      }
+    }
+  }
+
+  /* Set the SPI Rx DMA transfer complete callback if the transfer request is a
+     reception request (RXNE) */
+  if(hspi->State == HAL_SPI_STATE_BUSY_RX)
+  {
+    /* Set the SPI Rx DMA Half transfer complete callback */
+    hspi->hdmarx->XferHalfCpltCallback = SPI_DMAHalfReceiveCplt;
+    hspi->hdmarx->XferCpltCallback = SPI_DMAReceiveCplt;
+  }
+  else
+  {
+    /* Set the SPI Rx DMA Half transfer complete callback */
+    hspi->hdmarx->XferHalfCpltCallback = SPI_DMAHalfTransmitReceiveCplt;
+    hspi->hdmarx->XferCpltCallback = SPI_DMATransmitReceiveCplt;
+  }
+
+  /* Set the DMA error callback */
+  hspi->hdmarx->XferErrorCallback = SPI_DMAError;
+
+  /* Enable Rx DMA Request */
+  SET_BIT(hspi->Instance->CR2, SPI_CR2_RXDMAEN);
+
+  /* Enable the Rx DMA channel */
+  HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t) hspi->pRxBuffPtr, hspi->RxXferCount);
+
+  /* Set the SPI Tx DMA transfer complete callback as NULL because the communication closing
+  is performed in DMA reception complete callback  */
+  hspi->hdmatx->XferHalfCpltCallback = NULL;
+  hspi->hdmatx->XferCpltCallback = NULL;
+
+  /* Set the DMA error callback */
+  hspi->hdmatx->XferErrorCallback = SPI_DMAError;
+
+  /* Enable the Tx DMA channel */
+  HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->DR, hspi->TxXferCount);
+
+  /* Check if the SPI is already enabled */
+  if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+  {
+    /* Enable SPI peripheral */
+    __HAL_SPI_ENABLE(hspi);
+  }
+
+  /* Enable Tx DMA Request */
+  SET_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN);
+
+error :
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+  return errorcode;
+}
+
+/**
+  * @brief Pause the DMA Transfer.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for the specified SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_DMAPause(SPI_HandleTypeDef *hspi)
+{
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  /* Disable the SPI DMA Tx & Rx requests */
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Resume the DMA Transfer.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for the specified SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_DMAResume(SPI_HandleTypeDef *hspi)
+{
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+
+  /* Enable the SPI DMA Tx & Rx requests */
+  SET_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Stop the DMA Transfer.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for the specified SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_DMAStop(SPI_HandleTypeDef *hspi)
+{
+  /* The Lock is not implemented on this API to allow the user application
+     to call the HAL SPI API under callbacks HAL_SPI_TxCpltCallback() or HAL_SPI_RxCpltCallback() or HAL_SPI_TxRxCpltCallback():
+     when calling HAL_DMA_Abort() API the DMA TX/RX Transfer complete interrupt is generated
+     and the correspond call back is executed HAL_SPI_TxCpltCallback() or HAL_SPI_RxCpltCallback() or HAL_SPI_TxRxCpltCallback()
+     */
+
+  /* Abort the SPI DMA tx channel */
+  if(hspi->hdmatx != NULL)
+  {
+    HAL_DMA_Abort(hspi->hdmatx);
+  }
+  /* Abort the SPI DMA rx channel */
+  if(hspi->hdmarx != NULL)
+  {
+    HAL_DMA_Abort(hspi->hdmarx);
+  }
+
+  /* Disable the SPI DMA Tx & Rx requests */
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+  hspi->State = HAL_SPI_STATE_READY;
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handle SPI interrupt request.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for the specified SPI module.
+  * @retval None
+  */
+void HAL_SPI_IRQHandler(SPI_HandleTypeDef *hspi)
+{
+  uint32_t itsource = hspi->Instance->CR2;
+  uint32_t itflag   = hspi->Instance->SR;
+
+  /* SPI in mode Receiver ----------------------------------------------------*/
+  if(((itflag & SPI_FLAG_OVR) == RESET) &&
+     ((itflag & SPI_FLAG_RXNE) != RESET) && ((itsource & SPI_IT_RXNE) != RESET))
+  {
+    hspi->RxISR(hspi);
+    return;
+  }
+
+  /* SPI in mode Transmitter ---------------------------------------------------*/
+  if(((itflag & SPI_FLAG_TXE) != RESET) && ((itsource & SPI_IT_TXE) != RESET))
+  {
+    hspi->TxISR(hspi);
+    return;
+  }
+
+  /* SPI in Error Treatment ---------------------------------------------------*/
+  if((itflag & (SPI_FLAG_MODF | SPI_FLAG_OVR | SPI_FLAG_FRE)) != RESET)
+  {
+    /* SPI Overrun error interrupt occurred -------------------------------------*/
+    if((itflag & SPI_FLAG_OVR) != RESET)
+    {
+      if(hspi->State != HAL_SPI_STATE_BUSY_TX)
+      {
+        hspi->ErrorCode |= HAL_SPI_ERROR_OVR;
+        __HAL_SPI_CLEAR_OVRFLAG(hspi);
+      }
+      else
+      {
+        return;
+      }
+    }
+
+    /* SPI Mode Fault error interrupt occurred -------------------------------------*/
+    if((itflag & SPI_FLAG_MODF) != RESET)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_MODF;
+      __HAL_SPI_CLEAR_MODFFLAG(hspi);
+    }
+
+    /* SPI Frame error interrupt occurred ----------------------------------------*/
+    if((itflag & SPI_FLAG_FRE) != RESET)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FRE;
+      __HAL_SPI_CLEAR_FREFLAG(hspi);
+    }
+
+    __HAL_SPI_DISABLE_IT(hspi, SPI_IT_RXNE | SPI_IT_TXE | SPI_IT_ERR);
+    hspi->State = HAL_SPI_STATE_READY;
+    HAL_SPI_ErrorCallback(hspi);
+    return;
+  }
+}
+
+/**
+  * @brief Tx Transfer completed callback.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_TxCpltCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @brief Rx Transfer completed callback.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_RxCpltCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @brief Tx and Rx Transfer completed callback.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_TxRxCpltCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @brief Tx Half Transfer completed callback.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_TxHalfCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_TxHalfCpltCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @brief Rx Half Transfer completed callback.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_RxHalfCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_RxHalfCpltCallback() should be implemented in the user file
+   */
+}
+
+/**
+  * @brief Tx and Rx Half Transfer callback.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_TxRxHalfCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_TxRxHalfCpltCallback() should be implemented in the user file
+   */
+}
+
+/**
+  * @brief SPI error callback.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hspi);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_SPI_ErrorCallback should be implemented in the user file
+   */
+  /* NOTE : The ErrorCode parameter in the hspi handle is updated by the SPI processes
+            and user can use HAL_SPI_GetError() API to check the latest error occurred
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Exported_Functions_Group3 Peripheral State and Errors functions
+  *  @brief   SPI control functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral State and Errors functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the SPI.
+     (+) HAL_SPI_GetState() API can be helpful to check in run-time the state of the SPI peripheral
+     (+) HAL_SPI_GetError() check in run-time Errors occurring during communication
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the SPI handle state.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval SPI state
+  */
+HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi)
+{
+  /* Return SPI handle state */
+  return hspi->State;
+}
+
+/**
+  * @brief  Return the SPI error code.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval SPI error code in bitmap format
+  */
+uint32_t HAL_SPI_GetError(SPI_HandleTypeDef *hspi)
+{
+  return hspi->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+/** @addtogroup SPI_Private_Functions
+ *  @brief   Private functions
+  * @{
+  */
+
+/**
+  * @brief DMA SPI transmit process complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) != DMA_CCR_CIRC)
+  {
+    /* Disable Tx DMA Request */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN);
+
+    /* Check the end of the transaction */
+    if(SPI_EndRxTxTransaction(hspi,SPI_DEFAULT_TIMEOUT) != HAL_OK)
+    {
+      hspi->ErrorCode = HAL_SPI_ERROR_FLAG;
+    }
+
+    /* Clear overrun flag in 2 Lines communication mode because received data is not read */
+    if(hspi->Init.Direction == SPI_DIRECTION_2LINES)
+    {
+      __HAL_SPI_CLEAR_OVRFLAG(hspi);
+    }
+
+    hspi->TxXferCount = 0;
+    hspi->State = HAL_SPI_STATE_READY;
+
+    if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+    {
+      HAL_SPI_ErrorCallback(hspi);
+      return;
+    }
+  }
+  HAL_SPI_TxCpltCallback(hspi);
+}
+
+/**
+  * @brief DMA SPI receive process complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) != DMA_CCR_CIRC)
+  {
+    __IO uint16_t tmpreg;
+
+    /* CRC handling */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      /* Wait until TXE flag */
+      if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, SPI_DEFAULT_TIMEOUT) != HAL_OK)
+      {
+        /* Error on the CRC reception */
+        hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+      }
+      if(hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+      {
+        tmpreg = hspi->Instance->DR;
+        UNUSED(tmpreg); /* To avoid GCC warning */
+      }
+      else
+      {
+        tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+        UNUSED(tmpreg); /* To avoid GCC warning */
+
+        if(hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT)
+        {
+          if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, SPI_DEFAULT_TIMEOUT) != HAL_OK)
+          {
+            /* Error on the CRC reception */
+            hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+          }
+          tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+          UNUSED(tmpreg); /* To avoid GCC warning */
+        }
+      }
+    }
+
+    /* Disable Rx/Tx DMA Request (done by default to handle the case master rx direction 2 lines) */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+
+    /* Check the end of the transaction */
+    if(SPI_EndRxTransaction(hspi,SPI_DEFAULT_TIMEOUT)!=HAL_OK)
+    {
+      hspi->ErrorCode|= HAL_SPI_ERROR_FLAG;
+    }
+
+    hspi->RxXferCount = 0;
+    hspi->State = HAL_SPI_STATE_READY;
+
+    /* Check if CRC error occurred */
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+    {
+      hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+      __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+    }
+
+    if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+    {
+      HAL_SPI_ErrorCallback(hspi);
+      return;
+    }
+  }
+  HAL_SPI_RxCpltCallback(hspi);
+}
+
+/**
+  * @brief DMA SPI transmit receive process complete callback.
+  * @param  hdma : pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) != DMA_CCR_CIRC)
+  {
+    __IO int16_t tmpreg;
+    /* CRC handling */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      if((hspi->Init.DataSize == SPI_DATASIZE_8BIT) && (hspi->Init.CRCLength == SPI_CRC_LENGTH_8BIT))
+      {
+        if(SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_QUARTER_FULL, SPI_DEFAULT_TIMEOUT) != HAL_OK)
+        {
+          /* Error on the CRC reception */
+          hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+        }
+        tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
+        UNUSED(tmpreg); /* To avoid GCC warning */  
+      }
+      else
+      {
+        if(SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_HALF_FULL, SPI_DEFAULT_TIMEOUT) != HAL_OK)
+        {
+          /* Error on the CRC reception */
+          hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+        }
+        tmpreg = hspi->Instance->DR;
+        UNUSED(tmpreg); /* To avoid GCC warning */  
+      }
+    }
+
+    /* Check the end of the transaction */
+    if(SPI_EndRxTxTransaction(hspi,SPI_DEFAULT_TIMEOUT) != HAL_OK)
+    {
+      hspi->ErrorCode = HAL_SPI_ERROR_FLAG;
+    }
+  
+    /* Disable Rx/Tx DMA Request */
+    CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+
+    hspi->TxXferCount = 0;
+    hspi->RxXferCount = 0;
+    hspi->State = HAL_SPI_STATE_READY;
+
+    /* Check if CRC error occurred */
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+    {
+      hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+      __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+    }
+
+    if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+    {
+      HAL_SPI_ErrorCallback(hspi);
+      return;
+    }
+  }
+  HAL_SPI_TxRxCpltCallback(hspi);
+}
+
+/**
+  * @brief DMA SPI half transmit process complete callback.
+  * @param  hdma : pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAHalfTransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_SPI_TxHalfCpltCallback(hspi);
+}
+
+/**
+  * @brief DMA SPI half receive process complete callback.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAHalfReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_SPI_RxHalfCpltCallback(hspi);
+}
+
+/**
+  * @brief DMA SPI half transmit receive process complete callback.
+  * @param  hdma : pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAHalfTransmitReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_SPI_TxRxHalfCpltCallback(hspi);
+}
+
+/**
+  * @brief DMA SPI communication error callback.
+  * @param  hdma : pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAError(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Stop the disable DMA transfer on SPI side */
+  CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+
+  hspi->ErrorCode|= HAL_SPI_ERROR_DMA;
+  hspi->State = HAL_SPI_STATE_READY;
+  HAL_SPI_ErrorCallback(hspi);
+}
+
+/**
+  * @brief  Rx 8-bit handler for Transmit and Receive in Interrupt mode.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_2linesRxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  /* Receive data in packing mode */
+  if(hspi->RxXferCount > 1)
+  {
+    *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+    hspi->pRxBuffPtr += sizeof(uint16_t);
+    hspi->RxXferCount -= 2;
+    if(hspi->RxXferCount == 1) 
+    {
+      /* set fiforxthresold according the reception data length: 8bit */
+      SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+    }
+  }
+  /* Receive data in 8 Bit mode */
+  else
+  {
+    *hspi->pRxBuffPtr++ = *((__IO uint8_t *)&hspi->Instance->DR);
+    hspi->RxXferCount--;
+  }
+
+  /* check end of the reception */
+  if(hspi->RxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
+      hspi->RxISR =  SPI_2linesRxISR_8BITCRC;
+      return;
+    }
+
+    /* Disable RXNE interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, SPI_IT_RXNE);
+
+    if(hspi->TxXferCount == 0)
+    {
+      SPI_CloseRxTx_ISR(hspi);
+    }
+  }
+}
+
+/**
+  * @brief  Rx 8-bit handler for Transmit and Receive in Interrupt mode.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_2linesRxISR_8BITCRC(struct __SPI_HandleTypeDef *hspi)
+{
+  __IO uint8_t tmpreg = *((__IO uint8_t *)&hspi->Instance->DR);
+  UNUSED(tmpreg); /* To avoid GCC warning */
+
+  hspi->CRCSize--;
+
+  /* check end of the reception */
+  if(hspi->CRCSize == 0)
+  {
+    /* Disable RXNE interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, SPI_IT_RXNE);
+
+    if(hspi->TxXferCount == 0)
+    {
+      SPI_CloseRxTx_ISR(hspi);
+    }
+  }
+}
+
+/**
+  * @brief  Tx 8-bit handler for Transmit and Receive in Interrupt mode.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_2linesTxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  /* Transmit data in packing Bit mode */
+  if(hspi->TxXferCount >= 2)
+  {
+    hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+    hspi->pTxBuffPtr += sizeof(uint16_t);
+    hspi->TxXferCount -= 2;
+  }
+  /* Transmit data in 8 Bit mode */
+  else
+  {
+    *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+    hspi->TxXferCount--;
+  }
+
+  /* check the end of the transmission */
+  if(hspi->TxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+    }
+    /* Disable TXE interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, SPI_IT_TXE);
+
+    if(hspi->RxXferCount == 0)
+    {
+      SPI_CloseRxTx_ISR(hspi);
+    }
+  }
+}
+
+/**
+  * @brief  Rx 16-bit handler for Transmit and Receive in Interrupt mode.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_2linesRxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  /* Receive data in 16 Bit mode */
+  *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+  hspi->pRxBuffPtr += sizeof(uint16_t);
+  hspi->RxXferCount--;
+
+  if(hspi->RxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      hspi->RxISR =  SPI_2linesRxISR_16BITCRC;
+      return;
+    }
+
+    /* Disable RXNE interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, SPI_IT_RXNE);
+
+    if(hspi->TxXferCount == 0)
+    {
+      SPI_CloseRxTx_ISR(hspi);
+    }
+  }
+}
+
+/**
+  * @brief  Manage the CRC 16-bit receive for Transmit and Receive in Interrupt mode.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_2linesRxISR_16BITCRC(struct __SPI_HandleTypeDef *hspi)
+{
+  /* Receive data in 16 Bit mode */
+  __IO uint16_t tmpreg = hspi->Instance->DR;
+  UNUSED(tmpreg); /* To avoid GCC warning */
+
+  /* Disable RXNE interrupt */
+  __HAL_SPI_DISABLE_IT(hspi, SPI_IT_RXNE);
+
+  SPI_CloseRxTx_ISR(hspi);
+}
+
+/**
+  * @brief  Tx 16-bit handler for Transmit and Receive in Interrupt mode.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_2linesTxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  /* Transmit data in 16 Bit mode */
+  hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+  hspi->pTxBuffPtr += sizeof(uint16_t);
+  hspi->TxXferCount--;
+
+  /* Enable CRC Transmission */
+  if(hspi->TxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+    }
+    /* Disable TXE interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, SPI_IT_TXE);
+
+    if(hspi->RxXferCount == 0)
+    {
+      SPI_CloseRxTx_ISR(hspi);
+    }
+  }
+}
+
+/**
+  * @brief  Manage the CRC 8-bit receive in Interrupt context.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_RxISR_8BITCRC(struct __SPI_HandleTypeDef *hspi)
+{
+  __IO uint8_t tmpreg = *((uint8_t*)&hspi->Instance->DR);
+  UNUSED(tmpreg); /* To avoid GCC warning */
+
+  hspi->CRCSize--;
+
+  if(hspi->CRCSize == 0)
+  {
+    SPI_CloseRx_ISR(hspi);
+  }
+}
+
+/**
+  * @brief  Manage the receive 8-bit in Interrupt context.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_RxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  *hspi->pRxBuffPtr++ = (*(__IO uint8_t *)&hspi->Instance->DR);
+  hspi->RxXferCount--;
+
+  /* Enable CRC Transmission */
+  if((hspi->RxXferCount == 1) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE))
+  {
+    hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+  }
+
+  if(hspi->RxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      hspi->RxISR =  SPI_RxISR_8BITCRC;
+      return;
+    }
+    SPI_CloseRx_ISR(hspi);
+  }
+}
+
+/**
+  * @brief  Manage the CRC 16-bit receive in Interrupt context.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_RxISR_16BITCRC(struct __SPI_HandleTypeDef *hspi)
+{
+  __IO uint16_t tmpreg;
+
+  tmpreg = hspi->Instance->DR;
+  UNUSED(tmpreg); /* To avoid GCC warning */
+
+  /* Disable RXNE and ERR interrupt */
+  __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_RXNE | SPI_IT_ERR));
+
+  SPI_CloseRx_ISR(hspi);
+}
+
+/**
+  * @brief  Manage the 16-bit receive in Interrupt context.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_RxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  *((uint16_t *)hspi->pRxBuffPtr) = hspi->Instance->DR;
+  hspi->pRxBuffPtr += sizeof(uint16_t);
+  hspi->RxXferCount--;
+
+  /* Enable CRC Transmission */
+  if((hspi->RxXferCount == 1) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE))
+  {
+    hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+  }
+
+  if(hspi->RxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      hspi->RxISR = SPI_RxISR_16BITCRC;
+      return;
+    }
+    SPI_CloseRx_ISR(hspi);
+  }
+}
+
+/**
+  * @brief  Handle the data 8-bit transmit in Interrupt mode.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_TxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+  hspi->TxXferCount--;
+
+  if(hspi->TxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      /* Enable CRC Transmission */
+      hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+    }
+
+    SPI_CloseTx_ISR(hspi);
+  }
+}
+
+/**
+  * @brief  Handle the data 16-bit transmit in Interrupt mode.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_TxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
+{
+  /* Transmit data in 16 Bit mode */
+  hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+  hspi->pTxBuffPtr += sizeof(uint16_t);
+  hspi->TxXferCount--;
+
+  if(hspi->TxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+    {
+      /* Enable CRC Transmission */
+      hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+    }
+    SPI_CloseTx_ISR(hspi);
+  }
+}
+
+/**
+  * @brief Handle SPI Communication Timeout.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param Flag : SPI flag to check
+  * @param State : flag state to check
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SPI_WaitFlagStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Flag, uint32_t State, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+
+  while((hspi->Instance->SR & Flag) != State)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0) || ((HAL_GetTick()-tickstart) >= Timeout))
+      {
+        /* Disable the SPI and reset the CRC: the CRC value should be cleared
+        on both master and slave sides in order to resynchronize the master
+        and slave for their respective CRC calculation */
+
+        /* Disable TXE, RXNE and ERR interrupts for the interrupt process */
+        __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
+
+        if((hspi->Init.Mode == SPI_MODE_MASTER)&&((hspi->Init.Direction == SPI_DIRECTION_1LINE)||(hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY)))
+        {
+          /* Disable SPI peripheral */
+          __HAL_SPI_DISABLE(hspi);
+        }
+
+        /* Reset CRC Calculation */
+        if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+        {
+          SPI_RESET_CRC(hspi);
+        }
+
+        hspi->State= HAL_SPI_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hspi);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Handle SPI FIFO Communication Timeout.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param Fifo : Fifo to check
+  * @param State : Fifo state to check
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Fifo, uint32_t State, uint32_t Timeout)
+{
+  __IO uint8_t tmpreg;
+  uint32_t tickstart = HAL_GetTick();
+
+  while((hspi->Instance->SR & Fifo) != State)
+  {
+    if((Fifo == SPI_SR_FRLVL) && (State == SPI_FRLVL_EMPTY))
+    {
+      tmpreg = *((__IO uint8_t*)&hspi->Instance->DR);
+      UNUSED(tmpreg); /* To avoid GCC warning */
+    }
+
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0) || ((HAL_GetTick()-tickstart) >= Timeout))
+      {
+        /* Disable the SPI and reset the CRC: the CRC value should be cleared
+                  on both master and slave sides in order to resynchronize the master
+                 and slave for their respective CRC calculation */
+
+        /* Disable TXE, RXNE and ERR interrupts for the interrupt process */
+        __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
+
+        if((hspi->Init.Mode == SPI_MODE_MASTER)&&((hspi->Init.Direction == SPI_DIRECTION_1LINE)||(hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY)))
+        {
+          /* Disable SPI peripheral */
+          __HAL_SPI_DISABLE(hspi);
+        }
+
+        /* Reset CRC Calculation */
+        if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+        {
+          SPI_RESET_CRC(hspi);
+        }
+
+        hspi->State = HAL_SPI_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hspi);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Handle the check of the RX transaction complete.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @param Timeout : Timeout duration
+  * @retval None
+  */
+static HAL_StatusTypeDef SPI_EndRxTransaction(SPI_HandleTypeDef *hspi,  uint32_t Timeout)
+{
+  if((hspi->Init.Mode == SPI_MODE_MASTER)&&((hspi->Init.Direction == SPI_DIRECTION_1LINE)||(hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY)))
+  {
+    /* Disable SPI peripheral */
+    __HAL_SPI_DISABLE(hspi);
+  }
+  
+  /* Control the BSY flag */
+  if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_BSY, RESET, Timeout) != HAL_OK)
+  {
+    hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    return HAL_TIMEOUT;
+  }
+
+  if((hspi->Init.Mode == SPI_MODE_MASTER)&&((hspi->Init.Direction == SPI_DIRECTION_1LINE)||(hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY)))
+  {
+    /* Empty the FRLVL fifo */
+    if(SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, Timeout) != HAL_OK)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief Handle the check of the RXTX or TX transaction complete.
+  * @param hspi: SPI handle
+  * @param Timeout : Timeout duration
+  */
+static HAL_StatusTypeDef SPI_EndRxTxTransaction(SPI_HandleTypeDef *hspi, uint32_t Timeout)
+{
+  /* Control if the TX fifo is empty */
+  if(SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FTLVL, SPI_FTLVL_EMPTY, Timeout) != HAL_OK)
+  {
+    hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    return HAL_TIMEOUT;
+  }
+  /* Control the BSY flag */
+  if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_BSY, RESET, Timeout) != HAL_OK)
+  {
+    hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    return HAL_TIMEOUT;
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief Handle the end of the RXTX transaction.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_CloseRxTx_ISR(SPI_HandleTypeDef *hspi)
+{
+  /* Disable ERR interrupt */
+  __HAL_SPI_DISABLE_IT(hspi, SPI_IT_ERR);
+
+  /* Check the end of the transaction */
+  if(SPI_EndRxTxTransaction(hspi,SPI_DEFAULT_TIMEOUT)!=HAL_OK)
+  {
+    hspi->ErrorCode|= HAL_SPI_ERROR_FLAG;
+  }
+
+  /* Check if CRC error occurred */
+  if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+  {
+    hspi->State = HAL_SPI_STATE_READY;
+    hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+    __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+    HAL_SPI_ErrorCallback(hspi);
+  }
+  else
+  {
+    if(hspi->ErrorCode == HAL_SPI_ERROR_NONE)
+    {
+      if(hspi->State == HAL_SPI_STATE_BUSY_RX)
+      {
+      	hspi->State = HAL_SPI_STATE_READY;
+        HAL_SPI_RxCpltCallback(hspi);
+      }
+      else
+      {
+      	hspi->State = HAL_SPI_STATE_READY;
+        HAL_SPI_TxRxCpltCallback(hspi);
+      }
+    }
+    else
+    {
+      hspi->State = HAL_SPI_STATE_READY;
+      HAL_SPI_ErrorCallback(hspi);
+    }
+  }
+}
+
+/**
+  * @brief Handle the end of the RX transaction.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_CloseRx_ISR(SPI_HandleTypeDef *hspi)
+{
+    /* Disable RXNE and ERR interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_RXNE | SPI_IT_ERR));
+
+    /* Check the end of the transaction */
+    if(SPI_EndRxTransaction(hspi,SPI_DEFAULT_TIMEOUT)!=HAL_OK)
+    {
+      hspi->ErrorCode|= HAL_SPI_ERROR_FLAG;
+    }
+    hspi->State = HAL_SPI_STATE_READY;
+
+    /* Check if CRC error occurred */
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+    {
+      hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
+      __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+      HAL_SPI_ErrorCallback(hspi);
+    }
+    else
+    {
+      if(hspi->ErrorCode == HAL_SPI_ERROR_NONE)
+      {
+        HAL_SPI_RxCpltCallback(hspi);
+      }
+      else
+      {
+        HAL_SPI_ErrorCallback(hspi);
+      }
+    }
+}
+
+/**
+  * @brief Handle the end of the TX transaction.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for SPI module.
+  * @retval None
+  */
+static void SPI_CloseTx_ISR(SPI_HandleTypeDef *hspi)
+{
+  /* Disable TXE and ERR interrupt */
+  __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_ERR));
+
+  /* Check the end of the transaction */
+  if(SPI_EndRxTxTransaction(hspi,SPI_DEFAULT_TIMEOUT)!=HAL_OK)
+  {
+    hspi->ErrorCode|= HAL_SPI_ERROR_FLAG;
+  }
+
+  /* Clear overrun flag in 2 Lines communication mode because received is not read */
+  if(hspi->Init.Direction == SPI_DIRECTION_2LINES)
+  {
+    __HAL_SPI_CLEAR_OVRFLAG(hspi);
+  }
+
+  hspi->State = HAL_SPI_STATE_READY;
+  if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+  {
+    HAL_SPI_ErrorCallback(hspi);
+  }
+  else
+  {
+    HAL_SPI_TxCpltCallback(hspi);
+  }
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_spi_ex.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_spi_ex.c
@@ -1,0 +1,133 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_spi_ex.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Extended SPI HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          SPI peripheral extended functionalities :
+  *           + IO operation functions
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SPIEx SPIEx
+  * @brief SPI Extended HAL module driver
+  * @{
+  */
+#ifdef HAL_SPI_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/
+/** @defgroup SPIEx_Private_Constants SPIEx Private Constants
+  * @{
+  */
+#define SPI_FIFO_SIZE       4
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
+
+/** @defgroup SPIEx_Exported_Functions SPIEx Exported Functions
+  * @{
+  */
+
+/** @defgroup SPIEx_Exported_Functions_Group1 IO operation functions
+ *  @brief   Data transfers functions
+ *
+@verbatim
+  ==============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+ [..]
+    This subsection provides a set of extended functions to manage the SPI
+    data transfers.
+
+    (#) Rx data flush function:
+        (++) HAL_SPIEx_FlushRxFifo()
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Flush the RX fifo.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *               the configuration information for the specified SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPIEx_FlushRxFifo(SPI_HandleTypeDef *hspi)
+{
+  __IO uint32_t tmpreg;
+  uint8_t  count = 0;
+  while((hspi->Instance->SR & SPI_FLAG_FRLVL) !=  SPI_FRLVL_EMPTY)
+  {
+    count++;
+    tmpreg = hspi->Instance->DR;
+    UNUSED(tmpreg); /* To avoid GCC warning */
+    if(count == SPI_FIFO_SIZE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_tim.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_tim.c
@@ -1,0 +1,5383 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_tim.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   TIM HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Timer (TIM) peripheral:
+  *           + Time Base Initialization
+  *           + Time Base Start
+  *           + Time Base Start Interruption
+  *           + Time Base Start DMA
+  *           + Time Output Compare/PWM Initialization
+  *           + Time Output Compare/PWM Channel Configuration
+  *           + Time Output Compare/PWM  Start
+  *           + Time Output Compare/PWM  Start Interruption
+  *           + Time Output Compare/PWM Start DMA
+  *           + Time Input Capture Initialization
+  *           + Time Input Capture Channel Configuration
+  *           + Time Input Capture Start
+  *           + Time Input Capture Start Interruption
+  *           + Time Input Capture Start DMA
+  *           + Time One Pulse Initialization
+  *           + Time One Pulse Channel Configuration
+  *           + Time One Pulse Start
+  *           + Time Encoder Interface Initialization
+  *           + Time Encoder Interface Start
+  *           + Time Encoder Interface Start Interruption
+  *           + Time Encoder Interface Start DMA
+  *           + Commutation Event configuration with Interruption and DMA
+  *           + Time OCRef clear configuration
+  *           + Time External Clock configuration
+  @verbatim
+  ==============================================================================
+                      ##### TIMER Generic features #####
+  ==============================================================================
+  [..] The Timer features include:
+       (#) 16-bit up, down, up/down auto-reload counter.
+       (#) 16-bit programmable prescaler allowing dividing (also on the fly) the
+           counter clock frequency either by any factor between 1 and 65536.
+       (#) Up to 4 independent channels for:
+           (++) Input Capture
+           (++) Output Compare
+           (++) PWM generation (Edge and Center-aligned Mode)
+           (++) One-pulse mode output
+
+            ##### How to use this driver #####
+  ==============================================================================
+    [..]
+     (#) Initialize the TIM low level resources by implementing the following functions
+         depending on the selected feature:
+           (++) Time Base : HAL_TIM_Base_MspInit()
+           (++) Input Capture : HAL_TIM_IC_MspInit()
+           (++) Output Compare : HAL_TIM_OC_MspInit()
+           (++) PWM generation : HAL_TIM_PWM_MspInit()
+           (++) One-pulse mode output : HAL_TIM_OnePulse_MspInit()
+           (++) Encoder mode output : HAL_TIM_Encoder_MspInit()
+
+     (#) Initialize the TIM low level resources :
+        (##) Enable the TIM interface clock using __HAL_RCC_TIMx_CLK_ENABLE();
+        (##) TIM pins configuration
+            (+++) Enable the clock for the TIM GPIOs using the following function:
+             __HAL_RCC_GPIOx_CLK_ENABLE();
+            (+++) Configure these TIM pins in Alternate function mode using HAL_GPIO_Init();
+
+     (#) The external Clock can be configured, if needed (the default clock is the
+         internal clock from the APBx), using the following function:
+         HAL_TIM_ConfigClockSource, the clock configuration should be done before
+         any start function.
+
+     (#) Configure the TIM in the desired functioning mode using one of the
+       Initialization function of this driver:
+       (++) HAL_TIM_Base_Init: to use the Timer to generate a simple time base
+       (++) HAL_TIM_OC_Init and HAL_TIM_OC_ConfigChannel: to use the Timer to generate an
+            Output Compare signal.
+       (++) HAL_TIM_PWM_Init and HAL_TIM_PWM_ConfigChannel: to use the Timer to generate a
+            PWM signal.
+       (++) HAL_TIM_IC_Init and HAL_TIM_IC_ConfigChannel: to use the Timer to measure an
+            external signal.
+         (++) HAL_TIM_OnePulse_Init and HAL_TIM_OnePulse_ConfigChannel: to use the Timer
+              in One Pulse Mode.
+       (++) HAL_TIM_Encoder_Init: to use the Timer Encoder Interface.
+
+     (#) Activate the TIM peripheral using one of the start functions depending from the feature used:
+           (++) Time Base : HAL_TIM_Base_Start(), HAL_TIM_Base_Start_DMA(), HAL_TIM_Base_Start_IT()
+           (++) Input Capture :  HAL_TIM_IC_Start(), HAL_TIM_IC_Start_DMA(), HAL_TIM_IC_Start_IT()
+           (++) Output Compare : HAL_TIM_OC_Start(), HAL_TIM_OC_Start_DMA(), HAL_TIM_OC_Start_IT()
+           (++) PWM generation : HAL_TIM_PWM_Start(), HAL_TIM_PWM_Start_DMA(), HAL_TIM_PWM_Start_IT()
+           (++) One-pulse mode output : HAL_TIM_OnePulse_Start(), HAL_TIM_OnePulse_Start_IT()
+           (++) Encoder mode output : HAL_TIM_Encoder_Start(), HAL_TIM_Encoder_Start_DMA(), HAL_TIM_Encoder_Start_IT().
+
+     (#) The DMA Burst is managed with the two following functions:
+         HAL_TIM_DMABurst_WriteStart()
+         HAL_TIM_DMABurst_ReadStart()
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup TIM TIM
+  * @brief TIM HAL module driver
+  * @{
+  */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void TIM_TI1_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter);
+static void TIM_TI2_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter);
+static void TIM_TI2_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter);
+static void TIM_TI3_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter);
+static void TIM_TI4_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter);
+static void TIM_ITRx_SetConfig(TIM_TypeDef* TIMx, uint16_t InputTriggerSource);
+static void TIM_DMAPeriodElapsedCplt(DMA_HandleTypeDef *hdma);
+static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma);
+static void TIM_SlaveTimer_SetConfig(TIM_HandleTypeDef *htim,
+                                     TIM_SlaveConfigTypeDef * sSlaveConfig);
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup TIM_Exported_Functions TIM Exported Functions
+  * @{
+  */
+
+/** @defgroup TIM_Exported_Functions_Group1 Time Base functions
+ *  @brief    Time Base functions
+ *
+@verbatim
+  ==============================================================================
+              ##### Time Base functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Initialize and configure the TIM base.
+    (+) De-initialize the TIM base.
+    (+) Start the Time Base.
+    (+) Stop the Time Base.
+    (+) Start the Time Base and enable interrupt.
+    (+) Stop the Time Base and disable interrupt.
+    (+) Start the Time Base and enable DMA transfer.
+    (+) Stop the Time Base and disable DMA transfer.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM Time base Unit according to the specified
+  *         parameters in the TIM_HandleTypeDef and initialize the associated handle.
+  * @param  htim: TIM Base handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    htim->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK, NVIC */
+    HAL_TIM_Base_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Set the Time Base configuration */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitialize the TIM Base peripheral
+  * @param  htim: TIM Base handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_TIM_Base_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Base MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_Base_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitialize TIM Base MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_Base_MspDeInit could be implemented in the user file
+   */
+}
+
+
+/**
+  * @brief  Starts the TIM Base generation.
+  * @param  htim : TIM handle
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_Base_Start(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Change the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Base generation.
+  * @param  htim : TIM handle
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_Base_Stop(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Base generation in interrupt mode.
+  * @param  htim : TIM handle
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_Base_Start_IT(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+   /* Enable the TIM Update interrupt */
+   __HAL_TIM_ENABLE_IT(htim, TIM_IT_UPDATE);
+
+   /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Base generation in interrupt mode.
+  * @param  htim : TIM handle
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_Base_Stop_IT(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  /* Disable the TIM Update interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_UPDATE);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Base generation in DMA mode.
+  * @param  htim : TIM handle
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to peripheral.
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_INSTANCE(htim->Instance));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  /* Set the DMA Period elapsed callback */
+  htim->hdma[TIM_DMA_ID_UPDATE]->XferCpltCallback = TIM_DMAPeriodElapsedCplt;
+
+  /* Set the DMA error callback */
+  htim->hdma[TIM_DMA_ID_UPDATE]->XferErrorCallback = TIM_DMAError ;
+
+  /* Enable the DMA channel */
+  HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)pData, (uint32_t)&htim->Instance->ARR, Length);
+
+  /* Enable the TIM Update DMA request */
+  __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_UPDATE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Base generation in DMA mode.
+  * @param  htim : TIM handle
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_Base_Stop_DMA(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_INSTANCE(htim->Instance));
+
+  /* Disable the TIM Update DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_UPDATE);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group2 Time Output Compare functions
+ *  @brief    Time Output Compare functions
+ *
+@verbatim
+  ==============================================================================
+                  ##### Time Output Compare functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Initialize and configure the TIM Output Compare.
+    (+) De-initialize the TIM Output Compare.
+    (+) Start the Time Output Compare.
+    (+) Stop the Time Output Compare.
+    (+) Start the Time Output Compare and enable interrupt.
+    (+) Stop the Time Output Compare and disable interrupt.
+    (+) Start the Time Output Compare and enable DMA transfer.
+    (+) Stop the Time Output Compare and disable DMA transfer.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM Output Compare according to the specified
+  *         parameters in the TIM_HandleTypeDef and initialize the associated handle.
+  * @param  htim: TIM Output Compare handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Init(TIM_HandleTypeDef* htim)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    htim->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_OC_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Init the base time for the Output Compare */
+  TIM_Base_SetConfig(htim->Instance,  &htim->Init);
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitialize the TIM peripheral
+  * @param  htim: TIM Output Compare handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+   htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC and DMA */
+  HAL_TIM_OC_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Output Compare MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_OC_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_OC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitialize TIM Output Compare MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_OC_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_OC_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation.
+  * @param  htim : TIM Output Compare handle
+  * @param  Channel : TIM Channel to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_OC_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Enable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_OC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Disable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Ouput */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation in interrupt mode.
+  * @param  htim : TIM OC handle
+  * @param  Channel : TIM Channel to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Enable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation in interrupt mode.
+  * @param  htim : TIM Output Compare handle
+  * @param  Channel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Ouput */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation in DMA mode.
+  * @param  htim : TIM Output Compare handle
+  * @param  Channel : TIM Channel to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to TIM peripheral
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if(((uint32_t)pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length);
+
+      /* Enable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length);
+
+      /* Enable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,Length);
+
+      /* Enable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+     /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length);
+
+      /* Enable the TIM Capture/Compare 4 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+  default:
+    break;
+  }
+
+  /* Enable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation in DMA mode.
+  * @param  htim : TIM Output Compare handle
+  * @param  Channel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Ouput */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group3 Time PWM functions
+ *  @brief    Time PWM functions
+ *
+@verbatim
+  ==============================================================================
+                          ##### Time PWM functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Initialize and configure the TIM OPWM.
+    (+) De-initialize the TIM PWM.
+    (+) Start the Time PWM.
+    (+) Stop the Time PWM.
+    (+) Start the Time PWM and enable interrupt.
+    (+) Stop the Time PWM and disable interrupt.
+    (+) Start the Time PWM and enable DMA transfer.
+    (+) Stop the Time PWM and disable DMA transfer.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM PWM Time Base according to the specified
+  *         parameters in the TIM_HandleTypeDef and initialize the associated handle.
+  * @param  htim: TIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Init(TIM_HandleTypeDef *htim)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    htim->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_PWM_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Init the base time for the PWM */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitialize the TIM peripheral
+  * @param  htim: TIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC and DMA */
+  HAL_TIM_PWM_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM PWM MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_PWM_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitialize TIM PWM MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_PWM_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the PWM signal generation.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_PWM_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Enable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the PWM signal generation.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channels to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_PWM_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Disable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Ouput */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the PWM signal generation in interrupt mode.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Enable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the PWM signal generation in interrupt mode.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channels to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT (TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Ouput */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM PWM signal generation in DMA mode.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to TIM peripheral
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if(((uint32_t)pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length);
+
+      /* Enable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length);
+
+      /* Enable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,Length);
+
+      /* Enable the TIM Output Capture/Compare 3 request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+     /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length);
+
+      /* Enable the TIM Capture/Compare 4 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM PWM signal generation in DMA mode.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channels to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Ouput */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group4 Time Input Capture functions
+ *  @brief    Time Input Capture functions
+ *
+@verbatim
+  ==============================================================================
+              ##### Time Input Capture functions #####
+  ==============================================================================
+ [..]
+   This section provides functions allowing to:
+   (+) Initialize and configure the TIM Input Capture.
+   (+) De-initialize the TIM Input Capture.
+   (+) Start the Time Input Capture.
+   (+) Stop the Time Input Capture.
+   (+) Start the Time Input Capture and enable interrupt.
+   (+) Stop the Time Input Capture and disable interrupt.
+   (+) Start the Time Input Capture and enable DMA transfer.
+   (+) Stop the Time Input Capture and disable DMA transfer.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM Input Capture Time base according to the specified
+  *         parameters in the TIM_HandleTypeDef and initialize the associated handle.
+  * @param  htim: TIM Input Capture handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Init(TIM_HandleTypeDef *htim)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    htim->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_IC_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Init the base time for the input capture */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitialize the TIM peripheral
+  * @param  htim: TIM Input Capture handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC and DMA */
+  HAL_TIM_IC_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM INput Capture MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_IC_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_IC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitialize TIM Input Capture MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_IC_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_IC_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the TIM Input Capture measurement.
+  * @param  htim : TIM Input Capture handle
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_IC_Start (TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Enable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Input Capture measurement.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channels to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_IC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Disable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Input Capture measurement in interrupt mode.
+  * @param  htim : TIM Input Capture handle
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_IC_Start_IT (TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Enable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+  /* Enable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Input Capture measurement in interrupt mode.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channels to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Input Capture measurement on in DMA mode.
+  * @param  htim : TIM Input Capture handle
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  pData: The destination Buffer address.
+  * @param  Length: The length of data to be transferred from TIM peripheral to memory.
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData, Length);
+
+      /* Enable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData, Length);
+
+      /* Enable the TIM Capture/Compare 2  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)&htim->Instance->CCR3, (uint32_t)pData, Length);
+
+      /* Enable the TIM Capture/Compare 3  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)&htim->Instance->CCR4, (uint32_t)pData, Length);
+
+      /* Enable the TIM Capture/Compare 4  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Input Capture measurement on in DMA mode.
+  * @param  htim : TIM Input Capture handle
+  * @param  Channel : TIM Channels to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3  DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4  DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group5 Time One Pulse functions
+ *  @brief    Time One Pulse functions
+ *
+@verbatim
+  ==============================================================================
+                        ##### Time One Pulse functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Initialize and configure the TIM One Pulse.
+    (+) De-initialize the TIM One Pulse.
+    (+) Start the Time One Pulse.
+    (+) Stop the Time One Pulse.
+    (+) Start the Time One Pulse and enable interrupt.
+    (+) Stop the Time One Pulse and disable interrupt.
+    (+) Start the Time One Pulse and enable DMA transfer.
+    (+) Stop the Time One Pulse and disable DMA transfer.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM One Pulse Time Base according to the specified
+  *         parameters in the TIM_HandleTypeDef and initialize the associated handle.
+  * @param  htim: TIM OnePulse handle
+  * @param  OnePulseMode: Select the One pulse mode.
+  *         This parameter can be one of the following values:
+  *            @arg TIM_OPMODE_SINGLE: Only one pulse will be generated.
+  *            @arg TIM_OPMODE_REPETITIVE: Repetitive pulses will be generated.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Init(TIM_HandleTypeDef *htim, uint32_t OnePulseMode)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+  assert_param(IS_TIM_OPM_MODE(OnePulseMode));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    htim->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_OnePulse_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Configure the Time base in the One Pulse Mode */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+
+  /* Reset the OPM Bit */
+  htim->Instance->CR1 &= ~TIM_CR1_OPM;
+
+  /* Configure the OPM Mode */
+  htim->Instance->CR1 |= OnePulseMode;
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitialize the TIM One Pulse
+  * @param  htim: TIM One Pulse handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_TIM_OnePulse_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM One Pulse MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_OnePulse_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_OnePulse_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitialize TIM One Pulse MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_OnePulse_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_OnePulse_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the TIM One Pulse signal generation.
+  * @param  htim : TIM One Pulse handle
+  * @param  OutputChannel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_OnePulse_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(OutputChannel);
+
+  /* Enable the Capture compare and the Input Capture channels
+    (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
+    if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
+    if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output
+    in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be enabled together
+
+    No need to enable the counter, it's enabled automatically by hardware
+    (the counter starts in response to a stimulus and generate a pulse */
+
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM One Pulse signal generation.
+  * @param  htim : TIM One Pulse handle
+  * @param  OutputChannel : TIM Channels to be disable
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_OnePulse_Stop(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(OutputChannel);
+
+  /* Disable the Capture compare and the Input Capture channels
+  (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
+  if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
+  if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output
+  in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be disabled together */
+
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Ouput */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM One Pulse signal generation in interrupt mode.
+  * @param  htim : TIM One Pulse handle
+  * @param  OutputChannel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_OnePulse_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(OutputChannel);
+
+  /* Enable the Capture compare and the Input Capture channels
+    (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
+    if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
+    if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output
+    in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be enabled together
+
+    No need to enable the counter, it's enabled automatically by hardware
+    (the counter starts in response to a stimulus and generate a pulse */
+
+  /* Enable the TIM Capture/Compare 1 interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+
+  /* Enable the TIM Capture/Compare 2 interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Enable the main output */
+    __HAL_TIM_MOE_ENABLE(htim);
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM One Pulse signal generation in interrupt mode.
+  * @param  htim : TIM One Pulse handle
+  * @param  OutputChannel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(OutputChannel);
+
+  /* Disable the TIM Capture/Compare 1 interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+
+  /* Disable the TIM Capture/Compare 2 interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+
+  /* Disable the Capture compare and the Input Capture channels
+  (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
+  if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
+  if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output
+  in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be disabled together */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+
+  if(IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  {
+    /* Disable the Main Ouput */
+    __HAL_TIM_MOE_DISABLE(htim);
+  }
+
+  /* Disable the Peripheral */
+   __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group6 Time Encoder functions
+ *  @brief    Time Encoder functions
+ *
+@verbatim
+  ==============================================================================
+                          ##### Time Encoder functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Initialize and configure the TIM Encoder.
+    (+) De-initialize the TIM Encoder.
+    (+) Start the Time Encoder.
+    (+) Stop the Time Encoder.
+    (+) Start the Time Encoder and enable interrupt.
+    (+) Stop the Time Encoder and disable interrupt.
+    (+) Start the Time Encoder and enable DMA transfer.
+    (+) Stop the Time Encoder and disable DMA transfer.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM Encoder Interface and initialize the associated handle.
+  * @param  htim: TIM Encoder Interface handle
+  * @param  sConfig: TIM Encoder Interface configuration structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_InitTypeDef* sConfig)
+{
+  uint32_t tmpsmcr = 0;
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_ENCODER_MODE(sConfig->EncoderMode));
+  assert_param(IS_TIM_IC_SELECTION(sConfig->IC1Selection));
+  assert_param(IS_TIM_IC_SELECTION(sConfig->IC2Selection));
+  assert_param(IS_TIM_IC_POLARITY(sConfig->IC1Polarity));
+  assert_param(IS_TIM_IC_POLARITY(sConfig->IC2Polarity));
+  assert_param(IS_TIM_IC_PRESCALER(sConfig->IC1Prescaler));
+  assert_param(IS_TIM_IC_PRESCALER(sConfig->IC2Prescaler));
+  assert_param(IS_TIM_IC_FILTER(sConfig->IC1Filter));
+  assert_param(IS_TIM_IC_FILTER(sConfig->IC2Filter));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    htim->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_Encoder_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Reset the SMS bits */
+  htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+
+  /* Configure the Time base in the Encoder Mode */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+
+  /* Get the TIMx SMCR register value */
+  tmpsmcr = htim->Instance->SMCR;
+
+  /* Get the TIMx CCMR1 register value */
+  tmpccmr1 = htim->Instance->CCMR1;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = htim->Instance->CCER;
+
+  /* Set the encoder Mode */
+  tmpsmcr |= sConfig->EncoderMode;
+
+  /* Select the Capture Compare 1 and the Capture Compare 2 as input */
+  tmpccmr1 &= ~(TIM_CCMR1_CC1S | TIM_CCMR1_CC2S);
+  tmpccmr1 |= (sConfig->IC1Selection | (sConfig->IC2Selection << 8));
+
+  /* Set the Capture Compare 1 and the Capture Compare 2 prescalers and filters */
+  tmpccmr1 &= ~(TIM_CCMR1_IC1PSC | TIM_CCMR1_IC2PSC);
+  tmpccmr1 &= ~(TIM_CCMR1_IC1F | TIM_CCMR1_IC2F);
+  tmpccmr1 |= sConfig->IC1Prescaler | (sConfig->IC2Prescaler << 8);
+  tmpccmr1 |= (sConfig->IC1Filter << 4) | (sConfig->IC2Filter << 12);
+
+  /* Set the TI1 and the TI2 Polarities */
+  tmpccer &= ~(TIM_CCER_CC1P | TIM_CCER_CC2P);
+  tmpccer &= ~(TIM_CCER_CC1NP | TIM_CCER_CC2NP);
+  tmpccer |= sConfig->IC1Polarity | (sConfig->IC2Polarity << 4);
+
+  /* Write to TIMx SMCR */
+  htim->Instance->SMCR = tmpsmcr;
+
+  /* Write to TIMx CCMR1 */
+  htim->Instance->CCMR1 = tmpccmr1;
+
+  /* Write to TIMx CCER */
+  htim->Instance->CCER = tmpccer;
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  DeInitialize the TIM Encoder interface
+  * @param  htim: TIM Encoder handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_TIM_Encoder_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Encoder Interface MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_Encoder_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitialize TIM Encoder Interface MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_Encoder_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the TIM Encoder Interface.
+  * @param  htim : TIM Encoder Interface handle
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_ALL: TIM Channel 1 and TIM Channel 2 are selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_Encoder_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+  /* Enable the encoder interface channels */
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+      break;
+  }
+    case TIM_CHANNEL_2:
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+      break;
+  }
+    default :
+  {
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+     break;
+    }
+  }
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Encoder Interface.
+  * @param  htim : TIM Encoder Interface handle
+  * @param  Channel : TIM Channels to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_ALL: TIM Channel 1 and TIM Channel 2 are selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+    assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+   /* Disable the Input Capture channels 1 and 2
+    (in the EncoderInterface the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2) */
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+  {
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+      break;
+  }
+    case TIM_CHANNEL_2:
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+      break;
+  }
+    default :
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+     break;
+    }
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Encoder Interface in interrupt mode.
+  * @param  htim : TIM Encoder Interface handle
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_ALL: TIM Channel 1 and TIM Channel 2 are selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_Encoder_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+  /* Enable the encoder interface channels */
+  /* Enable the capture compare Interrupts 1 and/or 2 */
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+    __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+      break;
+  }
+    case TIM_CHANNEL_2:
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+    __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+      break;
+  }
+    default :
+  {
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+     __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+     __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+     break;
+    }
+  }
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Encoder Interface in interrupt mode.
+  * @param  htim : TIM Encoder Interface handle
+  * @param  Channel : TIM Channels to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_ALL: TIM Channel 1 and TIM Channel 2 are selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+  /* Disable the Input Capture channels 1 and 2
+    (in the EncoderInterface the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2) */
+  if(Channel == TIM_CHANNEL_1)
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+
+    /* Disable the capture compare Interrupts 1 */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+  }
+  else if(Channel == TIM_CHANNEL_2)
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+
+    /* Disable the capture compare Interrupts 2 */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+  }
+  else
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+
+    /* Disable the capture compare Interrupts 1 and 2 */
+    __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Encoder Interface in DMA mode.
+  * @param  htim : TIM Encoder Interface handle
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_ALL: TIM Channel 1 and TIM Channel 2 are selected
+  * @param  pData1: The destination Buffer address for IC1.
+  * @param  pData2: The destination Buffer address for IC2.
+  * @param  Length: The length of data to be transferred from TIM peripheral to memory.
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData1, uint32_t *pData2, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((((pData1 == 0) || (pData2 == 0) )) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t )pData1, Length);
+
+      /* Enable the TIM Input Capture DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+
+      /* Enable the Peripheral */
+      __HAL_TIM_ENABLE(htim);
+
+      /* Enable the Capture compare channel */
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError;
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData2, Length);
+
+      /* Enable the TIM Input Capture  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+
+      /* Enable the Peripheral */
+      __HAL_TIM_ENABLE(htim);
+
+      /* Enable the Capture compare channel */
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+    }
+    break;
+
+    case TIM_CHANNEL_ALL:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData1, Length);
+
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData2, Length);
+
+     /* Enable the Peripheral */
+      __HAL_TIM_ENABLE(htim);
+
+      /* Enable the Capture compare channel */
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+
+      /* Enable the TIM Input Capture  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+      /* Enable the TIM Input Capture  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    default:
+    break;
+  }
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Encoder Interface in DMA mode.
+  * @param  htim : TIM Encoder Interface handle
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_ALL: TIM Channel 1 and TIM Channel 2 are selected
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+
+  /* Disable the Input Capture channels 1 and 2
+    (in the EncoderInterface the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2) */
+  if(Channel == TIM_CHANNEL_1)
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+
+    /* Disable the capture compare DMA Request 1 */
+    __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+  }
+  else if(Channel == TIM_CHANNEL_2)
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+
+    /* Disable the capture compare DMA Request 2 */
+    __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+  }
+  else
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+
+    /* Disable the capture compare DMA Request 1 and 2 */
+    __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+  }
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+/** @defgroup TIM_Exported_Functions_Group7 TIM IRQ handler management
+ *  @brief    IRQ handler management
+ *
+@verbatim
+  ==============================================================================
+                        ##### IRQ handler management #####
+  ==============================================================================
+  [..]
+    This section provides Timer IRQ handler function.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  This function handles TIM interrupts requests.
+  * @param  htim: TIM  handle
+  * @retval None
+  */
+void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
+{
+  /* Capture compare 1 event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC1) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC1) !=RESET)
+    {
+      {
+        __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC1);
+        htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+
+        /* Input capture event */
+        if((htim->Instance->CCMR1 & TIM_CCMR1_CC1S) != 0x00)
+        {
+          HAL_TIM_IC_CaptureCallback(htim);
+        }
+        /* Output compare event */
+        else
+        {
+          HAL_TIM_OC_DelayElapsedCallback(htim);
+          HAL_TIM_PWM_PulseFinishedCallback(htim);
+        }
+        htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+      }
+    }
+  }
+  /* Capture compare 2 event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC2) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC2) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC2);
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
+      /* Input capture event */
+      if((htim->Instance->CCMR1 & TIM_CCMR1_CC2S) != 0x00)
+      {
+        HAL_TIM_IC_CaptureCallback(htim);
+      }
+      /* Output compare event */
+      else
+      {
+        HAL_TIM_OC_DelayElapsedCallback(htim);
+        HAL_TIM_PWM_PulseFinishedCallback(htim);
+      }
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+    }
+  }
+  /* Capture compare 3 event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC3) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC3) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC3);
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+      /* Input capture event */
+      if((htim->Instance->CCMR2 & TIM_CCMR2_CC3S) != 0x00)
+      {
+        HAL_TIM_IC_CaptureCallback(htim);
+      }
+      /* Output compare event */
+      else
+      {
+        HAL_TIM_OC_DelayElapsedCallback(htim);
+        HAL_TIM_PWM_PulseFinishedCallback(htim);
+      }
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+    }
+  }
+  /* Capture compare 4 event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC4) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC4) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC4);
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
+      /* Input capture event */
+      if((htim->Instance->CCMR2 & TIM_CCMR2_CC4S) != 0x00)
+      {
+        HAL_TIM_IC_CaptureCallback(htim);
+      }
+      /* Output compare event */
+      else
+      {
+        HAL_TIM_OC_DelayElapsedCallback(htim);
+        HAL_TIM_PWM_PulseFinishedCallback(htim);
+      }
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+    }
+  }
+  /* TIM Update event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_UPDATE) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_UPDATE) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_UPDATE);
+      HAL_TIM_PeriodElapsedCallback(htim);
+    }
+  }
+  /* TIM Break input event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_BREAK) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_BREAK) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_BREAK);
+      HAL_TIMEx_BreakCallback(htim);
+    }
+  }
+  /* TIM Trigger detection event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_TRIGGER) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_TRIGGER) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_TRIGGER);
+      HAL_TIM_TriggerCallback(htim);
+    }
+  }
+  /* TIM commutation event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_COM) != RESET)
+  {
+    if(__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_COM) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_FLAG_COM);
+      HAL_TIMEx_CommutationCallback(htim);
+    }
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group8 Peripheral Control functions
+ *  @brief   	Peripheral Control functions
+ *
+@verbatim
+  ==============================================================================
+                   ##### Peripheral Control functions #####
+  ==============================================================================
+ [..]
+   This section provides functions allowing to:
+      (+) Configure The Input Output channels for OC, PWM, IC or One Pulse mode.
+      (+) Configure External Clock source.
+      (+) Configure Complementary channels, break features and dead time.
+      (+) Configure Master and the Slave synchronization.
+      (+) Configure the DMA Burst Mode.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the TIM Output Compare Channels according to the specified
+  *         parameters in the TIM_OC_InitTypeDef.
+  * @param  htim: TIM Output Compare handle
+  * @param  sConfig: TIM Output Compare configuration structure
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CHANNELS(Channel));
+  assert_param(IS_TIM_OC_MODE(sConfig->OCMode));
+  assert_param(IS_TIM_OC_POLARITY(sConfig->OCPolarity));
+
+  /* Check input state */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      /* Configure the TIM Channel 1 in Output Compare */
+      TIM_OC1_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      /* Configure the TIM Channel 2 in Output Compare */
+      TIM_OC2_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+       assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+      /* Configure the TIM Channel 3 in Output Compare */
+      TIM_OC3_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+       /* Configure the TIM Channel 4 in Output Compare */
+       TIM_OC4_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    default:
+    break;
+  }
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Input Capture Channels according to the specified
+  *         parameters in the TIM_IC_InitTypeDef.
+  * @param  htim: TIM IC handle
+  * @param  sConfig: TIM Input Capture configuration structure
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitTypeDef* sConfig, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_IC_POLARITY(sConfig->ICPolarity));
+  assert_param(IS_TIM_IC_SELECTION(sConfig->ICSelection));
+  assert_param(IS_TIM_IC_PRESCALER(sConfig->ICPrescaler));
+  assert_param(IS_TIM_IC_FILTER(sConfig->ICFilter));
+
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  if (Channel == TIM_CHANNEL_1)
+  {
+    /* TI1 Configuration */
+    TIM_TI1_SetConfig(htim->Instance,
+               sConfig->ICPolarity,
+               sConfig->ICSelection,
+               sConfig->ICFilter);
+
+    /* Reset the IC1PSC Bits */
+    htim->Instance->CCMR1 &= ~TIM_CCMR1_IC1PSC;
+
+    /* Set the IC1PSC value */
+    htim->Instance->CCMR1 |= sConfig->ICPrescaler;
+  }
+  else if (Channel == TIM_CHANNEL_2)
+  {
+    /* TI2 Configuration */
+    assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+    TIM_TI2_SetConfig(htim->Instance,
+                      sConfig->ICPolarity,
+                      sConfig->ICSelection,
+                      sConfig->ICFilter);
+
+    /* Reset the IC2PSC Bits */
+    htim->Instance->CCMR1 &= ~TIM_CCMR1_IC2PSC;
+
+    /* Set the IC2PSC value */
+    htim->Instance->CCMR1 |= (sConfig->ICPrescaler << 8);
+  }
+  else if (Channel == TIM_CHANNEL_3)
+  {
+    /* TI3 Configuration */
+    assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+
+    TIM_TI3_SetConfig(htim->Instance,
+               sConfig->ICPolarity,
+               sConfig->ICSelection,
+               sConfig->ICFilter);
+
+    /* Reset the IC3PSC Bits */
+    htim->Instance->CCMR2 &= ~TIM_CCMR2_IC3PSC;
+
+    /* Set the IC3PSC value */
+    htim->Instance->CCMR2 |= sConfig->ICPrescaler;
+  }
+  else
+  {
+    /* TI4 Configuration */
+    assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+
+    TIM_TI4_SetConfig(htim->Instance,
+               sConfig->ICPolarity,
+               sConfig->ICSelection,
+               sConfig->ICFilter);
+
+    /* Reset the IC4PSC Bits */
+    htim->Instance->CCMR2 &= ~TIM_CCMR2_IC4PSC;
+
+    /* Set the IC4PSC value */
+    htim->Instance->CCMR2 |= (sConfig->ICPrescaler << 8);
+  }
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM PWM  channels according to the specified
+  *         parameters in the TIM_OC_InitTypeDef.
+  * @param  htim: TIM handle
+  * @param  sConfig: TIM PWM configuration structure
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel)
+{
+  __HAL_LOCK(htim);
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CHANNELS(Channel));
+  assert_param(IS_TIM_PWM_MODE(sConfig->OCMode));
+  assert_param(IS_TIM_OC_POLARITY(sConfig->OCPolarity));
+  assert_param(IS_TIM_FAST_STATE(sConfig->OCFastMode));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      /* Configure the Channel 1 in PWM mode */
+      TIM_OC1_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel1 */
+      htim->Instance->CCMR1 |= TIM_CCMR1_OC1PE;
+
+      /* Configure the Output Fast mode */
+      htim->Instance->CCMR1 &= ~TIM_CCMR1_OC1FE;
+      htim->Instance->CCMR1 |= sConfig->OCFastMode;
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      /* Configure the Channel 2 in PWM mode */
+      TIM_OC2_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel2 */
+      htim->Instance->CCMR1 |= TIM_CCMR1_OC2PE;
+
+      /* Configure the Output Fast mode */
+      htim->Instance->CCMR1 &= ~TIM_CCMR1_OC2FE;
+      htim->Instance->CCMR1 |= sConfig->OCFastMode << 8;
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+      /* Configure the Channel 3 in PWM mode */
+      TIM_OC3_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel3 */
+      htim->Instance->CCMR2 |= TIM_CCMR2_OC3PE;
+
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR2 &= ~TIM_CCMR2_OC3FE;
+      htim->Instance->CCMR2 |= sConfig->OCFastMode;
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+      /* Configure the Channel 4 in PWM mode */
+      TIM_OC4_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel4 */
+      htim->Instance->CCMR2 |= TIM_CCMR2_OC4PE;
+
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR2 &= ~TIM_CCMR2_OC4FE;
+      htim->Instance->CCMR2 |= sConfig->OCFastMode << 8;
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM One Pulse Channels according to the specified
+  *         parameters in the TIM_OnePulse_InitTypeDef.
+  * @param  htim: TIM One Pulse handle
+  * @param  sConfig: TIM One Pulse configuration structure
+  * @param  OutputChannel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @param  InputChannel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim,  TIM_OnePulse_InitTypeDef* sConfig, uint32_t OutputChannel,  uint32_t InputChannel)
+{
+  TIM_OC_InitTypeDef temp1;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_OPM_CHANNELS(OutputChannel));
+  assert_param(IS_TIM_OPM_CHANNELS(InputChannel));
+
+  if(OutputChannel != InputChannel)
+  {
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Extract the Ouput compare configuration from sConfig structure */
+  temp1.OCMode = sConfig->OCMode;
+  temp1.Pulse = sConfig->Pulse;
+  temp1.OCPolarity = sConfig->OCPolarity;
+  temp1.OCNPolarity = sConfig->OCNPolarity;
+  temp1.OCIdleState = sConfig->OCIdleState;
+  temp1.OCNIdleState = sConfig->OCNIdleState;
+
+    switch (OutputChannel)
+  {
+    case TIM_CHANNEL_1:
+    {
+        assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+
+      TIM_OC1_SetConfig(htim->Instance, &temp1);
+    }
+    break;
+    case TIM_CHANNEL_2:
+    {
+        assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+      TIM_OC2_SetConfig(htim->Instance, &temp1);
+    }
+    break;
+    default:
+    break;
+  }
+    switch (InputChannel)
+  {
+    case TIM_CHANNEL_1:
+    {
+        assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+
+      TIM_TI1_SetConfig(htim->Instance, sConfig->ICPolarity,
+                        sConfig->ICSelection, sConfig->ICFilter);
+
+    /* Reset the IC1PSC Bits */
+    htim->Instance->CCMR1 &= ~TIM_CCMR1_IC1PSC;
+
+    /* Select the Trigger source */
+        htim->Instance->SMCR &= ~TIM_SMCR_TS;
+    htim->Instance->SMCR |= TIM_TS_TI1FP1;
+
+    /* Select the Slave Mode */
+        htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+    htim->Instance->SMCR |= TIM_SLAVEMODE_TRIGGER;
+    }
+    break;
+    case TIM_CHANNEL_2:
+    {
+        assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+      TIM_TI2_SetConfig(htim->Instance, sConfig->ICPolarity,
+                 sConfig->ICSelection, sConfig->ICFilter);
+
+      /* Reset the IC2PSC Bits */
+        htim->Instance->CCMR1 &= ~TIM_CCMR1_IC2PSC;
+
+      /* Select the Trigger source */
+        htim->Instance->SMCR &= ~TIM_SMCR_TS;
+      htim->Instance->SMCR |= TIM_TS_TI2FP2;
+
+      /* Select the Slave Mode */
+        htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+      htim->Instance->SMCR |= TIM_SLAVEMODE_TRIGGER;
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Configure the DMA Burst to transfer Data from the memory to the TIM peripheral
+  * @param  htim: TIM handle
+  * @param  BurstBaseAddress: TIM Base address from when the DMA will starts the Data write
+  *         This parameters can be on of the following values:
+  *            @arg TIM_DMABASE_CR1
+  *            @arg TIM_DMABASE_CR2
+  *            @arg TIM_DMABASE_SMCR
+  *            @arg TIM_DMABASE_DIER
+  *            @arg TIM_DMABASE_SR
+  *            @arg TIM_DMABASE_EGR
+  *            @arg TIM_DMABASE_CCMR1
+  *            @arg TIM_DMABASE_CCMR2
+  *            @arg TIM_DMABASE_CCER
+  *            @arg TIM_DMABASE_CNT
+  *            @arg TIM_DMABASE_PSC
+  *            @arg TIM_DMABASE_ARR
+  *            @arg TIM_DMABASE_RCR
+  *            @arg TIM_DMABASE_CCR1
+  *            @arg TIM_DMABASE_CCR2
+  *            @arg TIM_DMABASE_CCR3
+  *            @arg TIM_DMABASE_CCR4
+  *            @arg TIM_DMABASE_BDTR
+  *            @arg TIM_DMABASE_DCR
+  * @param  BurstRequestSrc: TIM DMA Request sources
+  *         This parameters can be on of the following values:
+  *            @arg TIM_DMA_UPDATE: TIM update Interrupt source
+  *            @arg TIM_DMA_CC1: TIM Capture Compare 1 DMA source
+  *            @arg TIM_DMA_CC2: TIM Capture Compare 2 DMA source
+  *            @arg TIM_DMA_CC3: TIM Capture Compare 3 DMA source
+  *            @arg TIM_DMA_CC4: TIM Capture Compare 4 DMA source
+  *            @arg TIM_DMA_COM: TIM Commutation DMA source
+  *            @arg TIM_DMA_TRIGGER: TIM Trigger DMA source
+  * @param  BurstBuffer: The Buffer address.
+  * @param  BurstLength: DMA Burst length. This parameter can be one value
+  *         between: TIM_DMABurstLength_1Transfer and TIM_DMABurstLength_18Transfers.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc,
+                                              uint32_t* BurstBuffer, uint32_t  BurstLength)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMABURST_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_DMA_BASE(BurstBaseAddress));
+  assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
+  assert_param(IS_TIM_DMA_LENGTH(BurstLength));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((BurstBuffer == 0 ) && (BurstLength > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch(BurstRequestSrc)
+  {
+    case TIM_DMA_UPDATE:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_UPDATE]->XferCpltCallback = TIM_DMAPeriodElapsedCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_UPDATE]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback =  TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback =  TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback =  TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC4:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback =  TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_COM:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_COMMUTATION]->XferCpltCallback =  TIMEx_DMACommutationCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_COMMUTATION]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_COMMUTATION], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_TRIGGER:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_TRIGGER]->XferCpltCallback = TIM_DMATriggerCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_TRIGGER]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_TRIGGER], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    default:
+    break;
+  }
+   /* configure the DMA Burst Mode */
+   htim->Instance->DCR = BurstBaseAddress | BurstLength;
+
+   /* Enable the TIM DMA Request */
+   __HAL_TIM_ENABLE_DMA(htim, BurstRequestSrc);
+
+   htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM DMA Burst mode
+  * @param  htim: TIM handle
+  * @param  BurstRequestSrc: TIM DMA Request sources to disable
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
+
+  /* Abort the DMA transfer (at least disable the DMA channel) */
+  switch(BurstRequestSrc)
+  {
+    case TIM_DMA_UPDATE:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_UPDATE]);
+    }
+    break;
+    case TIM_DMA_CC1:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC1]);
+    }
+    break;
+    case TIM_DMA_CC2:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC2]);
+    }
+    break;
+    case TIM_DMA_CC3:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC3]);
+    }
+    break;
+    case TIM_DMA_CC4:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC4]);
+    }
+    break;
+    case TIM_DMA_COM:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_COMMUTATION]);
+    }
+    break;
+    case TIM_DMA_TRIGGER:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_TRIGGER]);
+    }
+    break;
+    default:
+    break;
+  }
+
+  /* Disable the TIM Update DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configure the DMA Burst to transfer Data from the TIM peripheral to the memory
+  * @param  htim: TIM handle
+  * @param  BurstBaseAddress: TIM Base address from when the DMA will starts the Data read
+  *         This parameters can be on of the following values:
+  *            @arg TIM_DMABASE_CR1
+  *            @arg TIM_DMABASE_CR2
+  *            @arg TIM_DMABASE_SMCR
+  *            @arg TIM_DMABASE_DIER
+  *            @arg TIM_DMABASE_SR
+  *            @arg TIM_DMABASE_EGR
+  *            @arg TIM_DMABASE_CCMR1
+  *            @arg TIM_DMABASE_CCMR2
+  *            @arg TIM_DMABASE_CCER
+  *            @arg TIM_DMABASE_CNT
+  *            @arg TIM_DMABASE_PSC
+  *            @arg TIM_DMABASE_ARR
+  *            @arg TIM_DMABASE_RCR
+  *            @arg TIM_DMABASE_CCR1
+  *            @arg TIM_DMABASE_CCR2
+  *            @arg TIM_DMABASE_CCR3
+  *            @arg TIM_DMABASE_CCR4
+  *            @arg TIM_DMABASE_BDTR
+  *            @arg TIM_DMABASE_DCR
+  * @param  BurstRequestSrc: TIM DMA Request sources
+  *         This parameters can be on of the following values:
+  *            @arg TIM_DMA_UPDATE: TIM update Interrupt source
+  *            @arg TIM_DMA_CC1: TIM Capture Compare 1 DMA source
+  *            @arg TIM_DMA_CC2: TIM Capture Compare 2 DMA source
+  *            @arg TIM_DMA_CC3: TIM Capture Compare 3 DMA source
+  *            @arg TIM_DMA_CC4: TIM Capture Compare 4 DMA source
+  *            @arg TIM_DMA_COM: TIM Commutation DMA source
+  *            @arg TIM_DMA_TRIGGER: TIM Trigger DMA source
+  * @param  BurstBuffer: The Buffer address.
+  * @param  BurstLength: DMA Burst length. This parameter can be one value
+  *         between: TIM_DMABurstLength_1Transfer and TIM_DMABurstLength_18Transfers.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc,
+                                             uint32_t  *BurstBuffer, uint32_t  BurstLength)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMABURST_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_DMA_BASE(BurstBaseAddress));
+  assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
+  assert_param(IS_TIM_DMA_LENGTH(BurstLength));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((BurstBuffer == 0 ) && (BurstLength > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch(BurstRequestSrc)
+  {
+    case TIM_DMA_UPDATE:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_UPDATE]->XferCpltCallback = TIM_DMAPeriodElapsedCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_UPDATE]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+       HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback =  TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback =  TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback =  TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_CC4:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback =  TIM_DMACaptureCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_COM:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_COMMUTATION]->XferCpltCallback =  TIMEx_DMACommutationCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_COMMUTATION]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_COMMUTATION], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    case TIM_DMA_TRIGGER:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_TRIGGER]->XferCpltCallback = TIM_DMATriggerCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_TRIGGER]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_TRIGGER], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);
+    }
+    break;
+    default:
+    break;
+  }
+
+  /* configure the DMA Burst Mode */
+  htim->Instance->DCR = BurstBaseAddress | BurstLength;
+
+  /* Enable the TIM DMA Request */
+  __HAL_TIM_ENABLE_DMA(htim, BurstRequestSrc);
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop the DMA burst reading
+  * @param  htim: TIM handle
+  * @param  BurstRequestSrc: TIM DMA Request sources to disable.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
+
+  /* Abort the DMA transfer (at least disable the DMA channel) */
+  switch(BurstRequestSrc)
+  {
+    case TIM_DMA_UPDATE:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_UPDATE]);
+    }
+    break;
+    case TIM_DMA_CC1:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC1]);
+    }
+    break;
+    case TIM_DMA_CC2:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC2]);
+    }
+    break;
+    case TIM_DMA_CC3:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC3]);
+    }
+    break;
+    case TIM_DMA_CC4:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_CC4]);
+    }
+    break;
+    case TIM_DMA_COM:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_COMMUTATION]);
+    }
+    break;
+    case TIM_DMA_TRIGGER:
+    {
+      HAL_DMA_Abort(htim->hdma[TIM_DMA_ID_TRIGGER]);
+    }
+    break;
+    default:
+    break;
+  }
+
+  /* Disable the TIM Update DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Generate a software event
+  * @param  htim: TIM handle
+  * @param  EventSource: specifies the event source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_EVENTSOURCE_UPDATE: Timer update Event source
+  *            @arg TIM_EVENTSOURCE_CC1: Timer Capture Compare 1 Event source
+  *            @arg TIM_EVENTSOURCE_CC2: Timer Capture Compare 2 Event source
+  *            @arg TIM_EVENTSOURCE_CC3: Timer Capture Compare 3 Event source
+  *            @arg TIM_EVENTSOURCE_CC4: Timer Capture Compare 4 Event source
+  *            @arg TIM_EVENTSOURCE_COM: Timer COM event source
+  *            @arg TIM_EVENTSOURCE_TRIGGER: Timer Trigger Event source
+  *            @arg TIM_EVENTSOURCE_BREAK: Timer Break event source
+  *            @arg TIM_EVENTSOURCE_BREAK2: Timer Break2 event source
+  * @retval None
+  */
+
+HAL_StatusTypeDef HAL_TIM_GenerateEvent(TIM_HandleTypeDef *htim, uint32_t EventSource)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_EVENT_SOURCE(EventSource));
+
+  /* Process Locked */
+  __HAL_LOCK(htim);
+
+  /* Change the TIM state */
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Set the event sources */
+  htim->Instance->EGR = EventSource;
+
+  /* Change the TIM state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the OCRef clear feature
+  * @param  htim: TIM handle
+  * @param  sClearInputConfig: pointer to a TIM_ClearInputConfigTypeDef structure that
+  *         contains the OCREF clear feature and parameters for the TIM peripheral.
+  * @param  Channel: specifies the TIM Channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1
+  *            @arg TIM_CHANNEL_2: TIM Channel 2
+  *            @arg TIM_CHANNEL_3: TIM Channel 3
+  *            @arg TIM_CHANNEL_4: TIM Channel 4
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim, TIM_ClearInputConfigTypeDef * sClearInputConfig, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_CHANNELS(Channel));
+  assert_param(IS_TIM_CLEARINPUT_SOURCE(sClearInputConfig->ClearInputSource));
+
+  /* Process Locked */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  if(sClearInputConfig->ClearInputSource == TIM_CLEARINPUTSOURCE_ETR)
+  {
+    /* Check the parameters */
+    assert_param(IS_TIM_CLEARINPUT_POLARITY(sClearInputConfig->ClearInputPolarity));
+    assert_param(IS_TIM_CLEARINPUT_PRESCALER(sClearInputConfig->ClearInputPrescaler));
+    assert_param(IS_TIM_CLEARINPUT_FILTER(sClearInputConfig->ClearInputFilter));
+
+    TIM_ETR_SetConfig(htim->Instance,
+                      sClearInputConfig->ClearInputPrescaler,
+                      sClearInputConfig->ClearInputPolarity,
+                      sClearInputConfig->ClearInputFilter);
+  }
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      if(sClearInputConfig->ClearInputState != RESET)
+      {
+      /* Enable the OCREF clear feature for Channel 1 */
+      htim->Instance->CCMR1 |= TIM_CCMR1_OC1CE;
+      }
+      else
+      {
+        /* Disable the OCREF clear feature for Channel 1 */
+        htim->Instance->CCMR1 &= ~TIM_CCMR1_OC1CE;
+      }
+    }
+    break;
+    case TIM_CHANNEL_2:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      if(sClearInputConfig->ClearInputState != RESET)
+      {
+      /* Enable the OCREF clear feature for Channel 2 */
+      htim->Instance->CCMR1 |= TIM_CCMR1_OC2CE;
+      }
+      else
+      {
+        /* Disable the OCREF clear feature for Channel 2 */
+        htim->Instance->CCMR1 &= ~TIM_CCMR1_OC2CE;
+      }
+    }
+    break;
+    case TIM_CHANNEL_3:
+    {
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+      if(sClearInputConfig->ClearInputState != RESET)
+      {
+      /* Enable the OCREF clear feature for Channel 3 */
+      htim->Instance->CCMR2 |= TIM_CCMR2_OC3CE;
+      }
+      else
+      {
+        /* Disable the OCREF clear feature for Channel 3 */
+        htim->Instance->CCMR2 &= ~TIM_CCMR2_OC3CE;
+      }
+    }
+    break;
+    case TIM_CHANNEL_4:
+    {
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+      if(sClearInputConfig->ClearInputState != RESET)
+      {
+      /* Enable the OCREF clear feature for Channel 4 */
+      htim->Instance->CCMR2 |= TIM_CCMR2_OC4CE;
+      }
+      else
+      {
+        /* Disable the OCREF clear feature for Channel 4 */
+        htim->Instance->CCMR2 &= ~TIM_CCMR2_OC4CE;
+      }
+    }
+    break;
+    default:
+    break;
+  }
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief   Configures the clock source to be used
+  * @param  htim: TIM handle
+  * @param  sClockSourceConfig: pointer to a TIM_ClockConfigTypeDef structure that
+  *         contains the clock source information for the TIM peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_ConfigClockSource(TIM_HandleTypeDef *htim, TIM_ClockConfigTypeDef * sClockSourceConfig)
+{
+  uint32_t tmpsmcr = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CLOCKSOURCE(sClockSourceConfig->ClockSource));
+
+  /* Reset the SMS, TS, ECE, ETPS and ETRF bits */
+  tmpsmcr = htim->Instance->SMCR;
+  tmpsmcr &= ~(TIM_SMCR_SMS | TIM_SMCR_TS);
+  tmpsmcr &= ~(TIM_SMCR_ETF | TIM_SMCR_ETPS | TIM_SMCR_ECE | TIM_SMCR_ETP);
+  htim->Instance->SMCR = tmpsmcr;
+
+  switch (sClockSourceConfig->ClockSource)
+  {
+  case TIM_CLOCKSOURCE_INTERNAL:
+    {
+      assert_param(IS_TIM_INSTANCE(htim->Instance));
+      /* Disable slave mode to clock the prescaler directly with the internal clock */
+      htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+    }
+    break;
+
+  case TIM_CLOCKSOURCE_ETRMODE1:
+    {
+      /* Check whether or not the timer instance supports external trigger input mode 1 (ETRF)*/
+      assert_param(IS_TIM_CLOCKSOURCE_ETRMODE1_INSTANCE(htim->Instance));
+
+      /* Check ETR input conditioning related parameters */
+      assert_param(IS_TIM_CLOCKPRESCALER(sClockSourceConfig->ClockPrescaler));
+      assert_param(IS_TIM_CLOCKPOLARITY(sClockSourceConfig->ClockPolarity));
+      assert_param(IS_TIM_CLOCKFILTER(sClockSourceConfig->ClockFilter));
+      
+      /* Configure the ETR Clock source */
+      TIM_ETR_SetConfig(htim->Instance,
+                        sClockSourceConfig->ClockPrescaler,
+                        sClockSourceConfig->ClockPolarity,
+                        sClockSourceConfig->ClockFilter);
+      /* Get the TIMx SMCR register value */
+      tmpsmcr = htim->Instance->SMCR;
+      /* Reset the SMS and TS Bits */
+      tmpsmcr &= ~(TIM_SMCR_SMS | TIM_SMCR_TS);
+      /* Select the External clock mode1 and the ETRF trigger */
+      tmpsmcr |= (TIM_SLAVEMODE_EXTERNAL1 | TIM_CLOCKSOURCE_ETRMODE1);
+      /* Write to TIMx SMCR */
+      htim->Instance->SMCR = tmpsmcr;
+    }
+    break;
+
+  case TIM_CLOCKSOURCE_ETRMODE2:
+    {
+      /* Check whether or not the timer instance supports external trigger input mode 2 (ETRF)*/
+      assert_param(IS_TIM_CLOCKSOURCE_ETRMODE2_INSTANCE(htim->Instance));
+
+      /* Check ETR input conditioning related parameters */
+      assert_param(IS_TIM_CLOCKPRESCALER(sClockSourceConfig->ClockPrescaler));
+      assert_param(IS_TIM_CLOCKPOLARITY(sClockSourceConfig->ClockPolarity));
+      assert_param(IS_TIM_CLOCKFILTER(sClockSourceConfig->ClockFilter));
+      
+      /* Configure the ETR Clock source */
+      TIM_ETR_SetConfig(htim->Instance,
+                        sClockSourceConfig->ClockPrescaler,
+                        sClockSourceConfig->ClockPolarity,
+                        sClockSourceConfig->ClockFilter);
+      /* Enable the External clock mode2 */
+      htim->Instance->SMCR |= TIM_SMCR_ECE;
+    }
+    break;
+
+  case TIM_CLOCKSOURCE_TI1:
+    {
+      /* Check whether or not the timer instance supports external clock mode 1 */
+      assert_param(IS_TIM_CLOCKSOURCE_TIX_INSTANCE(htim->Instance));
+
+      /* Check TI1 input conditioning related parameters */
+      assert_param(IS_TIM_CLOCKPOLARITY(sClockSourceConfig->ClockPolarity));
+      assert_param(IS_TIM_CLOCKFILTER(sClockSourceConfig->ClockFilter));
+      
+      TIM_TI1_ConfigInputStage(htim->Instance,
+                               sClockSourceConfig->ClockPolarity,
+                               sClockSourceConfig->ClockFilter);
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_TI1);
+    }
+    break;
+    
+  case TIM_CLOCKSOURCE_TI2:
+    {
+      /* Check whether or not the timer instance supports external clock mode 1 (ETRF)*/
+      assert_param(IS_TIM_CLOCKSOURCE_TIX_INSTANCE(htim->Instance));
+
+       /* Check TI2 input conditioning related parameters */
+      assert_param(IS_TIM_CLOCKPOLARITY(sClockSourceConfig->ClockPolarity));
+      assert_param(IS_TIM_CLOCKFILTER(sClockSourceConfig->ClockFilter));
+
+      TIM_TI2_ConfigInputStage(htim->Instance,
+                               sClockSourceConfig->ClockPolarity,
+                               sClockSourceConfig->ClockFilter);
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_TI2);
+    }
+    break;
+
+  case TIM_CLOCKSOURCE_TI1ED:
+    {
+      /* Check whether or not the timer instance supports external clock mode 1 */
+      assert_param(IS_TIM_CLOCKSOURCE_TIX_INSTANCE(htim->Instance));
+
+      /* Check TI1 input conditioning related parameters */
+      assert_param(IS_TIM_CLOCKPOLARITY(sClockSourceConfig->ClockPolarity));
+      assert_param(IS_TIM_CLOCKFILTER(sClockSourceConfig->ClockFilter));
+
+      TIM_TI1_ConfigInputStage(htim->Instance,
+                               sClockSourceConfig->ClockPolarity,
+                               sClockSourceConfig->ClockFilter);
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_TI1ED);
+    }
+    break;
+    
+  case TIM_CLOCKSOURCE_ITR0:
+    {
+      /* Check whether or not the timer instance supports internal trigger input */
+      assert_param(IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(htim->Instance));
+
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_ITR0);
+    }
+    break;
+    
+  case TIM_CLOCKSOURCE_ITR1:
+    {
+      /* Check whether or not the timer instance supports internal trigger input */
+      assert_param(IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(htim->Instance));
+
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_ITR1);
+    }
+    break;
+    
+  case TIM_CLOCKSOURCE_ITR2:
+    {
+      /* Check whether or not the timer instance supports internal trigger input */
+      assert_param(IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(htim->Instance));
+
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_ITR2);
+    }
+    break;
+    
+  case TIM_CLOCKSOURCE_ITR3:
+    {
+      /* Check whether or not the timer instance supports internal trigger input */
+      assert_param(IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(htim->Instance));
+
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_ITR3);
+    }
+    break;
+
+  default:
+    break;
+  }
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Selects the signal connected to the TI1 input: direct from CH1_input
+  *         or a XOR combination between CH1_input, CH2_input & CH3_input
+  * @param  htim: TIM handle.
+  * @param  TI1_Selection: Indicate whether or not channel 1 is connected to the
+  *         output of a XOR gate.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TI1SELECTION_CH1: The TIMx_CH1 pin is connected to TI1 input
+  *            @arg TIM_TI1SELECTION_XORCOMBINATION: The TIMx_CH1, CH2 and CH3
+  *            pins are connected to the TI1 input (XOR combination)
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_ConfigTI1Input(TIM_HandleTypeDef *htim, uint32_t TI1_Selection)
+{
+  uint32_t tmpcr2 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_TI1SELECTION(TI1_Selection));
+
+  /* Get the TIMx CR2 register value */
+  tmpcr2 = htim->Instance->CR2;
+
+  /* Reset the TI1 selection */
+  tmpcr2 &= ~TIM_CR2_TI1S;
+
+  /* Set the TI1 selection */
+  tmpcr2 |= TI1_Selection;
+
+  /* Write to TIMxCR2 */
+  htim->Instance->CR2 = tmpcr2;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the TIM in Slave mode
+  * @param  htim: TIM handle.
+  * @param  sSlaveConfig: pointer to a TIM_SlaveConfigTypeDef structure that
+  *         contains the selected trigger (internal trigger input, filtered
+  *         timer input or external trigger input) and the ) and the Slave
+  *         mode (Disable, Reset, Gated, Trigger, External clock mode 1).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchronization(TIM_HandleTypeDef *htim, TIM_SlaveConfigTypeDef * sSlaveConfig)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_SLAVE_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_SLAVE_MODE(sSlaveConfig->SlaveMode));
+  assert_param(IS_TIM_TRIGGER_SELECTION(sSlaveConfig->InputTrigger));
+
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  TIM_SlaveTimer_SetConfig(htim, sSlaveConfig);
+  
+  /* Disable Trigger Interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_TRIGGER);
+
+  /* Disable Trigger DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_TRIGGER);
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);  
+
+  return HAL_OK;
+    }
+
+/**
+  * @brief  Configures the TIM in Slave mode in interrupt mode
+  * @param  htim: TIM handle.
+  * @param  sSlaveConfig: pointer to a TIM_SlaveConfigTypeDef structure that
+  *         contains the selected trigger (internal trigger input, filtered
+  *         timer input or external trigger input) and the ) and the Slave 
+  *         mode (Disable, Reset, Gated, Trigger, External clock mode 1). 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchronization_IT(TIM_HandleTypeDef *htim, 
+                                                        TIM_SlaveConfigTypeDef * sSlaveConfig)
+    {
+      /* Check the parameters */
+  assert_param(IS_TIM_SLAVE_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_SLAVE_MODE(sSlaveConfig->SlaveMode));
+  assert_param(IS_TIM_TRIGGER_SELECTION(sSlaveConfig->InputTrigger));
+  
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  TIM_SlaveTimer_SetConfig(htim, sSlaveConfig);
+
+  /* Enable Trigger Interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_TRIGGER);
+
+  /* Disable Trigger DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_TRIGGER);
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);  
+
+  return HAL_OK;
+    }
+
+/**
+  * @brief  Read the captured value from Capture Compare unit
+  * @param  htim: TIM handle.
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval Captured value
+  */
+uint32_t HAL_TIM_ReadCapturedValue(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  uint32_t tmpreg = 0;
+
+  __HAL_LOCK(htim);
+
+  switch (Channel)
+  {
+  case TIM_CHANNEL_1:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+
+      /* Return the capture 1 value */
+      tmpreg =  htim->Instance->CCR1;
+
+      break;
+    }
+  case TIM_CHANNEL_2:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+      /* Return the capture 2 value */
+      tmpreg =   htim->Instance->CCR2;
+
+      break;
+    }
+
+  case TIM_CHANNEL_3:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+
+      /* Return the capture 3 value */
+      tmpreg =   htim->Instance->CCR3;
+
+      break;
+    }
+
+  case TIM_CHANNEL_4:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+
+      /* Return the capture 4 value */
+      tmpreg =   htim->Instance->CCR4;
+
+      break;
+    }
+
+  default:
+    break;
+  }
+
+  __HAL_UNLOCK(htim);
+  return tmpreg;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group9 TIM Callbacks functions
+ *  @brief    TIM Callbacks functions
+ *
+@verbatim
+  ==============================================================================
+                        ##### TIM Callbacks functions #####
+  ==============================================================================
+ [..]
+   This section provides TIM callback functions:
+   (+) Timer Period elapsed callback
+   (+) Timer Output Compare callback
+   (+) Timer Input capture callback
+   (+) Timer Trigger callback
+   (+) Timer Error callback
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Period elapsed callback in non-blocking mode
+  * @param  htim : TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the __HAL_TIM_PeriodElapsedCallback could be implemented in the user file
+   */
+
+}
+/**
+  * @brief  Output Compare callback in non-blocking mode
+  * @param  htim : TIM OC handle
+  * @retval None
+  */
+__weak void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the __HAL_TIM_OC_DelayElapsedCallback could be implemented in the user file
+   */
+}
+/**
+  * @brief  Input Capture callback in non-blocking mode
+  * @param  htim : TIM IC handle
+  * @retval None
+  */
+__weak void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the __HAL_TIM_IC_CaptureCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  PWM Pulse finished callback in non-blocking mode
+  * @param  htim : TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the __HAL_TIM_PWM_PulseFinishedCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Hall Trigger detection callback in non-blocking mode
+  * @param  htim : TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_TriggerCallback(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_TriggerCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Timer error callback in non-blocking mode
+  * @param  htim : TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_ErrorCallback(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIM_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Exported_Functions_Group10 Peripheral State functions
+ *  @brief   Peripheral State functions
+ *
+@verbatim
+  ==============================================================================
+                        ##### Peripheral State functions #####
+  ==============================================================================
+    [..]
+    This subsection permits to get in run-time the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the TIM Base handle state.
+  * @param  htim: TIM Base handle
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM OC handle state.
+  * @param  htim: TIM Ouput Compare handle
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_OC_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM PWM handle state.
+  * @param  htim: TIM handle
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM Input Capture handle state.
+  * @param  htim: TIM IC handle
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM One Pulse Mode handle state.
+  * @param  htim: TIM OPM handle
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM Encoder Mode handle state.
+  * @param  htim: TIM Encoder handle
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  TIM DMA error callback
+  * @param  hdma : pointer to DMA handle.
+  * @retval None
+  */
+void TIM_DMAError(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  htim->State= HAL_TIM_STATE_READY;
+
+  HAL_TIM_ErrorCallback(htim);
+}
+
+/**
+  * @brief  TIM DMA Delay Pulse complete callback.
+  * @param  hdma : pointer to DMA handle.
+  * @retval None
+  */
+void TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  htim->State= HAL_TIM_STATE_READY;
+
+  if (hdma == htim->hdma[TIM_DMA_ID_CC1])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC2])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC3])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
+  }
+
+  HAL_TIM_PWM_PulseFinishedCallback(htim);
+
+  htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+}
+/**
+  * @brief  TIM DMA Capture complete callback.
+  * @param  hdma : pointer to DMA handle.
+  * @retval None
+  */
+void TIM_DMACaptureCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  htim->State= HAL_TIM_STATE_READY;
+
+  if (hdma == htim->hdma[TIM_DMA_ID_CC1])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC2])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC3])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
+  }
+
+  HAL_TIM_IC_CaptureCallback(htim);
+
+  htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+}
+
+/**
+  * @brief  TIM DMA Period Elapse complete callback.
+  * @param  hdma : pointer to DMA handle.
+  * @retval None
+  */
+static void TIM_DMAPeriodElapsedCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  htim->State= HAL_TIM_STATE_READY;
+
+  HAL_TIM_PeriodElapsedCallback(htim);
+}
+
+/**
+  * @brief  TIM DMA Trigger callback.
+  * @param  hdma : pointer to DMA handle.
+  * @retval None
+  */
+static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  htim->State= HAL_TIM_STATE_READY;
+
+  HAL_TIM_TriggerCallback(htim);
+}
+
+/**
+  * @brief  Time Base configuration
+  * @param  TIMx: TIM peripheral
+  * @param  Structure: TIM Base configuration structure
+  * @retval None
+  */
+void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure)
+{
+  uint32_t tmpcr1 = 0;
+  tmpcr1 = TIMx->CR1;
+
+  /* Set TIM Time Base Unit parameters ---------------------------------------*/
+  if (IS_TIM_COUNTER_MODE_SELECT_INSTANCE(TIMx))
+  {
+    /* Select the Counter Mode */
+    tmpcr1 &= ~(TIM_CR1_DIR | TIM_CR1_CMS);
+    tmpcr1 |= Structure->CounterMode;
+  }
+
+  if(IS_TIM_CLOCK_DIVISION_INSTANCE(TIMx))
+  {
+    /* Set the clock division */
+    tmpcr1 &= ~TIM_CR1_CKD;
+    tmpcr1 |= (uint32_t)Structure->ClockDivision;
+  }
+
+  TIMx->CR1 = tmpcr1;
+
+  /* Set the Autoreload value */
+  TIMx->ARR = (uint32_t)Structure->Period ;
+
+  /* Set the Prescaler value */
+  TIMx->PSC = (uint32_t)Structure->Prescaler;
+
+  if (IS_TIM_REPETITION_COUNTER_INSTANCE(TIMx))
+  {
+    /* Set the Repetition Counter value */
+    TIMx->RCR = Structure->RepetitionCounter;
+  }
+
+  /* Generate an update event to reload the Prescaler
+     and the repetition counter(only for TIM1 and TIM8) value immediately */
+  TIMx->EGR = TIM_EGR_UG;
+}
+
+/**
+  * @brief  Time Ouput Compare 1 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The ouput configuration structure
+  * @retval None
+  */
+void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+   /* Disable the Channel 1: Reset the CC1E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC1E;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 =  TIMx->CR2;
+
+  /* Get the TIMx CCMR1 register value */
+  tmpccmrx = TIMx->CCMR1;
+
+  /* Reset the Output Compare Mode Bits */
+  tmpccmrx &= ~TIM_CCMR1_OC1M;
+  tmpccmrx &= ~TIM_CCMR1_CC1S;
+  /* Select the Output Compare Mode */
+  tmpccmrx |= OC_Config->OCMode;
+
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC1P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= OC_Config->OCPolarity;
+
+  if(IS_TIM_CCXN_INSTANCE(TIMx, TIM_CHANNEL_1))
+  {
+    /* Check parameters */
+    assert_param(IS_TIM_OCN_POLARITY(OC_Config->OCNPolarity));
+
+    /* Reset the Output N Polarity level */
+    tmpccer &= ~TIM_CCER_CC1NP;
+    /* Set the Output N Polarity */
+    tmpccer |= OC_Config->OCNPolarity;
+    /* Reset the Output N State */
+    tmpccer &= ~TIM_CCER_CC1NE;
+  }
+
+  if(IS_TIM_BREAK_INSTANCE(TIMx))
+  {
+    /* Check parameters */
+    assert_param(IS_TIM_OCNIDLE_STATE(OC_Config->OCNIdleState));
+    assert_param(IS_TIM_OCIDLE_STATE(OC_Config->OCIdleState));
+
+    /* Reset the Output Compare and Output Compare N IDLE State */
+    tmpcr2 &= ~TIM_CR2_OIS1;
+    tmpcr2 &= ~TIM_CR2_OIS1N;
+    /* Set the Output Idle state */
+    tmpcr2 |= OC_Config->OCIdleState;
+    /* Set the Output N Idle state */
+    tmpcr2 |= OC_Config->OCNIdleState;
+  }
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+
+  /* Write to TIMx CCMR1 */
+  TIMx->CCMR1 = tmpccmrx;
+
+  /* Set the Capture Compare Register value */
+  TIMx->CCR1 = OC_Config->Pulse;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Time Ouput Compare 2 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The ouput configuration structure
+  * @retval None
+  */
+void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+  /* Disable the Channel 2: Reset the CC2E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC2E;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 =  TIMx->CR2;
+
+  /* Get the TIMx CCMR1 register value */
+  tmpccmrx = TIMx->CCMR1;
+
+  /* Reset the Output Compare mode and Capture/Compare selection Bits */
+  tmpccmrx &= ~TIM_CCMR1_OC2M;
+  tmpccmrx &= ~TIM_CCMR1_CC2S;
+
+  /* Select the Output Compare Mode */
+  tmpccmrx |= (OC_Config->OCMode << 8);
+
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC2P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 4);
+
+  if(IS_TIM_CCXN_INSTANCE(TIMx, TIM_CHANNEL_2))
+  {
+    assert_param(IS_TIM_OCN_POLARITY(OC_Config->OCNPolarity));
+
+    /* Reset the Output N Polarity level */
+    tmpccer &= ~TIM_CCER_CC2NP;
+    /* Set the Output N Polarity */
+    tmpccer |= (OC_Config->OCNPolarity << 4);
+    /* Reset the Output N State */
+    tmpccer &= ~TIM_CCER_CC2NE;
+
+  }
+
+  if(IS_TIM_BREAK_INSTANCE(TIMx))
+  {
+    /* Check parameters */
+    assert_param(IS_TIM_OCNIDLE_STATE(OC_Config->OCNIdleState));
+    assert_param(IS_TIM_OCIDLE_STATE(OC_Config->OCIdleState));
+
+    /* Reset the Output Compare and Output Compare N IDLE State */
+    tmpcr2 &= ~TIM_CR2_OIS2;
+    tmpcr2 &= ~TIM_CR2_OIS2N;
+    /* Set the Output Idle state */
+    tmpcr2 |= (OC_Config->OCIdleState << 2);
+    /* Set the Output N Idle state */
+    tmpcr2 |= (OC_Config->OCNIdleState << 2);
+  }
+
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+
+  /* Write to TIMx CCMR1 */
+  TIMx->CCMR1 = tmpccmrx;
+
+  /* Set the Capture Compare Register value */
+  TIMx->CCR2 = OC_Config->Pulse;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Time Ouput Compare 3 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The ouput configuration structure
+  * @retval None
+  */
+void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+  /* Disable the Channel 3: Reset the CC2E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC3E;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 =  TIMx->CR2;
+
+  /* Get the TIMx CCMR2 register value */
+  tmpccmrx = TIMx->CCMR2;
+
+  /* Reset the Output Compare mode and Capture/Compare selection Bits */
+  tmpccmrx &= ~TIM_CCMR2_OC3M;
+  tmpccmrx &= ~TIM_CCMR2_CC3S;
+  /* Select the Output Compare Mode */
+  tmpccmrx |= OC_Config->OCMode;
+
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC3P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 8);
+
+  if(IS_TIM_CCXN_INSTANCE(TIMx, TIM_CHANNEL_3))
+  {
+    assert_param(IS_TIM_OCN_POLARITY(OC_Config->OCNPolarity));
+
+    /* Reset the Output N Polarity level */
+    tmpccer &= ~TIM_CCER_CC3NP;
+    /* Set the Output N Polarity */
+    tmpccer |= (OC_Config->OCNPolarity << 8);
+    /* Reset the Output N State */
+    tmpccer &= ~TIM_CCER_CC3NE;
+  }
+
+  if(IS_TIM_BREAK_INSTANCE(TIMx))
+  {
+    /* Check parameters */
+    assert_param(IS_TIM_OCNIDLE_STATE(OC_Config->OCNIdleState));
+    assert_param(IS_TIM_OCIDLE_STATE(OC_Config->OCIdleState));
+
+    /* Reset the Output Compare and Output Compare N IDLE State */
+    tmpcr2 &= ~TIM_CR2_OIS3;
+    tmpcr2 &= ~TIM_CR2_OIS3N;
+    /* Set the Output Idle state */
+    tmpcr2 |= (OC_Config->OCIdleState << 4);
+    /* Set the Output N Idle state */
+    tmpcr2 |= (OC_Config->OCNIdleState << 4);
+  }
+
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+
+  /* Write to TIMx CCMR2 */
+  TIMx->CCMR2 = tmpccmrx;
+
+  /* Set the Capture Compare Register value */
+  TIMx->CCR3 = OC_Config->Pulse;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Time Ouput Compare 4 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The ouput configuration structure
+  * @retval None
+  */
+void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+  /* Disable the Channel 4: Reset the CC4E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC4E;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 =  TIMx->CR2;
+
+  /* Get the TIMx CCMR2 register value */
+  tmpccmrx = TIMx->CCMR2;
+
+  /* Reset the Output Compare mode and Capture/Compare selection Bits */
+  tmpccmrx &= ~TIM_CCMR2_OC4M;
+  tmpccmrx &= ~TIM_CCMR2_CC4S;
+
+  /* Select the Output Compare Mode */
+  tmpccmrx |= (OC_Config->OCMode << 8);
+
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC4P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 12);
+
+  if(IS_TIM_BREAK_INSTANCE(TIMx))
+  {
+    assert_param(IS_TIM_OCIDLE_STATE(OC_Config->OCIdleState));
+
+   /* Reset the Output Compare IDLE State */
+    tmpcr2 &= ~TIM_CR2_OIS4;
+    /* Set the Output Idle state */
+    tmpcr2 |= (OC_Config->OCIdleState << 6);
+  }
+
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+
+  /* Write to TIMx CCMR2 */
+  TIMx->CCMR2 = tmpccmrx;
+
+  /* Set the Capture Compare Register value */
+  TIMx->CCR4 = OC_Config->Pulse;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+static void TIM_SlaveTimer_SetConfig(TIM_HandleTypeDef *htim,
+                                     TIM_SlaveConfigTypeDef * sSlaveConfig)
+{
+  uint32_t tmpsmcr = 0;
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Get the TIMx SMCR register value */
+  tmpsmcr = htim->Instance->SMCR;
+
+  /* Reset the Trigger Selection Bits */
+  tmpsmcr &= ~TIM_SMCR_TS;
+  /* Set the Input Trigger source */
+  tmpsmcr |= sSlaveConfig->InputTrigger;
+
+  /* Reset the slave mode Bits */
+  tmpsmcr &= ~TIM_SMCR_SMS;
+  /* Set the slave mode */
+  tmpsmcr |= sSlaveConfig->SlaveMode;
+
+  /* Write to TIMx SMCR */
+  htim->Instance->SMCR = tmpsmcr;
+ 
+  /* Configure the trigger prescaler, filter, and polarity */
+  switch (sSlaveConfig->InputTrigger)
+  {
+  case TIM_TS_ETRF:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CLOCKSOURCE_ETRMODE1_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPRESCALER(sSlaveConfig->TriggerPrescaler));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+      /* Configure the ETR Trigger source */
+      TIM_ETR_SetConfig(htim->Instance, 
+                        sSlaveConfig->TriggerPrescaler, 
+                        sSlaveConfig->TriggerPolarity, 
+                        sSlaveConfig->TriggerFilter);
+    }
+    break;
+    
+  case TIM_TS_TI1F_ED:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+  
+      /* Disable the Channel 1: Reset the CC1E Bit */
+      tmpccer = htim->Instance->CCER;
+      htim->Instance->CCER &= ~TIM_CCER_CC1E;
+      tmpccmr1 = htim->Instance->CCMR1;    
+      
+      /* Set the filter */
+      tmpccmr1 &= ~TIM_CCMR1_IC1F;
+      tmpccmr1 |= ((sSlaveConfig->TriggerFilter) << 4);
+      
+      /* Write to TIMx CCMR1 and CCER registers */
+      htim->Instance->CCMR1 = tmpccmr1;
+      htim->Instance->CCER = tmpccer;                               
+                               
+    }
+    break;
+    
+  case TIM_TS_TI1FP1:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+  
+      /* Configure TI1 Filter and Polarity */
+      TIM_TI1_ConfigInputStage(htim->Instance,
+                               sSlaveConfig->TriggerPolarity,
+                               sSlaveConfig->TriggerFilter);
+    }
+    break;
+    
+  case TIM_TS_TI2FP2:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+  
+      /* Configure TI2 Filter and Polarity */
+      TIM_TI2_ConfigInputStage(htim->Instance,
+                                sSlaveConfig->TriggerPolarity,
+                                sSlaveConfig->TriggerFilter);
+    }
+    break;
+    
+  case TIM_TS_ITR0:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+    
+  case TIM_TS_ITR1:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+    
+  case TIM_TS_ITR2:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+    
+  case TIM_TS_ITR3:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+       
+  default:
+    break;
+  }
+}
+
+/**
+  * @brief  Configure the TI1 as Input.
+  * @param  TIMx to select the TIM peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 1 is selected to be connected to IC1.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 1 is selected to be connected to IC2.
+  *            @arg TIM_ICSelection_TRC: TIM Input 1 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  * @note TIM_ICFilter and TIM_ICPolarity are not used in INDIRECT mode as TI2FP1
+  *       (on channel2 path) is used as the input signal. Therefore CCMR1 must be
+  *        protected against un-initialized filter and polarity values.
+  */
+void TIM_TI1_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 1: Reset the CC1E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC1E;
+  tmpccmr1 = TIMx->CCMR1;
+  tmpccer = TIMx->CCER;
+
+  /* Select the Input */
+  if(IS_TIM_CC2_INSTANCE(TIMx) != RESET)
+  {
+    tmpccmr1 &= ~TIM_CCMR1_CC1S;
+    tmpccmr1 |= TIM_ICSelection;
+  }
+  else
+  {
+    tmpccmr1 |= TIM_CCMR1_CC1S_0;
+  }
+
+  /* Set the filter */
+  tmpccmr1 &= ~TIM_CCMR1_IC1F;
+  tmpccmr1 |= ((TIM_ICFilter << 4) & TIM_CCMR1_IC1F);
+
+  /* Select the Polarity and set the CC1E Bit */
+  tmpccer &= ~(TIM_CCER_CC1P | TIM_CCER_CC1NP);
+  tmpccer |= (TIM_ICPolarity & (TIM_CCER_CC1P | TIM_CCER_CC1NP));
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the Polarity and Filter for TI1.
+  * @param  TIMx to select the TIM peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TIM_TI1_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 1: Reset the CC1E Bit */
+  tmpccer = TIMx->CCER;
+  TIMx->CCER &= ~TIM_CCER_CC1E;
+  tmpccmr1 = TIMx->CCMR1;
+
+  /* Set the filter */
+  tmpccmr1 &= ~TIM_CCMR1_IC1F;
+  tmpccmr1 |= (TIM_ICFilter << 4);
+
+  /* Select the Polarity and set the CC1E Bit */
+  tmpccer &= ~(TIM_CCER_CC1P | TIM_CCER_CC1NP);
+  tmpccer |= TIM_ICPolarity;
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI2 as Input.
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 2 is selected to be connected to IC2.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 2 is selected to be connected to IC1.
+  *            @arg TIM_ICSelection_TRC: TIM Input 2 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  * @note TIM_ICFilter and TIM_ICPolarity are not used in INDIRECT mode as TI1FP2
+  *       (on channel1 path) is used as the input signal. Therefore CCMR1 must be
+  *        protected against un-initialized filter and polarity values.
+  */
+static void TIM_TI2_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 2: Reset the CC2E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC2E;
+  tmpccmr1 = TIMx->CCMR1;
+  tmpccer = TIMx->CCER;
+
+  /* Select the Input */
+  tmpccmr1 &= ~TIM_CCMR1_CC2S;
+  tmpccmr1 |= (TIM_ICSelection << 8);
+
+  /* Set the filter */
+  tmpccmr1 &= ~TIM_CCMR1_IC2F;
+  tmpccmr1 |= ((TIM_ICFilter << 12) & TIM_CCMR1_IC2F);
+
+  /* Select the Polarity and set the CC2E Bit */
+  tmpccer &= ~(TIM_CCER_CC2P | TIM_CCER_CC2NP);
+  tmpccer |= ((TIM_ICPolarity << 4) & (TIM_CCER_CC2P | TIM_CCER_CC2NP));
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1 ;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the Polarity and Filter for TI2.
+  * @param  TIMx to select the TIM peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TIM_TI2_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 2: Reset the CC2E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC2E;
+  tmpccmr1 = TIMx->CCMR1;
+  tmpccer = TIMx->CCER;
+
+  /* Set the filter */
+  tmpccmr1 &= ~TIM_CCMR1_IC2F;
+  tmpccmr1 |= (TIM_ICFilter << 12);
+
+  /* Select the Polarity and set the CC2E Bit */
+  tmpccer &= ~(TIM_CCER_CC2P | TIM_CCER_CC2NP);
+  tmpccer |= (TIM_ICPolarity << 4);
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1 ;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI3 as Input.
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 3 is selected to be connected to IC3.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 3 is selected to be connected to IC4.
+  *            @arg TIM_ICSelection_TRC: TIM Input 3 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  * @note TIM_ICFilter and TIM_ICPolarity are not used in INDIRECT mode as TI3FP4
+  *       (on channel1 path) is used as the input signal. Therefore CCMR2 must be
+  *        protected against un-initialized filter and polarity values.
+  */
+static void TIM_TI3_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr2 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 3: Reset the CC3E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC3E;
+  tmpccmr2 = TIMx->CCMR2;
+  tmpccer = TIMx->CCER;
+
+  /* Select the Input */
+  tmpccmr2 &= ~TIM_CCMR2_CC3S;
+  tmpccmr2 |= TIM_ICSelection;
+
+  /* Set the filter */
+  tmpccmr2 &= ~TIM_CCMR2_IC3F;
+  tmpccmr2 |= ((TIM_ICFilter << 4) & TIM_CCMR2_IC3F);
+
+  /* Select the Polarity and set the CC3E Bit */
+  tmpccer &= ~(TIM_CCER_CC3P | TIM_CCER_CC3NP);
+  tmpccer |= ((TIM_ICPolarity << 8) & (TIM_CCER_CC3P | TIM_CCER_CC3NP));
+
+  /* Write to TIMx CCMR2 and CCER registers */
+  TIMx->CCMR2 = tmpccmr2;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI4 as Input.
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 4 is selected to be connected to IC4.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 4 is selected to be connected to IC3.
+  *            @arg TIM_ICSelection_TRC: TIM Input 4 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @note TIM_ICFilter and TIM_ICPolarity are not used in INDIRECT mode as TI4FP3
+  *       (on channel1 path) is used as the input signal. Therefore CCMR2 must be
+  *        protected against un-initialized filter and polarity values.
+  * @retval None
+  */
+static void TIM_TI4_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr2 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 4: Reset the CC4E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC4E;
+  tmpccmr2 = TIMx->CCMR2;
+  tmpccer = TIMx->CCER;
+
+  /* Select the Input */
+  tmpccmr2 &= ~TIM_CCMR2_CC4S;
+  tmpccmr2 |= (TIM_ICSelection << 8);
+
+  /* Set the filter */
+  tmpccmr2 &= ~TIM_CCMR2_IC4F;
+  tmpccmr2 |= ((TIM_ICFilter << 12) & TIM_CCMR2_IC4F);
+
+  /* Select the Polarity and set the CC4E Bit */
+  tmpccer &= ~(TIM_CCER_CC4P | TIM_CCER_CC4NP);
+  tmpccer |= ((TIM_ICPolarity << 12) & (TIM_CCER_CC4P | TIM_CCER_CC4NP));
+
+  /* Write to TIMx CCMR2 and CCER registers */
+  TIMx->CCMR2 = tmpccmr2;
+  TIMx->CCER = tmpccer ;
+}
+
+/**
+  * @brief  Selects the Input Trigger source
+  * @param  TIMx to select the TIM peripheral
+  * @param  InputTriggerSource: The Input Trigger source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TS_ITR0: Internal Trigger 0
+  *            @arg TIM_TS_ITR1: Internal Trigger 1
+  *            @arg TIM_TS_ITR2: Internal Trigger 2
+  *            @arg TIM_TS_ITR3: Internal Trigger 3
+  *            @arg TIM_TS_TI1F_ED: TI1 Edge Detector
+  *            @arg TIM_TS_TI1FP1: Filtered Timer Input 1
+  *            @arg TIM_TS_TI2FP2: Filtered Timer Input 2
+  *            @arg TIM_TS_ETRF: External Trigger input
+  * @retval None
+  */
+static void TIM_ITRx_SetConfig(TIM_TypeDef *TIMx, uint16_t InputTriggerSource)
+{
+  uint32_t tmpsmcr = 0;
+
+   /* Get the TIMx SMCR register value */
+   tmpsmcr = TIMx->SMCR;
+   /* Reset the TS Bits */
+   tmpsmcr &= ~TIM_SMCR_TS;
+   /* Set the Input Trigger source and the slave mode*/
+   tmpsmcr |= InputTriggerSource | TIM_SLAVEMODE_EXTERNAL1;
+   /* Write to TIMx SMCR */
+   TIMx->SMCR = tmpsmcr;
+}
+/**
+  * @brief  Configures the TIMx External Trigger (ETR).
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ExtTRGPrescaler: The external Trigger Prescaler.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ETRPRESCALER_DIV1 : ETRP Prescaler OFF.
+  *            @arg TIM_ETRPRESCALER_DIV2 : ETRP frequency divided by 2.
+  *            @arg TIM_ETRPRESCALER_DIV4 : ETRP frequency divided by 4.
+  *            @arg TIM_ETRPRESCALER_DIV8 : ETRP frequency divided by 8.
+  * @param  TIM_ExtTRGPolarity: The external Trigger Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ETRPOLARITY_INVERTED : active low or falling edge active.
+  *            @arg TIM_ETRPOLARITY_NONINVERTED : active high or rising edge active.
+  * @param  ExtTRGFilter: External Trigger Filter.
+  *          This parameter must be a value between 0x00 and 0x0F
+  * @retval None
+  */
+void TIM_ETR_SetConfig(TIM_TypeDef* TIMx, uint32_t TIM_ExtTRGPrescaler,
+                       uint32_t TIM_ExtTRGPolarity, uint32_t ExtTRGFilter)
+{
+  uint32_t tmpsmcr = 0;
+
+  tmpsmcr = TIMx->SMCR;
+
+  /* Reset the ETR Bits */
+  tmpsmcr &= ~(TIM_SMCR_ETF | TIM_SMCR_ETPS | TIM_SMCR_ECE | TIM_SMCR_ETP);
+
+  /* Set the Prescaler, the Filter value and the Polarity */
+  tmpsmcr |= (uint32_t)(TIM_ExtTRGPrescaler | (TIM_ExtTRGPolarity | (ExtTRGFilter << 8)));
+
+  /* Write to TIMx SMCR */
+  TIMx->SMCR = tmpsmcr;
+}
+
+/**
+  * @brief  Enables or disables the TIM Capture Compare Channel x.
+  * @param  TIMx to select the TIM peripheral
+  * @param  Channel: specifies the TIM Channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1
+  *            @arg TIM_CHANNEL_2: TIM Channel 2
+  *            @arg TIM_CHANNEL_3: TIM Channel 3
+  *            @arg TIM_CHANNEL_4: TIM Channel 4
+  * @param  ChannelState: specifies the TIM Channel CCxE bit new state.
+  *          This parameter can be: TIM_CCx_ENABLE or TIM_CCx_Disable.
+  * @retval None
+  */
+void TIM_CCxChannelCmd(TIM_TypeDef* TIMx, uint32_t Channel, uint32_t ChannelState)
+{
+  uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CC1_INSTANCE(TIMx));
+  assert_param(IS_TIM_CHANNELS(Channel));
+
+  tmp = TIM_CCER_CC1E << Channel;
+
+  /* Reset the CCxE Bit */
+  TIMx->CCER &= ~tmp;
+
+  /* Set or reset the CCxE Bit */
+  TIMx->CCER |=  (uint32_t)(ChannelState << Channel);
+}
+
+
+/**
+  * @}
+  */
+
+#endif /* HAL_TIM_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_tim_ex.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_tim_ex.c
@@ -1,0 +1,2711 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_tim_ex.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   TIM HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Timer Extended peripheral:
+  *           + Time Hall Sensor Interface Initialization
+  *           + Time Hall Sensor Interface Start
+  *           + Time Complementary signal break and dead time configuration
+  *           + Time Master and Slave synchronization configuration
+  *           + Time Output Compare/PWM Channel Configuration (for channels 5 and 6)
+  *           + Time OCRef clear configuration
+  *           + Timer remapping capabilities configuration
+  @verbatim
+  ==============================================================================
+                      ##### TIMER Extended features #####
+  ==============================================================================
+  [..]
+    The Timer Extended features include:
+    (#) Complementary outputs with programmable dead-time for :
+        (++) Output Compare
+        (++) PWM generation (Edge and Center-aligned Mode)
+        (++) One-pulse mode output
+    (#) Synchronization circuit to control the timer with external signals and to
+        interconnect several timers together.
+    (#) Break input to put the timer output signals in reset state or in a known state.
+    (#) Supports incremental (quadrature) encoder and hall-sensor circuitry for
+        positioning purposes
+
+            ##### How to use this driver #####
+  ==============================================================================
+    [..]
+     (#) Initialize the TIM low level resources by implementing the following functions
+         depending on the selected feature:
+           (++) Hall Sensor output : HAL_TIMEx_HallSensor_MspInit()
+
+     (#) Initialize the TIM low level resources :
+        (##) Enable the TIM interface clock using __HAL_RCC_TIMx_CLK_ENABLE();
+        (##) TIM pins configuration
+            (+++) Enable the clock for the TIM GPIOs using the following function:
+              __HAL_RCC_GPIOx_CLK_ENABLE();
+            (+++) Configure these TIM pins in Alternate function mode using HAL_GPIO_Init();
+
+     (#) The external Clock can be configured, if needed (the default clock is the
+         internal clock from the APBx), using the following function:
+         HAL_TIM_ConfigClockSource, the clock configuration should be done before
+         any start function.
+
+     (#) Configure the TIM in the desired functioning mode using one of the
+         initialization function of this driver:
+          (++) HAL_TIMEx_HallSensor_Init() and HAL_TIMEx_ConfigCommutationEvent(): to use the
+              Timer Hall Sensor Interface and the commutation event with the corresponding
+              Interrupt and DMA request if needed (Note that One Timer is used to interface
+             with the Hall sensor Interface and another Timer should be used to use
+             the commutation event).
+
+     (#) Activate the TIM peripheral using one of the start functions:
+           (++) Complementary Output Compare : HAL_TIMEx_OCN_Start(), HAL_TIMEx_OCN_Start_DMA(), HAL_TIMEx_OC_Start_IT()
+           (++) Complementary PWM generation : HAL_TIMEx_PWMN_Start(), HAL_TIMEx_PWMN_Start_DMA(), HAL_TIMEx_PWMN_Start_IT()
+           (++) Complementary One-pulse mode output : HAL_TIMEx_OnePulseN_Start(), HAL_TIMEx_OnePulseN_Start_IT()
+           (++) Hall Sensor output : HAL_TIMEx_HallSensor_Start(), HAL_TIMEx_HallSensor_Start_DMA(), HAL_TIMEx_HallSensor_Start_IT().
+
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+*/
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup TIMEx TIMEx
+  * @brief TIM Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define BDTR_BKF_SHIFT (16)
+#define BDTR_BK2F_SHIFT (20)
+#define TIMx_ETRSEL_MASK ((uint32_t)0x0001C000) 
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void TIM_OC5_SetConfig(TIM_TypeDef *TIMx,
+                              TIM_OC_InitTypeDef *OC_Config);
+
+static void TIM_OC6_SetConfig(TIM_TypeDef *TIMx,
+                              TIM_OC_InitTypeDef *OC_Config);
+
+static void TIM_CCxNChannelCmd(TIM_TypeDef* TIMx, uint32_t Channel, uint32_t ChannelNState);
+
+/* Private functions ---------------------------------------------------------*/
+/**
+  * @brief  Timer Ouput Compare 5 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The ouput configuration structure
+  * @retval None
+  */
+static void TIM_OC5_SetConfig(TIM_TypeDef *TIMx,
+                              TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+  /* Disable the output: Reset the CCxE Bit */
+  TIMx->CCER &= ~TIM_CCER_CC5E;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 =  TIMx->CR2;
+  /* Get the TIMx CCMR1 register value */
+  tmpccmrx = TIMx->CCMR3;
+
+  /* Reset the Output Compare Mode Bits */
+  tmpccmrx &= ~(TIM_CCMR3_OC5M);
+  /* Select the Output Compare Mode */
+  tmpccmrx |= OC_Config->OCMode;
+
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC5P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 16);
+
+  if(IS_TIM_BREAK_INSTANCE(TIMx))
+  {
+    /* Reset the Output Compare IDLE State */
+    tmpcr2 &= ~TIM_CR2_OIS5;
+    /* Set the Output Idle state */
+    tmpcr2 |= (OC_Config->OCIdleState << 8);
+  }
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+
+  /* Write to TIMx CCMR3 */
+  TIMx->CCMR3 = tmpccmrx;
+
+  /* Set the Capture Compare Register value */
+  TIMx->CCR5 = OC_Config->Pulse;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Timer Ouput Compare 6 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The ouput configuration structure
+  * @retval None
+  */
+static void TIM_OC6_SetConfig(TIM_TypeDef *TIMx,
+                              TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+  /* Disable the output: Reset the CCxE Bit */
+  TIMx->CCER &= ~TIM_CCER_CC6E;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 =  TIMx->CR2;
+  /* Get the TIMx CCMR1 register value */
+  tmpccmrx = TIMx->CCMR3;
+
+  /* Reset the Output Compare Mode Bits */
+  tmpccmrx &= ~(TIM_CCMR3_OC6M);
+  /* Select the Output Compare Mode */
+  tmpccmrx |= (OC_Config->OCMode << 8);
+
+  /* Reset the Output Polarity level */
+  tmpccer &= (uint32_t)~TIM_CCER_CC6P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 20);
+
+  if(IS_TIM_BREAK_INSTANCE(TIMx))
+  {
+    /* Reset the Output Compare IDLE State */
+    tmpcr2 &= ~TIM_CR2_OIS6;
+    /* Set the Output Idle state */
+    tmpcr2 |= (OC_Config->OCIdleState << 10);
+  }
+
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+
+  /* Write to TIMx CCMR3 */
+  TIMx->CCMR3 = tmpccmrx;
+
+  /* Set the Capture Compare Register value */
+  TIMx->CCR6 = OC_Config->Pulse;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup TIMEx_Exported_Functions TIM Extended Exported Functions
+  * @{
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group1 Extended Timer Hall Sensor functions
+  * @brief    Timer Hall Sensor functions
+  *
+@verbatim
+  ==============================================================================
+                      ##### Timer Hall Sensor functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Initialize and configure TIM HAL Sensor.
+    (+) De-initialize TIM HAL Sensor.
+    (+) Start the Hall Sensor Interface.
+    (+) Stop the Hall Sensor Interface.
+    (+) Start the Hall Sensor Interface and enable interrupts.
+    (+) Stop the Hall Sensor Interface and disable interrupts.
+    (+) Start the Hall Sensor Interface and enable DMA transfers.
+    (+) Stop the Hall Sensor Interface and disable DMA transfers.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM Hall Sensor Interface and initialize the associated handle.
+  * @param  htim: TIM Encoder Interface handle
+  * @param  sConfig: TIM Hall Sensor configuration structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef *htim, TIM_HallSensor_InitTypeDef* sConfig)
+{
+  TIM_OC_InitTypeDef OC_Config;
+
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+  assert_param(IS_TIM_IC_POLARITY(sConfig->IC1Polarity));
+  assert_param(IS_TIM_IC_PRESCALER(sConfig->IC1Prescaler));
+  assert_param(IS_TIM_IC_FILTER(sConfig->IC1Filter));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    htim->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIMEx_HallSensor_MspInit(htim);
+  }
+
+  /* Set the TIM state */
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Configure the Time base in the Encoder Mode */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+
+  /* Configure the Channel 1 as Input Channel to interface with the three Outputs of the  Hall sensor */
+  TIM_TI1_SetConfig(htim->Instance, sConfig->IC1Polarity, TIM_ICSELECTION_TRC, sConfig->IC1Filter);
+
+  /* Reset the IC1PSC Bits */
+  htim->Instance->CCMR1 &= ~TIM_CCMR1_IC1PSC;
+  /* Set the IC1PSC value */
+  htim->Instance->CCMR1 |= sConfig->IC1Prescaler;
+
+  /* Enable the Hall sensor interface (XOR function of the three inputs) */
+  htim->Instance->CR2 |= TIM_CR2_TI1S;
+
+  /* Select the TIM_TS_TI1F_ED signal as Input trigger for the TIM */
+  htim->Instance->SMCR &= ~TIM_SMCR_TS;
+  htim->Instance->SMCR |= TIM_TS_TI1F_ED;
+
+  /* Use the TIM_TS_TI1F_ED signal to reset the TIM counter each edge detection */
+  htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+  htim->Instance->SMCR |= TIM_SLAVEMODE_RESET;
+
+  /* Program channel 2 in PWM 2 mode with the desired Commutation_Delay*/
+  OC_Config.OCFastMode = TIM_OCFAST_DISABLE;
+  OC_Config.OCIdleState = TIM_OCIDLESTATE_RESET;
+  OC_Config.OCMode = TIM_OCMODE_PWM2;
+  OC_Config.OCNIdleState = TIM_OCNIDLESTATE_RESET;
+  OC_Config.OCNPolarity = TIM_OCNPOLARITY_HIGH;
+  OC_Config.OCPolarity = TIM_OCPOLARITY_HIGH;
+  OC_Config.Pulse = sConfig->Commutation_Delay;
+
+  TIM_OC2_SetConfig(htim->Instance, &OC_Config);
+
+  /* Select OC2REF as trigger output on TRGO: write the MMS bits in the TIMx_CR2
+    register to 101 */
+  htim->Instance->CR2 &= ~TIM_CR2_MMS;
+  htim->Instance->CR2 |= TIM_TRGO_OC2REF;
+
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitialize the TIM Hall Sensor interface
+  * @param  htim: TIM Hall Sensor handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_TIMEx_HallSensor_MspDeInit(htim);
+
+  /* Change TIM state */
+  htim->State = HAL_TIM_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Hall Sensor MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIMEx_HallSensor_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIMEx_HallSensor_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitialize TIM Hall Sensor MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIMEx_HallSensor_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIMEx_HallSensor_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Starts the TIM Hall Sensor Interface.
+  * @param  htim : TIM Hall Sensor handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+
+  /* Enable the Input Capture channels 1
+    (in the Hall Sensor Interface the Three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Hall sensor Interface.
+  * @param  htim : TIM Hall Sensor handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+
+  /* Disable the Input Capture channels 1, 2 and 3
+    (in the Hall Sensor Interface the Three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Hall Sensor Interface in interrupt mode.
+  * @param  htim : TIM Hall Sensor handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_IT(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+
+  /* Enable the capture compare Interrupts 1 event */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+
+  /* Enable the Input Capture channels 1
+    (in the Hall Sensor Interface the Three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Hall Sensor Interface in interrupt mode.
+  * @param  htim : TIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_IT(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+
+  /* Disable the Input Capture channels 1
+    (in the Hall Sensor Interface the Three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+
+  /* Disable the capture compare Interrupts event */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Hall Sensor Interface in DMA mode.
+  * @param  htim : TIM Hall Sensor handle
+  * @param  pData: The destination Buffer address.
+  * @param  Length: The length of data to be transferred from TIM peripheral to memory.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+
+   if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if(((uint32_t)pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  /* Enable the Input Capture channels 1
+    (in the Hall Sensor Interface the Three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+
+  /* Set the DMA Input Capture 1 Callback */
+  htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMACaptureCplt;
+  /* Set the DMA error callback */
+  htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
+
+  /* Enable the DMA channel for Capture 1*/
+  HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData, Length);
+
+  /* Enable the capture compare 1 Interrupt */
+  __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Hall Sensor Interface in DMA mode.
+  * @param  htim : TIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_DMA(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance));
+
+  /* Disable the Input Capture channels 1
+    (in the Hall Sensor Interface the Three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+
+
+  /* Disable the capture compare Interrupts 1 event */
+  __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group2 Extended Timer Complementary Output Compare functions
+  *  @brief   Timer Complementary Output Compare functions
+  *
+@verbatim
+  ==============================================================================
+              ##### Timer Complementary Output Compare functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Start the Complementary Output Compare/PWM.
+    (+) Stop the Complementary Output Compare/PWM.
+    (+) Start the Complementary Output Compare/PWM and enable interrupts.
+    (+) Stop the Complementary Output Compare/PWM and disable interrupts.
+    (+) Start the Complementary Output Compare/PWM and enable DMA transfers.
+    (+) Stop the Complementary Output Compare/PWM and disable DMA transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation on the complementary
+  *         output.
+  * @param  htim : TIM Output Compare handle
+  * @param  Channel : TIM Channel to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  /* Enable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Ouput */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation on the complementary
+  *         output.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  /* Disable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+  /* Disable the Main Ouput */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation in interrupt mode
+  *         on the complementary output.
+  * @param  htim : TIM OC handle
+  * @param  Channel : TIM Channel to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Enable the TIM Output Compare interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Output Compare interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Output Compare interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Output Compare interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the TIM Break interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_BREAK);
+  
+  /* Enable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Ouput */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation in interrupt mode
+  *         on the complementary output.
+  * @param  htim : TIM Output Compare handle
+  * @param  Channel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  uint32_t tmpccer = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Output Compare interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Output Compare interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Output Compare interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Output Compare interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+  /* Disable the TIM Break interrupt (only if no more channel is active) */
+  tmpccer = htim->Instance->CCER;
+  if ((tmpccer & (TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE)) == RESET)
+  {
+    __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
+  }
+
+  /* Disable the Main Ouput */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation in DMA mode
+  *         on the complementary output.
+  * @param  htim : TIM Output Compare handle
+  * @param  Channel : TIM Channel to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to TIM peripheral
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if(((uint32_t)pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length);
+
+      /* Enable the TIM Output Compare DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length);
+
+      /* Enable the TIM Output Compare DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+{
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,Length);
+
+      /* Enable the TIM Output Compare DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+     /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length);
+
+      /* Enable the TIM Output Compare DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Ouput */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation in DMA mode
+  *         on the complementary output.
+  * @param  htim : TIM Output Compare handle
+  * @param  Channel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Output Compare DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Output Compare DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Output Compare DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Output Compare interrupt */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+  /* Disable the Main Ouput */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group3 Extended Timer Complementary PWM functions
+  * @brief    Timer Complementary PWM functions
+  *
+@verbatim
+  ==============================================================================
+                 ##### Timer Complementary PWM functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Start the Complementary PWM.
+    (+) Stop the Complementary PWM.
+    (+) Start the Complementary PWM and enable interrupts.
+    (+) Stop the Complementary PWM and disable interrupts.
+    (+) Start the Complementary PWM and enable DMA transfers.
+    (+) Stop the Complementary PWM and disable DMA transfers.
+    (+) Start the Complementary Input Capture measurement.
+    (+) Stop the Complementary Input Capture.
+    (+) Start the Complementary Input Capture and enable interrupts.
+    (+) Stop the Complementary Input Capture and disable interrupts.
+    (+) Start the Complementary Input Capture and enable DMA transfers.
+    (+) Stop the Complementary Input Capture and disable DMA transfers.
+    (+) Start the Complementary One Pulse generation.
+    (+) Stop the Complementary One Pulse.
+    (+) Start the Complementary One Pulse and enable interrupts.
+    (+) Stop the Complementary One Pulse and disable interrupts.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Starts the PWM signal generation on the complementary output.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channel to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  /* Enable the complementary PWM output  */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Ouput */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the PWM signal generation on the complementary output.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  /* Disable the complementary PWM output  */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+  /* Disable the Main Ouput */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the PWM signal generation in interrupt mode on the
+  *         complementary output.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Enable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the TIM Break interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_BREAK);
+
+  /* Enable the complementary PWM output  */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Ouput */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the PWM signal generation in interrupt mode on the
+  *         complementary output.
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT (TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  uint32_t tmpccer = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the complementary PWM output  */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+  
+  /* Disable the TIM Break interrupt (only if no more channel is active) */
+  tmpccer = htim->Instance->CCER;
+  if ((tmpccer & (TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE)) == RESET)
+  {
+    __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
+  }
+
+  /* Disable the Main Ouput */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM PWM signal generation in DMA mode on the
+  *         complementary output
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channel to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to TIM peripheral
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if(((uint32_t)pData == 0 ) && (Length > 0))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length);
+
+      /* Enable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length);
+
+      /* Enable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,Length);
+
+      /* Enable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+     /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = TIM_DMADelayPulseCplt;
+
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = TIM_DMAError ;
+
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length);
+
+      /* Enable the TIM Capture/Compare 4 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Enable the complementary PWM output  */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Ouput */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM PWM signal generation in DMA mode on the complementary
+  *         output
+  * @param  htim : TIM handle
+  * @param  Channel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Disable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  /* Disable the complementary PWM output */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+  /* Disable the Main Ouput */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group4 Extended Timer Complementary One Pulse functions
+  * @brief    Timer Complementary One Pulse functions
+  *
+@verbatim
+  ==============================================================================
+                ##### Timer Complementary One Pulse functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Start the Complementary One Pulse generation.
+    (+) Stop the Complementary One Pulse.
+    (+) Start the Complementary One Pulse and enable interrupts.
+    (+) Stop the Complementary One Pulse and disable interrupts.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Starts the TIM One Pulse signal generation on the complementary
+  *         output.
+  * @param  htim : TIM One Pulse handle
+  * @param  OutputChannel : TIM Channel to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+  {
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
+
+  /* Enable the complementary One Pulse output */
+  TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Ouput */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM One Pulse signal generation on the complementary
+  *         output.
+  * @param  htim : TIM One Pulse handle
+  * @param  OutputChannel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
+
+  /* Disable the complementary One Pulse output */
+  TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_DISABLE);
+
+  /* Disable the Main Ouput */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM One Pulse signal generation in interrupt mode on the
+  *         complementary channel.
+  * @param  htim : TIM One Pulse handle
+  * @param  OutputChannel : TIM Channel to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
+
+  /* Enable the TIM Capture/Compare 1 interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+
+  /* Enable the TIM Capture/Compare 2 interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+
+  /* Enable the complementary One Pulse output */
+  TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_ENABLE);
+
+  /* Enable the Main Ouput */
+  __HAL_TIM_MOE_ENABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM One Pulse signal generation in interrupt mode on the
+  *         complementary channel.
+  * @param  htim : TIM One Pulse handle
+  * @param  OutputChannel : TIM Channel to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
+
+  /* Disable the TIM Capture/Compare 1 interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+
+  /* Disable the TIM Capture/Compare 2 interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+
+  /* Disable the complementary One Pulse output */
+  TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_DISABLE);
+
+  /* Disable the Main Ouput */
+  __HAL_TIM_MOE_DISABLE(htim);
+
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group5 Extended Peripheral Control functions
+  * @brief    Peripheral Control functions
+  *
+@verbatim
+  ==============================================================================
+                    ##### Peripheral Control functions #####
+  ==============================================================================
+  [..]
+    This section provides functions allowing to:
+    (+) Configure the commutation event in case of use of the Hall sensor interface.
+      (+) Configure Output channels for OC and PWM mode.
+
+      (+) Configure Complementary channels, break features and dead time.
+      (+) Configure Master synchronization.
+      (+) Configure timer remapping capabilities.
+      (+) Enable or disable channel grouping
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configure the TIM commutation event sequence.
+  * @note  This function is mandatory to use the commutation event in order to
+  *        update the configuration at each commutation detection on the TRGI input of the Timer,
+  *        the typical use of this feature is with the use of another Timer(interface Timer)
+  *        configured in Hall sensor interface, this interface Timer will generate the
+  *        commutation at its TRGO output (connected to Timer used in this function) each time
+  *        the TI1 of the Interface Timer detect a commutation at its input TI1.
+  * @param  htim: TIM handle
+  * @param  InputTrigger : the Internal trigger corresponding to the Timer Interfacing with the Hall sensor
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TS_ITR0: Internal trigger 0 selected
+  *            @arg TIM_TS_ITR1: Internal trigger 1 selected
+  *            @arg TIM_TS_ITR2: Internal trigger 2 selected
+  *            @arg TIM_TS_ITR3: Internal trigger 3 selected
+  *            @arg TIM_TS_NONE: No trigger is needed
+  * @param  CommutationSource : the Commutation Event source
+  *          This parameter can be one of the following values:
+  *            @arg TIM_COMMUTATION_TRGI: Commutation source is the TRGI of the Interface Timer
+  *            @arg TIM_COMMUTATION_SOFTWARE:  Commutation source is set by software using the COMG bit
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent(TIM_HandleTypeDef *htim, uint32_t  InputTrigger, uint32_t  CommutationSource)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_COMMUTATION_EVENT_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_INTERNAL_TRIGGEREVENT_SELECTION(InputTrigger));
+
+  __HAL_LOCK(htim);
+
+  if ((InputTrigger == TIM_TS_ITR0) || (InputTrigger == TIM_TS_ITR1) ||
+      (InputTrigger == TIM_TS_ITR2) || (InputTrigger == TIM_TS_ITR3))
+  {
+    /* Select the Input trigger */
+    htim->Instance->SMCR &= ~TIM_SMCR_TS;
+    htim->Instance->SMCR |= InputTrigger;
+  }
+
+  /* Select the Capture Compare preload feature */
+  htim->Instance->CR2 |= TIM_CR2_CCPC;
+  /* Select the Commutation event source */
+  htim->Instance->CR2 &= ~TIM_CR2_CCUS;
+  htim->Instance->CR2 |= CommutationSource;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configure the TIM commutation event sequence with interrupt.
+  * @note  This function is mandatory to use the commutation event in order to
+  *        update the configuration at each commutation detection on the TRGI input of the Timer,
+  *        the typical use of this feature is with the use of another Timer(interface Timer)
+  *        configured in Hall sensor interface, this interface Timer will generate the
+  *        commutation at its TRGO output (connected to Timer used in this function) each time
+  *        the TI1 of the Interface Timer detect a commutation at its input TI1.
+  * @param  htim: TIM handle
+  * @param  InputTrigger : the Internal trigger corresponding to the Timer Interfacing with the Hall sensor
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TS_ITR0: Internal trigger 0 selected
+  *            @arg TIM_TS_ITR1: Internal trigger 1 selected
+  *            @arg TIM_TS_ITR2: Internal trigger 2 selected
+  *            @arg TIM_TS_ITR3: Internal trigger 3 selected
+  *            @arg TIM_TS_NONE: No trigger is needed
+  * @param  CommutationSource : the Commutation Event source
+  *          This parameter can be one of the following values:
+  *            @arg TIM_COMMUTATION_TRGI: Commutation source is the TRGI of the Interface Timer
+  *            @arg TIM_COMMUTATION_SOFTWARE:  Commutation source is set by software using the COMG bit
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent_IT(TIM_HandleTypeDef *htim, uint32_t  InputTrigger, uint32_t  CommutationSource)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_COMMUTATION_EVENT_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_INTERNAL_TRIGGEREVENT_SELECTION(InputTrigger));
+
+  __HAL_LOCK(htim);
+
+  if ((InputTrigger == TIM_TS_ITR0) || (InputTrigger == TIM_TS_ITR1) ||
+      (InputTrigger == TIM_TS_ITR2) || (InputTrigger == TIM_TS_ITR3))
+  {
+    /* Select the Input trigger */
+    htim->Instance->SMCR &= ~TIM_SMCR_TS;
+    htim->Instance->SMCR |= InputTrigger;
+  }
+
+  /* Select the Capture Compare preload feature */
+  htim->Instance->CR2 |= TIM_CR2_CCPC;
+  /* Select the Commutation event source */
+  htim->Instance->CR2 &= ~TIM_CR2_CCUS;
+  htim->Instance->CR2 |= CommutationSource;
+
+  /* Enable the Commutation Interrupt Request */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_COM);
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configure the TIM commutation event sequence with DMA.
+  * @note  This function is mandatory to use the commutation event in order to
+  *        update the configuration at each commutation detection on the TRGI input of the Timer,
+  *        the typical use of this feature is with the use of another Timer(interface Timer)
+  *        configured in Hall sensor interface, this interface Timer will generate the
+  *        commutation at its TRGO output (connected to Timer used in this function) each time
+  *        the TI1 of the Interface Timer detect a commutation at its input TI1.
+  * @note  The user should configure the DMA in his own software, in This function only the COMDE bit is set
+  * @param  htim: TIM handle
+  * @param  InputTrigger : the Internal trigger corresponding to the Timer Interfacing with the Hall sensor
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TS_ITR0: Internal trigger 0 selected
+  *            @arg TIM_TS_ITR1: Internal trigger 1 selected
+  *            @arg TIM_TS_ITR2: Internal trigger 2 selected
+  *            @arg TIM_TS_ITR3: Internal trigger 3 selected
+  *            @arg TIM_TS_NONE: No trigger is needed
+  * @param  CommutationSource : the Commutation Event source
+  *          This parameter can be one of the following values:
+  *            @arg TIM_COMMUTATION_TRGI: Commutation source is the TRGI of the Interface Timer
+  *            @arg TIM_COMMUTATION_SOFTWARE:  Commutation source is set by software using the COMG bit
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent_DMA(TIM_HandleTypeDef *htim, uint32_t  InputTrigger, uint32_t  CommutationSource)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_COMMUTATION_EVENT_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_INTERNAL_TRIGGEREVENT_SELECTION(InputTrigger));
+
+  __HAL_LOCK(htim);
+
+  if ((InputTrigger == TIM_TS_ITR0) || (InputTrigger == TIM_TS_ITR1) ||
+      (InputTrigger == TIM_TS_ITR2) || (InputTrigger == TIM_TS_ITR3))
+  {
+    /* Select the Input trigger */
+    htim->Instance->SMCR &= ~TIM_SMCR_TS;
+    htim->Instance->SMCR |= InputTrigger;
+  }
+
+  /* Select the Capture Compare preload feature */
+  htim->Instance->CR2 |= TIM_CR2_CCPC;
+  /* Select the Commutation event source */
+  htim->Instance->CR2 &= ~TIM_CR2_CCUS;
+  htim->Instance->CR2 |= CommutationSource;
+
+  /* Enable the Commutation DMA Request */
+  /* Set the DMA Commutation Callback */
+  htim->hdma[TIM_DMA_ID_COMMUTATION]->XferCpltCallback = TIMEx_DMACommutationCplt;
+  /* Set the DMA error callback */
+  htim->hdma[TIM_DMA_ID_COMMUTATION]->XferErrorCallback = TIM_DMAError;
+
+  /* Enable the Commutation DMA Request */
+  __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_COM);
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Output Compare Channels according to the specified
+  *         parameters in the TIM_OC_InitTypeDef.
+  * @param  htim: TIM Output Compare handle
+  * @param  sConfig: TIM Output Compare configuration structure
+  * @param  Channel : TIM Channels to configure
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  *            @arg TIM_CHANNEL_ALL: all output channels supported by the timer instance selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim,
+                                           TIM_OC_InitTypeDef* sConfig,
+                                           uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CHANNELS(Channel));
+  assert_param(IS_TIM_OC_MODE(sConfig->OCMode));
+  assert_param(IS_TIM_OC_POLARITY(sConfig->OCPolarity));
+
+  /* Check input state */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+
+     /* Configure the TIM Channel 1 in Output Compare */
+      TIM_OC1_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+      /* Configure the TIM Channel 2 in Output Compare */
+      TIM_OC2_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+
+      /* Configure the TIM Channel 3 in Output Compare */
+      TIM_OC3_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+
+       /* Configure the TIM Channel 4 in Output Compare */
+       TIM_OC4_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_5:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC5_INSTANCE(htim->Instance));
+
+       /* Configure the TIM Channel 5 in Output Compare */
+       TIM_OC5_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    case TIM_CHANNEL_6:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC6_INSTANCE(htim->Instance));
+
+       /* Configure the TIM Channel 6 in Output Compare */
+       TIM_OC6_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM PWM  channels according to the specified
+  *         parameters in the TIM_OC_InitTypeDef.
+  * @param  htim: TIM PWM handle
+  * @param  sConfig: TIM PWM configuration structure
+  * @param  Channel : TIM Channels to be configured
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
+  *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
+  *            @arg TIM_CHANNEL_ALL: all PWM channels supported by the timer instance selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim,
+                                            TIM_OC_InitTypeDef* sConfig,
+                                            uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CHANNELS(Channel));
+  assert_param(IS_TIM_PWM_MODE(sConfig->OCMode));
+  assert_param(IS_TIM_OC_POLARITY(sConfig->OCPolarity));
+  assert_param(IS_TIM_FAST_STATE(sConfig->OCFastMode));
+
+  /* Check input state */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+
+      /* Configure the Channel 1 in PWM mode */
+      TIM_OC1_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel1 */
+      htim->Instance->CCMR1 |= TIM_CCMR1_OC1PE;
+
+      /* Configure the Output Fast mode */
+      htim->Instance->CCMR1 &= ~TIM_CCMR1_OC1FE;
+      htim->Instance->CCMR1 |= sConfig->OCFastMode;
+    }
+    break;
+
+    case TIM_CHANNEL_2:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+      /* Configure the Channel 2 in PWM mode */
+      TIM_OC2_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel2 */
+      htim->Instance->CCMR1 |= TIM_CCMR1_OC2PE;
+
+      /* Configure the Output Fast mode */
+      htim->Instance->CCMR1 &= ~TIM_CCMR1_OC2FE;
+      htim->Instance->CCMR1 |= sConfig->OCFastMode << 8;
+    }
+    break;
+
+    case TIM_CHANNEL_3:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+
+      /* Configure the Channel 3 in PWM mode */
+      TIM_OC3_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel3 */
+      htim->Instance->CCMR2 |= TIM_CCMR2_OC3PE;
+
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR2 &= ~TIM_CCMR2_OC3FE;
+      htim->Instance->CCMR2 |= sConfig->OCFastMode;
+    }
+    break;
+
+    case TIM_CHANNEL_4:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+
+      /* Configure the Channel 4 in PWM mode */
+      TIM_OC4_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel4 */
+      htim->Instance->CCMR2 |= TIM_CCMR2_OC4PE;
+
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR2 &= ~TIM_CCMR2_OC4FE;
+      htim->Instance->CCMR2 |= sConfig->OCFastMode << 8;
+    }
+    break;
+
+    case TIM_CHANNEL_5:
+    {
+       /* Check the parameters */
+      assert_param(IS_TIM_CC5_INSTANCE(htim->Instance));
+
+     /* Configure the Channel 5 in PWM mode */
+      TIM_OC5_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel5*/
+      htim->Instance->CCMR3 |= TIM_CCMR3_OC5PE;
+
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR3 &= ~TIM_CCMR3_OC5FE;
+      htim->Instance->CCMR3 |= sConfig->OCFastMode;
+    }
+    break;
+
+    case TIM_CHANNEL_6:
+    {
+       /* Check the parameters */
+      assert_param(IS_TIM_CC6_INSTANCE(htim->Instance));
+
+     /* Configure the Channel 5 in PWM mode */
+      TIM_OC6_SetConfig(htim->Instance, sConfig);
+
+      /* Set the Preload enable bit for channel6 */
+      htim->Instance->CCMR3 |= TIM_CCMR3_OC6PE;
+
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR3 &= ~TIM_CCMR3_OC6FE;
+      htim->Instance->CCMR3 |= sConfig->OCFastMode << 8;
+    }
+    break;
+
+    default:
+    break;
+  }
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the OCRef clear feature
+  * @param  htim: TIM handle
+  * @param  sClearInputConfig: pointer to a TIM_ClearInputConfigTypeDef structure that
+  *         contains the OCREF clear feature and parameters for the TIM peripheral.
+  * @param  Channel: specifies the TIM Channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_Channel_1: TIM Channel 1
+  *            @arg TIM_Channel_2: TIM Channel 2
+  *            @arg TIM_Channel_3: TIM Channel 3
+  *            @arg TIM_Channel_4: TIM Channel 4
+  *            @arg TIM_Channel_5: TIM Channel 5
+  *            @arg TIM_Channel_6: TIM Channel 6
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim,
+                                           TIM_ClearInputConfigTypeDef *sClearInputConfig,
+                                           uint32_t Channel)
+{
+  uint32_t tmpsmcr = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_OCXREF_CLEAR_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_CLEARINPUT_SOURCE(sClearInputConfig->ClearInputSource));
+
+  /* Check input state */
+  __HAL_LOCK(htim);
+
+  switch (sClearInputConfig->ClearInputSource)
+  {
+    case TIM_CLEARINPUTSOURCE_NONE:
+    {
+      /* Get the TIMx SMCR register value */
+      tmpsmcr = htim->Instance->SMCR;
+      
+      /* Clear the OCREF clear selection bit */
+      tmpsmcr &= ~TIM_SMCR_OCCS;
+
+      /* Clear the ETR Bits */
+      tmpsmcr &= ~(TIM_SMCR_ETF | TIM_SMCR_ETPS | TIM_SMCR_ECE | TIM_SMCR_ETP);
+
+      /* Set TIMx_SMCR */
+      htim->Instance->SMCR = tmpsmcr;
+   }
+    break;
+
+    case TIM_CLEARINPUTSOURCE_OCREFCLR:
+    {
+      /* Clear the OCREF clear selection bit */
+      htim->Instance->SMCR &= ~TIM_SMCR_OCCS;
+    }
+    break;
+
+    case TIM_CLEARINPUTSOURCE_ETR:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CLEARINPUT_POLARITY(sClearInputConfig->ClearInputPolarity));
+      assert_param(IS_TIM_CLEARINPUT_PRESCALER(sClearInputConfig->ClearInputPrescaler));
+      assert_param(IS_TIM_CLEARINPUT_FILTER(sClearInputConfig->ClearInputFilter));
+
+      TIM_ETR_SetConfig(htim->Instance,
+                        sClearInputConfig->ClearInputPrescaler,
+                        sClearInputConfig->ClearInputPolarity,
+                        sClearInputConfig->ClearInputFilter);
+
+      /* Set the OCREF clear selection bit */
+      htim->Instance->SMCR |= TIM_SMCR_OCCS;
+    }
+    break;
+    
+  default:
+    break;
+  }
+
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+      {
+        if(sClearInputConfig->ClearInputState != RESET)
+        {
+          /* Enable the OCREF clear feature for Channel 1 */
+          htim->Instance->CCMR1 |= TIM_CCMR1_OC1CE;
+        }
+        else
+        {
+          /* Disable the OCREF clear feature for Channel 1 */
+          htim->Instance->CCMR1 &= ~TIM_CCMR1_OC1CE;
+        }
+      }
+      break;
+    case TIM_CHANNEL_2:
+      {
+        if(sClearInputConfig->ClearInputState != RESET)
+        {
+          /* Enable the OCREF clear feature for Channel 2 */
+          htim->Instance->CCMR1 |= TIM_CCMR1_OC2CE;
+        }
+        else
+        {
+          /* Disable the OCREF clear feature for Channel 2 */
+          htim->Instance->CCMR1 &= ~TIM_CCMR1_OC2CE;
+        }
+      }
+    break;
+    case TIM_CHANNEL_3:
+      {
+        if(sClearInputConfig->ClearInputState != RESET)
+        {
+          /* Enable the OCREF clear feature for Channel 3 */
+          htim->Instance->CCMR2 |= TIM_CCMR2_OC3CE;
+        }
+        else
+        {
+          /* Disable the OCREF clear feature for Channel 3 */
+          htim->Instance->CCMR2 &= ~TIM_CCMR2_OC3CE;
+        }
+      }
+    break;
+    case TIM_CHANNEL_4:
+      {
+        if(sClearInputConfig->ClearInputState != RESET)
+        {
+          /* Enable the OCREF clear feature for Channel 4 */
+          htim->Instance->CCMR2 |= TIM_CCMR2_OC4CE;
+        }
+        else
+        {
+          /* Disable the OCREF clear feature for Channel 4 */
+          htim->Instance->CCMR2 &= ~TIM_CCMR2_OC4CE;
+        }
+      }
+    break;
+    case TIM_CHANNEL_5:
+      {
+        if(sClearInputConfig->ClearInputState != RESET)
+        {
+          /* Enable the OCREF clear feature for Channel 1 */
+          htim->Instance->CCMR3 |= TIM_CCMR3_OC5CE;
+        }
+        else
+        {
+          /* Disable the OCREF clear feature for Channel 1 */
+          htim->Instance->CCMR3 &= ~TIM_CCMR3_OC5CE;
+        }
+      }
+    break;
+    case TIM_CHANNEL_6:
+      {
+        if(sClearInputConfig->ClearInputState != RESET)
+        {
+          /* Enable the OCREF clear feature for Channel 1 */
+          htim->Instance->CCMR3 |= TIM_CCMR3_OC6CE;
+        }
+        else
+        {
+          /* Disable the OCREF clear feature for Channel 1 */
+          htim->Instance->CCMR3 &= ~TIM_CCMR3_OC6CE;
+        }
+      }
+    break;
+    default:
+    break;
+  }
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the TIM in master mode.
+  * @param  htim: TIM handle.
+  * @param  sMasterConfig: pointer to a TIM_MasterConfigTypeDef structure that
+  *         contains the selected trigger output (TRGO) and the Master/Slave
+  *         mode.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim,
+                                                      TIM_MasterConfigTypeDef * sMasterConfig)
+{
+  uint32_t tmpcr2;
+  uint32_t tmpsmcr;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_SYNCHRO_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_TRGO_SOURCE(sMasterConfig->MasterOutputTrigger));
+  assert_param(IS_TIM_MSM_STATE(sMasterConfig->MasterSlaveMode));
+
+  /* Check input state */
+  __HAL_LOCK(htim);
+
+ /* Get the TIMx CR2 register value */
+  tmpcr2 = htim->Instance->CR2;
+
+  /* Get the TIMx SMCR register value */
+  tmpsmcr = htim->Instance->SMCR;
+
+  /* If the timer supports ADC synchronization through TRGO2, set the master mode selection 2 */
+  if (IS_TIM_TRGO2_INSTANCE(htim->Instance))
+  {
+    /* Check the parameters */
+    assert_param(IS_TIM_TRGO2_SOURCE(sMasterConfig->MasterOutputTrigger2));
+
+    /* Clear the MMS2 bits */
+    tmpcr2 &= ~TIM_CR2_MMS2;
+    /* Select the TRGO2 source*/
+    tmpcr2 |= sMasterConfig->MasterOutputTrigger2;
+  }
+
+  /* Reset the MMS Bits */
+  tmpcr2 &= ~TIM_CR2_MMS;
+  /* Select the TRGO source */
+  tmpcr2 |=  sMasterConfig->MasterOutputTrigger;
+
+  /* Reset the MSM Bit */
+  tmpsmcr &= ~TIM_SMCR_MSM;
+  /* Set master mode */
+  tmpsmcr |= sMasterConfig->MasterSlaveMode;
+
+  /* Update TIMx CR2 */
+  htim->Instance->CR2 = tmpcr2;
+
+  /* Update TIMx SMCR */
+  htim->Instance->SMCR = tmpsmcr;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief   Configures the Break feature, dead time, Lock level, OSSI/OSSR State
+  *         and the AOE(automatic output enable).
+  * @param  htim: TIM handle
+  * @param  sBreakDeadTimeConfig: pointer to a TIM_ConfigBreakDeadConfigTypeDef structure that
+  *         contains the BDTR Register configuration  information for the TIM peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
+                                                TIM_BreakDeadTimeConfigTypeDef * sBreakDeadTimeConfig)
+{
+  uint32_t tmpbdtr = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_BREAK_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_OSSR_STATE(sBreakDeadTimeConfig->OffStateRunMode));
+  assert_param(IS_TIM_OSSI_STATE(sBreakDeadTimeConfig->OffStateIDLEMode));
+  assert_param(IS_TIM_LOCK_LEVEL(sBreakDeadTimeConfig->LockLevel));
+  assert_param(IS_TIM_DEADTIME(sBreakDeadTimeConfig->DeadTime));
+  assert_param(IS_TIM_BREAK_STATE(sBreakDeadTimeConfig->BreakState));
+  assert_param(IS_TIM_BREAK_POLARITY(sBreakDeadTimeConfig->BreakPolarity));
+  assert_param(IS_TIM_BREAK_FILTER(sBreakDeadTimeConfig->BreakFilter));
+  assert_param(IS_TIM_AUTOMATIC_OUTPUT_STATE(sBreakDeadTimeConfig->AutomaticOutput));
+
+  /* Check input state */
+  __HAL_LOCK(htim);
+
+  /* Set the Lock level, the Break enable Bit and the Polarity, the OSSR State,
+     the OSSI State, the dead time value and the Automatic Output Enable Bit */
+  if (IS_TIM_BKIN2_INSTANCE(htim->Instance))
+  {
+    assert_param(IS_TIM_BREAK2_STATE(sBreakDeadTimeConfig->Break2State));
+    assert_param(IS_TIM_BREAK2_POLARITY(sBreakDeadTimeConfig->Break2Polarity));
+    assert_param(IS_TIM_BREAK_FILTER(sBreakDeadTimeConfig->Break2Filter));
+
+    /* Clear the BDTR bits */
+    tmpbdtr &= ~(TIM_BDTR_DTG | TIM_BDTR_LOCK |  TIM_BDTR_OSSI |
+                 TIM_BDTR_OSSR | TIM_BDTR_BKE | TIM_BDTR_BKP |
+                 TIM_BDTR_AOE | TIM_BDTR_MOE | TIM_BDTR_BKF |
+                 TIM_BDTR_BK2F | TIM_BDTR_BK2E | TIM_BDTR_BK2P);
+
+    /* Set the BDTR bits */
+    tmpbdtr |= sBreakDeadTimeConfig->DeadTime;
+    tmpbdtr |= sBreakDeadTimeConfig->LockLevel;
+    tmpbdtr |= sBreakDeadTimeConfig->OffStateIDLEMode;
+    tmpbdtr |= sBreakDeadTimeConfig->OffStateRunMode;
+    tmpbdtr |= sBreakDeadTimeConfig->BreakState;
+    tmpbdtr |= sBreakDeadTimeConfig->BreakPolarity;
+    tmpbdtr |= sBreakDeadTimeConfig->AutomaticOutput;
+    tmpbdtr |= (sBreakDeadTimeConfig->BreakFilter << BDTR_BKF_SHIFT);
+    tmpbdtr |= (sBreakDeadTimeConfig->Break2Filter << BDTR_BK2F_SHIFT);
+    tmpbdtr |= sBreakDeadTimeConfig->Break2State;
+    tmpbdtr |= sBreakDeadTimeConfig->Break2Polarity;
+  }
+  else
+  {
+    /* Clear the BDTR bits */
+    tmpbdtr &= ~(TIM_BDTR_DTG | TIM_BDTR_LOCK |  TIM_BDTR_OSSI |
+                 TIM_BDTR_OSSR | TIM_BDTR_BKE | TIM_BDTR_BKP |
+                 TIM_BDTR_AOE | TIM_BDTR_MOE | TIM_BDTR_BKF);
+
+    /* Set the BDTR bits */
+    tmpbdtr |= sBreakDeadTimeConfig->DeadTime;
+    tmpbdtr |= sBreakDeadTimeConfig->LockLevel;
+    tmpbdtr |= sBreakDeadTimeConfig->OffStateIDLEMode;
+    tmpbdtr |= sBreakDeadTimeConfig->OffStateRunMode;
+    tmpbdtr |= sBreakDeadTimeConfig->BreakState;
+    tmpbdtr |= sBreakDeadTimeConfig->BreakPolarity;
+    tmpbdtr |= sBreakDeadTimeConfig->AutomaticOutput;
+    tmpbdtr |= (sBreakDeadTimeConfig->BreakFilter << BDTR_BKF_SHIFT);
+  }
+
+  /* Set TIMx_BDTR */
+  htim->Instance->BDTR = tmpbdtr;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the break input source.
+  * @param  htim: TIM handle.
+  * @param  BreakInput: Break input to configure
+  *          This parameter can be one of the following values:
+  *            @arg TIM_BREAKINPUT_BRK: Timer break input
+  *            @arg TIM_BREAKINPUT_BRK2: Timer break 2 input
+  * @param  sBreakInputConfig: Break input source configuration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_ConfigBreakInput(TIM_HandleTypeDef *htim,
+                                             uint32_t BreakInput,
+                                             TIMEx_BreakInputConfigTypeDef *sBreakInputConfig)
+
+{
+  uint32_t tmporx = 0;
+  uint32_t bkin_enable_mask = 0;
+  uint32_t bkin_polarity_mask = 0;
+  uint32_t bkin_enable_bitpos = 0;
+  uint32_t bkin_polarity_bitpos = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_BREAK_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_BREAKINPUT(BreakInput));
+  assert_param(IS_TIM_BREAKINPUTSOURCE(sBreakInputConfig->Source));
+  assert_param(IS_TIM_BREAKINPUTSOURCE_STATE(sBreakInputConfig->Enable));
+
+  if (sBreakInputConfig->Source != TIM_BREAKINPUTSOURCE_DFSDM)
+  {
+    assert_param(IS_TIM_BREAKINPUTSOURCE_POLARITY(sBreakInputConfig->Polarity));
+  }
+  
+  /* Check input state */
+  __HAL_LOCK(htim);
+  
+  switch(sBreakInputConfig->Source)
+  {
+  case TIM_BREAKINPUTSOURCE_BKIN:
+    {
+      bkin_enable_mask = TIM1_OR2_BKINE;
+      bkin_enable_bitpos = 0;
+      bkin_polarity_mask = TIM1_OR2_BKINP;
+      bkin_polarity_bitpos = 9;
+    }
+    break;
+  case TIM_BREAKINPUTSOURCE_COMP1:
+    {
+      bkin_enable_mask = TIM1_OR2_BKCMP1E;
+      bkin_enable_bitpos = 1;
+      bkin_polarity_mask = TIM1_OR2_BKCMP1P;
+      bkin_polarity_bitpos = 10;
+    }
+    break;
+  case TIM_BREAKINPUTSOURCE_COMP2:
+    {
+      bkin_enable_mask = TIM1_OR2_BKCMP2E;
+      bkin_enable_bitpos = 2;
+      bkin_polarity_mask = TIM1_OR2_BKCMP2P;
+      bkin_polarity_bitpos = 11;
+    }
+    break;
+  case TIM_BREAKINPUTSOURCE_DFSDM:
+    {
+      bkin_enable_mask = TIM1_OR2_BKDFBK0E;
+      bkin_enable_bitpos = 8;
+    }
+    break;    
+  default:
+    break;
+  }
+  
+  switch(BreakInput)
+  {
+    case TIM_BREAKINPUT_BRK:
+      {
+        /* Get the TIMx_OR2 register value */
+        tmporx = htim->Instance->OR2;
+        
+        /* Enable the break input */
+        tmporx &= ~bkin_enable_mask;
+        tmporx |= (sBreakInputConfig->Enable << bkin_enable_bitpos) & bkin_enable_mask;
+        
+        /* Set the break input polarity */
+        if (sBreakInputConfig->Source != TIM_BREAKINPUTSOURCE_DFSDM)
+        {
+          tmporx &= ~bkin_polarity_mask;
+          tmporx |= (sBreakInputConfig->Polarity << bkin_polarity_bitpos) & bkin_polarity_mask;
+        }
+        
+        /* Set TIMx_OR2 */
+        htim->Instance->OR2 = tmporx;        
+      }
+        break;
+    case TIM_BREAKINPUT_BRK2:
+      {
+        /* Get the TIMx_OR3 register value */
+        tmporx = htim->Instance->OR3;
+        
+        /* Enable the break input */
+        tmporx &= ~bkin_enable_mask;
+        tmporx |= (sBreakInputConfig->Enable << bkin_enable_bitpos) & bkin_enable_mask;
+        
+        /* Set the break input polarity */
+        if (sBreakInputConfig->Source != TIM_BREAKINPUTSOURCE_DFSDM)
+        {
+          tmporx &= ~bkin_polarity_mask;
+          tmporx |= (sBreakInputConfig->Polarity << bkin_polarity_bitpos) & bkin_polarity_mask;
+        }
+        
+        /* Set TIMx_OR3 */
+        htim->Instance->OR3 = tmporx;        
+      }
+      break;    
+  default:
+    break;
+  }
+  
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the TIMx Remapping input capabilities.
+  * @param  htim: TIM handle.
+  * @param  Remap: specifies the TIM remapping source.
+  *
+  *         For TIM1, the parameter is a combination of 4 fields (field1 | field2 | field3 | field4):
+  *
+  *                   field1 can have the following values:
+  *            @arg TIM_TIM1_ETR_ADC1_NONE:           TIM1_ETR is not connected to any ADC1 AWD (analog watchdog)
+  *            @arg TIM_TIM1_ETR_ADC1_AWD1:           TIM1_ETR is connected to ADC1 AWD1
+  *            @arg TIM_TIM1_ETR_ADC1_AWD2:           TIM1_ETR is connected to ADC1 AWD2
+  *            @arg TIM_TIM1_ETR_ADC1_AWD3:           TIM1_ETR is connected to ADC1 AWD3
+  *
+  *                   field2 can have the following values:
+  *            @arg TIM_TIM1_ETR_ADC3_NONE:           TIM1_ETR is not connected to any ADC3 AWD (analog watchdog)
+  *            @arg TIM_TIM1_ETR_ADC3_AWD1:           TIM1_ETR is connected to ADC3 AWD1
+  *            @arg TIM_TIM1_ETR_ADC3_AWD2:           TIM1_ETR is connected to ADC3 AWD2
+  *            @arg TIM_TIM1_ETR_ADC3_AWD3:           TIM1_ETR is connected to ADC3 AWD3
+  *
+  *                   field3 can have the following values:
+  *            @arg TIM_TIM1_TI1_GPIO:                TIM1 TI1 is connected to GPIO
+  *            @arg TIM_TIM1_TI1_COMP1:               TIM1 TI1 is connected to COMP1 output
+  *
+  *                   field4 can have the following values:
+  *            @arg TIM_TIM1_ETR_COMP1:               TIM1_ETR is connected to COMP1 output
+  *            @arg TIM_TIM1_ETR_COMP2:               TIM1_ETR is connected to COMP2 output
+  *            @note  When field4 is set to TIM_TIM1_ETR_COMP1 or TIM_TIM1_ETR_COMP2 field1 and field2 values are not significant 
+  *
+  *         For TIM2, the parameter is a combination of 3 fields (field1 | field2 | field3):
+  *
+  *                   field1 can have the following values:
+  *            @arg TIM_TIM2_ITR1_TIM8_TRGO:          TIM2_ITR1 is connected to TIM8_TRGO
+  *            @arg TIM_TIM2_ITR1_OTG_FS_SOF:         TIM2_ITR1 is connected to OTG_FS SOF
+  *
+  *                   field2 can have the following values:
+  *            @arg TIM_TIM2_ETR_GPIO:                TIM2_ETR is connected to GPIO
+  *            @arg TIM_TIM2_ETR_LSE:                 TIM2_ETR is connected to LSE
+  *            @arg TIM_TIM2_ETR_COMP1:               TIM2_ETR is connected to COMP1 output
+  *            @arg TIM_TIM2_ETR_COMP2:               TIM2_ETR is connected to COMP2 output
+  *
+  *                   field3 can have the following values:
+  *            @arg TIM_TIM2_TI4_GPIO:                TIM2 TI4 is connected to GPIO
+  *            @arg TIM_TIM2_TI4_COMP1:               TIM2 TI4 is connected to COMP1 output
+  *            @arg TIM_TIM2_TI4_COMP2:               TIM2 TI4 is connected to COMP2 output
+  *            @arg TIM_TIM2_TI4_COMP1_COMP2:         TIM2 TI4 is connected to logical OR between COMP1 and COMP2 output
+  *
+  *         For TIM3, the parameter is a combination 2 fields(field1 | field2):
+  *
+  *                   field1 can have the following values:
+  *            @arg TIM_TIM3_TI1_GPIO:                TIM3 TI1 is connected to GPIO
+  *            @arg TIM_TIM3_TI1_COMP1:               TIM3 TI1 is connected to COMP1 output
+  *            @arg TIM_TIM3_TI1_COMP2:               TIM3 TI1 is connected to COMP2 output
+  *            @arg TIM_TIM3_TI1_COMP1_COMP2:         TIM3 TI1 is connected to logical OR between COMP1 and COMP2 output
+  *
+  *                   field2 can have the following values:
+  *            @arg TIM_TIM3_ETR_GPIO:                TIM3_ETR is connected to GPIO
+  *            @arg TIM_TIM3_ETR_COMP1:               TIM3_ETR is connected to COMP1 output
+  *
+  *         For TIM8, the parameter is a combination of 3 fields (field1 | field2 | field3):
+  *
+  *                   field1 can have the following values:
+  *            @arg TIM_TIM8_ETR_ADC2_NONE:          TIM8_ETR is not connected to any ADC2 AWD (analog watchdog)
+  *            @arg TIM_TIM8_ETR_ADC2_AWD1:          TIM8_ETR is connected to ADC2 AWD1
+  *            @arg TIM_TIM8_ETR_ADC2_AWD2:          TIM8_ETR is connected to ADC2 AWD2
+  *            @arg TIM_TIM8_ETR_ADC2_AWD3:          TIM8_ETR is connected to ADC2 AWD3
+  *
+  *                   field2 can have the following values:
+  *            @arg TIM_TIM8_ETR_ADC3_NONE:          TIM8_ETR is not connected to any ADC3 AWD (analog watchdog)
+  *            @arg TIM_TIM8_ETR_ADC3_AWD1:          TIM8_ETR is connected to ADC3 AWD1
+  *            @arg TIM_TIM8_ETR_ADC3_AWD2:          TIM8_ETR is connected to ADC3 AWD2
+  *            @arg TIM_TIM8_ETR_ADC3_AWD3:          TIM8_ETR is connected to ADC3 AWD3
+  *
+  *                   field3 can have the following values:
+  *            @arg TIM_TIM8_TI1_GPIO:               TIM8 TI1 is connected to GPIO
+  *            @arg TIM_TIM8_TI1_COMP2:              TIM8 TI1 is connected to COMP2 output
+  *
+  *                   field4 can have the following values:
+  *            @arg TIM_TIM8_ETR_COMP1:               TIM8_ETR is connected to COMP1 output
+  *            @arg TIM_TIM8_ETR_COMP2:               TIM8_ETR is connected to COMP2 output
+  *            @note  When field4 is set to TIM_TIM8_ETR_COMP1 or TIM_TIM8_ETR_COMP2 field1 and field2 values are not significant 
+  *
+  *         For TIM15, the parameter is a combination of 3 fields (field1 | field2):
+  *
+  *                   field1 can have the following values:
+  *            @arg TIM_TIM15_TI1_GPIO:              TIM15 TI1 is connected to GPIO
+  *            @arg TIM_TIM15_TI1_LSE:               TIM15 TI1 is connected to LSE
+  *
+  *                   field2 can have the following values:
+  *            @arg TIM_TIM15_ENCODERMODE_NONE:      No redirection 
+  *            @arg TIM_TIM15_ENCODERMODE_TIM2:      TIM2 IC1 and TIM2 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively
+  *            @arg TIM_TIM15_ENCODERMODE_TIM3:      TIM3 IC1 and TIM3 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively
+  *            @arg TIM_TIM15_ENCODERMODE_TIM4:      TIM4 IC1 and TIM4 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively
+  *
+  *         For TIM16, the parameter can have the following values:
+  *            @arg TIM_TIM16_TI1_GPIO:              TIM16 TI1 is connected to GPIO
+  *            @arg TIM_TIM16_TI1_LSI:               TIM16 TI1 is connected to LSI
+  *            @arg TIM_TIM16_TI1_LSE:               TIM16 TI1 is connected to LSE
+  *            @arg TIM_TIM16_TI1_RTC:               TIM16 TI1 is connected to RTC wakeup interrupt
+  *
+  *         For TIM17, the parameter can have the following values:
+  *            @arg TIM_TIM17_TI1_GPIO:              TIM17 TI1 is connected to GPIO
+  *            @arg TIM_TIM17_TI1_MSI:               TIM17 TI1 is connected to MSI  (contraints: MSI clock < 1/4 TIM APB clock)
+  *            @arg TIM_TIM17_TI1_HSE_32:            TIM17 TI1 is connected to HSE div 32
+  *            @arg TIM_TIM17_TI1_MCO:               TIM17 TI1 is connected to MCO
+  *
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap)
+{
+  uint32_t tmpor1 = 0;
+  uint32_t tmpor2 = 0;
+  
+  __HAL_LOCK(htim);
+
+  /* Check parameters */
+  assert_param(IS_TIM_REMAP_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_REMAP(Remap));
+  
+  /* Set ETR_SEL bit field (if required) */
+  if (IS_TIM_ETRSEL_INSTANCE(htim->Instance))
+  {
+    tmpor2 = htim->Instance->OR2;
+    tmpor2 &= ~TIMx_ETRSEL_MASK;
+    tmpor2 |= (Remap & TIMx_ETRSEL_MASK);
+    
+    /* Set TIMx_OR2 */
+    htim->Instance->OR2 = tmpor2;        
+  }
+  
+  /* Set other remapping capabilities */
+  tmpor1 = Remap;
+  tmpor1 &= ~TIMx_ETRSEL_MASK;
+
+  /* Set TIMx_OR1 */
+  htim->Instance->OR1 = Remap;
+  
+  /* Set TIMx_OR1 */
+  htim->Instance->OR1 = tmpor1;        
+  
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Group channel 5 and channel 1, 2 or 3
+  * @param  htim: TIM handle.
+  * @param  Channels: specifies the reference signal(s) the OC5REF is combined with.
+  *         This parameter can be any combination of the following values:
+  *         TIM_GROUPCH5_NONE: No effect of OC5REF on OC1REFC, OC2REFC and OC3REFC
+  *         TIM_GROUPCH5_OC1REFC: OC1REFC is the logical AND of OC1REFC and OC5REF
+  *         TIM_GROUPCH5_OC2REFC: OC2REFC is the logical AND of OC2REFC and OC5REF
+  *         TIM_GROUPCH5_OC3REFC: OC3REFC is the logical AND of OC3REFC and OC5REF
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_GroupChannel5(TIM_HandleTypeDef *htim, uint32_t Channels)
+{
+  /* Check parameters */
+  assert_param(IS_TIM_COMBINED3PHASEPWM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_GROUPCH5(Channels));
+
+  /* Process Locked */
+  __HAL_LOCK(htim);
+
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Clear GC5Cx bit fields */
+  htim->Instance->CCR5 &= ~(TIM_CCR5_GC5C3|TIM_CCR5_GC5C2|TIM_CCR5_GC5C1);
+
+  /* Set GC5Cx bit fields */
+  htim->Instance->CCR5 |= Channels;
+
+  htim->State = HAL_TIM_STATE_READY;
+
+  __HAL_UNLOCK(htim);
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group6 Extended Callbacks functions
+  * @brief    Extended Callbacks functions
+  *
+@verbatim
+  ==============================================================================
+                    ##### Extended Callbacks functions #####
+  ==============================================================================
+  [..]
+    This section provides Extended TIM callback functions:
+    (+) Timer Commutation callback
+    (+) Timer Break callback
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Hall commutation changed callback in non-blocking mode
+  * @param  htim : TIM handle
+  * @retval None
+  */
+__weak void HAL_TIMEx_CommutationCallback(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIMEx_CommutationCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Hall Break detection callback in non-blocking mode
+  * @param  htim : TIM handle
+  * @retval None
+  */
+__weak void HAL_TIMEx_BreakCallback(TIM_HandleTypeDef *htim)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(htim);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TIMEx_BreakCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIMEx_Exported_Functions_Group7 Extended Peripheral State functions
+  * @brief    Extended Peripheral State functions
+  *
+@verbatim
+  ==============================================================================
+                ##### Extended Peripheral State functions #####
+  ==============================================================================
+  [..]
+    This subsection permits to get in run-time the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the TIM Hall Sensor interface handle state.
+  * @param  htim: TIM Hall Sensor handle
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIMEx_HallSensor_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  TIM DMA Commutation callback.
+  * @param  hdma : pointer to DMA handle.
+  * @retval None
+  */
+void TIMEx_DMACommutationCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  htim->State= HAL_TIM_STATE_READY;
+
+  HAL_TIMEx_CommutationCallback(htim);
+}
+
+/**
+  * @brief  Enables or disables the TIM Capture Compare Channel xN.
+  * @param  TIMx to select the TIM peripheral
+  * @param  Channel: specifies the TIM Channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_Channel_1: TIM Channel 1
+  *            @arg TIM_Channel_2: TIM Channel 2
+  *            @arg TIM_Channel_3: TIM Channel 3
+  * @param  ChannelNState: specifies the TIM Channel CCxNE bit new state.
+  *          This parameter can be: TIM_CCxN_ENABLE or TIM_CCxN_Disable.
+  * @retval None
+  */
+static void TIM_CCxNChannelCmd(TIM_TypeDef* TIMx, uint32_t Channel, uint32_t ChannelNState)
+{
+  uint32_t tmp = 0;
+
+  tmp = TIM_CCER_CC1NE << Channel;
+
+  /* Reset the CCxNE Bit */
+  TIMx->CCER &=  ~tmp;
+
+  /* Set or reset the CCxNE Bit */
+  TIMx->CCER |=  (uint32_t)(ChannelNState << Channel);
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_TIM_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_uart.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_uart.c
@@ -1,0 +1,2117 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_uart.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   UART HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Universal Asynchronous Receiver Transmitter Peripheral (UART).
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *
+  *
+  @verbatim
+ ===============================================================================
+                        ##### How to use this driver #####
+ ===============================================================================
+  [..]
+    The UART HAL driver can be used as follows:
+
+    (#) Declare a UART_HandleTypeDef handle structure (eg. UART_HandleTypeDef huart).
+    (#) Initialize the UART low level resources by implementing the HAL_UART_MspInit() API:
+        (++) Enable the USARTx interface clock.
+        (++) UART pins configuration:
+            (+++) Enable the clock for the UART GPIOs.
+            (+++) Configure these UART pins as alternate function pull-up.
+        (++) NVIC configuration if you need to use interrupt process (HAL_UART_Transmit_IT()
+             and HAL_UART_Receive_IT() APIs):
+            (+++) Configure the USARTx interrupt priority.
+            (+++) Enable the NVIC USART IRQ handle.
+            (++) UART interrupts handling:
+              -@@-  The specific UART interrupts (Transmission complete interrupt,
+                RXNE interrupt and Error Interrupts) are managed using the macros
+                __HAL_UART_ENABLE_IT() and __HAL_UART_DISABLE_IT() inside the transmit and receive processes.
+        (++) DMA Configuration if you need to use DMA process (HAL_UART_Transmit_DMA()
+             and HAL_UART_Receive_DMA() APIs):
+            (+++) Declare a DMA handle structure for the Tx/Rx channel.
+            (+++) Enable the DMAx interface clock.
+            (+++) Configure the declared DMA handle structure with the required Tx/Rx parameters.
+            (+++) Configure the DMA Tx/Rx channel.
+            (+++) Associate the initialized DMA handle to the UART DMA Tx/Rx handle.
+            (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx/Rx channel.
+
+    (#) Program the Baud Rate, Word Length, Stop Bit, Parity, Hardware
+        flow control and Mode (Receiver/Transmitter) in the huart handle Init structure.
+
+    (#) If required, program UART advanced features (TX/RX pins swap, auto Baud rate detection,...)
+        in the huart handle AdvancedInit structure.
+
+    (#) For the UART asynchronous mode, initialize the UART registers by calling
+        the HAL_UART_Init() API.
+
+    (#) For the UART Half duplex mode, initialize the UART registers by calling
+        the HAL_HalfDuplex_Init() API.
+
+    (#) For the UART LIN (Local Interconnection Network) mode, initialize the UART registers
+        by calling the HAL_LIN_Init() API.
+
+    (#) For the UART Multiprocessor mode, initialize the UART registers
+        by calling the HAL_MultiProcessor_Init() API.
+
+    (#) For the UART RS485 Driver Enabled mode, initialize the UART registers
+        by calling the HAL_RS485Ex_Init() API.
+
+    [..]
+    (@) These API's (HAL_UART_Init(), HAL_HalfDuplex_Init(), HAL_LIN_Init(), HAL_MultiProcessor_Init(),
+        also configure the low level Hardware GPIO, CLOCK, CORTEX...etc) by
+        calling the customized HAL_UART_MspInit() API.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup UART UART
+  * @brief HAL UART module driver
+  * @{
+  */
+
+#ifdef HAL_UART_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @defgroup UART_Private_Constants UART Private Constants
+  * @{
+  */
+#define UART_CR1_FIELDS  ((uint32_t)(USART_CR1_M | USART_CR1_PCE | USART_CR1_PS | \
+                                     USART_CR1_TE | USART_CR1_RE | USART_CR1_OVER8)) /*!< UART or USART CR1 fields of parameters set by UART_SetConfig API */
+
+#define UART_LPUART_BRR_MIN           ((uint32_t)0x00000300)  /* LPUART BRR minimum authorized value */
+#define UART_LPUART_BRR_MAX           ((uint32_t)0x000FFFFF)  /* LPUART BRR maximum authorized value */                                                                      
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @addtogroup UART_Private_Functions
+  * @{
+  */
+static void UART_DMATransmitCplt(DMA_HandleTypeDef *hdma);
+static void UART_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
+static void UART_DMARxHalfCplt(DMA_HandleTypeDef *hdma);
+static void UART_DMATxHalfCplt(DMA_HandleTypeDef *hdma);
+static void UART_DMAError(DMA_HandleTypeDef *hdma);
+static HAL_StatusTypeDef UART_Transmit_IT(UART_HandleTypeDef *huart);
+static HAL_StatusTypeDef UART_EndTransmit_IT(UART_HandleTypeDef *huart);
+static HAL_StatusTypeDef UART_Receive_IT(UART_HandleTypeDef *huart);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup UART_Exported_Functions UART Exported Functions
+  * @{
+  */
+
+/** @defgroup UART_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and Configuration functions
+  *
+@verbatim
+===============================================================================
+            ##### Initialization and Configuration functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to initialize the USARTx or the UARTy
+    in asynchronous mode.
+      (+) For the asynchronous mode the parameters below can be configured:
+        (++) Baud Rate
+        (++) Word Length
+        (++) Stop Bit
+        (++) Parity: If the parity is enabled, then the MSB bit of the data written
+             in the data register is transmitted but is changed by the parity bit.
+        (++) Hardware flow control
+        (++) Receiver/transmitter modes
+        (++) Over Sampling Method
+        (++) One-Bit Sampling Method
+      (+) For the asynchronous mode, the following advanced features can be configured as well:
+        (++) TX and/or RX pin level inversion
+        (++) data logical level inversion
+        (++) RX and TX pins swap
+        (++) RX overrun detection disabling
+        (++) DMA disabling on RX error
+        (++) MSB first on communication line
+        (++) auto Baud rate detection
+    [..]
+    The HAL_UART_Init(), HAL_HalfDuplex_Init(), HAL_LIN_Init()and HAL_MultiProcessor_Init()API
+    follow respectively the UART asynchronous, UART Half duplex, UART LIN mode
+    and UART multiprocessor mode configuration procedures (details for the procedures
+    are available in reference manual).
+
+@endverbatim
+
+  Depending on the frame length defined by the M1 and M0 bits (7-bit, 
+  8-bit or 9-bit), the possible UART formats are listed in the 
+  following table.
+  
+  Table 1. UART frame format.
+    +-----------------------------------------------------------------------+
+    |  M1 bit |  M0 bit |  PCE bit  |             UART frame                |
+    |---------|---------|-----------|---------------------------------------|
+    |    0    |    0    |    0      |    | SB |    8 bit data   | STB |     |
+    |---------|---------|-----------|---------------------------------------|
+    |    0    |    0    |    1      |    | SB | 7 bit data | PB | STB |     |
+    |---------|---------|-----------|---------------------------------------|
+    |    0    |    1    |    0      |    | SB |    9 bit data   | STB |     |
+    |---------|---------|-----------|---------------------------------------|
+    |    0    |    1    |    1      |    | SB | 8 bit data | PB | STB |     |
+    |---------|---------|-----------|---------------------------------------|
+    |    1    |    0    |    0      |    | SB |    7 bit data   | STB |     |
+    |---------|---------|-----------|---------------------------------------|
+    |    1    |    0    |    1      |    | SB | 6 bit data | PB | STB |     |
+    +-----------------------------------------------------------------------+
+
+  * @{
+  */
+
+/**
+  * @brief Initialize the UART mode according to the specified
+  *         parameters in the UART_InitTypeDef and initialize the associated handle.
+  * @param huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Init(UART_HandleTypeDef *huart)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  if(huart->Init.HwFlowCtl != UART_HWCONTROL_NONE)
+  {
+    /* Check the parameters */
+    assert_param(IS_UART_HWFLOW_INSTANCE(huart->Instance));
+  }
+  else
+  {
+    /* Check the parameters */
+    assert_param((IS_UART_INSTANCE(huart->Instance)) || (IS_LPUART_INSTANCE(huart->Instance)));
+  }
+
+  if(huart->State == HAL_UART_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    huart->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK */
+    HAL_UART_MspInit(huart);
+  }
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  /* Set the UART Communication parameters */
+  if (UART_SetConfig(huart) == HAL_ERROR)
+  {
+    return HAL_ERROR;
+  }
+
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
+  /* In asynchronous mode, the following bits must be kept cleared:
+  - LINEN and CLKEN bits in the USART_CR2 register,
+  - SCEN, HDSEL and IREN  bits in the USART_CR3 register.*/
+  huart->Instance->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
+  huart->Instance->CR3 &= ~(USART_CR3_SCEN | USART_CR3_HDSEL | USART_CR3_IREN);
+
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief Initialize the half-duplex mode according to the specified
+  *         parameters in the UART_InitTypeDef and creates the associated handle.
+  * @param huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HalfDuplex_Init(UART_HandleTypeDef *huart)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check UART instance */
+  assert_param(IS_UART_HALFDUPLEX_INSTANCE(huart->Instance));
+
+  if(huart->State == HAL_UART_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    huart->Lock = HAL_UNLOCKED;
+  
+    /* Init the low level hardware : GPIO, CLOCK */
+    HAL_UART_MspInit(huart);
+  }
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  /* Set the UART Communication parameters */
+  if (UART_SetConfig(huart) == HAL_ERROR)
+  {
+    return HAL_ERROR;
+  }
+
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
+  /* In half-duplex mode, the following bits must be kept cleared:
+  - LINEN and CLKEN bits in the USART_CR2 register,
+  - SCEN and IREN bits in the USART_CR3 register.*/
+  huart->Instance->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
+  huart->Instance->CR3 &= ~(USART_CR3_IREN | USART_CR3_SCEN);
+
+  /* Enable the Half-Duplex mode by setting the HDSEL bit in the CR3 register */
+  huart->Instance->CR3 |= USART_CR3_HDSEL;
+
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+
+/**
+  * @brief Initialize the LIN mode according to the specified
+  *         parameters in the UART_InitTypeDef and creates the associated handle .
+  * @param huart: UART handle.
+  * @param BreakDetectLength: specifies the LIN break detection length.
+  *        This parameter can be one of the following values:
+  *          @arg @ref UART_LINBREAKDETECTLENGTH_10B 10-bit break detection
+  *          @arg @ref UART_LINBREAKDETECTLENGTH_11B 11-bit break detection
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LIN_Init(UART_HandleTypeDef *huart, uint32_t BreakDetectLength)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the LIN UART instance */
+  assert_param(IS_UART_LIN_INSTANCE(huart->Instance));
+  /* Check the Break detection length parameter */
+  assert_param(IS_UART_LIN_BREAK_DETECT_LENGTH(BreakDetectLength));
+
+  /* LIN mode limited to 16-bit oversampling only */
+  if(huart->Init.OverSampling == UART_OVERSAMPLING_8)
+  {
+    return HAL_ERROR;
+  }
+  /* LIN mode limited to 8-bit data length */
+  if(huart->Init.WordLength != UART_WORDLENGTH_8B)
+  {
+    return HAL_ERROR;
+  }
+
+  if(huart->State == HAL_UART_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    huart->Lock = HAL_UNLOCKED;
+  
+    /* Init the low level hardware : GPIO, CLOCK */
+    HAL_UART_MspInit(huart);
+  }
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  /* Set the UART Communication parameters */
+  if (UART_SetConfig(huart) == HAL_ERROR)
+  {
+    return HAL_ERROR;
+  }
+
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
+  /* In LIN mode, the following bits must be kept cleared:
+  - LINEN and CLKEN bits in the USART_CR2 register,
+  - SCEN and IREN bits in the USART_CR3 register.*/
+  huart->Instance->CR2 &= ~(USART_CR2_CLKEN);
+  huart->Instance->CR3 &= ~(USART_CR3_HDSEL | USART_CR3_IREN | USART_CR3_SCEN);
+
+  /* Enable the LIN mode by setting the LINEN bit in the CR2 register */
+  huart->Instance->CR2 |= USART_CR2_LINEN;
+
+  /* Set the USART LIN Break detection length. */
+  MODIFY_REG(huart->Instance->CR2, USART_CR2_LBDL, BreakDetectLength);
+
+    /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+
+
+/**
+  * @brief Initialize the multiprocessor mode according to the specified
+  *         parameters in the UART_InitTypeDef and initialize the associated handle.
+  * @param huart: UART handle.
+  * @param Address: UART node address (4-, 6-, 7- or 8-bit long).
+  * @param WakeUpMethod: specifies the UART wakeup method.
+  *        This parameter can be one of the following values:
+  *          @arg @ref UART_WAKEUPMETHOD_IDLELINE WakeUp by an idle line detection
+  *          @arg @ref UART_WAKEUPMETHOD_ADDRESSMARK WakeUp by an address mark
+  * @note  If the user resorts to idle line detection wake up, the Address parameter
+  *        is useless and ignored by the initialization function.
+  * @note  If the user resorts to address mark wake up, the address length detection
+  *        is configured by default to 4 bits only. For the UART to be able to
+  *        manage 6-, 7- or 8-bit long addresses detection, the API
+  *        HAL_MultiProcessorEx_AddressLength_Set() must be called after
+  *        HAL_MultiProcessor_Init().
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_MultiProcessor_Init(UART_HandleTypeDef *huart, uint8_t Address, uint32_t WakeUpMethod)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the wake up method parameter */
+  assert_param(IS_UART_WAKEUPMETHOD(WakeUpMethod));
+
+  if(huart->State == HAL_UART_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    huart->Lock = HAL_UNLOCKED;
+  
+    /* Init the low level hardware : GPIO, CLOCK */
+    HAL_UART_MspInit(huart);
+  }
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  /* Set the UART Communication parameters */
+  if (UART_SetConfig(huart) == HAL_ERROR)
+  {
+    return HAL_ERROR;
+  }
+
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
+  /* In multiprocessor mode, the following bits must be kept cleared:
+  - LINEN and CLKEN bits in the USART_CR2 register,
+  - SCEN, HDSEL and IREN  bits in the USART_CR3 register. */
+  huart->Instance->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
+  huart->Instance->CR3 &= ~(USART_CR3_SCEN | USART_CR3_HDSEL | USART_CR3_IREN);
+
+  if (WakeUpMethod == UART_WAKEUPMETHOD_ADDRESSMARK)
+  {
+    /* If address mark wake up method is chosen, set the USART address node */
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_ADD, ((uint32_t)Address << UART_CR2_ADDRESS_LSB_POS));
+  }
+
+  /* Set the wake up method by setting the WAKE bit in the CR1 register */
+  MODIFY_REG(huart->Instance->CR1, USART_CR1_WAKE, WakeUpMethod);
+
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+
+
+
+/**
+  * @brief DeInitialize the UART peripheral.
+  * @param huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_DeInit(UART_HandleTypeDef *huart)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param((IS_UART_INSTANCE(huart->Instance)) || (IS_LPUART_INSTANCE(huart->Instance)));
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  huart->Instance->CR1 = 0x0;
+  huart->Instance->CR2 = 0x0;
+  huart->Instance->CR3 = 0x0;
+
+  /* DeInit the low level hardware */
+  HAL_UART_MspDeInit(huart);
+
+  huart->ErrorCode = HAL_UART_ERROR_NONE;
+  huart->State = HAL_UART_STATE_RESET;
+
+  /* Process Unlock */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Initialize the UART MSP.
+  * @param huart: UART handle.
+  * @retval None
+  */
+__weak void HAL_UART_MspInit(UART_HandleTypeDef *huart)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(huart);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_MspInit can be implemented in the user file
+   */
+}
+
+/**
+  * @brief DeInitialize the UART MSP.
+  * @param huart: UART handle.
+  * @retval None
+  */
+__weak void HAL_UART_MspDeInit(UART_HandleTypeDef *huart)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(huart);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_MspDeInit can be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup UART_Exported_Functions_Group2 IO operation functions
+  *  @brief UART Transmit/Receive functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    This subsection provides a set of functions allowing to manage the UART asynchronous
+    and Half duplex data transfers.
+
+    (#) There are two mode of transfer:
+       (+) Blocking mode: The communication is performed in polling mode.
+            The HAL status of all data processing is returned by the same function
+            after finishing transfer.
+       (+) No-Blocking mode: The communication is performed using Interrupts
+           or DMA, These API's return the HAL status.
+           The end of the data processing will be indicated through the
+           dedicated UART IRQ when using Interrupt mode or the DMA IRQ when
+           using DMA mode.
+           The HAL_UART_TxCpltCallback(), HAL_UART_RxCpltCallback() user callbacks
+           will be executed respectively at the end of the transmit or Receive process
+           The HAL_UART_ErrorCallback()user callback will be executed when a communication error is detected
+
+    (#) Blocking mode API's are :
+        (+) HAL_UART_Transmit()
+        (+) HAL_UART_Receive()
+
+    (#) Non-Blocking mode API's with Interrupt are :
+        (+) HAL_UART_Transmit_IT()
+        (+) HAL_UART_Receive_IT()
+        (+) HAL_UART_IRQHandler()
+
+    (#) No-Blocking mode API's with DMA are :
+        (+) HAL_UART_Transmit_DMA()
+        (+) HAL_UART_Receive_DMA()
+        (+) HAL_UART_DMAPause()
+        (+) HAL_UART_DMAResume()
+        (+) HAL_UART_DMAStop()
+
+    (#) A set of Transfer Complete Callbacks are provided in No_Blocking mode:
+        (+) HAL_UART_TxHalfCpltCallback()
+        (+) HAL_UART_TxCpltCallback()
+        (+) HAL_UART_RxHalfCpltCallback()
+        (+) HAL_UART_RxCpltCallback()
+        (+) HAL_UART_ErrorCallback()
+
+
+    -@- In the Half duplex communication, it is forbidden to run the transmit
+        and receive process in parallel, the UART state HAL_UART_STATE_BUSY_TX_RX can't be useful.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Send an amount of data in blocking mode.
+  * @param huart: UART handle.
+  * @param pData: Pointer to data buffer.
+  * @param Size: Amount of data to be sent.
+  * @param Timeout: Timeout duration.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+   uint16_t* tmp;
+
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_RX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a non-blocking receive process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_RX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+
+    huart->TxXferSize = Size;
+    huart->TxXferCount = Size;
+    while(huart->TxXferCount > 0)
+    {
+      huart->TxXferCount--;
+        if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TXE, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) pData;
+        huart->Instance->TDR = (*tmp & (uint16_t)0x01FF);
+        pData += 2;
+      }
+      else
+      {
+        huart->Instance->TDR = (*pData++ & (uint8_t)0xFF);
+      }
+    }
+    if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TC, RESET, Timeout) != HAL_OK)
+    {
+      return HAL_TIMEOUT;
+    }
+    /* Check if a non-blocking receive Process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_READY;
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in blocking mode.
+  * @param huart: UART handle.
+  * @param pData: pointer to data buffer.
+  * @param Size: amount of data to be received.
+  * @param Timeout: Timeout duration.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint16_t* tmp;
+  uint16_t uhMask;
+
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_TX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a non-blocking transmit process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_RX;
+    }
+
+    huart->RxXferSize = Size;
+    huart->RxXferCount = Size;
+
+    /* Computation of UART mask to apply to RDR register */
+    UART_MASK_COMPUTATION(huart);
+    uhMask = huart->Mask;
+
+    /* as long as data have to be received */
+    while(huart->RxXferCount > 0)
+    {
+      huart->RxXferCount--;
+        if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) pData ;
+        *tmp = (uint16_t)(huart->Instance->RDR & uhMask);
+        pData +=2;
+      }
+      else
+      {
+        *pData++ = (uint8_t)(huart->Instance->RDR & (uint8_t)uhMask);
+      }
+    }
+
+    /* Check if a non-blocking transmit Process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_READY;
+    }
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Send an amount of data in interrupt mode.
+  * @param huart: UART handle.
+  * @param pData: pointer to data buffer.
+  * @param Size: amount of data to be sent.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_RX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->pTxBuffPtr = pData;
+    huart->TxXferSize = Size;
+    huart->TxXferCount = Size;
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a receive process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_RX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    /* Enable the UART Transmit Data Register Empty Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in interrupt mode.
+  * @param huart: UART handle.
+  * @param pData: pointer to data buffer.
+  * @param Size: amount of data to be received.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_TX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->pRxBuffPtr = pData;
+    huart->RxXferSize = Size;
+    huart->RxXferCount = Size;
+
+    /* Computation of UART mask to apply to RDR register */
+    UART_MASK_COMPUTATION(huart);
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a transmit process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_RX;
+    }
+
+    /* Enable the UART Parity Error Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_PE);
+
+    /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_ERR);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    /* Enable the UART Data Register not empty Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_RXNE);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Send an amount of data in DMA mode.
+  * @param huart: UART handle.
+  * @param pData: pointer to data buffer.
+  * @param Size: amount of data to be sent.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_RX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->pTxBuffPtr = pData;
+    huart->TxXferSize = Size;
+    huart->TxXferCount = Size;
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a receive process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_RX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+
+    /* Set the UART DMA transfer complete callback */
+    huart->hdmatx->XferCpltCallback = UART_DMATransmitCplt;
+
+    /* Set the UART DMA Half transfer complete callback */
+    huart->hdmatx->XferHalfCpltCallback = UART_DMATxHalfCplt;
+
+    /* Set the DMA error callback */
+    huart->hdmatx->XferErrorCallback = UART_DMAError;
+
+    /* Enable the UART transmit DMA channel */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(huart->hdmatx, *(uint32_t*)tmp, (uint32_t)&huart->Instance->TDR, Size);
+
+    /* Clear the TC flag in the ICR register */
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
+
+    /* Enable the DMA transfer for transmit request by setting the DMAT bit
+       in the UART CR3 register */
+    huart->Instance->CR3 |= USART_CR3_DMAT;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in DMA mode.
+  * @param huart: UART handle.
+  * @param pData: pointer to data buffer.
+  * @param Size: amount of data to be received.
+  * @note   When the UART parity is enabled (PCE = 1), the received data contain
+  *         the parity bit (MSB position).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_TX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->pRxBuffPtr = pData;
+    huart->RxXferSize = Size;
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a transmit process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_RX;
+    }
+
+    /* Set the UART DMA transfer complete callback */
+    huart->hdmarx->XferCpltCallback = UART_DMAReceiveCplt;
+
+    /* Set the UART DMA Half transfer complete callback */
+    huart->hdmarx->XferHalfCpltCallback = UART_DMARxHalfCplt;
+
+    /* Set the DMA error callback */
+    huart->hdmarx->XferErrorCallback = UART_DMAError;
+
+    /* Enable the DMA channel */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(huart->hdmarx, (uint32_t)&huart->Instance->RDR, *(uint32_t*)tmp, Size);
+
+    /* Enable the DMA transfer for the receiver request by setting the DMAR bit
+       in the UART CR3 register */
+     huart->Instance->CR3 |= USART_CR3_DMAR;
+
+     /* Process Unlocked */
+     __HAL_UNLOCK(huart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Pause the DMA Transfer.
+  * @param huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_DMAPause(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  if(huart->State == HAL_UART_STATE_BUSY_TX)
+  {
+    /* Disable the UART DMA Tx request */
+    huart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAT);
+  }
+  else if(huart->State == HAL_UART_STATE_BUSY_RX)
+  {
+    /* Disable the UART DMA Rx request */
+    huart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAR);
+  }
+  else if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+  {
+    /* Disable the UART DMA Tx request */
+    huart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAT);
+    /* Disable the UART DMA Rx request */
+    huart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAR);
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Resume the DMA Transfer.
+  * @param huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_DMAResume(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  if(huart->State == HAL_UART_STATE_BUSY_TX)
+  {
+    /* Enable the UART DMA Tx request */
+    huart->Instance->CR3 |= USART_CR3_DMAT;
+  }
+  else if(huart->State == HAL_UART_STATE_BUSY_RX)
+  {
+    /* Clear the Overrun flag before resuming the Rx transfer */
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
+
+    /* Enable the UART DMA Rx request */
+    huart->Instance->CR3 |= USART_CR3_DMAR;
+  }
+  else if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+  {
+    /* Clear the Overrun flag before resuming the Rx transfer */
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
+
+    /* Enable the UART DMA Rx request  before the DMA Tx request */
+    huart->Instance->CR3 |= USART_CR3_DMAR;
+
+    /* Enable the UART DMA Tx request */
+    huart->Instance->CR3 |= USART_CR3_DMAT;
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Stop the DMA Transfer.
+  * @param huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_DMAStop(UART_HandleTypeDef *huart)
+{
+  /* The Lock is not implemented on this API to allow the user application
+     to call the HAL UART API under callbacks HAL_UART_TxCpltCallback() / HAL_UART_RxCpltCallback() /
+     HAL_UART_TxHalfCpltCallback / HAL_UART_RxHalfCpltCallback: 
+     indeed, when HAL_DMA_Abort() API is called, the DMA TX/RX Transfer or Half Transfer complete  
+     interrupt is generated if the DMA transfer interruption occurs at the middle or at the end of 
+     the stream and the corresponding call back is executed. */
+
+  /* Disable the UART Tx/Rx DMA requests */
+  huart->Instance->CR3 &= ~USART_CR3_DMAT;
+  huart->Instance->CR3 &= ~USART_CR3_DMAR;
+
+  /* Abort the UART DMA tx channel */
+  if(huart->hdmatx != NULL)
+  {
+    HAL_DMA_Abort(huart->hdmatx);
+  }
+  /* Abort the UART DMA rx channel */
+  if(huart->hdmarx != NULL)
+  {
+    HAL_DMA_Abort(huart->hdmarx);
+  }
+
+  huart->State = HAL_UART_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Handle UART interrupt request.
+  * @param huart: UART handle.
+  * @retval None
+  */
+void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
+{
+  /* UART parity error interrupt occurred -------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_PE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_PE) != RESET))
+  {
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_PEF);
+
+    huart->ErrorCode |= HAL_UART_ERROR_PE;
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+  }
+
+  /* UART frame error interrupt occurred --------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_FE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET))
+  {
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_FEF);
+
+    huart->ErrorCode |= HAL_UART_ERROR_FE;
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+  }
+
+  /* UART noise error interrupt occurred --------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_NE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET))
+  {
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_NEF);
+
+    huart->ErrorCode |= HAL_UART_ERROR_NE;
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+  }
+
+  /* UART Over-Run interrupt occurred -----------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET))
+  {
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
+
+    huart->ErrorCode |= HAL_UART_ERROR_ORE;
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+  }
+
+   /* Call UART Error Call back function if need be --------------------------*/
+  if(huart->ErrorCode != HAL_UART_ERROR_NONE)
+  {
+    HAL_UART_ErrorCallback(huart);
+  }
+
+  /* UART wakeup from Stop mode interrupt occurred -------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_WUF) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_WUF) != RESET))
+  {
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_WUF);
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+    HAL_UARTEx_WakeupCallback(huart);
+  }
+
+  /* UART in mode Receiver ---------------------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET))
+  {
+    UART_Receive_IT(huart);
+  }
+
+
+  /* UART in mode Transmitter ------------------------------------------------*/
+ if((__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) &&(__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET))
+  {
+    UART_Transmit_IT(huart);
+  }
+
+  /* UART in mode Transmitter (transmission end) -----------------------------*/
+ if((__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET) &&(__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TC) != RESET))
+  {
+    UART_EndTransmit_IT(huart);
+  }
+
+}
+
+/**
+  * @brief Tx Transfer completed callback.
+  * @param huart: UART handle.
+  * @retval None
+  */
+__weak void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(huart);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_TxCpltCallback can be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  Tx Half Transfer completed callback.
+  * @param  huart: UART handle.
+  * @retval None
+  */
+__weak void HAL_UART_TxHalfCpltCallback(UART_HandleTypeDef *huart)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(huart);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_UART_TxHalfCpltCallback can be implemented in the user file.
+   */
+}
+
+/**
+  * @brief Rx Transfer completed callback.
+  * @param huart: UART handle.
+  * @retval None
+  */
+__weak void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(huart);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_RxCpltCallback can be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  Rx Half Transfer completed callback.
+  * @param  huart: UART handle.
+  * @retval None
+  */
+__weak void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(huart);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_UART_RxHalfCpltCallback can be implemented in the user file.
+   */
+}
+
+/**
+  * @brief UART error callback.
+  * @param huart: UART handle.
+  * @retval None
+  */
+__weak void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(huart);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_ErrorCallback can be implemented in the user file.
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup UART_Exported_Functions_Group3 Peripheral Control functions
+  *  @brief   UART control functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the UART.
+     (+) HAL_MultiProcessor_EnableMuteMode() API enables mute mode
+     (+) HAL_MultiProcessor_DisableMuteMode() API disables mute mode
+     (+) HAL_MultiProcessor_EnterMuteMode() API enters mute mode
+     (+) HAL_MultiProcessor_EnableMuteMode() API enables mute mode
+     (+) UART_SetConfig() API configures the UART peripheral
+     (+) UART_AdvFeatureConfig() API optionally configures the UART advanced features
+     (+) UART_CheckIdleState() API ensures that TEACK and/or REACK are set after initialization
+     (+) UART_Wakeup_AddressConfig() API configures the wake-up from stop mode parameters
+     (+) HAL_HalfDuplex_EnableTransmitter() API disables receiver and enables transmitter
+     (+) HAL_HalfDuplex_EnableReceiver() API disables transmitter and enables receiver
+     (+) HAL_LIN_SendBreak() API transmits the break characters
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Enable UART in mute mode (does not mean UART enters mute mode;
+  * to enter mute mode, HAL_MultiProcessor_EnterMuteMode() API must be called).
+  * @param huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_MultiProcessor_EnableMuteMode(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Enable USART mute mode by setting the MME bit in the CR1 register */
+  huart->Instance->CR1 |= USART_CR1_MME;
+
+  huart->State = HAL_UART_STATE_READY;
+
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief Disable UART mute mode (does not mean the UART actually exits mute mode
+  * as it may not have been in mute mode at this very moment).
+  * @param huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_MultiProcessor_DisableMuteMode(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+   /* Disable USART mute mode by clearing the MME bit in the CR1 register */
+  huart->Instance->CR1 &= ~(USART_CR1_MME);
+
+  huart->State = HAL_UART_STATE_READY;
+
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief Enter UART mute mode (means UART actually enters mute mode).
+  * @note  To exit from mute mode, HAL_MultiProcessor_DisableMuteMode() API must be called.
+  * @param huart: UART handle.
+  * @retval None
+  */
+void HAL_MultiProcessor_EnterMuteMode(UART_HandleTypeDef *huart)
+{
+  __HAL_UART_SEND_REQ(huart, UART_MUTE_MODE_REQUEST);
+}
+
+/**
+  * @brief  Enable the UART transmitter and disable the UART receiver.
+  * @param  huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HalfDuplex_EnableTransmitter(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Clear TE and RE bits */
+  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TE | USART_CR1_RE));
+  /* Enable the USART's transmit interface by setting the TE bit in the USART CR1 register */
+  SET_BIT(huart->Instance->CR1, USART_CR1_TE);
+
+  huart->State= HAL_UART_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enable the UART receiver and disable the UART transmitter.
+  * @param  huart: UART handle.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_HalfDuplex_EnableReceiver(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Clear TE and RE bits */
+  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TE | USART_CR1_RE));
+  /* Enable the USART's receive interface by setting the RE bit in the USART CR1 register */
+  SET_BIT(huart->Instance->CR1, USART_CR1_RE);
+
+  huart->State = HAL_UART_STATE_READY;
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Transmit break characters.
+  * @param  huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LIN_SendBreak(UART_HandleTypeDef *huart)
+{
+  /* Check the parameters */
+  assert_param(IS_UART_LIN_INSTANCE(huart->Instance));
+
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Send break characters */
+  huart->Instance->RQR |= UART_SENDBREAK_REQUEST;
+
+  huart->State = HAL_UART_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+
+/**
+  * @}
+  */
+
+/** @defgroup UART_Exported_Functions_Group4 Peripheral State and Error functions
+ *  @brief   UART Peripheral State functions
+ *
+@verbatim
+  ==============================================================================
+            ##### Peripheral State and Error functions #####
+  ==============================================================================
+    [..]
+    This subsection provides functions allowing to :
+      (+) Return the UART handle state.
+      (+) Return the UART handle error code
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Return the UART handle state.
+  * @param  huart : pointer to a UART_HandleTypeDef structure that contains
+  *              the configuration information for the specified UART.
+  * @retval HAL state
+  */
+HAL_UART_StateTypeDef HAL_UART_GetState(UART_HandleTypeDef *huart)
+{
+  return huart->State;
+}
+
+/**
+* @brief  Return the UART handle error code.
+* @param  huart : pointer to a UART_HandleTypeDef structure that contains
+  *              the configuration information for the specified UART.
+* @retval UART Error Code
+*/
+uint32_t HAL_UART_GetError(UART_HandleTypeDef *huart)
+{
+  return huart->ErrorCode;
+}
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup UART_Private_Functions UART Private Functions
+  * @{
+  */
+
+/**
+  * @brief Configure the UART peripheral.
+  * @param huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
+{
+  uint32_t tmpreg                     = 0x00000000;
+  UART_ClockSourceTypeDef clocksource = UART_CLOCKSOURCE_UNDEFINED;
+  uint16_t brrtemp                    = 0x0000;
+  uint16_t usartdiv                   = 0x0000;
+  HAL_StatusTypeDef ret               = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_UART_BAUDRATE(huart->Init.BaudRate));
+  assert_param(IS_UART_WORD_LENGTH(huart->Init.WordLength));
+  if(UART_INSTANCE_LOWPOWER(huart))
+  {
+    assert_param(IS_LPUART_STOPBITS(huart->Init.StopBits));  
+  }
+  else
+  {
+    assert_param(IS_UART_STOPBITS(huart->Init.StopBits));
+    assert_param(IS_UART_ONE_BIT_SAMPLE(huart->Init.OneBitSampling));
+  }
+
+  assert_param(IS_UART_PARITY(huart->Init.Parity));
+  assert_param(IS_UART_MODE(huart->Init.Mode));
+  assert_param(IS_UART_HARDWARE_FLOW_CONTROL(huart->Init.HwFlowCtl));
+  assert_param(IS_UART_OVERSAMPLING(huart->Init.OverSampling));
+
+
+  /*-------------------------- USART CR1 Configuration -----------------------*/
+  /* Clear M, PCE, PS, TE, RE and OVER8 bits and configure
+   *  the UART Word Length, Parity, Mode and oversampling:
+   *  set the M bits according to huart->Init.WordLength value
+   *  set PCE and PS bits according to huart->Init.Parity value
+   *  set TE and RE bits according to huart->Init.Mode value
+   *  set OVER8 bit according to huart->Init.OverSampling value */
+  tmpreg = (uint32_t)huart->Init.WordLength | huart->Init.Parity | huart->Init.Mode | huart->Init.OverSampling ;
+  MODIFY_REG(huart->Instance->CR1, UART_CR1_FIELDS, tmpreg);
+
+  /*-------------------------- USART CR2 Configuration -----------------------*/
+  /* Configure the UART Stop Bits: Set STOP[13:12] bits according
+   * to huart->Init.StopBits value */
+  MODIFY_REG(huart->Instance->CR2, USART_CR2_STOP, huart->Init.StopBits);
+
+  /*-------------------------- USART CR3 Configuration -----------------------*/
+  /* Configure
+   * - UART HardWare Flow Control: set CTSE and RTSE bits according
+   *   to huart->Init.HwFlowCtl value
+   * - one-bit sampling method versus three samples' majority rule according
+   *   to huart->Init.OneBitSampling (not applicable to LPUART) */
+  tmpreg = (uint32_t)huart->Init.HwFlowCtl;
+  if (!(UART_INSTANCE_LOWPOWER(huart)))
+  {
+    tmpreg |= huart->Init.OneBitSampling;
+  }
+  MODIFY_REG(huart->Instance->CR3, (USART_CR3_RTSE | USART_CR3_CTSE | USART_CR3_ONEBIT), tmpreg);
+
+  /*-------------------------- USART BRR Configuration -----------------------*/
+  UART_GETCLOCKSOURCE(huart, clocksource);
+
+  /* Check LPUART instance */
+  if(UART_INSTANCE_LOWPOWER(huart))
+  {
+    /* Retrieve frequency clock */
+    tmpreg = 0;
+
+    switch (clocksource)
+    {
+    case UART_CLOCKSOURCE_PCLK1:
+      tmpreg = HAL_RCC_GetPCLK1Freq();
+      break;
+    case UART_CLOCKSOURCE_HSI:
+      tmpreg = (uint32_t) HSI_VALUE;
+      break;
+    case UART_CLOCKSOURCE_SYSCLK:
+      tmpreg = HAL_RCC_GetSysClockFreq();
+      break;
+    case UART_CLOCKSOURCE_LSE:
+      tmpreg = (uint32_t) LSE_VALUE;
+      break;
+    case UART_CLOCKSOURCE_UNDEFINED:
+    default:
+        ret = HAL_ERROR;
+      break;
+    }
+
+    /* if proper clock source reported */
+    if (tmpreg != 0)
+    {
+      /* ensure that Frequency clock is in the range [3 * baudrate, 4096 * baudrate] */
+      if ( (tmpreg < (3 * huart->Init.BaudRate) ) ||
+           (tmpreg > (4096 * huart->Init.BaudRate) ))
+      {
+        ret = HAL_ERROR;
+      }
+      else
+      {
+        switch (clocksource)
+        {
+        case UART_CLOCKSOURCE_PCLK1:
+            tmpreg = (uint32_t)(UART_DIV_LPUART(HAL_RCC_GetPCLK1Freq(), huart->Init.BaudRate));
+          break;
+        case UART_CLOCKSOURCE_HSI:
+            tmpreg = (uint32_t)(UART_DIV_LPUART(HSI_VALUE, huart->Init.BaudRate));
+          break;
+        case UART_CLOCKSOURCE_SYSCLK:
+            tmpreg = (uint32_t)(UART_DIV_LPUART(HAL_RCC_GetSysClockFreq(), huart->Init.BaudRate));
+          break;
+        case UART_CLOCKSOURCE_LSE:
+            tmpreg = (uint32_t)(UART_DIV_LPUART(LSE_VALUE, huart->Init.BaudRate));
+          break;
+        case UART_CLOCKSOURCE_UNDEFINED:
+        default:
+            ret = HAL_ERROR;
+          break;
+        }
+   
+        if ((tmpreg >= UART_LPUART_BRR_MIN) && (tmpreg <= UART_LPUART_BRR_MAX))
+        {
+           huart->Instance->BRR = tmpreg;
+        }
+        else
+        {
+          ret = HAL_ERROR;
+        }
+      }  /*   if ( (tmpreg < (3 * huart->Init.BaudRate) ) || (tmpreg > (4096 * huart->Init.BaudRate) )) */
+    } /* if (tmpreg != 0) */
+  }
+  /* Check UART Over Sampling to set Baud Rate Register */
+  else if (huart->Init.OverSampling == UART_OVERSAMPLING_8)
+  {
+    switch (clocksource)
+    {
+    case UART_CLOCKSOURCE_PCLK1:
+        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(HAL_RCC_GetPCLK1Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_PCLK2:
+        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_HSI:
+        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(HSI_VALUE, huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_SYSCLK:
+        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(HAL_RCC_GetSysClockFreq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_LSE:
+        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(LSE_VALUE, huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_UNDEFINED:
+    default:
+        ret = HAL_ERROR;
+      break;
+    }
+
+    brrtemp = usartdiv & 0xFFF0;
+    brrtemp |= (uint16_t)((usartdiv & (uint16_t)0x000F) >> 1U);
+    huart->Instance->BRR = brrtemp;
+  }
+  else
+  {
+    switch (clocksource)
+    {
+    case UART_CLOCKSOURCE_PCLK1:
+        huart->Instance->BRR = (uint16_t)(UART_DIV_SAMPLING16(HAL_RCC_GetPCLK1Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_PCLK2:
+        huart->Instance->BRR = (uint16_t)(UART_DIV_SAMPLING16(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_HSI:
+        huart->Instance->BRR = (uint16_t)(UART_DIV_SAMPLING16(HSI_VALUE, huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_SYSCLK:
+        huart->Instance->BRR = (uint16_t)(UART_DIV_SAMPLING16(HAL_RCC_GetSysClockFreq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_LSE:
+        huart->Instance->BRR = (uint16_t)(UART_DIV_SAMPLING16(LSE_VALUE, huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_UNDEFINED:
+    default:
+        ret = HAL_ERROR;
+      break;
+    }
+  }
+
+  return ret;
+
+}
+
+/**
+  * @brief Configure the UART peripheral advanced features.
+  * @param huart: UART handle.
+  * @retval None
+  */
+void UART_AdvFeatureConfig(UART_HandleTypeDef *huart)
+{
+  /* Check whether the set of advanced features to configure is properly set */
+  assert_param(IS_UART_ADVFEATURE_INIT(huart->AdvancedInit.AdvFeatureInit));
+
+  /* if required, configure TX pin active level inversion */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_TXINVERT_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_TXINV(huart->AdvancedInit.TxPinLevelInvert));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_TXINV, huart->AdvancedInit.TxPinLevelInvert);
+  }
+
+  /* if required, configure RX pin active level inversion */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_RXINVERT_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_RXINV(huart->AdvancedInit.RxPinLevelInvert));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_RXINV, huart->AdvancedInit.RxPinLevelInvert);
+  }
+
+  /* if required, configure data inversion */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_DATAINVERT_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_DATAINV(huart->AdvancedInit.DataInvert));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_DATAINV, huart->AdvancedInit.DataInvert);
+  }
+
+  /* if required, configure RX/TX pins swap */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_SWAP_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_SWAP(huart->AdvancedInit.Swap));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_SWAP, huart->AdvancedInit.Swap);
+  }
+
+  /* if required, configure RX overrun detection disabling */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_RXOVERRUNDISABLE_INIT))
+  {
+    assert_param(IS_UART_OVERRUN(huart->AdvancedInit.OverrunDisable));
+    MODIFY_REG(huart->Instance->CR3, USART_CR3_OVRDIS, huart->AdvancedInit.OverrunDisable);
+  }
+
+  /* if required, configure DMA disabling on reception error */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_DMADISABLEONERROR_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_DMAONRXERROR(huart->AdvancedInit.DMADisableonRxError));
+    MODIFY_REG(huart->Instance->CR3, USART_CR3_DDRE, huart->AdvancedInit.DMADisableonRxError);
+  }
+
+  /* if required, configure auto Baud rate detection scheme */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_AUTOBAUDRATE_INIT))
+  {
+    assert_param(IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(huart->Instance));
+    assert_param(IS_UART_ADVFEATURE_AUTOBAUDRATE(huart->AdvancedInit.AutoBaudRateEnable));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_ABREN, huart->AdvancedInit.AutoBaudRateEnable);
+    /* set auto Baudrate detection parameters if detection is enabled */
+    if(huart->AdvancedInit.AutoBaudRateEnable == UART_ADVFEATURE_AUTOBAUDRATE_ENABLE)
+    {
+      assert_param(IS_UART_ADVFEATURE_AUTOBAUDRATEMODE(huart->AdvancedInit.AutoBaudRateMode));
+      MODIFY_REG(huart->Instance->CR2, USART_CR2_ABRMODE, huart->AdvancedInit.AutoBaudRateMode);
+    }
+  }
+
+  /* if required, configure MSB first on communication line */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_MSBFIRST_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_MSBFIRST(huart->AdvancedInit.MSBFirst));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_MSBFIRST, huart->AdvancedInit.MSBFirst);
+  }
+}
+
+/**
+  * @brief Check the UART Idle State.
+  * @param huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart)
+{
+  /* Initialize the UART ErrorCode */
+  huart->ErrorCode = HAL_UART_ERROR_NONE;
+
+  /* Check if the Transmitter is enabled */
+  if((huart->Instance->CR1 & USART_CR1_TE) == USART_CR1_TE)
+  {
+    /* Wait until TEACK flag is set */
+    if(UART_WaitOnFlagUntilTimeout(huart, USART_ISR_TEACK, RESET, HAL_UART_TIMEOUT_VALUE) != HAL_OK)
+    {
+      /* Timeout occurred */
+      return HAL_TIMEOUT;
+    }
+  }
+  /* Check if the Receiver is enabled */
+  if((huart->Instance->CR1 & USART_CR1_RE) == USART_CR1_RE)
+  {
+    /* Wait until REACK flag is set */
+    if(UART_WaitOnFlagUntilTimeout(huart, USART_ISR_REACK, RESET,  HAL_UART_TIMEOUT_VALUE) != HAL_OK)
+    {
+      /* Timeout occurred */
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Initialize the UART State */
+  huart->State= HAL_UART_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief DMA UART transmit process complete callback.
+  * @param hdma: DMA handle.
+  * @retval None
+  */
+static void UART_DMATransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  UART_HandleTypeDef* huart = ( UART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  /* DMA Normal mode */
+  if ( HAL_IS_BIT_CLR(hdma->Instance->CCR, DMA_CCR_CIRC) )
+  {  
+    huart->TxXferCount = 0;
+  
+    /* Disable the DMA transfer for transmit request by resetting the DMAT bit
+    in the UART CR3 register */
+    huart->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_DMAT);
+
+    /* Enable the UART Transmit Complete Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+  }
+  /* DMA Circular mode */
+  else
+  {
+    HAL_UART_TxCpltCallback(huart);
+  }
+
+}
+
+/**
+  * @brief DMA UART transmit process half complete callback.
+  * @param hdma : DMA handle.
+  * @retval None
+  */
+static void UART_DMATxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  UART_HandleTypeDef* huart = (UART_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_UART_TxHalfCpltCallback(huart);
+}
+
+/**
+  * @brief DMA UART receive process complete callback.
+  * @param hdma: DMA handle.
+  * @retval None
+  */
+static void UART_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  UART_HandleTypeDef* huart = ( UART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  /* DMA Normal mode */
+  if ( HAL_IS_BIT_CLR(hdma->Instance->CCR, DMA_CCR_CIRC) )
+  {
+    huart->RxXferCount = 0;
+
+    /* Disable the DMA transfer for the receiver request by resetting the DMAR bit
+       in the UART CR3 register */
+    huart->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_DMAR);
+
+    /* Check if a transmit Process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_READY;
+    }
+  }
+  
+  HAL_UART_RxCpltCallback(huart);
+}
+
+/**
+  * @brief  Handle UART Communication Timeout.
+  * @param  huart: UART handle.
+  * @param  Flag: specifies the UART flag to check.
+  * @param  Status: the Flag status (SET or RESET).
+  * @param  Timeout: Timeout duration.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_t Flag, FlagStatus Status, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {
+    while(__HAL_UART_GET_FLAG(huart, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_RXNE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+
+          huart->State= HAL_UART_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(huart);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_UART_GET_FLAG(huart, Flag) != RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_RXNE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+
+          huart->State= HAL_UART_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(huart);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief DMA UART receive process half complete callback.
+  * @param hdma : DMA handle.
+  * @retval None
+  */
+static void UART_DMARxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  UART_HandleTypeDef* huart = (UART_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_UART_RxHalfCpltCallback(huart);
+}
+
+/**
+  * @brief DMA UART communication error callback.
+  * @param hdma: DMA handle.
+  * @retval None
+  */
+static void UART_DMAError(DMA_HandleTypeDef *hdma)
+{
+  UART_HandleTypeDef* huart = ( UART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  huart->RxXferCount = 0;
+  huart->TxXferCount = 0;
+  huart->State= HAL_UART_STATE_READY;
+  huart->ErrorCode |= HAL_UART_ERROR_DMA;
+  HAL_UART_ErrorCallback(huart);
+}
+
+/**
+  * @brief Send an amount of data in interrupt mode.
+  * @note   Function is called under interruption only, once
+  *         interruptions have been enabled by HAL_UART_Transmit_IT().
+  * @param  huart: UART handle.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef UART_Transmit_IT(UART_HandleTypeDef *huart)
+{
+  uint16_t* tmp;
+
+  if ((huart->State == HAL_UART_STATE_BUSY_TX) || (huart->State == HAL_UART_STATE_BUSY_TX_RX))
+  {
+
+    if(huart->TxXferCount == 0)
+    {
+      /* Disable the UART Transmit Data Register Empty Interrupt */
+      __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
+
+      /* Enable the UART Transmit Complete Interrupt */
+      __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+
+      return HAL_OK;
+    }
+    else
+    {
+      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) huart->pTxBuffPtr;
+        huart->Instance->TDR = (*tmp & (uint16_t)0x01FF);
+        huart->pTxBuffPtr += 2;
+      }
+      else
+      {
+        huart->Instance->TDR = (uint8_t)(*huart->pTxBuffPtr++ & (uint8_t)0xFF);
+      }
+
+      huart->TxXferCount--;
+
+      return HAL_OK;
+    }
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+
+/**
+  * @brief  Wrap up transmission in non-blocking mode.
+  * @param  huart: pointer to a UART_HandleTypeDef structure that contains
+  *                the configuration information for the specified UART module.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef UART_EndTransmit_IT(UART_HandleTypeDef *huart)
+{
+  /* Disable the UART Transmit Complete Interrupt */
+  __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
+
+  /* Check if a receive process is ongoing or not */
+  if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+  {
+    huart->State = HAL_UART_STATE_BUSY_RX;
+  }
+  else
+  {
+    /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+
+    huart->State = HAL_UART_STATE_READY;
+  }
+
+  HAL_UART_TxCpltCallback(huart);
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief Receive an amount of data in interrupt mode.
+  * @note   Function is called under interruption only, once
+  *         interruptions have been enabled by HAL_UART_Receive_IT()
+  * @param  huart: UART handle.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef UART_Receive_IT(UART_HandleTypeDef *huart)
+{
+  uint16_t* tmp;
+  uint16_t uhMask = huart->Mask;
+
+  if((huart->State == HAL_UART_STATE_BUSY_RX) || (huart->State == HAL_UART_STATE_BUSY_TX_RX))
+  {
+
+    if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+    {
+      tmp = (uint16_t*) huart->pRxBuffPtr ;
+      *tmp = (uint16_t)(huart->Instance->RDR & uhMask);
+      huart->pRxBuffPtr +=2;
+    }
+    else
+    {
+      *huart->pRxBuffPtr++ = (uint8_t)(huart->Instance->RDR & (uint8_t)uhMask);
+    }
+
+    if(--huart->RxXferCount == 0)
+    {
+      __HAL_UART_DISABLE_IT(huart, UART_IT_RXNE);
+
+      /* Check if a transmit Process is ongoing or not */
+      if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+      {
+        huart->State = HAL_UART_STATE_BUSY_TX;
+      }
+      else
+      {
+        /* Disable the UART Parity Error Interrupt */
+        __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
+
+        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+        __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+
+        huart->State = HAL_UART_STATE_READY;
+      }
+
+      HAL_UART_RxCpltCallback(huart);
+
+      return HAL_OK;
+    }
+
+    return HAL_OK;
+  }
+  else
+  {
+    /* Clear RXNE interrupt flag */
+    __HAL_UART_SEND_REQ(huart, UART_RXDATA_FLUSH_REQUEST);
+
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_UART_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_hal_uart.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_uart.c
@@ -2101,6 +2101,44 @@ static HAL_StatusTypeDef UART_Receive_IT(UART_HandleTypeDef *huart)
   }
 }
 
+
+/**
+  * @brief Calculate register BRR value without using uint64.
+  * @note   This function is added by the micropython project.
+  * @param  fck: Input clock frequency to the uart block in Hz.
+  * @param  baud: baud rate should be one of {300, 600, 1200, 2400, 4800, 9600, 19200, 57600, 115200}.
+  * @retval BRR value
+  */
+uint32_t HAL_UART_CalcBrr(uint32_t fck, uint32_t baud)
+{
+    const struct
+    {
+        uint32_t limit;
+        uint32_t div;
+    } comDiv[]= {
+        {1<<31, 300 }, /* must by >= 256 */
+        {1<<30, 150 }, /* must by >= 128 */
+        {1<<29,  75 }, /* must by >= 64 */
+        {1<<28,  50 }, /* must by >= 32 */
+        {1<<27,  20 }, /* must by >= 16 */
+        {1<<26,  10 }, /* must by >= 8 */
+        {1<<25,   5 }, /* must by >= 4 */
+        {1<<24,   2 }  /* must by >= 2 */
+    };
+    const uint32_t comDivCnt = sizeof(comDiv)/sizeof(comDiv[0]);
+    uint8_t i;
+    for (i=0; i<comDivCnt ;i++)
+    {
+        if (fck >= comDiv[i].limit)
+        {
+            fck  /= comDiv[i].div;
+            baud /= comDiv[i].div;
+            break;
+        }
+    }
+    return (fck<<8)/baud;
+}
+
 /**
   * @}
   */

--- a/stmhal/hal/l4/src/stm32l4xx_hal_uart_ex.c
+++ b/stmhal/hal/l4/src/stm32l4xx_hal_uart_ex.c
@@ -1,0 +1,462 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_uart_ex.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   Extended UART HAL module driver.
+  *          This file provides firmware functions to manage the following extended
+  *          functionalities of the Universal Asynchronous Receiver Transmitter Peripheral (UART).
+  *           + Initialization and de-initialization functions
+  *           + Peripheral Control functions
+  *
+  *
+  @verbatim
+  ==============================================================================
+               ##### UART peripheral extended features  #####
+  ==============================================================================
+
+    (#) Declare a UART_HandleTypeDef handle structure.
+
+    (#) For the UART RS485 Driver Enable mode, initialize the UART registers
+        by calling the HAL_RS485Ex_Init() API.
+
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup UARTEx UARTEx
+  * @brief UART Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_UART_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/** @defgroup UARTEx_Private_Functions UARTEx Private Functions
+  * @{
+  */
+static void UARTEx_Wakeup_AddressConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup UARTEx_Exported_Functions  UARTEx Exported Functions
+  * @{
+  */
+
+/** @defgroup UARTEx_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @brief    Extended Initialization and Configuration Functions
+  *
+@verbatim
+===============================================================================
+            ##### Initialization and Configuration functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to initialize the USARTx or the UARTy
+    in asynchronous mode.
+      (+) For the asynchronous mode the parameters below can be configured:
+        (++) Baud Rate
+        (++) Word Length
+        (++) Stop Bit
+        (++) Parity: If the parity is enabled, then the MSB bit of the data written
+             in the data register is transmitted but is changed by the parity bit.
+        (++) Hardware flow control
+        (++) Receiver/transmitter modes
+        (++) Over Sampling Method
+        (++) One-Bit Sampling Method
+      (+) For the asynchronous mode, the following advanced features can be configured as well:
+        (++) TX and/or RX pin level inversion
+        (++) data logical level inversion
+        (++) RX and TX pins swap
+        (++) RX overrun detection disabling
+        (++) DMA disabling on RX error
+        (++) MSB first on communication line
+        (++) auto Baud rate detection
+    [..]
+    The HAL_RS485Ex_Init() API follows the UART RS485 mode configuration
+     procedures (details for the procedures are available in reference manual).
+
+@endverbatim
+
+  Depending on the frame length defined by the M1 and M0 bits (7-bit, 
+  8-bit or 9-bit), the possible UART formats are listed in the 
+  following table.
+  
+    Table 1. UART frame format.
+    +-----------------------------------------------------------------------+
+    |  M1 bit |  M0 bit |  PCE bit  |             UART frame                |
+    |---------|---------|-----------|---------------------------------------|
+    |    0    |    0    |    0      |    | SB |    8 bit data   | STB |     |
+    |---------|---------|-----------|---------------------------------------|
+    |    0    |    0    |    1      |    | SB | 7 bit data | PB | STB |     |
+    |---------|---------|-----------|---------------------------------------|
+    |    0    |    1    |    0      |    | SB |    9 bit data   | STB |     |
+    |---------|---------|-----------|---------------------------------------|
+    |    0    |    1    |    1      |    | SB | 8 bit data | PB | STB |     |
+    |---------|---------|-----------|---------------------------------------|
+    |    1    |    0    |    0      |    | SB |    7 bit data   | STB |     |
+    |---------|---------|-----------|---------------------------------------|
+    |    1    |    0    |    1      |    | SB | 6 bit data | PB | STB |     |
+    +-----------------------------------------------------------------------+
+
+  * @{
+  */
+
+/**
+  * @brief Initialize the RS485 Driver enable feature according to the specified
+  *         parameters in the UART_InitTypeDef and creates the associated handle.
+  * @param huart: UART handle.
+  * @param Polarity: select the driver enable polarity.
+  *        This parameter can be one of the following values:
+  *          @arg @ref UART_DE_POLARITY_HIGH DE signal is active high
+  *          @arg @ref UART_DE_POLARITY_LOW  DE signal is active low
+  * @param AssertionTime: Driver Enable assertion time:
+  *                         5-bit value defining the time between the activation of the DE (Driver Enable)
+  *                         signal and the beginning of the start bit. It is expressed in sample time
+  *                         units (1/8 or 1/16 bit time, depending on the oversampling rate)
+  * @param DeassertionTime: Driver Enable deassertion time:
+  *                         5-bit value defining the time between the end of the last stop bit, in a
+  *                         transmitted message, and the de-activation of the DE (Driver Enable) signal.
+  *                         It is expressed in sample time units (1/8 or 1/16 bit time, depending on the
+  *                         oversampling rate).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RS485Ex_Init(UART_HandleTypeDef *huart, uint32_t Polarity, uint32_t AssertionTime, uint32_t DeassertionTime)
+{
+  uint32_t temp = 0x0;
+
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+  /* Check the Driver Enable UART instance */
+  assert_param(IS_UART_DRIVER_ENABLE_INSTANCE(huart->Instance));
+
+  /* Check the Driver Enable polarity */
+  assert_param(IS_UART_DE_POLARITY(Polarity));
+
+  /* Check the Driver Enable assertion time */
+  assert_param(IS_UART_ASSERTIONTIME(AssertionTime));
+
+  /* Check the Driver Enable deassertion time */
+  assert_param(IS_UART_DEASSERTIONTIME(DeassertionTime));
+
+  if(huart->State == HAL_UART_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    huart->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX */
+    HAL_UART_MspInit(huart);
+  }
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  /* Set the UART Communication parameters */
+  if (UART_SetConfig(huart) == HAL_ERROR)
+  {
+    return HAL_ERROR;
+  }
+
+  if(huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
+  /* Enable the Driver Enable mode by setting the DEM bit in the CR3 register */
+  SET_BIT(huart->Instance->CR3, USART_CR3_DEM);
+
+  /* Set the Driver Enable polarity */
+  MODIFY_REG(huart->Instance->CR3, USART_CR3_DEP, Polarity);
+
+  /* Set the Driver Enable assertion and deassertion times */
+  temp = (AssertionTime << UART_CR1_DEAT_ADDRESS_LSB_POS);
+  temp |= (DeassertionTime << UART_CR1_DEDT_ADDRESS_LSB_POS);
+  MODIFY_REG(huart->Instance->CR1, (USART_CR1_DEDT|USART_CR1_DEAT), temp);
+
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+
+/**
+  * @}
+  */
+
+/** @defgroup UARTEx_Exported_Functions_Group3 Peripheral Control functions
+  * @brief    Extended Peripheral Control functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================
+    [..] This section provides the following functions:
+     (+) HAL_UARTEx_EnableClockStopMode() API enables the UART clock (HSI or LSE only) during stop mode
+     (+) HAL_UARTEx_DisableClockStopMode() API disables the above functionality
+     (+) HAL_MultiProcessorEx_AddressLength_Set() API optionally sets the UART node address
+         detection length to more than 4 bits for multiprocessor address mark wake up.
+     (+) HAL_UARTEx_StopModeWakeUpSourceConfig() API defines the wake-up from stop mode
+         trigger: address match, Start Bit detection or RXNE bit status.
+     (+) HAL_UARTEx_EnableStopMode() API enables the UART to wake up the MCU from stop mode
+     (+) HAL_UARTEx_DisableStopMode() API disables the above functionality
+     (+) HAL_UARTEx_WakeupCallback() called upon UART wakeup interrupt
+
+
+@endverbatim
+  * @{
+  */
+
+
+
+
+/**
+  * @brief By default in multiprocessor mode, when the wake up method is set
+  *        to address mark, the UART handles only 4-bit long addresses detection;
+  *        this API allows to enable longer addresses detection (6-, 7- or 8-bit
+  *        long).
+  * @note  Addresses detection lengths are: 6-bit address detection in 7-bit data mode, 
+  *        7-bit address detection in 8-bit data mode, 8-bit address detection in 9-bit data mode.
+  * @param huart: UART handle.
+  * @param AddressLength: this parameter can be one of the following values:
+  *          @arg @ref UART_ADDRESS_DETECT_4B 4-bit long address
+  *          @arg @ref UART_ADDRESS_DETECT_7B 6-, 7- or 8-bit long address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_MultiProcessorEx_AddressLength_Set(UART_HandleTypeDef *huart, uint32_t AddressLength)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the address length parameter */
+  assert_param(IS_UART_ADDRESSLENGTH_DETECT(AddressLength));
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  /* Set the address length */
+  MODIFY_REG(huart->Instance->CR2, USART_CR2_ADDM7, AddressLength);
+
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+
+/**
+  * @brief Set Wakeup from Stop mode interrupt flag selection.
+  * @param huart: UART handle.
+  * @param WakeUpSelection: address match, Start Bit detection or RXNE bit status.
+  * This parameter can be one of the following values:
+  *      @arg @ref UART_WAKEUP_ON_ADDRESS
+  *      @arg @ref UART_WAKEUP_ON_STARTBIT
+  *      @arg @ref UART_WAKEUP_ON_READDATA_NONEMPTY
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_StopModeWakeUpSourceConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* check the wake-up from stop mode UART instance */
+  assert_param(IS_UART_WAKEUP_FROMSTOP_INSTANCE(huart->Instance));
+  /* check the wake-up selection parameter */
+  assert_param(IS_UART_WAKEUP_SELECTION(WakeUpSelection.WakeUpEvent));
+
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  /* Set the wake-up selection scheme */
+  MODIFY_REG(huart->Instance->CR3, USART_CR3_WUS, WakeUpSelection.WakeUpEvent);
+
+  if (WakeUpSelection.WakeUpEvent == UART_WAKEUP_ON_ADDRESS)
+  {
+    UARTEx_Wakeup_AddressConfig(huart, WakeUpSelection);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+
+  /* Wait until REACK flag is set */
+  if(UART_WaitOnFlagUntilTimeout(huart, USART_ISR_REACK, RESET, HAL_UART_TIMEOUT_VALUE) != HAL_OK)
+  {
+    status = HAL_TIMEOUT;
+  }
+  else
+  {
+    /* Initialize the UART State */
+    huart->State = HAL_UART_STATE_READY;
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return status;
+}
+
+
+/**
+  * @brief Enable UART Stop Mode.
+  * @note The UART is able to wake up the MCU from Stop 1 mode as long as UART clock is HSI or LSE.
+  * @param huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_EnableStopMode(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Set UESM bit */
+  SET_BIT(huart->Instance->CR1, USART_CR1_UESM);
+
+  huart->State = HAL_UART_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Disable UART Stop Mode.
+  * @param huart: UART handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_DisableStopMode(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Clear UESM bit */
+  CLEAR_BIT(huart->Instance->CR1, USART_CR1_UESM);
+
+  huart->State = HAL_UART_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief UART wakeup from Stop mode callback.
+  * @param huart: UART handle.
+  * @retval None
+  */
+__weak void HAL_UARTEx_WakeupCallback(UART_HandleTypeDef *huart)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(huart);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UARTEx_WakeupCallback can be implemented in the user file.
+   */
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup UARTEx_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief Initialize the UART wake-up from stop mode parameters when triggered by address detection.
+  * @param huart: UART handle.
+  * @param WakeUpSelection: UART wake up from stop mode parameters.
+  * @retval None
+  */
+static void UARTEx_Wakeup_AddressConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection)
+{
+  assert_param(IS_UART_ADDRESSLENGTH_DETECT(WakeUpSelection.AddressLength));
+
+  /* Set the USART address length */
+  MODIFY_REG(huart->Instance->CR2, USART_CR2_ADDM7, WakeUpSelection.AddressLength);
+
+  /* Set the USART address node */
+  MODIFY_REG(huart->Instance->CR2, USART_CR2_ADD, ((uint32_t)WakeUpSelection.Address << UART_CR2_ADDRESS_LSB_POS));
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_UART_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_ll_sdmmc.c
+++ b/stmhal/hal/l4/src/stm32l4xx_ll_sdmmc.c
@@ -1,0 +1,496 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_ll_sdmmc.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   SDMMC Low Layer HAL module driver.  
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the SDMMC peripheral:
+  *           + Initialization/de-initialization functions
+  *           + I/O operation functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                       ##### SDMMC peripheral features #####
+  ==============================================================================        
+    [..] The SD/SDMMC MMC card host interface (SDMMC) provides an interface between the APB2
+         peripheral bus and MultiMedia cards (MMCs), SD memory cards, SDMMC cards and CE-ATA
+         devices.
+    
+    [..] The SDMMC features include the following:
+         (+) Full compliance with MultiMedia Card System Specification Version 4.2. Card support
+             for three different data bus modes: 1-bit (default), 4-bit and 8-bit
+         (+) Full compatibility with previous versions of MultiMedia Cards (forward compatibility)
+         (+) Full compliance with SD Memory Card Specifications Version 2.0
+         (+) Full compliance with SD I/O Card Specification Version 2.0: card support for two
+             different data bus modes: 1-bit (default) and 4-bit
+         (+) Full support of the CE-ATA features (full compliance with CE-ATA digital protocol
+             Rev1.1)
+         (+) Data transfer up to 48 MHz for the 8 bit mode
+         (+) Data and command output enable signals to control external bidirectional drivers.
+                 
+   
+                           ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      This driver is a considered as a driver of service for external devices drivers 
+      that interfaces with the SDMMC peripheral.
+      According to the device used (SD card/ MMC card / SDMMC card ...), a set of APIs 
+      is used in the device's driver to perform SDMMC operations and functionalities.
+   
+      This driver is almost transparent for the final user, it is only used to implement other
+      functionalities of the external device.
+   
+    [..]
+      (+) The SDMMC clock (SDMMCCLK = 48 MHz) is coming from a specific output (MSI, PLLUSB1CLK,
+          PLLUSB2CLK). Before start working with SDMMC peripheral make sure that the
+          PLL is well configured.
+          The SDMMC peripheral uses two clock signals:
+          (++) SDMMC adapter clock (SDMMCCLK = 48 MHz)
+          (++) APB2 bus clock (PCLK2)
+       
+          -@@- PCLK2 and SDMMC_CK clock frequencies must respect the following condition:
+               Frequency(PCLK2) >= (3 / 8 x Frequency(SDMMC_CK))
+  
+      (+) Enable/Disable peripheral clock using RCC peripheral macros related to SDMMC
+          peripheral.
+
+      (+) Enable the Power ON State using the SDMMC_PowerState_ON(SDMMCx) 
+          function and disable it using the function SDMMC_PowerState_OFF(SDMMCx).
+                
+      (+) Enable/Disable the clock using the __SDMMC_ENABLE()/__SDMMC_DISABLE() macros.
+  
+      (+) Enable/Disable the peripheral interrupts using the macros __SDMMC_ENABLE_IT(hSDMMC, IT) 
+          and __SDMMC_DISABLE_IT(hSDMMC, IT) if you need to use interrupt mode. 
+  
+      (+) When using the DMA mode 
+          (++) Configure the DMA in the MSP layer of the external device
+          (++) Active the needed channel Request 
+          (++) Enable the DMA using __SDMMC_DMA_ENABLE() macro or Disable it using the macro
+               __SDMMC_DMA_DISABLE().
+  
+      (+) To control the CPSM (Command Path State Machine) and send 
+          commands to the card use the SDMMC_SendCommand(SDMMCx), 
+          SDMMC_GetCommandResponse() and SDMMC_GetResponse() functions. First, user has
+          to fill the command structure (pointer to SDMMC_CmdInitTypeDef) according 
+          to the selected command to be sent.
+          The parameters that should be filled are:
+           (++) Command Argument
+           (++) Command Index
+           (++) Command Response type
+           (++) Command Wait
+           (++) CPSM Status (Enable or Disable).
+  
+          -@@- To check if the command is well received, read the SDMMC_CMDRESP
+              register using the SDMMC_GetCommandResponse().
+              The SDMMC responses registers (SDMMC_RESP1 to SDMMC_RESP2), use the
+              SDMMC_GetResponse() function.
+  
+      (+) To control the DPSM (Data Path State Machine) and send/receive 
+           data to/from the card use the SDMMC_DataConfig(), SDMMC_GetDataCounter(), 
+          SDMMC_ReadFIFO(), SDMMC_WriteFIFO() and SDMMC_GetFIFOCount() functions.
+  
+    *** Read Operations ***
+    =======================
+    [..]
+      (#) First, user has to fill the data structure (pointer to
+          SDMMC_DataInitTypeDef) according to the selected data type to be received.
+          The parameters that should be filled are:
+           (++) Data TimeOut
+           (++) Data Length
+           (++) Data Block size
+           (++) Data Transfer direction: should be from card (To SDMMC)
+           (++) Data Transfer mode
+           (++) DPSM Status (Enable or Disable)
+                                     
+      (#) Configure the SDMMC resources to receive the data from the card
+          according to selected transfer mode (Refer to Step 8, 9 and 10).
+  
+      (#) Send the selected Read command (refer to step 11).
+                    
+      (#) Use the SDMMC flags/interrupts to check the transfer status.
+  
+    *** Write Operations ***
+    ========================
+    [..]
+     (#) First, user has to fill the data structure (pointer to
+         SDMMC_DataInitTypeDef) according to the selected data type to be received.
+         The parameters that should be filled are:
+          (++) Data TimeOut
+          (++) Data Length
+          (++) Data Block size
+          (++) Data Transfer direction:  should be to card (To CARD)
+          (++) Data Transfer mode
+          (++) DPSM Status (Enable or Disable)
+  
+     (#) Configure the SDMMC resources to send the data to the card according to 
+         selected transfer mode.
+                     
+     (#) Send the selected Write command.
+                    
+     (#) Use the SDMMC flags/interrupts to check the transfer status.
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+/** @addtogroup STM32L4xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SDMMC_LL SDMMC Low Layer
+  * @brief Low layer module for SD
+  * @{
+  */
+
+#if defined (HAL_SD_MODULE_ENABLED)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup SDMMC_LL_Exported_Functions SDMMC Low Layer Exported Functions
+  * @{
+  */
+
+/** @defgroup HAL_SDMMC_LL_Group1 Initialization de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+ ===============================================================================
+              ##### Initialization/de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+ 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the SDMMC according to the specified
+  *         parameters in the SDMMC_InitTypeDef and initialize the associated handle.
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @param  Init: SDMMC initialization structure   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef SDMMC_Init(SDMMC_TypeDef *SDMMCx, SDMMC_InitTypeDef Init)
+{
+  /* Check the parameters */
+  assert_param(IS_SDMMC_ALL_INSTANCE(SDMMCx));
+  assert_param(IS_SDMMC_CLOCK_EDGE(Init.ClockEdge)); 
+  assert_param(IS_SDMMC_CLOCK_BYPASS(Init.ClockBypass));
+  assert_param(IS_SDMMC_CLOCK_POWER_SAVE(Init.ClockPowerSave));
+  assert_param(IS_SDMMC_BUS_WIDE(Init.BusWide));
+  assert_param(IS_SDMMC_HARDWARE_FLOW_CONTROL(Init.HardwareFlowControl));
+  assert_param(IS_SDMMC_CLKDIV(Init.ClockDiv));
+  
+  /* Set SDMMC configuration parameters */
+  /* Write to SDMMC CLKCR */
+  MODIFY_REG(SDMMCx->CLKCR, CLKCR_CLEAR_MASK, Init.ClockEdge           |\
+                                              Init.ClockBypass         |\
+                                              Init.ClockPowerSave      |\
+                                              Init.BusWide             |\
+                                              Init.HardwareFlowControl |\
+                                              Init.ClockDiv);  
+
+  return HAL_OK;
+}
+
+
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SDMMC_LL_Group2 IO operation functions 
+ *  @brief   Data transfers functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### I/O operation functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to manage the SDMMC data 
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Read data (word) from Rx FIFO in blocking mode (polling) 
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval HAL status
+  */
+uint32_t SDMMC_ReadFIFO(SDMMC_TypeDef *SDMMCx)
+{
+  /* Read data from Rx FIFO */ 
+  return (SDMMCx->FIFO);
+}
+
+/**
+  * @brief  Write data (word) to Tx FIFO in blocking mode (polling) 
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @param  pWriteData: pointer to data to write
+  * @retval HAL status
+  */
+HAL_StatusTypeDef SDMMC_WriteFIFO(SDMMC_TypeDef *SDMMCx, uint32_t *pWriteData)
+{ 
+  /* Write data to FIFO */ 
+  SDMMCx->FIFO = *pWriteData;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_SDMMC_LL_Group3 Peripheral Control functions 
+ *  @brief   management functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the SDMMC data 
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Set SDMMC Power state to ON. 
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval HAL status
+  */
+HAL_StatusTypeDef SDMMC_PowerState_ON(SDMMC_TypeDef *SDMMCx)
+{  
+  /* Set power state to ON */ 
+  SDMMCx->POWER = SDMMC_POWER_PWRCTRL;
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief  Set SDMMC Power state to OFF. 
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval HAL status
+  */
+HAL_StatusTypeDef SDMMC_PowerState_OFF(SDMMC_TypeDef *SDMMCx)
+{
+  /* Set power state to OFF */
+  SDMMCx->POWER = (uint32_t)0x00000000;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get SDMMC Power state. 
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval Power status of the controller. The returned value can be one of the 
+  *         following values:
+  *            - 0x00: Power OFF
+  *            - 0x02: Power UP
+  *            - 0x03: Power ON 
+  */
+uint32_t SDMMC_GetPowerState(SDMMC_TypeDef *SDMMCx)  
+{
+  return (SDMMCx->POWER & SDMMC_POWER_PWRCTRL);
+}
+
+/**
+  * @brief  Configure the SDMMC command path according to the specified parameters in
+  *         SDMMC_CmdInitTypeDef structure and send the command 
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @param  Command: pointer to a SDMMC_CmdInitTypeDef structure that contains 
+  *         the configuration information for the SDMMC command
+  * @retval HAL status
+  */
+HAL_StatusTypeDef SDMMC_SendCommand(SDMMC_TypeDef *SDMMCx, SDMMC_CmdInitTypeDef *Command)
+{
+  /* Check the parameters */
+  assert_param(IS_SDMMC_CMD_INDEX(Command->CmdIndex));
+  assert_param(IS_SDMMC_RESPONSE(Command->Response));
+  assert_param(IS_SDMMC_WAIT(Command->WaitForInterrupt));
+  assert_param(IS_SDMMC_CPSM(Command->CPSM));
+
+  /* Set the SDMMC Argument value */
+  SDMMCx->ARG = Command->Argument;
+
+  /* Set SDMMC command parameters */
+  /* Write to SDMMC CMD register */
+  MODIFY_REG(SDMMCx->CMD, CMD_CLEAR_MASK, Command->CmdIndex         |\
+                                          Command->Response         |\
+                                          Command->WaitForInterrupt |\
+                                          Command->CPSM); 
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Return the command index of last command for which response received
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval Command index of the last command response received
+  */
+uint8_t SDMMC_GetCommandResponse(SDMMC_TypeDef *SDMMCx)
+{
+  return (uint8_t)(SDMMCx->RESPCMD);
+}
+
+
+/**
+  * @brief  Return the response received from the card for the last command
+  * @param  SDMMCx: Pointer to SDMMC register base    
+  * @param  Response: Specifies the SDMMC response register. 
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_RESP1: Response Register 1
+  *            @arg SDMMC_RESP2: Response Register 2
+  *            @arg SDMMC_RESP3: Response Register 3
+  *            @arg SDMMC_RESP4: Response Register 4  
+  * @retval The Corresponding response register value
+  */
+uint32_t SDMMC_GetResponse(SDMMC_TypeDef *SDMMCx, uint32_t Response)
+{
+  __IO uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_SDMMC_RESP(Response));
+  
+  /* Get the response */
+  tmp = (uint32_t)&(SDMMCx->RESP1) + Response;
+  
+  return (*(__IO uint32_t *) tmp);
+}  
+
+/**
+  * @brief  Configure the SDMMC data path according to the specified 
+  *         parameters in the SDMMC_DataInitTypeDef.
+  * @param  SDMMCx: Pointer to SDMMC register base  
+  * @param  Data : pointer to a SDMMC_DataInitTypeDef structure 
+  *         that contains the configuration information for the SDMMC data.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef SDMMC_DataConfig(SDMMC_TypeDef *SDMMCx, SDMMC_DataInitTypeDef* Data)
+{
+  /* Check the parameters */
+  assert_param(IS_SDMMC_DATA_LENGTH(Data->DataLength));
+  assert_param(IS_SDMMC_BLOCK_SIZE(Data->DataBlockSize));
+  assert_param(IS_SDMMC_TRANSFER_DIR(Data->TransferDir));
+  assert_param(IS_SDMMC_TRANSFER_MODE(Data->TransferMode));
+  assert_param(IS_SDMMC_DPSM(Data->DPSM));
+
+  /* Set the SDMMC Data TimeOut value */
+  SDMMCx->DTIMER = Data->DataTimeOut;
+
+  /* Set the SDMMC DataLength value */
+  SDMMCx->DLEN = Data->DataLength;
+
+  /* Set the SDMMC data configuration parameters */
+  /* Write to SDMMC DCTRL */
+  MODIFY_REG(SDMMCx->DCTRL, DCTRL_CLEAR_MASK, Data->DataBlockSize |\
+                                              Data->TransferDir   |\
+                                              Data->TransferMode  |\
+                                              Data->DPSM);
+
+  return HAL_OK;
+
+}
+
+/**
+  * @brief  Returns number of remaining data bytes to be transferred.
+  * @param  SDMMCx: Pointer to SDMMC register base
+  * @retval Number of remaining data bytes to be transferred
+  */
+uint32_t SDMMC_GetDataCounter(SDMMC_TypeDef *SDMMCx)
+{
+  return (SDMMCx->DCOUNT);
+}
+
+/**
+  * @brief  Get the FIFO data
+  * @param  SDMMCx: Pointer to SDMMC register base 
+  * @retval Data received
+  */
+uint32_t SDMMC_GetFIFOCount(SDMMC_TypeDef *SDMMCx)
+{
+  return (SDMMCx->FIFO);
+}
+
+
+/**
+  * @brief  Sets one of the two options of inserting read wait interval.
+  * @param  SDMMCx: Pointer to SDMMC register base   
+  * @param  SDMMC_ReadWaitMode: SDMMC Read Wait operation mode.
+  *          This parameter can be:
+  *            @arg SDMMC_READ_WAIT_MODE_CLK: Read Wait control by stopping SDMMCCLK
+  *            @arg SDMMC_READ_WAIT_MODE_DATA2: Read Wait control using SDMMC_DATA2
+  * @retval None
+  */
+HAL_StatusTypeDef SDMMC_SetSDMMCReadWaitMode(SDMMC_TypeDef *SDMMCx, uint32_t SDMMC_ReadWaitMode)
+{
+  /* Check the parameters */
+  assert_param(IS_SDMMC_READWAIT_MODE(SDMMC_ReadWaitMode));
+  
+  /* Set SDMMC read wait mode */
+  MODIFY_REG(SDMMCx->DCTRL, SDMMC_DCTRL_RWMOD, SDMMC_ReadWaitMode); 
+  
+  return HAL_OK;  
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* (HAL_SD_MODULE_ENABLED) */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stmhal/hal/l4/src/stm32l4xx_ll_usb.c
+++ b/stmhal/hal/l4/src/stm32l4xx_ll_usb.c
@@ -1,0 +1,1630 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_ll_usb.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    29-January-2016
+  * @brief   USB Low Layer HAL module driver.
+  *   
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the USB Peripheral Controller:
+  *           + Initialization/de-initialization functions
+  *           + I/O operation functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                    ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      (#) Fill parameters of Init structure in USB_OTG_CfgTypeDef structure.
+  
+      (#) Call USB_CoreInit() API to initialize the USB Core peripheral.
+
+      (#) The upper HAL HCD/PCD driver will call the right routines for its internal processes.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_hal.h"
+
+#if defined(STM32L475xx) || defined(STM32L476xx) || defined(STM32L485xx) || defined(STM32L486xx)
+
+/** @addtogroup STM32L4xx_LL_USB_DRIVER
+  * @{
+  */
+
+#if defined (HAL_PCD_MODULE_ENABLED) || defined (HAL_HCD_MODULE_ENABLED)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx);
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup LL_USB_Exported_Functions USB Low Layer Exported Functions
+  * @{
+  */
+
+/** @defgroup LL_USB_Group1 Initialization/de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+ ===============================================================================
+              ##### Initialization/de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+ 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the USB Core
+  * @param  USBx: USB Instance
+  * @param  cfg: pointer to a USB_OTG_CfgTypeDef structure that contains
+  *         the configuration information for the specified USBx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(cfg);
+
+  /* Select FS Embedded PHY */
+  USBx->GUSBCFG |= USB_OTG_GUSBCFG_PHYSEL;
+  
+  /* Reset after a PHY select and set Host mode */
+  USB_CoreReset(USBx);
+  
+  /* Deactivate the power down*/
+  USBx->GCCFG = USB_OTG_GCCFG_PWRDWN;
+  
+  /* Enable srpcap*/
+  USBx->GUSBCFG |= USB_OTG_GUSBCFG_SRPCAP;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_EnableGlobalInt
+  *         Enables the controller's Global Int in the AHB Config reg
+  * @param  USBx: Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EnableGlobalInt(USB_OTG_GlobalTypeDef *USBx)
+{
+  USBx->GAHBCFG |= USB_OTG_GAHBCFG_GINT;
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  USB_DisableGlobalInt
+  *         Disable the controller's Global Int in the AHB Config reg
+  * @param  USBx: Selected device
+  * @retval HAL status
+*/
+HAL_StatusTypeDef USB_DisableGlobalInt(USB_OTG_GlobalTypeDef *USBx)
+{
+  USBx->GAHBCFG &= ~USB_OTG_GAHBCFG_GINT;
+  return HAL_OK;
+}
+   
+/**
+  * @brief  USB_SetCurrentMode : Set functional mode
+  * @param  USBx: Selected device
+  * @param  mode:  current core mode
+  *          This parameter can be one of these values:
+  *            @arg USB_OTG_DEVICE_MODE: Peripheral mode
+  *            @arg USB_OTG_HOST_MODE: Host mode
+  *            @arg USB_OTG_DRD_MODE: Dual Role Device mode  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_SetCurrentMode(USB_OTG_GlobalTypeDef *USBx , USB_OTG_ModeTypeDef mode)
+{
+  USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_FHMOD | USB_OTG_GUSBCFG_FDMOD); 
+  
+  if ( mode == USB_OTG_HOST_MODE)
+  {
+    USBx->GUSBCFG |= USB_OTG_GUSBCFG_FHMOD; 
+  }
+  else if ( mode == USB_OTG_DEVICE_MODE)
+  {
+    USBx->GUSBCFG |= USB_OTG_GUSBCFG_FDMOD; 
+  }
+  HAL_Delay(50);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_DevInit : Initializes the USB_OTG controller registers 
+  *         for device mode
+  * @param  USBx: Selected device
+  * @param  cfg: pointer to a USB_OTG_CfgTypeDef structure that contains
+  *         the configuration information for the specified USBx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+{
+  uint32_t i = 0;
+
+  /*Activate VBUS Sensing B */
+  USBx->GCCFG |= USB_OTG_GCCFG_VBDEN;
+  
+  if (cfg.vbus_sensing_enable == 0)
+  {
+    /* Deactivate VBUS Sensing B */
+    USBx->GCCFG &= ~ USB_OTG_GCCFG_VBDEN;
+    
+    /* B-peripheral session valid override enable*/ 
+    USBx->GOTGCTL |= USB_OTG_GOTGCTL_BVALOEN;
+    USBx->GOTGCTL |= USB_OTG_GOTGCTL_BVALOVAL;
+  }
+   
+  /* Restart the Phy Clock */
+  USBx_PCGCCTL = 0;
+
+  /* Device mode configuration */
+  USBx_DEVICE->DCFG |= DCFG_FRAME_INTERVAL_80;
+  
+  /* Set Full speed phy */
+  USB_SetDevSpeed (USBx , USB_OTG_SPEED_FULL);
+
+  /* Flush the FIFOs */
+  USB_FlushTxFifo(USBx , 0x10); /* all Tx FIFOs */
+  USB_FlushRxFifo(USBx);
+  
+  /* Clear all pending Device Interrupts */
+  USBx_DEVICE->DIEPMSK = 0;
+  USBx_DEVICE->DOEPMSK = 0;
+  USBx_DEVICE->DAINT = 0xFFFFFFFF;
+  USBx_DEVICE->DAINTMSK = 0;
+  
+  for (i = 0; i < cfg.dev_endpoints; i++)
+  {
+    if ((USBx_INEP(i)->DIEPCTL & USB_OTG_DIEPCTL_EPENA) == USB_OTG_DIEPCTL_EPENA)
+    {
+      USBx_INEP(i)->DIEPCTL = (USB_OTG_DIEPCTL_EPDIS | USB_OTG_DIEPCTL_SNAK);
+    }
+    else
+    {
+      USBx_INEP(i)->DIEPCTL = 0;
+    }
+    
+    USBx_INEP(i)->DIEPTSIZ = 0;
+    USBx_INEP(i)->DIEPINT  = 0xFF;
+  }
+  
+  for (i = 0; i < cfg.dev_endpoints; i++)
+  {
+    if ((USBx_OUTEP(i)->DOEPCTL & USB_OTG_DOEPCTL_EPENA) == USB_OTG_DOEPCTL_EPENA)
+    {
+      USBx_OUTEP(i)->DOEPCTL = (USB_OTG_DOEPCTL_EPDIS | USB_OTG_DOEPCTL_SNAK);
+    }
+    else
+    {
+      USBx_OUTEP(i)->DOEPCTL = 0;
+    }
+    
+    USBx_OUTEP(i)->DOEPTSIZ = 0;
+    USBx_OUTEP(i)->DOEPINT  = 0xFF;
+  }
+  
+  USBx_DEVICE->DIEPMSK &= ~(USB_OTG_DIEPMSK_TXFURM);
+  
+  if (cfg.dma_enable == 1)
+  {
+    /*Set threshold parameters */
+    USBx_DEVICE->DTHRCTL = (USB_OTG_DTHRCTL_TXTHRLEN_6 | USB_OTG_DTHRCTL_RXTHRLEN_6);
+    USBx_DEVICE->DTHRCTL |= (USB_OTG_DTHRCTL_RXTHREN | USB_OTG_DTHRCTL_ISOTHREN | USB_OTG_DTHRCTL_NONISOTHREN);
+    
+    i= USBx_DEVICE->DTHRCTL;
+  }
+  
+  /* Disable all interrupts. */
+  USBx->GINTMSK = 0;
+  
+  /* Clear any pending interrupts */
+  USBx->GINTSTS = 0xBFFFFFFF;
+
+  /* Enable the common interrupts */
+  if (cfg.dma_enable == DISABLE)
+  {
+    USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM; 
+  }
+
+    /* Enable interrupts matching to the Device mode ONLY */
+  USBx->GINTMSK |= (USB_OTG_GINTMSK_USBSUSPM | USB_OTG_GINTMSK_USBRST |\
+                    USB_OTG_GINTMSK_ENUMDNEM | USB_OTG_GINTMSK_IEPINT |\
+                    USB_OTG_GINTMSK_OEPINT   | USB_OTG_GINTMSK_IISOIXFRM|\
+                    USB_OTG_GINTMSK_PXFRM_IISOOXFRM | USB_OTG_GINTMSK_WUIM);
+
+  if(cfg.Sof_enable)
+  {
+    USBx->GINTMSK |= USB_OTG_GINTMSK_SOFM;
+  }
+
+  if (cfg.vbus_sensing_enable == ENABLE)
+  {
+    USBx->GINTMSK |= (USB_OTG_GINTMSK_SRQIM | USB_OTG_GINTMSK_OTGINT); 
+  }
+  
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  USB_OTG_FlushTxFifo : Flush a Tx FIFO
+  * @param  USBx: Selected device
+  * @param  num: FIFO number
+  *         This parameter can be a value from 1 to 15
+            15 means Flush all Tx FIFOs
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_FlushTxFifo (USB_OTG_GlobalTypeDef *USBx, uint32_t num )
+{
+  uint32_t count = 0;
+ 
+  USBx->GRSTCTL = ( USB_OTG_GRSTCTL_TXFFLSH |(uint32_t)( num << 6)); 
+ 
+  do
+  {
+    if (++count > 200000)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_TXFFLSH) == USB_OTG_GRSTCTL_TXFFLSH);
+  
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  USB_FlushRxFifo : Flush Rx FIFO
+  * @param  USBx: Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_FlushRxFifo(USB_OTG_GlobalTypeDef *USBx)
+{
+  uint32_t count = 0;
+  
+  USBx->GRSTCTL = USB_OTG_GRSTCTL_RXFFLSH;
+  
+  do
+  {
+    if (++count > 200000)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_RXFFLSH) == USB_OTG_GRSTCTL_RXFFLSH);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_SetDevSpeed :Initializes the DevSpd field of DCFG register 
+  *         depending the PHY type and the enumeration speed of the device.
+  * @param  USBx: Selected device
+  * @param  speed: device speed
+  *          This parameter can be one of these values:
+  *            @arg USB_OTG_SPEED_HIGH: High speed mode
+  *            @arg USB_OTG_SPEED_HIGH_IN_FULL: High speed core in Full Speed mode
+  *            @arg USB_OTG_SPEED_FULL: Full speed mode
+  *            @arg USB_OTG_SPEED_LOW: Low speed mode
+  * @retval  Hal status
+  */
+HAL_StatusTypeDef USB_SetDevSpeed(USB_OTG_GlobalTypeDef *USBx , uint8_t speed)
+{
+  USBx_DEVICE->DCFG |= speed;
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_GetDevSpeed :Return the  Dev Speed 
+  * @param  USBx: Selected device
+  * @retval speed : device speed
+  *          This parameter can be one of these values:
+  *            @arg USB_OTG_SPEED_HIGH: High speed mode
+  *            @arg USB_OTG_SPEED_FULL: Full speed mode
+  *            @arg USB_OTG_SPEED_LOW: Low speed mode
+  */
+uint8_t USB_GetDevSpeed(USB_OTG_GlobalTypeDef *USBx)
+{
+  uint8_t speed = 0;
+  
+  if((USBx_DEVICE->DSTS & USB_OTG_DSTS_ENUMSPD) == DSTS_ENUMSPD_HS_PHY_30MHZ_OR_60MHZ)
+  {
+    speed = USB_OTG_SPEED_HIGH;
+  }
+  else if (((USBx_DEVICE->DSTS & USB_OTG_DSTS_ENUMSPD) == DSTS_ENUMSPD_FS_PHY_30MHZ_OR_60MHZ)||
+           ((USBx_DEVICE->DSTS & USB_OTG_DSTS_ENUMSPD) == DSTS_ENUMSPD_FS_PHY_48MHZ))
+  {
+    speed = USB_OTG_SPEED_FULL;
+  }
+  else if((USBx_DEVICE->DSTS & USB_OTG_DSTS_ENUMSPD) == DSTS_ENUMSPD_LS_PHY_6MHZ)
+  {
+    speed = USB_OTG_SPEED_LOW;
+  }
+  
+  return speed;
+}
+
+/**
+  * @brief  Activate and configure an endpoint
+  * @param  USBx: Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_ActivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
+{
+  if (ep->is_in == 1)
+  {
+   USBx_DEVICE->DAINTMSK |= USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num)));
+   
+    if (((USBx_INEP(ep->num)->DIEPCTL) & USB_OTG_DIEPCTL_USBAEP) == 0)
+    {
+      USBx_INEP(ep->num)->DIEPCTL |= ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP)); 
+    } 
+
+  }
+  else
+  {
+     USBx_DEVICE->DAINTMSK |= USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16);
+     
+    if (((USBx_OUTEP(ep->num)->DOEPCTL) & USB_OTG_DOEPCTL_USBAEP) == 0)
+    {
+      USBx_OUTEP(ep->num)->DOEPCTL |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+       (USB_OTG_DIEPCTL_SD0PID_SEVNFRM)| (USB_OTG_DOEPCTL_USBAEP));
+    } 
+  }
+  return HAL_OK;
+}
+/**
+  * @brief  Activate and configure a dedicated endpoint
+  * @param  USBx: Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
+{
+  static __IO uint32_t debug = 0;
+  
+  /* Read DEPCTLn register */
+  if (ep->is_in == 1)
+  {
+    if (((USBx_INEP(ep->num)->DIEPCTL) & USB_OTG_DIEPCTL_USBAEP) == 0)
+    {
+      USBx_INEP(ep->num)->DIEPCTL |= ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP)); 
+    } 
+    
+    
+    debug  |= ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP)); 
+    
+   USBx_DEVICE->DEACHMSK |= USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num)));
+  }
+  else
+  {
+    if (((USBx_OUTEP(ep->num)->DOEPCTL) & USB_OTG_DOEPCTL_USBAEP) == 0)
+    {
+      USBx_OUTEP(ep->num)->DOEPCTL |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+        ((ep->num) << 22 ) | (USB_OTG_DOEPCTL_USBAEP));
+      
+      debug = (uint32_t)(((uint32_t )USBx) + USB_OTG_OUT_ENDPOINT_BASE + (0)*USB_OTG_EP_REG_SIZE);
+      debug = (uint32_t )&USBx_OUTEP(ep->num)->DOEPCTL;
+      debug |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+        ((ep->num) << 22 ) | (USB_OTG_DOEPCTL_USBAEP)); 
+    } 
+    
+     USBx_DEVICE->DEACHMSK |= USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16);
+  }
+
+  return HAL_OK;
+}
+/**
+  * @brief  De-activate and de-initialize an endpoint
+  * @param  USBx: Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_DeactivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
+{
+  /* Read DEPCTLn register */
+  if (ep->is_in == 1)
+  {
+   USBx_DEVICE->DEACHMSK &= ~(USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num))));
+   USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num))));   
+   USBx_INEP(ep->num)->DIEPCTL &= ~ USB_OTG_DIEPCTL_USBAEP;   
+  }
+  else
+  {
+     USBx_DEVICE->DEACHMSK &= ~(USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16));
+     USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16));     
+     USBx_OUTEP(ep->num)->DOEPCTL &= ~USB_OTG_DOEPCTL_USBAEP;      
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  De-activate and de-initialize a dedicated endpoint
+  * @param  USBx: Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_DeactivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
+{
+  /* Read DEPCTLn register */
+  if (ep->is_in == 1)
+  {
+   USBx_INEP(ep->num)->DIEPCTL &= ~ USB_OTG_DIEPCTL_USBAEP;
+   USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num))));
+  }
+  else
+  {
+     USBx_OUTEP(ep->num)->DOEPCTL &= ~USB_OTG_DOEPCTL_USBAEP; 
+     USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16));
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_EPStartXfer : setup and starts a transfer over an EP
+  * @param  USBx: Selected device
+  * @param  ep: pointer to endpoint structure
+  * @param  dma: USB dma enabled or disabled 
+  *          This parameter can be one of these values:
+  *           0 : DMA feature not used 
+  *           1 : DMA feature used  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EPStartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma)
+{
+  uint16_t pktcnt = 0;
+  
+  /* IN endpoint */
+  if (ep->is_in == 1)
+  {
+    /* Zero Length Packet? */
+    if (ep->xfer_len == 0)
+    {
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT); 
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_PKTCNT & (1 << 19)) ;
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ); 
+    }
+    else
+    {
+      /* Program the transfer size and packet count
+      * as follows: xfersize = N * maxpacket +
+      * short_packet pktcnt = N + (short_packet
+      * exist ? 1 : 0)
+      */
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ);
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT); 
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_PKTCNT & (((ep->xfer_len + ep->maxpacket -1)/ ep->maxpacket) << 19)) ;
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_XFRSIZ & ep->xfer_len); 
+      
+      if (ep->type == EP_TYPE_ISOC)
+      {
+        USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_MULCNT); 
+        USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_MULCNT & (1 << 29)); 
+      }       
+    }
+
+    if (dma == 1)
+    {
+      USBx_INEP(ep->num)->DIEPDMA = (uint32_t)(ep->dma_addr);
+    }
+    else
+    {
+      if (ep->type != EP_TYPE_ISOC)
+      {
+        /* Enable the Tx FIFO Empty Interrupt for this EP */
+        if (ep->xfer_len > 0)
+        {
+          USBx_DEVICE->DIEPEMPMSK |= 1 << ep->num;
+        }
+      }
+    }
+
+    if (ep->type == EP_TYPE_ISOC)
+    {
+      if ((USBx_DEVICE->DSTS & ( 1 << 8 )) == 0)
+      {
+        USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_SODDFRM;
+      }
+      else
+      {
+        USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_SD0PID_SEVNFRM;
+      }
+    } 
+    
+    /* EP enable, IN data in FIFO */
+    USBx_INEP(ep->num)->DIEPCTL |= (USB_OTG_DIEPCTL_CNAK | USB_OTG_DIEPCTL_EPENA);
+    
+    if (ep->type == EP_TYPE_ISOC)
+    {
+      USB_WritePacket(USBx, ep->xfer_buff, ep->num, ep->xfer_len, dma);   
+    }    
+  }
+  else /* OUT endpoint */
+  {
+    /* Program the transfer size and packet count as follows:
+    * pktcnt = N
+    * xfersize = N * maxpacket
+    */  
+    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_XFRSIZ); 
+    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_PKTCNT); 
+      
+    if (ep->xfer_len == 0)
+    {
+      USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_XFRSIZ & ep->maxpacket);
+      USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (1 << 19)) ;      
+    }
+    else
+    {
+      pktcnt = (ep->xfer_len + ep->maxpacket -1)/ ep->maxpacket; 
+      USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (pktcnt << 19)); ;
+      USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_XFRSIZ & (ep->maxpacket * pktcnt)); 
+    }
+
+    if (dma == 1)
+    {
+      USBx_OUTEP(ep->num)->DOEPDMA = (uint32_t)ep->xfer_buff;
+    }
+    
+    if (ep->type == EP_TYPE_ISOC)
+    {
+      if ((USBx_DEVICE->DSTS & ( 1 << 8 )) == 0)
+      {
+        USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_SODDFRM;
+      }
+      else
+      {
+        USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_SD0PID_SEVNFRM;
+      }
+    }
+    /* EP enable */
+    USBx_OUTEP(ep->num)->DOEPCTL |= (USB_OTG_DOEPCTL_CNAK | USB_OTG_DOEPCTL_EPENA);
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_EP0StartXfer : setup and starts a transfer over the EP  0
+  * @param  USBx: Selected device
+  * @param  ep: pointer to endpoint structure
+  * @param  dma: USB dma enabled or disabled 
+  *          This parameter can be one of these values:
+  *           0 : DMA feature not used 
+  *           1 : DMA feature used  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EP0StartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma)
+{
+  /* IN endpoint */
+  if (ep->is_in == 1)
+  {
+    /* Zero Length Packet? */
+    if (ep->xfer_len == 0)
+    {
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT); 
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_PKTCNT & (1 << 19)) ;
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ); 
+    }
+    else
+    {
+      /* Program the transfer size and packet count
+      * as follows: xfersize = N * maxpacket +
+      * short_packet pktcnt = N + (short_packet
+      * exist ? 1 : 0)
+      */
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ);
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT); 
+      
+      if(ep->xfer_len > ep->maxpacket)
+      {
+        ep->xfer_len = ep->maxpacket;
+      }
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_PKTCNT & (1 << 19)) ;
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_XFRSIZ & ep->xfer_len); 
+    
+    }
+    
+    if (dma == 1)
+    {
+      USBx_INEP(ep->num)->DIEPDMA = (uint32_t)(ep->dma_addr);
+    }
+    else
+    {
+      /* Enable the Tx FIFO Empty Interrupt for this EP */
+      if (ep->xfer_len > 0)
+      {
+        USBx_DEVICE->DIEPEMPMSK |= 1 << (ep->num);
+      }
+    }
+    
+    /* EP enable, IN data in FIFO */
+    USBx_INEP(ep->num)->DIEPCTL |= (USB_OTG_DIEPCTL_CNAK | USB_OTG_DIEPCTL_EPENA);   
+  }
+  else /* OUT endpoint */
+  {
+    /* Program the transfer size and packet count as follows:
+    * pktcnt = N
+    * xfersize = N * maxpacket
+    */
+    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_XFRSIZ); 
+    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_PKTCNT); 
+      
+    if (ep->xfer_len > 0)
+    {
+      ep->xfer_len = ep->maxpacket;
+    }
+    
+    USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (1 << 19));
+    USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_XFRSIZ & (ep->maxpacket)); 
+    
+
+    if (dma == 1)
+    {
+      USBx_OUTEP(ep->num)->DOEPDMA = (uint32_t)(ep->xfer_buff);
+    }
+    
+    /* EP enable */
+    USBx_OUTEP(ep->num)->DOEPCTL |= (USB_OTG_DOEPCTL_CNAK | USB_OTG_DOEPCTL_EPENA);    
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_WritePacket : Writes a packet into the Tx FIFO associated 
+  *         with the EP/channel
+  * @param  USBx: Selected device           
+  * @param  src:  pointer to source buffer
+  * @param  ch_ep_num: endpoint or host channel number
+  * @param  len: Number of bytes to write
+  * @param  dma: USB dma enabled or disabled 
+  *          This parameter can be one of these values:
+  *           0 : DMA feature not used 
+  *           1 : DMA feature used  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uint8_t ch_ep_num, uint16_t len, uint8_t dma)
+{
+  uint32_t count32b= 0 , i= 0;
+  
+  if (dma == 0)
+  {
+    count32b =  (len + 3) / 4;
+    for (i = 0; i < count32b; i++, src += 4)
+    {
+      USBx_DFIFO(ch_ep_num) = *((__packed uint32_t *)src);
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_ReadPacket : read a packet from the Tx FIFO associated 
+  *         with the EP/channel
+  * @param  USBx: Selected device  
+  * @param  src: source pointer
+  * @param  ch_ep_num: endpoint or host channel number
+  * @param  len: Number of bytes to read
+  * @param  dma: USB dma enabled or disabled 
+  *          This parameter can be one of these values:
+  *           0 : DMA feature not used 
+  *           1 : DMA feature used  
+  * @retval pointer to destination buffer
+  */
+void *USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len)
+{
+  uint32_t i=0;
+  uint32_t count32b = (len + 3) / 4;
+  
+  for ( i = 0; i < count32b; i++, dest += 4 )
+  {
+    *(__packed uint32_t *)dest = USBx_DFIFO(0);
+    
+  }
+  return ((void *)dest);
+}
+
+/**
+  * @brief  USB_EPSetStall : set a stall condition over an EP
+  * @param  USBx: Selected device
+  * @param  ep: pointer to endpoint structure   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EPSetStall(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep)
+{
+  if (ep->is_in == 1)
+  {
+    if (((USBx_INEP(ep->num)->DIEPCTL) & USB_OTG_DIEPCTL_EPENA) == 0)
+    {
+      USBx_INEP(ep->num)->DIEPCTL &= ~(USB_OTG_DIEPCTL_EPDIS); 
+    } 
+    USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_STALL;
+  }
+  else
+  {
+    if (((USBx_OUTEP(ep->num)->DOEPCTL) & USB_OTG_DOEPCTL_EPENA) == 0)
+    {
+      USBx_OUTEP(ep->num)->DOEPCTL &= ~(USB_OTG_DOEPCTL_EPDIS); 
+    } 
+    USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_STALL;
+  }
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  USB_EPClearStall : Clear a stall condition over an EP
+  * @param  USBx: Selected device
+  * @param  ep: pointer to endpoint structure   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EPClearStall(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
+{
+  if (ep->is_in == 1)
+  {
+    USBx_INEP(ep->num)->DIEPCTL &= ~USB_OTG_DIEPCTL_STALL;
+    if (ep->type == EP_TYPE_INTR || ep->type == EP_TYPE_BULK)
+    {
+       USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_SD0PID_SEVNFRM; /* DATA0 */
+    }    
+  }
+  else
+  {
+    USBx_OUTEP(ep->num)->DOEPCTL &= ~USB_OTG_DOEPCTL_STALL;
+    if (ep->type == EP_TYPE_INTR || ep->type == EP_TYPE_BULK)
+    {
+      USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_SD0PID_SEVNFRM; /* DATA0 */
+    }    
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_StopDevice : Stop the USB device mode
+  * @param  USBx: Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_StopDevice(USB_OTG_GlobalTypeDef *USBx)
+{
+  uint32_t i;
+  
+  /* Clear Pending interrupt */
+  for (i = 0; i < 15 ; i++)
+  {
+    USBx_INEP(i)->DIEPINT  = 0xFF;
+    USBx_OUTEP(i)->DOEPINT  = 0xFF;
+  }
+  USBx_DEVICE->DAINT = 0xFFFFFFFF;
+  
+  /* Clear interrupt masks */
+  USBx_DEVICE->DIEPMSK  = 0;
+  USBx_DEVICE->DOEPMSK  = 0;
+  USBx_DEVICE->DAINTMSK = 0;
+  
+  /* Flush the FIFO */
+  USB_FlushRxFifo(USBx);
+  USB_FlushTxFifo(USBx ,  0x10 );  
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_SetDevAddress : Stop the USB device mode
+  * @param  USBx: Selected device
+  * @param  address: new device address to be assigned
+  *          This parameter can be a value from 0 to 255
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  USB_SetDevAddress (USB_OTG_GlobalTypeDef *USBx, uint8_t address)
+{
+  USBx_DEVICE->DCFG &= ~ (USB_OTG_DCFG_DAD);
+  USBx_DEVICE->DCFG |= (address << 4) & USB_OTG_DCFG_DAD ;
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  USB_DevConnect : Connect the USB device by enabling the pull-up/pull-down
+  * @param  USBx: Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  USB_DevConnect (USB_OTG_GlobalTypeDef *USBx)
+{
+  USBx_DEVICE->DCTL &= ~USB_OTG_DCTL_SDIS ; 
+  HAL_Delay(3);
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  USB_DevDisconnect : Disconnect the USB device by disabling the pull-up/pull-down
+  * @param  USBx: Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  USB_DevDisconnect (USB_OTG_GlobalTypeDef *USBx)
+{
+  USBx_DEVICE->DCTL |= USB_OTG_DCTL_SDIS ; 
+  HAL_Delay(3);
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  USB_ReadInterrupts: return the global USB interrupt status
+  * @param  USBx: Selected device
+  * @retval HAL status
+  */
+uint32_t  USB_ReadInterrupts (USB_OTG_GlobalTypeDef *USBx)
+{
+  uint32_t v = 0;
+  
+  v = USBx->GINTSTS;
+  v &= USBx->GINTMSK;
+  return v;  
+}
+
+/**
+  * @brief  USB_ReadDevAllOutEpInterrupt: return the USB device OUT endpoints interrupt status
+  * @param  USBx: Selected device
+  * @retval HAL status
+  */
+uint32_t USB_ReadDevAllOutEpInterrupt (USB_OTG_GlobalTypeDef *USBx)
+{
+  uint32_t v;
+  v  = USBx_DEVICE->DAINT;
+  v &= USBx_DEVICE->DAINTMSK;
+  return ((v & 0xffff0000) >> 16);
+}
+
+/**
+  * @brief  USB_ReadDevAllInEpInterrupt: return the USB device IN endpoints interrupt status
+  * @param  USBx: Selected device
+  * @retval HAL status
+  */
+uint32_t USB_ReadDevAllInEpInterrupt (USB_OTG_GlobalTypeDef *USBx)
+{
+  uint32_t v;
+  v  = USBx_DEVICE->DAINT;
+  v &= USBx_DEVICE->DAINTMSK;
+  return ((v & 0xFFFF));
+}
+
+/**
+  * @brief  Returns Device OUT EP Interrupt register
+  * @param  USBx: Selected device
+  * @param  epnum: endpoint number
+  *          This parameter can be a value from 0 to 15
+  * @retval Device OUT EP Interrupt register
+  */
+uint32_t USB_ReadDevOutEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum)
+{
+  uint32_t v;
+  v  = USBx_OUTEP(epnum)->DOEPINT;
+  v &= USBx_DEVICE->DOEPMSK;
+  return v;
+}
+
+/**
+  * @brief  Returns Device IN EP Interrupt register
+  * @param  USBx: Selected device
+  * @param  epnum: endpoint number
+  *          This parameter can be a value from 0 to 15
+  * @retval Device IN EP Interrupt register
+  */
+uint32_t USB_ReadDevInEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum)
+{
+  uint32_t v, msk, emp;
+  
+  msk = USBx_DEVICE->DIEPMSK;
+  emp = USBx_DEVICE->DIEPEMPMSK;
+  msk |= ((emp >> epnum) & 0x1) << 7;
+  v = USBx_INEP(epnum)->DIEPINT & msk;
+  return v;
+}
+
+/**
+  * @brief  USB_ClearInterrupts: clear a USB interrupt
+  * @param  USBx: Selected device
+  * @param  interrupt: interrupt flag
+  * @retval None
+  */
+void  USB_ClearInterrupts (USB_OTG_GlobalTypeDef *USBx, uint32_t interrupt)
+{
+  USBx->GINTSTS |= interrupt; 
+}
+
+/**
+  * @brief  Returns USB core mode
+  * @param  USBx: Selected device
+  * @retval return core mode : Host or Device
+  *          This parameter can be one of these values:
+  *           0 : Host 
+  *           1 : Device
+  */
+uint32_t USB_GetMode(USB_OTG_GlobalTypeDef *USBx)
+{
+  return ((USBx->GINTSTS ) & 0x1);
+}
+
+
+/**
+  * @brief  Activate EP0 for Setup transactions
+  * @param  USBx: Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  USB_ActivateSetup (USB_OTG_GlobalTypeDef *USBx)
+{
+  /* Set the MPS of the IN EP based on the enumeration speed */
+  USBx_INEP(0)->DIEPCTL &= ~USB_OTG_DIEPCTL_MPSIZ;
+  
+  if((USBx_DEVICE->DSTS & USB_OTG_DSTS_ENUMSPD) == DSTS_ENUMSPD_LS_PHY_6MHZ)
+  {
+    USBx_INEP(0)->DIEPCTL |= 3;
+  }
+  USBx_DEVICE->DCTL |= USB_OTG_DCTL_CGINAK;
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Prepare the EP0 to start the first control setup
+  * @param  USBx: Selected device
+  * @param  dma: USB dma enabled or disabled 
+  *          This parameter can be one of these values:
+  *           0 : DMA feature not used 
+  *           1 : DMA feature used  
+  * @param  psetup: pointer to setup packet
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EP0_OutStart(USB_OTG_GlobalTypeDef *USBx, uint8_t dma, uint8_t *psetup)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(psetup);
+
+  USBx_OUTEP(0)->DOEPTSIZ = 0;
+  USBx_OUTEP(0)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (1 << 19)) ;
+  USBx_OUTEP(0)->DOEPTSIZ |= (3 * 8);
+  USBx_OUTEP(0)->DOEPTSIZ |=  USB_OTG_DOEPTSIZ_STUPCNT;  
+  
+  if (dma == 1)
+  {
+    USBx_OUTEP(0)->DOEPDMA = (uint32_t)psetup;
+    /* EP enable */
+    USBx_OUTEP(0)->DOEPCTL = 0x80008000;
+  }
+  
+  return HAL_OK;  
+}
+
+
+/**
+  * @brief  Reset the USB Core (needed after USB clock settings change)
+  * @param  USBx: Selected device
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx)
+{
+  uint32_t count = 0;
+
+  /* Wait for AHB master IDLE state. */
+  do
+  {
+    if (++count > 200000)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_AHBIDL) == 0);
+  
+  /* Core Soft Reset */
+  count = 0;
+  USBx->GRSTCTL |= USB_OTG_GRSTCTL_CSRST;
+
+  do
+  {
+    if (++count > 200000)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_CSRST) == USB_OTG_GRSTCTL_CSRST);
+  
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  USB_HostInit : Initializes the USB OTG controller registers 
+  *         for Host mode 
+  * @param  USBx: Selected device
+  * @param  cfg: pointer to a USB_OTG_CfgTypeDef structure that contains
+  *         the configuration information for the specified USBx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+{
+  uint32_t i;
+  
+  /* Restart the Phy Clock */
+  USBx_PCGCCTL = 0;
+    
+  /*Activate VBUS Sensing B */
+  USBx->GCCFG |= USB_OTG_GCCFG_VBDEN;
+  
+  /* Disable the FS/LS support mode only */
+  if((cfg.speed == USB_OTG_SPEED_FULL)&&
+     (USBx != USB_OTG_FS))
+  {
+    USBx_HOST->HCFG |= USB_OTG_HCFG_FSLSS; 
+  }
+  else
+  {
+    USBx_HOST->HCFG &= ~(USB_OTG_HCFG_FSLSS);  
+  }
+
+  /* Make sure the FIFOs are flushed. */
+  USB_FlushTxFifo(USBx, 0x10 ); /* all Tx FIFOs */
+  USB_FlushRxFifo(USBx);
+
+  /* Clear all pending HC Interrupts */
+  for (i = 0; i < cfg.Host_channels; i++)
+  {
+    USBx_HC(i)->HCINT = 0xFFFFFFFF;
+    USBx_HC(i)->HCINTMSK = 0;
+  }
+  
+  /* Enable VBUS driving */
+  USB_DriveVbus(USBx, 1);
+  
+  HAL_Delay(200);
+  
+  /* Disable all interrupts. */
+  USBx->GINTMSK = 0;
+  
+  /* Clear any pending interrupts */
+  USBx->GINTSTS = 0xFFFFFFFF;
+  
+  /* set Rx FIFO size */
+  USBx->GRXFSIZ  = (uint32_t )0x80; 
+  USBx->DIEPTXF0_HNPTXFSIZ = (uint32_t )(((0x60 << 16)& USB_OTG_NPTXFD) | 0x80);
+  USBx->HPTXFSIZ = (uint32_t )(((0x40 << 16)& USB_OTG_HPTXFSIZ_PTXFD) | 0xE0);
+  
+  /* Enable the common interrupts */
+  if (cfg.dma_enable == DISABLE)
+  {
+    USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM; 
+  }
+
+    /* Enable interrupts matching to the Host mode ONLY */
+  USBx->GINTMSK |= (USB_OTG_GINTMSK_PRTIM            | USB_OTG_GINTMSK_HCIM |\
+                    USB_OTG_GINTMSK_SOFM             |USB_OTG_GINTSTS_DISCINT|\
+                    USB_OTG_GINTMSK_PXFRM_IISOOXFRM  | USB_OTG_GINTMSK_WUIM);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_InitFSLSPClkSel : Initializes the FSLSPClkSel field of the 
+  *         HCFG register on the PHY type and set the right frame interval
+  * @param  USBx: Selected device
+  * @param  freq: clock frequency
+  *          This parameter can be one of these values:
+  *           HCFG_48_MHZ : Full Speed 48 MHz Clock 
+  *           HCFG_6_MHZ : Low Speed 6 MHz Clock 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_InitFSLSPClkSel(USB_OTG_GlobalTypeDef *USBx , uint8_t freq)
+{
+  USBx_HOST->HCFG &= ~(USB_OTG_HCFG_FSLSPCS);
+  USBx_HOST->HCFG |= (freq & USB_OTG_HCFG_FSLSPCS);
+  
+  if (freq ==  HCFG_48_MHZ)
+  {
+    USBx_HOST->HFIR = (uint32_t)48000;
+  }
+  else if (freq ==  HCFG_6_MHZ)
+  {
+    USBx_HOST->HFIR = (uint32_t)6000;
+  } 
+  return HAL_OK;  
+}
+
+/**
+* @brief  USB_OTG_ResetPort : Reset Host Port
+  * @param  USBx: Selected device
+  * @retval HAL status
+  * @note   (1)The application must wait at least 10 ms
+  *   before clearing the reset bit.
+  */
+HAL_StatusTypeDef USB_ResetPort(USB_OTG_GlobalTypeDef *USBx)
+{
+  __IO uint32_t hprt0;
+  
+  hprt0 = USBx_HPRT0;
+  
+  hprt0 &= ~(USB_OTG_HPRT_PENA    | USB_OTG_HPRT_PCDET |\
+    USB_OTG_HPRT_PENCHNG | USB_OTG_HPRT_POCCHNG );
+  
+  USBx_HPRT0 = (USB_OTG_HPRT_PRST | hprt0);  
+  HAL_Delay (10);                                /* See Note #1 */
+  USBx_HPRT0 = ((~USB_OTG_HPRT_PRST) & hprt0); 
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_DriveVbus : activate or de-activate vbus
+  * @param  state: VBUS state
+  *          This parameter can be one of these values:
+  *           0 : VBUS Active 
+  *           1 : VBUS Inactive
+  * @retval HAL status
+*/
+HAL_StatusTypeDef USB_DriveVbus (USB_OTG_GlobalTypeDef *USBx, uint8_t state)
+{
+  __IO uint32_t hprt0;
+
+  hprt0 = USBx_HPRT0;
+  hprt0 &= ~(USB_OTG_HPRT_PENA    | USB_OTG_HPRT_PCDET |\
+                         USB_OTG_HPRT_PENCHNG | USB_OTG_HPRT_POCCHNG );
+  
+  if (((hprt0 & USB_OTG_HPRT_PPWR) == 0 ) && (state == 1 ))
+  {
+    USBx_HPRT0 = (USB_OTG_HPRT_PPWR | hprt0); 
+  }
+  if (((hprt0 & USB_OTG_HPRT_PPWR) == USB_OTG_HPRT_PPWR) && (state == 0 ))
+  {
+    USBx_HPRT0 = ((~USB_OTG_HPRT_PPWR) & hprt0); 
+  }
+  return HAL_OK; 
+}
+
+/**
+  * @brief  Return Host Core speed
+  * @param  USBx: Selected device
+  * @retval speed : Host speed
+  *          This parameter can be one of these values:
+  *            @arg USB_OTG_SPEED_HIGH: High speed mode
+  *            @arg USB_OTG_SPEED_FULL: Full speed mode
+  *            @arg USB_OTG_SPEED_LOW: Low speed mode
+  */
+uint32_t USB_GetHostSpeed (USB_OTG_GlobalTypeDef *USBx)
+{
+  __IO uint32_t hprt0;
+  
+  hprt0 = USBx_HPRT0;
+  return ((hprt0 & USB_OTG_HPRT_PSPD) >> 17);
+}
+
+/**
+  * @brief  Return Host Current Frame number
+  * @param  USBx: Selected device
+  * @retval current frame number
+*/
+uint32_t USB_GetCurrentFrame (USB_OTG_GlobalTypeDef *USBx)
+{
+  return (USBx_HOST->HFNUM & USB_OTG_HFNUM_FRNUM);
+}
+
+/**
+  * @brief  Initialize a host channel
+  * @param  USBx: Selected device
+  * @param  ch_num : Channel number
+  *         This parameter can be a value from 1 to 15
+  * @param  epnum: Endpoint number
+  *          This parameter can be a value from 1 to 15
+  * @param  dev_address: Current device address
+  *          This parameter can be a value from 0 to 255
+  * @param  speed: Current device speed
+  *          This parameter can be one of these values:
+  *            @arg USB_OTG_SPEED_HIGH: High speed mode
+  *            @arg USB_OTG_SPEED_FULL: Full speed mode
+  *            @arg USB_OTG_SPEED_LOW: Low speed mode
+  * @param  ep_type: Endpoint Type
+  *          This parameter can be one of these values:
+  *            @arg EP_TYPE_CTRL: Control type
+  *            @arg EP_TYPE_ISOC: Isochronous type
+  *            @arg EP_TYPE_BULK: Bulk type
+  *            @arg EP_TYPE_INTR: Interrupt type
+  * @param  mps: Max Packet Size
+  *          This parameter can be a value from 0 to32K
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_HC_Init(USB_OTG_GlobalTypeDef *USBx,  
+                              uint8_t ch_num,
+                              uint8_t epnum,
+                              uint8_t dev_address,
+                              uint8_t speed,
+                              uint8_t ep_type,
+                              uint16_t mps)
+{
+    
+  /* Clear old interrupt conditions for this host channel. */
+  USBx_HC(ch_num)->HCINT = 0xFFFFFFFF;
+  
+  /* Enable channel interrupts required for this transfer. */
+  switch (ep_type) 
+  {
+  case EP_TYPE_CTRL:
+  case EP_TYPE_BULK:
+    
+    USBx_HC(ch_num)->HCINTMSK = USB_OTG_HCINTMSK_XFRCM  |\
+                                USB_OTG_HCINTMSK_STALLM |\
+                                USB_OTG_HCINTMSK_TXERRM |\
+                                USB_OTG_HCINTMSK_DTERRM |\
+                                USB_OTG_HCINTMSK_AHBERR |\
+                                USB_OTG_HCINTMSK_NAKM ;
+ 
+    if (epnum & 0x80) 
+    {
+      USBx_HC(ch_num)->HCINTMSK |= USB_OTG_HCINTMSK_BBERRM;
+    }
+    break;
+    
+  case EP_TYPE_INTR:
+    
+    USBx_HC(ch_num)->HCINTMSK = USB_OTG_HCINTMSK_XFRCM  |\
+                                USB_OTG_HCINTMSK_STALLM |\
+                                USB_OTG_HCINTMSK_TXERRM |\
+                                USB_OTG_HCINTMSK_DTERRM |\
+                                USB_OTG_HCINTMSK_NAKM   |\
+                                USB_OTG_HCINTMSK_AHBERR |\
+                                USB_OTG_HCINTMSK_FRMORM ;    
+    
+    if (epnum & 0x80) 
+    {
+      USBx_HC(ch_num)->HCINTMSK |= USB_OTG_HCINTMSK_BBERRM;
+    }
+    
+    break;
+  case EP_TYPE_ISOC:
+    
+    USBx_HC(ch_num)->HCINTMSK = USB_OTG_HCINTMSK_XFRCM  |\
+                                USB_OTG_HCINTMSK_ACKM   |\
+                                USB_OTG_HCINTMSK_AHBERR |\
+                                USB_OTG_HCINTMSK_FRMORM ;   
+    
+    if (epnum & 0x80) 
+    {
+      USBx_HC(ch_num)->HCINTMSK |= (USB_OTG_HCINTMSK_TXERRM | USB_OTG_HCINTMSK_BBERRM);      
+    }
+    break;
+  }
+  
+  /* Enable the top level host channel interrupt. */
+  USBx_HOST->HAINTMSK |= (1 << ch_num);
+  
+  /* Make sure host channel interrupts are enabled. */
+  USBx->GINTMSK |= USB_OTG_GINTMSK_HCIM;
+  
+  /* Program the HCCHAR register */
+  USBx_HC(ch_num)->HCCHAR = (((dev_address << 22) & USB_OTG_HCCHAR_DAD)  |\
+                             (((epnum & 0x7F)<< 11) & USB_OTG_HCCHAR_EPNUM)|\
+                             ((((epnum & 0x80) == 0x80)<< 15) & USB_OTG_HCCHAR_EPDIR)|\
+                             (((speed == HPRT0_PRTSPD_LOW_SPEED)<< 17) & USB_OTG_HCCHAR_LSDEV)|\
+                             ((ep_type << 18) & USB_OTG_HCCHAR_EPTYP)|\
+                             (mps & USB_OTG_HCCHAR_MPSIZ));
+    
+  if (ep_type == EP_TYPE_INTR)
+  {
+    USBx_HC(ch_num)->HCCHAR |= USB_OTG_HCCHAR_ODDFRM ;
+  }
+
+  return HAL_OK; 
+}
+
+/**
+  * @brief  Start a transfer over a host channel
+  * @param  USBx: Selected device
+  * @param  hc: pointer to host channel structure
+  * @param  dma: USB dma enabled or disabled 
+  *          This parameter can be one of these values:
+  *           0 : DMA feature not used 
+  *           1 : DMA feature used  
+  * @retval HAL state
+  */
+#if defined   (__CC_ARM) /*!< ARM Compiler */
+#pragma O0
+#elif defined (__GNUC__) /*!< GNU Compiler */
+#pragma GCC optimize ("O0")
+#endif /* __CC_ARM */
+HAL_StatusTypeDef USB_HC_StartXfer(USB_OTG_GlobalTypeDef *USBx, USB_OTG_HCTypeDef *hc, uint8_t dma)
+{
+  uint8_t  is_oddframe = 0; 
+  uint16_t len_words = 0;   
+  uint16_t num_packets = 0;
+  uint16_t max_hc_pkt_count = 256;
+  uint32_t tmpreg = 0;
+    
+  /* Compute the expected number of packets associated to the transfer */
+  if (hc->xfer_len > 0)
+  {
+    num_packets = (hc->xfer_len + hc->max_packet - 1) / hc->max_packet;
+    
+    if (num_packets > max_hc_pkt_count)
+    {
+      num_packets = max_hc_pkt_count;
+      hc->xfer_len = num_packets * hc->max_packet;
+    }
+  }
+  else
+  {
+    num_packets = 1;
+  }
+  if (hc->ep_is_in)
+  {
+    hc->xfer_len = num_packets * hc->max_packet;
+  }
+  
+  /* Initialize the HCTSIZn register */
+  USBx_HC(hc->ch_num)->HCTSIZ = (((hc->xfer_len) & USB_OTG_HCTSIZ_XFRSIZ)) |\
+    ((num_packets << 19) & USB_OTG_HCTSIZ_PKTCNT) |\
+      (((hc->data_pid) << 29) & USB_OTG_HCTSIZ_DPID);
+  
+  if (dma)
+  {
+    /* xfer_buff MUST be 32-bits aligned */
+    USBx_HC(hc->ch_num)->HCDMA = (uint32_t)hc->xfer_buff;
+  }
+  
+  is_oddframe = (USBx_HOST->HFNUM & 0x01) ? 0 : 1;
+  USBx_HC(hc->ch_num)->HCCHAR &= ~USB_OTG_HCCHAR_ODDFRM;
+  USBx_HC(hc->ch_num)->HCCHAR |= (is_oddframe << 29);
+  
+  /* Set host channel enable */
+  tmpreg = USBx_HC(hc->ch_num)->HCCHAR;
+  tmpreg &= ~USB_OTG_HCCHAR_CHDIS;
+  tmpreg |= USB_OTG_HCCHAR_CHENA;
+  USBx_HC(hc->ch_num)->HCCHAR = tmpreg;
+  
+  if (dma == 0) /* Slave mode */
+  {  
+    if((hc->ep_is_in == 0) && (hc->xfer_len > 0))
+    {
+      switch(hc->ep_type) 
+      {
+        /* Non periodic transfer */
+      case EP_TYPE_CTRL:
+      case EP_TYPE_BULK:
+        
+        len_words = (hc->xfer_len + 3) / 4;
+        
+        /* check if there is enough space in FIFO space */
+        if(len_words > (USBx->HNPTXSTS & 0xFFFF))
+        {
+          /* need to process data in nptxfempty interrupt */
+          USBx->GINTMSK |= USB_OTG_GINTMSK_NPTXFEM;
+        }
+        break;
+        /* Periodic transfer */
+      case EP_TYPE_INTR:
+      case EP_TYPE_ISOC:
+        len_words = (hc->xfer_len + 3) / 4;
+        /* check if there is enough space in FIFO space */
+        if(len_words > (USBx_HOST->HPTXSTS & 0xFFFF)) /* split the transfer */
+        {
+          /* need to process data in ptxfempty interrupt */
+          USBx->GINTMSK |= USB_OTG_GINTMSK_PTXFEM;          
+        }
+        break;
+        
+      default:
+        break;
+      }
+      
+      /* Write packet into the Tx FIFO. */
+      USB_WritePacket(USBx, hc->xfer_buff, hc->ch_num, hc->xfer_len, 0);
+    }
+  }
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief Read all host channel interrupts status
+  * @param  USBx: Selected device
+  * @retval HAL state
+  */
+uint32_t USB_HC_ReadInterrupt (USB_OTG_GlobalTypeDef *USBx)
+{
+  return ((USBx_HOST->HAINT) & 0xFFFF);
+}
+
+/**
+  * @brief  Halt a host channel
+  * @param  USBx: Selected device
+  * @param  hc_num: Host Channel number
+  *         This parameter can be a value from 1 to 15
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_HC_Halt(USB_OTG_GlobalTypeDef *USBx , uint8_t hc_num)
+{
+  uint32_t count = 0;
+  
+  /* Check for space in the request queue to issue the halt. */
+  if (((USBx_HC(hc_num)->HCCHAR) & (HCCHAR_CTRL << 18)) || ((USBx_HC(hc_num)->HCCHAR) & (HCCHAR_BULK << 18)))
+  {
+    USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHDIS;
+    
+    if ((USBx->HNPTXSTS & 0xFFFF) == 0)
+    {
+      USBx_HC(hc_num)->HCCHAR &= ~USB_OTG_HCCHAR_CHENA;
+      USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;  
+      USBx_HC(hc_num)->HCCHAR &= ~USB_OTG_HCCHAR_EPDIR;
+      do 
+      {
+        if (++count > 1000) 
+        {
+          break;
+        }
+      } 
+      while ((USBx_HC(hc_num)->HCCHAR & USB_OTG_HCCHAR_CHENA) == USB_OTG_HCCHAR_CHENA);     
+    }
+    else
+    {
+      USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA; 
+    }
+  }
+  else
+  {
+    USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHDIS;
+    
+    if ((USBx_HOST->HPTXSTS & 0xFFFF) == 0)
+    {
+      USBx_HC(hc_num)->HCCHAR &= ~USB_OTG_HCCHAR_CHENA;
+      USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;  
+      USBx_HC(hc_num)->HCCHAR &= ~USB_OTG_HCCHAR_EPDIR;
+      do 
+      {
+        if (++count > 1000) 
+        {
+          break;
+        }
+      } 
+      while ((USBx_HC(hc_num)->HCCHAR & USB_OTG_HCCHAR_CHENA) == USB_OTG_HCCHAR_CHENA);     
+    }
+    else
+    {
+       USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA; 
+    }
+  }
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initiate Do Ping protocol
+  * @param  USBx: Selected device
+  * @param  hc_num: Host Channel number
+  *         This parameter can be a value from 1 to 15
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_DoPing(USB_OTG_GlobalTypeDef *USBx , uint8_t ch_num)
+{
+  uint8_t  num_packets = 1;
+  uint32_t tmpreg = 0;
+  
+  USBx_HC(ch_num)->HCTSIZ = ((num_packets << 19) & USB_OTG_HCTSIZ_PKTCNT) |\
+                                USB_OTG_HCTSIZ_DOPING;
+  
+  /* Set host channel enable */
+  tmpreg = USBx_HC(ch_num)->HCCHAR;
+  tmpreg &= ~USB_OTG_HCCHAR_CHDIS;
+  tmpreg |= USB_OTG_HCCHAR_CHENA;
+  USBx_HC(ch_num)->HCCHAR = tmpreg;
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Stop Host Core
+  * @param  USBx: Selected device
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_StopHost(USB_OTG_GlobalTypeDef *USBx)
+{
+  uint8_t i;
+  uint32_t count = 0;
+  uint32_t value;
+  
+  USB_DisableGlobalInt(USBx);
+  
+    /* Flush FIFO */
+  USB_FlushTxFifo(USBx, 0x10);
+  USB_FlushRxFifo(USBx);
+  
+  /* Flush out any leftover queued requests. */
+  for (i = 0; i <= 15; i++)
+  {   
+
+    value = USBx_HC(i)->HCCHAR ;
+    value |=  USB_OTG_HCCHAR_CHDIS;
+    value &= ~USB_OTG_HCCHAR_CHENA;  
+    value &= ~USB_OTG_HCCHAR_EPDIR;
+    USBx_HC(i)->HCCHAR = value;
+  }
+  
+  /* Halt all channels to put them into a known state. */  
+  for (i = 0; i <= 15; i++)
+  {   
+    value = USBx_HC(i)->HCCHAR ;
+    
+    value |= USB_OTG_HCCHAR_CHDIS;
+    value |= USB_OTG_HCCHAR_CHENA;  
+    value &= ~USB_OTG_HCCHAR_EPDIR;
+    
+    USBx_HC(i)->HCCHAR = value;
+    do 
+    {
+      if (++count > 1000) 
+      {
+        break;
+      }
+    } 
+    while ((USBx_HC(i)->HCCHAR & USB_OTG_HCCHAR_CHENA) == USB_OTG_HCCHAR_CHENA);
+  }
+
+  /* Clear any pending Host interrupts */  
+  USBx_HOST->HAINT = 0xFFFFFFFF;
+  USBx->GINTSTS = 0xFFFFFFFF;
+  USB_EnableGlobalInt(USBx);
+  return HAL_OK;  
+}
+/**
+  * @}
+  */
+
+#endif /* defined (HAL_PCD_MODULE_ENABLED) || defined (HAL_HCD_MODULE_ENABLED) */
+
+/**
+  * @}
+  */
+
+#endif /* STM32L475xx || STM32L476xx || STM32L485xx || STM32L486xx */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
This is the 2nd PR in a series of PR to support the STM32L4 series in micropython. (see http://forum.micropython.org/viewtopic.php?f=12&t=1332&sid=64e2f63af49643c3edee159171f4a365)

I add the hal files from STM32Cube_FW_L4_V1.3.0 with windows line ending converted to unix. Only basic hal files are added. In addition the QSPI support is included to support later the QSPI flash as mass storage.
