### PR TITLE
[RFC] Add fuzzer for Python code using llvm-libfuzzer

### DIFF
--- a/tests/libfuzzer/Makefile
+++ b/tests/libfuzzer/Makefile
@@ -1,0 +1,118 @@
+all:
+	@echo
+	@echo 'Use the following sequence:'
+	@echo
+	@echo '  make build    -  build micropython unix port with libfuzzer instrumentation'
+	@echo '  make prepare  -  generate test cases and set up folders for the fuzzer'
+	@echo '  make run      -  run the fuzzer'
+	@echo
+	@echo 'Run "make clean" to really clean up - this also deletes the test cases and crashes!'
+	@echo
+
+build:
+	# setup
+	git submodule update --init
+	make -C ../../unix deplibs
+
+	# get + build libfuzzer
+	-git clone https://chromium.googlesource.com/chromium/llvm-project/llvm/lib/Fuzzer
+	clang++ -c -g -O2 -std=c++11 Fuzzer/*.cpp -IFuzzer
+	ar ruv libFuzzer.a Fuzzer*.o
+	rm Fuzzer*.o
+	
+	# build micropython and pyexec.c + readline.c
+	# clang fails at pyexec.c for some reason (just comment out the offending line manually for now)
+
+	# it also will fail to build the actual target, since main() in main.c has to be renamed temporarily
+	# not linking main.o is not an option, as stuff outside of main() in main.c is used in other files
+	sed -i 's/main(/main2(/g' ../../unix/main.c
+
+	# UBSAN and ASAN do NOT like micropython's way to handle memory in their default configuration at all!
+	# Still need to investigate what to disable to still get useful output
+	#make -C ../../unix CC=clang LIB_SRC_C_EXTRA="utils/pyexec.c mp-readline/readline.c" COPT="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-coverage=edge,indirect-calls,8bit-counters,trace-cmp" LDFLAGS_EXTRA="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-coverage=edge,indirect-calls,8bit-counters,trace-cmp"
+	
+	# use only LSAN for now
+	-make -C ../../unix CC=clang LIB_SRC_C_EXTRA="utils/pyexec.c mp-readline/readline.c" COPT="-fsanitize=leak -fsanitize-coverage=edge,indirect-calls,8bit-counters,trace-cmp" LDFLAGS_EXTRA="-fsanitize=leak -fsanitize-coverage=edge,indirect-calls,8bit-counters,trace-cmp"
+
+	# revert the edits:
+	sed -i 's/main2(/main(/g' ../../unix/main.c
+	
+	# build fuzzer
+	#clang -c python_fuzzer.cc -g -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-coverage=edge,indirect-calls,8bit-counters,trace-cmp \
+	clang -c python_fuzzer.cc -g -fsanitize=leak -fsanitize-coverage=edge,indirect-calls,8bit-counters,trace-cmp \
+	-I ../../ \
+	-I ../../unix \
+	-I ../../unix/build
+
+	# link
+	# (ideally code from main.c won't be needed in the future any more, so no need to link main.o)
+	#clang++ -g -o python_fuzzer -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=undefined libFuzzer.a python_fuzzer.o \
+	clang++ -g -o python_fuzzer -fsanitize=leak libFuzzer.a python_fuzzer.o \
+	../../unix/build/alloc.o \
+	../../unix/build/coverage.o \
+	../../unix/build/fatfs_port.o \
+	../../unix/build/file.o \
+	../../unix/build/gccollect.o \
+	../../unix/build/input.o \
+	../../unix/build/main.o \
+	../../unix/build/mod*.o \
+	../../unix/build/unix_mphal.o \
+	../../unix/build/build/*.o \
+	../../unix/build/extmod/*.o \
+	../../unix/build/lib/fatfs/*.o \
+	../../unix/build/lib/fatfs/option/*.o \
+	../../unix/build/lib/mp-readline/*.o \
+	../../unix/build/lib/timeutils/*.o \
+	../../unix/build/lib/utils/*.o \
+	../../unix/build/py/*.o \
+	../../lib/libffi/build_dir/out/lib/libffi.a \
+	../../lib/axtls/ssl/*.o \
+	../../lib/axtls/crypto/*.o
+
+prepare:
+	mkdir -p corpus/
+	mkdir -p crashes/
+	mkdir -p tests/
+	mkdir -p manual_tests/
+
+	# Bootstrap python syntax from an emoji of a pile of poo.
+	# See http://lcamtuf.blogspot.co.at/2014/11/pulling-jpegs-out-of-thin-air.html
+	echo -e "\xf0\x9f\x92\xa9" > ./manual_tests/poo.py
+	echo "print('Hello World!')" > ./manual_tests/hello_world.py
+	echo "import math\n1 + 1 == 3" > ./manual_tests/math.py
+	# maybe also use existing tests as seed here?
+	# some do crash though...
+	find ../../tests -name \*.py -exec cp {} ./tests/ \;
+
+run:
+	# max. 3 seconds for one input
+	# consider it "slow" if it takes more than 2 seconds
+	# use experimental trace feature
+	# up to 128 results (uses half of all CPU cores available by default and will spawn a new worker once a timeout or bug was found)
+	# only generate ascii files
+	# write "artifacts" aka crashes to the ./crashes directory
+	# disable stdout for fuzzers, as it will only spam the console/logs (especially once they discover multiplication on strings...)
+	# load test cases from ./corpus and ./manual_tests
+	./python_fuzzer -timeout=3 -report_slow_units=2 -use_traces=1 -jobs=2048 -only_ascii=1 -artifact_prefix=./crashes/ -close_fd_mask=1 ./corpus/ ./manual_tests/
+
+	# for later...
+	#./python_fuzzer -timeout=3 -report_slow_units=1 -use_traces=1 -jobs=128 -only_ascii=1 -artifact_prefix=./crashes/ -close_fd_mask=1 ./corpus/ ./manual_tests/ ./tests/
+
+coverage:
+	mkdir -p cov/
+	# only one single run of all test cases, with higher timeouts
+	# needs sancov from llvm 3.9 for html-report apparently
+	LSAN_OPTIONS="coverage=1:html_cov_report=1:coverage_dir=./cov/" ./python_fuzzer -timeout=10 -report_slow_units=5 -artifact_prefix=./crashes/ -close_fd_mask=1 -runs=0 ./corpus/ ./manual_tests/
+	sancov -not-covered-functions ./cov/python_fuzzer.*.sancov -obj=python_fuzzer
+	sancov -covered-functions ./cov/python_fuzzer.*.sancov -obj=python_fuzzer
+
+consolidate:
+	mv ./corpus ./corpus_old
+	mkdir -p ./corpus
+	# merges all relevant tests (using higher timeouts to catch relatively slow ones too) into the first folder
+	./python_fuzzer -timeout=10 -report_slow_units=5 -artifact_prefix=./crashes/ -close_fd_mask=1 -runs=0 -merge=1 ./corpus/ ./corpus_old/ ./manual_tests/
+	#./python_fuzzer -timeout=10 -report_slow_units=5 -artifact_prefix=./crashes/ -close_fd_mask=1 -runs=0 -merge=1 ./corpus/ ./corpus_old/ ./manual_tests/ ./tests/
+	rm -rf ./corpus_old
+
+clean:
+	rm -rf *.log libFuzzer.a python_fuzzer.o python_fuzzer ./corpus ./cov ./crashes ./Fuzzer ./manual_tests ./tests

--- a/tests/libfuzzer/Makefile
+++ b/tests/libfuzzer/Makefile
@@ -4,6 +4,7 @@ all:
 	@echo
 	@echo '  make build    -  build micropython unix port with libfuzzer instrumentation'
 	@echo '  make prepare  -  generate test cases and set up folders for the fuzzer'
+	@echo '  make consolidate  -  run all imported and generated tests cases, keep relevant ones'
 	@echo '  make run      -  run the fuzzer'
 	@echo
 	@echo 'Run "make clean" to really clean up - this also deletes the test cases and crashes!'
@@ -89,7 +90,6 @@ prepare:
 	rm ./tests/memoryerror.py
 	rm ./tests/run-tests-exp.py
 
-
 run:
 	# max. 3 seconds for one input
 	# consider it "slow" if it takes more than 2 seconds
@@ -98,8 +98,8 @@ run:
 	# only generate ascii files
 	# write "artifacts" aka crashes to the ./crashes directory
 	# disable stdout for fuzzers, as it will only spam the console/logs (especially once they discover multiplication on strings...)
-	# load test cases from ./corpus, ./tests and ./manual_tests
-	./python_fuzzer -timeout=3 -report_slow_units=1 -use_traces=1 -jobs=128 -only_ascii=1 -artifact_prefix=./crashes/ -close_fd_mask=1 ./corpus/ ./manual_tests/ ./tests/
+	# load test cases from ./corpus and ./manual_tests - if you want to include ./tests, just run "make consolidate"
+	./python_fuzzer -timeout=3 -report_slow_units=2 -use_traces=1 -jobs=128 -only_ascii=1 -artifact_prefix=./crashes/ -close_fd_mask=1 ./corpus/ ./manual_tests/
 
 coverage:
 	mkdir -p cov/
@@ -112,8 +112,8 @@ coverage:
 consolidate:
 	mv ./corpus ./corpus_old
 	mkdir -p ./corpus
-	# merges all relevant tests (using higher timeouts to catch relatively slow ones too) into the first folder
-	./python_fuzzer -timeout=10 -report_slow_units=5 -artifact_prefix=./crashes/ -close_fd_mask=1 -runs=0 -merge=1 ./corpus/ ./corpus_old/ ./manual_tests/ ./tests/
+	# merges all relevant tests into the first folder
+	./python_fuzzer -timeout=3 -report_slow_units=2 -use_traces=1 -artifact_prefix=./crashes/ -close_fd_mask=1 -runs=0 -merge=1 ./corpus/ ./corpus_old/ ./manual_tests/ ./tests/
 	rm -rf ./corpus_old
 
 clean:

--- a/tests/libfuzzer/Makefile
+++ b/tests/libfuzzer/Makefile
@@ -80,9 +80,15 @@ prepare:
 	echo -e "\xf0\x9f\x92\xa9" > ./manual_tests/poo.py
 	echo "print('Hello World!')" > ./manual_tests/hello_world.py
 	echo "import math\n1 + 1 == 3" > ./manual_tests/math.py
-	# maybe also use existing tests as seed here?
-	# some do crash though...
+	
+	# use existing tests as seed
 	find ../../tests -name \*.py -exec cp {} ./tests/ \;
+	# some do crash though...
+	# manually remove them until the fuzzer is improved
+	rm ./tests/rge_sm.py
+	rm ./tests/memoryerror.py
+	rm ./tests/run-tests-exp.py
+
 
 run:
 	# max. 3 seconds for one input
@@ -92,11 +98,8 @@ run:
 	# only generate ascii files
 	# write "artifacts" aka crashes to the ./crashes directory
 	# disable stdout for fuzzers, as it will only spam the console/logs (especially once they discover multiplication on strings...)
-	# load test cases from ./corpus and ./manual_tests
-	./python_fuzzer -timeout=3 -report_slow_units=2 -use_traces=1 -jobs=2048 -only_ascii=1 -artifact_prefix=./crashes/ -close_fd_mask=1 ./corpus/ ./manual_tests/
-
-	# for later...
-	#./python_fuzzer -timeout=3 -report_slow_units=1 -use_traces=1 -jobs=128 -only_ascii=1 -artifact_prefix=./crashes/ -close_fd_mask=1 ./corpus/ ./manual_tests/ ./tests/
+	# load test cases from ./corpus, ./tests and ./manual_tests
+	./python_fuzzer -timeout=3 -report_slow_units=1 -use_traces=1 -jobs=128 -only_ascii=1 -artifact_prefix=./crashes/ -close_fd_mask=1 ./corpus/ ./manual_tests/ ./tests/
 
 coverage:
 	mkdir -p cov/
@@ -110,8 +113,7 @@ consolidate:
 	mv ./corpus ./corpus_old
 	mkdir -p ./corpus
 	# merges all relevant tests (using higher timeouts to catch relatively slow ones too) into the first folder
-	./python_fuzzer -timeout=10 -report_slow_units=5 -artifact_prefix=./crashes/ -close_fd_mask=1 -runs=0 -merge=1 ./corpus/ ./corpus_old/ ./manual_tests/
-	#./python_fuzzer -timeout=10 -report_slow_units=5 -artifact_prefix=./crashes/ -close_fd_mask=1 -runs=0 -merge=1 ./corpus/ ./corpus_old/ ./manual_tests/ ./tests/
+	./python_fuzzer -timeout=10 -report_slow_units=5 -artifact_prefix=./crashes/ -close_fd_mask=1 -runs=0 -merge=1 ./corpus/ ./corpus_old/ ./manual_tests/ ./tests/
 	rm -rf ./corpus_old
 
 clean:

--- a/tests/libfuzzer/python_fuzzer.cc
+++ b/tests/libfuzzer/python_fuzzer.cc
@@ -1,0 +1,71 @@
+/*#include <stdint.h>
+#include <stdio.h>
+#include <string.h>*/
+
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <errno.h>
+
+extern "C" {
+#include "py/nlr.h"
+#include "py/compile.h"
+#include "py/runtime.h"
+#include "py/repl.h"
+#include "py/gc.h"
+#include "lib/utils/pyexec.h"
+#include "py/stackctrl.h"
+}
+
+
+// modelled after micropython/minimal/main.c
+// and micropython/unix/main.c
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char *data, size_t size) {    
+    
+    //Initialize stuff (?)
+    mp_stack_ctrl_init();
+
+    mp_stack_set_limit(40000 * (BYTES_PER_WORD / 4));
+
+    #if MICROPY_ENABLE_GC
+    // Heap size of GC heap (if enabled)
+    // Make it larger on a 64 bit machine, because pointers are larger.
+    long heap_size = 1024*1024 * (sizeof(mp_uint_t) / 4);
+    char *heap = (char*)malloc(heap_size);
+    gc_init(heap, heap + heap_size);
+    #endif
+
+    mp_init();
+
+    mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, (const char*)data, size, 0);
+
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        qstr source_name = lex->source_name;
+        mp_parse_tree_t parse_tree = mp_parse(lex, MP_PARSE_FILE_INPUT);
+        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, MP_EMIT_OPT_NONE, true);
+        mp_call_function_0(module_fun);
+        nlr_pop();
+    } else {
+        // uncaught exception
+        //mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
+        mp_deinit();
+        #if MICROPY_ENABLE_GC && !defined(NDEBUG)
+        free(heap);
+        #endif
+        return 0;
+    }
+    mp_deinit();
+    #if MICROPY_ENABLE_GC && !defined(NDEBUG)
+    free(heap);
+    #endif
+    return 0;
+}

