### PR TITLE
Fix for negative  temperature computing for ROM 0x28

### DIFF
--- a/drivers/onewire/ds18x20.py
+++ b/drivers/onewire/ds18x20.py
@@ -93,6 +93,11 @@ class DS18X20(object):
             temp = temp_read - 0.25 + (count_per_c - count_remain) / count_per_c
             return temp
         elif rom0 == 0x28:
-            return (temp_msb << 8 | temp_lsb) / 16
+            		
+            temp = (temp_msb << 8 | temp_lsb) / 16
+            if (temp_msb & 0xf8) == 0xf8 :  # for negative temperature
+               temp -= 0x1000
+
+            return temp
         else:
             assert False


### PR DESCRIPTION
            There is a bug with  negative temperature computing. For instance if we have msb =255 and lsb 207 we are dealing with negative temperature then previous computing out was 4093 instead of -3 degrees. So I changed the code as following
	
```
            temp = (temp_msb << 8 | temp_lsb) / 16

            if (temp_msb & 0xf8) == 0xf8 :  # for negative temperature
               temp -= 0x1000

            return temp
```