### PR TITLE
esp8266, stmhal, zephyr: Rename machine.Pin high/low methods to on/off.

### DIFF
--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -139,23 +139,23 @@ class SSD1306_SPI(SSD1306):
 
     def write_cmd(self, cmd):
         self.spi.init(baudrate=self.rate, polarity=0, phase=0)
-        self.cs.high()
-        self.dc.low()
-        self.cs.low()
+        self.cs(1)
+        self.dc(0)
+        self.cs(0)
         self.spi.write(bytearray([cmd]))
-        self.cs.high()
+        self.cs(1)
 
     def write_data(self, buf):
         self.spi.init(baudrate=self.rate, polarity=0, phase=0)
-        self.cs.high()
-        self.dc.high()
-        self.cs.low()
+        self.cs(1)
+        self.dc(1)
+        self.cs(0)
         self.spi.write(buf)
-        self.cs.high()
+        self.cs(1)
 
     def poweron(self):
-        self.res.high()
+        self.res(1)
         time.sleep_ms(1)
-        self.res.low()
+        self.res(0)
         time.sleep_ms(10)
-        self.res.high()
+        self.res(1)

--- a/drivers/onewire/ds18x20.py
+++ b/drivers/onewire/ds18x20.py
@@ -7,11 +7,11 @@ temperature sensors.  It supports multiple devices on the same 1-wire bus.
 The following example assumes the ground of your DS18x20 is connected to
 Y11, vcc is connected to Y9 and the data pin is connected to Y10.
 
->>> from pyb import Pin
+>>> from machine import Pin
 >>> gnd = Pin('Y11', Pin.OUT_PP)
->>> gnd.low()
+>>> gnd.off()
 >>> vcc = Pin('Y9', Pin.OUT_PP)
->>> vcc.high()
+>>> vcc.on()
 
 >>> from ds18x20 import DS18X20
 >>> d = DS18X20(Pin('Y10'))

--- a/drivers/sdcard/sdcard.py
+++ b/drivers/sdcard/sdcard.py
@@ -130,7 +130,7 @@ class SDCard:
         raise OSError("timeout waiting for v2 card")
 
     def cmd(self, cmd, arg, crc, final=0, release=True):
-        self.cs.low()
+        self.cs(0)
 
         # create and send the command
         buf = self.cmdbuf
@@ -150,12 +150,12 @@ class SDCard:
                 for j in range(final):
                     self.spi.write(b'\xff')
                 if release:
-                    self.cs.high()
+                    self.cs(1)
                     self.spi.write(b'\xff')
                 return response
 
         # timeout
-        self.cs.high()
+        self.cs(1)
         self.spi.write(b'\xff')
         return -1
 
@@ -164,15 +164,15 @@ class SDCard:
         self.spi.read(1, 0xff) # ignore stuff byte
         for _ in range(_CMD_TIMEOUT):
             if self.spi.read(1, 0xff)[0] == 0xff:
-                self.cs.high()
+                self.cs(1)
                 self.spi.write(b'\xff')
                 return 0    # OK
-        self.cs.high()
+        self.cs(1)
         self.spi.write(b'\xff')
         return 1 # timeout
 
     def readinto(self, buf):
-        self.cs.low()
+        self.cs(0)
 
         # read until start byte (0xff)
         while self.spi.read(1, 0xff)[0] != 0xfe:
@@ -186,11 +186,11 @@ class SDCard:
         self.spi.write(b'\xff')
         self.spi.write(b'\xff')
 
-        self.cs.high()
+        self.cs(1)
         self.spi.write(b'\xff')
 
     def write(self, token, buf):
-        self.cs.low()
+        self.cs(0)
 
         # send: start of block, data, checksum
         self.spi.read(1, token)
@@ -200,7 +200,7 @@ class SDCard:
 
         # check the response
         if (self.spi.read(1, 0xff)[0] & 0x1f) != 0x05:
-            self.cs.high()
+            self.cs(1)
             self.spi.write(b'\xff')
             return
 
@@ -208,18 +208,18 @@ class SDCard:
         while self.spi.read(1, 0xff)[0] == 0:
             pass
 
-        self.cs.high()
+        self.cs(1)
         self.spi.write(b'\xff')
 
     def write_token(self, token):
-        self.cs.low()
+        self.cs(0)
         self.spi.read(1, token)
         self.spi.write(b'\xff')
         # wait for write to finish
         while self.spi.read(1, 0xff)[0] == 0x00:
             pass
 
-        self.cs.high()
+        self.cs(1)
         self.spi.write(b'\xff')
 
     def count(self):

--- a/esp8266/machine_pin.c
+++ b/esp8266/machine_pin.c
@@ -336,21 +336,19 @@ STATIC mp_obj_t pyb_pin_value(mp_uint_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_pin_value_obj, 1, 2, pyb_pin_value);
 
-// pin.low()
-STATIC mp_obj_t pyb_pin_low(mp_obj_t self_in) {
+STATIC mp_obj_t pyb_pin_off(mp_obj_t self_in) {
     pyb_pin_obj_t *self = self_in;
     pin_set(self->phys_port, 0);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_pin_low_obj, pyb_pin_low);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_pin_off_obj, pyb_pin_off);
 
