### PR TITLE
Adc l4 ch16 fix

### DIFF
--- a/stmhal/adc.c
+++ b/stmhal/adc.c
@@ -189,7 +189,7 @@ STATIC void adc_init_single(pyb_obj_adc_t *adc_obj) {
 #endif
 }
 
-STATIC void adc_config_channel(ADC_HandleTypeDef *adchandle, uint32_t channel) {
+STATIC void adc_config_channel(ADC_HandleTypeDef *adcHandle, uint32_t channel) {
     ADC_ChannelConfTypeDef sConfig;
 
     sConfig.Channel = channel;
@@ -205,7 +205,7 @@ STATIC void adc_config_channel(ADC_HandleTypeDef *adchandle, uint32_t channel) {
 #endif
     sConfig.Offset = 0;
 
-    HAL_ADC_ConfigChannel(adchandle, &sConfig);
+    HAL_ADC_ConfigChannel(adcHandle, &sConfig);
 }
 
 STATIC uint32_t adc_read_channel(ADC_HandleTypeDef *adcHandle) {

--- a/stmhal/boards/make-pins.py
+++ b/stmhal/boards/make-pins.py
@@ -303,7 +303,7 @@ class Pins(object):
     def print_adc(self, adc_num):
         print('');
         print('const pin_obj_t * const pin_adc{:d}[] = {{'.format(adc_num))
-        for channel in range(16):
+        for channel in range(17):
             adc_found = False
             for named_pin in self.cpu_pins:
                 pin = named_pin.pin()
@@ -314,6 +314,10 @@ class Pins(object):
                     break
             if not adc_found:
                 print('  NULL,    // {:d}'.format(channel))
+            if channel == 15:
+                print('#if defined(MCU_SERIES_L4)')
+            if channel == 16:
+                print('#endif')
         print('};')
 
 


### PR DESCRIPTION
Fixing the STM32L4 ADC channel 16 (the L4 names its channels CH1-16 rather than 0-15). See https://github.com/micropython/micropython/issues/2243
