### PR TITLE
Add embeddable MicroPython component

### DIFF
--- a/embed/Makefile
+++ b/embed/Makefile
@@ -1,0 +1,274 @@
+ECHO = @echo
+RM = rm
+MKDIR = mkdir
+PYTHON = python
+TRANSFORM = transform.py
+AMALGAMATE = amalgamate.py
+
+BUILD = build
+HEADER_BUILD = $(BUILD)/genhdr
+
+PY_SRC = ../py
+
+TR_SRC_PY_H = $(addprefix $(BUILD)/py/,\
+	mpconfig.h \
+	misc.h \
+	mpprint.h \
+	nlr.h \
+	qstr.h \
+	obj.h \
+	objlist.h \
+	objtuple.h \
+	objexcept.h \
+	mpstate.h \
+	mpz.h \
+	runtime0.h \
+	lexer.h \
+	parse.h \
+	compile.h \
+	emitglue.h \
+	runtime.h \
+	builtin.h \
+	repl.h \
+	gc.h \
+	stackctrl.h \
+	stream.h \
+	binary.h \
+	objint.h \
+	formatfloat.h \
+	unicode.h \
+	parsenum.h \
+        smallint.h \
+	scope.h \
+	emit.h \
+	bc0.h \
+	bc.h \
+	objstr.h \
+	objmodule.h \
+	objgenerator.h \
+	frozenmod.h \
+	objfun.h \
+	objtype.h \
+	parsenumbase.h \
+	mperrno.h \
+	mphal.h \
+	ringbuf.h \
+	)
+
+TR_SRC_PY_C = $(addprefix $(BUILD)/py/,\
+	malloc.c \
+	qstr.c \
+	mpprint.c \
+	vstr.c \
+	unicode.c \
+	mpz.c \
+	gc.c \
+	nlrsetjmp.c \
+	lexer.c \
+	lexerstr.c \
+	lexerunix.c \
+	parse.c \
+	scope.c \
+	emitcommon.c \
+	emitbc.c \
+	compile.c \
+	formatfloat.c \
+	parsenumbase.c \
+	parsenum.c \
+	emitglue.c \
+	runtime.c \
+	nativeglue.c \
+	stackctrl.c \
+	argcheck.c \
+	warning.c \
+	map.c \
+	opmethods.c \
+	sequence.c \
+	stream.c \
+	binary.c \
+	builtinimport.c \
+	builtinevex.c \
+	obj.c \
+	objattrtuple.c \
+	objarray.c \
+	objbool.c \
+	objboundmeth.c \
+	objcell.c \
+	objclosure.c \
+	objcomplex.c \
+	objdict.c \
+	objenumerate.c \
+	objexcept.c \
+	objfilter.c \
+	objfloat.c \
+	objfun.c \
+	objgenerator.c \
+	objgetitemiter.c \
+	objint.c \
+	objint_longlong.c \
+	objint_mpz.c \
+	objlist.c \
+	objmap.c \
+	objmodule.c \
+	objobject.c \
+	objpolyiter.c \
+	objproperty.c \
+	objnone.c \
+	objnamedtuple.c \
+	objrange.c \
+	objreversed.c \
+	objset.c \
+	objsingleton.c \
+	objslice.c \
+	objstr.c \
+	objstrunicode.c \
+	objstringio.c \
+	objtuple.c \
+	objtype.c \
+	objzip.c \
+	modarray.c \
+	modbuiltins.c \
+	modcollections.c \
+	modgc.c \
+	modio.c \
+	modmath.c \
+	modcmath.c \
+	modmicropython.c \
+	modstruct.c \
+	modsys.c \
+	bc.c \
+	vm.c \
+	showbc.c \
+	repl.c \
+	smallint.c \
+	frozenmod.c \
+	)
+
+TR_SRC_EXTMOD_H = $(addprefix $(BUILD)/extmod/,\
+	modubinascii.h \
+	)
+
+TR_SRC_EXTMOD_C = $(addprefix $(BUILD)/extmod/,\
+	moductypes.c \
+	modujson.c \
+	modure.c \
+	moduheapq.c \
+	moduhashlib.c \
+	modubinascii.c \
+	)
+
+#	py/mpstate.c \
+	py/nlrx86.c \
+	py/nlrx64.c \
+	py/nlrthumb.c \
+	py/nlrxtensa.c \
+	py/asmx64.c \
+	py/emitnx64.c \
+	py/asmx86.c \
+	py/emitnx86.c \
+	py/asmthumb.c \
+	py/emitnthumb.c \
+	py/asmarm.c \
+	py/emitnarm.c \
+	py/emitinlinethumb.c \
+
+TR_SRC_GENHDR_H = $(addprefix $(HEADER_BUILD)/,\
+	mpversion.h \
+	qstrdefs.generated.h \
+	)
+
+QSTR_DEFS = ../py/qstrdefs.h
+SRC_QSTR = $(TR_SRC_PY_H) $(TR_SRC_PY_C) $(TR_SRC_EXTMOD_H) $(TR_SRC_EXTMOD_C)
+
+TR_SRC_H = $(TR_SRC_PY_H) $(BUILD)/py/grammar.h $(BUILD)/py/vmentrytable.h $(TR_SRC_EXTMOD_H) $(TR_SRC_GENHDR_H)
+TR_SRC_C = $(TR_SRC_PY_C) $(TR_SRC_EXTMOD_C)
+
+ifeq ("$(origin V)", "command line")
+    BUILD_VERBOSE=$(V)
+endif
+ifndef BUILD_VERBOSE
+    BUILD_VERBOSE = 0
+endif
+ifeq ($(BUILD_VERBOSE),0)
+    $(info Use make V=1 or set BUILD_VERBOSE to increase build verbosity.)
+    Q = @
+else
+    Q =
+endif
+
+.PHONY: all clean source amalgamation FORCE
+
+all: embed
+
+# Anything that depends on FORCE will be considered out-of-date
+FORCE:
+
+py extmod genhdr:
+	$(Q)$(MKDIR) -p $(BUILD)/$@
+
+$(BUILD)/py/%.c: ../py/%.c $(TRANSFORM) | py
+	$(ECHO) "TR $<"
+	$(Q)python $(TRANSFORM) $< > $@
+
+$(BUILD)/py/%.h: ../py/%.h $(TRANSFORM) | py
+	$(ECHO) "TR $<"
+	$(Q) python $(TRANSFORM) $< > $@
+
+$(BUILD)/extmod/%.c: ../extmod/%.c $(TRANSFORM) | extmod
+	$(ECHO) "TR $<"
+	$(Q) python $(TRANSFORM) $< > $@
+
+$(BUILD)/extmod/%.h: ../extmod/%.h $(TRANSFORM) | extmod
+	$(ECHO) "TR $<"
+	$(Q) python $(TRANSFORM) $< > $@
+
+$(HEADER_BUILD)/mpversion.h: FORCE | genhdr
+	$(Q)$(PYTHON) ../py/makeversionhdr.py $@
+
+$(HEADER_BUILD)/qstrdefs.generated.h: $(QSTR_DEFS) $(SRC_QSTR) | genhdr
+	$(ECHO) "GEN $@"
+	$(Q)cat $(SRC_QSTR) > $(HEADER_BUILD)/abc
+	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdefs.py filter $(HEADER_BUILD)/abc $(HEADER_BUILD) $(HEADER_BUILD)/def
+	$(Q)echo "QCFG(BYTES_IN_LEN, (1))" > $(HEADER_BUILD)/geh
+	$(Q)echo "QCFG(BYTES_IN_HASH, (2))" >> $(HEADER_BUILD)/geh
+	$(Q)grep "^Q(" $(QSTR_DEFS) >> $(HEADER_BUILD)/geh
+	$(Q)cat $(HEADER_BUILD)/def >> $(HEADER_BUILD)/geh
+	$(Q)$(PYTHON) $(PY_SRC)/makeqstrdata.py $(HEADER_BUILD)/geh > $@
+
+source: $(TR_SRC_H) $(TR_SRC_C)
+
+amalgamation: upy.h upy.c
+
+upy.h: $(TR_SRC_H) util.h
+	$(ECHO) "GEN $@"
+	$(Q)echo '#define MP_CONFIGFILE "mpconfigport.h"' > upy.h
+	$(Q)echo '#include <stdarg.h>' >> upy.h
+	$(Q)echo '#define MICROPY_QSTR_BYTES_IN_LEN (1)' >> upy.h
+	$(Q)echo '#define MICROPY_QSTR_BYTES_IN_HASH (2)' >> upy.h
+	$(Q)echo '#define MP_SSIZE_MAX (0x7fffffff)' >> upy.h
+	$(Q)cat $(TR_SRC_PY_H) $(TR_SRC_EXTMOD_H) | python $(AMALGAMATE) >> upy.h
+	$(Q)cat util.h >> upy.h
+
+upy.c: $(TR_SRC_H) $(TR_SRC_C) util.c
+	$(ECHO) "GEN $@"
+	$(Q)echo '#include "upy.h"' > upy.c
+	$(Q)cat $(TR_SRC_PY_C) $(TR_SRC_EXTMOD_C) | python $(AMALGAMATE) >> upy.c
+	$(Q)cat util.c >> upy.c
+
+upy.o: upy.c upy.h
+	$(ECHO) "CC $<"
+	$(Q)$(CC) -Os -Wall -c $<
+
+libmicropython.a: upy.o
+	$(ECHO) "AR $@"
+	$(Q)$(AR) rc $@ $^
+
+embed: embed.c libmicropython.a
+	$(ECHO) "BUILD $@"
+	$(Q)$(CC) embed.c -lm -lmicropython -L. -o $@
+
+clean:
+	$(RM) -rf $(BUILD)
+	$(RM) -rf upy.c upy.h upy.o
+	$(RM) -rf libmicropython.a
+	$(RM) -rf embed

