### PR TITLE
py: Support object __getattr__, __delattr__ and __setattr__

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -636,6 +636,12 @@ typedef double mp_float_t;
 #define MICROPY_PY_DESCRIPTORS (0)
 #endif
 
+// Whether to support object (__getattr__, __delattr__ and __setattr__)
+// This costs some code size and makes all load attrs and store attrs slow
+#ifndef MICROPY_PY_ATTRS_METHODS
+#define MICROPY_PY_ATTRS_METHODS (0)
+#endif
+
 // Support for async/await/async for/async with
 #ifndef MICROPY_PY_ASYNC_AWAIT
 #define MICROPY_PY_ASYNC_AWAIT (1)

--- a/py/objobject.c
+++ b/py/objobject.c
@@ -59,12 +59,63 @@ STATIC mp_obj_t object___new__(mp_obj_t cls) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(object___new___fun_obj, object___new__);
 STATIC MP_DEFINE_CONST_STATICMETHOD_OBJ(object___new___obj, MP_ROM_PTR(&object___new___fun_obj));
 
+#if MICROPY_PY_ATTRS_METHODS
+STATIC mp_obj_t object___setattr__(mp_obj_t self_in, mp_obj_t attr_in, mp_obj_t value) {
+    mp_obj_type_t *type = mp_obj_get_type(self_in);
+    if (type->locals_dict != NULL) {
+        mp_map_t *locals_map = &type->locals_dict->map;
+        mp_map_lookup(locals_map, MP_OBJ_NEW_QSTR(mp_obj_str_get_qstr(attr_in)), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = value;
+        return value;
+    } else {
+        return mp_const_none;
+    }
+}
+MP_DEFINE_CONST_FUN_OBJ_3(object___setattr___obj, object___setattr__);
+
+STATIC mp_obj_t object___getattr__(mp_obj_t self_in, mp_obj_t attr_in) {
+    mp_obj_type_t *type = mp_obj_get_type(self_in);
+    if (type->locals_dict != NULL) {
+        mp_map_t *locals_map = &type->locals_dict->map;
+        qstr attr = mp_obj_str_get_qstr(attr_in);
+        mp_map_elem_t *elem = mp_map_lookup(locals_map, MP_OBJ_NEW_QSTR(attr), MP_MAP_LOOKUP);
+        if (elem == NULL) {
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_AttributeError,
+                "'%s' object has no attribute '%q'",
+                mp_obj_get_type_str(self_in), attr));
+        }
+        return elem->value;
+    } else {
+        return mp_const_none;
+    }
+}
+MP_DEFINE_CONST_FUN_OBJ_2(object___getattr___obj, object___getattr__);
+
+STATIC mp_obj_t object___delattr__(mp_obj_t self_in, mp_obj_t attr_in) {
+    mp_obj_type_t *type = mp_obj_get_type(self_in);
+    if (type->locals_dict != NULL) {
+        mp_map_t *locals_map = &type->locals_dict->map;
+        mp_map_lookup(locals_map, MP_OBJ_NEW_QSTR(mp_obj_str_get_qstr(attr_in)), MP_MAP_LOOKUP_REMOVE_IF_FOUND);
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(object___delattr___obj, object___delattr__);
+#endif
+
 STATIC const mp_rom_map_elem_t object_locals_dict_table[] = {
     #if MICROPY_CPYTHON_COMPAT
     { MP_ROM_QSTR(MP_QSTR___init__), MP_ROM_PTR(&object___init___obj) },
     #endif
     #if MICROPY_CPYTHON_COMPAT
     { MP_ROM_QSTR(MP_QSTR___new__), MP_ROM_PTR(&object___new___obj) },
+    #endif
+    #if (MICROPY_CPYTHON_COMPAT && MICROPY_PY_ATTRS_METHODS)
+    { MP_ROM_QSTR(MP_QSTR___delattr__), MP_ROM_PTR(&object___delattr___obj) },
+    #endif
+    #if (MICROPY_CPYTHON_COMPAT && MICROPY_PY_ATTRS_METHODS)
+    { MP_ROM_QSTR(MP_QSTR___getattr__), MP_ROM_PTR(&object___getattr___obj) },
+    #endif
+    #if (MICROPY_CPYTHON_COMPAT && MICROPY_PY_ATTRS_METHODS)
+    { MP_ROM_QSTR(MP_QSTR___setattr__), MP_ROM_PTR(&object___setattr___obj) },
     #endif
 };
 

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -533,6 +533,15 @@ STATIC void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *des
 
     // try __getattr__
     if (attr != MP_QSTR___getattr__) {
+
+        #if MICROPY_PY_ATTRS_METHODS
+        // if __getattr__ was called with attr == __setattr__  return MP_OBJ_NULL for indicate success
+        if (attr == MP_QSTR___setattr__) {
+            dest[0] = MP_OBJ_NULL;
+            return;
+        }
+        #endif
+
         mp_obj_t dest2[3];
         mp_load_method_maybe(self_in, MP_QSTR___getattr__, dest2);
         if (dest2[0] != MP_OBJ_NULL) {
@@ -626,10 +635,39 @@ STATIC bool mp_obj_instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t val
 
     if (value == MP_OBJ_NULL) {
         // delete attribute
+        #if MICROPY_PY_ATTRS_METHODS
+        // try __delattr__ first
+        if (attr != MP_QSTR___delattr__) {
+            mp_obj_t attr_delattr_method[3];
+            mp_load_method_maybe(self_in, MP_QSTR___delattr__, attr_delattr_method);
+            if (attr_delattr_method[0] != MP_OBJ_NULL) {
+                // __delattr__ exists, call it and return its result
+                attr_delattr_method[2] = MP_OBJ_NEW_QSTR(attr);
+                mp_call_method_n_kw(1, 0, attr_delattr_method);
+                return true;
+            }
+        }
+        #endif
+
         mp_map_elem_t *elem = mp_map_lookup(&self->members, MP_OBJ_NEW_QSTR(attr), MP_MAP_LOOKUP_REMOVE_IF_FOUND);
         return elem != NULL;
     } else {
         // store attribute
+        #if MICROPY_PY_ATTRS_METHODS
+        // try __setattr__ first
+        if (attr != MP_QSTR___setattr__) {
+            mp_obj_t attr_setattr_method[4];
+            mp_load_method_maybe(self_in, MP_QSTR___setattr__, attr_setattr_method);
+            if (attr_setattr_method[0] != MP_OBJ_NULL) {
+                // __setattr__ exists, call it and return its result
+                attr_setattr_method[2] = MP_OBJ_NEW_QSTR(attr);
+                attr_setattr_method[3] = value;
+                mp_call_method_n_kw(2, 0, attr_setattr_method);
+                return true;
+            }
+        }
+        #endif
+
         mp_map_lookup(&self->members, MP_OBJ_NEW_QSTR(attr), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = value;
         return true;
     }

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -531,11 +531,14 @@ STATIC void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *des
         return;
     }
 
-    // try __getattr__
-    if (attr != MP_QSTR___getattr__) {
-
+    // try __getattribute__ or __getattr__
+    if (
         #if MICROPY_PY_ATTRS_METHODS
-        // if __getattr__ was called with attr == __setattr__  return MP_OBJ_NULL for indicate success
+        attr != MP_QSTR___getattribute__ && 
+        #endif
+        attr != MP_QSTR___getattr__) {
+        #if MICROPY_PY_ATTRS_METHODS
+        // if the requested attr is __setattr__ assign MP_OBJECT_NULL to dest[0] to indicate success
         if (attr == MP_QSTR___setattr__) {
             dest[0] = MP_OBJ_NULL;
             return;
@@ -543,6 +546,17 @@ STATIC void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *des
         #endif
 
         mp_obj_t dest2[3];
+        #if MICROPY_PY_ATTRS_METHODS
+        mp_load_method_maybe(self_in, MP_QSTR___getattribute__, dest2);
+        if (dest2[0] != MP_OBJ_NULL) {
+            // __getattribute__ exists, call it and return its result
+            // if this fails to load the requested attr, we ignore the attribute error and try to call __getattr__
+            dest2[2] = MP_OBJ_NEW_QSTR(attr);
+            dest[0] = mp_call_method_n_kw(1, 0, dest2);
+            return;
+        }
+        #endif
+
         mp_load_method_maybe(self_in, MP_QSTR___getattr__, dest2);
         if (dest2[0] != MP_OBJ_NULL) {
             // __getattr__ exists, call it and return its result

--- a/tests/basics/delgetsetattr.py
+++ b/tests/basics/delgetsetattr.py
@@ -1,0 +1,25 @@
+# test __delattr__ ,__getattr__ and __setattr__
+
+class A:
+    def __init__(self, d):
+        self.d = d
+
+    def __getattr__(self, attr):
+        if  attr in self.d:
+            return self.d[attr]
+        else:
+            raise AttributeError(attr)
+
+    def __setattr__(self, attr, value):
+        super(A, self).__setattr__(attr, value)
+
+    def __delattr__(self, attr):
+        del self.d[attr]
+
+a = A({'a':1, 'b':2})
+print(a.a, a.b)
+try:
+    del a.a
+    print(a.a)
+except AttributeError:
+    print("AttributeError")

--- a/tests/basics/delgetsetattr.py
+++ b/tests/basics/delgetsetattr.py
@@ -1,8 +1,11 @@
-# test __delattr__ ,__getattr__ and __setattr__
+# test __delattr__ , __getattribute__, __getattr__ and __setattr__
 
 class A:
     def __init__(self, d):
         self.d = d
+
+    def __getattribute__(self, attr):
+        return super(A, self).__getattribute__(attr)
 
     def __getattr__(self, attr):
         if  attr in self.d:

--- a/tests/basics/delgetsetattr.py.exp
+++ b/tests/basics/delgetsetattr.py.exp
@@ -1,0 +1,2 @@
+1 2
+AttributeError

--- a/unix/mpconfigport_coverage.h
+++ b/unix/mpconfigport_coverage.h
@@ -36,3 +36,4 @@
 #define MICROPY_FSUSERMOUNT            (1)
 #define MICROPY_VFS_FAT                (1)
 #define MICROPY_PY_FRAMEBUF            (1)
+#define MICROPY_PY_ATTRS_METHODS       (1)


### PR DESCRIPTION
This patch implements methods `__delattr__`, `__getattr__` and `__setattr__` for user-type and allows the use of calls like `super(A, self).__setattr__('a', 1)`

for discussion see #2375