### PR TITLE
Added the rename method to the module uos

### DIFF
--- a/esp8266/moduos.c
+++ b/esp8266/moduos.c
@@ -97,6 +97,15 @@ STATIC mp_obj_t os_remove(mp_obj_t path_in) {
     return vfs_proxy_call(MP_QSTR_remove, 1, &path_in);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_remove_obj, os_remove);
+
+STATIC mp_obj_t os_rename(mp_obj_t path_old, mp_obj_t path_new) {
+    mp_obj_t args[2];
+    args[0] = path_old;
+    args[1] = path_new;
+    return vfs_proxy_call(MP_QSTR_rename, 2, args);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(os_rename_obj, os_rename);
+
 #endif
 
 STATIC mp_obj_t os_urandom(mp_obj_t num) {
@@ -130,6 +139,7 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_listdir), MP_ROM_PTR(&os_listdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_mkdir), MP_ROM_PTR(&os_mkdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&os_remove_obj) },
+    { MP_ROM_QSTR(MP_QSTR_rename), MP_ROM_PTR(&os_rename_obj) },
     #endif
 };
 


### PR DESCRIPTION
esp8266/moduos.c: Addition of the rename method to module uos.

That one was missing in the module, even if it was available in the vfs object. The change consist of adding the name and preparing the call to the underlying vfs module, similar to what was already implemented e.g. for remove.  
Rename is useful by itself, or for instance for a safe file replace, consisting of the sequence:
- write to a temp file
- delete the original file
- rename the temp file to the original file's name
