### PR TITLE
Remove 'name' member from mp_obj_module_t struct.

### DIFF
--- a/cc3200/mods/modmachine.c
+++ b/cc3200/mods/modmachine.c
@@ -213,6 +213,5 @@ STATIC MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table
 
 const mp_obj_module_t machine_module = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_umachine,
     .globals = (mp_obj_dict_t*)&machine_module_globals,
 };

--- a/cc3200/mods/modnetwork.c
+++ b/cc3200/mods/modnetwork.c
@@ -161,7 +161,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_network_globals, mp_module_network_globals
 
 const mp_obj_module_t mp_module_network = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_network,
     .globals = (mp_obj_dict_t*)&mp_module_network_globals,
 };
 

--- a/cc3200/mods/modubinascii.c
+++ b/cc3200/mods/modubinascii.c
@@ -58,6 +58,5 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_binascii_globals, mp_module_binascii_globa
 
 const mp_obj_module_t mp_module_ubinascii = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_ubinascii,
     .globals = (mp_obj_dict_t*)&mp_module_binascii_globals,
 };

--- a/cc3200/mods/moduhashlib.c
+++ b/cc3200/mods/moduhashlib.c
@@ -204,7 +204,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_hashlib_globals, mp_module_hashlib_globals
 
 const mp_obj_module_t mp_module_uhashlib = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uhashlib,
     .globals = (mp_obj_dict_t*)&mp_module_hashlib_globals,
 };
 

--- a/cc3200/mods/moduos.c
+++ b/cc3200/mods/moduos.c
@@ -602,6 +602,5 @@ STATIC MP_DEFINE_CONST_DICT(os_module_globals, os_module_globals_table);
 
 const mp_obj_module_t mp_module_uos = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uos,
     .globals = (mp_obj_dict_t*)&os_module_globals,
 };

--- a/cc3200/mods/modusocket.c
+++ b/cc3200/mods/modusocket.c
@@ -541,6 +541,5 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_usocket_globals, mp_module_usocket_globals
 
 const mp_obj_module_t mp_module_usocket = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_usocket,
     .globals = (mp_obj_dict_t*)&mp_module_usocket_globals,
 };

--- a/cc3200/mods/modussl.c
+++ b/cc3200/mods/modussl.c
@@ -152,7 +152,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_ussl_globals, mp_module_ussl_globals_table
 
 const mp_obj_module_t mp_module_ussl = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_ussl,
     .globals = (mp_obj_dict_t*)&mp_module_ussl_globals,
 };
 

--- a/cc3200/mods/modutime.c
+++ b/cc3200/mods/modutime.c
@@ -196,6 +196,5 @@ STATIC MP_DEFINE_CONST_DICT(time_module_globals, time_module_globals_table);
 
 const mp_obj_module_t mp_module_utime = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_utime,
     .globals = (mp_obj_dict_t*)&time_module_globals,
 };

--- a/cc3200/mods/modwipy.c
+++ b/cc3200/mods/modwipy.c
@@ -26,6 +26,5 @@ STATIC MP_DEFINE_CONST_DICT(wipy_module_globals, wipy_module_globals_table);
 
 const mp_obj_module_t wipy_module = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_wipy,
     .globals = (mp_obj_dict_t*)&wipy_module_globals,
 };

--- a/esp8266/modesp.c
+++ b/esp8266/modesp.c
@@ -748,6 +748,5 @@ STATIC MP_DEFINE_CONST_DICT(esp_module_globals, esp_module_globals_table);
 
 const mp_obj_module_t esp_module = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_esp,
     .globals = (mp_obj_dict_t*)&esp_module_globals,
 };

--- a/esp8266/modmachine.c
+++ b/esp8266/modmachine.c
@@ -271,7 +271,6 @@ STATIC MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table
 
 const mp_obj_module_t mp_module_machine = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_umachine,
     .globals = (mp_obj_dict_t*)&machine_module_globals,
 };
 

