### PR TITLE
L4 integration: Adapted DMA to STM32L4 MCU series.

### DIFF
--- a/stmhal/dac.c
+++ b/stmhal/dac.c
@@ -67,7 +67,7 @@
 ///     dac = DAC(1)
 ///     dac.write_timed(buf, 400 * len(buf), mode=DAC.CIRCULAR)
 
-#if MICROPY_HW_ENABLE_DAC
+#if defined(MICROPY_HW_ENABLE_DAC) && MICROPY_HW_ENABLE_DAC
 
 STATIC DAC_HandleTypeDef DAC_Handle;
 
@@ -139,7 +139,7 @@ typedef enum {
 typedef struct _pyb_dac_obj_t {
     mp_obj_base_t base;
     uint32_t dac_channel; // DAC_CHANNEL_1 or DAC_CHANNEL_2
-    DMA_Stream_TypeDef *dma_stream; // DMA1_Stream5 or DMA1_Stream6
+    const dma_descr_t *tx_dma_descr;
     uint16_t pin; // GPIO_PIN_4 or GPIO_PIN_5
     uint8_t bits; // 8 or 12
     uint8_t state;
@@ -162,7 +162,13 @@ STATIC mp_obj_t pyb_dac_init_helper(pyb_dac_obj_t *self, mp_uint_t n_args, const
     HAL_GPIO_Init(GPIOA, &GPIO_InitStructure);
 
     // DAC peripheral clock
+#if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
     __DAC_CLK_ENABLE();
+#elif defined(MCU_SERIES_L4)
+    __HAL_RCC_DAC1_CLK_ENABLE();
+#else
+    #error Unsupported Processor
+#endif
 
     // stop anything already going on
     HAL_DAC_Stop(&DAC_Handle, self->dac_channel);
@@ -217,11 +223,11 @@ STATIC mp_obj_t pyb_dac_make_new(const mp_obj_type_t *type, mp_uint_t n_args, mp
     if (dac_id == 1) {
         dac->pin = GPIO_PIN_4;
         dac->dac_channel = DAC_CHANNEL_1;
-        dac->dma_stream = DMA_STREAM_DAC1;
+        dac->tx_dma_descr = &dma_DAC_1_TX;
     } else if (dac_id == 2) {
         dac->pin = GPIO_PIN_5;
         dac->dac_channel = DAC_CHANNEL_2;
-        dac->dma_stream = DMA_STREAM_DAC2;
+        dac->tx_dma_descr = &dma_DAC_2_TX;
     } else {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "DAC %d does not exist", dac_id));
     }
@@ -371,9 +377,12 @@ mp_obj_t pyb_dac_write_timed(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_
 
     __DMA1_CLK_ENABLE();
 
+    DMA_HandleTypeDef DMA_Handle;
+    /* Get currently configured dma */
+    dma_init_handle(&DMA_Handle, self->tx_dma_descr, (void*)NULL);
     /*
-    DMA_Cmd(self->dma_stream, DISABLE);
-    while (DMA_GetCmdStatus(self->dma_stream) != DISABLE) {
+    DMA_Cmd(DMA_Handle->Instance, DISABLE);
+    while (DMA_GetCmdStatus(DMA_Handle->Instance) != DISABLE) {
     }
 
     DAC_Cmd(self->dac_channel, DISABLE);
@@ -389,16 +398,10 @@ mp_obj_t pyb_dac_write_timed(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_
     DAC_Init(self->dac_channel, &DAC_InitStructure);
     */
 
-    // DMA1_Stream[67] channel7 configuration
-    DMA_HandleTypeDef DMA_Handle;
-    DMA_Handle.Instance = self->dma_stream;
-
     // Need to deinit DMA first
     DMA_Handle.State = HAL_DMA_STATE_READY;
     HAL_DMA_DeInit(&DMA_Handle);
 
-    DMA_Handle.Init.Channel = DMA_CHANNEL_DAC1;  // DAC1 & DAC2 both use the same channel
-    DMA_Handle.Init.Direction = DMA_MEMORY_TO_PERIPH;
     DMA_Handle.Init.PeriphInc = DMA_PINC_DISABLE;
     DMA_Handle.Init.MemInc = DMA_MINC_ENABLE;
     if (self->bits == 8) {
@@ -410,10 +413,12 @@ mp_obj_t pyb_dac_write_timed(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_
     }
     DMA_Handle.Init.Mode = args[2].u_int;
     DMA_Handle.Init.Priority = DMA_PRIORITY_HIGH;
+#if ! defined(MCU_SERIES_L4)
     DMA_Handle.Init.FIFOMode = DMA_FIFOMODE_DISABLE;
     DMA_Handle.Init.FIFOThreshold = DMA_FIFO_THRESHOLD_HALFFULL;
     DMA_Handle.Init.MemBurst = DMA_MBURST_SINGLE;
     DMA_Handle.Init.PeriphBurst = DMA_PBURST_SINGLE;
+#endif
     HAL_DMA_Init(&DMA_Handle);
 
     if (self->dac_channel == DAC_CHANNEL_1) {
@@ -444,8 +449,8 @@ mp_obj_t pyb_dac_write_timed(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_
 
     /*
     // enable DMA stream
-    DMA_Cmd(self->dma_stream, ENABLE);
-    while (DMA_GetCmdStatus(self->dma_stream) == DISABLE) {
+    DMA_Cmd(DMA_Handle->Instance, ENABLE);
+    while (DMA_GetCmdStatus(DMA_Handle->Instance) == DISABLE) {
     }
 
     // enable DAC channel

--- a/stmhal/dma.c
+++ b/stmhal/dma.c
@@ -33,9 +33,145 @@
 #include "py/obj.h"
 #include "irq.h"
 
-#define NSTREAMS_PER_CONTROLLER_LOG2 (3)
-#define NSTREAMS_PER_CONTROLLER (1 << NSTREAMS_PER_CONTROLLER_LOG2)
+
+typedef enum {
+    dma_id_not_defined=-1,
+    dma_id_0,
+    dma_id_1,
+    dma_id_2,
+    dma_id_3,
+    dma_id_4,
+    dma_id_5,
+    dma_id_6,
+    dma_id_7,
+    dma_id_8,
+    dma_id_9,
+    dma_id_10,
+    dma_id_11,
+    dma_id_12,
+    dma_id_13,
+    dma_id_14,
+    dma_id_15,
+} dma_id_t;
+
+typedef struct _dma_descr_t {
+#if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
+    DMA_Stream_TypeDef  *instance;
+#elif defined(MCU_SERIES_L4)
+    DMA_Channel_TypeDef *instance;
+#else
+#error "Unsupported Processor"
+#endif
+    uint32_t        sub_instance;
+    uint32_t        transfer_direction; /* Transfer direction Periphery to memory or vis-versa */
+    dma_id_t        id;
+    const DMA_InitTypeDef *init;
+} dma_descr_t;
+
 #define NCONTROLLERS            (2)
+
+// Default parameters to dma_init() shared by spi and i2c; Channel and Direction
+// vary depending on the peripheral instance so they get passed separately
+static const DMA_InitTypeDef dma_init_struct_spi_i2c = {
+#if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
+    .Channel             = 0,
+#elif defined(MCU_SERIES_L4)
+    .Request             = 0,
+#endif
+    .Direction           = 0,
+    .PeriphInc           = DMA_PINC_DISABLE,
+    .MemInc              = DMA_MINC_ENABLE,
+    .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,
+    .MemDataAlignment    = DMA_MDATAALIGN_BYTE,
+    .Mode                = DMA_NORMAL,
+    .Priority            = DMA_PRIORITY_LOW,
+#if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
+    .FIFOMode            = DMA_FIFOMODE_DISABLE,
+    .FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL,
+    .MemBurst            = DMA_MBURST_INC4,
+    .PeriphBurst         = DMA_PBURST_INC4
+#endif
+};
+
+#if defined(MICROPY_HW_HAS_SDCARD) && MICROPY_HW_HAS_SDCARD
+// Parameters to dma_init() for SDIO tx and rx.
+static const DMA_InitTypeDef dma_init_struct_sdio = {
+#if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
+    .Channel             = 0,
+#elif defined(MCU_SERIES_L4)
+    .Request             = 0,
+#endif
+    .Direction           = 0,
+    .PeriphInc           = DMA_PINC_DISABLE,
+    .MemInc              = DMA_MINC_ENABLE,
+    .PeriphDataAlignment = DMA_PDATAALIGN_WORD,
+    .MemDataAlignment    = DMA_MDATAALIGN_WORD,
+#if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
+    .Mode                = DMA_PFCTRL,
+#elif defined(MCU_SERIES_L4)
+    .Mode                = DMA_NORMAL,
+#endif
+    .Priority            = DMA_PRIORITY_VERY_HIGH,
+#if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
+    .FIFOMode            = DMA_FIFOMODE_ENABLE,
+    .FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL,
+    .MemBurst            = DMA_MBURST_INC4,
+    .PeriphBurst         = DMA_PBURST_INC4,
+#endif
+};
+#endif
+
+#if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
+/*
+ * Configuration for STM32F4xx series
+ */
+
+// These are ordered by DMAx_Stream number, and within a stream by channel
+// number. The duplicate streams are ok as long as they aren't used at the
+// same time.
+//
+// Currently I2C and SPI are synchronous and they call dma_init/dma_deinit
+// around each transfer.
+    // DMA1 streams
+const dma_descr_t dma_I2C_1_RX = { DMA1_Stream0, DMA_CHANNEL_1, DMA_PERIPH_TO_MEMORY, dma_id_0  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_3_RX = { DMA1_Stream2, DMA_CHANNEL_0, DMA_PERIPH_TO_MEMORY, dma_id_2  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_3_RX = { DMA1_Stream2, DMA_CHANNEL_3, DMA_PERIPH_TO_MEMORY, dma_id_2  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_2_RX = { DMA1_Stream2, DMA_CHANNEL_7, DMA_PERIPH_TO_MEMORY, dma_id_2  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_2_RX = { DMA1_Stream3, DMA_CHANNEL_0, DMA_PERIPH_TO_MEMORY, dma_id_3  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_2_TX = { DMA1_Stream4, DMA_CHANNEL_0, DMA_MEMORY_TO_PERIPH, dma_id_4  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_3_TX = { DMA1_Stream4, DMA_CHANNEL_3, DMA_MEMORY_TO_PERIPH, dma_id_4  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_DAC_1_TX = { DMA1_Stream5, DMA_CHANNEL_7, DMA_MEMORY_TO_PERIPH, dma_id_5  , NULL};
+const dma_descr_t dma_DAC_2_TX = { DMA1_Stream6, DMA_CHANNEL_7, DMA_MEMORY_TO_PERIPH, dma_id_6  , NULL};
+const dma_descr_t dma_SPI_3_TX = { DMA1_Stream7, DMA_CHANNEL_0, DMA_MEMORY_TO_PERIPH, dma_id_7  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_1_TX = { DMA1_Stream7, DMA_CHANNEL_1, DMA_MEMORY_TO_PERIPH, dma_id_7  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_2_TX = { DMA1_Stream7, DMA_CHANNEL_7, DMA_MEMORY_TO_PERIPH, dma_id_7  , &dma_init_struct_spi_i2c};
+    /* Not prefered streams on DMA1                                                                      ;
+const dma_descr_t dma_SPI_3_RX = { DMA1_Stream0, DMA_CHANNEL_0, DMA_PERIPH_TO_MEMORY, dma_id_0  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_1_TX = { DMA1_Stream6, DMA_CHANNEL_1, DMA_MEMORY_TO_PERIPH, dma_id_6  , &dma_init_struct_spi_i2c}; */
+    // DMA2 streams                                                                                      ;
+const dma_descr_t dma_SPI_1_RX = { DMA2_Stream2, DMA_CHANNEL_3, DMA_PERIPH_TO_MEMORY, dma_id_10 , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_5_RX = { DMA2_Stream3, DMA_CHANNEL_2, DMA_PERIPH_TO_MEMORY, dma_id_11 , &dma_init_struct_spi_i2c};
+#if defined(MICROPY_HW_HAS_SDCARD) && MICROPY_HW_HAS_SDCARD
+const dma_descr_t dma_SDIO_0_RX= { DMA2_Stream3, DMA_CHANNEL_4, DMA_PERIPH_TO_MEMORY, dma_id_11 , &dma_init_struct_sdio};
+#endif
+const dma_descr_t dma_SPI_4_RX = { DMA2_Stream3, DMA_CHANNEL_5, DMA_PERIPH_TO_MEMORY, dma_id_11 , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_5_TX = { DMA2_Stream4, DMA_CHANNEL_2, DMA_MEMORY_TO_PERIPH, dma_id_12 , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_4_TX = { DMA2_Stream4, DMA_CHANNEL_5, DMA_MEMORY_TO_PERIPH, dma_id_12 , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_6_TX = { DMA2_Stream5, DMA_CHANNEL_1, DMA_MEMORY_TO_PERIPH, dma_id_13 , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_1_TX = { DMA2_Stream5, DMA_CHANNEL_3, DMA_MEMORY_TO_PERIPH, dma_id_13 , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_6_RX = { DMA2_Stream6, DMA_CHANNEL_1, DMA_PERIPH_TO_MEMORY, dma_id_14 , &dma_init_struct_spi_i2c};
+#if defined(MICROPY_HW_HAS_SDCARD) && MICROPY_HW_HAS_SDCARD
+const dma_descr_t dma_SDIO_0_TX= { DMA2_Stream6, DMA_CHANNEL_4, DMA_MEMORY_TO_PERIPH, dma_id_14 , &dma_init_struct_sdio};
+#endif
+    /* Not prefered streams on DMA2
+const dma_descr_t dma_SPI_1_TX = { DMA2_Stream3, DMA_CHANNEL_3, DMA_MEMORY_TO_PERIPH, dma_id_11 , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_1_RX = { DMA2_Stream0, DMA_CHANNEL_3, DMA_PERIPH_TO_MEMORY, dma_id_8  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_4_RX = { DMA2_Stream0, DMA_CHANNEL_4, DMA_PERIPH_TO_MEMORY, dma_id_8  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_4_TX = { DMA2_Stream1, DMA_CHANNEL_4, DMA_MEMORY_TO_PERIPH, dma_id_9  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_5_RX = { DMA2_Stream5, DMA_CHANNEL_7, DMA_PERIPH_TO_MEMORY, dma_id_13 , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_5_TX = { DMA2_Stream6, DMA_CHANNEL_7, DMA_MEMORY_TO_PERIPH, dma_id_14 , &dma_init_struct_spi_i2c}; */
+
+#define NSTREAMS_PER_CONTROLLER (8)
 #define NSTREAM                 (NCONTROLLERS * NSTREAMS_PER_CONTROLLER)
 
 static const uint8_t dma_irqn[NSTREAM] = {
@@ -56,72 +192,130 @@ static const uint8_t dma_irqn[NSTREAM] = {
     DMA2_Stream6_IRQn,
     DMA2_Stream7_IRQn,
 };
+#elif defined(MCU_SERIES_L4)
+// These are ordered by DMAx_Channel number, and within a channel by request
+// number. The duplicate streams are ok as long as they aren't used at the
+// same time.
+    // DMA1 streams
+const dma_descr_t dma_ADC_1_RX = { DMA1_Channel1, DMA_REQUEST_0, DMA_PERIPH_TO_MEMORY, dma_id_0  , NULL};
+const dma_descr_t dma_ADC_2_RX = { DMA1_Channel2, DMA_REQUEST_0, DMA_PERIPH_TO_MEMORY, dma_id_1  , NULL};
+const dma_descr_t dma_SPI_1_RX = { DMA1_Channel2, DMA_REQUEST_1, DMA_PERIPH_TO_MEMORY, dma_id_1  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_3_TX = { DMA1_Channel2, DMA_REQUEST_3, DMA_MEMORY_TO_PERIPH, dma_id_1  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_ADC_3_RX = { DMA1_Channel3, DMA_REQUEST_0, DMA_PERIPH_TO_MEMORY, dma_id_2  , NULL};
+const dma_descr_t dma_SPI_1_TX = { DMA1_Channel3, DMA_REQUEST_1, DMA_MEMORY_TO_PERIPH, dma_id_2  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_3_RX = { DMA1_Channel3, DMA_REQUEST_3, DMA_PERIPH_TO_MEMORY, dma_id_2  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_DAC_1_TX = { DMA1_Channel3, DMA_REQUEST_6, DMA_MEMORY_TO_PERIPH, dma_id_2  , NULL};
+const dma_descr_t dma_SPI_2_RX = { DMA1_Channel4, DMA_REQUEST_1, DMA_PERIPH_TO_MEMORY, dma_id_3  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_2_TX = { DMA1_Channel4, DMA_REQUEST_3, DMA_MEMORY_TO_PERIPH, dma_id_3  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_DAC_2_TX = { DMA1_Channel4, DMA_REQUEST_5, DMA_MEMORY_TO_PERIPH, dma_id_3  , NULL};
+const dma_descr_t dma_SPI_2_TX = { DMA1_Channel5, DMA_REQUEST_1, DMA_MEMORY_TO_PERIPH, dma_id_4  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_2_RX = { DMA1_Channel5, DMA_REQUEST_3, DMA_PERIPH_TO_MEMORY, dma_id_4  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_1_TX = { DMA1_Channel6, DMA_REQUEST_3, DMA_MEMORY_TO_PERIPH, dma_id_5  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_1_RX = { DMA1_Channel7, DMA_REQUEST_3, DMA_PERIPH_TO_MEMORY, dma_id_6  , &dma_init_struct_spi_i2c};
+    // DMA2 streams
+const dma_descr_t dma_SPI_3_RX = { DMA2_Channel1, DMA_REQUEST_3, DMA_PERIPH_TO_MEMORY, dma_id_7  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_SPI_3_TX = { DMA2_Channel2, DMA_REQUEST_3, DMA_MEMORY_TO_PERIPH, dma_id_8  , &dma_init_struct_spi_i2c};
+/* Not prefered
+const dma_descr_t dma_ADC_1_RX = { DMA2_Channel3, DMA_REQUEST_0, DMA_PERIPH_TO_MEMORY, dma_id_9  , NULL};
+const dma_descr_t dma_SPI_1_RX = { DMA2_Channel3, DMA_REQUEST_4, DMA_PERIPH_TO_MEMORY, dma_id_9  , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_ADC_2_RX = { DMA2_Channel4, DMA_REQUEST_0, DMA_PERIPH_TO_MEMORY, dma_id_10 , NULL};
+const dma_descr_t dma_DAC_1_TX = { DMA2_Channel4, DMA_REQUEST_3, DMA_MEMORY_TO_PERIPH, dma_id_10 , NULL};
+const dma_descr_t dma_SPI_1_TX = { DMA2_Channel4, DMA_REQUEST_4, DMA_MEMORY_TO_PERIPH, dma_id_10 , &dma_init_struct_spi_i2c}; */
+#if MICROPY_HW_HAS_SDCARD
+const dma_descr_t dma_SDIO_0_TX= { DMA2_Channel4, DMA_REQUEST_7, DMA_MEMORY_TO_PERIPH, dma_id_10 , &dma_init_struct_sdio};
+#endif
+/* Not prefered
+const dma_descr_t dma_ADC_3_RX = { DMA2_Channel5, DMA_REQUEST_0, DMA_PERIPH_TO_MEMORY, dma_id_11 , NULL};
+const dma_descr_t dma_DAC_2_TX = { DMA2_Channel5, DMA_REQUEST_3, DMA_MEMORY_TO_PERIPH, dma_id_11 , NULL};
+const dma_descr_t dma_SDIO_0_TX= { DMA2_Channel5, DMA_REQUEST_7, DMA_MEMORY_TO_PERIPH, dma_id_11 , &dma_init_struct_sdio};
+const dma_descr_t dma_I2C_1_RX = { DMA2_Channel6, DMA_REQUEST_5, DMA_PERIPH_TO_MEMORY, dma_id_12 , &dma_init_struct_spi_i2c};
+const dma_descr_t dma_I2C_1_TX = { DMA2_Channel7, DMA_REQUEST_5, DMA_MEMORY_TO_PERIPH, dma_id_13 , &dma_init_struct_spi_i2c}; */
 
-// Default parameters to dma_init() shared by spi and i2c; Channel and Direction
-// vary depending on the peripheral instance so they get passed separately
-const DMA_InitTypeDef dma_init_struct_spi_i2c = {
-    .Channel             = 0,
-    .Direction           = 0,
-    .PeriphInc           = DMA_PINC_DISABLE,
-    .MemInc              = DMA_MINC_ENABLE,
-    .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,
-    .MemDataAlignment    = DMA_MDATAALIGN_BYTE,
-    .Mode                = DMA_NORMAL,
-    .Priority            = DMA_PRIORITY_LOW,
-    .FIFOMode            = DMA_FIFOMODE_DISABLE,
-    .FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL,
-    .MemBurst            = DMA_MBURST_INC4,
-    .PeriphBurst         = DMA_PBURST_INC4
+#define NSTREAMS_PER_CONTROLLER (7)
+#define NSTREAM                 (NCONTROLLERS * NSTREAMS_PER_CONTROLLER)
+static const uint8_t dma_irqn[NSTREAM] = {
+    DMA1_Channel1_IRQn,
+    DMA1_Channel2_IRQn,
+    DMA1_Channel3_IRQn,
+    DMA1_Channel4_IRQn,
+    DMA1_Channel5_IRQn,
+    DMA1_Channel6_IRQn,
+    DMA1_Channel7_IRQn,
+    DMA2_Channel1_IRQn,
+    DMA2_Channel2_IRQn,
+    DMA2_Channel3_IRQn,
+    DMA2_Channel4_IRQn,
+    DMA2_Channel5_IRQn,
+    DMA2_Channel6_IRQn,
+    DMA2_Channel7_IRQn,
 };
+#endif
 
 static DMA_HandleTypeDef *dma_handle[NSTREAM] = {NULL};
-static uint8_t  dma_last_channel[NSTREAM];
+static uint8_t  dma_last_sub_instance[NSTREAM];
 static volatile uint32_t dma_enable_mask = 0;
 
-volatile dma_idle_count_t dma_idle;
+#if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
+
+#define DMA_SUB_INSTANCE_AS_UINT8(dma_channel)   (((dma_channel) & DMA_SxCR_CHSEL) >> 25)
+
+void DMA1_Stream0_IRQHandler(void) { IRQ_ENTER(DMA1_Stream0_IRQn); if (dma_handle[dma_id_0]  != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_0]); } IRQ_EXIT(DMA1_Stream0_IRQn); }
+void DMA1_Stream1_IRQHandler(void) { IRQ_ENTER(DMA1_Stream1_IRQn); if (dma_handle[dma_id_1]  != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_1]); } IRQ_EXIT(DMA1_Stream1_IRQn); }
+void DMA1_Stream2_IRQHandler(void) { IRQ_ENTER(DMA1_Stream2_IRQn); if (dma_handle[dma_id_2]  != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_2]); } IRQ_EXIT(DMA1_Stream2_IRQn); }
+void DMA1_Stream3_IRQHandler(void) { IRQ_ENTER(DMA1_Stream3_IRQn); if (dma_handle[dma_id_3]  != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_3]); } IRQ_EXIT(DMA1_Stream3_IRQn); }
+void DMA1_Stream4_IRQHandler(void) { IRQ_ENTER(DMA1_Stream4_IRQn); if (dma_handle[dma_id_4]  != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_4]); } IRQ_EXIT(DMA1_Stream4_IRQn); }
+void DMA1_Stream5_IRQHandler(void) { IRQ_ENTER(DMA1_Stream5_IRQn); if (dma_handle[dma_id_5]  != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_5]); } IRQ_EXIT(DMA1_Stream5_IRQn); }
+void DMA1_Stream6_IRQHandler(void) { IRQ_ENTER(DMA1_Stream6_IRQn); if (dma_handle[dma_id_6]  != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_6]); } IRQ_EXIT(DMA1_Stream6_IRQn); }
+void DMA1_Stream7_IRQHandler(void) { IRQ_ENTER(DMA1_Stream7_IRQn); if (dma_handle[dma_id_7]  != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_7]); } IRQ_EXIT(DMA1_Stream7_IRQn); }
+void DMA2_Stream0_IRQHandler(void) { IRQ_ENTER(DMA2_Stream0_IRQn); if (dma_handle[dma_id_8]  != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_8]); } IRQ_EXIT(DMA2_Stream0_IRQn); }
+void DMA2_Stream1_IRQHandler(void) { IRQ_ENTER(DMA2_Stream1_IRQn); if (dma_handle[dma_id_9]  != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_9]); } IRQ_EXIT(DMA2_Stream1_IRQn); }
+void DMA2_Stream2_IRQHandler(void) { IRQ_ENTER(DMA2_Stream2_IRQn); if (dma_handle[dma_id_10] != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_10]); } IRQ_EXIT(DMA2_Stream2_IRQn); }
+void DMA2_Stream3_IRQHandler(void) { IRQ_ENTER(DMA2_Stream3_IRQn); if (dma_handle[dma_id_11] != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_11]); } IRQ_EXIT(DMA2_Stream3_IRQn); }
+void DMA2_Stream4_IRQHandler(void) { IRQ_ENTER(DMA2_Stream4_IRQn); if (dma_handle[dma_id_12] != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_12]); } IRQ_EXIT(DMA2_Stream4_IRQn); }
+void DMA2_Stream5_IRQHandler(void) { IRQ_ENTER(DMA2_Stream5_IRQn); if (dma_handle[dma_id_13] != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_13]); } IRQ_EXIT(DMA2_Stream5_IRQn); }
+void DMA2_Stream6_IRQHandler(void) { IRQ_ENTER(DMA2_Stream6_IRQn); if (dma_handle[dma_id_14] != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_14]); } IRQ_EXIT(DMA2_Stream6_IRQn); }
+void DMA2_Stream7_IRQHandler(void) { IRQ_ENTER(DMA2_Stream7_IRQn); if (dma_handle[dma_id_15] != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_15]); } IRQ_EXIT(DMA2_Stream7_IRQn); }
 
 #define DMA1_ENABLE_MASK    0x00ff  // Bits in dma_enable_mask corresponfing to DMA1
 #define DMA2_ENABLE_MASK    0xff00  // Bits in dma_enable_mask corresponding to DMA2
