### PR TITLE
ESP8266: Fixed scan unable to discover hidden SSID problem

### DIFF
--- a/esp8266/modnetwork.c
+++ b/esp8266/modnetwork.c
@@ -182,7 +182,9 @@ STATIC mp_obj_t esp_scan(mp_obj_t self_in) {
     }
     mp_obj_t list = mp_obj_new_list(0, NULL);
     esp_scan_list = &list;
-    wifi_station_scan(NULL, (scan_done_cb_t)esp_scan_cb);
+    struct scan_config config = {0};
+    config.show_hidden = true;
+    wifi_station_scan(&config, (scan_done_cb_t)esp_scan_cb);
     while (esp_scan_list != NULL) {
         // our esp_scan_cb is called via ets_loop_iter so it's safe to set the
         // esp_scan_list variable to NULL without disabling interrupts


### PR DESCRIPTION
Provide scan_config structure to enable discovery of hidden SSID.