### PR TITLE
lib/oofatfs/ff.h: ffconf.h not included (FFCONF_H undefined)

### DIFF
--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -38,7 +38,7 @@
 #include "py/mperrno.h"
 #include "lib/oofatfs/ff.h"
 #include "extmod/vfs_fat.h"
-#include "timeutils.h"
+#include "lib/timeutils/timeutils.h"
 
 #if _MAX_SS == _MIN_SS
 #define SECSIZE(fs) (_MIN_SS)

--- a/lib/oofatfs/ff.h
+++ b/lib/oofatfs/ff.h
@@ -50,7 +50,7 @@ typedef uint32_t DWORD;
 /* This type MUST be 64-bit (Remove this for C89 compatibility) */
 typedef uint64_t QWORD;
 
-#include FFCONF_H          /* FatFs configuration options */
+#include "ffconf.h"          /* FatFs configuration options */
 
 #if _FATFS != _FFCONF
 #error Wrong configuration file (ffconf.h).


### PR DESCRIPTION
Not sure if FFCONF_H should be defined somewhere else, but including ffconf.h directly should be OK here anyway.