### PR TITLE
drivers/display/lcd160cr: Use correct variable in set_power().

### DIFF
--- a/drivers/display/lcd160cr.py
+++ b/drivers/display/lcd160cr.py
@@ -203,7 +203,7 @@ class LCD160CR:
     #### SETUP COMMANDS ####
 
     def set_power(self, on):
-        self.pwr(value)
+        self.pwr(on)
         sleep_ms(15)
 
     def set_orient(self, orient):


### PR DESCRIPTION
When calling `LCD160CR.set_power(on)` it returns `NameError: name 'value' is not defined` no matter what value is provided. This should fix it.

I also think the [functions documentation](http://docs.micropython.org/en/latest/pyboard/library/lcd160cr.html#lcd160cr.LCD160CR.set_power) is too vague about what values are accepted for `on`.