### PR TITLE
stmhal: automatically calculate which objects will fit in FLASH_ISR [RFC]

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -34,6 +34,14 @@ STFLASH ?= st-flash
 OPENOCD ?= openocd
 OPENOCD_CONFIG ?= boards/openocd_stm32f4.cfg
 
+SECTOR_SIZE ?= 16384
+ifeq ($(MCU_SERIES), l4)
+SECTOR_SIZE = 2048
+endif
+ifeq ($(MCU_SERIES), f7)
+SECTOR_SIZE = 32768
+endif
+
 CROSS_COMPILE = arm-none-eabi-
 
 INC += -I.
@@ -60,7 +68,7 @@ CFLAGS += $(COPT)
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += -DSTM32_HAL_H='<stm32$(MCU_SERIES)xx_hal.h>'
 
-LDFLAGS = -nostdlib -L $(LD_DIR) -T $(LD_FILE) -Map=$(@:.elf=.map) --cref
+LDFLAGS = -nostdlib -L$(BUILD)/genhdr -L$(LD_DIR) -T$(LD_FILE)
 LIBS =
 
 # Remove uncalled code from the final image.
@@ -260,13 +268,6 @@ OBJ += $(addprefix $(BUILD)/, $(SRC_USBDEV:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_MOD:.c=.o))
 OBJ += $(BUILD)/pins_$(BOARD).o
 
-# We put ff.o and stm32f4xx_hal_sd.o into the first 16K section with the ISRs.
-# If we compile these using -O0 then it won't fit. So if you really want these
-# to be compiled with -O0, then edit stm32f405.ld (in the .isr_vector section)
-# and comment out the following 2 lines.
-$(BUILD)/$(FATFS_DIR)/ff.o: COPT += -Os
-$(BUILD)/$(HAL_DIR)/src/stm32$(MCU_SERIES)xx_hal_sd.o: COPT += -Os
-
 all: $(BUILD)/firmware.dfu $(BUILD)/firmware.hex
 
 ifneq ($(FROZEN_DIR),)
@@ -333,9 +334,17 @@ $(BUILD)/firmware.hex: $(BUILD)/firmware.elf
 	$(ECHO) "Create $@"
 	$(Q)$(OBJCOPY) -O ihex $< $@
 
+$(BUILD)/genhdr/isr.ld: $(OBJ)
+	$(ECHO) "Create $@"
+	$(Q)touch $(BUILD)/genhdr/isr.ld
+	$(Q)$(LD) $(LDFLAGS) --print-gc-sections -o /tmp/a.out $^ 2>&1 > /dev/null \
+		| awk '{print $$5}' | sed s/\'//g > $(BUILD)/discarded.txt
+	$(Q)$(PYTHON) objfit.py -s $(SECTOR_SIZE) -d $(BUILD)/discarded.txt $^ > $@
+
+$(BUILD)/firmware.elf: |$(BUILD)/genhdr/isr.ld
 $(BUILD)/firmware.elf: $(OBJ)
 	$(ECHO) "LINK $@"
-	$(Q)$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
+	$(Q)$(LD) $(LDFLAGS) -Map=$(@:.elf=.map) --cref -o $@ $^ $(LIBS)
 	$(Q)$(SIZE) $@
 
 MAKE_PINS = boards/make-pins.py

--- a/stmhal/boards/common.ld
+++ b/stmhal/boards/common.ld
@@ -14,8 +14,7 @@ SECTIONS
            out. */
 
         . = ALIGN(4);
-        */ff.o(.text*)
-        */stm32f4xx_hal_sd.o(.text*)
+       INCLUDE isr.ld
 
         . = ALIGN(4);
     } >FLASH_ISR

