### PR TITLE
select for ESP8266

### DIFF
--- a/esp8266/Makefile
+++ b/esp8266/Makefile
@@ -83,6 +83,7 @@ SRC_C = \
 	modpybhspi.c \
 	modesp.c \
 	modnetwork.c \
+	moduselect.c \
 	modutime.c \
 	moduos.c \
 	modmachine.c \

--- a/esp8266/moduselect.c
+++ b/esp8266/moduselect.c
@@ -35,6 +35,7 @@ extern const mp_obj_type_t lwip_socket_type;
 // FIXME: move to an LWIP header
 typedef struct _lwip_socket_obj_t lwip_socket_obj_t;
 bool lwip_has_incoming(lwip_socket_obj_t *);
+bool lwip_is_closed(lwip_socket_obj_t *);
 
 
 typedef enum
@@ -152,12 +153,11 @@ poll_poll(uint n_args, const mp_obj_t *args) {
                 lwip_socket_obj_t *socket = elem->obj;
 
                 if (elem->flags & POLL_IN && lwip_has_incoming(socket)) {
-                    printf("INPUT!\n");
                     flags |= POLL_IN;
                 }
 
-                if (elem->flags & POLL_OUT) {
-                    // FIXME
+                if (elem->flags & POLL_HUP && lwip_is_closed(socket)) {
+                    flags |= POLL_HUP;
                 }
 
             } else {

--- a/esp8266/moduselect.c
+++ b/esp8266/moduselect.c
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+
+#include "py/obj.h"
+
+
+enum {
+    POLL_IN   = 1 << 0,
+    POLL_OUT  = 1 << 1,
+    POLL_ERR    = 1 << 2,
+    POLL_HUP    = 1 << 3,
+};
+
+
+STATIC const mp_map_elem_t uselect_globals_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_uselect) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_select), MP_OBJ_NEW_QSTR(MP_QSTR_select) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_POLLIN), MP_OBJ_NEW_SMALL_INT(POLL_IN) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_POLLOUT), MP_OBJ_NEW_SMALL_INT(POLL_OUT) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_POLLERR), MP_OBJ_NEW_SMALL_INT(POLL_ERR) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_POLLHUP), MP_OBJ_NEW_SMALL_INT(POLL_HUP) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(uselect_globals, uselect_globals_table);
+
+
+const mp_obj_module_t uselect_module = {
+    .base = { &mp_type_module },
+    .name = MP_QSTR_uselect,
+    .globals = (mp_obj_dict_t*) &uselect_globals,
+};

--- a/esp8266/moduselect.c
+++ b/esp8266/moduselect.c
@@ -27,19 +27,132 @@
 #include <stdio.h>
 
 #include "py/obj.h"
