### PR TITLE
L4 integration: Added new lines for building for l4 series.

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -47,6 +47,7 @@ INC += -I../lib/timeutils
 CFLAGS_CORTEX_M = -mthumb -mabi=aapcs-linux -mfpu=fpv4-sp-d16 -mfloat-abi=hard -fsingle-precision-constant -Wdouble-promotion
 CFLAGS_MCU_f4 = $(CFLAGS_CORTEX_M) -mtune=cortex-m4 -mcpu=cortex-m4 -DMCU_SERIES_F4
 CFLAGS_MCU_f7 = $(CFLAGS_CORTEX_M) -mtune=cortex-m7 -mcpu=cortex-m7 -DMCU_SERIES_F7
+CFLAGS_MCU_l4 = $(CFLAGS_CORTEX_M) -mtune=cortex-m4 -mcpu=cortex-m4 -DMCU_SERIES_L4
 
 CFLAGS = $(INC) -Wall -Wpointer-arith -Werror -ansi -std=gnu99 -nostdlib $(CFLAGS_MOD)
 CFLAGS += -D$(CMSIS_MCU)


### PR DESCRIPTION
This is the 4th PR in a series of PR to support the STM32L4 series in micropython. (see http://forum.micropython.org/viewtopic.php?f=12&t=1332&sid=64e2f63af49643c3edee159171f4a365)

I add the modifications to the Makefile to support the build of the new platform. I had to add the inclusion of the libgcc as on line 965 of the stm32l4xx_hal_uart.h there is a division with 64bit parameter (Macro UART_DIV_LPUART). The **PCLK** can be the system clock which is on L4 up to 80MHz. Multiply 80MHz by 256 is larger than 2**32. Is there a better way to solve this problem? 

Including libgcc still gives link error:
arm-none-eabi-ld: warning: /usr/lib/gcc/arm-none-eabi/4.9.3/armv7e-m/fpu/libgcc.a(bpabi.o) uses variable-size enums yet the output is to use 32-bit enums; use of enum values across objects may fail
arm-none-eabi-ld: warning: /usr/lib/gcc/arm-none-eabi/4.9.3/armv7e-m/fpu/libgcc.a(_divdi3.o) uses variable-size enums yet the output is to use 32-bit enums; use of enum values across objects may fail
arm-none-eabi-ld: warning: /usr/lib/gcc/arm-none-eabi/4.9.3/armv7e-m/fpu/libgcc.a(_udivdi3.o) uses variable-size enums yet the output is to use 32-bit enums; use of enum values across objects may fail

How can this be solved?
