### PR TITLE
Add a note on how to stop REPL flooding caused by wrong password

### DIFF
--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -24,6 +24,12 @@ The ``machine`` module::
     machine.freq()          # get the current frequency of the CPU
     machine.freq(160000000) # set the CPU frequency to 160 MHz
 
+In case you mistyped your wi-fi router's password while configuring
+wlan connection, the underlying wi-fi sub-system will keep trying
+to reconnect, flooding your REPL. In this situation, you can turn
+off vendor O/S debugging messages (see the snippet below), fix the
+error, and enable debugging messages.
+
 The ``esp`` module::
 
     import esp


### PR DESCRIPTION
Added a note to esp docs (quickstart.rst) re [#2005](https://github.com/micropython/micropython/issues/2005#issuecomment-213607149)
