### PR TITLE
ntptime: support different ntp hosts

### DIFF
--- a/esp8266/scripts/ntptime.py
+++ b/esp8266/scripts/ntptime.py
@@ -10,10 +10,10 @@ except:
 # (date(2000, 1, 1) - date(1900, 1, 1)).days * 24*60*60
 NTP_DELTA = 3155673600
 
-def time():
+def time(host):
     NTP_QUERY = bytearray(48)
     NTP_QUERY[0] = 0x1b
-    addr = socket.getaddrinfo('pool.ntp.org', 123)[0][-1]
+    addr = socket.getaddrinfo(host, 123)[0][-1]
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(1)
     res = s.sendto(NTP_QUERY, addr)
@@ -24,8 +24,8 @@ def time():
 
 # There's currently no timezone support in MicroPython, so
 # utime.localtime() will return UTC time (as if it was .gmtime())
-def settime():
-    t = time()
+def settime(host='pool.ntp.org'):
+    t = time(host)
     import machine
     import utime
     tm = utime.localtime(t)

--- a/esp8266/scripts/ntptime.py
+++ b/esp8266/scripts/ntptime.py
@@ -10,10 +10,12 @@ except:
 # (date(2000, 1, 1) - date(1900, 1, 1)).days * 24*60*60
 NTP_DELTA = 3155673600
 
-def time(host):
+host='pool.ntp.org'
+
+def time(host_=None):
     NTP_QUERY = bytearray(48)
     NTP_QUERY[0] = 0x1b
-    addr = socket.getaddrinfo(host, 123)[0][-1]
+    addr = socket.getaddrinfo(host_ or host, 123)[0][-1]
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(1)
     res = s.sendto(NTP_QUERY, addr)
@@ -24,8 +26,8 @@ def time(host):
 
 # There's currently no timezone support in MicroPython, so
 # utime.localtime() will return UTC time (as if it was .gmtime())
-def settime(host='pool.ntp.org'):
-    t = time(host)
+def settime(host_=None):
+    t = time(host_)
     import machine
     import utime
     tm = utime.localtime(t)


### PR DESCRIPTION
This is useful to choose other area specific ntp pools or a local ntp server (e.g., a router).
