### PR TITLE
Fixed I2C mappings for STM32F429DISC board

### DIFF
--- a/stmhal/boards/STM32F429DISC/mpconfigboard.h
+++ b/stmhal/boards/STM32F429DISC/mpconfigboard.h
@@ -29,8 +29,8 @@
 #define MICROPY_HW_UART2_PINS (GPIO_PIN_8 | GPIO_PIN_9)
 
 // I2C busses
-#define MICROPY_HW_I2C1_SCL (pin_A8)
-#define MICROPY_HW_I2C1_SDA (pin_C9)
+#define MICROPY_HW_I2C3_SCL (pin_A8)
+#define MICROPY_HW_I2C3_SDA (pin_C9)
 
 // SPI busses
 //#define MICROPY_HW_SPI1_NSS     (pin_A4)

--- a/stmhal/boards/STM32F429DISC/mpconfigboard.h
+++ b/stmhal/boards/STM32F429DISC/mpconfigboard.h
@@ -29,8 +29,10 @@
 #define MICROPY_HW_UART2_PINS (GPIO_PIN_8 | GPIO_PIN_9)
 
 // I2C busses
-#define MICROPY_HW_I2C1_SCL (pin_A8)
-#define MICROPY_HW_I2C1_SDA (pin_C9)
+#define MICROPY_HW_I2C1_SCL (pin_B6)
+#define MICROPY_HW_I2C1_SDA (pin_B7)
+#define MICROPY_HW_I2C3_SCL (pin_A8)
+#define MICROPY_HW_I2C3_SDA (pin_C9)
 
 // SPI busses
 //#define MICROPY_HW_SPI1_NSS     (pin_A4)

--- a/stmhal/boards/STM32F429DISC/mpconfigboard.h
+++ b/stmhal/boards/STM32F429DISC/mpconfigboard.h
@@ -29,8 +29,6 @@
 #define MICROPY_HW_UART2_PINS (GPIO_PIN_8 | GPIO_PIN_9)
 
 // I2C busses
-#define MICROPY_HW_I2C1_SCL (pin_B6)
-#define MICROPY_HW_I2C1_SDA (pin_B7)
 #define MICROPY_HW_I2C3_SCL (pin_A8)
 #define MICROPY_HW_I2C3_SDA (pin_C9)
 


### PR DESCRIPTION
Hi, I was trying to use I2C1 port on STM32F429 Discovery board (mapped on PA8, PC9 according to mpconfigboard.h) but nobody replied on the bus when doing a scan. I then noticed that the pin mappings were not correct. This patch enables to use I2C3 on PA8, PC9.
