### PR TITLE
py/modthread.c: thread_lock_release: Check lock already unlocked.

### DIFF
--- a/py/modthread.c
+++ b/py/modthread.c
@@ -84,8 +84,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(thread_lock_acquire_obj, 1, 3, thread
 
 STATIC mp_obj_t thread_lock_release(mp_obj_t self_in) {
     mp_obj_thread_lock_t *self = MP_OBJ_TO_PTR(self_in);
-    // TODO check if already unlocked
     self->locked = false;
+    if (!self->mutex) {
+        //already unlocked
+        mp_raise_RuntimeError("release unlocked lock");
+    }
     MP_THREAD_GIL_EXIT();
     mp_thread_mutex_unlock(&self->mutex);
     MP_THREAD_GIL_ENTER();

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1438,6 +1438,10 @@ NORETURN void mp_raise_TypeError(const char *msg) {
     mp_raise_msg(&mp_type_TypeError, msg);
 }
 
+NORETURN void mp_raise_RuntimeError(const char *msg) {
+    mp_raise_msg(&mp_type_RuntimeError, msg);
+}
+
 NORETURN void mp_raise_OSError(int errno_) {
     nlr_raise(mp_obj_new_exception_arg1(&mp_type_OSError, MP_OBJ_NEW_SMALL_INT(errno_)));
 }

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -149,6 +149,7 @@ NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const char *msg);
 //NORETURN void nlr_raise_msg_varg(const mp_obj_type_t *exc_type, const char *fmt, ...);
 NORETURN void mp_raise_ValueError(const char *msg);
 NORETURN void mp_raise_TypeError(const char *msg);
+NORETURN void mp_raise_RuntimeError(const char *msg);
 NORETURN void mp_raise_OSError(int errno_);
 NORETURN void mp_not_implemented(const char *msg); // Raise NotImplementedError with given message
 NORETURN void mp_exc_recursion_depth(void);


### PR DESCRIPTION
    py/modthread.c: thread_lock_release: Check lock already unlocked.
    py/runtime.h: Add mp_raise_RuntimeError method.
    py/runtime.c: Implement mp_raise_RuntimeError method.