### PR TITLE
stmhal/extint: swint() should be a no-op when interrupt is disabled

### DIFF
--- a/stmhal/extint.c
+++ b/stmhal/extint.c
@@ -251,10 +251,13 @@ void extint_swint(uint line) {
     if (line >= EXTI_NUM_VECTORS) {
         return;
     }
+    //we need 0 to 1 transition to trigger the interrupt
 #if defined(MCU_SERIES_L4)
-    EXTI->SWIER1 = (1 << line);
+    EXTI->SWIER1 &= ~(1 << line);
+    EXTI->SWIER1 |= (1 << line);
 #else
-    EXTI->SWIER = (1 << line);
+    EXTI->SWIER &= ~(1 << line);
+    EXTI->SWIER |= (1 << line);
 #endif
 }
 


### PR DESCRIPTION
if user tries to call `swint()` while interrupt is disabled
flag in SWIER is set but it can be cleared only by interrupt
from different EXTI line
## Example case:

``` Python
>>> import pyb
>>> ext1 = pyb.ExtInt('X1', pyb.ExtInt.IRQ_RISING, pyb.Pin.PULL_DOWN, lambda l:print('line:', l))
>>> ext2 = pyb.ExtInt('X2', pyb.ExtInt.IRQ_RISING, pyb.Pin.PULL_DOWN, lambda l:print('line:', l))
>>> ext1.disable()
>>> ext1.swint()  # SWIER[0] is set - no interrupt because IMR[0] is not set
>>> ext1.enable()
>>> ext1.swint()  # SWIER[0] is already set - no interrupt
# nothing happens
>>> ext2.swint()  # interrupt caused by this call clears SWIER[1] but also SWIER[0]
line: 1
>>> ext1.swint()  # SWIER[0] changed from 0 to 1 - interrupt
line: 0
```
## Reference

From RM0090:

```
Bits 22:0 SWIERx: Software Interrupt on line x
   If interrupt are enabled on line x in the EXTI_IMR register, writing '1' to SWIERx bit when it is
   set at '0' sets the corresponding pending bit in the EXTI_PR register, thus resulting in an
   interrupt request generation.
   This bit is cleared by clearing the corresponding bit in EXTI_PR (by writing a 1 to the bit).
```
