### PR TITLE
modstruct: add support for 'c' format code

### DIFF
--- a/py/modstruct.c
+++ b/py/modstruct.c
@@ -108,7 +108,7 @@ STATIC mp_obj_t struct_calcsize(mp_obj_t fmt_in) {
             cnt = get_fmt_num(&fmt);
         }
 
-        if (*fmt == 's') {
+        if (*fmt == 's' || *fmt == 'c') {
             size += cnt;
         } else {
             mp_uint_t align;
@@ -168,6 +168,12 @@ STATIC mp_obj_t struct_unpack_from(size_t n_args, const mp_obj_t *args) {
             item = mp_obj_new_bytes(p, sz);
             p += sz;
             res->items[i++] = item;
+        } else if (*fmt == 'c') {
+            while (sz--) {
+                item = mp_obj_new_bytes(p, 1);
+                ++p;
+                res->items[i++] = item;
+            }
         } else {
             while (sz--) {
                 item = mp_binary_get_val(fmt_type, *fmt, &p);
@@ -183,6 +189,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(struct_unpack_from_obj, 2, 3, struct_unpack_
 STATIC void struct_pack_into_internal(mp_obj_t fmt_in, byte *p, byte* end_p, size_t n_args, const mp_obj_t *args) {
     const char *fmt = mp_obj_str_get_str(fmt_in);
     char fmt_type = get_fmt_type(&fmt);
+    mp_buffer_info_t bufinfo;
 
     size_t i;
     for (i = 0; i < n_args;) {
@@ -199,7 +206,6 @@ STATIC void struct_pack_into_internal(mp_obj_t fmt_in, byte *p, byte* end_p, siz
         }
 
         if (*fmt == 's') {
-            mp_buffer_info_t bufinfo;
             mp_get_buffer_raise(args[i++], &bufinfo, MP_BUFFER_READ);
             mp_uint_t to_copy = sz;
             if (bufinfo.len < to_copy) {
@@ -208,6 +214,16 @@ STATIC void struct_pack_into_internal(mp_obj_t fmt_in, byte *p, byte* end_p, siz
             memcpy(p, bufinfo.buf, to_copy);
             memset(p + to_copy, 0, sz - to_copy);
             p += sz;
+        } else if (*fmt == 'c') {
+            while (sz--) {
+                mp_get_buffer_raise(args[i++], &bufinfo, MP_BUFFER_READ);
+                if (bufinfo.len != 1 || bufinfo.typecode != 'B') {
+                    // Should we allow a typecode of BYTEARRAY_TYPECODE as well?
+                    // TODO: raise a struct.error instead of ValueError.
+                    mp_raise_ValueError("char format requires a bytes object of length 1");
+                }
+                *p++ = *(byte *)(bufinfo.buf);
+            }
         } else {
             while (sz--) {
                 mp_binary_set_val(fmt_type, *fmt, args[i++], &p);


### PR DESCRIPTION
A colleague wanted to use the 'c' format code in the struct module.  I think I've implemented it correctly, and tested both `pack()` and `unpack()`.  Under Windows, Python 3.5.2 throws an exception when passing a one-byte string as a parameter to `struct.pack()`, but in MicroPython, the `mp_buffer_info_t` looks the same for both `b'C'` and `'C'`.

Also, I should be throwing a `struct.error` exception, but that hasn't been implemented elsewhere in the module yet, so I just fell back on a `ValueError`.

```
>>> struct.unpack('<HBB5c', b'\x01\x00\x02\x03ABCD')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: buffer too small
>>> struct.unpack('<HBB5c', b'\x01\x00\x02\x03ABCDE')
(1, 2, 3, b'A', b'B', b'C', b'D', b'E')
>>> struct.unpack('<HBB5c', b'\x01\x00\x02\x03ABCDEF')
(1, 2, 3, b'A', b'B', b'C', b'D', b'E')
>>> struct.pack('<HBB5c', 1, 2, 3, b'A', b'B', b'C', b'D', b'E')
b'\x01\x00\x02\x03ABCDE'
>>> struct.pack('<HBB5c', 1, 2, 3, b'A', b'B', 'C', b'D', b'E')
b'\x01\x00\x02\x03ABCDE'
>>> struct.pack('<HBB5c', 1, 2, 3, b'A', b'BX', b'C', b'D', b'E')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: char format requires a bytes object of length 1
```