### PR TITLE
docs: Quick ref links

### DIFF
--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -17,14 +17,14 @@ Tab-completion is useful to find out what methods an object has.
 Paste mode (ctrl-E) is useful to paste a large slab of Python code into
 the REPL.
 
-The ``machine`` module::
+The :mod:`machine` module::
 
     import machine
 
     machine.freq()          # get the current frequency of the CPU
     machine.freq(160000000) # set the CPU frequency to 160 MHz
 
-The ``esp`` module::
+The :mod:`esp` module::
 
     import esp
 
@@ -34,7 +34,7 @@ The ``esp`` module::
 Networking
 ----------
 
-The ``network`` module::
+See :mod:`network` and :ref:`network.WLAN <network.WLAN>`. ::
 
     import network
 
@@ -63,13 +63,13 @@ A useful function for connecting to your local WiFi network is::
                 pass
         print('network config:', wlan.ifconfig())
 
-Once the network is established the ``socket`` module can be used
+Once the network is established the :mod:`socket` module can be used
 to create and use TCP/UDP sockets as usual.
 
 Delay and timing
 ----------------
 
-Use the ``time`` module::
+Use the :mod:`time` module::
 
     import time
 
@@ -82,7 +82,7 @@ Use the ``time`` module::
 Timers
 ------
 
-Virtual (RTOS-based) timers are supported. Use the ``machine.Timer`` class
+Virtual (RTOS-based) timers are supported. Use the :ref:`machine.Timer <machine.Timer>` class
 with timer ID of -1::
 
     from machine import Timer
@@ -96,7 +96,7 @@ The period is in milliseconds.
 Pins and GPIO
 -------------
 
-Use the ``machine.Pin`` class::
+See :ref:`machine.Pin <machine.Pin>`. ::
 
     from machine import Pin
 
@@ -130,7 +130,7 @@ PWM can be enabled on all pins except Pin(16).  There is a single frequency
 for all channels, with range between 1 and 1000 (measured in Hz).  The duty
 cycle is between 0 and 1023 inclusive.
 
-Use the ``machine.PWM`` class::
+Use the :ref:`machine.PWM <machine.PWM>` class::
 
     from machine import Pin, PWM
 
@@ -149,7 +149,7 @@ ADC (analog to digital conversion)
 ADC is available on a dedicated pin.
 Note that input voltages on the ADC pin must be between 0v and 1.0v.
 
-Use the ``machine.ADC`` class::
+Use the :ref:`machine.ADC <machine.ADC>` class::
 
     from machine import ADC
 
@@ -158,6 +158,8 @@ Use the ``machine.ADC`` class::
 
 SPI bus
 -------
+
+See the :ref:`machine.SPI <machine.SPI>` class::
 
 The SPI driver is implemented in software and works on all pins::
 
@@ -186,6 +188,8 @@ The SPI driver is implemented in software and works on all pins::
 I2C bus
 -------
 
+See the :ref:`machine.I2C <machine.I2C>` class::
+
 The I2C driver is implemented in software and works on all pins::
 
     from machine import Pin, I2C
@@ -201,6 +205,8 @@ The I2C driver is implemented in software and works on all pins::
 
 Deep-sleep mode
 ---------------
+
+See the :ref:`machine.RTC <machine.RTC>` class::
 
 Connect GPIO16 to the reset pin (RST on HUZZAH).  Then the following code
 can be used to sleep, wake and check the reset cause::

--- a/docs/library/machine.ADC.rst
+++ b/docs/library/machine.ADC.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: machine
+.. _machine.ADC:
 
 class ADC -- analog to digital conversion
 =========================================

--- a/docs/library/machine.I2C.rst
+++ b/docs/library/machine.I2C.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: machine
+.. _machine.I2C:
 
 class I2C -- a two-wire serial protocol
 =======================================

--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: machine
+.. _machine.Pin:
 
 class Pin -- control I/O pins
 =============================

--- a/docs/library/machine.RTC.rst
+++ b/docs/library/machine.RTC.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: machine
+.. _machine.RTC:
 
 class RTC -- real time clock
 ============================

