### PR TITLE
esp8266: Factory function for SPI

### DIFF
--- a/esp8266/Makefile
+++ b/esp8266/Makefile
@@ -78,7 +78,7 @@ SRC_C = \
 	modpybrtc.c \
 	modpybadc.c \
 	modpybuart.c \
-	modpybspi.c \
+	modpybsoftspi.c \
 	modesp.c \
 	modnetwork.c \
 	modutime.c \

--- a/esp8266/esp8266.ld
+++ b/esp8266/esp8266.ld
@@ -141,7 +141,7 @@ SECTIONS
         *modpybadc.o(.literal*, .text*)
         *modpybuart.o(.literal*, .text*)
         *modpybi2c.o(.literal*, .text*)
-        *modpybspi.o(.literal*, .text*)
+        *modpybsoftspi.o(.literal*, .text*)
         *modesp.o(.literal* .text*)
         *modnetwork.o(.literal* .text*)
         *moduos.o(.literal* .text*)

--- a/esp8266/modmachine.c
+++ b/esp8266/modmachine.c
@@ -251,7 +251,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ADC), MP_ROM_PTR(&pyb_adc_type) },
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&pyb_uart_type) },
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&machine_i2c_type) },
-    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&pyb_spi_type) },
+    { MP_ROM_QSTR(MP_QSTR_SoftSPI), MP_ROM_PTR(&pyb_softspi_type) },
 
     // wake abilities
     { MP_ROM_QSTR(MP_QSTR_DEEPSLEEP), MP_ROM_INT(MACHINE_WAKE_DEEPSLEEP) },

--- a/esp8266/modmachine.c
+++ b/esp8266/modmachine.c
@@ -225,6 +225,43 @@ STATIC mp_obj_t machine_enable_irq(mp_obj_t state_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(machine_enable_irq_obj, machine_enable_irq);
 
+
+STATIC mp_obj_t machine_spi(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_index, ARG_baudrate, ARG_polarity, ARG_phase, ARG_sck, ARG_mosi, ARG_miso };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_index, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_polarity, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_phase, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_sck, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_mosi, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_miso, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args),
+                     allowed_args, args);
+    switch (args[ARG_index].u_int) {
+        case -1:
+            // create and return SoftSPI
+            break;
+        case 0:
+            if (args[ARG_sck].u_obj != MP_OBJ_NULL ||
+                args[ARG_miso].u_obj != MP_OBJ_NULL ||
+                args[ARG_mosi].u_obj != MP_OBJ_NULL) {
+                nlr_raise(mp_obj_new_exception_msg_varg(
+                    &mp_type_ValueError, "hardware SPI has fixed pins"));
+            }
+            // create and return HSPI
+            break;
+        default:
+            nlr_raise(mp_obj_new_exception_msg_varg(
+                &mp_type_ValueError, "no such SPI peripheral"));
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(machine_spi_obj, 1, machine_spi);
+
+
 STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_umachine) },
     { MP_ROM_QSTR(MP_QSTR_mem8), MP_ROM_PTR(&machine_mem8_obj) },
@@ -252,6 +289,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&pyb_uart_type) },
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&machine_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SoftSPI), MP_ROM_PTR(&pyb_softspi_type) },
+    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&machine_spi_obj) },
 
     // wake abilities
     { MP_ROM_QSTR(MP_QSTR_DEEPSLEEP), MP_ROM_INT(MACHINE_WAKE_DEEPSLEEP) },

--- a/esp8266/modpyb.h
+++ b/esp8266/modpyb.h
@@ -9,7 +9,7 @@ extern const mp_obj_type_t pyb_adc_type;
 extern const mp_obj_type_t pyb_rtc_type;
 extern const mp_obj_type_t pyb_uart_type;
 extern const mp_obj_type_t pyb_i2c_type;
-extern const mp_obj_type_t pyb_spi_type;
+extern const mp_obj_type_t pyb_softspi_type;
 
 MP_DECLARE_CONST_FUN_OBJ(pyb_info_obj);
 

--- a/esp8266/modpybsoftspi.c
+++ b/esp8266/modpybsoftspi.c
@@ -36,7 +36,7 @@
 #include "py/stream.h"
 #include "py/mphal.h"
 
