### PR TITLE
unix: Fix execstack builds for ARM

### DIFF
--- a/py/nlrx64.S
+++ b/py/nlrx64.S
@@ -258,5 +258,5 @@ nlr_jump:
 
 #endif // defined(__x86_64__) && !MICROPY_NLR_SETJMP
 #if defined(linux)
-    .section    .note.GNU-stack,"",@progbits
+    .section    .note.GNU-stack,"",%progbits
 #endif

--- a/py/nlrx86.S
+++ b/py/nlrx86.S
@@ -191,5 +191,5 @@ nlr_jump:
 
 #endif // defined(__i386__) && !MICROPY_NLR_SETJMP
 #if defined(linux)
-    .section    .note.GNU-stack,"",@progbits
+    .section    .note.GNU-stack,"",%progbits
 #endif

--- a/py/nlrxtensa.S
+++ b/py/nlrxtensa.S
@@ -115,5 +115,5 @@ nlr_jump:
 
 #endif // defined(__xtensa__)
 #if defined(linux)
-    .section    .note.GNU-stack,"",@progbits
+    .section    .note.GNU-stack,"",%progbits
 #endif


### PR DESCRIPTION
It seems that the gcc toolchain on the RaspberryPi
likes %progbits instead of @progbits. I verified that
%progbits also works under x86, so this should
fix #2848 and fix #2842

I verified that unix and mpy-cross both compile
on my RaspberryPi and on my x64 machine.