### PR TITLE
docs: Added clarification about UART timeouts

### DIFF
--- a/docs/library/pyb.UART.rst
+++ b/docs/library/pyb.UART.rst
@@ -87,7 +87,7 @@ Methods
          - ``stop`` is the number of stop bits, 1 or 2.
          - ``flow`` sets the flow control type. Can be 0, ``UART.RTS``, ``UART.CTS``
            or ``UART.RTS | UART.CTS``.
-         - ``timeout`` is the timeout in milliseconds to wait for the first character.
+         - ``timeout`` is the timeout in milliseconds to wait for writing/reading the first character.
          - ``timeout_char`` is the timeout in milliseconds to wait between characters.
          - ``read_buf_len`` is the character length of the read buffer (0 to disable).
     
@@ -110,11 +110,6 @@ Methods
     .. method:: UART.any()
 
        Returns the number of bytes waiting (may be 0).
-
-    .. method:: UART.writechar(char)
-
-      Write a single character on the bus.  ``char`` is an integer to write.
-      Return value: ``None``. See note below if CTS flow control is used.
 
 .. method:: UART.read([nbytes])
 
@@ -166,6 +161,13 @@ Methods
 
       Return value: number of bytes written. If a timeout occurs and no bytes
       were written returns ``None``.
+
+.. only:: port_pyboard
+
+    .. method:: UART.writechar(char)
+
+      Write a single character on the bus.  ``char`` is an integer to write.
+      Return value: ``None``. See note below if CTS flow control is used.
 
 .. method:: UART.sendbreak()
 


### PR DESCRIPTION
As discussed in #2660 the two UART timeouts given to the constructor (first char, between chars) is valid for reading **and** writing. Updated the documentation to clarify.