--- a/esp8266/modnetwork.c
+++ b/esp8266/modnetwork.c
@@ -484,6 +484,5 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_network_globals, mp_module_network_globals
 
 const mp_obj_module_t network_module = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_network,
     .globals = (mp_obj_dict_t*)&mp_module_network_globals,
 };

--- a/esp8266/modonewire.c
+++ b/esp8266/modonewire.c
@@ -117,6 +117,5 @@ STATIC MP_DEFINE_CONST_DICT(onewire_module_globals, onewire_module_globals_table
 
 const mp_obj_module_t onewire_module = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_onewire,
     .globals = (mp_obj_dict_t*)&onewire_module_globals,
 };

--- a/esp8266/moduos.c
+++ b/esp8266/moduos.c
@@ -178,6 +178,5 @@ STATIC MP_DEFINE_CONST_DICT(os_module_globals, os_module_globals_table);
 
 const mp_obj_module_t uos_module = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uos,
     .globals = (mp_obj_dict_t*)&os_module_globals,
 };

--- a/esp8266/modutime.c
+++ b/esp8266/modutime.c
@@ -173,6 +173,5 @@ STATIC MP_DEFINE_CONST_DICT(time_module_globals, time_module_globals_table);
 
 const mp_obj_module_t utime_module = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_utime,
     .globals = (mp_obj_dict_t*)&time_module_globals,
 };

--- a/extmod/modbtree.c
+++ b/extmod/modbtree.c
@@ -387,7 +387,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_btree_globals, mp_module_btree_globals_tab
 
 const mp_obj_module_t mp_module_btree = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_btree,
     .globals = (mp_obj_dict_t*)&mp_module_btree_globals,
 };
 

--- a/extmod/modframebuf.c
+++ b/extmod/modframebuf.c
@@ -213,7 +213,6 @@ STATIC MP_DEFINE_CONST_DICT(framebuf_module_globals, framebuf_module_globals_tab
 
 const mp_obj_module_t mp_module_framebuf = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_framebuf,
     .globals = (mp_obj_dict_t*)&framebuf_module_globals,
 };
 

--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -1309,7 +1309,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_lwip_globals, mp_module_lwip_globals_table
 
 const mp_obj_module_t mp_module_lwip = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_lwip,
     .globals = (mp_obj_dict_t*)&mp_module_lwip_globals,
 };
 

--- a/extmod/modubinascii.c
+++ b/extmod/modubinascii.c
@@ -232,7 +232,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_binascii_globals, mp_module_binascii_globa
 
 const mp_obj_module_t mp_module_ubinascii = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_ubinascii,
     .globals = (mp_obj_dict_t*)&mp_module_binascii_globals,
 };
 

--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -710,7 +710,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_uctypes_globals, mp_module_uctypes_globals
 
 const mp_obj_module_t mp_module_uctypes = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uctypes,
     .globals = (mp_obj_dict_t*)&mp_module_uctypes_globals,
 };
 

--- a/extmod/moduhashlib.c
+++ b/extmod/moduhashlib.c
@@ -151,7 +151,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_hashlib_globals, mp_module_hashlib_globals
 
 const mp_obj_module_t mp_module_uhashlib = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uhashlib,
     .globals = (mp_obj_dict_t*)&mp_module_hashlib_globals,
 };
 

--- a/extmod/moduheapq.c
+++ b/extmod/moduheapq.c
@@ -116,7 +116,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_uheapq_globals, mp_module_uheapq_globals_t
 
 const mp_obj_module_t mp_module_uheapq = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uheapq,
     .globals = (mp_obj_dict_t*)&mp_module_uheapq_globals,
 };
 

--- a/extmod/modujson.c
+++ b/extmod/modujson.c
@@ -260,7 +260,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_ujson_globals, mp_module_ujson_globals_tab
 
 const mp_obj_module_t mp_module_ujson = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_ujson,
     .globals = (mp_obj_dict_t*)&mp_module_ujson_globals,
 };
 

