### PR TITLE
nlrthumb: remove empty clobbered list from nlr_jump epilog

### DIFF
--- a/py/nlrthumb.c
+++ b/py/nlrthumb.c
@@ -125,7 +125,6 @@ NORETURN __attribute__((naked)) void nlr_jump(void *val) {
     "bx     lr                  \n" // return
     :                               // output operands
     : "r"(top)                      // input operands
-    :                               // clobbered registers
     );
 
     for (;;); // needed to silence compiler warning


### PR DESCRIPTION
According to GCC's manual an empty clobbered list should not be prefixed by a colon (see https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html).
GCC 4.3.3 (Sourcery G++ Lite 2009q1-203) cares about this and errors out.
