### PR TITLE
stmhal: put common definitions from linker files to common.ld

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -18,6 +18,7 @@ QSTR_DEFS = qstrdefsport.h $(BUILD)/pins_qstr.h $(BUILD)/modstm_qstr.h
 # include py core make definitions
 include ../py/py.mk
 
+LD_DIR=boards
 CMSIS_DIR=cmsis
 HAL_DIR=hal/$(MCU_SERIES)
 USBDEV_DIR=usbdev
@@ -59,7 +60,7 @@ CFLAGS += $(COPT)
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += -DSTM32_HAL_H='<stm32$(MCU_SERIES)xx_hal.h>'
 
-LDFLAGS = -nostdlib -T $(LD_FILE) -Map=$(@:.elf=.map) --cref
+LDFLAGS = -nostdlib -L$(LD_DIR) -T $(LD_FILE) -Map=$(@:.elf=.map) --cref
 LIBS =
 
 # Remove uncalled code from the final image.

--- a/stmhal/boards/common.ld
+++ b/stmhal/boards/common.ld
@@ -1,0 +1,82 @@
+ENTRY(Reset_Handler)
+
+/* define output sections */
+SECTIONS
+{
+    /* The startup code goes first into FLASH */
+    .isr_vector :
+    {
+        . = ALIGN(4);
+        KEEP(*(.isr_vector)) /* Startup code */
+
+        /* This first flash block is 16K annd the isr vectors only take up
+           about 400 bytes. So we pull in a couple of object files to pad it
+           out. */
+
+        . = ALIGN(4);
+        */ff.o(.text*)
+        */stm32f4xx_hal_sd.o(.text*)
+
+        . = ALIGN(4);
+    } >FLASH_ISR
+   
+    /* The program code and other data goes into FLASH */
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text*)          /* .text* sections (code) */
+        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    /*  *(.glue_7)   */    /* glue arm to thumb code */
+    /*  *(.glue_7t)  */    /* glue thumb to arm code */
+
+        . = ALIGN(4);
+        _etext = .;        /* define a global symbol at end of code */
+    } >FLASH_TEXT
+        
+    /* used by the startup to initialize data */
+    _sidata = LOADADDR(.data);
+        
+    /* This is the initialized data section
+    The program executes knowing that the data is in the RAM
+    but the loader puts the initial values in the FLASH (inidata).
+    It is one task of the startup to copy the initial values from FLASH to RAM. */
+    .data :
+    {
+        . = ALIGN(4);
+        _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */ 
+        *(.data*)          /* .data* sections */
+
+        . = ALIGN(4);
+        _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
+    } >RAM AT> FLASH_TEXT
+            
+    /* Uninitialized data section */
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;         /* define a global symbol at bss start; used by startup code */
+        *(.bss*)
+        *(COMMON)
+
+        . = ALIGN(4);
+        _ebss = .;         /* define a global symbol at bss end; used by startup code and GC */
+    } >RAM
+
+    /* this is to define the start of the heap, and make sure we have a minimum size */
+    .heap :
+    {
+        . = ALIGN(4);
+        . = . + _minimum_heap_size;
+        . = ALIGN(4);
+    } >RAM
+
+    /* this just checks there is enough RAM for the stack */
+    .stack :
+    {
+        . = ALIGN(4);
+        . = . + _minimum_stack_size;
+        . = ALIGN(4);
+    } >RAM
+
+    .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/stmhal/boards/stm32f401.ld
+++ b/stmhal/boards/stm32f401.ld
@@ -13,8 +13,6 @@ MEMORY
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x018000 /* 96 KiB */
 }
 
-ENTRY(Reset_Handler)
-
 /* produce a link error if there is not this amount of RAM for these sections */
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
@@ -24,114 +22,11 @@ _minimum_heap_size = 16K;
    aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
 
+/* define common sections and symbols */
+INCLUDE common.ld
+
 /* RAM extents for the garbage collector */
+_ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_heap_start = _ebss; /* heap starts just after statically allocated memory */
 _heap_end = 0x20014000; /* tunable */
