### PR TITLE
Added errno attribute to OSError class.

### DIFF
--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -161,6 +161,8 @@ STATIC void exception_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
         dest[0] = MP_OBJ_FROM_PTR(self->args);
     } else if (self->base.type == &mp_type_StopIteration && attr == MP_QSTR_value) {
         dest[0] = mp_obj_exception_get_value(self_in);
+    } else if (self->base.type == &mp_type_OSError && attr == MP_QSTR_errno) {
+        dest[0] = mp_obj_exception_get_value(self_in);
     }
 }
 


### PR DESCRIPTION
I added "errno" as an alias for args[0] for exception objects with baseclass OSError in similar fashion to how StopIteration gets "value".
