### PR TITLE
unix/freedos: djgpp errno.h have no ENOTSUP, so define it as "next number"

### DIFF
--- a/unix/mpconfigport_freedos.h
+++ b/unix/mpconfigport_freedos.h
@@ -36,3 +36,9 @@
 
 // djgpp dirent struct does not have d_ino field
 #undef _DIRENT_HAVE_D_INO
+
+// djgpp errno.h have no ENOTSUP
+#include <errno.h>
+#ifndef ENOTSUP
+    #define ENOTSUP 42
+#endif


### PR DESCRIPTION
#1956 solution(?)

This compiles just fine with djgpp.
42, cause [41](http://www.delorie.com/djgpp/doc/libc/libc_293.html) is the last one.