+
+#elif defined(MCU_SERIES_L4)
+
+#define DMA_SUB_INSTANCE_AS_UINT8(dma_request)   (dma_request)
+
+void DMA1_Channel1_IRQHandler(void) { IRQ_ENTER(DMA1_Channel1_IRQn); if (dma_handle[dma_id_0] != NULL)  { HAL_DMA_IRQHandler(dma_handle[dma_id_0]); } IRQ_EXIT(DMA1_Channel1_IRQn); }
+void DMA1_Channel2_IRQHandler(void) { IRQ_ENTER(DMA1_Channel2_IRQn); if (dma_handle[dma_id_1] != NULL)  { HAL_DMA_IRQHandler(dma_handle[dma_id_1]); } IRQ_EXIT(DMA1_Channel2_IRQn); }
+void DMA1_Channel3_IRQHandler(void) { IRQ_ENTER(DMA1_Channel3_IRQn); if (dma_handle[dma_id_2] != NULL)  { HAL_DMA_IRQHandler(dma_handle[dma_id_2]); } IRQ_EXIT(DMA1_Channel3_IRQn); }
+void DMA1_Channel4_IRQHandler(void) { IRQ_ENTER(DMA1_Channel4_IRQn); if (dma_handle[dma_id_3] != NULL)  { HAL_DMA_IRQHandler(dma_handle[dma_id_3]); } IRQ_EXIT(DMA1_Channel4_IRQn); }
+void DMA1_Channel5_IRQHandler(void) { IRQ_ENTER(DMA1_Channel5_IRQn); if (dma_handle[dma_id_4] != NULL)  { HAL_DMA_IRQHandler(dma_handle[dma_id_4]); } IRQ_EXIT(DMA1_Channel5_IRQn); }
+void DMA1_Channel6_IRQHandler(void) { IRQ_ENTER(DMA1_Channel6_IRQn); if (dma_handle[dma_id_5] != NULL)  { HAL_DMA_IRQHandler(dma_handle[dma_id_5]); } IRQ_EXIT(DMA1_Channel6_IRQn); }
+void DMA1_Channel7_IRQHandler(void) { IRQ_ENTER(DMA1_Channel7_IRQn); if (dma_handle[dma_id_6] != NULL)  { HAL_DMA_IRQHandler(dma_handle[dma_id_6]); } IRQ_EXIT(DMA1_Channel7_IRQn); }
+void DMA2_Channel1_IRQHandler(void) { IRQ_ENTER(DMA2_Channel1_IRQn); if (dma_handle[dma_id_7] != NULL)  { HAL_DMA_IRQHandler(dma_handle[dma_id_7]); } IRQ_EXIT(DMA2_Channel1_IRQn); }
+void DMA2_Channel2_IRQHandler(void) { IRQ_ENTER(DMA2_Channel2_IRQn); if (dma_handle[dma_id_8] != NULL)  { HAL_DMA_IRQHandler(dma_handle[dma_id_8]); } IRQ_EXIT(DMA2_Channel2_IRQn); }
+void DMA2_Channel3_IRQHandler(void) { IRQ_ENTER(DMA2_Channel3_IRQn); if (dma_handle[dma_id_9] != NULL)  { HAL_DMA_IRQHandler(dma_handle[dma_id_9]); } IRQ_EXIT(DMA2_Channel3_IRQn); }
+void DMA2_Channel4_IRQHandler(void) { IRQ_ENTER(DMA2_Channel4_IRQn); if (dma_handle[dma_id_10] != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_10]);} IRQ_EXIT(DMA2_Channel4_IRQn); }
+void DMA2_Channel5_IRQHandler(void) { IRQ_ENTER(DMA2_Channel5_IRQn); if (dma_handle[dma_id_11] != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_11]);} IRQ_EXIT(DMA2_Channel5_IRQn); }
+void DMA2_Channel6_IRQHandler(void) { IRQ_ENTER(DMA2_Channel6_IRQn); if (dma_handle[dma_id_12] != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_12]);} IRQ_EXIT(DMA2_Channel6_IRQn); }
+void DMA2_Channel7_IRQHandler(void) { IRQ_ENTER(DMA2_Channel7_IRQn); if (dma_handle[dma_id_13] != NULL) { HAL_DMA_IRQHandler(dma_handle[dma_id_13]);} IRQ_EXIT(DMA2_Channel7_IRQn); }
+
+#define DMA1_ENABLE_MASK    0x007f  // Bits in dma_enable_mask corresponfing to DMA1
+#define DMA2_ENABLE_MASK    0x3f80  // Bits in dma_enable_mask corresponding to DMA2
+
+#endif
+
+volatile dma_idle_count_t dma_idle;
+
 #define DMA_INVALID_CHANNEL 0xff    // Value stored in dma_last_channel which means invalid
