### PR TITLE
py/modmicropython: Add micropython.opt_level([value]) function.

### DIFF
--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -34,6 +34,16 @@
 // Various builtins specific to MicroPython runtime,
 // living in micropython module
 
+STATIC mp_obj_t mp_micropython_opt_level(size_t n_args, const mp_obj_t *args) {
+    if (n_args == 0) {
+        return MP_OBJ_NEW_SMALL_INT(MP_STATE_VM(mp_optimise_value));
+    } else {
+        MP_STATE_VM(mp_optimise_value) = mp_obj_get_int(args[0]);
+        return mp_const_none;
+    }
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_micropython_opt_level_obj, 0, 1, mp_micropython_opt_level);
+
 #if MICROPY_PY_MICROPYTHON_MEM_INFO
 
 #if MICROPY_MEM_STATS
@@ -121,6 +131,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_alloc_emergency_exception_buf_obj, mp_alloc_
 STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_micropython) },
     { MP_ROM_QSTR(MP_QSTR_const), MP_ROM_PTR(&mp_identity_obj) },
+    { MP_ROM_QSTR(MP_QSTR_opt_level), MP_ROM_PTR(&mp_micropython_opt_level_obj) },
 #if MICROPY_PY_MICROPYTHON_MEM_INFO
 #if MICROPY_MEM_STATS
     { MP_ROM_QSTR(MP_QSTR_mem_total), MP_ROM_PTR(&mp_micropython_mem_total_obj) },


### PR DESCRIPTION
CPython has no way to control/change the optimisation level at runtime.  It can only be done at the command line using -O.  I discussed a bit upstream about adding such runtime functionality, because it would be useful in uPy to control this value (otherwise it's hardcoded in the firmware).  The first message is https://mail.python.org/pipermail/python-ideas/2016-September/042213.html and the "resolution" is https://mail.python.org/pipermail/python-ideas/2016-September/042313.html

See also #2329.

This PR allows to get/set at runtime the optimisation level of the compiler.

Eg:

```
import micropython as mp
exec('print(__debug__)') # prints True
mp.opt_level(1)
exec('print(__debug__)') # prints False
```

In "production" mode you can set a high optimsation level to save some RAM, for example.