--- a/stmhal/objfit.py
+++ b/stmhal/objfit.py
@@ -1,0 +1,71 @@
+from __future__ import print_function
+import subprocess
+import argparse
+import os
+import re
+from itertools import chain
+
+SIZE = 'arm-none-eabi-size'
+
+def find_best_fit(it, capacity):
+    items = sorted(it, key=lambda x: x[1])
+    total = 0
+    while True:
+        will_fit = [o for o in items if total + o[1] <= capacity]
+        if will_fit == []:
+            break
+        o = will_fit[-1]  # biggest fitting object
+        total += o[1]
+        items.remove(o)
+        yield o
+
+
+def get_sections_size(filename, regex):
+    """return combined size of all sections matching <regex> from <filename>"""
+    return sum(x[1] for x in get_sections(filename, regex))
+
+
+def get_sections(filename, regex):
+    """return all sections from <filename> with name matching <regex>"""
+    output = subprocess.check_output([SIZE, '-A', filename])
+    def parse_line(line):
+        name, size_str = line.split()[:2]
+        size = int(size_str)
+        # align to a word size
+        if size % 4:
+            size += 4 - (size % 4)
+        return name, size
+    return (parse_line(line) for line in output.splitlines() if regex.match(line))
+
+
+def main():
+    cmd_parser = argparse.ArgumentParser(description="Find best matching sections that can fit into first FLASH sector.")
+    cmd_parser.add_argument('-s', '--sector-size', type=int, action='store', help='size of FLASH sector')
+    cmd_parser.add_argument('-d', '--discard', action='store', help='list of discarded sections')
+    cmd_parser.add_argument('files', nargs="+", action='store', help='input files')
+    args = cmd_parser.parse_args()
+
+    try:
+        startup = [f for f in args.files if f.endswith('startup_stm32.o')][0]
+        capacity = args.sector_size - get_sections_size(startup, re.compile(r'\.isr_vector'))
+    except IndexError:
+        raise ValueError('section ".isr_vector" not found')
+
+    # find all .text.* sections
+    re_text = re.compile(r'\.text\.')
+    objects = chain.from_iterable(get_sections(f, re_text) for f in args.files)
+
+    # filter out sections discarded by linker
+    if args.discard:
+        with open(args.discard) as h:
+            discarded = set(h.read().splitlines())
+            objects = filter(lambda o: o[0] not in discarded, objects)
+
+    # find which sections will best fit into 'capacity'
+    # print linker script entries to stdout
+    for obj in find_best_fit(objects, capacity):
+        print('*(%s)  /* %d bytes */' % obj)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I have noticed that 9310dad broke build for L4 series MCU, we get following linker error:

```
arm-none-eabi-ld: build-LIMIFROG/firmware.elf section `.isr_vector' will not fit in region `FLASH_ISR'
arm-none-eabi-ld: region `FLASH_ISR' overflowed by 8332 bytes
```

The problem is in definition of this section in `common.ld`:

```
    /* The startup code goes first into FLASH */
    .isr_vector :
    {
        . = ALIGN(4);
        KEEP(*(.isr_vector)) /* Startup code */

        /* This first flash block is 16K annd the isr vectors only take up
           about 400 bytes. So we pull in a couple of object files to pad it
           out. */

        . = ALIGN(4);
        */ff.o(.text*)
        */stm32f4xx_hal_sd.o(.text*)

        . = ALIGN(4);
    } >FLASH_ISR
```

I have copied it from stm32f405.ld and it worked for it very nicely because stm32f4 series have sector of size 16 K and those two files after optimization fit there almost ideally.

Unfortunately same code won't work on stm32f2 because it has only 2 K per sector (and FLASH_ISR should always take single sector) and thus after rejecting `stm32f4xx_hal_sd.o` which doesn't exist for this board we try to fit large `ff.o`  object into ~1.6 K of space left inside `.isr_vector` section and we get the overflow error.

As I feel responsible for introducing this bug, I have came up with a solution.

Instead of manually finding best fitting objects which can be placed inside the space left in first sector I found a way to do it automatically on each build.

After compilation I use `objfit.py` to create a fragment of a linker script `$(BUILD)/genhdr/isr.ld` which gets included into common.ld inside `.isr_vector` section.

