### PR TITLE
Support 32-bit compilation on OS X Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_script:
   - sudo apt-get update -qq || true
   - sudo apt-get install -y python3 gcc-multilib pkg-config libffi-dev libffi-dev:i386 qemu-system gcc-mingw-w64
   - sudo apt-get install -y --force-yes gcc-arm-none-eabi
+  # For testing osx-32bit stuff
+  - sudo apt-get install -y clang-3.6
   # For teensy build
   - sudo apt-get install realpath
   # For coverage testing
@@ -48,6 +50,12 @@ script:
   - (cd tests && MICROPY_CPYTHON3=python3.4 MICROPY_MICROPYTHON=../unix/micropython_coverage ./run-tests -d thread)
   - (cd tests && MICROPY_CPYTHON3=python3.4 MICROPY_MICROPYTHON=../unix/micropython_coverage ./run-tests --emit native)
   - (cd tests && MICROPY_CPYTHON3=python3.4 MICROPY_MICROPYTHON=../unix/micropython_coverage ./run-tests --via-mpy -d basics)
+
+  # LLVM 32-bit Clang build to test osx-32bit fix
+  - make -C unix clean
+  - make -C unix CC=clang-3.6 MICROPY_FORCE_32BIT=1 deplibs
+  - make -C unix CC=clang-3.6 MICROPY_FORCE_32BIT=1
+  - make -C unix CC=clang-3.6 MICROPY_FORCE_32BIT=1 test
 
 after_success:
   - (cd unix && coveralls --root .. --build-root . --gcov $(which gcov) --gcov-options '\-o build-coverage/' --include py --include extmod)

--- a/py/nlrx86.S
+++ b/py/nlrx86.S
@@ -37,9 +37,18 @@
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define NLR_OS_WINDOWS
+#endif
+
+#if defined(__APPLE__) && defined(__MACH__)
+#define NLR_OS_MAC
+#endif
+
+#if defined(NLR_OS_WINDOWS) || defined(NLR_OS_MAC)
 #define NLR_TOP (_mp_state_ctx + NLR_TOP_OFFSET)
+#define MP_THREAD_GET_STATE _mp_thread_get_state
 #else
 #define NLR_TOP (mp_state_ctx + NLR_TOP_OFFSET)
+#define MP_THREAD_GET_STATE mp_thread_get_state
 #endif
 
 // offset of nlr_top within mp_state_thread_t structure
@@ -54,6 +63,9 @@
 #if defined(NLR_OS_WINDOWS)
     .globl  _nlr_push
     .def    _nlr_push; .scl 2; .type 32; .endef
+_nlr_push:
+#elif defined(NLR_OS_MAC)
+    .globl  _nlr_push
 _nlr_push:
 #else
     .globl  nlr_push
@@ -75,7 +87,7 @@ nlr_push:
     mov     %edx, NLR_TOP           # stor new nlr_buf (to make linked list)
 #else
     // to check: stack is aligned to 16-byte boundary before this call
-    call    mp_thread_get_state     # get mp_state_thread ptr into eax
+    call    MP_THREAD_GET_STATE     # get mp_state_thread ptr into eax
     mov     4(%esp), %edx           # load nlr_buf argument into edx (edx clobbered by call)
     mov     NLR_TOP_TH_OFF(%eax), %ecx # get thread.nlr_top (last nlr_buf)
     mov     %ecx, (%edx)            # store it
@@ -84,7 +96,7 @@ nlr_push:
 
     xor     %eax, %eax              # return 0, normal return
     ret                             # return
-#if !defined(NLR_OS_WINDOWS)
+#if !defined(NLR_OS_WINDOWS) && !defined(NLR_OS_MAC)
     .size   nlr_push, .-nlr_push
 #endif
 
@@ -94,6 +106,9 @@ nlr_push:
 #if defined(NLR_OS_WINDOWS)
     .globl  _nlr_pop
     .def    _nlr_pop; .scl 2; .type 32; .endef
+_nlr_pop:
+#elif defined(NLR_OS_MAC)
+    .globl  _nlr_pop
 _nlr_pop:
 #else
     .globl  nlr_pop
@@ -106,14 +121,14 @@ nlr_pop:
     mov     (%eax), %eax            # load prev nlr_buf
     mov     %eax, NLR_TOP           # store nlr_top (to unlink list)
 #else
