### PR TITLE
drivers-onewire: Enable pull up

### DIFF
--- a/drivers/onewire/onewire.py
+++ b/drivers/onewire/onewire.py
@@ -60,7 +60,7 @@ class OneWire:
 
         # cache a bunch of methods and attributes.  This is necessary in _write_bit and 
         # _read_bit to achieve the timing required by the OneWire protocol.
-        self.cache = (pin.init, pin.value, pin.OUT_PP, pin.IN, pin.PULL_NONE)
+        self.cache = (pin.init, pin.value, pin.OUT_PP, pin.IN, pin.PULL_UP)
 
         pin.init(pin.IN, pin.PULL_UP)
 


### PR DESCRIPTION
The driver seems to be be enabling the pullup resistor
in some places, but not this one. Making this one
little change allows onewire devices to be used with no
external pullup resistor.