### PR TITLE
stmhal/{accel,lcd}: use GPIO_{set,clear}_pin

### DIFF
--- a/stmhal/accel.c
+++ b/stmhal/accel.c
@@ -27,8 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include STM32_HAL_H
-
+#include "py/mphal.h"
 #include "py/nlr.h"
 #include "py/runtime.h"
 #include "pin.h"
@@ -61,7 +60,7 @@ void accel_init(void) {
     GPIO_InitTypeDef GPIO_InitStructure;
 
     // PB5 is connected to AVDD; pull high to enable MMA accel device
-    MICROPY_HW_MMA_AVDD_PIN.gpio->BSRRH = MICROPY_HW_MMA_AVDD_PIN.pin_mask; // turn off AVDD
+    GPIO_clear_pin(MICROPY_HW_MMA_AVDD_PIN.gpio, MICROPY_HW_MMA_AVDD_PIN.pin_mask); // turn off AVDD
     GPIO_InitStructure.Pin = MICROPY_HW_MMA_AVDD_PIN.pin_mask;
     GPIO_InitStructure.Mode = GPIO_MODE_OUTPUT_PP;
     GPIO_InitStructure.Speed = GPIO_SPEED_LOW;
@@ -82,9 +81,9 @@ STATIC void accel_start(void) {
     i2c_init(&I2CHandle1);
 
     // turn off AVDD, wait 30ms, turn on AVDD, wait 30ms again
-    MICROPY_HW_MMA_AVDD_PIN.gpio->BSRRH = MICROPY_HW_MMA_AVDD_PIN.pin_mask; // turn off
+    GPIO_clear_pin(MICROPY_HW_MMA_AVDD_PIN.gpio, MICROPY_HW_MMA_AVDD_PIN.pin_mask); // turn off
     HAL_Delay(30);
-    MICROPY_HW_MMA_AVDD_PIN.gpio->BSRRL = MICROPY_HW_MMA_AVDD_PIN.pin_mask; // turn on
+    GPIO_set_pin(MICROPY_HW_MMA_AVDD_PIN.gpio, MICROPY_HW_MMA_AVDD_PIN.pin_mask); // turn on
     HAL_Delay(30);
 
     HAL_StatusTypeDef status;

--- a/stmhal/lcd.c
+++ b/stmhal/lcd.c
@@ -26,8 +26,8 @@
 
 #include <stdio.h>
 #include <string.h>
-#include STM32_HAL_H
 
+#include "py/mphal.h"
 #include "py/nlr.h"
 #include "py/runtime.h"
 
@@ -113,16 +113,16 @@ STATIC void lcd_delay(void) {
 
 STATIC void lcd_out(pyb_lcd_obj_t *lcd, int instr_data, uint8_t i) {
     lcd_delay();
-    lcd->pin_cs1->gpio->BSRRH = lcd->pin_cs1->pin_mask; // CS=0; enable
+    GPIO_clear_pin(lcd->pin_cs1->gpio, lcd->pin_cs1->pin_mask); // CS=0; enable
     if (instr_data == LCD_INSTR) {
-        lcd->pin_a0->gpio->BSRRH = lcd->pin_a0->pin_mask; // A0=0; select instr reg
+        GPIO_clear_pin(lcd->pin_a0->gpio, lcd->pin_a0->pin_mask); // A0=0; select instr reg
     } else {
-        lcd->pin_a0->gpio->BSRRL = lcd->pin_a0->pin_mask; // A0=1; select data reg
+        GPIO_set_pin(lcd->pin_a0->gpio, lcd->pin_a0->pin_mask); // A0=1; select data reg
     }
     lcd_delay();
     HAL_SPI_Transmit(lcd->spi, &i, 1, 1000);
     lcd_delay();
-    lcd->pin_cs1->gpio->BSRRL = lcd->pin_cs1->pin_mask; // CS=1; disable
+    GPIO_set_pin(lcd->pin_cs1->gpio, lcd->pin_cs1->pin_mask); // CS=1; disable
 }
 
 // write a string to the LCD at the current cursor location
@@ -262,10 +262,10 @@ STATIC mp_obj_t pyb_lcd_make_new(const mp_obj_type_t *type, mp_uint_t n_args, mp
     spi_init(lcd->spi, false);
 
     // set the pins to default values
-    lcd->pin_cs1->gpio->BSRRL = lcd->pin_cs1->pin_mask;
-    lcd->pin_rst->gpio->BSRRL = lcd->pin_rst->pin_mask;
-    lcd->pin_a0->gpio->BSRRL = lcd->pin_a0->pin_mask;
-    lcd->pin_bl->gpio->BSRRH = lcd->pin_bl->pin_mask;
+    GPIO_set_pin(lcd->pin_cs1->gpio, lcd->pin_cs1->pin_mask);
+    GPIO_set_pin(lcd->pin_rst->gpio, lcd->pin_rst->pin_mask);
+    GPIO_set_pin(lcd->pin_a0->gpio, lcd->pin_a0->pin_mask);
+    GPIO_clear_pin(lcd->pin_bl->gpio, lcd->pin_bl->pin_mask);
 
     // init the pins to be push/pull outputs
     GPIO_InitTypeDef GPIO_InitStructure;
@@ -287,9 +287,9 @@ STATIC mp_obj_t pyb_lcd_make_new(const mp_obj_type_t *type, mp_uint_t n_args, mp
 
     // init the LCD
     HAL_Delay(1); // wait a bit
-    lcd->pin_rst->gpio->BSRRH = lcd->pin_rst->pin_mask; // RST=0; reset
+    GPIO_clear_pin(lcd->pin_rst->gpio, lcd->pin_rst->pin_mask); // RST=0; reset
     HAL_Delay(1); // wait for reset; 2us min
-    lcd->pin_rst->gpio->BSRRL = lcd->pin_rst->pin_mask; // RST=1; enable
+    GPIO_set_pin(lcd->pin_rst->gpio, lcd->pin_rst->pin_mask); // RST=1; enable
     HAL_Delay(1); // wait for reset; 2us min
     lcd_out(lcd, LCD_INSTR, 0xa0); // ADC select, normal
     lcd_out(lcd, LCD_INSTR, 0xc0); // common output mode select, normal (this flips the display)
@@ -372,9 +372,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(pyb_lcd_contrast_obj, pyb_lcd_contrast);
 STATIC mp_obj_t pyb_lcd_light(mp_obj_t self_in, mp_obj_t value) {
     pyb_lcd_obj_t *self = self_in;
     if (mp_obj_is_true(value)) {
-        self->pin_bl->gpio->BSRRL = self->pin_bl->pin_mask; // set pin high to turn backlight on
+        GPIO_set_pin(self->pin_bl->gpio, self->pin_bl->pin_mask); // set pin high to turn backlight on
     } else {
-        self->pin_bl->gpio->BSRRH = self->pin_bl->pin_mask; // set pin low to turn backlight off
+        GPIO_clear_pin(self->pin_bl->gpio, self->pin_bl->pin_mask); // set pin low to turn backlight off
     }
     return mp_const_none;
 }


### PR DESCRIPTION
different HAL versions implement GPIO differently (BSRR vs BSRRH+BSRRL),
this way both drivers are portable between different HAL's
