### PR TITLE
py/objnamedtuple: Allow passing field names as a tuple.

### DIFF
--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -165,10 +165,7 @@ STATIC mp_obj_t new_namedtuple_type(mp_obj_t name_in, mp_obj_t fields_in) {
         fields_in = mp_obj_str_split(1, &fields_in);
     }
     #endif
-    if (!MP_OBJ_IS_TYPE(fields_in, &mp_type_list)) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_TypeError, "list required"));
-    }
-    mp_obj_list_get(fields_in, &n_fields, &fields);
+    mp_obj_get_array(fields_in, &n_fields, &fields);
     return mp_obj_new_namedtuple_type(name, n_fields, fields);
 }
 MP_DEFINE_CONST_FUN_OBJ_2(mp_namedtuple_obj, new_namedtuple_type);

--- a/tests/basics/namedtuple1.py
+++ b/tests/basics/namedtuple1.py
@@ -62,8 +62,13 @@ except TypeError:
     print("TypeError")
 
 # Try single string
-T3 = namedtuple("TupComma", "foo bar")
+T3 = namedtuple("TupString", "foo bar")
 t = T3(1, 2)
+print(t.foo, t.bar)
+
+# Try tuple
+T4 = namedtuple("TupTuple", ("foo",  "bar"))
+t = T4(1, 2)
 print(t.foo, t.bar)
 
 # Try single string with comma field seperator


### PR DESCRIPTION
Trying to create a namedtuple based on the [documentation](http://docs.micropython.org/en/latest/pyboard/library/ucollections.html) fails.
Currently named tuple accepts only strings or lists for fields.
This PR adds the option to pass field names as a tuple.
