### PR TITLE
docs/spi: add information for data size

### DIFF
--- a/docs/library/pyb.SPI.rst
+++ b/docs/library/pyb.SPI.rst
@@ -66,6 +66,7 @@ Methods
            use of ``prescaler`` overrides ``baudrate``.
          - ``polarity`` can be 0 or 1, and is the level the idle clock line sits at.
          - ``phase`` can be 0 or 1 to sample data on the first or second clock edge
+         - ``bits`` can be 8 or 16, and is the data size.
            respectively.
          - ``firstbit`` can be ``SPI.MSB`` or ``SPI.LSB``.
          - ``crc`` can be None for no CRC, or a polynomial specifier.


### PR DESCRIPTION
Hi, 
think that was forgotten: data size description of bits in the class SPI.  I added the information that the data size can also be 16.
