### PR TITLE
qemu-arm: Enable gcc LTO option for nlrthumb.c

### DIFF
--- a/py/nlrthumb.c
+++ b/py/nlrthumb.c
@@ -71,7 +71,7 @@ __attribute__((naked)) unsigned int nlr_push(nlr_buf_t *nlr) {
     return 0; // needed to silence compiler warning
 }
 
-unsigned int nlr_push_tail(nlr_buf_t *nlr) {
+__attribute__((used)) unsigned int nlr_push_tail(nlr_buf_t *nlr) {
     nlr_buf_t **top = &MP_STATE_THREAD(nlr_top);
     nlr->prev = *top;
     *top = nlr;

--- a/qemu-arm/Makefile
+++ b/qemu-arm/Makefile
@@ -53,9 +53,6 @@ OBJ_TEST += $(addprefix $(BUILD)/, $(SRC_TEST_C:.c=.o))
 OBJ_TEST += $(addprefix $(BUILD)/, $(SRC_S:.s=.o))
 OBJ_TEST += $(BUILD)/tinytest.o
 
-# we can't use LTO for nlrthumb.c because it contains inline assembler
-$(PY_BUILD)/nlrthumb.o: CFLAGS += -fno-lto
-
 all: run
 
 run: $(BUILD)/firmware.elf


### PR DESCRIPTION
LTO can't "see" inside naked functions, but we can mark `nlr_push_tail` as used.
