### PR TITLE
tests/extmod/vfs_fat: Improve VFS test coverage.

### DIFF
--- a/tests/extmod/vfs_fat_fileio.py
+++ b/tests/extmod/vfs_fat_fileio.py
@@ -1,0 +1,160 @@
+import sys
+import uos
+import uerrno
+try:
+    uos.VfsFat
+except AttributeError:
+    print("SKIP")
+    sys.exit()
+
+
+class RAMFS:
+
+    SEC_SIZE = 512
+
+    def __init__(self, blocks):
+        self.data = bytearray(blocks * self.SEC_SIZE)
+
+    def readblocks(self, n, buf):
+        #print("readblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
+        for i in range(len(buf)):
+            buf[i] = self.data[n * self.SEC_SIZE + i]
+
+    def writeblocks(self, n, buf):
+        #print("writeblocks(%s, %x)" % (n, id(buf)))
+        for i in range(len(buf)):
+            self.data[n * self.SEC_SIZE + i] = buf[i]
+
+    def ioctl(self, op, arg):
+        #print("ioctl(%d, %r)" % (op, arg))
+        if op == 4:  # BP_IOCTL_SEC_COUNT
+            return len(self.data) // self.SEC_SIZE
+        if op == 5:  # BP_IOCTL_SEC_SIZE
+            return self.SEC_SIZE
+
+
+try:
+    bdev = RAMFS(48)
+except MemoryError:
+    print("SKIP")
+    sys.exit()
+
+uos.VfsFat.mkfs(bdev)
+vfs = uos.VfsFat(bdev, "/ramdisk")
+
+# file IO
+f = vfs.open("foo_file.txt", "w")
+print(str(f)[:17], str(f)[-1:])
+f.write("hello!")
+f.flush()
+f.close()
+try:
+    f.write("world!")
+except OSError as e:
+    print(e.args[0] == uerrno.EINVAL)
+
+try:
+    f.read()
+except OSError as e:
+    print(e.args[0] == uerrno.EINVAL)
+
+try:
+    f.flush()
+except OSError as e:
+    print(e.args[0] == uerrno.EINVAL)
+
+try:
+    f.close()
+except OSError as e:
+    print(e.args[0] == uerrno.EINVAL)
+
+try:
+    vfs.open("foo_file.txt", "x")
+except OSError as e:
+    print(e.args[0] == uerrno.EEXIST)
+
+with vfs.open("foo_file.txt", "a") as f:
+    f.write("world!")
+
+with vfs.open("foo_file.txt") as f2:
+    print(f2.read())
+    print(f2.tell())
+
+    f2.seek(0, 0) # SEEK_SET
+    print(f2.read(1))
+
+    f2.seek(0, 1) # SEEK_CUR
+    print(f2.read(1))
+    try:
+        f2.seek(1, 1) # SEEK_END
+    except OSError as e:
+        print(e.args[0] == uerrno.EOPNOTSUPP)
+
+    f2.seek(-2, 2) # SEEK_END
+    print(f2.read(1))
+
+# dirs
+vfs.mkdir("foo_dir")
+
+try:
+    vfs.rmdir("foo_file.txt")
+except OSError as e:
+    print(e.args[0] == 20) # uerrno.ENOTDIR
+
+try:
+    vfs.mkdir("foo_dir")
+except OSError as e:
+    print(e.args[0] == uerrno.EEXIST)
+
+try:
+    vfs.remove("foo_dir")
+except OSError as e:
+    print(e.args[0] == uerrno.EISDIR)
+
+try:
+    vfs.remove("no_file.txt")
+except OSError as e:
+    print(e.args[0] == uerrno.ENOENT)
+
+try:
+    vfs.rename("foo_dir", "/null")
+except OSError as e:
+    print(e.args[0] == uerrno.ENODEV)
+
+# file in dir
+with vfs.open("foo_dir/file-in-dir.txt", "w+t") as f:
+    f.write("data in file")
+
+with vfs.open("foo_dir/file-in-dir.txt", "r+b") as f:
+    print(f.read())
+
+with vfs.open("foo_dir/sub_file.txt", "w") as f:
+    f.write("subdir file")
+
+# directory not empty
+try:
+    vfs.rmdir("foo_dir")
+except OSError as e:
+    print(e.args[0] == uerrno.EACCES)
+
+# trim full path
+vfs.rename("foo_dir/file-in-dir.txt", "/ramdisk/foo_dir/file.txt")
+print(vfs.listdir("foo_dir"))
+
+vfs.rename("foo_dir/file.txt", "moved-to-root.txt")
+print(vfs.listdir())
+
+# valid removes
+vfs.remove("foo_dir/sub_file.txt")
+vfs.remove("foo_file.txt")
+vfs.rmdir("foo_dir")
+print(vfs.listdir())
+
+# disk full
+try:
+    bsize = vfs.statvfs("/ramdisk")[0]
+    free = vfs.statvfs("/ramdisk")[2] + 1
+    f = vfs.open("large_file.txt", "wb")
+    f.write(bytearray(bsize * free))
+except OSError as e:
+    print("ENOSPC:", e.args[0] == 28) # uerrno.ENOSPC

--- a/tests/extmod/vfs_fat_fileio.py.exp
+++ b/tests/extmod/vfs_fat_fileio.py.exp
@@ -1,0 +1,23 @@
+<io.TextIOWrapper >
+True
+True
+True
+True
+True
+hello!world!
+12
+h
+e
+True
+d
+True
+True
+True
+True
+True
+b'data in file'
+True
+['sub_file.txt', 'file.txt']
+['foo_file.txt', 'foo_dir', 'moved-to-root.txt']
+['moved-to-root.txt']
+ENOSPC: True

--- a/tests/extmod/vfs_fat_ramdisk.py.exp
+++ b/tests/extmod/vfs_fat_ramdisk.py.exp
@@ -1,23 +1,19 @@
 True
 True
+True
 statvfs: (512, 512, 14, 14, 14, 0, 0, 0, 0, 255)
 getcwd: /ramdisk
-hello!
-True
 True
 ['foo_file.txt']
+stat root: (16384, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+stat disk: (16384, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+stat file: (32768, 0, 0, 0, 0, 0, 6, -631238400, -631238400, -631238400)
 True
-[]
-['foo_dir']
 True
-['file-in-dir.txt']
-['foo_dir', 'moved-to-root.txt']
 getcwd: /ramdisk/foo_dir
 []
-['sub_file.txt']
 True
 getcwd: /ramdisk
 True
-['moved-to-root.txt']
 True
-['moved-to-root.txt']
+[b'foo_file.txt', b'foo_dir']

--- a/tools/tinytest-codegen.py
+++ b/tools/tinytest-codegen.py
@@ -53,7 +53,7 @@ exclude_tests = (
     'extmod/ujson_dumps_float.py', 'extmod/ujson_loads_float.py',
     'extmod/uctypes_native_float.py', 'extmod/uctypes_le_float.py',
     'extmod/machine_pinbase.py', 'extmod/machine_pulse.py',
-    'extmod/vfs_fat_ramdisk.py',
+    'extmod/vfs_fat_ramdisk.py', 'extmod/vfs_fat_fileio.py',
 )
 
 output = []


### PR DESCRIPTION
Cases:
- Statvfs invalid blockdev
- String print of file object
- Flush file
- Attempting to read/write on closed file
- Various stat scenarios (root, disk, file, invalid file)
- Mkdir error
- Rename with full path, check_path trims
- Rename to non existing block device
- Bytestring listdir
- Getcwd call error

This will conflict with #2507 and will be resolved after it gets approved/discarded.
