### PR TITLE
SSD1306_I2C poweron method

### DIFF
--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -122,7 +122,7 @@ class SSD1306_I2C(SSD1306):
         self.i2c.stop()
 
     def poweron(self):
-        pass
+        self.write_cmd(SET_DISP | 0x01)
 
 
 class SSD1306_SPI(SSD1306):


### PR DESCRIPTION
I was using a OLED display with the SSD1306 diver and noticed that the ``SSD1306_I2C`` class does not implement the ``poweron`` method.

Looking at the ``init_display`` I found  way to implement it that seems to make sense and worked very well for me.