### PR TITLE
stmhal: Add virtual com port support for STM32L476DISC.

### DIFF
--- a/stmhal/boards/STM32L476DISC/mpconfigboard.h
+++ b/stmhal/boards/STM32L476DISC/mpconfigboard.h
@@ -29,6 +29,10 @@
 #define MICROPY_HW_UART2_PORT (GPIOD)
 #define MICROPY_HW_UART2_PINS (GPIO_PIN_5 | GPIO_PIN_6)
 
+// USART 2 is connected to the virtual com port on the ST-LINK
+#define MICROPY_HW_UART_REPL        PYB_UART_2
+#define MICROPY_HW_UART_REPL_BAUD   115200
+
 // I2C busses
 #define MICROPY_HW_I2C1_SCL (pin_B6)
 #define MICROPY_HW_I2C1_SDA (pin_B7)


### PR DESCRIPTION
Like many other STM32 development boards, the STM32L476DISC board has a USART which is connected to the ST-LINK virtual com interface. This change enables access to the REPL through the virtual com port on the ST-LINK similar to what is already enabled for the several other STM32 boards such as the STM32F7DISC.
