### PR TITLE
Implement vfs ilistdir()

### DIFF
--- a/cc3200/mods/moduos.c
+++ b/cc3200/mods/moduos.c
@@ -155,6 +155,7 @@ STATIC const mp_map_elem_t os_module_globals_table[] = {
 
     { MP_OBJ_NEW_QSTR(MP_QSTR_chdir),           (mp_obj_t)&mp_vfs_chdir_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_getcwd),          (mp_obj_t)&mp_vfs_getcwd_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ilistdir),        (mp_obj_t)&mp_vfs_ilistdir_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_listdir),         (mp_obj_t)&mp_vfs_listdir_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_mkdir),           (mp_obj_t)&mp_vfs_mkdir_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_rename),          (mp_obj_t)&mp_vfs_rename_obj},

--- a/esp8266/moduos.c
+++ b/esp8266/moduos.c
@@ -93,6 +93,7 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     #endif
     #if MICROPY_VFS_FAT
     { MP_ROM_QSTR(MP_QSTR_VfsFat), MP_ROM_PTR(&mp_fat_vfs_type) },
+    { MP_ROM_QSTR(MP_QSTR_ilistdir), MP_ROM_PTR(&mp_vfs_ilistdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_listdir), MP_ROM_PTR(&mp_vfs_listdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_mkdir), MP_ROM_PTR(&mp_vfs_mkdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_rmdir), MP_ROM_PTR(&mp_vfs_rmdir_obj) },

