### PR TITLE
stmhal: fix examples in openocd configs to include addresses

### DIFF
--- a/stmhal/boards/openocd_stm32f4.cfg
+++ b/stmhal/boards/openocd_stm32f4.cfg
@@ -4,7 +4,7 @@
 # To flash your firmware:
 #
 #    $ openocd -f openocd_stm32f4.cfg \
-#        -c "stm_flash build-BOARD/firmware0.bin build-BOARD/firmware1.bin"
+#        -c "stm_flash build-BOARD/firmware0.bin 0x08000000 build-BOARD/firmware1.bin 0x08020000"
 #
 # For a gdb server on port 3333:
 #

--- a/stmhal/boards/openocd_stm32f7.cfg
+++ b/stmhal/boards/openocd_stm32f7.cfg
@@ -4,7 +4,7 @@
 # To flash your firmware:
 #
 #    $ openocd -f openocd_stm32f7.cfg \
-#        -c "stm_flash build-BOARD/firmware0.bin build-BOARD/firmware1.bin"
+#        -c "stm_flash build-BOARD/firmware0.bin 0x08000000 build-BOARD/firmware1.bin 0x08020000"
 #
 # For a gdb server on port 3333:
 #

--- a/stmhal/boards/openocd_stm32l4.cfg
+++ b/stmhal/boards/openocd_stm32l4.cfg
@@ -4,7 +4,7 @@
 # To flash your firmware:
 #
 #    $ openocd -f openocd_stm32l4.cfg \
-#        -c "stm_flash build-BOARD/firmware0.bin build-BOARD/firmware1.bin"
+#        -c "stm_flash build-BOARD/firmware0.bin 0x08000000 build-BOARD/firmware1.bin 0x08004000"
 #
 # For a gdb server on port 3333:
 #


### PR DESCRIPTION
Allow changing the firmware name by simply overriding FIRMWARE variable. Offers greater flexibility when used in various CI systems etc.

(Also included is a small fix to openocd configs where invocation examples were not changed to reflect the new API)