### PR TITLE
Allow building the cross compiler with MSVC

### DIFF
--- a/mpy-cross/mpconfigport.h
+++ b/mpy-cross/mpconfigport.h
@@ -94,6 +94,9 @@ typedef unsigned long mp_uint_t; // must be pointer size
 #include <stdint.h>
 typedef __int64 mp_int_t;
 typedef unsigned __int64 mp_uint_t;
+#elif defined ( _MSC_VER ) && defined( _WIN64 )
+typedef __int64 mp_int_t;
+typedef unsigned __int64 mp_uint_t;
 #else
 // These are definitions for machines where sizeof(int) == sizeof(void*),
 // regardless for actual size.
@@ -124,3 +127,33 @@ typedef long mp_off_t;
 #endif
 
 #include <stdint.h>
+
+// MSVC specifics - see windows/mpconfigport.h for explanation
+#ifdef _MSC_VER
+
+#define NORETURN                    __declspec(noreturn)
+#undef MP_NOINLINE
+#define MP_NOINLINE                 __declspec(noinline)
+#define MP_LIKELY(x)                (x)
+#define MP_UNLIKELY(x)              (x)
+#define MICROPY_PORT_CONSTANTS      { "dummy", 0 }
+#ifdef _WIN64
+#define MP_SSIZE_MAX                _I64_MAX
+#else
+#define MP_SSIZE_MAX                _I32_MAX
+#endif
+#define restrict
+#define inline                      __inline
+#define alignof(t)                  __alignof(t)
+#undef MICROPY_ALLOC_PATH_MAX
+#define MICROPY_ALLOC_PATH_MAX      260
+#ifdef _WIN64
+#define SSIZE_MAX                   _I64_MAX
+typedef __int64                     ssize_t;
+#else
+#define SSIZE_MAX                   _I32_MAX
+typedef int                         ssize_t;
+#endif
+#define MP_ENDIANNESS_LITTLE        (1)
+
+#endif

--- a/ports/windows/.appveyor.yml
+++ b/ports/windows/.appveyor.yml
@@ -16,6 +16,7 @@ platform:
 
 build:
   project: ports/windows/micropython.vcxproj
+  project: ports/windows/mpy-cross.vcxproj
   verbosity: normal
 
 test_script:

--- a/ports/windows/.gitignore
+++ b/ports/windows/.gitignore
@@ -6,6 +6,6 @@
 *.pdb
 *.ilk
 *.filters
