### PR TITLE
L4 hal sd card working

### DIFF
--- a/stmhal/dma.c
+++ b/stmhal/dma.c
@@ -267,8 +267,10 @@ const dma_descr_t dma_ADC_2_RX = { DMA2_Channel4, DMA_REQUEST_0, DMA_PERIPH_TO_M
 const dma_descr_t dma_DAC_1_TX = { DMA2_Channel4, DMA_REQUEST_3, DMA_MEMORY_TO_PERIPH, dma_id_10,  &dma_init_struct_dac };
 const dma_descr_t dma_SPI_1_TX = { DMA2_Channel4, DMA_REQUEST_4, DMA_MEMORY_TO_PERIPH, dma_id_10,  &dma_init_struct_spi_i2c };
 */
-#if MICROPY_HW_HAS_SDCARD
+#if defined(MICROPY_HW_HAS_SDCARD) && MICROPY_HW_HAS_SDCARD
+// defined twice as L4 HAL only needs one channel and can correctly switch direction but sdcard.c needs two channels
 const dma_descr_t dma_SDIO_0_TX= { DMA2_Channel4, DMA_REQUEST_7, DMA_MEMORY_TO_PERIPH, dma_id_10,  &dma_init_struct_sdio };
+const dma_descr_t dma_SDIO_0_RX= { DMA2_Channel4, DMA_REQUEST_7, DMA_PERIPH_TO_MEMORY, dma_id_10,  &dma_init_struct_sdio };
 #endif
 /* not preferred streams
 const dma_descr_t dma_ADC_3_RX = { DMA2_Channel5, DMA_REQUEST_0, DMA_PERIPH_TO_MEMORY, dma_id_11,  NULL };

--- a/stmhal/dma.h
+++ b/stmhal/dma.h
@@ -73,7 +73,8 @@ extern const dma_descr_t dma_I2C_1_TX;
 extern const dma_descr_t dma_I2C_1_RX;
 extern const dma_descr_t dma_SPI_3_RX;
 extern const dma_descr_t dma_SPI_3_TX;
-extern const dma_descr_t dma_SDIO_1_TX;
+extern const dma_descr_t dma_SDIO_0_TX;
+extern const dma_descr_t dma_SDIO_0_RX;
 
 #endif
 

--- a/stmhal/hal/HALCOMMITS
+++ b/stmhal/hal/HALCOMMITS
@@ -4,6 +4,9 @@ should be separate from any other changes and should be listed here, most
 recent commit at the top of the list.  This makes it easier to upgrade to
 a new HAL version.
 
+e2becb4a0509df52f0f055ee7a63d02f4c6e8583
+stmhal: Port of f4 hal commit 1d7fb82 to l4 hal
+
 d4c33499579eb8f4febec2f5f01f5021f719fdaf
 stmhal: L4: Adapt UART HAL to avoid 64-bit integer division.
 

--- a/stmhal/hal/l4/inc/stm32l4xx_hal_sd.h
+++ b/stmhal/hal/l4/inc/stm32l4xx_hal_sd.h
@@ -643,8 +643,9 @@ void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd);
   * @{
   */
 /* Blocking mode: Polling */
-HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
-HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
+// dpgeorge: read/write functions renamed to emphasise that address is given by block number
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_BlockNumber(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint32_t BlockNumber, uint32_t BlockSize, uint32_t NumberOfBlocks);
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_BlockNumber(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint32_t BlockNumber, uint32_t BlockSize, uint32_t NumberOfBlocks);
 HAL_SD_ErrorTypedef HAL_SD_Erase(SD_HandleTypeDef *hsd, uint64_t startaddr, uint64_t endaddr);
 
 /* Non-Blocking mode: Interrupt */
@@ -659,8 +660,9 @@ void HAL_SD_XferCpltCallback(SD_HandleTypeDef *hsd);
 void HAL_SD_XferErrorCallback(SD_HandleTypeDef *hsd);
 
 /* Non-Blocking mode: DMA */
-HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
-HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
+// dpgeorge: read/write functions renamed to emphasise that address is given by block number
+HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_BlockNumber_DMA(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint32_t BlockNumber, uint32_t BlockSize, uint32_t NumberOfBlocks);
+HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_BlockNumber_DMA(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint32_t BlockNumber, uint32_t BlockSize, uint32_t NumberOfBlocks);
 HAL_SD_ErrorTypedef HAL_SD_CheckWriteOperation(SD_HandleTypeDef *hsd, uint32_t Timeout);
 HAL_SD_ErrorTypedef HAL_SD_CheckReadOperation(SD_HandleTypeDef *hsd, uint32_t Timeout);
 /**

--- a/stmhal/sdcard.c
+++ b/stmhal/sdcard.c
@@ -40,9 +40,9 @@
 
 #if MICROPY_HW_HAS_SDCARD
 
-#if defined(MCU_SERIES_F7)
+#if defined(MCU_SERIES_F7) || defined(MCU_SERIES_L4)
 
-// The F7 series calls the peripheral SDMMC rather than SDIO, so provide some
+// The F7 & L4 series calls the peripheral SDMMC rather than SDIO, so provide some
 // #defines for backwards compatability.
 
 #define SDIO    SDMMC1
@@ -64,11 +64,6 @@
 #define SDIO_HARDWARE_FLOW_CONTROL_ENABLE   SDMMC_HARDWARE_FLOW_CONTROL_ENABLE
 
 #define SDIO_TRANSFER_CLK_DIV               SDMMC_TRANSFER_CLK_DIV
-
-#elif defined(MCU_SERIES_L4)
-
-// The L4 series is not supported
-#error Unsupported Processor
 
 #endif
 


### PR DESCRIPTION
These change enable SD card to work on the L4 port

Port of f4 hal commit 1d7fb82 to l4 hal
Just matching previous hal changes

Pretty sure 1d7fb82 is not needed as there l4 hal already has that as a 64bit math
https://github.com/micropython/micropython/blob/master/stmhal/hal/l4/src/stm32l4xx_hal_sd.c#L1591

There is a little hack in dam.c to define one of the channels twice, since sdcard.c expects two channels one TX one RX
