### PR TITLE
stmhal: Cleanup and simplify linker scripts

### DIFF
--- a/stmhal/boards/common.ld
+++ b/stmhal/boards/common.ld
@@ -1,5 +1,9 @@
 ENTRY(Reset_Handler)
 
+/* produce a link error if there is not this amount of RAM for these sections */
+_minimum_stack_size = 2K;
+_minimum_heap_size = 16K;
+
 /* define output sections */
 SECTIONS
 {
@@ -27,7 +31,7 @@ SECTIONS
 
         . = ALIGN(4);
     } >FLASH_ISR
-   
+
     /* The program code and other data goes into FLASH */
     .text :
     {
@@ -40,10 +44,10 @@ SECTIONS
         . = ALIGN(4);
         _etext = .;        /* define a global symbol at end of code */
     } >FLASH_TEXT
-        
+
     /* used by the startup to initialize data */
     _sidata = LOADADDR(.data);
-        
+
     /* This is the initialized data section
     The program executes knowing that the data is in the RAM
     but the loader puts the initial values in the FLASH (inidata).
@@ -51,13 +55,13 @@ SECTIONS
     .data :
     {
         . = ALIGN(4);
-        _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */ 
+        _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
         *(.data*)          /* .data* sections */
 
         . = ALIGN(4);
         _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
     } >RAM AT> FLASH_TEXT
-            
+
     /* Uninitialized data section */
     .bss :
     {
@@ -88,3 +92,14 @@ SECTIONS
 
     .ARM.attributes 0 : { *(.ARM.attributes) }
 }
+
+/* RAM extents for the garbage collector */
+_ram_start = ORIGIN(RAM);
+_ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_heap_start = _ebss; /* heap starts just after statically allocated memory */
+_heap_end = _ram_end - 0x4000; /* tunable */
+
+/* Define the top end of the stack.  The stack is full descending so begins just
+   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
+   aligned for a call. */
+_estack = _ram_end;

--- a/stmhal/boards/stm32f401xd.ld
+++ b/stmhal/boards/stm32f401xd.ld
@@ -5,27 +5,12 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 0x060000 /* entire flash, 384 KiB */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 0x004000 /* sector 0, 16 KiB */
-    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 0x01C000 /* sectors 1,2,3 are 16K, 4 is 64K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 0x040000 /* sectors 5,6 2*128KiB = 256 KiB */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x018000 /* 96 KiB */
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 384K
+    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K     /* sector 0: 16K */
+    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 64K     /* sectors 1-4: 3*16K+16K(of 64) = 64K */
+    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 256K    /* sectors 5-6: 2*128K = 256K */
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 96K
 }
-
-/* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
-_minimum_heap_size = 16K;
- 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
 
 /* define common sections and symbols */
 INCLUDE common.ld
-
-/* RAM extents for the garbage collector */
-_ram_start = ORIGIN(RAM);
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20014000; /* tunable */

--- a/stmhal/boards/stm32f401xe.ld
+++ b/stmhal/boards/stm32f401xe.ld
@@ -5,27 +5,12 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 0x080000 /* entire flash, 512 KiB */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 0x004000 /* sector 0, 16 KiB */
-    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 0x01C000 /* sectors 1,2,3 are 16K, 4 is 64K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 0x060000 /* sectors 5,6,7 3*128KiB = 384 KiB */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x018000 /* 96 KiB */
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K
+    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K     /* sector 0: 16K */
+    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 64K     /* sectors 1-4: 3*16K+16K(of 64) = 64K */
+    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 384K    /* sectors 5-7: 3*128K = 384K */
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 96K
 }
-
-/* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
-_minimum_heap_size = 16K;
- 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
 
 /* define common sections and symbols */
 INCLUDE common.ld
-
-/* RAM extents for the garbage collector */
-_ram_start = ORIGIN(RAM);
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20014000; /* tunable */

--- a/stmhal/boards/stm32f405.ld
+++ b/stmhal/boards/stm32f405.ld
@@ -5,27 +5,13 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 0x100000 /* entire flash, 1 MiB */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 0x004000 /* sector 0, 16 KiB */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 0x080000 /* sectors 5,6,7,8, 4*128KiB = 512 KiB (could increase it more) */
-    CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 0x010000 /* 64 KiB */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x020000 /* 128 KiB */
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
+    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K     /* sector 0: 16K */
+    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 112K    /* sectors 1-4: 3*16K+64K = 112K */
+    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 896K    /* sectors 5-11: 7*128K = 896K */
+    CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 64K
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
 }
