### PR TITLE
extmod/machine_pulse: Make time_pulse_us() not throw exceptions.

### DIFF
--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -118,12 +118,15 @@ Miscellaneous functions
    microseconds.  The `pulse_level` argument should be 0 to time a low pulse
    or 1 to time a high pulse.
 
-   The function first waits while the pin input is different to the `pulse_level`
-   parameter, then times the duration that the pin is equal to `pulse_level`.
+   If the current input value of the pin is different to `pulse_level`,
+   the function first (*) waits until the pin input becomes equal to `pulse_level`,
+   then (**) times the duration that the pin is equal to `pulse_level`.
    If the pin is already equal to `pulse_level` then timing starts straight away.
 
-   The function will raise an OSError with ETIMEDOUT if either of the waits is
-   longer than the given timeout value (which is in microseconds).
+   The function will return -2 if there was timeout waiting for condition marked
+   (*) above, and -1 if there was timeout during the main measurement, marked (**)
+   above. The timeout is the same for both cases and given by `timeout_us` (which
+   is in microseconds).
 
 .. _machine_constants:
 

--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -65,7 +65,7 @@ STATIC mp_obj_t dht_readinto(mp_obj_t pin_in, mp_obj_t buf_in) {
 
     // time pulse, should be 80us
     ticks = machine_time_pulse_us(pin, 1, 150);
-    if (ticks == (mp_uint_t)-1) {
+    if ((mp_int_t)ticks < 0) {
         goto timeout;
     }
 
@@ -73,7 +73,7 @@ STATIC mp_obj_t dht_readinto(mp_obj_t pin_in, mp_obj_t buf_in) {
     uint8_t *buf = bufinfo.buf;
     for (int i = 0; i < 40; ++i) {
         ticks = machine_time_pulse_us(pin, 1, 100);
-        if (ticks == (mp_uint_t)-1) {
+        if ((mp_int_t)ticks < 0) {
             goto timeout;
         }
         buf[i / 8] = (buf[i / 8] << 1) | (ticks > 48);

--- a/extmod/machine_pulse.c
+++ b/extmod/machine_pulse.c
@@ -34,7 +34,7 @@ mp_uint_t machine_time_pulse_us(mp_hal_pin_obj_t pin, int pulse_level, mp_uint_t
     mp_uint_t start = mp_hal_ticks_us();
     while (mp_hal_pin_read(pin) != pulse_level) {
         if ((mp_uint_t)(mp_hal_ticks_us() - start) >= timeout_us) {
-            return (mp_uint_t)-1;
+            return (mp_uint_t)-2;
         }
     }
     start = mp_hal_ticks_us();
@@ -57,9 +57,7 @@ STATIC mp_obj_t machine_time_pulse_us_(size_t n_args, const mp_obj_t *args) {
         timeout_us = mp_obj_get_int(args[2]);
     }
     mp_uint_t us = machine_time_pulse_us(pin, level, timeout_us);
-    if (us == (mp_uint_t)-1) {
-        mp_raise_OSError(MP_ETIMEDOUT);
-    }
+    // May return -1 or -2 in case of timeout
     return mp_obj_new_int(us);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_time_pulse_us_obj, 2, 3, machine_time_pulse_us_);

--- a/tests/extmod/machine_pulse.py
+++ b/tests/extmod/machine_pulse.py
@@ -43,12 +43,5 @@ t = machine.time_pulse_us(p, 0)
 print(type(t))
 
 p = ConstPin(0)
-try:
-    machine.time_pulse_us(p, 1, 10)
-except OSError:
-    print("OSError")
-
-try:
-    machine.time_pulse_us(p, 0, 10)
-except OSError:
-    print("OSError")
+print(machine.time_pulse_us(p, 1, 10))
+print(machine.time_pulse_us(p, 0, 10))

--- a/tests/extmod/machine_pulse.py.exp
+++ b/tests/extmod/machine_pulse.py.exp
@@ -5,5 +5,5 @@ value: 1
 value: 0
 value: 1
 <class 'int'>
-OSError
-OSError
+-2
+-1


### PR DESCRIPTION
machine.time_pulse_us() is intended to provide very fine timing, including
while working with signal bursts, where each transition is tracked in row.
Throwing and handling an exception may take too much time and "signal loss".
So instead, in case of a timeout, just return negative value. Cases of
timeout while waiting for initial signal stabilization, and during actual
timing, are recognized.

The documentation is updated accordingly, and rewritten somewhat to clarify
the function behavior.