-
-/* define output sections */
-SECTIONS
-{
-    /* The startup code goes first into FLASH */
-    .isr_vector :
-    {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector)) /* Startup code */
-
-        /* This first flash block is 16K annd the isr vectors only take up
-           about 400 bytes. So we pull in a couple of object files to pad it
-           out. */
-
-        . = ALIGN(4);
-        */ff.o(.text*)
-        */stm32f4xx_hal_sd.o(.text*)
-
-        . = ALIGN(4);
-    } >FLASH_ISR
-   
-    /* The program code and other data goes into FLASH */
-    .text :
-    {
-        . = ALIGN(4);
-        *(.text*)          /* .text* sections (code) */
-        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
-    /*  *(.glue_7)   */    /* glue arm to thumb code */
-    /*  *(.glue_7t)  */    /* glue thumb to arm code */
-
-        . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
-    } >FLASH_TEXT
-     
-    /*
-    .ARM.extab :
-    {
-        *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } >FLASH
-
-    .ARM :
-    {
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        __exidx_end = .;
-    } >FLASH
-    */
-        
-    /* used by the startup to initialize data */
-    _sidata = LOADADDR(.data);
-        
-    /* This is the initialized data section
-    The program executes knowing that the data is in the RAM
-    but the loader puts the initial values in the FLASH (inidata).
-    It is one task of the startup to copy the initial values from FLASH to RAM. */
-    .data :
-    {
-        . = ALIGN(4);
-        _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
-        _ram_start = .;    /* create a global symbol at ram start for garbage collector */
-        *(.data*)          /* .data* sections */
-
-        . = ALIGN(4);
-        _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM AT> FLASH_TEXT
-            
-    /* Uninitialized data section */
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;         /* define a global symbol at bss start; used by startup code */
-        *(.bss*)
-        *(COMMON)
-
-        . = ALIGN(4);
-        _ebss = .;         /* define a global symbol at bss end; used by startup code and GC */
-    } >RAM
-
-    /* this is to define the start of the heap, and make sure we have a minimum size */
-    .heap :
-    {
-        . = ALIGN(4);
-	PROVIDE ( end = . );
-	PROVIDE ( _end = . );
-        _heap_start = .;    /* define a global symbol at heap start */
-        . = . + _minimum_heap_size;
-    } >RAM
-
-    /* this just checks there is enough RAM for the stack */
-    .stack :
-    {
-        . = ALIGN(4);
-        . = . + _minimum_stack_size;
-        . = ALIGN(4);
-    } >RAM
-
-    /* Remove information from the standard libraries */
-    /*
-    /DISCARD/ :
-    {
-        libc.a ( * )
-        libm.a ( * )
-        libgcc.a ( * )
-    }
-    */
-
-    .ARM.attributes 0 : { *(.ARM.attributes) }
-}

--- a/stmhal/boards/stm32f405.ld
+++ b/stmhal/boards/stm32f405.ld
@@ -12,8 +12,6 @@ MEMORY
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x020000 /* 128 KiB */
 }
 
-ENTRY(Reset_Handler)
-
 /* produce a link error if there is not this amount of RAM for these sections */
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
@@ -23,114 +21,11 @@ _minimum_heap_size = 16K;
    aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
 
+/* define common sections and symbols */
+INCLUDE common.ld
+
 /* RAM extents for the garbage collector */
+_ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_heap_start = _ebss; /* heap starts just after statically allocated memory */
 _heap_end = 0x2001c000; /* tunable */