-
-/* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
-_minimum_heap_size = 16K;
- 
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
 
 /* define common sections and symbols */
 INCLUDE common.ld
-
-/* RAM extents for the garbage collector */
-_ram_start = ORIGIN(RAM);
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2001c000; /* tunable */

--- a/stmhal/boards/stm32f411.ld
+++ b/stmhal/boards/stm32f411.ld
@@ -5,27 +5,12 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 0x080000 /* entire flash, 512 KiB */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 0x004000 /* sector 0, 16 KiB */
-                                                             /* sectors 1,2,3 are 16K, 4 is 64K (for filesystem) */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 0x060000 /* sectors 5,6,7 3*128KiB = 384 KiB */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x020000 /* 128 KiB */
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K
+    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K     /* sector 0: 16K */
+    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 64K     /* sectors 1-4: 3*16K+16K(of 64K) = 64K */
+    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 384K    /* sectors 5-7: 3*128K = 384K */
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
 }
- 
-/* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
-_minimum_heap_size = 16K;
- 
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM) - 1;
 
 /* define common sections and symbols */
 INCLUDE common.ld
-
-/* RAM extents for the garbage collector */
-_ram_start = ORIGIN(RAM);
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2001c000; /* tunable */

--- a/stmhal/boards/stm32f429.ld
+++ b/stmhal/boards/stm32f429.ld
@@ -4,28 +4,14 @@
 
 /* Specify the memory areas */
 MEMORY
-{                                                   
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 0x0200000 /* entire flash, 2048 KiB */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 0x0004000 /* sector 0, 16 KiB */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 0x0088000 /* sectors 5,6,7,8, 4*128KiB = 512 KiB (could increase it more) */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x0030000 /* 192 KiB */
-    SDRAM(xrw)      : ORIGIN = 0xC0000000, LENGTH = 0x0800000 /* 8 MByte */
+{
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K     /* sector 0: 16K */
+    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 112K    /* sectors 1-4: 3*16K+64K = 112K */
+    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 896K    /* sectors 5-11: 7*128K = 896K */
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 192K
+    SDRAM(xrw)      : ORIGIN = 0xC0000000, LENGTH = 8192K
 }
- 
-/* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
-_minimum_heap_size = 16K;
- 
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM) - 1;
 
 /* define common sections and symbols */
 INCLUDE common.ld
-
-/* RAM extents for the garbage collector */
-_ram_start = ORIGIN(RAM);
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2001c000; /* tunable */

--- a/stmhal/boards/stm32f439.ld
+++ b/stmhal/boards/stm32f439.ld
@@ -5,25 +5,14 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 0x200000 /* entire flash, 2048 KiB */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 0x004000 /* sector 0, 16 KiB */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 0x080000 /* sectors 5,6,7,8, 4*128KiB = 512 KiB (could increase it more) */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x030000 /* 192 KiB */
-    CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 0x010000 /* 64 KiB */
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K     /* sector 0: 16K */
+    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 896K    /* sectors 5-11: 7*128K = 896K */
+    FLASH_FS (rx)   : ORIGIN = 0x08100000, LENGTH = 192K    /* sectors 12-17: 4*16K+64K+64K(of 128K) = 192K */
+    FLASH_FS2 (rx)  : ORIGIN = 0x08140000, LENGTH = 64K     /* sector 18: 64K(of 128K) */
+    CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 64K
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 192K
 }
-
-/* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
-_minimum_heap_size = 16K;
-
-/* top end of the stack */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
 
 /* define common sections and symbols */
 INCLUDE common.ld
-
-/* RAM extents for the garbage collector */
-_ram_start = ORIGIN(RAM);
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2002c000; /* tunable */

