### PR TITLE
esp8266: Only execute main.py if in friendly REPL mode.

### DIFF
--- a/esp8266/main.c
+++ b/esp8266/main.c
@@ -65,7 +65,9 @@ STATIC void mp_reset(void) {
 #if MICROPY_MODULE_FROZEN
     pyexec_frozen_module("_boot.py");
     pyexec_file("boot.py");
-    pyexec_file("main.py");
+    if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
+        pyexec_file("main.py");
+    }
 #endif
 }
 


### PR DESCRIPTION
This should fix #2936.