### PR TITLE
py/emitglue.c: provide mp_raw_code_load_file for any unix architecture

### DIFF
--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -379,7 +379,7 @@ mp_raw_code_t *mp_raw_code_load_mem(const byte *buf, size_t len) {
 // here we define mp_raw_code_load_file depending on the port
 // TODO abstract this away properly
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__) || (defined(__arm__) && (defined(__unix__)))
+#if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__) || defined(__unix__)
 // unix file reader
 
 #include <sys/stat.h>


### PR DESCRIPTION
This fixes build issues for the unix (Linux) port for architectures other than x86 and arm.

http://autobuild.buildroot.net/results/061c66987e9c33a6641c8183f5e0badae516fc1d
http://autobuild.buildroot.net/results/62e5b5c6d9dca0f41fb4e7d462ebfbb02f8d29da
http://autobuild.buildroot.net/results/a6437a49659a7b2983269e758dba9fa5a29240d7

Signed-off-by: Chris Packham chris.packham@alliedtelesis.co.nz
