### PR TITLE
stmhal/hydrabus hydrabus tests

### DIFF
--- a/stmhal/boards/HYDRABUS/mpconfigboard.h
+++ b/stmhal/boards/HYDRABUS/mpconfigboard.h
@@ -23,18 +23,22 @@
 #define MICROPY_HW_CLK_PLLQ (7)
 
 // UART config
+#define MICROPY_HW_UART1_NAME   "XB"
 #define MICROPY_HW_UART1_TX     (pin_A9)
 #define MICROPY_HW_UART1_RX     (pin_A10)
 #define MICROPY_HW_UART2_TX     (pin_A2)
 #define MICROPY_HW_UART2_RX     (pin_A3)
 #define MICROPY_HW_UART2_RTS    (pin_A1)
 #define MICROPY_HW_UART2_CTS    (pin_A0)
+#define MICROPY_HW_UART3_NAME   "YB"
 #define MICROPY_HW_UART3_TX     (pin_D8)
 #define MICROPY_HW_UART3_RX     (pin_D9)
 #define MICROPY_HW_UART3_RTS    (pin_D12)
 #define MICROPY_HW_UART3_CTS    (pin_D11)
+#define MICROPY_HW_UART4_NAME   "XA"
 #define MICROPY_HW_UART4_TX     (pin_A0)
 #define MICROPY_HW_UART4_RX     (pin_A1)
+#define MICROPY_HW_UART6_NAME   "YA"
 #define MICROPY_HW_UART6_TX     (pin_C6)
 #define MICROPY_HW_UART6_RX     (pin_C7)
 

--- a/stmhal/boards/HYDRABUS/mpconfigboard.h
+++ b/stmhal/boards/HYDRABUS/mpconfigboard.h
@@ -49,10 +49,12 @@
 #define MICROPY_HW_I2C2_SDA (pin_B11)
 
 // SPI busses
+#define MICROPY_HW_SPI1_NAME "X"
 #define MICROPY_HW_SPI1_NSS  (pin_A4)
 #define MICROPY_HW_SPI1_SCK  (pin_A5)
 #define MICROPY_HW_SPI1_MISO (pin_A6)
 #define MICROPY_HW_SPI1_MOSI (pin_A7)
+#define MICROPY_HW_SPI2_NAME "Y"
 #define MICROPY_HW_SPI2_NSS  (pin_B12)
 #define MICROPY_HW_SPI2_SCK  (pin_B13)
 #define MICROPY_HW_SPI2_MISO (pin_B14)

--- a/tests/pyb/spi.py
+++ b/tests/pyb/spi.py
@@ -1,7 +1,7 @@
 from pyb import SPI
 
 # test we can correctly create by id or name
-for bus in (-1, 0, 1, 2, 3, "X", "Y", "Z"):
+for bus in (-1, 0, 1, 2, 4, "X", "Y", "Z"):
     try:
         SPI(bus)
         print("SPI", bus)

--- a/tests/pyb/spi.py.exp
+++ b/tests/pyb/spi.py.exp
@@ -2,7 +2,7 @@ ValueError -1
 ValueError 0
 SPI 1
 SPI 2
-ValueError 3
+ValueError 4
 SPI X
 SPI Y
 ValueError Z

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -296,10 +296,12 @@ def run_tests(pyb, tests, args, base_path="."):
             skip_tests.add('float/bytes_construct.py')      # requires fp32
             skip_tests.add('float/bytearray_construct.py')  # requires fp32
             skip_tests.add('misc/rge_sm.py')                # too large
+        elif args.target == 'hydrabus':
+            skip_tests.add('pyb/accel.py')                  # No accelerometer on Hydrabus board.
         elif args.target == 'minimal':
             skip_tests.add('misc/rge_sm.py')                # too large
             skip_tests.add('micropython/opt_level.py')      # don't assume line numbers are stored
-
+    
     # Some tests are known to fail on 64-bit machines
     if pyb is None and platform.architecture()[0] == '64bit':
         pass
@@ -438,7 +440,7 @@ def main():
     cmd_parser.add_argument('files', nargs='*', help='input test files')
     args = cmd_parser.parse_args()
 
-    EXTERNAL_TARGETS = ('pyboard', 'wipy', 'esp8266', 'minimal')
+    EXTERNAL_TARGETS = ('pyboard', 'wipy', 'esp8266', 'minimal', 'hydrabus')
     if args.target in EXTERNAL_TARGETS:
         import pyboard
         pyb = pyboard.Pyboard(args.device, args.baudrate, args.user, args.password)
@@ -450,7 +452,7 @@ def main():
 
     if len(args.files) == 0:
         if args.test_dirs is None:
-            if args.target == 'pyboard':
+            if args.target in ('pyboard', 'hydrabus'):
                 # run pyboard tests
                 test_dirs = ('basics', 'micropython', 'float', 'misc', 'stress', 'extmod', 'pyb', 'pybnative', 'inlineasm')
             elif args.target in ('esp8266', 'minimal'):


### PR DESCRIPTION
Add "XA", "XB", "YA" and "YB" uart names for hydrabus board.
Add SPI "X" and "Y" names.
Add hydrabus target.
Update SPI tests.