### PR TITLE
esp8266/modnetwork.c: Expose configuration for station hostname

### DIFF
--- a/esp8266/modnetwork.c
+++ b/esp8266/modnetwork.c
@@ -336,6 +336,15 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         cfg.ap.channel = mp_obj_get_int(kwargs->table[i].value);
                         break;
                     }
+                    case QS(MP_QSTR_hostname): {
+                        req_if = STATION_IF;
+                        if (self->if_id == STATION_IF) {
+                            mp_uint_t len;
+                            const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
+                            wifi_station_set_hostname((char*)s);
+                        }
+                        break;
+                    }
                     default:
                         goto unknown;
                 }
@@ -388,6 +397,11 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
         case QS(MP_QSTR_channel):
             req_if = SOFTAP_IF;
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.channel);
+            break;
+        case QS(MP_QSTR_hostname):
+            req_if = STATION_IF;
+            char* s = wifi_station_get_hostname();
+            val = mp_obj_new_str(s, strlen(s), false);
             break;
         default:
             goto unknown;

--- a/esp8266/modnetwork.c
+++ b/esp8266/modnetwork.c
@@ -397,11 +397,12 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             req_if = SOFTAP_IF;
             val = MP_OBJ_NEW_SMALL_INT(cfg.ap.channel);
             break;
-        case QS(MP_QSTR_hostname):
+        case QS(MP_QSTR_hostname): {
             req_if = STATION_IF;
             char* s = wifi_station_get_hostname();
             val = mp_obj_new_str(s, strlen(s), false);
             break;
+        }
         default:
             goto unknown;
     }

--- a/esp8266/modnetwork.c
+++ b/esp8266/modnetwork.c
@@ -339,8 +339,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                     case QS(MP_QSTR_hostname): {
                         req_if = STATION_IF;
                         if (self->if_id == STATION_IF) {
-                            mp_uint_t len;
-                            const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
+                            const char *s = mp_obj_str_get_str(kwargs->table[i].value);
                             wifi_station_set_hostname((char*)s);
                         }
                         break;


### PR DESCRIPTION
The ESP SDK supports configuring the hostname that is reported when doing a DHCP request in station mode.  This commit exposes that under network.config('hostname') as a read/write value similar to other parameters.

The behavior should compare to what exists in other ESP8266 firmware like NodeMcu: [gethostname](https://nodemcu.readthedocs.io/en/master/en/modules/wifi/#wifistagethostname), [sethostname](nodemcu.readthedocs.io/en/master/en/modules/wifi/#wifistasethostname) and the implementation is pretty similar as well: NodeMcu [gethostname](https://github.com/nodemcu/nodemcu-firmware/blob/3328c66f2c1c4b83f96b3c869b2167bb2ab183a2/app/modules/wifi.c#L921), [sethostname](https://github.com/nodemcu/nodemcu-firmware/blob/3328c66f2c1c4b83f96b3c869b2167bb2ab183a2/app/modules/wifi.c#L948)

This allows customization of how the hostname for the device appears when looking at DHCP client lists in routers.  Assuming the DHCP server is tied in with the DNS server (like with a home router) this should allow for the set hostname to be resolvable easing IP issues at least in some cases.

See forum discussion here: https://forum.micropython.org/viewtopic.php?f=16&t=2584 indicating there is at least some interest for this feature.
