### PR TITLE
mpconfigport.h: don't include stdio.h if macOS

### DIFF
--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -305,5 +305,7 @@ void mp_unix_mark_exec(void);
 #define _DIRENT_HAVE_D_INO (1)
 #endif
 
+#ifndef __APPLE__
 // For debugging purposes, make printf() available to any source file.
 #include <stdio.h>
+#endif


### PR DESCRIPTION
Fixes build errors such as
"../lib/utils/printf.c:43:5: error: expected parameter declarator"
