### PR TITLE
py/sequence: Fix bounds checking for negative-step list slices.

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -834,8 +834,8 @@ const mp_obj_t *mp_obj_property_get(mp_obj_t self_in);
 
 // slice indexes resolved to particular sequence
 typedef struct {
-    mp_uint_t start;
-    mp_uint_t stop;
+    mp_int_t start;
+    mp_int_t stop;
     mp_int_t step;
 } mp_bound_slice_t;
 

--- a/tests/basics/list_slice_3arg.py
+++ b/tests/basics/list_slice_3arg.py
@@ -26,3 +26,15 @@ print(x[-1:-1:-1])
 print(x[-1:-2:-1])
 print(x[-1:-11:-1])
 print(x[-10:-11:-1])
+
+print(x[:-15:-1])
+
+if len([][::-1]):
+	print('Skipping crashing tests with negative step.')
+else:
+	print([][::-1])
+	print([1][::-1])
+	print([][:-20:-1])
+	print([1][:-20:-1])
+	print([][-20::-1])
+	print([1][-20::-1])


### PR DESCRIPTION
Some issues with negative-step list slices came up during @mikewadsten's fuzz testing.  I investigated, and looked at how CPython converted its slice parameters.  I ended up copying CPython's technique (assuming it wouldn't create any licensing issues).

In order to use uint for the start and stop values, the old code treated the stop index as inclusive for negative steps (instead of exclusive as on positive steps).  This complicated some conditionals and value conversions.  Switching to signed integers in `mp_bound_slice_t` simplified the code and allowed for code reuse when mapping start/stop to be within range.

I've reviewed the code for areas referencing `mp_bound_slice_t` and calling `mp_seq_get_fast_slice_indexes()`, and there's only one place that accepts negative-step slices that could have been affected by that change.

Of course we'll see if anything comes up from running the full test suite.  Some day soon I'll figure out how to run the suite against a Windows MicroPython build...