### PR TITLE
Use mp_obj_get_array where sequence may be a tuple or a list.

### DIFF
--- a/py/objfun.c
+++ b/py/objfun.c
@@ -511,17 +511,11 @@ STATIC mp_uint_t convert_obj_for_inline_asm(mp_obj_t obj) {
             // convert float to int (could also pass in float registers)
             return (mp_int_t)mp_obj_float_get(obj);
 #endif
-        } else if (type == &mp_type_tuple) {
+        } else if (type == &mp_type_tuple || type == &mp_type_list) {
             // pointer to start of tuple (could pass length, but then could use len(x) for that)
             mp_uint_t len;
             mp_obj_t *items;
-            mp_obj_tuple_get(obj, &len, &items);
-            return (mp_uint_t)items;
-        } else if (type == &mp_type_list) {
-            // pointer to start of list (could pass length, but then could use len(x) for that)
-            mp_uint_t len;
-            mp_obj_t *items;
-            mp_obj_list_get(obj, &len, &items);
+            mp_obj_get_array(obj, &len, &items);
             return (mp_uint_t)items;
         } else {
             mp_buffer_info_t bufinfo;

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -430,16 +430,13 @@ STATIC mp_obj_t str_join(mp_obj_t self_in, mp_obj_t arg) {
     // process args
     mp_uint_t seq_len;
     mp_obj_t *seq_items;
-    if (MP_OBJ_IS_TYPE(arg, &mp_type_tuple)) {
-        mp_obj_tuple_get(arg, &seq_len, &seq_items);
-    } else {
-        if (!MP_OBJ_IS_TYPE(arg, &mp_type_list)) {
-            // arg is not a list, try to convert it to one
-            // TODO: Try to optimize?
-            arg = mp_type_list.make_new(&mp_type_list, 1, 0, &arg);
-        }
-        mp_obj_list_get(arg, &seq_len, &seq_items);
+
+    if (!MP_OBJ_IS_TYPE(arg, &mp_type_list) && !MP_OBJ_IS_TYPE(arg, &mp_type_tuple)) {
+        // arg is not a list nor a tuple, try to convert it to a list
+        // TODO: Try to optimize?
+        arg = mp_type_list.make_new(&mp_type_list, 1, 0, &arg);
     }
+    mp_obj_get_array(arg, &seq_len, &seq_items);
 
     // count required length
     size_t required_len = 0;

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -797,11 +797,7 @@ void mp_unpack_sequence(mp_obj_t seq_in, size_t num, mp_obj_t *items) {
     mp_uint_t seq_len;
     if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple) || MP_OBJ_IS_TYPE(seq_in, &mp_type_list)) {
         mp_obj_t *seq_items;
-        if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple)) {
-            mp_obj_tuple_get(seq_in, &seq_len, &seq_items);
-        } else {
-            mp_obj_list_get(seq_in, &seq_len, &seq_items);
-        }
+        mp_obj_get_array(seq_in, &seq_len, &seq_items);
         if (seq_len < num) {
             goto too_short;
         } else if (seq_len > num) {
@@ -851,11 +847,7 @@ void mp_unpack_ex(mp_obj_t seq_in, size_t num_in, mp_obj_t *items) {
     mp_uint_t seq_len;
     if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple) || MP_OBJ_IS_TYPE(seq_in, &mp_type_list)) {
         mp_obj_t *seq_items;
-        if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple)) {
-            mp_obj_tuple_get(seq_in, &seq_len, &seq_items);
-        } else {
-            mp_obj_list_get(seq_in, &seq_len, &seq_items);
-        }
+        mp_obj_get_array(seq_in, &seq_len, &seq_items);
         if (seq_len < num_left + num_right) {
             goto too_short;
         }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -854,11 +854,6 @@ void mp_unpack_ex(mp_obj_t seq_in, size_t num_in, mp_obj_t *items) {
         if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple)) {
             mp_obj_tuple_get(seq_in, &seq_len, &seq_items);
         } else {
-            if (num_left == 0 && num_right == 0) {
-                // *a, = b # sets a to b if b is a list
-                items[0] = seq_in;
-                return;
-            }
             mp_obj_list_get(seq_in, &seq_len, &seq_items);
         }
         if (seq_len < num_left + num_right) {

--- a/tests/basics/string_join.py
+++ b/tests/basics/string_join.py
@@ -14,6 +14,11 @@ print(','.join('abc' for i in range(5)))
 print(b','.join([b'abc', b'123']))
 
 try:
+    ''.join(None)
+except TypeError:
+    print("TypeError")
+
+try:
     print(b','.join(['abc', b'123']))
 except TypeError:
     print("TypeError")

--- a/tests/basics/unpack1.py
+++ b/tests/basics/unpack1.py
@@ -41,7 +41,7 @@ a, *b, c = 24, 25, 26, 27   ; print(a, b)
 
 a = [28, 29]
 *b, = a
-print(a, b, a == b)
+print(a, b, a == b, a is b)
 
 [*a] = [1, 2, 3]
 print(a)


### PR DESCRIPTION
This patch:
* reduces code size (-80 B on unix, -60 B on stmhal),
* fixes #2934.