--- a/tests/libfuzzer/python_fuzzer.cc
+++ b/tests/libfuzzer/python_fuzzer.cc
@@ -21,6 +21,7 @@ extern "C" {
 #include "py/runtime.h"
 #include "py/repl.h"
 #include "py/gc.h"
+#include "py/obj.h"
 #include "lib/utils/pyexec.h"
 #include "py/stackctrl.h"
 }
@@ -44,6 +45,12 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char *data, size_t size) {
     #endif
 
     mp_init();
+
+    char *fakeargv[] = {"fuzzer", "foo", "bar"};
+    mp_obj_list_init((mp_obj_list_t*)MP_OBJ_TO_PTR(mp_sys_argv), 0);
+    for (int i = 0; i < 3; i++) {
+        mp_obj_list_append(mp_sys_argv, MP_OBJ_NEW_QSTR(qstr_from_str(fakeargv[i])));
+    }
 
     mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, (const char*)data, size, 0);
 

--- a/tests/libfuzzer/python_fuzzer.cc
+++ b/tests/libfuzzer/python_fuzzer.cc
@@ -63,12 +63,7 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char *data, size_t size) {
         nlr_pop();
     } else {
         // uncaught exception
-        //mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
-        mp_deinit();
-        #if MICROPY_ENABLE_GC && !defined(NDEBUG)
-        free(heap);
-        #endif
-        return 0;
+        mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
     }
     mp_deinit();
     #if MICROPY_ENABLE_GC && !defined(NDEBUG)


