### PR TITLE
Fixed issue with AP being configured while not being active

### DIFF
--- a/esp8266/scripts/inisetup.py
+++ b/esp8266/scripts/inisetup.py
@@ -5,6 +5,7 @@ from flashbdev import bdev
 def wifi():
     import ubinascii
     ap_if = network.WLAN(network.AP_IF)
+    ap_if.active(True)
     essid = b"MicroPython-%s" % ubinascii.hexlify(ap_if.config("mac")[-3:])
     ap_if.config(essid=essid, authmode=network.AUTH_WPA_WPA2_PSK, password=b"micropythoN")
 


### PR DESCRIPTION
AP mode should be explicitly enabled. Had a crash because of this after flashing the firmware.