-typedef struct _pyb_spi_obj_t {
+typedef struct _pyb_softspi_obj_t {
     mp_obj_base_t base;
     uint32_t baudrate;
     uint8_t polarity;
@@ -44,9 +44,9 @@ typedef struct _pyb_spi_obj_t {
     mp_hal_pin_obj_t sck;
     mp_hal_pin_obj_t mosi;
     mp_hal_pin_obj_t miso;
-} pyb_spi_obj_t;
+} pyb_softspi_obj_t;
 
-STATIC void mp_hal_spi_transfer(pyb_spi_obj_t *self, size_t src_len, const uint8_t *src_buf, size_t dest_len, uint8_t *dest_buf) {
+STATIC void mp_hal_spi_transfer(pyb_softspi_obj_t *self, size_t src_len, const uint8_t *src_buf, size_t dest_len, uint8_t *dest_buf) {
     // only MSB transfer is implemented
     uint32_t delay_half = 500000 / self->baudrate + 1;
     for (size_t i = 0; i < src_len || i < dest_len; ++i) {
@@ -86,13 +86,13 @@ STATIC void mp_hal_spi_transfer(pyb_spi_obj_t *self, size_t src_len, const uint8
 /******************************************************************************/
 // MicroPython bindings for SPI
 
-STATIC void pyb_spi_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    pyb_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
+STATIC void pyb_softspi_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    pyb_softspi_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_printf(print, "SPI(baudrate=%u, polarity=%u, phase=%u, sck=%u, mosi=%u, miso=%u)",
         self->baudrate, self->polarity, self->phase, self->sck, self->mosi, self->miso);
 }
 
-STATIC void pyb_spi_init_helper(pyb_spi_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+STATIC void pyb_softspi_init_helper(pyb_softspi_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_baudrate, ARG_polarity, ARG_phase, ARG_sck, ARG_mosi, ARG_miso };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = -1} },
@@ -131,10 +131,10 @@ STATIC void pyb_spi_init_helper(pyb_spi_obj_t *self, size_t n_args, const mp_obj
     mp_hal_pin_input(self->miso);
 }
 
-STATIC mp_obj_t pyb_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t pyb_softspi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
-    pyb_spi_obj_t *self = m_new_obj(pyb_spi_obj_t);
-    self->base.type = &pyb_spi_type;
+    pyb_softspi_obj_t *self = m_new_obj(pyb_softspi_obj_t);
+    self->base.type = &pyb_softspi_type;
     // set defaults
     self->baudrate = 500000;
     self->polarity = 0;
@@ -144,18 +144,18 @@ STATIC mp_obj_t pyb_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_
     self->miso = 12;
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
-    pyb_spi_init_helper(self, n_args, args, &kw_args);
+    pyb_softspi_init_helper(self, n_args, args, &kw_args);
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC mp_obj_t pyb_spi_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
-    pyb_spi_init_helper(args[0], n_args - 1, args + 1, kw_args);
+STATIC mp_obj_t pyb_softspi_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    pyb_softspi_init_helper(args[0], n_args - 1, args + 1, kw_args);
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_KW(pyb_spi_init_obj, 1, pyb_spi_init);
+MP_DEFINE_CONST_FUN_OBJ_KW(pyb_softspi_init_obj, 1, pyb_softspi_init);
 
-STATIC mp_obj_t pyb_spi_read(size_t n_args, const mp_obj_t *args) {
-    pyb_spi_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+STATIC mp_obj_t pyb_softspi_read(size_t n_args, const mp_obj_t *args) {
+    pyb_softspi_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     uint8_t write_byte = 0;
     if (n_args == 3) {
         write_byte = mp_obj_get_int(args[2]);
@@ -165,10 +165,10 @@ STATIC mp_obj_t pyb_spi_read(size_t n_args, const mp_obj_t *args) {
     mp_hal_spi_transfer(self, 1, &write_byte, vstr.len, (uint8_t*)vstr.buf);
     return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
 }
-MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_spi_read_obj, 2, 3, pyb_spi_read);
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_softspi_read_obj, 2, 3, pyb_softspi_read);
 
-STATIC mp_obj_t pyb_spi_readinto(size_t n_args, const mp_obj_t *args) {
-    pyb_spi_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+STATIC mp_obj_t pyb_softspi_readinto(size_t n_args, const mp_obj_t *args) {
+    pyb_softspi_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_WRITE);
     uint8_t write_byte = 0;
@@ -178,19 +178,19 @@ STATIC mp_obj_t pyb_spi_readinto(size_t n_args, const mp_obj_t *args) {
     mp_hal_spi_transfer(self, 1, &write_byte, bufinfo.len, (uint8_t*)bufinfo.buf);
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_spi_readinto_obj, 2, 3, pyb_spi_readinto);
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_softspi_readinto_obj, 2, 3, pyb_softspi_readinto);
 
-STATIC mp_obj_t pyb_spi_write(mp_obj_t self_in, mp_obj_t wr_buf_in) {
-    pyb_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
+STATIC mp_obj_t pyb_softspi_write(mp_obj_t self_in, mp_obj_t wr_buf_in) {
+    pyb_softspi_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_buffer_info_t src_buf;
     mp_get_buffer_raise(wr_buf_in, &src_buf, MP_BUFFER_READ);
     mp_hal_spi_transfer(self, src_buf.len, (const uint8_t*)src_buf.buf, 0, NULL);
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_2(pyb_spi_write_obj, pyb_spi_write);
+MP_DEFINE_CONST_FUN_OBJ_2(pyb_softspi_write_obj, pyb_softspi_write);
 
-STATIC mp_obj_t pyb_spi_write_readinto(mp_obj_t self_in, mp_obj_t wr_buf_in, mp_obj_t rd_buf_in) {
-    pyb_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
+STATIC mp_obj_t pyb_softspi_write_readinto(mp_obj_t self_in, mp_obj_t wr_buf_in, mp_obj_t rd_buf_in) {
+    pyb_softspi_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_buffer_info_t src_buf;
     mp_get_buffer_raise(wr_buf_in, &src_buf, MP_BUFFER_READ);
     mp_buffer_info_t dest_buf;
@@ -201,22 +201,22 @@ STATIC mp_obj_t pyb_spi_write_readinto(mp_obj_t self_in, mp_obj_t wr_buf_in, mp_
     mp_hal_spi_transfer(self, src_buf.len, (const uint8_t*)src_buf.buf, dest_buf.len, (uint8_t*)dest_buf.buf);
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_3(pyb_spi_write_readinto_obj, pyb_spi_write_readinto);
+MP_DEFINE_CONST_FUN_OBJ_3(pyb_softspi_write_readinto_obj, pyb_softspi_write_readinto);
 
-STATIC const mp_rom_map_elem_t pyb_spi_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&pyb_spi_init_obj) },
-    { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&pyb_spi_read_obj) },
-    { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&pyb_spi_readinto_obj) },
-    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&pyb_spi_write_obj) },
-    { MP_ROM_QSTR(MP_QSTR_write_readinto), MP_ROM_PTR(&pyb_spi_write_readinto_obj) },
+STATIC const mp_rom_map_elem_t pyb_softspi_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&pyb_softspi_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&pyb_softspi_read_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&pyb_softspi_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&pyb_softspi_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write_readinto), MP_ROM_PTR(&pyb_softspi_write_readinto_obj) },
 };
 
-STATIC MP_DEFINE_CONST_DICT(pyb_spi_locals_dict, pyb_spi_locals_dict_table);
+STATIC MP_DEFINE_CONST_DICT(pyb_softspi_locals_dict, pyb_softspi_locals_dict_table);
 
-const mp_obj_type_t pyb_spi_type = {
+const mp_obj_type_t pyb_softspi_type = {
     { &mp_type_type },
     .name = MP_QSTR_SPI,
-    .print = pyb_spi_print,
-    .make_new = pyb_spi_make_new,
-    .locals_dict = (mp_obj_dict_t*)&pyb_spi_locals_dict,
+    .print = pyb_softspi_print,
+    .make_new = pyb_softspi_make_new,
+    .locals_dict = (mp_obj_dict_t*)&pyb_softspi_locals_dict,
 };


### PR DESCRIPTION
Rename machine.SPI to machine.SoftSPI and create a factory function machine.SPI that will call either machine.SoftSPI or machine.HSPI depending on the parameters.
