### PR TITLE
extmod/machine_i2c: Use writes not reads in i2c.scan

### DIFF
--- a/extmod/machine_i2c.c
+++ b/extmod/machine_i2c.c
@@ -272,7 +272,7 @@ STATIC mp_obj_t machine_i2c_scan(mp_obj_t self_in) {
     // 7-bit addresses 0b0000xxx and 0b1111xxx are reserved
     for (int addr = 0x08; addr < 0x78; ++addr) {
         mp_hal_i2c_start(self);
-        int ack = mp_hal_i2c_write_byte(self, (addr << 1) | 1);
+        int ack = mp_hal_i2c_write_byte(self, (addr << 1));
         if (ack) {
             mp_obj_list_append(list, MP_OBJ_NEW_SMALL_INT(addr));
         }


### PR DESCRIPTION
As per discussion in #2449, using write requests instead of read requests for `I2C.scan()` seems to support a larger number of devices (especially ones that are write-only) and to be more compatible with what the hardware i2c on PyBoard does.

I have tested this change with a number of I²C devices I have at hand:
- SSD1306 OLED display (address 60)
- HT16K33 LED Matrix (address 112)
- Atmega328p running in slave mode using Arduino's `<Wire.h>` library (address 9)
- WeMos D1 Mini Motor shield (address 48)

Especially the last device is problematic, as it pulls down the data line as soon as it encounters any errors in the transmission. Thus, with all four devices connected to the same bus, the "read" scan results in:

```
>>> i2c.scan()
[9, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119]
```

Using writes seems to be more robust, as even a read-only I²C device has to implement writes in order to be able to receive the address of the register to read. Using writes, with the same four devices on the bus, the result is:

```
>>> i2c.scan()
[9, 48, 60, 112]
```
