### PR TITLE
stmhal/sdcard : clean/invalidate cache before DMA transfert in SDCARD…

### DIFF
--- a/stmhal/mphalport.h
+++ b/stmhal/mphalport.h
@@ -6,10 +6,16 @@
 // go in some MCU-specific header, but for now it lives here.
 #if defined(MCU_SERIES_F4)
 #define MP_HAL_UNIQUE_ID_ADDRESS (0x1fff7a10)
+#define MP_HAL_CLEANINVALIDATECACHE(addr, size)
+#define MP_HAL_CLEANCACHE(addr, size)
 #elif defined(MCU_SERIES_F7)
 #define MP_HAL_UNIQUE_ID_ADDRESS (0x1ff0f420)
+#define MP_HAL_CLEANINVALIDATECACHE(addr, size) (SCB_CleanInvalidateDCache_by_Addr((uint32_t*)((uint32_t)addr & ~0x1f), ((uint32_t)(addr + size + 0x1f) & ~0x1f) - ((uint32_t)addr & ~0x1f)))
+#define MP_HAL_CLEANCACHE(addr, size) (SCB_CleanDCache_by_Addr((uint32_t*)((uint32_t)addr & ~0x1f), ((uint32_t)(addr + size + 0x1f) & ~0x1f) - ((uint32_t)addr & ~0x1f)))
 #elif defined(MCU_SERIES_L4)
 #define MP_HAL_UNIQUE_ID_ADDRESS (0x1fff7590)
+#define MP_HAL_CLEANINVALIDATECACHE(addr, size)
+#define MP_HAL_CLEANCACHE(addr, size)
 #else
 #error mphalport.h: Unrecognized MCU_SERIES
 #endif

--- a/stmhal/mphalport.h
+++ b/stmhal/mphalport.h
@@ -6,10 +6,16 @@
 // go in some MCU-specific header, but for now it lives here.
 #if defined(MCU_SERIES_F4)
 #define MP_HAL_UNIQUE_ID_ADDRESS (0x1fff7a10)
+#define MP_HAL_CLEANINVALIDATECACHE(addr, size)
+#define MP_HAL_CLEANCACHE(addr, size)
 #elif defined(MCU_SERIES_F7)
 #define MP_HAL_UNIQUE_ID_ADDRESS (0x1ff0f420)
+#define MP_HAL_CLEANINVALIDATECACHE(addr, size) (SCB_CleanInvalidateDCache_by_Addr((uint32_t*)(((uint32_t)addr ) & ~(0x1F)), (size) + ((uint32_t)addr - (((uint32_t)addr ) & ~(0x1F)))))
+#define MP_HAL_CLEANCACHE(addr, size) (SCB_CleanDCache_by_Addr((uint32_t*)(((uint32_t)addr) & ~(0x1F)), (size) + ((uint32_t)addr - (((uint32_t)addr) & ~(0x1F)))));
 #elif defined(MCU_SERIES_L4)
 #define MP_HAL_UNIQUE_ID_ADDRESS (0x1fff7590)
+#define MP_HAL_CLEANINVALIDATECACHE(addr, size)
+#define MP_HAL_CLEANCACHE(addr, size)
 #else
 #error mphalport.h: Unrecognized MCU_SERIES
 #endif


### PR DESCRIPTION
… on STM32F7.

Add 2 macros in mphalport.h that clean and invalidate data caches only on STM32F7 MCU. They are needed to ensure the cache coherency before/after DMA transferts.
 * MP_HAL_CLEANINVALIDATECACHE cleans and invalidate the data cache. It must be called before starting a DMA transfert from the peripheral to the RAM memory.
 * MP_HAL_CLEANCACHE clean the data cache. It must be called before starting a DMA transfert from the RAM memory to the peripheral.

Call these macros in sdcard.c, before reading from and writing to the SDCard, when DMA is used.

This issue was discussed here : https://github.com/micropython/micropython/issues/1677