### PR TITLE
zephyr: adds 96boards Carbon configuration with network disabled

### DIFF
--- a/zephyr/prj_96b_carbon.conf
+++ b/zephyr/prj_96b_carbon.conf
@@ -1,0 +1,4 @@
+# No networking for carbon
+CONFIG_NETWORKING=n
+CONFIG_NET_IPV4=n
+CONFIG_NET_IPV6=n


### PR DESCRIPTION
Disables networking by default in 96boards Carbon, otherwise, zephyr gets stuck in the  init_zephyr function call (trying to have networking setup). This patch enables us to have a working REPL.