### PR TITLE
Added defines to configure SDIO pins

### DIFF
--- a/stmhal/sdcard.c
+++ b/stmhal/sdcard.c
@@ -86,6 +86,26 @@
 
 #else
 
+//If no custom SDIO pins defined, use the default ones
+#ifndef MICROPY_HW_SDMMC_D0
+    #define MICROPY_HW_SDMMC_D0 (pin_C8)
+#endif
+#ifndef MICROPY_HW_SDMMC_D1
+    #define MICROPY_HW_SDMMC_D1 (pin_C9)
+#endif
+#ifndef MICROPY_HW_SDMMC_D2
+    #define MICROPY_HW_SDMMC_D2 (pin_C10)
+#endif
+#ifndef MICROPY_HW_SDMMC_D3
+    #define MICROPY_HW_SDMMC_D3 (pin_C11)
+#endif
+#ifndef MICROPY_HW_SDMMC_CK
+    #define MICROPY_HW_SDMMC_CK (pin_C12)
+#endif
+#ifndef MICROPY_HW_SDMMC_CMD
+    #define MICROPY_HW_SDMMC_CMD (pin_D2)
+#endif
+
 // These are definitions for F4 MCUs so there is a common macro across all MCUs.
 
 #define SDMMC_CLK_ENABLE() __SDIO_CLK_ENABLE()
@@ -128,12 +148,12 @@ void sdcard_init(void) {
     mp_hal_pin_config_alt(&MICROPY_HW_SDMMC2_D3, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, AF_FN_SDMMC, 2);
     #else
     // Default SDIO/SDMMC1 config
-    mp_hal_pin_config(&pin_C8, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, GPIO_AF12_SDIO);
-    mp_hal_pin_config(&pin_C9, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, GPIO_AF12_SDIO);
-    mp_hal_pin_config(&pin_C10, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, GPIO_AF12_SDIO);
-    mp_hal_pin_config(&pin_C11, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, GPIO_AF12_SDIO);
-    mp_hal_pin_config(&pin_C12, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, GPIO_AF12_SDIO);
-    mp_hal_pin_config(&pin_D2, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, GPIO_AF12_SDIO);
+    mp_hal_pin_config(&MICROPY_HW_SDMMC_D0, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, GPIO_AF12_SDIO);
+    mp_hal_pin_config(&MICROPY_HW_SDMMC_D1, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, GPIO_AF12_SDIO);
+    mp_hal_pin_config(&MICROPY_HW_SDMMC_D2, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, GPIO_AF12_SDIO);
+    mp_hal_pin_config(&MICROPY_HW_SDMMC_D3, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, GPIO_AF12_SDIO);
+    mp_hal_pin_config(&MICROPY_HW_SDMMC_CK, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, GPIO_AF12_SDIO);
+    mp_hal_pin_config(&MICROPY_HW_SDMMC_CMD, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, GPIO_AF12_SDIO);
     #endif
 
     // configure the SD card detect pin


### PR DESCRIPTION
I had to change the pins of the SDIO Peripherals in order to get all the interfaces working on the Nucleo F411. So i changed the hard-coded setup of the SDIO pins to defines which, if they are not defined default to the standard pins.