### PR TITLE
Fix negative temperature in ds18x20 driver

### DIFF
--- a/esp8266/modules/ds18x20.py
+++ b/esp8266/modules/ds18x20.py
@@ -43,4 +43,8 @@ class DS18X20:
                 t = buf[0] >> 1
             return t - 0.25 + (buf[7] - buf[6]) / buf[7]
         else:
-            return (buf[1] << 8 | buf[0]) / 16
+            t = buf[1] << 8 | buf[0]
+            if t & 0x8000:  # bit sign set
+                t = (t ^ 0xffff) + 1 # 2's complement
+                return -(t / 16.0)
+            return t / 16.0


### PR DESCRIPTION
As per discussion on this forum thread http://forum.micropython.org/viewtopic.php?f=16&t=2564#p15232
I think there is a bug in Onewire ds18x20 driver with negative temperatures. 

The proposed fix is just for Dallas temperature sensors of 0x28 class. I have no possibility to check for 0x10 but I guess there is a similar issue with negative values.

Fix has been tested and provide correct results for negative temperatures. Code was derived from similar code working for Arduino.