### PR TITLE
L4 integration: Modification to startup code, clock configuration & IRQ.

### DIFF
--- a/stmhal/startup_stm32.S
+++ b/stmhal/startup_stm32.S
@@ -44,10 +44,12 @@
   */
 
   .syntax unified
-#if defined(MCU_SERIES_M7)
+#if defined(MCU_SERIES_F7)
   .cpu cortex-m7
-#else
+#elif defined(MCU_SERIES_F4) || defined(MCU_SERIES_L4)
   .cpu cortex-m4
+#else
+  #error "Unknown MCU Series"
 #endif
   .fpu softvfp
   .thumb
@@ -164,7 +166,11 @@ g_pfnVectors:
 
   /* External Interrupts */
   .word     WWDG_IRQHandler                   /* Window WatchDog              */
+#if defined(MCU_SERIES_L4)
+  .word     PVD_PVM_IRQHandler                /* PVD and PVM through EXTI line detection */
+#else
   .word     PVD_IRQHandler                    /* PVD through EXTI Line detection */
+#endif
   .word     TAMP_STAMP_IRQHandler             /* Tamper and TimeStamps through the EXTI line */
   .word     RTC_WKUP_IRQHandler               /* RTC Wakeup through the EXTI line */
   .word     FLASH_IRQHandler                  /* FLASH                        */
@@ -174,6 +180,16 @@ g_pfnVectors:
   .word     EXTI2_IRQHandler                  /* EXTI Line2                   */
   .word     EXTI3_IRQHandler                  /* EXTI Line3                   */
   .word     EXTI4_IRQHandler                  /* EXTI Line4                   */
+#if defined(MCU_SERIES_L4)
+  .word     DMA1_Channel1_IRQHandler          /* DMA1 Channel 1               */
+  .word     DMA1_Channel2_IRQHandler          /* DMA1 Channel 2               */
+  .word     DMA1_Channel3_IRQHandler          /* DMA1 Channel 3               */
+  .word     DMA1_Channel4_IRQHandler          /* DMA1 Channel 4               */
+  .word     DMA1_Channel5_IRQHandler          /* DMA1 Channel 5               */
+  .word     DMA1_Channel6_IRQHandler          /* DMA1 Channel 6               */
+  .word     DMA1_Channel7_IRQHandler          /* DMA1 Channel 7               */
+  .word     ADC1_2_IRQHandler                 /* ADC1 and ADC2                */
+#else
   .word     DMA1_Stream0_IRQHandler           /* DMA1 Stream 0                */
   .word     DMA1_Stream1_IRQHandler           /* DMA1 Stream 1                */
   .word     DMA1_Stream2_IRQHandler           /* DMA1 Stream 2                */
@@ -182,14 +198,21 @@ g_pfnVectors:
   .word     DMA1_Stream5_IRQHandler           /* DMA1 Stream 5                */
   .word     DMA1_Stream6_IRQHandler           /* DMA1 Stream 6                */
   .word     ADC_IRQHandler                    /* ADC1, ADC2 and ADC3s         */
+#endif
   .word     CAN1_TX_IRQHandler                /* CAN1 TX                      */
   .word     CAN1_RX0_IRQHandler               /* CAN1 RX0                     */
   .word     CAN1_RX1_IRQHandler               /* CAN1 RX1                     */
   .word     CAN1_SCE_IRQHandler               /* CAN1 SCE                     */
   .word     EXTI9_5_IRQHandler                /* External Line[9:5]s          */
+#if defined(MCU_SERIES_L4)
+  .word     TIM1_BRK_TIM15_IRQHandler         /* TIM1 Break and TIM15         */
+  .word     TIM1_UP_TIM16_IRQHandler          /* TIM1 Update and TIM16        */
+  .word     TIM1_TRG_COM_TIM17_IRQHandler     /* TIM1 Trigger and Commutation and TIM17 */
+#else
   .word     TIM1_BRK_TIM9_IRQHandler          /* TIM1 Break and TIM9          */
   .word     TIM1_UP_TIM10_IRQHandler          /* TIM1 Update and TIM10        */
   .word     TIM1_TRG_COM_TIM11_IRQHandler     /* TIM1 Trigger and Commutation and TIM11 */
