### PR TITLE
stmhal/timer: Clear interrupt flag before setting callback

### DIFF
--- a/stmhal/timer.c
+++ b/stmhal/timer.c
@@ -1302,6 +1302,7 @@ STATIC mp_obj_t pyb_timer_channel_callback(mp_obj_t self_in, mp_obj_t callback) 
     } else if (mp_obj_is_callable(callback)) {
         self->callback = callback;
         uint8_t tim_id = self->timer->tim_id;
+        __HAL_TIM_CLEAR_IT(&self->timer->tim, TIMER_IRQ_MASK(self->channel));
         if (tim_id == 1) {
             HAL_NVIC_EnableIRQ(TIM1_CC_IRQn);
         #if defined(TIM8) // STM32F401 doesn't have a TIM8


### PR DESCRIPTION
Sometimes when setting a channel callback the callback fires immediately, even if the compare register is set to a value far into the future. This happens when the free running counter has previously been equal to what happens to be in the compare register. This can be demonstrated with the following code.
```python
from pyb import Timer
from time import sleep

def cb(o):
    print('cb')

tim = Timer(2,prescaler=0xffff, period=0x3fffffff)
c = tim.channel(1, mode=Timer.OC_TIMING, compare=tim.counter()+20)
sleep(1)
print('Setting compare')
c.compare(tim.counter()+10000)
print('Setting callback')
c.callback(cb)
print('Disabling callback')
c.callback(None)
```
The callback is called even if it is disabled before the counter reaches the compare value. This patch make sure that there is no pending interrupt when setting a callback.