### PR DESCRIPTION
This is not yet styled according to the guidelines or feature complete, more of a proof of concept that I'd like some feedback on.

As https://github.com/micropython/micropython/pull/1884 ran into the issue that byte code is assumed to be correct, this will first compile any input (making the fuzzer slower of course) and then execute the result. The benefit is that the compiler is fuzzed too, the downside is the slowdown due to compilation. It is however possible to write a second fuzzer with the same instrumentation to explicitly fuzz just bytecode.

ASAN and UBSAN do really not like your code as your memory management is more "hands-on" and I have to research more into what checks to disable to still make them trigger on useful errors. For now, only LSAN is enabled.
I also likely did stuff horribly wrong in python_fuzzer.cc (e.g. not setting up sys.argc/sys.argv properly) and it would be great if someone could look over it and tell me where I'm wrong or how to improve.

The basic idea of libfuzzer is to provide some random bytes that then get used as input by whatever is being fuzzed. Similar to AFL, libfuzzer then will check which parts of the code were active in processing the input and then modify it accordingly, creating the next input.

It is possible to bootstrap the fuzzer using the existing test cases, at the moment I seem to fail a couple of them on my machine though, so the more radical approach of just letting the fuzzer figure out the whole syntax on its own is used.

Unlike AFL, libfuzzer will stop once a timeout or crash is reached. The -jobs parameter decides how many such fragments will be collected until the process ends. Timeouts will happen frequently while fuzzing randomly mutated input into a programming language, since already the small program "9**99999" will run for quite a while.

"make consolidate" will run over the existing corpus and reduce it to useful test cases, so if you later provide test cases with very high coverage manually, you can still keep using fuzzed results but will get rid of a lot of tiny noisy test cases.

"make coverage" should in the future generate a html report similar to lcov. Maybe it might be a better approach to just build an actual gcov enabled binary and do "proper" coverage reporting with lcov, I didn't find a lot of eye candy options for sancov, also the html stuff is a relatively new feature.

Looking forward to your comments! :)
