### PR TITLE
esp8266/modnetwork.c: Add network.wlan.sniffer() function.

### DIFF
--- a/esp8266/ieee80211.h
+++ b/esp8266/ieee80211.h
@@ -1,0 +1,55 @@
+#ifndef __IEEE80211_H__
+#define __IEEE80211_H__
+#include <ctype.h>
+
+/* ==============================================
+ * Promiscous callback structures, see ESP manual
+ * ============================================== */
+ 
+struct RxControl {
+    signed rssi:8;
+    unsigned rate:4;
+    unsigned is_group:1;
+    unsigned:1;
+    unsigned sig_mode:2;
+    unsigned legacy_length:12;
+    unsigned damatch0:1;
+    unsigned damatch1:1;
+    unsigned bssidmatch0:1;
+    unsigned bssidmatch1:1;
+    unsigned MCS:7;
+    unsigned CWB:1;
+    unsigned HT_length:16;
+    unsigned Smoothing:1;
+    unsigned Not_Sounding:1;
+    unsigned:1;
+    unsigned Aggregation:1;
+    unsigned STBC:2;
+    unsigned FEC_CODING:1;
+    unsigned SGI:1;
+    unsigned rxend_state:8;
+    unsigned ampdu_cnt:8;
+    unsigned channel:4;
+    unsigned:12;
+};
+ 
+struct LenSeq {
+    uint16_t length;
+    uint16_t seq;
+    uint8_t  address3[6];
+};
+
+struct sniffer_buf {
+    struct RxControl rx_ctrl;
+    uint8_t buf[36];
+    uint16_t cnt;
+    struct LenSeq lenseq[1];
+};
+
+struct sniffer_buf2{
+    struct RxControl rx_ctrl;
+    uint8_t buf[112];
+    uint16_t cnt;
+    uint16_t len;
+};
+#endif

--- a/esp8266/modnetwork.c
+++ b/esp8266/modnetwork.c
@@ -30,6 +30,7 @@
 
 #include "py/nlr.h"
 #include "py/objlist.h"
+#include "py/objstr.h"
 #include "py/runtime.h"
 #include "py/mphal.h"
 #include "lib/netutils/netutils.h"
@@ -200,6 +201,116 @@ STATIC mp_obj_t esp_scan(mp_obj_t self_in) {
     return list;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_scan_obj, esp_scan);
