### PR TITLE
zephyr: Remove obsolete ALL_LIBS workaround

### DIFF
--- a/zephyr/Makefile
+++ b/zephyr/Makefile
@@ -80,7 +80,6 @@ $(LIBMICROPYTHON): $(Z_SYSGEN_H)
 build/genhdr/qstr.i.last: $(Z_SYSGEN_H)
 
 $(Z_SYSGEN_H):
-	rm -f $(LIBMICROPYTHON)
 	-$(MAKE) -f Makefile.zephyr BOARD=$(BOARD) CONF_FILE=$(CONF_FILE)
 
 minimal:


### PR DESCRIPTION
As of 2016-11-07, Zephyr now handles ALL_LIBS dependancies correctly:
https://gerrit.zephyrproject.org/r/#/c/5086/

With Zephyr handling things properly we can remove the corresponding
workaround from the micropython build system.