### PR TITLE
esp8266/main.c: Clear the command lines history when (re)booting

### DIFF
--- a/esp8266/main.c
+++ b/esp8266/main.c
@@ -37,6 +37,7 @@
 #include "lib/utils/pyexec.h"
 #include "gccollect.h"
 #include "user_interface.h"
+#include "readline.h"
 
 STATIC char heap[28 * 1024];
 
@@ -57,6 +58,7 @@ STATIC void mp_reset(void) {
     MP_STATE_PORT(mp_kbd_exception) = mp_obj_new_exception(&mp_type_KeyboardInterrupt);
     MP_STATE_PORT(term_obj) = MP_OBJ_NULL;
     pin_init0();
+    readline_init0();
 #if MICROPY_MODULE_FROZEN
     pyexec_frozen_module("_boot.py");
     pyexec_file("boot.py");

--- a/lib/libm/kf_rem_pio2.c
+++ b/lib/libm/kf_rem_pio2.c
@@ -86,7 +86,8 @@ twon8  =  3.9062500000e-03; /* 0x3b800000 */
 
     /* compute q[0],q[1],...q[jk] */
 	for (i=0;i<=jk;i++) {
-	    for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j]; q[i] = fw;
+	    for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j];
+	    q[i] = fw;
 	}
 
 	jz = jk;

--- a/lib/libm/sf_cos.c
+++ b/lib/libm/sf_cos.c
@@ -25,12 +25,6 @@
 #include "fdlibm.h"
 
 #ifdef __STDC__
-static const float one=1.0;
-#else
-static float one=1.0;
-#endif
-
-#ifdef __STDC__
 	float cosf(float x)
 #else
 	float cosf(x)

--- a/tests/extmod/btree1.py
+++ b/tests/extmod/btree1.py
@@ -54,3 +54,6 @@ for k, v in db.items(None, None, btree.DESC):
 
 print(list(db.keys()))
 print(list(db.values()))
+
+for k in db:
+    print(k)

--- a/tests/extmod/btree1.py.exp
+++ b/tests/extmod/btree1.py.exp
@@ -27,3 +27,6 @@ KeyError
 (b'bar1', b'foo1')
 [b'bar1', b'foo1', b'foo3']
 [b'foo1', b'bar1', b'bar3']
+b'bar1'
+b'foo1'
+b'foo3'

--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -158,6 +158,7 @@ extern const struct _mp_obj_module_t mp_module_os;
 extern const struct _mp_obj_module_t mp_module_time;
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_OBJ_NEW_QSTR(MP_QSTR_utime), (mp_obj_t)&mp_module_time }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_umachine), (mp_obj_t)&mp_module_machine }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_uos), (mp_obj_t)&mp_module_os }, \
 
 #if MICROPY_USE_READLINE == 1

--- a/windows/msvc/sources.props
+++ b/windows/msvc/sources.props
@@ -14,6 +14,7 @@
     <ClCompile Include="$(PyBaseDir)unix\modtime.c"/>
     <ClCompile Include="$(PyBaseDir)unix\modmachine.c" />
     <ClCompile Include="$(PyBaseDir)extmod\machine_mem.c" />
+    <ClCompile Include="$(PyBaseDir)extmod\machine_pinbase.c" />
     <ClCompile Include="$(PyBaseDir)extmod\modubinascii.c" />
     <ClCompile Include="$(PyBaseDir)extmod\moductypes.c" />
     <ClCompile Include="$(PyBaseDir)extmod\moduhashlib.c" />


### PR DESCRIPTION
Not clearing the command lines history sometimes resulted in
strange output when going back after reset. If it is intended
to keep the history after soft reset, then the clearing must
be moved e.g. to the start of init_done().
