### PR TITLE
docs/conf.py: Add myself as a copyright holder on the docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ source_suffix = '.rst'
 
 # General information about the project.
 project = 'MicroPython'
-copyright = '2014-2016, Damien P. George and contributors'
+copyright = '2014-2017, Damien P. George, Paul Sokolovsky, and contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -253,7 +253,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
   (master_doc, 'MicroPython.tex', 'MicroPython Documentation',
-   'Damien P. George and contributors', 'manual'),
+   'Damien P. George, Paul Sokolovsky, and contributors', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -283,7 +283,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'micropython', 'MicroPython Documentation',
-     ['Damien P. George and contributors'], 1),
+     ['Damien P. George, Paul Sokolovsky, and contributors'], 1),
 ]
 
 # If true, show URL addresses after external links.
@@ -297,7 +297,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   (master_doc, 'MicroPython', 'MicroPython Documentation',
-   'Damien P. George and contributors', 'MicroPython', 'One line description of project.',
+   'Damien P. George, Paul Sokolovsky, and contributors', 'MicroPython', 'One line description of project.',
    'Miscellaneous'),
 ]
 


### PR DESCRIPTION
Based on the following statistics:

$ git log docs |grep Author | sort | uniq -c | sort -n -r
    175 Author: Paul Sokolovsky
    135 Author: Damien George
     31 Author: Daniel Campora
     26 Author: danicampora
     14 Author: Peter Hinch

git blame stats script from http://stackoverflow.com/a/13687302/496009:

$ sh git-authors docs
   9977 author Damien George
   2679 author Paul Sokolovsky
   1699 author Daniel Campora
   1580 author danicampora
   1286 author Peter Hinch
    282 author Shuning Bian
    249 author Dave Hylands

Total lines per this script: 18417, my contribution is 14.5%.
