### PR TITLE
extmod/framebuf: Add circle() method

### DIFF
--- a/extmod/modframebuf.c
+++ b/extmod/modframebuf.c
@@ -42,6 +42,17 @@ typedef struct _mp_obj_framebuf1_t {
     uint16_t width, height, stride;
 } mp_obj_framebuf1_t;
 
+// Helper functions for getting/setting pixels.
+STATIC inline void framebuf1_setpixel(const mp_obj_framebuf1_t *fb, int x, int y, uint8_t color) {
+    size_t index = (y >> 3) * fb->stride + x;
+    uint8_t offset = y & 0x07;
+    fb->buf[index] = (fb->buf[index] & ~(0x01 << offset)) | (color != 0) << offset;
+}
+
+STATIC inline uint8_t framebuf1_getpixel(const mp_obj_framebuf1_t *fb, int x, int y) {
+    return (fb->buf[(y >> 3) * fb->stride + x] >> (y & 0x07)) & 0x01;
+}
+
 STATIC mp_obj_t framebuf1_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 3, 4, false);
 
@@ -174,11 +185,67 @@ STATIC mp_obj_t framebuf1_text(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(framebuf1_text_obj, 4, 5, framebuf1_text);
 
+STATIC mp_obj_t framebuf1_circle(size_t n_args, const mp_obj_t *args) {
+    mp_obj_framebuf1_t *self = MP_OBJ_TO_PTR(args[0]);
+    mp_int_t x0 = mp_obj_get_int(args[1]);
+    mp_int_t y0 = mp_obj_get_int(args[2]);
+    mp_int_t r = mp_obj_get_int(args[3]);
+    mp_int_t col = 1;
+    if (n_args >= 5) {
+        col = mp_obj_get_int(args[4]);
+    }
+
+    if (
+        (x0 - r < 0) ||
+        (x0 + r > self->width) ||
+        (y0 - r < 0) ||
+        (y0 + r > self->height)
+    ) {
+        // Out of bounds, no-op.
+        return mp_const_none;
+    }
+
+    mp_int_t f = 1 - r;
+    mp_int_t ddF_x = 1;
+    mp_int_t ddF_y = -2 * r;
+    mp_int_t x = 0;
+    mp_int_t y = r;
+
+    framebuf1_setpixel(self, x0, y0 + r, col);
+    framebuf1_setpixel(self, x0, y0 - r, col);
+    framebuf1_setpixel(self, x0 + r, y0, col);
+    framebuf1_setpixel(self, x0 - r, y0, col);
+
+    while (x < y) {
+        if (f >= 0) {
+            y--;
+            ddF_y += 2;
+            f += ddF_y;
+        }
+
+        x++;
+        ddF_x += 2;
+        f += ddF_x;
+
+        framebuf1_setpixel(self, x0 + x, y0 + y, col);
+        framebuf1_setpixel(self, x0 - x, y0 + y, col);
+        framebuf1_setpixel(self, x0 + x, y0 - y, col);
+        framebuf1_setpixel(self, x0 - x, y0 - y, col);
+        framebuf1_setpixel(self, x0 + y, y0 + x, col);
+        framebuf1_setpixel(self, x0 - y, y0 + x, col);
+        framebuf1_setpixel(self, x0 + y, y0 - x, col);
+        framebuf1_setpixel(self, x0 - y, y0 - x, col);
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(framebuf1_circle_obj, 4, 5, framebuf1_circle);
+
 STATIC const mp_rom_map_elem_t framebuf1_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_fill), MP_ROM_PTR(&framebuf1_fill_obj) },
     { MP_ROM_QSTR(MP_QSTR_pixel), MP_ROM_PTR(&framebuf1_pixel_obj) },
     { MP_ROM_QSTR(MP_QSTR_scroll), MP_ROM_PTR(&framebuf1_scroll_obj) },
     { MP_ROM_QSTR(MP_QSTR_text), MP_ROM_PTR(&framebuf1_text_obj) },
+    { MP_ROM_QSTR(MP_QSTR_circle), MP_ROM_PTR(&framebuf1_circle_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(framebuf1_locals_dict, framebuf1_locals_dict_table);
 


### PR DESCRIPTION
Leading on from #2367 and its new `framebuf1_setpixel()` and `framebuf1_getpixel()` methods.
~~Untested - currently experiencing compile issues~~
