### PR TITLE
esp8266/modpybhspi: Add a HSPI module for hardware SPI support (esp-open-rtos version)

### DIFF
--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -183,6 +183,27 @@ The SPI driver is implemented in software and works on all pins::
     spi.write_readinto(b'1234', buf) # write to MOSI and read from MISO into the buffer
     spi.write_readinto(buf, buf) # write buf to MOSI and read MISO back into buf
 
+
+Hardware SPI
+------------
+
+The hardware SPI is faster (up to 80Mhz), but only works on following pins:
+``MISO``=12, ``MOSI``=13, ``SCK``=14, ``CS``=15 (you may be handling ``CS``
+yourself on a different pin)::
+
+    from machine import Pin, HSPI
+
+    spi = HSPI(baudrate=800000000, polarity=0, phase=0)
+    spi.init(baudrate=20000000) # set the baudrate
+
+    spi.read(10)            # read 10 bytes on MISO
+
+    buf = bytearray(50)     # create a buffer
+    spi.readinto(buf)       # read into the given buffer (reads 50 bytes in this case)
+
+    spi.write(b'12345')     # write 5 bytes on MOSI
+
+
 I2C bus
 -------
 

--- a/esp8266/Makefile
+++ b/esp8266/Makefile
@@ -74,6 +74,7 @@ SRC_C = \
 	modpybadc.c \
 	modpybuart.c \
 	modpybspi.c \
+	modpybhspi.c \
 	modesp.c \
 	modnetwork.c \
 	modutime.c \
@@ -84,6 +85,8 @@ SRC_C = \
 	$(BUILD)/frozen.c \
 	fatfs_port.c \
 	axtls_helpers.c \
+	esp_spi.c \
+	esp_iomux.c \
 
 STM_SRC_C = $(addprefix stmhal/,\
 	pybstdio.c \

--- a/esp8266/common_macros.h
+++ b/esp8266/common_macros.h
@@ -1,0 +1,113 @@
+/* Some common compiler macros
+ *
+ * Not esp8266-specific.
+ *
+ * Part of esp-open-rtos
+ * Copyright (C) 2015 Superhouse Automation Pty Ltd
+ * BSD Licensed as described in the file LICENSE
+ */
+
+#ifndef _COMMON_MACROS_H
+#define _COMMON_MACROS_H
+
+#include <sys/cdefs.h>
+
+#define UNUSED __attributed((unused))
+
+#ifndef BIT
+#define BIT(X) (1<<(X))
+#endif
+
+/* These macros convert values to/from bitfields specified by *_M and *_S (mask
+ * and shift) constants.  Used primarily with ESP8266 register access.
+ */
+
+#define VAL2FIELD(fieldname, value) ((value) << fieldname##_S)
+#define FIELD2VAL(fieldname, regbits) (((regbits) >> fieldname##_S) & fieldname##_M)
+
+#define FIELD_MASK(fieldname) (fieldname##_M << fieldname##_S)
+#define SET_FIELD(regbits, fieldname, value) (((regbits) & ~FIELD_MASK(fieldname)) | VAL2FIELD(fieldname, value))
+
+/* VAL2FIELD/SET_FIELD do not normally check to make sure that the passed value
+ * will fit in the specified field (without clobbering other bits).  This makes
+ * them faster and is usually fine.  If you do need to make sure that the value
+ * will not overflow the field, use VAL2FIELD_M or SET_FIELD_M (which will
+ * first mask the supplied value to only the allowed number of bits) instead.
+ */
+#define VAL2FIELD_M(fieldname, value) (((value) & fieldname##_M) << fieldname##_S)
+#define SET_FIELD_M(regbits, fieldname, value) (((regbits) & ~FIELD_MASK(fieldname)) | VAL2FIELD_M(fieldname, value))
+
+/* Use the IRAM macro to place functions into Instruction RAM (IRAM)
+   instead of flash (aka irom).
+
+   (This is the opposite to the Espressif SDK, where functions default
+   to being placed in IRAM but the ICACHE_FLASH_ATTR attribute will
+   place them in flash.)
+
+   Use the IRAM attribute for functions which are called when the
+   flash may not be available (for example during NMI exceptions), or
+   for functions which are called very frequently and need high
+   performance.
+
+   Usage example:
+
+   void IRAM high_performance_function(void)
+   {
+       // do important thing here
+   }
+
+   Bear in mind IRAM is limited (32KB), compared to up to 1MB of flash.
+*/
+#define IRAM __attribute__((section(".iram1.text")))
+
+/* Use the RAM macro to place constant data (rodata) into RAM (data
+   RAM) instead of the default placement in flash. This is useful for
+   constant data which needs high performance access.
+
+   Usage example:
+
+   const RAM uint8_t constants[] = { 1, 2, 3, 7 };
+
+   When placing string literals in RAM, they need to be declared with
+   the type "const char[]" not "const char *"
+
+   Usage example:
+
+   const RAM char hello_world[] = "Hello World";
+*/
+#define RAM __attribute__((section(".data")))
+
+/* Use the IRAM_DATA macro to place data into Instruction RAM (IRAM)
+   instead of the default of flash (for constant data) or data RAM
+   (for non-constant data).
+
+   This may be useful to free up data RAM. However all data read from
+   any instruction space (either IRAM or Flash) must be 32-bit aligned
+   word reads. Reading unaligned data stored with IRAM_DATA will be
+   slower than reading data stored in RAM. You can't perform unaligned
+   writes to IRAM.
+*/
+#define IRAM_DATA __attribute__((section(".iram1.data")))
+
+/* Use the IROM macro to store constant values in IROM flash. In
+  esp-open-rtos this is already the default location for most constant
+  data (rodata), so you don't need this attribute in 99% of cases.
+
+  The exceptions are to mark data in the core & freertos libraries,
+  where the default for constant data storage is RAM.
+
+  (Unlike the Espressif SDK you don't need to use an attribute like
+  ICACHE_FLASH_ATTR for functions, they go into flash by default.)
+
+  Important to note: IROM flash is accessed via 32-bit word aligned
+  reads. esp-open-rtos does some magic to "fix" unaligned reads, but
+  performance is reduced.
+*/
+#ifdef	__cplusplus
+    #define IROM __attribute__((section(".irom0.literal")))
+#else
+    #define IROM __attribute__((section(".irom0.literal"))) const
+#endif
+
+
+#endif

--- a/esp8266/esp/clocks.h
+++ b/esp8266/esp/clocks.h
@@ -1,0 +1,28 @@
+/* esp/clocks.h
+ *
+ * ESP8266 internal clock values
+ *
+ * At the moment there's not a lot known about varying clock speeds
+ * apart from doubling the CPU clock. It may be possible to set clock
+ * domains differently somehow.
+ *
+ * Part of esp-open-rtos
+ * Copyright (C) 2015 Superhouse Automation Pty Ltd
+ * BSD Licensed as described in the file LICENSE
+ */
+#ifndef _ESP_CLOCKS_H
+#define _ESP_CLOCKS_H
+
+/* CPU clock, can be overclocked to 160MHz via a dport register setting */
+#define CPU_CLK_FREQ 80*1000000
+
+/* Main peripheral clock
+
+   This is also the master frequency for the UART and the TIMER module
+   (before divisors applied to either.)
+ */
+#ifndef APB_CLK_FREQ
+#define APB_CLK_FREQ CPU_CLK_FREQ
+#endif
+
+#endif

--- a/esp8266/esp/gpio.h
+++ b/esp8266/esp/gpio.h
@@ -1,0 +1,150 @@
+/** esp_iomux.h
+ *
+ * GPIO functions.
+ *
+ * Part of esp-open-rtos
+ * Copyright (C) 2015 Superhouse Automation Pty Ltd
+ * BSD Licensed as described in the file LICENSE
+ */
+#ifndef _ESP_GPIO_H
+#define _ESP_GPIO_H
+#include <stdbool.h>
+#include "esp/gpio_regs.h"
+#include "esp/iomux.h"
+#include "esp/interrupts.h"
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    GPIO_INPUT,
+    GPIO_OUTPUT,         /* "Standard" push-pull output */
+    GPIO_OUT_OPEN_DRAIN, /* Open drain output */
+} gpio_direction_t;
+
+/* Enable GPIO on the specified pin, and set it to input or output mode
+ */
+void gpio_enable(const uint8_t gpio_num, const gpio_direction_t direction);
+
+/* Enable/disable internal pullup resistor for a particular GPIO
+ *
+ * Note: According to Espressif, pullup resistor values are between 30K and
+ * 100K ohms (see http://bbs.espressif.com/viewtopic.php?t=1079#p4097)
+ * However, measured values suggest that the actual value is likely to be close
+ * to 47K in reality.
+ *
+ * NOTE: The enabled_during_sleep setting is currently untested (please send
+ * feedback if you give it a try)
+ */
+void gpio_set_pullup(uint8_t gpio_num, bool enabled, bool enabled_during_sleep);
+
+/* Disable GPIO on the specified pin, and set it Hi-Z.
+ *
+ * If later muxing this pin to a different function, make sure to set
+ * IOMUX_PIN_OUTPUT_ENABLE if necessary to enable the output buffer.
+ */
+static inline void gpio_disable(const uint8_t gpio_num)
+{
+    GPIO.ENABLE_OUT_CLEAR = BIT(gpio_num);
+    *gpio_iomux_reg(gpio_num) &= ~IOMUX_PIN_OUTPUT_ENABLE;
+}
+
+/* Set whether the specified pin continues to drive its output when the ESP8266
+ * goes into sleep mode.  Note that this setting is reset to off whenever
+ * gpio_enable is called, so this must be called after calling that function.
+ *
+ * NOTE: This functionality is currently untested (please send feedback if you
+ * give it a try)
+ */
+static inline void gpio_set_output_on_sleep(const uint8_t gpio_num, bool enabled)
+{
+    if (enabled) {
+        IOMUX.PIN[gpio_to_iomux(gpio_num)] |= IOMUX_PIN_OUTPUT_ENABLE_SLEEP;
+    } else {
+        IOMUX.PIN[gpio_to_iomux(gpio_num)] &= ~IOMUX_PIN_OUTPUT_ENABLE_SLEEP;
+    }
+}
+
+/* Set output of a pin high or low.
+ *
+ * Only works if pin has been set to GPIO_OUTPUT or GPIO_OUT_OPEN_DRAIN via
+ * gpio_enable()
+ *
+ * If the mode is GPIO_OUT_OPEN_DRAIN, setting it low (false) will pull the pin
+ * down to ground, but setting it high (true) will allow it to float.  Note
+ * that even in GPIO_OUT_OPEN_DRAIN mode, the input gates are still physically
+ * connected to the pin, and can be damaged if the voltage is not in either the
+ * "low" or "high" range.  Make sure there is some sort of pull-up resistor on
+ * the line to avoid floating logic lines!
+ */
+static inline void gpio_write(const uint8_t gpio_num, const bool set)
+{
+    if (set)
+        GPIO.OUT_SET = BIT(gpio_num) & GPIO_OUT_PIN_MASK;
+    else
+        GPIO.OUT_CLEAR = BIT(gpio_num) & GPIO_OUT_PIN_MASK;
+}
+
+/* Toggle output of a pin
+ *
+ * Only works if pin has been set to GPIO_OUTPUT or GPIO_OUT_OPEN_DRAIN via
+ * gpio_enable()
+ *
+ * See notes in gpio_write() about GPIO_OUT_OPEN_DRAIN mode.
+ */
+static inline void gpio_toggle(const uint8_t gpio_num)
+{
+    /* Why implement like this instead of GPIO_OUT_REG ^= xxx?
+       Concurrency. If an interrupt or higher priority task writes to
+       GPIO_OUT between reading and writing, only the gpio_num pin can
+       get an invalid value. Prevents one task from clobbering another
+       task's pins, without needing to disable/enable interrupts.
+    */
+    if(GPIO.OUT & BIT(gpio_num))
+        GPIO.OUT_CLEAR = BIT(gpio_num) & GPIO_OUT_PIN_MASK;
+    else
+        GPIO.OUT_SET = BIT(gpio_num) & GPIO_OUT_PIN_MASK;
+}
+
+/* Read input value of a GPIO pin.
+ *
+ * If pin is set GPIO_INPUT, this reads the level on the pin.
+ * If pin is set GPIO_OUTPUT, this reads the level at which the pin is
+ * currently being driven (i.e. the last value written).
+ * If pin is set GPIO_OUT_OPEN_DRAIN, when the pin is written low, this will
+ * return low (false), when the pin is written high, this will behave like
+ * GPIO_INPUT.
+ */
+static inline bool gpio_read(const uint8_t gpio_num)
+{
+    return GPIO.IN & BIT(gpio_num);
+}
+
+extern void gpio_interrupt_handler(void);
+
+/* Set the interrupt type for a given pin
+ *
+ * If int_type is not GPIO_INTTYPE_NONE, the gpio_interrupt_handler will be
+ * attached and unmasked.
+ */
+static inline void gpio_set_interrupt(const uint8_t gpio_num, const gpio_inttype_t int_type)
+{
+    GPIO.CONF[gpio_num] = SET_FIELD(GPIO.CONF[gpio_num], GPIO_CONF_INTTYPE, int_type);
+    if(int_type != GPIO_INTTYPE_NONE) {
+        _xt_isr_attach(INUM_GPIO, gpio_interrupt_handler);
+        _xt_isr_unmask(1<<INUM_GPIO);
+    }
+}
+
+/* Return the interrupt type set for a pin */
+static inline gpio_inttype_t gpio_get_interrupt(const uint8_t gpio_num)
+{
+    return (gpio_inttype_t)FIELD2VAL(GPIO_CONF_INTTYPE, GPIO.CONF[gpio_num]);
+}
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif

