### PR TITLE
stmhal: Use attribute to avoid inlining.

### DIFF
--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -165,9 +165,8 @@ static const char fresh_readme_txt[] =
 "Please visit http://micropython.org/help/ for further help.\r\n"
 ;
 
-// we don't make this function static because it needs a lot of stack and we
-// want it to be executed without using stack within main() function
-void init_flash_fs(uint reset_mode) {
+// avoid inlining to avoid stack usage within main()
+MP_NOINLINE STATIC void init_flash_fs(uint reset_mode) {
     // init the vfs object
     fs_user_mount_t *vfs = &fs_user_mount_flash;
     vfs->str = "/flash";


### PR DESCRIPTION
Use MP_NOINLINE macro to avoid inlining of init_flash_fs. This helps
to keep stack usage of main() low.

Note: Even though there is a nice comment this confused me quite a bit until I realized that making the function not static has done to make sure the compiler does not inline the function. I guess if LTO or something similar is used the compiler might still inline that function...