-    call    mp_thread_get_state     # get mp_state_thread ptr into eax
+    call    MP_THREAD_GET_STATE     # get mp_state_thread ptr into eax
     mov     NLR_TOP_TH_OFF(%eax), %ecx # get thread.nlr_top (last nlr_buf)
     mov     (%ecx), %ecx            # load prev nlr_buf
     mov     %ecx, NLR_TOP_TH_OFF(%eax) # store prev nlr_buf (to unlink list)
 #endif
 
     ret                             # return
-#if !defined(NLR_OS_WINDOWS)
+#if !defined(NLR_OS_WINDOWS) && !defined(NLR_OS_MAC)
     .size   nlr_pop, .-nlr_pop
 #endif
 
@@ -124,6 +139,9 @@ nlr_pop:
     .globl  _nlr_jump
     .def    _nlr_jump; .scl 2; .type 32; .endef
 _nlr_jump:
+#elif defined(NLR_OS_MAC)
+    .globl  _nlr_jump
+_nlr_jump:
 #else
     .globl  nlr_jump
     .type   nlr_jump, @function
@@ -133,7 +151,7 @@ nlr_jump:
 #if !MICROPY_PY_THREAD
     mov     NLR_TOP, %edx           # load nlr_top
     test    %edx, %edx              # check for nlr_top being NULL
-#if defined(NLR_OS_WINDOWS)
+#if defined(NLR_OS_WINDOWS) || defined(NLR_OS_MAC)
     je      _nlr_jump_fail           # fail if nlr_top is NULL
 #else
     je      nlr_jump_fail           # fail if nlr_top is NULL
@@ -143,10 +161,10 @@ nlr_jump:
     mov     (%edx), %eax            # load prev nlr_top
     mov     %eax, NLR_TOP           # store nlr_top (to unlink list)
 #else
-    call    mp_thread_get_state     # get mp_state_thread ptr into eax
+    call    MP_THREAD_GET_STATE     # get mp_state_thread ptr into eax
     mov     NLR_TOP_TH_OFF(%eax), %edx # get thread.nlr_top (last nlr_buf)
     test    %edx, %edx              # check for nlr_top being NULL
-#if defined(NLR_OS_WINDOWS)
+#if defined(NLR_OS_WINDOWS) || defined(NLR_OS_MAC)
     je      _nlr_jump_fail          # fail if nlr_top is NULL
 #else
     je      nlr_jump_fail           # fail if nlr_top is NULL
@@ -167,7 +185,7 @@ nlr_jump:
     xor     %eax, %eax              # clear return register
     inc     %al                     # increase to make 1, non-local return
     ret                             # return
-#if !defined(NLR_OS_WINDOWS)
+#if !defined(NLR_OS_WINDOWS) && !defined(NLR_OS_MAC)
     .size   nlr_jump, .-nlr_jump
 #endif
 

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -58,10 +58,14 @@ endif
 
 # On OSX, 'gcc' is a symlink to clang unless a real gcc is installed.
 # The unix port of micropython on OSX must be compiled with clang,
-# while cross-compile ports require gcc, so we test here for OSX and 
+# while cross-compile ports require gcc, so we test here for OSX and
 # if necessary override the value of 'CC' set in py/mkenv.mk
 ifeq ($(UNAME_S),Darwin)
+ifeq ($(MICROPY_FORCE_32BIT),1)
+CC = clang -m32
+else
 CC = clang
+endif
 # Use clang syntax for map file
 LDFLAGS_ARCH = -Wl,-map,$@.map -Wl,-dead_strip
 else

--- a/unix/gccollect.c
+++ b/unix/gccollect.c
@@ -80,6 +80,18 @@ STATIC void gc_helper_get_regs(regs_t arr) {
     register long esi asm ("esi");
     register long edi asm ("edi");
     register long ebp asm ("ebp");
+#ifdef __clang__
+    // TODO:
+    // This is dirty workaround for Clang. It tries to get around
+    // uncompliant (wrt to GCC) behavior of handling register variables.
+    // Application of this patch here is random, and done only to unbreak
+    // MacOS build. Better, cross-arch ways to deal with Clang issues should
+    // be found.
+    asm("" : "=r"(ebx));
+    asm("" : "=r"(esi));
+    asm("" : "=r"(edi));
+    asm("" : "=r"(ebp));
+#endif
     arr[0] = ebx;
     arr[1] = esi;
     arr[2] = edi;


### PR DESCRIPTION
While 64-bit clang has been supported since #607, x86 still didn't work. This should fix that, although in a similarly hacky way.