-
-/* define output sections */
-SECTIONS
-{
-    /* The startup code goes first into FLASH */
-    .isr_vector :
-    {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector)) /* Startup code */
-
-        /* This first flash block is 16K annd the isr vectors only take up
-           about 400 bytes. So we pull in a couple of object files to pad it
-           out. */
-
-        . = ALIGN(4);
-        */ff.o(.text*)
-        */stm32f4xx_hal_sd.o(.text*)
-
-        . = ALIGN(4);
-    } >FLASH_ISR
-   
-    /* The program code and other data goes into FLASH */
-    .text :
-    {
-        . = ALIGN(4);
-        *(.text*)          /* .text* sections (code) */
-        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
-    /*  *(.glue_7)   */    /* glue arm to thumb code */
-    /*  *(.glue_7t)  */    /* glue thumb to arm code */
-
-        . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
-    } >FLASH_TEXT
-     
-    /*
-    .ARM.extab :
-    {
-        *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } >FLASH
-
-    .ARM :
-    {
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        __exidx_end = .;
-    } >FLASH
-    */
-        
-    /* used by the startup to initialize data */
-    _sidata = LOADADDR(.data);
-        
-    /* This is the initialized data section
-    The program executes knowing that the data is in the RAM
-    but the loader puts the initial values in the FLASH (inidata).
-    It is one task of the startup to copy the initial values from FLASH to RAM. */
-    .data :
-    {
-        . = ALIGN(4);
-        _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
-        _ram_start = .;    /* create a global symbol at ram start for garbage collector */
-        *(.data*)          /* .data* sections */
-
-        . = ALIGN(4);
-        _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM AT> FLASH_TEXT
-            
-    /* Uninitialized data section */
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;         /* define a global symbol at bss start; used by startup code */
-        *(.bss*)
-        *(COMMON)
-
-        . = ALIGN(4);
-        _ebss = .;         /* define a global symbol at bss end; used by startup code and GC */
-    } >RAM
-
-    /* this is to define the start of the heap, and make sure we have a minimum size */
-    .heap :
-    {
-        . = ALIGN(4);
-	PROVIDE ( end = . );
-	PROVIDE ( _end = . );
-        _heap_start = .;    /* define a global symbol at heap start */
-        . = . + _minimum_heap_size;
-    } >RAM
-
-    /* this just checks there is enough RAM for the stack */
-    .stack :
-    {
-        . = ALIGN(4);
-        . = . + _minimum_stack_size;
-        . = ALIGN(4);
-    } >RAM
-
-    /* Remove information from the standard libraries */
-    /*
-    /DISCARD/ :
-    {
-        libc.a ( * )
-        libm.a ( * )
-        libgcc.a ( * )
-    }
-    */
-
-    .ARM.attributes 0 : { *(.ARM.attributes) }
-}

--- a/stmhal/boards/stm32f411.ld
+++ b/stmhal/boards/stm32f411.ld
@@ -21,110 +21,11 @@ _minimum_heap_size = 16K;
 /*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
 _estack = ORIGIN(RAM) + LENGTH(RAM) - 1;
 
+/* define common sections and symbols */
+INCLUDE common.ld
+
 /* RAM extents for the garbage collector */
+_ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_heap_start = _ebss; /* heap starts just after statically allocated memory */
 _heap_end = 0x2001c000; /* tunable */
-
-/* define output sections */
-SECTIONS
-{
-    /* The startup code goes first into FLASH */
-    .isr_vector :
-    {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector)) /* Startup code */
-
-        . = ALIGN(4);
-    } >FLASH_ISR
-   
-    /* The program code and other data goes into FLASH */
-    .text :
-    {
-        . = ALIGN(4);
-        *(.text)           /* .text sections (code) */
-        *(.text*)          /* .text* sections (code) */
-        *(.rodata)         /* .rodata sections (constants, strings, etc.) */
-        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
-    /*  *(.glue_7)   */    /* glue arm to thumb code */
-    /*  *(.glue_7t)  */    /* glue thumb to arm code */
-
-        . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
-    } >FLASH_TEXT
-     
-    /*
-    .ARM.extab :
-    {
-        *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } >FLASH
-
-    .ARM :
-    {
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        __exidx_end = .;
-    } >FLASH
-    */
-        
-    /* used by the startup to initialize data */
-    _sidata = LOADADDR(.data);
-        
-    /* This is the initialized data section
-    The program executes knowing that the data is in the RAM
-    but the loader puts the initial values in the FLASH (inidata).
-    It is one task of the startup to copy the initial values from FLASH to RAM. */
-    .data :
-    {
-        . = ALIGN(4);
-        _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
-        _ram_start = .;    /* create a global symbol at ram start for garbage collector */
-        *(.data)           /* .data sections */
-        *(.data*)          /* .data* sections */
-
-        . = ALIGN(4);
-        _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM AT> FLASH_TEXT
-            
-    /* Uninitialized data section */
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;         /* define a global symbol at bss start; used by startup code */
-        *(.bss)
-        *(.bss*)
-        *(COMMON)
-
-        . = ALIGN(4);
-        _ebss = .;         /* define a global symbol at bss end; used by startup code and GC */
-    } >RAM
-
-    /* this is to define the start of the heap, and make sure we have a minimum size */
-    .heap :
-    {
-        . = ALIGN(4);
-	PROVIDE ( end = . );
-	PROVIDE ( _end = . );
-        _heap_start = .;    /* define a global symbol at heap start */
-        . = . + _minimum_heap_size;
-    } >RAM
-
-    /* this just checks there is enough RAM for the stack */
-    .stack :
-    {
-        . = ALIGN(4);
-        . = . + _minimum_stack_size;
-        . = ALIGN(4);
-    } >RAM
-
-    /* Remove information from the standard libraries */
-    /*
-    /DISCARD/ :
-    {
-        libc.a ( * )
-        libm.a ( * )
-        libgcc.a ( * )
-    }
-    */
-
-    .ARM.attributes 0 : { *(.ARM.attributes) }
-}

