### PR TITLE
py/builtinimport: Identify empty string earlier in import() error path.

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -331,6 +331,9 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
         }
 
         uint new_mod_l = (mod_len == 0 ? (size_t)(p - this_name) : (size_t)(p - this_name) + 1 + mod_len);
+        if (new_mod_l == 0) {
+            mp_raise_ValueError("cannot perform relative import");
+        }
         char *new_mod = alloca(new_mod_l);
         memcpy(new_mod, this_name, p - this_name);
         if (mod_len != 0) {
@@ -340,9 +343,6 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
 
         qstr new_mod_q = qstr_from_strn(new_mod, new_mod_l);
         DEBUG_printf("Resolved base name for relative import: '%s'\n", qstr_str(new_mod_q));
-        if (new_mod_q == MP_QSTR_) {
-            mp_raise_ValueError("cannot perform relative import");
-        }
         module_name = MP_OBJ_NEW_QSTR(new_mod_q);
         mod_str = new_mod;
         mod_len = new_mod_l;


### PR DESCRIPTION
Variable `new_mod_q` will always be `MP_QSTR_` when `new_mod_l` is 0, so avoid 0-byte `alloca()`, `memcpy()`, etc. and fail as soon as possible.  This code triggered by `from . import foo`.

I was debugging a failure in our platform support code where I ended up with an empty string in another QSTR pool, which caused the original `import()` code to fail due to a qstr mismatch.  I fixed my code, but also felt that there's an improvement here to identify the empty string and fail sooner.

And, if `qstr_find_strn()` does enough lookups where `str_len == 0`, it might be worth special-case code to return `MP_QSTR_` instead of searching backwards through almost every QSTR entry to find it.