### PR TITLE
esp8266: Add support for dht sensors

### DIFF
--- a/esp8266/Makefile
+++ b/esp8266/Makefile
@@ -65,6 +65,7 @@ SRC_C = \
 	esppwm.c \
 	esponewire.c \
 	espneopixel.c \
+	espdht.c \
 	intr.c \
 	modpyb.c \
 	modpybpin.c \
@@ -79,6 +80,7 @@ SRC_C = \
 	moduos.c \
 	modmachine.c \
 	modonewire.c \
+	moddht.c \
 	ets_alt_task.c \
 	$(BUILD)/frozen.c \
 	fatfs_port.c \

--- a/esp8266/esp8266.ld
+++ b/esp8266/esp8266.ld
@@ -148,6 +148,7 @@ SECTIONS
         *modlwip.o(.literal* .text*)
         *modsocket.o(.literal* .text*)
         *modonewire.o(.literal* .text*)
+        *moddht.o(.literal* .text*)
 
         /* we put as much rodata as possible in this section */
         /* note that only rodata accessed as a machine word is allowed here */

--- a/esp8266/espdht.c
+++ b/esp8266/espdht.c
@@ -1,0 +1,143 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Seong-Woo Kim
+ * Copyright (c) 2015-2016 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+
+#include "etshal.h"
+#include "user_interface.h"
+#include "modpyb.h"
+#include "gpio.h"
+#include "espdht.h"
+
+#define LOW  0
+#define HIGH 1
+#define TIMEOUT 200
+#define DHT_PULSES 40
+
+static double dht_humidity;
+static double dht_temperature;
+static uint8_t dht_bytes[5];
+
+static uint32_t disable_irq(void) {
+    ets_intr_lock();
+    return 0;
+}
+
+static void enable_irq(uint32_t i) {
+    ets_intr_unlock();
+}
+
+static void mp_hal_delay_us_no_irq(uint32_t us) {
+    uint32_t start = system_get_time();
+    while (system_get_time() - start < us) {
+    }
+}
+
+#define DELAY_US mp_hal_delay_us_no_irq
+
+int esp_dht_detect_edge(uint pin, uint value, int timeout) {
+    int counter = 0;
+    while (pin_get(pin) == value && counter < timeout) {
+        DELAY_US(1);
+        ++counter;
+    }
+    if (counter > timeout) {
+        return -1;
+    }
+    return counter;
+}
+
+int esp_dht_readSensor(uint pin) {
+    uint8_t n = 0;
+
+    // Pin LOW
+    pin_set(pin, 0);
+    DELAY_US(20000);
+    uint32_t i = disable_irq();
+    pin_set(pin, 1);
+    DELAY_US(40);
+    // Set Pin INPUT
+    gpio_output_set(0, 0, 0, 1 << pin);
+
+    // GET Acknowledge or Timeout
+    if (esp_dht_detect_edge(pin, LOW, TIMEOUT) == -1)
+        return DHT_ERROR_TIMEOUT;
+
+    // GET HIGH
+    if (esp_dht_detect_edge(pin, HIGH, TIMEOUT) == -1)
+        return DHT_ERROR_TIMEOUT;
+
+    // Read output - 40 bits : 5 bytes
+    for (n = 0; n < DHT_PULSES; n++) {
+        if (esp_dht_detect_edge(pin, LOW, TIMEOUT) == -1)
+            return DHT_ERROR_TIMEOUT;
+        uint32_t start = system_get_time();
+        if (esp_dht_detect_edge(pin, HIGH, TIMEOUT) == -1)
+            return DHT_ERROR_TIMEOUT;
+        dht_bytes[n/8] <<= 1;
+        if ((system_get_time() - start) > 40) {
+            dht_bytes[n/8] |= 1;
+        }
+    }
+    enable_irq(i);
+    pin_set(pin, 1);
+
+    return DHT_OK;
+}
+
+int esp_dht_read(uint pin) {
+    int value = esp_dht_readSensor(pin);
+    if (value != DHT_OK) {
+        dht_humidity = DHT_INVALID_VALUE;
+        dht_temperature = DHT_INVALID_VALUE;
+        return value;
+    }
+    // DHT11
+    if (dht_bytes[1] == 0 && dht_bytes[3] == 0) {
+        dht_humidity = (float)dht_bytes[0];
+        dht_temperature = (float)dht_bytes[2];
+    } else {
+        dht_humidity = (float)((dht_bytes[0] << 8 | dht_bytes[1])*0.1);
+        dht_temperature = (float)((dht_bytes[2] << 8 | dht_bytes[3])*0.1);
+    }
+
+    uint8_t sum = dht_bytes[0] + dht_bytes[1] + dht_bytes[2] + dht_bytes[3];
+    if (dht_bytes[4] != sum)
+    {
+        return DHT_ERROR_CHECKSUM;
+    }
+    return DHT_OK;
+}
+
+float esp_dht_readhumi(void) {
+    return dht_humidity;
+}
+
+float esp_dht_readtemp(void) {
+    return dht_temperature;
+}
+

