### PR TITLE
py/makeqstrdefs.py: use python 2.6 syntax

### DIFF
--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -11,7 +11,7 @@ import os
 
 # Blacklist of qstrings that are specially handled in further
 # processing and should be ignored
-QSTRING_BLACK_LIST = {'NULL', 'number_of', }
+QSTRING_BLACK_LIST = set(['NULL', 'number_of'])
 
 
 def write_out(fname, output):


### PR DESCRIPTION
py/makeqstrdefs.py declares that it works with python 2.6 however the
syntax used to initialise of a set with values was only added in python
2.7. This leads to build failures when the host system doesn't have
python 2.7 or newer.

http://autobuild.buildroot.net/results/2b6fc56b98474e66febb673a14a860bd16746172
http://autobuild.buildroot.net/results/a0d49d9a23f4e2d3724639bd23008128b11d281d

Instead of using the new syntax pass a list of initial values through
set() to achieve the same result. This should work for python versions
from at least 2.6 onwards.

Helped-by: Thomas Petazzoni thomas.petazzoni@free-electrons.com
Signed-off-by: Chris Packham judge.packham@gmail.com
