### PR TITLE
Add pyb.wfe() function. Execute wfe instead of wfi in machine.idle.

### DIFF
--- a/cc3200/hal/cc3200_asm.h
+++ b/cc3200/hal/cc3200_asm.h
@@ -46,10 +46,24 @@ static inline void __WFI(void) {
                     "    isb      \n"
                     "    wfi      \n");
 }
+
+__attribute__(( always_inline ))
+static inline void __WFE(void) {
+    __asm volatile ("    dsb      \n"
+                    "    isb      \n"
+                    "    wfe      \n");
+}
+
 #else
 // For some reason the debugger gets disconnected when entering any of the sleep modes
 __attribute__(( always_inline ))
 static inline void __WFI(void) {
+    __asm volatile ("    dsb      \n"
+                    "    isb      \n");
+}
+
+__attribute__(( always_inline ))
+static inline void __WFE(void) {
     __asm volatile ("    dsb      \n"
                     "    isb      \n");
 }

--- a/stmhal/irq.c
+++ b/stmhal/irq.c
@@ -45,6 +45,14 @@ STATIC mp_obj_t pyb_wfi(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(pyb_wfi_obj, pyb_wfi);
 
+STATIC mp_obj_t pyb_wfe(void) {
+    __WFE();
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_0(pyb_wfe_obj, pyb_wfe);
+
+
+
 /// \function disable_irq()
 /// Disable interrupt requests.
 /// Returns the previous IRQ state: `False`/`True` for disabled/enabled IRQs

--- a/stmhal/irq.h
+++ b/stmhal/irq.h
@@ -71,6 +71,7 @@ static inline void restore_irq_pri(uint32_t basepri) {
 #endif
 
 MP_DECLARE_CONST_FUN_OBJ_0(pyb_wfi_obj);
+MP_DECLARE_CONST_FUN_OBJ_0(pyb_wfe_obj);
 MP_DECLARE_CONST_FUN_OBJ_0(pyb_disable_irq_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(pyb_enable_irq_obj);
 MP_DECLARE_CONST_FUN_OBJ_0(pyb_irq_stats_obj);

--- a/stmhal/modmachine.c
+++ b/stmhal/modmachine.c
@@ -530,7 +530,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
 #if MICROPY_HW_ENABLE_RNG
     { MP_ROM_QSTR(MP_QSTR_rng),                 MP_ROM_PTR(&pyb_rng_get_obj) },
 #endif
-    { MP_ROM_QSTR(MP_QSTR_idle),                MP_ROM_PTR(&pyb_wfi_obj) },
+    { MP_ROM_QSTR(MP_QSTR_idle),                MP_ROM_PTR(&pyb_wfe_obj) },
     { MP_ROM_QSTR(MP_QSTR_sleep),               MP_ROM_PTR(&machine_sleep_obj) },
     { MP_ROM_QSTR(MP_QSTR_deepsleep),           MP_ROM_PTR(&machine_deepsleep_obj) },
     { MP_ROM_QSTR(MP_QSTR_reset_cause),         MP_ROM_PTR(&machine_reset_cause_obj) },

--- a/stmhal/modpyb.c
+++ b/stmhal/modpyb.c
@@ -119,7 +119,7 @@ STATIC const mp_rom_map_elem_t pyb_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_unique_id), MP_ROM_PTR(&machine_unique_id_obj) },
     { MP_ROM_QSTR(MP_QSTR_freq), MP_ROM_PTR(&machine_freq_obj) },
     { MP_ROM_QSTR(MP_QSTR_repl_info), MP_ROM_PTR(&pyb_set_repl_info_obj) },
-
+    { MP_ROM_QSTR(MP_QSTR_wfe), MP_ROM_PTR(&pyb_wfe_obj) },
     { MP_ROM_QSTR(MP_QSTR_wfi), MP_ROM_PTR(&pyb_wfi_obj) },
     { MP_ROM_QSTR(MP_QSTR_disable_irq), MP_ROM_PTR(&pyb_disable_irq_obj) },
     { MP_ROM_QSTR(MP_QSTR_enable_irq), MP_ROM_PTR(&pyb_enable_irq_obj) },

--- a/teensy/teensy_hal.h
+++ b/teensy/teensy_hal.h
@@ -112,6 +112,10 @@ __attribute__(( always_inline )) static inline void __WFI(void) {
   __asm volatile ("wfi");
 }
 
+__attribute__(( always_inline )) static inline void __WFE(void) {
+  __asm volatile ("wfe");
+}
+
 void mp_hal_set_interrupt_char(int c);
 
 void mp_hal_gpio_clock_enable(GPIO_TypeDef *gpio);


### PR DESCRIPTION
The wfi instruction puts the CPU into sleep mode unconditionally which means that it will go to sleep even if there is a pending interrupt. the result is that in some cases, pending interrupts will not be seviced until some other event wakes the CPU. Wfe on the other hand, does not put the cpu to sleep if there is a pending interrupt. So in most cases it is safer to call wfe instead of wfi.

It can be verified with the following code. It is simply a loop that wait for a timer interrupt to happen. Timer 2 is only used to measure the number of 10s of us that elapses between the interrupt and the execution of the main contents of the loop. Running this will eventually result in a maximum delay of 1ms. I guess that the situation is saved by the systick. Replacing pyb.wfi() with pyb.wfe() results in a maximum delay of 40 us even after an longer period of execution.

```python
import pyb
import gc
from pyb import Pin

flag = False
t1 = 0
t2 = 0

pin = Pin('X1', Pin.OUT_PP)
#10us
tim2 = pyb.Timer(2, prescaler=840, period=0x3FFFFFFF)
tim4 = pyb.Timer(4, freq=12)

def cb(t):
    global flag
    global t1
    t1 = tim2.counter()
    flag = True    

tim4.callback(cb)
tmax = 0
print('start')
while True:
    if not flag:
        pin.low()
        pyb.wfi()
        #pass
        pin.high()
    else:    
        t2 = tim2.counter()
        flag = False
        #t2 = tim2.counter()
        diff = t2-t1
        if diff > tmax:
            tmax = diff
        print(diff, tmax)
        gc.collect()

```