+#endif
   .word     TIM1_CC_IRQHandler                /* TIM1 Capture Compare         */
   .word     TIM2_IRQHandler                   /* TIM2                         */
   .word     TIM3_IRQHandler                   /* TIM3                         */
@@ -205,13 +228,24 @@ g_pfnVectors:
   .word     USART3_IRQHandler                 /* USART3                       */
   .word     EXTI15_10_IRQHandler              /* External Line[15:10]s        */
   .word     RTC_Alarm_IRQHandler              /* RTC Alarm (A and B) through EXTI Line */
+#if defined(MCU_SERIES_L4)
+  .word     DFSDM3_IRQHandler                 /* Digital filter for sigma delta modulator 3 */
+  .word     TIM8_BRK_IRQHandler               /* TIM8 Break                   */
+  .word     TIM8_UP_IRQHandler                /* TIM8 Update                  */
+  .word     TIM8_TRG_COM_IRQHandler           /* TIM8 Trigger and Commutation */
+#else
   .word     OTG_FS_WKUP_IRQHandler            /* USB OTG FS Wakeup through EXTI line */
   .word     TIM8_BRK_TIM12_IRQHandler         /* TIM8 Break and TIM12         */
   .word     TIM8_UP_TIM13_IRQHandler          /* TIM8 Update and TIM13        */
   .word     TIM8_TRG_COM_TIM14_IRQHandler     /* TIM8 Trigger and Commutation and TIM14 */
+#endif
   .word     TIM8_CC_IRQHandler                /* TIM8 Capture Compare         */
+#if defined(MCU_SERIES_L4)
+  .word     ADC3_IRQHandler                   /* ADC3 global interrupt        */
+#else
   .word     DMA1_Stream7_IRQHandler           /* DMA1 Stream7                 */
-#if defined(MCU_SERIES_F7)
+#endif
+#if defined(MCU_SERIES_F7) || defined(MCU_SERIES_L4)
   .word     FMC_IRQHandler                    /* FMC                          */
   .word     SDMMC1_IRQHandler                 /* SDMMC1                       */
 #else
@@ -224,6 +258,19 @@ g_pfnVectors:
   .word     UART5_IRQHandler                  /* UART5                        */
   .word     TIM6_DAC_IRQHandler               /* TIM6 and DAC1&2 underrun errors */
   .word     TIM7_IRQHandler                   /* TIM7                         */
+#if defined(MCU_SERIES_L4)
+  .word     DMA2_Channel1_IRQHandler          /* DMA2 Channel 1               */
+  .word     DMA2_Channel2_IRQHandler          /* DMA2 Channel 2               */
+  .word     DMA2_Channel3_IRQHandler          /* DMA2 Channel 3               */
+  .word     DMA2_Channel4_IRQHandler          /* DMA2 Channel 4               */
+  .word     DMA2_Channel5_IRQHandler          /* DMA2 Channel 5               */
+  .word     DFSDM0_IRQHandler                 /* Digital filter for sigma delta modulator 0 */
+  .word     DFSDM1_IRQHandler                 /* Digital filter for sigma delta modulator 1 */
+  .word     DFSDM2_IRQHandler                 /* Digital filter for sigma delta modulator 2 */
+  .word     COMP_IRQHandler                   /* Comporator thru EXTI line    */
+  .word     LPTIM1_IRQHandler                 /* Low power timer 1            */
+  .word     LPTIM2_IRQHandler                 /* Low power timer 2            */
+#else
   .word     DMA2_Stream0_IRQHandler           /* DMA2 Stream 0                */
   .word     DMA2_Stream1_IRQHandler           /* DMA2 Stream 1                */
   .word     DMA2_Stream2_IRQHandler           /* DMA2 Stream 2                */
@@ -235,20 +282,40 @@ g_pfnVectors:
   .word     CAN2_RX0_IRQHandler               /* CAN2 RX0                     */
   .word     CAN2_RX1_IRQHandler               /* CAN2 RX1                     */
   .word     CAN2_SCE_IRQHandler               /* CAN2 SCE                     */
