### PR TITLE
py/lexer: Accept \n or \r after line continuation character.

### DIFF
--- a/py/lexer.c
+++ b/py/lexer.c
@@ -137,23 +137,18 @@ STATIC void next_char(mp_lexer_t *lex) {
     lex->chr1 = lex->chr2;
     lex->chr2 = lex->reader.readbyte(lex->reader.data);
 
-    if (lex->chr0 == '\r') {
+    if (lex->chr1 == '\r') {
         // CR is a new line, converted to LF
-        lex->chr0 = '\n';
-        if (lex->chr1 == '\n') {
-            // CR LF is a single new line
-            lex->chr1 = lex->chr2;
+        lex->chr1 = '\n';
+        if (lex->chr2 == '\n') {
+            // CR LF is a single new line, throw out the extra LF
             lex->chr2 = lex->reader.readbyte(lex->reader.data);
         }
     }
 
-    if (lex->chr2 == MP_LEXER_EOF) {
-        // EOF, check if we need to insert a newline at end of file
-        if (lex->chr1 != MP_LEXER_EOF && lex->chr1 != '\n') {
-            // if lex->chr1 == '\r' then this makes a CR LF which will be converted to LF above
-            // otherwise it just inserts a LF
-            lex->chr2 = '\n';
-        }
+    // check if we need to insert a newline at end of file
+    if (lex->chr2 == MP_LEXER_EOF && lex->chr1 != MP_LEXER_EOF && lex->chr1 != '\n') {
+        lex->chr2 = '\n';
     }
 }
 

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -422,7 +422,7 @@ STATIC bool skip_whitespace(mp_lexer_t *lex, bool stop_at_newline) {
                 next_char(lex);
             }
             // had_physical_newline will be set on next loop
-        } else if (is_char_and(lex, '\\', '\n')) {
+        } else if (is_char(lex, '\\') && is_char_following_or(lex, '\n', '\r')) {
             // line-continuation, so don't set had_physical_newline
             next_char(lex);
             next_char(lex);

--- a/py/lexer.c
+++ b/py/lexer.c
@@ -422,7 +422,7 @@ STATIC bool skip_whitespace(mp_lexer_t *lex, bool stop_at_newline) {
                 next_char(lex);
             }
             // had_physical_newline will be set on next loop
-        } else if (is_char(lex, '\\') && is_char_following_or(lex, '\n', '\r')) {
+        } else if (is_char_and(lex, '\\', '\n')) {
             // line-continuation, so don't set had_physical_newline
             next_char(lex);
             next_char(lex);

--- a/tests/basics/lexer.py
+++ b/tests/basics/lexer.py
@@ -27,6 +27,14 @@ print(eval("1\r"))
 print(eval("12\r"))
 print(eval("123\r"))
 
+# line continuation
+print(eval("'123' \\\r '456'"))
+print(eval("'123' \\\n '456'"))
+print(eval("'123' \\\r\n '456'"))
+print(eval("'123'\\\r'456'"))
+print(eval("'123'\\\n'456'"))
+print(eval("'123'\\\r\n'456'"))
+
 # backslash used to escape a line-break in a string
 print('a\
 b')


### PR DESCRIPTION
One of our users ran across another bug in the lexer.  If you make use of the line continuation character in paste mode (pasting sample code with long lines) the device throws a SyntaxError.

Minor change requires checking `chr1` against both `'\n'` and `'\r'` since `next_char()` only performs newline conversions on `chr0`.

And now that I've written that, I realized we can bump the CR LF processing up to the `chr1` position from `chr0`, simplifying it slightly, and then we'll only see `'\r'` in `chr2` (where we need to wait to see if it's followed by a `'\n'` to consume).