### PR TITLE
windows/msvc: Include machine_pinbase.c in build

### DIFF
--- a/windows/mpconfigport.h
+++ b/windows/mpconfigport.h
@@ -158,6 +158,7 @@ extern const struct _mp_obj_module_t mp_module_os;
 extern const struct _mp_obj_module_t mp_module_time;
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_OBJ_NEW_QSTR(MP_QSTR_utime), (mp_obj_t)&mp_module_time }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_umachine), (mp_obj_t)&mp_module_machine }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_uos), (mp_obj_t)&mp_module_os }, \
 
 #if MICROPY_USE_READLINE == 1

--- a/windows/msvc/sources.props
+++ b/windows/msvc/sources.props
@@ -14,6 +14,7 @@
     <ClCompile Include="$(PyBaseDir)unix\modtime.c"/>
     <ClCompile Include="$(PyBaseDir)unix\modmachine.c" />
     <ClCompile Include="$(PyBaseDir)extmod\machine_mem.c" />
+    <ClCompile Include="$(PyBaseDir)extmod\machine_pinbase.c" />
     <ClCompile Include="$(PyBaseDir)extmod\modubinascii.c" />
     <ClCompile Include="$(PyBaseDir)extmod\moductypes.c" />
     <ClCompile Include="$(PyBaseDir)extmod\moduhashlib.c" />


### PR DESCRIPTION
Fixes linker errors since [ad229477]