+#endif
   .word     OTG_FS_IRQHandler                 /* USB OTG FS                   */
+#if defined(MCU_SERIES_L4)
+  .word     DMA2_Channel6_IRQHandler          /* DMA2 Channel 6               */
+  .word     DMA2_Channel7_IRQHandler          /* DMA2 Channel 7               */
+  .word     LPUART1_IRQHandler                /* Low power UART               */
+  .word     QUADSPI_IRQHandler                /* Quad SPI                     */
+#else
   .word     DMA2_Stream5_IRQHandler           /* DMA2 Stream 5                */
   .word     DMA2_Stream6_IRQHandler           /* DMA2 Stream 6                */
   .word     DMA2_Stream7_IRQHandler           /* DMA2 Stream 7                */
   .word     USART6_IRQHandler                 /* USART6                       */
+#endif
   .word     I2C3_EV_IRQHandler                /* I2C3 event                   */
   .word     I2C3_ER_IRQHandler                /* I2C3 error                   */
+#if defined(MCU_SERIES_L4)
+  .word     SAI1_IRQHandler                   /* Serial audio interface 1     */
+  .word     SAI2_IRQHandler                   /* Serial audio interface 2     */
+  .word     SWPMI1_IRQHandler                 /* Single wire protocole 1      */
+  .word     TSC_IRQHandler                    /* Touch sensig controller      */
+  .word     LCD_IRQHandler                    /* LCD                          */
+#else
   .word     OTG_HS_EP1_OUT_IRQHandler         /* USB OTG HS End Point 1 Out   */
   .word     OTG_HS_EP1_IN_IRQHandler          /* USB OTG HS End Point 1 In    */
   .word     OTG_HS_WKUP_IRQHandler            /* USB OTG HS Wakeup through EXTI */
   .word     OTG_HS_IRQHandler                 /* USB OTG HS                   */
   .word     DCMI_IRQHandler                   /* DCMI                         */
+#endif
   .word     0                                 /* CRYP crypto                  */
+#if defined(MCU_SERIES_L4)
+ .word      RNG_IRQHandler                    /* Random number generator      */
+#else
   .word     HASH_RNG_IRQHandler               /* Hash and Rng                 */
+#endif
   .word     FPU_IRQHandler                    /* FPU                          */
 
 #if defined(MCU_SERIES_F7)
@@ -307,8 +374,13 @@ g_pfnVectors:
    .weak      WWDG_IRQHandler
    .thumb_set WWDG_IRQHandler,Default_Handler
 
+#if defined(MCU_SERIES_L4)
+   .weak      PVD_PVM_IRQHandler
+   .thumb_set PVD_PVM_IRQHandler,Default_Handler
+#else
    .weak      PVD_IRQHandler
    .thumb_set PVD_IRQHandler,Default_Handler
+#endif
 
    .weak      TAMP_STAMP_IRQHandler
    .thumb_set TAMP_STAMP_IRQHandler,Default_Handler
@@ -337,6 +409,31 @@ g_pfnVectors:
    .weak      EXTI4_IRQHandler
    .thumb_set EXTI4_IRQHandler,Default_Handler
 
+#if defined(MCU_SERIES_L4)
+   .weak   DMA1_Channel1_IRQHandler
+   .thumb_set DMA1_Channel1_IRQHandler,Default_Handler
+
+   .weak   DMA1_Channel2_IRQHandler
+   .thumb_set DMA1_Channel2_IRQHandler,Default_Handler
+
+   .weak   DMA1_Channel3_IRQHandler
+   .thumb_set DMA1_Channel3_IRQHandler,Default_Handler
+
+   .weak   DMA1_Channel4_IRQHandler
+   .thumb_set DMA1_Channel4_IRQHandler,Default_Handler
+
+   .weak   DMA1_Channel5_IRQHandler
+   .thumb_set DMA1_Channel5_IRQHandler,Default_Handler
+
+   .weak   DMA1_Channel6_IRQHandler
+   .thumb_set DMA1_Channel6_IRQHandler,Default_Handler
+
+   .weak   DMA1_Channel7_IRQHandler
+   .thumb_set DMA1_Channel7_IRQHandler,Default_Handler
+
+   .weak    ADC1_2_IRQHandler
+   .thumb_set ADC1_2_IRQHandler,Default_Handler
+#else
    .weak      DMA1_Stream0_IRQHandler
    .thumb_set DMA1_Stream0_IRQHandler,Default_Handler
 
