### PR TITLE
esp8266: Add stat(), chdir() and rmdir() to module uos and vfs

### DIFF
--- a/esp8266/moduos.c
+++ b/esp8266/moduos.c
@@ -38,6 +38,7 @@
 #include "esp_mphal.h"
 #include "user_interface.h"
 
+
 extern const mp_obj_type_t mp_fat_vfs_type;
 
 STATIC const qstr os_uname_info_fields[] = {
@@ -93,6 +94,11 @@ STATIC mp_obj_t os_mkdir(mp_obj_t path_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_mkdir_obj, os_mkdir);
 
+STATIC mp_obj_t os_chdir(mp_obj_t path_in) {
+    return vfs_proxy_call(MP_QSTR_chdir, 1, &path_in);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_chdir_obj, os_chdir);
+
 STATIC mp_obj_t os_remove(mp_obj_t path_in) {
     return vfs_proxy_call(MP_QSTR_remove, 1, &path_in);
 }
@@ -106,6 +112,10 @@ STATIC mp_obj_t os_rename(mp_obj_t path_old, mp_obj_t path_new) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(os_rename_obj, os_rename);
 
+STATIC mp_obj_t os_stat(mp_obj_t path_in) {
+    return vfs_proxy_call(MP_QSTR_stat, 1, &path_in);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_stat_obj, os_stat);
 #endif
 
 STATIC mp_obj_t os_urandom(mp_obj_t num) {
@@ -138,8 +148,11 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_VfsFat), MP_ROM_PTR(&mp_fat_vfs_type) },
     { MP_ROM_QSTR(MP_QSTR_listdir), MP_ROM_PTR(&os_listdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_mkdir), MP_ROM_PTR(&os_mkdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_chdir), MP_ROM_PTR(&os_chdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&os_remove_obj) },
+    { MP_ROM_QSTR(MP_QSTR_rmdir), MP_ROM_PTR(&os_remove_obj) },
     { MP_ROM_QSTR(MP_QSTR_rename), MP_ROM_PTR(&os_rename_obj) },
+    { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&os_stat_obj) },
     #endif
 };
 

--- a/esp8266/moduos.c
+++ b/esp8266/moduos.c
@@ -38,7 +38,6 @@
 #include "esp_mphal.h"
 #include "user_interface.h"
 
-
 extern const mp_obj_type_t mp_fat_vfs_type;
 
 STATIC const qstr os_uname_info_fields[] = {

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -34,7 +34,6 @@
 #include "lib/fatfs/diskio.h"
 #include "extmod/vfs_fat_file.h"
 #include "extmod/fsusermount.h"
-
 #include "timeutils.h"
 
 
@@ -139,7 +138,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_chdir_obj, fat_vfs_chdir);
 //   path_equal(/, /) -> true
 // second argument must be in canonical form (meaning no trailing slash, unless it's just /)
 STATIC bool path_equal(const char *path, const char *path_canonical) {
-    for (; *path_canonical != '\0' && *path == *path_canonical; ++path, ++path_canonical) {
+    while (*path_canonical != '\0' && *path == *path_canonical) {
+        ++path;
+        ++path_canonical;
     }
     if (*path_canonical != '\0') {
         return false;

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -35,6 +35,9 @@
 #include "extmod/vfs_fat_file.h"
 #include "extmod/fsusermount.h"
 
+#include "timeutils.h"
+
+
 #define mp_obj_fat_vfs_t fs_user_mount_t
 
 STATIC mp_obj_t fat_vfs_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
@@ -83,8 +86,8 @@ STATIC mp_obj_t fat_vfs_remove(mp_obj_t vfs_in, mp_obj_t path_in) {
         case FR_OK:
             return mp_const_none;
         default:
-            // TODO: standard errno's
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "Error removing file '%s'", path));
+            nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError,
+                MP_OBJ_NEW_SMALL_INT(fresult_to_errno_table[res])));
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_remove_obj, fat_vfs_remove);
@@ -94,11 +97,11 @@ STATIC mp_obj_t fat_vfs_rename(mp_obj_t vfs_in, mp_obj_t path_in, mp_obj_t path_
     const char *old_path = mp_obj_str_get_str(path_in);
     const char *new_path = mp_obj_str_get_str(path_out);
     FRESULT res = f_rename(old_path, new_path);
-    switch (res) {
-        case FR_OK:
-            return mp_const_none;
-        default:
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "Error renaming file '%s' to '%s'", old_path, new_path));
+    if (res == FR_OK) {
+        return mp_const_none;
+    } else {
+        nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError,
+            MP_OBJ_NEW_SMALL_INT(fresult_to_errno_table[res])));
     }
 
 }
