### PR TITLE
esp8266/Makefile: flash options for deploy

### DIFF
--- a/esp8266/Makefile
+++ b/esp8266/Makefile
@@ -18,6 +18,8 @@ FROZEN_DIR = scripts
 FROZEN_MPY_DIR = modules
 PORT ?= /dev/ttyACM0
 BAUD ?= 115200
+FLASH_MODE ?= qio
+FLASH_SIZE ?= 8m
 CROSS_COMPILE = xtensa-lx106-elf-
 ESP_SDK = $(shell $(CC) -print-sysroot)/usr
 
@@ -188,7 +190,7 @@ $(BUILD)/frozen_mpy.c: $(FROZEN_MPY_MPY_FILES) $(BUILD)/genhdr/qstrdefs.generate
 
 deploy: $(BUILD)/firmware-combined.bin
 	$(ECHO) "Writing $< to the board"
-	$(Q)esptool.py --port $(PORT) --baud $(BAUD) write_flash --verify --flash_size=8m 0 $<
+	$(Q)esptool.py --port $(PORT) --baud $(BAUD) write_flash --verify --flash_size=$(FLASH_SIZE) --flash_mode=$(FLASH_MODE) 0 $<
 	#$(Q)esptool.py --port $(PORT) --baud $(BAUD) write_flash --flash_size=8m 0 $(BUILD)/firmware.elf-0x00000.bin 0x9000 $(BUILD)/firmware.elf-0x0[1-f]000.bin
 
 reset:

--- a/esp8266/README.md
+++ b/esp8266/README.md
@@ -70,9 +70,10 @@ $ make deploy
 ```
 This will use the `esptool.py` script to download the images.  You must have
 your ESP module in the bootloader mode, and connected to a serial port on your PC.
-The default serial port is `/dev/ttyACM0`.  To specify another, use, eg:
+The default serial port is `/dev/ttyACM0`, flash mode is `qio` and flash size is `8m`.
+To specify other values, use, eg:
 ```bash
-$ make PORT=/dev/ttyUSB0 deploy
+$ make PORT=/dev/ttyUSB0 FLASH_MODE=qio FLASH_SIZE=8m deploy
 ```
 
 The image produced is `firmware-combined.bin`, to be flashed at 0x00000.


### PR DESCRIPTION
Added options to `make deploy` so can be used in ESP8266 boards with other flash configuration.
For example NodeMCU DEVKIT V1.0 needs `make FLASH_MODE=dio FLASH_SIZE=32m deploy`.
