### PR TITLE
stmhal: Add OpenOCD configuration for STM32L4.

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -317,23 +317,24 @@ else
 	$(Q)$(DFU_UTIL) -a 0 -d $(DEVICE) -D $<
 endif
 
+FLASH_ADDR ?= 0x08000000
 TEXT_ADDR ?= 0x08020000
 
 deploy-stlink: $(BUILD)/firmware.dfu
 	$(ECHO) "Writing $(BUILD)/firmware0.bin to the board via ST-LINK"
-	$(Q)$(STFLASH) write $(BUILD)/firmware0.bin 0x08000000
+	$(Q)$(STFLASH) write $(BUILD)/firmware0.bin $(FLASH_ADDR)
 	$(ECHO) "Writing $(BUILD)/firmware1.bin to the board via ST-LINK"
 	$(Q)$(STFLASH) --reset write $(BUILD)/firmware1.bin $(TEXT_ADDR)
 
 deploy-openocd: $(BUILD)/firmware.dfu
 	$(ECHO) "Writing $(BUILD)/firmware{0,1}.bin to the board via ST-LINK using OpenOCD"
-	$(Q)$(OPENOCD) -f $(OPENOCD_CONFIG) -c "stm_flash $(BUILD)/firmware0.bin $(BUILD)/firmware1.bin"
+	$(Q)$(OPENOCD) -f $(OPENOCD_CONFIG) -c "stm_flash $(BUILD)/firmware0.bin $(FLASH_ADDR) $(BUILD)/firmware1.bin $(TEXT_ADDR)"
 
 $(BUILD)/firmware.dfu: $(BUILD)/firmware.elf
 	$(ECHO) "Create $@"
 	$(Q)$(OBJCOPY) -O binary -j .isr_vector $^ $(BUILD)/firmware0.bin
 	$(Q)$(OBJCOPY) -O binary -j .text -j .data $^ $(BUILD)/firmware1.bin
-	$(Q)$(PYTHON) $(DFU) -b 0x08000000:$(BUILD)/firmware0.bin -b $(TEXT_ADDR):$(BUILD)/firmware1.bin $@
+	$(Q)$(PYTHON) $(DFU) -b $(FLASH_ADDR):$(BUILD)/firmware0.bin -b $(TEXT_ADDR):$(BUILD)/firmware1.bin $@
 
 $(BUILD)/firmware.hex: $(BUILD)/firmware.elf
 	$(ECHO) "Create $@"

--- a/stmhal/boards/STM32L476DISC/mpconfigboard.mk
+++ b/stmhal/boards/STM32L476DISC/mpconfigboard.mk
@@ -3,3 +3,4 @@ CMSIS_MCU = STM32L476xx
 AF_FILE = boards/stm32l476_af.csv
 LD_FILE = boards/stm32l476xg.ld
 TEXT_ADDR = 0x08004000
+OPENOCD_CONFIG = boards/openocd_stm32l4.cfg

--- a/stmhal/boards/openocd_stm32f4.cfg
+++ b/stmhal/boards/openocd_stm32f4.cfg
@@ -17,17 +17,17 @@ source [find target/stm32f4x.cfg]
 reset_config srst_only
 init
 
-proc stm_flash { BIN0 BIN1 } {
+proc stm_flash { BIN0 ADDR0 BIN1 ADDR1 } {
     reset halt
     sleep 100
     wait_halt 2
-    flash write_image erase $BIN0 0x08000000
+    flash write_image erase $BIN0 $ADDR0
     sleep 100
-    verify_image $BIN0 0x08000000
+    verify_image $BIN0 $ADDR0
     sleep 100
-    flash write_image erase $BIN1 0x08020000
+    flash write_image erase $BIN1 $ADDR1
     sleep 100
-    verify_image $BIN1 0x08020000
+    verify_image $BIN1 $ADDR1
     sleep 100
     reset run
     shutdown

--- a/stmhal/boards/openocd_stm32l4.cfg
+++ b/stmhal/boards/openocd_stm32l4.cfg
@@ -17,17 +17,17 @@ source [find target/stm32l4x.cfg]
 reset_config srst_only
 init
 
-proc stm_flash { BIN0 BIN1 } {
+proc stm_flash { BIN0 ADDR0 BIN1 ADDR1 } {
     reset halt
     sleep 100
     wait_halt 2
-    flash write_image erase $BIN0 0x08000000
+    flash write_image erase $BIN0 $ADDR0
     sleep 100
-    verify_image $BIN0 0x08000000
+    verify_image $BIN0 $ADDR0
     sleep 100
-    flash write_image erase $BIN1 0x08004000
+    flash write_image erase $BIN1 $ADDR1
     sleep 100
-    verify_image $BIN1 0x08004000
+    verify_image $BIN1 $ADDR1
     sleep 100
     reset run
     shutdown

--- a/stmhal/boards/openocd_stm32l4.cfg
+++ b/stmhal/boards/openocd_stm32l4.cfg
@@ -1,0 +1,42 @@
+# This script configures OpenOCD for use with an ST-Link V2 programmer/debugger
+# and an STM32L4 target microcontroller.
+#
+# To flash your firmware:
+#
+#    $ openocd -f openocd_stm32l4.cfg \
+#        -c "stm_flash build-BOARD/firmware0.bin build-BOARD/firmware1.bin"
+#
+# For a gdb server on port 3333:
+#
+#    $ openocd -f openocd_stm32l4.cfg
+
+
+source [find interface/stlink-v2-1.cfg]
+transport select hla_swd
+source [find target/stm32l4x.cfg]
+reset_config srst_only
+init
+
+proc stm_flash { BIN0 BIN1 } {
+    reset halt
+    sleep 100
+    wait_halt 2
+    flash write_image erase $BIN0 0x08000000
+    sleep 100
+    verify_image $BIN0 0x08000000
+    sleep 100
+    flash write_image erase $BIN1 0x08004000
+    sleep 100
+    verify_image $BIN1 0x08004000
+    sleep 100
+    reset run
+    shutdown
+}
+
+proc stm_erase {} {
+    reset halt
+    sleep 100
+    stm32l4x mass_erase 0
+    sleep 100
+    shutdown
+}


### PR DESCRIPTION
Adding an OpenOCD configuration file for the STM32L4 series. There are two differences from the F4 series:
- Newer ST-Link/v2-1 vs. ST-Link/v2
- Different TEXT_ADDR (0x08004000) for firmware1.bin which changed recently in 1f433c719b1d29a44c52befdf1476d154ebb3c68

Not sure if there is a way to pull in TEXT_ADDR automatically from the mpconfigboard.mk file for each board? That would probably be the most ideal place rather than having them hard-coded in these files.
