### PR TITLE
.gitignore: add *.pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ tests/*.out
 # Python cache files
 ######################
 __pycache__/
+*.pyc
 
 # Customized Makefile/project overrides
 ######################


### PR DESCRIPTION
Example:

```
~/git/micropython/esp8266 $ make
...
LINK build/firmware.elf
   text    data     bss     dec     hex filename
 524604    1056   56208  581868   8e0ec build/firmware.elf
Create build/firmware-combined.bin
('flash    ', 33456)
('padding  ', 3408)
('irom0text', 492248)
('total    ', 529112)
('md5      ', 'b6b9f8f387e48aa2099546071f77d583')
~/git/micropython/esp8266 $ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

    ../py/makeqstrdata.pyc

nothing added to commit but untracked files present (use "git add" to track)
```
