### PR TITLE
Added operators tests

### DIFF
--- a/stmhal/adc.c
+++ b/stmhal/adc.c
@@ -131,7 +131,13 @@ STATIC void adc_init_single(pyb_obj_adc_t *adc_obj) {
       mp_hal_gpio_clock_enable(pin->gpio);
       GPIO_InitTypeDef GPIO_InitStructure;
       GPIO_InitStructure.Pin = pin->pin_mask;
+#if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
       GPIO_InitStructure.Mode = GPIO_MODE_ANALOG;
+#elif defined(MCU_SERIES_L4)
+      GPIO_InitStructure.Mode = GPIO_MODE_ANALOG_ADC_CONTROL;
+#else
+    #error Unsupported processor
+#endif
       GPIO_InitStructure.Pull = GPIO_NOPULL;
       HAL_GPIO_Init(pin->gpio, &GPIO_InitStructure);
     }
@@ -140,7 +146,6 @@ STATIC void adc_init_single(pyb_obj_adc_t *adc_obj) {
 
     ADC_HandleTypeDef *adcHandle = &adc_obj->handle;
     adcHandle->Instance                   = ADCx;
-    adcHandle->Init.Resolution            = ADC_RESOLUTION12b;
     adcHandle->Init.ContinuousConvMode    = DISABLE;
     adcHandle->Init.DiscontinuousConvMode = DISABLE;
     adcHandle->Init.NbrOfDiscConversion   = 0;
@@ -148,15 +153,19 @@ STATIC void adc_init_single(pyb_obj_adc_t *adc_obj) {
     adcHandle->Init.DataAlign             = ADC_DATAALIGN_RIGHT;
     adcHandle->Init.NbrOfConversion       = 1;
     adcHandle->Init.DMAContinuousRequests = DISABLE;
-    adcHandle->Init.EOCSelection          = DISABLE;
 #if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
+    adcHandle->Init.Resolution            = ADC_RESOLUTION12b;
     adcHandle->Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV2;
     adcHandle->Init.ScanConvMode          = DISABLE;
     adcHandle->Init.ExternalTrigConv      = ADC_EXTERNALTRIGCONV_T1_CC1;
+    adcHandle->Init.EOCSelection          = DISABLE;
 #elif defined(MCU_SERIES_L4)
-    adcHandle->Init.ClockPrescaler        = ADC_CLOCK_ASYNC_DIV2;
+    adcHandle->Init.Resolution            = ADC_RESOLUTION_12B;
+    adcHandle->Init.ClockPrescaler        = ADC_CLOCK_ASYNC_DIV1;
     adcHandle->Init.ScanConvMode          = ADC_SCAN_DISABLE;
-    adcHandle->Init.ExternalTrigConv      = ADC_EXTERNALTRIG_T1_CC1;
+    adcHandle->Init.EOCSelection          = ADC_EOC_SINGLE_CONV;
+    adcHandle->Init.ExternalTrigConv      = ADC_SOFTWARE_START;
+    adcHandle->Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
     adcHandle->Init.LowPowerAutoWait      = DISABLE;
     adcHandle->Init.Overrun               = ADC_OVR_DATA_PRESERVED;
     adcHandle->Init.OversamplingMode      = DISABLE;
@@ -165,30 +174,42 @@ STATIC void adc_init_single(pyb_obj_adc_t *adc_obj) {
 #endif
 
     HAL_ADC_Init(adcHandle);
+
+#if defined(MCU_SERIES_L4)
+    ADC_MultiModeTypeDef multimode;
+    multimode.Mode = ADC_MODE_INDEPENDENT;
+    if (HAL_ADCEx_MultiModeConfigChannel(adcHandle, &multimode) != HAL_OK)
+    {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Can not set multimode on ADC1 channel: %d", adc_obj->channel));
+    }
+#endif
 }
 
-STATIC void adc_config_channel(pyb_obj_adc_t *adc_obj) {
+STATIC void adc_config_channel(ADC_HandleTypeDef *adc_handle, uint32_t channel) {
     ADC_ChannelConfTypeDef sConfig;
 
-    sConfig.Channel = adc_obj->channel;
+    sConfig.Channel = channel;
     sConfig.Rank = 1;
 #if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
     sConfig.SamplingTime = ADC_SAMPLETIME_15CYCLES;
 #elif defined(MCU_SERIES_L4)
     sConfig.SamplingTime = ADC_SAMPLETIME_12CYCLES_5;
+    sConfig.SingleDiff = ADC_SINGLE_ENDED;
+    sConfig.OffsetNumber = ADC_OFFSET_NONE;
 #else
     #error Unsupported processor
 #endif
     sConfig.Offset = 0;
 
-    HAL_ADC_ConfigChannel(&adc_obj->handle, &sConfig);
+    HAL_ADC_ConfigChannel(adc_handle, &sConfig);
 }
 
 STATIC uint32_t adc_read_channel(ADC_HandleTypeDef *adcHandle) {
     uint32_t rawValue = 0;
 
     HAL_ADC_Start(adcHandle);
-    if (HAL_ADC_PollForConversion(adcHandle, 10) == HAL_OK && HAL_ADC_GetState(adcHandle) == HAL_ADC_STATE_EOC_REG) {
+    if (HAL_ADC_PollForConversion(adcHandle, 10) == HAL_OK
+        && (HAL_ADC_GetState(adcHandle) & HAL_ADC_STATE_EOC_REG) == HAL_ADC_STATE_EOC_REG) {
         rawValue = HAL_ADC_GetValue(adcHandle);
     }
     HAL_ADC_Stop(adcHandle);
@@ -252,7 +273,7 @@ STATIC mp_obj_t adc_make_new(const mp_obj_type_t *type, mp_uint_t n_args, mp_uin
 STATIC mp_obj_t adc_read(mp_obj_t self_in) {
     pyb_obj_adc_t *self = self_in;
 
-    adc_config_channel(self);
+    adc_config_channel(&self->handle, self->channel);
     uint32_t data = adc_read_channel(&self->handle);
     return mp_obj_new_int(data);
 }
@@ -313,7 +334,7 @@ STATIC mp_obj_t adc_read_timed(mp_obj_t self_in, mp_obj_t buf_in, mp_obj_t freq_
     }
 
     // configure the ADC channel
-    adc_config_channel(self);
+    adc_config_channel(&self->handle, self->channel);
 
     // This uses the timer in polling mode to do the sampling
     // TODO use DMA
@@ -446,19 +467,7 @@ void adc_init_all(pyb_adc_all_obj_t *adc_all, uint32_t resolution) {
 }
 
 uint32_t adc_config_and_read_channel(ADC_HandleTypeDef *adcHandle, uint32_t channel) {
-    ADC_ChannelConfTypeDef sConfig;
-    sConfig.Channel = channel;
-    sConfig.Rank = 1;
-#if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
-    sConfig.SamplingTime = ADC_SAMPLETIME_15CYCLES;
-#elif defined(MCU_SERIES_L4)
-    sConfig.SamplingTime = ADC_SAMPLETIME_12CYCLES_5;
-#else
-    #error Unsupported processor
-#endif
-    sConfig.Offset = 0;
-    HAL_ADC_ConfigChannel(adcHandle, &sConfig);
-
+    adc_config_channel(adcHandle, channel);
     return adc_read_channel(adcHandle);
 }
 

--- a/tests/basics/special_methods.py
+++ b/tests/basics/special_methods.py
@@ -1,0 +1,158 @@
+# call tests for python operators
+# TODO: add the sequences related operators
+
+
+class cud():
+
+    def __init__(self):
+        print("__init__ called")
+        pass
+
+    def __repr__(self):
+        print("__repr__ called")
+        return ""
+
+# Comparisons
+    def __lt__(self, other):
+        print("__lt__ called")
+        pass
+
+    def __le__(self, other):
+        print("__le__ called")
+        pass
+
+    def __eq__(self, other):
+        print("__eq__ called")
+        pass
+
+    def __ne__(self, other):
+        print("__ne__ called")
+        pass
+
+    def __ge__(self, other):
+        print("__ge__ called")
+        pass
+
+    def __gt__(self, other):
+        print("__gt__ called")
+        pass
+
+# Math
+    def __abs__(self):
+        print("__abs__ called")
+        pass
+
+    def __add__(self, other):
+        print("__add__ called")
+        pass
+
+    def __and__(self, other):
+        print("__and__ called")
+        pass
+
+    def __floordiv__(self, other):
+        print("__floordiv__ called")
+        pass
+
+    def __index__(self, other):
+        print("__index__ called")
+        pass
+
+    def __inv__(self):
+        print("__inv__ called")
+        pass
+
+    def __invert__(self):
+        print("__invert__ called")
+        pass
+
+    def __lshift__(self, val):
+        print("__lshift__ called")
+        pass
+
+    def __mod__(self, val):
+        print("__mod__ called")
+        pass
+
+    def __mul__(self, other):
+        print("__mul__ called")
+        pass
+
+    def __matmul__(self, other):
+        print("__matmul__ called")
+        pass
+
+    def __neg__(self):
+        print("__neg__ called")
+        pass
+
+    def __or__(self, other):
+        print("__or__ called")
+        pass
+
+    def __pos__(self):
+        print("__pos__ called")
+        pass
+
+    def __pow__(self, val):
+        print("__pow__ called")
+        pass
+
+    def __rshift__(self, val):
+        print("__rshift__ called")
+        pass
+
+    def __sub__(self, other):
+        print("__sub__ called")
+        pass
+
+    def __truediv__(self, other):
+        print("__truediv__ called")
+        pass
+
+    def __div__(self, other):
+        print("__div__ called")
+        pass
+
+    def __xor__(self, other):
+        print("__xor__ called")
+        pass
+
+cud1 = cud()
+cud2 = cud()
+str(cud1)
+cud1 < cud2
+cud1 <= cud2
+cud1 == cud2
+# TODO: ne is not supported, !(eq) is called instead
+#cud1 != cud2
+cud1 >= cud2
+cud1 > cud2
+cud1 + cud2
+# TODO: binary and is not supported
+#cud1 & cud2
+cud2 // cud1
+~cud1
+# TODO: binary lshift is not supported
+# cud1<<1
+# TODO: modulus is not supported
+#cud1 % 2
+cud1 * cud2
+cud1 * 2
+-cud1
+# TODO: binary or is not supported
+#cud1 | cud2
++cud1
+# TODO: pow is not supported
+# cud1**2
+# TODO: rshift is not suported
+# cud1>>1
+cud1 - cud2
+cud1 / cud2
+cud1 / 2
+# TODO: xor is not supported
+# cud1^cud2
+
+# TODO: in the followin test, cpython still calls __eq__
+# cud3=cud1
+# cud3==cud1


### PR DESCRIPTION
Following this issue: https://github.com/micropython/micropython/issues/2317

The test results are similar on the unix and esp8266 ports, however they currently fails:
- `__eq__` is called instead of `__ne__` 
- bitwise operators seems to be unsupported (rshift, lshift, and, or, xor)
