### PR TITLE
extmod/utimeq: Fix possible redefinition of DEBUG macro

### DIFF
--- a/py/nlr.h
+++ b/py/nlr.h
@@ -85,7 +85,7 @@ NORETURN void nlr_jump(void *val);
 NORETURN void nlr_jump_fail(void *val);
 
 // use nlr_raise instead of nlr_jump so that debugging is easier
-#ifndef DEBUG
+#ifndef MICROPY_DEBUG_NLR
 #define nlr_raise(val) nlr_jump(MP_OBJ_TO_PTR(val))
 #else
 #include "mpstate.h"

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -40,14 +40,6 @@
 
 #if MICROPY_LONGINT_IMPL == MICROPY_LONGINT_IMPL_LONGLONG
 
-// Python3 no longer has "l" suffix for long ints. We allow to use it
-// for debugging purpose though.
-#ifdef DEBUG
-#define SUFFIX "l"
-#else
-#define SUFFIX ""
-#endif
-
 #if MICROPY_PY_SYS_MAXSIZE
 // Export value for sys.maxsize
 const mp_obj_int_t mp_maxsize_obj = {{&mp_type_int}, MP_SSIZE_MAX};

--- a/windows/msvc/debug.props
+++ b/windows/msvc/debug.props
@@ -4,10 +4,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
   </PropertyGroup>
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <PreprocessorDefinitions>DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-  </ItemDefinitionGroup>
+  <ItemDefinitionGroup />
   <ItemGroup />
 </Project>


### PR DESCRIPTION
DEBUG is already 'reserved' as a global preprocessor definition because
it is used in nlr.h. For instance the msvc port defines DEBUG on the
compiler commandline in debug builds.
As such defining it again might emit compiler warnings and is confusing.
So, in modutimeq, rename DEBUG to MICROPY_UTIMEQ_DEBUG.

@pfalcon I'm not sure if there is a convention for names of per-file local macros so I just picked one with similar naming as the global ones.