### PR TITLE
esp8266/scripts/inisetup: Activate the AP before setting it up

### DIFF
--- a/esp8266/scripts/inisetup.py
+++ b/esp8266/scripts/inisetup.py
@@ -6,6 +6,7 @@ def wifi():
     import ubinascii
     ap_if = network.WLAN(network.AP_IF)
     essid = b"MicroPython-%s" % ubinascii.hexlify(ap_if.config("mac")[-3:])
+    ap_if.active(True)
     ap_if.config(essid=essid, authmode=network.AUTH_WPA_WPA2_PSK, password=b"micropythoN")
 
 def check_bootsec():


### PR DESCRIPTION
Avoids an exception at initialization that happens, when the firmware
has been flashed on a module that had the AP deactivated, which in turn
leads to not creating the filesystem etc.

See http://forum.micropython.org/viewtopic.php?f=16&t=2309
