### PR TITLE
WIP py/objtype: Implement __call__ handling for instance w/o heap alloc.

### DIFF
--- a/py/objtype.c
+++ b/py/objtype.c
@@ -687,9 +687,8 @@ STATIC mp_obj_t instance_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value
     }
 }
 
-STATIC mp_obj_t mp_obj_instance_get_call(mp_obj_t self_in) {
+STATIC mp_obj_t mp_obj_instance_get_call(mp_obj_t self_in, mp_obj_t *member) {
     mp_obj_instance_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_obj_t member[2] = {MP_OBJ_NULL, MP_OBJ_NULL};
     struct class_lookup_data lookup = {
         .obj = self,
         .attr = MP_QSTR___call__,
@@ -702,11 +701,13 @@ STATIC mp_obj_t mp_obj_instance_get_call(mp_obj_t self_in) {
 }
 
 bool mp_obj_instance_is_callable(mp_obj_t self_in) {
-    return mp_obj_instance_get_call(self_in) != MP_OBJ_NULL;
+    mp_obj_t member[2] = {MP_OBJ_NULL, MP_OBJ_NULL};
+    return mp_obj_instance_get_call(self_in, member) != MP_OBJ_NULL;
 }
 
 mp_obj_t mp_obj_instance_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_obj_t call = mp_obj_instance_get_call(self_in);
+    mp_obj_t member[2] = {MP_OBJ_NULL, MP_OBJ_NULL};
+    mp_obj_t call = mp_obj_instance_get_call(self_in, member);
     if (call == MP_OBJ_NULL) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_msg(&mp_type_TypeError, "object not callable");
@@ -719,8 +720,14 @@ mp_obj_t mp_obj_instance_call(mp_obj_t self_in, size_t n_args, size_t n_kw, cons
     if (call == MP_OBJ_SENTINEL) {
         return mp_call_function_n_kw(self->subobj[0], n_args, n_kw, args);
     }
-    mp_obj_t meth = mp_obj_new_bound_meth(call, self_in);
-    return mp_call_function_n_kw(meth, n_args, n_kw, args);
+
+    size_t n_total = n_args + 2 * n_kw;
+    mp_obj_t *args2 = alloca(sizeof(mp_obj_t) * (1 + n_total));
+    args2[0] = member[1];
+    memcpy(args2 + 1, args, n_total * sizeof(mp_obj_t));
+    return mp_call_function_n_kw(member[0], n_args + 1, n_kw, &args2[0]);
+//    mp_obj_t meth = mp_obj_new_bound_meth(call, self_in);
+//    return mp_call_function_n_kw(meth, n_args, n_kw, args);
 }
 
 STATIC mp_obj_t instance_getiter(mp_obj_t self_in) {


### PR DESCRIPTION
@dpgeorge , did you know that calling `__call__` on instances always leads to heap alloc? The code was originally implemented in such way by me. As you can see, the patch is awful, it duplicates code in objboundmeth.c, etc.

Why mp_call_function_n_kw() wasn't originally implemented in such a way as to require a slot for self at the beginning of args, then skip it if not needed? Unless there were good reasons, let's refactor that now ;-).
