### PR TITLE
esp8266: fix UART parity setting

### DIFF
--- a/esp8266/modpybuart.c
+++ b/esp8266/modpybuart.c
@@ -112,9 +112,11 @@ STATIC void pyb_uart_init_helper(pyb_uart_obj_t *self, size_t n_args, const mp_o
     if (args[ARG_parity].u_obj != MP_OBJ_NULL) {
         if (args[ARG_parity].u_obj == mp_const_none) {
             UartDev.parity = UART_NONE_BITS;
+            UartDev.exist_parity = UART_STICK_PARITY_DIS;
             self->parity = 0;
         } else {
             mp_int_t parity = mp_obj_get_int(args[ARG_parity].u_obj);
+            UartDev.exist_parity = UART_STICK_PARITY_EN;
             if (parity & 1) {
                 UartDev.parity = UART_ODD_BITS;
                 self->parity = 1;

--- a/esp8266/uart.h
+++ b/esp8266/uart.h
@@ -1,6 +1,8 @@
 #ifndef _INCLUDED_UART_H_
 #define _INCLUDED_UART_H_
 
+#include <eagle_soc.h>
+
 #define UART0 (0)
 #define UART1 (1)
 
@@ -18,14 +20,14 @@ typedef enum {
 } UartStopBitsNum;
 
 typedef enum {
-    UART_NONE_BITS = 0,
-    UART_ODD_BITS   = 0,
-    UART_EVEN_BITS = BIT4
+    UART_NONE_BITS  = 0,
+    UART_ODD_BITS   = BIT0,
+    UART_EVEN_BITS  = 0
 } UartParityMode;
 
 typedef enum {
     UART_STICK_PARITY_DIS   = 0,
-    UART_STICK_PARITY_EN    = BIT3 | BIT5
+    UART_STICK_PARITY_EN    = BIT1
 } UartExistParity;
 
 typedef enum {


### PR DESCRIPTION
The configuration bits for the UART register were wrong and the parity couldn't be enabled, because the `exist_parity` member hasn't been updated. I took [this ESP8266 register description](http://esp8266.ru/esp8266-uart-reg/) as reference.

Verification has been done with a logic analyzer.
