### PR TITLE
Fixes for using btree with the file system

### DIFF
--- a/extmod/modbtree.c
+++ b/extmod/modbtree.c
@@ -81,6 +81,15 @@ STATIC void btree_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind
     mp_printf(print, "<btree %p>", self->db);
 }
 
+
+STATIC mp_obj_t btree_sync(mp_obj_t self_in) {
+    mp_obj_btree_t *self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(__bt_sync(self->db,0));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(btree_sync_obj, btree_sync);
+
+
+
 STATIC mp_obj_t btree_close(mp_obj_t self_in) {
     mp_obj_btree_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_NEW_SMALL_INT(__bt_close(self->db));
@@ -314,6 +323,7 @@ STATIC mp_obj_t btree_binary_op(mp_uint_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) 
 
 STATIC const mp_rom_map_elem_t btree_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_close), MP_ROM_PTR(&btree_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR_sync), MP_ROM_PTR(&btree_sync_obj) },
     { MP_ROM_QSTR(MP_QSTR_get), MP_ROM_PTR(&btree_get_obj) },
     { MP_ROM_QSTR(MP_QSTR_put), MP_ROM_PTR(&btree_put_obj) },
     { MP_ROM_QSTR(MP_QSTR_seq), MP_ROM_PTR(&btree_seq_obj) },

--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -108,15 +108,6 @@ STATIC mp_uint_t file_obj_write(mp_obj_t self_in, const void *buf, mp_uint_t siz
     return sz_out;
 }
 
-STATIC mp_obj_t file_obj_flush(mp_obj_t self_in) {
-    pyb_file_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    FRESULT res = f_sync(&self->fp);
-    if (res != FR_OK) {
-        mp_raise_OSError(fresult_to_errno_table[res]);
-    }
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(file_obj_flush_obj, file_obj_flush);
 
 STATIC mp_obj_t file_obj_close(mp_obj_t self_in) {
     pyb_file_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -139,11 +130,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(file_obj___exit___obj, 4, 4, file_obj
 
 STATIC mp_uint_t file_obj_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, int *errcode) {
     pyb_file_obj_t *self = MP_OBJ_TO_PTR(o_in);
+    FRESULT res;
 
-    if (request == MP_STREAM_FLUSH) {
-	file_obj_flush(o_in);
-	return 0;
-    }
+    
     
     if (request == MP_STREAM_SEEK) {
         struct mp_stream_seek_t *s = (struct mp_stream_seek_t*)(uintptr_t)arg;
@@ -164,12 +153,21 @@ STATIC mp_uint_t file_obj_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg,
             case 2: // SEEK_END
                 f_lseek(&self->fp, f_size(&self->fp) + s->offset);
                 break;
-        }
-
+        } else if (request == MP_STREAM_FLUSH) {
+	    res = f_sync(&self->fp);
+	    if (res != FR_OK) {
+		mp_raise_OSError(fresult_to_errno_table[res]);
+	    }
+	    return mp_const_none;
+	} else {
         s->offset = f_tell(&self->fp);
         return 0;
 
-    } else {
+    }
+
+
+
+    else {
         *errcode = MP_EINVAL;
         return MP_STREAM_ERROR;
     }
@@ -248,7 +246,7 @@ STATIC const mp_rom_map_elem_t rawfile_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_readline), MP_ROM_PTR(&mp_stream_unbuffered_readline_obj) },
     { MP_ROM_QSTR(MP_QSTR_readlines), MP_ROM_PTR(&mp_stream_unbuffered_readlines_obj) },
     { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&mp_stream_write_obj) },
-    { MP_ROM_QSTR(MP_QSTR_flush), MP_ROM_PTR(&file_obj_flush_obj) },
+    { MP_ROM_QSTR(MP_QSTR_flush), MP_ROM_PTR(&mp_stream_flush_obj) },
     { MP_ROM_QSTR(MP_QSTR_close), MP_ROM_PTR(&file_obj_close_obj) },
     { MP_ROM_QSTR(MP_QSTR_seek), MP_ROM_PTR(&mp_stream_seek_obj) },
     { MP_ROM_QSTR(MP_QSTR_tell), MP_ROM_PTR(&mp_stream_tell_obj) },

--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -153,21 +153,20 @@ STATIC mp_uint_t file_obj_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg,
             case 2: // SEEK_END
                 f_lseek(&self->fp, f_size(&self->fp) + s->offset);
                 break;
-        } else if (request == MP_STREAM_FLUSH) {
-	    res = f_sync(&self->fp);
-	    if (res != FR_OK) {
-		mp_raise_OSError(fresult_to_errno_table[res]);
-	    }
-	    return mp_const_none;
-	} else {
-        s->offset = f_tell(&self->fp);
-        return 0;
+        }
 
-    }
-
-
-
-    else {
+	s->offset = f_tell(&self->fp);
+	return 0;
+	
+    } else if (request == MP_STREAM_FLUSH) {
+	res = f_sync(&self->fp);
+	if (res != FR_OK) {
+	    mp_raise_OSError(fresult_to_errno_table[res]);
+	    
+	}
+	return 0;
+	
+    } else {
         *errcode = MP_EINVAL;
         return MP_STREAM_ERROR;
     }

--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -140,6 +140,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(file_obj___exit___obj, 4, 4, file_obj
 STATIC mp_uint_t file_obj_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, int *errcode) {
     pyb_file_obj_t *self = MP_OBJ_TO_PTR(o_in);
 
+    if (request == MP_STREAM_FLUSH) {
+	file_obj_flush(o_in);
+	return 0;
+    }
+    
     if (request == MP_STREAM_SEEK) {
         struct mp_stream_seek_t *s = (struct mp_stream_seek_t*)(uintptr_t)arg;
 


### PR DESCRIPTION
2 different patches -

1) when btree is running an does a sync, it ends up using mp_stream_posix_fsync which did a fsync by using a ioctl call, the problem was that the file ioctl didn't fulfill the flush request. 

2) add the ability to sync the db when using btree. This is merely a proxy for  Berkeley __bt_sync and exposes as db.sync() with no options - 