### PR TITLE
py/modmicropython: Add micropython.kbd_intr() function.

### DIFF
--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -31,6 +31,7 @@
 #include "py/stackctrl.h"
 #include "py/runtime.h"
 #include "py/gc.h"
+#include "py/mphal.h"
 
 // Various builtins specific to MicroPython runtime,
 // living in micropython module
@@ -129,6 +130,14 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_heap_unlock_obj, mp_micropython_
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_alloc_emergency_exception_buf_obj, mp_alloc_emergency_exception_buf);
 #endif
 
+#if MICROPY_KBD_EXCEPTION
+STATIC mp_obj_t mp_micropython_kbd_intr(mp_obj_t int_chr_in) {
+    mp_hal_set_interrupt_char(mp_obj_get_int(int_chr_in));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_micropython_kbd_intr_obj, mp_micropython_kbd_intr);
+#endif
+
 #if MICROPY_ENABLE_SCHEDULER
 STATIC mp_obj_t mp_micropython_schedule(mp_obj_t function, mp_obj_t arg) {
     if (!mp_sched_schedule(function, arg)) {
@@ -161,6 +170,9 @@ STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     #if MICROPY_ENABLE_GC
     { MP_ROM_QSTR(MP_QSTR_heap_lock), MP_ROM_PTR(&mp_micropython_heap_lock_obj) },
     { MP_ROM_QSTR(MP_QSTR_heap_unlock), MP_ROM_PTR(&mp_micropython_heap_unlock_obj) },
+    #endif
+    #if MICROPY_KBD_EXCEPTION
+    { MP_ROM_QSTR(MP_QSTR_kbd_intr), MP_ROM_PTR(&mp_micropython_kbd_intr_obj) },
     #endif
     #if MICROPY_ENABLE_SCHEDULER
     { MP_ROM_QSTR(MP_QSTR_schedule), MP_ROM_PTR(&mp_micropython_schedule_obj) },

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -445,7 +445,7 @@
 #   endif
 #endif
 
-// Whether to provide the mp_kbd_exception object
+// Whether to provide the mp_kbd_exception object, and micropython.kbd_intr function
 #ifndef MICROPY_KBD_EXCEPTION
 #define MICROPY_KBD_EXCEPTION (0)
 #endif

--- a/tests/micropython/kbd_intr.py
+++ b/tests/micropython/kbd_intr.py
@@ -1,0 +1,13 @@
+# test the micropython.kbd_intr() function
+
+import micropython
+
+try:
+    micropython.kbd_intr
+except AttributeError:
+    print('SKIP')
+    import sys
+    sys.exit()
+
+# just check we can actually call it
+micropython.kbd_intr(3)


### PR DESCRIPTION
This function controls the character that's used to (asynchronously) raise a KeyboardInterrupt exception.  Passing "-1" allows to disable the interception of the interrupt character (as long as a port allows such a behaviour).

This would fix #2990 and https://github.com/bbcmicrobit/micropython/issues/423, and provide a port-agnostic replacement for stmhal's `USB_VCP.set_interrupt()`.

BUT, there is an alternative, more sophisticated way to do a similar thing: namely to allow to disable (and then restore) the native/built-in REPL stream (eg USB VCP in stmhal, UART0 in esp8266).  See #2891 for a PR related to this idea, and also discussion in #2814.  It's probably best to go for that solution straight away but it requires some investment to get it to work.