### PR TITLE
py/sequence: Return early from mp_seq_multiply if len is zero.

### DIFF
--- a/py/objlist.c
+++ b/py/objlist.c
@@ -129,7 +129,7 @@ STATIC mp_obj_t list_binary_op(mp_uint_t op, mp_obj_t lhs, mp_obj_t rhs) {
             if (!mp_obj_get_int_maybe(rhs, &n)) {
                 return MP_OBJ_NULL; // op not supported
             }
-            if (n < 0) {
+            if (n < 0 || o->len == 0) {
                 n = 0;
             }
             mp_obj_list_t *s = list_new(o->len * n);

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -305,7 +305,7 @@ mp_obj_t mp_obj_str_binary_op(mp_uint_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
         if (!mp_obj_get_int_maybe(rhs_in, &n)) {
             return MP_OBJ_NULL; // op not supported
         }
-        if (n <= 0) {
+        if (n <= 0 || lhs_len == 0) {
             if (lhs_type == &mp_type_str) {
                 return MP_OBJ_NEW_QSTR(MP_QSTR_); // empty str
             } else {

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -153,7 +153,7 @@ mp_obj_t mp_obj_tuple_binary_op(mp_uint_t op, mp_obj_t lhs, mp_obj_t rhs) {
             if (!mp_obj_get_int_maybe(rhs, &n)) {
                 return MP_OBJ_NULL; // op not supported
             }
-            if (n <= 0) {
+            if (n <= 0 || o->len == 0) {
                 return mp_const_empty_tuple;
             }
             mp_obj_tuple_t *s = MP_OBJ_TO_PTR(mp_obj_new_tuple(o->len * n, NULL));


### PR DESCRIPTION
Currently, multiplying an empty sequence (tuple, list, or string) with a very large number can take several seconds to execute, even though the operation is effectively a no-op.

This patch makes it so that `mp_seq_multiply` returns early if the `len` argument (the number of items in the sequence being multiplied) is zero, because there's nothing to do.

Putting this check down in mp_seq_multiply seems cleaner than adding an equivalent check to objlist.c, objtuple.c, and objstr.c.