--- a/embed/amalgamate.py
+++ b/embed/amalgamate.py
@@ -1,0 +1,59 @@
+import sys
+
+grammar = None
+re15 = None
+log = False
+build_dir = 'build'
+
+verbatim_files = {
+    '#include "genhdr/qstrdefs.generated.h"\n': ['genhdr/qstrdefs.generated.h', None],
+    '#include "genhdr/mpversion.h"\n': ['genhdr/mpversion.h', None],
+    '#include "py/grammar.h"\n': ['py/grammar.h', None],
+    '    #include "py/vmentrytable.h"\n': ['py/vmentrytable.h', None],
+    '#include "re1.5/re1.5.h"\n': ['../extmod/re1.5/re1.5.h', None],
+    '#include "re1.5/compilecode.c"\n': ['../extmod/re1.5/compilecode.c', None],
+    '#include "re1.5/dumpcode.c"\n': ['../extmod/re1.5/dumpcode.c', None],
+    '#include "re1.5/recursiveloop.c"\n': ['../extmod/re1.5/recursiveloop.c', None],
+    '#include "re1.5/charclass.c"\n': ['../extmod/re1.5/charclass.c', None],
+    '#include "crypto-algorithms/sha256.h"\n': ['../extmod/crypto-algorithms/sha256.h', None],
+    '#include "crypto-algorithms/sha256.c"\n': ['../extmod/crypto-algorithms/sha256.c', None],
+}
+
+for line in sys.stdin:
+    if line in verbatim_files:
+        vf = verbatim_files[line]
+        if vf[1] is None:
+            vf_filename = vf[0]
+            if not vf_filename.startswith('..'):
+                vf_filename = build_dir + '/' + vf_filename
+            with open(vf_filename) as f:
+                ls = []
+                for l in f:
+                    if l.startswith('#define EMIT('):
+                        ls.append('#undef EMIT\n')
+                        ls.append(l)
+                    elif not l.startswith('#include'):
+                        ls.append(l)
+                vf[1] = ''.join(ls)
+        sys.stdout.write(vf[1])
+    elif line.startswith('#include "py/'):
+        sys.stdout.write('//' + line)
+    elif line.startswith('#include "extmod/'):
+        sys.stdout.write('//' + line)
+    elif line == '#include <mphalport.h>\n':
+        sys.stdout.write('//' + line)
+    elif line == '#include <mpconfigport.h>\n':
+        sys.stdout.write('#include "mpconfigport.h"\n')
+    elif line.startswith('#define DIG_MASK '):
+        sys.stdout.write('#undef DIG_MASK\n')
+        sys.stdout.write(line)
+    elif line == 'STATIC const uint8_t log_base2_floor[] = {\n':
+        if log:
+            for l in sys.stdin:
+                if l == '};\n':
+                    break
+        else:
+            sys.stdout.write(line)
+            log = True
+    else:
+        sys.stdout.write(line)

