### PR TITLE
Create map_iter_next() from core of dict_iter_next(), make use where appropriate

### DIFF
--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -57,10 +57,9 @@ STATIC void mp_help_print_info_about_object(mp_obj_t name_o, mp_obj_t value) {
 
 #if MICROPY_PY_BUILTINS_HELP_MODULES
 STATIC void mp_help_add_from_map(mp_obj_t list, const mp_map_t *map) {
-    for (size_t i = 0; i < map->alloc; i++) {
-        if (MP_MAP_SLOT_IS_FILLED(map, i)) {
-            mp_obj_list_append(list, map->table[i].key);
-        }
+    mp_map_elem_t *elem;
+    for (size_t i = 0; (elem = mp_map_iter_next(map, &i)); ) {
+        mp_obj_list_append(list, elem->key);
     }
 }
 
@@ -100,7 +99,7 @@ STATIC void mp_help_print_modules(void) {
     // print the list of modules in a column-first order
     #define NUM_COLUMNS (4)
     #define COLUMN_WIDTH (18)
-    mp_uint_t len;
+    size_t len;
     mp_obj_t *items;
     mp_obj_list_get(list, &len, &items);
     unsigned int num_rows = (len + NUM_COLUMNS - 1) / NUM_COLUMNS;

--- a/py/map.c
+++ b/py/map.c
@@ -127,14 +127,13 @@ void mp_map_clear(mp_map_t *map) {
 // the iteration is held in *cur and should be initialised with zero for the
 // first call.  Will return NULL when no more elements are available.
 mp_map_elem_t *mp_map_iter_next(const mp_map_t *map, size_t *cur) {
-    size_t max;
-
     if (map) {
-        max = map->alloc;
+        size_t max = map->alloc;
         for (size_t i = *cur; i < max; i++) {
-            if (MP_MAP_SLOT_IS_FILLED(map, i)) {
+            mp_map_elem_t *elem = &(map->table[i]);
+            if (elem->key != MP_OBJ_NULL && elem->key != MP_OBJ_SENTINEL) {
                 *cur = i + 1;
-                return &(map->table[i]);
+                return elem;
             }
         }
     }

--- a/py/map.c
+++ b/py/map.c
@@ -123,6 +123,25 @@ void mp_map_clear(mp_map_t *map) {
     map->table = NULL;
 }
 
+// This is a helper function to iterate through a map.  The state of
+// the iteration is held in *cur and should be initialised with zero for the
+// first call.  Will return NULL when no more elements are available.
+mp_map_elem_t *mp_map_iter_next(const mp_map_t *map, size_t *cur) {
+    size_t max;
+
+    if (map) {
+        max = map->alloc;
+        for (size_t i = *cur; i < max; i++) {
+            if (MP_MAP_SLOT_IS_FILLED(map, i)) {
+                *cur = i + 1;
+                return &(map->table[i]);
+            }
+        }
+    }
+    
+    return NULL;
+}
+
 STATIC void mp_map_rehash(mp_map_t *map) {
     size_t old_alloc = map->alloc;
     size_t new_alloc = get_hash_alloc_greater_or_equal_to(map->alloc + 1);

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -225,20 +225,16 @@ STATIC mp_obj_t mp_builtin_dir(size_t n_args, const mp_obj_t *args) {
     }
 
     mp_obj_t dir = mp_obj_new_list(0, NULL);
+    mp_map_elem_t *elem;
     if (dict != NULL) {
-        for (mp_uint_t i = 0; i < dict->map.alloc; i++) {
-            if (MP_MAP_SLOT_IS_FILLED(&dict->map, i)) {
-                mp_obj_list_append(dir, dict->map.table[i].key);
-            }
+        for (size_t i = 0; (elem = mp_map_iter_next(&dict->map, &i)); ) {
+            mp_obj_list_append(dir, elem->key);
         }
     }
-    if (members != NULL) {
-        for (mp_uint_t i = 0; i < members->alloc; i++) {
-            if (MP_MAP_SLOT_IS_FILLED(members, i)) {
-                mp_obj_list_append(dir, members->table[i].key);
-            }
-        }
+    for (size_t i = 0; (elem = mp_map_iter_next(members, &i)); ) {
+        mp_obj_list_append(dir, elem->key);
     }
+    
     return dir;
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_dir_obj, 0, 1, mp_builtin_dir);

--- a/py/modthread.c
+++ b/py/modthread.c
@@ -233,11 +233,10 @@ STATIC mp_obj_t mod_thread_start_new_thread(size_t n_args, const mp_obj_t *args)
         th_args = m_new_obj_var(thread_entry_args_t, mp_obj_t, pos_args_len + 2 * map->used);
         th_args->n_kw = map->used;
         // copy across the keyword arguments
-        for (size_t i = 0, n = pos_args_len; i < map->alloc; ++i) {
-            if (MP_MAP_SLOT_IS_FILLED(map, i)) {
-                th_args->args[n++] = map->table[i].key;
-                th_args->args[n++] = map->table[i].value;
-            }
+		mp_map_elem_t *elem;
+        for (size_t i = 0, n = pos_args_len; (elem = mp_map_iter_next(map, &i)); ) {
+            th_args->args[n++] = elem->key;
+            th_args->args[n++] = elem->value;
         }
     }
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -379,6 +379,7 @@ mp_map_t *mp_map_new(size_t n);
 void mp_map_deinit(mp_map_t *map);
 void mp_map_free(mp_map_t *map);
 mp_map_elem_t *mp_map_lookup(mp_map_t *map, mp_obj_t index, mp_map_lookup_kind_t lookup_kind);
+mp_map_elem_t *mp_map_iter_next(const mp_map_t *map, size_t *cur);
 void mp_map_clear(mp_map_t *map);
 void mp_map_dump(mp_map_t *map);
 

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -38,22 +38,7 @@
 
 STATIC mp_obj_t dict_update(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
 
-// This is a helper function to iterate through a dictionary.  The state of
-// the iteration is held in *cur and should be initialised with zero for the
-// first call.  Will return NULL when no more elements are available.
-STATIC mp_map_elem_t *dict_iter_next(mp_obj_dict_t *dict, size_t *cur) {
-    size_t max = dict->map.alloc;
-    mp_map_t *map = &dict->map;
-
-    for (size_t i = *cur; i < max; i++) {
-        if (MP_MAP_SLOT_IS_FILLED(map, i)) {
-            *cur = i + 1;
-            return &(map->table[i]);
-        }
-    }
-
-    return NULL;
-}
+#define dict_iter_next(dict, cur) mp_map_iter_next(&((dict)->map), cur)
 
 STATIC void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(self_in);
@@ -201,7 +186,7 @@ typedef struct _mp_obj_dict_it_t {
 
 STATIC mp_obj_t dict_it_iternext(mp_obj_t self_in) {
     mp_obj_dict_it_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_map_elem_t *next = dict_iter_next(MP_OBJ_TO_PTR(self->dict), &self->cur);
+    mp_map_elem_t *next = dict_iter_next((mp_obj_dict_t *)MP_OBJ_TO_PTR(self->dict), &self->cur);
 
     if (next == NULL) {
         return MP_OBJ_STOP_ITERATION;
@@ -436,7 +421,7 @@ typedef struct _mp_obj_dict_view_t {
 STATIC mp_obj_t dict_view_it_iternext(mp_obj_t self_in) {
     mp_check_self(MP_OBJ_IS_TYPE(self_in, &dict_view_it_type));
     mp_obj_dict_view_it_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_map_elem_t *next = dict_iter_next(MP_OBJ_TO_PTR(self->dict), &self->cur);
+    mp_map_elem_t *next = dict_iter_next((mp_obj_dict_t *)MP_OBJ_TO_PTR(self->dict), &self->cur);
 
     if (next == NULL) {
         return MP_OBJ_STOP_ITERATION;

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -186,7 +186,7 @@ typedef struct _mp_obj_dict_it_t {
 
 STATIC mp_obj_t dict_it_iternext(mp_obj_t self_in) {
     mp_obj_dict_it_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_map_elem_t *next = dict_iter_next((mp_obj_dict_t *)MP_OBJ_TO_PTR(self->dict), &self->cur);
+    mp_map_elem_t *next = dict_iter_next((mp_obj_dict_t*)MP_OBJ_TO_PTR(self->dict), &self->cur);
 
     if (next == NULL) {
         return MP_OBJ_STOP_ITERATION;
@@ -380,10 +380,9 @@ STATIC mp_obj_t dict_update(size_t n_args, const mp_obj_t *args, mp_map_t *kwarg
     }
 
     // update the dict with any keyword args
-    for (size_t i = 0; i < kwargs->alloc; i++) {
-        if (MP_MAP_SLOT_IS_FILLED(kwargs, i)) {
-            mp_map_lookup(&self->map, kwargs->table[i].key, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = kwargs->table[i].value;
-        }
+    mp_map_elem_t *elem;
+    for (size_t i = 0; (elem = mp_map_iter_next(kwargs, &i)); ) {
+        mp_map_lookup(&self->map, elem->key, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = elem->value;
     }
 
     return mp_const_none;
@@ -421,7 +420,7 @@ typedef struct _mp_obj_dict_view_t {
 STATIC mp_obj_t dict_view_it_iternext(mp_obj_t self_in) {
     mp_check_self(MP_OBJ_IS_TYPE(self_in, &dict_view_it_type));
     mp_obj_dict_view_it_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_map_elem_t *next = dict_iter_next((mp_obj_dict_t *)MP_OBJ_TO_PTR(self->dict), &self->cur);
+    mp_map_elem_t *next = dict_iter_next((mp_obj_dict_t*)MP_OBJ_TO_PTR(self->dict), &self->cur);
 
     if (next == NULL) {
         return MP_OBJ_STOP_ITERATION;

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -484,10 +484,9 @@ STATIC void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *des
         // it will not result in modifications to the actual instance members.
         mp_map_t *map = &self->members;
         mp_obj_t attr_dict = mp_obj_new_dict(map->used);
-        for (size_t i = 0; i < map->alloc; ++i) {
-            if (MP_MAP_SLOT_IS_FILLED(map, i)) {
-                mp_obj_dict_store(attr_dict, map->table[i].key, map->table[i].value);
-            }
+        mp_map_elem_t *e;
+        for (size_t i = 0; (e = mp_map_iter_next(map, &i)); ) {
+            mp_obj_dict_store(attr_dict, e->key, e->value);
         }
         dest[0] = attr_dict;
         return;


### PR DESCRIPTION
I noticed a common code pattern for walking the elements of a map, saw a helper function specific to `mp_obj_dict_t`, and decided to generalize it for all maps.  See issue #3105.

I have only made changes to core files, but this should work for `extmod/moductypes.c`, `extmod/moduselect.c`, and `esp8266/modnetwork.c` as well, and I can update them for this pull request if desired.