--- a/stmhal/boards/stm32f429.ld
+++ b/stmhal/boards/stm32f429.ld
@@ -21,110 +21,11 @@ _minimum_heap_size = 16K;
 /*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
 _estack = ORIGIN(RAM) + LENGTH(RAM) - 1;
 
+/* define common sections and symbols */
+INCLUDE common.ld
+
 /* RAM extents for the garbage collector */
+_ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_heap_start = _ebss; /* heap starts just after statically allocated memory */
 _heap_end = 0x2001c000; /* tunable */
-
-/* define output sections */
-SECTIONS
-{
-    /* The startup code goes first into FLASH */
-    .isr_vector :
-    {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector)) /* Startup code */
-
-        . = ALIGN(4);
-    } >FLASH_ISR
-   
-    /* The program code and other data goes into FLASH */
-    .text :
-    {
-        . = ALIGN(4);
-        *(.text)           /* .text sections (code) */
-        *(.text*)          /* .text* sections (code) */
-        *(.rodata)         /* .rodata sections (constants, strings, etc.) */
-        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
-    /*  *(.glue_7)   */    /* glue arm to thumb code */
-    /*  *(.glue_7t)  */    /* glue thumb to arm code */
-
-        . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
-    } >FLASH_TEXT
-     
-    /*
-    .ARM.extab :
-    {
-        *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } >FLASH
-
-    .ARM :
-    {
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        __exidx_end = .;
-    } >FLASH
-    */
-        
-    /* used by the startup to initialize data */
-    _sidata = LOADADDR(.data);
-        
-    /* This is the initialized data section
-    The program executes knowing that the data is in the RAM
-    but the loader puts the initial values in the FLASH (inidata).
-    It is one task of the startup to copy the initial values from FLASH to RAM. */
-    .data :
-    {
-        . = ALIGN(4);
-        _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
-        _ram_start = .;    /* create a global symbol at ram start for garbage collector */
-        *(.data)           /* .data sections */
-        *(.data*)          /* .data* sections */
-
-        . = ALIGN(4);
-        _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM AT> FLASH_TEXT
-            
-    /* Uninitialized data section */
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;         /* define a global symbol at bss start; used by startup code */
-        *(.bss)
-        *(.bss*)
-        *(COMMON)
-
-        . = ALIGN(4);
-        _ebss = .;         /* define a global symbol at bss end; used by startup code and GC */
-    } >RAM
-
-    /* this is to define the start of the heap, and make sure we have a minimum size */
-    .heap :
-    {
-        . = ALIGN(4);
-	PROVIDE ( end = . );
-	PROVIDE ( _end = . );
-        _heap_start = .;    /* define a global symbol at heap start */
-        . = . + _minimum_heap_size;
-    } >RAM
-
-    /* this just checks there is enough RAM for the stack */
-    .stack :
-    {
-        . = ALIGN(4);
-        . = . + _minimum_stack_size;
-        . = ALIGN(4);
-    } >RAM
-
-    /* Remove information from the standard libraries */
-    /*
-    /DISCARD/ :
-    {
-        libc.a ( * )
-        libm.a ( * )
-        libgcc.a ( * )
-    }
-    */
-
-    .ARM.attributes 0 : { *(.ARM.attributes) }
-}

--- a/stmhal/boards/stm32f439.ld
+++ b/stmhal/boards/stm32f439.ld
@@ -19,110 +19,11 @@ _minimum_heap_size = 16K;
 /* top end of the stack */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
 
+/* define common sections and symbols */
+INCLUDE common.ld
+
 /* RAM extents for the garbage collector */
+_ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_heap_start = _ebss; /* heap starts just after statically allocated memory */
 _heap_end = 0x2002c000; /* tunable */
