### PR TITLE
esp8266/moduos.c: Add stat() to the module uos of esp8266

### DIFF
--- a/esp8266/moduos.c
+++ b/esp8266/moduos.c
@@ -138,6 +138,11 @@ STATIC mp_obj_t os_dupterm_notify(mp_obj_t obj_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_dupterm_notify_obj, os_dupterm_notify);
 
+STATIC mp_obj_t os_stat(mp_obj_t path_in) {
+    return vfs_proxy_call(MP_QSTR_stat, 1, &path_in);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_stat_obj, os_stat);
+
 STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_uos) },
     { MP_ROM_QSTR(MP_QSTR_uname), MP_ROM_PTR(&os_uname_obj) },
@@ -154,6 +159,7 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_getcwd), MP_ROM_PTR(&os_getcwd_obj) },
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&os_remove_obj) },
     { MP_ROM_QSTR(MP_QSTR_rename), MP_ROM_PTR(&os_rename_obj) },
+    { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&os_stat_obj) },
     #endif
 };
 


### PR DESCRIPTION
```
This implementation makes use of vfs.stat() and
therefore has the same properties. Known deviations
for all ports: uos.stat(".") on the top level returns
the error code 22, EINVAL. The same happens with
uos.stat("dirname/") where dirname IS the name of
a directory.
```