-
-#define DMA_CHANNEL_AS_UINT8(dma_channel)   (((dma_channel) & DMA_SxCR_CHSEL) >> 24)
-
-void DMA1_Stream0_IRQHandler(void) { IRQ_ENTER(DMA1_Stream0_IRQn); if (dma_handle[0] != NULL) { HAL_DMA_IRQHandler(dma_handle[0]); } IRQ_EXIT(DMA1_Stream0_IRQn); }
-void DMA1_Stream1_IRQHandler(void) { IRQ_ENTER(DMA1_Stream1_IRQn); if (dma_handle[1] != NULL) { HAL_DMA_IRQHandler(dma_handle[1]); } IRQ_EXIT(DMA1_Stream1_IRQn); }
-void DMA1_Stream2_IRQHandler(void) { IRQ_ENTER(DMA1_Stream2_IRQn); if (dma_handle[2] != NULL) { HAL_DMA_IRQHandler(dma_handle[2]); } IRQ_EXIT(DMA1_Stream2_IRQn); }
-void DMA1_Stream3_IRQHandler(void) { IRQ_ENTER(DMA1_Stream3_IRQn); if (dma_handle[3] != NULL) { HAL_DMA_IRQHandler(dma_handle[3]); } IRQ_EXIT(DMA1_Stream3_IRQn); }
-void DMA1_Stream4_IRQHandler(void) { IRQ_ENTER(DMA1_Stream4_IRQn); if (dma_handle[4] != NULL) { HAL_DMA_IRQHandler(dma_handle[4]); } IRQ_EXIT(DMA1_Stream4_IRQn); }
-void DMA1_Stream5_IRQHandler(void) { IRQ_ENTER(DMA1_Stream5_IRQn); if (dma_handle[5] != NULL) { HAL_DMA_IRQHandler(dma_handle[5]); } IRQ_EXIT(DMA1_Stream5_IRQn); }
-void DMA1_Stream6_IRQHandler(void) { IRQ_ENTER(DMA1_Stream6_IRQn); if (dma_handle[6] != NULL) { HAL_DMA_IRQHandler(dma_handle[6]); } IRQ_EXIT(DMA1_Stream6_IRQn); }
-void DMA1_Stream7_IRQHandler(void) { IRQ_ENTER(DMA1_Stream7_IRQn); if (dma_handle[7] != NULL) { HAL_DMA_IRQHandler(dma_handle[7]); } IRQ_EXIT(DMA1_Stream7_IRQn); }
-void DMA2_Stream0_IRQHandler(void) { IRQ_ENTER(DMA2_Stream0_IRQn); if (dma_handle[8] != NULL) { HAL_DMA_IRQHandler(dma_handle[8]); } IRQ_EXIT(DMA2_Stream0_IRQn); }
-void DMA2_Stream1_IRQHandler(void) { IRQ_ENTER(DMA2_Stream1_IRQn); if (dma_handle[9] != NULL) { HAL_DMA_IRQHandler(dma_handle[9]); } IRQ_EXIT(DMA2_Stream1_IRQn); }
-void DMA2_Stream2_IRQHandler(void) { IRQ_ENTER(DMA2_Stream2_IRQn); if (dma_handle[10] != NULL) { HAL_DMA_IRQHandler(dma_handle[10]); } IRQ_EXIT(DMA2_Stream2_IRQn); }
-void DMA2_Stream3_IRQHandler(void) { IRQ_ENTER(DMA2_Stream3_IRQn); if (dma_handle[11] != NULL) { HAL_DMA_IRQHandler(dma_handle[11]); } IRQ_EXIT(DMA2_Stream3_IRQn); }
-void DMA2_Stream4_IRQHandler(void) { IRQ_ENTER(DMA2_Stream4_IRQn); if (dma_handle[12] != NULL) { HAL_DMA_IRQHandler(dma_handle[12]); } IRQ_EXIT(DMA2_Stream4_IRQn); }
-void DMA2_Stream5_IRQHandler(void) { IRQ_ENTER(DMA2_Stream5_IRQn); if (dma_handle[13] != NULL) { HAL_DMA_IRQHandler(dma_handle[13]); } IRQ_EXIT(DMA2_Stream5_IRQn); }
-void DMA2_Stream6_IRQHandler(void) { IRQ_ENTER(DMA2_Stream6_IRQn); if (dma_handle[14] != NULL) { HAL_DMA_IRQHandler(dma_handle[14]); } IRQ_EXIT(DMA2_Stream6_IRQn); }
-void DMA2_Stream7_IRQHandler(void) { IRQ_ENTER(DMA2_Stream7_IRQn); if (dma_handle[15] != NULL) { HAL_DMA_IRQHandler(dma_handle[15]); } IRQ_EXIT(DMA2_Stream7_IRQn); }
 
 #define DMA1_IS_CLK_ENABLED()   ((RCC->AHB1ENR & RCC_AHB1ENR_DMA1EN) != 0)
 #define DMA2_IS_CLK_ENABLED()   ((RCC->AHB1ENR & RCC_AHB1ENR_DMA2EN) != 0)
 
