### PR TITLE
unix: Add 19200 baud to termios

### DIFF
--- a/unix/modtermios.c
+++ b/unix/modtermios.c
@@ -134,6 +134,9 @@ STATIC const mp_rom_map_elem_t mp_module_termios_globals_table[] = {
     C(TCSANOW),
 
     C(B9600),
+    #ifdef B19200
+    C(B19200),
+    #endif
     #ifdef B57600
     C(B57600),
     #endif


### PR DESCRIPTION
Actually, I miss a few other baud rates and serial settings as well.

Don't know exactly what the policy for balancing usability and size is in Micropython yet.