@@ -111,22 +114,123 @@ STATIC mp_obj_t fat_vfs_mkdir(mp_obj_t vfs_in, mp_obj_t path_o) {
     switch (res) {
         case FR_OK:
             return mp_const_none;
-        case FR_EXIST:
-            // TODO should be FileExistsError
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "File exists: '%s'", path));
         default:
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "Error creating directory '%s'", path));
+            nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError,
+                MP_OBJ_NEW_SMALL_INT(fresult_to_errno_table[res])));
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_mkdir_obj, fat_vfs_mkdir);
+
+STATIC mp_obj_t fat_vfs_chdir(mp_obj_t vfs_in, mp_obj_t path_o) {
+    (void)vfs_in;
+    const char *path = mp_obj_str_get_str(path_o);
+    FRESULT res = f_chdir(path);
+    switch (res) {
+        case FR_OK:
+            return mp_const_none;
+        default:
+            nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError,
+                MP_OBJ_NEW_SMALL_INT(fresult_to_errno_table[res])));
+    }
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_chdir_obj, fat_vfs_chdir);
+
+// Checks for path equality, ignoring trailing slashes:
+//   path_equal(/, /) -> true
+// second argument must be in canonical form (meaning no trailing slash, unless it's just /)
+STATIC bool path_equal(const char *path, const char *path_canonical) {
+    for (; *path_canonical != '\0' && *path == *path_canonical; ++path, ++path_canonical) {
+    }
+    if (*path_canonical != '\0') {
+        return false;
+    }
+    for (; *path == '/'; ++path) {
+    }
+    return *path == '\0';
+}
+
+/// \function stat(path)
+/// Get the status of a file or directory.
+STATIC mp_obj_t fat_vfs_stat(mp_obj_t vfs_in, mp_obj_t path_in) {
+    const char *path = mp_obj_str_get_str(path_in);
+
+    FILINFO fno;
+#if _USE_LFN
+    fno.lfname = NULL;
+    fno.lfsize = 0;
+#endif
+
+    FRESULT res;
+    if (path_equal(path, "/")) {
+        // stat root directory
+	fno.fsize = 0;
+	fno.fdate = 0;
+	fno.ftime = 0;
+	fno.fattrib = AM_DIR;
+    } else {
+        res = FR_NO_PATH;
+        for (size_t i = 0; i < MP_ARRAY_SIZE(MP_STATE_PORT(fs_user_mount)); ++i) {
+            fs_user_mount_t *vfs = MP_STATE_PORT(fs_user_mount)[i];
+            if (vfs != NULL && path_equal(path, vfs->str)) {
+                // stat mounted device directory
+                fno.fsize = 0;
+                fno.fdate = 0;
+                fno.ftime = 0;
+                fno.fattrib = AM_DIR;
+                res = FR_OK;
+            }
+        }
+        if (res == FR_NO_PATH) {
+            // stat normal file
+            res = f_stat(path, &fno);
+        }
+        if (res != FR_OK) {
+            nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError,
+                MP_OBJ_NEW_SMALL_INT(fresult_to_errno_table[res])));
+        }
+    }
+
+    mp_obj_tuple_t *t = mp_obj_new_tuple(10, NULL);
+    mp_int_t mode = 0;
+    if (fno.fattrib & AM_DIR) {
+        mode |= 0x4000; // stat.S_IFDIR
+    } else {
+        mode |= 0x8000; // stat.S_IFREG
+    }
+    mp_int_t seconds = timeutils_seconds_since_2000(
+        1980 + ((fno.fdate >> 9) & 0x7f),
+        (fno.fdate >> 5) & 0x0f,
+        fno.fdate & 0x1f,
+        (fno.ftime >> 11) & 0x1f,
+        (fno.ftime >> 5) & 0x3f,
+        2 * (fno.ftime & 0x1f)
+    );
+    t->items[0] = MP_OBJ_NEW_SMALL_INT(mode); // st_mode
+    t->items[1] = MP_OBJ_NEW_SMALL_INT(0); // st_ino
+    t->items[2] = MP_OBJ_NEW_SMALL_INT(0); // st_dev
+    t->items[3] = MP_OBJ_NEW_SMALL_INT(0); // st_nlink
+    t->items[4] = MP_OBJ_NEW_SMALL_INT(0); // st_uid
+    t->items[5] = MP_OBJ_NEW_SMALL_INT(0); // st_gid
+    t->items[6] = MP_OBJ_NEW_SMALL_INT(fno.fsize); // st_size
+    t->items[7] = MP_OBJ_NEW_SMALL_INT(seconds); // st_atime
+    t->items[8] = MP_OBJ_NEW_SMALL_INT(seconds); // st_mtime
+    t->items[9] = MP_OBJ_NEW_SMALL_INT(seconds); // st_ctime
+
+    return t;
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_stat_obj, fat_vfs_stat);
 
 STATIC const mp_rom_map_elem_t fat_vfs_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_mkfs), MP_ROM_PTR(&fat_vfs_mkfs_obj) },
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&fat_vfs_open_obj) },
     { MP_ROM_QSTR(MP_QSTR_listdir), MP_ROM_PTR(&fat_vfs_listdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_mkdir), MP_ROM_PTR(&fat_vfs_mkdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_chdir), MP_ROM_PTR(&fat_vfs_chdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&fat_vfs_remove_obj) },
