### PR TITLE
py/repl: If there're no better alternatives, try to complete "import".

### DIFF
--- a/py/repl.c
+++ b/py/repl.c
@@ -126,6 +126,7 @@ bool mp_repl_continue_with_input(const char *input) {
 
 mp_uint_t mp_repl_autocomplete(const char *str, mp_uint_t len, const mp_print_t *print, const char **compl_str) {
     // scan backwards to find start of "a.b.c" chain
+    const char *org_str = str;
     const char *top = str + len;
     for (const char *s = top; --s >= str;) {
         if (!(unichar_isalpha(*s) || unichar_isdigit(*s) || *s == '_' || *s == '.')) {
@@ -219,6 +220,16 @@ mp_uint_t mp_repl_autocomplete(const char *str, mp_uint_t len, const mp_print_t 
 
             // nothing found
             if (n_found == 0) {
+                // If there're no better alternatives, and if it's first word
+                // in the line, try to complete "import".
+                if (s_start == org_str) {
+                    static char import_str[] = "import ";
+                    if (memcmp(s_start, import_str, s_len) == 0) {
+                        *compl_str = import_str + s_len;
+                        return sizeof(import_str) - 1 - s_len;
+                    }
+                }
+
                 return 0;
             }
 


### PR DESCRIPTION
Also do that only for the first word in a line. The idea is that when you
start up interpreter, high chance that you want to do an import. With this
patch, this can be achieved with "i<tab>".
