### PR TITLE
stmhal: fix wrong usage of gcc -print-libgcc-file-name

### DIFF
--- a/stmhal/Makefile
+++ b/stmhal/Makefile
@@ -76,7 +76,7 @@ COPT += -Os -DNDEBUG
 endif
 
 # uncomment this if you want libgcc
-#LIBS += $(shell $(CC) -print-libgcc-file-name)
+#LIBS += $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
 SRC_LIB = $(addprefix lib/,\
 	libc/string0.c \


### PR DESCRIPTION
See https://github.com/micropython/micropython/issues/2786 for more info