### PR TITLE
windows: Make msvc project file support any version from VS2013 to VS…

### DIFF
--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -7,4 +7,5 @@
 *.ilk
 *.filters
 /build/*
+.vs/*
 *.VC.*db

--- a/windows/micropython.vcxproj
+++ b/windows/micropython.vcxproj
@@ -26,26 +26,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
…2017

Instead of having the PlatformToolset property hardcoded to a specific
version just set it to the value of DefaultPlatformToolset: this gets
defined according to the commandline environment in which the build was
started.
Instead of just supporting VS2015 the project can now be built by any
version from VS2013 to VS2017 and normally future versions as well, without
quirks like VS asking whether you want to upgrade the project to the latest
version (as was the case when opening the project in VS2017) or not being
able to build at all (as was the case when opening the project in VS2013).

Also adjust the .gitignore file to ignore any artefacts from VS2017.

Technically VS2012/VS2010 are supported like this as well but I didn't test this and I'm pretty sure their compiler lacks the needed C99 support anyway.
