### PR TITLE
py/objstringio: Prevent negative string position for BytesIO object.

### DIFF
--- a/py/objstringio.c
+++ b/py/objstringio.c
@@ -95,24 +95,17 @@ STATIC mp_uint_t stringio_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg,
     switch (request) {
         case MP_STREAM_SEEK: {
             struct mp_stream_seek_t *s = (struct mp_stream_seek_t*)arg;
-            mp_int_t new_pos = s->offset;
+            mp_uint_t ref = 0;
             switch (s->whence) {
                 case 1: // SEEK_CUR
-                    new_pos += o->pos;
+                    ref = o->pos;
                     break;
                 case 2: // SEEK_END
-                    new_pos += o->vstr->len;
+                    ref = o->vstr->len;
                     break;
             }
-            if (new_pos < 0) {
-                if (s->offset > 0) {
-                    // adding positive offset overflowed to a negative value
-                    mp_raise_msg(&mp_type_OverflowError, "new position too large");
-                }
-                // negative offset went past start of string; reset to start
-                new_pos = 0;
-            }
-            o->pos = s->offset = new_pos;
+            o->pos = ref + s->offset;
+            s->offset = o->pos;
             return 0;
         }
         case MP_STREAM_FLUSH:

--- a/tests/io/bytesio_ext.py
+++ b/tests/io/bytesio_ext.py
@@ -22,3 +22,12 @@ a.seek(0)
 arr = bytearray(10)
 print(a.readinto(arr))
 print(arr)
+
+# negative seek should limit offset to 0
+a = io.BytesIO()
+a.seek(10)
+if a.seek(-100, 1) != 0:
+	print('Negative seek allowed, now at', a.seek(0, 1))
+else:
+    a.write(b'123')
+    print(a.getvalue())


### PR DESCRIPTION
This is a change related to maintaining the current position in a BytesIO object.  Since MicroPython treats StringIO objects as identical to BytesIO, it affects those objects as well.

In existing code, we store a negative offset as a large unsigned value, which creates wrap-around issues in `stringio_write()`, causing it to miscalculate the need to call `vstr_add_len()` and potentially write bytes outside of the memory allocated to the vstr.

This change will increase code size, but attempts to follow behavior of CPython for negative offsets and repeated seeks past the current position until the offset exceeds some maximum.

Modifying test code to perform the write without checking the return of `seek()` will lead to a crash.

My original fix included changing `pos` of `mp_obj_stringio_t` from `mp_uint_t` to `mp_int_t`, but I don't think it's necessary.  `pos` should never exceed the maximum value of a signed `mp_int_t`.