### PR TITLE
Fix ESP8266 Network tutorial

### DIFF
--- a/docs/esp8266/tutorial/network_tcp.rst
+++ b/docs/esp8266/tutorial/network_tcp.rst
@@ -36,7 +36,7 @@ information they hold.
 Using the IP address we can make a socket and connect to the server::
 
     >>> s = socket.socket()
-    >>> s.connect(addr[0][-1])
+    >>> s.connect(addr)
 
 Now that we are connected we can download and display the data::
 


### PR DESCRIPTION
The socket should either connect to `addr` or `addr_info[0][-1]`. Not to `addr[0][-1]`.