--- a/extmod/modurandom.c
+++ b/extmod/modurandom.c
@@ -215,7 +215,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_urandom_globals, mp_module_urandom_globals
 
 const mp_obj_module_t mp_module_urandom = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_urandom,
     .globals = (mp_obj_dict_t*)&mp_module_urandom_globals,
 };
 

--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -237,7 +237,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_re_globals, mp_module_re_globals_table);
 
 const mp_obj_module_t mp_module_ure = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_ure,
     .globals = (mp_obj_dict_t*)&mp_module_re_globals,
 };
 

--- a/extmod/modussl_axtls.c
+++ b/extmod/modussl_axtls.c
@@ -196,7 +196,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_ssl_globals, mp_module_ssl_globals_table);
 
 const mp_obj_module_t mp_module_ussl = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_ussl,
     .globals = (mp_obj_dict_t*)&mp_module_ssl_globals,
 };
 

--- a/extmod/moduzlib.c
+++ b/extmod/moduzlib.c
@@ -204,7 +204,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_uzlib_globals, mp_module_uzlib_globals_tab
 
 const mp_obj_module_t mp_module_uzlib = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uzlib,
     .globals = (mp_obj_dict_t*)&mp_module_uzlib_globals,
 };
 

--- a/extmod/modwebrepl.c
+++ b/extmod/modwebrepl.c
@@ -340,7 +340,7 @@ STATIC const mp_obj_type_t webrepl_type = {
 };
 
 STATIC const mp_map_elem_t webrepl_module_globals_table[] = {
-    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_websocket) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR__webrepl) },
     { MP_OBJ_NEW_QSTR(MP_QSTR__webrepl), (mp_obj_t)&webrepl_type },
     { MP_OBJ_NEW_QSTR(MP_QSTR_password), (mp_obj_t)&webrepl_set_password_obj },
 };
@@ -349,7 +349,6 @@ STATIC MP_DEFINE_CONST_DICT(webrepl_module_globals, webrepl_module_globals_table
 
 const mp_obj_module_t mp_module_webrepl = {
     .base = { &mp_type_module },
-    .name = MP_QSTR__webrepl,
     .globals = (mp_obj_dict_t*)&webrepl_module_globals,
 };
 

--- a/extmod/modwebsocket.c
+++ b/extmod/modwebsocket.c
@@ -313,7 +313,6 @@ STATIC MP_DEFINE_CONST_DICT(websocket_module_globals, websocket_module_globals_t
 
 const mp_obj_module_t mp_module_websocket = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_websocket,
     .globals = (mp_obj_dict_t*)&websocket_module_globals,
 };
 

--- a/pic16bit/modpyb.c
+++ b/pic16bit/modpyb.c
@@ -66,6 +66,5 @@ STATIC MP_DEFINE_CONST_DICT(pyb_module_globals, pyb_module_globals_table);
 
 const mp_obj_module_t pyb_module = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_pyb,
     .globals = (mp_obj_dict_t*)&pyb_module_globals,
 };

--- a/py/modarray.c
+++ b/py/modarray.c
@@ -37,7 +37,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_array_globals, mp_module_array_globals_tab
 
 const mp_obj_module_t mp_module_array = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_array,
     .globals = (mp_obj_dict_t*)&mp_module_array_globals,
 };
 

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -577,6 +577,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin_id_obj, mp_obj_id);
 MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin_len_obj, mp_obj_len);
 
 STATIC const mp_rom_map_elem_t mp_module_builtins_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_builtins) },
+
     // built-in core functions
     { MP_ROM_QSTR(MP_QSTR___build_class__), MP_ROM_PTR(&mp_builtin___build_class___obj) },
     { MP_ROM_QSTR(MP_QSTR___import__), MP_ROM_PTR(&mp_builtin___import___obj) },
@@ -727,6 +729,5 @@ MP_DEFINE_CONST_DICT(mp_module_builtins_globals, mp_module_builtins_globals_tabl
 
 const mp_obj_module_t mp_module_builtins = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_builtins,
     .globals = (mp_obj_dict_t*)&mp_module_builtins_globals,
 };