Example of generated `isr.ld` contents for PYBV10:

```
*(.text.mp_execute_bytecode)  /* 3896 bytes */
*(.text.HAL_DMA_IRQHandler)  /* 2564 bytes */
*(.text.emit_inline_thumb_op)  /* 2408 bytes */
*(.text.f_mkfs)  /* 1644 bytes */
*(.text.mp_lexer_next_token_into)  /* 1568 bytes */
*(.text.__ieee754_lgammaf_r)  /* 1544 bytes */
*(.text.mp_obj_str_format_helper)  /* 1472 bytes */
*(.text.HAL_DMA_DeInit)  /* 888 bytes */
*(.text.USBD_CDC_MSC_HID_GetDeviceQualifierDescriptor)  /* 8 bytes */
```

And related fragment of firmware.map after linking:

```
.isr_vector     0x0000000008000000     0x4000
                0x0000000008000000                . = ALIGN (0x4)
 *(.isr_vector)
 .isr_vector    0x0000000008000000      0x188 build-PYBV10/startup_stm32.o
                0x0000000008000000                g_pfnVectors
                0x0000000008000188                . = ALIGN (0x4)
 *(.text.mp_execute_bytecode)
 .text.mp_execute_bytecode
                0x0000000008000188      0xf38 build-PYBV10/py/vm.o
                0x0000000008000188                mp_execute_bytecode
 *(.text.HAL_DMA_IRQHandler)
 .text.HAL_DMA_IRQHandler
                0x00000000080010c0      0xa04 build-PYBV10/hal/f4/src/stm32f4xx_hal_dma.o
                0x00000000080010c0                HAL_DMA_IRQHandler
 *(.text.emit_inline_thumb_op)
 .text.emit_inline_thumb_op
                0x0000000008001ac4      0x968 build-PYBV10/py/emitinlinethumb.o
 *(.text.f_mkfs)
 .text.f_mkfs   0x000000000800242c      0x66c build-PYBV10/lib/fatfs/ff.o
                0x000000000800242c                f_mkfs
 *(.text.mp_lexer_next_token_into)
 .text.mp_lexer_next_token_into
                0x0000000008002a98      0x620 build-PYBV10/py/lexer.o
 *(.text.__ieee754_lgammaf_r)
 .text.__ieee754_lgammaf_r
                0x00000000080030b8      0x608 build-PYBV10/lib/libm/erf_lgamma.o
                0x00000000080030b8                __ieee754_lgammaf_r
 *(.text.mp_obj_str_format_helper)
 .text.mp_obj_str_format_helper
                0x00000000080036c0      0x5c0 build-PYBV10/py/objstr.o
 *(.text.HAL_DMA_DeInit)
 .text.HAL_DMA_DeInit
                0x0000000008003c80      0x378 build-PYBV10/hal/f4/src/stm32f4xx_hal_dma.o
                0x0000000008003c80                HAL_DMA_DeInit
 *(.text.USBD_CDC_MSC_HID_GetDeviceQualifierDescriptor)
 .text.USBD_CDC_MSC_HID_GetDeviceQualifierDescriptor
                0x0000000008003ff8        0x8 build-PYBV10/usbdev/class/src/usbd_cdc_msc_hid.o
                0x0000000008003ff8                USBD_CDC_MSC_HID_GetDeviceQualifierDescriptor
                0x0000000008004000                . = ALIGN (0x4)
```

I have decided to use objects not entire files because it gives better granularity and we already use '-ffunction-sections' and '-fdata-sections' so why not?

The biggest problem I couldn't come around is that in order to find discarded sections I need to link executable twice - first to find the discarded sections (output is stored in /tmp/a.out) and second to create final executable with properly linked sections.

It seems to work well, `.isr_vector` gets completely filled for f4, l4 and f7 boards without overflow.
Also despite linking twice, build process doesn't take noticeably longer time.

This is not a complete PR it is more a RFC on the general idea.