-
-/* define output sections */
-SECTIONS
-{
-    /* The startup code goes first into FLASH */
-    .isr_vector :
-    {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector)) /* Startup code */
-
-        . = ALIGN(4);
-    } >FLASH_ISR
-
-    /* The program code and other data goes into FLASH */
-    .text :
-    {
-        . = ALIGN(4);
-        *(.text)           /* .text sections (code) */
-        *(.text*)          /* .text* sections (code) */
-        *(.rodata)         /* .rodata sections (constants, strings, etc.) */
-        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
-    /*  *(.glue_7)   */    /* glue arm to thumb code */
-    /*  *(.glue_7t)  */    /* glue thumb to arm code */
-
-        . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
-    } >FLASH_TEXT
-
-    /*
-    .ARM.extab :
-    {
-        *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } >FLASH
-
-    .ARM :
-    {
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        __exidx_end = .;
-    } >FLASH
-    */
-
-    /* used by the startup to initialize data */
-    _sidata = LOADADDR(.data);
-
-    /* This is the initialized data section
-    The program executes knowing that the data is in the RAM
-    but the loader puts the initial values in the FLASH (inidata).
-    It is one task of the startup to copy the initial values from FLASH to RAM. */
-    .data :
-    {
-        . = ALIGN(4);
-        _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
-        _ram_start = .;    /* create a global symbol at ram start for garbage collector */
-        *(.data)           /* .data sections */
-        *(.data*)          /* .data* sections */
-
-        . = ALIGN(4);
-        _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM AT> FLASH_TEXT
-
-    /* Uninitialized data section */
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;         /* define a global symbol at bss start; used by startup code */
-        *(.bss)
-        *(.bss*)
-        *(COMMON)
-
-        . = ALIGN(4);
-        _ebss = .;         /* define a global symbol at bss end; used by startup code and GC */
-    } >RAM
-
-    /* this is to define the start of the heap, and make sure we have a minimum size */
-    .heap :
-    {
-        . = ALIGN(4);
-	PROVIDE ( end = . );
-	PROVIDE ( _end = . );
-        _heap_start = .;    /* define a global symbol at heap start */
-        . = . + _minimum_heap_size;
-    } >RAM
-
-    /* this just checks there is enough RAM for the stack */
-    .stack :
-    {
-        . = ALIGN(4);
-        . = . + _minimum_stack_size;
-        . = ALIGN(4);
-    } >RAM
-
-    /* Remove information from the standard libraries */
-    /*
-    /DISCARD/ :
-    {
-        libc.a ( * )
-        libm.a ( * )
-        libgcc.a ( * )
-    }
-    */
-
-    .ARM.attributes 0 : { *(.ARM.attributes) }
-}

--- a/stmhal/boards/stm32f746.ld
+++ b/stmhal/boards/stm32f746.ld
@@ -13,8 +13,6 @@ MEMORY
     RAM (xrw)       : ORIGIN = 0x20010000, LENGTH = 256K    /* SRAM1 = 240K, SRAM2 = 16K */
 }
 
-ENTRY(Reset_Handler)
-
 /* produce a link error if there is not this amount of RAM for these sections */
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
@@ -24,114 +22,11 @@ _minimum_heap_size = 16K;
    aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
 
+/* define common sections and symbols */
+INCLUDE common.ld
+
 /* RAM extents for the garbage collector */
+_ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_heap_start = _ebss; /* heap starts just after statically allocated memory */
 _heap_end = 0x2004c000; /* tunable */
