### PR TITLE
stmhal: implement CSS - reset on HSE failure

### DIFF
--- a/stmhal/stm32_it.c
+++ b/stmhal/stm32_it.c
@@ -192,6 +192,8 @@ void HardFault_Handler(void) {
   * @retval None
   */
 void NMI_Handler(void) {
+	/* Handle CSS interrupt */
+	HAL_RCC_NMI_IRQHandler();
 }
 
 /**

--- a/stmhal/system_stm32.c
+++ b/stmhal/system_stm32.c
@@ -320,6 +320,9 @@ void SystemClock_Config(void)
   RCC_ClkInitTypeDef RCC_ClkInitStruct;
   RCC_OscInitTypeDef RCC_OscInitStruct;
 
+  /* Protect against HSE malfunction */
+  HAL_RCC_EnableCSS();
+
     #if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
   /* Enable Power Control clock */
   __PWR_CLK_ENABLE();
@@ -483,6 +486,10 @@ void SystemClock_Config(void)
 
     HAL_SYSTICK_CLKSourceConfig(SYSTICK_CLKSOURCE_HCLK);
 #endif
+}
+
+void HAL_RCC_CSSCallback(void) {
+	NVIC_SystemReset();
 }
 
 void HAL_MspInit(void) {


### PR DESCRIPTION
If the high speed external oscillator fails/glitches, this patch will restart the board in an attempt to recover. Without this patch, in my testing the board hangs indefinitely (or at least longer than I bothered to measure!)

Board runs on internal oscillator to process the callback for this event.

Resolves #2683 