### PR TITLE
py/objfloat, py/modmath: Ensure M_PI and M_E defined.

### DIFF
--- a/py/modmath.c
+++ b/py/modmath.c
@@ -30,6 +30,10 @@
 #if MICROPY_PY_BUILTINS_FLOAT && MICROPY_PY_MATH
 
 #include <math.h>
+// Depending on standards conformance, M_PI may not be defined
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 /// \module math - mathematical functions
 ///

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -37,6 +37,13 @@
 #if MICROPY_PY_BUILTINS_FLOAT
 
 #include <math.h>
+// Depending on standards conformance, M_E and M_PI may not be defined
+#ifndef M_E
+#define M_E 2.7182818284590452354
+#endif
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 #include "py/formatfloat.h"
 
 #if MICROPY_OBJ_REPR != MICROPY_OBJ_REPR_C && MICROPY_OBJ_REPR != MICROPY_OBJ_REPR_D


### PR DESCRIPTION
In some compliation enviroments (e.g. mbed online compiler) with
strict standards compliance, math.h does not define constants such
as M_PI.  Provide fallback definitions of M_E and M_PI where needed.