--- a/stmhal/boards/stm32f746.ld
+++ b/stmhal/boards/stm32f746.ld
@@ -1,32 +1,17 @@
 /*
-    GNU linker script for STM32F405
+    GNU linker script for STM32F746
 */
 
 /* Specify the memory areas */
 MEMORY
 {
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 32K     /* sector 0, 32K */
-    FLASH_FS (r)    : ORIGIN = 0x08008000, LENGTH = 96K     /* sectors 1, 2, 3 (32K each) */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 896K    /* sectors 4-7 1*128Kib 3*256KiB = 896K */
-    DTCM (xrw)      : ORIGIN = 0x20000000, LENGTH = 64K     /* Used for storage cache */
+    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 32K     /* sector 0: 32K */
+    FLASH_FS (rx)   : ORIGIN = 0x08008000, LENGTH = 96K     /* sectors 1-3: 3*32K = 96K */
+    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 896K    /* sectors 4-7: 1*128K + 3*256K = 896K */
+    DTCM (xrw)      : ORIGIN = 0x20000000, LENGTH = 64K
     RAM (xrw)       : ORIGIN = 0x20010000, LENGTH = 256K    /* SRAM1 = 240K, SRAM2 = 16K */
 }
 
-/* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
-_minimum_heap_size = 16K;
-
-/* Define tho top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
 /* define common sections and symbols */
 INCLUDE common.ld
-
-/* RAM extents for the garbage collector */
-_ram_start = ORIGIN(RAM);
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x2004c000; /* tunable */

--- a/stmhal/boards/stm32l476xe.ld
+++ b/stmhal/boards/stm32l476xe.ld
@@ -4,32 +4,17 @@
 
 /* Specify the memory areas */
 MEMORY
-{                                                   
+{
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 0x0004000 /* sectors 0-7, 16 KiB */
-    FLASH_TEXT (rx) : ORIGIN = 0x08004000, LENGTH = 0x005C000 /* sectors 8-191, 368 KiB */
-    FLASH_FS (r)    : ORIGIN = 0x08060000, LENGTH = 0x0020000 /* sectors 192-255, 128 KiB */
+    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K     /* sectors 0-7: 8*2K = 16K */
+    FLASH_TEXT (rx) : ORIGIN = 0x08004000, LENGTH = 368K    /* sectors 8-191: 184*2K = 368K */
+    FLASH_FS (r)    : ORIGIN = 0x08060000, LENGTH = 128K    /* sectors 192-255: 64*2K = 128K */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 96K
     SRAM2 (xrw)     : ORIGIN = 0x10000000, LENGTH = 32K
 }
 
-/* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
-_minimum_heap_size = 16K;
- 
-/* Define the top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
 /* define common sections and symbols */
 INCLUDE common.ld
-
-/* RAM extents for the garbage collector */
-_ram_start = ORIGIN(RAM);
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20014000; /* tunable */
 
 _flash_fs_start = ORIGIN(FLASH_FS);
 _flash_fs_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/stmhal/boards/stm32l476xg.ld
+++ b/stmhal/boards/stm32l476xg.ld
@@ -4,34 +4,17 @@
 
 /* Specify the memory areas */
 MEMORY
-{                                                   
+{
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 0x0004000 /* sectors 0-7, 16 KiB */
-    FLASH_TEXT (rx) : ORIGIN = 0x08004000, LENGTH = 0x007C000 /* sectors 8-255, 496 KiB */
-    FLASH_FS (r)    : ORIGIN = 0x08080000, LENGTH = 0x0080000 /* sectors 256-511 512 KiB */
+    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K     /* sectors 0-7: 8*2K = 16K */
+    FLASH_TEXT (rx) : ORIGIN = 0x08004000, LENGTH = 496K    /* sectors 8-255: 248*2K = 496K */
+    FLASH_FS (r)    : ORIGIN = 0x08080000, LENGTH = 512K    /* sectors 256-511: 256*2K = 512K */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 96K
     SRAM2 (xrw)     : ORIGIN = 0x10000000, LENGTH = 32K
 }
 
-ENTRY(Reset_Handler)
-
-/* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
-_minimum_heap_size = 16K;
- 
-/* Define the top end of the stack.  The stack is full descending so begins just
-   above last byte of RAM.  Note that EABI requires the stack to be 8-byte
-   aligned for a call. */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
 /* define common sections and symbols */
 INCLUDE common.ld
-
-/* RAM extents for the garbage collector */
-_ram_start = ORIGIN(RAM);
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_start = _ebss; /* heap starts just after statically allocated memory */
-_heap_end = 0x20014000; /* tunable */
 
 _flash_fs_start = ORIGIN(FLASH_FS);
 _flash_fs_end   = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);


### PR DESCRIPTION
* move common definition to common.ld
* increase FLASH_TEXT size where possible (F405, F429, F439)
* use ###K notation for LENGTH fields
* unify style of comments about sector sizes