### PR TITLE
I2C pin for the STM32F411 Discovery board

### DIFF
--- a/stmhal/boards/STM32F411DISC/mpconfigboard.h
+++ b/stmhal/boards/STM32F411DISC/mpconfigboard.h
@@ -35,7 +35,7 @@
 
 // I2C busses
 #define MICROPY_HW_I2C1_SCL (pin_B6)
-#define MICROPY_HW_I2C1_SDA (pin_B7)
+#define MICROPY_HW_I2C1_SDA (pin_B9)
 //#define MICROPY_HW_I2C2_SCL (pin_B10)
 //#define MICROPY_HW_I2C2_SDA (pin_B11)
 #define MICROPY_HW_I2C3_SCL (pin_A8)


### PR DESCRIPTION
The pin had to be changed to get the I2C sensors on board to work.
The chip has two possible pins for each of the I2C signals. This is described in the [datasheet](http://www.st.com/content/ccc/resource/technical/document/user_manual/e9/d2/00/5e/15/46/44/0e/DM00148985.pdf/files/DM00148985.pdf/jcr:content/translations/en.DM00148985.pdf) on page 22