### PR TITLE
py/objstringio: Fix StringIO/BytesIO reads at or beyond EOF.

### DIFF
--- a/py/objstringio.c
+++ b/py/objstringio.c
@@ -56,6 +56,9 @@ STATIC mp_uint_t stringio_read(mp_obj_t o_in, void *buf, mp_uint_t size, int *er
     (void)errcode;
     mp_obj_stringio_t *o = MP_OBJ_TO_PTR(o_in);
     check_stringio_is_open(o);
+    if (o->vstr->len <= o->pos) {  // read to EOF, or seeked to EOF or beyond
+        return 0;
+    }
     mp_uint_t remaining = o->vstr->len - o->pos;
     if (size > remaining) {
         size = remaining;

--- a/tests/io/bytesio_ext.py
+++ b/tests/io/bytesio_ext.py
@@ -4,6 +4,10 @@ try:
 except ImportError:
     import io
 
+a = io.BytesIO(b"foobar")
+a.seek(10)
+print(a.read(10))
+
 a = io.BytesIO()
 print(a.seek(8))
 a.write(b"123")

--- a/tests/io/stringio1.py
+++ b/tests/io/stringio1.py
@@ -13,10 +13,6 @@ print(a.getvalue())
 print(a.read())
 print(a.read())
 
-a = io.StringIO("foobar")
-a.seek(10)
-print(repr(a.read(10)))
-
 a = io.StringIO()
 a.write("foo")
 print(a.getvalue())

--- a/tests/io/stringio1.py
+++ b/tests/io/stringio1.py
@@ -13,6 +13,10 @@ print(a.getvalue())
 print(a.read())
 print(a.read())
 
+a = io.StringIO("foobar")
+a.seek(10)
+print(repr(a.read(10)))
+
 a = io.StringIO()
 a.write("foo")
 print(a.getvalue())


### PR DESCRIPTION
This was one of the serious issues @mikewadsten found during his fuzz testing.  If you used `seek()` to go beyond the end of a `StringIO` object, you could then `read()` any/all of that address space.  On an embedded platform, you could use huge integers to wrap around and access the memory before the object as well.

The updated test demonstrates the failure well -- it should print an empty string, but you're likely to see a 10-byte string starting with some `\x00' values.

I have a separate pull request that addresses related issues with `write()` when using a negative seek (or multiple, large positive seeks for wraparound) that could result in MicroPython writing to addresses outside of space allocated to the `vstr`.