@@ -360,6 +457,7 @@ g_pfnVectors:
 
    .weak      ADC_IRQHandler
    .thumb_set ADC_IRQHandler,Default_Handler
+#endif
 
    .weak      CAN1_TX_IRQHandler
    .thumb_set CAN1_TX_IRQHandler,Default_Handler
@@ -376,6 +474,16 @@ g_pfnVectors:
    .weak      EXTI9_5_IRQHandler
    .thumb_set EXTI9_5_IRQHandler,Default_Handler
 
+#if defined(MCU_SERIES_L4)
+   .weak      TIM1_BRK_TIM15_IRQHandler
+   .thumb_set TIM1_BRK_TIM15_IRQHandler,Default_Handler
+
+   .weak      TIM1_UP_TIM16_IRQHandler
+   .thumb_set TIM1_UP_TIM16_IRQHandler,Default_Handler
+
+   .weak      TIM1_TRG_COM_TIM17_IRQHandler
+   .thumb_set TIM1_TRG_COM_TIM17_IRQHandler,Default_Handler
+#else
    .weak      TIM1_BRK_TIM9_IRQHandler
    .thumb_set TIM1_BRK_TIM9_IRQHandler,Default_Handler
 
@@ -384,6 +492,7 @@ g_pfnVectors:
 
    .weak      TIM1_TRG_COM_TIM11_IRQHandler
    .thumb_set TIM1_TRG_COM_TIM11_IRQHandler,Default_Handler
+#endif
 
    .weak      TIM1_CC_IRQHandler
    .thumb_set TIM1_CC_IRQHandler,Default_Handler
@@ -430,6 +539,19 @@ g_pfnVectors:
    .weak      RTC_Alarm_IRQHandler
    .thumb_set RTC_Alarm_IRQHandler,Default_Handler
 
+#if defined(MCU_SERIES_L4)
+   .weak      DFSDM3_IRQHandler
+   .thumb_set DFSDM3_IRQHandler,Default_Handler
+
+   .weak      TIM8_BRK_IRQHandler
+   .thumb_set TIM8_BRK_IRQHandler,Default_Handler
+
+   .weak      TIM8_UP_IRQHandler
+   .thumb_set TIM8_UP_IRQHandler,Default_Handler
+
+   .weak      TIM8_TRG_COM_IRQHandler
+   .thumb_set TIM8_TRG_COM_IRQHandler,Default_Handler
+#else
    .weak      OTG_FS_WKUP_IRQHandler
    .thumb_set OTG_FS_WKUP_IRQHandler,Default_Handler
 
@@ -441,14 +563,20 @@ g_pfnVectors:
 
    .weak      TIM8_TRG_COM_TIM14_IRQHandler
    .thumb_set TIM8_TRG_COM_TIM14_IRQHandler,Default_Handler
+#endif
 
    .weak      TIM8_CC_IRQHandler
    .thumb_set TIM8_CC_IRQHandler,Default_Handler
 
+#if defined(MCU_SERIES_L4)
+   .weak      ADC3_IRQHandler
+   .thumb_set ADC3_IRQHandler,Default_Handler
+#else
    .weak      DMA1_Stream7_IRQHandler
    .thumb_set DMA1_Stream7_IRQHandler,Default_Handler
+#endif
 
-#if defined(MCU_SERIES_F7)
+#if defined(MCU_SERIES_F7) || defined(MCU_SERIES_L4)
    .weak      FMC_IRQHandler
    .thumb_set FMC_IRQHandler,Default_Handler
 
@@ -480,6 +608,40 @@ g_pfnVectors:
    .weak      TIM7_IRQHandler
    .thumb_set TIM7_IRQHandler,Default_Handler
 
