### PR TITLE
py/{builtinimport,frozenmod}: Rework frozen modules support.

### DIFF
--- a/py/frozenmod.c
+++ b/py/frozenmod.c
@@ -43,6 +43,24 @@ extern const char mp_frozen_str_names[];
 extern const uint32_t mp_frozen_str_sizes[];
 extern const char mp_frozen_str_content[];
 
+mp_import_stat_t mp_frozen_stat(const char *str) {
+    size_t len = strlen(str);
+    const char *name = mp_frozen_str_names;
+
+    for (int i = 0; *name != 0; i++) {
+        size_t l = strlen(name);
+        if (l >= len && !memcmp(str, name, len)) {
+            if (name[len] == 0) {
+                return MP_IMPORT_STAT_FILE;
+            } else if (name[len] == '/') {
+                return MP_IMPORT_STAT_DIR;
+            }
+        }
+        name += l + 1;
+    }
+    return MP_IMPORT_STAT_NO_EXIST;
+}
+
 STATIC mp_lexer_t *mp_find_frozen_str(const char *str, size_t len) {
     const char *name = mp_frozen_str_names;
 

--- a/tools/make-frozen.py
+++ b/tools/make-frozen.py
@@ -23,7 +23,8 @@ import os
 
 
 def module_name(f):
-    return f[:-len(".py")]
+    return f
+#    return f[:-len(".py")]
 
 modules = []
 
@@ -40,7 +41,7 @@ print("#include <stdint.h>")
 print("const char mp_frozen_str_names[] = {")
 for f, st in modules:
     m = module_name(f)
-    print('"%s\\0"' % m.replace("/", "."))
+    print('"%s\\0"' % m)
 print('"\\0"};')
 
 print("const uint32_t mp_frozen_str_sizes[] = {")


### PR DESCRIPTION
Now frozen modules is treated just as a kind of VFS, and all operations
performed on it correspond to operations on normal filesystem. This allows
to support packages properly, and potentially also data files.

TODO: The natural extension of this would be to remove parallel structure
for .mpy frozen modules, and just reuse this new infrastructure.
