### PR TITLE
docs: Make the machine.RTC reflect reality on esp8266

### DIFF
--- a/docs/library/machine.RTC.rst
+++ b/docs/library/machine.RTC.rst
@@ -9,54 +9,40 @@ and time.
 Example usage::
 
     rtc = machine.RTC()
-    rtc.init((2014, 5, 1, 4, 13, 0, 0, 0))
-    print(rtc.now())
+    rtc.datetime((2014, 5, 1, 0, 4, 13, 0, 0))
+    print(rtc.datetime())
 
 
 Constructors
 ------------
 
-.. class:: RTC(id=0, ...)
+.. class:: RTC()
 
-   Create an RTC object. See init for parameters of initialization.
+   Create an RTC object.
 
 Methods
 -------
 
-.. method:: RTC.init(datetime)
+.. method:: RTC.datetime([datetime])
 
-   Initialise the RTC. Datetime is a tuple of the form:
-   
-      ``(year, month, day[, hour[, minute[, second[, microsecond[, tzinfo]]]]])``
+   Get or set the current datetime. Datetime is a tuple of the form:
 
-.. method:: RTC.now()
+      ``(year, month, day[, weekday[, hour[, minute[, second[, microsecond]]]]])``
 
-   Get get the current datetime tuple.
+.. method:: RTC.memory([buffer])
 
-.. method:: RTC.deinit()
+    Get or set the contents of non-volatile memory.
 
-   Resets the RTC to the time of January 1, 2015 and starts running it again.
+.. method:: RTC.alarm(id, time)
 
-.. method:: RTC.alarm(id, time, /*, repeat=False)
+   Set the RTC alarm. Time is a millisecond value to program the alarm to
+   current time + time_in_ms in the future.
 
-   Set the RTC alarm. Time might be either a millisecond value to program the alarm to
-   current time + time_in_ms in the future, or a datetimetuple. If the time passed is in
-   milliseconds, repeat can be set to ``True`` to make the alarm periodic.
-
-.. method:: RTC.alarm_left(alarm_id=0)
-
-   Get the number of milliseconds left before the alarm expires.
-
-.. method:: RTC.cancel(alarm_id=0)
-
-   Cancel a running alarm.
-
-.. method:: RTC.irq(\*, trigger, handler=None, wake=machine.IDLE)
+.. method:: RTC.irq(\*, trigger, wake=machine.IDLE)
 
    Create an irq object triggered by a real time clock alarm.
 
       - ``trigger`` must be ``RTC.ALARM0``
-      - ``handler`` is the function to be called when the callback is triggered.
       - ``wake`` specifies the sleep mode from where this interrupt can wake
         up the system.
 


### PR DESCRIPTION
The documentation for `machine.RTC` is completely worng, not only
specifying wrong method names, but also wrong order of values in
the time tuple. Updated based on the source code.