+#include "py/nlr.h"
 
 
-enum {
+typedef enum
+_uselect_poll_flags {
     POLL_IN   = 1 << 0,
     POLL_OUT  = 1 << 1,
     POLL_ERR    = 1 << 2,
     POLL_HUP    = 1 << 3,
+} uselect_poll_flags;
+
+
+/* \class Poll - poll class */
+typedef struct
+_uselect_poll_t {
+    mp_obj_base_t base;
+    mp_map_t poll_map;
+} uselect_poll_t;
+
+
+typedef struct
+_poll_obj_t {
+    mp_obj_t obj;
+    uselect_poll_flags flags;
+} poll_obj_t;
+
+
+/* \method register(obj[, eventmask]) */
+STATIC mp_obj_t
+poll_register(uint n_args, const mp_obj_t *args) {
+    uselect_poll_t *self = args[0];
+    mp_obj_t *obj = args[1];
+    mp_uint_t flags;
+    mp_map_elem_t *elem;
+
+    if (n_args == 3) {
+        flags = mp_obj_get_int(args[2]);
+    } else {
+        flags = POLL_IN | POLL_OUT;
+    }
+
+    elem = mp_map_lookup(&self->poll_map,
+                         mp_obj_id(obj),
+                         MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
+
+    if (elem->value == NULL) {
+        /* Check the type of the object */
+        mp_obj_type_t *type = mp_obj_get_type(obj);
+        const mp_stream_p_t *stream_p = type->protocol;
+
+        if (stream_p == NULL || stream_p->ioctl == NULL) {
+            nlr_raise(mp_obj_new_exception_msg(&mp_type_TypeError,
+                        "object with stream.ioctl required"));
+        }
+
+        /* Create a new map entry */
+        poll_obj_t *poll_obj = elem->value = m_new_obj(poll_obj_t);
+        poll_obj->obj = obj;
+    }
+
+    ((poll_obj_t *) elem->value)->flags = flags;
+
+    return mp_const_none;
+}
+
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(poll_register_obj, 2, 3, poll_register);
+
+
+/* \method unregister(obj) */
+STATIC mp_obj_t
+poll_unregister(mp_obj_t self_in, mp_obj_t obj_in) {
+    uselect_poll_t *self = self_in;
+    mp_map_lookup(&self->poll_map,
+                  mp_obj_id(obj_in),
+                  MP_MAP_LOOKUP_REMOVE_IF_FOUND);
+
+    // FIXME raise KeyError if obj didn't exist in map
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(poll_unregister_obj, poll_unregister);
+
+
+STATIC const mp_map_elem_t
+poll_locals_dict_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR_register), (mp_obj_t) &poll_register_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_unregister), (mp_obj_t) &poll_unregister_obj },
+    /* Modify is an alias for register, they're basically the same */
+    { MP_OBJ_NEW_QSTR(MP_QSTR_modify), (mp_obj_t) &poll_register_obj },
+    /* { MP_OBJ_NEW_QSTR(MP_QSTR_poll), (mp_obj_t) &poll_poll_obj }, */
+};
+
+STATIC MP_DEFINE_CONST_DICT(poll_locals_dict, poll_locals_dict_table);
+
+
+STATIC const
+mp_obj_type_t uselect_type_poll = {
+    { &mp_type_type },
+    .name = MP_QSTR_poll,
+    .locals_dict = (mp_obj_t) &poll_locals_dict,
 };
 
 
-STATIC const mp_map_elem_t uselect_globals_table[] = {
+/* \function poll() */
+STATIC mp_obj_t
+uselect_poll(void) {
+    uselect_poll_t *self = m_new_obj(uselect_poll_t);
+
+    self->base.type = &uselect_type_poll;
+    mp_map_init(&self->poll_map, 0);
+
+    return self;
+}
+
+MP_DEFINE_CONST_FUN_OBJ_0(uselect_poll_obj, uselect_poll);
+
+
+/* Module-level attributes */
+STATIC const mp_map_elem_t
+uselect_globals_table[] = {
+    /* Module */
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_uselect) },
+    /* Functions */
+    // FIXME: placeholder
     { MP_OBJ_NEW_QSTR(MP_QSTR_select), MP_OBJ_NEW_QSTR(MP_QSTR_select) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_poll), (mp_obj_t) &uselect_poll_obj },
+    /* Constants */
     { MP_OBJ_NEW_QSTR(MP_QSTR_POLLIN), MP_OBJ_NEW_SMALL_INT(POLL_IN) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_POLLOUT), MP_OBJ_NEW_SMALL_INT(POLL_OUT) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_POLLERR), MP_OBJ_NEW_SMALL_INT(POLL_ERR) },
