### PR TITLE
Add optimisation to parser to fold constant logical expressions

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -243,23 +243,13 @@ STATIC void compile_generic_tuple(compiler_t *comp, mp_parse_node_struct_t *pns)
     c_tuple(comp, MP_PARSE_NODE_NULL, pns);
 }
 
-STATIC bool node_is_const_false(mp_parse_node_t pn) {
-    return MP_PARSE_NODE_IS_TOKEN_KIND(pn, MP_TOKEN_KW_FALSE)
-        || (MP_PARSE_NODE_IS_SMALL_INT(pn) && MP_PARSE_NODE_LEAF_SMALL_INT(pn) == 0);
-}
-
-STATIC bool node_is_const_true(mp_parse_node_t pn) {
-    return MP_PARSE_NODE_IS_TOKEN_KIND(pn, MP_TOKEN_KW_TRUE)
-        || (MP_PARSE_NODE_IS_SMALL_INT(pn) && MP_PARSE_NODE_LEAF_SMALL_INT(pn) != 0);
-}
-
 STATIC void c_if_cond(compiler_t *comp, mp_parse_node_t pn, bool jump_if, int label) {
-    if (node_is_const_false(pn)) {
+    if (mp_parse_node_is_const_false(pn)) {
         if (jump_if == false) {
             EMIT_ARG(jump, label);
         }
         return;
-    } else if (node_is_const_true(pn)) {
+    } else if (mp_parse_node_is_const_true(pn)) {
         if (jump_if == true) {
             EMIT_ARG(jump, label);
         }
@@ -1218,14 +1208,14 @@ STATIC void compile_if_stmt(compiler_t *comp, mp_parse_node_struct_t *pns) {
     uint l_end = comp_next_label(comp);
 
     // optimisation: don't emit anything when "if False"
-    if (!node_is_const_false(pns->nodes[0])) {
+    if (!mp_parse_node_is_const_false(pns->nodes[0])) {
         uint l_fail = comp_next_label(comp);
         c_if_cond(comp, pns->nodes[0], false, l_fail); // if condition
 
         compile_node(comp, pns->nodes[1]); // if block
 
         // optimisation: skip everything else when "if True"
-        if (node_is_const_true(pns->nodes[0])) {
+        if (mp_parse_node_is_const_true(pns->nodes[0])) {
             goto done;
         }
 
@@ -1250,14 +1240,14 @@ STATIC void compile_if_stmt(compiler_t *comp, mp_parse_node_struct_t *pns) {
         mp_parse_node_struct_t *pns_elif = (mp_parse_node_struct_t*)pn_elif[i];
 
         // optimisation: don't emit anything when "if False"
-        if (!node_is_const_false(pns_elif->nodes[0])) {
+        if (!mp_parse_node_is_const_false(pns_elif->nodes[0])) {
             uint l_fail = comp_next_label(comp);
             c_if_cond(comp, pns_elif->nodes[0], false, l_fail); // elif condition
 
             compile_node(comp, pns_elif->nodes[1]); // elif block
 
             // optimisation: skip everything else when "elif True"
-            if (node_is_const_true(pns_elif->nodes[0])) {
+            if (mp_parse_node_is_const_true(pns_elif->nodes[0])) {
                 goto done;
             }
 
@@ -1294,9 +1284,9 @@ done:
 STATIC void compile_while_stmt(compiler_t *comp, mp_parse_node_struct_t *pns) {
     START_BREAK_CONTINUE_BLOCK
 
-    if (!node_is_const_false(pns->nodes[0])) { // optimisation: don't emit anything for "while False"
+    if (!mp_parse_node_is_const_false(pns->nodes[0])) { // optimisation: don't emit anything for "while False"
         uint top_label = comp_next_label(comp);
-        if (!node_is_const_true(pns->nodes[0])) { // optimisation: don't jump to cond for "while True"
+        if (!mp_parse_node_is_const_true(pns->nodes[0])) { // optimisation: don't jump to cond for "while True"
             EMIT_ARG(jump, continue_label);
         }
         EMIT_ARG(label_assign, top_label);

--- a/py/compile.c
+++ b/py/compile.c
@@ -1403,13 +1403,13 @@ STATIC void compile_for_stmt(compiler_t *comp, mp_parse_node_struct_t *pns) {
             if (1 <= n_args && n_args <= 3) {
                 optimize = true;
                 if (n_args == 1) {
-                    pn_range_start = mp_parse_node_new_leaf(MP_PARSE_NODE_SMALL_INT, 0);
+                    pn_range_start = mp_parse_node_new_small_int(0);
                     pn_range_end = args[0];
-                    pn_range_step = mp_parse_node_new_leaf(MP_PARSE_NODE_SMALL_INT, 1);
+                    pn_range_step = mp_parse_node_new_small_int(1);
                 } else if (n_args == 2) {
                     pn_range_start = args[0];
                     pn_range_end = args[1];
-                    pn_range_step = mp_parse_node_new_leaf(MP_PARSE_NODE_SMALL_INT, 1);
+                    pn_range_step = mp_parse_node_new_small_int(1);
                 } else {
                     pn_range_start = args[0];
                     pn_range_end = args[1];

--- a/py/parse.c
+++ b/py/parse.c
@@ -234,6 +234,16 @@ mp_parse_node_t mp_parse_node_new_leaf(size_t kind, mp_int_t arg) {
     return (mp_parse_node_t)(kind | (arg << 4));
 }
 
+bool mp_parse_node_is_const_false(mp_parse_node_t pn) {
+    return MP_PARSE_NODE_IS_TOKEN_KIND(pn, MP_TOKEN_KW_FALSE)
+        || (MP_PARSE_NODE_IS_SMALL_INT(pn) && MP_PARSE_NODE_LEAF_SMALL_INT(pn) == 0);
+}
+
+bool mp_parse_node_is_const_true(mp_parse_node_t pn) {
+    return MP_PARSE_NODE_IS_TOKEN_KIND(pn, MP_TOKEN_KW_TRUE)
+        || (MP_PARSE_NODE_IS_SMALL_INT(pn) && MP_PARSE_NODE_LEAF_SMALL_INT(pn) != 0);
+}
+
 bool mp_parse_node_get_int_maybe(mp_parse_node_t pn, mp_obj_t *o) {
     if (MP_PARSE_NODE_IS_SMALL_INT(pn)) {
         *o = MP_OBJ_NEW_SMALL_INT(MP_PARSE_NODE_LEAF_SMALL_INT(pn));

--- a/py/parse.c
+++ b/py/parse.c
@@ -227,13 +227,6 @@ STATIC void pop_rule(parser_t *parser, const rule_t **rule, size_t *arg_i, size_
     *src_line = parser->rule_stack[parser->rule_stack_top].src_line;
 }
 
-mp_parse_node_t mp_parse_node_new_leaf(size_t kind, mp_int_t arg) {
-    if (kind == MP_PARSE_NODE_SMALL_INT) {
-        return (mp_parse_node_t)(kind | (arg << 1));
-    }
-    return (mp_parse_node_t)(kind | (arg << 4));
-}
-
 bool mp_parse_node_is_const_false(mp_parse_node_t pn) {
     return MP_PARSE_NODE_IS_TOKEN_KIND(pn, MP_TOKEN_KW_FALSE)
         || (MP_PARSE_NODE_IS_SMALL_INT(pn) && MP_PARSE_NODE_LEAF_SMALL_INT(pn) == 0);
@@ -418,7 +411,7 @@ STATIC void push_result_token(parser_t *parser, const rule_t *rule) {
         mp_map_elem_t *elem;
         if (rule->rule_id == RULE_atom
             && (elem = mp_map_lookup(&parser->consts, MP_OBJ_NEW_QSTR(id), MP_MAP_LOOKUP)) != NULL) {
-            pn = mp_parse_node_new_leaf(MP_PARSE_NODE_SMALL_INT, MP_OBJ_SMALL_INT_VALUE(elem->value));
+            pn = mp_parse_node_new_small_int(MP_OBJ_SMALL_INT_VALUE(elem->value));
         } else {
             pn = mp_parse_node_new_leaf(MP_PARSE_NODE_ID, id);
         }
@@ -429,7 +422,7 @@ STATIC void push_result_token(parser_t *parser, const rule_t *rule) {
     } else if (lex->tok_kind == MP_TOKEN_INTEGER) {
         mp_obj_t o = mp_parse_num_integer(lex->vstr.buf, lex->vstr.len, 0, lex);
         if (MP_OBJ_IS_SMALL_INT(o)) {
-            pn = mp_parse_node_new_leaf(MP_PARSE_NODE_SMALL_INT, MP_OBJ_SMALL_INT_VALUE(o));
+            pn = mp_parse_node_new_small_int(MP_OBJ_SMALL_INT_VALUE(o));
         } else {
             pn = make_node_const_object(parser, lex->tok_line, o);
         }
@@ -658,7 +651,7 @@ STATIC bool fold_constants(parser_t *parser, const rule_t *rule, size_t num_args
         pop_result(parser);
     }
     if (MP_OBJ_IS_SMALL_INT(arg0)) {
-        push_result_node(parser, mp_parse_node_new_leaf(MP_PARSE_NODE_SMALL_INT, MP_OBJ_SMALL_INT_VALUE(arg0)));
+        push_result_node(parser, mp_parse_node_new_small_int(MP_OBJ_SMALL_INT_VALUE(arg0)));
     } else {
         // TODO reuse memory for parse node struct?
         push_result_node(parser, make_node_const_object(parser, 0, arg0));

--- a/py/parse.h
+++ b/py/parse.h
@@ -76,7 +76,12 @@ typedef struct _mp_parse_node_struct_t {
 #define MP_PARSE_NODE_STRUCT_KIND(pns) ((pns)->kind_num_nodes & 0xff)
 #define MP_PARSE_NODE_STRUCT_NUM_NODES(pns) ((pns)->kind_num_nodes >> 8)
 
-mp_parse_node_t mp_parse_node_new_leaf(size_t kind, mp_int_t arg);
+static inline mp_parse_node_t mp_parse_node_new_small_int(mp_int_t val) {
+    return (mp_parse_node_t)(MP_PARSE_NODE_SMALL_INT | ((mp_uint_t)val << 1));
+}
+static inline mp_parse_node_t mp_parse_node_new_leaf(size_t kind, mp_int_t arg) {
+    return (mp_parse_node_t)(kind | ((mp_uint_t)arg << 4));
+}
 bool mp_parse_node_is_const_false(mp_parse_node_t pn);
 bool mp_parse_node_is_const_true(mp_parse_node_t pn);
 bool mp_parse_node_get_int_maybe(mp_parse_node_t pn, mp_obj_t *o);

--- a/py/parse.h
+++ b/py/parse.h
@@ -77,6 +77,8 @@ typedef struct _mp_parse_node_struct_t {
 #define MP_PARSE_NODE_STRUCT_NUM_NODES(pns) ((pns)->kind_num_nodes >> 8)
 
 mp_parse_node_t mp_parse_node_new_leaf(size_t kind, mp_int_t arg);
+bool mp_parse_node_is_const_false(mp_parse_node_t pn);
+bool mp_parse_node_is_const_true(mp_parse_node_t pn);
 bool mp_parse_node_get_int_maybe(mp_parse_node_t pn, mp_obj_t *o);
 int mp_parse_node_extract_list(mp_parse_node_t *pn, size_t pn_kind, mp_parse_node_t **nodes);
 void mp_parse_node_print(mp_parse_node_t pn, size_t indent);

--- a/tests/basics/logic_constfolding.py
+++ b/tests/basics/logic_constfolding.py
@@ -1,0 +1,26 @@
+# tests logical constant folding in parser
+
+def f_true():
+    print('f_true')
+    return True
+
+def f_false():
+    print('f_false')
+    return False
+
+print(0 or False)
+print(1 or foo)
+print(f_false() or 1 or foo)
+print(f_false() or 1 or f_true())
+
+print(0 and foo)
+print(1 and True)
+print(f_true() and 0 and foo)
+print(f_true() and 1 and f_false())
+
+print(not 0)
+print(not False)
+print(not 1)
+print(not True)
+print(not not 0)
+print(not not 1)


### PR DESCRIPTION
This PR optimises constants used in `and`, `or` and `not` expressions.  It does full optimisation, for example:
```python
1 or foo() # optimised to 1
0 and foo() # optimised to 0
1 and True # optimised to True
foo() and 1 and bar() # optimised to foo() and bar()
foo() or 1 or bar() # optimised to foo() or 1
```
It costs about 200 bytes of code space.  Note that even minimal/bare-arm ports have constant folding enabled so this PR increases their size.