### PR TITLE
drivers/nrf24l01 Make the driver work on newer ports

### DIFF
--- a/drivers/nrf24l01/nrf24l01.py
+++ b/drivers/nrf24l01/nrf24l01.py
@@ -18,6 +18,7 @@ TX_ADDR     = const(0x10)
 RX_PW_P0    = const(0x11)
 FIFO_STATUS = const(0x17)
 DYNPD	    = const(0x1c)
+FEATURE     = const(0x1d)
 
 # CONFIG register
 EN_CRC      = const(0x08) # enable CRC

--- a/drivers/nrf24l01/nrf24l01.py
+++ b/drivers/nrf24l01/nrf24l01.py
@@ -217,7 +217,7 @@ class NRF24L01:
         start = utime.ticks_ms()
         result = None
         while (result is None and
-               utime.ticks_diff(start, utime.ticks_ms()) < timeout):
+               utime.ticks_diff(utime.ticks_ms(), start) < timeout):
             result = self.send_done() # 1 == success, 2 == fail
         if result == 2:
             raise OSError("send failed")

--- a/drivers/nrf24l01/nrf24l01.py
+++ b/drivers/nrf24l01/nrf24l01.py
@@ -46,6 +46,7 @@ RX_EMPTY    = const(0x01) # 1 if RX FIFO is empty
 # constants for instructions
 R_RX_PL_WID  = const(0x60) # read RX payload width
 R_RX_PAYLOAD = const(0x61) # read RX payload
+ACTIVATE     = const(0x80) # activate a feature
 W_TX_PAYLOAD = const(0xa0) # write TX payload
 FLUSH_TX     = const(0xe1) # flush TX FIFO
 FLUSH_RX     = const(0xe2) # flush RX FIFO
@@ -141,6 +142,12 @@ class NRF24L01:
     def flush_tx(self):
         self.cs.low()
         self.spi.read(1, FLUSH_TX)
+        self.cs.high()
+
+    def activate(self, data=0x73):
+        self.cs.low()
+        self.spi.read(1, FLUSH_TX)
+        self.spi.read(1, data)
         self.cs.high()
 
     # power is one of POWER_x defines; speed is one of SPEED_x defines


### PR DESCRIPTION
The driver used `pyb` module, which doesn't exist on newer ports,
such as the ESP8266 one. This patch makes two changes:
- Use _FOO with the const() variables, to save some memory.
- Use the `time` module in place of the `pyb` module for delays.
- Use `spi.read`/`spi.write` instead of `spi.send`/`spi.receive`.
- Drop some non-portable parameters to spi and pin initialization.
