### PR TITLE
extmod/modframebuf: Bugfix -- fill when height not divisible by 8

### DIFF
--- a/extmod/modframebuf.c
+++ b/extmod/modframebuf.c
@@ -68,7 +68,8 @@ STATIC mp_obj_t framebuf1_fill(mp_obj_t self_in, mp_obj_t col_in) {
     if (col) {
         col = 0xff;
     }
-    for (int y = 0; y < self->height / 8; ++y) {
+    int end = (self->height + 7) >> 3;
+    for (int y = 0; y < end; ++y) {
         memset(self->buf + y * self->stride, col, self->width);
     }
     return mp_const_none;
@@ -101,8 +102,9 @@ STATIC mp_obj_t framebuf1_scroll(mp_obj_t self_in, mp_obj_t xstep_in, mp_obj_t y
     mp_obj_framebuf1_t *self = MP_OBJ_TO_PTR(self_in);
     mp_int_t xstep = mp_obj_get_int(xstep_in);
     mp_int_t ystep = mp_obj_get_int(ystep_in);
+    int end = (self->height + 7) >> 3;
     if (xstep == 0 && ystep > 0) {
-        for (int y = self->height / 8; y > 0;) {
+        for (int y = end; y > 0;) {
             --y;
             for (int x = 0; x < self->width; ++x) {
                 int prev = 0;
@@ -113,10 +115,10 @@ STATIC mp_obj_t framebuf1_scroll(mp_obj_t self_in, mp_obj_t xstep_in, mp_obj_t y
             }
         }
     } else if (xstep == 0 && ystep < 0) {
-        for (int y = 0; y < self->height / 8; ++y) {
+        for (int y = 0; y < end; ++y) {
             for (int x = 0; x < self->width; ++x) {
                 int prev = 0;
-                if (y + 1 < self->height / 8) {
+                if (y + 1 < end) {
                     prev = self->buf[(y + 1) * self->stride + x] << (8 + ystep);
                 }
                 self->buf[y * self->stride + x] = (self->buf[y * self->stride + x] >> -ystep) | prev;


### PR DESCRIPTION
There is a bug in `framebuf1_fill` function, that makes it leave a few
lines unfilled at the bottom if the height is not divisible by 8.

A similar bug is suspected in the `framebuf1_scroll` function, but I
can't think of an easy fix for it.