--- a/extmod/vfs.c
+++ b/extmod/vfs.c
@@ -286,7 +286,49 @@ mp_obj_t mp_vfs_getcwd(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(mp_vfs_getcwd_obj, mp_vfs_getcwd);
 
-mp_obj_t mp_vfs_listdir(size_t n_args, const mp_obj_t *args) {
+typedef struct _mp_vfs_ilistdir_it_t {
+    mp_obj_base_t base;
+    mp_fun_1_t iternext;
+    union {
+        mp_vfs_mount_t *vfs;
+        mp_obj_t iter;
+    } cur;
+    bool is_str;
+    bool is_iter;
+} mp_vfs_ilistdir_it_t;
+
+STATIC mp_obj_t mp_vfs_ilistdir_it_iternext(mp_obj_t self_in) {
+    mp_vfs_ilistdir_it_t *self = MP_OBJ_TO_PTR(self_in);
+    if (self->is_iter) {
+        // continue delegating to root dir
+        return mp_iternext(self->cur.iter);
+    } else if (self->cur.vfs == NULL) {
+        // finished iterating mount points and no root dir is mounted
+        return MP_OBJ_STOP_ITERATION;
+    } else {
+        // continue iterating mount points
+        mp_vfs_mount_t *vfs = self->cur.vfs;
+        self->cur.vfs = vfs->next;
+        if (vfs->len == 1) {
+            // vfs is mounted at root dir, delegate to it
+            mp_obj_t root = mp_obj_new_str("/", 1, false);
+            self->is_iter = true;
+            self->cur.iter = mp_vfs_proxy_call(vfs, MP_QSTR_ilistdir, 1, &root);
+            return mp_iternext(self->cur.iter);
+        } else {
+            // a mounted directory
+            mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(3, NULL));
+            t->items[0] = mp_obj_new_str_of_type(
+                self->is_str ? &mp_type_str : &mp_type_bytes,
+                (const byte*)vfs->str + 1, vfs->len - 1);
+            t->items[1] = MP_OBJ_NEW_SMALL_INT(MP_S_IFDIR);
+            t->items[2] = MP_OBJ_NEW_SMALL_INT(0); // no inode number
+            return MP_OBJ_FROM_PTR(t);
+        }
+    }
+}
+
+mp_obj_t mp_vfs_ilistdir(size_t n_args, const mp_obj_t *args) {
     mp_obj_t path_in;
     if (n_args == 1) {
         path_in = args[0];
@@ -299,22 +341,29 @@ mp_obj_t mp_vfs_listdir(size_t n_args, const mp_obj_t *args) {
 
     if (vfs == MP_VFS_ROOT) {
         // list the root directory
-        mp_obj_t dir_list = mp_obj_new_list(0, NULL);
-        for (vfs = MP_STATE_VM(vfs_mount_table); vfs != NULL; vfs = vfs->next) {
-            if (vfs->len == 1) {
-                // vfs is mounted at root dir, delegate to it
-                mp_obj_t root = mp_obj_new_str("/", 1, false);
-                mp_obj_t dir_list2 = mp_vfs_proxy_call(vfs, MP_QSTR_listdir, 1, &root);
-                dir_list = mp_binary_op(MP_BINARY_OP_ADD, dir_list, dir_list2);
-            } else {
-                mp_obj_list_append(dir_list, mp_obj_new_str_of_type(mp_obj_get_type(path_in),
-                    (const byte*)vfs->str + 1, vfs->len - 1));
-            }
-        }
-        return dir_list;
+        mp_vfs_ilistdir_it_t *iter = m_new_obj(mp_vfs_ilistdir_it_t);
+        iter->base.type = &mp_type_polymorph_iter;
+        iter->iternext = mp_vfs_ilistdir_it_iternext;
+        iter->cur.vfs = MP_STATE_VM(vfs_mount_table);
+        iter->is_str = mp_obj_get_type(path_in) == &mp_type_str;
+        iter->is_iter = false;
+        return MP_OBJ_FROM_PTR(iter);
     }
 
-    return mp_vfs_proxy_call(vfs, MP_QSTR_listdir, 1, &path_out);
+    return mp_vfs_proxy_call(vfs, MP_QSTR_ilistdir, 1, &path_out);
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_vfs_ilistdir_obj, 0, 1, mp_vfs_ilistdir);
+
+mp_obj_t mp_vfs_listdir(size_t n_args, const mp_obj_t *args) {
+    mp_obj_t iter = mp_vfs_ilistdir(n_args, args);
+    mp_obj_t dir_list = mp_obj_new_list(0, NULL);
+    mp_obj_t next;
+    while ((next = mp_iternext(iter)) != MP_OBJ_STOP_ITERATION) {
+        mp_obj_t *items;
+        mp_obj_get_array_fixed_n(next, 3, &items);
+        mp_obj_list_append(dir_list, items[0]);
+    }
+    return dir_list;
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_vfs_listdir_obj, 0, 1, mp_vfs_listdir);
 

--- a/extmod/vfs.h
+++ b/extmod/vfs.h
@@ -35,6 +35,10 @@
 #define MP_VFS_NONE ((mp_vfs_mount_t*)1)
 #define MP_VFS_ROOT ((mp_vfs_mount_t*)0)
 
+// MicroPython's port-standardized versions of stat constants
+#define MP_S_IFDIR (0x4000)
+#define MP_S_IFREG (0x8000)
+
 // constants for block protocol ioctl
 #define BP_IOCTL_INIT           (1)
 #define BP_IOCTL_DEINIT         (2)
@@ -56,6 +60,7 @@ mp_obj_t mp_vfs_umount(mp_obj_t mnt_in);
 mp_obj_t mp_vfs_open(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
 mp_obj_t mp_vfs_chdir(mp_obj_t path_in);
 mp_obj_t mp_vfs_getcwd(void);
+mp_obj_t mp_vfs_ilistdir(size_t n_args, const mp_obj_t *args);
 mp_obj_t mp_vfs_listdir(size_t n_args, const mp_obj_t *args);
 mp_obj_t mp_vfs_mkdir(mp_obj_t path_in);
 mp_obj_t mp_vfs_remove(mp_obj_t path_in);
@@ -69,6 +74,7 @@ MP_DECLARE_CONST_FUN_OBJ_1(mp_vfs_umount_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(mp_vfs_open_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(mp_vfs_chdir_obj);
 MP_DECLARE_CONST_FUN_OBJ_0(mp_vfs_getcwd_obj);
+MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mp_vfs_ilistdir_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mp_vfs_listdir_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(mp_vfs_mkdir_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(mp_vfs_remove_obj);

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -91,7 +91,7 @@ STATIC MP_DEFINE_CONST_STATICMETHOD_OBJ(fat_vfs_mkfs_obj, MP_ROM_PTR(&fat_vfs_mk
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(fat_vfs_open_obj, fatfs_builtin_open_self);
 
-STATIC mp_obj_t fat_vfs_listdir_func(size_t n_args, const mp_obj_t *args) {
+STATIC mp_obj_t fat_vfs_ilistdir_func(size_t n_args, const mp_obj_t *args) {
     mp_obj_fat_vfs_t *self = MP_OBJ_TO_PTR(args[0]);
     bool is_str_type = true;
     const char *path;
@@ -104,9 +104,9 @@ STATIC mp_obj_t fat_vfs_listdir_func(size_t n_args, const mp_obj_t *args) {
         path = "";
     }
 
-    return fat_vfs_listdir2(self, path, is_str_type);
+    return fat_vfs_ilistdir2(self, path, is_str_type);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(fat_vfs_listdir_obj, 1, 2, fat_vfs_listdir_func);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(fat_vfs_ilistdir_obj, 1, 2, fat_vfs_ilistdir_func);
 
 STATIC mp_obj_t fat_vfs_remove_internal(mp_obj_t vfs_in, mp_obj_t path_in, mp_int_t attr) {
     mp_obj_fat_vfs_t *self = MP_OBJ_TO_PTR(vfs_in);
@@ -321,7 +321,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(fat_vfs_umount_obj, vfs_fat_umount);
 STATIC const mp_rom_map_elem_t fat_vfs_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_mkfs), MP_ROM_PTR(&fat_vfs_mkfs_obj) },
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&fat_vfs_open_obj) },
-    { MP_ROM_QSTR(MP_QSTR_listdir), MP_ROM_PTR(&fat_vfs_listdir_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ilistdir), MP_ROM_PTR(&fat_vfs_ilistdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_mkdir), MP_ROM_PTR(&fat_vfs_mkdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_rmdir), MP_ROM_PTR(&fat_vfs_rmdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_chdir), MP_ROM_PTR(&fat_vfs_chdir_obj) },

--- a/extmod/vfs_fat.h
+++ b/extmod/vfs_fat.h
@@ -57,4 +57,4 @@ mp_import_stat_t fat_vfs_import_stat(struct _fs_user_mount_t *vfs, const char *p
 mp_obj_t fatfs_builtin_open_self(mp_obj_t self_in, mp_obj_t path, mp_obj_t mode);
 MP_DECLARE_CONST_FUN_OBJ_KW(mp_builtin_open_obj);
 
-mp_obj_t fat_vfs_listdir2(struct _fs_user_mount_t *vfs, const char *path, bool is_str_type);
+mp_obj_t fat_vfs_ilistdir2(struct _fs_user_mount_t *vfs, const char *path, bool is_str_type);

--- a/extmod/vfs_fat_misc.c
+++ b/extmod/vfs_fat_misc.c
@@ -34,51 +34,64 @@
 #include "extmod/vfs_fat.h"
 #include "py/lexer.h"
 
-// TODO: actually, the core function should be ilistdir()
-
-mp_obj_t fat_vfs_listdir2(fs_user_mount_t *vfs, const char *path, bool is_str_type) {
-    FRESULT res;
-    FILINFO fno;
+typedef struct _mp_vfs_fat_ilistdir_it_t {
+    mp_obj_base_t base;
+    mp_fun_1_t iternext;
+    bool is_str;
     FF_DIR dir;
+} mp_vfs_fat_ilistdir_it_t;
 
-    res = f_opendir(&vfs->fatfs, &dir, path);
+STATIC mp_obj_t mp_vfs_fat_ilistdir_it_iternext(mp_obj_t self_in) {
+    mp_vfs_fat_ilistdir_it_t *self = MP_OBJ_TO_PTR(self_in);
+
+    for (;;) {
+        FILINFO fno;
+        FRESULT res = f_readdir(&self->dir, &fno);
+        char *fn = fno.fname;
+        if (res != FR_OK || fn[0] == 0) {
+            // stop on error or end of dir
+            break;
+        }
+        if (fn[0] == '.' && (fn[1] == 0 || (fn[1] == '.' && fn[2] == 0))) {
+            // skip . and ..
+            continue;
+        }
+
+        // make 3-tuple with info about this entry
+        mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(3, NULL));
+        if (self->is_str) {
+            t->items[0] = mp_obj_new_str(fn, strlen(fn), false);
+        } else {
+            t->items[0] = mp_obj_new_bytes((const byte*)fn, strlen(fn));
+        }
+        if (fno.fattrib & AM_DIR) {
+            // dir
+            t->items[1] = MP_OBJ_NEW_SMALL_INT(MP_S_IFDIR);
+        } else {
+            // file
+            t->items[1] = MP_OBJ_NEW_SMALL_INT(MP_S_IFREG);
+        }
+        t->items[2] = MP_OBJ_NEW_SMALL_INT(0); // no inode number
+
+        return MP_OBJ_FROM_PTR(t);
+    }
+
+    // ignore error because we may be closing a second time
+    f_closedir(&self->dir);
+
+    return MP_OBJ_STOP_ITERATION;
+}
+
+mp_obj_t fat_vfs_ilistdir2(fs_user_mount_t *vfs, const char *path, bool is_str_type) {
+    mp_vfs_fat_ilistdir_it_t *iter = m_new_obj(mp_vfs_fat_ilistdir_it_t);
+    iter->base.type = &mp_type_polymorph_iter;
+    iter->iternext = mp_vfs_fat_ilistdir_it_iternext;
+    iter->is_str = is_str_type;
+    FRESULT res = f_opendir(&vfs->fatfs, &iter->dir, path);
     if (res != FR_OK) {
         mp_raise_OSError(fresult_to_errno_table[res]);
     }
-
-    mp_obj_t dir_list = mp_obj_new_list(0, NULL);
-
-    for (;;) {
-        res = f_readdir(&dir, &fno);                   /* Read a directory item */
-        if (res != FR_OK || fno.fname[0] == 0) break;  /* Break on error or end of dir */
-        if (fno.fname[0] == '.' && fno.fname[1] == 0) continue;             /* Ignore . entry */
-        if (fno.fname[0] == '.' && fno.fname[1] == '.' && fno.fname[2] == 0) continue;             /* Ignore .. entry */
-
-        char *fn = fno.fname;
-
-        /*
-        if (fno.fattrib & AM_DIR) {
-            // dir
-        } else {
-            // file
-        }
-        */
-
-        // make a string object for this entry
-        mp_obj_t entry_o;
-        if (is_str_type) {
-            entry_o = mp_obj_new_str(fn, strlen(fn), false);
-        } else {
-            entry_o = mp_obj_new_bytes((const byte*)fn, strlen(fn));
-        }
-
-        // add the entry to the list
-        mp_obj_list_append(dir_list, entry_o);
-    }
-
-    f_closedir(&dir);
-
-    return dir_list;
+    return MP_OBJ_FROM_PTR(iter);
 }
 
 mp_import_stat_t fat_vfs_import_stat(fs_user_mount_t *vfs, const char *path) {

--- a/qemu-arm/moduos.c
+++ b/qemu-arm/moduos.c
@@ -31,6 +31,7 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_chdir), MP_ROM_PTR(&mp_vfs_chdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_getcwd), MP_ROM_PTR(&mp_vfs_getcwd_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ilistdir), MP_ROM_PTR(&mp_vfs_ilistdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_listdir), MP_ROM_PTR(&mp_vfs_listdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_mkdir), MP_ROM_PTR(&mp_vfs_mkdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&mp_vfs_remove_obj) },

--- a/stmhal/moduos.c
+++ b/stmhal/moduos.c
@@ -135,6 +135,7 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_chdir), MP_ROM_PTR(&mp_vfs_chdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_getcwd), MP_ROM_PTR(&mp_vfs_getcwd_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ilistdir), MP_ROM_PTR(&mp_vfs_ilistdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_listdir), MP_ROM_PTR(&mp_vfs_listdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_mkdir), MP_ROM_PTR(&mp_vfs_mkdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&mp_vfs_remove_obj) },

--- a/tests/extmod/vfs_basic.py
+++ b/tests/extmod/vfs_basic.py
@@ -20,9 +20,9 @@ class Filesystem:
         print(self.id, 'mount', readonly, mkfs)
     def umount(self):
         print(self.id, 'umount')
-    def listdir(self, dir):
-        print(self.id, 'listdir', dir)
-        return ['a%d' % self.id]
+    def ilistdir(self, dir):
+        print(self.id, 'ilistdir', dir)
+        return iter([('a%d' % self.id, 0, 0)])
     def chdir(self, dir):
         print(self.id, 'chdir', dir)
     def getcwd(self):
@@ -63,6 +63,18 @@ print(uos.getcwd())
 # basic mounting and listdir
 uos.mount(Filesystem(1), '/test_mnt')
 print(uos.listdir())
+
+# ilistdir
+i = uos.ilistdir()
+print(next(i))
+try:
+    next(i)
+except StopIteration:
+    print('StopIteration')
+try:
+    next(i)
+except StopIteration:
+    print('StopIteration')
 
 # referencing the mount point in different ways
 print(uos.listdir('test_mnt'))

--- a/tests/extmod/vfs_basic.py.exp
+++ b/tests/extmod/vfs_basic.py.exp
@@ -2,20 +2,23 @@
 /
 1 mount False False
 ['test_mnt']
-1 listdir /
+('test_mnt', 16384, 0)
+StopIteration
+StopIteration
+1 ilistdir /
 ['a1']
-1 listdir /
+1 ilistdir /
 ['a1']
 2 mount True False
 ['test_mnt', 'test_mnt2']
-2 listdir /
+2 ilistdir /
 ['a2']
 3 mount False False
 OSError
 OSError
 OSError
 1 chdir /
-1 listdir 
+1 ilistdir 
 ['a1']
 1 getcwd
 /test_mntdir1
@@ -33,19 +36,19 @@ OSError
 2 umount
 OSError
 3 mount False False
-3 listdir /
+3 ilistdir /
 ['a3']
 3 open test r
 4 mount False False
-3 listdir /
+3 ilistdir /
 ['mnt', 'a3']
-4 listdir /
+4 ilistdir /
 ['a4']
 4 chdir /
-4 listdir 
+4 ilistdir 
 ['a4']
 3 chdir /subdir
-3 listdir 
+3 ilistdir 
 ['a3']
 3 chdir /
 3 umount

--- a/tests/extmod/vfs_fat_fileio1.py
+++ b/tests/extmod/vfs_fat_fileio1.py
@@ -115,4 +115,4 @@ except OSError as e:
     print(e.args[0] == 20) # uerrno.ENOTDIR
 
 vfs.remove("foo_file.txt")
-print(vfs.listdir())
+print(list(vfs.ilistdir()))

--- a/tests/extmod/vfs_fat_fileio1.py.exp
+++ b/tests/extmod/vfs_fat_fileio1.py.exp
@@ -10,4 +10,4 @@ e
 True
 d
 True
-['foo_dir']
+[('foo_dir', 16384, 0)]

--- a/tests/extmod/vfs_fat_fileio2.py
+++ b/tests/extmod/vfs_fat_fileio2.py
@@ -91,23 +91,23 @@ except OSError as e:
 
 # trim full path
 vfs.rename("foo_dir/file-in-dir.txt", "foo_dir/file.txt")
-print(vfs.listdir("foo_dir"))
+print(list(vfs.ilistdir("foo_dir")))
 
 vfs.rename("foo_dir/file.txt", "moved-to-root.txt")
-print(vfs.listdir())
+print(list(vfs.ilistdir()))
 
 # check that renaming to existing file will overwrite it
 with open("temp", "w") as f:
     f.write("new text")
 vfs.rename("temp", "moved-to-root.txt")
-print(vfs.listdir())
+print(list(vfs.ilistdir()))
 with open("moved-to-root.txt") as f:
     print(f.read())
 
 # valid removes
 vfs.remove("foo_dir/sub_file.txt")
 vfs.rmdir("foo_dir")
-print(vfs.listdir())
+print(list(vfs.ilistdir()))
 
 # disk full
 try:

--- a/tests/extmod/vfs_fat_fileio2.py.exp
+++ b/tests/extmod/vfs_fat_fileio2.py.exp
@@ -3,9 +3,9 @@ True
 True
 b'data in file'
 True
-['sub_file.txt', 'file.txt']
-['foo_dir', 'moved-to-root.txt']
-['foo_dir', 'moved-to-root.txt']
+[('sub_file.txt', 32768, 0), ('file.txt', 32768, 0)]
+[('foo_dir', 16384, 0), ('moved-to-root.txt', 32768, 0)]
+[('foo_dir', 16384, 0), ('moved-to-root.txt', 32768, 0)]
 new text
-['moved-to-root.txt']
+[('moved-to-root.txt', 32768, 0)]
 ENOSPC: True

--- a/tests/extmod/vfs_fat_oldproto.py
+++ b/tests/extmod/vfs_fat_oldproto.py
@@ -53,10 +53,10 @@ uos.mount(vfs, "/ramdisk")
 with vfs.open("file.txt", "w") as f:
     f.write("hello!")
 
-print(vfs.listdir())
+print(list(vfs.ilistdir()))
 
 with vfs.open("file.txt", "r") as f:
     print(f.read())
 
 vfs.remove("file.txt")
-print(vfs.listdir())
+print(list(vfs.ilistdir()))

--- a/tests/extmod/vfs_fat_oldproto.py.exp
+++ b/tests/extmod/vfs_fat_oldproto.py.exp
@@ -1,3 +1,3 @@
-['file.txt']
+[('file.txt', 32768, 0)]
 hello!
 []

--- a/tests/extmod/vfs_fat_ramdisk.py
+++ b/tests/extmod/vfs_fat_ramdisk.py
@@ -65,7 +65,7 @@ except OSError as e:
 
 with vfs.open("foo_file.txt", "w") as f:
     f.write("hello!")
-print(vfs.listdir())
+print(list(vfs.ilistdir()))
 
 print("stat root:", vfs.stat("/"))
 print("stat file:", vfs.stat("foo_file.txt")[:-3]) # timestamps differ across runs
@@ -76,7 +76,7 @@ print(b"hello!" in bdev.data)
 vfs.mkdir("foo_dir")
 vfs.chdir("foo_dir")
 print("getcwd:", vfs.getcwd())
-print(vfs.listdir())
+print(list(vfs.ilistdir()))
 
 with vfs.open("sub_file.txt", "w") as f:
     f.write("subdir file")
@@ -92,4 +92,4 @@ print("getcwd:", vfs.getcwd())
 uos.umount(vfs)
 
 vfs = uos.VfsFat(bdev)
-print(vfs.listdir(b""))
+print(list(vfs.ilistdir(b"")))

--- a/tests/extmod/vfs_fat_ramdisk.py.exp
+++ b/tests/extmod/vfs_fat_ramdisk.py.exp
@@ -3,7 +3,7 @@ True
 statvfs: (512, 512, 16, 16, 16, 0, 0, 0, 0, 255)
 getcwd: /
 True
-['foo_file.txt']
+[('foo_file.txt', 32768, 0)]
 stat root: (16384, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 stat file: (32768, 0, 0, 0, 0, 0, 6)
 True
@@ -12,4 +12,4 @@ getcwd: /foo_dir
 []
 True
 getcwd: /
-[b'foo_file.txt', b'foo_dir']
+[(b'foo_file.txt', 32768, 0), (b'foo_dir', 16384, 0)]

--- a/unix/moduos_vfs.c
+++ b/unix/moduos_vfs.c
@@ -42,6 +42,7 @@ STATIC const mp_rom_map_elem_t uos_vfs_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_chdir), MP_ROM_PTR(&mp_vfs_chdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_getcwd), MP_ROM_PTR(&mp_vfs_getcwd_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ilistdir), MP_ROM_PTR(&mp_vfs_ilistdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_listdir), MP_ROM_PTR(&mp_vfs_listdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_mkdir), MP_ROM_PTR(&mp_vfs_mkdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&mp_vfs_remove_obj) },


### PR DESCRIPTION
This PR implements mp_vfs_ilistdir(), and rewrites mp_vfs_listdir() in terms of it.

It also changes VfsFat.listdir() to VfsFat.ilistdir().

Tests are updated and ilistdir() is added to ports uos module.

TODO:
- check what numbers to use for 2nd entry in returned tuple; currently it uses 0x4000 for dirs, 0x8000 for files
- check if FAT FS has something to put in the 3rd entry in the tuple, the "inode"
- test on esp8266 and pyboard
- add tests for calling next() on an exhausted ilistdir iterator, to ensure it raises StopIteration again and doesn't crash