### PR TITLE
StringIO/BytesIO: seek to negative offset resets file position to 0

### DIFF
--- a/py/objstringio.c
+++ b/py/objstringio.c
@@ -125,8 +125,19 @@ STATIC mp_uint_t stringio_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg,
                     ref = o->vstr->len;
                     break;
             }
-            o->pos = ref + s->offset;
-            s->offset = o->pos;
+            mp_uint_t new_pos = ref + s->offset;
+            if (s->offset < 0) {
+                if (new_pos > ref) {
+                    // Negative offset from SEEK_CUR or SEEK_END went past 0.
+                    // CPython sets position to 0, POSIX returns an EINVAL error
+                    new_pos = 0;
+                }
+            } else if (new_pos < ref) {
+                // positive offset went beyond the limit of mp_uint_t
+                *errcode = MP_EINVAL;  // replace with MP_EOVERFLOW when defined
+                return MP_STREAM_ERROR;
+            }
+            s->offset = o->pos = new_pos;
             return 0;
         }
         case MP_STREAM_FLUSH:

--- a/tests/io/bytesio_ext.py
+++ b/tests/io/bytesio_ext.py
@@ -26,3 +26,12 @@ a.seek(0)
 arr = bytearray(10)
 print(a.readinto(arr))
 print(arr)
+
+# negative seek should limit offset to 0
+a = io.BytesIO()
+a.seek(10)
+if a.seek(-100, 1) != 0:
+	print('Negative seek allowed, now at', a.seek(0, 1))
+else:
+    a.write(b'123')
+    print(a.getvalue())


### PR DESCRIPTION
Code split off of pull request #3093, see that issue for full history.

There has been some discussion of the preferred behavior when the user seeks past the start of a StringIO/BytesIO object.  This commit sets the file position to 0, following CPython behavior.

@pfalcon has a compelling argument that we should follow POSIX `lseek()` behavior and return an `EINVAL` error.

This code already returns an `EINVAL` if the seek would take the file position past the limits of an `mp_uint_t`.  It wouldn't be difficult to change behavior to return an error, but it would require an update to `tests/io/bytesio_ext.py` and not comparing its output with that of Python3.

With a merge of #3110, there's less urgency in incorporating these changes.