### PR TITLE
tests/net_inet/test_tls_sites.py: Integration test for SSL connections.

### DIFF
--- a/tests/net_inet/README
+++ b/tests/net_inet/README
@@ -1,0 +1,5 @@
+This direcctory contains network tests which require Internet connection.
+Note that these tests are not run as part of the main testsuite and need
+to be run seperately (from the main test/ directory):
+
+    ./run-tests net_inet/*.py

--- a/tests/net_inet/test_tls_sites.py
+++ b/tests/net_inet/test_tls_sites.py
@@ -1,0 +1,56 @@
+try:
+    import usocket as _socket
+except:
+    import _socket
+try:
+    import ussl as ssl
+except:
+    import ssl
+
+
+def test_one(site, opts):
+    ai = _socket.getaddrinfo(site, 443)
+    addr = ai[0][-1]
+
+    s = _socket.socket()
+
+    try:
+        s.connect(addr)
+
+        if "sni" in opts:
+            s = ssl.wrap_socket(s, server_hostname=opts["host"])
+        else:
+            s = ssl.wrap_socket(s)
+
+        s.write(b"GET / HTTP/1.0\r\n\r\n")
+        resp = s.read(4096)
+#        print(resp)
+
+    finally:
+        s.close()
+
+
+SITES = [
+    "google.com",
+    "www.google.com",
+    "api.telegram.org",
+#    "w9rybpfril.execute-api.ap-southeast-2.amazonaws.com",
+    {"host": "w9rybpfril.execute-api.ap-southeast-2.amazonaws.com", "sni": True},
+]
+
+
+def main():
+    for site in SITES:
+        opts = {}
+        if isinstance(site, dict):
+            opts = site
+            site = opts["host"]
+
+        try:
+            test_one(site, opts)
+            print(site, "ok")
+        except Exception as e:
+            print(site, repr(e))
+
+
+main()

--- a/tests/net_inet/test_tls_sites.py.exp
+++ b/tests/net_inet/test_tls_sites.py.exp
@@ -1,0 +1,4 @@
+google.com ok
+www.google.com ok
+api.telegram.org ok
+w9rybpfril.execute-api.ap-southeast-2.amazonaws.com ok


### PR DESCRIPTION
This attempts to bootstrap network tests for MicroPython. This commits
sets test/net_inet/ as place for tests which require access to wide
Internet. They aren't intended to be run as part of the main testsuite,
instead to be run manually on demand.

test_tls_sites.py in particular check that it's possible to establish
SSL/TLS connection to select sites on the Internet: few references ones,
plus those for which problems were reported, and resolved.