+    { MP_ROM_QSTR(MP_QSTR_rmdir), MP_ROM_PTR(&fat_vfs_remove_obj) },
     { MP_ROM_QSTR(MP_QSTR_rename), MP_ROM_PTR(&fat_vfs_rename_obj) },
+    { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&fat_vfs_stat_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(fat_vfs_locals_dict, fat_vfs_locals_dict_table);
 

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -219,7 +219,7 @@ STATIC mp_obj_t fat_vfs_stat(mp_obj_t vfs_in, mp_obj_t path_in) {
     t->items[8] = MP_OBJ_NEW_SMALL_INT(seconds); // st_mtime
     t->items[9] = MP_OBJ_NEW_SMALL_INT(seconds); // st_ctime
 
-    return t;
+    return (mp_obj_t)t;
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_stat_obj, fat_vfs_stat);

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -154,6 +154,7 @@ STATIC bool path_equal(const char *path, const char *path_canonical) {
 /// \function stat(path)
 /// Get the status of a file or directory.
 STATIC mp_obj_t fat_vfs_stat(mp_obj_t vfs_in, mp_obj_t path_in) {
+    (void)vfs_in;
     const char *path = mp_obj_str_get_str(path_in);
 
     FILINFO fno;
@@ -192,7 +193,7 @@ STATIC mp_obj_t fat_vfs_stat(mp_obj_t vfs_in, mp_obj_t path_in) {
         }
     }
 
-    mp_obj_tuple_t *t = mp_obj_new_tuple(10, NULL);
+    mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(10, NULL));
     mp_int_t mode = 0;
     if (fno.fattrib & AM_DIR) {
         mode |= 0x4000; // stat.S_IFDIR

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -145,7 +145,8 @@ STATIC bool path_equal(const char *path, const char *path_canonical) {
     if (*path_canonical != '\0') {
         return false;
     }
-    for (; *path == '/'; ++path) {
+    while (*path == '/') {
+        ++path;
     }
     return *path == '\0';
 }

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -15,6 +15,7 @@ include ../py/py.mk
 
 INC +=  -I.
 INC +=  -I..
+INC += -I../lib/timeutils
 INC += -I$(BUILD)
 
 # compiler settings
@@ -160,6 +161,7 @@ endif
 
 LIB_SRC_C = $(addprefix lib/,\
 	$(LIB_SRC_C_EXTRA) \
+	timeutils/timeutils.c \
 	utils/printf.c \
 	fatfs/ff.c \
 	fatfs/option/ccsbcs.c \


### PR DESCRIPTION
```
esp8266/moduos.c:
    added proxy stubs for stat() and chdir(), and an alias for rmdir()
extmod/vfs_fat.c:
    - added the functions fo stat() and chdir() and an alias for rmdir()
    - replaced the text error messages by the Posix error numbers using
      the mechanism already provided
```
