### PR TITLE
extmod/vfs_fat: Checks for remove() and rmdir().

### DIFF
--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include "py/nlr.h"
 #include "py/runtime.h"
+#include "py/mperrno.h"
 #include "lib/fatfs/ff.h"
 #include "lib/fatfs/diskio.h"
 #include "extmod/vfs_fat_file.h"
@@ -76,24 +77,44 @@ STATIC mp_obj_t fat_vfs_listdir_func(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(fat_vfs_listdir_obj, 1, 2, fat_vfs_listdir_func);
 
+STATIC mp_obj_t fat_vfs_remove_internal(const char* path, mp_int_t attr) {
+    FILINFO fno;
+#if _USE_LFN
+    fno.lfname = NULL;
+    fno.lfsize = 0;
+#endif
+    FRESULT res = f_stat(path, &fno);
+
+    if (FR_OK != res) {
+        mp_raise_OSError(fresult_to_errno_table[res]);
+    }
+
+    // check if path is a file or directory
+    if ((fno.fattrib & AM_DIR) == attr) {
+        res = f_unlink(path);
+
+        if (FR_OK != res) {
+            mp_raise_OSError(fresult_to_errno_table[res]);
+        }
+        return mp_const_none;
+    } else {
+        mp_raise_OSError(attr ? MP_ENOTDIR : MP_EISDIR);
+    }
+}
+
 STATIC mp_obj_t fat_vfs_remove(mp_obj_t vfs_in, mp_obj_t path_in) {
     (void)vfs_in;
     const char *path = mp_obj_str_get_str(path_in);
-    // TODO check that path is actually a file before trying to unlink it
-    FRESULT res = f_unlink(path);
-    if (res == FR_OK) {
-        return mp_const_none;
-    } else {
-        mp_raise_OSError(fresult_to_errno_table[res]);
-    }
+
+    return fat_vfs_remove_internal(path, 0); // 0 == file attribute
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_remove_obj, fat_vfs_remove);
 
 STATIC mp_obj_t fat_vfs_rmdir(mp_obj_t vfs_in, mp_obj_t path_in) {
-    // TODO: Currently just redirects to fat_vfs_remove(), which are
-    // backed by the same underlying FatFs function. Should at least
-    // check that path is actually a dir.
-    return fat_vfs_remove(vfs_in, path_in);
+    (void) vfs_in;
+    const char *path = mp_obj_str_get_str(path_in);
+
+    return fat_vfs_remove_internal(path, AM_DIR);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_rmdir_obj, fat_vfs_rmdir);
 

--- a/tests/extmod/vfs_fat_ramdisk.py.exp
+++ b/tests/extmod/vfs_fat_ramdisk.py.exp
@@ -1,5 +1,10 @@
 statvfs: (512, 512, 14, 14, 14, 0, 0, 0, 0, 255)
 getcwd: /ramdisk
 hello!
+True
+True
 getcwd: /ramdisk/foo_dir
+True
 getcwd: /ramdisk
+True
+['moved-to-root.txt']


### PR DESCRIPTION
Please note, I haven't run the tests on this yet.
I noticed the TODOs when I was working on the last PR.

I've split the unlink function to avoid repeating the code. From what I see, there is no fatfs attribute that tells us it's a file, i.e if it's not a directory it's a file ([example of readdir()](http://elm-chan.org/fsw/ff/en/readdir.html)).

I am planning to continue to improve the coverage of vfs_fat.c after this approved/discarded.
