### PR TITLE
tests/extmod/common: Separate common RAMFS class.

### DIFF
--- a/tests/extmod/common/ramfs.py
+++ b/tests/extmod/common/ramfs.py
@@ -1,0 +1,59 @@
+# common RAM VFS
+class RAMFS_RO:
+
+    SEC_SIZE = 512
+
+    def __init__(self, blocks):
+        self.data = bytearray(blocks * self.SEC_SIZE)
+
+    def readblocks(self, n, buf):
+        #print("readblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
+        for i in range(len(buf)):
+            buf[i] = self.data[n * self.SEC_SIZE + i]
+
+
+class RAMFS_RW(RAMFS_RO):
+
+    def __init__(self, blocks):
+        super().__init__(blocks)
+
+    def writeblocks(self, n, buf):
+        #print("writeblocks(%s, %x)" % (n, id(buf)))
+        for i in range(len(buf)):
+            self.data[n * self.SEC_SIZE + i] = buf[i]
+
+
+class RAMFS_IOCTL_RO(RAMFS_RO):
+
+    def __init__(self, blocks):
+        super().__init__(blocks)
+
+    def ioctl(self, op, arg):
+        #print("ioctl(%d, %r)" % (op, arg))
+        if op == 4:  # BP_IOCTL_SEC_COUNT
+            return len(self.data) // self.SEC_SIZE
+        if op == 5:  # BP_IOCTL_SEC_SIZE
+            return self.SEC_SIZE
+
+
+class RAMFS_IOCTL_RW(RAMFS_RW, RAMFS_IOCTL_RO):
+
+    def __init__(self, blocks):
+        super().__init__(blocks)
+
+
+class RAMFS_OLD_RO(RAMFS_RO):
+
+    def __init__(self, blocks):
+        super().__init__(blocks)
+
+    def sync(self):
+        pass
+
+    def count(self):
+        return len(self.data) // self.SEC_SIZE
+
+
+class RAMFS_OLD_RW(RAMFS_OLD_RO, RAMFS_RW):
+    def __init__(self, blocks):
+        super().__init__(blocks)

--- a/tests/extmod/vfs_fat_fileio.py
+++ b/tests/extmod/vfs_fat_fileio.py
@@ -7,34 +7,10 @@ except AttributeError:
     print("SKIP")
     sys.exit()
 
-
-class RAMFS:
-
-    SEC_SIZE = 512
-
-    def __init__(self, blocks):
-        self.data = bytearray(blocks * self.SEC_SIZE)
-
-    def readblocks(self, n, buf):
-        #print("readblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
-        for i in range(len(buf)):
-            buf[i] = self.data[n * self.SEC_SIZE + i]
-
-    def writeblocks(self, n, buf):
-        #print("writeblocks(%s, %x)" % (n, id(buf)))
-        for i in range(len(buf)):
-            self.data[n * self.SEC_SIZE + i] = buf[i]
-
-    def ioctl(self, op, arg):
-        #print("ioctl(%d, %r)" % (op, arg))
-        if op == 4:  # BP_IOCTL_SEC_COUNT
-            return len(self.data) // self.SEC_SIZE
-        if op == 5:  # BP_IOCTL_SEC_SIZE
-            return self.SEC_SIZE
-
+from common.ramfs import RAMFS_IOCTL_RW
 
 try:
-    bdev = RAMFS(48)
+    bdev = RAMFS_IOCTL_RW(48)
 except MemoryError:
     print("SKIP")
     sys.exit()

--- a/tests/extmod/vfs_fat_ramdisk.py
+++ b/tests/extmod/vfs_fat_ramdisk.py
@@ -7,34 +7,10 @@ except AttributeError:
     print("SKIP")
     sys.exit()
 
-
-class RAMFS:
-
-    SEC_SIZE = 512
-
-    def __init__(self, blocks):
-        self.data = bytearray(blocks * self.SEC_SIZE)
-
-    def readblocks(self, n, buf):
-        #print("readblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
-        for i in range(len(buf)):
-            buf[i] = self.data[n * self.SEC_SIZE + i]
-
-    def writeblocks(self, n, buf):
-        #print("writeblocks(%s, %x)" % (n, id(buf)))
-        for i in range(len(buf)):
-            self.data[n * self.SEC_SIZE + i] = buf[i]
-
-    def ioctl(self, op, arg):
-        #print("ioctl(%d, %r)" % (op, arg))
-        if op == 4:  # BP_IOCTL_SEC_COUNT
-            return len(self.data) // self.SEC_SIZE
-        if op == 5:  # BP_IOCTL_SEC_SIZE
-            return self.SEC_SIZE
-
+from common.ramfs import RAMFS_IOCTL_RW
 
 try:
-    bdev = RAMFS(48)
+    bdev = RAMFS_IOCTL_RW(48)
 except MemoryError:
     print("SKIP")
     sys.exit()


### PR DESCRIPTION
I would like to propose having a "common"/"generic" subdirectory that can hold the code to be reused by multiple tests. This is an example of RAMFS class being separated and extended to cover "old" and "ioctl" block devices, which can be used by tests as needed. I have updated fileio and ramdisk tests, I additionally have fsusermount cases in #2542 which will benefit from this, rather than duplicating the class across each test file. Please share your thoughts!
