### PR TITLE
esp8266: Added os.statvfs() to get filesystem status.

### DIFF
--- a/esp8266/moduos.c
+++ b/esp8266/moduos.c
@@ -152,6 +152,11 @@ STATIC mp_obj_t os_stat(mp_obj_t path_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_stat_obj, os_stat);
 
+STATIC mp_obj_t os_statvfs(mp_obj_t path_in) {
+    return vfs_proxy_call(MP_QSTR_statvfs, 1, &path_in);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_statvfs_obj, os_statvfs);
+
 STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_uos) },
     { MP_ROM_QSTR(MP_QSTR_uname), MP_ROM_PTR(&os_uname_obj) },
@@ -170,6 +175,7 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&os_remove_obj) },
     { MP_ROM_QSTR(MP_QSTR_rename), MP_ROM_PTR(&os_rename_obj) },
     { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&os_stat_obj) },
+    { MP_ROM_QSTR(MP_QSTR_statvfs), MP_ROM_PTR(&os_statvfs_obj) },
     { MP_ROM_QSTR(MP_QSTR_umount), MP_ROM_PTR(&os_umount_obj) },
     #endif
 };

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -250,6 +250,37 @@ STATIC mp_obj_t fat_vfs_stat(mp_obj_t vfs_in, mp_obj_t path_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_stat_obj, fat_vfs_stat);
 
+/// \function statvfs(path)
+/// Get the status of a VFS.
+STATIC mp_obj_t fat_vfs_statvfs(mp_obj_t vfs_in, mp_obj_t path_in) {
+    (void)vfs_in;
+    const char *path = mp_obj_str_get_str(path_in);
+
+    FATFS *fatfs;
+    DWORD nclst;
+    FRESULT res = f_getfree(path, &nclst, &fatfs);
+    if (FR_OK != res) {
+        nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError,
+          MP_OBJ_NEW_SMALL_INT(fresult_to_errno_table[res])));
+    }
+
+    mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(10, NULL));
+
+    t->items[0] = MP_OBJ_NEW_SMALL_INT(fatfs->csize * fatfs->ssize); // f_bsize
+    t->items[1] = t->items[0]; // f_frsize
+    t->items[2] = MP_OBJ_NEW_SMALL_INT((fatfs->n_fatent - 2) * fatfs->csize); // f_blocks
+    t->items[3] = MP_OBJ_NEW_SMALL_INT(nclst); // f_bfree
+    t->items[4] = t->items[3]; // f_bavail
+    t->items[5] = MP_OBJ_NEW_SMALL_INT(0); // f_files
+    t->items[6] = MP_OBJ_NEW_SMALL_INT(0); // f_ffree
+    t->items[7] = MP_OBJ_NEW_SMALL_INT(0); // f_favail
+    t->items[8] = MP_OBJ_NEW_SMALL_INT(0); // f_flags
+    t->items[9] = MP_OBJ_NEW_SMALL_INT(_MAX_LFN); // f_namemax
+
+    return MP_OBJ_FROM_PTR(t);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_statvfs_obj, fat_vfs_statvfs);
+
 // Unmount the filesystem
 STATIC mp_obj_t fat_vfs_umount(mp_obj_t vfs_in) {
     fatfs_umount(((fs_user_mount_t *)vfs_in)->readblocks[1]);
@@ -268,6 +299,7 @@ STATIC const mp_rom_map_elem_t fat_vfs_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&fat_vfs_remove_obj) },
     { MP_ROM_QSTR(MP_QSTR_rename), MP_ROM_PTR(&fat_vfs_rename_obj) },
     { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&fat_vfs_stat_obj) },
+    { MP_ROM_QSTR(MP_QSTR_statvfs), MP_ROM_PTR(&fat_vfs_statvfs_obj) },
     { MP_ROM_QSTR(MP_QSTR_umount), MP_ROM_PTR(&fat_vfs_umount_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(fat_vfs_locals_dict, fat_vfs_locals_dict_table);

--- a/tests/extmod/vfs_fat_ramdisk.py
+++ b/tests/extmod/vfs_fat_ramdisk.py
@@ -45,6 +45,7 @@ assert b"FOO_FILETXT" not in bdev.data
 assert b"hello!" not in bdev.data
 
 vfs = uos.VfsFat(bdev, "/ramdisk")
+assert vfs.statvfs("/ramdisk") == (512, 512, 14, 14, 14, 0, 0, 0, 0, 255)
 
 print("getcwd:", vfs.getcwd())
 


### PR DESCRIPTION
From [forum discussion](http://forum.micropython.org/viewtopic.php?f=16&t=2361&sid=9536319ce528e47d86970d6b269ddca8).

Example use case (markxr):
- Check free fs space
- If less than some threshold, delete the oldest file
- Write data to new file....

`os.getfree(path)` returns the free space available in the VFS. Is the block size assumed to be 512 bit? Not sure about leaving it hardcoded.
