### PR TITLE
py/asmthumb: Flush D-cache, and invalidate I-cache on STM32F7

### DIFF
--- a/py/asmthumb.c
+++ b/py/asmthumb.c
@@ -90,6 +90,14 @@ void asm_thumb_start_pass(asm_thumb_t *as, uint pass) {
 void asm_thumb_end_pass(asm_thumb_t *as) {
     (void)as;
     // could check labels are resolved...
+#if defined(MCU_SERIES_F7)
+    if (as->pass == ASM_THUMB_PASS_EMIT) {
+        // flush D-cache, so the code emited is stored in memory
+        SCB_CleanDCache_by_Addr((uint32_t *)as->code_base, as->code_size);        
+        // invalidate I-cache
+        SCB_InvalidateICache();
+    }
+#endif
 }
 
 // all functions must go through this one to emit bytes


### PR DESCRIPTION
Related to https://github.com/micropython/micropython/pull/2384
Tested on a STM32F7DISCO at 216MHz.
All tests generating code (inlineasm, native, viper) now pass, except pybnative/while.py, but that's because there is no LED(2).
