### PR TITLE
extmod/modubinascii: Fix crc32() function on 32-bit platforms.

### DIFF
--- a/extmod/modubinascii.c
+++ b/extmod/modubinascii.c
@@ -208,9 +208,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(mod_binascii_b2a_base64_obj, mod_binascii_b2a_base64);
 mp_obj_t mod_binascii_crc32(size_t n_args, const mp_obj_t *args) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);
-    uint32_t crc = (n_args > 1) ? mp_obj_get_int(args[1]) : 0;
+    uint32_t crc = (n_args > 1) ? mp_obj_get_int_truncated(args[1]) : 0;
     crc = uzlib_crc32(bufinfo.buf, bufinfo.len, crc ^ 0xffffffff);
-    return MP_OBJ_NEW_SMALL_INT(crc ^ 0xffffffff);
+    return mp_obj_new_int_from_uint(crc ^ 0xffffffff);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_binascii_crc32_obj, 1, 2, mod_binascii_crc32);
 #endif


### PR DESCRIPTION
ubinascii.crc32() implementation fails on 32-bit platforms

When uPy is build using MICROPY_FORCE_32BIT=1 function ubinascii.crc32() fails the unit test in `tests/extmod/ubinascii_crc32.py`.

result:

```
-0x3eb05cc7
0x190a55ad
-0x9354f5
0x11267e8a
-0x3eb05cc7
0x190a55ad
-0x9354f5
0x11267e8a
```

expected:

```
0x414fa339
0x190a55ad
0xff6cab0b
0x91267e8a
0x414fa339
0x190a55ad
0xff6cab0b
0x91267e8a
```

Everything works when uPy is built in 64-bit mode.

The proposed change fixes the issue on 32-bit platforms.
