### PR TITLE
esp8266/ets_alt_task.c: Prevent spurious large increment of ticks_ms()

### DIFF
--- a/esp8266/ets_alt_task.c
+++ b/esp8266/ets_alt_task.c
@@ -120,11 +120,13 @@ bool ets_loop_iter(void) {
     }
 
     // handle overflow of system microsecond counter
+    ets_intr_lock();
     uint32_t system_time_cur = system_get_time();
     if (system_time_cur < system_time_prev) {
         system_time_high_word += 1; // record overflow of low 32-bits
     }
     system_time_prev = system_time_cur;
+    ets_intr_unlock();
 
     //static unsigned cnt;
     bool progress = false;


### PR DESCRIPTION
This happened when the overflow counter for ticks_ms() was interrupted
by an external hard interrupt (issue #3076).