### PR TITLE
msvc: Remove directory with generated files when cleaning

### DIFF
--- a/windows/msvc/genhdr.targets
+++ b/windows/msvc/genhdr.targets
@@ -87,6 +87,10 @@ using(var outFile = System.IO.File.CreateText(OutputFile)) {
     <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="CopyFileIfDifferent" Properties="SourceFile=$(TmpFile);DestFile=$(DestFile)"/>
   </Target>
 
+  <Target Name="RemoveGeneratedFiles" AfterTargets="Clean">
+    <RemoveDir Directories="$(DestDir)"/>
+  </Target>
+  
   <!--Copies SourceFile to DestFile only if SourceFile's content differs from DestFile's.
       We use this to 'touch' the generated files only when they are really newer
       so a build is only triggered if the generated content actually changed,


### PR DESCRIPTION
This assures after cleaning all build artefacts (qstr related files,
generated version header) have been removed.

Before this patch this wasn't the case which could cause build errors because the qstr files weren't deleted, and the qstr generation code doesn't detect all possible changes leading (actually I'm not sure if this is known, I guess so?) resulting in missing qstr definitions.
Example for reproduction:
- start from clean build
- in mpconfigport.h, delete the line with ```#define MICROPY_STACK_CHECK (1)```
- build
- restore said line mpconfigport.h
- build -> MP_QSTR_stack_use is undeclared in modmicropython.c
After that last step if clean doesn't remove the generated qstr files the error gets never fixed.