-
-/* define output sections */
-SECTIONS
-{
-    /* The startup code goes first into FLASH */
-    .isr_vector :
-    {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector)) /* Startup code */
-
-        /* This first flash block is 16K annd the isr vectors only take up
-           about 400 bytes. So we pull in a couple of object files to pad it
-           out. */
-
-        . = ALIGN(4);
-        */ff.o(.text*)
-        */stm32f4xx_hal_sd.o(.text*)
-
-        . = ALIGN(4);
-    } >FLASH_ISR
-
-    /* The program code and other data goes into FLASH */
-    .text :
-    {
-        . = ALIGN(4);
-        *(.text*)          /* .text* sections (code) */
-        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
-    /*  *(.glue_7)   */    /* glue arm to thumb code */
-    /*  *(.glue_7t)  */    /* glue thumb to arm code */
-
-        . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
-    } >FLASH_TEXT
-
-    /*
-    .ARM.extab :
-    {
-        *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } >FLASH
-
-    .ARM :
-    {
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        __exidx_end = .;
-    } >FLASH
-    */
-
-    /* used by the startup to initialize data */
-    _sidata = LOADADDR(.data);
-
-    /* This is the initialized data section
-    The program executes knowing that the data is in the RAM
-    but the loader puts the initial values in the FLASH (inidata).
-    It is one task of the startup to copy the initial values from FLASH to RAM. */
-    .data :
-    {
-        . = ALIGN(4);
-        _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
-        _ram_start = .;    /* create a global symbol at ram start for garbage collector */
-        *(.data*)          /* .data* sections */
-
-        . = ALIGN(4);
-        _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM AT> FLASH_TEXT
-
-    /* Uninitialized data section */
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;         /* define a global symbol at bss start; used by startup code */
-        *(.bss*)
-        *(COMMON)
-
-        . = ALIGN(4);
-        _ebss = .;         /* define a global symbol at bss end; used by startup code and GC */
-    } >RAM
-
-    /* this is to define the start of the heap, and make sure we have a minimum size */
-    .heap :
-    {
-        . = ALIGN(4);
-        PROVIDE ( end = . );
-        PROVIDE ( _end = . );
-        _heap_start = .;    /* define a global symbol at heap start */
-        . = . + _minimum_heap_size;
-    } >RAM
-
-    /* this just checks there is enough RAM for the stack */
-    .stack :
-    {
-        . = ALIGN(4);
-        . = . + _minimum_stack_size;
-        . = ALIGN(4);
-    } >RAM
-
-    /* Remove information from the standard libraries */
-    /*
-    /DISCARD/ :
-    {
-        libc.a ( * )
-        libm.a ( * )
-        libgcc.a ( * )
-    }
-    */
-
-    .ARM.attributes 0 : { *(.ARM.attributes) }
-}

--- a/stmhal/boards/stm32l476xe.ld
+++ b/stmhal/boards/stm32l476xe.ld
@@ -13,8 +13,6 @@ MEMORY
     SRAM2 (xrw)     : ORIGIN = 0x10000000, LENGTH = 32K
 }
 
-ENTRY(Reset_Handler)
-
 /* produce a link error if there is not this amount of RAM for these sections */
 _minimum_stack_size = 2K;
 _minimum_heap_size = 16K;
@@ -24,111 +22,11 @@ _minimum_heap_size = 16K;
    aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
 
+/* define common sections and symbols */
+INCLUDE common.ld
+
 /* RAM extents for the garbage collector */
+_ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_heap_start = _ebss; /* heap starts just after statically allocated memory */
 _heap_end = 0x20014000; /* tunable */
-
-
-/* define output sections */
-SECTIONS
-{
-    /* The startup code goes first into FLASH */
-    .isr_vector :
-    {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector)) /* Startup code */
-
-        . = ALIGN(4);
-    } >FLASH_ISR
-   
-    /* The program code and other data goes into FLASH */
-    .text :
-    {
-        . = ALIGN(4);
-        *(.text)           /* .text sections (code) */
-        *(.text*)          /* .text* sections (code) */
-        *(.rodata)         /* .rodata sections (constants, strings, etc.) */
-        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
-    /*  *(.glue_7)   */    /* glue arm to thumb code */
-    /*  *(.glue_7t)  */    /* glue thumb to arm code */
-
-        . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
-    } >FLASH_TEXT
-     
-    /*
-    .ARM.extab :
-    {
-        *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } >FLASH
-
-    .ARM :
-    {
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        __exidx_end = .;
-    } >FLASH
-    */
-        
-    /* used by the startup to initialize data */
-    _sidata = LOADADDR(.data);
-        
-    /* This is the initialized data section
-    The program executes knowing that the data is in the RAM
-    but the loader puts the initial values in the FLASH (inidata).
-    It is one task of the startup to copy the initial values from FLASH to RAM. */
-    .data :
-    {
-        . = ALIGN(4);
-        _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
-        _ram_start = .;    /* create a global symbol at ram start for garbage collector */
-        *(.data)           /* .data sections */
-        *(.data*)          /* .data* sections */
-
-        . = ALIGN(4);
-        _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM AT> FLASH_TEXT
-            
-    /* Uninitialized data section */
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;         /* define a global symbol at bss start; used by startup code */
-        *(.bss)
-        *(.bss*)
-        *(COMMON)
-
-        . = ALIGN(4);
-        _ebss = .;         /* define a global symbol at bss end; used by startup code and GC */
-    } >RAM
-
-    /* this is to define the start of the heap, and make sure we have a minimum size */
-    .heap :
-    {
-        . = ALIGN(4);
-        PROVIDE ( end = . );
-        PROVIDE ( _end = . );
-        _heap_start = .;    /* define a global symbol at heap start */
-        . = . + _minimum_heap_size;
-    } >RAM
-
-    /* this just checks there is enough RAM for the stack */
-    .stack :
-    {
-        . = ALIGN(4);
-        . = . + _minimum_stack_size;
-        . = ALIGN(4);
-    } >RAM
-
-    /* Remove information from the standard libraries */
-    /*
-    /DISCARD/ :
-    {
-        libc.a ( * )
-        libm.a ( * )
-        libgcc.a ( * )
-    }
-    */
-
-    .ARM.attributes 0 : { *(.ARM.attributes) }
-}

