### PR TITLE
[OLIMEX_E407] SD Card detect always return true if SD Card Detect pin…

### DIFF
--- a/stmhal/boards/OLIMEX_E407/mpconfigboard.h
+++ b/stmhal/boards/OLIMEX_E407/mpconfigboard.h
@@ -75,10 +75,10 @@
 #define MICROPY_HW_LED_ON(pin)      (pin->gpio->BSRRH = pin->pin_mask)
 #define MICROPY_HW_LED_OFF(pin)     (pin->gpio->BSRRL = pin->pin_mask)
 
-// SD card detect switch
-#define MICROPY_HW_SDCARD_DETECT_PIN        (pin_C11)
-#define MICROPY_HW_SDCARD_DETECT_PULL       (GPIO_PULLUP)
-#define MICROPY_HW_SDCARD_DETECT_PRESENT    (GPIO_PIN_RESET)
+// SD card detect switch (no card detect pin available on E407 board)
+//#define MICROPY_HW_SDCARD_DETECT_PIN        (pin_XXX)
+//#define MICROPY_HW_SDCARD_DETECT_PULL       (GPIO_PULLUP)
+//#define MICROPY_HW_SDCARD_DETECT_PRESENT    (GPIO_PIN_RESET)
 
 // USB config
 #define MICROPY_HW_USB_VBUS_DETECT_PIN (pin_A9)

--- a/stmhal/boards/OLIMEX_E407/mpconfigboard.h
+++ b/stmhal/boards/OLIMEX_E407/mpconfigboard.h
@@ -77,8 +77,8 @@
 
 // SD card detect switch (no card detect pin available on E407 board)
 //#define MICROPY_HW_SDCARD_DETECT_PIN        (pin_XXX)
-//#define MICROPY_HW_SDCARD_DETECT_PULL       (GPIO_PULLUP)
-//#define MICROPY_HW_SDCARD_DETECT_PRESENT    (GPIO_PIN_RESET)
+#define MICROPY_HW_SDCARD_DETECT_PULL       (GPIO_NOPULL)
+#define MICROPY_HW_SDCARD_DETECT_PRESENT    (GPIO_PIN_SET)
 
 // USB config
 #define MICROPY_HW_USB_VBUS_DETECT_PIN (pin_A9)

--- a/stmhal/sdcard.c
+++ b/stmhal/sdcard.c
@@ -99,11 +99,13 @@ void sdcard_init(void) {
 
     // configure the SD card detect pin
     // we do this here so we can detect if the SD card is inserted before powering it on
+#ifdef MICROPY_HW_SDCARD_DETECT_PIN
     GPIO_Init_Structure.Mode = GPIO_MODE_INPUT;
     GPIO_Init_Structure.Pull = MICROPY_HW_SDCARD_DETECT_PULL;
     GPIO_Init_Structure.Speed = GPIO_SPEED_HIGH;
     GPIO_Init_Structure.Pin = MICROPY_HW_SDCARD_DETECT_PIN.pin_mask;
     HAL_GPIO_Init(MICROPY_HW_SDCARD_DETECT_PIN.gpio, &GPIO_Init_Structure);
+#endif
 }
 
 void HAL_SD_MspInit(SD_HandleTypeDef *hsd) {
@@ -123,7 +125,11 @@ void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd) {
 }
 
 bool sdcard_is_present(void) {
+#ifdef MICROPY_HW_SDCARD_DETECT_PIN
     return HAL_GPIO_ReadPin(MICROPY_HW_SDCARD_DETECT_PIN.gpio, MICROPY_HW_SDCARD_DETECT_PIN.pin_mask) == MICROPY_HW_SDCARD_DETECT_PRESENT;
+#else
+    return true;  // assume card is always present if no present detect pin is defined.
+#endif
 }
 
 bool sdcard_power_on(void) {


### PR DESCRIPTION
… not defined.

Always return true for CD Card Detect function if no SD Card Detect pin is defined.  This allows boards such as the Olimex E407 to use the SD Card even though it doesn't have an SD Card Detect output on the SD Card socket.
