### PR TITLE
Initial implementation of machine.Signal

### DIFF
--- a/esp8266/machine_pin.c
+++ b/esp8266/machine_pin.c
@@ -37,6 +37,7 @@
 #include "py/runtime.h"
 #include "py/gc.h"
 #include "py/mphal.h"
+#include "extmod/virtpin.h"
 #include "modmachine.h"
 
 #define GET_TRIGGER(phys_port) \
@@ -374,6 +375,23 @@ STATIC mp_obj_t pyb_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pyb_pin_irq_obj, 1, pyb_pin_irq);
 
+STATIC mp_uint_t pin_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode);
+STATIC mp_uint_t pin_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    (void)errcode;
+    pyb_pin_obj_t *self = self_in;
+
+    switch (request) {
+        case MP_PIN_READ: {
+            return pin_get(self->phys_port);
+        }
+        case MP_PIN_WRITE: {
+            pin_set(self->phys_port, arg);
+            return 0;
+        }
+    }
+    return -1;
+}
+
 STATIC const mp_map_elem_t pyb_pin_locals_dict_table[] = {
     // instance methods
     { MP_OBJ_NEW_QSTR(MP_QSTR_init),    (mp_obj_t)&pyb_pin_init_obj },
@@ -396,12 +414,17 @@ STATIC const mp_map_elem_t pyb_pin_locals_dict_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(pyb_pin_locals_dict, pyb_pin_locals_dict_table);
 
+STATIC const mp_pin_p_t pin_pin_p = {
+    .ioctl = pin_ioctl,
+};
+
 const mp_obj_type_t pyb_pin_type = {
     { &mp_type_type },
     .name = MP_QSTR_Pin,
     .print = pyb_pin_print,
     .make_new = pyb_pin_make_new,
     .call = pyb_pin_call,
+    .protocol = &pin_pin_p,
     .locals_dict = (mp_obj_t)&pyb_pin_locals_dict,
 };
 

--- a/esp8266/modmachine.c
+++ b/esp8266/modmachine.c
@@ -31,6 +31,7 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "extmod/machine_mem.h"
+#include "extmod/machine_signal.h"
 #include "extmod/machine_pulse.h"
 #include "extmod/machine_i2c.h"
 #include "modmachine.h"
@@ -251,6 +252,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_Timer), MP_ROM_PTR(&esp_timer_type) },
     { MP_ROM_QSTR(MP_QSTR_WDT), MP_ROM_PTR(&esp_wdt_type) },
     { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&pyb_pin_type) },
+    { MP_ROM_QSTR(MP_QSTR_Signal), MP_ROM_PTR(&machine_signal_type) },
     { MP_ROM_QSTR(MP_QSTR_PWM), MP_ROM_PTR(&pyb_pwm_type) },
     { MP_ROM_QSTR(MP_QSTR_ADC), MP_ROM_PTR(&pyb_adc_type) },
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&pyb_uart_type) },

--- a/examples/hwapi/hwconfig_esp8266_esp12.py
+++ b/examples/hwapi/hwconfig_esp8266_esp12.py
@@ -1,5 +1,5 @@
-from machine import Pin
+from machine import Pin, Signal
 
 # ESP12 module as used by many boards
-# Blue LED on pin 2
-LED = Pin(2, Pin.OUT)
+# Blue LED on pin 2, active low (inverted)
+LED = Signal(Pin(2, Pin.OUT), inverted=True)

