### PR TITLE
stmhal/modusocket: set self->nic to MP_OBJ_NULL after socket close

### DIFF
--- a/stmhal/modusocket.c
+++ b/stmhal/modusocket.c
@@ -83,6 +83,7 @@ STATIC mp_obj_t socket_close(mp_obj_t self_in) {
     mod_network_socket_obj_t *self = self_in;
     if (self->nic != MP_OBJ_NULL) {
         self->nic_type->close(self);
+        self->nic = MP_OBJ_NULL;
     }
     return mp_const_none;
 }


### PR DESCRIPTION
This patch makes second and next calls to <socket>.close() a no-op.
It prevents GC from closing the underlying resource after user
already used <socket>.close() explicitly.

fixes #2355
