### PR TITLE
esp8266: Set reasonable date & time stamps for files.

### DIFF
--- a/esp8266/fatfs_port.c
+++ b/esp8266/fatfs_port.c
@@ -1,6 +1,41 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014, 2016 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/obj.h"
 #include "lib/fatfs/ff.h"
-#include "lib/fatfs/diskio.h"
+#include "timeutils.h"
+#include "modpybrtc.h"
 
 DWORD get_fattime(void) {
-    return 0;
+
+    uint64_t msecs = pyb_rtc_get_us_since_2000() / 1000000;
+
+    timeutils_struct_time_t tm;
+    timeutils_seconds_since_2000_to_struct_time(msecs, &tm);
+
+    return (((DWORD)(tm.tm_year - 1980) << 25) | ((DWORD)tm.tm_mon << 21) | ((DWORD)tm.tm_mday << 16) |
+           ((DWORD)tm.tm_hour << 11) | ((DWORD)tm.tm_min << 5) | ((DWORD)tm.tm_sec >> 1));
 }

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -186,7 +186,7 @@ STATIC mp_obj_t fat_vfs_stat(mp_obj_t vfs_in, mp_obj_t path_in) {
     if (path_equal(path, "/")) {
         // stat root directory
         fno.fsize = 0;
-        fno.fdate = 0;
+        fno.fdate = 0x2821;
         fno.ftime = 0;
         fno.fattrib = AM_DIR;
     } else {
@@ -196,7 +196,7 @@ STATIC mp_obj_t fat_vfs_stat(mp_obj_t vfs_in, mp_obj_t path_in) {
             if (vfs != NULL && path_equal(path, vfs->str)) {
                 // stat mounted device directory
                 fno.fsize = 0;
-                fno.fdate = 0;
+                fno.fdate = 0x2821;
                 fno.ftime = 0;
                 fno.fattrib = AM_DIR;
                 res = FR_OK;


### PR DESCRIPTION
Changed files: esp8266/fatfs_port.c and extmod/vfs_fat.c
The time stamp is taken from the RTC for all newly generated
or changed files. RTC must be maintained separately.
The dummy time stamp set in vfs.stat() for the TLD is set to
Jan 1, 2000, avoiding invalid time values.
