### PR TITLE
Convert "len" arg from mp_uint_t to size_t for tuple, list and string data accessors

### DIFF
--- a/cc3200/mods/modusocket.c
+++ b/cc3200/mods/modusocket.c
@@ -737,7 +737,7 @@ STATIC const mp_obj_type_t socket_type = {
 // function usocket.getaddrinfo(host, port)
 /// \function getaddrinfo(host, port)
 STATIC mp_obj_t mod_usocket_getaddrinfo(mp_obj_t host_in, mp_obj_t port_in) {
-    mp_uint_t hlen;
+    size_t hlen;
     const char *host = mp_obj_str_get_data(host_in, &hlen);
     mp_int_t port = mp_obj_get_int(port_in);
 

--- a/cc3200/mods/modutime.c
+++ b/cc3200/mods/modutime.c
@@ -102,7 +102,7 @@ STATIC mp_obj_t time_localtime(mp_uint_t n_args, const mp_obj_t *args) {
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(time_localtime_obj, 0, 1, time_localtime);
 
 STATIC mp_obj_t time_mktime(mp_obj_t tuple) {
-    mp_uint_t len;
+    size_t len;
     mp_obj_t *elem;
 
     mp_obj_get_array(tuple, &len, &elem);

--- a/cc3200/mods/modwlan.c
+++ b/cc3200/mods/modwlan.c
@@ -773,7 +773,7 @@ STATIC mp_obj_t wlan_init_helper(wlan_obj_t *self, const mp_arg_val_t *args) {
     wlan_validate_mode(mode);
 
     // get the ssid
-    mp_uint_t ssid_len = 0;
+    size_t ssid_len = 0;
     const char *ssid = NULL;
     if (args[1].u_obj != NULL) {
         ssid = mp_obj_str_get_data(args[1].u_obj, &ssid_len);
@@ -782,7 +782,7 @@ STATIC mp_obj_t wlan_init_helper(wlan_obj_t *self, const mp_arg_val_t *args) {
 
     // get the auth config
     uint8_t auth = SL_SEC_TYPE_OPEN;
-    mp_uint_t key_len = 0;
+    size_t key_len = 0;
     const char *key = NULL;
     if (args[2].u_obj != mp_const_none) {
         mp_obj_t *sec;
@@ -922,13 +922,13 @@ STATIC mp_obj_t wlan_connect(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // get the ssid
-    mp_uint_t ssid_len;
+    size_t ssid_len;
     const char *ssid = mp_obj_str_get_data(args[0].u_obj, &ssid_len);
     wlan_validate_ssid_len(ssid_len);
 
     // get the auth config
     uint8_t auth = SL_SEC_TYPE_OPEN;
-    mp_uint_t key_len = 0;
+    size_t key_len = 0;
     const char *key = NULL;
     if (args[1].u_obj != mp_const_none) {
         mp_obj_t *sec;
@@ -1077,7 +1077,7 @@ STATIC mp_obj_t wlan_ssid (mp_uint_t n_args, const mp_obj_t *args) {
     if (n_args == 1) {
         return mp_obj_new_str((const char *)self->ssid, strlen((const char *)self->ssid), false);
     } else {
-        mp_uint_t len;
+        size_t len;
         const char *ssid = mp_obj_str_get_data(args[1], &len);
         wlan_validate_ssid_len(len);
         wlan_set_ssid(ssid, len, false);
@@ -1101,7 +1101,7 @@ STATIC mp_obj_t wlan_auth (mp_uint_t n_args, const mp_obj_t *args) {
     } else {
         // get the auth config
         uint8_t auth = SL_SEC_TYPE_OPEN;
-        mp_uint_t key_len = 0;
+        size_t key_len = 0;
         const char *key = NULL;
         if (args[1] != mp_const_none) {
             mp_obj_t *sec;

--- a/cc3200/mods/pybrtc.c
+++ b/cc3200/mods/pybrtc.c
@@ -196,7 +196,7 @@ STATIC uint pyb_rtc_datetime_s_us(const mp_obj_t datetime, uint32_t *seconds) {
 
     // set date and time
     mp_obj_t *items;
-    uint len;
+    size_t len;
     mp_obj_get_array(datetime, &len, &items);
 
     // verify the tuple

--- a/cc3200/mods/pybuart.c
+++ b/cc3200/mods/pybuart.c
@@ -388,7 +388,7 @@ STATIC mp_obj_t pyb_uart_init_helper(pyb_uart_obj_t *self, const mp_arg_val_t *a
     uint flowcontrol = UART_FLOWCONTROL_NONE;
     if (pins_o != mp_const_none) {
         mp_obj_t *pins;
-        mp_uint_t n_pins = 2;
+        size_t n_pins = 2;
         if (pins_o == MP_OBJ_NULL) {
             // use the default pins
             pins = (mp_obj_t *)pyb_uart_def_pin[self->uart_id];
@@ -454,7 +454,7 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size
     if (args[0].u_obj == MP_OBJ_NULL) {
         if (args[5].u_obj != MP_OBJ_NULL) {
             mp_obj_t *pins;
-            mp_uint_t n_pins = 2;
+            size_t n_pins = 2;
             mp_obj_get_array(args[5].u_obj, &n_pins, &pins);
             // check the Tx pin (or the Rx if Tx is None)
             if (pins[0] == mp_const_none) {

--- a/esp8266/modnetwork.c
+++ b/esp8266/modnetwork.c
@@ -97,7 +97,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_active_obj, 1, 2, esp_active);
 STATIC mp_obj_t esp_connect(mp_uint_t n_args, const mp_obj_t *args) {
     require_if(args[0], STATION_IF);
     struct station_config config = {{0}};
-    mp_uint_t len;
+    size_t len;
     const char *p;
 
     if (n_args > 1) {
@@ -311,7 +311,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                     }
                     case QS(MP_QSTR_essid): {
                         req_if = SOFTAP_IF;
-                        mp_uint_t len;
+                        size_t len;
                         const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
                         len = MIN(len, sizeof(cfg.ap.ssid));
                         memcpy(cfg.ap.ssid, s, len);
@@ -330,7 +330,7 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                     }
                     case QS(MP_QSTR_password): {
                         req_if = SOFTAP_IF;
-                        mp_uint_t len;
+                        size_t len;
                         const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
                         len = MIN(len, sizeof(cfg.ap.password) - 1);
                         memcpy(cfg.ap.password, s, len);

--- a/esp8266/modutime.c
+++ b/esp8266/modutime.c
@@ -84,7 +84,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(time_localtime_obj, 0, 1, time_localtime);
 /// which expresses a time as per localtime. It returns an integer which is
 /// the number of seconds since Jan 1, 2000.
 STATIC mp_obj_t time_mktime(mp_obj_t tuple) {
-    mp_uint_t len;
+    size_t len;
     mp_obj_t *elem;
     mp_obj_get_array(tuple, &len, &elem);
 

--- a/extmod/modbtree.c
+++ b/extmod/modbtree.c
@@ -97,12 +97,8 @@ STATIC mp_obj_t btree_put(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     mp_obj_btree_t *self = MP_OBJ_TO_PTR(args[0]);
     DBT key, val;
-    // Different ports may have different type sizes
-    mp_uint_t v;
-    key.data = (void*)mp_obj_str_get_data(args[1], &v);
-    key.size = v;
-    val.data = (void*)mp_obj_str_get_data(args[2], &v);
-    val.size = v;
+    key.data = (void*)mp_obj_str_get_data(args[1], &key.size);
+    val.data = (void*)mp_obj_str_get_data(args[2], &val.size);
     return MP_OBJ_NEW_SMALL_INT(__bt_put(self->db, &key, &val, 0));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(btree_put_obj, 3, 4, btree_put);
@@ -110,10 +106,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(btree_put_obj, 3, 4, btree_put);
 STATIC mp_obj_t btree_get(size_t n_args, const mp_obj_t *args) {
     mp_obj_btree_t *self = MP_OBJ_TO_PTR(args[0]);
     DBT key, val;
-    // Different ports may have different type sizes
-    mp_uint_t v;
-    key.data = (void*)mp_obj_str_get_data(args[1], &v);
-    key.size = v;
+    key.data = (void*)mp_obj_str_get_data(args[1], &key.size);
     int res = __bt_get(self->db, &key, &val, 0);
     if (res == RET_SPECIAL) {
         if (n_args > 2) {
@@ -132,10 +125,7 @@ STATIC mp_obj_t btree_seq(size_t n_args, const mp_obj_t *args) {
     int flags = MP_OBJ_SMALL_INT_VALUE(args[1]);
     DBT key, val;
     if (n_args > 2) {
-        // Different ports may have different type sizes
-        mp_uint_t v;
-        key.data = (void*)mp_obj_str_get_data(args[2], &v);
-        key.size = v;
+        key.data = (void*)mp_obj_str_get_data(args[2], &key.size);
     }
 
     int res = __bt_seq(self->db, &key, &val, flags);
@@ -206,14 +196,11 @@ STATIC mp_obj_t btree_iternext(mp_obj_t self_in) {
     mp_obj_btree_t *self = MP_OBJ_TO_PTR(self_in);
     DBT key, val;
     int res;
-    // Different ports may have different type sizes
-    mp_uint_t v;
     bool desc = self->flags & FLAG_DESC;
     if (self->start_key != MP_OBJ_NULL) {
         int flags = R_FIRST;
         if (self->start_key != mp_const_none) {
-            key.data = (void*)mp_obj_str_get_data(self->start_key, &v);
-            key.size = v;
+            key.data = (void*)mp_obj_str_get_data(self->start_key, &key.size);
             flags = R_CURSOR;
         } else if (desc) {
             flags = R_LAST;
@@ -231,8 +218,7 @@ STATIC mp_obj_t btree_iternext(mp_obj_t self_in) {
 
     if (self->end_key != mp_const_none) {
         DBT end_key;
-        end_key.data = (void*)mp_obj_str_get_data(self->end_key, &v);
-        end_key.size = v;
+        end_key.data = (void*)mp_obj_str_get_data(self->end_key, &end_key.size);
         BTREE *t = self->db->internal;
         int cmp = t->bt_cmp(&key, &end_key);
         if (desc) {
@@ -264,13 +250,10 @@ STATIC mp_obj_t btree_iternext(mp_obj_t self_in) {
 
 STATIC mp_obj_t btree_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
     mp_obj_btree_t *self = MP_OBJ_TO_PTR(self_in);
-    // Different ports may have different type sizes
-    mp_uint_t v;
     if (value == MP_OBJ_NULL) {
         // delete
         DBT key;
-        key.data = (void*)mp_obj_str_get_data(index, &v);
-        key.size = v;
+        key.data = (void*)mp_obj_str_get_data(index, &key.size);
         int res = __bt_delete(self->db, &key, 0);
         if (res == RET_SPECIAL) {
             nlr_raise(mp_obj_new_exception(&mp_type_KeyError));
@@ -280,8 +263,7 @@ STATIC mp_obj_t btree_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
     } else if (value == MP_OBJ_SENTINEL) {
         // load
         DBT key, val;
-        key.data = (void*)mp_obj_str_get_data(index, &v);
-        key.size = v;
+        key.data = (void*)mp_obj_str_get_data(index, &key.size);
         int res = __bt_get(self->db, &key, &val, 0);
         if (res == RET_SPECIAL) {
             nlr_raise(mp_obj_new_exception(&mp_type_KeyError));
@@ -291,10 +273,8 @@ STATIC mp_obj_t btree_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
     } else {
         // store
         DBT key, val;
-        key.data = (void*)mp_obj_str_get_data(index, &v);
-        key.size = v;
-        val.data = (void*)mp_obj_str_get_data(value, &v);
-        val.size = v;
+        key.data = (void*)mp_obj_str_get_data(index, &key.size);
+        val.data = (void*)mp_obj_str_get_data(value, &val.size);
         int res = __bt_put(self->db, &key, &val, 0);
         CHECK_ERROR(res);
         return mp_const_none;
@@ -305,10 +285,8 @@ STATIC mp_obj_t btree_binary_op(mp_uint_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) 
     mp_obj_btree_t *self = MP_OBJ_TO_PTR(lhs_in);
     switch (op) {
         case MP_BINARY_OP_IN: {
-            mp_uint_t v;
             DBT key, val;
-            key.data = (void*)mp_obj_str_get_data(rhs_in, &v);
-            key.size = v;
+            key.data = (void*)mp_obj_str_get_data(rhs_in, &key.size);
             int res = __bt_get(self->db, &key, &val, 0);
             CHECK_ERROR(res);
             return mp_obj_new_bool(res != RET_SPECIAL);

--- a/extmod/modujson.c
+++ b/extmod/modujson.c
@@ -274,7 +274,7 @@ STATIC mp_obj_t mod_ujson_load(mp_obj_t stream_obj) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_ujson_load_obj, mod_ujson_load);
 
 STATIC mp_obj_t mod_ujson_loads(mp_obj_t obj) {
-    mp_uint_t len;
+    size_t len;
     const char *buf = mp_obj_str_get_data(obj, &len);
     vstr_t vstr = {len, len, (char*)buf, true};
     mp_obj_stringio_t sio = {{&mp_type_stringio}, &vstr, 0};

--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -96,7 +96,7 @@ STATIC mp_obj_t ure_exec(bool is_anchored, uint n_args, const mp_obj_t *args) {
     (void)n_args;
     mp_obj_re_t *self = MP_OBJ_TO_PTR(args[0]);
     Subject subj;
-    mp_uint_t len;
+    size_t len;
     subj.begin = mp_obj_str_get_data(args[1], &len);
     subj.end = subj.begin + len;
     int caps_num = (self->re.sub + 1) * 2;
@@ -128,7 +128,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(re_search_obj, 2, 4, re_search);
 STATIC mp_obj_t re_split(size_t n_args, const mp_obj_t *args) {
     mp_obj_re_t *self = MP_OBJ_TO_PTR(args[0]);
     Subject subj;
-    mp_uint_t len;
+    size_t len;
     subj.begin = mp_obj_str_get_data(args[1], &len);
     subj.end = subj.begin + len;
     int caps_num = (self->re.sub + 1) * 2;

--- a/extmod/moduselect.c
+++ b/extmod/moduselect.c
@@ -113,7 +113,7 @@ STATIC mp_uint_t poll_map_poll(mp_map_t *poll_map, mp_uint_t *rwx_num) {
 /// \function select(rlist, wlist, xlist[, timeout])
 STATIC mp_obj_t select_select(uint n_args, const mp_obj_t *args) {
     // get array data from tuple/list arguments
-    mp_uint_t rwx_len[3];
+    size_t rwx_len[3];
     mp_obj_t *r_array, *w_array, *x_array;
     mp_obj_get_array(args[0], &rwx_len[0], &r_array);
     mp_obj_get_array(args[1], &rwx_len[1], &w_array);

--- a/extmod/modussl_mbedtls.c
+++ b/extmod/modussl_mbedtls.c
@@ -156,13 +156,13 @@ STATIC mp_obj_ssl_socket_t *socket_new(mp_obj_t sock, struct ssl_args *args) {
     mbedtls_ssl_set_bio(&o->ssl, &o->sock, _mbedtls_ssl_send, _mbedtls_ssl_recv, NULL);
 
     if (args->key.u_obj != MP_OBJ_NULL) {
-        mp_uint_t key_len;
+        size_t key_len;
         const byte *key = (const byte*)mp_obj_str_get_data(args->key.u_obj, &key_len);
         // len should include terminating null
         ret = mbedtls_pk_parse_key(&o->pkey, key, key_len + 1, NULL, 0);
         assert(ret == 0);
 
-        mp_uint_t cert_len;
+        size_t cert_len;
         const byte *cert = (const byte*)mp_obj_str_get_data(args->cert.u_obj, &cert_len);
         // len should include terminating null
         ret = mbedtls_x509_crt_parse(&o->cert, cert, cert_len + 1);

--- a/extmod/modwebrepl.c
+++ b/extmod/modwebrepl.c
@@ -308,7 +308,7 @@ STATIC mp_obj_t webrepl_close(mp_obj_t self_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(webrepl_close_obj, webrepl_close);
 
 STATIC mp_obj_t webrepl_set_password(mp_obj_t passwd_in) {
-    mp_uint_t len;
+    size_t len;
     const char *passwd = mp_obj_str_get_data(passwd_in, &len);
     if (len > sizeof(webrepl_passwd) - 1) {
         mp_raise_ValueError("");

--- a/extmod/vfs.c
+++ b/extmod/vfs.c
@@ -134,7 +134,7 @@ mp_obj_t mp_vfs_mount(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args
     mp_arg_parse_all(n_args - 2, pos_args + 2, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // get the mount point
-    mp_uint_t mnt_len;
+    size_t mnt_len;
     const char *mnt_str = mp_obj_str_get_data(pos_args[1], &mnt_len);
 
     // see if we need to auto-detect and create the filesystem
@@ -180,7 +180,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(mp_vfs_mount_obj, 2, mp_vfs_mount);
 mp_obj_t mp_vfs_umount(mp_obj_t mnt_in) {
     // remove vfs from the mount table
     mp_vfs_mount_t *vfs = NULL;
-    mp_uint_t mnt_len;
+    size_t mnt_len;
     const char *mnt_str = NULL;
     if (MP_OBJ_IS_STR(mnt_in)) {
         mnt_str = mp_obj_str_get_data(mnt_in, &mnt_len);

--- a/lib/netutils/netutils.c
+++ b/lib/netutils/netutils.c
@@ -56,7 +56,7 @@ mp_obj_t netutils_format_inet_addr(uint8_t *ip, mp_uint_t port, netutils_endian_
 }
 
 void netutils_parse_ipv4_addr(mp_obj_t addr_in, uint8_t *out_ip, netutils_endian_t endian) {
-    mp_uint_t addr_len;
+    size_t addr_len;
     const char *addr_str = mp_obj_str_get_data(addr_in, &addr_len);
     if (addr_len == 0) {
         // special case of no address given

--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -78,7 +78,7 @@ STATIC mp_obj_t mp_builtin_compile(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
 
     // get the source
-    mp_uint_t str_len;
+    size_t str_len;
     const char *str = mp_obj_str_get_data(args[0], &str_len);
 
     // get the filename
@@ -128,7 +128,7 @@ STATIC mp_obj_t eval_exec_helper(size_t n_args, const mp_obj_t *args, mp_parse_i
     }
     #endif
 
-    mp_uint_t str_len;
+    size_t str_len;
     const char *str = mp_obj_str_get_data(args[0], &str_len);
 
     // create the lexer

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -97,7 +97,7 @@ STATIC mp_import_stat_t stat_dir_or_file(vstr_t *path) {
 STATIC mp_import_stat_t find_file(const char *file_str, uint file_len, vstr_t *dest) {
 #if MICROPY_PY_SYS
     // extract the list of paths
-    mp_uint_t path_num;
+    size_t path_num;
     mp_obj_t *path_items;
     mp_obj_list_get(mp_sys_path, &path_num, &path_items);
 

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -111,7 +111,7 @@ STATIC mp_import_stat_t find_file(const char *file_str, uint file_len, vstr_t *d
         // go through each path looking for a directory or file
         for (mp_uint_t i = 0; i < path_num; i++) {
             vstr_reset(dest);
-            mp_uint_t p_len;
+            size_t p_len;
             const char *p = mp_obj_str_get_data(path_items[i], &p_len);
             if (p_len > 0) {
                 vstr_add_strn(dest, p, p_len);
@@ -265,7 +265,7 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
         }
     }
 
-    mp_uint_t mod_len;
+    size_t mod_len;
     const char *mod_str = mp_obj_str_get_data(module_name, &mod_len);
 
     if (level != 0) {
@@ -296,7 +296,7 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
         DEBUG_printf("\n");
 #endif
 
-        mp_uint_t this_name_l;
+        size_t this_name_l;
         const char *this_name = mp_obj_str_get_data(this_name_q, &this_name_l);
 
         const char *p = this_name + this_name_l;

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -336,7 +336,7 @@ STATIC mp_obj_t mp_builtin_oct(mp_obj_t o_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin_oct_obj, mp_builtin_oct);
 
 STATIC mp_obj_t mp_builtin_ord(mp_obj_t o_in) {
-    mp_uint_t len;
+    size_t len;
     const char *str = mp_obj_str_get_data(o_in, &len);
     #if MICROPY_PY_BUILTINS_STR_UNICODE
     if (MP_OBJ_IS_STR(o_in)) {
@@ -397,9 +397,9 @@ STATIC mp_obj_t mp_builtin_print(size_t n_args, const mp_obj_t *args, mp_map_t *
     mp_map_elem_t *sep_elem = mp_map_lookup(kwargs, MP_OBJ_NEW_QSTR(MP_QSTR_sep), MP_MAP_LOOKUP);
     mp_map_elem_t *end_elem = mp_map_lookup(kwargs, MP_OBJ_NEW_QSTR(MP_QSTR_end), MP_MAP_LOOKUP);
     const char *sep_data = " ";
-    mp_uint_t sep_len = 1;
+    size_t sep_len = 1;
     const char *end_data = "\n";
-    mp_uint_t end_len = 1;
+    size_t end_len = 1;
     if (sep_elem != NULL && sep_elem->value != mp_const_none) {
         sep_data = mp_obj_str_get_data(sep_elem->value, &sep_len);
     }

--- a/py/modthread.c
+++ b/py/modthread.c
@@ -215,7 +215,7 @@ STATIC mp_obj_t mod_thread_start_new_thread(size_t n_args, const mp_obj_t *args)
     thread_entry_args_t *th_args;
 
     // get positional arguments
-    mp_uint_t pos_args_len;
+    size_t pos_args_len;
     mp_obj_t *pos_args_items;
     mp_obj_get_array(args[1], &pos_args_len, &pos_args_items);
 

--- a/py/obj.c
+++ b/py/obj.c
@@ -321,7 +321,7 @@ void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
 #endif
 
 // note: returned value in *items may point to the interior of a GC block
-void mp_obj_get_array(mp_obj_t o, mp_uint_t *len, mp_obj_t **items) {
+void mp_obj_get_array(mp_obj_t o, size_t *len, mp_obj_t **items) {
     if (MP_OBJ_IS_TYPE(o, &mp_type_tuple)) {
         mp_obj_tuple_get(o, len, items);
     } else if (MP_OBJ_IS_TYPE(o, &mp_type_list)) {
@@ -338,7 +338,7 @@ void mp_obj_get_array(mp_obj_t o, mp_uint_t *len, mp_obj_t **items) {
 
 // note: returned value in *items may point to the interior of a GC block
 void mp_obj_get_array_fixed_n(mp_obj_t o, size_t len, mp_obj_t **items) {
-    mp_uint_t seq_len;
+    size_t seq_len;
     mp_obj_get_array(o, &seq_len, items);
     if (seq_len != len) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {

--- a/py/obj.h
+++ b/py/obj.h
@@ -676,7 +676,7 @@ mp_float_t mp_obj_get_float(mp_obj_t self_in);
 void mp_obj_get_complex(mp_obj_t self_in, mp_float_t *real, mp_float_t *imag);
 #endif
 //qstr mp_obj_get_qstr(mp_obj_t arg);
-void mp_obj_get_array(mp_obj_t o, mp_uint_t *len, mp_obj_t **items); // *items may point inside a GC block
+void mp_obj_get_array(mp_obj_t o, size_t *len, mp_obj_t **items); // *items may point inside a GC block
 void mp_obj_get_array_fixed_n(mp_obj_t o, size_t len, mp_obj_t **items); // *items may point inside a GC block
 size_t mp_get_index(const mp_obj_type_t *type, size_t len, mp_obj_t index, bool is_slice);
 mp_obj_t mp_obj_id(mp_obj_t o_in);
@@ -728,7 +728,7 @@ mp_obj_t mp_obj_complex_binary_op(mp_uint_t op, mp_float_t lhs_real, mp_float_t 
 #endif
 
 // tuple
-void mp_obj_tuple_get(mp_obj_t self_in, mp_uint_t *len, mp_obj_t **items);
+void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items);
 void mp_obj_tuple_del(mp_obj_t self_in);
 mp_int_t mp_obj_tuple_hash(mp_obj_t self_in);
 
@@ -737,7 +737,7 @@ struct _mp_obj_list_t;
 void mp_obj_list_init(struct _mp_obj_list_t *o, size_t n);
 mp_obj_t mp_obj_list_append(mp_obj_t self_in, mp_obj_t arg);
 mp_obj_t mp_obj_list_remove(mp_obj_t self_in, mp_obj_t value);
-void mp_obj_list_get(mp_obj_t self_in, mp_uint_t *len, mp_obj_t **items);
+void mp_obj_list_get(mp_obj_t self_in, size_t *len, mp_obj_t **items);
 void mp_obj_list_set_len(mp_obj_t self_in, size_t len);
 void mp_obj_list_store(mp_obj_t self_in, mp_obj_t index, mp_obj_t value);
 mp_obj_t mp_obj_list_sort(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);

--- a/py/obj.h
+++ b/py/obj.h
@@ -712,7 +712,7 @@ void mp_init_emergency_exception_buf(void);
 bool mp_obj_str_equal(mp_obj_t s1, mp_obj_t s2);
 qstr mp_obj_str_get_qstr(mp_obj_t self_in); // use this if you will anyway convert the string to a qstr
 const char *mp_obj_str_get_str(mp_obj_t self_in); // use this only if you need the string to be null terminated
-const char *mp_obj_str_get_data(mp_obj_t self_in, mp_uint_t *len);
+const char *mp_obj_str_get_data(mp_obj_t self_in, size_t *len);
 mp_obj_t mp_obj_str_intern(mp_obj_t str);
 void mp_str_print_quoted(const mp_print_t *print, const byte *str_data, size_t str_len, bool is_bytes);
 

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -80,7 +80,7 @@ STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, si
         case 1:
             if (MP_OBJ_IS_STR(args[0])) {
                 // a string, parse it
-                mp_uint_t l;
+                size_t l;
                 const char *s = mp_obj_str_get_data(args[0], &l);
                 return mp_parse_num_decimal(s, l, true, true, NULL);
             } else if (MP_OBJ_IS_TYPE(args[0], &mp_type_complex)) {

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -89,7 +89,7 @@ STATIC mp_obj_t float_make_new(const mp_obj_type_t *type_in, size_t n_args, size
         default:
             if (MP_OBJ_IS_STR(args[0])) {
                 // a string, parse it
-                mp_uint_t l;
+                size_t l;
                 const char *s = mp_obj_str_get_data(args[0], &l);
                 return mp_parse_num_decimal(s, l, false, false, NULL);
             } else if (mp_obj_is_float(args[0])) {

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -513,7 +513,7 @@ STATIC mp_uint_t convert_obj_for_inline_asm(mp_obj_t obj) {
 #endif
         } else if (type == &mp_type_tuple || type == &mp_type_list) {
             // pointer to start of tuple (could pass length, but then could use len(x) for that)
-            mp_uint_t len;
+            size_t len;
             mp_obj_t *items;
             mp_obj_get_array(obj, &len, &items);
             return (mp_uint_t)items;

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -501,7 +501,7 @@ STATIC mp_uint_t convert_obj_for_inline_asm(mp_obj_t obj) {
         return mp_obj_int_get_truncated(obj);
     } else if (MP_OBJ_IS_STR(obj)) {
         // pointer to the string (it's probably constant though!)
-        mp_uint_t l;
+        size_t l;
         return (mp_uint_t)mp_obj_str_get_data(obj, &l);
     } else {
         mp_obj_type_t *type = mp_obj_get_type(obj);

--- a/py/objint.c
+++ b/py/objint.c
@@ -56,7 +56,7 @@ STATIC mp_obj_t mp_obj_int_make_new(const mp_obj_type_t *type_in, size_t n_args,
                 return args[0];
             } else if (MP_OBJ_IS_STR_OR_BYTES(args[0])) {
                 // a string, parse it
-                mp_uint_t l;
+                size_t l;
                 const char *s = mp_obj_str_get_data(args[0], &l);
                 return mp_parse_num_integer(s, l, 0, NULL);
 #if MICROPY_PY_BUILTINS_FLOAT
@@ -72,7 +72,7 @@ STATIC mp_obj_t mp_obj_int_make_new(const mp_obj_type_t *type_in, size_t n_args,
         default: {
             // should be a string, parse it
             // TODO proper error checking of argument types
-            mp_uint_t l;
+            size_t l;
             const char *s = mp_obj_str_get_data(args[0], &l);
             return mp_parse_num_integer(s, l, mp_obj_get_int(args[1]), NULL);
         }

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -192,7 +192,7 @@ STATIC mp_obj_t list_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
 #if MICROPY_PY_BUILTINS_SLICE
         if (MP_OBJ_IS_TYPE(index, &mp_type_slice)) {
             mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
-            mp_uint_t value_len; mp_obj_t *value_items;
+            size_t value_len; mp_obj_t *value_items;
             mp_obj_get_array(value, &value_len, &value_items);
             mp_bound_slice_t slice_out;
             if (!mp_seq_get_fast_slice_indexes(self->len, index, &slice_out)) {
@@ -475,7 +475,7 @@ mp_obj_t mp_obj_new_list(size_t n, mp_obj_t *items) {
     return MP_OBJ_FROM_PTR(o);
 }
 
-void mp_obj_list_get(mp_obj_t self_in, mp_uint_t *len, mp_obj_t **items) {
+void mp_obj_list_get(mp_obj_t self_in, size_t *len, mp_obj_t **items) {
     mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
     *len = self->len;
     *items = self->items;

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -158,7 +158,7 @@ STATIC mp_obj_t mp_obj_new_namedtuple_type(qstr name, size_t n_fields, mp_obj_t 
 
 STATIC mp_obj_t new_namedtuple_type(mp_obj_t name_in, mp_obj_t fields_in) {
     qstr name = mp_obj_str_get_qstr(name_in);
-    mp_uint_t n_fields;
+    size_t n_fields;
     mp_obj_t *fields;
     #if MICROPY_CPYTHON_COMPAT
     if (MP_OBJ_IS_STR(fields_in)) {

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -284,7 +284,7 @@ mp_obj_t mp_obj_str_binary_op(mp_uint_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
     // check for modulo
     if (op == MP_BINARY_OP_MODULO) {
         mp_obj_t *args = &rhs_in;
-        mp_uint_t n_args = 1;
+        size_t n_args = 1;
         mp_obj_t dict = MP_OBJ_NULL;
         if (MP_OBJ_IS_TYPE(rhs_in, &mp_type_tuple)) {
             // TODO: Support tuple subclasses?
@@ -428,7 +428,7 @@ STATIC mp_obj_t str_join(mp_obj_t self_in, mp_obj_t arg) {
     GET_STR_DATA_LEN(self_in, sep_str, sep_len);
 
     // process args
-    mp_uint_t seq_len;
+    size_t seq_len;
     mp_obj_t *seq_items;
 
     if (!MP_OBJ_IS_TYPE(arg, &mp_type_list) && !MP_OBJ_IS_TYPE(arg, &mp_type_tuple)) {

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -513,7 +513,7 @@ mp_obj_t mp_obj_str_split(size_t n_args, const mp_obj_t *args) {
             bad_implicit_conversion(sep);
         }
 
-        mp_uint_t sep_len;
+        size_t sep_len;
         const char *sep_str = mp_obj_str_get_data(sep, &sep_len);
 
         if (sep_len == 0) {
@@ -611,7 +611,7 @@ STATIC mp_obj_t str_rsplit(size_t n_args, const mp_obj_t *args) {
     if (sep == mp_const_none) {
         mp_not_implemented("rsplit(None,n)");
     } else {
-        mp_uint_t sep_len;
+        size_t sep_len;
         const char *sep_str = mp_obj_str_get_data(sep, &sep_len);
 
         if (sep_len == 0) {
@@ -1306,12 +1306,12 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
             switch (type) {
                 case '\0': // no explicit format type implies 's'
                 case 's': {
-                    mp_uint_t slen;
+                    size_t slen;
                     const char *s = mp_obj_str_get_data(arg, &slen);
                     if (precision < 0) {
                         precision = slen;
                     }
-                    if (slen > (mp_uint_t)precision) {
+                    if (slen > (size_t)precision) {
                         slen = precision;
                     }
                     mp_print_strn(&print, s, slen, flags, fill, width);
@@ -1452,7 +1452,7 @@ not_enough_args:
         switch (*str) {
             case 'c':
                 if (MP_OBJ_IS_STR(arg)) {
-                    mp_uint_t slen;
+                    size_t slen;
                     const char *s = mp_obj_str_get_data(arg, &slen);
                     if (slen != 1) {
                         mp_raise_TypeError("%%c requires int or char");
@@ -2097,7 +2097,7 @@ const char *mp_obj_str_get_str(mp_obj_t self_in) {
     }
 }
 
-const char *mp_obj_str_get_data(mp_obj_t self_in, mp_uint_t *len) {
+const char *mp_obj_str_get_data(mp_obj_t self_in, size_t *len) {
     if (MP_OBJ_IS_STR_OR_BYTES(self_in)) {
         GET_STR_DATA_LEN(self_in, s, l);
         *len = l;

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -244,7 +244,7 @@ mp_obj_t mp_obj_new_tuple(size_t n, const mp_obj_t *items) {
     return MP_OBJ_FROM_PTR(o);
 }
 
-void mp_obj_tuple_get(mp_obj_t self_in, mp_uint_t *len, mp_obj_t **items) {
+void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items) {
     assert(MP_OBJ_IS_TYPE(self_in, &mp_type_tuple));
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
     *len = self->len;

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -916,7 +916,7 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     // TODO might need to make a copy of locals_dict; at least that's how CPython does it
 
     // Basic validation of base classes
-    mp_uint_t len;
+    size_t len;
     mp_obj_t *items;
     mp_obj_tuple_get(bases_tuple, &len, &items);
     for (size_t i = 0; i < len; i++) {
@@ -1098,7 +1098,7 @@ bool mp_obj_is_subclass_fast(mp_const_obj_t object, mp_const_obj_t classinfo) {
 }
 
 STATIC mp_obj_t mp_obj_is_subclass(mp_obj_t object, mp_obj_t classinfo) {
-    mp_uint_t len;
+    size_t len;
     mp_obj_t *items;
     if (MP_OBJ_IS_TYPE(classinfo, &mp_type_type)) {
         len = 1;

--- a/py/repl.c
+++ b/py/repl.c
@@ -153,7 +153,7 @@ mp_uint_t mp_repl_autocomplete(const char *str, mp_uint_t len, const mp_print_t 
             mp_obj_t obj = MP_OBJ_NULL;
             for (mp_uint_t i = 0; i < dict->map.alloc; i++) {
                 if (MP_MAP_SLOT_IS_FILLED(&dict->map, i)) {
-                    mp_uint_t d_len;
+                    size_t d_len;
                     const char *d_str = mp_obj_str_get_data(dict->map.table[i].key, &d_len);
                     if (s_len == d_len && strncmp(s_start, d_str, d_len) == 0) {
                         obj = dict->map.table[i].value;
@@ -197,7 +197,7 @@ mp_uint_t mp_repl_autocomplete(const char *str, mp_uint_t len, const mp_print_t 
             mp_uint_t match_len = 0;
             for (mp_uint_t i = 0; i < dict->map.alloc; i++) {
                 if (MP_MAP_SLOT_IS_FILLED(&dict->map, i)) {
-                    mp_uint_t d_len;
+                    size_t d_len;
                     const char *d_str = mp_obj_str_get_data(dict->map.table[i].key, &d_len);
                     if (s_len <= d_len && strncmp(s_start, d_str, s_len) == 0) {
                         if (match_str == NULL) {
@@ -247,7 +247,7 @@ mp_uint_t mp_repl_autocomplete(const char *str, mp_uint_t len, const mp_print_t 
             int line_len = MAX_LINE_LEN; // force a newline for first word
             for (mp_uint_t i = 0; i < dict->map.alloc; i++) {
                 if (MP_MAP_SLOT_IS_FILLED(&dict->map, i)) {
-                    mp_uint_t d_len;
+                    size_t d_len;
                     const char *d_str = mp_obj_str_get_data(dict->map.table[i].key, &d_len);
                     if (s_len <= d_len && strncmp(s_start, d_str, s_len) == 0) {
                         int gap = (line_len + WORD_SLOT_LEN - 1) / WORD_SLOT_LEN * WORD_SLOT_LEN - line_len;

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -670,7 +670,7 @@ void mp_call_prepare_args_n_kw_var(bool have_self, size_t n_args_n_kw, const mp_
         // optimise the case of a tuple and list
 
         // get the items
-        mp_uint_t len;
+        size_t len;
         mp_obj_t *items;
         mp_obj_get_array(pos_seq, &len, &items);
 
@@ -799,7 +799,7 @@ mp_obj_t mp_call_method_n_kw_var(bool have_self, size_t n_args_n_kw, const mp_ob
 
 // unpacked items are stored in reverse order into the array pointed to by items
 void mp_unpack_sequence(mp_obj_t seq_in, size_t num, mp_obj_t *items) {
-    mp_uint_t seq_len;
+    size_t seq_len;
     if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple) || MP_OBJ_IS_TYPE(seq_in, &mp_type_list)) {
         mp_obj_t *seq_items;
         mp_obj_get_array(seq_in, &seq_len, &seq_items);
@@ -849,7 +849,7 @@ void mp_unpack_ex(mp_obj_t seq_in, size_t num_in, mp_obj_t *items) {
     size_t num_left = num_in & 0xff;
     size_t num_right = (num_in >> 8) & 0xff;
     DEBUG_OP_printf("unpack ex " UINT_FMT " " UINT_FMT "\n", num_left, num_right);
-    mp_uint_t seq_len;
+    size_t seq_len;
     if (MP_OBJ_IS_TYPE(seq_in, &mp_type_tuple) || MP_OBJ_IS_TYPE(seq_in, &mp_type_list)) {
         mp_obj_t *seq_items;
         mp_obj_get_array(seq_in, &seq_len, &seq_items);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1330,7 +1330,7 @@ import_error:
     }
 
     mp_load_method_maybe(module, MP_QSTR___name__, dest);
-    mp_uint_t pkg_name_len;
+    size_t pkg_name_len;
     const char *pkg_name = mp_obj_str_get_data(dest[0], &pkg_name_len);
 
     const uint dot_name_len = pkg_name_len + 1 + qstr_len(name);

--- a/stmhal/can.c
+++ b/stmhal/can.c
@@ -631,8 +631,8 @@ STATIC mp_obj_t pyb_can_setfilter(mp_uint_t n_args, const mp_obj_t *pos_args, mp
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_uint_t len;
-    mp_uint_t rtr_len;
+    size_t len;
+    size_t rtr_len;
     mp_uint_t rtr_masks[4] = {0, 0, 0, 0};
     mp_obj_t *rtr_flags;
     mp_obj_t *params;

--- a/stmhal/lcd.c
+++ b/stmhal/lcd.c
@@ -373,7 +373,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(pyb_lcd_light_obj, pyb_lcd_light);
 /// Write the string `str` to the screen.  It will appear immediately.
 STATIC mp_obj_t pyb_lcd_write(mp_obj_t self_in, mp_obj_t str) {
     pyb_lcd_obj_t *self = self_in;
-    mp_uint_t len;
+    size_t len;
     const char *data = mp_obj_str_get_data(str, &len);
     lcd_write_strn(self, data, len);
     return mp_const_none;
@@ -445,7 +445,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_lcd_pixel_obj, 4, 4, pyb_lcd_pixe
 STATIC mp_obj_t pyb_lcd_text(mp_uint_t n_args, const mp_obj_t *args) {
     // extract arguments
     pyb_lcd_obj_t *self = args[0];
-    mp_uint_t len;
+    size_t len;
     const char *data = mp_obj_str_get_data(args[1], &len);
     int x0 = mp_obj_get_int(args[2]);
     int y0 = mp_obj_get_int(args[3]);

--- a/stmhal/modnwcc3k.c
+++ b/stmhal/modnwcc3k.c
@@ -477,11 +477,11 @@ STATIC mp_obj_t cc3k_connect(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // get ssid
-    mp_uint_t ssid_len;
+    size_t ssid_len;
     const char *ssid = mp_obj_str_get_data(args[0].u_obj, &ssid_len);
 
     // get key and sec
-    mp_uint_t key_len = 0;
+    size_t key_len = 0;
     const char *key = NULL;
     mp_uint_t sec = WLAN_SEC_UNSEC;
     if (args[1].u_obj != mp_const_none) {

--- a/stmhal/modusocket.c
+++ b/stmhal/modusocket.c
@@ -388,7 +388,7 @@ STATIC const mp_obj_type_t socket_type = {
 
 // function usocket.getaddrinfo(host, port)
 STATIC mp_obj_t mod_usocket_getaddrinfo(mp_obj_t host_in, mp_obj_t port_in) {
-    mp_uint_t hlen;
+    size_t hlen;
     const char *host = mp_obj_str_get_data(host_in, &hlen);
     mp_int_t port = mp_obj_get_int(port_in);
 

--- a/stmhal/modutime.c
+++ b/stmhal/modutime.c
@@ -100,7 +100,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(time_localtime_obj, 0, 1, time_localtime);
 /// the number of seconds since Jan 1, 2000.
 STATIC mp_obj_t time_mktime(mp_obj_t tuple) {
 
-    mp_uint_t len;
+    size_t len;
     mp_obj_t *elem;
 
     mp_obj_get_array(tuple, &len, &elem);

--- a/unix/main.c
+++ b/unix/main.c
@@ -437,7 +437,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
         path = "~/.micropython/lib:/usr/lib/micropython";
         #endif
     }
-    mp_uint_t path_num = 1; // [0] is for current dir (or base dir of the script)
+    size_t path_num = 1; // [0] is for current dir (or base dir of the script)
     if (*path == ':') {
         path_num++;
     }


### PR DESCRIPTION
Ever since the introduction of the nan-boxing build option there has been a slow conversion of mp_uint_t types to size_t, for variables/arguments which count things related to memory sizes/lengths (eg number of bytes in a string, or elements in an array).  The reason for the change is that with nan-boxing the mp_uint_t type is 64 bits wide, and using this type to count memory locations on a 32-bit arch is wasteful.  It makes a real difference to the (code and RAM) size of nan-boxing builds to convert mp_uint_t to size_t, and also improves efficiency/speed.  The change makes no difference to builds that don't use nan-boxing.

In this patch such changes are made to the data accesor functions for tuple, list and string, which are change to:
```c
void mp_obj_get_array(mp_obj_t o, size_t *len, mp_obj_t **items);
void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items);
void mp_obj_list_get(mp_obj_t self_in, size_t *len, mp_obj_t **items);
const char *mp_obj_str_get_data(mp_obj_t self_in, size_t *len);
```
The change is that `mp_uint_t *len` becomes `size_t *len`.

The reason for putting this up as a PR is not really so it can be reviewed, but rather as a warning/notice to people maintaining other ports that the above functions changed and code that calls them may need updating.