### PR TITLE
docs: machine, pyb: Use fully qualified names.

### DIFF
--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -1,7 +1,8 @@
+.. currentmodule:: machine
 .. _machine.Pin:
 
-class Pin -- control I/O pins
-=============================
+class machine.Pin -- control I/O pins
+=====================================
 
 A pin is the basic object to control I/O pins (also known as GPIO -
 general-purpose input/output). It has methods to set

--- a/docs/library/pyb.Pin.rst
+++ b/docs/library/pyb.Pin.rst
@@ -1,6 +1,7 @@
+.. currentmodule:: pyb
 .. _pyb.Pin:
 
-class Pin -- control I/O pins
+class pyb.Pin -- control I/O pins
 =============================
 
 A pin is the basic object to control I/O pins.  It has methods to set


### PR DESCRIPTION
This helps with indexes and especially with search results.
