### PR TITLE
py: implement equality check for range()

### DIFF
--- a/py/objrange.c
+++ b/py/objrange.c
@@ -137,6 +137,21 @@ STATIC mp_obj_t range_unary_op(mp_uint_t op, mp_obj_t self_in) {
     }
 }
 
+STATIC mp_obj_t range_equal(mp_obj_t self_in, mp_obj_t other_in) {
+    mp_obj_range_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_obj_range_t *other = MP_OBJ_TO_PTR(other_in);
+    return (self->start == other->start) && (self->stop == other->stop) && (self->step == other->step) ? mp_const_true : mp_const_false;
+}
+
+STATIC mp_obj_t range_binary_op(mp_uint_t op, mp_obj_t lhs, mp_obj_t rhs) {
+    switch (op) {
+        case MP_BINARY_OP_EQUAL:
+            return range_equal(lhs, rhs);
+        default:
+            return MP_OBJ_NULL; // op not supported
+    }
+}
+
 STATIC mp_obj_t range_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
     if (value == MP_OBJ_SENTINEL) {
         // load
@@ -190,6 +205,7 @@ const mp_obj_type_t mp_type_range = {
     .print = range_print,
     .make_new = range_make_new,
     .unary_op = range_unary_op,
+    .binary_op = range_binary_op,
     .subscr = range_subscr,
     .getiter = range_getiter,
 #if MICROPY_PY_BUILTINS_RANGE_ATTRS


### PR DESCRIPTION
Micropython:

```
>>> x = range(7)
>>> y = range(7)
>>> id(x)
4143768592
>>> id(y)
4143768640
>>> x == y
False
```

(C)Python3:

```
>>> x = range(7)
>>> y = range(7)
>>> id(x)
140481841389808
>>> id(y)
140481840774816
>>> x == y
True
>>> 
```

It seems that Python3 treats two same ranges as equal even if they are different objects. This is not true for Micropython.

This patch fixes the behaviour.