### PR TITLE
Condition-out gc calls from pyexec

### DIFF
--- a/bare-arm/main.c
+++ b/bare-arm/main.c
@@ -34,9 +34,6 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-void gc_collect(void) {
-}
-
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
     return NULL;
 }

--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -110,7 +110,9 @@ STATIC int parse_compile_execute(void *source, mp_parse_input_kind_t input_kind,
     if ((exec_flags & EXEC_FLAG_ALLOW_DEBUGGING) && repl_display_debugging_info) {
         mp_uint_t ticks = mp_hal_ticks_ms() - start; // TODO implement a function that does this properly
         printf("took " UINT_FMT " ms\n", ticks);
+	#if MICROPY_ENABLE_GC
         gc_collect();
+	#endif
         // qstr info
         {
             mp_uint_t n_pool, n_qstr, n_str_data_bytes, n_total_bytes;
@@ -118,8 +120,10 @@ STATIC int parse_compile_execute(void *source, mp_parse_input_kind_t input_kind,
             printf("qstr:\n  n_pool=" UINT_FMT "\n  n_qstr=" UINT_FMT "\n  n_str_data_bytes=" UINT_FMT "\n  n_total_bytes=" UINT_FMT "\n", n_pool, n_qstr, n_str_data_bytes, n_total_bytes);
         }
 
+        #if MICROPY_ENABLE_GC
         // GC info
         gc_dump_info();
+	#endif
     }
 
     if (exec_flags & EXEC_FLAG_PRINT_EOF) {


### PR DESCRIPTION
A port which uses lib/utils/pyexec.c but which (for whatever reason) does not enable garbage collection needs to implement a stub gc_collect function.

This PR conditions-out calls to gc_collect and gc_dump_info from lib/utils/pyexec.c
The bare-arm port is updated to remove the stub.