--- a/py/modcmath.c
+++ b/py/modcmath.c
@@ -160,7 +160,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_cmath_globals, mp_module_cmath_globals_tab
 
 const mp_obj_module_t mp_module_cmath = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_cmath,
     .globals = (mp_obj_dict_t*)&mp_module_cmath_globals,
 };
 

--- a/py/modcollections.c
+++ b/py/modcollections.c
@@ -40,7 +40,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_collections_globals, mp_module_collections
 
 const mp_obj_module_t mp_module_collections = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_ucollections,
     .globals = (mp_obj_dict_t*)&mp_module_collections_globals,
 };
 

--- a/py/modgc.c
+++ b/py/modgc.c
@@ -119,7 +119,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_gc_globals, mp_module_gc_globals_table);
 
 const mp_obj_module_t mp_module_gc = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_gc,
     .globals = (mp_obj_dict_t*)&mp_module_gc_globals,
 };
 

--- a/py/modio.c
+++ b/py/modio.c
@@ -153,7 +153,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_io_globals, mp_module_io_globals_table);
 
 const mp_obj_module_t mp_module_io = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uio,
     .globals = (mp_obj_dict_t*)&mp_module_io_globals,
 };
 

--- a/py/modmath.c
+++ b/py/modmath.c
@@ -268,7 +268,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_math_globals, mp_module_math_globals_table
 
 const mp_obj_module_t mp_module_math = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_math,
     .globals = (mp_obj_dict_t*)&mp_module_math_globals,
 };
 

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -145,6 +145,5 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_micropython_globals, mp_module_micropython
 
 const mp_obj_module_t mp_module_micropython = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_micropython,
     .globals = (mp_obj_dict_t*)&mp_module_micropython_globals,
 };

--- a/py/modstruct.c
+++ b/py/modstruct.c
@@ -265,7 +265,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_struct_globals, mp_module_struct_globals_t
 
 const mp_obj_module_t mp_module_ustruct = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_ustruct,
     .globals = (mp_obj_dict_t*)&mp_module_struct_globals,
 };
 

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -203,7 +203,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_sys_globals, mp_module_sys_globals_table);
 
 const mp_obj_module_t mp_module_sys = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_sys,
     .globals = (mp_obj_dict_t*)&mp_module_sys_globals,
 };
 

--- a/py/modthread.c
+++ b/py/modthread.c
@@ -294,7 +294,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_thread_globals, mp_module_thread_globals_t
 
 const mp_obj_module_t mp_module_thread = {
     .base = { &mp_type_module },
-    .name = MP_QSTR__thread,
     .globals = (mp_obj_dict_t*)&mp_module_thread_globals,
 };
 

--- a/py/moduerrno.c
+++ b/py/moduerrno.c
@@ -89,7 +89,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_uerrno_globals, mp_module_uerrno_globals_t
 
 const mp_obj_module_t mp_module_uerrno = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uerrno,
     .globals = (mp_obj_dict_t*)&mp_module_uerrno_globals,
 };
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -765,7 +765,6 @@ MP_DECLARE_CONST_FUN_OBJ(mp_identity_obj);
 // module
 typedef struct _mp_obj_module_t {
     mp_obj_base_t base;
-    qstr name;
     mp_obj_dict_t *globals;
 } mp_obj_module_t;
 mp_obj_dict_t *mp_obj_module_get_globals(mp_obj_t self_in);

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -39,7 +39,7 @@ STATIC void module_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kin
 
     const char *module_name = "";
     mp_map_elem_t *elem = mp_map_lookup(&self->globals->map, MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_MAP_LOOKUP);