--- a/embed/embed.c
+++ b/embed/embed.c
@@ -1,0 +1,17 @@
+// demo embedding MicroPython into a C program
+
+#include "upy.h"
+
+static uint8_t heap0[64*1024];
+static uint8_t heap1[32*1024];
+
+int main(int argc, char **argv) {
+    mp_state_ctx_t *mp0 = micropy_create(heap0, sizeof(heap0));
+    mp_state_ctx_t *mp1 = micropy_create(heap1, sizeof(heap1));
+    micropy_exec_str(mp0, "print([x + 1 for x in range(10)])\nx=1");
+    micropy_exec_str(mp0, "print(globals())\n");
+    micropy_exec_str(mp1, "try: print(x)\nexcept: print('x not defined')");
+    micropy_destroy(mp0);
+    micropy_destroy(mp1);
+    return 0;
+}

--- a/embed/mpconfigport.h
+++ b/embed/mpconfigport.h
@@ -1,0 +1,129 @@
+#include <stdint.h>
+
+// options to control how Micro Python is built
+
+#define MICROPY_ALLOC_PATH_MAX      (256)
+#define MICROPY_NLR_SETJMP          (1)
+#define MICROPY_EMIT_X64            (0)
+#define MICROPY_EMIT_THUMB          (0)
+#define MICROPY_EMIT_INLINE_THUMB   (0)
+#define MICROPY_COMP_MODULE_CONST   (0)
+#define MICROPY_COMP_CONST          (0)
+#define MICROPY_COMP_DOUBLE_TUPLE_ASSIGN (0)
+#define MICROPY_COMP_TRIPLE_TUPLE_ASSIGN (0)
+#define MICROPY_ENABLE_GC           (1)
+#define MICROPY_ENABLE_FINALISER    (1)
+#define MICROPY_STACK_CHECK         (1)
+#define MICROPY_MALLOC_USES_ALLOCATED_SIZE (0)
+#define MICROPY_MEM_STATS           (0)
+#define MICROPY_DEBUG_PRINTERS      (0)
+#define MICROPY_REPL_EVENT_DRIVEN   (0)
+#define MICROPY_HELPER_REPL         (1)
+#define MICROPY_HELPER_LEXER_UNIX   (1)
+#define MICROPY_ENABLE_SOURCE_LINE  (1)
+#define MICROPY_ENABLE_DOC_STRING   (0)
+#define MICROPY_ERROR_REPORTING     (MICROPY_ERROR_REPORTING_NORMAL)
+#define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_MPZ)
+#define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_DOUBLE)
+#define MICROPY_OPT_COMPUTED_GOTO   (1)
+#define MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE (1)
+#define MICROPY_CPYTHON_COMPAT      (1)
+#define MICROPY_PY_FUNCTION_ATTRS   (1)
+#define MICROPY_PY_DESCRIPTORS      (1)
+#define MICROPY_PY_BUILTINS_STR_UNICODE (1)
+#define MICROPY_PY_BUILTINS_STR_SPLITLINES (1)
+#define MICROPY_PY_BUILTINS_BYTEARRAY (1)
+#define MICROPY_PY_BUILTINS_MEMORYVIEW (1)
+#define MICROPY_PY_BUILTINS_FROZENSET (1)
+#define MICROPY_PY_BUILTINS_COMPILE (1)
+#define MICROPY_PY_BUILTINS_SET     (1)
+#define MICROPY_PY_BUILTINS_SLICE   (1)
+#define MICROPY_PY_BUILTINS_PROPERTY (1)
+#define MICROPY_PY_ALL_SPECIAL_METHODS (1)
+#define MICROPY_PY_ARRAY_SLICE_ASSIGN (1)
+#define MICROPY_PY___FILE__         (1)
+#define MICROPY_PY_GC               (1)
+#define MICROPY_PY_ARRAY            (1)
+#define MICROPY_PY_COLLECTIONS      (1)
+#define MICROPY_PY_MATH             (0)
+#define MICROPY_PY_CMATH            (0)
+#define MICROPY_PY_IO               (0)
+#define MICROPY_PY_STRUCT           (1)
+#define MICROPY_PY_SYS              (1)
+#define MICROPY_PY_SYS_EXIT         (1)
+#define MICROPY_PY_SYS_PLATFORM     "linux"
+#define MICROPY_PY_SYS_MAXSIZE      (1)
+
+#define MICROPY_PY_UCTYPES          (1)
+#define MICROPY_PY_UZLIB            (0) // tinf has callback without state
+#define MICROPY_PY_UJSON            (1)
+#define MICROPY_PY_URE              (1)
+#define MICROPY_PY_UHEAPQ           (1)
+#define MICROPY_PY_UHASHLIB         (1)
+#define MICROPY_PY_UBINASCII        (1)
+#define MICROPY_PY_MACHINE          (1)
+
+extern const struct _mp_obj_module_t mp_module_os;
+extern const struct _mp_obj_module_t mp_module_time;
+extern const struct _mp_obj_module_t mp_module_termios;
+extern const struct _mp_obj_module_t mp_module_socket;
+extern const struct _mp_obj_module_t mp_module_ffi;
+
+// type definitions for the specific machine
+
+#ifdef __LP64__
+typedef long mp_int_t; // must be pointer size
+typedef unsigned long mp_uint_t; // must be pointer size
+#else
+// These are definitions for machines where sizeof(int) == sizeof(void*),
+// regardless for actual size.
+typedef int mp_int_t; // must be pointer size
+typedef unsigned int mp_uint_t; // must be pointer size
+#endif
+
+#define BYTES_PER_WORD sizeof(mp_int_t)
+
+// Cannot include <sys/types.h>, as it may lead to symbol name clashes
+#if _FILE_OFFSET_BITS == 64 && !defined(__LP64__)
+typedef long long mp_off_t;
+#else
+typedef long mp_off_t;
+#endif
+
+typedef void *machine_ptr_t; // must be of pointer size
+typedef const void *machine_const_ptr_t; // must be of pointer size
+
+void mp_unix_alloc_exec(mp_uint_t min_size, void** ptr, mp_uint_t *size);
+void mp_unix_free_exec(void *ptr, mp_uint_t size);
+void mp_unix_mark_exec(void);
+#define MP_PLAT_ALLOC_EXEC(min_size, ptr, size) mp_unix_alloc_exec(min_size, ptr, size)
+#define MP_PLAT_FREE_EXEC(ptr, size) mp_unix_free_exec(ptr, size)
+
+#define MP_PLAT_PRINT_STRN(str, len) fwrite(str, 1, len, stdout)
+
+// extra built in names to add to the global namespace
+#if MICROPY_PY_IO
+extern const struct _mp_obj_fun_builtin_t mp_builtin_open_obj;
+#define MICROPY_PORT_BUILTINS \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_open), (mp_obj_t)&mp_builtin_open_obj }, \
+
+#endif
+
+// We need to provide a declaration/definition of alloca()
+#include <alloca.h>
+
+int mp_hal_stdin_rx_chr(void);
+void mp_hal_stdout_tx_str(const char *str);
+void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len);
+void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len);
+
+static inline void mp_hal_set_interrupt_char(char c) {}
+
+#define MICROPY_HW_BOARD_NAME "minimal"
+#define MICROPY_HW_MCU_NAME "unknown-cpu"
+
+#ifdef __linux__
+#define MICROPY_MIN_USE_STDOUT (1)
+#endif
+
+#define MP_STATE_PORT MP_STATE_VM

