### PR TITLE
Use MP heap instead of VLA in signal_make_new().

### DIFF
--- a/extmod/machine_signal.c
+++ b/extmod/machine_signal.c
@@ -58,7 +58,7 @@ STATIC mp_obj_t signal_make_new(const mp_obj_type_t *type, size_t n_args, size_t
         // If first argument isn't a Pin-like object, we filter out "invert"
         // from keyword arguments and pass them all to the exported Pin
         // constructor to create one.
-        mp_obj_t pin_args[n_args + n_kw * 2];
+        MP_SCOPED_ALLOC(mp_obj_t, pin_args, n_args + n_kw * 2);
         memcpy(pin_args, args, n_args * sizeof(mp_obj_t));
         const mp_obj_t *src = args + n_args;
         mp_obj_t *dst = pin_args + n_args;
@@ -88,6 +88,7 @@ STATIC mp_obj_t signal_make_new(const mp_obj_type_t *type, size_t n_args, size_t
         // will just ignore it as set a concrete type. If not, we'd need
         // to expose port's "default" pin type too.
         pin = MICROPY_PY_MACHINE_PIN_MAKE_NEW(NULL, n_args, n_kw, pin_args);
+        MP_SCOPED_FREE(pin_args);
     }
     else
     #endif

--- a/py/misc.h
+++ b/py/misc.h
@@ -100,6 +100,20 @@ size_t m_get_current_bytes_allocated(void);
 size_t m_get_peak_bytes_allocated(void);
 #endif
 
+#if MICROPY_SCOPED_VAR_IMPL == MICROPY_SCOPED_VAR_IMPL_VLA
+#define MP_SCOPED_ALLOC(type, var, num)  type var[num]
+#define MP_SCOPED_FREE(type)
+#elif MICROPY_SCOPED_VAR_IMPL == MICROPY_SCOPED_VAR_IMPL_ALLOCA
+#define MP_SCOPED_ALLOC(type, var, num)  type *var = alloca(sizeof(type) * (num))
+#define MP_SCOPED_FREE(type)
+#elif MICROPY_SCOPED_VAR_IMPL == MICROPY_SCOPED_VAR_IMPL_HEAP
+#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+#error cannot use SCOPED_VAR_IMPL_HEAP with MALLOC_USES_ALLOCATED_SIZE
+#endif
+#define MP_SCOPED_ALLOC(type, var, num)  type *var = m_new(type, num)
+#define MP_SCOPED_FREE(var)              m_free(var)
+#endif
+
 /** array helpers ***********************************************/
 
 // get the number of elements in a fixed-size array

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -233,6 +233,18 @@
 #define alloca(x) m_malloc(x)
 #endif
 
+// Various strategies for allocating small, variable-length arrays
+// limited to the current function/scope.  Preferred method is VLA,
+// but backup methods are to use alloca() or the heap depending on
+// what a platform/compiler supports.
+#define MICROPY_SCOPED_VAR_IMPL_VLA (0)
+#define MICROPY_SCOPED_VAR_IMPL_ALLOCA (1)
+#define MICROPY_SCOPED_VAR_IMPL_HEAP (2)
+
+#ifndef MICROPY_SCOPED_VAR_IMPL
+#define MICROPY_SCOPED_VAR_IMPL (MICROPY_SCOPED_VAR_IMPL_VLA)
+#endif
+
 /*****************************************************************************/
 /* MicroPython emitters                                                     */
 


### PR DESCRIPTION
Some compilers will use heap instead of stack for variable-length arrays, and won't clean up that space if we throw an exception (for example, in `signal_make_new()`).  For example, IAR's ARM compiler requires enabling VLA support and warns against using it with `longjmp()`.

New code allocates space on MicroPython heap that the garbage collector can reclaim if we don't call `m_del()` due to an exception.