+#if defined(MCU_SERIES_L4)
+   .weak      DMA2_Channel1_IRQHandler
+   .thumb_set DMA2_Channel1_IRQHandler,Default_Handler
+
+   .weak      DMA2_Channel2_IRQHandler
+   .thumb_set DMA2_Channel2_IRQHandler,Default_Handler
+
+   .weak      DMA2_Channel3_IRQHandler
+   .thumb_set DMA2_Channel3_IRQHandler,Default_Handler
+
+   .weak      DMA2_Channel4_IRQHandler
+   .thumb_set DMA2_Channel4_IRQHandler,Default_Handler
+
+   .weak      DMA2_Channel5_IRQHandler
+   .thumb_set DMA2_Channel5_IRQHandler,Default_Handler
+
+   .weak      DFSDM0_IRQHandler
+   .thumb_set DFSDM0_IRQHandler,Default_Handler
+
+   .weak      DFSDM1_IRQHandler
+   .thumb_set DFSDM1_IRQHandler,Default_Handler
+
+   .weak      DFSDM2_IRQHandler
+   .thumb_set DFSDM2_IRQHandler,Default_Handler
+
+   .weak      COMP_IRQHandler
+   .thumb_set COMP_IRQHandler,Default_Handler
+
+   .weak      LPTIM1_IRQHandler
+   .thumb_set LPTIM1_IRQHandler,Default_Handler
+
+   .weak      LPTIM2_IRQHandler
+   .thumb_set LPTIM2_IRQHandler,Default_Handler
+#else
    .weak      DMA2_Stream0_IRQHandler
    .thumb_set DMA2_Stream0_IRQHandler,Default_Handler
 
@@ -512,10 +674,24 @@ g_pfnVectors:
 
    .weak      CAN2_SCE_IRQHandler
    .thumb_set CAN2_SCE_IRQHandler,Default_Handler
+#endif
 
    .weak      OTG_FS_IRQHandler
    .thumb_set OTG_FS_IRQHandler,Default_Handler
 
+#if defined(MCU_SERIES_L4)
+   .weak      DMA2_Channel6_IRQHandler
+   .thumb_set DMA2_Channel6_IRQHandler,Default_Handler
+
+   .weak      DMA2_Channel7_IRQHandler
+   .thumb_set DMA2_Channel7_IRQHandler,Default_Handler
+
+   .weak      LPUART1_IRQHandler
+   .thumb_set LPUART1_IRQHandler,Default_Handler
+
+   .weak      QUADSPI_IRQHandler
+   .thumb_set QUADSPI_IRQHandler,Default_Handler
+#else
    .weak      DMA2_Stream5_IRQHandler
    .thumb_set DMA2_Stream5_IRQHandler,Default_Handler
 
@@ -527,6 +703,7 @@ g_pfnVectors:
 
    .weak      USART6_IRQHandler
    .thumb_set USART6_IRQHandler,Default_Handler
+#endif
 
    .weak      I2C3_EV_IRQHandler
    .thumb_set I2C3_EV_IRQHandler,Default_Handler
@@ -534,6 +711,25 @@ g_pfnVectors:
    .weak      I2C3_ER_IRQHandler
    .thumb_set I2C3_ER_IRQHandler,Default_Handler
 
+#if defined(MCU_SERIES_L4)
+   .weak      SAI1_IRQHandler
+   .thumb_set SAI1_IRQHandler,Default_Handler
+
+   .weak      SAI2_IRQHandler
+   .thumb_set SAI2_IRQHandler,Default_Handler
+
+   .weak      SWPMI1_IRQHandler
+   .thumb_set SWPMI1_IRQHandler,Default_Handler
+
+   .weak      TSC_IRQHandler
+   .thumb_set TSC_IRQHandler,Default_Handler
+
+   .weak      LCD_IRQHandler
+   .thumb_set LCD_IRQHandler,Default_Handler
+
+   .weak      RNG_IRQHandler
+   .thumb_set RNG_IRQHandler,Default_Handler
+#else
    .weak      OTG_HS_EP1_OUT_IRQHandler
    .thumb_set OTG_HS_EP1_OUT_IRQHandler,Default_Handler
 