--- a/esp8266/esp/gpio_regs.h
+++ b/esp8266/esp/gpio_regs.h
@@ -1,0 +1,150 @@
+/* esp/gpio_regs.h
+ *
+ * ESP8266 GPIO register definitions
+ *
+ * Not compatible with ESP SDK register access code.
+ */
+
+#ifndef _ESP_GPIO_REGS_H
+#define _ESP_GPIO_REGS_H
+
+#include "esp/types.h"
+#include "common_macros.h"
+
+#define GPIO_BASE 0x60000300
+#define GPIO (*(struct GPIO_REGS *)(GPIO_BASE))
+
+/** GPIO output registers GPIO.OUT, GPIO.OUT_SET, GPIO.OUT_CLEAR:
+ *
+ * _SET and _CLEAR write-only registers set and clear bits in the main register,
+ * respectively.
+ *
+ * i.e.
+ *   GPIO.OUT_SET = BIT(3);
+ * and
+ *   GPIO.OUT |= BIT(3);
+ *
+ * ... are equivalent, but the former uses fewer CPU cycles.
+ *
+ * ENABLE_OUT / ENABLE_OUT_SET / ENABLE_OUT_CLEAR:
+ *
+ * Determine whether the corresponding GPIO has its output enabled or not.
+ * When clear, GPIO can function as an input.  When set, GPIO will drive its
+ * output (and IN register will simply reflect the output state).
+ *
+ * (_SET/_CLEAR function similarly to OUT registers)
+ *
+ * STATUS / STATUS_SET / STATUS_CLEAR:
+ *
+ * Indicates which GPIOs have triggered an interrupt.  Interrupt status should
+ * be reset by writing to STATUS or STATUS_CLEAR.
+ *
+ * (_SET/_CLEAR function similarly to OUT registers)
+ */
+
+struct GPIO_REGS {
+    uint32_t volatile OUT;              // 0x00
+    uint32_t volatile OUT_SET;          // 0x04
+    uint32_t volatile OUT_CLEAR;        // 0x08
+    uint32_t volatile ENABLE_OUT;       // 0x0c
+    uint32_t volatile ENABLE_OUT_SET;   // 0x10
+    uint32_t volatile ENABLE_OUT_CLEAR; // 0x14
+    uint32_t volatile IN;               // 0x18
+    uint32_t volatile STATUS;           // 0x1c
+    uint32_t volatile STATUS_SET;       // 0x20
+    uint32_t volatile STATUS_CLEAR;     // 0x24
+    uint32_t volatile CONF[16];         // 0x28 - 0x64
+    uint32_t volatile PWM;              // 0x68
+    uint32_t volatile RTC_CALIB;        // 0x6c
+    uint32_t volatile RTC_CALIB_RESULT; // 0x70
+};
+
+_Static_assert(sizeof(struct GPIO_REGS) == 0x74, "GPIO_REGS is the wrong size");
+
+/* Details for additional OUT register fields */
+
+/* Bottom 16 bits of GPIO.OUT are for GPIOs 0-15, but upper 16 bits
+   are used to configure the input signalling pins for Bluetooth
+   Coexistence config (see esp/phy.h for a wrapper function).
+*/
+#define GPIO_OUT_PIN_MASK 0x0000FFFF
+#define GPIO_OUT_BT_COEXIST_MASK 0x03FF0000
+#define GPIO_OUT_BT_ACTIVE_ENABLE BIT(24)
+#define GPIO_OUT_BT_PRIORITY_ENABLE BIT(25)
+#define GPIO_OUT_BT_ACTIVE_PIN_M 0x0F
+#define GPIO_OUT_BT_ACTIVE_PIN_S 16
+#define GPIO_OUT_BT_PRIORITY_PIN_M 0x0F
+#define GPIO_OUT_BT_PRIORITY_PIN_S 20
+
+/* Details for CONF[i] registers */
+
+/* GPIO.CONF[i] control the pin behavior for the corresponding GPIO in/output.
+ *
+ * GPIO_CONF_CONFIG (multi-value)
+ *     FIXME: Unclear what these do.  Need to find a better name.
+ *
+ * GPIO_CONF_WAKEUP_ENABLE (boolean)
+ *     Can an interrupt contion on this pin wake the processor from a sleep
+ *     state?
+ *
+ * GPIO_CONF_INTTYPE (multi-value)
+ *     Under what conditions this GPIO input should generate an interrupt.
+ *     (see gpio_inttype_t enum below for values)
+ *
+ * GPIO_CONF_OPEN_DRAIN (boolean)
+ *     If this bit is set, the pin is in "open drain" mode - a high output state
+ *     will leave the pin floating but not source any current. If bit is cleared,
+ *     the pin is in push/pull mode so a high output state will drive the pin up
+ *     to +Vcc (3.3V).  In either case, a low output state will pull the pin down
+ *     to ground.
+ *
+ *     GPIO_CONF_OPEN_DRAIN does not appear to work on all pins.
+ *
+ *
+ * GPIO_CONF_SOURCE_PWM (boolean)
+ *     When set, GPIO pin output will be connected to the sigma-delta PWM
+ *     generator (controlled by the GPIO.PWM register).  When cleared, pin
+ *     output will function as a normal GPIO output (controlled by the
+ *     GPIO.OUT* registers).
+ */
+
+#define GPIO_CONF_CONFIG_M       0x00000003
+#define GPIO_CONF_CONFIG_S       11
+#define GPIO_CONF_WAKEUP_ENABLE  BIT(10)
+#define GPIO_CONF_INTTYPE_M      0x00000007
+#define GPIO_CONF_INTTYPE_S      7
+#define GPIO_CONF_OPEN_DRAIN     BIT(2)
+#define GPIO_CONF_SOURCE_PWM     BIT(0)
+
+/* Valid values for the GPIO_CONF_INTTYPE field */
+typedef enum {
+    GPIO_INTTYPE_NONE       = 0,
+    GPIO_INTTYPE_EDGE_POS   = 1,
+    GPIO_INTTYPE_EDGE_NEG   = 2,
+    GPIO_INTTYPE_EDGE_ANY   = 3,
+    GPIO_INTTYPE_LEVEL_LOW  = 4,
+    GPIO_INTTYPE_LEVEL_HIGH = 5,
+} gpio_inttype_t;
+
+/* Details for PWM register */
+
+#define GPIO_PWM_ENABLE          BIT(16)
+#define GPIO_PWM_PRESCALER_M     0x000000ff
+#define GPIO_PWM_PRESCALER_S     8
+#define GPIO_PWM_TARGET_M        0x000000ff
+#define GPIO_PWM_TARGET_S        0
+
+/* Details for RTC_CALIB register */
+
+#define GPIO_RTC_CALIB_START     BIT(31)
+#define GPIO_RTC_CALIB_PERIOD_M  0x000003ff
+#define GPIO_RTC_CALIB_PERIOD_S  0
+
+/* Details for RTC_CALIB_RESULT register */
+
+#define GPIO_RTC_CALIB_RESULT_READY       BIT(31)
+#define GPIO_RTC_CALIB_RESULT_READY_REAL  BIT(30)
+#define GPIO_RTC_CALIB_RESULT_VALUE_M     0x000fffff
+#define GPIO_RTC_CALIB_RESULT_VALUE_S     0
+
+#endif /* _ESP_GPIO_REGS_H */

--- a/esp8266/esp/interrupts.h
+++ b/esp8266/esp/interrupts.h
@@ -1,0 +1,104 @@
+/* ESP8266 Xtensa interrupt management functions
+ *
+ * Some (w/ sdk_ prefix) are implemented in binary libs, rest are
+ * inlines replacing functions in the binary libraries.
+ *
+ * Part of esp-open-rtos
+ * Copyright (C) 2015 Superhouse Automation Pty Ltd
+ * BSD Licensed as described in the file LICENSE
+ */
+#ifndef _XTENSA_INTERRUPTS_H
+#define _XTENSA_INTERRUPTS_H
+#include <stdint.h>
+#include <stdbool.h>
+#include <xtruntime.h>
+#include <xtensa/hal.h>
+#include <common_macros.h>
+
+/* Interrupt numbers for level 1 exception handler. */
+typedef enum {
+    INUM_SLC = 1,
+    INUM_SPI = 2,
+    INUM_GPIO = 4,
+    INUM_UART = 5,
+    INUM_TICK = 6, /* RTOS timer tick, possibly xtensa CPU CCOMPARE0(?) */
+    INUM_SOFT = 7,
+    INUM_WDT = 8,
+    INUM_TIMER_FRC1 = 9,
+
+    /* FRC2 default handler. Configured by sdk_ets_timer_init, which
+       runs as part of default libmain.a startup code, assigns
+       interrupt handler to sdk_vApplicationTickHook+0x68
+     */
+    INUM_TIMER_FRC2 = 10,
+} xt_isr_num_t;
+
+void sdk__xt_int_exit (void);
+void _xt_user_exit (void);
+void sdk__xt_tick_timer_init (void);
+void sdk__xt_timer_int(void);
+void sdk__xt_timer_int1(void);
+
+static inline uint32_t _xt_get_intlevel(void)
+{
+    uint32_t level;
+    __asm__ volatile("rsr %0, intlevel" : "=a"(level));
+    return level;
+}
+
+/* Disable interrupts and return the old ps value, to pass into
+   _xt_restore_interrupts later.
+
+   This is desirable to use in place of
+   portDISABLE_INTERRUPTS/portENABLE_INTERRUPTS for
+   non-FreeRTOS & non-portable code.
+*/
+static inline uint32_t _xt_disable_interrupts(void)
+{
+    uint32_t old_level;
+    __asm__ volatile ("rsil %0, " XTSTR(XCHAL_EXCM_LEVEL) : "=a" (old_level));
+    return old_level;
+}
+
+/* Restore PS level. Intended to be used with _xt_disable_interrupts */
+static inline void _xt_restore_interrupts(uint32_t new_ps)
+{
+    __asm__ volatile ("wsr %0, ps; rsync" :: "a" (new_ps));
+}
+
+/* ESPTODO: the mask/unmask functions aren't thread safe */
+
+static inline void _xt_isr_unmask(uint32_t unmask)
+{
+    uint32_t intenable;
+    asm volatile ("rsr %0, intenable" : "=a" (intenable));
+    intenable |= unmask;
+    asm volatile ("wsr %0, intenable; esync" :: "a" (intenable));
+}
+
+static inline void _xt_isr_mask (uint32_t mask)
+{
+    uint32_t intenable;
+    asm volatile ("rsr %0, intenable" : "=a" (intenable));
+    intenable &= ~mask;
+    asm volatile ("wsr %0, intenable; esync" :: "a" (intenable));
+}
+
+static inline uint32_t _xt_read_ints (void)
+{
+    uint32_t interrupt;
+    asm volatile ("rsr %0, interrupt" : "=a" (interrupt));
+    return interrupt;
+}
+
+static inline void _xt_clear_ints(uint32_t mask)
+{
+    asm volatile ("wsr %0, intclear; esync" :: "a" (mask));
+}
+
+typedef void (* _xt_isr)(void);
+/* This function is implemeneted in FreeRTOS port.c at the moment,
+   should be moved or converted to an inline */
+void        _xt_isr_attach (uint8_t i, _xt_isr func);
+
+#endif

