### PR TITLE
mpy-cross: Use binary file translation mode for creating mpy files on…

### DIFF
--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -49,6 +49,10 @@ SRC_C = \
 	main.c \
 	gccollect.c \
 
+ifeq ($(OS),Windows_NT)
+SRC_C += windows/fmode.c
+endif
+
 OBJ = $(PY_O)
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 

--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -35,6 +35,9 @@
 #include "py/runtime.h"
 #include "py/gc.h"
 #include "py/stackctrl.h"
+#ifdef _WIN32
+#include "windows/fmode.h"
+#endif
 
 // Command line options, with their defaults
 STATIC uint emit_opt = MP_EMIT_OPT_NONE;
@@ -185,6 +188,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
     gc_init(heap, heap + heap_size);
 
     mp_init();
+#ifdef _WIN32
+    set_fmode_binary();
+#endif
     mp_obj_list_init(mp_sys_path, 0);
     mp_obj_list_init(mp_sys_argv, 0);
 

--- a/windows/fmode.c
+++ b/windows/fmode.c
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013-2016 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "fmode.h"
+#include "py/mpconfig.h"
+#include <fcntl.h>
+#include <stdlib.h>
+
+// Workaround for setting file translation mode: we must distinguish toolsets
+// since mingw has no _set_fmode, and altering msvc's _fmode directly has no effect
+STATIC int set_fmode_impl(int mode) {
+#ifndef _MSC_VER
+    _fmode = mode;
+    return 0;
+#else
+    return _set_fmode(mode);
+#endif
+}
+
+void set_fmode_binary(void) {
+    set_fmode_impl(O_BINARY);
+}
+
+void set_fmode_text(void) {
+    set_fmode_impl(O_TEXT);
+}

--- a/windows/fmode.h
+++ b/windows/fmode.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013-2016 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef __MICROPY_INCLUDED_WINDOWS_FMODE_H__
+#define __MICROPY_INCLUDED_WINDOWS_FMODE_H__
+
+// Treat files opened by open() as binary. No line ending translation is done.
+void set_fmode_binary(void);
+
+// Treat files opened by open() as text.
+// When reading from the file \r\n will be converted to \n.
+// When writing to the file \n will be converted into \r\n.
+void set_fmode_text(void);
+
+#endif


### PR DESCRIPTION
… windows

This is a fix for https://github.com/micropython/micropython/issues/2209:
by default a file created using open() uses text translation mode so writing
\n to it will result in the file having \r\n. This is obviously problematic
for binary .mpy files, so provide functions for setting the open mode
and use binary mode in mpy-cross' main().

The implementation is in a source file so the makefile needs to know this. If that is a concern I could put the implementation in the header but that feels less clean and not really consistent with the rest of uPy.
