### PR TITLE
unix: fix segmentation fault on linking FreeDOS build with DJGPP

### DIFF
--- a/unix/.gitignore
+++ b/unix/.gitignore
@@ -3,10 +3,12 @@ build-fast
 build-minimal
 build-coverage
 build-nanbox
+build-freedos
 micropython
 micropython_fast
 micropython_minimal
 micropython_coverage
 micropython_nanbox
+micropython_freedos*
 *.py
 *.gcov

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -235,7 +235,10 @@ freedos:
 	PROG=micropython_freedos \
 	MICROPY_PY_SOCKET=0 \
 	MICROPY_PY_FFI=0 \
-	MICROPY_PY_JNI=0
+	MICROPY_PY_JNI=0 \
+	MICROPY_PY_BTREE=0 \
+	MICROPY_PY_THREAD=0 \
+	MICROPY_PY_USSL=0
 
 # build an interpreter for coverage testing and do the testing
 coverage:

--- a/unix/mpconfigport_freedos.h
+++ b/unix/mpconfigport_freedos.h
@@ -37,8 +37,4 @@
 // djgpp dirent struct does not have d_ino field
 #undef _DIRENT_HAVE_D_INO
 
-// djgpp errno.h have no ENOTSUP
-#include <errno.h>
-#ifndef ENOTSUP
-#define ENOTSUP 88
-#endif
+#define MICROPY_USE_INTERNAL_ERRNO  (1)


### PR DESCRIPTION
* add FreeDOS build files to gitignore
* make `fatfs` module optional
* use internal ERRNO
* add `--no-gc-sections` to `LDFLAGS_EXTRA`

Original commit by @prusnak (https://github.com/prusnak/micropython/commit/a97e0886ac479b58ca8bed6c28a8ac9bdf24dca7)