--- a/esp8266/esp/iomux.h
+++ b/esp8266/esp/iomux.h
@@ -1,0 +1,87 @@
+/** esp/iomux.h
+ *
+ * Configuration of iomux registers.
+ *
+ * Part of esp-open-rtos
+ * Copyright (C) 2015 Superhouse Automation Pty Ltd
+ * BSD Licensed as described in the file LICENSE
+ */
+#ifndef _ESP_IOMUX_H
+#define _ESP_IOMUX_H
+#include "esp/types.h"
+#include "esp/iomux_regs.h"
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+/**
+ * Convert a GPIO pin number to an iomux register index.
+ *
+ * This function should evaluate to a constant if the gpio_number is
+ * known at compile time, or return the result from a lookup table if not.
+ *
+ */
+uint8_t IRAM gpio_to_iomux(const uint8_t gpio_number);
+
+/**
+ * Convert an iomux register index to a GPIO pin number.
+ *
+ * This function should evaluate to a constant if the iomux_num is
+ * known at compile time, or return the result from a lookup table if not.
+ *
+ */
+uint8_t IRAM iomux_to_gpio(const uint8_t iomux_num);
+
+/**
+ * Directly get the IOMUX register for a particular gpio number
+ *
+ * ie *gpio_iomux_reg(3) is equivalent to IOMUX_GPIO3
+ */
+inline static esp_reg_t gpio_iomux_reg(const uint8_t gpio_number)
+{
+    return &(IOMUX.PIN[gpio_to_iomux(gpio_number)]);
+}
+
+inline static void iomux_set_function(uint8_t iomux_num, uint32_t func)
+{
+    uint32_t prev = IOMUX.PIN[iomux_num] & ~IOMUX_PIN_FUNC_MASK;
+    IOMUX.PIN[iomux_num] = IOMUX_FUNC(func) | prev;
+}
+
+inline static void iomux_set_direction_flags(uint8_t iomux_num, uint32_t dir_flags)
+{
+    uint32_t mask = IOMUX_PIN_OUTPUT_ENABLE | IOMUX_PIN_OUTPUT_ENABLE_SLEEP;
+    uint32_t prev = IOMUX.PIN[iomux_num] & ~mask;
+    IOMUX.PIN[iomux_num] = dir_flags | prev;
+}
+
+inline static void iomux_set_pullup_flags(uint8_t iomux_num, uint32_t pullup_flags)
+{
+    uint32_t mask = IOMUX_PIN_PULLUP | IOMUX_PIN_PULLDOWN | IOMUX_PIN_PULLUP_SLEEP | IOMUX_PIN_PULLDOWN_SLEEP;
+    uint32_t prev = IOMUX.PIN[iomux_num] & ~mask;
+    IOMUX.PIN[iomux_num] = pullup_flags | prev;
+}
+
+/**
+ * Set a pin to the GPIO function.
+ *
+ * This allows you to set pins to GPIO without knowing in advance the
+ * exact register masks to use.
+ *
+ * Sets the function and direction, but leaves the pullup configuration the
+ * same as before.
+ */
+inline static void iomux_set_gpio_function(uint8_t gpio_number, bool output_enable)
+{
+    const uint8_t iomux_num = gpio_to_iomux(gpio_number);
+    const uint32_t func = iomux_num > 11 ? 0 : 3;
+    iomux_set_function(iomux_num, func);
+    iomux_set_direction_flags(iomux_num, output_enable ? IOMUX_PIN_OUTPUT_ENABLE : 0);
+}
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif

--- a/esp8266/esp/iomux_regs.h
+++ b/esp8266/esp/iomux_regs.h
@@ -1,0 +1,151 @@
+/* esp/iomux_regs.h
+ *
+ * ESP8266 IOMUX register definitions
+ *
+ * Not compatible with ESP SDK register access code.
+ *
+ * Note that IOMUX register order is _not_ the same as GPIO order. See
+ * esp/iomux.h for programmer-friendly IOMUX configuration options.
+ */
+
+#ifndef _ESP_IOMUX_REGS_H
+#define _ESP_IOMUX_REGS_H
+
+#include "esp/types.h"
+#include "common_macros.h"
+
+#define IOMUX_BASE 0x60000800
+#define IOMUX (*(struct IOMUX_REGS *)(IOMUX_BASE))
+
+struct IOMUX_REGS {
+    uint32_t volatile CONF;    // 0x00
+    uint32_t volatile PIN[16]; // 0x04 - 0x40
+};
+
+_Static_assert(sizeof(struct IOMUX_REGS) == 0x44, "IOMUX_REGS is the wrong size");
+
+/* Details for CONF register */
+
+#define IOMUX_CONF_SPI0_CLOCK_EQU_SYS_CLOCK  BIT(8)
+#define IOMUX_CONF_SPI1_CLOCK_EQU_SYS_CLOCK  BIT(9)
+
+/* Details for PIN registers */
+
+#define IOMUX_PIN_OUTPUT_ENABLE        BIT(0)
+#define IOMUX_PIN_OUTPUT_ENABLE_SLEEP  BIT(1)
+#define IOMUX_PIN_PULLDOWN_SLEEP       BIT(2)
+#define IOMUX_PIN_PULLUP_SLEEP         BIT(3)
+#define IOMUX_PIN_FUNC_LOW_M           0x00000003
+#define IOMUX_PIN_FUNC_LOW_S           4
+#define IOMUX_PIN_PULLDOWN             BIT(6)
+#define IOMUX_PIN_PULLUP               BIT(7)
+#define IOMUX_PIN_FUNC_HIGH_M          0x00000004
+#define IOMUX_PIN_FUNC_HIGH_S          6
+
+#define IOMUX_PIN_FUNC_MASK            0x00000130
+
+/* WARNING: Macro evaluates argument twice */
+#define IOMUX_FUNC(val) (VAL2FIELD_M(IOMUX_PIN_FUNC_LOW, val) | VAL2FIELD_M(IOMUX_PIN_FUNC_HIGH, val))
+
+/* WARNING: Macro evaluates argument twice */
+#define IOMUX_FUNC_VALUE(regbits) (FIELD2VAL(IOMUX_PIN_FUNC_LOW, regbits) | FIELD2VAL(IOMUX_PIN_FUNC_HIGH, regbits))
+
+#define IOMUX_SET_FUNC(regbits, funcval) (((regbits) & ~IOMUX_PIN_FUNC_MASK) | (funcval))
+
+#define IOMUX_GPIO0   IOMUX.PIN[12]
+#define IOMUX_GPIO1   IOMUX.PIN[5]
+#define IOMUX_GPIO2   IOMUX.PIN[13]
+#define IOMUX_GPIO3   IOMUX.PIN[4]
+#define IOMUX_GPIO4   IOMUX.PIN[14]
+#define IOMUX_GPIO5   IOMUX.PIN[15]
+#define IOMUX_GPIO6   IOMUX.PIN[6]
+#define IOMUX_GPIO7   IOMUX.PIN[7]
+#define IOMUX_GPIO8   IOMUX.PIN[8]
+#define IOMUX_GPIO9   IOMUX.PIN[9]
+#define IOMUX_GPIO10  IOMUX.PIN[10]
+#define IOMUX_GPIO11  IOMUX.PIN[11]
+#define IOMUX_GPIO12  IOMUX.PIN[0]
+#define IOMUX_GPIO13  IOMUX.PIN[1]
+#define IOMUX_GPIO14  IOMUX.PIN[2]
+#define IOMUX_GPIO15  IOMUX.PIN[3]
+
+#define IOMUX_GPIO0_FUNC_GPIO              IOMUX_FUNC(0)
+#define IOMUX_GPIO0_FUNC_SPI0_CS2          IOMUX_FUNC(1)
+#define IOMUX_GPIO0_FUNC_CLOCK_OUT         IOMUX_FUNC(4)
+
+#define IOMUX_GPIO1_FUNC_UART0_TXD         IOMUX_FUNC(0)
+#define IOMUX_GPIO1_FUNC_SPI0_CS1          IOMUX_FUNC(1)
+#define IOMUX_GPIO1_FUNC_GPIO              IOMUX_FUNC(3)
+#define IOMUX_GPIO1_FUNC_CLOCK_RTC_BLINK   IOMUX_FUNC(4)
+
+#define IOMUX_GPIO2_FUNC_GPIO              IOMUX_FUNC(0)
+#define IOMUX_GPIO2_FUNC_I2SO_WS           IOMUX_FUNC(1)
+#define IOMUX_GPIO2_FUNC_UART1_TXD         IOMUX_FUNC(2)
+#define IOMUX_GPIO2_FUNC_UART0_TXD         IOMUX_FUNC(4)
+
+#define IOMUX_GPIO3_FUNC_UART0_RXD         IOMUX_FUNC(0)
+#define IOMUX_GPIO3_FUNC_I2SO_DATA         IOMUX_FUNC(1)
+#define IOMUX_GPIO3_FUNC_GPIO              IOMUX_FUNC(3)
+#define IOMUX_GPIO3_FUNC_CLOCK_XTAL_BLINK  IOMUX_FUNC(4)
+
+#define IOMUX_GPIO4_FUNC_GPIO              IOMUX_FUNC(0)
+#define IOMUX_GPIO4_FUNC_CLOCK_XTAL        IOMUX_FUNC(1)
+
+#define IOMUX_GPIO5_FUNC_GPIO              IOMUX_FUNC(0)
+#define IOMUX_GPIO5_FUNC_CLOCK_RTC         IOMUX_FUNC(1)
+
+#define IOMUX_GPIO6_FUNC_SD_CLK            IOMUX_FUNC(0)
+#define IOMUX_GPIO6_FUNC_SPI0_CLK          IOMUX_FUNC(1)
+#define IOMUX_GPIO6_FUNC_GPIO              IOMUX_FUNC(3)
+#define IOMUX_GPIO6_FUNC_UART1_CTS         IOMUX_FUNC(4)
+
+#define IOMUX_GPIO7_FUNC_SD_DATA0          IOMUX_FUNC(0)
+#define IOMUX_GPIO7_FUNC_SPI0_Q_MISO       IOMUX_FUNC(1)
+#define IOMUX_GPIO7_FUNC_GPIO              IOMUX_FUNC(3)
+#define IOMUX_GPIO7_FUNC_UART1_TXD         IOMUX_FUNC(4)
+
+#define IOMUX_GPIO8_FUNC_SD_DATA1          IOMUX_FUNC(0)
+#define IOMUX_GPIO8_FUNC_SPI0_D_MOSI       IOMUX_FUNC(1)
+#define IOMUX_GPIO8_FUNC_GPIO              IOMUX_FUNC(3)
+#define IOMUX_GPIO8_FUNC_UART1_RXD         IOMUX_FUNC(4)
+
+#define IOMUX_GPIO9_FUNC_SD_DATA2          IOMUX_FUNC(0)
+#define IOMUX_GPIO9_FUNC_SPI0_HD           IOMUX_FUNC(1)
+#define IOMUX_GPIO9_FUNC_GPIO              IOMUX_FUNC(3)
+#define IOMUX_GPIO9_FUNC_SPI1_HD           IOMUX_FUNC(4)
+
+#define IOMUX_GPIO10_FUNC_SD_DATA3         IOMUX_FUNC(0)
+#define IOMUX_GPIO10_FUNC_SPI0_WP          IOMUX_FUNC(1)
+#define IOMUX_GPIO10_FUNC_GPIO             IOMUX_FUNC(3)
+#define IOMUX_GPIO10_FUNC_SPI1_WP          IOMUX_FUNC(4)
+
+#define IOMUX_GPIO11_FUNC_SD_CMD           IOMUX_FUNC(0)
+#define IOMUX_GPIO11_FUNC_SPI0_CS0         IOMUX_FUNC(1)
+#define IOMUX_GPIO11_FUNC_GPIO             IOMUX_FUNC(3)
+#define IOMUX_GPIO11_FUNC_UART1_RTS        IOMUX_FUNC(4)
+
+#define IOMUX_GPIO12_FUNC_MTDI             IOMUX_FUNC(0)
+#define IOMUX_GPIO12_FUNC_I2SI_DATA        IOMUX_FUNC(1)
+#define IOMUX_GPIO12_FUNC_SPI1_Q_MISO      IOMUX_FUNC(2)
+#define IOMUX_GPIO12_FUNC_GPIO             IOMUX_FUNC(3)
+#define IOMUX_GPIO12_FUNC_UART0_DTR        IOMUX_FUNC(4)
+
+#define IOMUX_GPIO13_FUNC_MTCK             IOMUX_FUNC(0)
+#define IOMUX_GPIO13_FUNC_I2SI_BCK         IOMUX_FUNC(1)
+#define IOMUX_GPIO13_FUNC_SPI1_D_MOSI      IOMUX_FUNC(2)
+#define IOMUX_GPIO13_FUNC_GPIO             IOMUX_FUNC(3)
+#define IOMUX_GPIO13_FUNC_UART0_CTS        IOMUX_FUNC(4)
+
+#define IOMUX_GPIO14_FUNC_MTMS             IOMUX_FUNC(0)
+#define IOMUX_GPIO14_FUNC_I2SI_WS          IOMUX_FUNC(1)
+#define IOMUX_GPIO14_FUNC_SPI1_CLK         IOMUX_FUNC(2)
+#define IOMUX_GPIO14_FUNC_GPIO             IOMUX_FUNC(3)
+#define IOMUX_GPIO14_FUNC_UART0_DSR        IOMUX_FUNC(4)
+
+#define IOMUX_GPIO15_FUNC_MTDO             IOMUX_FUNC(0)
+#define IOMUX_GPIO15_FUNC_I2SO_BCK         IOMUX_FUNC(1)
+#define IOMUX_GPIO15_FUNC_SPI1_CS0         IOMUX_FUNC(2)
+#define IOMUX_GPIO15_FUNC_GPIO             IOMUX_FUNC(3)
+#define IOMUX_GPIO15_FUNC_UART0_RTS        IOMUX_FUNC(4)
+
+#endif /* _ESP_IOMUX_REGS_H */