@@ -49,7 +162,8 @@ STATIC const mp_map_elem_t uselect_globals_table[] = {
 STATIC MP_DEFINE_CONST_DICT(uselect_globals, uselect_globals_table);
 
 
-const mp_obj_module_t uselect_module = {
+const mp_obj_module_t
+uselect_module = {
     .base = { &mp_type_module },
     .name = MP_QSTR_uselect,
     .globals = (mp_obj_dict_t*) &uselect_globals,

--- a/esp8266/mpconfigport.h
+++ b/esp8266/mpconfigport.h
@@ -137,6 +137,7 @@ extern const struct _mp_obj_module_t esp_module;
 extern const struct _mp_obj_module_t network_module;
 extern const struct _mp_obj_module_t utime_module;
 extern const struct _mp_obj_module_t uos_module;
+extern const struct _mp_obj_module_t uselect_module;
 extern const struct _mp_obj_module_t mp_module_lwip;
 extern const struct _mp_obj_module_t mp_module_machine;
 extern const struct _mp_obj_module_t onewire_module;
@@ -146,6 +147,7 @@ extern const struct _mp_obj_module_t onewire_module;
     { MP_OBJ_NEW_QSTR(MP_QSTR_lwip), (mp_obj_t)&mp_module_lwip }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_socket), (mp_obj_t)&mp_module_lwip }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_usocket), (mp_obj_t)&mp_module_lwip }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_uselect), (mp_obj_t)&uselect_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_network), (mp_obj_t)&network_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_utime), (mp_obj_t)&utime_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_uos), (mp_obj_t)&uos_module }, \
@@ -155,6 +157,7 @@ extern const struct _mp_obj_module_t onewire_module;
 #define MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS \
     { MP_OBJ_NEW_QSTR(MP_QSTR_time), (mp_obj_t)&utime_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_os), (mp_obj_t)&uos_module }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_select), (mp_obj_t)&uselect_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_json), (mp_obj_t)&mp_module_ujson }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_errno), (mp_obj_t)&mp_module_uerrno }, \
 

--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -269,12 +269,18 @@ static inline void exec_user_callback(lwip_socket_obj_t *socket) {
     }
 }
 