--- a/embed/transform.py
+++ b/embed/transform.py
@@ -1,0 +1,371 @@
+"""
+This script transforms MicroPython source files so the mp_state_ctx global
+variable is passed as the first argument to (almost) all functions.
+
+Be warned, there are many dragons here!
+
+TODO: convert qstr to mp_qstr_t
+"""
+
+import sys
+import re
+
+mp_prefix = "micropy_"
+state_arg = "struct _mp_state_ctx_t *mp_state"
+state_var = "mp_state"
+
+def process_do_nothing(match):
+    return match.group(0)
+
+def process_fun_decl_defn_incomplete(match):
+    d = match.groupdict()
+    fun = d["fun"]
+
+    if fun.startswith("mp_"):
+        fun = fun[3:]
+
+    args = "%s, %s" % (state_arg, d["args"])
+
+    return "%s%s%s%s(%s," % (d["static"], d["rettype"], mp_prefix, fun, args)
+
+def process_fun_decl_defn(match, trailing):
+    d = match.groupdict()
+    fun = d["fun"]
+
+    if fun in ("DEBUG_printf",) or fun.startswith("utf8_") or fun.startswith("unichar_") or fun.startswith("MP_"):
+        return match.group(0)
+
+    if fun == "set_clear":
+        # because mp_set_clear is distinct from set_clear
+        fun = "obj_set_clear"
+
+    if fun.startswith("mp_"):
+        fun = fun[3:]
+
+    if d["args"] == "void":
+        args = state_arg
+    else:
+        args = "%s, %s" % (state_arg, d["args"])
+
+    #if d["static"] is None:
+    #    return "%s%s%s(%s)%s" % (d["rettype"], mp_prefix, fun, args, trailing)
+    #else:
+    return "%s%s%s%s(%s)%s" % (d["static"], d["rettype"], mp_prefix, fun, args, trailing)
+
+def process_fun_decl(match):
+    return process_fun_decl_defn(match, ";")
+
+def process_fun_defn(match):
+    return process_fun_decl_defn(match, " {")
+
+def process_fun_defn_oneline(match):
+    return process_fun_decl_defn(match, match.groupdict()["body"])
+
+def process_struct_init(match):
+    d = match.groupdict()
+    value = d["value"]
+
+    if value in ("false", "true"):
+        return match.group(0)
+
+    if value.startswith("mp_"):
+        value = value[3:]
+
+    return "    .%s = %s%s,%s" % (d["member"], mp_prefix, value, d["end"])
+
+def process_type_fun_typedef(match):
+    d = match.groupdict()
+
+    if d["args"] == "void":
+        args = state_arg
+    else:
+        args = "%s, %s" % (state_arg, d["args"])
+
+    return "%s(%s);" % (d["head"], args)
+
+def process_fun_obj_defn(match):
+    d = match.groupdict()
+    fun = d["fun"]
+    #if fun in ("mp_globals_get", "mp_locals_get"):
+    #    return "%s(%s%s);" % (d["head"], d["args"], fun)
+    if fun == "set_clear":
+        fun = "obj_set_clear"
+    elif fun.startswith("mp_"):
+        fun = fun[3:]
+    return "%s(%s%s%s);" % (d["head"], d["args"], mp_prefix, fun)
+
+def process_compile_def(match):
+    return "#define c(f) %scompile_##f" % mp_prefix
+
+def process_gc_def(match):
+    d = match.groupdict()
+    fun1 = d["fun1"]
+    fun2 = d["fun2"]
+    if fun1 == "free":
+        return "#define free(p) %sgc_free(%s, (p))" % (mp_prefix, state_var)
+    else:
+        return "#define realloc(p, n) %sgc_realloc(%s, (p), (n))" % (mp_prefix, state_var)
+
+def process_locals_globals(match):
+    d = match.groupdict()
+    dct = d["dict"]
+    op = d["op"]
+    if d["op"] == "get":
+        return "static inline mp_obj_dict_t *%s%s_get(%s) { return %s->dict_%s; }" % (mp_prefix, dct, state_arg, state_var, dct)
+    else:
+        return "static inline void %s%s_set(%s, mp_obj_dict_t *d) { %s->dict_%s = d; }" % (mp_prefix, dct, state_arg, state_var, dct)
+
+c_functions = (
+    "open",
+    "read",
+    "write",
+    "close",
+    "sizeof",
+    "offsetof",
+    "va_start",
+    "va_end",
+    "va_copy",
+    "va_arg",
+    "assert",
+    "longjmp",
+    "setjmp",
+    "strlen",
+    "strchr",
+    "strncmp",
+    "memset",
+    "memcpy",
+    "memmove",
+    "memcmp",
+    "alloca",
+    "malloc",
+    "malloc_with_finaliser",
+    "realloc",
+    "free",
+    "printf",
+    "vprintf",
+    "sprintf",
+    "snprintf",
+    "vsnprintf",
+    "isnan",
+    "isinf",
+    "signbit",
+    "fpclassify",
+    "DEBUG_printf",
+    "QDEF", # macro for qstrs
+    "op", # argument for str_caseconv
+    "allocator", # argument for emit_write_uint
+    "f", # argument for apply_to_single_or_list
+    "comp_fun", # variable in compile_node
+    "re1_5_recursiveloopprog",
+    "re1_5_sizecode",
+    "re1_5_compilecode",
+    "re1_5_dumpcode",
+    "re1_5_fatal",
+    "sha256_init",
+    "sha256_update",
+    "sha256_final",
+)
+
+def x1_vm(m):
+    return "(%s)->vm.%s" % (state_var, m.groupdict()["field"])
+
+def x1_ctx(m):
+    return "(%s)->%s" % (state_var, m.groupdict()["field"])
+
+def x1_mem(m):
+    return "(%s)->mem.%s" % (state_var, m.groupdict()["field"])
+
+def x2(m):
+    fun = m.groupdict()["fun"]
+    if fun in c_functions:
+        return m.group(0)
+    if fun.startswith("utf8_") or fun.startswith("unichar_"):
+        return m.group(0)
+    assert not fun.startswith(mp_prefix)
+
+    if fun in ("stream_next_byte", "stream_close", "io_func"):
+        # special cases
+        return "%s(%s, " % (fun, state_var)
+
+    if fun == "set_clear":
+        # because mp_set_clear is distinct from set_clear
+        fun = "obj_set_clear"
+    if fun.startswith("mp_"):
+        fun = fun[3:]
+    if m.groupdict()["closeparen"] is None:
+        return "%s%s(%s, " % (mp_prefix, fun, state_var)
+    else:
+        return "%s%s(%s)" % (mp_prefix, fun, state_var)
+
+def ins_state_var(m):
+    d = m.groupdict()
+    if d["closeparen"] is None:
+        return "%s(%s, " % (d["prefix"], state_var)
+    else:
+        return "%s(%s)" % (d["prefix"], state_var)
+
+def tr_mp_fun(m):
+    fun = m.group(0)
+    if fun.startswith("mp_"):
+        fun = fun[3:]
+    return mp_prefix + fun
+
+def tr_lo_gl_get(m):
+    return "%s->dict_%s" % (state_var, m.group(1))
+
+def tr_lo_gl_set(m):
+    return "%s->dict_%s = %s" % (state_var, m.group(1), m.group(2))
+
+xxx = (
+    (x1_vm, re.compile(r"MP_STATE_VM\((?P<field>[a-z0-9_]+)\)")),
+    (x1_ctx, re.compile(r"MP_STATE_CTX\((?P<field>[a-z0-9_]+)\)")),
+    (x1_mem, re.compile(r"MP_STATE_MEM\((?P<field>[a-z0-9_]+)\)")),
+
+    # globals/locals
+    (tr_lo_gl_get, re.compile(r"mp_(locals|globals)_get\(\)")),
+    (tr_lo_gl_set, re.compile(r"mp_(locals|globals)_set\(([a-z_\->]+)\)")),
+
+    (x2, re.compile(r"(?<=[ ()!*])(?P<fun>[a-z][a-z0-9_]+)\((?P<closeparen>\))?")),
+
+    (ins_state_var, re.compile(r"(?P<prefix>(\.|->)(print|make_new|call|unary_op|binary_op|attr|subscr|getiter|iternext|buffer_p\.get_buffer))\((?P<closeparen>\))?")),
+    (ins_state_var, re.compile(r"(?P<prefix>stream_p->(read|write|ioctl))\((?P<closeparen>\))?")),
+    #(ins_state_var, re.compile(r"(?P<prefix>\(mp_fun_(0|1|2|3|var|kw)_t\)self->fun\))\((?P<closeparen>\))?")),
+    (ins_state_var, re.compile(r"(?P<prefix>self->fun\.(_0|_1|_2|_3|var|kw))\((?P<closeparen>\))?")),
+    (ins_state_var, re.compile(r"(?P<prefix>print->print_strn)\((?P<closeparen>\))?")),
+    (ins_state_var, re.compile(r"(?P<prefix>lex->stream_next_byte)\((?P<closeparen>\))?")),
+    (ins_state_var, re.compile(r"(?P<prefix>lex->stream_close)\((?P<closeparen>\))?")),
+    (ins_state_var, re.compile(r"(?P<prefix>emit_method_table->[a-z_]+)\((?P<closeparen>\))?")),
+    #(ins_state_var, re.compile(r"(?P<prefix>\(\*allocator\))\((?P<closeparen>\))?")),
+    (ins_state_var, re.compile(r"(?P<prefix>allocator)\((?P<closeparen>\))?")),
+    (ins_state_var, re.compile(r"(?P<prefix> f)\((?P<closeparen>\))?")),
+    (ins_state_var, re.compile(r"(?P<prefix>comp_fun)\((?P<closeparen>\))?")),
+
+    # these functions are used as pointers within expressions
+    (tr_mp_fun, re.compile(r"(?<!_)(plat_print_strn|mp_obj_tuple_getiter|dict_make_new|dict_it_iternext|list_it_iternext|set_it_iternext|bytes_it_iternext|str_it_iternext|tuple_it_iternext|mp_obj_str_binary_op|vstr_printf|mp_obj_str_get_buffer|mp_obj_instance_call|mp_obj_exception_make_new|mp_obj_instance_make_new|str_buf_next_byte|str_buf_free|file_buf_next_byte|file_buf_close|mp_stream_write|mp_stream_write_adaptor|array_subscr)(?!_)")),
+    (tr_mp_fun, re.compile(r"vstr_add_strn(?!\()")),
+    # these are used as pointers, specifically to set up a dynamic mp_obj_type_t struct
+    (tr_mp_fun, re.compile(r"instance_print|instance_unary_op|instance_binary_op|mp_obj_instance_attr|instance_subscr|instance_getiter|instance_get_buffer")),
+    (tr_mp_fun, re.compile(r"namedtuple_(print|make_new|attr)|mp_obj_tuple_unary_op|mp_obj_tuple_binary_op|mp_obj_tuple_subscr|mp_obj_tuple_getiter")),
+    # for emit_bc and compiler
+    (x2, re.compile(r"(?P<fun>mp_emit_bc_##fun)\((?P<closeparen>\))?")),
+    (tr_mp_fun, re.compile(r"mp_emit_bc_[a-z_]+")),
+    (tr_mp_fun, re.compile(r"mp_emit_bc_##fun")),
+    (tr_mp_fun, re.compile(r"(?<!_)emit_get_cur_to_write_[a-z_]+")),
+    # these are used as pointers in the compiler
+    (tr_mp_fun, re.compile(r"(?<!_)(compile_funcdef_lambdef_param|c_del_stmt|compile_dotted_as_name|compile_string|compile_bytes|compile_const_object|compile_scope_func_param|compile_scope_func_annotations|compile_scope_lambda_param)")),
+)
+
+def process_generic(line):
+    if line.startswith("#define MP_STATE_"):
+        return line
+    elif line.startswith("#define NORETURN"):
+        return line
+    elif line.startswith("#define "):
+        pass
+    elif line.startswith("static inline "):
+        pass
+    elif line.startswith("extern const mp_emit_method_table_id_ops_t mp_emit_bc_method"):
+        pass
+    elif line.startswith("const mp_emit_method_table_id_ops_t mp_emit_bc_method"):
+        pass
+    elif line.startswith("const mp_print_t "):
+        pass
+    elif not line.startswith("    "):
+        return line
+
+    # TODO: don't process strings
+
+    for xx, rr in xxx:
+        last_idx = 0
+        parts = []
+        for m in rr.finditer(line):
+            parts.append(line[last_idx:m.start()])
+            parts.append(xx(m))
+            last_idx = m.end()
+        parts.append(line[last_idx:])
+        line = "".join(parts)
+
+    return line
+
+regex_type = r"(const )?(void|int|uint|long long|size_t|unsigned int|char|byte|bool|unichar|vstr_t|qstr|scope_t|id_info_t|emit_t|mpz_t|mp_[a-z_]+_t) \*?"
+line_regexs = (
+    (process_locals_globals, re.compile(r"static inline (mp_obj_dict_t \*|void )mp_(?P<dict>locals|globals)_(?P<op>[gs]et)\(.+\) \{ .+; \}$")),
+    (process_fun_decl, re.compile(r"(?P<static>(STATIC )?(NORETURN )?)(?P<rettype>" + regex_type + r")(?P<fun>[A-Za-z0-9_]+)\((?P<args>.+)\);$")),
+    (process_fun_defn, re.compile(r"(?P<static>((STATIC|static) (inline )?)?(NORETURN )?)(?P<rettype>" + regex_type + r")(?P<fun>[A-Za-z0-9_]+)\((?P<args>.+)\) {$")),
+    (process_fun_defn_oneline, re.compile(r"(?P<static>static inline )(?P<rettype>" + regex_type + r")(?P<fun>[A-Za-z0-9_]+)\((?P<args>.+)\)(?P<body> {.*})$")),
+    (process_fun_decl_defn_incomplete, re.compile(r"(?P<static>(STATIC )?(NORETURN )?)(?P<rettype>" + regex_type + r")(?P<fun>[A-Za-z0-9_]+)\((?P<args>.+),$")),
+    #(process_fun_defn, re.compile(r"(?P<static>static inline )(?P<rettype>" + regex_type + r")(?P<fun>mp_(locals|globals)_(get|set))\((?P<args>.+)\) {$")),
+    (process_do_nothing, re.compile(r" *#(el)?if .+$")),
+    (process_do_nothing, re.compile(r"static inline .+$")),
+    (process_do_nothing, re.compile(r"#define (or|and|and_ident|and_blank|tok|rule|opt_rule)\(.+$")),
+    (process_compile_def, re.compile(r"#define c\(f\) compile_##f$")),
+    (process_gc_def, re.compile(r"#define (?P<fun1>free|realloc) (?P<fun2>gc_[a-z]+)$")),
+    (process_struct_init, re.compile(r"    \.(?P<member>[a-z_]+) = (?P<value>[a-z_]+),(?P<end>( \\)?)$")),
+    (process_struct_init, re.compile(r"    \.(?P<member>[a-z_]+ = \{ \.[a-z_]+) = (?P<value>[a-z_]+)(?P<end> \},)$")),
+    (process_type_fun_typedef, re.compile(r"(?P<head>typedef " + regex_type + r"\(\*mp_(print_strn|fun_0|fun_1|fun_2|fun_3|fun_var|fun_kw|print_fun|make_new_fun|call_fun|unary_op_fun|binary_op_fun|attr_fun|subscr_fun|lexer_stream_next_byte|lexer_stream_close)_t\))\((?P<args>.+)\);$")),
+    (process_type_fun_typedef, re.compile(r"(?P<head>typedef " + regex_type + r"\(\*(emit_allocator|apply_list_fun)_t\))\((?P<args>.+)\);$")),
+    (process_type_fun_typedef, re.compile(r"(?P<head>typedef void \(\*compile_function_t\))\((?P<args>.+)\);$")),
+    (process_type_fun_typedef, re.compile(r"(?P<head>typedef void \(\*list_fun_t\))\((?P<args>.+)\);$")),
+    (process_type_fun_typedef, re.compile(r"(?P<head>    typedef mp_uint_t \(\*io_func_t\))\((?P<args>.+)\);$")),
+    (process_type_fun_typedef, re.compile(r"(?P<head>    void \(\*print_strn\))\((?P<args>.+)\);$")),
+    (process_type_fun_typedef, re.compile(r"(?P<head>    mp_int_t \(\*get_buffer\))\((?P<args>.+)\);$")),
+    (process_type_fun_typedef, re.compile(r"(?P<head>    mp_uint_t \(\*(read|write|ioctl)\))\((?P<args>.+)\);$")),
+    (process_type_fun_typedef, re.compile(r"(?P<head>    (void|bool) \(\*[a-z_]+\))\((?P<args>emit_t \*emit.*)\);$")),
+    (process_fun_obj_defn, re.compile(r"(?P<head>(STATIC )?MP_DEFINE_CONST_FUN_OBJ([A-Z0-9_]*))\((?P<args>.+, )(?P<fun>[a-z0-9_]+)\);$")),
+    (lambda m: "", re.compile(r"    \.globals = \(mp_obj_dict_t\*\)&MP_STATE_VM\(dict_main\),$")), # XXX
+
+    # sys.path, sys.argv, sys.modules handling
+    # at the moment we remove these from the sys module, but they still exist in the state
+    (lambda m:
+        r"",
+        re.compile(r"    \{ MP_ROM_QSTR\(MP_QSTR_path\), MP_ROM_PTR\(&MP_STATE_VM\(mp_sys_path_obj\)\) \},$")),
+    (lambda m:
+        r"",
+        re.compile(r"    \{ MP_ROM_QSTR\(MP_QSTR_argv\), MP_ROM_PTR\(&MP_STATE_VM\(mp_sys_argv_obj\)\) \},$")),
+    (lambda m:
+        r"",
+        re.compile(r"    \{ MP_ROM_QSTR\(MP_QSTR_modules\), MP_ROM_PTR\(&MP_STATE_VM\(mp_loaded_modules_dict\)\) \},$")),
+
+    (lambda m: "    ((defval == MP_OBJ_NULL) ? " + mp_prefix + "load_method : " + mp_prefix + "load_method_maybe)(" + state_var + ", base, attr, dest);", re.compile(r"    \(\(defval == MP_OBJ_NULL\) \? mp_load_method : mp_load_method_maybe\)\(base, attr, dest\);$")),
+    (lambda m: "    void **ptrs = (void**)(void*)&" + state_var + "->dict_locals;", re.compile(r"    void \*\*ptrs = \(void\*\*\)\(void\*\)&mp_state_ctx;$")),
+    (process_generic, None),
+)
+
+def process_line(line):
+    m = re.search(r" *//", line)
+    if m:
+        comment = line[m.start():]
+        line = line[:m.start()]
+    else:
+        comment = ""
+
+    for fun, regex in line_regexs:
+        if regex is None:
+            line = fun(line)
+            break
+        else:
+            m = regex.match(line)
+            if m:
+                line = fun(m)
+                break
+
+    return line + comment
+
+def do_work(filename):
+    with open(filename) as f:
+        lines = f.readlines()
+
+    for f, l in (
+            ("py/misc.h", 37),
+            ("py/parse.h", 33),
+            ("py/mphal.h", 36),
+            ("py/mpprint.h", 42),
+            ("py/formatfloat.c", 30)):
+        if filename.endswith(f):
+            lines.insert(l, "struct _mp_state_ctx_t;\n")
+
+    for line in lines:
+        line = line[:-1] # strip trailing \n
+        print(process_line(line))
+
+do_work(sys.argv[1])

