### PR TITLE
stmhal: Disable network and usocket for ESPRUINO_PICO

### DIFF
--- a/stmhal/boards/ESPRUINO_PICO/mpconfigboard.h
+++ b/stmhal/boards/ESPRUINO_PICO/mpconfigboard.h
@@ -2,6 +2,9 @@
 #define MICROPY_HW_MCU_NAME         "STM32F401CD"
 #define MICROPY_PY_SYS_PLATFORM     "pyboard"
 
+#define MICROPY_PY_USOCKET          (0)
+#define MICROPY_PY_NETWORK          (0)
+
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_FLASH        (1)
 #define MICROPY_HW_HAS_SDCARD       (0)

--- a/stmhal/main.c
+++ b/stmhal/main.c
@@ -586,7 +586,9 @@ soft_reset:
     dac_init();
 #endif
 
+#if MICROPY_PY_NETWORK
     mod_network_init();
+#endif
 
     // At this point everything is fully configured and initialised.
 

--- a/stmhal/modnetwork.c
+++ b/stmhal/modnetwork.c
@@ -28,6 +28,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "py/mpconfig.h"
+
+#if MICROPY_PY_NETWORK
+
 #include "py/nlr.h"
 #include "py/objlist.h"
 #include "py/runtime.h"
@@ -88,3 +92,5 @@ const mp_obj_module_t mp_module_network = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_network_globals,
 };
+
+#endif  // MICROPY_PY_NETWORK

--- a/stmhal/modusocket.c
+++ b/stmhal/modusocket.c
@@ -27,6 +27,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "py/mpconfig.h"
+
+#if MICROPY_PY_USOCKET
+
 #include "py/nlr.h"
 #include "py/objtuple.h"
 #include "py/objlist.h"
@@ -446,3 +450,5 @@ const mp_obj_module_t mp_module_usocket = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_usocket_globals,
 };
+
+#endif  // MICROPY_PY_USOCKET

--- a/stmhal/mpconfigport.h
+++ b/stmhal/mpconfigport.h
@@ -28,6 +28,9 @@
 #ifndef __INCLUDED_MPCONFIGPORT_H
 #define __INCLUDED_MPCONFIGPORT_H
 
+// board specific definitions
+#include "mpconfigboard.h"
+
 // options to control how Micro Python is built
 
 #define MICROPY_ALLOC_PATH_MAX      (128)
@@ -97,6 +100,14 @@
 #define MICROPY_PY_MACHINE_SPI_MIN_DELAY (0)
 #define MICROPY_PY_FRAMEBUF         (1)
 
+#ifndef MICROPY_PY_USOCKET
+#define MICROPY_PY_USOCKET          (1)
+#endif
+
+#ifndef MICROPY_PY_NETWORK
+#define MICROPY_PY_NETWORK          (1)
+#endif
+
 #define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF   (1)
 #define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE  (0)
 
@@ -122,6 +133,20 @@ extern const struct _mp_obj_module_t mp_module_uselect;
 extern const struct _mp_obj_module_t mp_module_usocket;
 extern const struct _mp_obj_module_t mp_module_network;
 
+#if MICROPY_PY_USOCKET
+#define SOCKET_BUILTIN_MODULE               { MP_OBJ_NEW_QSTR(MP_QSTR_usocket), (mp_obj_t)&mp_module_usocket },
+#define SOCKET_BUILTIN_MODULE_WEAK_LINKS    { MP_OBJ_NEW_QSTR(MP_QSTR_socket), (mp_obj_t)&mp_module_usocket },
+#else
+#define SOCKET_BUILTIN_MODULE
+#define SOCKET_BUILTIN_MODULE_WEAK_LINKS
+#endif
+
+#if MICROPY_PY_NETWORK
+#define NETWORK_BUILTIN_MODULE              { MP_OBJ_NEW_QSTR(MP_QSTR_network), (mp_obj_t)&mp_module_network },
+#else
+#define NETWORK_BUILTIN_MODULE
+#endif
+
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_OBJ_NEW_QSTR(MP_QSTR_umachine), (mp_obj_t)&machine_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_pyb), (mp_obj_t)&pyb_module }, \
@@ -129,8 +154,8 @@ extern const struct _mp_obj_module_t mp_module_network;
     { MP_OBJ_NEW_QSTR(MP_QSTR_uos), (mp_obj_t)&mp_module_uos }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_utime), (mp_obj_t)&mp_module_utime }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_uselect), (mp_obj_t)&mp_module_uselect }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_usocket), (mp_obj_t)&mp_module_usocket }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_network), (mp_obj_t)&mp_module_network }, \
+    SOCKET_BUILTIN_MODULE \
+    NETWORK_BUILTIN_MODULE \
 
 #define MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS \
     { MP_OBJ_NEW_QSTR(MP_QSTR_binascii), (mp_obj_t)&mp_module_ubinascii }, \
@@ -142,7 +167,7 @@ extern const struct _mp_obj_module_t mp_module_network;
     { MP_OBJ_NEW_QSTR(MP_QSTR_os), (mp_obj_t)&mp_module_uos }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_time), (mp_obj_t)&mp_module_utime }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_select), (mp_obj_t)&mp_module_uselect }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_socket), (mp_obj_t)&mp_module_usocket }, \
+    SOCKET_BUILTIN_MODULE_WEAK_LINKS \
     { MP_OBJ_NEW_QSTR(MP_QSTR_struct), (mp_obj_t)&mp_module_ustruct }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_machine), (mp_obj_t)&machine_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_errno), (mp_obj_t)&mp_module_uerrno }, \
@@ -243,9 +268,6 @@ static inline mp_uint_t disable_irq(void) {
 // at the moment only USB_FS is supported
 #define USE_DEVICE_MODE
 //#define USE_HOST_MODE
-
-// board specific definitions
-#include "mpconfigboard.h"
 
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>


### PR DESCRIPTION
This turns off modusocket and modnetwork for the ESPRUINO_PICO. This reduces the image size by 2.2K
