### PR TITLE
py: Reduce str/repr precision of float numbers when floats are 30-bit.

### DIFF
--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -50,7 +50,11 @@ STATIC void complex_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_
     mp_obj_complex_t *o = MP_OBJ_TO_PTR(o_in);
 #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
     char buf[16];
+    #if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_C
+    const int precision = 6;
+    #else
     const int precision = 7;
+    #endif
 #else
     char buf[32];
     const int precision = 16;

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -113,7 +113,11 @@ STATIC void float_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t 
     mp_float_t o_val = mp_obj_float_get(o_in);
 #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
     char buf[16];
+    #if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_C
+    const int precision = 6;
+    #else
     const int precision = 7;
+    #endif
 #else
     char buf[32];
     const int precision = 16;


### PR DESCRIPTION
With 30-bit floats there aren't enough bits to faithfully print 7 decimal digits, so reduce the precision to 6 digits.

Fixes #2616.