### PR TITLE
stmhal: fix USB HID Receive

### DIFF
--- a/stmhal/usb.c
+++ b/stmhal/usb.c
@@ -607,7 +607,11 @@ STATIC mp_obj_t pyb_usb_hid_send(mp_obj_t self_in, mp_obj_t report_in) {
     }
 
     // send the data
-    USBD_HID_SendReport(&hUSBDDevice, bufinfo.buf, bufinfo.len);
+    if (USBD_OK == USBD_HID_SendReport(&hUSBDDevice, bufinfo.buf, bufinfo.len)) {
+        return mp_obj_new_int(bufinfo.len);
+    } else {
+        return mp_obj_new_int(0);
+    }
 #endif
 
     return mp_const_none;

--- a/stmhal/usb.c
+++ b/stmhal/usb.c
@@ -636,6 +636,9 @@ STATIC mp_uint_t pyb_usb_hid_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint_
     if (request == MP_STREAM_POLL) {
         mp_uint_t flags = arg;
         ret = 0;
+        if ((flags & MP_STREAM_POLL_RD) && USBD_HID_RxNum() > 0) {
+            ret |= MP_STREAM_POLL_RD;
+        }
         if ((flags & MP_STREAM_POLL_WR) && USBD_HID_CanSendReport(&hUSBDDevice)) {
             ret |= MP_STREAM_POLL_WR;
         }

--- a/stmhal/usbd_hid_interface.c
+++ b/stmhal/usbd_hid_interface.c
@@ -45,20 +45,34 @@
 
 /* Private variables ---------------------------------------------------------*/
 
-static __IO uint8_t dev_is_connected = 0; // indicates if we are connected
-
 static uint8_t buffer[2][HID_DATA_FS_MAX_PACKET_SIZE]; // pair of buffers to read individual packets into
 static int8_t current_read_buffer = 0; // which buffer to read from
-static uint32_t last_read_len; // length of last read
+static uint32_t last_read_len = 0; // length of last read
 static int8_t current_write_buffer = 0; // which buffer to write to
 
-
 /* Private function prototypes -----------------------------------------------*/
+static int8_t HID_Itf_Init     (void);
 static int8_t HID_Itf_Receive  (uint8_t* pbuf, uint32_t Len);
 
 const USBD_HID_ItfTypeDef USBD_HID_fops = {
+    HID_Itf_Init,
     HID_Itf_Receive
 };
+
+/**
+  * @brief  HID_Itf_Init
+  *         Initializes the HID media low layer
+  * @param  None
+  * @retval Result of the opeartion: USBD_OK if all operations are OK else USBD_FAIL
+  */
+static int8_t HID_Itf_Init(void)
+{
+    current_read_buffer = 0;
+    last_read_len = 0;
+    current_write_buffer = 0;
+    USBD_HID_SetRxBuffer(&hUSBDDevice, buffer[current_write_buffer]);
+    return USBD_OK;
+}
 
 /**
   * @brief  HID_Itf_Receive

--- a/stmhal/usbd_hid_interface.c
+++ b/stmhal/usbd_hid_interface.c
@@ -89,7 +89,8 @@ static int8_t HID_Itf_Receive(uint8_t* Buf, uint32_t Len) {
     // initiate next USB packet transfer, to append to existing data in buffer
     USBD_HID_SetRxBuffer(&hUSBDDevice, buffer[current_write_buffer]);
     USBD_HID_ReceivePacket(&hUSBDDevice);
-
+    // Set NAK to indicate we need to process read buffer
+    USBD_HID_SetNAK(&hUSBDDevice);
     return USBD_OK;
 }
 
@@ -124,6 +125,9 @@ int USBD_HID_Rx(uint8_t *buf, uint32_t len, uint32_t timeout) {
     // Copy bytes from device to user buffer
     memcpy(buf, buffer[current_read_buffer], last_read_len);
     current_read_buffer = !current_read_buffer;
+
+    // Clear NAK to indicate we are ready to read more data
+    USBD_HID_ClearNAK(&hUSBDDevice);
 
     // Success, return number of bytes read
     return last_read_len;

--- a/stmhal/usbd_hid_interface.c
+++ b/stmhal/usbd_hid_interface.c
@@ -93,6 +93,11 @@ static int8_t HID_Itf_Receive(uint8_t* Buf, uint32_t Len) {
     return USBD_OK;
 }
 
+// Returns number of ready rx buffers.
+int USBD_HID_RxNum(void) {
+    return (current_read_buffer != current_write_buffer);
+}
+
 // timout in milliseconds.
 // Returns number of bytes read from the device.
 int USBD_HID_Rx(uint8_t *buf, uint32_t len, uint32_t timeout) {

--- a/stmhal/usbd_hid_interface.h
+++ b/stmhal/usbd_hid_interface.h
@@ -6,4 +6,5 @@
 
 extern const USBD_HID_ItfTypeDef USBD_HID_fops;
 
+int USBD_HID_RxNum(void);
 int USBD_HID_Rx(uint8_t *buf, uint32_t len, uint32_t timeout);

--- a/stmhal/usbdev/class/inc/usbd_cdc_msc_hid.h
+++ b/stmhal/usbdev/class/inc/usbd_cdc_msc_hid.h
@@ -48,6 +48,7 @@ typedef struct {
 } USBD_CDC_HandleTypeDef;
 
 typedef struct _USBD_HID_Itf {
+  int8_t (* Init)   (void);
   int8_t (* Receive)(uint8_t *, uint32_t);
 } USBD_HID_ItfTypeDef;
 

--- a/stmhal/usbdev/class/inc/usbd_cdc_msc_hid.h
+++ b/stmhal/usbdev/class/inc/usbd_cdc_msc_hid.h
@@ -116,5 +116,7 @@ uint8_t USBD_HID_SetRxBuffer(USBD_HandleTypeDef *pdev, uint8_t *pbuff);
 uint8_t USBD_HID_ReceivePacket(USBD_HandleTypeDef *pdev);
 int USBD_HID_CanSendReport(USBD_HandleTypeDef *pdev);
 uint8_t USBD_HID_SendReport(USBD_HandleTypeDef *pdev, uint8_t *report, uint16_t len);
+uint8_t USBD_HID_SetNAK(USBD_HandleTypeDef *pdev);
+uint8_t USBD_HID_ClearNAK(USBD_HandleTypeDef *pdev);
 
 #endif // _USB_CDC_MSC_CORE_H_

--- a/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
+++ b/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
@@ -724,6 +724,8 @@ static uint8_t USBD_CDC_MSC_HID_Init(USBD_HandleTypeDef *pdev, uint8_t cfgidx) {
                        USBD_EP_TYPE_INTR,
                        mps_out);
 
+        HID_fops->Init();
+
         // Prepare Out endpoint to receive next packet
         USBD_LL_PrepareReceive(pdev, hid_out_ep, HID_ClassData.RxBuffer, mps_out);
 

--- a/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
+++ b/stmhal/usbdev/class/src/usbd_cdc_msc_hid.c
@@ -1093,6 +1093,24 @@ uint8_t USBD_HID_SendReport(USBD_HandleTypeDef *pdev, uint8_t *report, uint16_t 
     return USBD_OK;
 }
 
+uint8_t USBD_HID_SetNAK(USBD_HandleTypeDef *pdev) {
+    // get USBx object from pdev (needed for USBx_OUTEP macro below)
+    PCD_HandleTypeDef *hpcd = pdev->pData;
+    USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+    // set NAK on HID OUT endpoint
+    USBx_OUTEP(HID_OUT_EP_WITH_CDC)->DOEPCTL |= USB_OTG_DOEPCTL_SNAK;
+    return USBD_OK;
+}
+
+uint8_t USBD_HID_ClearNAK(USBD_HandleTypeDef *pdev) {
+    // get USBx object from pdev (needed for USBx_OUTEP macro below)
+    PCD_HandleTypeDef *hpcd = pdev->pData;
+    USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+    // clear NAK on HID OUT endpoint
+    USBx_OUTEP(HID_OUT_EP_WITH_CDC)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
+    return USBD_OK;
+}
+
 // CDC/MSC/HID interface class callback structure
 USBD_ClassTypeDef USBD_CDC_MSC_HID = {
     USBD_CDC_MSC_HID_Init,


### PR DESCRIPTION
I found a bug in the USB HID Receive code that resulted in first read packet always containing no data just zeroes. All subsequent reads were OK.

This patch fixes the issue by adding Init method to HID_fops, which sets the buffer correctly even for the first packet.

Also there is a SNAK/CNAK mechanism that implements flow control in case user does not call recv method often enough (it tells host side to stop sending more data).