### PR TITLE
extmod/modlwip: ioctl POLL: Fix handling of peer closed socket.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -1143,8 +1143,11 @@ STATIC mp_uint_t lwip_socket_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_
             ret |= MP_STREAM_POLL_WR;
         }
 
-        if (flags & MP_STREAM_POLL_HUP && socket->state == STATE_PEER_CLOSED) {
-            ret |= MP_STREAM_POLL_HUP;
+        if (socket->state == STATE_PEER_CLOSED) {
+            // Peer-closed socket is both readable and writable: read will
+            // return EOF, write - error. Without this poll will hang on a
+            // socket which was closed by peer.
+            ret |= flags & (MP_STREAM_POLL_RD | MP_STREAM_POLL_WR);
         }
 
     } else {


### PR DESCRIPTION
Peer-closed socket is both readable and writable: read will return EOF,
write - error. Without this poll will hang on such socket.

Note that we don't return POLLHUP, based on argumentation in
http://www.greenend.org.uk/rjk/tech/poll.html that it should apply to
deeper disconnects, for example for networking, that would be link layer
disconnect (e.g. WiFi went down).