### PR TITLE
STM: Added additional clock configuration defines

### DIFF
--- a/stmhal/system_stm32.c
+++ b/stmhal/system_stm32.c
@@ -323,7 +323,6 @@ void SystemClock_Config(void)
     #if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
   /* Enable Power Control clock */
   __PWR_CLK_ENABLE();
-
   /* The voltage scaling allows optimizing the power consumption when the device is
      clocked below the maximum system frequency, to update the voltage scaling value
      regarding system frequency refer to product datasheet.  */
@@ -337,11 +336,21 @@ void SystemClock_Config(void)
     }
     #endif
 
-    /* Enable HSE Oscillator and activate PLL with HSE as source */
-    #if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
-    RCC_OscInitStruct.HSEState = RCC_HSE_ON;
-    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+    /* Enable Oscillator set up the different clock sources */
+    #if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)    
+        /* Select the oscillator source by the given defines */
+        #if defined(MICROPY_HW_CLK_USE_HSI)
+        RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+        RCC_OscInitStruct.HSEState = RCC_HSE_OFF;
+        RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+        RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+        RCC_OscInitStruct.HSICalibrationValue = 16;
+        #elif        
+        RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+        RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+        RCC_OscInitStruct.HSIState = RCC_HSI_OFF;
+        RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE; 
+        #endif 
     #elif defined(MCU_SERIES_L4)
     RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_LSE|RCC_OSCILLATORTYPE_MSI;
     RCC_OscInitStruct.LSEState = RCC_LSE_ON;
@@ -409,8 +418,16 @@ void SystemClock_Config(void)
 
     RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
     #if defined(MCU_SERIES_F4) || defined(MCU_SERIES_F7)
-    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
-    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;
+    
+    /*Set up the peripheral bus clocks*/
+    #if !defined MICROPY_HW_CLK_ABP1DIV
+        #define MICROPY_HW_CLK_ABP1DIV RCC_HCLK_DIV4
+    #endif
+    #if !defined MICROPY_HW_CLK_ABP2DIV
+        #define MICROPY_HW_CLK_ABP2DIV RCC_HCLK_DIV2
+    #endif
+    RCC_ClkInitStruct.APB1CLKDivider = MICROPY_HW_CLK_ABP1DIV;
+    RCC_ClkInitStruct.APB2CLKDivider = MICROPY_HW_CLK_ABP2DIV;
     #elif defined(MCU_SERIES_L4)
     RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
     RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;


### PR DESCRIPTION
To have more control over the initial clock configuration I added three new defines.
Those are:
**MICROPY_HW_CLK_USE_HSI** to select the internal clock source instead of the external
**MICROPY_HW_CLK_ABP1DIV** to set the divisor value of the the first peripheral bus
**MICROPY_HW_CLK_ABP2DIV** to set the divisor value of the the second peripheral bus

If the defines are not set, the values will default to the original ones from the previous revision. So this change shouldn't brake anything while enabling the use of the internal oscillator.