### PR TITLE
WIP: Allow to mount VFS at root dir

### DIFF
--- a/esp8266/main.c
+++ b/esp8266/main.c
@@ -50,8 +50,8 @@ STATIC void mp_reset(void) {
     mp_init();
     mp_obj_list_init(mp_sys_path, 0);
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_)); // current dir (or base dir of the script)
-    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_flash_slash_lib));
-    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_flash));
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_lib));
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_));
     mp_obj_list_init(mp_sys_argv, 0);
     MP_STATE_PORT(term_obj) = MP_OBJ_NULL;
     MP_STATE_PORT(dupterm_arr_obj) = MP_OBJ_NULL;

--- a/esp8266/modules/_boot.py
+++ b/esp8266/modules/_boot.py
@@ -5,9 +5,7 @@ from flashbdev import bdev
 
 try:
     if bdev:
-        vfs = uos.VfsFat(bdev)
-        uos.mount(vfs, '/flash')
-        uos.chdir('/flash')
+        uos.mount(bdev, '/')
 except OSError:
     import inisetup
     vfs = inisetup.setup()

--- a/esp8266/qstrdefsport.h
+++ b/esp8266/qstrdefsport.h
@@ -27,5 +27,5 @@
 // qstrs specific to this port, only needed if they aren't auto-generated
 
 // Entries for sys.path
-Q(/flash)
-Q(/flash/lib)
+Q(/)
+Q(/lib)

--- a/tests/extmod/vfs_basic.py
+++ b/tests/extmod/vfs_basic.py
@@ -109,3 +109,23 @@ try:
     uos.umount('/test_mnt')
 except OSError:
     print('OSError')
+
+# root dir
+uos.mount(Filesystem(3), '/')
+print(uos.listdir())
+open('test')
+
+uos.mount(Filesystem(4), '/mnt')
+print(uos.listdir())
+print(uos.listdir('/mnt'))
+uos.chdir('/mnt')
+print(uos.listdir())
+
+# chdir to a subdir within root-mounted vfs, and then listdir
+uos.chdir('/subdir')
+print(uos.listdir())
+uos.chdir('/')
+
+uos.umount('/')
+print(uos.listdir('/'))
+uos.umount('/mnt')

--- a/tests/extmod/vfs_basic.py.exp
+++ b/tests/extmod/vfs_basic.py.exp
@@ -32,3 +32,22 @@ OSError
 1 umount
 2 umount
 OSError
+3 mount False False
+3 listdir /
+['a3']
+3 open test r
+4 mount False False
+3 listdir /
+['mnt', 'a3']
+4 listdir /
+['a4']
+4 chdir /
+4 listdir 
+['a4']
+3 chdir /subdir
+3 listdir 
+['a3']
+3 chdir /
+3 umount
+['mnt']
+4 umount

--- a/tests/extmod/vfs_fat_more.py
+++ b/tests/extmod/vfs_fat_more.py
@@ -1,0 +1,104 @@
+import sys
+import uerrno
+try:
+    import uos_vfs as uos
+    open = uos.vfs_open
+except ImportError:
+    import uos
+try:
+    uos.VfsFat
+except AttributeError:
+    print("SKIP")
+    sys.exit()
+
+
+class RAMFS:
+
+    SEC_SIZE = 512
+
+    def __init__(self, blocks):
+        self.data = bytearray(blocks * self.SEC_SIZE)
+
+    def readblocks(self, n, buf):
+        #print("readblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
+        for i in range(len(buf)):
+            buf[i] = self.data[n * self.SEC_SIZE + i]
+
+    def writeblocks(self, n, buf):
+        #print("writeblocks(%s, %x)" % (n, id(buf)))
+        for i in range(len(buf)):
+            self.data[n * self.SEC_SIZE + i] = buf[i]
+
+    def ioctl(self, op, arg):
+        #print("ioctl(%d, %r)" % (op, arg))
+        if op == 4:  # BP_IOCTL_SEC_COUNT
+            return len(self.data) // self.SEC_SIZE
+        if op == 5:  # BP_IOCTL_SEC_SIZE
+            return self.SEC_SIZE
+
+
+try:
+    bdev = RAMFS(50)
+    bdev2 = RAMFS(50)
+except MemoryError:
+    print("SKIP")
+    sys.exit()
+
+uos.VfsFat.mkfs(bdev)
+uos.mount(bdev, '/')
+
+print(uos.getcwd())
+
+f = open('test.txt', 'w')
+f.write('hello')
+f.close()
+
+print(uos.listdir())
+print(uos.listdir('/'))
+print(uos.stat('')[:-3])
+print(uos.stat('/')[:-3])
+print(uos.stat('test.txt')[:-3])
+print(uos.stat('/test.txt')[:-3])
+
+f = open('/test.txt')
+print(f.read())
+f.close()
+
+uos.rename('test.txt', 'test2.txt')
+print(uos.listdir())
+uos.rename('test2.txt', '/test3.txt')
+print(uos.listdir())
+uos.rename('/test3.txt', 'test4.txt')
+print(uos.listdir())
+uos.rename('/test4.txt', '/test5.txt')
+print(uos.listdir())
+
+uos.mkdir('dir')
+print(uos.listdir())
+uos.mkdir('/dir2')
+print(uos.listdir())
+uos.mkdir('dir/subdir')
+print(uos.listdir('dir'))
+for exist in ('', '/', 'dir', '/dir', 'dir/subdir'):
+    try:
+        uos.mkdir(exist)
+    except OSError as er:
+        print('mkdir OSError', er.args[0] == 17) # EEXIST
+
+uos.chdir('/')
+print(uos.stat('test5.txt')[:-3])
+
+uos.VfsFat.mkfs(bdev2)
+uos.mount(bdev2, '/sys')
+print(uos.listdir())
+print(uos.listdir('sys'))
+print(uos.listdir('/sys'))
+
+uos.rmdir('dir2')
+uos.remove('test5.txt')
+print(uos.listdir())
+
+uos.umount('/')
+print(uos.getcwd())
+print(uos.listdir())
+print(uos.listdir('sys'))

--- a/tests/extmod/vfs_fat_more.py.exp
+++ b/tests/extmod/vfs_fat_more.py.exp
@@ -1,0 +1,28 @@
+/
+['test.txt']
+['test.txt']
+(16384, 0, 0, 0, 0, 0, 0)
+(16384, 0, 0, 0, 0, 0, 0)
+(32768, 0, 0, 0, 0, 0, 5)
+(32768, 0, 0, 0, 0, 0, 5)
+hello
+['test2.txt']
+['test3.txt']
+['test4.txt']
+['test5.txt']
+['test5.txt', 'dir']
+['test5.txt', 'dir', 'dir2']
+['subdir']
+mkdir OSError True
+mkdir OSError True
+mkdir OSError True
+mkdir OSError True
+mkdir OSError True
+(32768, 0, 0, 0, 0, 0, 5)
+['sys', 'test5.txt', 'dir', 'dir2']
+[]
+[]
+['sys', 'dir']
+/
+['sys']
+[]


### PR DESCRIPTION
This is WIP to server as a proof of concept (or not) for #2920.  It allows to mount a VFS at the root dir, and also at other (1st level) dirs within the root.  Eg you can do:
```python
os.mount(vfs, '/')
os.mount(sd_vfs, '/sd')
```
Current increases in code size are (for those ports that changed): stmhal: 120, cc3200: 128, esp8266: 112.