### PR TITLE
esp8266/espneopixel.c: disable irq during eps.neopixel_write.

### DIFF
--- a/esp8266/espneopixel.c
+++ b/esp8266/espneopixel.c
@@ -9,6 +9,7 @@
 #include "eagle_soc.h"
 #include "user_interface.h"
 #include "espneopixel.h"
+#include "py/mphal.h"
 
 #define NEO_KHZ400 (1)
 
@@ -47,6 +48,7 @@ void /*ICACHE_RAM_ATTR*/ esp_neopixel_write(uint8_t pin, uint8_t *pixels, uint32
   }
 #endif
 
+  mp_uint_t irq_state = mp_hal_quiet_timing_enter();
   for(t = time0;; t = time0) {
     if(pix & mask) t = time1;                             // Bit high duration
     while(((c = _getCycleCount()) - startTime) < period); // Wait for bit start
@@ -61,4 +63,5 @@ void /*ICACHE_RAM_ATTR*/ esp_neopixel_write(uint8_t pin, uint8_t *pixels, uint32
     }
   }
   while((_getCycleCount() - startTime) < period); // Wait for last bit
+  mp_hal_quiet_timing_exit(irq_state);
 }


### PR DESCRIPTION
Interrupts during neopixel_write cause timing problems and therefore wrong light patterns. Switching IRQs off should help to keep the strict timing schedule.
Even switching IRQs off helps a lot, the clock frequency of 80 MHz seems to low for the correct timing. Setting the frequency to 160 MHz (machine.freq(160000000)), I tested successful addressing 149 pixels on a 5m roll. I had this run for several minutes without any visible glitch in the LED illumination patterns.

There is still an issue:
Interrupt disabling and enabling seems to be slow. Disable and enable the interrupt for each write cylce slows down the update rate significantly. To be fair the test scenario had a ratio of 143 to 1 irq switching. Thus, I wonder what is better: 
- a non-out-of-the-box working neopixel driver which requires careful manual setting of the interrupt functions within python
- or a out-of-the-box working neopixel driver which slows down the update rate.

One idea would be to pass a flag to switch the irq-control in C 'on' or 'off', whereas 'on' would be be the standard value. That would allow advanced users to take irq control over and manually fine-tune the python code. 

Another observation, it seems to make almost no difference wether the interrupt is set in the C code or in the python code. However, the recent introduction of the frozen bytecode feature seems to slow down the execution a bit (measured around 7%).
Below is a small test script, I used to test the effect of the patch and to compare it to irq settings directly from within python. 

``` python
# Create a star tail pattern with 6 LEDs
import machine
machine.freq(160000000)
import neopixel
import time

n = 149
R = 255
G = 255
B = 255
pin = machine.Pin(4,machine.Pin.OUT)
light = neopixel.NeoPixel(pin,n)

#start = time.ticks_ms() #test irq effects on exec speed
for x in range(10): # run 10 times for statistics 
    #rescue_me = machine.disable_irq() # irq off before loop
    for i in range(6,n): # light loop
        light.fill((0,0,0))
        for trail in range(6):
            light[i-trail]   = (R>>trail,G>>trail,B>>trail)
        #rescue_me = machine.disable_irq() #irq off for write only
        light.write()
        #machine.enable_irq(rescue_me) #irq on after write
    machine.enable_irq(rescue_me) #irq on after loop
print(time.ticks_ms()-start)
```

This results in:

| Test | Result / ms/cycle (avg. over 10 cycles) |
| --- | --- |
| With interrupts switching in C (patch) | 3661.8 |
| With interrupts switching in python around write function | 3678.9 |
| Single interrupt switching over the entire light loop | 2014.2 |