-/build/*
+/build*/*
 .vs/*
 *.VC.*db

--- a/ports/windows/init.c
+++ b/ports/windows/init.c
@@ -31,6 +31,7 @@
 #include <crtdbg.h>
 #endif
 #include "sleep.h"
+#include "fmode.h"
 
 extern BOOL WINAPI console_sighandler(DWORD evt);
 
@@ -61,6 +62,7 @@ void init() {
     // https://msdn.microsoft.com/en-us/library/bb531344(v=vs.140).aspx
     _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
+    set_fmode_binary();
 }
 
 void deinit() {

--- a/ports/windows/micropython.vcxproj
+++ b/ports/windows/micropython.vcxproj
@@ -25,29 +25,19 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/ports/windows/micropython.vcxproj
+++ b/ports/windows/micropython.vcxproj
@@ -82,6 +82,15 @@
     <Link />
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="$(PyBaseDir)lib\mp-readline\*.c" />
+    <ClCompile Include="$(PyBaseDir)ports\windows\*.c" />
+    <ClCompile Include="$(PyBaseDir)ports\unix\file.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\gccollect.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\input.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\main.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\modos.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\modtime.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\modmachine.c" />
   </ItemGroup>
   <Import Project="msvc/sources.props" />
   <Import Project="msvc/genhdr.targets" />

--- a/ports/windows/micropython.vcxproj
+++ b/ports/windows/micropython.vcxproj
@@ -91,6 +91,7 @@
     <ClCompile Include="$(PyBaseDir)ports\unix\modos.c"/>
     <ClCompile Include="$(PyBaseDir)ports\unix\modtime.c"/>
     <ClCompile Include="$(PyBaseDir)ports\unix\modmachine.c" />
+    <ClCompile Include="$(PyBaseDir)extmod\machine_pulse.c" />
   </ItemGroup>
   <Import Project="msvc/sources.props" />
   <Import Project="msvc/genhdr.targets" />

--- a/ports/windows/mpy-cross.vcxproj
+++ b/ports/windows/mpy-cross.vcxproj
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{740F3A30-3B6C-4B59-9C50-AE4D5A4A9D12}</ProjectGuid>
+    <RootNamespace>mpy-cross</RootNamespace>
+    <PyBuildingMpyCross>True</PyBuildingMpyCross>
+    <PyBuildDir>$(MSBuildThisFileDirectory)\buildmpy-cross\</PyBuildDir>
+    <PyIncDirs>$(MSBuildThisFileDirectory)\..\..\mpy-cross</PyIncDirs>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="msvc/common.props" />
+    <Import Project="msvc/debug.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="msvc/common.props" />
+    <Import Project="msvc/release.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="msvc/common.props" />
+    <Import Project="msvc/debug.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="msvc/common.props" />
+    <Import Project="msvc/release.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros">
+    <CustomPropsFile Condition="'$(CustomPropsFile)'==''">msvc/user.props</CustomPropsFile>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile />
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile />
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile />
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile />
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="$(PyBaseDir)mpy-cross\gccollect.c"/>
+    <ClCompile Include="$(PyBaseDir)mpy-cross\main.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\windows\fmode.c" />
+  </ItemGroup>
+  <Import Project="msvc/sources.props" />
+  <Import Project="msvc/genhdr.targets" />
+  <Import Project="$(CustomPropsFile)" Condition="exists('$(CustomPropsFile)')" />
+  <Target Name="GenHeaders" BeforeTargets="BuildGenerateSources" DependsOnTargets="GenerateHeaders">
+  </Target>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/ports/windows/msvc/common.props
+++ b/ports/windows/msvc/common.props
@@ -8,6 +8,7 @@
     <OutDir>$(PyOutDir)</OutDir>
     <IntDir>$(PyIntDir)</IntDir>
     <PyFileCopyCookie>$(PyBuildDir)copycookie$(Configuration)$(Platform)</PyFileCopyCookie>
+    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/ports/windows/msvc/debug.props
+++ b/ports/windows/msvc/debug.props
@@ -3,6 +3,8 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <ItemDefinitionGroup />
   <ItemGroup />

--- a/ports/windows/msvc/paths.props
+++ b/ports/windows/msvc/paths.props
@@ -28,7 +28,7 @@
     <PyBuildDir Condition="'$(PyBuildDir)' == ''">$(PyWinDir)build\</PyBuildDir>
 
     <!-- All include directories needed for uPy -->
-    <PyIncDirs>$(PyBaseDir);$(PyWinDir);$(PyBuildDir);$(PyWinDir)msvc</PyIncDirs>
+    <PyIncDirs>$(PyIncDirs);$(PyBaseDir);$(PyWinDir);$(PyBuildDir);$(PyWinDir)msvc</PyIncDirs>
 
     <!-- Within PyBuildDir different subdirectories are used based on configuration and platform.
          By default these are chosen based on the Configuration and Platform properties, but

--- a/ports/windows/msvc/release.props
+++ b/ports/windows/msvc/release.props
@@ -2,7 +2,10 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
+  <PropertyGroup>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
       <OptimizeReferences>true</OptimizeReferences>

--- a/ports/windows/msvc/sources.props
+++ b/ports/windows/msvc/sources.props
@@ -3,17 +3,7 @@
   <Import Project="paths.props" Condition="'$(PyPathsIncluded)' != 'True'"/>
   <ItemGroup>
     <ClCompile Include="$(PyBaseDir)py\*.c" />
-    <ClCompile Include="$(PyBaseDir)ports\windows\*.c" />
     <ClCompile Include="$(PyBaseDir)ports\windows\msvc\*.c" />
-    <ClCompile Include="$(PyBaseDir)lib\mp-readline\*.c" />
-    <ClCompile Include="$(PyBaseDir)lib\utils\printf.c" />
-    <ClCompile Include="$(PyBaseDir)ports\unix\file.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\gccollect.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\input.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\main.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\modos.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\modtime.c"/>
-    <ClCompile Include="$(PyBaseDir)ports\unix\modmachine.c" />
     <ClCompile Include="$(PyBaseDir)extmod\machine_mem.c" />
     <ClCompile Include="$(PyBaseDir)extmod\machine_pinbase.c" />
     <ClCompile Include="$(PyBaseDir)extmod\machine_pulse.c" />

--- a/ports/windows/msvc/sources.props
+++ b/ports/windows/msvc/sources.props
@@ -6,7 +6,6 @@
     <ClCompile Include="$(PyBaseDir)ports\windows\msvc\*.c" />
     <ClCompile Include="$(PyBaseDir)extmod\machine_mem.c" />
     <ClCompile Include="$(PyBaseDir)extmod\machine_pinbase.c" />
-    <ClCompile Include="$(PyBaseDir)extmod\machine_pulse.c" />
     <ClCompile Include="$(PyBaseDir)extmod\machine_signal.c" />
     <ClCompile Include="$(PyBaseDir)extmod\modubinascii.c" />
     <ClCompile Include="$(PyBaseDir)extmod\moductypes.c" />

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -377,7 +377,7 @@ void mp_raw_code_save(mp_raw_code_t *rc, mp_print_t *print) {
 // here we define mp_raw_code_save_file depending on the port
 // TODO abstract this away properly
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__unix__)
+#if defined(__i386__) || defined(__x86_64__) || defined(_WIN32) || defined(__unix__)
 
 #include <unistd.h>
 #include <sys/stat.h>


### PR DESCRIPTION
This PR adds a build configuration to allow building mpy-cross using MSVC.