### PR TITLE
extmod/uctypes: Allow full 32-bit address range.

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -125,7 +125,7 @@ STATIC mp_obj_t uctypes_struct_make_new(const mp_obj_type_t *type, size_t n_args
     mp_arg_check_num(n_args, n_kw, 2, 3, false);
     mp_obj_uctypes_struct_t *o = m_new_obj(mp_obj_uctypes_struct_t);
     o->base.type = type;
-    o->addr = (void*)(uintptr_t)mp_obj_get_int(args[0]);
+    o->addr = (void*)(uintptr_t)mp_obj_int_get_truncated(args[0]);
     o->desc = args[1];
     o->flags = LAYOUT_NATIVE;
     if (n_args == 3) {


### PR DESCRIPTION
Use mp_obj_int_get_truncated to allow the full 32-bit address range
as first parameter.

Useful to access SysTick timer:
    >>> SYST = uctypes.struct(0xE000E010, { "CSR": uctypes.UINT32 | 0, "RVR": uctypes.UINT32 | 4, "CVR": uctypes.UINT32 | 8 })
    >>> SYST.CSR = 0x5
    >>> SYST.RVR = 123
    >>> SYST.CVR
    67
    >>> SYST.CVR
    19
    >>> 
