### PR TITLE
py/mkrules.mk: Add dependency of .mpy files upon mpy-cross.

### DIFF
--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -1,3 +1,14 @@
+# The following is a temporary hack to forefully undefine vars that might have
+# be defined by a calling Makefile (from recursive make).
+# TODO: Find a better way to be able to call this Makefile recursively.
+override undefine COPT
+override undefine CFLAGS_EXTRA
+override undefine LDFLAGS_EXTRA
+override undefine FROZEN_DIR
+override undefine FROZEN_MPY_DIR
+override undefine BUILD
+override undefine PROG
+
 include ../py/mkenv.mk
 
 # define main target

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -102,15 +102,19 @@ $(BUILD)/frozen.c: $(wildcard $(FROZEN_DIR)/*) $(HEADER_BUILD) $(FROZEN_EXTRA_DE
 endif
 
 ifneq ($(FROZEN_MPY_DIR),)
+# to build the MicroPython cross compiler
+$(TOP)/mpy-cross/mpy-cross: $(TOP)/py/*.[ch] $(TOP)/mpy-cross/*.[ch] $(TOP)/windows/fmode.c
+	$(Q)$(MAKE) -C $(TOP)/mpy-cross
+
 # make a list of all the .py files that need compiling and freezing
 FROZEN_MPY_PY_FILES := $(shell find -L $(FROZEN_MPY_DIR) -type f -name '*.py' | $(SED) -e 's=^$(FROZEN_MPY_DIR)/==')
 FROZEN_MPY_MPY_FILES := $(addprefix $(BUILD)/frozen_mpy/,$(FROZEN_MPY_PY_FILES:.py=.mpy))
 
 # to build .mpy files from .py files
-$(BUILD)/frozen_mpy/%.mpy: $(FROZEN_MPY_DIR)/%.py
+$(BUILD)/frozen_mpy/%.mpy: $(FROZEN_MPY_DIR)/%.py $(TOP)/mpy-cross/mpy-cross
 	@$(ECHO) "MPY $<"
 	$(Q)$(MKDIR) -p $(dir $@)
-	$(Q)$(MPY_CROSS) -o $@ -s $(^:$(FROZEN_MPY_DIR)/%=%) $(MPY_CROSS_FLAGS) $^
+	$(Q)$(MPY_CROSS) -o $@ -s $(<:$(FROZEN_MPY_DIR)/%=%) $(MPY_CROSS_FLAGS) $<
 
 # to build frozen_mpy.c from all .mpy files
 $(BUILD)/frozen_mpy.c: $(FROZEN_MPY_MPY_FILES) $(BUILD)/genhdr/qstrdefs.generated.h


### PR DESCRIPTION
This ensures that mpy-cross is automatically built (and is up-to-date) for ports that use frozen bytecode.  It also makes sure that .mpy files are re-built if mpy-cross is changed.

I used a simple *.[ch] pattern match for getting the dependencies, which should be good enough.

@dhylands what do you think of it?