### PR TITLE
esp8266/modous: Add unmount method

### DIFF
--- a/esp8266/moduos.c
+++ b/esp8266/moduos.c
@@ -123,6 +123,10 @@ STATIC mp_obj_t os_rename(mp_obj_t path_old, mp_obj_t path_new) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(os_rename_obj, os_rename);
 
+STATIC mp_obj_t os_umount(void) {
+    return vfs_proxy_call(MP_QSTR_umount, 0, NULL);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(os_umount_obj, os_umount);
 #endif
 
 STATIC mp_obj_t os_urandom(mp_obj_t num) {
@@ -166,6 +170,7 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&os_remove_obj) },
     { MP_ROM_QSTR(MP_QSTR_rename), MP_ROM_PTR(&os_rename_obj) },
     { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&os_stat_obj) },
+    { MP_ROM_QSTR(MP_QSTR_umount), MP_ROM_PTR(&os_umount_obj) },
     #endif
 };
 

--- a/extmod/fsusermount.c
+++ b/extmod/fsusermount.c
@@ -162,7 +162,7 @@ STATIC mp_obj_t fatfs_mount(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(fsuser_mount_obj, 2, fatfs_mount);
 
-STATIC mp_obj_t fatfs_umount(mp_obj_t bdev_or_path_in) {
+mp_obj_t fatfs_umount(mp_obj_t bdev_or_path_in) {
     size_t i = 0;
     if (MP_OBJ_IS_STR(bdev_or_path_in)) {
         mp_uint_t mnt_len;

--- a/extmod/fsusermount.h
+++ b/extmod/fsusermount.h
@@ -55,6 +55,7 @@ typedef struct _fs_user_mount_t {
 } fs_user_mount_t;
 
 fs_user_mount_t *fatfs_mount_mkfs(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args, bool mkfs);
+mp_obj_t fatfs_umount(mp_obj_t bdev_or_path_in);
 
 MP_DECLARE_CONST_FUN_OBJ(fsuser_mount_obj);
 MP_DECLARE_CONST_FUN_OBJ(fsuser_umount_obj);

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -250,6 +250,14 @@ STATIC mp_obj_t fat_vfs_stat(mp_obj_t vfs_in, mp_obj_t path_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_stat_obj, fat_vfs_stat);
 
+// Unmount the filesystem
+STATIC mp_obj_t fat_vfs_umount(mp_obj_t vfs_in) {
+    fatfs_umount(((fs_user_mount_t *)vfs_in)->readblocks[1]);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(fat_vfs_umount_obj, fat_vfs_umount);
+
+
 STATIC const mp_rom_map_elem_t fat_vfs_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_mkfs), MP_ROM_PTR(&fat_vfs_mkfs_obj) },
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&fat_vfs_open_obj) },
@@ -261,6 +269,7 @@ STATIC const mp_rom_map_elem_t fat_vfs_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&fat_vfs_remove_obj) },
     { MP_ROM_QSTR(MP_QSTR_rename), MP_ROM_PTR(&fat_vfs_rename_obj) },
     { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&fat_vfs_stat_obj) },
+    { MP_ROM_QSTR(MP_QSTR_umount), MP_ROM_PTR(&fat_vfs_umount_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(fat_vfs_locals_dict, fat_vfs_locals_dict_table);
 


### PR DESCRIPTION
Fixes #2338.

This is a more object-oriented approach, where uos is only a proxy
for the methods on the vfs object. Unfortunately, it's a much dirtier
patch, as some internals had to be exposed (the STATIC method removed)
for this to work. It also takes more memory in the object dicts.
