### PR TITLE
stmhal: Consistently enable USB SOF Irqs for all USB modes (FS and HS)

### DIFF
--- a/stmhal/usbd_conf.c
+++ b/stmhal/usbd_conf.c
@@ -429,7 +429,7 @@ if (pdev->id == USB_PHY_HS_ID)
   pcd_hs_handle.Init.dma_enable = 0;
   pcd_hs_handle.Init.low_power_enable = 0;
   pcd_hs_handle.Init.phy_itface = PCD_PHY_EMBEDDED;
-  pcd_hs_handle.Init.Sof_enable = 0;
+  pcd_hs_handle.Init.Sof_enable = 1;
   pcd_hs_handle.Init.speed = PCD_SPEED_HIGH_IN_FULL;
 #if !defined(MICROPY_HW_USB_VBUS_DETECT_PIN)
   pcd_hs_handle.Init.vbus_sensing_enable = 0; // No VBUS Sensing on USB0
@@ -463,7 +463,7 @@ if (pdev->id == USB_PHY_HS_ID)
   
   pcd_hs_handle.Init.low_power_enable = 0;
   pcd_hs_handle.Init.phy_itface = PCD_PHY_ULPI;
-  pcd_hs_handle.Init.Sof_enable = 0;
+  pcd_hs_handle.Init.Sof_enable = 1;
   pcd_hs_handle.Init.speed = PCD_SPEED_HIGH;
   pcd_hs_handle.Init.vbus_sensing_enable = 1;
   /* Link The driver to the stack */


### PR DESCRIPTION
SOF irqs are now standard for rx/tx USB transfers, so enable them for both USB FS and HS modes
fixes #1944
