### PR TITLE
zephyr/Makefile: Rework to use modern, official build integration.

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -142,8 +142,15 @@ clean-prog:
 endif
 
 LIBMICROPYTHON = libmicropython.a
+
+# We can execute extra commands after library creation using
+# LIBMICROPYTHON_EXTRA_CMD. This may be needed e.g. to integrate
+# with 3rd-party projects which don't have proper dependency
+# tracking. Then LIBMICROPYTHON_EXTRA_CMD can e.g. touch some
+# other file to cause needed effect, e.g. relinking with new lib.
 lib $(LIBMICROPYTHON): $(OBJ)
 	$(AR) rcs $(LIBMICROPYTHON) $^
+	$(LIBMICROPYTHON_EXTRA_CMD)
 
 clean:
 	$(RM) -rf $(BUILD) $(CLEAN_EXTRA)

--- a/zephyr/Makefile
+++ b/zephyr/Makefile
@@ -18,7 +18,6 @@ MICROPY_HEAP_SIZE = 16384
 FROZEN_DIR = scripts
 
 # Zephyr (generated) config files - must be defined before include below
-Z_SYSGEN_H = outdir/$(OUTDIR_PREFIX)/misc/generated/sysgen/sysgen.h
 Z_EXPORTS = outdir/$(OUTDIR_PREFIX)/Makefile.export
 include $(Z_EXPORTS)
 
@@ -71,15 +70,13 @@ $(GENERIC_TARGETS): $(LIBMICROPYTHON)
 $(CLEAN_TARGETS):  clean
 
 $(GENERIC_TARGETS) $(KCONFIG_TARGETS) $(CLEAN_TARGETS):
-	$(RM) -f outdir/$(OUTDIR_PREFIX)/zephyr.lnk
 	$(MAKE) -f Makefile.zephyr BOARD=$(BOARD) CONF_FILE=$(CONF_FILE) $@
 
-$(LIBMICROPYTHON): $(Z_SYSGEN_H)
-build/genhdr/qstr.i.last: $(Z_SYSGEN_H)
+$(LIBMICROPYTHON): | $(Z_EXPORTS)
+build/genhdr/qstr.i.last: | $(Z_EXPORTS)
 
-$(Z_SYSGEN_H):
-	rm -f $(LIBMICROPYTHON)
-	-$(MAKE) -f Makefile.zephyr BOARD=$(BOARD) CONF_FILE=$(CONF_FILE)
+# If we recreate libmicropython, also cause zephyr.bin relink
+LIBMICROPYTHON_EXTRA_CMD = -$(RM) -f outdir/$(OUTDIR_PREFIX)/zephyr.lnk
 
 # Clean Zephyr things too
 clean: z_clean


### PR DESCRIPTION
Build happens in 3 stages:

1. Zephyr config header and make vars are generated from prj.conf.
2. libmicropython is built using them.
3. Zephyr is built and final link happens.