### PR TITLE
docs/*/quickref.rst: Use new semantics of utime.ticks_diff()

### DIFF
--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -83,7 +83,7 @@ Use the :mod:`time <utime>` module::
     time.sleep_ms(500)      # sleep for 500 milliseconds
     time.sleep_us(10)       # sleep for 10 microseconds
     start = time.ticks_ms() # get millisecond counter
-    delta = time.ticks_diff(start, time.ticks_ms()) # compute time difference
+    delta = time.ticks_diff(time.ticks_ms(), start) # compute time difference
 
 Timers
 ------

--- a/docs/pyboard/quickref.rst
+++ b/docs/pyboard/quickref.rst
@@ -37,7 +37,7 @@ Use the :mod:`time <utime>` module::
     time.sleep_ms(500)      # sleep for 500 milliseconds
     time.sleep_us(10)       # sleep for 10 microseconds
     start = time.ticks_ms() # get value of millisecond counter
-    delta = time.ticks_diff(start, time.ticks_ms()) # compute time difference
+    delta = time.ticks_diff(time.ticks_ms(), start) # compute time difference
 
 LEDs
 ----

--- a/docs/reference/speed_python.rst
+++ b/docs/reference/speed_python.rst
@@ -132,7 +132,7 @@ The following enables any function or method to be timed by adding an
         def new_func(*args, **kwargs):
             t = time.ticks_us()
             result = f(*args, **kwargs)
-            delta = time.ticks_diff(t, time.ticks_us())
+            delta = time.ticks_diff(time.ticks_us(), t)
             print('Function {} Time = {:6.3f}ms'.format(myname, delta/1000))
             return result
         return new_func


### PR DESCRIPTION
Adjustment of the documentation to fit the new  semantic of `utime.ticks_diff()` (#2217).