### PR TITLE
esp8266/scripts/: Add fill() to NeoPixel

### DIFF
--- a/esp8266/scripts/neopixel.py
+++ b/esp8266/scripts/neopixel.py
@@ -20,5 +20,12 @@ class NeoPixel:
         i = index * 3
         return self.buf[i + 1], self.buf[i], self.buf[i + 2]
 
+    def fill(self, color):
+        r, g, b = color
+        for i in range(len(self.buf) / 3):
+            self.buf[i * 3] = g
+            self.buf[i * 3 + 1] = r
+            self.buf[i * 3 + 2] = b
+
     def write(self):
         neopixel_write(self.pin, self.buf, True)


### PR DESCRIPTION
Added a reset() method to the NeoPixel driver, for quickly clearing the buffer.
I am not sure if redefining `self.buf` as a new `bytearray()` is the most efficient pattern.

a) Replace buffer:

```
self.buf = bytearray(self.n * 3)
```

vs b) loop and set each:

```
for i in range(np.n):
    np[i] = (0,0,0)
```

Complete example

```
from machine import Pin
from neopixel import NeoPixel
pin = Pin(5, Pin.OUT)
np = NeoPixel(pin, 8)
np[0] = (255, 0, 0)
np[1] = (0, 255, 0)
np[2] = (0, 0, 255)
np.write()
...
np.reset()
np.write()
```