--- a/stmhal/boards/stm32l476xg.ld
+++ b/stmhal/boards/stm32l476xg.ld
@@ -24,111 +24,11 @@ _minimum_heap_size = 16K;
    aligned for a call. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
 
+/* define common sections and symbols */
+INCLUDE common.ld
+
 /* RAM extents for the garbage collector */
+_ram_start = ORIGIN(RAM);
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_heap_start = _ebss; /* heap starts just after statically allocated memory */
 _heap_end = 0x20014000; /* tunable */
-
-
-/* define output sections */
-SECTIONS
-{
-    /* The startup code goes first into FLASH */
-    .isr_vector :
-    {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector)) /* Startup code */
-
-        . = ALIGN(4);
-    } >FLASH_ISR
-   
-    /* The program code and other data goes into FLASH */
-    .text :
-    {
-        . = ALIGN(4);
-        *(.text)           /* .text sections (code) */
-        *(.text*)          /* .text* sections (code) */
-        *(.rodata)         /* .rodata sections (constants, strings, etc.) */
-        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
-    /*  *(.glue_7)   */    /* glue arm to thumb code */
-    /*  *(.glue_7t)  */    /* glue thumb to arm code */
-
-        . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
-    } >FLASH_TEXT
-     
-    /*
-    .ARM.extab :
-    {
-        *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } >FLASH
-
-    .ARM :
-    {
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        __exidx_end = .;
-    } >FLASH
-    */
-        
-    /* used by the startup to initialize data */
-    _sidata = LOADADDR(.data);
-        
-    /* This is the initialized data section
-    The program executes knowing that the data is in the RAM
-    but the loader puts the initial values in the FLASH (inidata).
-    It is one task of the startup to copy the initial values from FLASH to RAM. */
-    .data :
-    {
-        . = ALIGN(4);
-        _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
-        _ram_start = .;    /* create a global symbol at ram start for garbage collector */
-        *(.data)           /* .data sections */
-        *(.data*)          /* .data* sections */
-
-        . = ALIGN(4);
-        _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM AT> FLASH_TEXT
-            
-    /* Uninitialized data section */
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;         /* define a global symbol at bss start; used by startup code */
-        *(.bss)
-        *(.bss*)
-        *(COMMON)
-
-        . = ALIGN(4);
-        _ebss = .;         /* define a global symbol at bss end; used by startup code and GC */
-    } >RAM
-
-    /* this is to define the start of the heap, and make sure we have a minimum size */
-    .heap :
-    {
-        . = ALIGN(4);
-        PROVIDE ( end = . );
-        PROVIDE ( _end = . );
-        _heap_start = .;    /* define a global symbol at heap start */
-        . = . + _minimum_heap_size;
-    } >RAM
-
-    /* this just checks there is enough RAM for the stack */
-    .stack :
-    {
-        . = ALIGN(4);
-        . = . + _minimum_stack_size;
-        . = ALIGN(4);
-    } >RAM
-
-    /* Remove information from the standard libraries */
-    /*
-    /DISCARD/ :
-    {
-        libc.a ( * )
-        libm.a ( * )
-        libgcc.a ( * )
-    }
-    */
-
-    .ARM.attributes 0 : { *(.ARM.attributes) }
-}


### PR DESCRIPTION
FLASH/RAM memory layout is exactly the same for all boards, they differ only in capacities, starting addresses and heap location.