--- a/embed/util.c
+++ b/embed/util.c
@@ -1,0 +1,90 @@
+#include <setjmp.h>
+
+void micropy_gc_collect(mp_state_ctx_t *mp) {
+    micropy_gc_collect_start(mp);
+    jmp_buf regs;
+    setjmp(regs);
+    // GC stack (and regs because we captured them)
+    void **regs_ptr = (void**)(void*)&regs;
+    micropy_gc_collect_root(mp, regs_ptr, ((mp_uint_t)mp->vm.stack_top - (mp_uint_t)&regs) / sizeof(mp_uint_t));
+    micropy_gc_collect_end(mp);
+}
+
+uint micropy_import_stat(mp_state_ctx_t *mp, const char *path) {
+    return MP_IMPORT_STAT_NO_EXIST;
+}
+
+void micropy_nlr_jump_fail(mp_state_ctx_t *mp, void *val) {
+    micropy_printf(mp, &mp_plat_print, "FATAL: uncaught NLR %p\n", val);
+    exit(1);
+}
+
+/*
+mp_obj_t mp_builtin_open(mp_state_ctx_t *mp, mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    micropy_nlr_raise(mp, micropy_obj_new_exception_msg(mp, &mp_type_OSError, "open() not implemented"));
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
+*/
+
+mp_state_ctx_t *micropy_create(void *heap, size_t heap_size) {
+    mp_state_ctx_t *mp = heap;
+    micropy_stack_ctrl_init(mp);
+    micropy_stack_set_limit(mp, 40000 * (BYTES_PER_WORD / 4));
+    heap += sizeof(mp_state_ctx_t);
+    heap_size -= sizeof(mp_state_ctx_t);
+    micropy_gc_init(mp, heap, heap + heap_size);
+    micropy_init(mp);
+    return mp;
+}
+
+void micropy_destroy(mp_state_ctx_t *mp) {
+    micropy_deinit(mp);
+}
+
+STATIC int micropy_execute_from_lexer(mp_state_ctx_t *mp, mp_lexer_t *lex, mp_parse_input_kind_t input_kind, bool is_repl) {
+    if (lex == NULL) {
+        micropy_printf(mp, &mp_plat_print, "MemoryError: lexer could not allocate memory\n");
+        return 1;
+    }
+
+    nlr_buf_t nlr;
+    if (micropy_nlr_push(mp, &nlr) == 0) {
+        qstr source_name = lex->source_name;
+
+        #if MICROPY_PY___FILE__
+        if (input_kind == MP_PARSE_FILE_INPUT) {
+            micropy_store_global(mp, MP_QSTR___file__, MP_OBJ_NEW_QSTR(source_name));
+        }
+        #endif
+
+        mp_parse_tree_t pt = micropy_parse(mp, lex, input_kind);
+        mp_obj_t module_fun = micropy_compile(mp, &pt, source_name, MP_EMIT_OPT_NONE, is_repl);
+        micropy_call_function_0(mp, module_fun);
+
+        micropy_nlr_pop(mp);
+        return 0;
+
+    } else {
+        // uncaught exception
+        mp_obj_t exc = nlr.ret_val;
+        // check for SystemExit
+        if (micropy_obj_is_subclass_fast(mp, micropy_obj_get_type(mp, exc), &mp_type_SystemExit)) {
+            // None is an exit value of 0; an int is its value; anything else is 1
+            mp_obj_t exit_val = micropy_obj_exception_get_value(mp, exc);
+            mp_int_t val = 0;
+            if (exit_val != mp_const_none && !micropy_obj_get_int_maybe(mp, exit_val, &val)) {
+                val = 1;
+            }
+            return 0x100 | (val & 255);
+        }
+
+        // Report all other exceptions
+        micropy_obj_print_exception(mp, &mp_plat_print, exc);
+        return 1;
+    }
+}
+
+int micropy_exec_str(mp_state_ctx_t *mp, const char *str) {
+    mp_lexer_t *lex = micropy_lexer_new_from_str_len(mp, MP_QSTR__lt_stdin_gt_, str, strlen(str), false);
+    return micropy_execute_from_lexer(mp, lex, MP_PARSE_FILE_INPUT, false);
+}

