### PR TITLE
py/nlrx64: Fix for Mac OS.

### DIFF
--- a/py/nlrx64.c
+++ b/py/nlrx64.c
@@ -61,6 +61,9 @@ unsigned int nlr_push(nlr_buf_t *nlr) {
     #else
 
     __asm volatile (
+    #if defined(__APPLE__) || defined(__MACH__)
+    "pop    %rbp                \n" // undo function's prelude
+    #endif
     "movq   (%rsp), %rax        \n" // load return %rip
     "movq   %rax, 16(%rdi)      \n" // store %rip into nlr_buf
     "movq   %rbp, 24(%rdi)      \n" // store %rbp into nlr_buf
@@ -70,7 +73,11 @@ unsigned int nlr_push(nlr_buf_t *nlr) {
     "movq   %r13, 56(%rdi)      \n" // store %r13 into nlr_buf
     "movq   %r14, 64(%rdi)      \n" // store %r14 into nlr_buf
     "movq   %r15, 72(%rdi)      \n" // store %r15 into nlr_buf
+    #if defined(__APPLE__) || defined(__MACH__)
+    "jmp    _nlr_push_tail      \n" // do the rest in C
+    #else
     "jmp    nlr_push_tail       \n" // do the rest in C
+    #endif
     );
 
     #endif


### PR DESCRIPTION
Should fix #2941.