### PR TITLE
stmhal: Fix broken USB REPL on STM32F429DISC board

### DIFF
--- a/stmhal/usbd_conf.c
+++ b/stmhal/usbd_conf.c
@@ -429,7 +429,7 @@ if (pdev->id == USB_PHY_HS_ID)
   pcd_hs_handle.Init.dma_enable = 0;
   pcd_hs_handle.Init.low_power_enable = 0;
   pcd_hs_handle.Init.phy_itface = PCD_PHY_EMBEDDED;
-  pcd_hs_handle.Init.Sof_enable = 0;
+  pcd_hs_handle.Init.Sof_enable = 1;
   pcd_hs_handle.Init.speed = PCD_SPEED_HIGH_IN_FULL;
 #if !defined(MICROPY_HW_USB_VBUS_DETECT_PIN)
   pcd_hs_handle.Init.vbus_sensing_enable = 0; // No VBUS Sensing on USB0


### PR DESCRIPTION
USB REPL has been broken since commit d363133
This small patch is fixing issue #1944
Original patch by @hoihu
