### PR TITLE
py: Use correct exception message for implicit conversion to str or b…

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -2065,9 +2065,10 @@ STATIC void bad_implicit_conversion(mp_obj_t self_in) {
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_raise_TypeError("can't convert to str implicitly");
     } else {
+        const qstr src_name = mp_obj_get_type(self_in)->name;
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
-            "can't convert '%s' object to str implicitly",
-            mp_obj_get_type_str(self_in)));
+            "can't convert '%q' object to %q implicitly",
+            src_name, src_name == MP_QSTR_str ? MP_QSTR_bytes : MP_QSTR_str));
     }
 }
 


### PR DESCRIPTION
…ytes

When terse error reporting is not active use the actual target type in
the exception message instead of always reporting conversion 'to str'
fails even if it happens to actually be 'to bytes'. See #2957.

Note in the 3 functions near the end of the file I used 'str' as target type no matter what but that seems reasonable.

Also maybe it's worth having a check_implicit_conversion to reduce some duplication? Like
```
void check_bad_implicit_conversion(mp_obj_t src, mp_obj_type_t *targetType) {
    mp_obj_type_t *srcType = mp_obj_get_type(src);
    if (srcType  != targetType) {
        bad_implicit_conversion(srcType, targetType);
    }
}
```
so all occurrences of
```
if (mp_obj_get_type(args[1]) != self_type) {
    bad_implicit_conversion(args[1], self_type);
}
```
can be replaced with just ```check_bad_implicit_conversion(args[1], self_type)```