### PR TITLE
py: bugfixes from Coverity

### DIFF
--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -183,7 +183,6 @@ STATIC void emit_write_bytecode_byte(emit_t *emit, byte b1) {
 }
 
 STATIC void emit_write_bytecode_byte_byte(emit_t* emit, byte b1, byte b2) {
-    assert((b2 & (~0xff)) == 0);
     byte *c = emit_get_cur_to_write_bytecode(emit, 2);
     c[0] = b1;
     c[1] = b2;
@@ -550,7 +549,6 @@ void mp_emit_bc_load_null(emit_t *emit) {
 
 void mp_emit_bc_load_fast(emit_t *emit, qstr qst, mp_uint_t local_num) {
     (void)qst;
-    assert(local_num >= 0);
     emit_bc_pre(emit, 1);
     if (local_num <= 15) {
         emit_write_bytecode_byte(emit, MP_BC_LOAD_FAST_MULTI + local_num);
@@ -608,7 +606,6 @@ void mp_emit_bc_load_subscr(emit_t *emit) {
 
 void mp_emit_bc_store_fast(emit_t *emit, qstr qst, mp_uint_t local_num) {
     (void)qst;
-    assert(local_num >= 0);
     emit_bc_pre(emit, -1);
     if (local_num <= 15) {
         emit_write_bytecode_byte(emit, MP_BC_STORE_FAST_MULTI + local_num);
@@ -927,7 +924,7 @@ void mp_emit_bc_return_value(emit_t *emit) {
 }
 
 void mp_emit_bc_raise_varargs(emit_t *emit, mp_uint_t n_args) {
-    assert(0 <= n_args && n_args <= 2);
+    assert(n_args <= 2);
     emit_bc_pre(emit, -n_args);
     emit_write_bytecode_byte_byte(emit, MP_BC_RAISE_VARARGS, n_args);
 }

--- a/py/mpz.c
+++ b/py/mpz.c
@@ -1652,7 +1652,10 @@ char *mpz_as_str(const mpz_t *i, mp_uint_t base) {
 // assumes enough space as calculated by mp_int_format_size
 // returns length of string, not including null byte
 mp_uint_t mpz_as_str_inpl(const mpz_t *i, mp_uint_t base, const char *prefix, char base_char, char comma, char *str) {
-    if (str == NULL || base < 2 || base > 32) {
+    if (str == NULL) {
+        return 0;
+    }
+    if (base < 2 || base > 32) {
         str[0] = 0;
         return 0;
     }

--- a/py/warning.c
+++ b/py/warning.c
@@ -38,6 +38,7 @@ void mp_warning(const char *msg, ...) {
     mp_print_str(&mp_plat_print, "Warning: ");
     mp_vprintf(&mp_plat_print, msg, args);
     mp_print_str(&mp_plat_print, "\n");
+    va_end(args);
 }
 
 void mp_emitter_warning(pass_kind_t pass, const char *msg) {


### PR DESCRIPTION
Recently, I've been trying Coverity for my projects and I tried it also for MicroPython. There were some interesting findings (around 35) and I'd like to know if you are interested in processing them and what would be the best way how to do it.

I see two options:

a) You go directly to https://scan.coverity.com/projects/micropython/view_defects and I'll give you admin access (needs login with Github ...). We could assess the issues, mark false positives, etc. there.

b) I start preparing pull requests and we'll discuss the changes here in comments of pull requests.

a) puts more effort on your side, b) on mine side.

Included in this PR are two examples of trivial findings. Others would probably need more discussion.

Tell me what you think. Also are you interested in removing asserts that are always true? (second commit of this PR).