+
+STATIC mp_obj_t *esp_sniffer_list = NULL;
+STATIC mp_obj_t esp_sniffer_mac_filter;
+
+STATIC void esp_sniffer_cb(void *result, uint16_t len){
+    if (esp_sniffer_list == NULL){
+        return ;
+    }
+    if (len > 27){
+        nlr_buf_t nlr;
+        if(nlr_push(&nlr) == 0){
+            mp_obj_t source = mp_obj_new_bytes((const byte *)result + 16, 6);
+            mp_obj_t dest = mp_obj_new_bytes((const byte *)result + 22, 6);
+
+            if ((esp_sniffer_mac_filter != mp_const_empty_bytes) &&\
+                    (!mp_obj_str_equal(esp_sniffer_mac_filter, source))){
+                nlr_pop();
+                return ;
+            }
+
+            mp_obj_t *mac_items;
+            size_t mac_num;
+            mp_obj_list_get(*esp_sniffer_list, &mac_num, &mac_items);
+            for(uint16_t i = 0; i < mac_num; i ++){
+                size_t item_num;
+                mp_obj_t *items;
+                mp_obj_tuple_get(mac_items[i], &item_num, &items);
+                if (mp_obj_str_equal(items[0], source) && mp_obj_str_equal(items[1], dest)){
+                    items[2] = mp_obj_new_int_from_uint(MP_OBJ_SMALL_INT_VALUE(items[2])+1);
+                    nlr_pop();
+                    return ;
+                }
+            }
+            mp_obj_tuple_t *t = mp_obj_new_tuple(3, NULL);
+            t->items[0] = source;
+            t->items[1] = dest;
+            t->items[2] = mp_obj_new_int_from_uint(1);
+            mp_obj_list_append(*esp_sniffer_list, MP_OBJ_FROM_PTR(t));
+            nlr_pop();
+        } else {
+            mp_obj_print_exception(&mp_plat_print, MP_OBJ_FROM_PTR(nlr.ret_val));
+            *esp_sniffer_list = MP_OBJ_NULL;
+        }
+    }
+}
+
+STATIC mp_obj_t esp_sniffer(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args){
+    require_if(pos_args[0], STATION_IF);
+    if ((wifi_get_opmode() & STATION_MODE) == 0){
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError,
+                    "STA must be active"));
+    }
+
+    enum {ARG_mac, ARG_ch, ARG_timeout};
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_mac, MP_ARG_OBJ, {.u_obj = mp_const_empty_bytes} },
+        { MP_QSTR_ch, MP_ARG_INT, {.u_int = 1} },
+        { MP_QSTR_timeout, MP_ARG_INT, {.u_int = 1} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    
+    if (MP_OBJ_IS_STR_OR_BYTES(args[ARG_mac].u_obj)){
+        esp_sniffer_mac_filter = args[ARG_mac].u_obj;
+    }else{
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_TypeError,
+                    "invalid mac type"));
+    }
+
+    uint32_t ch = args[ARG_ch].u_int;
+    uint32_t timeout_us = args[ARG_timeout].u_int * 1000000;
+    timeout_us  = timeout_us > 1000000? timeout_us : 1000000;
+
+    mp_obj_t list = mp_obj_new_list(0, NULL);
+    esp_sniffer_list = &list;
+
+    //Disconnect all connections
+    wifi_station_disconnect();
+    //Register the callback function
+    wifi_set_promiscuous_rx_cb((wifi_promiscuous_cb_t)esp_sniffer_cb);
+    //Set the channel
+    wifi_set_channel(ch);
+    //Set the mac address to filter
+    /*
+    if (args[ARG_mac].u_obj != mp_const_none){
+        wifi_promiscuous_set_mac((const uint8_t *)mac);
+    }
+    */
+    wifi_promiscuous_enable(1);
+    uint32_t start = system_get_time();
+    while (esp_sniffer_list != NULL){
+        if (MP_STATE_VM(mp_pending_exception) != NULL){
+            esp_sniffer_list = NULL;
+            mp_obj_t obj = MP_STATE_VM(mp_pending_exception);
+            MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
+            nlr_raise(obj);
+        }
+        if (system_get_time() - start >= timeout_us){
+            esp_sniffer_list = NULL;
+        }
+        ets_loop_iter();
+    }
+    if (list == MP_OBJ_NULL){
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "sniffer failed"));
+    }
+    wifi_promiscuous_enable(0);
+    return list;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp_sniffer_obj, 1, esp_sniffer);
 
 /// \method isconnected()
 /// Return True if connected to an AP and an IP address has been assigned,
@@ -433,6 +544,7 @@ STATIC const mp_map_elem_t wlan_if_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_disconnect), (mp_obj_t)&esp_disconnect_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_status), (mp_obj_t)&esp_status_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_scan), (mp_obj_t)&esp_scan_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_sniffer), (mp_obj_t)&esp_sniffer_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_isconnected), (mp_obj_t)&esp_isconnected_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_config), (mp_obj_t)&esp_config_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ifconfig), (mp_obj_t)&esp_ifconfig_obj },


### PR DESCRIPTION
I noticed that esp8266 has a promiscuous mode.So I use this mode to write a sniffer function.This function sniffs the mac address of the device that is linked to the specified device.

#### Function definition:
>class wlan.network.sniffer(mac=*, ch=1, timeout=1)
>[(source mac, dest mac, Number of packets captured)]

#### Example:
```python
>> import network
>> ap = network.WLAN(network.AP_IF)
>> ap.active(False)  #First: Close AP mode
>> sta = network.WLAN(network.STA_IF)
>> sta.active(True) #Second: Open STA mode
>> sta.scan() #Scan all AP
[(b'Drone', b'\xa8\x15M@\xe98', 1, -35, 4, 0), (b'EXCEL', b'\x0cr,x\x88\xc0', 1, -62, 4, 0), (b'ics543', b'$ih\x8f\x8c\x8e', 1, -56, 4, 0), (b'ics542', b'\xa8\x15M\xe7\n\xf8', 1, -60, 4, 0), (b'TP-LINK_15C4', b'\xd0\xc7\xc0\x84\x15\xc4', 1, -57, 4, 0), (b'Jedi', b'\xd4\xee\x07\x15D\xd6', 1, -72, 4, 0)]
>>> sta.sniffer(mac= b'\xa8\x15M@\xe98', ch=1, timeout=10) #sniffs specified device 10s
[(b'\xa8\x15M@\xe98', b'\x8cpZ\xeeL`', 84), (b'\xa8\x15M@\xe98', b'`\x834\xbd\xf5:', 1)]
```
