### PR TITLE
Gc dump improvements

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -768,7 +768,7 @@ void gc_dump_alloc_table(void) {
                 }
                 break;
             }
-            case AT_TAIL: c = 't'; break;
+            case AT_TAIL: c = '-'; break;
             case AT_MARK: c = 'm'; break;
         }
         mp_printf(&mp_plat_print, "%c", c);

--- a/py/gc.c
+++ b/py/gc.c
@@ -693,11 +693,8 @@ void gc_dump_alloc_table(void) {
             }
             // print header for new line of blocks
             // (the cast to uint32_t is for 16-bit ports)
-            #if EXTENSIVE_HEAP_PROFILING
+            //mp_printf(&mp_plat_print, "\n%05x: ", (uint)(PTR_FROM_BLOCK(bl) & (uint32_t)0xfffff));
             mp_printf(&mp_plat_print, "\n%05x: ", (uint)((bl * BYTES_PER_BLOCK) & (uint32_t)0xfffff));
-            #else
-            mp_printf(&mp_plat_print, "\n%05x: ", (uint)(PTR_FROM_BLOCK(bl) & (uint32_t)0xfffff));
-            #endif
         }
         int c = ' ';
         switch (ATB_GET_KIND(bl)) {


### PR DESCRIPTION
Following https://github.com/micropython/micropython/commit/3d7f3f00e03ef165aebef68a5f9710631494654b, there're less obvious changes. Note that if '-' is considered not distinguishable enough, '=' can be used instead.
