### PR TITLE
Disable CAN1 CLK in pyb_can_deinit.

### DIFF
--- a/stmhal/can.c
+++ b/stmhal/can.c
@@ -422,6 +422,7 @@ STATIC mp_obj_t pyb_can_deinit(mp_obj_t self_in) {
         HAL_NVIC_DisableIRQ(CAN2_RX1_IRQn);
         __CAN2_FORCE_RESET();
         __CAN2_RELEASE_RESET();
+        __CAN1_CLK_DISABLE(); // Enabled with CAN2 clk
         __CAN2_CLK_DISABLE();
     }
     return mp_const_none;


### PR DESCRIPTION
* CAN1 CLK is enabled when CAN2 is initialized see [can.c:116](https://github.com/micropython/micropython/blob/master/stmhal/can.c#L116).