### PR TITLE
py/builtinimport.c: Fix compile error during DEBUG=1 builds

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -211,14 +211,14 @@ STATIC void do_load(mp_obj_t module_obj, vstr_t *file) {
         void *modref;
         #if MICROPY_MODULE_FROZEN
         int frozen_type = mp_find_frozen_module(file_str, file->len, &modref);
-        #else
-        int frozen_type = MP_FROZEN_NONE;
-        #endif
         #if MICROPY_PERSISTENT_CODE_LOAD || MICROPY_MODULE_FROZEN_MPY
         if (frozen_type == MP_FROZEN_MPY) {
             do_execute_raw_code(module_obj, modref);
             return;
         }
+        #endif
+        #else
+        int frozen_type = MP_FROZEN_NONE;
         #endif
         if (frozen_type == MP_FROZEN_NONE) {
             modref = mp_lexer_new_from_file(file_str);


### PR DESCRIPTION
This patch moves a few lines of. Without it, the following error
is seen when doing a DEBUG=1 build for the PYBV10 board.

```
CC ../py/builtinimport.c
../py/builtinimport.c: In function 'do_load':
../py/builtinimport.c:219:13: error: 'modref' may be used uninitialized in this function [-Werror=maybe-uninitialized]
             do_execute_raw_code(module_obj, modref);
             ^
```
