### PR TITLE
docs/esp8266/quickref: New way to get MAC address

### DIFF
--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -43,7 +43,7 @@ The ``network`` module::
     wlan.scan()             # scan for access points
     wlan.isconnected()      # check if the station is connected to an AP
     wlan.connect('essid', 'password') # connect to an AP
-    wlan.mac()              # get the interface's MAC adddress
+    wlan.config('mac')      # get the interface's MAC adddress
     wlan.ifconfig()         # get the interface's IP/netmask/gw/DNS addresses
 
     ap = network.WLAN(network.AP_IF) # create access-point interface


### PR DESCRIPTION
The old way, `wlan.mac()` no longer works, updated to `wlan.config('mac')`. As reported on the forum at http://forum.micropython.org/viewtopic.php?f=16&t=1890&p=10610