--- a/embed/util.h
+++ b/embed/util.h
@@ -1,0 +1,3 @@
+mp_state_ctx_t *micropy_create(void *heap, size_t heap_size);
+void micropy_destroy(mp_state_ctx_t *mp);
+int micropy_exec_str(mp_state_ctx_t *mp, const char *str);

--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -83,11 +83,21 @@ def cat_together():
         print("QSTR not updated")
 
 
+def do_filter(in_f, out_f):
+    output = []
+    for line in in_f:
+        for match in re.findall(r'MP_QSTR_[_a-zA-Z0-9]+', line):
+            name = match.replace('MP_QSTR_', '')
+            if name not in QSTRING_BLACK_LIST:
+                output.append('Q(' + name + ')')
+    out_f.write("\n".join(output) + "\n")
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Generates qstr definitions from a specified source')
 
     parser.add_argument('command',
-        help='Command (split/cat)')
+        help='Command (split/cat/filter)')
     parser.add_argument('input_filename',
         help='Name of the input file (when not specified, the script reads standard input)')
     parser.add_argument('output_dir',
@@ -107,3 +117,8 @@ if __name__ == "__main__":
 
     if args.command == "cat":
         cat_together()
+
+    if args.command == "filter":
+        with open(args.input_filename) as infile:
+            with open(args.output_file, "w") as outfile:
+                do_filter(infile, outfile)


### PR DESCRIPTION
This PR adds a "port" with the following features:
- convert uPy source to add a custom prefix to all functions
- convert uPy source to add the state structure as the first argument to all functions
- amalgamate uPy source into a single .c and .h file
- build libmicropython.a from the amalgamated source
- provide a simple embedded example

The outputs are:
- upy.c and upy.h: a completely self-contained distribution of the core+extmod components
- libmicropython.a: just a compiled versionu of upy.c (with specific options from mpconfigport.h)
- embed: a demo, built from embed.c and libmicropython.a
