### PR TITLE
mp-readline/readline.c: Add REPL support for CTRL-L

### DIFF
--- a/lib/mp-readline/readline.h
+++ b/lib/mp-readline/readline.h
@@ -31,6 +31,7 @@
 #define CHAR_CTRL_E (5)
 #define CHAR_CTRL_F (6)
 #define CHAR_CTRL_K (11)
+#define CHAR_CTRL_L (12)
 #define CHAR_CTRL_N (14)
 #define CHAR_CTRL_P (16)
 #define CHAR_CTRL_U (21)


### PR DESCRIPTION
`CTRL-L` clears the screen and redraws the current prompt and input buffer.  The cursor's position in the input buffer is maintained.