--- a/esp8266/esp/spi.h
+++ b/esp8266/esp/spi.h
@@ -1,0 +1,273 @@
+/**
+ * \file Hardware SPI master driver
+ *
+ * Part of esp-open-rtos
+ *
+ * \copyright Ruslan V. Uss, 2016
+ * BSD Licensed as described in the file LICENSE
+ */
+#ifndef _ESP_SPI_H_
+#define _ESP_SPI_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include "esp/spi_regs.h"
+#include "esp/clocks.h"
+
+/**
+ * Macro for use with spi_init and spi_set_frequency_div.
+ * SPI frequency = 80000000 / divider / count
+ * dvider must be in 1..8192 and count in 1..64
+ */
+#define SPI_GET_FREQ_DIV(divider, count) (((count) << 16) | ((divider) & 0xffff))
+
+/**
+ * Predefinded SPI frequency dividers
+ */
+#define SPI_FREQ_DIV_125K SPI_GET_FREQ_DIV(64, 10) ///< 125kHz
+#define SPI_FREQ_DIV_250K SPI_GET_FREQ_DIV(32, 10) ///< 250kHz
+#define SPI_FREQ_DIV_500K SPI_GET_FREQ_DIV(16, 10) ///< 500kHz
+#define SPI_FREQ_DIV_1M   SPI_GET_FREQ_DIV(8, 10)  ///< 1MHz
+#define SPI_FREQ_DIV_2M   SPI_GET_FREQ_DIV(4, 10)  ///< 2MHz
+#define SPI_FREQ_DIV_4M   SPI_GET_FREQ_DIV(2, 10)  ///< 4MHz
+#define SPI_FREQ_DIV_8M   SPI_GET_FREQ_DIV(5,  2)  ///< 8MHz
+#define SPI_FREQ_DIV_10M  SPI_GET_FREQ_DIV(4,  2)  ///< 10MHz
+#define SPI_FREQ_DIV_20M  SPI_GET_FREQ_DIV(2,  2)  ///< 20MHz
+#define SPI_FREQ_DIV_40M  SPI_GET_FREQ_DIV(1,  2)  ///< 40MHz
+#define SPI_FREQ_DIV_80M  SPI_GET_FREQ_DIV(1,  1)  ///< 80MHz
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef enum _spi_mode_t {
+    SPI_MODE0 = 0,  ///< CPOL = 0, CPHA = 0
+    SPI_MODE1,      ///< CPOL = 0, CPHA = 1
+    SPI_MODE2,      ///< CPOL = 1, CPHA = 0
+    SPI_MODE3       ///< CPOL = 1, CPHA = 1
+} spi_mode_t;
+
+typedef enum _spi_endianness_t {
+    SPI_LITTLE_ENDIAN = 0,
+    SPI_BIG_ENDIAN
+} spi_endianness_t;
+
+typedef enum _spi_word_size_t {
+    SPI_8BIT  = 1,  ///< 1 byte
+    SPI_16BIT = 2,  ///< 2 bytes
+    SPI_32BIT = 4   ///< 4 bytes
+} spi_word_size_t;
+
+/**
+ * SPI bus settings
+ */
+typedef struct
+{
+    spi_mode_t mode;              ///< Bus mode
+    uint32_t freq_divider;        ///< Bus frequency as a divider. See spi_init()
+    bool msb;                     ///< MSB first if true
+    spi_endianness_t endianness;  ///< Bus byte order
+    bool minimal_pins;            ///< Minimal set of pins if true. Spee spi_init()
+} spi_settings_t;
+
+/**
+ * \brief Initalize SPI bus
+ * Initalize specified SPI bus and setup appropriate pins:
+ * Bus 0:
+ *   - MISO = GPIO 7
+ *   - MOSI = GPIO 8
+ *   - SCK  = GPIO 6
+ *   - CS0  = GPIO 11 (if minimal_pins is false)
+ *   - HD   = GPIO 9  (if minimal_pins is false)
+ *   - WP   = GPIO 10 (if minimal_pins is false)
+ * Bus 1:
+ *   - MISO = GPIO 12
+ *   - MOSI = GPIO 13
+ *   - SCK  = GPIO 14
+ *   - CS0  = GPIO 15 (if minimal_pins is false)
+ * Note that system flash memory is on the bus 0!
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \param mode Bus mode
+ * \param freq_divider SPI bus frequency divider, use SPI_GET_FREQ_DIV() or predefined value
+ * \param msb Bit order, MSB first if true
+ * \param endianness Byte order
+ * \param minimal_pins If true use the minimal set of pins: MISO, MOSI and SCK.
+ * \return false when error
+ */
+bool spi_init(uint8_t bus, spi_mode_t mode, uint32_t freq_divider, bool msb, spi_endianness_t endianness, bool minimal_pins);
+/**
+ * \brief Initalize SPI bus
+ * spi_init() wrapper.
+ * Example:
+ *
+ *     const spi_settings_t my_settings = {
+ *         .mode = SPI_MODE0,
+ *         .freq_divider = SPI_FREQ_DIV_4M,
+ *         .msb = true,
+ *         .endianness = SPI_LITTLE_ENDIAN,
+ *         .minimal_pins = true
+ *     }
+ *     ....
+ *     spi_settings_t old;
+ *     spi_get_settings(1, &old); // save current settings
+ *     //spi_init(1, SPI_MODE0, SPI_FREQ_DIV_4M, true, SPI_LITTLE_ENDIAN, true); // use own settings
+ *     // or
+ *     spi_set_settings(1, &my_settings);
+ *     // some work with spi here
+ *     ....
+ *     spi_set_settings(1, &old); // restore saved settings
+ *
+ * \param s Pointer to the settings structure
+ * \return false when error
+ */
+static inline bool spi_set_settings(uint8_t bus, const spi_settings_t *s)
+{
+    return spi_init(bus, s->mode, s->freq_divider, s->msb, s->endianness, s->minimal_pins);
+}
+/**
+ * \brief Get current settings of the SPI bus
+ * See spi_set_settings().
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \param s Pointer to the structure that receives SPI bus settings
+ */
+void spi_get_settings(uint8_t bus, spi_settings_t *s);
+
+/**
+ * \brief Set SPI bus mode
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \param mode Bus mode
+ */
+void spi_set_mode(uint8_t bus, spi_mode_t mode);
+/**
+ * \brief Get mode of the SPI bus
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \return Bus mode
+ */
+spi_mode_t spi_get_mode(uint8_t bus);
+
+/**
+ * \brief Set SPI bus frequency
+ * Examples:
+ *
+ *     spi_set_frequency_div(1, SPI_FREQ_DIV_8M); // 8 MHz, predefined value
+ *     ...
+ *     spi_set_frequency_div(1, SPI_GET_FREQ_DIV(8, 10)); // divider = 8, count = 10,
+ *                                                        // frequency = 80000000 Hz / 8 / 10 = 1000000 Hz
+ *
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \param divider Predivider of the system bus frequency (80MHz) in the 2 low
+ *     bytes and period pulses count in the third byte. Please note that
+ *     divider must be be in range 1..8192 and count in range 2..64. Use the
+ *     macro SPI_GET_FREQ_DIV(divider, count) to get the correct parameter value.
+ */
+void spi_set_frequency_div(uint8_t bus, uint32_t divider);
+/**
+ * \brief Get SPI bus frequency as a divider
+ * Example:
+ *
+ *   uint32_t old_freq = spi_get_frequency_div(1);
+ *   spi_set_frequency_div(1, SPI_FREQ_DIV_8M);
+ *   ...
+ *   spi_set_frequency_div(1, old_freq);
+ *
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \return SPI frequency, as divider.
+ */
+inline uint32_t spi_get_frequency_div(uint8_t bus)
+{
+    return (FIELD2VAL(SPI_CLOCK_DIV_PRE, SPI(bus).CLOCK) + 1) |
+           (FIELD2VAL(SPI_CLOCK_COUNT_NUM, SPI(bus).CLOCK) + 1);
+}
+/**
+ * \brief Get SPI bus frequency in Hz
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \return SPI frequency, Hz
+ */
+inline uint32_t spi_get_frequency_hz(uint8_t bus)
+{
+    return APB_CLK_FREQ /
+        (FIELD2VAL(SPI_CLOCK_DIV_PRE, SPI(bus).CLOCK) + 1) /
+        (FIELD2VAL(SPI_CLOCK_COUNT_NUM, SPI(bus).CLOCK) + 1);
+}
+
+/**
+ * \brief Set SPI bus bit order
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \param msb Bit order, MSB first if true
+ */
+void spi_set_msb(uint8_t bus, bool msb);
+/**
+ * \brief Get SPI bus bit order
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \return msb Bit order, MSB first if true
+ */
+inline bool spi_get_msb(uint8_t bus)
+{
+    return !(SPI(bus).CTRL0 & (SPI_CTRL0_WR_BIT_ORDER | SPI_CTRL0_RD_BIT_ORDER));
+}
+
+/**
+ * \brief Set SPI bus byte order
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \param endianness Byte order
+ */
+void spi_set_endianness(uint8_t bus, spi_endianness_t endianness);
+/**
+ * \brief Get SPI bus byte order
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \return endianness Byte order
+ */
+inline spi_endianness_t spi_get_endianness(uint8_t bus)
+{
+    return SPI(bus).USER0 & (SPI_USER0_WR_BYTE_ORDER | SPI_USER0_RD_BYTE_ORDER)
+        ? SPI_BIG_ENDIAN
+        : SPI_LITTLE_ENDIAN;
+}
+
+/**
+ * \brief Transfer 8 bits over SPI
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \param data Byte to send
+ * \return Received byte
+ */
+uint8_t spi_transfer_8(uint8_t bus, uint8_t data);
+/**
+ * \brief Transfer 16 bits over SPI
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \param data Word to send
+ * \return Received word
+ */
+uint16_t spi_transfer_16(uint8_t bus, uint16_t data);
+/**
+ * \brief Transfer 32 bits over SPI
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \param data dword to send
+ * \return Received dword
+ */
+uint32_t spi_transfer_32(uint8_t bus, uint32_t data);
+/**
+ * \brief Transfer buffer of words over SPI
+ * Please note that the buffer size is in words, not in bytes!
+ * Example:
+ *
+ *    const uint16_t out_buf[] = { 0xa0b0, 0xa1b1, 0xa2b2, 0xa3b3 };
+ *    uint16_t in_buf[sizeof(out_buf)];
+ *    spi_init(1, SPI_MODE1, SPI_FREQ_DIV_4M, true, SPI_BIG_ENDIAN, true);
+ *    spi_transfer(1, out_buf, in_buf, sizeof(out_buf), SPI_16BIT); // len = 4 words * 2 bytes = 8 bytes
+ *
+ * \param bus Bus ID: 0 - system, 1 - user
+ * \param out_data Data to send.
+ * \param in_data Receive buffer. If NULL, received data will be lost.
+ * \param len Buffer size in words
+ * \param word_size Size of the word
+ * \return Transmitted/received words count
+ */
+size_t spi_transfer(uint8_t bus, const void *out_data, void *in_data, size_t len, spi_word_size_t word_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ESP_SPI_H_ */

--- a/esp8266/esp/spi_regs.h
+++ b/esp8266/esp/spi_regs.h
@@ -1,0 +1,246 @@
+/** esp/spi.h
+ *
+ * Configuration of SPI registers.
+ *
+ * Part of esp-open-rtos
+ * Copyright (C) 2015 Superhouse Automation Pty Ltd
+ * BSD Licensed as described in the file LICENSE
+ */
+#ifndef _SPI_REGS_H
+#define _SPI_REGS_H
+
+#include "esp/types.h"
+#include "common_macros.h"
+
+/* Register definitions for the SPI peripherals on the ESP8266.
+ *
+ * There are twp SPI devices built into the ESP8266:
+ *   SPI(0) is at 0x60000200
+ *   SPI(1) is at 0x60000100
+ * (note that the device number order is reversed in memory)
+ *
+ * Each device is allocated a block of 64 32-bit registers (256 bytes of
+ * address space) to communicate with application code.
+ */
+
+#define SPI_BASE 0x60000200
+#define SPI(i) (*(struct SPI_REGS *)(0x60000200 - (i)*0x100))
+
+#define SPI0_BASE SPI_BASE
+#define SPI1_BASE (SPI_BASE - 0x100)
+
+struct SPI_REGS {
+    uint32_t volatile CMD;          // 0x00
+    uint32_t volatile ADDR;         // 0x04
+    uint32_t volatile CTRL0;        // 0x08
+    uint32_t volatile CTRL1;        // 0x0c
+    uint32_t volatile RSTATUS;      // 0x10
+    uint32_t volatile CTRL2;        // 0x14
+    uint32_t volatile CLOCK;        // 0x18
+    uint32_t volatile USER0;        // 0x1c
+    uint32_t volatile USER1;        // 0x20
+    uint32_t volatile USER2;        // 0x24
+    uint32_t volatile WSTATUS;      // 0x28
+    uint32_t volatile PIN;          // 0x2c
+    uint32_t volatile SLAVE0;       // 0x30
+    uint32_t volatile SLAVE1;       // 0x34
+    uint32_t volatile SLAVE2;       // 0x38
+    uint32_t volatile SLAVE3;       // 0x3c
+    uint32_t volatile W0;           // 0x40
+    uint32_t volatile W1;           // 0x44
+    uint32_t volatile W2;           // 0x48
+    uint32_t volatile W3;           // 0x4c
+    uint32_t volatile W4;           // 0x50
+    uint32_t volatile W5;           // 0x54
+    uint32_t volatile W6;           // 0x58
+    uint32_t volatile W7;           // 0x5c
+    uint32_t volatile W8;           // 0x60
+    uint32_t volatile W9;           // 0x64
+    uint32_t volatile W10;          // 0x68
+    uint32_t volatile W11;          // 0x6c
+    uint32_t volatile W12;          // 0x70
+    uint32_t volatile W13;          // 0x74
+    uint32_t volatile W14;          // 0x78
+    uint32_t volatile W15;          // 0x7c
+    uint32_t volatile _unused[28];  // 0x80 - 0xec
+    uint32_t volatile EXT0;         // 0xf0
+    uint32_t volatile EXT1;         // 0xf4
+    uint32_t volatile EXT2;         // 0xf8
+    uint32_t volatile EXT3;         // 0xfc
+};
+
+_Static_assert(sizeof(struct SPI_REGS) == 0x100, "SPI_REGS is the wrong size");
+
+/* Details for CMD register */
+
+#define SPI_CMD_USR                        BIT(18)
+
+/* Details for CTRL0 register */
+
+#define SPI_CTRL0_WR_BIT_ORDER             BIT(26)
+#define SPI_CTRL0_RD_BIT_ORDER             BIT(25)
+#define SPI_CTRL0_QIO_MODE                 BIT(24)
+#define SPI_CTRL0_DIO_MODE                 BIT(23)
+#define SPI_CTRL0_QOUT_MODE                BIT(20)
+#define SPI_CTRL0_DOUT_MODE                BIT(14)
+#define SPI_CTRL0_FASTRD_MODE              BIT(13)
+#define SPI_CTRL0_CLOCK_EQU_SYS_CLOCK      BIT(12)
+#define SPI_CTRL0_CLOCK_NUM_M              0x0000000F
+#define SPI_CTRL0_CLOCK_NUM_S              8
+#define SPI_CTRL0_CLOCK_HIGH_M             0x0000000F
+#define SPI_CTRL0_CLOCK_HIGH_S             4
+#define SPI_CTRL0_CLOCK_LOW_M              0x0000000F
+#define SPI_CTRL0_CLOCK_LOW_S              0
+
+/* Mask for the CLOCK_NUM/CLOCK_HIGH/CLOCK_LOW combined, in case one wants
+ * to set them all as a single value.
+ */
+#define SPI_CTRL0_CLOCK_M                  0x00000FFF
+#define SPI_CTRL0_CLOCK_S                  0
+
+/* Details for CTRL2 register */
+
+#define SPI_CTRL2_CS_DELAY_NUM_M           0x0000000F
+#define SPI_CTRL2_CS_DELAY_NUM_S           28
+#define SPI_CTRL2_CS_DELAY_MODE_M          0x00000003
+#define SPI_CTRL2_CS_DELAY_MODE_S          26
+#define SPI_CTRL2_MOSI_DELAY_NUM_M         0x00000007
+#define SPI_CTRL2_MOSI_DELAY_NUM_S         23
+#define SPI_CTRL2_MOSI_DELAY_MODE_M        0x00000003
+#define SPI_CTRL2_MOSI_DELAY_MODE_S        21
+#define SPI_CTRL2_MISO_DELAY_NUM_M         0x00000007
+#define SPI_CTRL2_MISO_DELAY_NUM_S         18
+#define SPI_CTRL2_MISO_DELAY_MODE_M        0x00000003
+#define SPI_CTRL2_MISO_DELAY_MODE_S        16
+
+/* Details for CLOCK register */
+
+#define SPI_CLOCK_EQU_SYS_CLOCK            BIT(31)
+#define SPI_CLOCK_DIV_PRE_M                0x00001FFF
+#define SPI_CLOCK_DIV_PRE_S                18
+#define SPI_CLOCK_COUNT_NUM_M              0x0000003F
+#define SPI_CLOCK_COUNT_NUM_S              12
+#define SPI_CLOCK_COUNT_HIGH_M             0x0000003F
+#define SPI_CLOCK_COUNT_HIGH_S             6
+#define SPI_CLOCK_COUNT_LOW_M              0x0000003F
+#define SPI_CLOCK_COUNT_LOW_S              0
+
+/* Mask for the COUNT_NUM/COUNT_HIGH/COUNT_LOW combined, in case one wants
+ * to set them all as a single value.
+ */
+#define SPI_CTRL0_COUNT_M                  0x0003FFFF
+#define SPI_CTRL0_COUNT_S                  0
+
+/* Details for USER0 register */
+
+#define SPI_USER0_COMMAND                  BIT(31)
+#define SPI_USER0_ADDR                     BIT(30)
+#define SPI_USER0_DUMMY                    BIT(29)
+#define SPI_USER0_MISO                     BIT(28)
+#define SPI_USER0_MOSI                     BIT(27)
+#define SPI_USER0_MOSI_HIGHPART            BIT(25)
+#define SPI_USER0_MISO_HIGHPART            BIT(24)
+#define SPI_USER0_SIO                      BIT(16)
+#define SPI_USER0_FWRITE_QIO               BIT(15)
+#define SPI_USER0_FWRITE_DIO               BIT(14)
+#define SPI_USER0_FWRITE_QUAD              BIT(13)
+#define SPI_USER0_FWRITE_DUAL              BIT(12)
+#define SPI_USER0_WR_BYTE_ORDER            BIT(11)
+#define SPI_USER0_RD_BYTE_ORDER            BIT(10)
+#define SPI_USER0_CLOCK_OUT_EDGE           BIT(7)
+#define SPI_USER0_CLOCK_IN_EDGE            BIT(6)
+#define SPI_USER0_CS_SETUP                 BIT(5)
+#define SPI_USER0_CS_HOLD                  BIT(4)
+#define SPI_USER0_FLASH_MODE               BIT(2)
+#define SPI_USER0_DUPLEX                   BIT(0)
+
+/* Details for USER1 register */
+
+#define SPI_USER1_ADDR_BITLEN_M            0x0000003F
+#define SPI_USER1_ADDR_BITLEN_S            26
+#define SPI_USER1_MOSI_BITLEN_M            0x000001FF
+#define SPI_USER1_MOSI_BITLEN_S            17
+#define SPI_USER1_MISO_BITLEN_M            0x000001FF
+#define SPI_USER1_MISO_BITLEN_S            8
+#define SPI_USER1_DUMMY_CYCLELEN_M         0x000000FF
+#define SPI_USER1_DUMMY_CYCLELEN_S         0
+
+/* Details for USER2 register */
+
+#define SPI_USER2_COMMAND_BITLEN_M         0x0000000F
+#define SPI_USER2_COMMAND_BITLEN_S         28
+#define SPI_USER2_COMMAND_VALUE_M          0x0000FFFF
+#define SPI_USER2_COMMAND_VALUE_S          0
+
+/* Details for PIN register */
+
+#define SPI_PIN_IDLE_EDGE                  BIT(29)  ///< CPOL
+#define SPI_PIN_CS2_DISABLE                BIT(2)
+#define SPI_PIN_CS1_DISABLE                BIT(1)
+#define SPI_PIN_CS0_DISABLE                BIT(0)
+
+/* Details for SLAVE0 register */
+
+#define SPI_SLAVE0_SYNC_RESET              BIT(31)
+#define SPI_SLAVE0_MODE                    BIT(30)
+#define SPI_SLAVE0_WR_RD_BUF_EN            BIT(29)
+#define SPI_SLAVE0_WR_RD_STA_EN            BIT(28)
+#define SPI_SLAVE0_CMD_DEFINE              BIT(27)
+#define SPI_SLAVE0_TRANS_COUNT_M           0x0000000F
+#define SPI_SLAVE0_TRANS_COUNT_S           23
+#define SPI_SLAVE0_TRANS_DONE_EN           BIT(9)
+#define SPI_SLAVE0_WR_STA_DONE_EN          BIT(8)
+#define SPI_SLAVE0_RD_STA_DONE_EN          BIT(7)
+#define SPI_SLAVE0_WR_BUF_DONE_EN          BIT(6)
+#define SPI_SLAVE0_RD_BUF_DONE_EN          BIT(5)
+#define SPI_SLAVE0_INT_EN_M                0x0000001f
+#define SPI_SLAVE0_INT_EN_S                5
+#define SPI_SLAVE0_TRANS_DONE              BIT(4)
+#define SPI_SLAVE0_WR_STA_DONE             BIT(3)
+#define SPI_SLAVE0_RD_STA_DONE             BIT(2)
+#define SPI_SLAVE0_WR_BUF_DONE             BIT(1)
+#define SPI_SLAVE0_RD_BUF_DONE             BIT(0)
+
+/* Details for SLAVE1 register */
+
+#define SPI_SLAVE1_STATUS_BITLEN_M         0x0000001F
+#define SPI_SLAVE1_STATUS_BITLEN_S         27
+#define SPI_SLAVE1_BUF_BITLEN_M            0x000001FF
+#define SPI_SLAVE1_BUF_BITLEN_S            16
+#define SPI_SLAVE1_RD_ADDR_BITLEN_M        0x0000003F
+#define SPI_SLAVE1_RD_ADDR_BITLEN_S        10
+#define SPI_SLAVE1_WR_ADDR_BITLEN_M        0x0000003F
+#define SPI_SLAVE1_WR_ADDR_BITLEN_S        4
+#define SPI_SLAVE1_WRSTA_DUMMY_ENABLE      BIT(3)
+#define SPI_SLAVE1_RDSTA_DUMMY_ENABLE      BIT(2)
+#define SPI_SLAVE1_WRBUF_DUMMY_ENABLE      BIT(1)
+#define SPI_SLAVE1_RDBUF_DUMMY_ENABLE      BIT(0)
+
+/* Details for SLAVE2 register */
+
+#define SPI_SLAVE2_WRBUF_DUMMY_CYCLELEN_M  0x000000FF
+#define SPI_SLAVE2_WRBUF_DUMMY_CYCLELEN_S  24
+#define SPI_SLAVE2_RDBUF_DUMMY_CYCLELEN_M  0x000000FF
+#define SPI_SLAVE2_RDBUF_DUMMY_CYCLELEN_S  16
+#define SPI_SLAVE2_WRSTR_DUMMY_CYCLELEN_M  0x000000FF
+#define SPI_SLAVE2_WRSTR_DUMMY_CYCLELEN_S  8
+#define SPI_SLAVE2_RDSTR_DUMMY_CYCLELEN_M  0x000000FF
+#define SPI_SLAVE2_RDSTR_DUMMY_CYCLELEN_S  0
+
+/* Details for SLAVE3 register */
+
+#define SPI_SLAVE3_WRSTA_CMD_VALUE_M       0x000000FF
+#define SPI_SLAVE3_WRSTA_CMD_VALUE_S       24
+#define SPI_SLAVE3_RDSTA_CMD_VALUE_M       0x000000FF
+#define SPI_SLAVE3_RDSTA_CMD_VALUE_S       16
+#define SPI_SLAVE3_WRBUF_CMD_VALUE_M       0x000000FF
+#define SPI_SLAVE3_WRBUF_CMD_VALUE_S       8
+#define SPI_SLAVE3_RDBUF_CMD_VALUE_M       0x000000FF
+#define SPI_SLAVE3_RDBUF_CMD_VALUE_S       0
+
+/* Details for EXT3 register */
+
+#define SPI_EXT3_INT_HOLD_ENABLE_M         0x00000003
+#define SPI_EXT3_INT_HOLD_ENABLE_S         0
+
+#endif /* _SPI_REGS_H */

--- a/esp8266/esp/types.h
+++ b/esp8266/esp/types.h
@@ -1,0 +1,9 @@
+#ifndef _ESP_TYPES_H
+#define _ESP_TYPES_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef volatile uint32_t *esp_reg_t;
+
+#endif /* _ESP_TYPES_H */

--- a/esp8266/esp8266.ld
+++ b/esp8266/esp8266.ld
@@ -141,6 +141,7 @@ SECTIONS
         *modpybuart.o(.literal*, .text*)
         *modpybi2c.o(.literal*, .text*)
         *modpybspi.o(.literal*, .text*)
+        *modpybhspi.o(.literal*, .text*)
         *modesp.o(.literal* .text*)
         *modnetwork.o(.literal* .text*)
         *moduos.o(.literal* .text*)

--- a/esp8266/esp_iomux.c
+++ b/esp8266/esp_iomux.c
@@ -1,0 +1,21 @@
+/* Compiler-level implementation for esp/iomux.h and esp/iomux_private.h
+ *
+ * Part of esp-open-rtos
+ * Copyright (C) 2015 Superhouse Automation Pty Ltd
+ * BSD Licensed as described in the file LICENSE
+ */
+#include "esp/iomux.h"
+#include "common_macros.h"
+
+const static IRAM_DATA uint32_t IOMUX_TO_GPIO[] = { 12, 13, 14, 15, 3, 1, 6, 7, 8, 9, 10, 11, 0, 2, 4, 5 };
+const static IRAM_DATA uint32_t GPIO_TO_IOMUX[] = { 12, 5, 13, 4, 14, 15, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3 };
+
+uint8_t IRAM gpio_to_iomux(const uint8_t gpio_number)
+{
+    return GPIO_TO_IOMUX[gpio_number];
+}
+
+uint8_t IRAM iomux_to_gpio(const uint8_t iomux_number)
+{
+    return IOMUX_TO_GPIO[iomux_number];
+}

--- a/esp8266/esp_spi.c
+++ b/esp8266/esp_spi.c
@@ -1,0 +1,251 @@
+/*
+ * ESP hardware SPI master driver
+ *
+ * Part of esp-open-rtos
+ * Copyright (c) Ruslan V. Uss, 2016
+ * BSD Licensed as described in the file LICENSE
+ */
+#include "esp/spi.h"
+
+#include "esp/iomux.h"
+#include "esp/gpio.h"
+#include <string.h>
+
+#define _SPI0_SCK_GPIO  6
+#define _SPI0_MISO_GPIO 7
+#define _SPI0_MOSI_GPIO 8
+#define _SPI0_HD_GPIO   9
+#define _SPI0_WP_GPIO   10
+#define _SPI0_CS0_GPIO  11
+
+#define _SPI1_MISO_GPIO 12
+#define _SPI1_MOSI_GPIO 13
+#define _SPI1_SCK_GPIO  14
+#define _SPI1_CS0_GPIO  15
+
+#define _SPI0_FUNC 1
+#define _SPI1_FUNC 2
+
+#define _SPI_BUF_SIZE 64
+
+static bool _minimal_pins[2] = {false, false};
+
+inline static void _set_pin_function(uint8_t pin, uint32_t function)
+{
+    iomux_set_function(gpio_to_iomux(pin), function);
+}
+
+bool spi_init(uint8_t bus, spi_mode_t mode, uint32_t freq_divider, bool msb, spi_endianness_t endianness, bool minimal_pins)
+{
+    switch (bus)
+    {
+        case 0:
+            _set_pin_function(_SPI0_MISO_GPIO, _SPI0_FUNC);
+            _set_pin_function(_SPI0_MOSI_GPIO, _SPI0_FUNC);
+            _set_pin_function(_SPI0_SCK_GPIO, _SPI0_FUNC);
+            if (!minimal_pins)
+            {
+                _set_pin_function(_SPI0_HD_GPIO, _SPI0_FUNC);
+                _set_pin_function(_SPI0_WP_GPIO, _SPI0_FUNC);
+                _set_pin_function(_SPI0_CS0_GPIO, _SPI0_FUNC);
+            }
+            break;
+        case 1:
+            _set_pin_function(_SPI1_MISO_GPIO, _SPI1_FUNC);
+            _set_pin_function(_SPI1_MOSI_GPIO, _SPI1_FUNC);
+            _set_pin_function(_SPI1_SCK_GPIO, _SPI1_FUNC);
+            if (!minimal_pins)
+                _set_pin_function(_SPI1_CS0_GPIO, _SPI1_FUNC);
+            break;
+        default:
+            return false;
+    }
+
+    _minimal_pins[bus] = minimal_pins;
+    SPI(bus).USER0 = SPI_USER0_MOSI | SPI_USER0_CLOCK_IN_EDGE | SPI_USER0_DUPLEX |
+        (minimal_pins ? 0 : (SPI_USER0_CS_HOLD | SPI_USER0_CS_SETUP));
+
+    spi_set_frequency_div(bus, freq_divider);
+    spi_set_mode(bus, mode);
+    spi_set_msb(bus, msb);
+    spi_set_endianness(bus, endianness);
+
+    return true;
+}
+
+void spi_get_settings(uint8_t bus, spi_settings_t *s)
+{
+    s->mode = spi_get_mode(bus);
+    s->freq_divider = spi_get_frequency_div(bus);
+    s->msb = spi_get_msb(bus);
+    s->endianness = spi_get_endianness(bus);
+    s->minimal_pins = _minimal_pins[bus];
+}
+
+void spi_set_mode(uint8_t bus, spi_mode_t mode)
+{
+    bool cpha = (uint8_t)mode & 1;
+    bool cpol = (uint8_t)mode & 2;
+    if (cpol)
+        cpha = !cpha;  // CPHA must be inverted when CPOL = 1, I have no idea why
+
+    // CPHA
+    if (cpha)
+        SPI(bus).USER0 |= SPI_USER0_CLOCK_OUT_EDGE;
+    else
+        SPI(bus).USER0 &= ~SPI_USER0_CLOCK_OUT_EDGE;
+
+    // CPOL - see http://bbs.espressif.com/viewtopic.php?t=342#p5384
+    if (cpol)
+        SPI(bus).PIN |= SPI_PIN_IDLE_EDGE;
+    else
+        SPI(bus).PIN &= ~SPI_PIN_IDLE_EDGE;
+}
+
+spi_mode_t spi_get_mode(uint8_t bus)
+{
+    uint8_t cpha = SPI(bus).USER0 & SPI_USER0_CLOCK_OUT_EDGE ? 1 : 0;
+    uint8_t cpol = SPI(bus).PIN & SPI_PIN_IDLE_EDGE ? 2 : 0;
+
+    return (spi_mode_t)(cpol | (cpol ? 1 - cpha : cpha)); // see spi_set_mode
+}
+
+void spi_set_msb(uint8_t bus, bool msb)
+{
+    if (msb)
+        SPI(bus).CTRL0 &= ~(SPI_CTRL0_WR_BIT_ORDER | SPI_CTRL0_RD_BIT_ORDER);
+    else
+        SPI(bus).CTRL0 |= (SPI_CTRL0_WR_BIT_ORDER | SPI_CTRL0_RD_BIT_ORDER);
+}
+
+void spi_set_endianness(uint8_t bus, spi_endianness_t endianness)
+{
+    if (endianness == SPI_BIG_ENDIAN)
+        SPI(bus).USER0 |= (SPI_USER0_WR_BYTE_ORDER | SPI_USER0_RD_BYTE_ORDER);
+    else
+        SPI(bus).USER0 &= ~(SPI_USER0_WR_BYTE_ORDER | SPI_USER0_RD_BYTE_ORDER);
+}
+
+void spi_set_frequency_div(uint8_t bus, uint32_t divider)
+{
+    uint32_t predivider = (divider & 0xffff) - 1;
+    uint32_t count = (divider >> 16) - 1;
+    if (count || predivider)
+    {
+        IOMUX.CONF &= ~(bus == 0 ? IOMUX_CONF_SPI0_CLOCK_EQU_SYS_CLOCK : IOMUX_CONF_SPI1_CLOCK_EQU_SYS_CLOCK);
+        SPI(bus).CLOCK = VAL2FIELD_M(SPI_CLOCK_DIV_PRE, predivider) |
+                         VAL2FIELD_M(SPI_CLOCK_COUNT_NUM, count) |
+                         VAL2FIELD_M(SPI_CLOCK_COUNT_HIGH, count / 2) |
+                         VAL2FIELD_M(SPI_CLOCK_COUNT_LOW, count);
+    }
+    else
+    {
+        IOMUX.CONF |= bus == 0 ? IOMUX_CONF_SPI0_CLOCK_EQU_SYS_CLOCK : IOMUX_CONF_SPI1_CLOCK_EQU_SYS_CLOCK;
+        SPI(bus).CLOCK = SPI_CLOCK_EQU_SYS_CLOCK;
+    }
+}
+
+inline static void _set_size(uint8_t bus, uint8_t bytes)
+{
+    uint32_t bits = ((uint32_t)bytes << 3) - 1;
+    SPI(bus).USER1 = SET_FIELD(SPI(bus).USER1, SPI_USER1_MISO_BITLEN, bits);
+    SPI(bus).USER1 = SET_FIELD(SPI(bus).USER1, SPI_USER1_MOSI_BITLEN, bits);
+}
+
+inline static void _wait(uint8_t bus)
+{
+    while (SPI(bus).CMD & SPI_CMD_USR)
+        ;
+}
+
+inline static void _start(uint8_t bus)
+{
+    SPI(bus).CMD |= SPI_CMD_USR;
+}
+
+inline static uint32_t _swap_bytes(uint32_t value)
+{
+    return (value << 24) | ((value << 8) & 0x00ff0000) | ((value >> 8) & 0x0000ff00) | (value >> 24);
+}
+
+inline static uint32_t _swap_words(uint32_t value)
+{
+    return (value << 16) | (value >> 16);
+}
+
+static void _spi_buf_prepare(uint8_t bus, size_t len, spi_endianness_t e, spi_word_size_t word_size)
+{
+    if (e == SPI_LITTLE_ENDIAN || word_size == SPI_32BIT) return;
+
+    size_t count = word_size == SPI_16BIT ? (len + 1) / 2 : (len + 3) / 4;
+    uint32_t *data = (uint32_t *)&SPI(bus).W0;
+    for (size_t i = 0; i < count; i ++)
+    {
+        data[i] = word_size == SPI_16BIT
+            ? _swap_words(data[i])
+            : _swap_bytes(data[i]);
+    }
+}
+
+static void _spi_buf_transfer(uint8_t bus, const void *out_data, void *in_data,
+    size_t len, spi_endianness_t e, spi_word_size_t word_size)
+{
+    _wait(bus);
+    size_t bytes = len * (uint8_t)word_size;
+    _set_size(bus, bytes);
+    memcpy((void *)&SPI(bus).W0, out_data, bytes);
+    _spi_buf_prepare(bus, len, e, word_size);
+    _start(bus);
+    _wait(bus);
+    if (in_data)
+    {
+        _spi_buf_prepare(bus, len, e, word_size);
+        memcpy(in_data, (void *)&SPI(bus).W0, bytes);
+    }
+}
+
+uint8_t spi_transfer_8(uint8_t bus, uint8_t data)
+{
+    uint8_t res;
+    _spi_buf_transfer(bus, &data, &res, 1, spi_get_endianness(bus), SPI_8BIT);
+    return res;
+}
+
+uint16_t spi_transfer_16(uint8_t bus, uint16_t data)
+{
+    uint16_t res;
+    _spi_buf_transfer(bus, &data, &res, 1, spi_get_endianness(bus), SPI_16BIT);
+    return res;
+}
+
+uint32_t spi_transfer_32(uint8_t bus, uint32_t data)
+{
+    uint32_t res;
+    _spi_buf_transfer(bus, &data, &res, 1, spi_get_endianness(bus), SPI_32BIT);
+    return res;
+}
+
+size_t spi_transfer(uint8_t bus, const void *out_data, void *in_data, size_t len, spi_word_size_t word_size)
+{
+    if (!out_data || !len) return 0;
+
+    spi_endianness_t e = spi_get_endianness(bus);
+    uint8_t buf_size = _SPI_BUF_SIZE / (uint8_t)word_size;
+
+    size_t blocks = len / buf_size;
+    for (size_t i = 0; i < blocks; i++)
+    {
+        size_t offset = i * _SPI_BUF_SIZE;
+        _spi_buf_transfer(bus, (const uint8_t *)out_data + offset,
+            in_data ? (uint8_t *)in_data + offset : NULL, buf_size, e, word_size);
+    }
+
+    uint8_t tail = len % buf_size;
+    if (tail)
+    {
+        _spi_buf_transfer(bus, (const uint8_t *)out_data + blocks * _SPI_BUF_SIZE,
+            in_data ? (uint8_t *)in_data + blocks * _SPI_BUF_SIZE : NULL, tail, e, word_size);
+    }
+
+    return len;
+}

--- a/esp8266/modmachine.c
+++ b/esp8266/modmachine.c
@@ -237,6 +237,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&pyb_uart_type) },
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&machine_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&pyb_spi_type) },
+    { MP_ROM_QSTR(MP_QSTR_HSPI), MP_ROM_PTR(&pyb_hspi_type) },
 
     // wake abilities
     { MP_ROM_QSTR(MP_QSTR_DEEPSLEEP), MP_ROM_INT(MACHINE_WAKE_DEEPSLEEP) },

