### PR TITLE
Update USB HID documentation

### DIFF
--- a/docs/library/pyb.USB_HID.rst
+++ b/docs/library/pyb.USB_HID.rst
@@ -1,0 +1,28 @@
+.. currentmodule:: pyb
+
+class USB_HID -- USB Human Interface Device (HID)
+=================================================
+
+The USB_HID class allows creation of an object representing the USB
+Human Interface Device (HID) interface.  It can be used to emulate
+a peripheral such as a mouse or keyboard.
+
+Before you can use this class, you need to use :meth:`pyb.usb_mode()` to set the USB mode to include the HID interface.
+
+Constructors
+------------
+
+.. class:: pyb.USB_HID()
+
+   Create a new USB_HID object.
+
+
+Methods
+-------
+
+.. method:: USB_HID.send(data)
+
+   Send data over the USB HID interface:
+
+     - ``data`` is the data to send (a tuple/list of integers, or a
+       bytearray).

--- a/docs/library/pyb.rst
+++ b/docs/library/pyb.rst
@@ -188,7 +188,7 @@ Miscellaneous functions
        Takes a 4-tuple (or list) and sends it to the USB host (the PC) to
        signal a HID mouse-motion event.
     
-       .. note:: This function is deprecated.  Use pyb.USB_HID().send(...) instead.
+       .. note:: This function is deprecated.  Use :meth:`pyb.USB_HID.send()` instead.
     
     .. function:: info([dump_alloc_table])
     
@@ -254,6 +254,33 @@ Miscellaneous functions
     
        Returns a string of 12 bytes (96 bits), which is the unique ID of the MCU.
 
+.. function:: usb_mode([modestr], vid=0xf055, pid=0x9801, hid=pyb.hid_mouse)
+
+   If called with no arguments, return the current USB mode as a string.
+
+   If called with ``modestr`` provided, attempts to set USB mode.
+   This can only be done when called from ``boot.py`` before
+   :meth:`pyb.main()` has been called.  The following values of
+   ``modestr`` are understood:
+
+   - ``None``: disables USB
+   - ``'VCP'``: enable with VCP (Virtual COM Port) interface
+   - ``'VCP+MSC'``: enable with VCP and MSC (mass storage device class)
+   - ``'VCP+HID'``: enable with VCP and HID (human interface device)
+
+   For backwards compatibility, ``'CDC'`` is understood to mean
+   ``'VCP'`` (and similarly for ``'CDC+MSC'`` and ``'CDC+HID'``).
+
+   The ``vid`` and ``pid`` parameters allow you to specify the VID
+   (vendor id) and PID (product id).
+
+   If enabling HID mode, you may also specify the HID details by
+   passing the ``hid`` keyword parameter.  It takes a tuple of
+   (subclass, protocol, max packet length, polling interval, report
+   descriptor).  By default it will set appropriate values for a USB
+   mouse.  There is also a ``pyb.hid_keyboard`` constant, which is an
+   appropriate tuple for a USB keyboard.
+
 Classes
 -------
 
@@ -277,4 +304,5 @@ Classes
        pyb.Switch.rst
        pyb.Timer.rst
        pyb.UART.rst
+       pyb.USB_HID.rst
        pyb.USB_VCP.rst

--- a/docs/pyboard/tutorial/usb_mouse.rst
+++ b/docs/pyboard/tutorial/usb_mouse.rst
@@ -13,23 +13,23 @@ will look something like this::
 
     import pyb
     #pyb.main('main.py') # main script to run after this one
-    #pyb.usb_mode('CDC+MSC') # act as a serial and a storage device
-    #pyb.usb_mode('CDC+HID') # act as a serial device and a mouse
+    #pyb.usb_mode('VCP+MSC') # act as a serial and a storage device
+    #pyb.usb_mode('VCP+HID') # act as a serial device and a mouse
 
 To enable the mouse mode, uncomment the last line of the file, to
 make it look like::
 
-    pyb.usb_mode('CDC+HID') # act as a serial device and a mouse
+    pyb.usb_mode('VCP+HID') # act as a serial device and a mouse
 
 If you already changed your ``boot.py`` file, then the minimum code it
 needs to work is::
 
     import pyb
-    pyb.usb_mode('CDC+HID')
+    pyb.usb_mode('VCP+HID')
 
-This tells the pyboard to configure itself as a CDC (serial) and HID
-(human interface device, in our case a mouse) USB device when it boots
-up.
+This tells the pyboard to configure itself as a VCP (Virtual COM Port,
+ie serial port) and HID (human interface device, in our case a mouse)
+USB device when it boots up.
 
 Eject/unmount the pyboard drive and reset it using the RST switch.
 Your PC should now detect the pyboard as a mouse!
