### PR TITLE
L4 integration: Modifications to main.

### DIFF
--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -367,13 +367,15 @@ int main(void) {
     __GPIOC_CLK_ENABLE();
     __GPIOD_CLK_ENABLE();
 
-    #if defined(__HAL_RCC_DTCMRAMEN_CLK_ENABLE)
-    // The STM32F746 doesn't really have CCM memory, but it does have DTCM,
-    // which behaves more or less like normal SRAM.
-    __HAL_RCC_DTCMRAMEN_CLK_ENABLE();
-    #else
-    // enable the CCM RAM
-    __CCMDATARAMEN_CLK_ENABLE();
+    #if defined(MCU_SERIES_F4) ||  defined(MCU_SERIES_F7)
+        #if defined(__HAL_RCC_DTCMRAMEN_CLK_ENABLE)
+        // The STM32F746 doesn't really have CCM memory, but it does have DTCM,
+        // which behaves more or less like normal SRAM.
+        __HAL_RCC_DTCMRAMEN_CLK_ENABLE();
+        #else
+        // enable the CCM RAM
+        __CCMDATARAMEN_CLK_ENABLE();
+        #endif
     #endif
 
     #if defined(MICROPY_BOARD_EARLY_INIT)


### PR DESCRIPTION
This is a PR in a series (#1888, #1890, #1903, #1904, #1916, #1917, #1918, #1919, #1920, #1921, #1922, #1924, #1925, #1929, #1937 ) of PR to support the STM32L4 series in micropython. (see http://forum.micropython.org/viewtopic.php?f=12&t=1332&sid=64e2f63af49643c3edee159171f4a365)

The macro `__CCMDATARAMEN_CLK_ENABLE` is defined as `__HAL_RCC_CCMDATARAMEN_CLK_ENABLE` in stm32_hal_legacy.h on the l4 but on l4 `__HAL_RCC_CCMDATARAMEN_CLK_ENABLE` can not be resolved. Therefore I do not use this code on L4. 

I use SRAM2 on L4 for storage cache which is clocked in run mode (See table 20 in RM0351, STM32l4 reference manual from October 2015).