-static int get_dma_id(DMA_Stream_TypeDef *dma_stream) {
-    int dma_id;
-    if (dma_stream < DMA2_Stream0) {
-        dma_id = dma_stream - DMA1_Stream0;
-    } else {
-        dma_id =  NSTREAMS_PER_CONTROLLER + (dma_stream - DMA2_Stream0);
-    }
-    return dma_id;
-}
-
 // Resets the idle counter for the DMA controller associated with dma_id.
-static void dma_tickle(int dma_id) {
-    dma_idle.counter[(dma_id >> NSTREAMS_PER_CONTROLLER_LOG2) & 1] = 1;
+static void dma_tickle(dma_id_t dma_id) {
+    dma_idle.counter[(dma_id < NSTREAMS_PER_CONTROLLER) ? 0 : 1] = 1;
 }
 
-static void dma_enable_clock(int dma_id) {
+static void dma_enable_clock(dma_id_t dma_id) {
     // We don't want dma_tick_handler() to turn off the clock right after we
     // enable it, so we need to mark the channel in use in an atomic fashion.
     mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
@@ -129,7 +323,7 @@ static void dma_enable_clock(int dma_id) {
     dma_enable_mask |= (1 << dma_id);
     MICROPY_END_ATOMIC_SECTION(irq_state);
 
-    if (dma_id <= 7) {
+    if (dma_id < NSTREAMS_PER_CONTROLLER) {
         if (((old_enable_mask & DMA1_ENABLE_MASK) == 0) && !DMA1_IS_CLK_ENABLED()) {
             __DMA1_CLK_ENABLE();
 
@@ -137,7 +331,7 @@ static void dma_enable_clock(int dma_id) {
             // in dma_last_channel (for DMA1) needs to be invalidated.
 
             for (int channel = 0; channel < NSTREAMS_PER_CONTROLLER; channel++) {
-                dma_last_channel[channel] = DMA_INVALID_CHANNEL;
+                dma_last_sub_instance[channel] = DMA_INVALID_CHANNEL;
             }
         }
     } else {
@@ -148,13 +342,13 @@ static void dma_enable_clock(int dma_id) {
             // in dma_last_channel (for DMA1) needs to be invalidated.
 
             for (int channel = NSTREAMS_PER_CONTROLLER; channel < NSTREAM; channel++) {
-                dma_last_channel[channel] = DMA_INVALID_CHANNEL;
+                dma_last_sub_instance[channel] = DMA_INVALID_CHANNEL;
             }
         }
     }
 }
 
-static void dma_disable_clock(int dma_id) {
+static void dma_disable_clock(dma_id_t dma_id) {
     // We just mark the clock as disabled here, but we don't actually disable it.
     // We wait for the timer to expire first, which means that back-to-back
     // transfers don't have to initialize as much.
@@ -162,61 +356,74 @@ static void dma_disable_clock(int dma_id) {
     dma_enable_mask &= ~(1 << dma_id);
 }
 
-void dma_init(DMA_HandleTypeDef *dma, DMA_Stream_TypeDef *dma_stream, const DMA_InitTypeDef *dma_init, uint32_t dma_channel, uint32_t direction, void *data) {
-    int dma_id = get_dma_id(dma_stream);
-    //printf("dma_init(%p, %p(%d), 0x%x, 0x%x, %p)\n", dma, dma_stream, dma_id, (uint)dma_channel, (uint)direction, data);
+void dma_init_handle(DMA_HandleTypeDef *dma, const dma_descr_t * dma_descr, void *data) {
+    if (dma_descr != NULL) {
+        // initialise parameters
+        dma->Instance = dma_descr->instance;
+        dma->Init = *dma_descr->init;
+        dma->Init.Direction = dma_descr->transfer_direction;
+#if defined(MCU_SERIES_L4)
+        dma->Init.Request = dma_descr->sub_instance;
+#else
+        dma->Init.Channel = dma_descr->sub_instance;
+#endif
+        // half of __HAL_LINKDMA(data, xxx, *dma)
+        // caller must implement other half by doing: data->xxx = dma
+        dma->Parent = data;
+    }
 
+    return;
+}
+
+void dma_init(DMA_HandleTypeDef *dma, const dma_descr_t * dma_descr, void *data){
     // Some drivers allocate the DMA_HandleTypeDef from the stack
     // (i.e. dac, i2c, spi) and for those cases we need to clear the
     // structure so we don't get random values from the stack)
     memset(dma, 0, sizeof(*dma));
 
-    // set global pointer for IRQ handler
-    dma_handle[dma_id] = dma;
 
-    // initialise parameters
-    dma->Instance = dma_stream;
-    dma->Init = *dma_init;
-    dma->Init.Direction = direction;
-    dma->Init.Channel = dma_channel;
+    if (dma_descr != NULL) {
+        dma_id_t dma_id  = dma_descr->id;
 
-    // half of __HAL_LINKDMA(data, xxx, *dma)
-    // caller must implement other half by doing: data->xxx = dma
-    dma->Parent = data;
+        dma_init_handle(dma, dma_descr, data);
+        // set global pointer for IRQ handler
+        dma_handle[dma_id] = dma;
 
-    dma_enable_clock(dma_id);
+        dma_enable_clock(dma_id);
 
-    // if this stream was previously configured for this channel then we
-    // can skip most of the initialisation
-    uint8_t channel_uint8 = DMA_CHANNEL_AS_UINT8(dma_channel);
-    if (dma_last_channel[dma_id] == channel_uint8) {
-        goto same_channel;
+        // if this stream was previously configured for this channel/request then we
+        // can skip most of the initialisation
+        uint8_t sub_inst = DMA_SUB_INSTANCE_AS_UINT8(dma_descr->sub_instance);
+        if (dma_last_sub_instance[dma_id] != sub_inst) {
+            dma_last_sub_instance[dma_id] = sub_inst;
+
+            // reset and configure DMA peripheral
+            if (HAL_DMA_GetState(dma) != HAL_DMA_STATE_RESET) {
+                HAL_DMA_DeInit(dma);
+            }
+            HAL_DMA_Init(dma);
+            HAL_NVIC_SetPriority(dma_irqn[dma_id], IRQ_PRI_DMA, IRQ_SUBPRI_DMA);
+        }
+
+        HAL_NVIC_EnableIRQ(dma_irqn[dma_id]);
     }
-    dma_last_channel[dma_id] = channel_uint8;
-
-    // reset and configure DMA peripheral
-    if (HAL_DMA_GetState(dma) != HAL_DMA_STATE_RESET) {
-        HAL_DMA_DeInit(dma);
-    }
-    HAL_DMA_Init(dma);
-    HAL_NVIC_SetPriority(dma_irqn[dma_id], IRQ_PRI_DMA, IRQ_SUBPRI_DMA);
-
-same_channel:
-    HAL_NVIC_EnableIRQ(dma_irqn[dma_id]);
 }
 
-void dma_deinit(DMA_HandleTypeDef *dma) {
-    int dma_id = get_dma_id(dma->Instance);
-    HAL_NVIC_DisableIRQ(dma_irqn[dma_id]);
-    dma_handle[dma_id] = NULL;
+void dma_deinit(const dma_descr_t * dma_descr) {
+    if (dma_descr != NULL) {
+        HAL_NVIC_DisableIRQ(dma_irqn[dma_descr->id]);
+        dma_handle[dma_descr->id] = NULL;
 
-    dma_disable_clock(dma_id);
+        dma_disable_clock(dma_descr->id);
+    }
 }
 
-void dma_invalidate_channel(DMA_Stream_TypeDef *dma_stream, uint32_t dma_channel) {
-    int dma_id = get_dma_id(dma_stream);
-    if (dma_last_channel[dma_id] == DMA_CHANNEL_AS_UINT8(dma_channel)) {
-        dma_last_channel[dma_id] = DMA_INVALID_CHANNEL;
+void dma_invalidate_channel(const dma_descr_t * dma_descr) {
+    if (dma_descr != NULL) {
+        dma_id_t dma_id = dma_descr->id;
+        if (dma_last_sub_instance[dma_id] == DMA_SUB_INSTANCE_AS_UINT8(dma_descr->sub_instance) ) {
+            dma_last_sub_instance[dma_id] = DMA_INVALID_CHANNEL;
+        }
     }
 }
 

--- a/stmhal/dma.h
+++ b/stmhal/dma.h
@@ -23,83 +23,61 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#ifndef __DMA_H__
+#define __DMA_H__
+typedef struct _dma_descr_t dma_descr_t;
 
-// These are ordered by DMAx_Stream number, and within a stream by channel
-// number. The duplicate streams are ok as long as they aren't used at the
-// same time.
-//
-// Currently I2C and SPI are synchronous and they call dma_init/dma_deinit
-// around each transfer.
-
-// DMA1 streams
-
-#define DMA_STREAM_I2C1_RX      DMA1_Stream0
-#define DMA_CHANNEL_I2C1_RX                     DMA_CHANNEL_1
-
-#define DMA_STREAM_SPI3_RX      DMA1_Stream2
-#define DMA_CHANNEL_SPI3_RX                     DMA_CHANNEL_0
-
-#define DMA_STREAM_I2C3_RX      DMA1_Stream2
-#define DMA_CHANNEL_I2C3_RX                     DMA_CHANNEL_3
-
-#define DMA_STREAM_I2C2_RX      DMA1_Stream2
-#define DMA_CHANNEL_I2C2_RX                     DMA_CHANNEL_7
-
-#define DMA_STREAM_SPI2_RX      DMA1_Stream3
-#define DMA_CHANNEL_SPI2_RX                     DMA_CHANNEL_0
-
-#define DMA_STREAM_SPI2_TX      DMA1_Stream4
-#define DMA_CHANNEL_SPI2_TX                     DMA_CHANNEL_0
-
-#define DMA_STREAM_I2C3_TX      DMA1_Stream4
-#define DMA_CHANNEL_I2C3_TX                     DMA_CHANNEL_3
-
-#define DMA_STREAM_DAC1         DMA1_Stream5
-#define DMA_CHANNEL_DAC1                        DMA_CHANNEL_7
-
-#define DMA_STREAM_DAC2         DMA1_Stream6
-#define DMA_CHANNEL_DAC2                        DMA_CHANNEL_7
-
-#define DMA_STREAM_SPI3_TX      DMA1_Stream7
-#define DMA_CHANNEL_SPI3_TX                     DMA_CHANNEL_0
-
-#define DMA_STREAM_I2C1_TX      DMA1_Stream7
-#define DMA_CHANNEL_I2C1_TX                     DMA_CHANNEL_1
-
-#define DMA_STREAM_I2C2_TX      DMA1_Stream7
-#define DMA_CHANNEL_I2C2_TX                     DMA_CHANNEL_7
-
+#if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
+extern const dma_descr_t dma_I2C_1_RX;
+extern const dma_descr_t dma_SPI_3_RX;
+extern const dma_descr_t dma_I2C_3_RX;
+extern const dma_descr_t dma_I2C_2_RX;
+extern const dma_descr_t dma_SPI_2_RX;
+extern const dma_descr_t dma_SPI_2_TX;
+extern const dma_descr_t dma_I2C_3_TX;
+extern const dma_descr_t dma_DAC_1_TX;
+extern const dma_descr_t dma_DAC_2_TX;
+extern const dma_descr_t dma_SPI_3_TX;
+extern const dma_descr_t dma_I2C_1_TX;
+extern const dma_descr_t dma_I2C_2_TX;
+extern const dma_descr_t dma_SPI_1_RX;
+extern const dma_descr_t dma_SPI_5_RX;
+#if defined(MICROPY_HW_HAS_SDCARD) && MICROPY_HW_HAS_SDCARD
+extern dma_descr_t dma_SDIO_0_RX;
+#endif
+extern const dma_descr_t dma_SPI_4_RX;
+extern const dma_descr_t dma_SPI_5_TX;
+extern const dma_descr_t dma_SPI_4_TX;
+extern const dma_descr_t dma_SPI_6_TX;
+extern const dma_descr_t dma_SPI_1_TX;
+extern const dma_descr_t dma_SPI_6_RX;
+#if defined(MICROPY_HW_HAS_SDCARD) && MICROPY_HW_HAS_SDCARD
+extern const dma_descr_t dma_SDIO_0_TX;
+#endif
+#elif defined(MCU_SERIES_L4)
+extern const dma_descr_t dma_ADC_1_RX;
+extern const dma_descr_t dma_ADC_2_RX;
+extern const dma_descr_t dma_SPI_1_RX;
+extern const dma_descr_t dma_I2C_3_TX;
+extern const dma_descr_t dma_ADC_3_RX;
+extern const dma_descr_t dma_SPI_1_TX;
+extern const dma_descr_t dma_I2C_3_RX;
+extern const dma_descr_t dma_DAC_1_TX;
+extern const dma_descr_t dma_SPI_2_RX;
+extern const dma_descr_t dma_I2C_2_TX;
+extern const dma_descr_t dma_DAC_2_TX;
+extern const dma_descr_t dma_SPI_2_TX;
+extern const dma_descr_t dma_I2C_2_RX;
+extern const dma_descr_t dma_I2C_1_TX;
+extern const dma_descr_t dma_I2C_1_RX;
 // DMA2 streams
+extern const dma_descr_t dma_SPI_3_RX;
+extern const dma_descr_t dma_SPI_3_TX;
+#if MICROPY_HW_HAS_SDCARD
+extern const dma_descr_t dma_SDIO_1_TX;
+#endif
+#endif
 
-#define DMA_STREAM_SPI1_RX      DMA2_Stream2
-#define DMA_CHANNEL_SPI1_RX                     DMA_CHANNEL_3
-
-#define DMA_STREAM_SPI5_RX      DMA2_Stream3
-#define DMA_CHANNEL_SPI5_RX                     DMA_CHANNEL_2
-
-#define DMA_STREAM_SDIO_RX      DMA2_Stream3
-#define DMA_CHANNEL_SDIO_RX                     DMA_CHANNEL_4
-
-#define DMA_STREAM_SPI4_RX      DMA2_Stream3
-#define DMA_CHANNEL_SPI4_RX                     DMA_CHANNEL_5
-
-#define DMA_STREAM_SPI5_TX      DMA2_Stream4
-#define DMA_CHANNEL_SPI5_TX                     DMA_CHANNEL_2
-
-#define DMA_STREAM_SPI4_TX      DMA2_Stream4
-#define DMA_CHANNEL_SPI4_TX                     DMA_CHANNEL_5
-
-#define DMA_STREAM_SPI6_TX      DMA2_Stream5
-#define DMA_CHANNEL_SPI6_TX                     DMA_CHANNEL_1
-
-#define DMA_STREAM_SPI1_TX      DMA2_Stream5
-#define DMA_CHANNEL_SPI1_TX                     DMA_CHANNEL_3
-
-#define DMA_STREAM_SPI6_RX      DMA2_Stream6
-#define DMA_CHANNEL_SPI6_RX                     DMA_CHANNEL_1
-
-#define DMA_STREAM_SDIO_TX      DMA2_Stream6
-#define DMA_CHANNEL_SDIO_TX                     DMA_CHANNEL_4
 
 typedef union {
     uint16_t    enabled;    // Used to test if both counters are == 0
@@ -113,9 +91,10 @@ extern volatile dma_idle_count_t dma_idle;
 #define DMA_IDLE_TICK_MAX           (8)     // 128 msec
 #define DMA_IDLE_TICK(tick)         (((tick) & DMA_SYSTICK_MASK) == 0)
 
-extern const DMA_InitTypeDef dma_init_struct_spi_i2c;
 
-void dma_init(DMA_HandleTypeDef *dma, DMA_Stream_TypeDef *dma_stream, const DMA_InitTypeDef *dma_init, uint32_t dma_channel, uint32_t direction, void *data);
-void dma_deinit(DMA_HandleTypeDef *dma);
-void dma_invalidate_channel(DMA_Stream_TypeDef *dma_stream, uint32_t dma_channel);
+void dma_init(DMA_HandleTypeDef *dma, const dma_descr_t * dma_descr, void *data);
+void dma_init_handle(DMA_HandleTypeDef *dma, const dma_descr_t * dma_descr, void *data);
+void dma_deinit(const dma_descr_t * dma_descr);
+void dma_invalidate_channel(const dma_descr_t * dma_descr);
 void dma_idle_handler(int controller);
+#endif //__DMA_H__

--- a/stmhal/i2c.c
+++ b/stmhal/i2c.c
@@ -101,25 +101,14 @@
 ///     i2c.mem_read(3, 0x42, 2)     # read 3 bytes from memory of slave 0x42,
 ///                                  #   starting at address 2 in the slave
 ///     i2c.mem_write('abc', 0x42, 2, timeout=1000)
-
-// Possible DMA configurations for I2C busses:
-// I2C1_TX: DMA1_Stream6.CHANNEL_1 or DMA1_Stream7.CHANNEL_1
-// I2C1_RX: DMA1_Stream0.CHANNEL_1 or DMA1_Stream5.CHANNEL_1
-// I2C2_TX: DMA1_Stream7.CHANNEL_7
-// I2C2_RX: DMA1_Stream2.CHANNEL_7 or DMA1_Stream3.CHANNEL_7
-// I2C3_TX: DMA1_Stream4.CHANNEL_3
-// I2C3_RX: DMA1_Stream2.CHANNEL_3
-
 #define PYB_I2C_MASTER (0)
 #define PYB_I2C_SLAVE  (1)
 
 typedef struct _pyb_i2c_obj_t {
     mp_obj_base_t base;
     I2C_HandleTypeDef *i2c;
-    DMA_Stream_TypeDef *tx_dma_stream;
-    uint32_t tx_dma_channel;
-    DMA_Stream_TypeDef *rx_dma_stream;
-    uint32_t rx_dma_channel;
+    const dma_descr_t *tx_dma_descr;
+    const dma_descr_t *rx_dma_descr;
 } pyb_i2c_obj_t;
 
 #if defined(MICROPY_HW_I2C1_SCL)
@@ -134,24 +123,24 @@ I2C_HandleTypeDef I2CHandle3 = {.Instance = NULL};
 
 STATIC const pyb_i2c_obj_t pyb_i2c_obj[] = {
     #if defined(MICROPY_HW_I2C1_SCL)
-    {{&pyb_i2c_type}, &I2CHandle1, DMA_STREAM_I2C1_TX, DMA_CHANNEL_I2C1_TX, DMA_STREAM_I2C1_RX, DMA_CHANNEL_I2C1_RX},
+    {{&pyb_i2c_type}, &I2CHandle1, &dma_I2C_1_TX, &dma_I2C_1_RX},
     #else
-    {{&pyb_i2c_type}, NULL, NULL, 0, NULL, 0},
+    {{&pyb_i2c_type}, NULL, NULL, NULL},
     #endif
     #if defined(MICROPY_HW_I2C2_SCL)
-    {{&pyb_i2c_type}, &I2CHandle2, DMA_STREAM_I2C2_TX, DMA_CHANNEL_I2C2_TX, DMA_STREAM_I2C2_RX, DMA_CHANNEL_I2C2_RX},
+    {{&pyb_i2c_type}, &I2CHandle2, &dma_I2C_2_TX, &dma_I2C_2_RX},
     #else
-    {{&pyb_i2c_type}, NULL, NULL, 0, NULL, 0},
+    {{&pyb_i2c_type}, NULL, NULL, NULL},
     #endif
     #if defined(MICROPY_HW_I2C3_SCL)
-    {{&pyb_i2c_type}, &I2CHandle3, DMA_STREAM_I2C3_TX, DMA_CHANNEL_I2C3_TX, DMA_STREAM_I2C3_RX, DMA_CHANNEL_I2C3_RX},
+    {{&pyb_i2c_type}, &I2CHandle3, &dma_I2C_3_TX, &dma_I2C_3_RX},
     #else
-    {{&pyb_i2c_type}, NULL, NULL, 0, NULL, 0},
+    {{&pyb_i2c_type}, NULL, NULL, NULL},
     #endif
 };
 
 #if defined(MICROPY_HW_I2C_BAUDRATE_TIMING)
-// The STM32F0, F3, and F7 use a TIMINGR register rather than ClockSpeed and
+// The STM32F0, F3, F7 and L4 use a TIMINGR register rather than ClockSpeed and
 // DutyCycle.
 
 STATIC const struct {
@@ -263,8 +252,8 @@ void i2c_init(I2C_HandleTypeDef *i2c) {
 
     // invalidate the DMA channels so they are initialised on first use
     const pyb_i2c_obj_t *self = &pyb_i2c_obj[i2c_unit - 1];
-    dma_invalidate_channel(self->tx_dma_stream, self->tx_dma_channel);
-    dma_invalidate_channel(self->rx_dma_stream, self->rx_dma_channel);
+    dma_invalidate_channel(self->tx_dma_descr);
+    dma_invalidate_channel(self->rx_dma_descr);
 }
 
 void i2c_deinit(I2C_HandleTypeDef *i2c) {
@@ -528,7 +517,7 @@ STATIC mp_obj_t pyb_i2c_send(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_
     // if IRQs are enabled then we can use DMA
     DMA_HandleTypeDef tx_dma;
     if (query_irq() == IRQ_STATE_ENABLED) {
-        dma_init(&tx_dma, self->tx_dma_stream, &dma_init_struct_spi_i2c, self->tx_dma_channel, DMA_MEMORY_TO_PERIPH, self->i2c);
+        dma_init(&tx_dma, self->tx_dma_descr, self->i2c);
         self->i2c->hdmatx = &tx_dma;
         self->i2c->hdmarx = NULL;
     }
@@ -538,7 +527,7 @@ STATIC mp_obj_t pyb_i2c_send(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_
     if (in_master_mode(self)) {
         if (args[1].u_int == PYB_I2C_MASTER_ADDRESS) {
             if (query_irq() == IRQ_STATE_ENABLED) {
-                dma_deinit(&tx_dma);
+                dma_deinit(self->tx_dma_descr);
             }
             nlr_raise(mp_obj_new_exception_msg(&mp_type_TypeError, "addr argument required"));
         }
@@ -561,7 +550,7 @@ STATIC mp_obj_t pyb_i2c_send(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_
         if (status == HAL_OK) {
             status = i2c_wait_dma_finished(self->i2c, args[2].u_int);
         }
-        dma_deinit(&tx_dma);
+        dma_deinit(self->tx_dma_descr);
     }
 
     if (status != HAL_OK) {
@@ -602,7 +591,7 @@ STATIC mp_obj_t pyb_i2c_recv(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_
     // if IRQs are enabled then we can use DMA
     DMA_HandleTypeDef rx_dma;
     if (query_irq() == IRQ_STATE_ENABLED) {
-        dma_init(&rx_dma, self->rx_dma_stream, &dma_init_struct_spi_i2c, self->rx_dma_channel, DMA_PERIPH_TO_MEMORY, self->i2c);
+        dma_init(&rx_dma, self->rx_dma_descr, self->i2c);
         self->i2c->hdmatx = NULL;
         self->i2c->hdmarx = &rx_dma;
     }
@@ -632,7 +621,7 @@ STATIC mp_obj_t pyb_i2c_recv(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_
         if (status == HAL_OK) {
             status = i2c_wait_dma_finished(self->i2c, args[2].u_int);
         }
-        dma_deinit(&rx_dma);
+        dma_deinit(self->rx_dma_descr);
     }
 
     if (status != HAL_OK) {
@@ -696,14 +685,14 @@ STATIC mp_obj_t pyb_i2c_mem_read(mp_uint_t n_args, const mp_obj_t *pos_args, mp_
         status = HAL_I2C_Mem_Read(self->i2c, i2c_addr, mem_addr, mem_addr_size, (uint8_t*)vstr.buf, vstr.len, args[3].u_int);
     } else {
         DMA_HandleTypeDef rx_dma;
-        dma_init(&rx_dma, self->rx_dma_stream, &dma_init_struct_spi_i2c, self->rx_dma_channel, DMA_PERIPH_TO_MEMORY, self->i2c);
+        dma_init(&rx_dma, self->rx_dma_descr, self->i2c);
         self->i2c->hdmatx = NULL;
         self->i2c->hdmarx = &rx_dma;
         status = HAL_I2C_Mem_Read_DMA(self->i2c, i2c_addr, mem_addr, mem_addr_size, (uint8_t*)vstr.buf, vstr.len);
         if (status == HAL_OK) {
             status = i2c_wait_dma_finished(self->i2c, args[3].u_int);
         }
-        dma_deinit(&rx_dma);
+        dma_deinit(self->rx_dma_descr);
     }
 
     if (status != HAL_OK) {
@@ -760,14 +749,14 @@ STATIC mp_obj_t pyb_i2c_mem_write(mp_uint_t n_args, const mp_obj_t *pos_args, mp
         status = HAL_I2C_Mem_Write(self->i2c, i2c_addr, mem_addr, mem_addr_size, bufinfo.buf, bufinfo.len, args[3].u_int);
     } else {
         DMA_HandleTypeDef tx_dma;
-        dma_init(&tx_dma, self->tx_dma_stream, &dma_init_struct_spi_i2c, self->tx_dma_channel, DMA_MEMORY_TO_PERIPH, self->i2c);
+        dma_init(&tx_dma, self->tx_dma_descr, self->i2c);
         self->i2c->hdmatx = &tx_dma;
         self->i2c->hdmarx = NULL;
         status = HAL_I2C_Mem_Write_DMA(self->i2c, i2c_addr, mem_addr, mem_addr_size, bufinfo.buf, bufinfo.len);
         if (status == HAL_OK) {
             status = i2c_wait_dma_finished(self->i2c, args[3].u_int);
         }
-        dma_deinit(&tx_dma);
+        dma_deinit(self->tx_dma_descr);
     }
 
     if (status != HAL_OK) {

--- a/stmhal/sdcard.c
+++ b/stmhal/sdcard.c
@@ -62,7 +62,8 @@
 #define SDIO_HARDWARE_FLOW_CONTROL_ENABLE   SDMMC_HARDWARE_FLOW_CONTROL_ENABLE
 
 #define SDIO_TRANSFER_CLK_DIV               SDMMC_TRANSFER_CLK_DIV
-
+#elif defined(MCU_SERIES_L4)
+#error Unsupported Processor
 #endif
 
 // TODO: Since SDIO is fundamentally half-duplex, we really only need to
@@ -76,22 +77,6 @@
 //       when no sdcard was being used.
 static SD_HandleTypeDef sd_handle;
 static DMA_HandleTypeDef sd_rx_dma, sd_tx_dma;
-
-// Parameters to dma_init() for SDIO tx and rx.
-static const DMA_InitTypeDef dma_init_struct_sdio = {
-    .Channel             = 0,
-    .Direction           = 0,
-    .PeriphInc           = DMA_PINC_DISABLE,
-    .MemInc              = DMA_MINC_ENABLE,
-    .PeriphDataAlignment = DMA_PDATAALIGN_WORD,
-    .MemDataAlignment    = DMA_MDATAALIGN_WORD,
-    .Mode                = DMA_PFCTRL,
-    .Priority            = DMA_PRIORITY_VERY_HIGH,
-    .FIFOMode            = DMA_FIFOMODE_ENABLE,
-    .FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL,
-    .MemBurst            = DMA_MBURST_INC4,
-    .PeriphBurst         = DMA_PBURST_INC4,
-};
 
 void sdcard_init(void) {
     GPIO_InitTypeDef GPIO_Init_Structure;
@@ -219,8 +204,7 @@ mp_uint_t sdcard_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t num_blo
         // we must disable USB irqs to prevent MSC contention with SD card
         uint32_t basepri = raise_irq_pri(IRQ_PRI_OTG_FS);
 
-        dma_init(&sd_rx_dma, DMA_STREAM_SDIO_RX, &dma_init_struct_sdio,
-            DMA_CHANNEL_SDIO_RX, DMA_PERIPH_TO_MEMORY, &sd_handle);
+        dma_init(&sd_rx_dma, &dma_SDIO_0_RX, &sd_handle);
         sd_handle.hdmarx = &sd_rx_dma;
 
         err = HAL_SD_ReadBlocks_BlockNumber_DMA(&sd_handle, (uint32_t*)dest, block_num, SDCARD_BLOCK_SIZE, num_blocks);
@@ -229,7 +213,7 @@ mp_uint_t sdcard_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t num_blo
             err = HAL_SD_CheckReadOperation(&sd_handle, 100000000);
         }
 
-        dma_deinit(sd_handle.hdmarx);
+        dma_deinit(&dma_SDIO_0_RX);
         sd_handle.hdmarx = NULL;
 
         restore_irq_pri(basepri);
@@ -256,9 +240,8 @@ mp_uint_t sdcard_write_blocks(const uint8_t *src, uint32_t block_num, uint32_t n
     if (query_irq() == IRQ_STATE_ENABLED) {
         // we must disable USB irqs to prevent MSC contention with SD card
         uint32_t basepri = raise_irq_pri(IRQ_PRI_OTG_FS);
-
-        dma_init(&sd_tx_dma, DMA_STREAM_SDIO_TX, &dma_init_struct_sdio,
-            DMA_CHANNEL_SDIO_TX, DMA_MEMORY_TO_PERIPH, &sd_handle);
+\
+        dma_init(&sd_rx_dma, &dma_SDIO_0_TX, &sd_handle);
         sd_handle.hdmatx = &sd_tx_dma;
 
         err = HAL_SD_WriteBlocks_BlockNumber_DMA(&sd_handle, (uint32_t*)src, block_num, SDCARD_BLOCK_SIZE, num_blocks);
@@ -266,7 +249,7 @@ mp_uint_t sdcard_write_blocks(const uint8_t *src, uint32_t block_num, uint32_t n
             // wait for DMA transfer to finish, with a large timeout
             err = HAL_SD_CheckWriteOperation(&sd_handle, 100000000);
         }
-        dma_deinit(sd_handle.hdmatx);
+        dma_deinit(&dma_SDIO_0_TX);
         sd_handle.hdmatx = NULL;
 
         restore_irq_pri(basepri);


### PR DESCRIPTION
This is the 5th PR in a series (#1888, #1890, #1903, #1904 ) of PR to support the STM32L4 series in micropython. (see http://forum.micropython.org/viewtopic.php?f=12&t=1332&sid=64e2f63af49643c3edee159171f4a365)

The topic is to change the dma code in a way, that the structure `DMA_Stream_TypeDef` (which is similar to `DMA_Channel_TypeDef` on stm32l4) is no more used outside of dma.c as this structure only exists for F4 series. Therefore I introduced a new structure (`dma_descr_t`) which handles all dma specific stuff for configuration. Further the periphery (spi, i2c, sdcard, dac) does not need to know the internals of the dma.

As a consequence a Periphery just asks for a dma to it self (defined by the enum `periphery_t` in dma.h) which instance of it self, and the direction of data transport. The DMA module then decides upon the Stream/Channel (stm32f4) or Channel/Request (stm32l4) should be used. These configuration are captured in the dma_transfer_info structure within dma.c. Further the initial setting (DMA_InitTypeDefs `dma_init_struct_spi_i2c` and `dma_init_struct_sdio`) is as well centralized in dma.c as these are as well MCU series specific.

This fix should work without the merge of the earlier PRs.
