### PR TITLE
#2318 Providing 'micropython.vcxproj.filters' is more convenient way …

### DIFF
--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -5,5 +5,4 @@
 *.exe
 *.pdb
 *.ilk
-*.filters
 /build/*

--- a/windows/micropython.vcxproj.filters
+++ b/windows/micropython.vcxproj.filters
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
…to separate types of the source codes and others.
- Currently there is no vcxproj.filters in windows directory because '*.filters' was added into .gitignore.
- However, providing 'micropython.vcxproj.filters' is more convenient way to separate types of the source codes (I mean *.cpp, *.c, *.h, ...) I think.
