### PR TITLE
esp8266: Add disable_irq/enable_irq to machine module

### DIFF
--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -18,25 +18,23 @@ Reset related functions
 
    Get the reset cause. See :ref:`constants <machine_constants>` for the possible return values.
 
-.. only:: port_wipy
+Interrupt related functions
+---------------------------
 
-    Interrupt related functions
-    ---------------------------
+.. function:: disable_irq()
 
-    .. function:: disable_irq()
+   Disable interrupt requests.
+   Returns the previous IRQ state: ``False``/``True`` for disabled/enabled IRQs
+   respectively.  This return value can be passed to enable_irq to restore
+   the IRQ to its original state.
 
-       Disable interrupt requests.
-       Returns the previous IRQ state: ``False``/``True`` for disabled/enabled IRQs
-       respectively.  This return value can be passed to enable_irq to restore
-       the IRQ to its original state.
+.. function:: enable_irq(state=True)
 
-    .. function:: enable_irq(state=True)
-
-       Enable interrupt requests.
-       If ``state`` is ``True`` (the default value) then IRQs are enabled.
-       If ``state`` is ``False`` then IRQs are disabled.  The most common use of
-       this function is to pass it the value returned by ``disable_irq`` to
-       exit a critical section.
+   Enable interrupt requests.
+   If ``state`` is ``True`` (the default value) then IRQs are enabled.
+   If ``state`` is ``False`` then IRQs are disabled.  The most common use of
+   this function is to pass it the value returned by ``disable_irq`` to
+   exit a critical section.
 
 Power related functions
 -----------------------

--- a/esp8266/ets_alt_task.c
+++ b/esp8266/ets_alt_task.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include "xtirq.h"
 #include "osapi.h"
 #include "os_type.h"
 #include "ets_sys.h"
@@ -108,6 +109,9 @@ bool ets_post(uint8 prio, os_signal_t sig, os_param_t param) {
 }
 
 bool ets_loop_iter(void) {
+    if (query_irq() != 0) {
+        return false;
+    }
     //static unsigned cnt;
     bool progress = false;
     for (volatile struct task_entry *t = emu_tasks; t < &emu_tasks[MP_ARRAY_SIZE(emu_tasks)]; t++) {

--- a/esp8266/modmachine.c
+++ b/esp8266/modmachine.c
@@ -34,6 +34,7 @@
 #include "modpyb.h"
 #include "modpybrtc.h"
 
+#include "xtirq.h"
 #include "os_type.h"
 #include "osapi.h"
 #include "etshal.h"
@@ -189,6 +190,17 @@ const mp_obj_type_t esp_timer_type = {
     .locals_dict = (mp_obj_t)&esp_timer_locals_dict,
 };
 
+STATIC mp_obj_t machine_disable_irq(void) {
+    return mp_obj_new_int(disable_irq());
+}
+MP_DEFINE_CONST_FUN_OBJ_0(machine_disable_irq_obj, machine_disable_irq);
+
+STATIC mp_obj_t machine_enable_irq(mp_obj_t state) {
+    enable_irq(mp_obj_get_int(state));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(machine_enable_irq_obj, machine_enable_irq);
+
 STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_umachine) },
     { MP_ROM_QSTR(MP_QSTR_mem8), MP_ROM_PTR(&machine_mem8_obj) },
@@ -200,6 +212,9 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_reset_cause), MP_ROM_PTR(&machine_reset_cause_obj) },
     { MP_ROM_QSTR(MP_QSTR_unique_id), MP_ROM_PTR(&machine_unique_id_obj) },
     { MP_ROM_QSTR(MP_QSTR_deepsleep), MP_ROM_PTR(&machine_deepsleep_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_disable_irq), MP_ROM_PTR(&machine_disable_irq_obj) },
+    { MP_ROM_QSTR(MP_QSTR_enable_irq), MP_ROM_PTR(&machine_enable_irq_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_RTC), MP_ROM_PTR(&pyb_rtc_type) },
     { MP_ROM_QSTR(MP_QSTR_Timer), MP_ROM_PTR(&esp_timer_type) },

--- a/esp8266/xtirq.h
+++ b/esp8266/xtirq.h
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef __MICROPY_INCLUDED_ESP8266_XTIRQ_H__
+#define __MICROPY_INCLUDED_ESP8266_XTIRQ_H__
+
+#include <stdint.h>
+
+// returns the value of "intlevel" from the PS register
+static inline uint32_t query_irq(void) {
+    uint32_t ps;
+    __asm__ volatile("rsr %0, ps" : "=a" (ps));
+    return ps & 0xf;
+}
+
+// irqs with a priority value lower or equal to "intlevel" will be disabled
+// "intlevel" should be between 0 and 15 inclusive, and should be an integer
+static inline uint32_t raise_irq_pri(uint32_t intlevel) {
+    uint32_t old_ps;
+    __asm__ volatile ("rsil %0, %1" : "=a" (old_ps) : "I" (intlevel));
+    return old_ps;
+}
+
+// "ps" should be the value returned from raise_irq_pri
+static inline void restore_irq_pri(uint32_t ps) {
+    __asm__ volatile ("wsr %0, ps; rsync" :: "a" (ps));
+}
+
+static inline uint32_t disable_irq(void) {
+    return raise_irq_pri(15);
+}
+
+static inline void enable_irq(uint32_t irq_state) {
+    restore_irq_pri(irq_state);
+}
+
+#endif // __MICROPY_INCLUDED_ESP8266_XTIRQ_H__


### PR DESCRIPTION
Here is an attempt at implementing the functions to control irqs.  The idea is that with irqs disabled everything is quiet and timing is predictable.  Hence the need to disable the ets_loop_iter code when irqs are disabled.

Because irqs may already be disabled when you use these functions the correct usage pattern is:

```
    irq_state = machine.disable_irq()
    # do stuff
    machine.enable_irq(irq_state)
```

But, if we were willing to change the machine API, we could actually do it all with only 1 function, ie:

```
    irq_state = machine.irq_active(False)
    # do stuff
    machine.irq_active(irq_state)
```

(And in a more general case you'd have irq priority levels and be able to raise/lower the levels, eg using machine.irq_priority.)

I guess this is all up for discussion, so this is just a starting point to kick such a discussion off.

See #2050.  And note the suggestion there to have a context manager to control irqs (instead of always having to write a try: finally: block).