--- a/esp8266/espdht.h
+++ b/esp8266/espdht.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Seong-Woo Kim
+ * Copyright (c) 2016 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef __MICROPY_INCLUDED_ESP8266_ESPDHT_H__
+#define __MICROPY_INCLUDED_ESP8266_ESPDHT_H__
+
+#define DHT_OK			0
+#define DHT_ERROR_TIMEOUT	-1
+#define DHT_ERROR_CHECKSUM	-2
+
+#define DHT_INVALID_VALUE	-1
+
+extern uint16_t esp_dht_timings[2];
+
+int esp_dht_read(uint pin);
+float esp_dht_readhumi(void);
+float esp_dht_readtemp(void);
+
+#endif // __MICROPY_INCLUDED_ESP8266_ESPDHT_H__

--- a/esp8266/moddht.c
+++ b/esp8266/moddht.c
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Seong-Woo Kim
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "py/obj.h"
+#include "py/mphal.h"
+#include "modpyb.h"
+#include "espdht.h"
+
+STATIC mp_obj_t dht_read(mp_obj_t pin_in) {
+    return MP_OBJ_NEW_SMALL_INT(esp_dht_read(mp_obj_get_pin(pin_in)));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(dht_read_obj, dht_read);
+
+STATIC mp_obj_t dht_readhumi(void) {
+    return mp_obj_new_float(esp_dht_readhumi());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(dht_readhumi_obj, dht_readhumi);
+
+STATIC mp_obj_t dht_readtemp(void) {
+    return mp_obj_new_float(esp_dht_readtemp());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(dht_readtemp_obj, dht_readtemp);
+
+STATIC const mp_map_elem_t dht_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_dht) },
+
+    { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR((mp_obj_t)&dht_read_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readhumi), MP_ROM_PTR((mp_obj_t)&dht_readhumi_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readtemp), MP_ROM_PTR((mp_obj_t)&dht_readtemp_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(dht_module_globals, dht_module_globals_table);
+
+const mp_obj_module_t dht_module = {
+    .base = { &mp_type_module },
+    .name = MP_QSTR_dht,
+    .globals = (mp_obj_dict_t*)&dht_module_globals,
+};

--- a/esp8266/mpconfigport.h
+++ b/esp8266/mpconfigport.h
@@ -126,6 +126,7 @@ extern const struct _mp_obj_module_t uos_module;
 extern const struct _mp_obj_module_t mp_module_lwip;
 extern const struct _mp_obj_module_t mp_module_machine;
 extern const struct _mp_obj_module_t onewire_module;
+extern const struct _mp_obj_module_t dht_module;
 
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_OBJ_NEW_QSTR(MP_QSTR_esp), (mp_obj_t)&esp_module }, \
@@ -137,6 +138,7 @@ extern const struct _mp_obj_module_t onewire_module;
     { MP_OBJ_NEW_QSTR(MP_QSTR_uos), (mp_obj_t)&uos_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_machine), (mp_obj_t)&mp_module_machine }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR__onewire), (mp_obj_t)&onewire_module }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR__dht), (mp_obj_t)&dht_module }, \
 
 #define MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS \
     { MP_OBJ_NEW_QSTR(MP_QSTR_time), (mp_obj_t)&utime_module }, \

--- a/esp8266/scripts/dht.py
+++ b/esp8266/scripts/dht.py
@@ -1,0 +1,25 @@
+# DHT Sensor driver for MicroPython on ESP8266
+# MIT license; Copyright (c) 2016 Seong-Woo Kim, Damien P. George
+
+import _dht
+
+class DHTError(Exception):
+    pass
+
+class DHT:
+
+    def __init__(self, pin):
+        self.pin = pin
+        self.pin.init(pin.OUT)
+
+    def read(self):
+        _dht.read(self.pin)
+        humidity = self.readhumi()
+        temperature = self.readtemp()
+        return (humidity, temperature)
+
+    def readhumi(self):
+        return _dht.readhumi()
+
+    def readtemp(self):
+        return _dht.readtemp()


### PR DESCRIPTION
I created a module of dht humidity/temperature sensors for esp8266. Dht11/Dht22 sensors for the module were tested and OK. You can program as follows:

import time
import machine, dht
ds = dht.DHT(machine.Pin(4))
while True:
    humi, temp = ds.read()
    print("Humidity={} Temperature={}".format(humi, temp))
    time.sleep_ms(1000)