@@ -121,9 +121,9 @@ If you leave your pyboard as-is, it'll behave as a mouse everytime you plug
 it in.  You probably want to change it back to normal.  To do this you need
 to first enter safe mode (see above), and then edit the ``boot.py`` file.
 In the ``boot.py`` file, comment out (put a # in front of) the line with the
-``CDC+HID`` setting, so it looks like::
+``VCP+HID`` setting, so it looks like::
 
-    #pyb.usb_mode('CDC+HID') # act as a serial device and a mouse
+    #pyb.usb_mode('VCP+HID') # act as a serial device and a mouse
 
 Save your file, eject/unmount the drive, and reset the pyboard.  It is now
 back to normal operating mode.

--- a/docs/pyboard/tutorial/usb_mouse.rst
+++ b/docs/pyboard/tutorial/usb_mouse.rst
@@ -41,7 +41,8 @@ To get the py-mouse to do anything we need to send mouse events to the PC.
 We will first do this manually using the REPL prompt.  Connect to your
 pyboard using your serial program and type the following::
 
-    >>> pyb.hid((0, 10, 0, 0))
+    >>> hid = pyb.USB_HID()
+    >>> hid.send((0, 10, 0, 0))
 
 Your mouse should move 10 pixels to the right!  In the command above you
 are sending 4 pieces of information: button status, x, y and scroll.  The
@@ -52,7 +53,7 @@ Let's make the mouse oscillate left and right::
     >>> import math
     >>> def osc(n, d):
     ...   for i in range(n):
-    ...     pyb.hid((0, int(20 * math.sin(i / 10)), 0, 0))
+    ...     hid.send((0, int(20 * math.sin(i / 10)), 0, 0))
     ...     pyb.delay(d)
     ...
     >>> osc(100, 50)
@@ -100,9 +101,10 @@ In ``main.py`` put the following code::
 
     switch = pyb.Switch()
     accel = pyb.Accel()
+    hid = pyb.USB_HID()
 
     while not switch():
-        pyb.hid((0, accel.x(), accel.y(), 0))
+        hid.send((0, accel.x(), accel.y(), 0))
         pyb.delay(20)
 
 Save your file, eject/unmount your pyboard drive, and reset it using the RST
@@ -112,7 +114,7 @@ the mouse around.  Try it out, and see if you can make the mouse stand still!
 Press the USR switch to stop the mouse motion.
 
 You'll note that the y-axis is inverted.  That's easy to fix: just put a
-minus sign in front of the y-coordinate in the ``pyb.hid()`` line above.
+minus sign in front of the y-coordinate in the ``hid.send()`` line above.
 
 Restoring your pyboard to normal
 --------------------------------

--- a/examples/SDdatalogger/boot.py
+++ b/examples/SDdatalogger/boot.py
@@ -16,10 +16,10 @@ pyb.LED(3).off()                # indicate that we finished waiting for the swit
 pyb.LED(4).on()                 # indicate that we are selecting the mode
 
 if switch_value:
-    pyb.usb_mode('CDC+MSC')
+    pyb.usb_mode('VCP+MSC')
     pyb.main('cardreader.py')           # if switch was pressed, run this
 else:
-    pyb.usb_mode('CDC+HID')
+    pyb.usb_mode('VCP+HID')
     pyb.main('datalogger.py')           # if switch wasn't pressed, run this
 
 pyb.LED(4).off()                # indicate that we finished selecting the mode

--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -137,8 +137,8 @@ static const char fresh_boot_py[] =
 "import machine\r\n"
 "import pyb\r\n"
 "#pyb.main('main.py') # main script to run after this one\r\n"
-"#pyb.usb_mode('CDC+MSC') # act as a serial and a storage device\r\n"
-"#pyb.usb_mode('CDC+HID') # act as a serial device and a mouse\r\n"
+"#pyb.usb_mode('VCP+MSC') # act as a serial and a storage device\r\n"
+"#pyb.usb_mode('VCP+HID') # act as a serial device and a mouse\r\n"
 ;
 
 static const char fresh_main_py[] =


### PR DESCRIPTION
Update the documentation around USB HID stuff. Adds docs for `pyb.usb_mode` and `pyb.USB_HID`, and updates the USB mouse tutorial.

I just went through the tutorial and these updates are all the things I wish had been in the docs before I started trying myself :smile: 

This addresses #1193.
