### PR TITLE
Add optional password argument to webrepl.start()

### DIFF
--- a/esp8266/scripts/webrepl.py
+++ b/esp8266/scripts/webrepl.py
@@ -49,14 +49,19 @@ def stop():
         listen_s.close()
 
 
-def start(port=8266):
+def start(port=8266, password=None):
     stop()
-    try:
-        import port_config
-        _webrepl.password(port_config.WEBREPL_PASS)
+    if password is None:
+        try:
+            import port_config
+            _webrepl.password(port_config.WEBREPL_PASS)
+            setup_conn(port, accept_conn)
+            print("Started webrepl in normal mode")
+        except:
+            import webrepl_setup
+            setup_conn(port, webrepl_setup.handle_conn)
+            print("Started webrepl in setup mode")
+    else:
+        _webrepl.password(password)
         setup_conn(port, accept_conn)
         print("Started webrepl in normal mode")
-    except:
-        import webrepl_setup
-        setup_conn(port, webrepl_setup.handle_conn)
-        print("Started webrepl in setup mode")


### PR DESCRIPTION
This commit fixes issue #2045