--- a/extmod/machine_signal.c
+++ b/extmod/machine_signal.c
@@ -1,0 +1,114 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Paul Sokolovsky
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mpconfig.h"
+#if MICROPY_PY_MACHINE
+
+#include "py/obj.h"
+#include "py/runtime.h"
+#include "extmod/virtpin.h"
+#include "extmod/machine_signal.h"
+
+// Signal class
+
+typedef struct _machine_signal_t {
+    mp_obj_base_t base;
+    mp_obj_t pin;
+    bool inverted;
+} machine_signal_t;
+
+STATIC mp_obj_t signal_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    enum { ARG_pin, ARG_inverted };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_, MP_ARG_OBJ | MP_ARG_REQUIRED },
+        { MP_QSTR_inverted, MP_ARG_BOOL, {.u_bool = false} },
+    };
+
+    mp_arg_val_t parsed_args[MP_ARRAY_SIZE(allowed_args)];
+
+    mp_arg_parse_all_kw_array(n_args, n_kw, args, MP_ARRAY_SIZE(allowed_args), allowed_args, parsed_args);
+
+    machine_signal_t *o = m_new_obj(machine_signal_t);
+    o->base.type = type;
+    o->pin = parsed_args[ARG_pin].u_obj;
+    o->inverted = parsed_args[ARG_inverted].u_bool;
+    return MP_OBJ_FROM_PTR(o);
+}
+
+STATIC mp_uint_t signal_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    (void)errcode;
+    machine_signal_t *self = MP_OBJ_TO_PTR(self_in);
+
+    switch (request) {
+        case MP_PIN_READ: {
+            return mp_virtual_pin_read(self->pin) ^ self->inverted;
+        }
+        case MP_PIN_WRITE: {
+            mp_virtual_pin_write(self->pin, arg ^ self->inverted);
+            return 0;
+        }
+    }
+    return -1;
+}
+
+// fast method for getting/setting signal value
+STATIC mp_obj_t signal_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    if (n_args == 0) {
+        // get pin
+        return MP_OBJ_NEW_SMALL_INT(mp_virtual_pin_read(self_in));
+    } else {
+        // set pin
+        mp_virtual_pin_write(self_in, mp_obj_is_true(args[0]));
+        return mp_const_none;
+    }
+}
+
+STATIC mp_obj_t signal_value(size_t n_args, const mp_obj_t *args) {
+    return signal_call(args[0], n_args - 1, 0, args + 1);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(signal_value_obj, 1, 2, signal_value);
+
+STATIC const mp_rom_map_elem_t signal_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&signal_value_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(signal_locals_dict, signal_locals_dict_table);
+
+STATIC const mp_pin_p_t signal_pin_p = {
+    .ioctl = signal_ioctl,
+};
+
+const mp_obj_type_t machine_signal_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_Signal,
+    .make_new = signal_make_new,
+    .call = signal_call,
+    .protocol = &signal_pin_p,
+    .locals_dict = (void*)&signal_locals_dict,
+};
+
+#endif // MICROPY_PY_MACHINE

--- a/extmod/machine_signal.h
+++ b/extmod/machine_signal.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Paul Sokolovsky
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#ifndef __MICROPY_INCLUDED_EXTMOD_MACHINE_SIGNAL_H__
+#define __MICROPY_INCLUDED_EXTMOD_MACHINE_SIGNAL_H__
+
+#include "py/obj.h"
+
+extern const mp_obj_type_t machine_signal_type;
+
+#endif // __MICROPY_INCLUDED_EXTMOD_MACHINE_SIGNAL_H__

--- a/py/py.mk
+++ b/py/py.mk
@@ -222,6 +222,7 @@ PY_O_BASENAME = \
 	../extmod/virtpin.o \
 	../extmod/machine_mem.o \
 	../extmod/machine_pinbase.o \
+	../extmod/machine_signal.o \
 	../extmod/machine_pulse.o \
 	../extmod/machine_i2c.o \
 	../extmod/machine_spi.o \


### PR DESCRIPTION
This implements a bare minimum of https://github.com/micropython/micropython/issues/2603 . machine.Signal is a cornerstone feature allowing to write portable applications interacting with hardware. As an immediate goal, it allows to fix currently broken (not working per specification) examples in examples/hwapi/ . An example of fix for soft_pwm.py for ESP8266 ESP-12 module is included - with it, LED fading happens as a smooth continuous wave, whereas currently it's discontinuous pulsations with blackouts.
