### PR TITLE
tests: Fix expected output of verbose cmdline test

### DIFF
--- a/tests/cmdline/cmd_showbc.py.exp
+++ b/tests/cmdline/cmd_showbc.py.exp
@@ -27,8 +27,7 @@ arg names:
 File cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ bytes)
 Raw bytecode (code_info_size=\\d\+, bytecode_size=\\d\+):
 ########
-\.\+5b
-arg names:
+\.\+rg names:
 (N_STATE 22)
 (N_EXC_STACK 2)
 (INIT_CELL 14)

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -267,7 +267,6 @@ def run_tests(pyb, tests, args):
     # Some tests use unsupported features on Windows
     if os.name == 'nt':
         skip_tests.add('import/import_file.py') # works but CPython prints forward slashes
-        skip_tests.add('cmdline/cmd_showbc.py') # fails on AppVeyor x86 builds
 
     # Some tests are known to fail with native emitter
     # Remove them from the below when they work


### PR DESCRIPTION
The output might contain more than one line ending in 5b so properly skip
everything until the next known point.
This fixes test failures in appveyor debug builds.

see https://github.com/micropython/micropython/commit/bb954d80a4bd467fc321df90cea2b248a90d1570 as well
