### PR TITLE
msvc: Add machine/pin-related sources to build

### DIFF
--- a/windows/msvc/sources.props
+++ b/windows/msvc/sources.props
@@ -15,6 +15,7 @@
     <ClCompile Include="$(PyBaseDir)unix\modmachine.c" />
     <ClCompile Include="$(PyBaseDir)extmod\machine_mem.c" />
     <ClCompile Include="$(PyBaseDir)extmod\machine_pinbase.c" />
+    <ClCompile Include="$(PyBaseDir)extmod\machine_signal.c" />
     <ClCompile Include="$(PyBaseDir)extmod\modubinascii.c" />
     <ClCompile Include="$(PyBaseDir)extmod\moductypes.c" />
     <ClCompile Include="$(PyBaseDir)extmod\moduhashlib.c" />
@@ -24,6 +25,7 @@
     <ClCompile Include="$(PyBaseDir)extmod\modure.c" />
     <ClCompile Include="$(PyBaseDir)extmod\moduzlib.c" />
     <ClCompile Include="$(PyBaseDir)extmod\utime_mphal.c" />
+    <ClCompile Include="$(PyBaseDir)extmod\virtpin.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(PyBaseDir)py\*.h" />


### PR DESCRIPTION
This fixes unresolved references after [f1ea3bc]