### PR TITLE
extmod/modbtree: do CHECK_ERROR after __bt_seq()

### DIFF
--- a/extmod/modbtree.c
+++ b/extmod/modbtree.c
@@ -133,6 +133,7 @@ STATIC mp_obj_t btree_seq(size_t n_args, const mp_obj_t *args) {
     }
 
     int res = __bt_seq(self->db, &key, &val, flags);
+    CHECK_ERROR(res);
     if (res == RET_SPECIAL) {
         return mp_const_none;
     }


### PR DESCRIPTION
In `btree_seq()`, when `__bt_seq()` gets called with invalid
`flags` argument it will return `RET_ERROR` and it won't
initialize `val`. If field `data` of uninitialized `val`
is passed to `mp_obj_new_bytes()` it causes a segfault.
