### PR TITLE
Update Readme file to disambiguate "make deploy"

### DIFF
--- a/esp8266/README.md
+++ b/esp8266/README.md
@@ -64,7 +64,7 @@ esptool.py --port /dev/ttyXXX erase_flash
 Erase flash also as a troubleshooting measure, if a module doesn't behave as
 expected.
 
-To flash MicroPython image to your ESP8266, use:
+To flash MicroPython image to your ESP8266, make sure you are in the ESP8266 directory and use:
 ```bash
 $ make deploy
 ```


### PR DESCRIPTION
Users do not necessarily have esptools.py on their path, and may have had to change folder to run it (like me). To such users, the present version does not make it explicit that 'make deploy' has to run from the ESP8266 directory.