@@ -551,6 +747,7 @@ g_pfnVectors:
 
    .weak      HASH_RNG_IRQHandler
    .thumb_set HASH_RNG_IRQHandler,Default_Handler
+#endif
 
    .weak      FPU_IRQHandler
    .thumb_set FPU_IRQHandler,Default_Handler

--- a/stmhal/stm32_it.c
+++ b/stmhal/stm32_it.c
@@ -477,6 +477,16 @@ void PVD_IRQHandler(void) {
     IRQ_EXIT(PVD_IRQn);
 }
 
+void PVD_PVM_IRQHandler(void) {
+    IRQ_ENTER(PVD_PVM_IRQn);
+    #if defined(MICROPY_HW_USE_ALT_IRQ_FOR_CDC)
+    extern void USBD_CDC_HAL_TIM_PeriodElapsedCallback(void);
+    USBD_CDC_HAL_TIM_PeriodElapsedCallback();
+    #endif
+    Handle_EXTI_Irq(EXTI_PVD_OUTPUT);
+    IRQ_EXIT(PVD_PVM_IRQn);
+}
+
 void RTC_Alarm_IRQHandler(void) {
     IRQ_ENTER(RTC_Alarm_IRQn);
     Handle_EXTI_Irq(EXTI_RTC_ALARM);
@@ -510,6 +520,12 @@ void TIM1_BRK_TIM9_IRQHandler(void) {
     IRQ_EXIT(TIM1_BRK_TIM9_IRQn);
 }
 
+void TIM1_BRK_TIM15_IRQHandler(void) {
+    IRQ_ENTER(TIM1_BRK_TIM15_IRQn);
+    timer_irq_handler(15);
+    IRQ_EXIT(TIM1_BRK_TIM15_IRQn);
+}
+
 void TIM1_UP_TIM10_IRQHandler(void) {
     IRQ_ENTER(TIM1_UP_TIM10_IRQn);
     timer_irq_handler(1);
@@ -517,11 +533,25 @@ void TIM1_UP_TIM10_IRQHandler(void) {
     IRQ_EXIT(TIM1_UP_TIM10_IRQn);
 }
 
+void TIM1_UP_TIM16_IRQHandler(void) {
+    IRQ_ENTER(TIM1_UP_TIM16_IRQn);
+    timer_irq_handler(1);
+    timer_irq_handler(16);
+    IRQ_EXIT(TIM1_UP_TIM16_IRQn);
+}
+
 void TIM1_TRG_COM_TIM11_IRQHandler(void) {
     IRQ_ENTER(TIM1_TRG_COM_TIM11_IRQn);
     timer_irq_handler(11);
     IRQ_EXIT(TIM1_TRG_COM_TIM11_IRQn);
 }
+
+void TIM1_TRG_COM_TIM17_IRQHandler(void) {
+    IRQ_ENTER(TIM1_TRG_COM_TIM17_IRQn);
+    timer_irq_handler(17);
+    IRQ_EXIT(TIM1_TRG_COM_TIM17_IRQn);
+}
+
 
 void TIM2_IRQHandler(void) {
     IRQ_ENTER(TIM2_IRQn);
@@ -571,6 +601,12 @@ void TIM8_UP_TIM13_IRQHandler(void) {
     timer_irq_handler(8);
     timer_irq_handler(13);
     IRQ_EXIT(TIM8_UP_TIM13_IRQn);
+}
+
+void TIM8_UP_IRQHandler(void) {
+    IRQ_ENTER(TIM8_UP_IRQn);
+    timer_irq_handler(8);
+    IRQ_EXIT(TIM8_UP_IRQn);
 }
 
 void TIM8_TRG_COM_TIM14_IRQHandler(void) {


### PR DESCRIPTION
This is the pre-last PR in a series (#1888, #1890, #1903, #1904, #1916, #1917, #1918, #1919, #1920, #1921, #1922, #1924 ) of PR to support the STM32L4 series in micropython. (see http://forum.micropython.org/viewtopic.php?f=12&t=1332&sid=64e2f63af49643c3edee159171f4a365)

What was `MCU_SERIES_M7` startup_stm32.S? I assume it was a typo as this define is nowhere else used.
