### PR TITLE
Docs: lcd160cr.rst get_line() describes usage.

### DIFF
--- a/docs/library/lcd160cr.rst
+++ b/docs/library/lcd160cr.rst
@@ -343,7 +343,8 @@ Advanced commands
 
 .. method:: LCD160CR.jpeg(buf)
 
-    Display a JPEG.  `buf` should contain the entire JPEG data.
+    Display a JPEG.  `buf` should contain the entire JPEG data. JPEG data should
+    not include EXIF information.
     The origin of the JPEG is set by :meth:`LCD160CR.set_pos`.
 
 .. method:: LCD160CR.jpeg_start(total_len)

--- a/docs/library/lcd160cr.rst
+++ b/docs/library/lcd160cr.rst
@@ -344,7 +344,8 @@ Advanced commands
 .. method:: LCD160CR.jpeg(buf)
 
     Display a JPEG.  `buf` should contain the entire JPEG data. JPEG data should
-    not include EXIF information.
+    not include EXIF information. The following encodings are supported: Baseline
+    DCT, Huffman coding, 8 bits per sample, 3 color components, YCbCr4:2:2.
     The origin of the JPEG is set by :meth:`LCD160CR.set_pos`.
 
 .. method:: LCD160CR.jpeg_start(total_len)

--- a/docs/library/lcd160cr.rst
+++ b/docs/library/lcd160cr.rst
@@ -150,7 +150,9 @@ The following methods manipulate individual pixels on the display.
 
 .. method:: LCD160CR.get_line(x, y, buf)
 
-    Get a line of pixels into the given buffer.
+    Get a line of pixels into the given buffer. Each pixel is returned as a
+    16-bit RGB value. To return a line of length N pixels, the buffer should
+    be a bytearray of size 2N +1 bytes. Byte zero should be ignored.
 
 .. method:: LCD160CR.screen_dump(buf)
 


### PR DESCRIPTION
Improved description of the usage of this method.