### PR TITLE
extmod/framebuf: Add the xstep!=0 case to scroll()

### DIFF
--- a/extmod/modframebuf.c
+++ b/extmod/modframebuf.c
@@ -103,7 +103,7 @@ STATIC mp_obj_t framebuf1_scroll(mp_obj_t self_in, mp_obj_t xstep_in, mp_obj_t y
     mp_int_t xstep = mp_obj_get_int(xstep_in);
     mp_int_t ystep = mp_obj_get_int(ystep_in);
     int end = (self->height + 7) >> 3;
-    if (xstep == 0 && ystep > 0) {
+    if (ystep > 0) {
         for (int y = end; y > 0;) {
             --y;
             for (int x = 0; x < self->width; ++x) {
@@ -114,7 +114,7 @@ STATIC mp_obj_t framebuf1_scroll(mp_obj_t self_in, mp_obj_t xstep_in, mp_obj_t y
                 self->buf[y * self->stride + x] = (self->buf[y * self->stride + x] << ystep) | prev;
             }
         }
-    } else if (xstep == 0 && ystep < 0) {
+    } else if (ystep < 0) {
         for (int y = 0; y < end; ++y) {
             for (int x = 0; x < self->width; ++x) {
                 int prev = 0;
@@ -125,7 +125,20 @@ STATIC mp_obj_t framebuf1_scroll(mp_obj_t self_in, mp_obj_t xstep_in, mp_obj_t y
             }
         }
     }
-    // TODO xstep!=0
+    if (xstep < 0) {
+        for (int y = 0; y < end; ++y) {
+            for (int x = 0; x < self->width + xstep; ++x) {
+                self->buf[y * self->stride + x] = self->buf[y * self->stride + x - xstep];
+            }
+        }
+    } else if (xstep > 0) {
+        for (int y = 0; y < end; ++y) {
+            for (int x = self->width - 1; x >= xstep; --x) {
+                self->buf[y * self->stride + x] = self->buf[y * self->stride + x - xstep];
+            }
+        }
+    }
+    // TODO: Should we clear the margin created by scrolling?
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(framebuf1_scroll_obj, framebuf1_scroll);


### PR DESCRIPTION
Adds horizontal scrolling. Right now, I'm just leaving the margins
created by the scrolling as they were -- so they will repeat the
edge of the framebuf. This is fast, and the user can always fill
the margins with a fill_rect call.

There are two other alternatives:
- we can clear them ourselves, like with vertical scroll (perhaps we
  want to have an extra argument specifying the color?)
- we can wrap around -- this is a bit tricky, would require to either
  do the scroll pixel by pixel, or create a buffer.
