### PR TITLE
L4 integration: Modification to mphalport.

### DIFF
--- a/stmhal/mphalport.c
+++ b/stmhal/mphalport.c
@@ -104,15 +104,15 @@ void mp_hal_gpio_clock_enable(GPIO_TypeDef *gpio) {
     } else if (gpio == GPIOH) {
         __GPIOH_CLK_ENABLE();
     #endif
-    #ifdef __GPIOI_CLK_ENABLE
+    #if defined(GPIOI) && defined(__GPIOI_CLK_ENABLE)
     } else if (gpio == GPIOI) {
         __GPIOI_CLK_ENABLE();
     #endif
-    #ifdef __GPIOJ_CLK_ENABLE
+    #if defined(GPIOJ) && defined(__GPIOJ_CLK_ENABLE)
     } else if (gpio == GPIOJ) {
         __GPIOJ_CLK_ENABLE();
     #endif
-    #ifdef __GPIOK_CLK_ENABLE
+    #if defined(GPIOK) && defined(__GPIOK_CLK_ENABLE)
     } else if (gpio == GPIOK) {
         __GPIOK_CLK_ENABLE();
     #endif

--- a/stmhal/mphalport.h
+++ b/stmhal/mphalport.h
@@ -8,13 +8,15 @@
 #define MP_HAL_UNIQUE_ID_ADDRESS (0x1fff7a10)
 #elif defined(MCU_SERIES_F7)
 #define MP_HAL_UNIQUE_ID_ADDRESS (0x1ff0f420)
+#elif defined(MCU_SERIES_L4)
+#define MP_HAL_UNIQUE_ID_ADDRESS (0x1fff7590)
 #else
 #error mphalport.h: Unrecognized MCU_SERIES
 #endif
 
 // Basic GPIO functions
 #define GPIO_read_pin(gpio, pin)        (((gpio)->IDR >> (pin)) & 1)
-#if defined(MCU_SERIES_F7)
+#if defined(MCU_SERIES_F7) || defined(MCU_SERIES_L4)
 #define GPIO_set_pin(gpio, pin_mask)    (((gpio)->BSRR) = (pin_mask))
 #define GPIO_clear_pin(gpio, pin_mask)  (((gpio)->BSRR) = ((pin_mask) << 16))
 #else


### PR DESCRIPTION
This is the 9th PR in a series (#1888, #1890, #1903, #1904, #1916, #1917, #1918, #1919, #1920 ) of PR to support the STM32L4 series in micropython. (see http://forum.micropython.org/viewtopic.php?f=12&t=1332&sid=64e2f63af49643c3edee159171f4a365)

This PR is independent of earlier PR.
