### PR TITLE
esp8266 Neopixel: Solve borderline timing issues with cpu at 80Mhz

### DIFF
--- a/esp8266/espneopixel.c
+++ b/esp8266/espneopixel.c
@@ -33,7 +33,7 @@ void /*ICACHE_RAM_ATTR*/ esp_neopixel_write(uint8_t pin, uint8_t *pixels, uint32
 #ifdef NEO_KHZ400
   if(is800KHz) {
 #endif
-    time0  = fcpu / 2500000; // 0.4us
+    time0  = fcpu / 2857143; // 0.35us
     time1  = fcpu / 1250000; // 0.8us
     period = fcpu /  800000; // 1.25us per bit
 #ifdef NEO_KHZ400


### PR DESCRIPTION
related to https://github.com/micropython/micropython/issues/2465
basically changed T0H to the value from the WS2812 specification.
