### PR TITLE
Add pkg-config file for micropython library

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -217,15 +217,25 @@ BINDIR = $(PREFIX)/bin
 PIPSRC = ../tools/pip-micropython
 PIPTARGET = pip-micropython
 
-install: micropython
+micropython.pc: micropython.pc.in
+	$(eval VERSION := $(shell grep -Po 'VERSION_STRING "\K.*[^"]' build/genhdr/mpversion.h))
+	sed -e 's![@]prefix[@]!$(PREFIX)!g' \
+		-e 's![@]version[@]!$(VERSION)!g' \
+ 		micropython.pc.in > $@
+
+install: micropython lib micropython.pc
 	install -d $(BINDIR)
 	install $(TARGET) $(BINDIR)/$(TARGET)
 	install $(PIPSRC) $(BINDIR)/$(PIPTARGET)
+	install -D micropython.pc $(PREFIX)/lib/pkgconfig
+	install libmicropython.a $(PREFIX)/lib
 
 # uninstall micropython
 uninstall:
 	-rm $(BINDIR)/$(TARGET)
 	-rm $(BINDIR)/$(PIPTARGET)
+	-rm $(PREFIX)/lib/pkgconfig/micropython.pc 
+	-rm $(PREFIX)/lib/libmicropython.a
 
 # build synthetically fast interpreter for benchmarking
 fast:

--- a/unix/micropython.pc.in
+++ b/unix/micropython.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=${prefix}  
+libdir=${exec_prefix}/lib
+includedir=${prefix}/micropython/include
+
+Name: micropython
+Description: Lightweight python implementation
+Version: @version@
+Libs: -lmicropython
+Cflags: -I${includedir}
+


### PR DESCRIPTION
Build and install library and pkg-config file on `make install`

Allows one to keep separate micropython and ones own code when embedding micropython on unix. 
