### PR TITLE
esp8266: add note in docs about simultaneous use of STA_IF and AP_IF

### DIFF
--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -267,6 +267,15 @@ For example::
     connect). Availability of the methods below depends on interface type.
     For example, only STA interface may ``connect()`` to an access point.
 
+    .. note::
+
+        Simultaneous operation of STA_IF and AP_IF interfaces is supported.
+
+        However, due to restrictions of the hardware, there may be performance
+        issues in the AP_IF, if the STA_IF is not connected and searching.
+        An application should manage these interfaces and for example
+        deactivate the STA_IF in environments where only the AP_IF is used.
+
     Methods
     -------
 


### PR DESCRIPTION
see also https://github.com/esp8266/Arduino/issues/1624

not knowing about the issues of AP_IF when STA_IF is scanning was failing a demonstration... let's save other people from embarrassment ;-)