+
+bool lwip_has_incoming(lwip_socket_obj_t *socket) {
+    return socket->incoming.pbuf != NULL;
+}
+
+
 // Callback for incoming UDP packets. We simply stash the packet and the source address,
 // in case we need it for recvfrom.
 STATIC void _lwip_udp_incoming(void *arg, struct udp_pcb *upcb, struct pbuf *p, ip_addr_t *addr, u16_t port) {
     lwip_socket_obj_t *socket = (lwip_socket_obj_t*)arg;
 
-    if (socket->incoming.pbuf != NULL) {
+    if (lwip_has_incoming(socket)) {
         // That's why they call it "unreliable". No room in the inn, drop the packet.
         pbuf_free(p);
     } else {
@@ -356,7 +362,7 @@ STATIC err_t _lwip_tcp_recv(void *arg, struct tcp_pcb *tcpb, struct pbuf *p, err
         return ERR_OK;
     }
 
-    if (socket->incoming.pbuf == NULL) {
+    if (!lwip_has_incoming(socket)) {
         socket->incoming.pbuf = p;
     } else {
         #ifdef SOCKET_SINGLE_PBUF
@@ -416,18 +422,18 @@ STATIC mp_uint_t lwip_udp_send(lwip_socket_obj_t *socket, const byte *buf, mp_ui
 // Helper function for recv/recvfrom to handle UDP packets
 STATIC mp_uint_t lwip_udp_receive(lwip_socket_obj_t *socket, byte *buf, mp_uint_t len, byte *ip, mp_uint_t *port, int *_errno) {
 
-    if (socket->incoming.pbuf == NULL) {
+    if (!lwip_has_incoming(socket)) {
         if (socket->timeout != -1) {
             for (mp_uint_t retries = socket->timeout / 100; retries--;) {
                 mp_hal_delay_ms(100);
-                if (socket->incoming.pbuf != NULL) break;
+                if (lwip_has_incoming(socket)) break;
             }
-            if (socket->incoming.pbuf == NULL) {
+            if (!lwip_has_incoming(socket)) {
                 *_errno = MP_ETIMEDOUT;
                 return -1;
             }
         } else {
-            while (socket->incoming.pbuf == NULL) {
+            while (!lwip_has_incoming(socket)) {
                 poll_sockets();
             }
         }
@@ -506,7 +512,7 @@ STATIC mp_uint_t lwip_tcp_receive(lwip_socket_obj_t *socket, byte *buf, mp_uint_
     // Check for any pending errors
     STREAM_ERROR_CHECK(socket);
 
-    if (socket->incoming.pbuf == NULL) {
+    if (!lwip_has_incoming(socket)) {
 
         // Non-blocking socket
         if (socket->timeout == 0) {
@@ -518,7 +524,7 @@ STATIC mp_uint_t lwip_tcp_receive(lwip_socket_obj_t *socket, byte *buf, mp_uint_
         }
 
         mp_uint_t start = mp_hal_ticks_ms();
-        while (socket->state == STATE_CONNECTED && socket->incoming.pbuf == NULL) {
+        while (socket->state == STATE_CONNECTED && !lwip_has_incoming(socket)) {
             if (socket->timeout != -1 && mp_hal_ticks_ms() - start > socket->timeout) {
                 *_errno = MP_ETIMEDOUT;
                 return -1;
@@ -527,7 +533,7 @@ STATIC mp_uint_t lwip_tcp_receive(lwip_socket_obj_t *socket, byte *buf, mp_uint_
         }
 
         if (socket->state == STATE_PEER_CLOSED) {
-            if (socket->incoming.pbuf == NULL) {
+            if (!lwip_has_incoming(socket)) {
                 // socket closed and no data left in buffer
                 return 0;
             }
@@ -568,8 +574,7 @@ STATIC mp_uint_t lwip_tcp_receive(lwip_socket_obj_t *socket, byte *buf, mp_uint_
 
 /*******************************************************************************/
 // The socket functions provided by lwip.socket.
-
-STATIC const mp_obj_type_t lwip_socket_type;
+const mp_obj_type_t lwip_socket_type;
 
 STATIC void lwip_socket_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     lwip_socket_obj_t *self = self_in;
@@ -651,7 +656,7 @@ STATIC mp_obj_t lwip_socket_close(mp_obj_t self_in) {
     }
     socket->pcb.tcp = NULL;
     socket->state = _ERR_BADF;
-    if (socket->incoming.pbuf != NULL) {
+    if (lwip_has_incoming(socket)) {
         if (!socket_is_listener) {
             pbuf_free(socket->incoming.pbuf);
         } else {
@@ -1155,7 +1160,7 @@ STATIC const mp_stream_p_t lwip_socket_stream_p = {
     .write = lwip_socket_write,
 };
 
-STATIC const mp_obj_type_t lwip_socket_type = {
+const mp_obj_type_t lwip_socket_type = {
     { &mp_type_type },
     .name = MP_QSTR_socket,
     .print = lwip_socket_print,

--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -274,6 +274,10 @@ bool lwip_has_incoming(lwip_socket_obj_t *socket) {
     return socket->incoming.pbuf != NULL;
 }
 
+bool lwip_is_closed(lwip_socket_obj_t *socket) {
+    return socket->state == STATE_PEER_CLOSED;
+}
+
 
 // Callback for incoming UDP packets. We simply stash the packet and the source address,
 // in case we need it for recvfrom.
@@ -516,7 +520,7 @@ STATIC mp_uint_t lwip_tcp_receive(lwip_socket_obj_t *socket, byte *buf, mp_uint_
 
         // Non-blocking socket
         if (socket->timeout == 0) {
-            if (socket->state == STATE_PEER_CLOSED) {
+            if (lwip_is_closed(socket)) {
                 return 0;
             }
             *_errno = MP_EAGAIN;
@@ -532,7 +536,7 @@ STATIC mp_uint_t lwip_tcp_receive(lwip_socket_obj_t *socket, byte *buf, mp_uint_
             poll_sockets();
         }
 
-        if (socket->state == STATE_PEER_CLOSED) {
+        if (lwip_is_closed(socket)) {
             if (!lwip_has_incoming(socket)) {
                 // socket closed and no data left in buffer
                 return 0;


### PR DESCRIPTION
An implementation of `select.poll` for the ESP8266. Currently implements `POLLIN` and `POLLHUP` but the others should be fairly easy to implement. Reaches quite deeply into `modlwip`, but maybe that's okay?

Fixes #2380
