### PR TITLE
Remove unreachable code related to relative imports

### DIFF
--- a/tests/import/builtin_import.py
+++ b/tests/import/builtin_import.py
@@ -1,0 +1,16 @@
+# test calling builtin import function
+
+# basic test
+__import__('builtins')
+
+# first arg should be a string
+try:
+    __import__(1)
+except TypeError:
+    print('TypeError')
+
+# level argument should be non-negative
+try:
+    __import__('xyz', None, None, None, -1)
+except ValueError:
+    print('ValueError')

--- a/tests/import/pkg7/subpkg1/subpkg2/mod3.py
+++ b/tests/import/pkg7/subpkg1/subpkg2/mod3.py
@@ -3,8 +3,7 @@ from ...mod2 import bar
 print(mod1.foo)
 print(bar)
 
-# when attempting relative import beyond top-level package uPy raises ImportError
-# whereas CPython raises a ValueError
+# attempted relative import beyond top-level package
 try:
     from .... import mod1
 except ValueError:


### PR DESCRIPTION
Unreachable code is removed and a test is added for calling `__import__` directly.

@pfalcon FYI