### PR TITLE
docs/reference/isr rules.rst two minor additions

### DIFF
--- a/docs/reference/isr_rules.rst
+++ b/docs/reference/isr_rules.rst
@@ -113,6 +113,7 @@ example ``pyb.i2c.recv()`` can accept a mutable buffer as its first argument: th
 A means of creating an object without employing a class or globals is as follows:
 
 .. code:: python
+
     def set_volume(t, buf=bytearray(3)):
         buf[0] = 0xa5
         buf[1] = t >> 4

--- a/docs/reference/isr_rules.rst
+++ b/docs/reference/isr_rules.rst
@@ -110,6 +110,17 @@ the flag. The memory allocation occurs in the main program code when the object 
 The MicroPython library I/O methods usually provide an option to use a pre-allocated buffer. For
 example ``pyb.i2c.recv()`` can accept a mutable buffer as its first argument: this enables its use in an ISR.
 
+A means of creating an object without employing a class or globals is as follows:
+
+.. code:: python
+    def set_volume(t, buf=bytearray(3)):
+        buf[0] = 0xa5
+        buf[1] = t >> 4
+        buf[2] = 0x5a
+        return buf
+
+The compiler instantiates the default argument at compile time.
+
 Use of Python objects
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -300,3 +311,19 @@ that access to the critical variables is denied. A simple example of a mutex may
 but only for the duration of eight machine instructions: the benefit of this approach is that other interrupts are
 virtually unaffected.
 
+Interrupts and the REPL
+~~~~~~~~~~~~~~~~~~~~~~~
+
+On the Pyboard interrupt handlers such as those associated with timers can
+continue to run after a program terminates. This may produce unexpected results
+where you might have expected the object raising the callback to have gone out
+of scope:
+
+.. code:: python
+
+    def bar():
+        foo = pyb.Timer(2, freq=4, callback=lambda t: print('.', end=''))
+
+    bar()
+
+This continues to run until the board is reset with ``ctrl D``.


### PR DESCRIPTION
1. Refers to the technique of instantiating an object for use in an ISR by specifying it as a default argument.
2. Footnote detailing the fact that interrupt handlers continue to be executed at the REPL.
