### PR TITLE
Fix typo in ESP8266 docs for usocket.listen()

### DIFF
--- a/docs/library/usocket.rst
+++ b/docs/library/usocket.rst
@@ -101,7 +101,7 @@ Methods
 
        Enable a server to accept connections. If backlog is specified, it must be at least 0 
        (if it's lower, it will be set to 0); and specifies the number of unaccepted connections
-       tha the system will allow before refusing new connections. If not specified, a default
+       that the system will allow before refusing new connections. If not specified, a default
        reasonable value is chosen.
 
     .. method:: socket.accept()


### PR DESCRIPTION
Fix a small typo in the documentation for the ESP8266 in the description of the method usocket.listen().
