### PR TITLE
stmhal: can now select USB and boot memory

### DIFF
--- a/stmhal/boards/STM32F439/mpconfigboard.h
+++ b/stmhal/boards/STM32F439/mpconfigboard.h
@@ -14,6 +14,9 @@
 #define MICROPY_HW_ENABLE_DAC       (1)
 #define MICROPY_HW_ENABLE_CAN       (1)
 
+//#define MICROPY_AVOID_USB_SD
+//#define MICROPY_BOOT_DIRECTORY "/flash"
+
 // SD card detect switch
 #if MICROPY_HW_HAS_SDCARD
 #define MICROPY_HW_SDCARD_DETECT_PIN        (pin_A8)

--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -507,20 +507,21 @@ soft_reset:
             mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_sd_slash_lib));
 
             if (first_soft_reset) {
-                // use SD card as medium for the USB MSD
-#if defined(USE_DEVICE_MODE)
-                pyb_usb_storage_medium = PYB_USB_STORAGE_MEDIUM_SDCARD;
-#endif
+                #if defined(USE_DEVICE_MODE)
+                    #if !defined(MICROPY_AVOID_USB_SD) // prevent exposing SD on USB
+                        // use SD card as medium for the USB MSD
+                        pyb_usb_storage_medium = PYB_USB_STORAGE_MEDIUM_SDCARD;
+                    #endif
+                #endif
             }
 
             #if defined(USE_DEVICE_MODE)
-            // only use SD card as current directory if that's what the USB medium is
-            if (pyb_usb_storage_medium == PYB_USB_STORAGE_MEDIUM_SDCARD)
-            #endif
-            {
+                #if !defined(MICROPY_BOOT_DIRECTORY)
+                    #define MICROPY_BOOT_DIRECTORY "/sd"
+                #endif
                 // use SD card as current directory
-                f_chdrive("/sd");
-            }
+                f_chdrive(MICROPY_BOOT_DIRECTORY);
+            #endif
         }
         no_mem_for_sd:;
     }


### PR DESCRIPTION
added MICROPY_AVOID_USB_SD which, when defined, avoids setting the USB mass storage device to the SD card and uses internal flash instead.

added MICROPY_BOOT_DIRECTORY which allows selection between running code from SD or internal flash
