### PR TITLE
builtinimport: add the module specified by -m to sys.modules as '__main__'

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -449,7 +449,7 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
                     mp_obj_dict_store(MP_OBJ_FROM_PTR(o->globals), MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR___main__));
                     #if MICROPY_CPYTHON_COMPAT
                     // Store module as "__main__" in the dictionary of loaded modules (returned by sys.modules).
-                    mp_obj_dict_store(&MP_STATE_VM(mp_loaded_modules_dict), MP_OBJ_NEW_QSTR(MP_QSTR___main__), module_obj);
+                    mp_obj_dict_store(MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_loaded_modules_dict)), MP_OBJ_NEW_QSTR(MP_QSTR___main__), module_obj);
                     // Store real name in "__main__" attribute. Choosen semi-randonly, to reuse existing qstr's.
                     mp_obj_dict_store(MP_OBJ_FROM_PTR(o->globals), MP_OBJ_NEW_QSTR(MP_QSTR___main__), MP_OBJ_NEW_QSTR(mod_name));
                     #endif


### PR DESCRIPTION
Improve MICROPY_CPYTHON_COMPAT when running scripts using -m. I found out unittest could not find tests in a module when the module was run using -m

```
# cd micropython-lib/unittest
# micropython -m test_unittest
Ran 0 tests
```

CPython works ok with -m

```
# python -m test_unittest
testEqual ... ok
testFail ... ok
testFalse ... ok
testIn ... ok
testIs ... ok
testIsInstance ... ok
testIsNone ... ok
testIsNot ... ok
testIsNotNone ... ok
testNotEqual ... ok
testRaises ... ok
testSkip ... skipped: test of skipping
testTrue ... ok
test_AlmostEqual ... ok
test_AmostEqualWithDelta ... ok
Ran 15 tests (1 skipped)
```

With this commit applied tests are found as expected:

```
# micropython -m test_unittest
testIsNotNone ... ok
test_AlmostEqual ... ok
testIsNone ... ok
testEqual ... ok
testTrue ... ok
testNotEqual ... ok
testIsInstance ... ok
test_AmostEqualWithDelta ... ok
testSkip ... skipped: test of skipping
testIn ... ok
testFail ... ok
testFalse ... ok
testIsNot ... ok
testRaises ... ok
testIs ... ok
Ran 15 tests (1 skipped)
```
