### PR TITLE
mpy-cross: Fix compiler detection for including windows/fmode.c

### DIFF
--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -49,10 +49,10 @@ SRC_C = \
 	main.c \
 	gccollect.c \
 
-ifeq ($(OS),Windows_NT)
-    ifeq (,$(findstring MSYS,$(UNAME_S)))
-        SRC_C += windows/fmode.c
-    endif
+# Add fmode when compiling with mingw gcc
+COMPILER_TARGET := $(shell $(CC) -dumpmachine)
+ifneq (,$(findstring mingw,$(COMPILER_TARGET)))
+	SRC_C += windows/fmode.c
 endif
 
 OBJ = $(PY_O)


### PR DESCRIPTION
fmode.c should only be included for builds targetting 'pure' windows, i.e.
msvc or mingw builds but not when using msys or cygwin's gcc (see #2298).
Just checking if the OS is windows and UNAME doesn't have msys stil leaves
the gate open for builds with cygwin's gcc since UNAME there is e.g.
CYGWIN_NT-6.1-WOW.
Fix this by checking for 'mingw' explicitly in the compiler version; both
gcc and clang have the -dumpmachine flag so the check should be ok for
all platforms.
