### PR TITLE
esp8266/esp8266.ld, esp8266_ota.ld: Grow main firmware size by 32KB.

### DIFF
--- a/esp8266/esp8266.ld
+++ b/esp8266/esp8266.ld
@@ -5,7 +5,7 @@ MEMORY
     dport0_0_seg : org = 0x3ff00000, len = 0x10
     dram0_0_seg :  org = 0x3ffe8000, len = 0x14000
     iram1_0_seg :  org = 0x40100000, len = 0x8000
-    irom0_0_seg :  org = 0x40209000, len = 0x87000
+    irom0_0_seg :  org = 0x40209000, len = 0x8f000
 }
 
 /* define common sections and symbols */

--- a/esp8266/esp8266_common.ld
+++ b/esp8266/esp8266_common.ld
@@ -19,6 +19,8 @@ EXTERN(_KernelExceptionVector)
 EXTERN(_NMIExceptionVector)
 EXTERN(_UserExceptionVector)
 
+_firmware_size = ORIGIN(irom0_0_seg) + LENGTH(irom0_0_seg) - 0x40200000;
+
 PROVIDE(_memmap_vecbase_reset = 0x40000000);
 
 /* Various memory-map dependent cache attribute settings: */

--- a/esp8266/esp8266_ota.ld
+++ b/esp8266/esp8266_ota.ld
@@ -6,7 +6,7 @@ MEMORY
     dram0_0_seg :  org = 0x3ffe8000, len = 0x14000
     iram1_0_seg :  org = 0x40100000, len = 0x8000
     /* 0x3c000 is size of bootloader, 0x9000 is size of packed RAM segments */
-    irom0_0_seg :  org = 0x40200000 + 0x3c000 + 0x9000, len = 0x87000
+    irom0_0_seg :  org = 0x40200000 + 0x3c000 + 0x9000, len = 0x8f000
 }
 
 /* define common sections and symbols */

--- a/esp8266/modesp.c
+++ b/esp8266/modesp.c
@@ -159,12 +159,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(esp_flash_size_obj, esp_flash_size);
 // we assume there's a yaota8266 bootloader.
 #define IS_OTA_FIRMWARE() ((*(uint32_t*)0x40200000 & 0xff00) == 0x100)
 
+extern byte _firmware_size[];
+
 STATIC mp_obj_t esp_flash_user_start(void) {
-    if (IS_OTA_FIRMWARE()) {
-        return MP_OBJ_NEW_SMALL_INT(0x3c000 + 0x90000);
-    } else {
-        return MP_OBJ_NEW_SMALL_INT(0x90000);
-    }
+    return MP_OBJ_NEW_SMALL_INT((uint32_t)_firmware_size);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(esp_flash_user_start_obj, esp_flash_user_start);
 

--- a/esp8266/modules/flashbdev.py
+++ b/esp8266/modules/flashbdev.py
@@ -3,7 +3,7 @@ import esp
 class FlashBdev:
 
     SEC_SIZE = 4096
-    RESERVED_SECS = 0
+    RESERVED_SECS = 1
     START_SEC = esp.flash_user_start() // SEC_SIZE + RESERVED_SECS
     NUM_BLK = 0x6b - RESERVED_SECS
 


### PR DESCRIPTION
To accommodate both system and user frozen modules.