--- a/docs/library/machine.SD.rst
+++ b/docs/library/machine.SD.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: machine
+.. _machine.SD:
 
 class SD -- secure digital memory card
 ======================================

--- a/docs/library/machine.SPI.rst
+++ b/docs/library/machine.SPI.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: machine
+.. _machine.SPI:
 
 class SPI -- a master-driven serial protocol
 ============================================

--- a/docs/library/machine.Timer.rst
+++ b/docs/library/machine.Timer.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: machine
+.. _machine.Timer:
 
 class Timer -- control internal timers
 ======================================

--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: machine
+.. _machine.UART:
 
 class UART -- duplex serial communication bus
 =============================================

--- a/docs/library/machine.WDT.rst
+++ b/docs/library/machine.WDT.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: machine
+.. _machine.WDT:
 
 class WDT -- watchdog timer
 ===========================

--- a/docs/library/pyb.Accel.rst
+++ b/docs/library/pyb.Accel.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: pyb
+.. _pyb.Accel:
 
 class Accel -- accelerometer control
 ====================================

--- a/docs/library/pyb.CAN.rst
+++ b/docs/library/pyb.CAN.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: pyb
+.. _pyb.CAN:
 
 class CAN -- controller area network communication bus
 ======================================================

--- a/docs/library/pyb.LCD.rst
+++ b/docs/library/pyb.LCD.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: pyb
+.. _pyb.LCD:
 
 class LCD -- LCD control for the LCD touch-sensor pyskin
 ========================================================

--- a/docs/library/pyb.Switch.rst
+++ b/docs/library/pyb.Switch.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: pyb
+.. _pyb.Switch:
 
 class Switch -- switch object
 =============================

--- a/docs/library/pyb.USB_VCP.rst
+++ b/docs/library/pyb.USB_VCP.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: pyb
+.. _pyb.USB_VCP:
 
 class USB_VCP -- USB virtual comm port
 ======================================

--- a/docs/wipy/quickref.rst
+++ b/docs/wipy/quickref.rst
@@ -53,7 +53,7 @@ See :ref:`machine.Timer <machine.Timer>` and :ref:`machine.Pin <machine.Pin>`. :
     tim_a = tim.channel(Timer.A, freq=1000)
     tim_a.time() # get the value in microseconds
     tim_a.freq(5) # 5 Hz
-    
+
     p_out = Pin('GP2', mode=Pin.OUT)
     tim_a.irq(handler=lambda t: p_out.toggle())
 
@@ -66,7 +66,7 @@ See :ref:`machine.Pin <machine.Pin>` and :ref:`machine.Timer <machine.Timer>`. :
 
     # timer 1 in PWM mode and width must be 16 buts
     tim = Timer(1, mode=Timer.PWM, width=16)
-    
+
     # enable channel A @1KHz with a 50.55% duty cycle
     tim_a = tim.channel(Timer.A, freq=1000, duty_cycle=5055)
 
@@ -146,7 +146,7 @@ See :ref:`machine.RTC <machine.RTC>` ::
         pass
         # do some non blocking operations
         # warning printing on an irq via telnet is not
-        # possible, only via UART 
+        # possible, only via UART
 
     # create a RTC alarm that expires after 5 seconds
     rtc.alarm(time=5000, repeat=False)
@@ -171,7 +171,7 @@ See :ref:`machine.SD <machine.SD>`. ::
     sd = SD()
     os.mount(sd, '/sd')
 
-WLAN (WiFi) 
+WLAN (WiFi)
 -----------
 
 See :ref:`network.WLAN <network.WLAN>` and :mod:`machine`. ::
@@ -197,7 +197,7 @@ See :ref:`network.WLAN <network.WLAN>` and :mod:`machine`. ::
 Telnet and FTP server
 ---------------------
 
-See :ref:`network.Server <network.Server>` ::
+See :ref:`network.Server <network.Server>`. ::
 
     from network import Server
 


### PR DESCRIPTION
In the esp8266 and wipy quick reference sections of the docs, module
names are now links to the module pages, just like they are for pyboard.
