### PR TITLE
py: Allow lexer to raise exceptions.

### DIFF
--- a/bare-arm/main.c
+++ b/bare-arm/main.c
@@ -6,15 +6,12 @@
 #include "py/compile.h"
 #include "py/runtime.h"
 #include "py/repl.h"
+#include "py/mperrno.h"
 
 void do_str(const char *src, mp_parse_input_kind_t input_kind) {
-    mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
-    if (lex == NULL) {
-        return;
-    }
-
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
+        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
         qstr source_name = lex->source_name;
         mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
         mp_obj_t module_fun = mp_compile(&parse_tree, source_name, MP_EMIT_OPT_NONE, true);
@@ -35,7 +32,7 @@ int main(int argc, char **argv) {
 }
 
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
-    return NULL;
+    mp_raise_OSError(MP_ENOENT);
 }
 
 mp_import_stat_t mp_import_stat(const char *path) {

--- a/esp8266/lexerstr32.c
+++ b/esp8266/lexerstr32.c
@@ -58,10 +58,7 @@ STATIC void str32_buf_free(void *sb_in) {
 }
 
 mp_lexer_t *mp_lexer_new_from_str32(qstr src_name, const char *str, mp_uint_t len, mp_uint_t free_len) {
-    mp_lexer_str32_buf_t *sb = m_new_obj_maybe(mp_lexer_str32_buf_t);
-    if (sb == NULL) {
-        return NULL;
-    }
+    mp_lexer_str32_buf_t *sb = m_new_obj(mp_lexer_str32_buf_t);
     sb->byte_off = (uint32_t)str & 3;
     sb->src_cur = (uint32_t*)(str - sb->byte_off);
     sb->val = *sb->src_cur++ >> sb->byte_off * 8;

--- a/esp8266/main.c
+++ b/esp8266/main.c
@@ -32,6 +32,7 @@
 #include "py/runtime0.h"
 #include "py/runtime.h"
 #include "py/stackctrl.h"
+#include "py/mperrno.h"
 #include "py/mphal.h"
 #include "py/gc.h"
 #include "lib/mp-readline/readline.h"
@@ -111,7 +112,7 @@ void user_init(void) {
 
 #if !MICROPY_VFS
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
-    return NULL;
+    mp_raise_OSError(MP_ENOENT);
 }
 
 mp_import_stat_t mp_import_stat(const char *path) {

--- a/examples/embedding/hello-embed.c
+++ b/examples/embedding/hello-embed.c
@@ -35,9 +35,10 @@
 
 static char heap[16384];
 
-mp_obj_t execute_from_lexer(mp_lexer_t *lex) {
+mp_obj_t execute_from_str(const char *str) {
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
+        mp_lexer_t *lex = mp_lexer_new_from_str_len(0/*MP_QSTR_*/, str, strlen(str), false);
         mp_parse_tree_t pt = mp_parse(lex, MP_PARSE_FILE_INPUT);
         mp_obj_t module_fun = mp_compile(&pt, lex->source_name, MP_EMIT_OPT_NONE, false);
         mp_call_function_0(module_fun);
@@ -58,8 +59,7 @@ int main() {
     mp_init();
 
     const char str[] = "print('Hello world of easy embedding!')";
-    mp_lexer_t *lex = mp_lexer_new_from_str_len(0/*MP_QSTR_*/, str, strlen(str), false);
-    if (execute_from_lexer(lex)) {
+    if (execute_from_str(str)) {
         printf("Error\n");
     }
 }

--- a/extmod/vfs_reader.c
+++ b/extmod/vfs_reader.c
@@ -27,7 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "py/nlr.h"
+#include "py/runtime.h"
 #include "py/stream.h"
 #include "py/reader.h"
 #include "extmod/vfs.h"
@@ -69,30 +69,19 @@ STATIC void mp_reader_vfs_close(void *data) {
     m_del_obj(mp_reader_vfs_t, reader);
 }
 
-int mp_reader_new_file(mp_reader_t *reader, const char *filename) {
-    mp_reader_vfs_t *rf = m_new_obj_maybe(mp_reader_vfs_t);
-    if (rf == NULL) {
-        return MP_ENOMEM;
-    }
-    // TODO we really should just let this function raise a uPy exception
-    nlr_buf_t nlr;
-    if (nlr_push(&nlr) == 0) {
-        mp_obj_t arg = mp_obj_new_str(filename, strlen(filename), false);
-        rf->file = mp_vfs_open(1, &arg, (mp_map_t*)&mp_const_empty_map);
-        int errcode;
-        rf->len = mp_stream_rw(rf->file, rf->buf, sizeof(rf->buf), &errcode, MP_STREAM_RW_READ | MP_STREAM_RW_ONCE);
-        nlr_pop();
-        if (errcode != 0) {
-            return errcode;
-        }
-    } else {
-        return MP_ENOENT; // assume error was "file not found"
+void mp_reader_new_file(mp_reader_t *reader, const char *filename) {
+    mp_reader_vfs_t *rf = m_new_obj(mp_reader_vfs_t);
+    mp_obj_t arg = mp_obj_new_str(filename, strlen(filename), false);
+    rf->file = mp_vfs_open(1, &arg, (mp_map_t*)&mp_const_empty_map);
+    int errcode;
+    rf->len = mp_stream_rw(rf->file, rf->buf, sizeof(rf->buf), &errcode, MP_STREAM_RW_READ | MP_STREAM_RW_ONCE);
+    if (errcode != 0) {
+        mp_raise_OSError(errcode);
     }
     rf->pos = 0;
     reader->data = rf;
     reader->readbyte = mp_reader_vfs_readbyte;
     reader->close = mp_reader_vfs_close;
-    return 0; // success
 }
 
 #endif // MICROPY_READER_VFS

--- a/lib/memzip/lexermemzip.c
+++ b/lib/memzip/lexermemzip.c
@@ -1,6 +1,8 @@
 #include <stdlib.h>
 
 #include "py/lexer.h"
+#include "py/runtime.h"
+#include "py/mperrno.h"
 #include "memzip.h"
 
 mp_lexer_t *mp_lexer_new_from_file(const char *filename)
@@ -9,7 +11,7 @@ mp_lexer_t *mp_lexer_new_from_file(const char *filename)
     size_t len;
 
     if (memzip_locate(filename, &data, &len) != MZ_OK) {
-        return NULL;
+        mp_raise_OSError(MP_ENOENT);
     }
 
     return mp_lexer_new_from_str_len(qstr_from_str(filename), (const char *)data, (mp_uint_t)len, 0);

--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -52,13 +52,15 @@ STATIC bool repl_display_debugging_info = 0;
 #define EXEC_FLAG_ALLOW_DEBUGGING (2)
 #define EXEC_FLAG_IS_REPL (4)
 #define EXEC_FLAG_SOURCE_IS_RAW_CODE (8)
+#define EXEC_FLAG_SOURCE_IS_VSTR (16)
+#define EXEC_FLAG_SOURCE_IS_FILENAME (32)
 
 // parses, compiles and executes the code in the lexer
 // frees the lexer before returning
 // EXEC_FLAG_PRINT_EOF prints 2 EOF chars: 1 after normal output, 1 after exception output
 // EXEC_FLAG_ALLOW_DEBUGGING allows debugging info to be printed after executing the code
 // EXEC_FLAG_IS_REPL is used for REPL inputs (flag passed on to mp_compile)
-STATIC int parse_compile_execute(void *source, mp_parse_input_kind_t input_kind, int exec_flags) {
+STATIC int parse_compile_execute(const void *source, mp_parse_input_kind_t input_kind, int exec_flags) {
     int ret = 0;
     uint32_t start = 0;
 
@@ -76,8 +78,16 @@ STATIC int parse_compile_execute(void *source, mp_parse_input_kind_t input_kind,
         #endif
         {
             #if MICROPY_ENABLE_COMPILER
+            mp_lexer_t *lex;
+            if (exec_flags & EXEC_FLAG_SOURCE_IS_VSTR) {
+                const vstr_t *vstr = source;
+                lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, vstr->buf, vstr->len, 0);
+            } else if (exec_flags & EXEC_FLAG_SOURCE_IS_FILENAME) {
+                lex = mp_lexer_new_from_file(source);
+            } else {
+                lex = (mp_lexer_t*)source;
+            }
             // source is a lexer, parse and compile the script
-            mp_lexer_t *lex = source;
             qstr source_name = lex->source_name;
             mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
             module_fun = mp_compile(&parse_tree, source_name, MP_EMIT_OPT_NONE, exec_flags & EXEC_FLAG_IS_REPL);
@@ -202,14 +212,9 @@ STATIC int pyexec_raw_repl_process_char(int c) {
         return PYEXEC_FORCED_EXIT;
     }
 
-    mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, MP_STATE_VM(repl_line)->buf, MP_STATE_VM(repl_line)->len, 0);
-    if (lex == NULL) {
-        mp_hal_stdout_tx_str("\x04MemoryError\r\n\x04");
-    } else {
-        int ret = parse_compile_execute(lex, MP_PARSE_FILE_INPUT, EXEC_FLAG_PRINT_EOF);
-        if (ret & PYEXEC_FORCED_EXIT) {
-            return ret;
-        }
+    int ret = parse_compile_execute(MP_STATE_VM(repl_line), MP_PARSE_FILE_INPUT, EXEC_FLAG_PRINT_EOF | EXEC_FLAG_SOURCE_IS_VSTR);
+    if (ret & PYEXEC_FORCED_EXIT) {
+        return ret;
     }
 
 reset:
@@ -285,14 +290,9 @@ STATIC int pyexec_friendly_repl_process_char(int c) {
         }
 
 exec: ;
-        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, vstr_str(MP_STATE_VM(repl_line)), vstr_len(MP_STATE_VM(repl_line)), 0);
-        if (lex == NULL) {
-            printf("MemoryError\n");
-        } else {
-            int ret = parse_compile_execute(lex, MP_PARSE_SINGLE_INPUT, EXEC_FLAG_ALLOW_DEBUGGING | EXEC_FLAG_IS_REPL);
-            if (ret & PYEXEC_FORCED_EXIT) {
-                return ret;
-            }
+        int ret = parse_compile_execute(MP_STATE_VM(repl_line), MP_PARSE_SINGLE_INPUT, EXEC_FLAG_ALLOW_DEBUGGING | EXEC_FLAG_IS_REPL | EXEC_FLAG_SOURCE_IS_VSTR);
+        if (ret & PYEXEC_FORCED_EXIT) {
+            return ret;
         }
 
 input_restart:
@@ -361,14 +361,9 @@ raw_repl_reset:
             return PYEXEC_FORCED_EXIT;
         }
 
-        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, line.buf, line.len, 0);
-        if (lex == NULL) {
-            printf("\x04MemoryError\n\x04");
-        } else {
-            int ret = parse_compile_execute(lex, MP_PARSE_FILE_INPUT, EXEC_FLAG_PRINT_EOF);
-            if (ret & PYEXEC_FORCED_EXIT) {
-                return ret;
-            }
+        int ret = parse_compile_execute(&line, MP_PARSE_FILE_INPUT, EXEC_FLAG_PRINT_EOF | EXEC_FLAG_SOURCE_IS_VSTR);
+        if (ret & PYEXEC_FORCED_EXIT) {
+            return ret;
         }
     }
 }
@@ -489,14 +484,9 @@ friendly_repl_reset:
             }
         }
 
-        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, vstr_str(&line), vstr_len(&line), 0);
-        if (lex == NULL) {
-            printf("MemoryError\n");
-        } else {
-            ret = parse_compile_execute(lex, parse_input_kind, EXEC_FLAG_ALLOW_DEBUGGING | EXEC_FLAG_IS_REPL);
-            if (ret & PYEXEC_FORCED_EXIT) {
-                return ret;
-            }
+        ret = parse_compile_execute(&line, parse_input_kind, EXEC_FLAG_ALLOW_DEBUGGING | EXEC_FLAG_IS_REPL | EXEC_FLAG_SOURCE_IS_VSTR);
+        if (ret & PYEXEC_FORCED_EXIT) {
+            return ret;
         }
     }
 }
@@ -505,14 +495,7 @@ friendly_repl_reset:
 #endif // MICROPY_ENABLE_COMPILER
 
 int pyexec_file(const char *filename) {
-    mp_lexer_t *lex = mp_lexer_new_from_file(filename);
-
-    if (lex == NULL) {
-        printf("could not open file '%s' for reading\n", filename);
-        return false;
-    }
-
-    return parse_compile_execute(lex, MP_PARSE_FILE_INPUT, 0);
+    return parse_compile_execute(filename, MP_PARSE_FILE_INPUT, 0);
 }
 
 #if MICROPY_MODULE_FROZEN

--- a/minimal/main.c
+++ b/minimal/main.c
@@ -7,18 +7,14 @@
 #include "py/runtime.h"
 #include "py/repl.h"
 #include "py/gc.h"
+#include "py/mperrno.h"
 #include "lib/utils/pyexec.h"
 
 #if MICROPY_ENABLE_COMPILER
 void do_str(const char *src, mp_parse_input_kind_t input_kind) {
-    mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
-    if (lex == NULL) {
-        printf("MemoryError: lexer could not allocate memory\n");
-        return;
-    }
-
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
+        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
         qstr source_name = lex->source_name;
         mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
         mp_obj_t module_fun = mp_compile(&parse_tree, source_name, MP_EMIT_OPT_NONE, true);
@@ -74,7 +70,7 @@ void gc_collect(void) {
 }
 
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
-    return NULL;
+    mp_raise_OSError(MP_ENOENT);
 }
 
 mp_import_stat_t mp_import_stat(const char *path) {

--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -57,14 +57,10 @@ STATIC void stderr_print_strn(void *env, const char *str, mp_uint_t len) {
 STATIC const mp_print_t mp_stderr_print = {NULL, stderr_print_strn};
 
 STATIC int compile_and_save(const char *file, const char *output_file, const char *source_file) {
-    mp_lexer_t *lex = mp_lexer_new_from_file(file);
-    if (lex == NULL) {
-        printf("could not open file '%s' for reading\n", file);
-        return 1;
-    }
-
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
+        mp_lexer_t *lex = mp_lexer_new_from_file(file);
+
         qstr source_name;
         if (source_file == NULL) {
             source_name = lex->source_name;

--- a/pic16bit/main.c
+++ b/pic16bit/main.c
@@ -33,6 +33,7 @@
 #include "py/runtime.h"
 #include "py/gc.h"
 #include "py/mphal.h"
+#include "py/mperrno.h"
 #include "lib/utils/pyexec.h"
 #include "readline.h"
 #include "board.h"
@@ -98,7 +99,7 @@ void gc_collect(void) {
 }
 
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
-    return NULL;
+    mp_raise_OSError(MP_ENOENT);
 }
 
 mp_import_stat_t mp_import_stat(const char *path) {

--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -136,9 +136,6 @@ STATIC mp_obj_t eval_exec_helper(size_t n_args, const mp_obj_t *args, mp_parse_i
     mp_lexer_t *lex;
     if (MICROPY_PY_BUILTINS_EXECFILE && parse_input_kind == MP_PARSE_SINGLE_INPUT) {
         lex = mp_lexer_new_from_file(str);
-        if (lex == NULL) {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "could not open file '%s'", str));
-        }
         parse_input_kind = MP_PARSE_FILE_INPUT;
     } else {
         lex = mp_lexer_new_from_str_len(MP_QSTR__lt_string_gt_, str, str_len, 0);

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -131,18 +131,7 @@ STATIC mp_import_stat_t find_file(const char *file_str, uint file_len, vstr_t *d
 }
 
 #if MICROPY_ENABLE_COMPILER
-STATIC void do_load_from_lexer(mp_obj_t module_obj, mp_lexer_t *lex, const char *fname) {
-
-    if (lex == NULL) {
-        // we verified the file exists using stat, but lexer could still fail
-        if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
-            mp_raise_msg(&mp_type_ImportError, "module not found");
-        } else {
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ImportError,
-                "no module named '%s'", fname));
-        }
-    }
-
+STATIC void do_load_from_lexer(mp_obj_t module_obj, mp_lexer_t *lex) {
     #if MICROPY_PY___FILE__
     qstr source_name = lex->source_name;
     mp_store_attr(module_obj, MP_QSTR___file__, MP_OBJ_NEW_QSTR(source_name));
@@ -207,7 +196,7 @@ STATIC void do_load(mp_obj_t module_obj, vstr_t *file) {
     // found the filename in the list of frozen files, then load and execute it.
     #if MICROPY_MODULE_FROZEN_STR
     if (frozen_type == MP_FROZEN_STR) {
-        do_load_from_lexer(module_obj, modref, file_str);
+        do_load_from_lexer(module_obj, modref);
         return;
     }
     #endif
@@ -235,7 +224,7 @@ STATIC void do_load(mp_obj_t module_obj, vstr_t *file) {
     #if MICROPY_ENABLE_COMPILER
     {
         mp_lexer_t *lex = mp_lexer_new_from_file(file_str);
-        do_load_from_lexer(module_obj, lex, file_str);
+        do_load_from_lexer(module_obj, lex);
         return;
     }
     #endif

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -699,13 +699,7 @@ void mp_lexer_to_next(mp_lexer_t *lex) {
 }
 
 mp_lexer_t *mp_lexer_new(qstr src_name, mp_reader_t reader) {
-    mp_lexer_t *lex = m_new_obj_maybe(mp_lexer_t);
-
-    // check for memory allocation error
-    if (lex == NULL) {
-        reader.close(reader.data);
-        return NULL;
-    }
+    mp_lexer_t *lex = m_new_obj(mp_lexer_t);
 
     lex->source_name = src_name;
     lex->reader = reader;
@@ -715,15 +709,8 @@ mp_lexer_t *mp_lexer_new(qstr src_name, mp_reader_t reader) {
     lex->nested_bracket_level = 0;
     lex->alloc_indent_level = MICROPY_ALLOC_LEXER_INDENT_INIT;
     lex->num_indent_level = 1;
-    lex->indent_level = m_new_maybe(uint16_t, lex->alloc_indent_level);
+    lex->indent_level = m_new(uint16_t, lex->alloc_indent_level);
     vstr_init(&lex->vstr, 32);
-
-    // check for memory allocation error
-    // note: vstr_init above may fail on malloc, but so may mp_lexer_to_next below
-    if (lex->indent_level == NULL) {
-        mp_lexer_free(lex);
-        return NULL;
-    }
 
     // store sentinel for first indentation level
     lex->indent_level[0] = 0;
@@ -764,9 +751,7 @@ mp_lexer_t *mp_lexer_new(qstr src_name, mp_reader_t reader) {
 
 mp_lexer_t *mp_lexer_new_from_str_len(qstr src_name, const char *str, size_t len, size_t free_len) {
     mp_reader_t reader;
-    if (!mp_reader_new_mem(&reader, (const byte*)str, len, free_len)) {
-        return NULL;
-    }
+    mp_reader_new_mem(&reader, (const byte*)str, len, free_len);
     return mp_lexer_new(src_name, reader);
 }
 
@@ -774,10 +759,7 @@ mp_lexer_t *mp_lexer_new_from_str_len(qstr src_name, const char *str, size_t len
 
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
     mp_reader_t reader;
-    int ret = mp_reader_new_file(&reader, filename);
-    if (ret != 0) {
-        return NULL;
-    }
+    mp_reader_new_file(&reader, filename);
     return mp_lexer_new(qstr_from_str(filename), reader);
 }
 
@@ -785,10 +767,7 @@ mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
 
 mp_lexer_t *mp_lexer_new_from_fd(qstr filename, int fd, bool close_fd) {
     mp_reader_t reader;
-    int ret = mp_reader_new_file_from_fd(&reader, fd, close_fd);
-    if (ret != 0) {
-        return NULL;
-    }
+    mp_reader_new_file_from_fd(&reader, fd, close_fd);
     return mp_lexer_new(filename, reader);
 }
 

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -225,18 +225,13 @@ mp_raw_code_t *mp_raw_code_load(mp_reader_t *reader) {
 
 mp_raw_code_t *mp_raw_code_load_mem(const byte *buf, size_t len) {
     mp_reader_t reader;
-    if (!mp_reader_new_mem(&reader, buf, len, 0)) {
-        m_malloc_fail(BYTES_PER_WORD); // we need to raise a MemoryError
-    }
+    mp_reader_new_mem(&reader, buf, len, 0);
     return mp_raw_code_load(&reader);
 }
 
 mp_raw_code_t *mp_raw_code_load_file(const char *filename) {
     mp_reader_t reader;
-    int ret = mp_reader_new_file(&reader, filename);
-    if (ret != 0) {
-        mp_raise_OSError(ret);
-    }
+    mp_reader_new_file(&reader, filename);
     return mp_raw_code_load(&reader);
 }
 

--- a/py/reader.h
+++ b/py/reader.h
@@ -39,8 +39,8 @@ typedef struct _mp_reader_t {
     void (*close)(void *data);
 } mp_reader_t;
 
-bool mp_reader_new_mem(mp_reader_t *reader, const byte *buf, size_t len, size_t free_len);
-int mp_reader_new_file(mp_reader_t *reader, const char *filename);
-int mp_reader_new_file_from_fd(mp_reader_t *reader, int fd, bool close_fd);
+void mp_reader_new_mem(mp_reader_t *reader, const byte *buf, size_t len, size_t free_len);
+void mp_reader_new_file(mp_reader_t *reader, const char *filename);
+void mp_reader_new_file_from_fd(mp_reader_t *reader, int fd, bool close_fd);
 
 #endif // MICROPY_INCLUDED_PY_READER_H

--- a/qemu-arm/main.c
+++ b/qemu-arm/main.c
@@ -12,15 +12,12 @@
 #include "py/stackctrl.h"
 #include "py/gc.h"
 #include "py/repl.h"
+#include "py/mperrno.h"
 
 void do_str(const char *src, mp_parse_input_kind_t input_kind) {
-    mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
-    if (lex == NULL) {
-        return;
-    }
-
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
+        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
         qstr source_name = lex->source_name;
         mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
         mp_obj_t module_fun = mp_compile(&parse_tree, source_name, MP_EMIT_OPT_NONE, true);
@@ -47,7 +44,7 @@ void gc_collect(void) {
 }
 
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
-    return NULL;
+    mp_raise_OSError(MP_ENOENT);
 }
 
 mp_import_stat_t mp_import_stat(const char *path) {

--- a/qemu-arm/test_main.c
+++ b/qemu-arm/test_main.c
@@ -11,7 +11,7 @@
 #include "py/runtime.h"
 #include "py/stackctrl.h"
 #include "py/gc.h"
-#include "py/repl.h"
+#include "py/mperrno.h"
 
 #include "tinytest.h"
 #include "tinytest_macros.h"
@@ -24,13 +24,9 @@ inline void do_str(const char *src) {
     gc_init(heap, (char*)heap + HEAP_SIZE);
     mp_init();
 
-    mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
-    if (lex == NULL) {
-        tt_abort_msg("Lexer initialization error");
-    }
-
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
+        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
         qstr source_name = lex->source_name;
         mp_parse_tree_t parse_tree = mp_parse(lex, MP_PARSE_FILE_INPUT);
         mp_obj_t module_fun = mp_compile(&parse_tree, source_name, MP_EMIT_OPT_NONE, false);
@@ -80,7 +76,7 @@ void gc_collect(void) {
 }
 
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
-    return NULL;
+    mp_raise_OSError(MP_ENOENT);
 }
 
 mp_import_stat_t mp_import_stat(const char *path) {

--- a/teensy/lexerfrozen.c
+++ b/teensy/lexerfrozen.c
@@ -1,11 +1,13 @@
 #include <stdio.h>
 
 #include "py/lexer.h"
+#include "py/runtime.h"
+#include "py/mperrno.h"
 
 mp_import_stat_t mp_import_stat(const char *path) {
     return MP_IMPORT_STAT_NO_EXIST;
 }
 
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
-    return NULL;
+    mp_raise_OSError(MP_ENOENT);
 }

--- a/unix/main.c
+++ b/unix/main.c
@@ -90,19 +90,33 @@ STATIC int handle_uncaught_exception(mp_obj_base_t *exc) {
     return 1;
 }
 
+#define LEX_SRC_STR (1)
+#define LEX_SRC_VSTR (2)
+#define LEX_SRC_FILENAME (3)
+#define LEX_SRC_STDIN (4)
+
 // Returns standard error codes: 0 for success, 1 for all other errors,
 // except if FORCED_EXIT bit is set then script raised SystemExit and the
 // value of the exit is in the lower 8 bits of the return value
-STATIC int execute_from_lexer(mp_lexer_t *lex, mp_parse_input_kind_t input_kind, bool is_repl) {
-    if (lex == NULL) {
-        printf("MemoryError: lexer could not allocate memory\n");
-        return 1;
-    }
-
+STATIC int execute_from_lexer(int source_kind, const void *source, mp_parse_input_kind_t input_kind, bool is_repl) {
     mp_hal_set_interrupt_char(CHAR_CTRL_C);
 
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
+        // create lexer based on source kind
+        mp_lexer_t *lex;
+        if (source_kind == LEX_SRC_STR) {
+            const char *line = source;
+            lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, line, strlen(line), false);
+        } else if (source_kind == LEX_SRC_VSTR) {
+            const vstr_t *vstr = source;
+            lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, vstr->buf, vstr->len, false);
+        } else if (source_kind == LEX_SRC_FILENAME) {
+            lex = mp_lexer_new_from_file((const char*)source);
+        } else { // LEX_SRC_STDIN
+            lex = mp_lexer_new_from_fd(MP_QSTR__lt_stdin_gt_, 0, false);
+        }
+
         qstr source_name = lex->source_name;
 
         #if MICROPY_PY___FILE__
@@ -240,8 +254,7 @@ STATIC int do_repl(void) {
 
         mp_hal_stdio_mode_orig();
 
-        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, line.buf, line.len, false);
-        ret = execute_from_lexer(lex, parse_input_kind, true);
+        ret = execute_from_lexer(LEX_SRC_VSTR, &line, parse_input_kind, true);
         if (ret & FORCED_EXIT) {
             return ret;
         }
@@ -268,8 +281,7 @@ STATIC int do_repl(void) {
             line = line3;
         }
 
-        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, line, strlen(line), false);
-        int ret = execute_from_lexer(lex, MP_PARSE_SINGLE_INPUT, true);
+        int ret = execute_from_lexer(LEX_SRC_STR, line, MP_PARSE_SINGLE_INPUT, true);
         if (ret & FORCED_EXIT) {
             return ret;
         }
@@ -280,13 +292,11 @@ STATIC int do_repl(void) {
 }
 
 STATIC int do_file(const char *file) {
-    mp_lexer_t *lex = mp_lexer_new_from_file(file);
-    return execute_from_lexer(lex, MP_PARSE_FILE_INPUT, false);
+    return execute_from_lexer(LEX_SRC_FILENAME, file, MP_PARSE_FILE_INPUT, false);
 }
 
 STATIC int do_str(const char *str) {
-    mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, str, strlen(str), false);
-    return execute_from_lexer(lex, MP_PARSE_FILE_INPUT, false);
+    return execute_from_lexer(LEX_SRC_STR, str, MP_PARSE_FILE_INPUT, false);
 }
 
 STATIC int usage(char **argv) {
@@ -585,8 +595,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
             ret = do_repl();
             prompt_write_history();
         } else {
-            mp_lexer_t *lex = mp_lexer_new_from_fd(MP_QSTR__lt_stdin_gt_, 0, false);
-            ret = execute_from_lexer(lex, MP_PARSE_FILE_INPUT, false);
+            ret = execute_from_lexer(LEX_SRC_STDIN, NULL, MP_PARSE_FILE_INPUT, false);
         }
     }
 

--- a/zephyr/main.c
+++ b/zephyr/main.c
@@ -44,14 +44,9 @@
 #include "lib/mp-readline/readline.h"
 
 void do_str(const char *src, mp_parse_input_kind_t input_kind) {
-    mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
-    if (lex == NULL) {
-        printf("MemoryError: lexer could not allocate memory\n");
-        return;
-    }
-
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
+        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
         qstr source_name = lex->source_name;
         mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
         mp_obj_t module_fun = mp_compile(&parse_tree, source_name, MP_EMIT_OPT_NONE, true);
@@ -130,7 +125,7 @@ void gc_collect(void) {
 }
 
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
-    return NULL;
+    mp_raise_OSError(ENOENT);
 }
 
 mp_import_stat_t mp_import_stat(const char *path) {


### PR DESCRIPTION
This patch refactors the error handling in the lexer, to simplify it (ie reduce code size).

A long time ago, when the lexer/parser/compiler were first written, the lexer and parser were designed so they didn't use exceptions (ie nlr) to report errors but rather returned an error code.  Over time that has gradually changed, the parser in particular has more and more ways of raising exceptions.  Also, the lexer never really handled all errors without raising, eg there were some memory errors which could raise an exception (and in these rare cases one would get a fatal nlr-not-handled fault).

This patch accepts the fact that the lexer can raise exceptions in some cases and allows it to raise exceptions to handle all its errors, which are for the most part just out-of-memory errors.  This makes the lexer a bit simpler, and also the persistent code stuff is simplified.

What this means for users of the lexer is that calls to it must be wrapped in a nlr handler.  But all uses of the lexer already have such an nlr handler for the parser (and compiler) so that doesn't put any extra burden on the callers.  It does mean though that there is a little bit of refactoring to do to move the lexer constructors within the nlr handler block.  Hence why this patch touches so many ports.

bare-arm is reduced by 52 bytes and esp8266 by 264 bytes (other ports should also be decreased but I didn't measure them).

RAM, stack and heap usage shouldn't be affected at all.