-// pin.high()
-STATIC mp_obj_t pyb_pin_high(mp_obj_t self_in) {
+STATIC mp_obj_t pyb_pin_on(mp_obj_t self_in) {
     pyb_pin_obj_t *self = self_in;
     pin_set(self->phys_port, 1);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_pin_high_obj, pyb_pin_high);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pyb_pin_on_obj, pyb_pin_on);
 
 // pin.irq(handler=None, trigger=IRQ_FALLING|IRQ_RISING, hard=False)
 STATIC mp_obj_t pyb_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -410,8 +408,8 @@ STATIC const mp_map_elem_t pyb_pin_locals_dict_table[] = {
     // instance methods
     { MP_OBJ_NEW_QSTR(MP_QSTR_init),    (mp_obj_t)&pyb_pin_init_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_value),   (mp_obj_t)&pyb_pin_value_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_low),     (mp_obj_t)&pyb_pin_low_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_high),    (mp_obj_t)&pyb_pin_high_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_off),     (mp_obj_t)&pyb_pin_off_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_on),      (mp_obj_t)&pyb_pin_on_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_irq),     (mp_obj_t)&pyb_pin_irq_obj },
 
     // class constants

--- a/stmhal/pin.c
+++ b/stmhal/pin.c
@@ -400,23 +400,19 @@ STATIC mp_obj_t pin_value(mp_uint_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pin_value_obj, 1, 2, pin_value);
 
-/// \method low()
-/// Set the pin to a low logic level.
-STATIC mp_obj_t pin_low(mp_obj_t self_in) {
+STATIC mp_obj_t pin_off(mp_obj_t self_in) {
     pin_obj_t *self = self_in;
     mp_hal_pin_low(self);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pin_low_obj, pin_low);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pin_off_obj, pin_off);
 
-/// \method high()
-/// Set the pin to a high logic level.
-STATIC mp_obj_t pin_high(mp_obj_t self_in) {
+STATIC mp_obj_t pin_on(mp_obj_t self_in) {
     pin_obj_t *self = self_in;
     mp_hal_pin_high(self);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pin_high_obj, pin_high);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pin_on_obj, pin_on);
 
 /// \method name()
 /// Get the pin name.
@@ -500,8 +496,11 @@ STATIC const mp_rom_map_elem_t pin_locals_dict_table[] = {
     // instance methods
     { MP_ROM_QSTR(MP_QSTR_init),    MP_ROM_PTR(&pin_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_value),   MP_ROM_PTR(&pin_value_obj) },
-    { MP_ROM_QSTR(MP_QSTR_low),     MP_ROM_PTR(&pin_low_obj) },
-    { MP_ROM_QSTR(MP_QSTR_high),    MP_ROM_PTR(&pin_high_obj) },
+    { MP_ROM_QSTR(MP_QSTR_off),     MP_ROM_PTR(&pin_off_obj) },
+    { MP_ROM_QSTR(MP_QSTR_on),      MP_ROM_PTR(&pin_on_obj) },
+    // Legacy names as used by pyb.Pin
+    { MP_ROM_QSTR(MP_QSTR_low),     MP_ROM_PTR(&pin_off_obj) },
+    { MP_ROM_QSTR(MP_QSTR_high),    MP_ROM_PTR(&pin_on_obj) },
     { MP_ROM_QSTR(MP_QSTR_name),    MP_ROM_PTR(&pin_name_obj) },
     { MP_ROM_QSTR(MP_QSTR_names),   MP_ROM_PTR(&pin_names_obj) },
     { MP_ROM_QSTR(MP_QSTR_af_list), MP_ROM_PTR(&pin_af_list_obj) },

--- a/zephyr/machine_pin.c
+++ b/zephyr/machine_pin.c
@@ -138,21 +138,19 @@ STATIC mp_obj_t machine_pin_value(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_pin_value_obj, 1, 2, machine_pin_value);
 
-// pin.low()
-STATIC mp_obj_t machine_pin_low(mp_obj_t self_in) {
+STATIC mp_obj_t machine_pin_off(mp_obj_t self_in) {
     machine_pin_obj_t *self = self_in;
     (void)gpio_pin_write(self->port, self->pin, 0);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_low_obj, machine_pin_low);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_off_obj, machine_pin_off);
 
-// pin.high()
-STATIC mp_obj_t machine_pin_high(mp_obj_t self_in) {
+STATIC mp_obj_t machine_pin_on(mp_obj_t self_in) {
     machine_pin_obj_t *self = self_in;
     (void)gpio_pin_write(self->port, self->pin, 1);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_high_obj, machine_pin_high);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_on_obj, machine_pin_on);
 
 STATIC mp_uint_t machine_pin_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
     (void)errcode;
@@ -176,8 +174,8 @@ STATIC const mp_map_elem_t machine_pin_locals_dict_table[] = {
     // instance methods
     { MP_OBJ_NEW_QSTR(MP_QSTR_init),    (mp_obj_t)&machine_pin_init_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_value),   (mp_obj_t)&machine_pin_value_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_low),     (mp_obj_t)&machine_pin_low_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_high),    (mp_obj_t)&machine_pin_high_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_off),     (mp_obj_t)&machine_pin_off_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_on),      (mp_obj_t)&machine_pin_on_obj },
 
     // class constants
     { MP_OBJ_NEW_QSTR(MP_QSTR_IN),        MP_OBJ_NEW_SMALL_INT(GPIO_DIR_IN) },


### PR DESCRIPTION
For consistent Pin/Signal class hierarchy. With it, Signal is a proper
(while still ducktyped) subclass of a Pin, and any (direct) usage of Pin
can be replace with Signal.