### PR TITLE
unix: add MICROPY_USE_LIBC_PRINTF compile time option, defaults to disabled

### DIFF
--- a/bare-arm/mpconfigport.h
+++ b/bare-arm/mpconfigport.h
@@ -42,6 +42,7 @@
 #define MICROPY_CPYTHON_COMPAT      (0)
 #define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_NONE)
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_NONE)
+#define MICROPY_USE_INTERNAL_PRINTF (0)
 
 // type definitions for the specific machine
 

--- a/cc3200/application.mk
+++ b/cc3200/application.mk
@@ -154,7 +154,6 @@ APP_LIB_SRC_C = $(addprefix lib/,\
 	timeutils/timeutils.c \
 	utils/pyexec.c \
 	utils/pyhelp.c \
-	utils/printf.c \
 	)
 	
 APP_STM_SRC_C = $(addprefix stmhal/,\

--- a/cc3200/bootmgr/bootloader.mk
+++ b/cc3200/bootmgr/bootloader.mk
@@ -67,7 +67,6 @@ BOOT_PY_SRC_C = $(addprefix py/,\
 
 BOOT_LIB_SRC_C = $(addprefix lib/,\
 	libc/string0.c \
-	utils/printf.c \
 	)
 
 OBJ  = $(addprefix $(BUILD)/, $(BOOT_HAL_SRC_C:.c=.o) $(BOOT_SL_SRC_C:.c=.o) $(BOOT_CC3100_SRC_C:.c=.o) $(BOOT_UTIL_SRC_C:.c=.o) $(BOOT_MISC_SRC_C:.c=.o))

--- a/cc3200/bootmgr/bootloader.mk
+++ b/cc3200/bootmgr/bootloader.mk
@@ -67,6 +67,7 @@ BOOT_PY_SRC_C = $(addprefix py/,\
 
 BOOT_LIB_SRC_C = $(addprefix lib/,\
 	libc/string0.c \
+	utils/printf.c \
 	)
 
 OBJ  = $(addprefix $(BUILD)/, $(BOOT_HAL_SRC_C:.c=.o) $(BOOT_SL_SRC_C:.c=.o) $(BOOT_CC3100_SRC_C:.c=.o) $(BOOT_UTIL_SRC_C:.c=.o) $(BOOT_MISC_SRC_C:.c=.o))

--- a/esp8266/Makefile
+++ b/esp8266/Makefile
@@ -129,7 +129,6 @@ LIB_SRC_C = $(addprefix lib/,\
 	timeutils/timeutils.c \
 	utils/pyexec.c \
 	utils/pyhelp.c \
-	utils/printf.c \
 	fatfs/ff.c \
 	fatfs/option/ccsbcs.c \
 	)

--- a/lib/utils/printf.c
+++ b/lib/utils/printf.c
@@ -24,6 +24,10 @@
  * THE SOFTWARE.
  */
 
+#include "py/mpconfig.h"
+
+#if MICROPY_USE_INTERNAL_PRINTF
+
 #include <stdint.h>
 #include <string.h>
 #include <stdarg.h>
@@ -127,3 +131,5 @@ int snprintf(char *str, size_t size, const char *fmt, ...) {
     va_end(ap);
     return ret;
 }
+
+#endif //MICROPY_USE_INTERNAL_PRINTF

--- a/minimal/Makefile
+++ b/minimal/Makefile
@@ -46,7 +46,6 @@ SRC_C = \
 	main.c \
 	uart_core.c \
 	lib/utils/stdout_helpers.c \
-	lib/utils/printf.c \
 	lib/utils/pyexec.c \
 	lib/libc/string0.c \
 	lib/mp-readline/readline.c \

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -581,6 +581,11 @@ typedef double mp_float_t;
 #define MICROPY_USE_INTERNAL_ERRNO (0)
 #endif
 
+// Whether to use internally defined *printf() functions (otherwise use system provided ones)
+#ifndef MICROPY_USE_INTERNAL_PRINTF
+#define MICROPY_USE_INTERNAL_PRINTF (1)
+#endif
+
 // Support for user-space VFS mount (selected ports)
 #ifndef MICROPY_FSUSERMOUNT
 #define MICROPY_FSUSERMOUNT (0)

--- a/py/py.mk
+++ b/py/py.mk
@@ -223,6 +223,7 @@ PY_O_BASENAME = \
 	../extmod/vfs_fat_misc.o \
 	../extmod/moduos_dupterm.o \
 	../lib/embed/abort_.o \
+	../lib/utils/printf.o \
 
 # prepend the build destination prefix to the py object files
 PY_O = $(addprefix $(PY_BUILD)/, $(PY_O_BASENAME))

--- a/qemu-arm/mpconfigport.h
+++ b/qemu-arm/mpconfigport.h
@@ -23,6 +23,7 @@
 #define MICROPY_PY_IO               (0)
 #define MICROPY_PY_SYS_EXIT         (1)
 #define MICROPY_PY_SYS_MAXSIZE      (1)
+#define MICROPY_USE_INTERNAL_PRINTF (0)
 
 // type definitions for the specific machine
 

--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -111,7 +111,6 @@ SRC_LIB = $(addprefix lib/,\
 	timeutils/timeutils.c \
 	utils/pyexec.c \
 	utils/pyhelp.c \
-	utils/printf.c \
 	)
 
 SRC_C = \

--- a/teensy/Makefile
+++ b/teensy/Makefile
@@ -110,7 +110,6 @@ LIB_SRC_C = $(addprefix lib/,\
 	mp-readline/readline.c \
 	utils/pyexec.c \
 	utils/pyhelp.c \
-	utils/printf.c \
 	)
 
 SRC_TEENSY = $(addprefix core/,\

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -157,7 +157,6 @@ endif
 
 LIB_SRC_C = $(addprefix lib/,\
 	$(LIB_SRC_C_EXTRA) \
-	utils/printf.c \
 	timeutils/timeutils.c \
 	)
 


### PR DESCRIPTION
Compile with MICROPY_USE_LIBC_PRINTF=1 to link against libc's *printf() functions.

```
# make -C unix
LINK micropython
   text    data     bss     dec     hex filename
 371073     872    1400  373345   5b261 micropython

# make -C unix/ MICROPY_USE_LIBC_PRINTF=1
LINK micropython
   text    data     bss     dec     hex filename
 370428     888    1400  372716   5afec micropython

# make -C unix/ minimal
 LINK micropython_minimal
   text    data     bss     dec     hex filename
 144317     408     716  145441   23821 micropython_minimal

# make -C unix/ MICROPY_USE_LIBC_PRINTF=1 minimal
LINK micropython_minimal
   text    data     bss     dec     hex filename
 143678     416     716  144810   235aa micropython_minimal

```
