### PR TITLE
windows/.gitignore: Ignore VC.db and VC.opendb files from VS2015

### DIFF
--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -7,3 +7,4 @@
 *.ilk
 *.filters
 /build/*
+*.VC.*db


### PR DESCRIPTION
Since VS2015 update 2 .db files are used for storing browsing info,
instead of .sdf files. If users don't specify a location for these files
excplicitly they end up in the project directory so ignore them.