### PR TITLE
docs: Added updated clarification about UART timeouts

### DIFF
--- a/docs/library/pyb.UART.rst
+++ b/docs/library/pyb.UART.rst
@@ -111,11 +111,6 @@ Methods
 
        Returns the number of bytes waiting (may be 0).
 
-    .. method:: UART.writechar(char)
-
-      Write a single character on the bus.  ``char`` is an integer to write.
-      Return value: ``None``. See note below if CTS flow control is used.
-
 .. method:: UART.read([nbytes])
 
    Read characters.  If ``nbytes`` is specified then read at most that many bytes.
@@ -166,6 +161,13 @@ Methods
 
       Return value: number of bytes written. If a timeout occurs and no bytes
       were written returns ``None``.
+
+.. only:: port_pyboard
+
+    .. method:: UART.writechar(char)
+
+      Write a single character on the bus.  ``char`` is an integer to write.
+      Return value: ``None``. See note below if CTS flow control is used.
 
 .. method:: UART.sendbreak()
 

--- a/docs/library/pyb.UART.rst
+++ b/docs/library/pyb.UART.rst
@@ -87,8 +87,8 @@ Methods
          - ``stop`` is the number of stop bits, 1 or 2.
          - ``flow`` sets the flow control type. Can be 0, ``UART.RTS``, ``UART.CTS``
            or ``UART.RTS | UART.CTS``.
-         - ``timeout`` is the timeout in milliseconds to wait for the first character.
-         - ``timeout_char`` is the timeout in milliseconds to wait between characters.
+         - ``timeout`` is the timeout in milliseconds to wait for writing/reading the first character.
+         - ``timeout_char`` is the timeout in milliseconds to wait between characters while writing or reading.
          - ``read_buf_len`` is the character length of the read buffer (0 to disable).
     
        This method will raise an exception if the baudrate could not be set within


### PR DESCRIPTION
As discussed in #2660 the two UART timeouts given to the constructor (first char, between chars) is valid for reading **and** writing. Updated the documentation to clarify.

Included suggestion of @dpgeorge made in the previous PR #2675.