--- a/esp8266/modpyb.h
+++ b/esp8266/modpyb.h
@@ -10,6 +10,7 @@ extern const mp_obj_type_t pyb_rtc_type;
 extern const mp_obj_type_t pyb_uart_type;
 extern const mp_obj_type_t pyb_i2c_type;
 extern const mp_obj_type_t pyb_spi_type;
+extern const mp_obj_type_t pyb_hspi_type;
 
 MP_DECLARE_CONST_FUN_OBJ(pyb_info_obj);
 

--- a/esp8266/modpybhspi.c
+++ b/esp8266/modpybhspi.c
@@ -1,0 +1,195 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "ets_sys.h"
+#include "etshal.h"
+#include "ets_alt_task.h"
+
+#include "py/runtime.h"
+#include "py/stream.h"
+#include "py/mphal.h"
+
+#include "esp/spi.h"
+
+
+typedef struct _pyb_hspi_obj_t {
+    mp_obj_base_t base;
+    uint32_t baudrate;
+    uint8_t polarity;
+    uint8_t phase;
+} pyb_hspi_obj_t;
+
+
+/******************************************************************************/
+// MicroPython bindings for HSPI
+
+STATIC void pyb_hspi_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    pyb_hspi_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "HSPI(baudrate=%u, polarity=%u, phase=%u)",
+        self->baudrate, self->polarity, self->phase);
+}
+
+STATIC void pyb_hspi_init_helper(pyb_hspi_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_baudrate, ARG_polarity, ARG_phase };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_polarity, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_phase, MP_ARG_INT, {.u_int = -1} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args),
+                     allowed_args, args);
+    uint16_t prediv;
+    uint8_t cntdiv;
+
+    if (args[ARG_baudrate].u_int != -1) {
+        self->baudrate = args[ARG_baudrate].u_int;
+    }
+    if (args[ARG_polarity].u_int != -1) {
+        self->polarity = args[ARG_polarity].u_int;
+    }
+    if (args[ARG_phase].u_int != -1) {
+        self->phase = args[ARG_phase].u_int;
+    }
+
+    if (self->baudrate == 80000000) {
+        // special case, no divider
+        prediv = 0;
+        cntdiv = 0;
+    } else {
+        // calculate the dividers
+        uint32_t divider = 40000000 / self->baudrate;
+        prediv = MIN(divider, 8191);
+        cntdiv = (divider / prediv) * 2; // cntdiv has to be even
+        if (cntdiv > 63 || cntdiv == 0 || prediv == 0) {
+            nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError,
+                                               "impossible baudrate"));
+        }
+        self->baudrate = 80000000 / (prediv * cntdiv);
+    }
+    uint8_t mode = SPI_MODE0;
+    if (self->polarity) {
+        if (self->phase) {
+            mode = SPI_MODE3;
+        } else {
+            mode = SPI_MODE2;
+        }
+    } else {
+        if (self->phase) {
+            mode = SPI_MODE1;
+        }
+    }
+    if (!spi_init(1, mode, SPI_GET_FREQ_DIV(prediv, cntdiv), true,
+                  SPI_LITTLE_ENDIAN, true)) {
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_RuntimeError,
+                                           "SPI initialization failed"));
+    }
+}
+
+STATIC mp_obj_t pyb_hspi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
+    pyb_hspi_obj_t *self = m_new_obj(pyb_hspi_obj_t);
+    self->base.type = &pyb_hspi_type;
+    // set defaults
+    self->baudrate = 80000000;
+    self->polarity = 0;
+    self->phase = 0;
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+    pyb_hspi_init_helper(self, n_args, args, &kw_args);
+    return MP_OBJ_FROM_PTR(self);
+}
+
+STATIC mp_obj_t pyb_hspi_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    pyb_hspi_init_helper(args[0], n_args - 1, args + 1, kw_args);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(pyb_hspi_init_obj, 1, pyb_hspi_init);
+
+STATIC mp_obj_t pyb_hspi_read(size_t n_args, const mp_obj_t *args) {
+    vstr_t vstr;
+    vstr_init_len(&vstr, mp_obj_get_int(args[1]));
+    for (size_t i = 0; i < vstr.len; ++i) {
+        ((uint8_t*)vstr.buf)[i] = spi_transfer_8(1, 0);
+        if (i & 1023) { // TODO this should depend on the baudrate
+            // make sure pending tasks have a chance to run
+            ets_loop_iter();
+        }
+    }
+    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_hspi_read_obj, 2, 2, pyb_hspi_read);
+
+STATIC mp_obj_t pyb_hspi_readinto(size_t n_args, const mp_obj_t *args) {
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_WRITE);
+    for (size_t i = 0; i < bufinfo.len; ++i) {
+        ((uint8_t*)bufinfo.buf)[i] = spi_transfer_8(1, 0);
+        if (i & 1023) {
+            // make sure pending tasks have a chance to run
+            ets_loop_iter();
+        }
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_hspi_readinto_obj, 2, 2, pyb_hspi_readinto);
+
+STATIC mp_obj_t pyb_hspi_write(mp_obj_t self_in, mp_obj_t wr_buf_in) {
+    mp_buffer_info_t src_buf;
+    mp_get_buffer_raise(wr_buf_in, &src_buf, MP_BUFFER_READ);
+    for (size_t i = 0; i < src_buf.len; ++i) {
+        uint8_t data = ((const uint8_t*)src_buf.buf)[i];
+        spi_transfer_8(1, data);
+        if (i & 1023) {
+            // make sure pending tasks have a chance to run
+            ets_loop_iter();
+        }
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(pyb_hspi_write_obj, pyb_hspi_write);
+
+
+STATIC const mp_rom_map_elem_t pyb_hspi_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&pyb_hspi_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&pyb_hspi_read_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&pyb_hspi_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&pyb_hspi_write_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(pyb_hspi_locals_dict, pyb_hspi_locals_dict_table);
+
+const mp_obj_type_t pyb_hspi_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_HSPI,
+    .print = pyb_hspi_print,
+    .make_new = pyb_hspi_make_new,
+    .locals_dict = (mp_obj_dict_t*)&pyb_hspi_locals_dict,
+};

--- a/esp8266/xtruntime.h
+++ b/esp8266/xtruntime.h
@@ -1,0 +1,184 @@
+/*
+ * xtruntime.h  --  general C definitions for single-threaded run-time
+ *
+ * Copyright (c) 2002-2008 Tensilica Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef XTRUNTIME_H
+#define XTRUNTIME_H
+
+#include <xtensa/config/core.h>
+#include <xtensa/config/specreg.h>
+
+#ifndef XTSTR
+#define _XTSTR(x)	# x
+#define XTSTR(x)	_XTSTR(x)
+#endif
+
+#define _xtos_set_execption_handler _xtos_set_exception_handler	/* backward compatibility */
+#define _xtos_set_saved_intenable	_xtos_ints_on	/* backward compatibility */
+#define _xtos_clear_saved_intenable	_xtos_ints_off	/* backward compatibility */
+
+#if !defined(_ASMLANGUAGE) && !defined(__ASSEMBLER__)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*typedef void (_xtos_timerdelta_func)(int);*/
+#ifdef __cplusplus
+typedef void (_xtos_handler_func)(...);
+#else
+typedef void (_xtos_handler_func)();
+#endif
+typedef _xtos_handler_func *_xtos_handler;
+
+/*
+ *  unsigned XTOS_SET_INTLEVEL(int intlevel);
+ *  This macro sets the current interrupt level.
+ *  The 'intlevel' parameter must be a constant.
+ *  This macro returns a 32-bit value that must be passed to
+ *  XTOS_RESTORE_INTLEVEL() to restore the previous interrupt level.
+ *  XTOS_RESTORE_JUST_INTLEVEL() also does this, but in XEA2 configs
+ *  it restores only PS.INTLEVEL rather than the entire PS register
+ *  and thus is slower.
+ */
+#if !XCHAL_HAVE_INTERRUPTS
+# define XTOS_SET_INTLEVEL(intlevel)		0
+# define XTOS_SET_MIN_INTLEVEL(intlevel)	0
+# define XTOS_RESTORE_INTLEVEL(restoreval)
+# define XTOS_RESTORE_JUST_INTLEVEL(restoreval)
+#elif XCHAL_HAVE_XEA2
+/*  In XEA2, we can simply safely set PS.INTLEVEL directly:  */
+/*  NOTE: these asm macros don't modify memory, but they are marked
+ *  as such to act as memory access barriers to the compiler because
+ *  these macros are sometimes used to delineate critical sections;
+ *  function calls are natural barriers (the compiler does not know
+ *  whether a function modifies memory) unless declared to be inlined.  */
+# define XTOS_SET_INTLEVEL(intlevel)		({ unsigned __tmp; \
+			__asm__ __volatile__(	"rsil	%0, " XTSTR(intlevel) "\n" \
+						: "=a" (__tmp) : : "memory" ); \
+			__tmp;})
+# define XTOS_SET_MIN_INTLEVEL(intlevel)		({ unsigned __tmp, __tmp2, __tmp3; \
+			__asm__ __volatile__(	"rsr	%0, " XTSTR(PS) "\n"	/* get old (current) PS.INTLEVEL */ \
+						"movi	%2, " XTSTR(intlevel) "\n" \
+						"extui	%1, %0, 0, 4\n"	/* keep only INTLEVEL bits of parameter */ \
+						"blt	%2, %1, 1f\n" \
+						"rsil	%0, " XTSTR(intlevel) "\n" \
+						"1:\n" \
+						: "=a" (__tmp), "=&a" (__tmp2), "=&a" (__tmp3) : : "memory" ); \
+			__tmp;})
+# define XTOS_RESTORE_INTLEVEL(restoreval)	do{ unsigned __tmp = (restoreval); \
+			__asm__ __volatile__(	"wsr	%0, " XTSTR(PS) " ; rsync\n" \
+						: : "a" (__tmp) : "memory" ); \
+			}while(0)
+# define XTOS_RESTORE_JUST_INTLEVEL(restoreval)	_xtos_set_intlevel(restoreval)
+#else
+/*  In XEA1, we have to rely on INTENABLE register virtualization:  */
+extern unsigned		_xtos_set_vpri( unsigned vpri );
+extern unsigned		_xtos_vpri_enabled;	/* current virtual priority */
+# define XTOS_SET_INTLEVEL(intlevel)		_xtos_set_vpri(~XCHAL_INTLEVEL_ANDBELOW_MASK(intlevel))
+# define XTOS_SET_MIN_INTLEVEL(intlevel)	_xtos_set_vpri(_xtos_vpri_enabled & ~XCHAL_INTLEVEL_ANDBELOW_MASK(intlevel))
+# define XTOS_RESTORE_INTLEVEL(restoreval)	_xtos_set_vpri(restoreval)
+# define XTOS_RESTORE_JUST_INTLEVEL(restoreval)	_xtos_set_vpri(restoreval)
+#endif
+
+/*
+ *  The following macros build upon the above.  They are generally used
+ *  instead of invoking the SET_INTLEVEL and SET_MIN_INTLEVEL macros directly.
+ *  They all return a value that can be used with XTOS_RESTORE_INTLEVEL()
+ *  or _xtos_restore_intlevel() or _xtos_restore_just_intlevel() to restore
+ *  the effective interrupt level to what it was before the macro was invoked.
+ *  In XEA2, the DISABLE macros are much faster than the MASK macros
+ *  (in all configs, DISABLE sets the effective interrupt level, whereas MASK
+ *  makes ensures the effective interrupt level is at least the level given
+ *  without lowering it; in XEA2 with INTENABLE virtualization, these macros
+ *  affect PS.INTLEVEL only, not the virtual priority, so DISABLE has partial
+ *  MASK semantics).
+ *
+ *  A typical critical section sequence might be:
+ *	unsigned rval = XTOS_DISABLE_EXCM_INTERRUPTS;
+ *	... critical section ...
+ *	XTOS_RESTORE_INTLEVEL(rval);
+ */
+/*  Enable all interrupts (those activated with _xtos_ints_on()):  */
+#define XTOS_ENABLE_INTERRUPTS		XTOS_SET_INTLEVEL(0)
+/*  Disable low priority level interrupts (they can interact with the OS):  */
+#define XTOS_DISABLE_LOWPRI_INTERRUPTS	XTOS_SET_INTLEVEL(XCHAL_NUM_LOWPRI_LEVELS)
+#define XTOS_MASK_LOWPRI_INTERRUPTS	XTOS_SET_MIN_INTLEVEL(XCHAL_NUM_LOWPRI_LEVELS)
+/*  Disable interrupts that can interact with the OS:  */
+#define XTOS_DISABLE_EXCM_INTERRUPTS	XTOS_SET_INTLEVEL(XCHAL_EXCM_LEVEL)
+#define XTOS_MASK_EXCM_INTERRUPTS	XTOS_SET_MIN_INTLEVEL(XCHAL_EXCM_LEVEL)
+#if 0 /* XTOS_LOCK_LEVEL is not exported to applications */
+/*  Disable interrupts that can interact with the OS, or manipulate virtual INTENABLE:  */
+#define XTOS_DISABLE_LOCK_INTERRUPTS	XTOS_SET_INTLEVEL(XTOS_LOCK_LEVEL)
+#define XTOS_MASK_LOCK_INTERRUPTS	XTOS_SET_MIN_INTLEVEL(XTOS_LOCK_LEVEL)
+#endif
+/*  Disable ALL interrupts (not for common use, particularly if one's processor
+ *  configuration has high-level interrupts and one cares about their latency):  */
+#define XTOS_DISABLE_ALL_INTERRUPTS	XTOS_SET_INTLEVEL(15)
+
+
+extern unsigned int	_xtos_ints_off( unsigned int mask );
+extern unsigned int	_xtos_ints_on( unsigned int mask );
+extern unsigned		_xtos_set_intlevel( int intlevel );
+extern unsigned		_xtos_set_min_intlevel( int intlevel );
+extern unsigned		_xtos_restore_intlevel( unsigned restoreval );
+extern unsigned		_xtos_restore_just_intlevel( unsigned restoreval );
+extern _xtos_handler	_xtos_set_interrupt_handler( int n, _xtos_handler f );
+extern _xtos_handler	_xtos_set_interrupt_handler_arg( int n, _xtos_handler f, void *arg );
+extern _xtos_handler	_xtos_set_exception_handler( int n, _xtos_handler f );
+
+extern void		_xtos_memep_initrams( void );
+extern void		_xtos_memep_enable( int flags );
+
+/*  Deprecated (but kept because they were documented):  */
+extern unsigned int	_xtos_read_ints( void );		/* use xthal_get_interrupt() instead */
+extern void		_xtos_clear_ints( unsigned int mask );	/* use xthal_set_intclear() instead */
+
+#if XCHAL_NUM_CONTEXTS > 1
+extern unsigned		_xtos_init_context(int context_num, int stack_size,
+					    _xtos_handler_func *start_func, int arg1);
+#endif
+
+/*  Deprecated:  */
+#if XCHAL_NUM_TIMERS > 0
+extern void		_xtos_timer_0_delta( int cycles );
+#endif
+#if XCHAL_NUM_TIMERS > 1
+extern void		_xtos_timer_1_delta( int cycles );
+#endif
+#if XCHAL_NUM_TIMERS > 2
+extern void		_xtos_timer_2_delta( int cycles );
+#endif
+#if XCHAL_NUM_TIMERS > 3
+extern void		_xtos_timer_3_delta( int cycles );
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_ASMLANGUAGE && !__ASSEMBLER__ */
+
+#endif /* XTRUNTIME_H */
+


### PR DESCRIPTION
This is a work in progress for adding support for fast hardware-based SPI to the ESP8266 port.
