### PR TITLE
mpy-cross: Fix mingw and msys2 compilation

### DIFF
--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -50,7 +50,9 @@ SRC_C = \
 	gccollect.c \
 
 ifeq ($(OS),Windows_NT)
-SRC_C += windows/fmode.c
+    ifeq (,$(findstring MSYS,$(UNAME_S)))
+        SRC_C += windows/fmode.c
+    endif
 endif
 
 OBJ = $(PY_O)

--- a/mpy-cross/mpconfigport.h
+++ b/mpy-cross/mpconfigport.h
@@ -87,6 +87,10 @@
 #ifdef __LP64__
 typedef long mp_int_t; // must be pointer size
 typedef unsigned long mp_uint_t; // must be pointer size
+#elif defined ( __MINGW32__ ) && defined( _WIN64 )
+#include <stdint.h>
+typedef __int64 mp_int_t;
+typedef unsigned __int64 mp_uint_t;
 #else
 // These are definitions for machines where sizeof(int) == sizeof(void*),
 // regardless for actual size.
@@ -115,6 +119,8 @@ typedef const void *machine_const_ptr_t; // must be of pointer size
 // We need to provide a declaration/definition of alloca()
 #ifdef __FreeBSD__
 #include <stdlib.h>
+#elif defined( _WIN32 )
+#include <malloc.h>
 #else
 #include <alloca.h>
 #endif


### PR DESCRIPTION
When compiling with msys2's gcc there's no need to apply the binary fmode
so adjust the Makefile to reflect that.
When compiling with mingw we need to include malloc.h since there is no
alloca.h, and the 64bit detection in mpconfigport.h needs some adjustment.

Note I don't know if the detection in the Makefile is ok when using cross-compilation for windows from a linux machine or when running wine. A better way might be to test the output of `$(CC) -dumpmachine,` but that would likely fail when using clang instead of gcc?