-    if (elem == NULL) {
+    if (elem != NULL) {
         module_name = mp_obj_str_get_str(elem->value);
     }
 

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -37,17 +37,23 @@ STATIC void module_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kin
     (void)kind;
     mp_obj_module_t *self = MP_OBJ_TO_PTR(self_in);
 
+    const char *module_name = "";
+    mp_map_elem_t *elem = mp_map_lookup(&self->globals->map, MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_MAP_LOOKUP);
+    if (elem == NULL) {
+        module_name = mp_obj_str_get_str(elem->value);
+    }
+
 #if MICROPY_PY___FILE__
     // If we store __file__ to imported modules then try to lookup this
     // symbol to give more information about the module.
-    mp_map_elem_t *elem = mp_map_lookup(&self->globals->map, MP_OBJ_NEW_QSTR(MP_QSTR___file__), MP_MAP_LOOKUP);
+    elem = mp_map_lookup(&self->globals->map, MP_OBJ_NEW_QSTR(MP_QSTR___file__), MP_MAP_LOOKUP);
     if (elem != NULL) {
-        mp_printf(print, "<module '%q' from '%s'>", self->name, mp_obj_str_get_str(elem->value));
+        mp_printf(print, "<module '%s' from '%s'>", module_name, mp_obj_str_get_str(elem->value));
         return;
     }
 #endif
 
-    mp_printf(print, "<module '%q'>", self->name);
+    mp_printf(print, "<module '%s'>", module_name);
 }
 
 STATIC void module_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
@@ -106,7 +112,6 @@ mp_obj_t mp_obj_new_module(qstr module_name) {
     // create new module object
     mp_obj_module_t *o = m_new_obj(mp_obj_module_t);
     o->base.type = &mp_type_module;
-    o->name = module_name;
     o->globals = MP_OBJ_TO_PTR(mp_obj_new_dict(MICROPY_MODULE_DICT_SIZE));
 
     // store __name__ entry in the module

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -55,7 +55,6 @@
 
 const mp_obj_module_t mp_module___main__ = {
     .base = { &mp_type_module },
-    .name = MP_QSTR___main__,
     .globals = (mp_obj_dict_t*)&MP_STATE_VM(dict_main),
 };
 

--- a/stmhal/modmachine.c
+++ b/stmhal/modmachine.c
@@ -559,7 +559,6 @@ STATIC MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table
 
 const mp_obj_module_t machine_module = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_umachine,
     .globals = (mp_obj_dict_t*)&machine_module_globals,
 };
 

--- a/stmhal/modnetwork.c
+++ b/stmhal/modnetwork.c
@@ -86,6 +86,5 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_network_globals, mp_module_network_globals
 
 const mp_obj_module_t mp_module_network = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_network,
     .globals = (mp_obj_dict_t*)&mp_module_network_globals,
 };

--- a/stmhal/modpyb.c
+++ b/stmhal/modpyb.c
@@ -229,6 +229,5 @@ STATIC MP_DEFINE_CONST_DICT(pyb_module_globals, pyb_module_globals_table);
 
 const mp_obj_module_t pyb_module = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_pyb,
     .globals = (mp_obj_dict_t*)&pyb_module_globals,
 };

--- a/stmhal/modstm.c
+++ b/stmhal/modstm.c
@@ -51,6 +51,5 @@ STATIC MP_DEFINE_CONST_DICT(stm_module_globals, stm_module_globals_table);
 
 const mp_obj_module_t stm_module = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_stm,
     .globals = (mp_obj_dict_t*)&stm_module_globals,
 };

--- a/stmhal/moduos.c
+++ b/stmhal/moduos.c
@@ -407,6 +407,5 @@ STATIC MP_DEFINE_CONST_DICT(os_module_globals, os_module_globals_table);
 
 const mp_obj_module_t mp_module_uos = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uos,
     .globals = (mp_obj_dict_t*)&os_module_globals,
 };

--- a/stmhal/moduselect.c
+++ b/stmhal/moduselect.c
@@ -307,6 +307,5 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_select_globals, mp_module_select_globals_t
 
 const mp_obj_module_t mp_module_uselect = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uselect,
     .globals = (mp_obj_dict_t*)&mp_module_select_globals,
 };

