### PR TITLE
Factor out common implementation of help(obj) into library function

### DIFF
--- a/cc3200/application.mk
+++ b/cc3200/application.mk
@@ -152,6 +152,7 @@ APP_LIB_SRC_C = $(addprefix lib/,\
 	netutils/netutils.c \
 	timeutils/timeutils.c \
 	utils/pyexec.c \
+	utils/pyhelp.c \
 	utils/printf.c \
 	)
 	

--- a/cc3200/misc/help.c
+++ b/cc3200/misc/help.c
@@ -27,20 +27,11 @@
 
 #include <stdio.h>
 
-#include "py/mpconfig.h"
-#include "py/obj.h"
+#include "lib/utils/pyhelp.h"
 
 STATIC const char help_text[] = "Welcome to MicroPython!\n"
                                 "For online help please visit http://micropython.org/help/.\n"
                                 "For further help on a specific object, type help(obj)\n";
-
-STATIC void pyb_help_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
-    printf("  ");
-    mp_obj_print(name_o, PRINT_STR);
-    printf(" -- ");
-    mp_obj_print(value, PRINT_STR);
-    printf("\n");
-}
 
 STATIC mp_obj_t pyb_help(uint n_args, const mp_obj_t *args) {
     if (n_args == 0) {
@@ -49,31 +40,7 @@ STATIC mp_obj_t pyb_help(uint n_args, const mp_obj_t *args) {
     }
     else {
         // try to print something sensible about the given object
-        printf("object ");
-        mp_obj_print(args[0], PRINT_STR);
-        printf(" is of type %s\n", mp_obj_get_type_str(args[0]));
-
-        mp_map_t *map = NULL;
-        if (MP_OBJ_IS_TYPE(args[0], &mp_type_module)) {
-            map = mp_obj_dict_get_map(mp_obj_module_get_globals(args[0]));
-        } else {
-            mp_obj_type_t *type;
-            if (MP_OBJ_IS_TYPE(args[0], &mp_type_type)) {
-                type = args[0];
-            } else {
-                type = mp_obj_get_type(args[0]);
-            }
-            if (type->locals_dict != MP_OBJ_NULL && MP_OBJ_IS_TYPE(type->locals_dict, &mp_type_dict)) {
-                map = mp_obj_dict_get_map(type->locals_dict);
-            }
-        }
-        if (map != NULL) {
-            for (uint i = 0; i < map->alloc; i++) {
-                if (map->table[i].key != MP_OBJ_NULL) {
-                    pyb_help_print_info_about_object(map->table[i].key, map->table[i].value);
-                }
-            }
-        }
+        pyhelp_print_obj(args[0]);
     }
     return mp_const_none;
 }

--- a/lib/utils/pyhelp.c
+++ b/lib/utils/pyhelp.c
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+
+#include "lib/utils/pyhelp.h"
+
+STATIC void pyhelp_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
+    printf("  ");
+    mp_obj_print(name_o, PRINT_STR);
+    printf(" -- ");
+    mp_obj_print(value, PRINT_STR);
+    printf("\n");
+}
+
+// Helper for 1-argument form of builtin help
+//
+// Typically a port will define a help function thus:
+//
+// STATIC const char *const myport_help_text =
+// "Welcome to MicroPython!\n"
+// "\n"
+// "...information specific to this port e.g. modules available...";
+// 
+// STATIC mp_obj_t myport_help(mp_uint_t n_args, const mp_obj_t *args) {
+//     if (n_args == 0) {
+//         printf("%s", myport_help_text);
+//     } else {
+//         pyhelp_print_obj(args[0]);
+//     }
+//     return mp_const_none;
+// }
+// MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_help_obj, 0, 1, myport_help);
+//
+void pyhelp_print_obj(const mp_obj_t obj) {
+    // try to print something sensible about the given object
+    printf("object ");
+    mp_obj_print(obj, PRINT_STR);
+    printf(" is of type %s\n", mp_obj_get_type_str(obj));
+
+    mp_map_t *map = NULL;
+    if (MP_OBJ_IS_TYPE(obj, &mp_type_module)) {
+        map = mp_obj_dict_get_map(mp_obj_module_get_globals(obj));
+    } else {
+        mp_obj_type_t *type;
+        if (MP_OBJ_IS_TYPE(obj, &mp_type_type)) {
+            type = obj;
+        } else {
+            type = mp_obj_get_type(obj);
+        }
+        if (type->locals_dict != MP_OBJ_NULL && MP_OBJ_IS_TYPE(type->locals_dict, &mp_type_dict)) {
+            map = mp_obj_dict_get_map(type->locals_dict);
+        }
+    }
+    if (map != NULL) {
+        for (uint i = 0; i < map->alloc; i++) {
+            if (map->table[i].key != MP_OBJ_NULL) {
+                pyhelp_print_info_about_object(map->table[i].key, map->table[i].value);
+            }
+        }
+    }
+}

