### PR TITLE
py: fix find command to work on OSX

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -108,7 +108,7 @@ endif
 
 ifneq ($(FROZEN_MPY_DIR),)
 # make a list of all the .py files that need compiling and freezing
-FROZEN_MPY_PY_FILES := $(shell find -L $(FROZEN_MPY_DIR) -type f -name '*.py' -printf '%P\n')
+FROZEN_MPY_PY_FILES := $(shell find -L $(FROZEN_MPY_DIR) -type f -name '*.py' | sed -e 's=^$(FROZEN_MPY_DIR)/==')
 FROZEN_MPY_MPY_FILES := $(addprefix $(BUILD)/frozen_mpy/,$(FROZEN_MPY_PY_FILES:.py=.mpy))
 
 # to build .mpy files from .py files


### PR DESCRIPTION
The Mac version of find doesn't support -printf, so this changes
things to use sed to strip off the leading path element instead.

This problem was discovered by a user on the forum. See: http://forum.micropython.org/viewtopic.php?f=6&t=1776&p=15792#p15778 for the discussion.