### PR TITLE
Allow file to respond to ioctl flush request

### DIFF
--- a/extmod/modbtree.c
+++ b/extmod/modbtree.c
@@ -81,6 +81,15 @@ STATIC void btree_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind
     mp_printf(print, "<btree %p>", self->db);
 }
 
+
+STATIC mp_obj_t btree_sync(mp_obj_t self_in) {
+    mp_obj_btree_t *self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(__bt_sync(self->db,0));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(btree_sync_obj, btree_sync);
+
+
+
 STATIC mp_obj_t btree_close(mp_obj_t self_in) {
     mp_obj_btree_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_NEW_SMALL_INT(__bt_close(self->db));
@@ -314,6 +323,7 @@ STATIC mp_obj_t btree_binary_op(mp_uint_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) 
 
 STATIC const mp_rom_map_elem_t btree_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_close), MP_ROM_PTR(&btree_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR_sync), MP_ROM_PTR(&btree_sync_obj) },
     { MP_ROM_QSTR(MP_QSTR_get), MP_ROM_PTR(&btree_get_obj) },
     { MP_ROM_QSTR(MP_QSTR_put), MP_ROM_PTR(&btree_put_obj) },
     { MP_ROM_QSTR(MP_QSTR_seq), MP_ROM_PTR(&btree_seq_obj) },

--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -140,6 +140,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(file_obj___exit___obj, 4, 4, file_obj
 STATIC mp_uint_t file_obj_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, int *errcode) {
     pyb_file_obj_t *self = MP_OBJ_TO_PTR(o_in);
 
+    if (request == MP_STREAM_FLUSH) {
+	file_obj_flush(o_in);
+	return 0;
+    }
+    
     if (request == MP_STREAM_SEEK) {
         struct mp_stream_seek_t *s = (struct mp_stream_seek_t*)(uintptr_t)arg;
 


### PR DESCRIPTION
btree uses mp_stream_posix_fsync to flush the file. mp_stream_posix_fsync uses an ioctl, but the vfs_fat_fs didn't support it for flush.

I was having problems getting persistant btree on the filesystem without this.

NB:  when opening the file you should not use "w" for the file mode because it implicitly truncates the file. I have had more luck with using "rab" for the file mode when opening.

It would be nice to have a db flush exposed to python.