### PR TITLE
examples/network Update http_server example to work with latest build

### DIFF
--- a/examples/network/http_server.py
+++ b/examples/network/http_server.py
@@ -18,7 +18,6 @@ def main(micropython_optimize=False):
     print("Bind address info:", ai)
     addr = ai[0][-1]
 
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     s.bind(addr)
     s.listen(5)
     print("Listening, connect your browser to http://<this_host>:8080/")
@@ -35,7 +34,7 @@ def main(micropython_optimize=False):
             # To read line-oriented protocol (like HTTP) from a socket (and
             # avoid short read problem), it must be wrapped in a stream (aka
             # file-like) object. That's how you do it in CPython:
-            client_stream = client_sock.makefile("rwb")
+            client_stream = client_sock.makefile()
         else:
             # .. but MicroPython socket objects support stream interface
             # directly, so calling .makefile() method is not required. If


### PR DESCRIPTION
http_server.py does not run on latest WiPy build.

System info:
(sysname='WiPy', nodename='WiPy', release='1.3.0', version='v1.8.2-103-g834e021 on 2016-08-19', machine='WiPy with CC3200')

Setting socket options fails.
`socket.SOL_SOCKET` and `socket.SO_REUSEADDR` do not exist.
Works fine without setting options.

Makefile fails.
`socket.makefile` does not accept `"rwb"` as argument.
Works by not specifying arguments.