--- a/lib/utils/pyhelp.h
+++ b/lib/utils/pyhelp.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Colin Hogben
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef __MICROPY_INCLUDED_LIB_UTILS_PYHELP_H__
+#define __MICROPY_INCLUDED_LIB_UTILS_PYHELP_H__
+
+#include "py/obj.h"
+
+void pyhelp_print_obj(const mp_obj_t obj);
+
+#endif // __MICROPY_INCLUDED_LIB_UTILS_PYHELP_H__

--- a/lib/utils/pyhelp.h
+++ b/lib/utils/pyhelp.h
@@ -1,28 +1,3 @@
-/*
- * This file is part of the Micro Python project, http://micropython.org/
- *
- * The MIT License (MIT)
- *
- * Copyright (c) 2016 Colin Hogben
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
 #ifndef __MICROPY_INCLUDED_LIB_UTILS_PYHELP_H__
 #define __MICROPY_INCLUDED_LIB_UTILS_PYHELP_H__
 

--- a/pic16bit/main.c
+++ b/pic16bit/main.c
@@ -113,6 +113,15 @@ MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
 void nlr_jump_fail(void *val) {
 }
 
+// REPL says 'Type "help()" for more information,
+// so provide a minimal implementation without wasting too much space.
+STATIC mp_obj_t minimal_help(void)
+{
+  printf("See docs.micropython.org\n");
+  return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_0(mp_builtin_help_obj, minimal_help);
+
 void NORETURN __fatal_error(const char *msg) {
     while (1);
 }

--- a/pic16bit/mpconfigport.h
+++ b/pic16bit/mpconfigport.h
@@ -92,6 +92,7 @@ typedef int mp_off_t;
 // extra builtin names to add to the global namespace
 extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
 #define MICROPY_PORT_BUILTINS \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_help), (mp_obj_t)&mp_builtin_help_obj }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_open), (mp_obj_t)&mp_builtin_open_obj },
 
 // extra builtin modules to add to the list of known ones

--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -110,6 +110,7 @@ SRC_LIB = $(addprefix lib/,\
 	netutils/netutils.c \
 	timeutils/timeutils.c \
 	utils/pyexec.c \
+	utils/pyhelp.c \
 	utils/printf.c \
 	)
 

--- a/stmhal/help.c
+++ b/stmhal/help.c
@@ -26,8 +26,7 @@
 
 #include <stdio.h>
 
-#include "py/nlr.h"
-#include "py/obj.h"
+#include "lib/utils/pyhelp.h"
 
 STATIC const char *help_text =
 "Welcome to MicroPython!\n"
@@ -72,14 +71,6 @@ STATIC const char *help_text =
 "For further help on a specific object, type help(obj)\n"
 ;
 
-STATIC void pyb_help_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
-    printf("  ");
-    mp_obj_print(name_o, PRINT_STR);
-    printf(" -- ");
-    mp_obj_print(value, PRINT_STR);
-    printf("\n");
-}
-
 STATIC mp_obj_t pyb_help(uint n_args, const mp_obj_t *args) {
     if (n_args == 0) {
         // print a general help message
@@ -87,32 +78,7 @@ STATIC mp_obj_t pyb_help(uint n_args, const mp_obj_t *args) {
 
     } else {
         // try to print something sensible about the given object
-
-        printf("object ");
-        mp_obj_print(args[0], PRINT_STR);
-        printf(" is of type %s\n", mp_obj_get_type_str(args[0]));
-
-        mp_map_t *map = NULL;
-        if (MP_OBJ_IS_TYPE(args[0], &mp_type_module)) {
-            map = mp_obj_dict_get_map(mp_obj_module_get_globals(args[0]));
-        } else {
-            mp_obj_type_t *type;
-            if (MP_OBJ_IS_TYPE(args[0], &mp_type_type)) {
-                type = args[0];
-            } else {
-                type = mp_obj_get_type(args[0]);
-            }
-            if (type->locals_dict != MP_OBJ_NULL && MP_OBJ_IS_TYPE(type->locals_dict, &mp_type_dict)) {
-                map = mp_obj_dict_get_map(type->locals_dict);
-            }
-        }
-        if (map != NULL) {
-            for (uint i = 0; i < map->alloc; i++) {
-                if (map->table[i].key != MP_OBJ_NULL) {
-                    pyb_help_print_info_about_object(map->table[i].key, map->table[i].value);
-                }
-            }
-        }
+        pyhelp_print_obj(args[0]);
     }
 
     return mp_const_none;

--- a/teensy/Makefile
+++ b/teensy/Makefile
@@ -109,6 +109,7 @@ LIB_SRC_C = $(addprefix lib/,\
 	libc/string0.c \
 	mp-readline/readline.c \
 	utils/pyexec.c \
+	utils/pyhelp.c \
 	utils/printf.c \
 	)
 

--- a/teensy/help.c
+++ b/teensy/help.c
@@ -26,7 +26,7 @@
 
 #include <stdio.h>
 
-#include "py/obj.h"
+#include "lib/utils/pyhelp.h"
 
 STATIC const char *help_text =
 "Welcome to MicroPython!\n"
@@ -70,14 +70,6 @@ STATIC const char *help_text =
 "For further help on a specific object, type help(obj)\n"
 ;
 
-STATIC void pyb_help_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
-    printf("  ");
-    mp_obj_print(name_o, PRINT_STR);
-    printf(" -- ");
-    mp_obj_print(value, PRINT_STR);
-    printf("\n");
-}
-
 STATIC mp_obj_t pyb_help(uint n_args, const mp_obj_t *args) {
     if (n_args == 0) {
         // print a general help message
@@ -85,32 +77,7 @@ STATIC mp_obj_t pyb_help(uint n_args, const mp_obj_t *args) {
 
     } else {
         // try to print something sensible about the given object
-
-        printf("object ");
-        mp_obj_print(args[0], PRINT_STR);
-        printf(" is of type %s\n", mp_obj_get_type_str(args[0]));
-
-        mp_map_t *map = NULL;
-        if (MP_OBJ_IS_TYPE(args[0], &mp_type_module)) {
-            map = mp_obj_dict_get_map(mp_obj_module_get_globals(args[0]));
-        } else {
-            mp_obj_type_t *type;
-            if (MP_OBJ_IS_TYPE(args[0], &mp_type_type)) {
-                type = args[0];
-            } else {
-                type = mp_obj_get_type(args[0]);
-            }
-            if (type->locals_dict != MP_OBJ_NULL && MP_OBJ_IS_TYPE(type->locals_dict, &mp_type_dict)) {
-                map = mp_obj_dict_get_map(type->locals_dict);
-            }
-        }
-        if (map != NULL) {
-            for (uint i = 0; i < map->alloc; i++) {
-                if (map->table[i].key != MP_OBJ_NULL) {
-                    pyb_help_print_info_about_object(map->table[i].key, map->table[i].value);
-                }
-            }
-        }
+        pyhelp_print_obj(args[0]);
     }
 
     return mp_const_none;


### PR DESCRIPTION
Several ports use identical code for the 1-argument form of the builtin help function.  Move this code to a library function and update existing help implementations to use it.  This should aid adding help implementations for other ports.
