### PR TITLE
extmod/vfs_fat_file: Check fatfs f_sync() and f_close() errors.

### DIFF
--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -110,14 +110,20 @@ STATIC mp_uint_t file_obj_write(mp_obj_t self_in, const void *buf, mp_uint_t siz
 
 STATIC mp_obj_t file_obj_flush(mp_obj_t self_in) {
     pyb_file_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    f_sync(&self->fp);
+    FRESULT res = f_sync(&self->fp);
+    if (res != FR_OK) {
+        mp_raise_OSError(fresult_to_errno_table[res]);
+    }
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(file_obj_flush_obj, file_obj_flush);
 
 STATIC mp_obj_t file_obj_close(mp_obj_t self_in) {
     pyb_file_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    f_close(&self->fp);
+    FRESULT res = f_close(&self->fp);
+    if (res != FR_OK) {
+        mp_raise_OSError(fresult_to_errno_table[res]);
+    }
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(file_obj_close_obj, file_obj_close);


### PR DESCRIPTION
As discussed in https://github.com/micropython/micropython/pull/2511#issuecomment-254389973
Two simple checks for file object flush() and close()
