### PR TITLE
py: Fix build problem with coverage

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -821,7 +821,7 @@ STATIC mp_obj_t str_rstrip(size_t n_args, const mp_obj_t *args) {
 STATIC mp_obj_t str_center(mp_obj_t str_in, mp_obj_t width_in) {
     GET_STR_DATA_LEN(str_in, str, str_len);
     int width = mp_obj_get_int(width_in);
-    if (str_len >= width) {
+    if ((int)str_len >= width) {
         return str_in;
     }
 


### PR DESCRIPTION
The GET_STR_DATA_LEN macro creates a size_t variable which causes this error when building the unix coverage build:

```
CC ../py/objstr.c
../py/objstr.c: In function ‘str_center’:
../py/objstr.c:824:17: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     if (str_len >= width) {
                 ^
```

Adding the cast resolves this.