--- a/stmhal/modusocket.c
+++ b/stmhal/modusocket.c
@@ -444,6 +444,5 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_usocket_globals, mp_module_usocket_globals
 
 const mp_obj_module_t mp_module_usocket = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_usocket,
     .globals = (mp_obj_dict_t*)&mp_module_usocket_globals,
 };

--- a/stmhal/modutime.c
+++ b/stmhal/modutime.c
@@ -213,6 +213,5 @@ STATIC MP_DEFINE_CONST_DICT(time_module_globals, time_module_globals_table);
 
 const mp_obj_module_t mp_module_utime = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_utime,
     .globals = (mp_obj_dict_t*)&time_module_globals,
 };

--- a/teensy/modpyb.c
+++ b/teensy/modpyb.c
@@ -354,6 +354,5 @@ STATIC MP_DEFINE_CONST_DICT(pyb_module_globals, pyb_module_globals_table);
 
 const mp_obj_module_t pyb_module = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_pyb,
     .globals = (mp_obj_dict_t*)&pyb_module_globals,
 };

--- a/unix/modffi.c
+++ b/unix/modffi.c
@@ -499,6 +499,5 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_ffi_globals, mp_module_ffi_globals_table);
 
 const mp_obj_module_t mp_module_ffi = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_ffi,
     .globals = (mp_obj_dict_t*)&mp_module_ffi_globals,
 };

--- a/unix/modjni.c
+++ b/unix/modjni.c
@@ -718,6 +718,5 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_jni_globals, mp_module_jni_globals_table);
 
 const mp_obj_module_t mp_module_jni = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_jni,
     .globals = (mp_obj_dict_t*)&mp_module_jni_globals,
 };

--- a/unix/modmachine.c
+++ b/unix/modmachine.c
@@ -91,7 +91,6 @@ STATIC MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table
 
 const mp_obj_module_t mp_module_machine = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_umachine,
     .globals = (mp_obj_dict_t*)&machine_module_globals,
 };
 

--- a/unix/modos.c
+++ b/unix/modos.c
@@ -253,6 +253,5 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_os_globals, mp_module_os_globals_table);
 
 const mp_obj_module_t mp_module_os = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uos,
     .globals = (mp_obj_dict_t*)&mp_module_os_globals,
 };

--- a/unix/modsocket.c
+++ b/unix/modsocket.c
@@ -586,6 +586,5 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_socket_globals, mp_module_socket_globals_t
 
 const mp_obj_module_t mp_module_socket = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_usocket,
     .globals = (mp_obj_dict_t*)&mp_module_socket_globals,
 };

--- a/unix/modtermios.c
+++ b/unix/modtermios.c
@@ -151,6 +151,5 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_termios_globals, mp_module_termios_globals
 
 const mp_obj_module_t mp_module_termios = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_termios,
     .globals = (mp_obj_dict_t*)&mp_module_termios_globals,
 };

--- a/unix/modtime.c
+++ b/unix/modtime.c
@@ -198,7 +198,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_time_globals, mp_module_time_globals_table
 
 const mp_obj_module_t mp_module_time = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_utime,
     .globals = (mp_obj_dict_t*)&mp_module_time_globals,
 };
 

--- a/unix/moduselect.c
+++ b/unix/moduselect.c
@@ -235,7 +235,6 @@ STATIC MP_DEFINE_CONST_DICT(mp_module_select_globals, mp_module_select_globals_t
 
 const mp_obj_module_t mp_module_uselect = {
     .base = { &mp_type_module },
-    .name = MP_QSTR_uselect,
     .globals = (mp_obj_dict_t*)&mp_module_select_globals,
 };
 


### PR DESCRIPTION
One can instead lookup `__name__` in the modules dict to get the value.

See #2433.

Savings are pretty small: esp8266 saves 92 bytes, stmhal saves 88, bare-arm goes up by 28 due to the complex lookup of `__name__` for module repr.
