### PR TITLE
Pin: Minor doc fix

### DIFF
--- a/docs/library/pyb.Pin.rst
+++ b/docs/library/pyb.Pin.rst
@@ -21,7 +21,7 @@ Usage Model:
     CPU pins which correspond to the board pins are available
     as ``pyb.cpu.Name``. For the CPU pins, the names are the port letter
     followed by the pin number. On the PYBv1.0, ``pyb.Pin.board.X1`` and
-    ``pyb.Pin.cpu.B6`` are the same pin.
+    ``pyb.Pin.cpu.A0`` are the same pin.
     
     You can also use strings::
     


### PR DESCRIPTION
On the PybV1.0, X1 maps to A0, not B6.

From forum post: http://forum.micropython.org/viewtopic.php?f=6&t=3006&e=1&view=unread#p17863