### PR TITLE
docs/machine.Pin: Remove __call__ from public API description.

### DIFF
--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -146,12 +146,6 @@ Methods
 
    When setting the value this method returns ``None``.
 
-.. method:: Pin.__call__([x])
-
-   Pin objects are callable.  The call method provides a (fast) shortcut to set
-   and get the value of the pin.  It is equivalent to Pin.value([x]).
-   See :meth:`Pin.value` for more details.
-
 .. method:: Pin.on()
 
    Set pin to "1" output level.


### PR DESCRIPTION
__call__ is considered an internal method, it's use is discouraged
in normal applications.