### PR TITLE
lcd.c: de-assert chip select after completing SPI transmission

### DIFF
--- a/stmhal/lcd.c
+++ b/stmhal/lcd.c
@@ -121,6 +121,8 @@ STATIC void lcd_out(pyb_lcd_obj_t *lcd, int instr_data, uint8_t i) {
     }
     lcd_delay();
     HAL_SPI_Transmit(lcd->spi, &i, 1, 1000);
+    lcd_delay();
+    lcd->pin_cs1->gpio->BSRRL = lcd->pin_cs1->pin_mask; // CS=1; disable
 }
 
 // write a string to the LCD at the current cursor location


### PR DESCRIPTION
The LCD interface library fails to deassert the chip select of the LCD after an SPI transmission. Consequently using the SPI with other peripherals disturbs the state of the LCD. This patch changes `lcd.lcd_out()` to deassert CS after each transmission to the LCD.
