### PR TITLE
msvc: Enable multi-processor compilation

### DIFF
--- a/windows/msvc/common.props
+++ b/windows/msvc/common.props
@@ -16,6 +16,8 @@
       <SDLCheck>false</SDLCheck>
       <WarningLevel>Level1</WarningLevel>
       <ExceptionHandling>false</ExceptionHandling>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
This will launch about as many compiler instances as there are logical
processors on a machine, and as such significantly speeds up compilation.
