### PR TITLE
Close socket after reading page content

### DIFF
--- a/docs/esp8266/tutorial/network_tcp.rst
+++ b/docs/esp8266/tutorial/network_tcp.rst
@@ -72,6 +72,7 @@ Let's define a function that can download and print a URL::
                 print(str(data, 'utf8'), end='')
             else:
                 break
+        s.close()
 
 Make sure that you import the socket module before running this function.  Then
 you can try::


### PR DESCRIPTION
I've got -2 error before adding `socket.close()`. Now it work's very well and the code is more clean.