### PR TITLE
Esp8266 uart fixes

### DIFF
--- a/esp8266/esp_mphal.h
+++ b/esp8266/esp_mphal.h
@@ -31,8 +31,6 @@
 #include "lib/utils/interrupt_char.h"
 #include "xtirq.h"
 
-void mp_keyboard_interrupt(void);
-
 struct _mp_print_t;
 // Structure for UART-only output via mp_printf()
 extern const struct _mp_print_t mp_debug_print;

--- a/esp8266/main.c
+++ b/esp8266/main.c
@@ -108,6 +108,7 @@ soft_reset:
     #endif
 }
 
+// Seems unused
 void user_init(void) {
     system_init_done_cb(init_done);
 }

--- a/esp8266/modesp.c
+++ b/esp8266/modesp.c
@@ -56,6 +56,16 @@ STATIC mp_obj_t esp_osdebug(mp_obj_t val) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_osdebug_obj, esp_osdebug);
 
+STATIC mp_obj_t esp_replinput(mp_obj_t val) {
+    if (val == mp_const_none) {
+        uart_os_input(-1);
+    } else {
+        uart_os_input(mp_obj_get_int(val));
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_replinput_obj, esp_replinput);
+
 STATIC mp_obj_t esp_sleep_type(mp_uint_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
         return mp_obj_new_int(wifi_get_sleep_type());
@@ -353,6 +363,7 @@ STATIC const mp_map_elem_t esp_module_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_esp) },
 
     { MP_OBJ_NEW_QSTR(MP_QSTR_osdebug), (mp_obj_t)&esp_osdebug_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_replinput), (mp_obj_t)&esp_replinput_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_sleep_type), (mp_obj_t)&esp_sleep_type_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_deepsleep), (mp_obj_t)&esp_deepsleep_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_flash_id), (mp_obj_t)&esp_flash_id_obj },

--- a/esp8266/uart.c
+++ b/esp8266/uart.c
@@ -117,7 +117,7 @@ void uart_flush(uint8 uart) {
 }
 
 /******************************************************************************
- * FunctionName : uart1_write_char
+ * FunctionName : uart_os_write_char
  * Description  : Internal used function
  *                Do some special deal while tx char is '\r' or '\n'
  * Parameters   : char c - character to tx
@@ -193,7 +193,7 @@ static void uart0_rx_intr_handler(void *para) {
         mp_hal_signal_input();
 
         // Clear pending FIFO interrupts
-        WRITE_PERI_REG(UART_INT_CLR(UART_REPL), UART_RXFIFO_TOUT_INT_CLR | UART_RXFIFO_FULL_INT_ST);
+        WRITE_PERI_REG(UART_INT_CLR(uart_no), UART_RXFIFO_TOUT_INT_CLR | UART_RXFIFO_FULL_INT_ST);
         ETS_UART_INTR_ENABLE();
     }
 }

--- a/esp8266/uart.h
+++ b/esp8266/uart.h
@@ -81,7 +81,7 @@ typedef struct {
     UartBautRate      baut_rate;
     UartBitsNum4Char  data_bits;
     UartExistParity   exist_parity;
-    UartParityMode    parity;    // chip size in byte
+    UartParityMode    parity;    // even/odd
     UartStopBitsNum   stop_bits;
     UartFlowCtrl      flow_ctrl;
     RcvMsgBuff        rcv_buff;
@@ -92,7 +92,6 @@ typedef struct {
 } UartDevice;
 
 void uart_init(UartBautRate uart0_br, UartBautRate uart1_br);
-int uart0_rx(void);
 bool uart_rx_wait(uint32_t timeout_us);
 int uart_rx_char(void);
 void uart_tx_one_char(uint8 uart, uint8 TxChar);

--- a/esp8266/uart.h
+++ b/esp8266/uart.h
@@ -98,6 +98,7 @@ int uart_rx_char(void);
 void uart_tx_one_char(uint8 uart, uint8 TxChar);
 void uart_flush(uint8 uart);
 void uart_os_config(int uart);
+void uart_os_input(int uart);
 void uart_setup(uint8 uart);
 // check status of rx/tx
 int uart_rx_any(uint8 uart);


### PR DESCRIPTION
Doing something like:
```python
data = bytes(bytearray(range(0x100)))
with serial.Serial(TTY, BAUD) as ser:
    ser.write(data)
```
when a ESP8266 is connected to the serial bus has the unfortunate effect of resetting the board.
Make it possible to put any data on the serial bus without REPL interpreting it.