### PR TITLE
lib/utils/pyhelp.c: Use mp_printf() instead of printf()

### DIFF
--- a/lib/utils/pyhelp.c
+++ b/lib/utils/pyhelp.c
@@ -29,11 +29,11 @@
 #include "lib/utils/pyhelp.h"
 
 STATIC void pyhelp_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
-    mp_printf(MP_PRINTER, "  ");
+    mp_printf(MP_PYTHON_PRINTER, "  ");
     mp_obj_print(name_o, PRINT_STR);
-    mp_printf(MP_PRINTER, " -- ");
+    mp_printf(MP_PYTHON_PRINTER, " -- ");
     mp_obj_print(value, PRINT_STR);
-    mp_printf(MP_PRINTER, "\n");
+    mp_printf(MP_PYTHON_PRINTER, "\n");
 }
 
 // Helper for 1-argument form of builtin help
@@ -57,9 +57,9 @@ STATIC void pyhelp_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
 //
 void pyhelp_print_obj(const mp_obj_t obj) {
     // try to print something sensible about the given object
-    mp_printf(MP_PRINTER, "object ");
+    mp_printf(MP_PYTHON_PRINTER, "object ");
     mp_obj_print(obj, PRINT_STR);
-    mp_printf(MP_PRINTER, " is of type %s\n", mp_obj_get_type_str(obj));
+    mp_printf(MP_PYTHON_PRINTER, " is of type %s\n", mp_obj_get_type_str(obj));
 
     mp_map_t *map = NULL;
     if (MP_OBJ_IS_TYPE(obj, &mp_type_module)) {

--- a/lib/utils/pyhelp.c
+++ b/lib/utils/pyhelp.c
@@ -29,11 +29,11 @@
 #include "lib/utils/pyhelp.h"
 
 STATIC void pyhelp_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
-    mp_printf(&MP_PRINT, "  ");
+    mp_printf(MP_PRINTER, "  ");
     mp_obj_print(name_o, PRINT_STR);
-    mp_printf(&MP_PRINT, " -- ");
+    mp_printf(MP_PRINTER, " -- ");
     mp_obj_print(value, PRINT_STR);
-    mp_printf(&MP_PRINT, "\n");
+    mp_printf(MP_PRINTER, "\n");
 }
 
 // Helper for 1-argument form of builtin help
@@ -57,9 +57,9 @@ STATIC void pyhelp_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
 //
 void pyhelp_print_obj(const mp_obj_t obj) {
     // try to print something sensible about the given object
-    mp_printf(&MP_PRINT, "object ");
+    mp_printf(MP_PRINTER, "object ");
     mp_obj_print(obj, PRINT_STR);
-    mp_printf(&MP_PRINT, " is of type %s\n", mp_obj_get_type_str(obj));
+    mp_printf(MP_PRINTER, " is of type %s\n", mp_obj_get_type_str(obj));
 
     mp_map_t *map = NULL;
     if (MP_OBJ_IS_TYPE(obj, &mp_type_module)) {

--- a/lib/utils/pyhelp.c
+++ b/lib/utils/pyhelp.c
@@ -29,11 +29,11 @@
 #include "lib/utils/pyhelp.h"
 
 STATIC void pyhelp_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
-    printf("  ");
+    mp_printf(&MP_PRINT, "  ");
     mp_obj_print(name_o, PRINT_STR);
-    printf(" -- ");
+    mp_printf(&MP_PRINT, " -- ");
     mp_obj_print(value, PRINT_STR);
-    printf("\n");
+    mp_printf(&MP_PRINT, "\n");
 }
 
 // Helper for 1-argument form of builtin help
@@ -57,9 +57,9 @@ STATIC void pyhelp_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
 //
 void pyhelp_print_obj(const mp_obj_t obj) {
     // try to print something sensible about the given object
-    printf("object ");
+    mp_printf(&MP_PRINT, "object ");
     mp_obj_print(obj, PRINT_STR);
-    printf(" is of type %s\n", mp_obj_get_type_str(obj));
+    mp_printf(&MP_PRINT, " is of type %s\n", mp_obj_get_type_str(obj));
 
     mp_map_t *map = NULL;
     if (MP_OBJ_IS_TYPE(obj, &mp_type_module)) {

--- a/py/mpprint.h
+++ b/py/mpprint.h
@@ -39,6 +39,12 @@
 #define PF_FLAG_ADD_PERCENT       (0x100)
 #define PF_FLAG_SHOW_OCTAL_LETTER (0x200)
 
+#if MICROPY_PY_IO
+#    define MP_PRINT mp_sys_stdout_print
+#else
+#    define MP_PRINT mp_plat_print
+#endif
+
 typedef void (*mp_print_strn_t)(void *data, const char *str, size_t len);
 
 typedef struct _mp_print_t {

--- a/py/mpprint.h
+++ b/py/mpprint.h
@@ -40,9 +40,9 @@
 #define PF_FLAG_SHOW_OCTAL_LETTER (0x200)
 
 #if MICROPY_PY_IO
-#    define MP_PRINT mp_sys_stdout_print
+#    define MP_PRINTER &mp_sys_stdout_print
 #else
-#    define MP_PRINT mp_plat_print
+#    define MP_PRINTER &mp_plat_print
 #endif
 
 typedef void (*mp_print_strn_t)(void *data, const char *str, size_t len);

--- a/py/mpprint.h
+++ b/py/mpprint.h
@@ -40,9 +40,9 @@
 #define PF_FLAG_SHOW_OCTAL_LETTER (0x200)
 
 #if MICROPY_PY_IO
-#    define MP_PRINTER &mp_sys_stdout_print
+#    define MP_PYTHON_PRINTER &mp_sys_stdout_print
 #else
-#    define MP_PRINTER &mp_plat_print
+#    define MP_PYTHON_PRINTER &mp_plat_print
 #endif
 
 typedef void (*mp_print_strn_t)(void *data, const char *str, size_t len);


### PR DESCRIPTION
Print all help using the same printer instead of using `printf()` for parts of the output.
