### PR TITLE
py/malloc: Fix m_malloc0 to clear memory if GC not enabled

### DIFF
--- a/py/malloc.c
+++ b/py/malloc.c
@@ -118,7 +118,7 @@ void *m_malloc0(size_t num_bytes) {
         return m_malloc_fail(num_bytes);
     }
     // If this config is set then the GC clears all memory, so we don't need to.
-    #if !MICROPY_GC_CONSERVATIVE_CLEAR
+    #if !(MICROPY_ENABLE_GC && MICROPY_GC_CONSERVATIVE_CLEAR)
     memset(ptr, 0, num_bytes);
     #endif
     return ptr;

--- a/py/malloc.c
+++ b/py/malloc.c
@@ -117,8 +117,9 @@ void *m_malloc0(size_t num_bytes) {
     if (ptr == NULL && num_bytes != 0) {
         return m_malloc_fail(num_bytes);
     }
-    // If this config is set then the GC clears all memory, so we don't need to.
-    #if !(MICROPY_ENABLE_GC && MICROPY_GC_CONSERVATIVE_CLEAR)
+    // If this config is set then the memory manager clears all memory,
+    // so we don't need to.
+    #if !MICROPY_GC_CONSERVATIVE_CLEAR
     memset(ptr, 0, num_bytes);
     #endif
     return ptr;

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -110,10 +110,11 @@
 // Be conservative and always clear to zero newly (re)allocated memory in the GC.
 // This helps eliminate stray pointers that hold on to memory that's no longer
 // used.  It decreases performance due to unnecessary memory clearing.
+// A memory manager which always clears memory can set this to 0.
 // TODO Do analysis to understand why some memory is not properly cleared and
 // find a more efficient way to clear it.
 #ifndef MICROPY_GC_CONSERVATIVE_CLEAR
-#define MICROPY_GC_CONSERVATIVE_CLEAR (1)
+#define MICROPY_GC_CONSERVATIVE_CLEAR (MICROPY_ENABLE_GC)
 #endif
 
 // Support automatic GC when reaching allocation threshold,


### PR DESCRIPTION
Another one picked up by valgrind; could affect anyone with MICROPY_ENABLE_GC false.