### PR TITLE
Add "slice" builtin name to modbuiltins

### DIFF
--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -617,6 +617,9 @@ STATIC const mp_rom_map_elem_t mp_module_builtins_globals_table[] = {
     #if MICROPY_PY_BUILTINS_SET
     { MP_ROM_QSTR(MP_QSTR_set), MP_ROM_PTR(&mp_type_set) },
     #endif
+    #if MICROPY_PY_BUILTINS_SLICE
+    { MP_ROM_QSTR(MP_QSTR_slice), MP_ROM_PTR(&mp_type_slice) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_str), MP_ROM_PTR(&mp_type_str) },
     { MP_ROM_QSTR(MP_QSTR_super), MP_ROM_PTR(&mp_type_super) },
     { MP_ROM_QSTR(MP_QSTR_tuple), MP_ROM_PTR(&mp_type_tuple) },

--- a/tests/basics/builtin_slice.py
+++ b/tests/basics/builtin_slice.py
@@ -4,4 +4,8 @@
 class A:
     def __getitem__(self, idx):
         print(idx)
-A()[1:2:3]
+        return idx
+s = A()[1:2:3]
+
+# check type
+print(type(s) is slice)


### PR DESCRIPTION
If a port implements slice objects then the "slice" name should be available in the builtins, at least so you can check if objects are of type slice.

I wasn't so brave at this stage to add an implementation of slice_make_new so that slices can be constructed, eg via `slice(10)`.

Note: after this the only missing builtin names are: ascii, delattr, format, vars.
